### PR TITLE
Use globalContentBox when converting global frame to local

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -14,6 +14,7 @@ import {
   rectContainsPoint,
   rectContainsPointInclusive,
   rectFromTwoPoints,
+  roundPointToNearestHalf,
   Size,
   size,
   sizeFitsInTarget,
@@ -717,16 +718,20 @@ export function getAbsoluteReparentPropertyChanges(
     MetadataUtils.findElementByElementPath(newParentStartingMetadata, newParent)
       ?.specialSizeMeasurements.globalContentBox ?? zeroCanvasRect
 
-  const offsetTL = pointDifference(newParentContentBox, currentParentContentBox)
-  const offsetBR = pointDifference(
-    canvasPoint({
-      x: currentParentContentBox.x + currentParentContentBox.width,
-      y: currentParentContentBox.y + currentParentContentBox.height,
-    }),
-    canvasPoint({
-      x: newParentContentBox.x + newParentContentBox.width,
-      y: newParentContentBox.y + newParentContentBox.height,
-    }),
+  const offsetTL = roundPointToNearestHalf(
+    pointDifference(newParentContentBox, currentParentContentBox),
+  )
+  const offsetBR = roundPointToNearestHalf(
+    pointDifference(
+      canvasPoint({
+        x: currentParentContentBox.x + currentParentContentBox.width,
+        y: currentParentContentBox.y + currentParentContentBox.height,
+      }),
+      canvasPoint({
+        x: newParentContentBox.x + newParentContentBox.width,
+        y: newParentContentBox.y + newParentContentBox.height,
+      }),
+    ),
   )
 
   const createAdjustCssLengthProperty = (

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -922,10 +922,19 @@ export const MetadataUtils = {
   ): LocalRectangle {
     const parent = this.findElementByElementPath(metadata, targetParent)
     if (parent != null) {
-      if (parent.specialSizeMeasurements.globalContentBox != null) {
+      if (
+        parent.specialSizeMeasurements.providesBoundsForAbsoluteChildren &&
+        parent.specialSizeMeasurements.globalContentBox != null
+      ) {
         return canvasRectangleToLocalRectangle(
           frame,
           parent.specialSizeMeasurements.globalContentBox,
+        )
+      }
+      if (parent.specialSizeMeasurements.coordinateSystemBounds != null) {
+        return canvasRectangleToLocalRectangle(
+          frame,
+          parent.specialSizeMeasurements.coordinateSystemBounds,
         )
       }
     }

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -43,6 +43,7 @@ import {
   CanvasRectangle,
   canvasRectangleToLocalRectangle,
   LocalRectangle,
+  roundPointToNearestHalf,
   Size,
 } from '../shared/math-utils'
 import { optionalMap } from '../shared/optional-utils'
@@ -921,16 +922,10 @@ export const MetadataUtils = {
   ): LocalRectangle {
     const parent = this.findElementByElementPath(metadata, targetParent)
     if (parent != null) {
-      if (
-        parent.specialSizeMeasurements.providesBoundsForAbsoluteChildren &&
-        parent.globalFrame != null
-      ) {
-        return canvasRectangleToLocalRectangle(frame, parent.globalFrame)
-      }
-      if (parent.specialSizeMeasurements.coordinateSystemBounds != null) {
+      if (parent.specialSizeMeasurements.globalContentBox != null) {
         return canvasRectangleToLocalRectangle(
           frame,
-          parent.specialSizeMeasurements.coordinateSystemBounds,
+          parent.specialSizeMeasurements.globalContentBox,
         )
       }
     }

--- a/editor/src/core/shared/math-utils.ts
+++ b/editor/src/core/shared/math-utils.ts
@@ -970,7 +970,7 @@ export function canvasRectangleToLocalRectangle(
   canvasRect: CanvasRectangle,
   parentRect: CanvasRectangle,
 ): LocalRectangle {
-  const diff = pointDifference(parentRect, canvasRect)
+  const diff = roundPointToNearestHalf(pointDifference(parentRect, canvasRect))
   return localRectangle({
     x: diff.x,
     y: diff.y,


### PR DESCRIPTION
**Problem:**
Snapping guidelines weren't showing when reparenting from flex to absolute in certain situations

**Fix:**
The actual issue here was that when reparenting from flex to absolute, we would need to trigger the escape hatch, which calculates the dragged element's local frame relative to its parent. This calculation uses the global frame of that element, and calculates the relative offset of that from the parent's global frame, whereas we should instead be calculating it relative to the parent's `globalContentBox`, as that will be used as the origin for the rendered child element.

Also, as the `globalContentBox` isn't rounded, I've added some rounding in the places where we are doing this.