### PR TITLE
Resize and move strategies check if properties are honoured.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
@@ -28,7 +28,7 @@ import {
   getMultiselectBounds,
   snapDrag,
 } from './shared-absolute-move-strategy-helpers'
-import { supportsStyle } from './absolute-utils'
+import { honoursPropsPosition } from './absolute-utils'
 
 export const absoluteMoveStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_MOVE',
@@ -38,10 +38,9 @@ export const absoluteMoveStrategy: CanvasStrategy = {
       const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
       return filteredSelectedElements.every((element) => {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
-
         return (
           elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
-          supportsStyle(canvasState, element)
+          honoursPropsPosition(canvasState, element)
         )
       })
     } else {

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -3,7 +3,9 @@ import {
   getPrintedUiJsCode,
   makeTestProjectCodeWithSnippet,
   renderTestEditorWithCode,
+  TestAppUID,
   TestScenePath,
+  TestSceneUID,
 } from '../ui-jsx.test-utils'
 import { act, fireEvent } from '@testing-library/react'
 import * as EP from '../../../core/shared/element-path'
@@ -28,6 +30,10 @@ import {
 } from '../canvas-types'
 import { wait } from '../../../utils/utils.test-utils'
 import { ControlDelay } from './canvas-strategy-types'
+import {
+  BakedInStoryboardVariableName,
+  BakedInStoryboardUID,
+} from '../../../core/model/scene-utils'
 
 function selectAndResizeElement(
   renderResult: EditorRenderResult,
@@ -201,7 +207,135 @@ export var storyboard = (
   </Storyboard>
 )`
 
+const projectDoesNotHonourSizeProperties = `
+import * as React from 'react'
+import { Scene, Storyboard, View } from 'utopia-api'
+
+export const App2 = (props) => {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 5,
+        left: 5,
+        width: 350,
+        height: 400,
+      }}
+      data-uid='aaa'
+      data-testid='aaa'
+    />
+  )
+}
+
+export var App = (props) => {
+  return (
+    <App2
+      data-uid='app2'
+      style={{ left: 20, top: 20, width: 300, height: 400 }}
+    />
+  )
+}
+
+export var ${BakedInStoryboardVariableName} = (props) => {
+  return (
+    <Storyboard data-uid='${BakedInStoryboardUID}'>
+      <Scene
+        style={{ left: 0, top: 0, width: 400, height: 400 }}
+        data-uid='${TestSceneUID}'
+      >
+        <App
+          data-uid='${TestAppUID}'
+          style={{ position: 'absolute', bottom: 0, left: 0, right: 0, top: 0 }}
+        />
+      </Scene>
+    </Storyboard>
+  )
+}
+`
+
+function projectDoesHonourSizeProperties(width: number, height: number): string {
+  return `import * as React from 'react'
+import { Scene, Storyboard, View } from 'utopia-api'
+
+export const App2 = (props) => {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: props.style.top,
+        left: props.style.left,
+        width: props.style.width,
+        height: props.style.height,
+      }}
+      data-uid='aaa'
+      data-testid='aaa'
+    />
+  )
+}
+
+export var App = (props) => {
+  return (
+    <App2
+      data-uid='app2'
+      style={{ left: 20, top: 20, width: ${width}, height: ${height} }}
+    />
+  )
+}
+
+export var ${BakedInStoryboardVariableName} = (props) => {
+  return (
+    <Storyboard data-uid='${BakedInStoryboardUID}'>
+      <Scene
+        style={{ left: 0, top: 0, width: 400, height: 400 }}
+        data-uid='${TestSceneUID}'
+      >
+        <App data-uid='${TestAppUID}' />
+      </Scene>
+    </Storyboard>
+  )
+}
+`
+}
+
 describe('Absolute Resize Strategy', () => {
+  it('resizes component instances that honour the size properties', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      projectDoesHonourSizeProperties(300, 300),
+      'await-first-dom-report',
+    )
+
+    const target = EP.appendNewElementPath(TestScenePath, ['app2'])
+    const dragDelta = windowPoint({ x: 40, y: -25 })
+
+    await renderResult.dispatch([selectComponents([target], false)], true)
+    act(() =>
+      selectAndResizeElement(renderResult, dragDelta, EdgePositionBottomRight, emptyModifiers),
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      projectDoesHonourSizeProperties(340, 275),
+    )
+  })
+  it('does not resize a component instance that does not honour the size properties', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      projectDoesNotHonourSizeProperties,
+      'await-first-dom-report',
+    )
+
+    const target = EP.appendNewElementPath(TestScenePath, ['app2'])
+    const dragDelta = windowPoint({ x: 40, y: -25 })
+
+    await renderResult.dispatch([selectComponents([target], false)], true)
+    act(() =>
+      selectAndResizeElement(renderResult, dragDelta, EdgePositionBottomRight, emptyModifiers),
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      projectDoesNotHonourSizeProperties,
+    )
+  })
   it('resizes absolute positioned element from bottom right edge', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -38,7 +38,7 @@ import * as EP from '../../../core/shared/element-path'
 import { ZeroSizeResizeControlWrapper } from '../controls/zero-sized-element-controls'
 import { SetCssLengthProperty, setCssLengthProperty } from '../commands/set-css-length-command'
 import { pushIntendedBounds } from '../commands/push-intended-bounds-command'
-import { supportsStyle } from './absolute-utils'
+import { honoursPropsPosition, honoursPropsSize } from './absolute-utils'
 
 export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_RESIZE_BOUNDING_BOX',
@@ -50,7 +50,8 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
         return (
           elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
-          supportsStyle(canvasState, element)
+          honoursPropsPosition(canvasState, element) &&
+          honoursPropsSize(canvasState, element)
         )
       })
     } else {

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
@@ -42,7 +42,7 @@ import Utils from '../../../utils/utils'
 import { StrategyState, InteractionSession } from './interaction-state'
 import { pushIntendedBounds } from '../commands/push-intended-bounds-command'
 import { CanvasFrameAndTarget } from '../canvas-types'
-import { supportsStyle } from './absolute-utils'
+import { honoursPropsPosition } from './absolute-utils'
 
 export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
   id: 'KEYBOARD_ABSOLUTE_MOVE',
@@ -53,7 +53,7 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
         return (
           elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
-          supportsStyle(canvasState, element)
+          honoursPropsPosition(canvasState, element)
         )
       })
     } else {

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
@@ -30,7 +30,7 @@ import {
 import { getMultiselectBounds } from './shared-absolute-move-strategy-helpers'
 import { setSnappingGuidelines } from '../commands/set-snapping-guidelines-command'
 import { pushIntendedBounds } from '../commands/push-intended-bounds-command'
-import { supportsStyle } from './absolute-utils'
+import { honoursPropsPosition, honoursPropsSize } from './absolute-utils'
 
 interface VectorAndEdge {
   movement: CanvasVector
@@ -80,7 +80,8 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
         return (
           elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
-          supportsStyle(canvasState, element)
+          honoursPropsPosition(canvasState, element) &&
+          honoursPropsSize(canvasState, element)
         )
       })
     } else {


### PR DESCRIPTION
**Problem:**
Resize and move strategies currently only check if an underlying component utilises the `style` property. But recent work for reparenting has gone beyond that and now checks for the use of the appropriate position and size properties.

**Fix:**
Replaced the old `supportsStyle` function usage with the new functions recently implemented for reparenting.

**Commit Details:**
- `absoluteMoveStrategy`, `absoluteResizeBoundingBoxStrategy`,
  `keyboardAbsoluteMoveStrategy` and `keyboardAbsoluteResizeStrategy`
  now utilise `honoursPropsPosition` and `honoursPropsSize` instead of
  `supportsStyle`.
