### PR TITLE
Fix/canvas strategies delay

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.browser2.tsx
@@ -25,7 +25,7 @@ import { emptyModifiers } from '../../../utils/modifiers'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { BakedInStoryboardUID } from '../../../core/model/scene-utils'
 import { SceneLabelTestID } from '../controls/select-mode/scene-label'
-import { wait } from '../../../utils/utils.test-utils'
+import { setupTearDownClock, wait } from '../../../utils/utils.test-utils'
 import { ControlDelay } from './canvas-strategy-types'
 
 function dragElement(
@@ -655,6 +655,7 @@ describe('Absolute Move Strategy', () => {
 })
 
 describe('Absolute Move Strategy Canvas Controls', () => {
+  const { clock } = setupTearDownClock()
   it('when an absolute positioned element is started to be moved parent outlines become visible', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
@@ -679,7 +680,7 @@ describe('Absolute Move Strategy Canvas Controls', () => {
     const target = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
     await startDragUsingActions(renderResult, target, zeroCanvasPoint)
 
-    await wait(ControlDelay + 10)
+    clock.current.tick(ControlDelay + 10)
     const parentOutlineControl = renderResult.renderedDOM.getByTestId('parent-outlines-control')
     expect(parentOutlineControl).toBeDefined()
     const parentBoundsControl = renderResult.renderedDOM.getByTestId('parent-bounds-control')

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.browser2.tsx
@@ -25,7 +25,7 @@ import { emptyModifiers } from '../../../utils/modifiers'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { BakedInStoryboardUID } from '../../../core/model/scene-utils'
 import { SceneLabelTestID } from '../controls/select-mode/scene-label'
-import { setupTearDownClock, wait } from '../../../utils/utils.test-utils'
+import { wait } from '../../../utils/utils.test-utils'
 import { ControlDelay } from './canvas-strategy-types'
 
 function dragElement(
@@ -655,7 +655,6 @@ describe('Absolute Move Strategy', () => {
 })
 
 describe('Absolute Move Strategy Canvas Controls', () => {
-  const { clock } = setupTearDownClock()
   it('when an absolute positioned element is started to be moved parent outlines become visible', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
@@ -680,7 +679,7 @@ describe('Absolute Move Strategy Canvas Controls', () => {
     const target = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
     await startDragUsingActions(renderResult, target, zeroCanvasPoint)
 
-    clock.current.tick(ControlDelay + 10)
+    await wait(ControlDelay + 10)
     const parentOutlineControl = renderResult.renderedDOM.getByTestId('parent-outlines-control')
     expect(parentOutlineControl).toBeDefined()
     const parentBoundsControl = renderResult.renderedDOM.getByTestId('parent-bounds-control')

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.browser2.tsx
@@ -25,6 +25,8 @@ import { emptyModifiers } from '../../../utils/modifiers'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { BakedInStoryboardUID } from '../../../core/model/scene-utils'
 import { SceneLabelTestID } from '../controls/select-mode/scene-label'
+import { wait } from '../../../utils/utils.test-utils'
+import { ControlDelay } from './canvas-strategy-types'
 
 function dragElement(
   canvasControl: HTMLElement,
@@ -677,6 +679,7 @@ describe('Absolute Move Strategy Canvas Controls', () => {
     const target = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
     await startDragUsingActions(renderResult, target, zeroCanvasPoint)
 
+    await wait(ControlDelay + 10)
     const parentOutlineControl = renderResult.renderedDOM.getByTestId('parent-outlines-control')
     expect(parentOutlineControl).toBeDefined()
     const parentBoundsControl = renderResult.renderedDOM.getByTestId('parent-bounds-control')

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -26,7 +26,7 @@ import {
   EdgePositionLeft,
   EdgePositionTopLeft,
 } from '../canvas-types'
-import { setupTearDownClock, wait } from '../../../utils/utils.test-utils'
+import { wait } from '../../../utils/utils.test-utils'
 import { ControlDelay } from './canvas-strategy-types'
 
 function selectAndResizeElement(
@@ -323,7 +323,6 @@ describe('Absolute Resize Strategy', () => {
 })
 
 describe('Absolute Resize Strategy Canvas Controls', () => {
-  const { clock } = setupTearDownClock()
   it('when an absolute positioned element is resized the parent outlines become visible', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
@@ -348,7 +347,7 @@ describe('Absolute Resize Strategy Canvas Controls', () => {
     const target = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
     await startDragUsingActions(renderResult, target, EdgePositionLeft, zeroCanvasPoint)
 
-    clock.current.tick(ControlDelay + 10)
+    await wait(ControlDelay + 10)
     const parentOutlineControl = renderResult.renderedDOM.getByTestId('parent-outlines-control')
     expect(parentOutlineControl).toBeDefined()
     const parentBoundsControl = renderResult.renderedDOM.getByTestId('parent-bounds-control')

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -26,7 +26,7 @@ import {
   EdgePositionLeft,
   EdgePositionTopLeft,
 } from '../canvas-types'
-import { wait } from '../../../utils/utils.test-utils'
+import { setupTearDownClock, wait } from '../../../utils/utils.test-utils'
 import { ControlDelay } from './canvas-strategy-types'
 
 function selectAndResizeElement(
@@ -323,6 +323,7 @@ describe('Absolute Resize Strategy', () => {
 })
 
 describe('Absolute Resize Strategy Canvas Controls', () => {
+  const { clock } = setupTearDownClock()
   it('when an absolute positioned element is resized the parent outlines become visible', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
@@ -347,7 +348,7 @@ describe('Absolute Resize Strategy Canvas Controls', () => {
     const target = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
     await startDragUsingActions(renderResult, target, EdgePositionLeft, zeroCanvasPoint)
 
-    await wait(ControlDelay + 10)
+    clock.current.tick(ControlDelay + 10)
     const parentOutlineControl = renderResult.renderedDOM.getByTestId('parent-outlines-control')
     expect(parentOutlineControl).toBeDefined()
     const parentBoundsControl = renderResult.renderedDOM.getByTestId('parent-bounds-control')

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -27,6 +27,7 @@ import {
   EdgePositionTopLeft,
 } from '../canvas-types'
 import { wait } from '../../../utils/utils.test-utils'
+import { ControlDelay } from './canvas-strategy-types'
 
 function selectAndResizeElement(
   renderResult: EditorRenderResult,
@@ -346,6 +347,7 @@ describe('Absolute Resize Strategy Canvas Controls', () => {
     const target = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
     await startDragUsingActions(renderResult, target, EdgePositionLeft, zeroCanvasPoint)
 
+    await wait(ControlDelay + 10)
     const parentOutlineControl = renderResult.renderedDOM.getByTestId('parent-outlines-control')
     expect(parentOutlineControl).toBeDefined()
     const parentBoundsControl = renderResult.renderedDOM.getByTestId('parent-bounds-control')

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -259,6 +259,7 @@ export const useDelayedCurrentStrategy = () => {
   const maybeDelayedCallback = React.useCallback(
     (currentStrategy: CanvasStrategyId | null) => {
       if (currentStrategy != null && delayedStrategyValue == null) {
+        // timer reset is not needed because the hierarchy selection mouseup clears interactionsession and activestrategy
         if (timer == null) {
           setTimer(
             window.setTimeout(() => {

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -235,7 +235,7 @@ export function applyCanvasStrategy(
   return strategy.apply(canvasState, interactionSession, strategyState)
 }
 
-const useDelayedCurrentStrategy = () => {
+export const useDelayedCurrentStrategy = () => {
   /**
    * onMouseDown selection shows canvas controls that are active when a strategy runs with a delay (double click selection in hierarchy)
    * but when a drag threshold passes before the timer ends it shows up without delay

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -242,8 +242,8 @@ const useDelayedCurrentStrategy = () => {
   const [timer, setTimer] = React.useState<number | null>(null)
 
   const delayedCallback = React.useCallback(
-    (currentStrategy: CanvasStrategyId | 'empty') => {
-      if (currentStrategy != 'empty' && currentStrategyValue == null) {
+    (currentStrategy: CanvasStrategyId | null) => {
+      if (currentStrategy != null && currentStrategyValue == null) {
         if (timer == null) {
           setTimer(
             window.setTimeout(() => {
@@ -253,8 +253,7 @@ const useDelayedCurrentStrategy = () => {
           )
         }
       } else {
-        const strategyValueToSet = currentStrategy === 'empty' ? null : currentStrategy
-        setCurrentStrategyValue(strategyValueToSet)
+        setCurrentStrategyValue(currentStrategy)
         if (timer != null) {
           window.clearTimeout(timer)
           setTimer(null)
@@ -263,13 +262,7 @@ const useDelayedCurrentStrategy = () => {
     },
     [currentStrategyValue, timer, setTimer, setCurrentStrategyValue],
   )
-  useSelectorWithCallback((store) => {
-    if (store.strategyState.currentStrategy != null) {
-      return store.strategyState.currentStrategy
-    } else {
-      return 'empty' // be careful `useSelectorWithCallback` skips the callback with null value
-    }
-  }, delayedCallback)
+  useSelectorWithCallback((store) => store.strategyState.currentStrategy, delayedCallback)
 
   return currentStrategyValue
 }

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -236,35 +236,35 @@ export function applyCanvasStrategy(
 }
 
 const useDelayedCurrentStrategy = () => {
-  const [currentStrategyValue, setCurrentStrategyValue] = React.useState<CanvasStrategyId | null>(
+  const [delayedStrategyValue, setDelayedStrategyValue] = React.useState<CanvasStrategyId | null>(
     null,
   )
   const [timer, setTimer] = React.useState<number | null>(null)
 
   const delayedCallback = React.useCallback(
     (currentStrategy: CanvasStrategyId | null) => {
-      if (currentStrategy != null && currentStrategyValue == null) {
+      if (currentStrategy != null && delayedStrategyValue == null) {
         if (timer == null) {
           setTimer(
             window.setTimeout(() => {
-              setCurrentStrategyValue(currentStrategy)
+              setDelayedStrategyValue(currentStrategy)
               setTimer(null)
             }, ControlDelay),
           )
         }
       } else {
-        setCurrentStrategyValue(currentStrategy)
+        setDelayedStrategyValue(currentStrategy)
         if (timer != null) {
           window.clearTimeout(timer)
           setTimer(null)
         }
       }
     },
-    [currentStrategyValue, timer, setTimer, setCurrentStrategyValue],
+    [delayedStrategyValue, timer, setTimer, setDelayedStrategyValue],
   )
   useSelectorWithCallback((store) => store.strategyState.currentStrategy, delayedCallback)
 
-  return currentStrategyValue
+  return delayedStrategyValue
 }
 
 export function useGetApplicableStrategyControls(): Array<ControlWithKey> {

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -259,7 +259,6 @@ export const useDelayedCurrentStrategy = () => {
   const maybeDelayedCallback = React.useCallback(
     (currentStrategy: CanvasStrategyId | null) => {
       if (currentStrategy != null && delayedStrategyValue == null) {
-        // timer reset is not needed because the hierarchy selection mouseup clears interactionsession and activestrategy
         if (timer == null) {
           setTimer(
             window.setTimeout(() => {

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -93,3 +93,5 @@ export interface CanvasStrategy {
     strategyState: StrategyState,
   ) => StrategyApplicationResult
 }
+
+export const ControlDelay = 300

--- a/editor/src/components/canvas/controls/select-mode/canvas-strategy-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-strategy-indicator.tsx
@@ -3,18 +3,19 @@ import { when } from '../../../../utils/react-conditionals'
 import { FlexRow, FlexColumn, useColorTheme, UtopiaStyles } from '../../../../uuiui'
 import { useEditorState } from '../../../editor/store/store-hook'
 import CanvasActions from '../../canvas-actions'
+import { useDelayedCurrentStrategy } from '../../canvas-strategies/canvas-strategies'
 import { CanvasStrategy } from '../../canvas-strategies/canvas-strategy-types'
 
 export const CanvasStrategyIndicator = React.memo(() => {
   const colorTheme = useColorTheme()
   const dispatch = useEditorState((store) => store.dispatch, 'CanvasStrategyIndicator dispatch')
-  const { activeStrategy, otherPossibleStrategies } = useEditorState(
+  const { otherPossibleStrategies } = useEditorState(
     (store) => ({
-      activeStrategy: store.strategyState.currentStrategy,
       otherPossibleStrategies: store.strategyState.sortedApplicableStrategies,
     }),
     'CanvasStrategyIndicator strategyState.currentStrategy',
   )
+  const activeStrategy = useDelayedCurrentStrategy()
 
   const onTabPressed = React.useCallback(
     (newStrategy: CanvasStrategy) => {

--- a/editor/src/components/editor/store/store-hook.spec.tsx
+++ b/editor/src/components/editor/store/store-hook.spec.tsx
@@ -99,11 +99,79 @@ describe('useSelectorWithCallback', () => {
     )
 
     storeHook.setState({
-      editor: { selectedViews: [EP.fromString('sb/scene:aaa')] } as EditorState,
+      editor: {
+        ...storeHook.getState().editor,
+        selectedViews: [EP.fromString('sb/scene:aaa')],
+      } as EditorState,
     })
 
     expect(hookRenders).toEqual(1)
     expect(callCount).toEqual(1)
+  })
+
+  it('The callback is fired when the store changes (nullable value)', () => {
+    const storeHook = createEmptyEditorStoreHook()
+
+    let hookRenders = 0
+    let callCount = 0
+
+    const { result } = renderHook<void, { storeHook: UseStore<EditorStorePatched> }>(
+      (props) => {
+        hookRenders++
+        return useSelectorWithCallback(
+          (store) => store.editor.focusedElementPath,
+          (newFocusedElementPath) => {
+            callCount++
+          },
+        )
+      },
+      {
+        wrapper: ContextProvider(storeHook),
+        initialProps: {
+          storeHook: storeHook,
+        },
+      },
+    )
+
+    expect(hookRenders).toEqual(1)
+    expect(callCount).toEqual(0)
+
+    storeHook.setState({
+      editor: {
+        ...storeHook.getState().editor,
+        focusedElementPath: EP.fromString('sb/scene:aaa'),
+      } as EditorState,
+    })
+
+    expect(hookRenders).toEqual(1)
+    expect(callCount).toEqual(1)
+
+    storeHook.setState({
+      editor: { ...storeHook.getState().editor, focusedElementPath: null } as EditorState,
+    })
+
+    expect(hookRenders).toEqual(1)
+    expect(callCount).toEqual(2)
+
+    storeHook.setState({
+      editor: {
+        ...storeHook.getState().editor,
+        selectedViews: [EP.fromString('sb/scene:aaa')],
+      } as EditorState,
+    })
+
+    expect(hookRenders).toEqual(1)
+    expect(callCount).toEqual(2)
+
+    storeHook.setState({
+      editor: {
+        ...storeHook.getState().editor,
+        focusedElementPath: EP.fromString('sb/scene:aaa/bbb'),
+      } as EditorState,
+    })
+
+    expect(hookRenders).toEqual(1)
+    expect(callCount).toEqual(3)
   })
 
   it('The callback is fired if the hook is rerendered in a race condition and happens earlier than the zustand subscriber could be notified', () => {
@@ -151,7 +219,10 @@ describe('useSelectorWithCallback', () => {
     }
 
     storeHook.setState({
-      editor: { selectedViews: [EP.fromString('sb/scene:aaa')] } as EditorState,
+      editor: {
+        ...storeHook.getState().editor,
+        selectedViews: [EP.fromString('sb/scene:aaa')],
+      } as EditorState,
     })
 
     storeHook.destroy()

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -167,22 +167,20 @@ export function useSelectorWithCallback<U>(
   const callbackRef = React.useRef(callback)
   callbackRef.current = callback // the callback function is possibly a new function instance every time this hook is called, but we don't want to re-subscribe because of that
 
-  const previouslySelectedStateRef = React.useRef(selectorRef.current(api.getState()))
+  const previouslySelectedStateRef = React.useRef<U>(selectorRef.current(api.getState()))
 
-  const innerCallback = React.useCallback<(newSlice: U | null) => void>(
+  const innerCallback = React.useCallback<(newSlice: U) => void>(
     (newSlice) => {
-      if (newSlice != null) {
-        // innerCallback is called by Zustand and also by us, to make sure everything is correct we run our own equality check before calling the user's callback here
-        if (!equalityFnRef.current(previouslySelectedStateRef.current, newSlice)) {
-          if (explainMe) {
-            console.info(
-              'selected state has a new value according to the provided equalityFn, notifying callback',
-              newSlice,
-            )
-          }
-          callbackRef.current(newSlice)
-          previouslySelectedStateRef.current = newSlice
+      // innerCallback is called by Zustand and also by us, to make sure everything is correct we run our own equality check before calling the user's callback here
+      if (!equalityFnRef.current(previouslySelectedStateRef.current, newSlice)) {
+        if (explainMe) {
+          console.info(
+            'selected state has a new value according to the provided equalityFn, notifying callback',
+            newSlice,
+          )
         }
+        callbackRef.current(newSlice)
+        previouslySelectedStateRef.current = newSlice
       }
     },
     [explainMe],

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -70,6 +70,7 @@ import {
   createEmptyStrategyState,
   StrategyState,
 } from '../components/canvas/canvas-strategies/interaction-state'
+import sinon, { SinonFakeTimers } from 'sinon'
 
 export function delay(time: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, time))
@@ -408,4 +409,19 @@ export function simplifiedMetadataMap(metadata: ElementInstanceMetadataMap): Sim
     return simplifiedMetadata(elementMetadata)
   }, metadata)
   return sanitizedSpyData
+}
+
+export const setupTearDownClock = (): { clock: { current: SinonFakeTimers } } => {
+  let clock: { current: SinonFakeTimers } = { current: null as any } // it will be non-null thanks to beforeEach
+  beforeEach(function () {
+    clock.current = sinon.useFakeTimers({
+      // the timers will tick so the editor is not totally broken, but we can fast-forward time at will
+      // WARNING: the Sinon fake timers will advance in 20ms increments
+      shouldAdvanceTime: true,
+    })
+  })
+  afterEach(function () {
+    clock.current?.restore()
+  })
+  return { clock: clock }
 }

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -70,7 +70,6 @@ import {
   createEmptyStrategyState,
   StrategyState,
 } from '../components/canvas/canvas-strategies/interaction-state'
-import sinon, { SinonFakeTimers } from 'sinon'
 
 export function delay(time: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, time))
@@ -409,19 +408,4 @@ export function simplifiedMetadataMap(metadata: ElementInstanceMetadataMap): Sim
     return simplifiedMetadata(elementMetadata)
   }, metadata)
   return sanitizedSpyData
-}
-
-export const setupTearDownClock = (): { clock: { current: SinonFakeTimers } } => {
-  let clock: { current: SinonFakeTimers } = { current: null as any } // it will be non-null thanks to beforeEach
-  beforeEach(function () {
-    clock.current = sinon.useFakeTimers({
-      // the timers will tick so the editor is not totally broken, but we can fast-forward time at will
-      // WARNING: the Sinon fake timers will advance in 20ms increments
-      shouldAdvanceTime: true,
-    })
-  })
-  afterEach(function () {
-    clock.current?.restore()
-  })
-  return { clock: clock }
 }


### PR DESCRIPTION
**Problem:**
When double click selecting elements in a deep hierarchy strategy canvas controls show up immediately when jumping through elements. It should be behind a short timeout.

**Fix:**
Added a new hook to show the controls for the active strategy with a small delay before it appears the first time (switching strategies by the user should show controls immediately). Updated `useSelectorWithCallback` to work with null values.

**Commit Details:**
- updated `useSelectorWithCallback`
- added new test + fix editorstate in other store-hook tests
- new hook for canvas controls `useDelayedCurrentStrategy`
