### PR TITLE
fix(strategy canvas controls) more delay, show as soon as the mouse is moved

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -276,7 +276,7 @@ export const useDelayedCurrentStrategy = () => {
   useSelectorWithCallback((store) => {
     if (
       store.editor.canvas.interactionSession?.interactionData.type === 'DRAG' &&
-      store.editor.canvas.interactionSession?.interactionData.drag != null
+      store.editor.canvas.interactionSession?.interactionData.hasMouseMoved
     ) {
       return store.strategyState.currentStrategy
     } else {

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -141,4 +141,4 @@ export interface CanvasStrategy {
   ) => StrategyApplicationResult
 }
 
-export const ControlDelay = 300
+export const ControlDelay = 600

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -31,6 +31,7 @@ export interface DragInteractionData {
   originalDragStart: CanvasPoint
   modifiers: Modifiers
   globalTime: number
+  hasMouseMoved: boolean
 }
 
 export interface KeyState {
@@ -157,6 +158,7 @@ export function createInteractionViaMouse(
       originalDragStart: mouseDownPoint,
       modifiers: modifiers,
       globalTime: Date.now(),
+      hasMouseMoved: false,
     },
     activeControl: activeControl,
     sourceOfUpdate: activeControl,
@@ -191,6 +193,7 @@ export function updateInteractionViaMouse(
         originalDragStart: currentState.interactionData.originalDragStart,
         modifiers: modifiers,
         globalTime: Date.now(),
+        hasMouseMoved: true,
       },
       activeControl: currentState.activeControl,
       sourceOfUpdate: sourceOfUpdate ?? currentState.activeControl,
@@ -277,6 +280,7 @@ export function updateInteractionViaKeyboard(
           originalDragStart: currentState.interactionData.originalDragStart,
           modifiers: modifiers,
           globalTime: Date.now(),
+          hasMouseMoved: currentState.interactionData.hasMouseMoved,
         },
         activeControl: currentState.activeControl,
         sourceOfUpdate: currentState.activeControl,

--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -30,7 +30,7 @@ import { AlwaysTrue, usePubSubAtomReadOnly } from '../../core/shared/atom-with-p
 import { ErrorMessage } from '../../core/shared/error-messages'
 import CanvasActions from './canvas-actions'
 import { EditorModes } from '../editor/editor-modes'
-import { CanvasStrategyIndicator } from './controls/select-mode/canvas-strategy-indicator'
+import { CanvasStrategyPicker } from './controls/select-mode/canvas-strategy-picker'
 import { when } from '../../utils/react-conditionals'
 import { isFeatureEnabled } from '../../utils/feature-switches'
 
@@ -125,7 +125,7 @@ export const CanvasWrapperComponent = React.memo(() => {
         >
           {safeMode ? <SafeModeErrorOverlay /> : <ErrorOverlayComponent />}
           <ModeSelectButtons />
-          {when(isFeatureEnabled('Canvas Strategies'), <CanvasStrategyIndicator />)}
+          {when(isFeatureEnabled('Canvas Strategies'), <CanvasStrategyPicker />)}
         </FlexColumn>
       </FlexRow>
     </FlexColumn>

--- a/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.tsx
@@ -6,14 +6,14 @@ import CanvasActions from '../../canvas-actions'
 import { useDelayedCurrentStrategy } from '../../canvas-strategies/canvas-strategies'
 import { CanvasStrategy } from '../../canvas-strategies/canvas-strategy-types'
 
-export const CanvasStrategyIndicator = React.memo(() => {
+export const CanvasStrategyPicker = React.memo(() => {
   const colorTheme = useColorTheme()
-  const dispatch = useEditorState((store) => store.dispatch, 'CanvasStrategyIndicator dispatch')
+  const dispatch = useEditorState((store) => store.dispatch, 'CanvasStrategyPicker dispatch')
   const { otherPossibleStrategies } = useEditorState(
     (store) => ({
       otherPossibleStrategies: store.strategyState.sortedApplicableStrategies,
     }),
-    'CanvasStrategyIndicator strategyState.currentStrategy',
+    'CanvasStrategyPicker strategyState.currentStrategy',
   )
   const activeStrategy = useDelayedCurrentStrategy()
 

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -246,6 +246,7 @@ describe('interactionStart', () => {
           "y": 200,
         },
         "globalTime": 1000,
+        "hasMouseMoved": false,
         "modifiers": Object {
           "alt": false,
           "cmd": false,
@@ -369,6 +370,7 @@ describe('interactionUpdatex', () => {
           "y": 200,
         },
         "globalTime": 1000,
+        "hasMouseMoved": false,
         "modifiers": Object {
           "alt": false,
           "cmd": false,
@@ -524,6 +526,7 @@ describe('interactionHardReset', () => {
           "y": 210,
         },
         "globalTime": 1000,
+        "hasMouseMoved": false,
         "modifiers": Object {
           "alt": false,
           "cmd": false,
@@ -742,6 +745,7 @@ describe('interactionUpdate with user changed strategy', () => {
           "y": 210,
         },
         "globalTime": 1000,
+        "hasMouseMoved": false,
         "modifiers": Object {
           "alt": false,
           "cmd": false,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1571,7 +1571,7 @@ export const ModifiersKeepDeepEquality: KeepDeepEqualityCall<Modifiers> = combin
 )
 
 export const DragInteractionDataKeepDeepEquality: KeepDeepEqualityCall<DragInteractionData> =
-  combine6EqualityCalls(
+  combine7EqualityCalls(
     (data) => data.dragStart,
     CanvasPointKeepDeepEquality,
     (data) => data.drag,
@@ -1584,7 +1584,9 @@ export const DragInteractionDataKeepDeepEquality: KeepDeepEqualityCall<DragInter
     ModifiersKeepDeepEquality,
     (data) => data.globalTime,
     createCallWithTripleEquals(),
-    (dragStart, drag, prevDrag, originalDragStart, modifiers, globalTime) => {
+    (data) => data.hasMouseMoved,
+    BooleanKeepDeepEquality,
+    (dragStart, drag, prevDrag, originalDragStart, modifiers, globalTime, hasMouseMoved) => {
       return {
         type: 'DRAG',
         dragStart: dragStart,
@@ -1593,6 +1595,7 @@ export const DragInteractionDataKeepDeepEquality: KeepDeepEqualityCall<DragInter
         originalDragStart: originalDragStart,
         modifiers: modifiers,
         globalTime: globalTime,
+        hasMouseMoved: hasMouseMoved,
       }
     },
   )


### PR DESCRIPTION
**Fix:**
Show strategy picker and controls immediately as the mouse is moved after mousedown instead of when reaching the drag threshold. Update timeout delay.

I also renamed `CanvasStrategyIndicator` to `CanvasStrategyPicker` because I always search for picker and it's named indicator 😅

**Commit Details:**
- `interactionData` extended with `hasMouseMoved` 
- control delay set to 600 ms
- rename canvas strategy picker
