### PR TITLE
Navigator reparent/reorder now re-uses the canvas strategies logic.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -16,7 +16,7 @@ import {
 import { ifAllowedToReparent, isAllowedToReparent } from './reparent-helpers'
 import { findReparentStrategy } from './reparent-strategy-helpers'
 import { offsetPoint } from '../../../core/shared/math-utils'
-import { getReparentCommands } from './reparent-utils'
+import { getReparentOutcome } from './reparent-utils'
 
 export const absoluteReparentStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_REPARENT',
@@ -94,7 +94,12 @@ export const absoluteReparentStrategy: CanvasStrategy = {
         ?.specialSizeMeasurements.providesBoundsForAbsoluteChildren ?? false
     const parentIsStoryboard = newParent == null ? false : EP.isStoryboardPath(newParent)
     const allowedToReparent = filteredSelectedElements.every((selectedElement) => {
-      return isAllowedToReparent(canvasState, strategyState, selectedElement)
+      return isAllowedToReparent(
+        canvasState.projectContents,
+        canvasState.openFile,
+        strategyState.startingMetadata,
+        selectedElement,
+      )
     })
 
     if (
@@ -111,20 +116,17 @@ export const absoluteReparentStrategy: CanvasStrategy = {
           canvasState,
         )
 
-        const newPath = EP.appendToPath(newParent, EP.toUid(selectedElement))
+        const { commands: reparentCommands, newPath } = getReparentOutcome(
+          canvasState.builtInDependencies,
+          projectContents,
+          nodeModules,
+          openFile,
+          selectedElement,
+          newParent,
+        )
         return {
           newPath: newPath,
-          commands: [
-            ...offsetCommands,
-            ...getReparentCommands(
-              canvasState.builtInDependencies,
-              projectContents,
-              nodeModules,
-              openFile,
-              selectedElement,
-              newParent,
-            ),
-          ],
+          commands: [...offsetCommands, ...reparentCommands],
         }
       })
 

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -48,7 +48,7 @@ import {
   InteractionCanvasState,
 } from './canvas-strategy-types'
 import { DragInteractionData, InteractionSession, StrategyState } from './interaction-state'
-import { getReparentCommands } from './reparent-utils'
+import { getReparentOutcome } from './reparent-utils'
 import { areAllSelectedElementsNonAbsolute } from './shared-absolute-move-strategy-helpers'
 
 export const escapeHatchStrategy: CanvasStrategy = {
@@ -271,14 +271,14 @@ function collectSetLayoutPropCommands(
     commands.push(...updatePinsCommands)
     if (shouldReparent) {
       commands.push(
-        ...getReparentCommands(
+        ...getReparentOutcome(
           canvasState.builtInDependencies,
           canvasState.projectContents,
           canvasState.nodeModules,
           canvasState.openFile,
           path,
           targetParent,
-        ),
+        ).commands,
       )
     }
     return { commands: commands, intendedBounds: intendedBounds }

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -20,6 +20,7 @@ import { updateHighlightedViews } from '../commands/update-highlighted-views-com
 import { setElementsToRerenderCommand } from '../commands/set-elements-to-rerender-command'
 import { ParentBounds } from '../controls/parent-bounds'
 import { getReorderIndex } from './reparent-strategy-helpers'
+import { absolute } from '../../../utils/utils'
 
 export const flexReorderStrategy: CanvasStrategy = {
   id: 'FLEX_REORDER',
@@ -108,7 +109,7 @@ export const flexReorderStrategy: CanvasStrategy = {
       } else {
         return {
           commands: [
-            reorderElement('always', target, realNewIndex),
+            reorderElement('always', target, absolute(realNewIndex)),
             setElementsToRerenderCommand([target]),
             updateHighlightedViews('mid-interaction', []),
             setCursorCommand('mid-interaction', CSSCursor.Move),

--- a/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
@@ -1,35 +1,36 @@
 import { foldEither } from '../../../core/shared/either'
-import { elementReferencesElsewhere } from '../../../core/shared/element-template'
+import {
+  ElementInstanceMetadataMap,
+  elementReferencesElsewhere,
+} from '../../../core/shared/element-template'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { CSSCursor } from '../canvas-types'
 import { setCursorCommand } from '../commands/set-cursor-command'
 import { InteractionCanvasState, StrategyApplicationResult } from './canvas-strategy-types'
 import { StrategyState } from './interaction-state'
-import * as EP from '../../../core/shared/element-path'
-import { honoursPropsPosition } from './absolute-utils'
+import { ProjectContentTreeRoot } from 'src/components/assets'
 
 export function isGeneratedElement(
-  canvasState: InteractionCanvasState,
+  projectContents: ProjectContentTreeRoot,
+  openFile: string | null | undefined,
   target: ElementPath,
 ): boolean {
-  return MetadataUtils.anyUnknownOrGeneratedElements(
-    canvasState.projectContents,
-    {},
-    canvasState.openFile ?? null,
-    [target],
-  )
+  return MetadataUtils.anyUnknownOrGeneratedElements(projectContents, {}, openFile ?? null, [
+    target,
+  ])
 }
 
 export function isAllowedToReparent(
-  canvasState: InteractionCanvasState,
-  strategyState: StrategyState,
+  projectContents: ProjectContentTreeRoot,
+  openFile: string | null | undefined,
+  startingMetadata: ElementInstanceMetadataMap,
   target: ElementPath,
 ): boolean {
-  if (isGeneratedElement(canvasState, target)) {
+  if (isGeneratedElement(projectContents, openFile, target)) {
     return false
   } else {
-    const metadata = MetadataUtils.findElementByElementPath(strategyState.startingMetadata, target)
+    const metadata = MetadataUtils.findElementByElementPath(startingMetadata, target)
     if (metadata == null) {
       return false
     } else {
@@ -38,7 +39,7 @@ export function isAllowedToReparent(
         (elementFromMetadata) => {
           return (
             !elementReferencesElsewhere(elementFromMetadata) &&
-            honoursPropsPosition(canvasState, target)
+            MetadataUtils.targetHonoursPropsPosition(projectContents, openFile, target)
           )
         },
         metadata.element,
@@ -53,7 +54,14 @@ export function ifAllowedToReparent(
   targets: Array<ElementPath>,
   ifAllowed: () => StrategyApplicationResult,
 ): StrategyApplicationResult {
-  const allowed = targets.every((target) => isAllowedToReparent(canvasState, strategyState, target))
+  const allowed = targets.every((target) => {
+    return isAllowedToReparent(
+      canvasState.projectContents,
+      canvasState.openFile,
+      strategyState.startingMetadata,
+      target,
+    )
+  })
   if (allowed) {
     return ifAllowed()
   } else {

--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -25,9 +25,9 @@ import {
 } from './canvas-strategy-types'
 import { InteractionSession, StrategyState } from './interaction-state'
 import { ifAllowedToReparent } from './reparent-helpers'
-import { getReparentCommands } from './reparent-utils'
+import { getReparentOutcome } from './reparent-utils'
 import { getDragTargets } from './shared-absolute-move-strategy-helpers'
-import Utils from '../../../utils/utils'
+import Utils, { absolute } from '../../../utils/utils'
 import { reverse } from '../../../core/shared/array-utils'
 
 interface ReorderElement {
@@ -288,8 +288,7 @@ export function applyFlexReparent(
         const target = filteredSelectedElements[0]
         const newParent = reparentResult.newParent
         // Reparent the element.
-        const newPath = EP.appendToPath(reparentResult.newParent, EP.toUid(target))
-        const reparentCommands = getReparentCommands(
+        const { commands: reparentCommands, newPath } = getReparentOutcome(
           canvasState.builtInDependencies,
           canvasState.projectContents,
           canvasState.nodeModules,
@@ -337,7 +336,7 @@ export function applyFlexReparent(
           )
           commands = [
             ...commandsBeforeReorder,
-            reorderElement('always', newPath, newIndex),
+            reorderElement('always', newPath, absolute(newIndex)),
             ...commandsAfterReorder,
           ]
         } else {

--- a/editor/src/components/canvas/commands/reorder-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/reorder-element-command.spec.tsx
@@ -1,3 +1,4 @@
+import { absolute } from '../../../utils/utils'
 import * as EP from '../../../core/shared/element-path'
 import { EditorState, withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import { getEditorState, makeTestProjectCodeWithSnippet } from '../ui-jsx.test-utils'
@@ -73,7 +74,7 @@ describe('runReorderElement', () => {
 
       const parent = EP.parentPath(target)
 
-      const reorderCommand = reorderElement('always', target, newIdx)
+      const reorderCommand = reorderElement('always', target, absolute(newIdx))
 
       const result = runReorderElement(originalEditorState, reorderCommand)
 

--- a/editor/src/components/canvas/commands/reorder-element-command.ts
+++ b/editor/src/components/canvas/commands/reorder-element-command.ts
@@ -1,3 +1,4 @@
+import { IndexPosition } from 'src/utils/utils'
 import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
 import * as EP from '../../../core/shared/element-path'
 import { ElementPath } from '../../../core/shared/project-file-types'
@@ -8,19 +9,19 @@ import { BaseCommand, CommandFunction, getPatchForComponentChange, WhenToRun } f
 export interface ReorderElement extends BaseCommand {
   type: 'REORDER_ELEMENT'
   target: ElementPath
-  newIndex: number
+  indexPosition: IndexPosition
 }
 
 export function reorderElement(
   whenToRun: WhenToRun,
   target: ElementPath,
-  newIndex: number,
+  indexPosition: IndexPosition,
 ): ReorderElement {
   return {
     type: 'REORDER_ELEMENT',
     whenToRun: whenToRun,
     target: target,
-    newIndex: newIndex,
+    indexPosition: indexPosition,
   }
 }
 
@@ -39,7 +40,7 @@ export const runReorderElement: CommandFunction<ReorderElement> = (
         editorState.canvas.openFile?.filename ?? null,
         components,
         command.target,
-        command.newIndex,
+        command.indexPosition,
       )
       return getPatchForComponentChange(
         success.topLevelElements,
@@ -52,7 +53,7 @@ export const runReorderElement: CommandFunction<ReorderElement> = (
   return {
     editorStatePatches: [patch],
     commandDescription: `Reorder Element ${EP.toUid(command.target)} to new index ${
-      command.newIndex
+      command.indexPosition
     }`,
   }
 }

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -74,7 +74,7 @@ export function runSimpleLocalEditorAction(
     case 'MOVE_SELECTED_FORWARD':
       return UPDATE_FNS.MOVE_SELECTED_FORWARD(state)
     case 'NAVIGATOR_REORDER':
-      return UPDATE_FNS.NAVIGATOR_REORDER(action, state, derivedState)
+      return UPDATE_FNS.NAVIGATOR_REORDER(action, state, derivedState, builtInDependencies)
     case 'UNSET_PROPERTY':
       return UPDATE_FNS.UNSET_PROPERTY(action, state, dispatch)
     case 'UNDO':
@@ -234,7 +234,7 @@ export function runSimpleLocalEditorAction(
     case 'DELETE_SELECTED':
       return UPDATE_FNS.DELETE_SELECTED(action, state, derivedState, dispatch)
     case 'WRAP_IN_VIEW':
-      return UPDATE_FNS.WRAP_IN_VIEW(action, state, derivedState, dispatch)
+      return UPDATE_FNS.WRAP_IN_VIEW(action, state, derivedState, dispatch, builtInDependencies)
     case 'WRAP_IN_ELEMENT':
       return UPDATE_FNS.WRAP_IN_ELEMENT(action, state, derivedState, dispatch)
     case 'OPEN_FLOATING_INSERT_MENU':

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -67,7 +67,7 @@ function onDrop(
   propsOfDropTargetItem: NavigatorItemDragAndDropWrapperProps,
   monitor: DropTargetMonitor,
   component: HTMLDivElement | null,
-) {
+): void {
   if (monitor != null && component != null) {
     const dragSelections = propsOfDraggedItem.getDragSelections()
     const filteredSelections = dragSelections.filter((selection) =>
@@ -79,22 +79,26 @@ function onDrop(
 
     switch (propsOfDropTargetItem.appropriateDropTargetHint?.type) {
       case 'before':
-        return propsOfDraggedItem.editorDispatch(
+        propsOfDraggedItem.editorDispatch(
           [placeComponentsBefore(draggedElements, target), clearHintAction],
           'everyone',
         )
+        break
       case 'after':
-        return propsOfDraggedItem.editorDispatch(
+        propsOfDraggedItem.editorDispatch(
           [placeComponentsAfter(draggedElements, target), clearHintAction],
           'everyone',
         )
+        break
       case 'reparent':
-        return propsOfDraggedItem.editorDispatch(
+        propsOfDraggedItem.editorDispatch(
           [reparentComponents(draggedElements, target), clearHintAction],
           'everyone',
         )
+        break
       default:
-        return propsOfDraggedItem.editorDispatch([clearHintAction], 'everyone')
+        propsOfDraggedItem.editorDispatch([clearHintAction], 'everyone')
+        break
     }
   }
 }
@@ -242,11 +246,13 @@ export class NavigatorItemDndWrapper extends PureComponent<
 
   render(): React.ReactElement {
     const props = this.props
+    const safeComponentId = EP.toVarSafeComponentId(this.props.elementPath)
 
     return (
       <div
         key='navigatorItem'
-        id={`navigator-item-${EP.toVarSafeComponentId(this.props.elementPath)}`}
+        id={`navigator-item-${safeComponentId}`}
+        data-testid={`navigator-item-${safeComponentId}`}
         style={{
           ...props.windowStyle,
         }}
@@ -301,12 +307,13 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
       beginDrag: beginDrag,
       canDrag: (monitor) => {
         const editorState = editorStateRef.current
-        return isAllowedToReparent(
+        const result = isAllowedToReparent(
           editorState.projectContents,
           editorState.canvas.openFile?.filename,
           editorState.jsxMetadata,
           props.elementPath,
         )
+        return result
       },
     }),
     [props],
@@ -333,12 +340,13 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
       },
       canDrop: (item: NavigatorItemDragAndDropWrapperProps, monitor) => {
         const editorState = editorStateRef.current
-        return MetadataUtils.targetSupportsChildren(
+        const result = MetadataUtils.targetSupportsChildren(
           editorState.projectContents,
           editorState.canvas.openFile?.filename,
           editorState.jsxMetadata,
           item.elementPath,
         )
+        return result
       },
     }),
     [props],
@@ -351,10 +359,11 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
     },
     [drop, dropRef],
   )
+  const safeComponentId = EP.toVarSafeComponentId(props.elementPath)
 
   return (
-    <div ref={attachDrop}>
-      <div ref={drag}>
+    <div ref={attachDrop} data-testid={`navigator-item-drop-${safeComponentId}`}>
+      <div ref={drag} data-testid={`navigator-item-drag-${safeComponentId}`}>
         <NavigatorItemDndWrapper {...props} isOver={isOver} isDragging={isDragging} />
       </div>
     </div>

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -1,0 +1,1114 @@
+import {
+  EditorRenderResult,
+  getPrintedUiJsCode,
+  renderTestEditorWithCode,
+  TestSceneUID,
+} from '../canvas/ui-jsx.test-utils'
+import { act, fireEvent } from '@testing-library/react'
+import { offsetPoint, windowPoint, WindowPoint } from '../../core/shared/math-utils'
+import { PrettierConfig } from 'utopia-vscode-common'
+import * as Prettier from 'prettier/standalone'
+import { BakedInStoryboardVariableName, BakedInStoryboardUID } from '../../core/model/scene-utils'
+import { CSSCursor } from '../canvas/canvas-types'
+import { getDomRectCenter } from '../../core/shared/dom-utils'
+import { selectComponents } from '../editor/actions/action-creators'
+import * as EP from '../../core/shared/element-path'
+
+interface CheckCursor {
+  cursor: CSSCursor | null
+}
+
+function dragElement(
+  renderResult: EditorRenderResult,
+  dragTargetID: string,
+  dropTargetID: string,
+  startPoint: WindowPoint,
+  dragDelta: WindowPoint,
+  hoverEvents: 'apply-hover-events' | 'do-not-apply-hover-events',
+): void {
+  const dragTarget = renderResult.renderedDOM.getByTestId(dragTargetID)
+  const dropTarget = renderResult.renderedDOM.getByTestId(dropTargetID)
+
+  const endPoint = offsetPoint(startPoint, dragDelta)
+
+  fireEvent(
+    dragTarget,
+    new MouseEvent('dragstart', {
+      bubbles: true,
+      cancelable: true,
+      clientX: startPoint.x,
+      clientY: startPoint.y,
+      buttons: 1,
+    }),
+  )
+
+  fireEvent(
+    dragTarget,
+    new MouseEvent('drag', {
+      bubbles: true,
+      cancelable: true,
+      clientX: endPoint.x,
+      clientY: endPoint.y,
+      movementX: dragDelta.x,
+      movementY: dragDelta.y,
+      buttons: 1,
+    }),
+  )
+
+  if (hoverEvents === 'apply-hover-events') {
+    fireEvent(
+      dropTarget,
+      new MouseEvent('dragenter', {
+        bubbles: true,
+        cancelable: true,
+        clientX: endPoint.x,
+        clientY: endPoint.y,
+        movementX: dragDelta.x,
+        movementY: dragDelta.y,
+        buttons: 1,
+      }),
+    )
+
+    fireEvent(
+      dropTarget,
+      new MouseEvent('dragover', {
+        bubbles: true,
+        cancelable: true,
+        clientX: endPoint.x,
+        clientY: endPoint.y,
+        movementX: dragDelta.x,
+        movementY: dragDelta.y,
+        buttons: 1,
+      }),
+    )
+
+    fireEvent(
+      dropTarget,
+      new MouseEvent('drop', {
+        bubbles: true,
+        cancelable: true,
+        clientX: endPoint.x,
+        clientY: endPoint.y,
+        buttons: 1,
+      }),
+    )
+  }
+}
+
+function getProjectCode(): string {
+  return `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+const unmoveableColour = 'orange'
+
+export var ${BakedInStoryboardVariableName} = (
+  <Storyboard data-uid='${BakedInStoryboardUID}'>
+    <Scene
+      style={{
+        backgroundColor: 'white',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 700,
+      }}
+      data-uid='${TestSceneUID}'
+    >
+      <div
+        style={{
+          backgroundColor: 'white',
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: 400,
+          height: 500,
+        }}
+        data-uid='sceneroot'
+        data-testid='sceneroot'
+        data-label='sceneroot'
+      >
+        <div
+          style={{
+            backgroundColor: 'teal',
+            position: 'absolute',
+            left: 255,
+            top: 35,
+            width: 109,
+            height: 123,
+          }}
+          data-uid='firstdiv'
+          data-testid='firstdiv'
+          data-label='firstdiv'
+        />
+        <div
+          style={{
+            backgroundColor: 'purple',
+            position: 'absolute',
+            left: 21,
+            top: 215.5,
+            width: 123,
+            height: 100,
+          }}
+          data-uid='seconddiv'
+          data-testid='seconddiv'
+          data-label='seconddiv'
+        />
+        <div
+          style={{
+            backgroundColor: 'green',
+            position: 'absolute',
+            left: 26,
+            top: 35,
+            width: 118,
+            height: 123,
+          }}
+          data-uid='thirddiv'
+          data-testid='thirddiv'
+          data-label='thirddiv'
+        />
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            height: 65,
+            width: 66,
+            position: 'absolute',
+            left: 265,
+            top: 233,
+          }}
+          data-uid='dragme'
+          data-testid='dragme'
+          data-label='dragme'
+        >
+          drag me
+        </div>
+        <div
+          style={{
+            backgroundColor: unmoveableColour,
+            height: 65,
+            width: 66,
+            position: 'absolute',
+            left: 265,
+            top: 300,
+          }}
+          data-uid='notdrag'
+          data-testid='notdrag'
+          data-label='notdrag'
+        >
+          not drag
+        </div>
+      </div>
+      <div
+        style={{
+          backgroundColor: 'white',
+          position: 'absolute',
+          left: 0,
+          top: 500,
+          width: 400,
+          height: 200,
+        }}
+        data-uid='parentsibling'
+        data-testid='parentsibling'
+        data-label='parentsibling'
+      />
+    </Scene>
+  </Storyboard>
+)
+`
+}
+
+function getProjectCodeDraggedToBeforeEverything(): string {
+  return `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+const unmoveableColour = 'orange'
+
+export var ${BakedInStoryboardVariableName} = (
+  <Storyboard data-uid='${BakedInStoryboardUID}'>
+    <Scene
+      style={{
+        backgroundColor: 'white',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 700,
+      }}
+      data-uid='${TestSceneUID}'
+    >
+      <div
+        style={{
+          backgroundColor: 'white',
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: 400,
+          height: 500,
+        }}
+        data-uid='sceneroot'
+        data-testid='sceneroot'
+        data-label='sceneroot'
+      >
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            height: 65,
+            width: 66,
+            position: 'absolute',
+            left: 265,
+            top: 233,
+          }}
+          data-uid='dragme'
+          data-testid='dragme'
+          data-label='dragme'
+        >
+          drag me
+        </div>
+        <div
+          style={{
+            backgroundColor: 'teal',
+            position: 'absolute',
+            left: 255,
+            top: 35,
+            width: 109,
+            height: 123,
+          }}
+          data-uid='firstdiv'
+          data-testid='firstdiv'
+          data-label='firstdiv'
+        />
+        <div
+          style={{
+            backgroundColor: 'purple',
+            position: 'absolute',
+            left: 21,
+            top: 215.5,
+            width: 123,
+            height: 100,
+          }}
+          data-uid='seconddiv'
+          data-testid='seconddiv'
+          data-label='seconddiv'
+        />
+        <div
+          style={{
+            backgroundColor: 'green',
+            position: 'absolute',
+            left: 26,
+            top: 35,
+            width: 118,
+            height: 123,
+          }}
+          data-uid='thirddiv'
+          data-testid='thirddiv'
+          data-label='thirddiv'
+        />
+        <div
+          style={{
+            backgroundColor: unmoveableColour,
+            height: 65,
+            width: 66,
+            position: 'absolute',
+            left: 265,
+            top: 300,
+          }}
+          data-uid='notdrag'
+          data-testid='notdrag'
+          data-label='notdrag'
+        >
+          not drag
+        </div>
+      </div>
+      <div
+        style={{
+          backgroundColor: 'white',
+          position: 'absolute',
+          left: 0,
+          top: 500,
+          width: 400,
+          height: 200,
+        }}
+        data-uid='parentsibling'
+        data-testid='parentsibling'
+        data-label='parentsibling'
+      />
+    </Scene>
+  </Storyboard>
+)
+`
+}
+
+function getProjectCodeDraggedToAfterFirstSibling(): string {
+  return `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+const unmoveableColour = 'orange'
+
+export var ${BakedInStoryboardVariableName} = (
+  <Storyboard data-uid='${BakedInStoryboardUID}'>
+    <Scene
+      style={{
+        backgroundColor: 'white',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 700,
+      }}
+      data-uid='${TestSceneUID}'
+    >
+      <div
+        style={{
+          backgroundColor: 'white',
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: 400,
+          height: 500,
+        }}
+        data-uid='sceneroot'
+        data-testid='sceneroot'
+        data-label='sceneroot'
+      >
+        <div
+          style={{
+            backgroundColor: 'teal',
+            position: 'absolute',
+            left: 255,
+            top: 35,
+            width: 109,
+            height: 123,
+          }}
+          data-uid='firstdiv'
+          data-testid='firstdiv'
+          data-label='firstdiv'
+        />
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            height: 65,
+            width: 66,
+            position: 'absolute',
+            left: 265,
+            top: 233,
+          }}
+          data-uid='dragme'
+          data-testid='dragme'
+          data-label='dragme'
+        >
+          drag me
+        </div>
+        <div
+          style={{
+            backgroundColor: 'purple',
+            position: 'absolute',
+            left: 21,
+            top: 215.5,
+            width: 123,
+            height: 100,
+          }}
+          data-uid='seconddiv'
+          data-testid='seconddiv'
+          data-label='seconddiv'
+        />
+        <div
+          style={{
+            backgroundColor: 'green',
+            position: 'absolute',
+            left: 26,
+            top: 35,
+            width: 118,
+            height: 123,
+          }}
+          data-uid='thirddiv'
+          data-testid='thirddiv'
+          data-label='thirddiv'
+        />
+        <div
+          style={{
+            backgroundColor: unmoveableColour,
+            height: 65,
+            width: 66,
+            position: 'absolute',
+            left: 265,
+            top: 300,
+          }}
+          data-uid='notdrag'
+          data-testid='notdrag'
+          data-label='notdrag'
+        >
+          not drag
+        </div>
+      </div>
+      <div
+        style={{
+          backgroundColor: 'white',
+          position: 'absolute',
+          left: 0,
+          top: 500,
+          width: 400,
+          height: 200,
+        }}
+        data-uid='parentsibling'
+        data-testid='parentsibling'
+        data-label='parentsibling'
+      />
+    </Scene>
+  </Storyboard>
+)
+`
+}
+
+function getProjectCodeDraggedToAfterLastSibling(): string {
+  return `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+const unmoveableColour = 'orange'
+
+export var ${BakedInStoryboardVariableName} = (
+  <Storyboard data-uid='${BakedInStoryboardUID}'>
+    <Scene
+      style={{
+        backgroundColor: 'white',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 700,
+      }}
+      data-uid='${TestSceneUID}'
+    >
+      <div
+        style={{
+          backgroundColor: 'white',
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: 400,
+          height: 500,
+        }}
+        data-uid='sceneroot'
+        data-testid='sceneroot'
+        data-label='sceneroot'
+      >
+        <div
+          style={{
+            backgroundColor: 'teal',
+            position: 'absolute',
+            left: 255,
+            top: 35,
+            width: 109,
+            height: 123,
+          }}
+          data-uid='firstdiv'
+          data-testid='firstdiv'
+          data-label='firstdiv'
+        />
+        <div
+          style={{
+            backgroundColor: 'purple',
+            position: 'absolute',
+            left: 21,
+            top: 215.5,
+            width: 123,
+            height: 100,
+          }}
+          data-uid='seconddiv'
+          data-testid='seconddiv'
+          data-label='seconddiv'
+        />
+        <div
+          style={{
+            backgroundColor: 'green',
+            position: 'absolute',
+            left: 26,
+            top: 35,
+            width: 118,
+            height: 123,
+          }}
+          data-uid='thirddiv'
+          data-testid='thirddiv'
+          data-label='thirddiv'
+        />
+        <div
+          style={{
+            backgroundColor: unmoveableColour,
+            height: 65,
+            width: 66,
+            position: 'absolute',
+            left: 265,
+            top: 300,
+          }}
+          data-uid='notdrag'
+          data-testid='notdrag'
+          data-label='notdrag'
+        >
+          not drag
+        </div>
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            height: 65,
+            width: 66,
+            position: 'absolute',
+            left: 265,
+            top: 233,
+          }}
+          data-uid='dragme'
+          data-testid='dragme'
+          data-label='dragme'
+        >
+          drag me
+        </div>
+      </div>
+      <div
+        style={{
+          backgroundColor: 'white',
+          position: 'absolute',
+          left: 0,
+          top: 500,
+          width: 400,
+          height: 200,
+        }}
+        data-uid='parentsibling'
+        data-testid='parentsibling'
+        data-label='parentsibling'
+      />
+    </Scene>
+  </Storyboard>
+)
+`
+}
+
+function getProjectCodeReparentedUnderCousin(): string {
+  return `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+const unmoveableColour = 'orange'
+
+export var ${BakedInStoryboardVariableName} = (
+  <Storyboard data-uid='${BakedInStoryboardUID}'>
+    <Scene
+      style={{
+        backgroundColor: 'white',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 700,
+      }}
+      data-uid='${TestSceneUID}'
+    >
+      <div
+        style={{
+          backgroundColor: 'white',
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: 400,
+          height: 500,
+        }}
+        data-uid='sceneroot'
+        data-testid='sceneroot'
+        data-label='sceneroot'
+      >
+        <div
+          style={{
+            backgroundColor: 'teal',
+            position: 'absolute',
+            left: 255,
+            top: 35,
+            width: 109,
+            height: 123,
+          }}
+          data-uid='firstdiv'
+          data-testid='firstdiv'
+          data-label='firstdiv'
+        />
+        <div
+          style={{
+            backgroundColor: 'purple',
+            position: 'absolute',
+            left: 21,
+            top: 215.5,
+            width: 123,
+            height: 100,
+          }}
+          data-uid='seconddiv'
+          data-testid='seconddiv'
+          data-label='seconddiv'
+        />
+        <div
+          style={{
+            backgroundColor: 'green',
+            position: 'absolute',
+            left: 26,
+            top: 35,
+            width: 118,
+            height: 123,
+          }}
+          data-uid='thirddiv'
+          data-testid='thirddiv'
+          data-label='thirddiv'
+        />
+        <div
+          style={{
+            backgroundColor: unmoveableColour,
+            height: 65,
+            width: 66,
+            position: 'absolute',
+            left: 265,
+            top: 300,
+          }}
+          data-uid='notdrag'
+          data-testid='notdrag'
+          data-label='notdrag'
+        >
+          not drag
+        </div>
+      </div>
+      <div
+        style={{
+          backgroundColor: 'white',
+          position: 'absolute',
+          left: 0,
+          top: 500,
+          width: 400,
+          height: 200,
+        }}
+        data-uid='parentsibling'
+        data-testid='parentsibling'
+        data-label='parentsibling'
+      >
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            height: 65,
+            width: 66,
+            position: 'absolute',
+            left: 265,
+            top: 233,
+          }}
+          data-uid='dragme'
+          data-testid='dragme'
+          data-label='dragme'
+        >
+          drag me
+        </div>
+      </div>
+    </Scene>
+  </Storyboard>
+)
+`
+}
+function getProjectCodeReparentedUnderFirstSibling(): string {
+  return `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+const unmoveableColour = 'orange'
+
+export var ${BakedInStoryboardVariableName} = (
+  <Storyboard data-uid='${BakedInStoryboardUID}'>
+    <Scene
+      style={{
+        backgroundColor: 'white',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 700,
+      }}
+      data-uid='${TestSceneUID}'
+    >
+      <div
+        style={{
+          backgroundColor: 'white',
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: 400,
+          height: 500,
+        }}
+        data-uid='sceneroot'
+        data-testid='sceneroot'
+        data-label='sceneroot'
+      >
+        <div
+          style={{
+            backgroundColor: 'teal',
+            position: 'absolute',
+            left: 255,
+            top: 35,
+            width: 109,
+            height: 123,
+          }}
+          data-uid='firstdiv'
+          data-testid='firstdiv'
+          data-label='firstdiv'
+        >
+          <div
+            style={{
+              backgroundColor: '#0091FFAA',
+              height: 65,
+              width: 66,
+              position: 'absolute',
+              left: 265,
+              top: 233,
+            }}
+            data-uid='dragme'
+            data-testid='dragme'
+            data-label='dragme'
+          >
+            drag me
+          </div>
+        </div>
+        <div
+          style={{
+            backgroundColor: 'purple',
+            position: 'absolute',
+            left: 21,
+            top: 215.5,
+            width: 123,
+            height: 100,
+          }}
+          data-uid='seconddiv'
+          data-testid='seconddiv'
+          data-label='seconddiv'
+        />
+        <div
+          style={{
+            backgroundColor: 'green',
+            position: 'absolute',
+            left: 26,
+            top: 35,
+            width: 118,
+            height: 123,
+          }}
+          data-uid='thirddiv'
+          data-testid='thirddiv'
+          data-label='thirddiv'
+        />
+        <div
+          style={{
+            backgroundColor: unmoveableColour,
+            height: 65,
+            width: 66,
+            position: 'absolute',
+            left: 265,
+            top: 300,
+          }}
+          data-uid='notdrag'
+          data-testid='notdrag'
+          data-label='notdrag'
+        >
+          not drag
+        </div>
+      </div>
+      <div
+        style={{
+          backgroundColor: 'white',
+          position: 'absolute',
+          left: 0,
+          top: 500,
+          width: 400,
+          height: 200,
+        }}
+        data-uid='parentsibling'
+        data-testid='parentsibling'
+        data-label='parentsibling'
+      />
+    </Scene>
+  </Storyboard>
+)
+`
+}
+
+describe('Navigator', () => {
+  before(() => {
+    viewport.set(2200, 1000)
+  })
+
+  it('reorders to before the first sibling', async () => {
+    const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
+
+    const dragMeElement = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-utopia_storyboard_uid/scene_aaa/sceneroot/dragme`,
+    )
+    const dragMeElementRect = dragMeElement.getBoundingClientRect()
+    const dragMeElementCenter = getDomRectCenter(dragMeElementRect)
+    const firstDivElement = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-utopia_storyboard_uid/scene_aaa/sceneroot/firstdiv`,
+    )
+    const firstDivElementRect = firstDivElement.getBoundingClientRect()
+    const firstDivElementCenter = getDomRectCenter(firstDivElementRect)
+    const dragTo = {
+      x: firstDivElementCenter.x,
+      y: firstDivElementRect.y + 3,
+    }
+
+    const dragDelta = windowPoint({
+      x: dragTo.x - dragMeElementCenter.x,
+      y: dragTo.y - dragMeElementCenter.y,
+    })
+
+    const targetElement = EP.fromString('utopia-storyboard-uid/scene-aaa/sceneroot/dragme')
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      await renderResult.dispatch([selectComponents([targetElement], false)], false)
+      await dispatchDone
+    })
+
+    act(() =>
+      dragElement(
+        renderResult,
+        `navigator-item-drag-utopia_storyboard_uid/scene_aaa/sceneroot/dragme`,
+        `navigator-item-drop-utopia_storyboard_uid/scene_aaa/sceneroot/firstdiv`,
+        windowPoint(dragMeElementCenter),
+        dragDelta,
+        'apply-hover-events',
+      ),
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      Prettier.format(getProjectCodeDraggedToBeforeEverything(), PrettierConfig),
+    )
+  })
+
+  it('reorders to after the first sibling', async () => {
+    const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
+
+    const dragMeElement = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-utopia_storyboard_uid/scene_aaa/sceneroot/dragme`,
+    )
+    const dragMeElementRect = dragMeElement.getBoundingClientRect()
+    const dragMeElementCenter = getDomRectCenter(dragMeElementRect)
+    const firstDivElement = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-utopia_storyboard_uid/scene_aaa/sceneroot/firstdiv`,
+    )
+    const firstDivElementRect = firstDivElement.getBoundingClientRect()
+    const firstDivElementCenter = getDomRectCenter(firstDivElementRect)
+    const dragTo = {
+      x: firstDivElementCenter.x,
+      y: firstDivElementRect.y + firstDivElementRect.height - 3,
+    }
+
+    const dragDelta = windowPoint({
+      x: dragTo.x - dragMeElementCenter.x,
+      y: dragTo.y - dragMeElementCenter.y,
+    })
+
+    const targetElement = EP.fromString('utopia-storyboard-uid/scene-aaa/sceneroot/dragme')
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      await renderResult.dispatch([selectComponents([targetElement], false)], false)
+      await dispatchDone
+    })
+
+    act(() =>
+      dragElement(
+        renderResult,
+        `navigator-item-drag-utopia_storyboard_uid/scene_aaa/sceneroot/dragme`,
+        `navigator-item-drop-utopia_storyboard_uid/scene_aaa/sceneroot/firstdiv`,
+        windowPoint(dragMeElementCenter),
+        dragDelta,
+        'apply-hover-events',
+      ),
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      Prettier.format(getProjectCodeDraggedToAfterFirstSibling(), PrettierConfig),
+    )
+  })
+
+  it('reorders to after the last sibling', async () => {
+    const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
+
+    const dragMeElement = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-utopia_storyboard_uid/scene_aaa/sceneroot/dragme`,
+    )
+    const dragMeElementRect = dragMeElement.getBoundingClientRect()
+    const dragMeElementCenter = getDomRectCenter(dragMeElementRect)
+    const notDraggableDivElement = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-utopia_storyboard_uid/scene_aaa/sceneroot/notdrag`,
+    )
+    const notDraggableDivElementRect = notDraggableDivElement.getBoundingClientRect()
+    const notDraggableDivElementCenter = getDomRectCenter(notDraggableDivElementRect)
+    const dragTo = {
+      x: notDraggableDivElementCenter.x,
+      y: notDraggableDivElementRect.y + notDraggableDivElementRect.height - 3,
+    }
+
+    const dragDelta = windowPoint({
+      x: dragTo.x - dragMeElementCenter.x,
+      y: dragTo.y - dragMeElementCenter.y,
+    })
+
+    const targetElement = EP.fromString('utopia-storyboard-uid/scene-aaa/sceneroot/dragme')
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      await renderResult.dispatch([selectComponents([targetElement], false)], false)
+      await dispatchDone
+    })
+
+    act(() =>
+      dragElement(
+        renderResult,
+        `navigator-item-drag-utopia_storyboard_uid/scene_aaa/sceneroot/dragme`,
+        `navigator-item-drop-utopia_storyboard_uid/scene_aaa/sceneroot/notdrag`,
+        windowPoint(dragMeElementCenter),
+        dragDelta,
+        'apply-hover-events',
+      ),
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      Prettier.format(getProjectCodeDraggedToAfterLastSibling(), PrettierConfig),
+    )
+  })
+
+  it('reparents under the first sibling', async () => {
+    const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
+
+    const dragMeElement = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-utopia_storyboard_uid/scene_aaa/sceneroot/dragme`,
+    )
+    const dragMeElementRect = dragMeElement.getBoundingClientRect()
+    const dragMeElementCenter = getDomRectCenter(dragMeElementRect)
+    const firstDivElement = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-utopia_storyboard_uid/scene_aaa/sceneroot/firstdiv`,
+    )
+    const firstDivElementRect = firstDivElement.getBoundingClientRect()
+    const firstDivElementCenter = getDomRectCenter(firstDivElementRect)
+    const dragTo = {
+      x: firstDivElementCenter.x,
+      y: firstDivElementRect.y + 10,
+    }
+
+    const dragDelta = windowPoint({
+      x: dragTo.x - dragMeElementCenter.x,
+      y: dragTo.y - dragMeElementCenter.y,
+    })
+
+    const targetElement = EP.fromString('utopia-storyboard-uid/scene-aaa/sceneroot/dragme')
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      await renderResult.dispatch([selectComponents([targetElement], false)], false)
+      await dispatchDone
+    })
+
+    act(() =>
+      dragElement(
+        renderResult,
+        `navigator-item-drag-utopia_storyboard_uid/scene_aaa/sceneroot/dragme`,
+        `navigator-item-drop-utopia_storyboard_uid/scene_aaa/sceneroot/firstdiv`,
+        windowPoint(dragMeElementCenter),
+        dragDelta,
+        'apply-hover-events',
+      ),
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      Prettier.format(getProjectCodeReparentedUnderFirstSibling(), PrettierConfig),
+    )
+  })
+
+  it('reparents under cousin element', async () => {
+    const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
+
+    const dragMeElement = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-utopia_storyboard_uid/scene_aaa/sceneroot/dragme`,
+    )
+    const dragMeElementRect = dragMeElement.getBoundingClientRect()
+    const dragMeElementCenter = getDomRectCenter(dragMeElementRect)
+    const cousinDivElement = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-utopia_storyboard_uid/scene_aaa/parentsibling`,
+    )
+    const cousinDivElementRect = cousinDivElement.getBoundingClientRect()
+    const cousinDivElementCenter = getDomRectCenter(cousinDivElementRect)
+    const dragTo = {
+      x: cousinDivElementCenter.x,
+      y: cousinDivElementRect.y + 10,
+    }
+
+    const dragDelta = windowPoint({
+      x: dragTo.x - dragMeElementCenter.x,
+      y: dragTo.y - dragMeElementCenter.y,
+    })
+
+    const targetElement = EP.fromString('utopia-storyboard-uid/scene-aaa/sceneroot/dragme')
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      await renderResult.dispatch([selectComponents([targetElement], false)], false)
+      await dispatchDone
+    })
+
+    act(() =>
+      dragElement(
+        renderResult,
+        `navigator-item-drag-utopia_storyboard_uid/scene_aaa/sceneroot/dragme`,
+        `navigator-item-drop-utopia_storyboard_uid/scene_aaa/parentsibling`,
+        windowPoint(dragMeElementCenter),
+        dragDelta,
+        'apply-hover-events',
+      ),
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      Prettier.format(getProjectCodeReparentedUnderCousin(), PrettierConfig),
+    )
+  })
+
+  it('attempt to reparent non-reparentable item', async () => {
+    const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
+
+    const notDragElement = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-utopia_storyboard_uid/scene_aaa/sceneroot/notdrag`,
+    )
+    const notDragElementRect = notDragElement.getBoundingClientRect()
+    const notDragElementCenter = getDomRectCenter(notDragElementRect)
+    const cousinDivElement = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-utopia_storyboard_uid/scene_aaa/parentsibling`,
+    )
+    const cousinDivElementRect = cousinDivElement.getBoundingClientRect()
+    const cousinDivElementCenter = getDomRectCenter(cousinDivElementRect)
+    const dragTo = {
+      x: cousinDivElementCenter.x,
+      y: cousinDivElementRect.y + 10,
+    }
+
+    const dragDelta = windowPoint({
+      x: dragTo.x - notDragElementCenter.x,
+      y: dragTo.y - notDragElementCenter.y,
+    })
+
+    const targetElement = EP.fromString('utopia-storyboard-uid/scene-aaa/sceneroot/notdrag')
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      await renderResult.dispatch([selectComponents([targetElement], false)], false)
+      await dispatchDone
+    })
+
+    act(() =>
+      dragElement(
+        renderResult,
+        `navigator-item-drag-utopia_storyboard_uid/scene_aaa/sceneroot/notdrag`,
+        `navigator-item-drop-utopia_storyboard_uid/scene_aaa/parentsibling`,
+        windowPoint(notDragElementCenter),
+        dragDelta,
+        'do-not-apply-hover-events',
+      ),
+    )
+
+    expect(renderResult.getEditorState().editor.navigator.dropTargetHint.type).toEqual(null)
+    expect(renderResult.getEditorState().editor.navigator.dropTargetHint.target).toEqual(null)
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      Prettier.format(getProjectCode(), PrettierConfig),
+    )
+  })
+})

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -170,6 +170,7 @@ export const NavigatorComponent = React.memo(() => {
       onMouseLeave={onMouseLeave}
       onContextMenu={onContextMenu}
       id={NavigatorContainerId}
+      data-testid={NavigatorContainerId}
       tabIndex={-1}
       style={{
         zIndex: 1,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -600,7 +600,7 @@ export const MetadataUtils = {
   },
   targetElementSupportsChildren(
     projectContents: ProjectContentTreeRoot,
-    openFile: string | null,
+    openFile: string | null | undefined,
     instance: ElementInstanceMetadata,
   ): boolean {
     return foldEither(
@@ -633,7 +633,7 @@ export const MetadataUtils = {
   },
   targetSupportsChildren(
     projectContents: ProjectContentTreeRoot,
-    openFile: string | null,
+    openFile: string | null | undefined,
     metadata: ElementInstanceMetadataMap,
     target: ElementPath,
   ): boolean {

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -286,7 +286,7 @@ export function getStoryboardUID(openComponents: UtopiaJSXComponent[]): string |
 
 export function getStoryboardElementPath(
   projectContents: ProjectContentTreeRoot,
-  openFile: string | null,
+  openFile: string | null | undefined,
 ): StaticElementPath | null {
   if (openFile != null) {
     const file = getContentsTreeFileFromString(projectContents, openFile)

--- a/editor/src/core/shared/dom-utils.ts
+++ b/editor/src/core/shared/dom-utils.ts
@@ -267,3 +267,10 @@ export function addScriptToPage(
 }
 
 export const JSX_CANVAS_LOOKUP_FUNCTION_NAME = 'utopiaCanvasJSXLookup'
+
+export function getDomRectCenter(rect: DOMRect): { x: number; y: number } {
+  return {
+    x: rect.x + rect.width / 2,
+    y: rect.y + rect.height / 2,
+  }
+}

--- a/editor/src/utils/utils.ts
+++ b/editor/src/utils/utils.ts
@@ -208,6 +208,33 @@ export function before(index: number): Before {
 
 export type IndexPosition = Front | Back | Absolute | After | Before
 
+export function shiftIndexPositionForRemovedElement(
+  indexPosition: IndexPosition,
+  removedElementIndex: number,
+): IndexPosition {
+  switch (indexPosition.type) {
+    case 'front':
+    case 'back':
+    case 'absolute':
+      return indexPosition
+    case 'before':
+      if (removedElementIndex < indexPosition.index) {
+        return before(indexPosition.index - 1)
+      } else {
+        return indexPosition
+      }
+    case 'after':
+      if (removedElementIndex < indexPosition.index) {
+        return after(indexPosition.index - 1)
+      } else {
+        return indexPosition
+      }
+    default:
+      const _exhaustiveCheck: never = indexPosition
+      throw new Error(`Unhandled index position ${JSON.stringify(indexPosition)}`)
+  }
+}
+
 export type Axis = 'x' | 'y'
 
 export type DiagonalAxis = 'TopLeftToBottomRight' | 'BottomLeftToTopRight'


### PR DESCRIPTION
**Problem:**
In the editor there's a divergence of behaviour where the navigator reparent/reorder logic is different to that used by the new canvas strategies. Ideally this would not be the case so that changes don't need to be repeated or potentially not updated in one or more locations.

**Fix:**
These changes take two main parts:
- Surface level functionality around checking if elements can be reparented or reparented into, which uses existing functions to perform those checks before a reparent/reorder interaction.
- Handling of the reparent/reorder interaction after it has been triggered which has involved rewriting the function that does most of the work in handling the existing navigator reparent editor action.

**Todo:**
While it will not change the implementation itself meaningfully, some browser tests will be added to this or in another PR subsequently to extend the existing navigator reparent tests.

**Commit Details:**
- Added utility function `shiftIndexPositionForRemovedElement` to handle
  the change that is necessary when using an `IndexPosition` which relates
  to a collection where the reordered element exists already in the array.
- Corrected the `canReparent` value used in the navigator item dnd container
  `onHover` function as it was actually checking the dragged item not the target
  item.
- Implemented `canDrag` and `canDrop` for `NavigatorItemContainer` to have them
  match up with the same checks that are implemented in the canvas.
- `editorMoveMultiSelectedTemplates` reimplemented to use `getReparentOutcome`
  and `reorderElement` to handle the update which originates from the navigator
  action.
- `ReorderElement` now uses `IndexPosition` instead of an absolute index.
- `reorderComponent` now uses `shiftIndexPositionForRemovedElement` to adjust
  the index position for the case when the element being removed makes the position
  invalid.
- `getReparentOutcome` is the newly renamed `getReparentCommands`, now avoids
  creating the commands to move something if it doesn't actually move. As well it
  now also returns the new path for the element in its reparented position.
- Refactored `isAllowedToReparent` to make it not be constrained to the use of
  canvas strategies alone.
