### PR TITLE
disallow reparent if parent stayed the same

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -151,18 +151,13 @@ export function findReparentStrategy(
   const parentStayedTheSame = filteredSelectedElements.some(
     (e) => EP.parentPath(e) === newParentPath,
   )
-  const newParentMetadata = MetadataUtils.findElementByElementPath(
-    strategyState.startingMetadata,
-    newParentPath,
-  )
-  const parentIsFlexLayout = MetadataUtils.isFlexLayoutedContainer(newParentMetadata)
 
   if (
     reparentResult.shouldReparent &&
     newParentPath != null &&
     // holding cmd forces a reparent even if the target parent was under the mouse at the interaction start
     (cmdPressed || newParentPath !== interactionState.startingTargetParentToFilterOut?.newParent) &&
-    (parentIsFlexLayout || !parentStayedTheSame) // TODO review this, as it is a result of a merge with master
+    !parentStayedTheSame
   ) {
     return reparentStrategyForParent(
       strategyState.startingMetadata,


### PR DESCRIPTION
**Problem:**
For some reason we allow the reparent strategy to activate when the parent stayed the same, but we are in a flex context. why?

**Fix:**
Do not allow the reparent strategies if the parent is the same but flex