### PR TITLE
fix(canvas) delay cursor and strategy picker too

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -236,7 +236,7 @@ export function applyCanvasStrategy(
 }
 
 export function useDelayedStrategyWithCallback<T>(
-  innerCallback: StateSelector<EditorStorePatched, T | null>,
+  selector: StateSelector<EditorStorePatched, T | null>,
 ): T | null {
   /**
    * onMouseDown selection shows canvas controls that are active when a strategy runs with a delay (double click selection in hierarchy)
@@ -275,13 +275,13 @@ export function useDelayedStrategyWithCallback<T>(
     [immediateCallback, delayedValue, timer, setTimer, setDelayedValue],
   )
 
-  useSelectorWithCallback(innerCallback, maybeDelayedCallback)
+  useSelectorWithCallback(selector, maybeDelayedCallback)
   useSelectorWithCallback((store) => {
     if (
       store.editor.canvas.interactionSession?.interactionData.type === 'DRAG' &&
       store.editor.canvas.interactionSession?.interactionData.hasMouseMoved
     ) {
-      return innerCallback(store)
+      return selector(store)
     } else {
       return null
     }
@@ -291,13 +291,13 @@ export function useDelayedStrategyWithCallback<T>(
 }
 
 export const useDelayedCurrentStrategy = () => {
-  const innerCallback = (store: EditorStorePatched) => store.strategyState.currentStrategy
-  return useDelayedStrategyWithCallback<CanvasStrategyId | null>(innerCallback)
+  const selector = (store: EditorStorePatched) => store.strategyState.currentStrategy
+  return useDelayedStrategyWithCallback<CanvasStrategyId | null>(selector)
 }
 
 export const useDelayedStrategyCursor = () => {
-  const innerCallback = (store: EditorStorePatched) => store.editor.canvas.cursor
-  return useDelayedStrategyWithCallback<CSSCursor | null>(innerCallback)
+  const selector = (store: EditorStorePatched) => store.editor.canvas.cursor
+  return useDelayedStrategyWithCallback<CSSCursor | null>(selector)
 }
 
 export function useGetApplicableStrategyControls(): Array<ControlWithKey> {

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -38,6 +38,8 @@ import {
 } from './flow-reorder-strategy'
 import { isInsertMode } from '../../editor/editor-modes'
 import { dragToInsertStrategy } from './drag-to-insert-strategy'
+import { CSSCursor } from '../../../uuiui-deps'
+import { StateSelector } from 'zustand'
 
 export const RegisteredCanvasStrategies: Array<CanvasStrategy> = [
   absoluteMoveStrategy,
@@ -233,58 +235,69 @@ export function applyCanvasStrategy(
   return strategy.apply(canvasState, interactionSession, strategyState)
 }
 
-export const useDelayedCurrentStrategy = () => {
+export function useDelayedStrategyWithCallback<T>(
+  innerCallback: StateSelector<EditorStorePatched, T | null>,
+): T | null {
   /**
    * onMouseDown selection shows canvas controls that are active when a strategy runs with a delay (double click selection in hierarchy)
    * but when a drag threshold passes before the timer ends it shows up without delay
    */
-  const [delayedStrategyValue, setDelayedStrategyValue] = React.useState<CanvasStrategyId | null>(
-    null,
-  )
+
+  const [delayedValue, setDelayedValue] = React.useState<T | null>(null)
   const [timer, setTimer] = React.useState<number | null>(null)
 
   const immediateCallback = React.useCallback(
-    (currentStrategy: CanvasStrategyId | null) => {
-      setDelayedStrategyValue(currentStrategy)
+    (currentValue: T | null) => {
+      setDelayedValue(currentValue)
       if (timer != null) {
         window.clearTimeout(timer)
         setTimer(null)
       }
     },
-    [timer, setTimer, setDelayedStrategyValue],
+    [timer, setTimer, setDelayedValue],
   )
 
   const maybeDelayedCallback = React.useCallback(
-    (currentStrategy: CanvasStrategyId | null) => {
-      if (currentStrategy != null && delayedStrategyValue == null) {
+    (currentValue: T | null) => {
+      if (currentValue != null && delayedValue == null) {
         if (timer == null) {
           setTimer(
             window.setTimeout(() => {
-              setDelayedStrategyValue(currentStrategy)
+              setDelayedValue(currentValue)
               setTimer(null)
             }, ControlDelay),
           )
         }
       } else {
-        immediateCallback(currentStrategy)
+        immediateCallback(currentValue)
       }
     },
-    [immediateCallback, delayedStrategyValue, timer, setTimer, setDelayedStrategyValue],
+    [immediateCallback, delayedValue, timer, setTimer, setDelayedValue],
   )
 
-  useSelectorWithCallback((store) => store.strategyState.currentStrategy, maybeDelayedCallback)
+  useSelectorWithCallback(innerCallback, maybeDelayedCallback)
   useSelectorWithCallback((store) => {
     if (
       store.editor.canvas.interactionSession?.interactionData.type === 'DRAG' &&
       store.editor.canvas.interactionSession?.interactionData.hasMouseMoved
     ) {
-      return store.strategyState.currentStrategy
+      return innerCallback(store)
     } else {
       return null
     }
   }, immediateCallback)
 
-  return delayedStrategyValue
+  return delayedValue
+}
+
+export const useDelayedCurrentStrategy = () => {
+  const innerCallback = (store: EditorStorePatched) => store.strategyState.currentStrategy
+  return useDelayedStrategyWithCallback<CanvasStrategyId | null>(innerCallback)
+}
+
+export const useDelayedStrategyCursor = () => {
+  const innerCallback = (store: EditorStorePatched) => store.editor.canvas.cursor
+  return useDelayedStrategyWithCallback<CSSCursor | null>(innerCallback)
 }
 
 export function useGetApplicableStrategyControls(): Array<ControlWithKey> {

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -235,7 +235,7 @@ export function applyCanvasStrategy(
   return strategy.apply(canvasState, interactionSession, strategyState)
 }
 
-export function useDelayedStrategyWithCallback<T>(
+export function useDelayedStrategy<T>(
   selector: StateSelector<EditorStorePatched, T | null>,
 ): T | null {
   /**
@@ -292,12 +292,12 @@ export function useDelayedStrategyWithCallback<T>(
 
 export const useDelayedCurrentStrategy = () => {
   const selector = (store: EditorStorePatched) => store.strategyState.currentStrategy
-  return useDelayedStrategyWithCallback<CanvasStrategyId | null>(selector)
+  return useDelayedStrategy<CanvasStrategyId | null>(selector)
 }
 
 export const useDelayedStrategyCursor = () => {
   const selector = (store: EditorStorePatched) => store.editor.canvas.cursor
-  return useDelayedStrategyWithCallback<CSSCursor | null>(selector)
+  return useDelayedStrategy<CSSCursor | null>(selector)
 }
 
 export function useGetApplicableStrategyControls(): Array<ControlWithKey> {

--- a/editor/src/components/canvas/controls/select-mode/cursor-overlay.tsx
+++ b/editor/src/components/canvas/controls/select-mode/cursor-overlay.tsx
@@ -6,6 +6,7 @@ import { cursorForMissingReparentedItems } from '../../canvas-strategies/reparen
 import { CSSCursor } from '../../canvas-types'
 import { getCursorFromDragState } from '../../canvas-utils'
 import Utils from '../../../../utils/utils'
+import { useDelayedStrategyCursor } from '../../canvas-strategies/canvas-strategies'
 
 export function getCursorForOverlay(editorState: EditorState): CSSCursor | null {
   const forMissingReparentedItems = cursorForMissingReparentedItems(
@@ -18,8 +19,9 @@ export function getCursorForOverlay(editorState: EditorState): CSSCursor | null 
 }
 
 export const CursorOverlay = React.memo(() => {
+  const strategyCursor = useDelayedStrategyCursor()
   const cursor = useEditorState((store) => {
-    return Utils.defaultIfNull(store.editor.canvas.cursor, getCursorFromDragState(store.editor))
+    return Utils.defaultIfNull(strategyCursor, getCursorFromDragState(store.editor))
   }, 'CursorOverlay cursor')
 
   const styleProps = React.useMemo(() => {


### PR DESCRIPTION
**Problem:**
Strategy picker and canvas controls are delayed when starting a drag, but canvas cursors still show up immediately.

**Fix:**
Delay canvas cursors too when a strategy starts. If the user moves the mouse it appears immediately.

**Commit Details:**
- add new hook to use the same delay as the strategy picker
