### PR TITLE
Reorder/reparent elements in flex container

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -23,8 +23,8 @@ import { ParentOutlines } from '../controls/parent-outlines'
 import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
 import { setElementsToRerenderCommand } from '../commands/set-elements-to-rerender-command'
 import { ParentBounds } from '../controls/parent-bounds'
-import { getReorderIndex } from './reparent-strategy-helpers'
 import { absolute } from '../../../utils/utils'
+import { reorderIndexForReorder } from './reparent-strategy-helpers'
 
 export const flexReorderStrategy: CanvasStrategy = {
   id: 'FLEX_REORDER',
@@ -91,11 +91,10 @@ export const flexReorderStrategy: CanvasStrategy = {
       const unpatchedIndex = siblingsOfTarget.findIndex((sibling) => EP.pathsEqual(sibling, target))
       const lastReorderIdx = strategyState.customStrategyState.lastReorderIdx ?? unpatchedIndex
 
-      const newIndex = getReorderIndex(
+      const newIndex = reorderIndexForReorder(
         strategyState.startingMetadata,
         siblingsOfTarget,
         pointOnCanvas,
-        target,
       )
 
       const realNewIndex = newIndex > -1 ? newIndex : lastReorderIdx


### PR DESCRIPTION
**Problem**
When reordering flex elements, the element being dragged is being inserted into wrong place

**Fix:**
Both reordering within a flex container, and reparenting to a flex container used the same function to determine to which index the element being dragged should move to. This PR adds a separate function for either case (`reorderIndexForReorder` and `reorderIndexForReparent`).

**Commit Details:**
- refactored `getReorderIndex` into two functions for the two separate use cases