### PR TITLE
Use the closest coordinate system bounds when re-parenting

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -719,11 +719,11 @@ export function getAbsoluteReparentPropertyChanges(
     return []
   }
 
-  const currentParentContentBox = MetadataUtils.getClosestParentCoordinateSystemBounds(
+  const currentParentContentBox = MetadataUtils.getParentCoordinateSystemBounds(
     EP.parentPath(target),
     targetStartingMetadata,
   )
-  const newParentContentBox = MetadataUtils.getClosestParentCoordinateSystemBounds(
+  const newParentContentBox = MetadataUtils.getParentCoordinateSystemBounds(
     newParent,
     newParentStartingMetadata,
   )

--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -719,13 +719,14 @@ export function getAbsoluteReparentPropertyChanges(
     return []
   }
 
-  const currentParentContentBox =
-    MetadataUtils.findElementByElementPath(targetStartingMetadata, EP.parentPath(target))
-      ?.specialSizeMeasurements.globalContentBox ?? zeroCanvasRect
-
-  const newParentContentBox =
-    MetadataUtils.findElementByElementPath(newParentStartingMetadata, newParent)
-      ?.specialSizeMeasurements.globalContentBox ?? zeroCanvasRect
+  const currentParentContentBox = MetadataUtils.getClosestParentCoordinateSystemBounds(
+    EP.parentPath(target),
+    targetStartingMetadata,
+  )
+  const newParentContentBox = MetadataUtils.getClosestParentCoordinateSystemBounds(
+    newParent,
+    newParentStartingMetadata,
+  )
 
   const offsetTL = roundPointToNearestHalf(
     pointDifference(newParentContentBox, currentParentContentBox),

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -2843,7 +2843,7 @@ describe('DOM Walker tests', () => {
           "display": "block",
           "flexDirection": "row",
           "globalContentBox": Object {
-            "height": 0,
+            "height": 812,
             "width": 375,
             "x": 0,
             "y": 0,
@@ -2948,7 +2948,7 @@ describe('DOM Walker tests', () => {
           "display": "block",
           "flexDirection": "row",
           "globalContentBox": Object {
-            "height": 0,
+            "height": 812,
             "width": 375,
             "x": 0,
             "y": 0,
@@ -3053,7 +3053,7 @@ describe('DOM Walker tests', () => {
           "display": "block",
           "flexDirection": "row",
           "globalContentBox": Object {
-            "height": 0,
+            "height": 812,
             "width": 375,
             "x": 0,
             "y": 0,

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -885,7 +885,11 @@ function getSpecialMeasurements(
     left: isRight(borderLeftWidth) ? borderLeftWidth.value.value : 0,
   }
 
-  const globalFrame = globalFrameForElement(element, scale, containerRectLazy)
+  const offsetParent = element.offsetParent as HTMLElement | null
+  const elementOrContainingParent =
+    providesBoundsForAbsoluteChildren || offsetParent == null ? element : offsetParent
+
+  const globalFrame = globalFrameForElement(elementOrContainingParent, scale, containerRectLazy)
   const globalContentBox = canvasRectangle({
     x: globalFrame.x + border.left,
     y: globalFrame.y + border.top,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -916,24 +916,16 @@ export const MetadataUtils = {
       }, Utils.asLocal(frame))
     }
   },
-  getClosestParentCoordinateSystemBounds: function (
+  getParentCoordinateSystemBounds: function (
     targetParent: ElementPath | null,
     metadata: ElementInstanceMetadataMap,
   ): CanvasRectangle {
     const parent = MetadataUtils.findElementByElementPath(metadata, targetParent)
     if (parent != null) {
-      if (parent.specialSizeMeasurements.providesBoundsForAbsoluteChildren) {
-        if (parent.specialSizeMeasurements.globalContentBox != null) {
-          return parent.specialSizeMeasurements.globalContentBox
-        } else if (parent.specialSizeMeasurements.coordinateSystemBounds != null) {
-          return parent.specialSizeMeasurements.coordinateSystemBounds
-        }
-      } else {
-        const closestOffsetParentPath = parent.specialSizeMeasurements.closestOffsetParentPath
-        return MetadataUtils.getClosestParentCoordinateSystemBounds(
-          closestOffsetParentPath,
-          metadata,
-        )
+      if (parent.specialSizeMeasurements.globalContentBox != null) {
+        return parent.specialSizeMeasurements.globalContentBox
+      } else if (parent.specialSizeMeasurements.coordinateSystemBounds != null) {
+        return parent.specialSizeMeasurements.coordinateSystemBounds
       }
     }
 
@@ -944,8 +936,10 @@ export const MetadataUtils = {
     metadata: ElementInstanceMetadataMap,
     frame: CanvasRectangle,
   ): LocalRectangle {
-    const closestParentCoordinateSystemBounds =
-      MetadataUtils.getClosestParentCoordinateSystemBounds(targetParent, metadata)
+    const closestParentCoordinateSystemBounds = MetadataUtils.getParentCoordinateSystemBounds(
+      targetParent,
+      metadata,
+    )
     return canvasRectangleToLocalRectangle(frame, closestParentCoordinateSystemBounds)
   },
   getElementLabelFromProps(allElementProps: AllElementProps, path: ElementPath): string | null {

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -45,6 +45,7 @@ import {
   LocalRectangle,
   roundPointToNearestHalf,
   Size,
+  zeroCanvasRect,
 } from '../shared/math-utils'
 import { optionalMap } from '../shared/optional-utils'
 import {
@@ -915,30 +916,37 @@ export const MetadataUtils = {
       }, Utils.asLocal(frame))
     }
   },
+  getClosestParentCoordinateSystemBounds: function (
+    targetParent: ElementPath | null,
+    metadata: ElementInstanceMetadataMap,
+  ): CanvasRectangle {
+    const parent = MetadataUtils.findElementByElementPath(metadata, targetParent)
+    if (parent != null) {
+      if (parent.specialSizeMeasurements.providesBoundsForAbsoluteChildren) {
+        if (parent.specialSizeMeasurements.globalContentBox != null) {
+          return parent.specialSizeMeasurements.globalContentBox
+        } else if (parent.specialSizeMeasurements.coordinateSystemBounds != null) {
+          return parent.specialSizeMeasurements.coordinateSystemBounds
+        }
+      } else {
+        const closestOffsetParentPath = parent.specialSizeMeasurements.closestOffsetParentPath
+        return MetadataUtils.getClosestParentCoordinateSystemBounds(
+          closestOffsetParentPath,
+          metadata,
+        )
+      }
+    }
+
+    return zeroCanvasRect
+  },
   getFrameRelativeToTargetContainingBlock: function (
     targetParent: ElementPath | null,
     metadata: ElementInstanceMetadataMap,
     frame: CanvasRectangle,
   ): LocalRectangle {
-    const parent = this.findElementByElementPath(metadata, targetParent)
-    if (parent != null) {
-      if (
-        parent.specialSizeMeasurements.providesBoundsForAbsoluteChildren &&
-        parent.specialSizeMeasurements.globalContentBox != null
-      ) {
-        return canvasRectangleToLocalRectangle(
-          frame,
-          parent.specialSizeMeasurements.globalContentBox,
-        )
-      }
-      if (parent.specialSizeMeasurements.coordinateSystemBounds != null) {
-        return canvasRectangleToLocalRectangle(
-          frame,
-          parent.specialSizeMeasurements.coordinateSystemBounds,
-        )
-      }
-    }
-    return Utils.asLocal(frame)
+    const closestParentCoordinateSystemBounds =
+      MetadataUtils.getClosestParentCoordinateSystemBounds(targetParent, metadata)
+    return canvasRectangleToLocalRectangle(frame, closestParentCoordinateSystemBounds)
   },
   getElementLabelFromProps(allElementProps: AllElementProps, path: ElementPath): string | null {
     const dataLabelProp = allElementProps?.[EP.toString(path)]?.[UTOPIA_LABEL_KEY]


### PR DESCRIPTION
**Problem:**
Re-parenting from a deep hierarchy to the canvas can offset the dragged element if the original parent doesn't provide the coordinate system bounds for the dragged element

**Fix:**
Find the closest coordinate system bounds (`globalContentBox` or `coordinateSystemBounds`) in the hierarchy above the old and new parents, and use those when calculating the offset to apply.