### PR TITLE
Cancel insert mode from more places.

### DIFF
--- a/editor/src/components/canvas/controls/breadcrumb-trail.tsx
+++ b/editor/src/components/canvas/controls/breadcrumb-trail.tsx
@@ -4,7 +4,7 @@ import { useKeepReferenceEqualityIfPossible } from '../../../utils/react-perform
 import { Utils } from '../../../uuiui-deps'
 import * as EP from '../../../core/shared/element-path'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { selectComponents } from '../../../components/editor/actions/action-creators'
+import { selectComponents } from '../../../components/editor/actions/meta-actions'
 import { Icons, UIRow, UtopiaTheme } from '../../../uuiui'
 import { ElementPath } from '../../../core/shared/project-file-types'
 
@@ -24,7 +24,7 @@ export const BreadcrumbTrail = React.memo(() => {
   }, 'TopMenuContextProvider')
 
   const onSelect = React.useCallback(
-    (path: ElementPath) => dispatch([selectComponents([path], false)], 'everyone'),
+    (path: ElementPath) => dispatch(selectComponents([path], false), 'everyone'),
     [dispatch],
   )
 

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -56,8 +56,8 @@ import { getLayoutPropertyOr } from '../../../core/layout/getLayoutProperty'
 import { mapDropNulls, safeIndex } from '../../../core/shared/array-utils'
 import { getStoryboardElementPath } from '../../../core/model/scene-utils'
 import { isSceneFromMetadata } from '../../../core/model/project-file-utils'
-import { RightMenuTab } from '../../editor/store/editor-state'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
+import { cancelInsertModeActions } from '../../../components/editor/actions/meta-actions'
 
 const DefaultWidth = 100
 const DefaultHeight = 100
@@ -429,12 +429,7 @@ export class InsertModeControlContainer extends React.Component<
     if (!this.props.mode.insertionStarted) {
       return
     }
-    const baseActions: EditorAction[] = [
-      EditorActions.updateEditorMode(EditorModes.selectMode()),
-      EditorActions.setRightMenuTab(RightMenuTab.Inspector),
-      EditorActions.clearHighlightedViews(),
-      CanvasActions.clearDragState(false),
-    ]
+    const baseActions: EditorAction[] = cancelInsertModeActions('ignore-it-completely')
     if (insertionSubjectIsJSXElement(this.props.mode.subject)) {
       const insertionSubject = this.props.mode.subject
       const insertionElement = insertionSubject.element

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -5,6 +5,7 @@ import { CanvasPoint, CanvasRectangle, CanvasVector } from '../../../core/shared
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { EditorAction } from '../../editor/action-types'
 import * as EditorActions from '../../editor/actions/action-creators'
+import * as MetaActions from '../../editor/actions/meta-actions'
 import { DuplicationState, RightMenuTab } from '../../editor/store/editor-state'
 import * as EP from '../../../core/shared/element-path'
 import { CanvasPositions, MoveDragState, ResizeDragState } from '../canvas-types'
@@ -120,12 +121,7 @@ export class SelectModeControlContainer extends React.Component<
        */
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          let selectActions = [
-            EditorActions.clearHighlightedViews(),
-            EditorActions.selectComponents(updatedSelection, false),
-            EditorActions.setRightMenuTab(RightMenuTab.Inspector),
-          ]
-          this.props.dispatch(selectActions, 'canvas')
+          this.props.dispatch(MetaActions.selectComponents(updatedSelection, false), 'canvas')
         })
       })
 

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -18,10 +18,11 @@ import Utils from '../../../../utils/utils'
 import {
   clearHighlightedViews,
   clearSelection,
-  selectComponents,
   setFocusedElement,
   setHighlightedView,
+  selectComponents,
 } from '../../../editor/actions/action-creators'
