### PR TITLE
Feature/canvas selection lock

### DIFF
--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -765,3 +765,5 @@ export const EdgePositionTopLeft: EdgePosition = { x: 0, y: 0 }
 export const EdgePositionBottomLeft: EdgePosition = { x: 0, y: 1 }
 export const EdgePositionBottomRight: EdgePosition = { x: 1, y: 1 }
 export const EdgePositionTopRight: EdgePosition = { x: 1, y: 0 }
+
+export type SelectionLocked = 'locked' | 'locked-hierarchy' | 'selectable'

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -184,10 +184,8 @@ function getAllLockedElementPaths(
   componentMetadata: ElementInstanceMetadataMap,
   lockedElements: LockedElements,
 ): Array<ElementPath> {
-  const descendantsOfHierarchyLocked = MetadataUtils.getAllPaths(componentMetadata).filter(
-    (path) => {
-      lockedElements.hierarchyLock.some((lockedPath) => EP.isDescendantOf(path, lockedPath))
-    },
+  const descendantsOfHierarchyLocked = MetadataUtils.getAllPaths(componentMetadata).filter((path) =>
+    MetadataUtils.isDescendantOfHierarchyLockedElement(path, lockedElements),
   )
   return [
     ...lockedElements.simpleLock,

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -180,6 +180,22 @@ function getSelectableSiblings(
   return siblings
 }
 
+function getAllLockedElementPaths(
+  componentMetadata: ElementInstanceMetadataMap,
+  lockedElements: LockedElements,
+): Array<ElementPath> {
+  const descendantsOfHierarchyLocked = MetadataUtils.getAllPaths(componentMetadata).filter(
+    (path) => {
+      lockedElements.hierarchyLock.some((lockedPath) => EP.isDescendantOf(path, lockedPath))
+    },
+  )
+  return [
+    ...lockedElements.simpleLock,
+    ...lockedElements.hierarchyLock,
+    ...descendantsOfHierarchyLocked,
+  ]
+}
+
 export function getSelectableViews(
   componentMetadata: ElementInstanceMetadataMap,
   selectedViews: Array<ElementPath>,
@@ -209,12 +225,9 @@ export function getSelectableViews(
 
   const nonSelectableElements = [
     ...hiddenInstances,
-    ...lockedElements.simpleLock,
-    ...lockedElements.hierarchyLock,
+    ...getAllLockedElementPaths(componentMetadata, lockedElements),
   ]
-  return filterHiddenInstances(nonSelectableElements, candidateViews).filter(
-    (filteredPath) => !EP.isStoryboardPath(filteredPath),
-  )
+  return filterHiddenInstances(nonSelectableElements, candidateViews)
 }
 
 function useFindValidTarget(): (

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -134,11 +134,13 @@ export function useMaybeHighlightElement(): {
   }
 }
 
-function filterHiddenInstances(
-  hiddenInstances: Array<ElementPath>,
+function filterNonSelectableElements(
+  nonSelectablePaths: Array<ElementPath>,
   paths: Array<ElementPath>,
 ): Array<ElementPath> {
-  return paths.filter((path) => hiddenInstances.every((hidden) => !EP.pathsEqual(path, hidden)))
+  return paths.filter((path) =>
+    nonSelectablePaths.every((nonSelectablePath) => !EP.pathsEqual(path, nonSelectablePath)),
+  )
 }
 
 function collectSelectableSiblings(
@@ -225,7 +227,7 @@ export function getSelectableViews(
     ...hiddenInstances,
     ...getAllLockedElementPaths(componentMetadata, lockedElements),
   ]
-  return filterHiddenInstances(nonSelectableElements, candidateViews)
+  return filterNonSelectableElements(nonSelectableElements, candidateViews)
 }
 
 function useFindValidTarget(): (

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -141,7 +141,7 @@ function filterHiddenInstances(
   return paths.filter((path) => hiddenInstances.every((hidden) => !EP.pathsEqual(path, hidden)))
 }
 
-function getSelectableSiblings(
+function collectSelectableSiblings(
   componentMetadata: ElementInstanceMetadataMap,
   selectedViews: Array<ElementPath>,
   childrenSelectable: boolean,
@@ -210,7 +210,7 @@ export function getSelectableViews(
     candidateViews = MetadataUtils.getAllPathsIncludingUnfurledFocusedComponents(componentMetadata)
   } else {
     const allRoots = MetadataUtils.getAllCanvasRootPaths(componentMetadata)
-    const siblings = getSelectableSiblings(
+    const siblings = collectSelectableSiblings(
       componentMetadata,
       selectedViews,
       childrenSelectable,

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -193,7 +193,14 @@ export function getSelectableViews(
     candidateViews = uniqueSelectableViews
   }
 
-  return filterHiddenInstances(hiddenInstances, candidateViews)
+  const nonSelectableElements = [
+    ...hiddenInstances,
+    // ...lockedElements,
+    // ...lockedElementsWithHierarchy,
+  ]
+  return filterHiddenInstances(nonSelectableElements, candidateViews).filter(
+    (filteredPath) => !EP.isStoryboardPath(filteredPath),
+  )
 }
 
 function useFindValidTarget(): (

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -210,7 +210,7 @@ export function getSelectableViews(
   const nonSelectableElements = [
     ...hiddenInstances,
     ...lockedElements.simpleLock,
-    ...lockedElements.withHierarchy,
+    ...lockedElements.hierarchyLock,
   ]
   return filterHiddenInstances(nonSelectableElements, candidateViews).filter(
     (filteredPath) => !EP.isStoryboardPath(filteredPath),

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -9,7 +9,12 @@ import {
 import { KeysPressed, Key } from '../../utils/keyboard'
 import { IndexPosition } from '../../utils/utils'
 import { CanvasRectangle, Size, WindowPoint, CanvasPoint } from '../../core/shared/math-utils'
-import { CanvasAction, CSSCursor, PinOrFlexFrameChange } from '../canvas/canvas-types'
+import {
+  CanvasAction,
+  CSSCursor,
+  PinOrFlexFrameChange,
+  SelectionLocked,
+} from '../canvas/canvas-types'
 import { CursorPosition } from '../code-editor/code-editor-utils'
 import { EditorPane, EditorPanel, ResizeLeftPane, SetFocus } from '../common/actions'
 import {
@@ -950,6 +955,12 @@ export interface SetElementsToRerender {
   value: ElementsToRerender
 }
 
+export type ToggleSelectionLock = {
+  action: 'TOGGLE_SELECTION_LOCK'
+  targets: Array<ElementPath>
+  newValue: SelectionLocked
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertScene
@@ -1105,6 +1116,7 @@ export type EditorAction =
   | ForceParseFile
   | RunEscapeHatch
   | SetElementsToRerender
+  | ToggleSelectionLock
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -43,7 +43,7 @@ import type {
   ProjectContentTreeRoot,
 } from '../../assets'
 import CanvasActions from '../../canvas/canvas-actions'
-import type { PinOrFlexFrameChange } from '../../canvas/canvas-types'
+import type { PinOrFlexFrameChange, SelectionLocked } from '../../canvas/canvas-types'
 import type { CursorPosition } from '../../code-editor/code-editor-utils'
 import type { EditorPane, EditorPanel } from '../../common/actions'
 import { Notice } from '../../common/notice'
@@ -209,6 +209,7 @@ import type {
   RemoveFromNodeModulesContents,
   RunEscapeHatch,
   UpdateMouseButtonsPressed,
+  ToggleSelectionLock,
 } from '../action-types'
 import {
   EditorModes,
@@ -1497,5 +1498,16 @@ export function runEscapeHatch(targets: Array<ElementPath>): RunEscapeHatch {
   return {
     action: 'RUN_ESCAPE_HATCH',
     targets: targets,
+  }
+}
+
+export function toggleSelectionLock(
+  targets: Array<ElementPath>,
+  newValue: SelectionLocked,
+): ToggleSelectionLock {
+  return {
+    action: 'TOGGLE_SELECTION_LOCK',
+    targets: targets,
+    newValue: newValue,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -113,6 +113,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_DRAG_INTERACTION_DATA':
     case 'SET_USERS_PREFERRED_STRATEGY':
     case 'SET_ELEMENTS_TO_RERENDER':
+    case 'TOGGLE_SELECTION_LOCK':
       return true
 
     case 'NEW':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4924,8 +4924,8 @@ export const UPDATE_FNS = {
           return update(working, {
             lockedElements: {
               simpleLock: { $set: working.lockedElements.simpleLock.concat(target) },
-              withHierarchy: {
-                $set: working.lockedElements.withHierarchy.filter(
+              hierarchyLock: {
+                $set: working.lockedElements.hierarchyLock.filter(
                   (element) => !EP.pathsEqual(element, target),
                 ),
               },
@@ -4939,7 +4939,7 @@ export const UPDATE_FNS = {
                   (element) => !EP.pathsEqual(element, target),
                 ),
               },
-              withHierarchy: { $set: working.lockedElements.withHierarchy.concat(target) },
+              hierarchyLock: { $set: working.lockedElements.hierarchyLock.concat(target) },
             },
           })
         case 'selectable':
@@ -4951,8 +4951,8 @@ export const UPDATE_FNS = {
                   (element) => !EP.pathsEqual(element, target),
                 ),
               },
-              withHierarchy: {
-                $set: working.lockedElements.withHierarchy.filter(
+              hierarchyLock: {
+                $set: working.lockedElements.hierarchyLock.filter(
                   (element) => !EP.pathsEqual(element, target),
                 ),
               },

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -830,7 +830,7 @@ export type AllElementProps = { [path: string]: ElementProps }
 
 export type LockedElements = {
   simpleLock: Array<ElementPath>
-  withHierarchy: Array<ElementPath>
+  hierarchyLock: Array<ElementPath>
 }
 
 // FIXME We need to pull out ProjectState from here
@@ -1698,7 +1698,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     warnedInstances: [],
     lockedElements: {
       simpleLock: [],
-      withHierarchy: [],
+      hierarchyLock: [],
     },
     mode: EditorModes.selectMode(),
     focusedPanel: 'canvas',
@@ -1993,7 +1993,7 @@ export function editorModelFromPersistentModel(
     warnedInstances: [],
     lockedElements: {
       simpleLock: [],
-      withHierarchy: [],
+      hierarchyLock: [],
     },
     mode: EditorModes.selectMode(),
     focusedPanel: 'canvas',

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -828,6 +828,11 @@ export type ElementProps = { [key: string]: any }
 
 export type AllElementProps = { [path: string]: ElementProps }
 
+export type LockedElements = {
+  simpleLock: Array<ElementPath>
+  withHierarchy: Array<ElementPath>
+}
+
 // FIXME We need to pull out ProjectState from here
 export interface EditorState {
   id: string | null
@@ -849,6 +854,7 @@ export interface EditorState {
   highlightedViews: Array<ElementPath>
   hiddenInstances: Array<ElementPath>
   warnedInstances: Array<ElementPath>
+  lockedElements: LockedElements
   mode: Mode
   focusedPanel: EditorPanel | null
   keysPressed: KeysPressed
@@ -914,6 +920,7 @@ export function editorState(
   highlightedViews: Array<ElementPath>,
   hiddenInstances: Array<ElementPath>,
   warnedInstances: Array<ElementPath>,
+  lockedElements: LockedElements,
   mode: Mode,
   focusedPanel: EditorPanel | null,
   keysPressed: KeysPressed,
@@ -978,6 +985,7 @@ export function editorState(
     highlightedViews: highlightedViews,
     hiddenInstances: hiddenInstances,
     warnedInstances: warnedInstances,
+    lockedElements: lockedElements,
     mode: mode,
     focusedPanel: focusedPanel,
     keysPressed: keysPressed,
@@ -1688,6 +1696,10 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     highlightedViews: [],
     hiddenInstances: [],
     warnedInstances: [],
+    lockedElements: {
+      simpleLock: [],
+      withHierarchy: [],
+    },
     mode: EditorModes.selectMode(),
     focusedPanel: 'canvas',
     keysPressed: {},
@@ -1979,6 +1991,10 @@ export function editorModelFromPersistentModel(
     highlightedViews: [],
     hiddenInstances: persistentModel.hiddenInstances,
     warnedInstances: [],
+    lockedElements: {
+      simpleLock: [],
+      withHierarchy: [],
+    },
     mode: EditorModes.selectMode(),
     focusedPanel: 'canvas',
     keysPressed: {},

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -344,6 +344,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.FORCE_PARSE_FILE(action, state)
     case 'RUN_ESCAPE_HATCH':
       return UPDATE_FNS.RUN_ESCAPE_HATCH(action, state, builtInDependencies)
+    case 'TOGGLE_SELECTION_LOCK':
+      return UPDATE_FNS.TOGGLE_SELECTION_LOCK(action, state)
     default:
       return state
   }

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -9,6 +9,7 @@ import {
   assetFile,
   AssetFile,
   Directory,
+  ElementPath,
   esCodeFile,
   ESCodeFile,
   esRemoteDependencyPlaceholder,
@@ -305,6 +306,7 @@ import {
   Theme,
   editorState,
   AllElementProps,
+  LockedElements,
 } from './editor-state'
 import {
   CornerGuideline,
@@ -2775,6 +2777,18 @@ export const EditorStatePreviewKeepDeepEquality: KeepDeepEqualityCall<EditorStat
 export const EditorStateHomeKeepDeepEquality: KeepDeepEqualityCall<EditorStateHome> =
   combine1EqualityCall((preview) => preview.visible, BooleanKeepDeepEquality, editorStateHome)
 
+export const EditorStateLockedElementsDeepEquality: KeepDeepEqualityCall<LockedElements> =
+  combine2EqualityCalls(
+    (locked) => locked.simpleLock,
+    ElementPathArrayKeepDeepEquality,
+    (locked) => locked.withHierarchy,
+    ElementPathArrayKeepDeepEquality,
+    (simpleLock: Array<ElementPath>, withHierarchy: Array<ElementPath>) => ({
+      simpleLock: simpleLock,
+      withHierarchy: withHierarchy,
+    }),
+  )
+
 export function CSSColorKeepDeepEquality(
   oldValue: CSSColor,
   newValue: CSSColor,
@@ -2976,6 +2990,10 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     oldValue.warnedInstances,
     newValue.warnedInstances,
   )
+  const lockedElementsResult = EditorStateLockedElementsDeepEquality(
+    oldValue.lockedElements,
+    newValue.lockedElements,
+  )
   const modeResult = ModeKeepDeepEquality(oldValue.mode, newValue.mode)
   const focusedPanelResult = createCallWithTripleEquals<EditorPanel | null>()(
     oldValue.focusedPanel,
@@ -3133,6 +3151,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     highlightedViewsResult.areEqual &&
     hiddenInstancesResult.areEqual &&
     warnedInstancesResult.areEqual &&
+    lockedElementsResult.areEqual &&
     modeResult.areEqual &&
     focusedPanelResult.areEqual &&
     keysPressedResult.areEqual &&
@@ -3200,6 +3219,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
       highlightedViewsResult.value,
       hiddenInstancesResult.value,
       warnedInstancesResult.value,
+      lockedElementsResult.value,
       modeResult.value,
       focusedPanelResult.value,
       keysPressedResult.value,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -2781,11 +2781,11 @@ export const EditorStateLockedElementsDeepEquality: KeepDeepEqualityCall<LockedE
   combine2EqualityCalls(
     (locked) => locked.simpleLock,
     ElementPathArrayKeepDeepEquality,
-    (locked) => locked.withHierarchy,
+    (locked) => locked.hierarchyLock,
     ElementPathArrayKeepDeepEquality,
-    (simpleLock: Array<ElementPath>, withHierarchy: Array<ElementPath>) => ({
+    (simpleLock: Array<ElementPath>, hierarchyLock: Array<ElementPath>) => ({
       simpleLock: simpleLock,
-      withHierarchy: withHierarchy,
+      hierarchyLock: hierarchyLock,
     }),
   )
 

--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -138,7 +138,7 @@ export const SelectionLockedIndicator: React.FunctionComponent<
         marginRight: 4,
         height: 18,
         width: 18,
-        opacity: shouldShow ? 1 : 0,
+        display: shouldShow ? 'block' : 'none',
       }}
     >
       {when(value === 'locked', <Icons.LockClosed color={color} />)}

--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -7,6 +7,12 @@ import { EditorDispatch } from '../../editor/action-types'
 import * as EditorActions from '../../editor/actions/action-creators'
 import * as EP from '../../../core/shared/element-path'
 import { useColorTheme, Button, Icons, SectionActionSheet } from '../../../uuiui'
+import { stopPropagation } from '../../inspector/common/inspector-utils'
+import { when } from '../../../utils/react-conditionals'
+import { useEditorState, useRefEditorState } from '../../editor/store/store-hook'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { getMetadata } from '../../editor/store/editor-state'
+import { SelectionLocked } from '../../canvas/canvas-types'
 
 interface NavigatorHintProps {
   shouldBeShown: boolean
@@ -92,6 +98,60 @@ export const VisibilityIndicator: React.FunctionComponent<
   )
 })
 
+interface SelectionLockedIndicatorProps {
+  shouldShow: boolean
+  value: SelectionLocked
+  selected: boolean
+  isDescendantOfLocked: boolean
+  onClick: (value: SelectionLocked) => void
+}
+
+export const SelectionLockedIndicator: React.FunctionComponent<
+  React.PropsWithChildren<SelectionLockedIndicatorProps>
+> = React.memo((props) => {
+  const { shouldShow, value, selected, isDescendantOfLocked, onClick } = props
+  const color = selected ? 'on-highlight-main' : 'main'
+
+  const handleClick = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      event.stopPropagation()
+      switch (value) {
+        case 'selectable':
+          onClick('locked-hierarchy')
+          break
+        case 'locked-hierarchy':
+          onClick('locked')
+          break
+        case 'locked':
+        default:
+          onClick('selectable')
+          break
+      }
+    },
+    [onClick, value],
+  )
+  return (
+    <Button
+      onClick={handleClick}
+      onMouseDown={stopPropagation}
+      style={{
+        marginRight: 4,
+        height: 18,
+        width: 18,
+        opacity: shouldShow ? 1 : 0,
+      }}
+    >
+      {when(value === 'locked', <Icons.LockClosed color={color} />)}
+      {when(value === 'locked-hierarchy', <Icons.LockClosedDot color={color} />)}
+      {when(
+        value === 'selectable' && !isDescendantOfLocked,
+        <Icons.LockOpen color={color} style={{ transform: 'scale(.85)' }} />,
+      )}
+      {when(value === 'selectable' && isDescendantOfLocked, <Icons.Dot color={color} />)}
+    </Button>
+  )
+})
+
 interface OriginalComponentNameLabelProps {
   selected: boolean
   instanceOriginalComponentName: string | null
@@ -134,11 +194,58 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
   const toggleHidden = React.useCallback(() => {
     dispatch([EditorActions.toggleHidden([elementPath])], 'everyone')
   }, [dispatch, elementPath])
+
+  const toggleSelectable = React.useCallback(
+    (newValue: SelectionLocked) => {
+      dispatch([EditorActions.toggleSelectionLock([elementPath], newValue)], 'everyone')
+    },
+    [dispatch, elementPath],
+  )
+
+  // move this to the navigator item selector???
+  const isLockedElement = useEditorState((store) => {
+    return store.editor.lockedElements.simpleLock.some((path) => EP.pathsEqual(elementPath, path))
+  }, 'NavigatorItemActionSheet isLockedElement')
+  const isLockedWithHierarchy = useEditorState((store) => {
+    return store.editor.lockedElements.withHierarchy.some((path) =>
+      EP.pathsEqual(elementPath, path),
+    )
+  }, 'NavigatorItemActionSheet isLockedWithHierarchy')
+
+  const jsxMetadataRef = useRefEditorState((store) => getMetadata(store.editor))
+  const isSceneElement = React.useMemo(
+    () => MetadataUtils.isProbablyScene(jsxMetadataRef.current, elementPath),
+    [elementPath, jsxMetadataRef],
+  )
+
+  const isDescendantOfLocked = useEditorState((store) => {
+    return store.editor.lockedElements.withHierarchy.some((path) =>
+      EP.isDescendantOf(elementPath, path),
+    )
+  }, 'NavigatorItemActionSheet descendant of locked')
+
   return (
     <SectionActionSheet>
       <OriginalComponentNameLabel
         selected={props.selected}
         instanceOriginalComponentName={props.instanceOriginalComponentName}
+      />
+      <SelectionLockedIndicator
+        key={`selection-locked-indicator-${EP.toVarSafeComponentId(elementPath)}`}
+        shouldShow={
+          !isSceneElement &&
+          (props.highlighted ||
+            props.selected ||
+            isLockedElement ||
+            isLockedWithHierarchy ||
+            isDescendantOfLocked)
+        }
+        value={
+          isLockedElement ? 'locked' : isLockedWithHierarchy ? 'locked-hierarchy' : 'selectable'
+        }
+        isDescendantOfLocked={isDescendantOfLocked}
+        selected={props.selected}
+        onClick={toggleSelectable}
       />
       <VisibilityIndicator
         key={`visibility-indicator-${EP.toVarSafeComponentId(elementPath)}`}

--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -83,7 +83,7 @@ export const VisibilityIndicator: React.FunctionComponent<
     <Button
       onClick={props.onClick}
       style={{
-        marginRight: 4,
+        marginRight: 2,
         height: 18,
         width: 18,
         opacity: props.shouldShow ? 1 : 0,
@@ -135,7 +135,7 @@ export const SelectionLockedIndicator: React.FunctionComponent<
       onClick={handleClick}
       onMouseDown={stopPropagation}
       style={{
-        marginRight: 4,
+        marginRight: 2,
         height: 18,
         width: 18,
         display: shouldShow ? 'block' : 'none',
@@ -202,7 +202,6 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
     [dispatch, elementPath],
   )
 
-  // move this to the navigator item selector???
   const isLockedElement = useEditorState((store) => {
     return store.editor.lockedElements.simpleLock.some((path) => EP.pathsEqual(elementPath, path))
   }, 'NavigatorItemActionSheet isLockedElement')

--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -218,8 +218,9 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
   )
 
   const isDescendantOfLocked = useEditorState((store) => {
-    return store.editor.lockedElements.hierarchyLock.some((path) =>
-      EP.isDescendantOf(elementPath, path),
+    return MetadataUtils.isDescendantOfHierarchyLockedElement(
+      elementPath,
+      store.editor.lockedElements,
     )
   }, 'NavigatorItemActionSheet descendant of locked')
 

--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -205,11 +205,11 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
   const isLockedElement = useEditorState((store) => {
     return store.editor.lockedElements.simpleLock.some((path) => EP.pathsEqual(elementPath, path))
   }, 'NavigatorItemActionSheet isLockedElement')
-  const isLockedWithHierarchy = useEditorState((store) => {
-    return store.editor.lockedElements.withHierarchy.some((path) =>
+  const isLockedHierarchy = useEditorState((store) => {
+    return store.editor.lockedElements.hierarchyLock.some((path) =>
       EP.pathsEqual(elementPath, path),
     )
-  }, 'NavigatorItemActionSheet isLockedWithHierarchy')
+  }, 'NavigatorItemActionSheet isLockedHierarchy')
 
   const jsxMetadataRef = useRefEditorState((store) => getMetadata(store.editor))
   const isSceneElement = React.useMemo(
@@ -218,7 +218,7 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
   )
 
   const isDescendantOfLocked = useEditorState((store) => {
-    return store.editor.lockedElements.withHierarchy.some((path) =>
+    return store.editor.lockedElements.hierarchyLock.some((path) =>
       EP.isDescendantOf(elementPath, path),
     )
   }, 'NavigatorItemActionSheet descendant of locked')
@@ -236,12 +236,10 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
           (props.highlighted ||
             props.selected ||
             isLockedElement ||
-            isLockedWithHierarchy ||
+            isLockedHierarchy ||
             isDescendantOfLocked)
         }
-        value={
-          isLockedElement ? 'locked' : isLockedWithHierarchy ? 'locked-hierarchy' : 'selectable'
-        }
+        value={isLockedElement ? 'locked' : isLockedHierarchy ? 'locked-hierarchy' : 'selectable'}
         isDescendantOfLocked={isDescendantOfLocked}
         selected={props.selected}
         onClick={toggleSelectable}

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -73,7 +73,6 @@ import {
   isUtopiaAPIComponentFromMetadata,
   isGivenUtopiaElementFromMetadata,
 } from './project-file-utils'
-import { ResizesContentProp } from './scene-utils'
 import { fastForEach } from '../shared/utils'
 import { objectValues, omit } from '../shared/object-utils'
 import { UTOPIA_LABEL_KEY } from './utopia-constants'
@@ -159,9 +158,6 @@ export const MetadataUtils = {
     paths: Array<ElementPath>,
   ): Array<ElementInstanceMetadata> {
     return stripNulls(paths.map((path) => MetadataUtils.findElementByElementPath(elementMap, path)))
-  },
-  isSceneTreatedAsGroup(allElementProps: AllElementProps, path: ElementPath): boolean {
-    return allElementProps?.[EP.toString(path)]?.[ResizesContentProp] ?? false
   },
   isProbablySceneFromMetadata(element: ElementInstanceMetadata | null): boolean {
     return (

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -76,7 +76,11 @@ import {
 import { fastForEach } from '../shared/utils'
 import { objectValues, omit } from '../shared/object-utils'
 import { UTOPIA_LABEL_KEY } from './utopia-constants'
-import { AllElementProps, withUnderlyingTarget } from '../../components/editor/store/editor-state'
+import {
+  AllElementProps,
+  LockedElements,
+  withUnderlyingTarget,
+} from '../../components/editor/store/editor-state'
 import { ProjectContentTreeRoot } from '../../components/assets'
 import { memoize } from '../shared/memoize'
 import { buildTree, ElementPathTree, getSubTree } from '../shared/element-path-tree'
@@ -1386,6 +1390,9 @@ export const MetadataUtils = {
         ? canvasRectangleToLocalRectangle(globalFrame, elementContainerBounds)
         : null
     return localFrame
+  },
+  isDescendantOfHierarchyLockedElement(path: ElementPath, lockedElements: LockedElements): boolean {
+    return lockedElements.hierarchyLock.some((lockedPath) => EP.isDescendantOf(path, lockedPath))
   },
 }
 

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -62,9 +62,6 @@ export const EmptyUtopiaCanvasComponent = convertScenesToUtopiaCanvasComponent([
 export const PathForSceneProps = PP.create(['props'])
 export const PathForSceneStyle = PP.create(['style'])
 
-export const ResizesContentProp = 'resizeContent'
-export const PathForResizeContent = PP.create([ResizesContentProp])
-
 export function createSceneUidFromIndex(sceneIndex: number): string {
   return `scene-${sceneIndex}`
 }


### PR DESCRIPTION
**Fix:**
Introducing selection locking on the canvas, it can be accessed in the navigator with the lock icon. 
Toggling has 3 modes:
1. selectable - unlocked icon
2. only the toggled element is locked (but children are selectable)
3. all of its descendants are locked too and they are not selectable on the canvas.

Scenes cannot be locked because the icon is not shown in the navigator for them.

**Commit Details:**
- added action `TOGGLE_SELECTION_LOCK`
- 2 browser tests
- new component in navigator `SelectionLockedIndicator`
- update `getSelectableViews` with locking and cleaning up old dynamic scene related filtering as it's not used anymore
- also cleaned up helper function `isSceneTreatedAsGroup`, this was also for the old dynamic scenes