### PR TITLE
make simple html elements absolutely positioned by default

### DIFF
--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -14,6 +14,7 @@ import {
   right,
 } from '../../core/shared/either'
 import {
+  absolutePositionStyle,
   emptyComments,
   isIntrinsicElementFromString,
   JSXAttributes,
@@ -22,6 +23,7 @@ import {
   jsxElementName,
   jsxElementWithoutUID,
   JSXElementWithoutUID,
+  parsedComments,
   simpleAttribute,
 } from '../../core/shared/element-template'
 import { dropFileExtension } from '../../core/shared/file-utils'
@@ -227,13 +229,13 @@ function makeHTMLDescriptor(
 }
 
 const basicHTMLElementsDescriptors = {
-  div: makeHTMLDescriptor('div', {}),
+  div: makeHTMLDescriptor('div', {}, absolutePositionStyle),
   span: makeHTMLDescriptor('span', {}),
-  h1: makeHTMLDescriptor('h1', {}),
-  h2: makeHTMLDescriptor('h2', {}),
+  h1: makeHTMLDescriptor('h1', {}, absolutePositionStyle),
+  h2: makeHTMLDescriptor('h2', {}, absolutePositionStyle),
   p: makeHTMLDescriptor('p', {}),
-  button: makeHTMLDescriptor('button', {}),
-  input: makeHTMLDescriptor('input', {}),
+  button: makeHTMLDescriptor('button', {}, absolutePositionStyle),
+  input: makeHTMLDescriptor('input', {}, absolutePositionStyle),
   video: makeHTMLDescriptor(
     'video',
     {
@@ -257,6 +259,7 @@ const basicHTMLElementsDescriptors = {
       simpleAttribute('style', {
         width: '250px',
         height: '120px',
+        position: 'absolute',
       }),
       simpleAttribute('controls', true),
       simpleAttribute('autoPlay', true),
@@ -278,6 +281,7 @@ const basicHTMLElementsDescriptors = {
       simpleAttribute('style', {
         width: '64px',
         height: '64px',
+        position: 'absolute',
       }),
       simpleAttribute('src', `/editor/icons/favicons/favicon-128.png?hash=${URL_HASH}`),
     ],

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -36,6 +36,10 @@ export const emptyComments: ParsedComments = {
   trailingComments: [],
 }
 
+export const absolutePositionStyle: JSXAttributes = [
+  simpleAttribute('style', { position: 'absolute' }),
+]
+
 export function isParsedCommentsEmpty(comments: ParsedComments): boolean {
   return comments.leadingComments.length === 0 && comments.trailingComments.length === 0
 }


### PR DESCRIPTION
**Problem:**
When inserting a basic HTML element by drawing on the canvas, the inserted element should be `position: absolute` default

**Fix:**
Basic HTML elements are created with absolute positioning by default.

**Commit Details:**
- Added a helper constant called `absolutePositionStyle`, which creates a `JSXAttributes` object which adds a style prop with absolute position
- applied above constant to `basicHTMLElementsDescriptors` (where applicable)
