### PR TITLE
Fix/visible except when other strategy

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -58,11 +58,15 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
     }
   },
   controlsToRender: [
-    { control: AbsoluteResizeControl, key: 'absolute-resize-control', show: 'always-visible' },
+    {
+      control: AbsoluteResizeControl,
+      key: 'absolute-resize-control',
+      show: 'visible-except-when-other-strategy-is-active',
+    },
     {
       control: ZeroSizeResizeControlWrapper,
       key: 'zero-size-resize-control',
-      show: 'always-visible',
+      show: 'visible-except-when-other-strategy-is-active',
     },
     { control: ParentOutlines, key: 'parent-outlines-control', show: 'visible-only-while-active' },
     { control: ParentBounds, key: 'parent-bounds-control', show: 'visible-only-while-active' },

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -245,7 +245,9 @@ export function useGetApplicableStrategyControls(): Array<ControlWithKey> {
       const filteredControls = s.controlsToRender.filter(
         (control) =>
           control.show === 'always-visible' ||
-          (control.show === 'visible-only-while-active' && s.id === currentStrategy),
+          (control.show === 'visible-only-while-active' && s.id === currentStrategy) ||
+          (control.show === 'visible-except-when-other-strategy-is-active' &&
+            (currentStrategy == null || s.id === currentStrategy)),
       )
       return addAllUniquelyBy(working, filteredControls, (l, r) => l.control === r.control)
     }, [])

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -61,7 +61,7 @@ export const escapeHatchStrategy: CanvasStrategy = {
     {
       control: ZeroSizeResizeControlWrapper,
       key: 'zero-size-resize-control',
-      show: 'always-visible',
+      show: 'visible-except-when-other-strategy-is-active',
     },
     {
       control: DragOutlineControl,

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
@@ -88,7 +88,11 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
     }
   },
   controlsToRender: [
-    { control: AbsoluteResizeControl, key: 'absolute-resize-control', show: 'always-visible' },
+    {
+      control: AbsoluteResizeControl,
+      key: 'absolute-resize-control',
+      show: 'visible-except-when-other-strategy-is-active',
+    },
   ],
   fitness: (canvasState, interactionState, sessionState) => {
     if (

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -476,7 +476,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
           {renderHighlightControls()}
           <LayoutParentControl />
           {when(
-            isFeatureEnabled('Canvas Strategies') && !anyStrategyActive,
+            isFeatureEnabled('Canvas Strategies'),
             <MultiSelectOutlineControl localSelectedElements={localSelectedViews} />,
           )}
           {when(isFeatureEnabled('Canvas Strategies'), <GuidelineControls />)}

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -250,6 +250,11 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
   const startDragStateAfterDragExceedsThreshold = useStartDragStateAfterDragExceedsThreshold()
   const strategyControls = useGetApplicableStrategyControls()
 
+  const anyStrategyActive = useEditorState(
+    (store) => store.strategyState.currentStrategy != null,
+    'currentStrategy',
+  )
+
   const { localSelectedViews, localHighlightedViews, setLocalSelectedViews } = props
   const cmdKeyPressed = props.editor.keysPressed['cmd'] ?? false
 
@@ -457,7 +462,10 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       {when(
         resizeStatus !== 'disabled',
         <>
-          {when(isCanvasStrategyOnAndSelectMode(props.editor.mode), <PinLines />)}
+          {when(
+            isCanvasStrategyOnAndSelectMode(props.editor.mode) && !anyStrategyActive,
+            <PinLines />,
+          )}
           {when(isCanvasStrategyOnAndSelectMode(props.editor.mode), <DistanceGuidelineControl />)}
           {when(
             isFeatureEnabled('Canvas Strategies') &&
@@ -468,7 +476,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
           {renderHighlightControls()}
           <LayoutParentControl />
           {when(
-            isFeatureEnabled('Canvas Strategies'),
+            isFeatureEnabled('Canvas Strategies') && !anyStrategyActive,
             <MultiSelectOutlineControl localSelectedElements={localSelectedViews} />,
           )}
           {when(isFeatureEnabled('Canvas Strategies'), <GuidelineControls />)}


### PR DESCRIPTION
**Problem:**
In figma and sketch, outline and resize controls disappear during drag to move.
https://screenshot.click/figma_drag_hides_canvas_controls.mp4

In utopia, they do not: https://screenshot.click/what_about__utopia.mp4

**Fix:**
https://screenshot.click/outline_visible_during_drag.mp4

**Commit Details:**
- Fix previously broken implementation for `visible-except-when-other-strategy-is-active` control type
- AbsoluteResizeControl and ZeroSizeResizeControlWrapper becomes `visible-except-when-other-strategy-is-active`
- PinLines should only be visible if there's no active strategy