### PR TITLE
fix(canvas) scene label height

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/scene-label.tsx
@@ -75,6 +75,7 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
   const scale = useEditorState((store) => store.editor.canvas.scale, 'SceneLabel scale')
   const baseFontSize = 9
   const scaledFontSize = baseFontSize / scale
+  const scaledLineHeight = 17 / scale
   const paddingY = scaledFontSize / 9
   const offsetY = scaledFontSize
   const offsetX = scaledFontSize
@@ -173,6 +174,7 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
             fontFamily:
               '-apple-system, BlinkMacSystemFont, Helvetica, "Segoe UI", Roboto,  Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
             fontSize: scaledFontSize,
+            lineHeight: `${scaledLineHeight}px`,
             whiteSpace: 'nowrap',
             overflow: 'hidden',
             textOverflow: 'ellipsis',


### PR DESCRIPTION
**Problem:**
When zoomed out the scene label text is not readable.

**Fix:**
Fix the scene label height.

**Before/after:**
<img width="306" alt="Screenshot 2022-09-06 at 16 12 49" src="https://user-images.githubusercontent.com/4403069/188658054-b9cb781e-8d97-4404-967d-3c95444e2806.png">
<img width="242" alt="Screenshot 2022-09-06 at 16 12 57" src="https://user-images.githubusercontent.com/4403069/188658085-9bce668d-ecf5-466b-83ca-eb97ec3a0cbc.png">


