### PR TITLE
Remove the near-but-not-quite-enough guidelines.

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1269,10 +1269,8 @@ function innerSnapPoint(
   let snappedGuideline: GuidelineWithSnappingVector | null = null
 
   guidelines.forEach((guideline) => {
-    if (guideline.activateSnap) {
-      snappedPoint = Utils.offsetPoint(snappedPoint, guideline.snappingVector)
-      snappedGuideline = guideline
-    }
+    snappedPoint = Utils.offsetPoint(snappedPoint, guideline.snappingVector)
+    snappedGuideline = guideline
   })
   return {
     point: snappedPoint,

--- a/editor/src/components/canvas/controls/guideline-control.tsx
+++ b/editor/src/components/canvas/controls/guideline-control.tsx
@@ -84,7 +84,7 @@ export function GuidelineControl(props: ResizeEdgeProps) {
         borderWidth: 0,
         borderLeftWidth: lineSize,
         borderTopWidth: lineSize,
-        borderStyle: props.guidelineWithSnapping.activateSnap ? 'solid' : 'dashed',
+        borderStyle: 'solid',
         borderColor: colorTheme.canvasLayoutStroke.value,
       }}
     />

--- a/editor/src/components/canvas/controls/guideline-controls.tsx
+++ b/editor/src/components/canvas/controls/guideline-controls.tsx
@@ -49,26 +49,20 @@ const scaleSelector = (store: EditorStorePatched) => store.editor.canvas.scale
 const GuidelineControl = React.memo<GuidelineProps>((props) => {
   const colorTheme = useColorTheme()
   const scale = useEditorState(scaleSelector, 'Guideline scale')
-  const controlRef = useGuideline(
-    props.index,
-    (result: { frame: CanvasRectangle; activateSnap: boolean } | null) => {
-      if (controlRef.current != null) {
-        if (result == null) {
-          controlRef.current.style.setProperty('display', 'none')
-        } else {
-          controlRef.current.style.setProperty('display', 'block')
-          controlRef.current.style.setProperty('left', `${result.frame.x - 0.5 / scale}px`)
-          controlRef.current.style.setProperty('top', `${result.frame.y - 0.5 / scale}px`)
-          controlRef.current.style.setProperty('width', `${result.frame.width}px`)
-          controlRef.current.style.setProperty('height', `${result.frame.height}px`)
-          controlRef.current.style.setProperty(
-            'border-style',
-            `${result.activateSnap ? 'solid' : 'dashed'}`,
-          )
-        }
+  const controlRef = useGuideline(props.index, (result: { frame: CanvasRectangle } | null) => {
+    if (controlRef.current != null) {
+      if (result == null) {
+        controlRef.current.style.setProperty('display', 'none')
+      } else {
+        controlRef.current.style.setProperty('display', 'block')
+        controlRef.current.style.setProperty('left', `${result.frame.x - 0.5 / scale}px`)
+        controlRef.current.style.setProperty('top', `${result.frame.y - 0.5 / scale}px`)
+        controlRef.current.style.setProperty('width', `${result.frame.width}px`)
+        controlRef.current.style.setProperty('height', `${result.frame.height}px`)
+        controlRef.current.style.setProperty('border-style', 'solid')
       }
-    },
-  )
+    }
+  })
 
   const key = `guideline-${props.index}`
   return (
@@ -91,12 +85,12 @@ const GuidelineControl = React.memo<GuidelineProps>((props) => {
 
 function useGuideline<T = HTMLDivElement>(
   index: number,
-  onChangeCallback: (result: { frame: CanvasRectangle; activateSnap: boolean } | null) => void,
+  onChangeCallback: (result: { frame: CanvasRectangle } | null) => void,
 ): React.RefObject<T> {
   const controlRef = React.useRef<T>(null)
 
   const guidelineCallback = React.useCallback(
-    (result: { frame: CanvasRectangle; activateSnap: boolean } | null) => {
+    (result: { frame: CanvasRectangle } | null) => {
       if (controlRef.current != null) {
         onChangeCallback(result)
       }
@@ -123,7 +117,6 @@ function useGuideline<T = HTMLDivElement>(
           })
           guidelineCallbackRef.current({
             frame: frame,
-            activateSnap: guidelineWithSnapping.activateSnap,
           })
           break
         }
@@ -136,7 +129,6 @@ function useGuideline<T = HTMLDivElement>(
           })
           guidelineCallbackRef.current({
             frame: frame,
-            activateSnap: guidelineWithSnapping.activateSnap,
           })
           break
         }

--- a/editor/src/components/canvas/controls/guideline-helpers.ts
+++ b/editor/src/components/canvas/controls/guideline-helpers.ts
@@ -156,11 +156,7 @@ export function getSnapDelta(
   )
   const winningGuidelines = oneGuidelinePerDimension(closestGuideLines)
   const delta = winningGuidelines.reduce((working, guideline) => {
-    if (guideline.activateSnap) {
-      return Utils.offsetPoint(working, guideline.snappingVector)
-    } else {
-      return working
-    }
+    return Utils.offsetPoint(working, guideline.snappingVector)
   }, Utils.zeroPoint as CanvasPoint)
   return {
     delta: Utils.roundPointToNearestHalf(delta),
@@ -261,10 +257,6 @@ export function applySnappingToPoint(
   guidelines: Array<GuidelineWithSnappingVector>,
 ): CanvasPoint {
   return oneGuidelinePerDimension(guidelines).reduce((p, guidelineResult) => {
-    if (guidelineResult.activateSnap) {
-      return Utils.offsetPoint(p, guidelineResult.snappingVector)
-    } else {
-      return p
-    }
+    return Utils.offsetPoint(p, guidelineResult.snappingVector)
   }, point)
 }

--- a/editor/src/components/canvas/guideline.ts
+++ b/editor/src/components/canvas/guideline.ts
@@ -75,18 +75,15 @@ type GuidelineWithDistance = {
 export interface GuidelineWithSnappingVector {
   guideline: Guideline
   snappingVector: CanvasVector
-  activateSnap: boolean
 }
 
 export function guidelineWithSnappingVector(
   guideline: Guideline,
   snappingVector: CanvasVector,
-  activateSnap: boolean,
 ): GuidelineWithSnappingVector {
   return {
     guideline: guideline,
     snappingVector: snappingVector,
-    activateSnap: activateSnap,
   }
 }
 
@@ -430,6 +427,9 @@ export const Guidelines = {
   newSnappingVectorIsEqual<C extends CoordinateMarker>(l: Point<C>, r: Point<C>): boolean {
     return Utils.magnitude(l) === Utils.magnitude(r)
   },
+  shouldSnap(snappingVector: Vector<any>, snappingThreshold: number, scale: number): boolean {
+    return Utils.magnitude(snappingVector) < snappingThreshold / scale
+  },
   getClosestGuidelinesAndOffsets(
     xs: Array<number>,
     ys: Array<number>,
@@ -448,27 +448,30 @@ export const Guidelines = {
           guideline,
           constrainedDragAxis,
         )
-        const guidelineAndOffset = {
-          guideline: guideline,
-          snappingVector: snappingVector,
-          activateSnap: Utils.magnitude(snappingVector) < snappingThreshold / scale,
-        }
+        const activateSnap = this.shouldSnap(snappingVector, snappingThreshold, scale)
+        if (activateSnap) {
+          const guidelineAndOffset = {
+            guideline: guideline,
+            snappingVector: snappingVector,
+            activateSnap: true,
+          }
 
-        if (
-          xGuidelinesAndOffsets.length === 0 ||
-          Guidelines.newSnappingVectorIsSmallest(
-            snappingVector,
-            xGuidelinesAndOffsets[0].snappingVector,
-          )
-        ) {
-          xGuidelinesAndOffsets = [guidelineAndOffset]
-        } else if (
-          Guidelines.newSnappingVectorIsEqual(
-            snappingVector,
-            xGuidelinesAndOffsets[0].snappingVector,
-          )
-        ) {
-          xGuidelinesAndOffsets.push(guidelineAndOffset)
+          if (
+            xGuidelinesAndOffsets.length === 0 ||
+            Guidelines.newSnappingVectorIsSmallest(
+              snappingVector,
+              xGuidelinesAndOffsets[0].snappingVector,
+            )
+          ) {
+            xGuidelinesAndOffsets = [guidelineAndOffset]
+          } else if (
+            Guidelines.newSnappingVectorIsEqual(
+              snappingVector,
+              xGuidelinesAndOffsets[0].snappingVector,
+            )
+          ) {
+            xGuidelinesAndOffsets.push(guidelineAndOffset)
+          }
         }
       } else if (guideline.type === 'YAxisGuideline' && constrainedDragAxis !== 'x') {
         const snappingVector = Guidelines.getOffsetToSnapToYGuideline(
@@ -476,70 +479,76 @@ export const Guidelines = {
           guideline,
           constrainedDragAxis,
         )
-        const guidelineAndOffset = {
-          guideline: guideline,
-          snappingVector: snappingVector,
-          activateSnap: Utils.magnitude(snappingVector) < snappingThreshold / scale,
-        }
+        const activateSnap = this.shouldSnap(snappingVector, snappingThreshold, scale)
+        if (activateSnap) {
+          const guidelineAndOffset = {
+            guideline: guideline,
+            snappingVector: snappingVector,
+            activateSnap: true,
+          }
 
-        if (
-          yGuidelinesAndOffsets.length === 0 ||
-          Guidelines.newSnappingVectorIsSmallest(
-            snappingVector,
-            yGuidelinesAndOffsets[0].snappingVector,
-          )
-        ) {
-          yGuidelinesAndOffsets = [guidelineAndOffset]
-        } else if (
-          Guidelines.newSnappingVectorIsEqual(
-            snappingVector,
-            yGuidelinesAndOffsets[0].snappingVector,
-          )
-        ) {
-          yGuidelinesAndOffsets.push(guidelineAndOffset)
+          if (
+            yGuidelinesAndOffsets.length === 0 ||
+            Guidelines.newSnappingVectorIsSmallest(
+              snappingVector,
+              yGuidelinesAndOffsets[0].snappingVector,
+            )
+          ) {
+            yGuidelinesAndOffsets = [guidelineAndOffset]
+          } else if (
+            Guidelines.newSnappingVectorIsEqual(
+              snappingVector,
+              yGuidelinesAndOffsets[0].snappingVector,
+            )
+          ) {
+            yGuidelinesAndOffsets.push(guidelineAndOffset)
+          }
         }
       }
     }
     Utils.fastForEach(guidelines, (guideline) => {
       if (guideline.type === 'CornerGuideline') {
         const snappingVector = Guidelines.getOffsetToSnapToCornerGuideline(corners, guideline)
-        const guidelineAndOffset = {
-          guideline: guideline,
-          snappingVector: snappingVector,
-          activateSnap: Utils.magnitude(snappingVector) < snappingThreshold / scale,
-        }
+        const activateSnap = this.shouldSnap(snappingVector, snappingThreshold, scale)
+        if (activateSnap) {
+          const guidelineAndOffset = {
+            guideline: guideline,
+            snappingVector: snappingVector,
+            activateSnap: true,
+          }
 
-        if (
-          xGuidelinesAndOffsets.length === 0 ||
-          Guidelines.newSnappingVectorIsSmallest(
-            snappingVector,
-            xGuidelinesAndOffsets[0].snappingVector,
-          )
-        ) {
-          xGuidelinesAndOffsets = [guidelineAndOffset]
-        } else if (
-          Guidelines.newSnappingVectorIsEqual(
-            snappingVector,
-            xGuidelinesAndOffsets[0].snappingVector,
-          )
-        ) {
-          xGuidelinesAndOffsets.push(guidelineAndOffset)
-        }
-        if (
-          yGuidelinesAndOffsets.length === 0 ||
-          Guidelines.newSnappingVectorIsSmallest(
-            snappingVector,
-            yGuidelinesAndOffsets[0].snappingVector,
-          )
-        ) {
-          yGuidelinesAndOffsets = [guidelineAndOffset]
-        } else if (
-          Guidelines.newSnappingVectorIsEqual(
-            snappingVector,
-            yGuidelinesAndOffsets[0].snappingVector,
-          )
-        ) {
-          yGuidelinesAndOffsets.push(guidelineAndOffset)
+          if (
+            xGuidelinesAndOffsets.length === 0 ||
+            Guidelines.newSnappingVectorIsSmallest(
+              snappingVector,
+              xGuidelinesAndOffsets[0].snappingVector,
+            )
+          ) {
+            xGuidelinesAndOffsets = [guidelineAndOffset]
+          } else if (
+            Guidelines.newSnappingVectorIsEqual(
+              snappingVector,
+              xGuidelinesAndOffsets[0].snappingVector,
+            )
+          ) {
+            xGuidelinesAndOffsets.push(guidelineAndOffset)
+          }
+          if (
+            yGuidelinesAndOffsets.length === 0 ||
+            Guidelines.newSnappingVectorIsSmallest(
+              snappingVector,
+              yGuidelinesAndOffsets[0].snappingVector,
+            )
+          ) {
+            yGuidelinesAndOffsets = [guidelineAndOffset]
+          } else if (
+            Guidelines.newSnappingVectorIsEqual(
+              snappingVector,
+              yGuidelinesAndOffsets[0].snappingVector,
+            )
+          ) {
+            yGuidelinesAndOffsets.push(guidelineAndOffset)
+          }
         }
       }
     })

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1526,13 +1526,11 @@ export const GuidelineKeepDeepEquality: KeepDeepEqualityCall<Guideline> = (oldVa
 }
 
 export const GuidelineWithSnappingVectorKeepDeepEquality: KeepDeepEqualityCall<GuidelineWithSnappingVector> =
-  combine3EqualityCalls(
+  combine2EqualityCalls(
     (guideline) => guideline.guideline,
     GuidelineKeepDeepEquality,
     (guideline) => guideline.snappingVector,
     CanvasPointKeepDeepEquality,
-    (guideline) => guideline.activateSnap,
-    createCallWithTripleEquals(),
     guidelineWithSnappingVector,
   )
 


### PR DESCRIPTION
**Problem:**
We no longer desire the near-but-not-quite-enough guidelines to continue existing.

**Fix:**
Since the distinction between those that are close enough is the `activateSnap` property, just remove that and only create guidelines when the condition for that property is true.

**Commit Details:**
- Removed the `activateSnap` property from `GuidelineWithSnappingVector`.
- Pull out the logic for determining if a guideline should snap into
  a function `shouldSnap`.
- Rework `getClosestGuidelinesAndOffsets` to not include guidelines if
  `shouldSnap` returns false.
- Since `activateSnap` no longer exists, the handling in `GuidelineControl`
  is simplified slightly.
- `innerSnapPoint` simplified a little due to `activateSnap` disappearing.
