### PR TITLE
Revert flex child reorder logic

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -23,8 +23,8 @@ import { ParentOutlines } from '../controls/parent-outlines'
 import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
 import { setElementsToRerenderCommand } from '../commands/set-elements-to-rerender-command'
 import { ParentBounds } from '../controls/parent-bounds'
-import { getReorderIndex } from './reparent-strategy-helpers'
 import { absolute } from '../../../utils/utils'
+import { reorderIndexForReorder } from './reparent-strategy-helpers'
 
 export const flexReorderStrategy: CanvasStrategy = {
   id: 'FLEX_REORDER',
@@ -91,11 +91,10 @@ export const flexReorderStrategy: CanvasStrategy = {
       const unpatchedIndex = siblingsOfTarget.findIndex((sibling) => EP.pathsEqual(sibling, target))
       const lastReorderIdx = strategyState.customStrategyState.lastReorderIdx ?? unpatchedIndex
 
-      const newIndex = getReorderIndex(
+      const newIndex = reorderIndexForReorder(
         strategyState.startingMetadata,
         siblingsOfTarget,
         pointOnCanvas,
-        target,
       )
 
       const realNewIndex = newIndex > -1 ? newIndex : lastReorderIdx

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -24,7 +24,6 @@ import { updateHighlightedViews } from '../commands/update-highlighted-views-com
 import { setElementsToRerenderCommand } from '../commands/set-elements-to-rerender-command'
 import { ParentBounds } from '../controls/parent-bounds'
 import { absolute } from '../../../utils/utils'
-import { reorderIndexForReorder } from './reparent-strategy-helpers'
 
 export const flexReorderStrategy: CanvasStrategy = {
   id: 'FLEX_REORDER',
@@ -132,4 +131,20 @@ export const flexReorderStrategy: CanvasStrategy = {
       }
     }
   },
+}
+
+function reorderIndexForReorder(
+  metadata: ElementInstanceMetadataMap,
+  siblings: Array<ElementPath>,
+  point: CanvasVector,
+): number {
+  const targetSiblingIdx = siblings.findIndex((sibling) => {
+    const frame = MetadataUtils.getFrameInCanvasCoords(sibling, metadata)
+    return (
+      frame != null &&
+      rectContainsPoint(frame, point) &&
+      MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(sibling, metadata)
+    )
+  })
+  return targetSiblingIdx
 }

--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -57,85 +57,20 @@ import {
 } from '../commands/adjust-css-length-command'
 import { updatePropIfExists } from '../commands/update-prop-if-exists-command'
 
-interface ReorderElement {
-  distance: number
-  centerPoint: CanvasPoint
-  closestSibling: ElementPath
-  siblingIndex: number
-}
-
-export function getReorderIndex(
+export function reorderIndexForReorder(
   metadata: ElementInstanceMetadataMap,
   siblings: Array<ElementPath>,
   point: CanvasVector,
-  existingElement: ElementPath | null,
 ): number {
-  let rowOrColumn: 'row' | 'column' | null = null
-
-  const first = siblings[0]
-  if (first != null) {
-    const parentPath = EP.parentPath(first)
-    if (parentPath != null) {
-      const parentMetadata = MetadataUtils.findElementByElementPath(metadata, parentPath)
-      if (parentMetadata?.specialSizeMeasurements.layoutSystemForChildren != 'flex') {
-        throw new Error(`Element ${EP.toString(parentPath)} is not a flex container`)
-      }
-
-      const flexDirection = parentMetadata?.specialSizeMeasurements.flexDirection
-      if (flexDirection != null) {
-        if (flexDirection.includes('row')) {
-          rowOrColumn = 'row'
-        } else if (flexDirection.includes('col')) {
-          rowOrColumn = 'column'
-        }
-      }
-    }
-  }
-
-  let reorderResult: ReorderElement | null = null
-  let siblingIndex: number = 0
-
-  for (const sibling of siblings) {
+  const targetSiblingIdx = siblings.findIndex((sibling) => {
     const frame = MetadataUtils.getFrameInCanvasCoords(sibling, metadata)
-    if (
+    return (
       frame != null &&
+      rectContainsPoint(frame, point) &&
       MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(sibling, metadata)
-    ) {
-      const centerPoint = Utils.getRectCenter(frame)
-      const distance = Utils.distance(point, centerPoint)
-      // First one that has been found or if it's closer than a previously found entry.
-      if (reorderResult == null || distance < reorderResult.distance) {
-        reorderResult = {
-          distance: distance,
-          centerPoint: centerPoint,
-          closestSibling: sibling,
-          siblingIndex: siblingIndex,
-        }
-      }
-    }
-    siblingIndex++
-  }
-
-  if (reorderResult == null) {
-    // We were unable to find an appropriate entry.
-    return -1
-  } else if (EP.pathsEqual(reorderResult.closestSibling, existingElement)) {
-    // Reparenting to the same position that the existing element started in.
-    return reorderResult.siblingIndex
-  } else {
-    // Check which "side" of the target this falls on.
-    let newIndex = reorderResult.siblingIndex
-    if (rowOrColumn === 'row') {
-      if (point.x > reorderResult.centerPoint.x) {
-        newIndex++
-      }
-    } else if (rowOrColumn === 'column') {
-      if (point.y > reorderResult.centerPoint.y) {
-        newIndex++
-      }
-    }
-    return newIndex
-  }
+    )
+  })
+  return targetSiblingIdx
 }
 
 export type ReparentStrategy =

--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -57,22 +57,6 @@ import {
 } from '../commands/adjust-css-length-command'
 import { updatePropIfExists } from '../commands/update-prop-if-exists-command'
 
-export function reorderIndexForReorder(
-  metadata: ElementInstanceMetadataMap,
-  siblings: Array<ElementPath>,
-  point: CanvasVector,
-): number {
-  const targetSiblingIdx = siblings.findIndex((sibling) => {
-    const frame = MetadataUtils.getFrameInCanvasCoords(sibling, metadata)
-    return (
-      frame != null &&
-      rectContainsPoint(frame, point) &&
-      MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(sibling, metadata)
-    )
-  })
-  return targetSiblingIdx
-}
-
 export type ReparentStrategy =
   | 'FLEX_REPARENT_TO_ABSOLUTE'
   | 'FLEX_REPARENT_TO_FLEX'


### PR DESCRIPTION
**Problem:**
When reordering flex elements, the element beign dragged was inserted into the wrong place

**Fix:**
Reverted reordering logic to the solution previously there

**Commit Details:**
- Reverted reordering logic to the solution previously there
- made sure flex reparent logic does not reuse the reorder logic
