### PR TITLE
Fix canvas ghosts from reparenting.

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -400,38 +400,6 @@ function runSelectiveDomWalker(
   }
 }
 
-// If the elements to focus on have specific paths in 2 consecutive passes, but those paths differ, then
-// for this pass treat it as `rerender-all-elements`, to ensure that the metadata gets cleaned up as
-// the previously focused elements may not now exist.
-// Also as some canvas strategies may not supply a specific set of elements to focus on, if
-// `rerender-all-elements` switches to a specific set of paths, ignore the specific set of paths
-// for the very first pass to get another `rerender-all-elements`.
-let lastElementsToFocusOn: ElementsToRerender = 'rerender-all-elements'
-function fixElementsToFocusOn(currentElementsToFocusOn: ElementsToRerender): ElementsToRerender {
-  let elementsToFocusOn: ElementsToRerender = currentElementsToFocusOn
-  switch (lastElementsToFocusOn) {
-    case 'rerender-all-elements':
-      switch (currentElementsToFocusOn) {
-        case 'rerender-all-elements':
-          break
-        default:
-          elementsToFocusOn = 'rerender-all-elements'
-      }
-      break
-    default:
-      switch (currentElementsToFocusOn) {
-        case 'rerender-all-elements':
-          break
-        default:
-          if (!arrayEquals(lastElementsToFocusOn, currentElementsToFocusOn, EP.pathsEqual)) {
-            elementsToFocusOn = 'rerender-all-elements'
-          }
-      }
-  }
-  lastElementsToFocusOn = currentElementsToFocusOn
-  return elementsToFocusOn
-}
-
 // Dom walker has 3 modes for performance reasons:
 // Fastest is the selective mode, this runs when elementsToFocusOn is not 'rerender-all-elements'. In this case it only collects the metadata of the elements in elementsToFocusOn
 // Middle speed is when initComplete is true, in this case it traverses the full dom but only collects the metadata for the not invalidated elements (stored in invalidatedPaths)
@@ -439,7 +407,7 @@ function fixElementsToFocusOn(currentElementsToFocusOn: ElementsToRerender): Ele
 export function runDomWalker({
   domWalkerMutableState,
   selectedViews,
-  elementsToFocusOn: currentElementsToFocusOn,
+  elementsToFocusOn,
   scale,
   additionalElementsToUpdate,
   rootMetadataInStateRef,
@@ -450,8 +418,6 @@ export function runDomWalker({
 } | null {
   const needsWalk =
     !domWalkerMutableState.initComplete || domWalkerMutableState.invalidatedPaths.size > 0
-
-  const elementsToFocusOn: ElementsToRerender = fixElementsToFocusOn(currentElementsToFocusOn)
 
   if (!needsWalk) {
     return null // early return to save performance


### PR DESCRIPTION
**Problem:**
Similar to https://github.com/concrete-utopia/utopia/pull/2496 we can observe canvas "ghost" values while reparenting around mostly from a parent to the canvas and back again.  This occurs due to the old parent not being re-rendered, so React just happily keeps the old child there in the hierarchy.

**Fix:**
The from https://github.com/concrete-utopia/utopia/pull/2496 has now been pulled up to the outer scope so that the canvas logic itself can take advantage of that fix.

**Commit Details:**
- Move `fixElementsToFocusOn` out of the dom walker file and removed
  the call from `runDomWalker`.
- `boundDispatch` now invokes the newly renamed `fixElementsToRerender`
  to update the value that is passed to `ElementsToRerenderGLOBAL`
  and the DOM walker.
