### PR TITLE
Handle dragging into the gap between flex elements.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
@@ -232,7 +232,7 @@ describe('Absolute Reparent To Flex Strategy', () => {
     }
 
     const dragDelta = windowPoint({
-      x: flexParentCenter.x - absoluteChildCenter.x,
+      x: flexParentCenter.x - absoluteChildCenter.x + 100,
       y: flexParentCenter.y - absoluteChildCenter.y,
     })
     await act(() => dragElement(renderResult, 'absolutechild', dragDelta, cmdModifier))
@@ -356,7 +356,7 @@ describe('Absolute Reparent To Flex Strategy', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     const dragDelta = windowPoint({
-      x: firstFlexChildCenter.x - absoluteChildCenter.x,
+      x: firstFlexChildCenter.x - absoluteChildCenter.x + 50,
       y: firstFlexChildCenter.y - absoluteChildCenter.y,
     })
     await act(() => dragElement(renderResult, 'absolutechild', dragDelta, cmdModifier))
@@ -425,10 +425,10 @@ describe('Absolute Reparent To Flex Strategy', () => {
           borderWidth: 10,
           borderColor: 'black',
           borderStyle: 'solid',
-          backgroundColor: 'yellow',
+          backgroundColor: 'teal',
         }}
-        data-uid='absolutechild'
-        data-testid='absolutechild'
+        data-uid='flexchild1'
+        data-testid='flexchild1'
       />
       <div
         style={{
@@ -437,10 +437,10 @@ describe('Absolute Reparent To Flex Strategy', () => {
           borderWidth: 10,
           borderColor: 'black',
           borderStyle: 'solid',
-          backgroundColor: 'teal',
+          backgroundColor: 'yellow',
         }}
-        data-uid='flexchild1'
-        data-testid='flexchild1'
+        data-uid='absolutechild'
+        data-testid='absolutechild'
       />
       <div
         style={{

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
@@ -20,13 +20,14 @@ import { flexReorderStrategy } from './flex-reorder-strategy'
 import { InteractionSession, StrategyState } from './interaction-state'
 import { createMouseInteractionForTests } from './interaction-state.test-utils'
 
-function getDefaultMetadata(): ElementInstanceMetadataMap {
+function getDefaultMetadata(flexDirection: string): ElementInstanceMetadataMap {
   return {
     'scene-aaa/app-entity:app-outer-div': {
       elementPath: elementPath([['scene-aaa', 'app-entity'], ['app-outer-div']]),
       globalFrame: canvasRectangle({ x: 0, y: 0, width: 375, height: 50 }),
       specialSizeMeasurements: {
-        flexDirection: 'row',
+        flexDirection: flexDirection,
+        layoutSystemForChildren: 'flex',
       } as SpecialSizeMeasurements,
     } as ElementInstanceMetadata,
     'scene-aaa/app-entity:app-outer-div/child-0': {
@@ -37,6 +38,7 @@ function getDefaultMetadata(): ElementInstanceMetadataMap {
       globalFrame: canvasRectangle({ x: 0, y: 0, width: 50, height: 50 }),
       specialSizeMeasurements: {
         parentLayoutSystem: 'flex',
+        parentFlexDirection: flexDirection,
       } as SpecialSizeMeasurements,
     } as ElementInstanceMetadata,
     'scene-aaa/app-entity:app-outer-div/child-1': {
@@ -47,6 +49,7 @@ function getDefaultMetadata(): ElementInstanceMetadataMap {
       globalFrame: canvasRectangle({ x: 60, y: 0, width: 50, height: 50 }),
       specialSizeMeasurements: {
         parentLayoutSystem: 'flex',
+        parentFlexDirection: flexDirection,
       } as SpecialSizeMeasurements,
     } as ElementInstanceMetadata,
     'scene-aaa/app-entity:app-outer-div/child-2': {
@@ -57,6 +60,7 @@ function getDefaultMetadata(): ElementInstanceMetadataMap {
       globalFrame: canvasRectangle({ x: 120, y: 0, width: 50, height: 50 }),
       specialSizeMeasurements: {
         parentLayoutSystem: 'flex',
+        parentFlexDirection: flexDirection,
       } as SpecialSizeMeasurements,
     } as ElementInstanceMetadata,
   }
@@ -69,16 +73,18 @@ function getMetadataWithAbsoluteChild(flexDirection: string): ElementInstanceMet
       globalFrame: canvasRectangle({ x: 0, y: 0, width: 375, height: 50 }),
       specialSizeMeasurements: {
         flexDirection: flexDirection,
+        layoutSystemForChildren: 'flex',
       } as SpecialSizeMeasurements,
     } as ElementInstanceMetadata,
     'scene-aaa/app-entity:app-outer-div/absolute-child': {
       elementPath: elementPath([
         ['scene-aaa', 'app-entity'],
-        ['app-outer-div', 'child-0'],
+        ['app-outer-div', 'absolute-child'],
       ]),
       globalFrame: canvasRectangle({ x: 0, y: 0, width: 50, height: 50 }),
       specialSizeMeasurements: {
         parentLayoutSystem: 'flex',
+        parentFlexDirection: flexDirection,
       } as SpecialSizeMeasurements,
     } as ElementInstanceMetadata,
     'scene-aaa/app-entity:app-outer-div/child-0': {
@@ -89,6 +95,7 @@ function getMetadataWithAbsoluteChild(flexDirection: string): ElementInstanceMet
       globalFrame: canvasRectangle({ x: 0, y: 0, width: 50, height: 50 }),
       specialSizeMeasurements: {
         parentLayoutSystem: 'flex',
+        parentFlexDirection: flexDirection,
       } as SpecialSizeMeasurements,
     } as ElementInstanceMetadata,
     'scene-aaa/app-entity:app-outer-div/child-1': {
@@ -99,6 +106,7 @@ function getMetadataWithAbsoluteChild(flexDirection: string): ElementInstanceMet
       globalFrame: canvasRectangle({ x: 60, y: 0, width: 50, height: 50 }),
       specialSizeMeasurements: {
         parentLayoutSystem: 'flex',
+        parentFlexDirection: flexDirection,
       } as SpecialSizeMeasurements,
     } as ElementInstanceMetadata,
     'scene-aaa/app-entity:app-outer-div/child-2': {
@@ -109,18 +117,20 @@ function getMetadataWithAbsoluteChild(flexDirection: string): ElementInstanceMet
       globalFrame: canvasRectangle({ x: 120, y: 0, width: 50, height: 50 }),
       specialSizeMeasurements: {
         parentLayoutSystem: 'flex',
+        parentFlexDirection: flexDirection,
       } as SpecialSizeMeasurements,
     } as ElementInstanceMetadata,
   }
 }
 
-function getReverseMetadata(): ElementInstanceMetadataMap {
+function getReverseMetadata(flexDirection: string): ElementInstanceMetadataMap {
   return {
     'scene-aaa/app-entity:app-outer-div': {
       elementPath: elementPath([['scene-aaa', 'app-entity'], ['app-outer-div']]),
       globalFrame: canvasRectangle({ x: 0, y: 0, width: 375, height: 50 }),
       specialSizeMeasurements: {
-        flexDirection: 'row-reverse',
+        flexDirection: flexDirection,
+        layoutSystemForChildren: 'flex',
       } as SpecialSizeMeasurements,
     } as ElementInstanceMetadata,
     'scene-aaa/app-entity:app-outer-div/child-0': {
@@ -131,6 +141,7 @@ function getReverseMetadata(): ElementInstanceMetadataMap {
       globalFrame: canvasRectangle({ x: 120, y: 0, width: 50, height: 50 }),
       specialSizeMeasurements: {
         parentLayoutSystem: 'flex',
+        parentFlexDirection: flexDirection,
       } as SpecialSizeMeasurements,
     } as ElementInstanceMetadata,
     'scene-aaa/app-entity:app-outer-div/child-1': {
@@ -141,6 +152,7 @@ function getReverseMetadata(): ElementInstanceMetadataMap {
       globalFrame: canvasRectangle({ x: 60, y: 0, width: 50, height: 50 }),
       specialSizeMeasurements: {
         parentLayoutSystem: 'flex',
+        parentFlexDirection: flexDirection,
       } as SpecialSizeMeasurements,
     } as ElementInstanceMetadata,
     'scene-aaa/app-entity:app-outer-div/child-2': {
@@ -151,6 +163,7 @@ function getReverseMetadata(): ElementInstanceMetadataMap {
       globalFrame: canvasRectangle({ x: 0, y: 0, width: 50, height: 50 }),
       specialSizeMeasurements: {
         parentLayoutSystem: 'flex',
+        parentFlexDirection: flexDirection,
       } as SpecialSizeMeasurements,
     } as ElementInstanceMetadata,
   }
@@ -248,7 +261,7 @@ describe('Flex Reorder Strategy', () => {
       initialEditor,
       canvasPoint({ x: 89, y: 27 }),
       canvasPoint({ x: 1, y: 1 }),
-      getDefaultMetadata(),
+      getDefaultMetadata('row'),
     )
 
     expect(finalEditor).toEqual(initialEditor)
@@ -297,7 +310,7 @@ describe('Flex Reorder Strategy', () => {
       initialEditor,
       canvasPoint({ x: 89, y: 27 }),
       canvasPoint({ x: 52, y: 0 }),
-      getDefaultMetadata(),
+      getDefaultMetadata('row'),
       2,
     )
 
@@ -481,7 +494,7 @@ describe('Flex Reorder Strategy', () => {
       initialEditor,
       canvasPoint({ x: 89, y: 27 }),
       canvasPoint({ x: 52, y: 0 }),
-      getReverseMetadata(),
+      getReverseMetadata('row-reverse'),
       0,
     )
 

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -89,6 +89,7 @@ export const flexReorderStrategy: CanvasStrategy = {
         strategyState.startingMetadata,
         siblingsOfTarget,
         pointOnCanvas,
+        target,
       )
 
       const realNewIndex = newIndex > -1 ? newIndex : lastReorderIdx

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.spec.browser2.tsx
@@ -217,7 +217,7 @@ describe('Flex Reparent To Flex Strategy', () => {
 
     await renderResult.getDispatchFollowUpActionsFinished()
     const dragDelta = windowPoint({
-      x: targetFlexParentCenter.x - firstFlexChildCenter.x,
+      x: targetFlexParentCenter.x - firstFlexChildCenter.x + 50,
       y: targetFlexParentCenter.y - firstFlexChildCenter.y,
     })
     act(() => dragElement(renderResult, 'flexchild3', dragDelta, cmdModifier))
@@ -327,7 +327,7 @@ describe('Flex Reparent To Flex Strategy', () => {
 
     await renderResult.getDispatchFollowUpActionsFinished()
     const dragDelta = windowPoint({
-      x: targetFlexChildCenter.x - flexChildToReparentCenter.x,
+      x: targetFlexChildCenter.x - flexChildToReparentCenter.x - 5,
       y: targetFlexChildCenter.y - flexChildToReparentCenter.y,
     })
     act(() => dragElement(renderResult, 'flexchild3', dragDelta, cmdModifier))

--- a/editor/src/components/editor/store/editor-update.spec.tsx
+++ b/editor/src/components/editor/store/editor-update.spec.tsx
@@ -779,13 +779,13 @@ describe('action MOVE_SELECTED_BACKWARD', () => {
       ...editor,
       selectedViews: [EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa', 'ddd'])],
     }
-    const reparentAction = moveSelectedBackward()
+    const actionToRun = moveSelectedBackward()
     const updatedEditor = runLocalEditorAction(
       editorWithSelectedView,
       derivedState,
       defaultUserState,
       workers,
-      reparentAction,
+      actionToRun,
       History.init(editor, derivedState),
       dispatch,
       emptyUiJsxCanvasContextData(),


### PR DESCRIPTION
**Problem:**
Dragging a component instance into a flex parent in the spaces where no flex child resides currently results in the instance being reparented in on the end of the existing flex children. But there are spaces like this between elements if attributes like `row-gap` are set, which results in the reparented instances jumping around.

**Fix:**
Rather than checking if the mouse position coincides with an existing element, we check for the closest existing element and then identify if the dragged element falls on the left or top "side" versus the right or bottom "side" as that means the reorder might need to be shifted to after the target versus being before the target.

**Commit Details:**
- `getReparentTargetForFlexElement` now indicates that reparenting
  into a flex parent should trigger a reorder.
- `getReorderIndex` now determines the index based on the distance
  between the mouse and the center point of the siblings.
- Corrected some tests that didn't line up with the changes introduced.
