### PR TITLE
Validate the use of style props during reparenting.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-multi-file.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-multi-file.spec.browser2.tsx
@@ -86,7 +86,7 @@ function dragElement(
 
 const defaultAbsoluteChildCode = `
 import * as React from 'react'
-export const AbsoluteChild = () => {
+export const AbsoluteChild = (absoluteChildProps) => {
   return (
     <div
       style={{
@@ -99,6 +99,7 @@ export const AbsoluteChild = () => {
         borderColor: 'black',
         borderStyle: 'solid',
         backgroundColor: 'yellow',
+        ...absoluteChildProps.style
       }}
       data-uid='absolutechild'
       data-testid='absolutechild'

--- a/editor/src/components/canvas/canvas-strategies/absolute-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-utils.ts
@@ -10,3 +10,25 @@ export function supportsStyle(canvasState: InteractionCanvasState, element: Elem
     'style',
   )
 }
+
+export function honoursPropsSize(
+  canvasState: InteractionCanvasState,
+  element: ElementPath,
+): boolean {
+  return MetadataUtils.targetHonoursPropsSize(
+    canvasState.projectContents,
+    canvasState.openFile,
+    element,
+  )
+}
+
+export function honoursPropsPosition(
+  canvasState: InteractionCanvasState,
+  element: ElementPath,
+): boolean {
+  return MetadataUtils.targetHonoursPropsPosition(
+    canvasState.projectContents,
+    canvasState.openFile,
+    element,
+  )
+}

--- a/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
@@ -7,6 +7,7 @@ import { setCursorCommand } from '../commands/set-cursor-command'
 import { InteractionCanvasState, StrategyApplicationResult } from './canvas-strategy-types'
 import { StrategyState } from './interaction-state'
 import * as EP from '../../../core/shared/element-path'
+import { honoursPropsPosition } from './absolute-utils'
 
 export function isGeneratedElement(
   canvasState: InteractionCanvasState,
@@ -34,7 +35,12 @@ export function isAllowedToReparent(
     } else {
       return foldEither(
         (_) => true,
-        (elementFromMetadata) => !elementReferencesElsewhere(elementFromMetadata),
+        (elementFromMetadata) => {
+          return (
+            !elementReferencesElsewhere(elementFromMetadata) &&
+            honoursPropsPosition(canvasState, target)
+          )
+        },
         metadata.element,
       )
     }

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -57,6 +57,8 @@ import {
 import * as PP from '../shared/property-path'
 import * as EP from '../shared/element-path'
 import {
+  componentHonoursPropsPosition,
+  componentHonoursPropsSize,
   componentUsesProperty,
   findJSXElementChildAtPath,
   getUtopiaID,
@@ -660,6 +662,50 @@ export const MetadataUtils = {
         return true
       } else {
         return componentUsesProperty(underlyingComponent, property)
+      }
+    }
+  },
+  targetHonoursPropsSize(
+    projectContents: ProjectContentTreeRoot,
+    openFile: string | null | undefined,
+    target: ElementPath,
+  ): boolean {
+    if (openFile == null) {
+      return false
+    } else {
+      const underlyingComponent = findUnderlyingTargetComponentImplementation(
+        projectContents,
+        {},
+        openFile,
+        target,
+      )
+      if (underlyingComponent == null) {
+        // Could be an external third party component, assuming true for now.
+        return true
+      } else {
+        return componentHonoursPropsSize(underlyingComponent)
+      }
+    }
+  },
+  targetHonoursPropsPosition(
+    projectContents: ProjectContentTreeRoot,
+    openFile: string | null | undefined,
+    target: ElementPath,
+  ): boolean {
+    if (openFile == null) {
+      return false
+    } else {
+      const underlyingComponent = findUnderlyingTargetComponentImplementation(
+        projectContents,
+        {},
+        openFile,
+        target,
+      )
+      if (underlyingComponent == null) {
+        // Could be an external third party component, assuming true for now.
+        return true
+      } else {
+        return componentHonoursPropsPosition(underlyingComponent)
       }
     }
   },

--- a/editor/src/core/model/element-template-utils.spec.ts
+++ b/editor/src/core/model/element-template-utils.spec.ts
@@ -378,6 +378,66 @@ export const TestComponent = (props) => {
     const result = componentHonoursPropsPosition(component)
     expect(result).toEqual(true)
   })
+  it('returns true for a component that uses top and right directly', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = (props) => {
+  return <div style={{position: 'absolute', right: props.style.right, top: props.style.top}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsPosition(component)
+    expect(result).toEqual(true)
+  })
+  it('returns false for a component that uses left and right only', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = (props) => {
+  return <div style={{position: 'absolute', left: props.style.left, right: props.style.right}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsPosition(component)
+    expect(result).toEqual(false)
+  })
+  it('returns false for a component that uses top only', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = (props) => {
+  return <div style={{position: 'absolute', top: props.style.top}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsPosition(component)
+    expect(result).toEqual(false)
+  })
+  it('returns false for a component that uses nothing from props', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = (props) => {
+  return <div style={{position: 'absolute'}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsPosition(component)
+    expect(result).toEqual(false)
+  })
+  it('returns false for a component that has no props parameter', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = () => {
+  return <div style={{position: 'absolute'}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsPosition(component)
+    expect(result).toEqual(false)
+  })
   it('returns true for a component that uses top and left directly with destructuring', () => {
     const component = getComponentFromCode(
       'TestComponent',
@@ -440,6 +500,42 @@ export const TestComponent = (props) => {
     )
     const result = componentHonoursPropsSize(component)
     expect(result).toEqual(true)
+  })
+  it('returns false for a component that uses width only', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = (props) => {
+  return <div style={{position: 'absolute', width: props.style.width}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsSize(component)
+    expect(result).toEqual(false)
+  })
+  it('returns false for a component that do not use anything from props', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = (props) => {
+  return <div style={{position: 'absolute'}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsSize(component)
+    expect(result).toEqual(false)
+  })
+  it('returns false for a component that has no props parameter', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = () => {
+  return <div style={{position: 'absolute'}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsSize(component)
+    expect(result).toEqual(false)
   })
   it('returns true for a component that uses width and height directly with destructuring', () => {
     const component = getComponentFromCode(

--- a/editor/src/core/model/element-template-utils.spec.ts
+++ b/editor/src/core/model/element-template-utils.spec.ts
@@ -14,6 +14,8 @@ import {
   isUtopiaJSXComponent,
 } from '../shared/element-template'
 import {
+  componentHonoursPropsPosition,
+  componentHonoursPropsSize,
   componentUsesProperty,
   getUtopiaID,
   guaranteeUniqueUids,
@@ -359,6 +361,120 @@ export const TestComponent = (props) => {
     `,
     )
     const result = componentUsesProperty(component, 'children')
