### PR TITLE
Prevent navigator ghosts as the item is reparented.

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -58,7 +58,7 @@ import {
 } from '../../core/shared/uid-utils'
 import { pluck, uniqBy } from '../../core/shared/array-utils'
 import { forceNotNull, optionalMap } from '../../core/shared/optional-utils'
-import { fastForEach } from '../../core/shared/utils'
+import { arrayEquals, fastForEach } from '../../core/shared/utils'
 import { MapLike } from 'typescript'
 import { isFeatureEnabled } from '../../utils/feature-switches'
 import type {
@@ -400,6 +400,29 @@ function runSelectiveDomWalker(
   }
 }
 
+// If the elements to focus on have specific paths in 2 consecutive passes, but those paths differ, then
+// for this pass treat it as `rerender-all-elements`, to ensure that the metadata gets cleaned up as
+// the previously focused elements may not now exist.
+let lastElementsToFocusOn: ElementsToRerender = 'rerender-all-elements'
+function fixElementsToFocusOn(currentElementsToFocusOn: ElementsToRerender): ElementsToRerender {
+  let elementsToFocusOn: ElementsToRerender = currentElementsToFocusOn
+  switch (currentElementsToFocusOn) {
+    case 'rerender-all-elements':
+      break
+    default:
+      switch (lastElementsToFocusOn) {
+        case 'rerender-all-elements':
+          break
+        default:
+          if (!arrayEquals(lastElementsToFocusOn, currentElementsToFocusOn, EP.pathsEqual)) {
+            elementsToFocusOn = 'rerender-all-elements'
+          }
+      }
+  }
+  lastElementsToFocusOn = currentElementsToFocusOn
+  return elementsToFocusOn
+}
+
 // Dom walker has 3 modes for performance reasons:
 // Fastest is the selective mode, this runs when elementsToFocusOn is not 'rerender-all-elements'. In this case it only collects the metadata of the elements in elementsToFocusOn
 // Middle speed is when initComplete is true, in this case it traverses the full dom but only collects the metadata for the not invalidated elements (stored in invalidatedPaths)
@@ -407,7 +430,7 @@ function runSelectiveDomWalker(
 export function runDomWalker({
   domWalkerMutableState,
   selectedViews,
-  elementsToFocusOn,
+  elementsToFocusOn: currentElementsToFocusOn,
   scale,
   additionalElementsToUpdate,
   rootMetadataInStateRef,
@@ -418,6 +441,8 @@ export function runDomWalker({
 } | null {
   const needsWalk =
     !domWalkerMutableState.initComplete || domWalkerMutableState.invalidatedPaths.size > 0
+
+  const elementsToFocusOn: ElementsToRerender = fixElementsToFocusOn(currentElementsToFocusOn)
 
   if (!needsWalk) {
     return null // early return to save performance


### PR DESCRIPTION
**Problem:**
While the user reparents, if they drag between multiple potential parents, the root element shows up as a "ghost" in the old locations it was briefly reparented to. This happens as a result of the metadata for the old locations never being cleaned up, adding an entry for each new parent that the elements are dragged over.

**Fix:**
This change introduces a tweak to the dom walker that momentarily re-renders the canvas when the focus changes from a given specific set of elements to another set of specific elements. As a result the metadata is rebuilt rather than modified, as there's nothing otherwise to remove the old metadata for the position the element was in.

**Commit Details:**
- Added `fixElementsToFocusOn` which caters for the case where the focus
  changes from one specific set of elements to another. If that is the
  case then momentarily all elements are rerendered to ensure that
  the metadata does not end up with old metadata from a previously
  focused element.