### PR TITLE
Unified reparent-to-flex apply function

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
@@ -1,39 +1,17 @@
-import * as EP from '../../../core/shared/element-path'
-import * as PP from '../../../core/shared/property-path'
-import { AllElementProps } from '../../editor/store/editor-state'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
+import { AllElementProps } from '../../editor/store/editor-state'
+import { ParentBounds } from '../controls/parent-bounds'
+import { ParentOutlines } from '../controls/parent-outlines'
+import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
 import {
   CanvasStrategy,
-  emptyStrategyApplicationResult,
   InteractionCanvasState,
   StrategyApplicationResult,
 } from './canvas-strategy-types'
 import { InteractionSession, StrategyState } from './interaction-state'
-import { ParentBounds } from '../controls/parent-bounds'
-import { ParentOutlines } from '../controls/parent-outlines'
-import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
-import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { applyFlexReparent, findReparentStrategy } from './reparent-strategy-helpers'
 import { getDragTargets } from './shared-absolute-move-strategy-helpers'
-import { getReparentTarget } from '../canvas-utils'
-import { ElementPath, PropertyPath } from '../../../core/shared/project-file-types'
-import { reparentElement } from '../commands/reparent-element-command'
-import { getReorderIndex } from './flex-reorder-strategy'
-import { offsetPoint } from '../../../core/shared/math-utils'
-import { reorderElement } from '../commands/reorder-element-command'
-import { CSSCursor } from '../canvas-types'
-import { setCursorCommand } from '../commands/set-cursor-command'
-import { setElementsToRerenderCommand } from '../commands/set-elements-to-rerender-command'
-import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
-import { CanvasCommand, foldAndApplyCommandsInner } from '../commands/commands'
-import { deleteProperties } from '../commands/delete-properties-command'
-import { updateSelectedViews } from '../commands/update-selected-views-command'
-import {
-  applyFlexReparent,
-  findReparentStrategy,
-  getReparentTargetForFlexElement,
-} from './reparent-strategy-helpers'
-import { getReparentCommands } from './reparent-utils'
-import { ifAllowedToReparent } from './reparent-helpers'
 
 export const absoluteReparentToFlexStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_REPARENT_TO_FLEX',

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
@@ -27,17 +27,13 @@ import { updateHighlightedViews } from '../commands/update-highlighted-views-com
 import { CanvasCommand, foldAndApplyCommandsInner } from '../commands/commands'
 import { deleteProperties } from '../commands/delete-properties-command'
 import { updateSelectedViews } from '../commands/update-selected-views-command'
-import { findReparentStrategy, getReparentTargetForFlexElement } from './reparent-strategy-helpers'
+import {
+  applyFlexReparent,
+  findReparentStrategy,
+  getReparentTargetForFlexElement,
+} from './reparent-strategy-helpers'
 import { getReparentCommands } from './reparent-utils'
 import { ifAllowedToReparent } from './reparent-helpers'
-
-const propertiesToRemove: Array<PropertyPath> = [
-  PP.create(['style', 'position']),
-  PP.create(['style', 'left']),
-  PP.create(['style', 'top']),
-  PP.create(['style', 'right']),
-  PP.create(['style', 'bottom']),
-]
 
 export const absoluteReparentToFlexStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_REPARENT_TO_FLEX',