+    expect(result).toEqual(true)
+  })
+})
+
+describe('componentHonoursPropsPosition', () => {
+  it('returns true for a component that uses top and left directly', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = (props) => {
+  return <div style={{position: 'absolute', left: props.style.left, top: props.style.top}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsPosition(component)
+    expect(result).toEqual(true)
+  })
+  it('returns true for a component that uses top and left directly with destructuring', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = ({style}) => {
+  return <div style={{position: 'absolute', left: style.left, top: style.top}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsPosition(component)
+    expect(result).toEqual(true)
+  })
+  it('returns true for a component that uses bottom and right directly', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = (props) => {
+  return <div style={{position: 'absolute', right: props.style.right, bottom: props.style.bottom}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsPosition(component)
+    expect(result).toEqual(true)
+  })
+  it('returns true for a component that spreads style into the props', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = (props) => {
+  return <div style={{position: 'absolute', ...props.style}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsPosition(component)
+    expect(result).toEqual(true)
+  })
+  it('returns true for a component that spreads style into the props with destructuring', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = ({style}) => {
+  return <div style={{position: 'absolute', ...style}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsPosition(component)
+    expect(result).toEqual(true)
+  })
+})
+
+describe('componentHonoursPropsSize', () => {
+  it('returns true for a component that uses width and height directly', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = (props) => {
+  return <div style={{position: 'absolute', width: props.style.width, height: props.style.height}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsSize(component)
+    expect(result).toEqual(true)
+  })
+  it('returns true for a component that uses width and height directly with destructuring', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = ({style}) => {
+  return <div style={{position: 'absolute', width: style.width, height: style.height}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsSize(component)
+    expect(result).toEqual(true)
+  })
+  it('returns true for a component that spreads style into the props', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = (props) => {
+  return <div style={{position: 'absolute', ...props.style}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsSize(component)
+    expect(result).toEqual(true)
+  })
+  it('returns true for a component that spreads style into the props with destructuring', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = ({style}) => {
+  return <div style={{position: 'absolute', ...style}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsSize(component)
     expect(result).toEqual(true)
   })
 })

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -6,7 +6,7 @@ import {
 } from '../../components/assets'
 import { importedFromWhere } from '../../components/editor/import-utils'
 import Utils, { IndexPosition } from '../../utils/utils'
-import { Either, isRight } from '../shared/either'
+import { Either, isRight, right } from '../shared/either'
 import {
   ElementInstanceMetadata,
   ElementsWithin,
@@ -32,6 +32,8 @@ import {
   JSXAttributesSpread,
   JSXArrayElement,
   JSXProperty,
+  isSpreadAssignment,
+  isJSXAttributeOtherJavaScript,
 } from '../shared/element-template'
 import {
   Imports,
@@ -42,6 +44,7 @@ import {
   ElementPath,
 } from '../shared/project-file-types'
 import * as EP from '../shared/element-path'
+import * as PP from '../shared/property-path'
 import {
   fixUtopiaElement,
   generateUID,
@@ -57,6 +60,8 @@ import {
 } from './project-file-utils'
 import { getStoryboardElementPath } from './scene-utils'
 import { TransientFilesState } from '../../components/editor/store/editor-state'
+import { getSimpleAttributeAtPath } from './element-metadata-utils'
+import { getJSXAttributeAtPath, GetJSXAttributeResult } from '../shared/jsx-attributes'
 
 function getAllUniqueUidsInner(
   projectContents: ProjectContentTreeRoot,
@@ -524,6 +529,202 @@ export function componentUsesProperty(component: UtopiaJSXComponent, property: s
     return false
   } else {
     return elementUsesProperty(component.rootElement, component.param, property)
+  }
+}
+
+export function componentHonoursPropsPosition(component: UtopiaJSXComponent): boolean {
+  if (component.param == null) {
+    return false
+  } else {
+    const rootElement = component.rootElement
+    if (isJSXElement(rootElement)) {
+      const leftStyleAttr = getJSXAttributeAtPath(rootElement.props, PP.create(['style', 'left']))
+      const topStyleAttr = getJSXAttributeAtPath(rootElement.props, PP.create(['style', 'top']))
+      const rightStyleAttr = getJSXAttributeAtPath(rootElement.props, PP.create(['style', 'right']))
+      const bottomStyleAttr = getJSXAttributeAtPath(
+        rootElement.props,
+        PP.create(['style', 'bottom']),
+      )
+      return (
+        ((propertyComesFromPropsStyle(component.param, leftStyleAttr, 'left') ||
+          propertyComesFromPropsStyle(component.param, rightStyleAttr, 'right')) &&
+          (propertyComesFromPropsStyle(component.param, topStyleAttr, 'top') ||
+            propertyComesFromPropsStyle(component.param, bottomStyleAttr, 'bottom'))) ||
+        propsStyleIsSpreadInto(component.param, rootElement.props)
+      )
+    } else {
+      return false
+    }
+  }
+}
+
+export function componentHonoursPropsSize(component: UtopiaJSXComponent): boolean {
+  if (component.param == null) {
+    return false
+  } else {
+    const rootElement = component.rootElement
+    if (isJSXElement(rootElement)) {
+      const widthStyleAttr = getJSXAttributeAtPath(rootElement.props, PP.create(['style', 'width']))
+      const heightStyleAttr = getJSXAttributeAtPath(
+        rootElement.props,
+        PP.create(['style', 'height']),
+      )
+      return (
+        (propertyComesFromPropsStyle(component.param, widthStyleAttr, 'width') &&
+          propertyComesFromPropsStyle(component.param, heightStyleAttr, 'height')) ||
+        propsStyleIsSpreadInto(component.param, rootElement.props)
+      )
+    } else {
+      return false
+    }
+  }
+}
+
+export function propsStyleIsSpreadInto(propsParam: Param, attributes: JSXAttributes): boolean {
+  const boundParam = propsParam.boundParam
+  switch (boundParam.type) {
+    case 'REGULAR_PARAM': {
+      const styleProp = getJSXAttributeAtPath(attributes, PP.create(['style']))
+      const styleAttribute = styleProp.attribute
+      switch (styleAttribute.type) {
+        case 'ATTRIBUTE_NOT_FOUND':
+          return false
+        case 'ATTRIBUTE_VALUE':
+          return false
+        case 'ATTRIBUTE_OTHER_JAVASCRIPT':
+          return false
+        case 'ATTRIBUTE_NESTED_ARRAY':
+          return false
+        case 'ATTRIBUTE_NESTED_OBJECT':
+          return styleAttribute.content.some((attributePart) => {
+            if (isSpreadAssignment(attributePart)) {
+              const spreadPart = attributePart.value
+              if (isJSXAttributeOtherJavaScript(spreadPart)) {
+                return (
+                  spreadPart.definedElsewhere.includes(boundParam.paramName) &&
+                  spreadPart.transpiledJavascript.includes(`${boundParam.paramName}.style`)
+                )
+              }
+            }
+            return false
+          })
+        case 'ATTRIBUTE_FUNCTION_CALL':
+          return false
+        case 'PART_OF_ATTRIBUTE_VALUE':
+          return false
+        default:
+          const _exhaustiveCheck: never = styleAttribute
+          throw new Error(`Unhandled attribute type: ${JSON.stringify(styleAttribute)}`)
+      }
+    }
+    case 'DESTRUCTURED_OBJECT': {
+      return boundParam.parts.some((part) => {
+        const partBoundParam = part.param.boundParam
+        if (partBoundParam.type === 'REGULAR_PARAM') {
+          // This handles the aliasing that may be applied to the destructured field.
+          const propertyToCheck = part.propertyName ?? partBoundParam.paramName
+          if (propertyToCheck === 'style') {
+            // This is the aliased name or if there's no alias the field name.
+            const propertyToLookFor = partBoundParam.paramName
+
+            const styleProp = getJSXAttributeAtPath(attributes, PP.create(['style']))
+            const styleAttribute = styleProp.attribute
+            switch (styleAttribute.type) {
+              case 'ATTRIBUTE_NOT_FOUND':
+                return false
+              case 'ATTRIBUTE_VALUE':
+                return false
+              case 'ATTRIBUTE_OTHER_JAVASCRIPT':
+                return false
+              case 'ATTRIBUTE_NESTED_ARRAY':
+                return false
+              case 'ATTRIBUTE_NESTED_OBJECT':
+                return styleAttribute.content.some((attributePart) => {
+                  if (isSpreadAssignment(attributePart)) {
+                    const spreadPart = attributePart.value
+                    if (isJSXAttributeOtherJavaScript(spreadPart)) {
+                      return (
+                        spreadPart.definedElsewhere.includes(propertyToLookFor) &&
+                        spreadPart.transpiledJavascript.includes(propertyToLookFor)
+                      )
+                    }
+                  }
+                  return false
+                })
+              case 'ATTRIBUTE_FUNCTION_CALL':
+                return false
+              case 'PART_OF_ATTRIBUTE_VALUE':
+                return false
+              default:
+                const _exhaustiveCheck: never = styleAttribute
+                throw new Error(`Unhandled attribute type: ${JSON.stringify(styleAttribute)}`)
+            }
+          }
+        }
+        return false
+      })
+    }
+    case 'DESTRUCTURED_ARRAY':
+      return false
+    default:
+      const _exhaustiveCheck: never = boundParam
+      throw new Error(`Unhandled param type: ${JSON.stringify(boundParam)}`)
+  }
+}
+
+export function propertyComesFromPropsStyle(
+  propsParam: Param,
+  result: GetJSXAttributeResult,
+  propName: string,
+): boolean {
+  const attribute = result.attribute
+  switch (attribute.type) {
+    case 'ATTRIBUTE_NOT_FOUND':
+      return false
+    case 'ATTRIBUTE_VALUE':
+      return false
+    case 'ATTRIBUTE_OTHER_JAVASCRIPT':
+      const boundParam = propsParam.boundParam
+      switch (boundParam.type) {
+        case 'REGULAR_PARAM':
+          return (
+            attribute.definedElsewhere.includes(boundParam.paramName) &&
+            attribute.javascript.includes(`${boundParam.paramName}.style.${propName}`)
+          )
+        case 'DESTRUCTURED_OBJECT':
+          return boundParam.parts.some((part) => {
+            const partBoundParam = part.param.boundParam
+            if (partBoundParam.type === 'REGULAR_PARAM') {
+              // This handles the aliasing that may be applied to the destructured field.
+              const propertyToCheck = part.propertyName ?? partBoundParam.paramName
+              if (propertyToCheck === 'style') {
+                // This is the aliased name or if there's no alias the field name.
+                const propertyToLookFor = partBoundParam.paramName
+                return (
+                  attribute.definedElsewhere.includes(propertyToLookFor) &&
+                  attribute.transpiledJavascript.includes(`${propertyToLookFor}.${propName}`)
+                )
+              } else {
+                return false
+              }
+            } else {
+              return false
+            }
+          })
+        default:
+          return false
+      }
+    case 'ATTRIBUTE_NESTED_ARRAY':
+      return false
+    case 'ATTRIBUTE_NESTED_OBJECT':
+      return false
+    case 'ATTRIBUTE_FUNCTION_CALL':
+      return false
+    case 'PART_OF_ATTRIBUTE_VALUE':
+      return false
+    default:
+      const _exhaustiveCheck: never = attribute
+      throw new Error(`Unhandled attribute type: ${JSON.stringify(attribute)}`)
   }
 }
 


### PR DESCRIPTION
**Problem:**
If a component does not carry positional properties (like `left`) from the `style` attribute into the root element making that component up, then it very likely will not be repositionable. We want something that can't be repositioned to also not be reparentable as well.

**Fix:**
Some very basic static analysis is performed to see if the appropriate properties are carried into the root element's style attribute or if the `style` attribute of the component props are spread into the `style` attribute of the root element.

**Commit Details:**
- Implemented `componentHonoursPropsPosition` and `componentHonoursPropsSize`
  which check if a component honours the position and size properties
  respectively by passing them into the root element.
- Created `propsStyleIsSpreadInto` which checks if the attributes provided
  have `props.style` spread into them.
- Added `propertyComesFromPropsStyle` which analyses the attributes of
  an element to see if a certain property has been utilised from the props
  parameter.
- Added `targetHonoursPropsSize` and `targetHonoursPropsPosition` to
  `MetadataUtils` which provide a higher level call over the
  `componentHonours...` functions.
- Added `honoursPropsPosition` and `honoursPropsSize` to simplify
  checking for canvas strategies.
- Prevent component instances from being reparented if they do not honour
  the position properties in the root element of the component.