### PR TITLE
fix the missing flex reparent indicators for the insert mode

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
@@ -40,6 +40,8 @@ import {
 } from '../../../core/shared/element-template'
 import { cmdModifier } from '../../../utils/modifiers'
 import { setJSXValueInAttributeAtPath } from '../../../core/shared/jsx-attributes'
+import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
+import { FlexReparentTargetIndicator } from '../controls/select-mode/flex-reparent-target-indicator'
 
 export const dragToInsertStrategy: CanvasStrategy = {
   id: 'DRAG_TO_INSERT',
@@ -52,6 +54,7 @@ export const dragToInsertStrategy: CanvasStrategy = {
     return insertionElementSubjects.length > 0
   },
   controlsToRender: [
+    // TODO the controlsToRender should instead use the controls of the actual canvas strategy -> to achieve that, this should be a function of the StrategyState here
     {
       control: ParentOutlines,
       key: 'parent-outlines-control',
@@ -60,6 +63,26 @@ export const dragToInsertStrategy: CanvasStrategy = {
     {
       control: ParentBounds,
       key: 'parent-bounds-control',
+      show: 'visible-only-while-active',
+    },
+    {
+      control: DragOutlineControl,
+      key: 'ghost-outline-control',
+      show: 'visible-only-while-active',
+    },
+    {
+      control: ParentOutlines,
+      key: 'parent-outlines-control',
+      show: 'visible-only-while-active',
+    },
+    {
+      control: ParentBounds,
+      key: 'parent-bounds-control',
+      show: 'visible-only-while-active',
+    },
+    {
+      control: FlexReparentTargetIndicator,
+      key: 'flex-reparent-target-indicator',
       show: 'visible-only-while-active',
     },
   ], // Uses existing hooks in select-mode-hooks.tsx

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -70,6 +70,7 @@ import { DistanceGuidelineControl } from './select-mode/distance-guideline-contr
 import { SceneLabelControl } from './select-mode/scene-label'
 import { PinLines } from './position-outline'
 import { CursorOverlay } from './select-mode/cursor-overlay'
+import { FlexReparentTargetIndicator } from './select-mode/flex-reparent-target-indicator'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
@@ -479,7 +480,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
           {when(isFeatureEnabled('Canvas Strategies'), <GuidelineControls />)}
           <OutlineHighlightControl />
           {when(
-            isCanvasStrategyOnAndSelectMode(props.editor.mode),
+            isCanvasStrategyOnAndSelectOrInsertMode(props.editor.mode),
             <>{strategyControls.map((c) => React.createElement(c.control, { key: c.key }))}</>,
           )}
         </>,
@@ -491,4 +492,8 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
 
 function isCanvasStrategyOnAndSelectMode(mode: Mode): boolean {
   return isFeatureEnabled('Canvas Strategies') && mode.type === 'select'
+}
+
+function isCanvasStrategyOnAndSelectOrInsertMode(mode: Mode): boolean {
+  return isFeatureEnabled('Canvas Strategies') && (mode.type === 'select' || mode.type === 'insert')
 }

--- a/editor/src/core/shared/redux-devtools.ts
+++ b/editor/src/core/shared/redux-devtools.ts
@@ -87,6 +87,9 @@ function sanitizeEditor(editor: EditorState) {
       mountCount: editor.canvas.mountCount,
       domWalkerInvalidateCount: editor.canvas.domWalkerInvalidateCount,
       canvasContentInvalidateCount: editor.canvas.canvasContentInvalidateCount,
+      controls: {
+        ...editor.canvas.controls,
+      },
       interactionSession: {
         interactionData: editor.canvas.interactionSession?.interactionData,
         metadata: simplifiedMetadataMap(editor.canvas.interactionSession?.metadata ?? {}) as any,


### PR DESCRIPTION
**Problem:**
During drag-to-inserting, all strategy controls/indicators were missing from the canvas.
Especially problemating that during drag-to-insert, the flex reparent indicator was missing, and without it there was no visible feedback about the insertion that's about to happen.

**Fix:**
- In new-canvas-controls, a new `isCanvasStrategyOnAndSelectOrInsertMode` function returns true if the mode is select OR insert
- Added the new flex reparent controls to the `controlsToRender` array of `dragToInsertStrategy` strategy