+import { cancelInsertModeActions } from '../../../editor/actions/meta-actions'
 import {
   AllElementProps,
   EditorState,
@@ -660,6 +661,9 @@ function useSelectOrLiveModeSelectAndHover(
           if (!foundTargetIsSelected) {
             // first we only set the selected views for the canvas controls
             setSelectedViewsForCanvasControlsOnly(updatedSelection)
+
+            // In either case cancel insert mode.
+            editorActions.push(...cancelInsertModeActions('ignore-it-completely'))
 
             // then we set the selected views for the editor state, 1 frame later
             if (updatedSelection.length === 0) {

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -12,10 +12,10 @@ import {
 } from '../../../core/shared/element-template'
 import {
   clearHighlightedViews,
-  selectComponents,
   setHighlightedView,
   setProp_UNSAFE,
 } from '../../editor/actions/action-creators'
+import { selectComponents } from '../../editor/actions/meta-actions'
 import { CanvasPoint, CanvasRectangle } from '../../../core/shared/math-utils'
 import { EditorDispatch } from '../../editor/action-types'
 import { isZeroSizedElement, ZeroControlSize } from './outline-utils'
@@ -94,7 +94,7 @@ const ZeroSizeSelectControl = React.memo((props: ZeroSizeSelectControlProps) => 
   const onControlMouseDown = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       event.stopPropagation()
-      dispatch([selectComponents([element.elementPath], false)], 'everyone')
+      dispatch(selectComponents([element.elementPath], false), 'everyone')
     },
     [dispatch, element.elementPath],
   )

--- a/editor/src/components/editor/actions/meta-actions.spec.ts
+++ b/editor/src/components/editor/actions/meta-actions.spec.ts
@@ -1,0 +1,87 @@
+import { cancelInsertModeActions } from './meta-actions'
+
+describe('cancelInsertModeActions', () => {
+  it(`returns the correct actions for 'apply-changes'`, () => {
+    const result = cancelInsertModeActions('apply-changes')
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "action": "CLEAR_INTERACTION_SESSION",
+          "applyChanges": true,
+        },
+        Object {
+          "action": "SWITCH_EDITOR_MODE",
+          "mode": Object {
+            "controlId": null,
+            "type": "select",
+          },
+        },
+        Object {
+          "action": "SET_RIGHT_MENU_TAB",
+          "tab": "inspector",
+        },
+        Object {
+          "action": "CLEAR_HIGHLIGHTED_VIEWS",
+        },
+        Object {
+          "action": "CLEAR_DRAG_STATE",
+          "applyChanges": false,
+        },
+      ]
+    `)
+  })
+  it(`returns the correct actions for 'do-not-apply-changes'`, () => {
+    const result = cancelInsertModeActions('do-not-apply-changes')
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "action": "CLEAR_INTERACTION_SESSION",
+          "applyChanges": false,
+        },
+        Object {
+          "action": "SWITCH_EDITOR_MODE",
+          "mode": Object {
+            "controlId": null,
+            "type": "select",
+          },
+        },
+        Object {
+          "action": "SET_RIGHT_MENU_TAB",
+          "tab": "inspector",
+        },
+        Object {
+          "action": "CLEAR_HIGHLIGHTED_VIEWS",
+        },
+        Object {
+          "action": "CLEAR_DRAG_STATE",
+          "applyChanges": false,
+        },
+      ]
+    `)
+  })
+  it(`returns the correct actions for 'ignore-it-completely'`, () => {
+    const result = cancelInsertModeActions('ignore-it-completely')
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "action": "SWITCH_EDITOR_MODE",
+          "mode": Object {
+            "controlId": null,
+            "type": "select",
+          },
+        },
+        Object {
+          "action": "SET_RIGHT_MENU_TAB",
+          "tab": "inspector",
+        },
+        Object {
+          "action": "CLEAR_HIGHLIGHTED_VIEWS",
+        },
+        Object {
+          "action": "CLEAR_DRAG_STATE",
+          "applyChanges": false,
+        },
+      ]
+    `)
+  })
+})

--- a/editor/src/components/editor/actions/meta-actions.ts
+++ b/editor/src/components/editor/actions/meta-actions.ts
@@ -1,0 +1,45 @@
+import { ElementPath } from '../../../core/shared/project-file-types'
+import { EditorModes } from '../editor-modes'
+import * as EditorActions from './action-creators'
+import CanvasActions from '../../canvas/canvas-actions'
+import { RightMenuTab } from '../store/editor-state'
+import { EditorAction } from '../action-types'
+
+type HandleInteractionSession = 'apply-changes' | 'do-not-apply-changes' | 'ignore-it-completely'
+
+export function cancelInsertModeActions(
+  handleInteractionSession: HandleInteractionSession,
+): Array<EditorAction> {
+  let result: Array<EditorAction> = []
+  // Determine if the interaction session is cleared or ignored.
+  switch (handleInteractionSession) {
+    case 'apply-changes':
+      result.push(CanvasActions.clearInteractionSession(true))
+      break
+    case 'do-not-apply-changes':
+      result.push(CanvasActions.clearInteractionSession(false))
+      break
+    case 'ignore-it-completely':
+      break
+    default:
+      const _exhaustiveCheck: never = handleInteractionSession
+      throw new Error(`Unhandled ${handleInteractionSession}.`)
+  }
+  // Common actions across all cases.
+  result.push(EditorActions.switchEditorMode(EditorModes.selectMode()))
+  result.push(EditorActions.setRightMenuTab(RightMenuTab.Inspector))
+  result.push(EditorActions.clearHighlightedViews())
+  result.push(CanvasActions.clearDragState(false))
+
+  return result
+}
+
+export function selectComponents(
+  target: Array<ElementPath>,
+  addToSelection: boolean,
+): Array<EditorAction> {
+  return [
+    ...cancelInsertModeActions('do-not-apply-changes'),
+    EditorActions.selectComponents(target, addToSelection),
+  ]
+}

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -30,6 +30,7 @@ import {
 import { toggleTextFormatting } from '../text-utils'
 import { EditorAction, EditorDispatch } from './action-types'
 import * as EditorActions from './actions/action-creators'
+import * as MetaActions from './actions/meta-actions'
 import {
   defaultEllipseElement,
   defaultRectangleElement,
@@ -115,16 +116,6 @@ import { CanvasMousePositionRaw, WindowMousePositionRaw } from '../../utils/glob
 import { getDragStateStart } from '../canvas/canvas-utils'
 import { isFeatureEnabled } from '../../utils/feature-switches'
 
-function cancelInsertModeActions(): Array<EditorAction> {
-  return [
-    EditorActions.switchEditorMode(EditorModes.selectMode()),
-    CanvasActions.clearDragState(false),
-    EditorActions.clearHighlightedViews(),
-    CanvasActions.clearInteractionSession(false),
-    EditorActions.setRightMenuTab(RightMenuTab.Inspector),
-  ]
-}
-
 function updateKeysPressed(
   keysPressed: KeysPressed,
   updatedCharacter: KeyCharacter,
@@ -177,7 +168,7 @@ function jumpToParentActions(selectedViews: Array<ElementPath>): Array<EditorAct
     case 'CLEAR':
       return [EditorActions.clearSelection()]
     default:
-      return [EditorActions.selectComponents([jumpResult], false)]
+      return MetaActions.selectComponents([jumpResult], false)
   }
 }
 
@@ -365,7 +356,7 @@ export function handleKeyDown(
     if (isSelectMode(editor.mode)) {
       const tabbedTo = Canvas.jumpToSibling(editor.selectedViews, editor.jsxMetadata, forwards)
       if (tabbedTo != null) {
-        return [EditorActions.selectComponents([tabbedTo], false)]
+        return MetaActions.selectComponents([tabbedTo], false)
       }
     }
     return []
@@ -425,7 +416,7 @@ export function handleKeyDown(
           } else {
             const childToSelect = Canvas.getFirstChild(editor.selectedViews, editor.jsxMetadata)
             if (childToSelect != null) {
-              return [EditorActions.selectComponents([childToSelect], false)]
+              return MetaActions.selectComponents([childToSelect], false)
             }
           }
         }
@@ -440,7 +431,7 @@ export function handleKeyDown(
       },
       [CANCEL_EVERYTHING_SHORTCUT]: () => {
         if (isInsertMode(editor.mode) || editor.rightMenu.selectedTab === RightMenuTab.Insert) {
-          return cancelInsertModeActions()
+          return MetaActions.cancelInsertModeActions('do-not-apply-changes')
         } else if (
           editor.canvas.dragState != null &&
           getDragStateStart(editor.canvas.dragState, editor.canvas.resizeOptions) != null
@@ -468,7 +459,7 @@ export function handleKeyDown(
           if (targetStack.length === 0 || nextTarget === null) {
             return [EditorActions.clearSelection()]
           } else {
-            return [EditorActions.selectComponents([nextTarget], false)]
+            return MetaActions.selectComponents([nextTarget], false)
           }
         }
         return []

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -31,7 +31,8 @@ import { MomentumContextMenu } from './context-menu-wrapper'
 import { useRefEditorState, useEditorState } from './editor/store/store-hook'
 import { CanvasContextMenuPortalTargetID } from '../core/shared/utils'
 import { EditorDispatch } from './editor/action-types'
-import { selectComponents, setHighlightedView } from './editor/actions/action-creators'
+import { setHighlightedView } from './editor/actions/action-creators'
+import { selectComponents } from './editor/actions/meta-actions'
 import * as EP from '../core/shared/element-path'
 import { ElementPath } from '../core/shared/project-file-types'
 import { useNamesAndIconsAllPaths } from './inspector/common/name-and-icon-hook'
@@ -105,7 +106,7 @@ function useCanvasContextMenuItems(
           },
           submenuName: 'Select Elements',
           enabled: true,
-          action: () => dispatch([selectComponents([path], false)], 'canvas'),
+          action: () => dispatch(selectComponents([path], false), 'canvas'),
           isHidden: (data: CanvasData) => {
             // Only run this once as the values used are the same for each and every
             // entry and `getAllTargetsAtPoint` is very expensive.

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -8,6 +8,7 @@ import * as ReactDOM from 'react-dom'
 import { ElementPath, ElementOriginType, Imports } from '../../../core/shared/project-file-types'
 import { EditorDispatch } from '../../editor/action-types'
 import * as EditorActions from '../../editor/actions/action-creators'
+import * as MetaActions from '../../editor/actions/meta-actions'
 import * as EP from '../../../core/shared/element-path'
 import {
   placeComponentsAfter,
@@ -217,7 +218,7 @@ function beginDrag(
   props: NavigatorItemDragAndDropWrapperProps,
 ): NavigatorItemDragAndDropWrapperProps {
   if (!props.selected) {
-    props.editorDispatch([EditorActions.selectComponents([props.elementPath], false)], 'leftpane')
+    props.editorDispatch(MetaActions.selectComponents([props.elementPath], false), 'leftpane')
   }
   return props
 }

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -10,6 +10,7 @@ import {
 import { ElementOriginType, ElementPath } from '../../../core/shared/project-file-types'
 import { EditorDispatch } from '../../editor/action-types'
 import * as EditorActions from '../../editor/actions/action-creators'
+import * as MetaActions from '../../editor/actions/meta-actions'
 import * as EP from '../../../core/shared/element-path'
 import { ExpandableIndicator } from './expandable-indicator'
 import { ItemLabel } from './item-label'
@@ -62,13 +63,13 @@ function selectItem(
   if (!selected) {
     if (event.metaKey && !event.shiftKey) {
       // adds to selection
-      dispatch([EditorActions.selectComponents([elementPath], true)], 'leftpane')
+      dispatch(MetaActions.selectComponents([elementPath], true), 'leftpane')
     } else if (event.shiftKey) {
       // selects range of items
       const targets = getSelectedViewsInRange(index)
-      dispatch([EditorActions.selectComponents(targets, false)], 'leftpane')
+      dispatch(MetaActions.selectComponents(targets, false), 'leftpane')
     } else {
-      dispatch([EditorActions.selectComponents([elementPath], false)], 'leftpane')
+      dispatch(MetaActions.selectComponents([elementPath], false), 'leftpane')
     }
   }
 }

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -100,6 +100,7 @@ import { getReparentTargetUnified } from '../components/canvas/canvas-strategies
 import { getDragTargets } from '../components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers'
 import { pickCanvasStateFromEditorState } from '../components/canvas/canvas-strategies/canvas-strategies'
 import { BuiltInDependencies } from '../core/es-modules/package-manager/built-in-dependencies-list'
+import { cancelInsertModeActions } from '../components/editor/actions/meta-actions'
 
 const webFrame = PROBABLY_ELECTRON ? requireElectron().webFrame : null
 
@@ -185,13 +186,9 @@ function handleCanvasEvent(model: CanvasModel, event: CanvasMouseEvent): Array<E
     model.editorState.canvas.interactionSession?.interactionData.type === 'DRAG'
   ) {
     const applyChanges = model.editorState.canvas.interactionSession?.interactionData.drag != null
-    optionalDragStateAction = [
-      CanvasActions.clearInteractionSession(applyChanges),
-      EditorActions.updateEditorMode(EditorModes.selectMode()),
-      EditorActions.setRightMenuTab(RightMenuTab.Inspector),
-      EditorActions.clearHighlightedViews(),
-      CanvasActions.clearDragState(false),
-    ]
+    optionalDragStateAction = cancelInsertModeActions(
+      applyChanges ? 'apply-changes' : 'do-not-apply-changes',
+    )
   } else if (!(insertMode && isOpenFileUiJs(model.editorState))) {
     switch (event.event) {
       case 'DRAG':


### PR DESCRIPTION
**Problem:**
Selecting an element in all the various places that is possible should cancel insert mode.

**Fix:**
Created a common function that fires the actions to clear insert mode and then select the target components, which can be used in place of the existing action creator.

**Commit Details:**
- Moved `cancelInsertModeActions` into `meta-actions.ts`.
- `cancelInsertModeActions` now takes a parameter which specifies
  what handling should be done for interaction sessions.
- Created alternative `selectComponents` function in `meta-actions.ts`
  for the case where it should cancel everything related to any
  insert mode completely.
- Changed a lot of the shortcuts from using the basic `selectComponents`
  to the new variant that cancels the insert mode.
- Context menu, navigator items and breadcrumb trail switched to using
  new `selectComponents` function.
- Two existing places that fired almost identical lists of actions to
  `cancelInsertModeActions` now use that function instead.
