### PR TITLE
flex insert/reparent indicator is drawn at the midpoint between targe…

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -57,8 +57,6 @@ import {
 } from '../commands/adjust-css-length-command'
 import { updatePropIfExists } from '../commands/update-prop-if-exists-command'
 
-const FlexReparentIndicatorSize = 2
-
 export type ReparentStrategy =
   | 'FLEX_REPARENT_TO_ABSOLUTE'
   | 'FLEX_REPARENT_TO_FLEX'
@@ -468,6 +466,8 @@ export function applyFlexReparent(
   interactionSession: InteractionSession,
   strategyState: StrategyState,
 ): StrategyApplicationResult {
+  const FlexReparentIndicatorSize = 2 / canvasState.scale
+
   const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
   const filteredSelectedElements = getDragTargets(selectedElements)
 

--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -206,6 +206,7 @@ export function getReparentTargetUnified(
 ): ReparentTarget {
   const projectContents = canvasState.projectContents
   const openFile = canvasState.openFile ?? null
+  const canvasScale = canvasState.scale
 
   const multiselectBounds: Size =
     MetadataUtils.getBoundingRectangleInCanvasCoords(filteredSelectedElements, metadata) ??
@@ -287,6 +288,7 @@ export function getReparentTargetUnified(
       metadata,
       flexElementPath,
       'padded-edge',
+      canvasScale,
     )
 
     const targetUnderMouseIndex = targets.findIndex((target) => {
@@ -331,6 +333,7 @@ export function getReparentTargetUnified(
       metadata,
       targetParentPath,
       'full-size',
+      canvasScale,
     )
 
     const targetUnderMouseIndex = targets.findIndex((target) => {
@@ -358,7 +361,10 @@ function drawTargetRectanglesForChildrenOfElement(
   metadata: ElementInstanceMetadataMap,
   flexElementPath: ElementPath,
   targetRectangleSize: 'padded-edge' | 'full-size',
+  canvasScale: number,
 ) {
+  const ExtraPadding = 10 / canvasScale
+
   const flexElement = MetadataUtils.findElementByElementPath(metadata, flexElementPath)
   const flexDirection = MetadataUtils.getFlexDirection(flexElement)
   const parentBounds = MetadataUtils.getFrameInCanvasCoords(flexElementPath, metadata)
@@ -409,8 +415,6 @@ function drawTargetRectanglesForChildrenOfElement(
 
       const normalizedStart = Math.min(start, end)
       const normalizedEnd = Math.max(start, end)
-
-      const ExtraPadding = 10
 
       const paddedStart = normalizedStart - ExtraPadding
       const paddedEnd = normalizedEnd + ExtraPadding


### PR DESCRIPTION
**Problem:**
The flex reparent/insert target indicators are attached to the flex sibling element. This is because the indicators were actually just a placeholder implementation while I worked on the reparent, but then in lieu of more time, I merged them to master.

**Fix:**
The indicators are now drawn in the geometric center between the two target siblings.

**Note:**
This is a variant to https://github.com/concrete-utopia/utopia/pull/2509 which uses the flex gap value

**This is how it looks like:**
https://screenshot.click/05-08-sklcu-x5x8g.mp4

**Details:**
- Calculating the indicator using the two target siblings instead of prepending it before the target succeeding sibling
- Adjusting the line width by canvas scale
- **Sneaked in fix** also using the canvas scale to alter the size of the flex insertion detection zones, so users have more controls over zoomed in canvases
