### PR TITLE
Navigator updates with reordering live.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.spec.browser2.tsx
@@ -8,6 +8,7 @@ import { act, fireEvent } from '@testing-library/react'
 import { CanvasControlsContainerID } from '../controls/new-canvas-controls'
 import { offsetPoint, windowPoint, WindowPoint } from '../../../core/shared/math-utils'
 import { emptyModifiers, Modifiers } from '../../../utils/modifiers'
+import * as EP from '../../../core/shared/element-path'
 
 const TestProject = `
 <div style={{ width: '100%', height: '100%', position: 'absolute' }} data-uid='container'>
@@ -171,7 +172,8 @@ function dragElement(
   targetTestId: string,
   dragDelta: WindowPoint,
   modifiers: Modifiers,
-) {
+  expectedNavigatorTargetsDuringMove: Array<string>,
+): void {
   const targetElement = renderResult.renderedDOM.getByTestId(targetTestId)
   const targetElementBounds = targetElement.getBoundingClientRect()
   const canvasControl = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
@@ -206,6 +208,10 @@ function dragElement(
     }),
   )
 
+  expect(renderResult.getEditorState().derived.visibleNavigatorTargets.map(EP.toString)).toEqual(
+    expectedNavigatorTargetsDuringMove,
+  )
+
   fireEvent(
     window,
     new MouseEvent('mouseup', {
@@ -229,7 +235,18 @@ describe('Flow Reorder Strategy (Mixed Display Type)', () => {
 
     // drag element 'CCC' up a little to replace it with it's direct sibling
     const dragDelta = windowPoint({ x: 0, y: -45 })
-    act(() => dragElement(renderResult, 'ccc', dragDelta, emptyModifiers))
+    act(() =>
+      dragElement(renderResult, 'ccc', dragDelta, emptyModifiers, [
+        'utopia-storyboard-uid/scene-aaa',
+        'utopia-storyboard-uid/scene-aaa/app-entity',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/aaa',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/ccc',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/bbb',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/ddd',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/eee',
+      ]),
+    )
 
     await renderResult.getDispatchFollowUpActionsFinished()
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
@@ -244,7 +261,18 @@ describe('Flow Reorder Strategy (Mixed Display Type)', () => {
 
     // drag element 'CCC' right to insert into the row
     const dragDelta = windowPoint({ x: 120, y: 0 })
-    act(() => dragElement(renderResult, 'ccc', dragDelta, emptyModifiers))
+    act(() =>
+      dragElement(renderResult, 'ccc', dragDelta, emptyModifiers, [
+        'utopia-storyboard-uid/scene-aaa',
+        'utopia-storyboard-uid/scene-aaa/app-entity',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/aaa',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/bbb',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/ddd',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/ccc',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/eee',
+      ]),
+    )
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
@@ -260,7 +288,18 @@ describe('Flow Reorder Strategy (Mixed Display Type)', () => {
 
     // drag element 'CCC' up to pull out of the row and insert into block
     const dragDelta = windowPoint({ x: 0, y: -100 })
-    act(() => dragElement(renderResult, 'ccc', dragDelta, emptyModifiers))
+    act(() =>
+      dragElement(renderResult, 'ccc', dragDelta, emptyModifiers, [
+        'utopia-storyboard-uid/scene-aaa',
+        'utopia-storyboard-uid/scene-aaa/app-entity',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/aaa',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/ccc',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/bbb',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/ddd',
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/eee',
+      ]),
+    )
 
     await renderResult.getDispatchFollowUpActionsFinished()
 

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -29,6 +29,7 @@ import {
   ElementInstanceMetadataMap,
   emptyComments,
   jsxAttributeValue,
+  jsxElement,
 } from '../../../core/shared/element-template'
 import {
   createEmptyStrategyState,
@@ -50,6 +51,7 @@ import { wildcardPatch } from '../../canvas/commands/wildcard-patch-command'
 import { runCanvasCommand } from '../../canvas/commands/commands'
 import { saveDOMReport } from '../actions/action-creators'
 import { RegisteredCanvasStrategies } from '../../canvas/canvas-strategies/canvas-strategies'
+import { right } from '../../../core/shared/either'
 
 beforeAll(() => {
   return jest.spyOn(Date, 'now').mockReturnValue(new Date(1000).getTime())
@@ -802,6 +804,7 @@ describe('only update metadata on SAVE_DOM_REPORT', () => {
       'new-entry': {
         elementPath: EP.fromString('new-entry'),
         specialSizeMeasurements: { position: 'absolute' },
+        element: right(jsxElement('div', 'aaa', [], [])),
       } as ElementInstanceMetadata,
     }
 
@@ -846,6 +849,7 @@ describe('only update metadata on SAVE_DOM_REPORT', () => {
       'new-entry': {
         elementPath: EP.fromString('new-entry'),
         specialSizeMeasurements: { position: 'absolute' },
+        element: right(jsxElement('div', 'aaa', [], [])),
       } as ElementInstanceMetadata,
     }
 

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -83,7 +83,7 @@ import {
 } from '../../components/editor/store/editor-state'
 import { ProjectContentTreeRoot } from '../../components/assets'
 import { memoize } from '../shared/memoize'
-import { buildTree, ElementPathTree, getSubTree } from '../shared/element-path-tree'
+import { buildTree, ElementPathTree, getSubTree, reorderTree } from '../shared/element-path-tree'
 import { findUnderlyingTargetComponentImplementation } from '../../components/custom-code/code-file'
 
 const ObjectPathImmutable: any = OPI
@@ -807,7 +807,11 @@ export const MetadataUtils = {
     } => {
       // Note: This will not necessarily be representative of the structured ordering in
       // the code that produced these elements.
-      const projectTree = buildTree(objectValues(metadata).map((m) => m.elementPath))
+      const projectTree = buildTree(objectValues(metadata).map((m) => m.elementPath)).map(
+        (subTree) => {
+          return reorderTree(subTree, metadata)
+        },
+      )
 
       // This function exists separately from getAllPaths because the Navigator handles collapsed views
       let navigatorTargets: Array<ElementPath> = []

--- a/editor/src/core/shared/element-path-tree.ts
+++ b/editor/src/core/shared/element-path-tree.ts
@@ -1,6 +1,11 @@
 import { ElementPath, ElementPathPart } from './project-file-types'
 import * as EP from './element-path'
 import { fastForEach } from './utils'
+import { ElementInstanceMetadataMap } from './element-template'
+import { MetadataUtils } from '../model/element-metadata-utils'
+import { foldEither } from './either'
+import { getUtopiaID } from '../model/element-template-utils'
+import { move } from './array-utils'
 
 export interface ElementPathTree {
   path: ElementPath
@@ -52,6 +57,51 @@ export function buildTree(elementPaths: Array<ElementPath>): ElementPathTreeRoot
     }
   }
   return result
+}
+
+export function reorderTree(
+  tree: ElementPathTree,
+  metadata: ElementInstanceMetadataMap,
+): ElementPathTree {
+  const element = MetadataUtils.findElementByElementPath(metadata, tree.path)
+  if (element == null) {
+    return tree
+  } else {
+    return foldEither(
+      () => {
+        return tree
+      },
+      (elementChild) => {
+        switch (elementChild.type) {
+          case 'JSX_ELEMENT': {
+            const updatedChildren = elementChild.children.reduce(
+              (workingTreeChildren, child, childIndex) => {
+                const uid = getUtopiaID(child)
+                const workingTreeIndex = workingTreeChildren.findIndex((workingTreeChild) => {
+                  return EP.toUid(workingTreeChild.path) === uid
+                })
+                if (workingTreeIndex === childIndex) {
+                  return workingTreeChildren
+                } else {
+                  return move(workingTreeIndex, childIndex, workingTreeChildren)
+                }
+              },
+              tree.children.map((child) => {
+                return reorderTree(child, metadata)
+              }),
+            )
+            return {
+              ...tree,
+              children: updatedChildren,
+            }
+          }
+          default:
+            return tree
+        }
+      },
+      element.element,
+    )
+  }
 }
 
 export function printTree(treeRoot: ElementPathTreeRoot): string {


### PR DESCRIPTION
**Problem:**
Currently due to the way the tree is built for the navigator, it leans on the insertion order of the metadata, which results in incorrect ordering if elements are only reordered and the metadata is updated instead of getting reconstructed.

**Fix:**
For cases which can be reordered by the user, the tree structure gets reordered based on the element structure relating to those elements. This is done by taking the ordering of the children in the elements and then applying that ordering back to the path tree.

**Commit Details:**
- Implemented `reorderTree` which takes the result produced by `buildTree` and
  corrects the ordering based on elements found within elements.
- Added a call to `reorderTree` to `createOrderedElementPathsFromElements`.
