### PR TITLE
Grey out a failed strategy in strategy picker

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
@@ -135,6 +135,7 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
         customState: {
           ...strategyState.customStrategyState,
           duplicatedElementNewUids: duplicatedElementNewUids,
+          success: 'success',
         },
       }
     } else {

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -13,6 +13,7 @@ export interface CustomStrategyState {
   escapeHatchActivated: boolean
   lastReorderIdx: number | null
   duplicatedElementNewUids: { [elementPath: string]: string }
+  success: 'success' | 'failure'
 }
 
 export function defaultCustomStrategyState(): CustomStrategyState {
@@ -20,6 +21,7 @@ export function defaultCustomStrategyState(): CustomStrategyState {
     escapeHatchActivated: false,
     lastReorderIdx: null,
     duplicatedElementNewUids: {},
+    success: 'success',
   }
 }
 

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -150,6 +150,7 @@ export const escapeHatchStrategy: CanvasStrategy = {
           customState: {
             ...strategyState.customStrategyState,
             escapeHatchActivated,
+            success: 'success',
           },
         }
       } else {

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -78,7 +78,10 @@ export const flexReorderStrategy: CanvasStrategy = {
       if (!isReorderAllowed(siblingsOfTarget)) {
         return {
           commands: [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
-          customState: null,
+          customState: {
+            ...strategyState.customStrategyState,
+            success: 'failure',
+          },
         }
       }
 
@@ -107,6 +110,7 @@ export const flexReorderStrategy: CanvasStrategy = {
           customState: {
             ...strategyState.customStrategyState,
             lastReorderIdx: realNewIndex,
+            success: 'success',
           },
         }
       } else {
@@ -120,6 +124,7 @@ export const flexReorderStrategy: CanvasStrategy = {
           customState: {
             ...strategyState.customStrategyState,
             lastReorderIdx: realNewIndex,
+            success: 'success',
           },
         }
       }

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
@@ -81,7 +81,10 @@ function flowReorderApplyCommon(
     if (!isReorderAllowed(siblingsOfTarget)) {
       return {
         commands: [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
-        customState: null,
+        customState: {
+          ...strategyState.customStrategyState,
+          success: 'failure',
+        },
       }
     }
 
@@ -116,6 +119,7 @@ function flowReorderApplyCommon(
         customState: {
           ...strategyState.customStrategyState,
           lastReorderIdx: realNewIndex,
+          success: 'success',
         },
       }
     } else {
@@ -130,6 +134,7 @@ function flowReorderApplyCommon(
         customState: {
           ...strategyState.customStrategyState,
           lastReorderIdx: realNewIndex,
+          success: 'success',
         },
       }
     }

--- a/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
@@ -67,7 +67,10 @@ export function ifAllowedToReparent(
   } else {
     return {
       commands: [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
-      customState: null,
+      customState: {
+        ...strategyState.customStrategyState,
+        success: 'failure',
+      },
     }
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -692,7 +692,10 @@ export function applyFlexReparent(
 
           return {
             commands: [...midInteractionCommands, ...interactionFinishCommands],
-            customState: strategyState.customStrategyState,
+            customState: {
+              ...strategyState.customStrategyState,
+              success: 'success',
+            },
           }
         }
       }

--- a/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.tsx
@@ -16,6 +16,10 @@ export const CanvasStrategyPicker = React.memo(() => {
     'CanvasStrategyPicker strategyState.currentStrategy',
   )
   const activeStrategy = useDelayedCurrentStrategy()
+  const isStrategyFailure = useEditorState(
+    (store) => store.strategyState?.customStrategyState.success === 'failure',
+    'Strategy success',
+  )
 
   const onTabPressed = React.useCallback(
     (newStrategy: CanvasStrategy) => {
@@ -87,6 +91,7 @@ export const CanvasStrategyPicker = React.memo(() => {
                     backgroundColor:
                       strategy.id === activeStrategy ? colorTheme.bg5.value : undefined,
                     color: colorTheme.textColor.value,
+                    opacity: isStrategyFailure && strategy.id === activeStrategy ? 0.5 : 1,
                   }}
                 >
                   {strategy.name}

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -220,6 +220,7 @@ describe('interactionStart', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
+          "success": "success",
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -280,6 +281,7 @@ describe('interactionStart', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
+          "success": "success",
         },
         "sortedApplicableStrategies": null,
         "startingAllElementProps": Object {},
@@ -344,6 +346,7 @@ describe('interactionUpdatex', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
+          "success": "success",
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -405,6 +408,7 @@ describe('interactionUpdatex', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
+          "success": "success",
         },
         "sortedApplicableStrategies": null,
         "startingAllElementProps": Object {},
@@ -497,6 +501,7 @@ describe('interactionHardReset', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
+          "success": "success",
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -563,6 +568,7 @@ describe('interactionHardReset', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
+          "success": "success",
         },
         "sortedApplicableStrategies": null,
         "startingAllElementProps": Object {},
@@ -716,6 +722,7 @@ describe('interactionUpdate with user changed strategy', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
+          "success": "success",
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -783,6 +790,7 @@ describe('interactionUpdate with user changed strategy', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
+          "success": "success",
         },
         "sortedApplicableStrategies": null,
         "startingAllElementProps": Object {},

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -158,7 +158,10 @@ export function interactionHardReset(
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: resetStrategyState.startingMetadata,
-        customStrategyState: strategyResult.customState ?? result.strategyState.customStrategyState,
+        customStrategyState: strategyResult.customState ?? {
+          ...result.strategyState.customStrategyState,
+          success: 'success',
+        },
         startingAllElementProps: resetStrategyState.startingAllElementProps,
       }
 
@@ -305,7 +308,10 @@ export function interactionStart(
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: newEditorState.canvas.interactionSession.metadata,
-        customStrategyState: strategyResult.customState ?? result.strategyState.customStrategyState,
+        customStrategyState: strategyResult.customState ?? {
+          ...result.strategyState.customStrategyState,
+          success: 'success',
+        },
         startingAllElementProps: newEditorState.canvas.interactionSession.allElementProps,
       }
 
@@ -396,7 +402,10 @@ function handleUserChangedStrategy(
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
-      customStrategyState: strategyResult.customState ?? strategyState.customStrategyState,
+      customStrategyState: strategyResult.customState ?? {
+        ...strategyState.customStrategyState,
+        success: 'success',
+      },
       startingAllElementProps: strategyState.startingAllElementProps,
     }
 
@@ -475,7 +484,10 @@ function handleAccumulatingKeypresses(
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: strategyState.startingMetadata,
-        customStrategyState: strategyResult.customState ?? strategyState.customStrategyState,
+        customStrategyState: strategyResult.customState ?? {
+          ...strategyState.customStrategyState,
+          success: 'success',
+        },
         startingAllElementProps: strategyState.startingAllElementProps,
       }
 
@@ -536,7 +548,10 @@ function handleUpdate(
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
-      customStrategyState: strategyResult.customState ?? strategyState.customStrategyState,
+      customStrategyState: strategyResult.customState ?? {
+        ...strategyState.customStrategyState,
+        success: 'success',
+      },
       startingAllElementProps: strategyState.startingAllElementProps,
     }
     return {


### PR DESCRIPTION
## Description

When a strategy failed to be applied, grey it out in the strategy picker

## Implementation

We do not have the concept of a failed strategy. As a quick solution I stored this in the custom strategy state.

The upside to this solution is that it is easy to set it from the strategy, the downside is that we need to make sure to set it back to `success` after a succesful application, no matter what strategy it is.

I did not want to modify all strategies, also not wanted this to be a potential error later in future strategies, so I chose the following solution: We already have the ugly solution that we don't change the custom strategy state when the strategy returns `null` for the state. I modified this to always set back the state to `success`, because that is the default. If a strategy wants a state to be set to `failure`, it needs to set that explicitly.

I know this is not the most beautiful solution, we can make it better later - e.g. by patching the custom state instead of setting it, and making it sure that if `success` is not set to `failure` explicitly, it should be set to `success`