### PR TITLE
Click to insert

### DIFF
--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -54,6 +54,9 @@ import { isSceneFromMetadata } from '../../../core/model/project-file-utils'
 import { RightMenuTab } from '../../editor/store/editor-state'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 
+const DefaultWidth = 100
+const DefaultHeight = 100
+
 // I feel comfortable having this function confined to this file only, since we absolutely shouldn't be trying
 // to set values that would fail whilst inserting elements. If that ever changes, this function should be binned
 // and we should handle those failures explicitly
@@ -249,6 +252,11 @@ export class InsertModeControlContainer extends React.Component<
     )
     const localFrame = Utils.getLocalRectangleInNewParentContext(parentOrigin, dragFrame)
 
+    if (localFrame.width === 0 && localFrame.height === 0) {
+      localFrame.width = DefaultWidth
+      localFrame.height = DefaultHeight
+    }
+
     return {
       [FramePoint.Left]: localFrame.x,
       [FramePoint.Top]: localFrame.y,
@@ -417,24 +425,7 @@ export class InsertModeControlContainer extends React.Component<
         getStoryboardElementPath(this.props.projectContents, this.props.openFile)
       let extraActions: EditorAction[] = []
 
-      if (
-        this.props.dragState != null &&
-        this.props.dragState.drag != null &&
-        Utils.distance(this.props.dragState.drag, Utils.zeroPoint as CanvasPoint) === 0
-      ) {
-        // image and text insertion with single click
-        if (
-          this.isImageInsertion(insertionElement, insertionSubject.importsToAdd) &&
-          this.state.dragFrame != null
-        ) {
-          element = this.getImageElementWithSize()
-        } else if (this.isTextInsertion(insertionElement, insertionSubject.importsToAdd)) {
-          element = insertionElement
-        }
-      } else {
-        // TODO Hidden Instances
-        element = this.elementWithDragFrame(insertionElement)
-      }
+      element = this.elementWithDragFrame(insertionElement)
 
       if (element == null) {
         this.props.dispatch(baseActions, 'everyone')

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -425,7 +425,26 @@ export class InsertModeControlContainer extends React.Component<
         getStoryboardElementPath(this.props.projectContents, this.props.openFile)
       let extraActions: EditorAction[] = []
 
-      element = this.elementWithDragFrame(insertionElement)
+      if (
+        this.props.dragState != null &&
+        this.props.dragState.drag != null &&
+        Utils.distance(this.props.dragState.drag, Utils.zeroPoint as CanvasPoint) === 0
+      ) {
+        // image and text insertion with single click
+        if (
+          this.isImageInsertion(insertionElement, insertionSubject.importsToAdd) &&
+          this.state.dragFrame != null
+        ) {
+          element = this.getImageElementWithSize()
+        } else if (this.isTextInsertion(insertionElement, insertionSubject.importsToAdd)) {
+          element = insertionElement
+        } else {
+          element = this.elementWithDragFrame(insertionElement)
+        }
+      } else {
+        // TODO Hidden Instances
+        element = this.elementWithDragFrame(insertionElement)
+      }
 
       if (element == null) {
         this.props.dispatch(baseActions, 'everyone')

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -19,7 +19,12 @@ import { PropertyPath, ElementPath, Imports } from '../../../core/shared/project
 import { Either, eitherToMaybe, isLeft, isRight, right } from '../../../core/shared/either'
 import { KeysPressed } from '../../../utils/keyboard'
 import Utils from '../../../utils/utils'
-import { CanvasPoint, CanvasRectangle, CanvasVector } from '../../../core/shared/math-utils'
+import {
+  CanvasPoint,
+  CanvasRectangle,
+  CanvasVector,
+  localRectangle,
+} from '../../../core/shared/math-utils'
 import { setFocus } from '../../common/actions'
 import { EditorAction } from '../../editor/action-types'
 import * as EditorActions from '../../editor/actions/action-creators'
@@ -252,16 +257,22 @@ export class InsertModeControlContainer extends React.Component<
     )
     const localFrame = Utils.getLocalRectangleInNewParentContext(parentOrigin, dragFrame)
 
-    if (localFrame.width === 0 && localFrame.height === 0) {
-      localFrame.width = DefaultWidth
-      localFrame.height = DefaultHeight
-    }
+    const frameIsZero = localFrame.width === 0 && localFrame.height === 0
+
+    const nonZeroLocalFrame = frameIsZero
+      ? localRectangle({
+          x: localFrame.x - DefaultWidth / 2,
+          y: localFrame.y - DefaultHeight / 2,
+          width: DefaultWidth,
+          height: DefaultHeight,
+        })
+      : localFrame
 
     return {
-      [FramePoint.Left]: localFrame.x,
-      [FramePoint.Top]: localFrame.y,
-      [FramePoint.Width]: localFrame.width,
-      [FramePoint.Height]: localFrame.height,
+      [FramePoint.Left]: nonZeroLocalFrame.x,
+      [FramePoint.Top]: nonZeroLocalFrame.y,
+      [FramePoint.Width]: nonZeroLocalFrame.width,
+      [FramePoint.Height]: nonZeroLocalFrame.height,
     }
   }
 

--- a/editor/src/components/canvas/controls/insert-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/insert-mode.spec.browser2.tsx
@@ -182,7 +182,7 @@ describe('Inserting', () => {
                 position: 'absolute',
                 left: 5,
                 top: 5,
-                width: 100,
+                width: 20,
                 height: 300,
               }}
             />

--- a/editor/src/components/canvas/controls/insert-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/insert-mode.spec.browser2.tsx
@@ -212,8 +212,8 @@ describe('Inserting', () => {
     const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
 
     const startPoint = slightlyOffsetWindowPointBecauseVeryWeirdIssue({
-      x: targetElementBounds.x + 5,
-      y: targetElementBounds.y + 5,
+      x: targetElementBounds.x + 65,
+      y: targetElementBounds.y + 55,
     })
     const endPoint = startPoint
 
@@ -248,7 +248,7 @@ describe('Inserting', () => {
               data-uid='ddd'
               style={{
                 position: 'absolute',
-                left: 5,
+                left: 15,
                 top: 5,
                 width: 100,
                 height: 100,

--- a/editor/src/components/canvas/controls/insert-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/insert-mode.spec.browser2.tsx
@@ -182,8 +182,76 @@ describe('Inserting', () => {
                 position: 'absolute',
                 left: 5,
                 top: 5,
-                width: 20,
+                width: 100,
                 height: 300,
+              }}
+            />
+          </div>
+          <div
+            data-uid='ccc'
+            style={{
+              position: 'absolute',
+              left: 10,
+              top: 200,
+              width: 380,
+              height: 190,
+              backgroundColor: '#FF0000',
+            }}
+          />
+        </div>
+      `),
+    )
+  })
+
+  it('Click to insert with default size', async () => {
+    const renderResult = await renderTestEditorWithCode(inputCode, 'await-first-dom-report')
+    await startInsertMode(renderResult.dispatch)
+
+    const targetElement = renderResult.renderedDOM.getByTestId('bbb')
+    const targetElementBounds = targetElement.getBoundingClientRect()
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    const startPoint = slightlyOffsetWindowPointBecauseVeryWeirdIssue({
+      x: targetElementBounds.x + 5,
+      y: targetElementBounds.y + 5,
+    })
+    const endPoint = startPoint
+
+    // Drag from inside bbb to inside ccc
+    await fireDragEvent(canvasControlsLayer, startPoint, endPoint)
+
+    // Check that the inserted element is a child of bbb
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          data-uid='aaa'
+          style={{
+            width: '100%',
+            height: '100%',
+            backgroundColor: '#FFFFFF',
+            position: 'relative',
+          }}
+        >
+          <div
+            data-uid='bbb'
+            data-testid='bbb'
+            style={{
+              position: 'absolute',
+              left: 10,
+              top: 10,
+              width: 380,
+              height: 180,
+              backgroundColor: '#d3d3d3',
+            }}
+          >
+            <div
+              data-uid='ddd'
+              style={{
+                position: 'absolute',
+                left: 5,
+                top: 5,
+                width: 100,
+                height: 100,
               }}
             />
           </div>


### PR DESCRIPTION
This is a very simple click-to-insert implementation based on the already existing drag-to-insert solution.
Click to insert was already allowed for utopia-api text and image components. For everything else, it was explicitly disallowed.
I just allowed it for everything, and added a default width-height, so they are not inserted it with zero dimensions.
I also added a new test case for click to insert.