@@ -104,87 +100,6 @@ export const absoluteReparentToFlexStrategy: CanvasStrategy = {
     interactionSession: InteractionSession,
     strategyState: StrategyState,
   ): StrategyApplicationResult {
-    const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
-
-    return ifAllowedToReparent(canvasState, strategyState, filteredSelectedElements, () => {
-      if (
-        interactionSession.interactionData.type == 'DRAG' &&
-        interactionSession.interactionData.drag != null
-      ) {
-        const reparentResult = getReparentTargetForFlexElement(
-          filteredSelectedElements,
-          interactionSession,
-          canvasState,
-          strategyState,
-        )
-
-        if (
-          reparentResult.shouldReparent &&
-          reparentResult.newParent != null &&
-          filteredSelectedElements.length === 1
-        ) {
-          const target = filteredSelectedElements[0]
-          const newParent = reparentResult.newParent
-          // Reparent the element.
-          const newPath = EP.appendToPath(reparentResult.newParent, EP.toUid(target))
-          const reparentCommands = getReparentCommands(
-            canvasState.builtInDependencies,
-            canvasState.projectContents,
-            canvasState.nodeModules,
-            canvasState.openFile,
-            target,
-            reparentResult.newParent,
-          )
-
-          // Strip the `position`, positional and dimension properties.
-          const commandToRemoveProperties = deleteProperties('always', newPath, propertiesToRemove)
-
-          const commandsBeforeReorder = [
-            ...reparentCommands,
-            updateSelectedViews('always', [newPath]),
-          ]
-
-          const commandsAfterReorder = [
-            commandToRemoveProperties,
-            setElementsToRerenderCommand([newPath]),
-            updateHighlightedViews('mid-interaction', []),
-            setCursorCommand('mid-interaction', CSSCursor.Move),
-          ]
-
-          let commands: Array<CanvasCommand>
-          if (reparentResult.shouldReorder) {
-            // Reorder the newly reparented element into the flex ordering.
-            const pointOnCanvas = offsetPoint(
-              interactionSession.interactionData.dragStart,
-              interactionSession.interactionData.drag,
-            )
-
-            const siblingsOfTarget = MetadataUtils.getChildrenPaths(
-              strategyState.startingMetadata,
-              newParent,
-            )
-
-            const newIndex = getReorderIndex(
-              strategyState.startingMetadata,
-              siblingsOfTarget,
-              pointOnCanvas,
-            )
-            commands = [
-              ...commandsBeforeReorder,
-              reorderElement('always', newPath, newIndex),
-              ...commandsAfterReorder,
-            ]
-          } else {
-            commands = [...commandsBeforeReorder, ...commandsAfterReorder]
-          }
-
-          return {
-            commands: commands,
-            customState: strategyState.customStrategyState,
-          }
-        }
-      }
-      return emptyStrategyApplicationResult
-    })
+    return applyFlexReparent('strip-absolute-props', canvasState, interactionSession, strategyState)
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -19,6 +19,7 @@ import { ParentOutlines } from '../controls/parent-outlines'
 import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
 import { setElementsToRerenderCommand } from '../commands/set-elements-to-rerender-command'
 import { ParentBounds } from '../controls/parent-bounds'
+import { getReorderIndex } from './reparent-strategy-helpers'
 
 export const flexReorderStrategy: CanvasStrategy = {
   id: 'FLEX_REORDER',
@@ -125,21 +126,4 @@ export const flexReorderStrategy: CanvasStrategy = {
       }
     }
   },
-}
-
-export function getReorderIndex(
-  metadata: ElementInstanceMetadataMap,
-  siblings: Array<ElementPath>,
-  point: CanvasVector,
-) {
-  const targetSiblingIdx = siblings.findIndex((sibling) => {
-    const frame = MetadataUtils.getFrameInCanvasCoords(sibling, metadata)
-    return (
-      frame != null &&
-      rectContainsPoint(frame, point) &&
-      MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(sibling, metadata)
-    )
-  })
-
-  return targetSiblingIdx
 }

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.tsx
@@ -15,7 +15,11 @@ import { DragOutlineControl } from '../controls/select-mode/drag-outline-control
 import { CanvasStrategy, emptyStrategyApplicationResult } from './canvas-strategy-types'
 import { getReorderIndex } from './flex-reorder-strategy'
 import { ifAllowedToReparent } from './reparent-helpers'
-import { findReparentStrategy, getReparentTargetForFlexElement } from './reparent-strategy-helpers'
+import {
+  applyFlexReparent,
+  findReparentStrategy,
+  getReparentTargetForFlexElement,
+} from './reparent-strategy-helpers'
 import { getReparentCommands } from './reparent-utils'
 import { getDragTargets } from './shared-absolute-move-strategy-helpers'
 
