### PR TITLE
Separate out client model from the core server code.

### DIFF
--- a/clientmodel/default.nix
+++ b/clientmodel/default.nix
@@ -1,0 +1,12 @@
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc8107"}:
+let
+  pkgs = nixpkgs.pkgs;
+  haskLib = pkgs.haskell.lib;
+  overriddenHaskellPackages = pkgs.haskell.packages.${compiler}.override {
+    overrides = self: super: {
+      utopia-clientmodel = super.callCabal2nix "utopia-clientmodel" (./lib) {};
+    };
+  };
+  utopia-clientmodel = overriddenHaskellPackages.utopia-clientmodel;
+in
+  utopia-clientmodel

--- a/clientmodel/lib/package.yaml
+++ b/clientmodel/lib/package.yaml
@@ -1,0 +1,43 @@
+version: 0.1.0.0
+license: AllRightsReserved
+author: Momentum Works 
+build-type: Simple
+name: utopia-clientmodel 
+
+ghc-options:
+  - -Wall
+  - -Werror
+  - -threaded
+  - -fno-warn-orphans
+  - -Wno-unused-imports
+
+default-extensions:
+  - NoImplicitPrelude
+  - OverloadedStrings
+  - DeriveGeneric
+  - DuplicateRecordFields
+  - FlexibleContexts
+  - MonoLocalBinds
+  - OverloadedStrings
+  - RankNTypes
+  - RecordWildCards
+  - TemplateHaskell
+  - TypeApplications
+  - TypeOperators
+  - DeriveDataTypeable
+  - DataKinds
+
+dependencies:
+  - base
+  - aeson
+  - generic-lens
+  - lens-aeson
+  - relude
+  - lens
+  - tasty
+  - unordered-containers
+  - text
+
+library:
+  source-dirs:
+    - src

--- a/clientmodel/lib/src/Utopia/ClientModel.hs
+++ b/clientmodel/lib/src/Utopia/ClientModel.hs
@@ -8,18 +8,18 @@ import           Control.Monad.Fail
 import           Data.Aeson
 import           Data.Aeson.Lens
 import           Data.Aeson.Types
+import           Data.Data
 import           Data.Generics.Product
 import           Data.Generics.Sum
