### PR TITLE
No reorder for generated elements

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.browser2.tsx
@@ -272,7 +272,7 @@ describe('Absolute Reparent Strategy', () => {
     const dragDelta = windowPoint({ x: 0, y: -150 })
     act(() =>
       dragElement(renderResult, 'child-to-reparent', dragDelta, cmdModifier, {
-        cursor: CSSCursor.ReparentNotPermitted,
+        cursor: CSSCursor.NotPermitted,
       }),
     )
 

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -1,5 +1,7 @@
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { offsetPoint } from '../../../core/shared/math-utils'
+import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
+import { CanvasVector, offsetPoint, rectContainsPoint } from '../../../core/shared/math-utils'
+import { ElementPath } from '../../../core/shared/project-file-types'
 import { reorderElement } from '../commands/reorder-element-command'
 import {
   CanvasStrategy,

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -25,6 +25,7 @@ import { setElementsToRerenderCommand } from '../commands/set-elements-to-rerend
 import { ParentBounds } from '../controls/parent-bounds'
 import { getReorderIndex } from './reparent-strategy-helpers'
 import { absolute } from '../../../utils/utils'
+import { isGeneratedElement } from './reparent-helpers'
 
 export const flexReorderStrategy: CanvasStrategy = {
   id: 'FLEX_REORDER',
@@ -77,6 +78,13 @@ export const flexReorderStrategy: CanvasStrategy = {
       const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
 
       const target = selectedElements[0]
+
+      if (isGeneratedElement(canvasState.projectContents, canvasState.openFile, target)) {
+        return {
+          commands: [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
+          customState: null,
+        }
+      }
 
       const siblingsOfTarget = MetadataUtils.getSiblings(
         strategyState.startingMetadata,

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
@@ -24,6 +24,7 @@ import {
   FlowReorderDragOutline,
 } from '../controls/flow-reorder-indicators'
 import { AllElementProps } from '../../editor/store/editor-state'
+import { isGeneratedElement } from './reparent-helpers'
 
 function isFlowReorderConversionApplicable(
   canvasState: InteractionCanvasState,
@@ -71,6 +72,13 @@ function flowReorderApplyCommon(
   if (interactionState.interactionData.drag != null) {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     const target = selectedElements[0] // TODO MULTISELECT??
+
+    if (isGeneratedElement(canvasState.projectContents, canvasState.openFile, target)) {
+      return {
+        commands: [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
+        customState: null,
+      }
+    }
 
     const siblingsOfTarget = MetadataUtils.getSiblings(strategyState.startingMetadata, target).map(
       (element) => element.elementPath,

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
@@ -25,6 +25,7 @@ import {
 } from '../controls/flow-reorder-indicators'
 import { AllElementProps } from '../../editor/store/editor-state'
 import { isGeneratedElement } from './reparent-helpers'
+import { isReorderAllowed } from './reorder-utils'
 
 function isFlowReorderConversionApplicable(
   canvasState: InteractionCanvasState,
@@ -73,16 +74,16 @@ function flowReorderApplyCommon(
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     const target = selectedElements[0] // TODO MULTISELECT??
 
-    if (isGeneratedElement(canvasState.projectContents, canvasState.openFile, target)) {
+    const siblingsOfTarget = MetadataUtils.getSiblings(strategyState.startingMetadata, target).map(
+      (element) => element.elementPath,
+    )
+
+    if (!isReorderAllowed(siblingsOfTarget)) {
       return {
         commands: [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
         customState: null,
       }
     }
-
-    const siblingsOfTarget = MetadataUtils.getSiblings(strategyState.startingMetadata, target).map(
-      (element) => element.elementPath,
-    )
 
     const rawPointOnCanvas = offsetPoint(
       interactionState.interactionData.dragStart,

--- a/editor/src/components/canvas/canvas-strategies/reorder-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/reorder-utils.ts
@@ -1,0 +1,12 @@
+import * as EP from '../../../core/shared/element-path'
+import { ElementPath } from '../../../core/shared/project-file-types'
+
+export function isReorderAllowed(siblings: Array<ElementPath>) {
+  return siblings.every((sibling) => !isRootOfGeneratedElement(sibling))
+}
+
+function isRootOfGeneratedElement(target: ElementPath): boolean {
+  const uid = EP.toUid(target)
+  const staticUid = EP.toStaticUid(target)
+  return uid !== staticUid
+}

--- a/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
@@ -66,7 +66,7 @@ export function ifAllowedToReparent(
     return ifAllowed()
   } else {
     return {
-      commands: [setCursorCommand('mid-interaction', CSSCursor.ReparentNotPermitted)],
+      commands: [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
       customState: null,
     }
   }

--- a/editor/src/components/canvas/canvas-strategies/reparent-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-utils.ts
@@ -233,7 +233,7 @@ export function cursorForMissingReparentedItems(
 ): CSSCursor | null {
   for (const reparentedToPath of reparentedToPaths) {
     if (!(EP.toString(reparentedToPath) in spyMetadata)) {
-      return CSSCursor.ReparentNotPermitted
+      return CSSCursor.NotPermitted
     }
   }
 

--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -59,7 +59,7 @@ export enum CSSCursor {
   BrowserAuto = 'auto',
   Duplicate = "-webkit-image-set( url( '/editor/cursors/cursor-duplicate.png ') 1x, url( '/editor/cursors/cursor-duplicate@2x.png ') 2x ) 4 4, default",
   OpenHand = "-webkit-image-set( url( '/editor/cursors/cursor-open-hand.png ') 1x, url( '/editor/cursors/cursor-open-hand@2x.png ') 2x ) 4 4, default",
-  ReparentNotPermitted = "-webkit-image-set( url( '/editor/cursors/cursor-no-reparent.png ') 1x, url( '/editor/cursors/cursor-no-reparent@2x.png ') 2x ) 4 4, default",
+  NotPermitted = "-webkit-image-set( url( '/editor/cursors/cursor-no-reparent.png ') 1x, url( '/editor/cursors/cursor-no-reparent@2x.png ') 2x ) 4 4, default",
   MagicHand = "-webkit-image-set( url( '/editor/cursors/cursor-magic-hand.png ') 1x, url( '/editor/cursors/cursor-magic-move@2x.png ') 2x ) 4 4, default",
 }
 


### PR DESCRIPTION
Reordering is disallowed for elements which are root elements of generated content. 
This can be detected by checking if dynamic uid is the same as the static one. 
To be safe, I also disallowed reordering when any of the siblings are root elements of generated content (to make sure we don't try to reorder between two dynamically generated instances of the same static element)