@@ -62,82 +66,6 @@ export const flexReparentToFlexStrategy: CanvasStrategy = {
     return 0
   },
   apply: (canvasState, interactionSession, strategyState) => {
-    const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
-    return ifAllowedToReparent(canvasState, strategyState, filteredSelectedElements, () => {
-      if (
-        interactionSession.interactionData.type == 'DRAG' &&
-        interactionSession.interactionData.drag != null
-      ) {
-        const reparentResult = getReparentTargetForFlexElement(
-          filteredSelectedElements,
-          interactionSession,
-          canvasState,
-          strategyState,
-        )
-
-        if (
-          reparentResult.shouldReparent &&
-          reparentResult.newParent != null &&
-          filteredSelectedElements.length === 1
-        ) {
-          const target = filteredSelectedElements[0]
-          const newParent = reparentResult.newParent
-          // Reparent the element.
-          const newPath = EP.appendToPath(reparentResult.newParent, EP.toUid(target))
-          const reparentCommands = getReparentCommands(
-            canvasState.builtInDependencies,
-            canvasState.projectContents,
-            canvasState.nodeModules,
-            canvasState.openFile,
-            target,
-            reparentResult.newParent,
-          )
-
-          const commandsBeforeReorder = [
-            ...reparentCommands,
-            updateSelectedViews('always', [newPath]),
-          ]
-
-          const commandsAfterReorder = [
-            setElementsToRerenderCommand([newPath]),
-            updateHighlightedViews('mid-interaction', []),
-            setCursorCommand('mid-interaction', CSSCursor.Move),
-          ]
-
-          let commands: Array<CanvasCommand>
-          if (reparentResult.shouldReorder) {
-            // Reorder the newly reparented element into the flex ordering.
-            const pointOnCanvas = offsetPoint(
-              interactionSession.interactionData.dragStart,
-              interactionSession.interactionData.drag,
-            )
-
-            const siblingsOfTarget = MetadataUtils.getChildrenPaths(
-              strategyState.startingMetadata,
-              newParent,
-            )
-
-            const newIndex = getReorderIndex(
-              strategyState.startingMetadata,
-              siblingsOfTarget,
-              pointOnCanvas,
-            )
-            commands = [
-              ...commandsBeforeReorder,
-              reorderElement('always', newPath, newIndex),
-              ...commandsAfterReorder,
-            ]
-          } else {
-            commands = [...commandsBeforeReorder, ...commandsAfterReorder]
-          }
-
-          return {
-            commands: commands,
-            customState: strategyState.customStrategyState,
-          }
-        }
-      }
-      return emptyStrategyApplicationResult
-    })
+    return applyFlexReparent('do-not-strip-props', canvasState, interactionSession, strategyState)
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.tsx
@@ -1,27 +1,9 @@
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import * as EP from '../../../core/shared/element-path'
-import { offsetPoint } from '../../../core/shared/math-utils'
-import { CSSCursor } from '../canvas-types'
-import { CanvasCommand } from '../commands/commands'
-import { reorderElement } from '../commands/reorder-element-command'
-import { reparentElement } from '../commands/reparent-element-command'
-import { setCursorCommand } from '../commands/set-cursor-command'
-import { setElementsToRerenderCommand } from '../commands/set-elements-to-rerender-command'
-import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
-import { updateSelectedViews } from '../commands/update-selected-views-command'
 import { ParentBounds } from '../controls/parent-bounds'
 import { ParentOutlines } from '../controls/parent-outlines'
 import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
-import { CanvasStrategy, emptyStrategyApplicationResult } from './canvas-strategy-types'
-import { getReorderIndex } from './flex-reorder-strategy'
-import { ifAllowedToReparent } from './reparent-helpers'
-import {
-  applyFlexReparent,
-  findReparentStrategy,
-  getReparentTargetForFlexElement,
-} from './reparent-strategy-helpers'
-import { getReparentCommands } from './reparent-utils'
-import { getDragTargets } from './shared-absolute-move-strategy-helpers'
+import { CanvasStrategy } from './canvas-strategy-types'
+import { applyFlexReparent, findReparentStrategy } from './reparent-strategy-helpers'
 
 export const flexReparentToFlexStrategy: CanvasStrategy = {
   id: 'FLEX_REPARENT_TO_FLEX',

--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -164,7 +164,7 @@ export function getReparentTargetForFlexElement(
   }
 }
 
-const propertiesToRemove: Array<PropertyPath> = [
+const absolutePropsToRemove: Array<PropertyPath> = [
   PP.create(['style', 'position']),
   PP.create(['style', 'left']),
   PP.create(['style', 'top']),
@@ -213,7 +213,7 @@ export function applyFlexReparent(
         // Strip the `position`, positional and dimension properties.
         const commandToRemoveProperties =
           stripAbsoluteProperties === 'strip-absolute-props'
-            ? [deleteProperties('always', newPath, propertiesToRemove)]
+            ? [deleteProperties('always', newPath, absolutePropsToRemove)]
             : []
 
         const commandsBeforeReorder = [

--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -1,11 +1,26 @@
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import * as EP from '../../../core/shared/element-path'
 import { offsetPoint } from '../../../core/shared/math-utils'
-import { ElementPath } from '../../../core/shared/project-file-types'
+import { ElementPath, PropertyPath } from '../../../core/shared/project-file-types'
+import * as PP from '../../../core/shared/property-path'
+import { CSSCursor } from '../canvas-types'
 import { getReparentTarget } from '../canvas-utils'
-import { absoluteMoveStrategy } from './absolute-move-strategy'
-import { InteractionCanvasState, emptyStrategyApplicationResult } from './canvas-strategy-types'
+import { CanvasCommand } from '../commands/commands'
+import { deleteProperties } from '../commands/delete-properties-command'
+import { reorderElement } from '../commands/reorder-element-command'
+import { setCursorCommand } from '../commands/set-cursor-command'
+import { setElementsToRerenderCommand } from '../commands/set-elements-to-rerender-command'
+import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
+import { updateSelectedViews } from '../commands/update-selected-views-command'
+import {
+  emptyStrategyApplicationResult,
+  InteractionCanvasState,
+  StrategyApplicationResult,
+} from './canvas-strategy-types'
+import { getReorderIndex } from './flex-reorder-strategy'
 import { InteractionSession, StrategyState } from './interaction-state'
+import { ifAllowedToReparent } from './reparent-helpers'
+import { getReparentCommands } from './reparent-utils'
 import { getDragTargets } from './shared-absolute-move-strategy-helpers'
 
 type ReparentStrategy =
@@ -147,4 +162,105 @@ export function getReparentTargetForFlexElement(
       }
     }
   }
+}
+
+const propertiesToRemove: Array<PropertyPath> = [
+  PP.create(['style', 'position']),
+  PP.create(['style', 'left']),
+  PP.create(['style', 'top']),
+  PP.create(['style', 'right']),
+  PP.create(['style', 'bottom']),
+]
+
+export function applyFlexReparent(
+  stripAbsoluteProperties: 'strip-absolute-props' | 'do-not-strip-props',
+  canvasState: InteractionCanvasState,
+  interactionSession: InteractionSession,
+  strategyState: StrategyState,
+): StrategyApplicationResult {
+  const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
+
+  return ifAllowedToReparent(canvasState, strategyState, filteredSelectedElements, () => {
+    if (
+      interactionSession.interactionData.type == 'DRAG' &&
+      interactionSession.interactionData.drag != null
+    ) {
+      const reparentResult = getReparentTargetForFlexElement(
+        filteredSelectedElements,
+        interactionSession,
+        canvasState,
+        strategyState,
+      )
+
+      if (
+        reparentResult.shouldReparent &&
+        reparentResult.newParent != null &&
+        filteredSelectedElements.length === 1
+      ) {
+        const target = filteredSelectedElements[0]
+        const newParent = reparentResult.newParent
+        // Reparent the element.
+        const newPath = EP.appendToPath(reparentResult.newParent, EP.toUid(target))
+        const reparentCommands = getReparentCommands(
+          canvasState.builtInDependencies,
+          canvasState.projectContents,
+          canvasState.nodeModules,
+          canvasState.openFile,
+          target,
+          reparentResult.newParent,
+        )
+
+        // Strip the `position`, positional and dimension properties.
+        const commandToRemoveProperties =
+          stripAbsoluteProperties === 'strip-absolute-props'
+            ? [deleteProperties('always', newPath, propertiesToRemove)]
+            : []
+
+        const commandsBeforeReorder = [
+          ...reparentCommands,
+          updateSelectedViews('always', [newPath]),
+        ]
+
+        const commandsAfterReorder = [
+          ...commandToRemoveProperties,
+          setElementsToRerenderCommand([newPath]),
+          updateHighlightedViews('mid-interaction', []),
+          setCursorCommand('mid-interaction', CSSCursor.Move),
+        ]
+
+        let commands: Array<CanvasCommand>
+        if (reparentResult.shouldReorder) {
+          // Reorder the newly reparented element into the flex ordering.
+          const pointOnCanvas = offsetPoint(
+            interactionSession.interactionData.dragStart,
+            interactionSession.interactionData.drag,
+          )
+
+          const siblingsOfTarget = MetadataUtils.getChildrenPaths(
+            strategyState.startingMetadata,
+            newParent,
+          )
+
+          const newIndex = getReorderIndex(
+            strategyState.startingMetadata,
+            siblingsOfTarget,
+            pointOnCanvas,
+          )
+          commands = [
+            ...commandsBeforeReorder,
+            reorderElement('always', newPath, newIndex),
+            ...commandsAfterReorder,
+          ]
+        } else {
+          commands = [...commandsBeforeReorder, ...commandsAfterReorder]
+        }
+
+        return {
+          commands: commands,
+          customState: strategyState.customStrategyState,
+        }
+      }
+    }
+    return emptyStrategyApplicationResult
+  })
 }

--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -1,6 +1,7 @@
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import * as EP from '../../../core/shared/element-path'
-import { offsetPoint } from '../../../core/shared/math-utils'
+import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
+import { CanvasVector, offsetPoint, rectContainsPoint } from '../../../core/shared/math-utils'
 import { ElementPath, PropertyPath } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
 import { CSSCursor } from '../canvas-types'
@@ -17,11 +18,27 @@ import {
   InteractionCanvasState,
   StrategyApplicationResult,
 } from './canvas-strategy-types'
-import { getReorderIndex } from './flex-reorder-strategy'
 import { InteractionSession, StrategyState } from './interaction-state'
 import { ifAllowedToReparent } from './reparent-helpers'
 import { getReparentCommands } from './reparent-utils'
 import { getDragTargets } from './shared-absolute-move-strategy-helpers'
+
+export function getReorderIndex(
+  metadata: ElementInstanceMetadataMap,
+  siblings: Array<ElementPath>,
+  point: CanvasVector,
+): number {
+  const targetSiblingIdx = siblings.findIndex((sibling) => {
+    const frame = MetadataUtils.getFrameInCanvasCoords(sibling, metadata)
+    return (
+      frame != null &&
+      rectContainsPoint(frame, point) &&
+      MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(sibling, metadata)
+    )
+  })
+
+  return targetSiblingIdx
+}
 
 type ReparentStrategy =
   | 'FLEX_REPARENT_TO_ABSOLUTE'


### PR DESCRIPTION
**Problem:**
The flex-reparent-to-flex and absolute-reparent-to-flex apply functions were almost identical, except the absolute-reparent-to-flex strategy strips absolute props. 

**Fix:**
Create a shared apply function with a flag to strip absolute props or not.
