### PR TITLE
Chore/strategy lifecycle

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
@@ -6,7 +6,7 @@ import { ElementInstanceMetadataMap } from '../../../core/shared/element-templat
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import { CSSCursor } from '../canvas-types'
-import { foldAndApplyCommandsInner, TransientOrNot } from '../commands/commands'
+import { foldAndApplyCommandsInner, WhenToRun } from '../commands/commands'
 import { DuplicateElement, duplicateElement } from '../commands/duplicate-element-command'
 import { setCursorCommand } from '../commands/set-cursor-command'
 import { setElementsToRerenderCommand } from '../commands/set-elements-to-rerender-command'
@@ -103,7 +103,7 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
           elementPath: newPath,
         }
 
-        duplicateCommands.push(duplicateElement('permanent', selectedElement, newUid))
+        duplicateCommands.push(duplicateElement('always', selectedElement, newUid))
         newPaths.push(newPath)
       })
 
@@ -111,8 +111,8 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
         commands: [
           ...duplicateCommands,
           setElementsToRerenderCommand([...canvasState.selectedElements, ...newPaths]),
-          updateSelectedViews('permanent', newPaths),
-          updateFunctionCommand('permanent', (editorState, transient) =>
+          updateSelectedViews('always', newPaths),
+          updateFunctionCommand('always', (editorState, transient) =>
             runMoveStrategyForFreshlyDuplicatedElements(
               canvasState.builtInDependencies,
               editorState,
@@ -124,7 +124,7 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
               transient,
             ),
           ),
-          setCursorCommand('transient', CSSCursor.Duplicate),
+          setCursorCommand('mid-interaction', CSSCursor.Duplicate),
         ],
         customState: {
           ...strategyState.customStrategyState,
@@ -134,7 +134,7 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
     } else {
       // Fallback for when the checks above are not satisfied.
       return {
-        commands: [setCursorCommand('transient', CSSCursor.Duplicate)],
+        commands: [setCursorCommand('mid-interaction', CSSCursor.Duplicate)],
         customState: null,
       }
     }
@@ -146,7 +146,7 @@ function runMoveStrategyForFreshlyDuplicatedElements(
   editorState: EditorState,
   strategyState: StrategyState,
   interactionState: InteractionSession,
-  transient: TransientOrNot,
+  transient: WhenToRun,
 ): Array<EditorStatePatch> {
   const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
 

--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
@@ -146,7 +146,7 @@ function runMoveStrategyForFreshlyDuplicatedElements(
   editorState: EditorState,
   strategyState: StrategyState,
   interactionState: InteractionSession,
-  transient: WhenToRun,
+  commandLifecycle: 'mid-interaction' | 'end-interaction',
 ): Array<EditorStatePatch> {
   const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
 
@@ -156,5 +156,5 @@ function runMoveStrategyForFreshlyDuplicatedElements(
     strategyState,
   ).commands
 
-  return foldAndApplyCommandsInner(editorState, [], [], moveCommands, transient).statePatches
+  return foldAndApplyCommandsInner(editorState, [], [], moveCommands, commandLifecycle).statePatches
 }

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -135,7 +135,7 @@ function dragByPixels(
     [],
     [],
     strategyResult.commands,
-    'always',
+    'end-interaction',
   ).editorState
 
   return finalEditor

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -135,7 +135,7 @@ function dragByPixels(
     [],
     [],
     strategyResult.commands,
-    'permanent',
+    'always',
   ).editorState
 
   return finalEditor

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
@@ -132,9 +132,9 @@ export function applyAbsoluteMoveCommon(
         commands: [
           ...commandsForSelectedElements.commands,
           pushIntendedBounds(commandsForSelectedElements.intendedBounds),
-          updateHighlightedViews('transient', []),
+          updateHighlightedViews('mid-interaction', []),
           setElementsToRerenderCommand(canvasState.selectedElements),
-          setCursorCommand('transient', CSSCursor.Select),
+          setCursorCommand('mid-interaction', CSSCursor.Select),
         ],
         customState: null,
       }
@@ -152,11 +152,11 @@ export function applyAbsoluteMoveCommon(
       return {
         commands: [
           ...commandsForSelectedElements.commands,
-          updateHighlightedViews('transient', []),
-          setSnappingGuidelines('transient', guidelinesWithSnappingVector),
+          updateHighlightedViews('mid-interaction', []),
+          setSnappingGuidelines('mid-interaction', guidelinesWithSnappingVector),
           pushIntendedBounds(commandsForSelectedElements.intendedBounds),
           setElementsToRerenderCommand(canvasState.selectedElements),
-          setCursorCommand('transient', CSSCursor.Select),
+          setCursorCommand('mid-interaction', CSSCursor.Select),
         ],
         customState: null,
       }

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
@@ -156,7 +156,7 @@ function reparentElement(
     [],
     [],
     strategyResult.commands,
-    'permanent',
+    'always',
   ).editorState
 
   return finalEditor

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
@@ -156,7 +156,7 @@ function reparentElement(
     [],
     [],
     strategyResult.commands,
-    'always',
+    'end-interaction',
   ).editorState
 
   return finalEditor

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
@@ -95,7 +95,7 @@ function dragByPixels(
     [],
     [],
     strategyResult.commands,
-    'always',
+    'end-interaction',
   ).editorState
 
   return finalEditor

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
@@ -95,7 +95,7 @@ function dragByPixels(
     [],
     [],
     strategyResult.commands,
-    'permanent',
+    'always',
   ).editorState
 
   return finalEditor

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -186,7 +186,7 @@ function reparentElement(
     [],
     [],
     strategyResult.commands,
-    'always',
+    'end-interaction',
   ).editorState
 
   return finalEditor

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -186,7 +186,7 @@ function reparentElement(
     [],
     [],
     strategyResult.commands,
-    'permanent',
+    'always',
   ).editorState
 
   return finalEditor

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -134,9 +134,9 @@ export const absoluteReparentStrategy: CanvasStrategy = {
         commands: [
           ...moveCommands.commands,
           ...commands.flatMap((c) => c.commands),
-          updateSelectedViews('permanent', newPaths),
+          updateSelectedViews('always', newPaths),
           setElementsToRerenderCommand(newPaths),
-          setCursorCommand('transient', CSSCursor.Move),
+          setCursorCommand('mid-interaction', CSSCursor.Move),
         ],
         customState: null,
       }

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
@@ -137,22 +137,18 @@ export const absoluteReparentToFlexStrategy: CanvasStrategy = {
           )
 
           // Strip the `position`, positional and dimension properties.
-          const commandToRemoveProperties = deleteProperties(
-            'permanent',
-            newPath,
-            propertiesToRemove,
-          )
+          const commandToRemoveProperties = deleteProperties('always', newPath, propertiesToRemove)
 
           const commandsBeforeReorder = [
             ...reparentCommands,
-            updateSelectedViews('permanent', [newPath]),
+            updateSelectedViews('always', [newPath]),
           ]
 
           const commandsAfterReorder = [
             commandToRemoveProperties,
             setElementsToRerenderCommand([newPath]),
-            updateHighlightedViews('transient', []),
-            setCursorCommand('transient', CSSCursor.Move),
+            updateHighlightedViews('mid-interaction', []),
+            setCursorCommand('mid-interaction', CSSCursor.Move),
           ]
 
           let commands: Array<CanvasCommand>
@@ -175,7 +171,7 @@ export const absoluteReparentToFlexStrategy: CanvasStrategy = {
             )
             commands = [
               ...commandsBeforeReorder,
-              reorderElement('permanent', newPath, newIndex),
+              reorderElement('always', newPath, newIndex),
               ...commandsAfterReorder,
             ]
           } else {

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -72,7 +72,7 @@ function multiselectResizeElements(
     [],
     [],
     strategyResult.commands,
-    'permanent',
+    'always',
   ).editorState
 }
 

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -72,7 +72,7 @@ function multiselectResizeElements(
     [],
     [],
     strategyResult.commands,
-    'always',
+    'end-interaction',
   ).editorState
 }
 

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -154,7 +154,7 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
                   elementParentBounds,
                   edgePosition,
                 ),
