### PR TITLE
Fix for element focus when reparenting from flex to absolute.

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -403,14 +403,23 @@ function runSelectiveDomWalker(
 // If the elements to focus on have specific paths in 2 consecutive passes, but those paths differ, then
 // for this pass treat it as `rerender-all-elements`, to ensure that the metadata gets cleaned up as
 // the previously focused elements may not now exist.
+// Also as some canvas strategies may not supply a specific set of elements to focus on, if
+// `rerender-all-elements` switches to a specific set of paths, ignore the specific set of paths
+// for the very first pass to get another `rerender-all-elements`.
 let lastElementsToFocusOn: ElementsToRerender = 'rerender-all-elements'
 function fixElementsToFocusOn(currentElementsToFocusOn: ElementsToRerender): ElementsToRerender {
   let elementsToFocusOn: ElementsToRerender = currentElementsToFocusOn
-  switch (currentElementsToFocusOn) {
+  switch (lastElementsToFocusOn) {
     case 'rerender-all-elements':
+      switch (currentElementsToFocusOn) {
+        case 'rerender-all-elements':
+          break
+        default:
+          elementsToFocusOn = 'rerender-all-elements'
+      }
       break
     default:
-      switch (lastElementsToFocusOn) {
+      switch (currentElementsToFocusOn) {
         case 'rerender-all-elements':
           break
         default:


### PR DESCRIPTION
**Problem:**
The fix in this PR: https://github.com/concrete-utopia/utopia/pull/2496 doesn't cater for the case when going from a flex parent to an absolute parent.

**Fix:**
Flex parents result in `rerender-all-elements` being passed for the elements to focus on, so reparenting to an absolute parent causes it to switch from that to a specific element. For that case now `fixElementsToFocusOn` will result in another round of `rerender-all-elements`.

**Commit Details:**
- Tweak to `fixElementsToFocusOn` for the case when going from a flex
  parent to an absolute parent.