-import qualified Data.HashMap.Strict       as M
-import           Data.Text                 hiding (foldl', reverse)
-import           Relude 
-import           Data.Data
+import qualified Data.HashMap.Strict   as M
+import           Data.Text             hiding (foldl', reverse)
 import           Data.Typeable
+import           Relude
 
 textToJSON :: Text -> Value
 textToJSON = toJSON
 
-type ElementPathPart = [Text] 
+type ElementPathPart = [Text]
 
 data ElementPath = ElementPath
                  { parts :: [ElementPathPart]
@@ -42,21 +42,21 @@ instance FromJSON RevisionsState where
     let possibleString = firstOf _String value
     in  case possibleString of
           (Just "PARSED_AHEAD") -> pure ParsedAhead
-          (Just "CODE_AHEAD") -> pure CodeAhead
-          (Just "BOTH_MATCH") -> pure BothMatch
-          (Just unknownType)  -> fail ("Unknown type: " <> unpack unknownType)
-          _                   -> fail "Unexpected value for RevisionsState."
+          (Just "CODE_AHEAD")   -> pure CodeAhead
+          (Just "BOTH_MATCH")   -> pure BothMatch
+          (Just unknownType)    -> fail ("Unknown type: " <> unpack unknownType)
+          _                     -> fail "Unexpected value for RevisionsState."
 
 instance ToJSON RevisionsState where
   toJSON ParsedAhead = textToJSON "PARSED_AHEAD"
-  toJSON CodeAhead = textToJSON "CODE_AHEAD"
-  toJSON BothMatch = textToJSON "BOTH_MATCH"
+  toJSON CodeAhead   = textToJSON "CODE_AHEAD"
+  toJSON BothMatch   = textToJSON "BOTH_MATCH"
 
 data ParseFailure = ParseFailure
-                  { diagnostics         :: Maybe [Value]
-                  , parsedJSON          :: Maybe Value
-                  , errorMessage        :: Maybe Text
-                  , errorMessages       :: [Value]
+                  { diagnostics   :: Maybe [Value]
+                  , parsedJSON    :: Maybe Value
+                  , errorMessage  :: Maybe Text
+                  , errorMessages :: [Value]
                   }
                   deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -67,12 +67,12 @@ instance ToJSON ParseFailure where
   toJSON = genericToJSON defaultOptions
 
 data ParseSuccess = ParseSuccess
-                  { imports                           :: Value
-                  , topLevelElements                  :: [Value]
-                  , highlightBounds                   :: Value
-                  , jsxFactoryFunction                :: Maybe Text
-                  , combinedTopLevelArbitraryBlock    :: Maybe Value
-                  , exportsDetail                     :: Value
+                  { imports                        :: Value
+                  , topLevelElements               :: [Value]
+                  , highlightBounds                :: Value
+                  , jsxFactoryFunction             :: Maybe Text
+                  , combinedTopLevelArbitraryBlock :: Maybe Value
+                  , exportsDetail                  :: Value
                   }
                   deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -86,10 +86,10 @@ data Unparsed = Unparsed
               deriving (Eq, Show, Generic, Data, Typeable)
 
 instance FromJSON Unparsed where
-  parseJSON = const $ pure Unparsed 
+  parseJSON = const $ pure Unparsed
 
 instance ToJSON Unparsed where
-  toJSON = const $ object [] 
+  toJSON = const $ object []
 
 data ParsedTextFile = ParsedTextFileFailure ParseFailure
                     | ParsedTextFileSuccess ParseSuccess
@@ -108,15 +108,15 @@ instance FromJSON ParsedTextFile where
 
 instance ToJSON ParsedTextFile where
   toJSON (ParsedTextFileFailure parseFailure) = over _Object (M.insert "type" "PARSE_FAILURE") $ toJSON parseFailure
-  toJSON (ParsedTextFileSuccess parseSuccess) = over _Object (M.insert "type" "PARSE_SUCCESS") $ toJSON parseSuccess 
+  toJSON (ParsedTextFileSuccess parseSuccess) = over _Object (M.insert "type" "PARSE_SUCCESS") $ toJSON parseSuccess
   toJSON (ParsedTextFileUnparsed unparsed) = over _Object (M.insert "type" "UNPARSED") $ toJSON unparsed
 
 -- This for the moment excludes the `parsed` field as
 -- that is a very deep and wide structure.
 data TextFileContents = TextFileContents
-                      { code            :: Text
-                      , parsed          :: ParsedTextFile
-                      , revisionsState  :: RevisionsState
+                      { code           :: Text
+                      , parsed         :: ParsedTextFile
+                      , revisionsState :: RevisionsState
                       }
                       deriving (Eq, Show, Generic, Data, Typeable)
 

--- a/clientmodel/lib/src/Utopia/ClientModel.hs
+++ b/clientmodel/lib/src/Utopia/ClientModel.hs
@@ -1,19 +1,7 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE MonoLocalBinds        #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeOperators         #-}
-
 {-|
   Functionality for manipulating the data held in `PersistentModel` in the client.
 -}
-module Utopia.Web.ClientModel where
+module Utopia.ClientModel where
 
 import           Control.Lens
 import           Control.Monad.Fail
@@ -24,16 +12,113 @@ import           Data.Generics.Product
 import           Data.Generics.Sum
 import qualified Data.HashMap.Strict       as M
 import           Data.Text                 hiding (foldl', reverse)
-import           Protolude
-import           Utopia.Web.Database.Types
-import           Utopia.Web.ServiceTypes
+import           Relude 
+import           Data.Data
+import           Data.Typeable
 
--- This is very specifically designed to be limited to what
--- we need on the server side.
+textToJSON :: Text -> Value
+textToJSON = toJSON
+
+type ElementPathPart = [Text] 
+
+data ElementPath = ElementPath
+                 { parts :: [ElementPathPart]
+                 }
+                 deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON ElementPath where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON ElementPath where
+  toJSON = genericToJSON defaultOptions
+
+data RevisionsState = ParsedAhead
+                    | CodeAhead
+                    | BothMatch
+                    deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON RevisionsState where
+  parseJSON value =
+    let possibleString = firstOf _String value
+    in  case possibleString of
+          (Just "PARSED_AHEAD") -> pure ParsedAhead
+          (Just "CODE_AHEAD") -> pure CodeAhead
+          (Just "BOTH_MATCH") -> pure BothMatch
+          (Just unknownType)  -> fail ("Unknown type: " <> unpack unknownType)
+          _                   -> fail "Unexpected value for RevisionsState."
+
+instance ToJSON RevisionsState where
+  toJSON ParsedAhead = textToJSON "PARSED_AHEAD"
+  toJSON CodeAhead = textToJSON "CODE_AHEAD"
+  toJSON BothMatch = textToJSON "BOTH_MATCH"
+
+data ParseFailure = ParseFailure
+                  { diagnostics         :: Maybe [Value]
+                  , parsedJSON          :: Maybe Value
+                  , errorMessage        :: Maybe Text
+                  , errorMessages       :: [Value]
+                  }
+                  deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON ParseFailure where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON ParseFailure where
+  toJSON = genericToJSON defaultOptions
+
+data ParseSuccess = ParseSuccess
+                  { imports                           :: Value
+                  , topLevelElements                  :: [Value]
+                  , highlightBounds                   :: Value
+                  , jsxFactoryFunction                :: Maybe Text
+                  , combinedTopLevelArbitraryBlock    :: Maybe Value
+                  , exportsDetail                     :: Value
+                  }
+                  deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON ParseSuccess where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON ParseSuccess where
+  toJSON = genericToJSON defaultOptions
+
+data Unparsed = Unparsed
+              deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON Unparsed where
+  parseJSON = const $ pure Unparsed 
+
+instance ToJSON Unparsed where
+  toJSON = const $ object [] 
+
+data ParsedTextFile = ParsedTextFileFailure ParseFailure
+                    | ParsedTextFileSuccess ParseSuccess
+                    | ParsedTextFileUnparsed Unparsed
+                    deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON ParsedTextFile where
+  parseJSON value =
+    let fileType = firstOf (key "type" . _String) value
+     in case fileType of
+          (Just "PARSE_FAILURE")  -> fmap ParsedTextFileFailure $ parseJSON value
+          (Just "PARSE_SUCCESS")  -> fmap ParsedTextFileSuccess $ parseJSON value
+          (Just "UNPARSED")       -> fmap ParsedTextFileUnparsed $ parseJSON value
+          (Just unknownType)      -> fail ("Unknown type: " <> unpack unknownType)
+          _                       -> fail "No type for ParsedTextFile specified."
+
+instance ToJSON ParsedTextFile where
+  toJSON (ParsedTextFileFailure parseFailure) = over _Object (M.insert "type" "PARSE_FAILURE") $ toJSON parseFailure
+  toJSON (ParsedTextFileSuccess parseSuccess) = over _Object (M.insert "type" "PARSE_SUCCESS") $ toJSON parseSuccess 
+  toJSON (ParsedTextFileUnparsed unparsed) = over _Object (M.insert "type" "UNPARSED") $ toJSON unparsed
+
+-- This for the moment excludes the `parsed` field as
+-- that is a very deep and wide structure.
 data TextFileContents = TextFileContents
-                      { code       :: Text
+                      { code            :: Text
+                      , parsed          :: ParsedTextFile
+                      , revisionsState  :: RevisionsState
                       }
-                      deriving (Eq, Show, Generic)
+                      deriving (Eq, Show, Generic, Data, Typeable)
 
 instance FromJSON TextFileContents where
   parseJSON = genericParseJSON defaultOptions
@@ -46,7 +131,7 @@ data TextFile = TextFile
               , lastSavedContents :: Maybe TextFileContents
               , lastRevisedTime   :: Double
               }
-              deriving (Eq, Show, Generic)
+              deriving (Eq, Show, Generic, Data, Typeable)
 
 instance FromJSON TextFile where
   parseJSON = genericParseJSON defaultOptions
@@ -61,7 +146,7 @@ data ImageFile = ImageFile
                , height    :: Maybe Double
                , hash      :: Integer
                }
-               deriving (Eq, Show, Generic)
+               deriving (Eq, Show, Generic, Data, Typeable)
 
 instance FromJSON ImageFile where
   parseJSON = genericParseJSON defaultOptions
@@ -70,7 +155,7 @@ instance ToJSON ImageFile where
   toJSON = genericToJSON defaultOptions
 
 data AssetFile = AssetFile
-                 deriving (Eq, Show, Generic)
+                 deriving (Eq, Show, Generic, Data, Typeable)
 
 instance FromJSON AssetFile where
   parseJSON = const $ pure AssetFile
@@ -81,7 +166,7 @@ instance ToJSON AssetFile where
 data ProjectFile = ProjectTextFile TextFile
                  | ProjectImageFile ImageFile
                  | ProjectAssetFile AssetFile
-                 deriving (Eq, Show, Generic)
+                 deriving (Eq, Show, Generic, Data, Typeable)
 
 instance FromJSON ProjectFile where
   parseJSON value =
@@ -98,13 +183,13 @@ instance ToJSON ProjectFile where
   toJSON (ProjectImageFile imageFile) = over _Object (M.insert "type" "IMAGE_FILE") $ toJSON imageFile
   toJSON (ProjectAssetFile assetFile) = over _Object (M.insert "type" "ASSET_FILE") $ toJSON assetFile
 
-type ProjectContentsTreeRoot = M.HashMap Text ProjectContentsTree
+type ProjectContentTreeRoot = M.HashMap Text ProjectContentsTree
 
 data ProjectContentDirectory = ProjectContentDirectory
                              { fullPath :: Text
-                             , children :: ProjectContentsTreeRoot
+                             , children :: ProjectContentTreeRoot
                              }
-                             deriving (Eq, Show, Generic)
+                             deriving (Eq, Show, Generic, Data, Typeable)
 
 instance FromJSON ProjectContentDirectory where
   parseJSON = genericParseJSON defaultOptions
@@ -116,7 +201,7 @@ data ProjectContentFile = ProjectContentFile
                         { fullPath :: Text
                         , content  :: ProjectFile
                         }
-                        deriving (Eq, Show, Generic)
+                        deriving (Eq, Show, Generic, Data, Typeable)
 
 instance FromJSON ProjectContentFile where
   parseJSON = genericParseJSON defaultOptions
@@ -126,7 +211,7 @@ instance ToJSON ProjectContentFile where
 
 data ProjectContentsTree = ProjectContentsTreeDirectory ProjectContentDirectory
                          | ProjectContentsTreeFile ProjectContentFile
-                         deriving (Eq, Show, Generic)
+                         deriving (Eq, Show, Generic, Data, Typeable)
 
 instance FromJSON ProjectContentsTree where
   parseJSON value =
@@ -144,9 +229,9 @@ instance ToJSON ProjectContentsTree where
 -- This is currently not a comprehensive definition for the persistent model the
 -- front-end can supply, so round tripping via this type is guaranteed to lose data.
 data PartialPersistentModel = PartialPersistentModel
-                            { projectContents :: ProjectContentsTreeRoot
+                            { projectContents :: ProjectContentTreeRoot
                             }
-                            deriving (Eq, Show, Generic)
+                            deriving (Eq, Show, Generic, Data, Typeable)
 
 instance FromJSON PartialPersistentModel where
   parseJSON = genericParseJSON defaultOptions
@@ -154,7 +239,7 @@ instance FromJSON PartialPersistentModel where
 instance ToJSON PartialPersistentModel where
   toJSON = genericToJSON defaultOptions
 
-getProjectContentsTreeFile :: ProjectContentsTreeRoot -> [Text] -> Maybe ProjectFile
+getProjectContentsTreeFile :: ProjectContentTreeRoot -> [Text] -> Maybe ProjectFile
 getProjectContentsTreeFile _ [] = Nothing
 getProjectContentsTreeFile projectContentsTree pathElements =
   let directoryContentLens filename = ix filename . _Ctor @"ProjectContentsTreeDirectory" . field @"children"
@@ -167,24 +252,4 @@ getProjectContentsTreeFile projectContentsTree pathElements =
 persistentModelFromJSON :: Value -> Either Text PartialPersistentModel
 persistentModelFromJSON value = first pack $ parseEither parseJSON value
 
-projectContentsTreeFromDecodedProject :: DecodedProject -> Either Text ProjectContentsTreeRoot
-projectContentsTreeFromDecodedProject decodedProject = do
-  let contentOfProject = view (field @"content") decodedProject
-  fmap (view (field @"projectContents")) $ persistentModelFromJSON contentOfProject
-
-projectContentsTreeFromSaveProjectRequest :: SaveProjectRequest -> Maybe (Either Text ProjectContentsTreeRoot)
-projectContentsTreeFromSaveProjectRequest saveProjectRequest =
-  let possiblePersistentModel = firstOf (field @"_content" . _Just) saveProjectRequest
-      possibleParsedPersistentModel = fmap persistentModelFromJSON possiblePersistentModel
-   in over (_Just . _Right) (view (field @"projectContents")) possibleParsedPersistentModel
-
-validateSaveRequest :: SaveProjectRequest -> Bool
-validateSaveRequest saveProjectRequest =
-  case projectContentsTreeFromSaveProjectRequest saveProjectRequest of
-    -- Contents not included, so nothing to validate.
-    Nothing                      -> True
-    -- Cannot parse JSON content.
-    Just (Left _)                -> False
-    -- Parsed content, need to validate the contents tree is not empty.
-    Just (Right projectContents) -> not $ M.null projectContents
 

--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -40,10 +40,10 @@ export function getAllProjectAssetFiles(
   return allProjectAssets
 }
 
-// Ensure this is kept up to date with server/src/Utopia/Web/ClientModel.hs.
+// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
 export type ProjectContentTreeRoot = { [key: string]: ProjectContentsTree }
 
-// Ensure this is kept up to date with server/src/Utopia/Web/ClientModel.hs.
+// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs
 export interface ProjectContentDirectory {
   type: 'PROJECT_CONTENT_DIRECTORY'
   fullPath: string
@@ -64,7 +64,7 @@ export function projectContentDirectory(
   }
 }
 
-// Ensure this is kept up to date with server/src/Utopia/Web/ClientModel.hs.
+// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
 export interface ProjectContentFile {
   type: 'PROJECT_CONTENT_FILE'
   fullPath: string
@@ -82,7 +82,7 @@ export function projectContentFile(
   }
 }
 
-// Ensure this is kept up to date with server/src/Utopia/Web/ClientModel.hs.
+// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
 export type ProjectContentsTree = ProjectContentDirectory | ProjectContentFile
 
 export function isProjectContentDirectory(

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -449,6 +449,7 @@ export function isUnparsed(parsed: ParsedTextFile): parsed is Unparsed {
   return parsed.type === 'UNPARSED'
 }
 
+// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
 export type ParsedTextFile = ParseFailure | ParseSuccess | Unparsed
 
 export function foldParsedTextFile<X>(
@@ -490,6 +491,7 @@ export function forEachParseSuccess(
   }
 }
 
+// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
 export interface ParsedJSONSuccess {
   type: 'SUCCESS'
   value: any
@@ -499,6 +501,7 @@ export function isParsedJSONSuccess(result: ParsedJSONResult): result is ParsedJ
   return result.type === 'SUCCESS'
 }
 
+// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
 export interface ParsedJSONFailure {
   type: 'FAILURE'
   codeSnippet: string
@@ -513,8 +516,10 @@ export function isParsedJSONFailure(result: ParsedJSONResult): result is ParsedJ
   return result.type === 'FAILURE'
 }
 
+// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
 export type ParsedJSONResult = ParsedJSONSuccess | ParsedJSONFailure
 
+// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
 export type RevisionsStateType = 'PARSED_AHEAD' | 'CODE_AHEAD' | 'BOTH_MATCH'
 
 export const RevisionsState = {
@@ -523,7 +528,7 @@ export const RevisionsState = {
   BothMatch: 'BOTH_MATCH',
 } as const
 
-// Ensure this is kept up to date with server/src/Utopia/Web/ClientModel.hs.
+// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
 export interface TextFileContents {
   code: string
   parsed: ParsedTextFile
@@ -542,7 +547,7 @@ export function textFileContents(
   }
 }
 
-// Ensure this is kept up to date with server/src/Utopia/Web/ClientModel.hs.
+// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
 export interface TextFile {
   type: 'TEXT_FILE'
   fileContents: TextFileContents
@@ -640,7 +645,7 @@ export function isEsRemoteDependencyPlaceholder(
   return projectFile != null && projectFile.type === 'ES_REMOTE_DEPENDENCY_PLACEHOLDER'
 }
 
-// Ensure this is kept up to date with server/src/Utopia/Web/ClientModel.hs.
+// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
 export interface ImageFile {
   type: 'IMAGE_FILE'
   imageType?: string
@@ -667,7 +672,7 @@ export function imageFile(
   }
 }
 
-// Ensure this is kept up to date with server/src/Utopia/Web/ClientModel.hs.
+// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
 export interface AssetFile {
   type: 'ASSET_FILE'
   base64?: string

--- a/server/default.nix
+++ b/server/default.nix
@@ -4,19 +4,17 @@ let
   compiler = "ghc8107";
   utopia-server = pkgs.haskell.packages.${compiler}.callCabal2nix "utopia-server" ./. {};
   haskell = pkgs.haskell.lib;
-
-  server-without-profile = haskell.disableLibraryProfiling (haskell.disableExecutableProfiling utopia-server);
-
-  server-disabled-database-tests = haskell.appendConfigureFlag server-without-profile "--flags -enable-external-tests";
-
-  server-tested = haskell.disableOptimization server-disabled-database-tests;
-
-  server-shell = haskell.addBuildTools server-tested [pkgs.nodejs pkgs.yarn]; 
-
-  server-dev = haskell.dontCheck server-tested;
+  trivial = pkgs.lib.trivial;
+  disableProfiling = pkg: haskell.disableLibraryProfiling (haskell.disableExecutableProfiling pkg);
+  disableExternalTests = pkg: haskell.appendConfigureFlag pkg "--flags -enable-external-tests";
+  withNodeTooling = pkg: haskell.addBuildTools pkg [pkgs.nodejs pkgs.yarn];
+  serverModifications = pkg: trivial.pipe pkg [disableProfiling disableExternalTests withNodeTooling];
+  overriddenHaskellPackages = pkgs.haskell.packages.${compiler}.override {
+    overrides = self: super: {
+      wai-extra = super.callHackage "wai-extra" "3.1.6" {};
+      utopia-clientmodel = super.callCabal2nix "utopia-clientmodel" (../clientmodel/lib) {};
+      utopia-web = serverModifications (super.callCabal2nix "utopia-web" (./.) {});
+    };
+  };
 in
-  {
-    server-dev = server-dev;
-    server-shell = server-shell;
-    server-tested = server-tested;
-  }
+  overriddenHaskellPackages.utopia-web

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -1,5 +1,5 @@
 name: utopia-web
-version: 0.1.0.4
+version: 0.1.1.0
 synopsis: Utopia Web
 description: Utopia Web
 github: concrete-utopia/utopia
@@ -81,6 +81,7 @@ dependencies:
   - transformers
   - unix
   - unordered-containers
+  - utopia-clientmodel
   - uuid
   - vector
   - wai

--- a/server/shell.nix
+++ b/server/shell.nix
@@ -1,4 +1,4 @@
 let
   defaultNix = (import ./default.nix);
 in
-  defaultNix.server-shell.env
+  defaultNix.env

--- a/server/src/Utopia/Web/Database.hs
+++ b/server/src/Utopia/Web/Database.hs
@@ -19,6 +19,8 @@ import           Control.Monad.Catch
 import           Control.Monad.Fail
 import           Data.Aeson
 import qualified Data.ByteString.Lazy            as BL
+import           Data.Generics.Product
+import           Data.Generics.Sum
 import           Data.Pool
 import           Data.Profunctor.Product.Default
 import           Data.String
@@ -35,8 +37,6 @@ import           System.Posix.User
 import           Utopia.ClientModel
 import           Utopia.Web.Database.Types
 import           Utopia.Web.Metrics              hiding (count)
-import           Data.Generics.Product
-import           Data.Generics.Sum
 
 data DatabaseMetrics = DatabaseMetrics
                      { _generateUniqueIDMetrics         :: InvocationMetric

--- a/server/src/Utopia/Web/Database.hs
+++ b/server/src/Utopia/Web/Database.hs
@@ -32,8 +32,11 @@ import           Opaleye.Trans
 import           Protolude                       hiding (get)
 import           System.Environment
 import           System.Posix.User
+import           Utopia.ClientModel
 import           Utopia.Web.Database.Types
 import           Utopia.Web.Metrics              hiding (count)
+import           Data.Generics.Product
+import           Data.Generics.Sum
 
 data DatabaseMetrics = DatabaseMetrics
                      { _generateUniqueIDMetrics         :: InvocationMetric
@@ -378,3 +381,8 @@ checkIfProjectIDReserved metrics pool projectId = invokeAndMeasure (_checkIfProj
     rowProjectId <- projectIDSelect
     where_ $ rowProjectId .== toFields projectId
   pure $ Protolude.not $ Protolude.null entries
+
+projectContentTreeFromDecodedProject :: DecodedProject -> Either Text ProjectContentTreeRoot
+projectContentTreeFromDecodedProject decodedProject = do
+  let contentOfProject = view (field @"content") decodedProject
+  fmap (view (field @"projectContents")) $ persistentModelFromJSON contentOfProject

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -13,7 +13,7 @@
   All the endpoints defined in "Utopia.Web.Types" are implemented here.
 -}
 module Utopia.Web.Endpoints where
-
+import qualified Data.HashMap.Strict       as M
 import           Control.Arrow                   ((&&&))
 import           Control.Lens
 import           Data.Aeson
@@ -42,7 +42,8 @@ import           Text.HTML.TagSoup
 import           Text.URI                        hiding (unRText, uriPath)
 import           Text.URI.Lens
 import           Utopia.Web.Assets
-import           Utopia.Web.ClientModel
+import           Utopia.ClientModel
+import           Utopia.Web.Database (projectContentTreeFromDecodedProject)
 import           Utopia.Web.Database.Types
 import qualified Utopia.Web.Database.Types       as DB
 import           Utopia.Web.Executors.Common
@@ -56,6 +57,22 @@ import           WaiAppStatic.Storage.Filesystem
 import           WaiAppStatic.Types
 
 type TagSoupTags = [Tag Text]
+
+projectContentTreeFromSaveProjectRequest :: SaveProjectRequest -> Maybe (Either Text ProjectContentTreeRoot)
+projectContentTreeFromSaveProjectRequest saveProjectRequest =
+  let possiblePersistentModel = firstOf (field @"_content" . _Just) saveProjectRequest
+      possibleParsedPersistentModel = fmap persistentModelFromJSON possiblePersistentModel
+   in over (_Just . _Right) (view (field @"projectContents")) possibleParsedPersistentModel
+
+validateSaveRequest :: SaveProjectRequest -> Bool
+validateSaveRequest saveProjectRequest =
+  case projectContentTreeFromSaveProjectRequest saveProjectRequest of
+    -- Contents not included, so nothing to validate.
+    Nothing                      -> True
+    -- Cannot parse JSON content.
+    Just (Left _)                -> False
+    -- Parsed content, need to validate the contents tree is not empty.
+    Just (Right projectContents) -> not $ M.null projectContents
 
 checkForUser :: Maybe Text -> (Maybe SessionUser -> ServerMonad a) -> ServerMonad a
 checkForUser (Just sessionCookie) action = do
@@ -419,7 +436,7 @@ deleteProjectEndpoint cookie (ProjectIdWithSuffix projectID _) = requireUser coo
 
 loadProjectFileContents :: DecodedProject -> [[Text]] -> Either Text (Maybe (ProjectFile, [Text]))
 loadProjectFileContents decodedProject pathsToCheck = do
-  projectContentsTree <- projectContentsTreeFromDecodedProject decodedProject
+  projectContentsTree <- projectContentTreeFromDecodedProject decodedProject
   let projectFile = getFirst $ foldMap (\path -> First $ fmap (\c -> (c, path)) $ getProjectContentsTreeFile projectContentsTree path) pathsToCheck
   pure projectFile
 

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -13,7 +13,6 @@
   All the endpoints defined in "Utopia.Web.Types" are implemented here.
 -}
 module Utopia.Web.Endpoints where
-import qualified Data.HashMap.Strict       as M
 import           Control.Arrow                   ((&&&))
 import           Control.Lens
 import           Data.Aeson
@@ -21,6 +20,7 @@ import           Data.Aeson.Lens
 import qualified Data.ByteString.Lazy            as BL
 import           Data.CaseInsensitive            hiding (traverse)
 import           Data.Generics.Product
+import qualified Data.HashMap.Strict             as M
 import qualified Data.Text                       as T
 import           Data.Text.Encoding
 import           Data.Time
@@ -41,9 +41,9 @@ import qualified Text.Blaze.Html5.Attributes     as HA
 import           Text.HTML.TagSoup
 import           Text.URI                        hiding (unRText, uriPath)
 import           Text.URI.Lens
-import           Utopia.Web.Assets
 import           Utopia.ClientModel
-import           Utopia.Web.Database (projectContentTreeFromDecodedProject)
+import           Utopia.Web.Assets
+import           Utopia.Web.Database             (projectContentTreeFromDecodedProject)
 import           Utopia.Web.Database.Types
 import qualified Utopia.Web.Database.Types       as DB
 import           Utopia.Web.Executors.Common

--- a/server/src/Utopia/Web/Packager/NPM.hs
+++ b/server/src/Utopia/Web/Packager/NPM.hs
@@ -29,7 +29,7 @@ import           System.IO.Temp
 import           System.Log.FastLogger
 import           System.Process
 import           Utopia.ClientModel
-import           Utopia.Web.Database (projectContentTreeFromDecodedProject)
+import           Utopia.Web.Database       (projectContentTreeFromDecodedProject)
 import qualified Utopia.Web.Database.Types as DB
 import           Utopia.Web.Logging
 import           Utopia.Web.Metrics

--- a/server/src/Utopia/Web/Packager/NPM.hs
+++ b/server/src/Utopia/Web/Packager/NPM.hs
@@ -28,7 +28,8 @@ import           System.IO.Error
 import           System.IO.Temp
 import           System.Log.FastLogger
 import           System.Process
-import           Utopia.Web.ClientModel
+import           Utopia.ClientModel
+import           Utopia.Web.Database (projectContentTreeFromDecodedProject)
 import qualified Utopia.Web.Database.Types as DB
 import           Utopia.Web.Logging
 import           Utopia.Web.Metrics
@@ -176,7 +177,7 @@ providedDependencies = ["utopia-api", "uuiui", "uuiui-deps", "react/jsx-runtime"
 
 getProjectDependenciesFromPackageJSON :: DB.DecodedProject -> [ProjectDependency]
 getProjectDependenciesFromPackageJSON decodedProject = either (const []) identity $ do
-  contentsTreeRoot <- first toS $ projectContentsTreeFromDecodedProject decodedProject
+  contentsTreeRoot <- first toS $ projectContentTreeFromDecodedProject decodedProject
   packageJsonFile <- maybe (Left "No package.json found.") pure $ getProjectContentsTreeFile contentsTreeRoot ["package.json"]
   packageJsonCode <- maybe (Left "package.json not a text file.") pure $ firstOf projectFileToCodeLens packageJsonFile
   MinimalPackageJSON{..} <- eitherDecode' $ BL.fromStrict $ encodeUtf8 packageJsonCode

--- a/server/src/Utopia/Web/Server.hs
+++ b/server/src/Utopia/Web/Server.hs
@@ -5,6 +5,7 @@
 
 module Utopia.Web.Server where
 
+import           Control.Concurrent              (ThreadId)
 import qualified Data.ByteString                 as B
 import qualified Data.ByteString.Char8           as S8
 import qualified Data.HashMap.Strict             as H
@@ -26,7 +27,6 @@ import           Utopia.Web.Logging
 import           Utopia.Web.ServantMonitoring
 import           Utopia.Web.Types
 import           Utopia.Web.Utils.Files
-import Control.Concurrent (ThreadId)
 
 data RequestTooLargeException = RequestTooLargeException
   deriving (Eq, Show)

--- a/server/test/Main.hs
+++ b/server/test/Main.hs
@@ -15,7 +15,7 @@ main = do
   defaultMain tree
 
 enableExternalTests :: Bool
-enableExternalTests = ENABLE_EXTERNAL_TESTS 
+enableExternalTests = ENABLE_EXTERNAL_TESTS
 
 tests :: IO TestTree
 tests = do

--- a/server/test/Test/Utopia/Web/Endpoints.hs
+++ b/server/test/Test/Utopia/Web/Endpoints.hs
@@ -22,8 +22,8 @@ import           Network.HTTP.Media.MediaType
 import           Network.HTTP.Types             (Status, badRequest400,
                                                  notFound404)
 import qualified Network.Socket.Wait            as W
+import           Prelude                        (String)
 import           Protolude
-import           Prelude (String)
 import           Servant
 import           Servant.Client
 import           Servant.Client.Core

--- a/server/test/Test/Utopia/Web/Endpoints.hs
+++ b/server/test/Test/Utopia/Web/Endpoints.hs
@@ -31,7 +31,7 @@ import           Servant.RawM.Client
 import           System.Timeout
 import           Test.Hspec
 import           Test.Utopia.Web.Executors.Test
-import           Utopia.Web.ClientModel
+import           Utopia.ClientModel
 import           Utopia.Web.Database.Types
 import           Utopia.Web.Executors.Common
 import           Utopia.Web.Servant
@@ -214,7 +214,7 @@ deleteAssetSpec enableExternalTests = databaseAround enableExternalTests $ \desc
                           $ ProjectContentsTreeFile
                           $ ProjectContentFile "/storyboard.js"
                           $ ProjectTextFile
-                          $ TextFile (TextFileContents "// Valid JS") Nothing 0.0
+                          $ TextFile (TextFileContents "// Valid JS" (ParsedTextFileUnparsed Unparsed) BothMatch) Nothing 0.0
       let persistentModel = object ["projectContents" .= projectContents]
       -- Create a project, save an asset, rename it and try to load it from the new path.
       loadedFromPath <- withClientEnv clientEnv $ do

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.6.
 --
 -- see: https://github.com/sol/hpack
 
 name:           utopia-web
-version:        0.1.0.4
+version:        0.1.1.0
 synopsis:       Utopia Web
 description:    Utopia Web
 category:       Development
@@ -30,7 +30,6 @@ executable utopia-web
       Utopia.Web.Auth
       Utopia.Web.Auth.Session
       Utopia.Web.Auth.Types
-      Utopia.Web.ClientModel
       Utopia.Web.Database
       Utopia.Web.Database.Migrations
       Utopia.Web.Database.Types
@@ -130,6 +129,7 @@ executable utopia-web
     , transformers
     , unix
     , unordered-containers
+    , utopia-clientmodel
     , uuid
     , vector
     , wai
@@ -155,7 +155,6 @@ test-suite utopia-web-test
       Utopia.Web.Auth
       Utopia.Web.Auth.Session
       Utopia.Web.Auth.Types
-      Utopia.Web.ClientModel
       Utopia.Web.Database
       Utopia.Web.Database.Migrations
       Utopia.Web.Database.Types
@@ -265,6 +264,7 @@ test-suite utopia-web-test
     , transformers
     , unix
     , unordered-containers
+    , utopia-clientmodel
     , uuid
     , vector
     , wai

--- a/shell.nix
+++ b/shell.nix
@@ -361,8 +361,8 @@ let
       #!/usr/bin/env bash
       set -e
       cabal-update
-      cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/server
-      ${pkgs.nodePackages.nodemon}/bin/nodemon --delay 200ms -e hs,yaml --watch src --watch package.yaml --exec run-server-inner
+      cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/
+      ${pkgs.nodePackages.nodemon}/bin/nodemon --delay 200ms -e hs,yaml --watch server/src --watch server/package.yaml --watch clientmodel/lib/src --watch clientmodel/lib/package.yaml --exec run-server-inner
     '')
   ];
 

--- a/shell.nix
+++ b/shell.nix
@@ -342,6 +342,8 @@ let
       find . -name '*.hs' | xargs ${pkgs.haskellPackages.stylish-haskell}/bin/stylish-haskell -i
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/server/test
       find . -name '*.hs' | xargs ${pkgs.haskellPackages.stylish-haskell}/bin/stylish-haskell -i
+      cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/clientmodel/lib/src
+      find . -name '*.hs' | xargs ${pkgs.haskellPackages.stylish-haskell}/bin/stylish-haskell -i
     '')
     (pkgs.writeScriptBin "run-server-inner" ''
       #!/usr/bin/env bash


### PR DESCRIPTION
**Problem:**
We want to be able to use the client model the server currently holds in other projects.

**Fix:**
Pulled out the client model code into its own project and in the process also expanded its coverage.

**Commit Details:**
- New `utopia-clientmodel` project now holds type definitions for
  the persisted model, which have been pulled out of `utopia-web`.
- `utopia-web` now depends on `utopia-clientmodel` for the above types.
- `watch-server` script updated to catch changes to both `utopia-web`
  and `utopia-clientmodel`.
- Some utility functions have moved around from the original client model
  file as they don't make any sense to be in `utopia-clientmodel`.