-                setSnappingGuidelines('transient', guidelinesWithSnappingVector), // TODO I think this will override the previous snapping guidelines
+                setSnappingGuidelines('mid-interaction', guidelinesWithSnappingVector), // TODO I think this will override the previous snapping guidelines
                 pushIntendedBounds([{ target: selectedElement, frame: newFrame }]),
               ]
             },
@@ -162,8 +162,8 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
           return {
             commands: [
               ...commandsForSelectedElements,
-              updateHighlightedViews('transient', []),
-              setCursorCommand('transient', pickCursorFromEdgePosition(edgePosition)),
+              updateHighlightedViews('mid-interaction', []),
+              setCursorCommand('mid-interaction', pickCursorFromEdgePosition(edgePosition)),
               setElementsToRerenderCommand(canvasState.selectedElements),
             ],
             customState: null,
@@ -172,8 +172,8 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
       } else {
         return {
           commands: [
-            setCursorCommand('transient', pickCursorFromEdgePosition(edgePosition)),
-            updateHighlightedViews('transient', []),
+            setCursorCommand('mid-interaction', pickCursorFromEdgePosition(edgePosition)),
+            updateHighlightedViews('mid-interaction', []),
           ],
           customState: null,
         }
@@ -209,7 +209,7 @@ function createResizeCommandsFromFrame(
     if (roundedDelta !== 0) {
       if (isRight(value) && value.value != null) {
         return adjustCssLengthProperty(
-          'permanent',
+          'always',
           selectedElement,
           stylePropPathMappingFn(pin, ['style']),
           roundedDelta * pinDirection,
@@ -219,7 +219,7 @@ function createResizeCommandsFromFrame(
       } else {
         const valueToSet = allPinsFromFrame(newFrame)[pin]
         return setCssLengthProperty(
-          'permanent',
+          'always',
           selectedElement,
           stylePropPathMappingFn(pin, ['style']),
           roundTo(valueToSet, 0),

--- a/editor/src/components/canvas/canvas-strategies/add-to-reparented-to-paths-command.ts
+++ b/editor/src/components/canvas/canvas-strategies/add-to-reparented-to-paths-command.ts
@@ -5,7 +5,7 @@ import {
   BaseCommand,
   CommandFunction,
   CommandFunctionResult,
-  TransientOrNot,
+  WhenToRun,
 } from '../commands/commands'
 
 export interface addToReparentedToPaths extends BaseCommand {
@@ -14,12 +14,12 @@ export interface addToReparentedToPaths extends BaseCommand {
 }
 
 export function addToReparentedToPaths(
-  transient: TransientOrNot,
+  whenToRun: WhenToRun,
   reparentedToPaths: Array<ElementPath>,
 ): addToReparentedToPaths {
   return {
     type: 'ADD_TO_REPARENTED_TO_PATHS',
-    transient: transient,
+    whenToRun: whenToRun,
     reparentedToPaths: reparentedToPaths,
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
@@ -201,7 +201,7 @@ function dragByPixels(
     [],
     [],
     strategyResult.commands,
-    'always',
+    'end-interaction',
   ).editorState
 
   return finalEditor

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
@@ -201,7 +201,7 @@ function dragByPixels(
     [],
     [],
     strategyResult.commands,
-    'permanent',
+    'always',
   ).editorState
 
   return finalEditor

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -152,7 +152,7 @@ export const escapeHatchStrategy: CanvasStrategy = {
         }
       } else {
         return {
-          commands: [setCursorCommand('transient', CSSCursor.Move)],
+          commands: [setCursorCommand('mid-interaction', CSSCursor.Move)],
           customState: null,
         }
       }
@@ -223,7 +223,7 @@ function collectMoveCommandsForSelectedElements(
   })
   commands.push(
     updateSelectedViews(
-      'permanent',
+      'always',
       selectedElements.map((path) => {
         return commonAncestor != null ? EP.appendToPath(commonAncestor, EP.toUid(path)) : path
       }),
@@ -260,7 +260,7 @@ function collectSetLayoutPropCommands(
       }
     })()
 
-    let commands: Array<CanvasCommand> = [convertToAbsolute('permanent', path)]
+    let commands: Array<CanvasCommand> = [convertToAbsolute('always', path)]
     const updatePinsCommands = createUpdatePinsCommands(
       path,
       metadata,
@@ -412,7 +412,7 @@ function collectHighlightCommand(
       return null
     }
   }, canvasState.selectedElements)
-  return showOutlineHighlight('transient', [...siblingFrames, ...draggedFrames])
+  return showOutlineHighlight('mid-interaction', [...siblingFrames, ...draggedFrames])
 }
 
 function findAbsoluteDescendantsToMove(
@@ -519,7 +519,7 @@ function createUpdatePinsCommands(
     const pinValue = pinValueToSet(framePin, fullFrame, parentFrame)
     commands.push(
       setCssLengthProperty(
-        'permanent',
+        'always',
         path,
         stylePropPathMappingFn(framePin, ['style']),
         pinValue,

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
@@ -197,7 +197,7 @@ function reorderElement(
     [],
     [],
     strategyResult.commands,
-    'always',
+    'end-interaction',
   ).editorState
 
   return finalEditor

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
@@ -197,7 +197,7 @@ function reorderElement(
     [],
     [],
     strategyResult.commands,
-    'permanent',
+    'always',
   ).editorState
 
   return finalEditor

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -95,8 +95,8 @@ export const flexReorderStrategy: CanvasStrategy = {
       if (realNewIndex === unpatchedIndex) {
         return {
           commands: [
-            updateHighlightedViews('transient', []),
-            setCursorCommand('transient', CSSCursor.Move),
+            updateHighlightedViews('mid-interaction', []),
+            setCursorCommand('mid-interaction', CSSCursor.Move),
           ],
           customState: {
             ...strategyState.customStrategyState,
@@ -106,10 +106,10 @@ export const flexReorderStrategy: CanvasStrategy = {
       } else {
         return {
           commands: [
-            reorderElement('permanent', target, realNewIndex),
+            reorderElement('always', target, realNewIndex),
             setElementsToRerenderCommand([target]),
-            updateHighlightedViews('transient', []),
-            setCursorCommand('transient', CSSCursor.Move),
+            updateHighlightedViews('mid-interaction', []),
+            setCursorCommand('mid-interaction', CSSCursor.Move),
           ],
           customState: {
             ...strategyState.customStrategyState,
@@ -120,7 +120,7 @@ export const flexReorderStrategy: CanvasStrategy = {
     } else {
       // Fallback for when the checks above are not satisfied.
       return {
-        commands: [setCursorCommand('transient', CSSCursor.Move)],
+        commands: [setCursorCommand('mid-interaction', CSSCursor.Move)],
         customState: null,
       }
     }

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
@@ -2,7 +2,7 @@ import { BuiltInDependencies } from '../../../core/es-modules/package-manager/bu
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { canvasPoint, offsetPoint, rectContainsPoint } from '../../../core/shared/math-utils'
 import { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
-import { foldAndApplyCommandsInner, TransientOrNot } from '../commands/commands'
+import { foldAndApplyCommandsInner, WhenToRun } from '../commands/commands'
 import { updateFunctionCommand } from '../commands/update-function-command'
 import { ParentBounds } from '../controls/parent-bounds'
 import { ParentOutlines } from '../controls/parent-outlines'
@@ -83,7 +83,7 @@ export const flexReparentToAbsoluteStrategy: CanvasStrategy = {
       return {
         commands: [
           ...escapeHatchCommands,
-          updateFunctionCommand('permanent', (editorState, transient): Array<EditorStatePatch> => {
+          updateFunctionCommand('always', (editorState, transient): Array<EditorStatePatch> => {
             return runAbsoluteReparentStrategyForFreshlyConvertedElement(
               canvasState.builtInDependencies,
               editorState,
@@ -104,7 +104,7 @@ function runAbsoluteReparentStrategyForFreshlyConvertedElement(
   editorState: EditorState,
   strategyState: StrategyState,
   interactionState: InteractionSession,
-  transient: TransientOrNot,
+  transient: WhenToRun,
 ): Array<EditorStatePatch> {
   const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
 

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
@@ -104,7 +104,7 @@ function runAbsoluteReparentStrategyForFreshlyConvertedElement(
   editorState: EditorState,
   strategyState: StrategyState,
   interactionState: InteractionSession,
-  transient: WhenToRun,
+  commandLifecycle: 'mid-interaction' | 'end-interaction',
 ): Array<EditorStatePatch> {
   const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
 
@@ -114,5 +114,6 @@ function runAbsoluteReparentStrategyForFreshlyConvertedElement(
     strategyState,
   ).commands
 
-  return foldAndApplyCommandsInner(editorState, [], [], reparentCommands, transient).statePatches
+  return foldAndApplyCommandsInner(editorState, [], [], reparentCommands, commandLifecycle)
+    .statePatches
 }

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.tsx
@@ -95,13 +95,13 @@ export const flexReparentToFlexStrategy: CanvasStrategy = {
 
           const commandsBeforeReorder = [
             ...reparentCommands,
-            updateSelectedViews('permanent', [newPath]),
+            updateSelectedViews('always', [newPath]),
           ]
 
           const commandsAfterReorder = [
             setElementsToRerenderCommand([newPath]),
-            updateHighlightedViews('transient', []),
-            setCursorCommand('transient', CSSCursor.Move),
+            updateHighlightedViews('mid-interaction', []),
+            setCursorCommand('mid-interaction', CSSCursor.Move),
           ]
 
           let commands: Array<CanvasCommand>
@@ -124,7 +124,7 @@ export const flexReparentToFlexStrategy: CanvasStrategy = {
             )
             commands = [
               ...commandsBeforeReorder,
-              reorderElement('permanent', newPath, newIndex),
+              reorderElement('always', newPath, newIndex),
               ...commandsAfterReorder,
             ]
           } else {

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
@@ -128,8 +128,8 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
         newFrame,
       )
 
-      commands.push(updateHighlightedViews('transient', []))
-      commands.push(setSnappingGuidelines('transient', guidelines))
+      commands.push(updateHighlightedViews('mid-interaction', []))
+      commands.push(setSnappingGuidelines('mid-interaction', guidelines))
       commands.push(pushIntendedBounds(intendedBounds))
       commands.push(setElementsToRerenderCommand(canvasState.selectedElements))
       return {

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
@@ -176,7 +176,7 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
         interactionState,
         newFrame,
       )
-      commands.push(setSnappingGuidelines('transient', guidelines))
+      commands.push(setSnappingGuidelines('mid-interaction', guidelines))
       commands.push(pushIntendedBounds(intendedBounds))
       commands.push(setElementsToRerenderCommand(canvasState.selectedElements))
       return {

--- a/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
@@ -70,7 +70,7 @@ export function pressKeys(
     [],
     [],
     strategyResult.commands,
-    'always',
+    'end-interaction',
   ).editorState
 
   return finalEditor

--- a/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
@@ -70,7 +70,7 @@ export function pressKeys(
     [],
     [],
     strategyResult.commands,
-    'permanent',
+    'always',
   ).editorState
 
   return finalEditor

--- a/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
@@ -52,7 +52,7 @@ export function ifAllowedToReparent(
     return ifAllowed()
   } else {
     return {
-      commands: [setCursorCommand('transient', CSSCursor.ReparentNotPermitted)],
+      commands: [setCursorCommand('mid-interaction', CSSCursor.ReparentNotPermitted)],
       customState: null,
     }
   }

--- a/editor/src/components/canvas/canvas-strategies/reparent-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-utils.ts
@@ -115,14 +115,14 @@ export function getReparentCommands(
         }
       })
 
-      return [addImportsToFile('permanent', newTargetPath, importsToAdd)]
+      return [addImportsToFile('always', newTargetPath, importsToAdd)]
     },
   )
 
-  result.push(reparentElement('permanent', selectedElement, newParent))
+  result.push(reparentElement('always', selectedElement, newParent))
 
   const newPath = EP.appendToPath(newParent, EP.toUid(selectedElement))
-  result.push(addToReparentedToPaths('transient', [newPath]))
+  result.push(addToReparentedToPaths('mid-interaction', [newPath]))
   result.push(...commandsToAddImports)
   return result
 }

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
@@ -120,7 +120,7 @@ function createMoveCommandsForElement(
     const parentDimension = horizontal ? elementParentBounds?.width : elementParentBounds?.height
 
     return adjustCssLengthProperty(
-      'permanent',
+      'always',
       selectedElement,
       stylePropPathMappingFn(pin, ['style']),
       updatedPropValue,
@@ -186,7 +186,7 @@ export function getAbsoluteOffsetCommandsForSelectedElement(
     if (isRight(value) && value.value != null) {
       // TODO what to do about missing properties?
       return adjustCssLengthProperty(
-        'permanent',
+        'always',
         target,
         stylePropPathMappingFn(pin, ['style']),
         newValue,

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-resize-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-resize-strategy-helpers.ts
@@ -58,7 +58,7 @@ export function createResizeCommands(
     if (isRight(value) && value.value != null) {
       // TODO what to do about missing properties?
       return adjustCssLengthProperty(
-        'permanent',
+        'always',
         selectedElement,
         stylePropPathMappingFn(pin, ['style']),
         (horizontal ? drag.x : drag.y) * (negative ? -1 : 1),

--- a/editor/src/components/canvas/commands/add-imports-to-file-command.ts
+++ b/editor/src/components/canvas/commands/add-imports-to-file-command.ts
@@ -11,7 +11,7 @@ import {
   RevisionsState,
   TextFile,
 } from '../../../core/shared/project-file-types'
-import { BaseCommand, TransientOrNot, CommandFunction, CommandFunctionResult } from './commands'
+import { BaseCommand, WhenToRun, CommandFunction, CommandFunctionResult } from './commands'
 import { Spec } from 'immutability-helper'
 import { ProjectContentTreeRoot } from '../../../components/assets'
 import { createProjectContentsPatch } from './patch-utils'
@@ -23,13 +23,13 @@ export interface AddImportsToFile extends BaseCommand {
 }
 
 export function addImportsToFile(
-  transient: TransientOrNot,
+  whenToRun: WhenToRun,
   targetFile: string,
   imports: Imports,
 ): AddImportsToFile {
   return {
     type: 'ADD_IMPORTS_TO_FILE',
-    transient: transient,
+    whenToRun: whenToRun,
     targetFile: targetFile,
     imports: imports,
   }

--- a/editor/src/components/canvas/commands/adjust-css-length-command.ts
+++ b/editor/src/components/canvas/commands/adjust-css-length-command.ts
@@ -17,7 +17,7 @@ import {
   printCSSNumber,
 } from '../../inspector/common/css-utils'
 import { applyValuesAtPath } from './adjust-number-command'
-import { BaseCommand, CommandFunction, CommandFunctionResult, TransientOrNot } from './commands'
+import { BaseCommand, CommandFunction, CommandFunctionResult, WhenToRun } from './commands'
 
 export interface AdjustCssLengthProperty extends BaseCommand {
   type: 'ADJUST_CSS_LENGTH_PROPERTY'
@@ -29,7 +29,7 @@ export interface AdjustCssLengthProperty extends BaseCommand {
 }
 
 export function adjustCssLengthProperty(
-  transient: TransientOrNot,
+  whenToRun: WhenToRun,
   target: ElementPath,
   property: PropertyPath,
   valuePx: number,
@@ -38,7 +38,7 @@ export function adjustCssLengthProperty(
 ): AdjustCssLengthProperty {
   return {
     type: 'ADJUST_CSS_LENGTH_PROPERTY',
-    transient: transient,
+    whenToRun: whenToRun,
     target: target,
     property: property,
     valuePx: valuePx,

--- a/editor/src/components/canvas/commands/adjust-number-command.spec.tsx
+++ b/editor/src/components/canvas/commands/adjust-number-command.spec.tsx
@@ -40,7 +40,7 @@ describe('adjustNumberProperty', () => {
     const delta = 10
 
     const adjustNumberPropertyCommand = adjustNumberProperty(
-      'permanent',
+      'always',
       cardInstancePath,
       stylePropPathMappingFn('left', ['style']),
       delta,
@@ -87,7 +87,7 @@ describe('adjustNumberProperty', () => {
 
     // left prop is missing, it should be just set to the delta value
     const adjustNumberPropertyCommand = adjustNumberProperty(
-      'permanent',
+      'always',
       elementPath,
       stylePropPathMappingFn('left', ['style']),
       delta,

--- a/editor/src/components/canvas/commands/adjust-number-command.ts
+++ b/editor/src/components/canvas/commands/adjust-number-command.ts
@@ -28,7 +28,7 @@ import {
   modifyUnderlyingForOpenFile,
   withUnderlyingTargetFromEditorState,
 } from '../../editor/store/editor-state'
-import type { BaseCommand, CommandFunction, TransientOrNot } from './commands'
+import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface AdjustNumberProperty extends BaseCommand {
   type: 'ADJUST_NUMBER_PROPERTY'
@@ -39,7 +39,7 @@ export interface AdjustNumberProperty extends BaseCommand {
 }
 
 export function adjustNumberProperty(
-  transient: TransientOrNot,
+  whenToRun: WhenToRun,
   target: ElementPath,
   property: PropertyPath,
   value: number | AdjustNumberInequalityCondition,
@@ -47,7 +47,7 @@ export function adjustNumberProperty(
 ): AdjustNumberProperty {
   return {
     type: 'ADJUST_NUMBER_PROPERTY',
-    transient: transient,
+    whenToRun: whenToRun,
     target: target,
     property: property,
     value: value,

--- a/editor/src/components/canvas/commands/commands.spec.ts
+++ b/editor/src/components/canvas/commands/commands.spec.ts
@@ -39,4 +39,26 @@ describe('foldAndApplyCommands', () => {
     )
     expect(result.accumulatedPatches).toMatchInlineSnapshot(`Array []`)
   })
+  it('should accumulate commands that are running on-complete', () => {
+    const editorState = createEditorState(NO_OP)
+    const result = foldAndApplyCommands(
+      editorState,
+      editorState,
+      [],
+      [setCursorCommand('on-complete', CSSCursor.Move)],
+      [],
+      'end-interaction',
+    )
+    expect(result.accumulatedPatches).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "canvas": Object {
+          "cursor": Object {
+            "$set": "-webkit-image-set( url( '/editor/cursors/cursor-moving.png ') 1x, url( '/editor/cursors/cursor-moving@2x.png ') 2x ) 4 4, default",
+          },
+        },
+      },
+    ]
+  `)
+  })
 })

--- a/editor/src/components/canvas/commands/commands.spec.ts
+++ b/editor/src/components/canvas/commands/commands.spec.ts
@@ -13,7 +13,7 @@ describe('foldAndApplyCommands', () => {
       [],
       [setCursorCommand('always', CSSCursor.Move)],
       [],
-      'always',
+      'end-interaction',
     )
     expect(result.accumulatedPatches).toMatchInlineSnapshot(`
       Array [
@@ -35,7 +35,7 @@ describe('foldAndApplyCommands', () => {
       [],
       [setCursorCommand('mid-interaction', CSSCursor.Move)],
       [],
-      'always',
+      'end-interaction',
     )
     expect(result.accumulatedPatches).toMatchInlineSnapshot(`Array []`)
   })

--- a/editor/src/components/canvas/commands/commands.spec.ts
+++ b/editor/src/components/canvas/commands/commands.spec.ts
@@ -11,9 +11,9 @@ describe('foldAndApplyCommands', () => {
       editorState,
       editorState,
       [],
-      [setCursorCommand('permanent', CSSCursor.Move)],
+      [setCursorCommand('always', CSSCursor.Move)],
       [],
-      'permanent',
+      'always',
     )
     expect(result.accumulatedPatches).toMatchInlineSnapshot(`
       Array [
@@ -33,9 +33,9 @@ describe('foldAndApplyCommands', () => {
       editorState,
       editorState,
       [],
-      [setCursorCommand('transient', CSSCursor.Move)],
+      [setCursorCommand('mid-interaction', CSSCursor.Move)],
       [],
-      'permanent',
+      'always',
     )
     expect(result.accumulatedPatches).toMatchInlineSnapshot(`Array []`)
   })

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -181,7 +181,10 @@ export function foldAndApplyCommandsInner(
       // Collate the patches.
       statePatches.push(...statePatch)
       // Do not accumulate commands that are not permanent.
-      if (shouldAccumulatePatches && command.whenToRun === 'always') {
+      if (
+        shouldAccumulatePatches &&
+        (command.whenToRun === 'always' || command.whenToRun === 'on-complete')
+      ) {
         accumulatedPatches.push(...statePatch)
       }
       workingCommandDescriptions.push({

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -163,13 +163,12 @@ export function foldAndApplyCommandsInner(
   let workingCommandDescriptions: Array<CommandDescription> = []
 
   const runCommand = (command: CanvasCommand, shouldAccumulatePatches: boolean) => {
-    const shouldRunCommand: boolean = (() => {
-      if (commandLifecycle === 'mid-interaction') {
-        return command.whenToRun === 'always' || command.whenToRun === 'mid-interaction'
-      } else {
-        return command.whenToRun === 'always' || command.whenToRun === 'on-complete'
-      }
-    })()
+    let shouldRunCommand: boolean
+    if (commandLifecycle === 'mid-interaction') {
+      shouldRunCommand = command.whenToRun === 'always' || command.whenToRun === 'mid-interaction'
+    } else {
+      shouldRunCommand = command.whenToRun === 'always' || command.whenToRun === 'on-complete'
+    }
 
     if (shouldRunCommand) {
       // Run the command with our current states.

--- a/editor/src/components/canvas/commands/convert-to-absolute-command.spec.tsx
+++ b/editor/src/components/canvas/commands/convert-to-absolute-command.spec.tsx
@@ -24,7 +24,7 @@ describe('convertToAbsolute', () => {
 
     const originalEditorState = renderResult.getEditorState().editor
 
-    const convertToAbsoluteCommand = convertToAbsolute('permanent', appInstancePath)
+    const convertToAbsoluteCommand = convertToAbsolute('always', appInstancePath)
     const result = runConvertToAbsolute(
       renderResult.getEditorState().editor,
       convertToAbsoluteCommand,

--- a/editor/src/components/canvas/commands/convert-to-absolute-command.ts
+++ b/editor/src/components/canvas/commands/convert-to-absolute-command.ts
@@ -5,20 +5,17 @@ import { ElementPath } from '../../../core/shared/project-file-types'
 import { EditorState } from '../../editor/store/editor-state'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 import { applyValuesAtPath } from './adjust-number-command'
-import { BaseCommand, CommandFunction, TransientOrNot } from './commands'
+import { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface ConvertToAbsolute extends BaseCommand {
   type: 'CONVERT_TO_ABSOLUTE'
   target: ElementPath
 }
 
-export function convertToAbsolute(
-  transient: TransientOrNot,
-  target: ElementPath,
-): ConvertToAbsolute {
+export function convertToAbsolute(transient: WhenToRun, target: ElementPath): ConvertToAbsolute {
   return {
     type: 'CONVERT_TO_ABSOLUTE',
-    transient: transient,
+    whenToRun: transient,
     target: target,
   }
 }

--- a/editor/src/components/canvas/commands/delete-properties-command.ts
+++ b/editor/src/components/canvas/commands/delete-properties-command.ts
@@ -16,7 +16,7 @@ import { drop } from '../../../core/shared/array-utils'
 import { foldEither } from '../../../core/shared/either'
 import { unsetJSXValuesAtPaths } from '../../../core/shared/jsx-attributes'
 import { ElementPath, PropertyPath, RevisionsState } from '../../../core/shared/project-file-types'
-import { BaseCommand, CommandFunction, TransientOrNot } from './commands'
+import { BaseCommand, CommandFunction, WhenToRun } from './commands'
 import * as EP from '../../../core/shared/element-path'
 import * as PP from '../../../core/shared/property-path'
 
@@ -27,13 +27,13 @@ export interface DeleteProperties extends BaseCommand {
 }
 
 export function deleteProperties(
-  transient: TransientOrNot,
+  whenToRun: WhenToRun,
   element: ElementPath,
   properties: Array<PropertyPath>,
 ): DeleteProperties {
   return {
     type: 'DELETE_PROPERTIES',
-    transient: transient,
+    whenToRun: whenToRun,
     element: element,
     properties: properties,
   }

--- a/editor/src/components/canvas/commands/duplicate-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/duplicate-element-command.spec.tsx
@@ -29,7 +29,7 @@ describe('runDuplicateElement', () => {
     const newUid = 'new-uid'
     const newPath = EP.appendToPath(EP.parentPath(targetPath), newUid)
 
-    const duplicateCommand = duplicateElement('permanent', targetPath, newUid)
+    const duplicateCommand = duplicateElement('always', targetPath, newUid)
 
     const result = runDuplicateElement(originalEditorState, duplicateCommand)
 
@@ -65,7 +65,7 @@ describe('runDuplicateElement', () => {
     const newUid = 'new-uid'
     const newPath = EP.appendToPath(EP.parentPath(targetPath), newUid)
 
-    const duplicateCommand = duplicateElement('permanent', targetPath, newUid)
+    const duplicateCommand = duplicateElement('always', targetPath, newUid)
 
     const result = runDuplicateElement(originalEditorState, duplicateCommand)
 
@@ -134,7 +134,7 @@ describe('runDuplicateElement', () => {
     const newUid = 'new-uid'
     const newPath = EP.appendToPath(EP.parentPath(targetPath), newUid)
 
-    const duplicateCommand = duplicateElement('permanent', targetPath, newUid)
+    const duplicateCommand = duplicateElement('always', targetPath, newUid)
 
     const result = runDuplicateElement(originalEditorState, duplicateCommand)
 

--- a/editor/src/components/canvas/commands/duplicate-element-command.ts
+++ b/editor/src/components/canvas/commands/duplicate-element-command.ts
@@ -7,12 +7,7 @@ import {
   withUnderlyingTargetFromEditorState,
 } from '../../editor/store/editor-state'
 import { duplicate } from '../canvas-utils'
-import {
-  BaseCommand,
-  CommandFunction,
-  getPatchForComponentChange,
-  TransientOrNot,
-} from './commands'
+import { BaseCommand, CommandFunction, getPatchForComponentChange, WhenToRun } from './commands'
 
 export interface DuplicateElement extends BaseCommand {
   type: 'DUPLICATE_ELEMENT'
@@ -21,13 +16,13 @@ export interface DuplicateElement extends BaseCommand {
 }
 
 export function duplicateElement(
-  transient: TransientOrNot,
+  whenToRun: WhenToRun,
   target: ElementPath,
   newUid: string,
 ): DuplicateElement {
   return {
     type: 'DUPLICATE_ELEMENT',
-    transient: transient,
+    whenToRun: whenToRun,
     target: target,
     newUid: newUid,
   }

--- a/editor/src/components/canvas/commands/push-intended-bounds-command.ts
+++ b/editor/src/components/canvas/commands/push-intended-bounds-command.ts
@@ -1,7 +1,7 @@
 import { toString } from '../../../core/shared/element-path'
 import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import { CanvasFrameAndTarget } from '../canvas-types'
-import type { BaseCommand, CommandFunction, TransientOrNot } from './commands'
+import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface PushIntendedBounds extends BaseCommand {
   type: 'PUSH_INTENDED_BOUNDS'
@@ -11,7 +11,7 @@ export interface PushIntendedBounds extends BaseCommand {
 export function pushIntendedBounds(value: Array<CanvasFrameAndTarget>): PushIntendedBounds {
   return {
     type: 'PUSH_INTENDED_BOUNDS',
-    transient: 'transient',
+    whenToRun: 'mid-interaction',
     value: value,
   }
 }

--- a/editor/src/components/canvas/commands/reorder-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/reorder-element-command.spec.tsx
@@ -73,7 +73,7 @@ describe('runReorderElement', () => {
 
       const parent = EP.parentPath(target)
 
-      const reorderCommand = reorderElement('permanent', target, newIdx)
+      const reorderCommand = reorderElement('always', target, newIdx)
 
       const result = runReorderElement(originalEditorState, reorderCommand)
 

--- a/editor/src/components/canvas/commands/reorder-element-command.ts
+++ b/editor/src/components/canvas/commands/reorder-element-command.ts
@@ -3,12 +3,7 @@ import * as EP from '../../../core/shared/element-path'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { EditorState, withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import { reorderComponent } from '../canvas-utils'
-import {
-  BaseCommand,
-  CommandFunction,
-  getPatchForComponentChange,
-  TransientOrNot,
-} from './commands'
+import { BaseCommand, CommandFunction, getPatchForComponentChange, WhenToRun } from './commands'
 
 export interface ReorderElement extends BaseCommand {
   type: 'REORDER_ELEMENT'
@@ -17,13 +12,13 @@ export interface ReorderElement extends BaseCommand {
 }
 
 export function reorderElement(
-  transient: TransientOrNot,
+  whenToRun: WhenToRun,
   target: ElementPath,
   newIndex: number,
 ): ReorderElement {
   return {
     type: 'REORDER_ELEMENT',
-    transient: transient,
+    whenToRun: whenToRun,
     target: target,
     newIndex: newIndex,
   }

--- a/editor/src/components/canvas/commands/reparent-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/reparent-element-command.spec.tsx
@@ -27,7 +27,7 @@ describe('runReparentElement', () => {
     ])
     const originalEditorState = renderResult.getEditorState().editor
 
-    const reparentCommand = reparentElement('permanent', targetPath, newParentPath)
+    const reparentCommand = reparentElement('always', targetPath, newParentPath)
 
     const result = runReparentElement(originalEditorState, reparentCommand)
 
@@ -77,7 +77,7 @@ describe('runReparentElement', () => {
     ])
     const originalEditorState = renderResult.getEditorState().editor
 
-    const reparentCommand = reparentElement('permanent', targetPath, newParentPath)
+    const reparentCommand = reparentElement('always', targetPath, newParentPath)
 
     const result = runReparentElement(originalEditorState, reparentCommand)
 

--- a/editor/src/components/canvas/commands/reparent-element-command.ts
+++ b/editor/src/components/canvas/commands/reparent-element-command.ts
@@ -8,12 +8,7 @@ import {
   insertElementAtPath,
   removeElementAtPath,
 } from '../../editor/store/editor-state'
-import {
-  BaseCommand,
-  CommandFunction,
-  getPatchForComponentChange,
-  TransientOrNot,
-} from './commands'
+import { BaseCommand, CommandFunction, getPatchForComponentChange, WhenToRun } from './commands'
 
 export interface ReparentElement extends BaseCommand {
   type: 'REPARENT_ELEMENT'
@@ -22,13 +17,13 @@ export interface ReparentElement extends BaseCommand {
 }
 
 export function reparentElement(
-  transient: TransientOrNot,
+  whenToRun: WhenToRun,
   target: ElementPath,
   newParent: ElementPath,
 ): ReparentElement {
   return {
     type: 'REPARENT_ELEMENT',
-    transient: transient,
+    whenToRun: whenToRun,
     target: target,
     newParent: newParent,
   }

--- a/editor/src/components/canvas/commands/set-css-length-command.spec.tsx
+++ b/editor/src/components/canvas/commands/set-css-length-command.spec.tsx
@@ -23,7 +23,7 @@ describe('setCssLengthProperty', () => {
 
     const valueToSet = 321
     const setCSSPropertyCommand = setCssLengthProperty(
-      'permanent',
+      'always',
       cardInstancePath,
       stylePropPathMappingFn('height', ['style']),
       valueToSet,

--- a/editor/src/components/canvas/commands/set-css-length-command.ts
+++ b/editor/src/components/canvas/commands/set-css-length-command.ts
@@ -17,7 +17,7 @@ import {
   printCSSNumber,
 } from '../../inspector/common/css-utils'
 import { applyValuesAtPath } from './adjust-number-command'
-import { BaseCommand, CommandFunction, TransientOrNot } from './commands'
+import { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface SetCssLengthProperty extends BaseCommand {
   type: 'SET_CSS_LENGTH_PROPERTY'
@@ -28,7 +28,7 @@ export interface SetCssLengthProperty extends BaseCommand {
 }
 
 export function setCssLengthProperty(
-  transient: TransientOrNot,
+  whenToRun: WhenToRun,
   target: ElementPath,
   property: PropertyPath,
   valuePx: number,
@@ -36,7 +36,7 @@ export function setCssLengthProperty(
 ): SetCssLengthProperty {
   return {
     type: 'SET_CSS_LENGTH_PROPERTY',
-    transient: transient,
+    whenToRun: whenToRun,
     target: target,
     property: property,
     valuePx: valuePx,

--- a/editor/src/components/canvas/commands/set-cursor-command.ts
+++ b/editor/src/components/canvas/commands/set-cursor-command.ts
@@ -1,19 +1,16 @@
 import { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import { CSSCursor } from '../canvas-types'
-import { BaseCommand, CommandFunction, TransientOrNot } from './commands'
+import { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface SetCursorCommand extends BaseCommand {
   type: 'SET_CURSOR_COMMAND'
   value: CSSCursor | null
 }
 
-export function setCursorCommand(
-  transient: TransientOrNot,
-  value: CSSCursor | null,
-): SetCursorCommand {
+export function setCursorCommand(whenToRun: WhenToRun, value: CSSCursor | null): SetCursorCommand {
   return {
     type: 'SET_CURSOR_COMMAND',
-    transient: transient,
+    whenToRun: whenToRun,
     value: value,
   }
 }

--- a/editor/src/components/canvas/commands/set-elements-to-rerender-command.ts
+++ b/editor/src/components/canvas/commands/set-elements-to-rerender-command.ts
@@ -1,6 +1,6 @@
 import * as EP from '../../../core/shared/element-path'
 import { EditorState, EditorStatePatch, ElementsToRerender } from '../../editor/store/editor-state'
-import { BaseCommand, CommandFunction, TransientOrNot } from './commands'
+import { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface SetElementsToRerenderCommand extends BaseCommand {
   type: 'SET_ELEMENTS_TO_RERENDER_COMMAND'
@@ -12,7 +12,7 @@ export function setElementsToRerenderCommand(
 ): SetElementsToRerenderCommand {
   return {
     type: 'SET_ELEMENTS_TO_RERENDER_COMMAND',
-    transient: 'transient',
+    whenToRun: 'mid-interaction',
     value: value,
   }
 }

--- a/editor/src/components/canvas/commands/set-snapping-guidelines-command.ts
+++ b/editor/src/components/canvas/commands/set-snapping-guidelines-command.ts
@@ -2,7 +2,7 @@ import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import type { GuidelineWithSnappingVector } from '../guideline'
-import type { BaseCommand, CommandFunction, TransientOrNot } from './commands'
+import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface SetSnappingGuidelines extends BaseCommand {
   type: 'SET_SNAPPING_GUIDELINES'
@@ -10,12 +10,12 @@ export interface SetSnappingGuidelines extends BaseCommand {
 }
 
 export function setSnappingGuidelines(
-  transient: TransientOrNot,
+  whenToRun: WhenToRun,
   value: Array<GuidelineWithSnappingVector>,
 ): SetSnappingGuidelines {
   return {
     type: 'SET_SNAPPING_GUIDELINES',
-    transient: transient,
+    whenToRun: whenToRun,
     value: value,
   }
 }

--- a/editor/src/components/canvas/commands/show-outline-highlight-command.ts
+++ b/editor/src/components/canvas/commands/show-outline-highlight-command.ts
@@ -1,6 +1,6 @@
 import { CanvasRectangle } from '../../../core/shared/math-utils'
 import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
-import type { BaseCommand, CommandFunction, TransientOrNot } from './commands'
+import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface ShowOutlineHighlight extends BaseCommand {
   type: 'SHOW_OUTLINE_HIGHLIGHT'
@@ -8,12 +8,12 @@ export interface ShowOutlineHighlight extends BaseCommand {
 }
 
 export function showOutlineHighlight(
-  transient: TransientOrNot,
+  whenToRun: WhenToRun,
   value: Array<CanvasRectangle>,
 ): ShowOutlineHighlight {
   return {
     type: 'SHOW_OUTLINE_HIGHLIGHT',
-    transient: transient,
+    whenToRun: whenToRun,
     value: value,
   }
 }

--- a/editor/src/components/canvas/commands/strategy-switched-command.ts
+++ b/editor/src/components/canvas/commands/strategy-switched-command.ts
@@ -18,7 +18,7 @@ export function strategySwitched(
 ): StrategySwitched {
   return {
     type: 'STRATEGY_SWITCHED',
-    transient: 'transient',
+    whenToRun: 'mid-interaction',
     reason,
     newStrategy,
     dataReset,

--- a/editor/src/components/canvas/commands/update-function-command.ts
+++ b/editor/src/components/canvas/commands/update-function-command.ts
@@ -17,12 +17,18 @@ import {
 
 export interface UpdateFunctionCommand extends BaseCommand {
   type: 'UPDATE_FUNCTION_COMMAND'
-  updateFunction: (editorState: EditorState, transient: WhenToRun) => Array<EditorStatePatch>
+  updateFunction: (
+    editorState: EditorState,
+    commandLifecycle: 'mid-interaction' | 'end-interaction',
+  ) => Array<EditorStatePatch>
 }
 
 export function updateFunctionCommand(
   whenToRun: WhenToRun,
-  updateFunction: (editorState: EditorState, transient: WhenToRun) => Array<EditorStatePatch>,
+  updateFunction: (
+    editorState: EditorState,
+    commandLifecycle: 'mid-interaction' | 'end-interaction',
+  ) => Array<EditorStatePatch>,
 ): UpdateFunctionCommand {
   return {
     type: 'UPDATE_FUNCTION_COMMAND',
@@ -34,7 +40,7 @@ export function updateFunctionCommand(
 export const runUpdateFunctionCommand = (
   editorState: EditorState,
   command: UpdateFunctionCommand,
-  commandLifecycle: WhenToRun,
+  commandLifecycle: 'mid-interaction' | 'end-interaction',
 ): CommandFunctionResult => {
   return {
     editorStatePatches: command.updateFunction(editorState, commandLifecycle),

--- a/editor/src/components/canvas/commands/update-function-command.ts
+++ b/editor/src/components/canvas/commands/update-function-command.ts
@@ -12,21 +12,21 @@ import {
   CommandFunction,
   CommandFunctionResult,
   getPatchForComponentChange,
-  TransientOrNot,
+  WhenToRun,
 } from './commands'
 
 export interface UpdateFunctionCommand extends BaseCommand {
   type: 'UPDATE_FUNCTION_COMMAND'
-  updateFunction: (editorState: EditorState, transient: TransientOrNot) => Array<EditorStatePatch>
+  updateFunction: (editorState: EditorState, transient: WhenToRun) => Array<EditorStatePatch>
 }
 
 export function updateFunctionCommand(
-  transient: TransientOrNot,
-  updateFunction: (editorState: EditorState, transient: TransientOrNot) => Array<EditorStatePatch>,
+  whenToRun: WhenToRun,
+  updateFunction: (editorState: EditorState, transient: WhenToRun) => Array<EditorStatePatch>,
 ): UpdateFunctionCommand {
   return {
     type: 'UPDATE_FUNCTION_COMMAND',
-    transient: transient,
+    whenToRun: whenToRun,
     updateFunction: updateFunction,
   }
 }
@@ -34,10 +34,10 @@ export function updateFunctionCommand(
 export const runUpdateFunctionCommand = (
   editorState: EditorState,
   command: UpdateFunctionCommand,
-  runningAsTransient: TransientOrNot,
+  commandLifecycle: WhenToRun,
 ): CommandFunctionResult => {
   return {
-    editorStatePatches: command.updateFunction(editorState, runningAsTransient),
+    editorStatePatches: command.updateFunction(editorState, commandLifecycle),
     commandDescription: `Update Callback`,
   }
 }

--- a/editor/src/components/canvas/commands/update-highlighted-views-command.ts
+++ b/editor/src/components/canvas/commands/update-highlighted-views-command.ts
@@ -1,7 +1,7 @@
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
-import type { BaseCommand, CommandFunction, TransientOrNot } from './commands'
+import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface UpdateHighlightedViews extends BaseCommand {
   type: 'UPDATE_HIGHLIGHTED_VIEWS'
@@ -9,12 +9,12 @@ export interface UpdateHighlightedViews extends BaseCommand {
 }
 
 export function updateHighlightedViews(
-  transient: TransientOrNot,
+  whenToRun: WhenToRun,
   value: Array<ElementPath>,
 ): UpdateHighlightedViews {
   return {
     type: 'UPDATE_HIGHLIGHTED_VIEWS',
-    transient: transient,
+    whenToRun: whenToRun,
     value: value,
   }
 }

--- a/editor/src/components/canvas/commands/update-selected-views-command.spec.tsx
+++ b/editor/src/components/canvas/commands/update-selected-views-command.spec.tsx
@@ -22,7 +22,7 @@ describe('updateSelectedViews', () => {
 
     const originalEditorState = renderResult.getEditorState().editor
 
-    const updateSelectedViewsCommand = updateSelectedViews('permanent', [targetPath])
+    const updateSelectedViewsCommand = updateSelectedViews('always', [targetPath])
 
     const result = runUpdateSelectedViews(originalEditorState, updateSelectedViewsCommand)
 

--- a/editor/src/components/canvas/commands/update-selected-views-command.ts
+++ b/editor/src/components/canvas/commands/update-selected-views-command.ts
@@ -1,7 +1,7 @@
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
-import type { BaseCommand, CommandFunction, TransientOrNot } from './commands'
+import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface UpdateSelectedViews extends BaseCommand {
   type: 'UPDATE_SELECTED_VIEWS'
@@ -9,12 +9,12 @@ export interface UpdateSelectedViews extends BaseCommand {
 }
 
 export function updateSelectedViews(
-  transient: TransientOrNot,
+  whenToRun: WhenToRun,
   value: Array<ElementPath>,
 ): UpdateSelectedViews {
   return {
     type: 'UPDATE_SELECTED_VIEWS',
-    transient: transient,
+    whenToRun: whenToRun,
     value: value,
   }
 }

--- a/editor/src/components/canvas/commands/wildcard-patch-command.spec.tsx
+++ b/editor/src/components/canvas/commands/wildcard-patch-command.spec.tsx
@@ -25,7 +25,7 @@ describe('wildcardPatch', () => {
       false,
     )
 
-    const wildcardCommand = wildcardPatch('permanent', { selectedViews: { $set: [] } })
+    const wildcardCommand = wildcardPatch('always', { selectedViews: { $set: [] } })
 
     const result = runWildcardPatch(renderResult.getEditorState().editor, wildcardCommand)
 

--- a/editor/src/components/canvas/commands/wildcard-patch-command.ts
+++ b/editor/src/components/canvas/commands/wildcard-patch-command.ts
@@ -1,15 +1,15 @@
 import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
-import type { BaseCommand, CommandFunction, TransientOrNot } from './commands'
+import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface WildcardPatch extends BaseCommand {
   type: 'WILDCARD_PATCH'
   patch: EditorStatePatch
 }
 
-export function wildcardPatch(transient: TransientOrNot, patch: EditorStatePatch): WildcardPatch {
+export function wildcardPatch(whenToRun: WhenToRun, patch: EditorStatePatch): WildcardPatch {
   return {
     type: 'WILDCARD_PATCH',
-    transient: transient,
+    whenToRun: whenToRun,
     patch: patch,
   }
 }

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -131,7 +131,7 @@ describe('interactionCancel', () => {
     editorStore.strategyState.accumulatedPatches = runCanvasCommand(
       editorStore.unpatchedEditor,
       wildcardPatch('always', { selectedViews: { $set: [] } }),
-      'always',
+      'end-interaction',
     ).editorStatePatches
     const actualResult = interactionCancel(editorStore, dispatchResultFromEditorStore(editorStore))
     expect(actualResult.newStrategyState.accumulatedPatches).toHaveLength(0)
@@ -210,8 +210,8 @@ describe('interactionStart', () => {
                 },
               },
             },
-            "transient": "permanent",
             "type": "WILDCARD_PATCH",
+            "whenToRun": "always",
           },
         ],
         "currentStrategyFitness": 10,
@@ -333,8 +333,8 @@ describe('interactionUpdatex', () => {
                 },
               },
             },
-            "transient": "permanent",
             "type": "WILDCARD_PATCH",
+            "whenToRun": "always",
           },
         ],
         "currentStrategyFitness": 10,
@@ -429,7 +429,7 @@ describe('interactionUpdate without strategy', () => {
     editorStore.strategyState.accumulatedPatches = runCanvasCommand(
       editorStore.unpatchedEditor,
       wildcardPatch('always', { canvas: { scale: { $set: 100 } } }),
-      'always',
+      'end-interaction',
     ).editorStatePatches
     const actualResult = interactionUpdate(
       [],
@@ -485,8 +485,8 @@ describe('interactionHardReset', () => {
                 },
               },
             },
-            "transient": "permanent",
             "type": "WILDCARD_PATCH",
+            "whenToRun": "always",
           },
         ],
         "currentStrategyFitness": 10,
@@ -590,7 +590,7 @@ describe('interactionUpdate with accumulating keypresses', () => {
     editorStore.strategyState.accumulatedPatches = runCanvasCommand(
       editorStore.unpatchedEditor,
       wildcardPatch('always', { focusedPanel: { $set: 'codeEditor' } }),
-      'always',
+      'end-interaction',
     ).editorStatePatches
 
     const actualResult = interactionUpdate(
@@ -703,8 +703,8 @@ describe('interactionUpdate with user changed strategy', () => {
                 },
               },
             },
-            "transient": "permanent",
             "type": "WILDCARD_PATCH",
+            "whenToRun": "always",
           },
         ],
         "currentStrategyFitness": 10,

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -130,8 +130,8 @@ describe('interactionCancel', () => {
     )
     editorStore.strategyState.accumulatedPatches = runCanvasCommand(
       editorStore.unpatchedEditor,
-      wildcardPatch('permanent', { selectedViews: { $set: [] } }),
-      'permanent',
+      wildcardPatch('always', { selectedViews: { $set: [] } }),
+      'always',
     ).editorStatePatches
     const actualResult = interactionCancel(editorStore, dispatchResultFromEditorStore(editorStore))
     expect(actualResult.newStrategyState.accumulatedPatches).toHaveLength(0)
@@ -165,7 +165,7 @@ const testStrategy: CanvasStrategy = {
     strategyState: StrategyState,
   ): StrategyApplicationResult {
     return {
-      commands: [wildcardPatch('permanent', { canvas: { scale: { $set: 100 } } })],
+      commands: [wildcardPatch('always', { canvas: { scale: { $set: 100 } } })],
       customState: defaultCustomStrategyState(),
     }
   },
@@ -428,8 +428,8 @@ describe('interactionUpdate without strategy', () => {
     editorStore.strategyState.currentStrategy = null
     editorStore.strategyState.accumulatedPatches = runCanvasCommand(
       editorStore.unpatchedEditor,
-      wildcardPatch('permanent', { canvas: { scale: { $set: 100 } } }),
-      'permanent',
+      wildcardPatch('always', { canvas: { scale: { $set: 100 } } }),
+      'always',
     ).editorStatePatches
     const actualResult = interactionUpdate(
       [],
@@ -585,12 +585,12 @@ describe('interactionUpdate with accumulating keypresses', () => {
     editorStore.strategyState.currentStrategy = 'PREVIOUS_STRATEGY' as CanvasStrategyId
     // the currentStrategyCommands should be added to accumulatedCommands
     editorStore.strategyState.currentStrategyCommands = [
-      wildcardPatch('permanent', { selectedViews: { $set: [EP.elementPath([['aaa']])] } }),
+      wildcardPatch('always', { selectedViews: { $set: [EP.elementPath([['aaa']])] } }),
     ]
     editorStore.strategyState.accumulatedPatches = runCanvasCommand(
       editorStore.unpatchedEditor,
-      wildcardPatch('permanent', { focusedPanel: { $set: 'codeEditor' } }),
-      'permanent',
+      wildcardPatch('always', { focusedPanel: { $set: 'codeEditor' } }),
+      'always',
     ).editorStatePatches
 
     const actualResult = interactionUpdate(

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -92,7 +92,7 @@ export function interactionFinished(
       result.strategyState.accumulatedPatches,
       [],
       strategyResult.commands,
-      'permanent',
+      'always',
     )
 
     return {
@@ -153,7 +153,7 @@ export function interactionHardReset(
         [],
         [],
         strategyResult.commands,
-        'transient',
+        'mid-interaction',
       )
       const newStrategyState: StrategyState = {
         currentStrategy: strategy.strategy.id,
@@ -299,7 +299,7 @@ export function interactionStart(
         [],
         [],
         strategyResult.commands,
-        'transient',
+        'mid-interaction',
       )
 
       const newStrategyState: StrategyState = {
@@ -391,7 +391,7 @@ function handleUserChangedStrategy(
       strategyState.accumulatedPatches,
       strategyChangedLogCommands.flatMap((c) => c.commands),
       strategyResult.commands,
-      'transient',
+      'mid-interaction',
     )
     const newStrategyState: StrategyState = {
       currentStrategy: strategy.strategy.id,
@@ -470,7 +470,7 @@ function handleAccumulatingKeypresses(
         strategyState.accumulatedPatches,
         strategyState.currentStrategyCommands,
         strategyResult.commands,
-        'transient',
+        'mid-interaction',
       )
       const newStrategyState: StrategyState = {
         currentStrategy: strategy?.strategy.id ?? null,
@@ -531,7 +531,7 @@ function handleUpdate(
       strategyState.accumulatedPatches,
       [],
       strategyResult.commands,
-      'transient',
+      'mid-interaction',
     )
     const newStrategyState: StrategyState = {
       currentStrategy: strategy?.strategy.id ?? null,

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -92,7 +92,7 @@ export function interactionFinished(
       result.strategyState.accumulatedPatches,
       [],
       strategyResult.commands,
-      'always',
+      'end-interaction',
     )
 
     return {


### PR DESCRIPTION
**Problem:**
Today commands can either be 'transient' or 'permanent'. Transient commands are only active during the interaction, 'permanent' commands run during the interaction, and at the end of the interaction too.

During the reparent spike, I realized that there is a case for third type of command which only runs at the end of the interaction, but not _during_ the interaction.

**Fix:**
This PR changes `transientOrNot` to `whenToRun`, and extends the type:
`'transient'` becomes `'mid-interaction'`
`'permanent'` becomes `'always'`
and I introduce a new `'on-complete'`.

**Commit Details:**
- `transientOrNot` -> `whenToRun`
- adding `commandLifecycle: 'mid-interaction' | 'end-interaction',` to the foldAndApplyCommands... family of functions
