### PR TITLE
Refactor/custom strategy state patch

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
@@ -18,8 +18,8 @@ import { absoluteMoveStrategy } from './absolute-move-strategy'
 import { pickCanvasStateFromEditorState } from './canvas-strategies'
 import {
   CanvasStrategy,
-  emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
+  strategyApplicationResult,
 } from './canvas-strategy-types'
 import { InteractionSession, interactionSession, StrategyState } from './interaction-state'
 import { getDragTargets } from './shared-absolute-move-strategy-helpers'
@@ -113,8 +113,8 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
         newPaths.push(newPath)
       })
 
-      return {
-        commands: [
+      return strategyApplicationResult(
+        [
           ...duplicateCommands,
           setElementsToRerenderCommand([...selectedElements, ...newPaths]),
           updateSelectedViews('always', newPaths),
@@ -132,16 +132,13 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
           ),
           setCursorCommand('mid-interaction', CSSCursor.Duplicate),
         ],
-        customStatePatch: {
+        {
           duplicatedElementNewUids: duplicatedElementNewUids,
         },
-      }
+      )
     } else {
       // Fallback for when the checks above are not satisfied.
-      return {
-        commands: [setCursorCommand('mid-interaction', CSSCursor.Duplicate)],
-        customStatePatch: {},
-      }
+      return strategyApplicationResult([setCursorCommand('mid-interaction', CSSCursor.Duplicate)])
     }
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
@@ -132,17 +132,15 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
           ),
           setCursorCommand('mid-interaction', CSSCursor.Duplicate),
         ],
-        customState: {
-          ...strategyState.customStrategyState,
+        customStatePatch: {
           duplicatedElementNewUids: duplicatedElementNewUids,
-          success: 'success',
         },
       }
     } else {
       // Fallback for when the checks above are not satisfied.
       return {
         commands: [setCursorCommand('mid-interaction', CSSCursor.Duplicate)],
-        customState: null,
+        customStatePatch: {},
       }
     }
   },

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -128,7 +128,7 @@ function dragByPixels(
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customStatePatch).toEqual({})
 
   const finalEditor = foldAndApplyCommands(
     editorState,

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -129,6 +129,7 @@ function dragByPixels(
   )
 
   expect(strategyResult.customStatePatch).toEqual({})
+  expect(strategyResult.status).toEqual('success')
 
   const finalEditor = foldAndApplyCommands(
     editorState,

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
@@ -17,7 +17,7 @@ import { determineConstrainedDragAxis } from '../controls/select-mode/move-utils
 import { ConstrainedDragAxis, GuidelineWithSnappingVector } from '../guideline'
 import {
   CanvasStrategy,
-  failedStrategyApplicationResult,
+  emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
   strategyApplicationResult,
@@ -111,7 +111,7 @@ export const absoluteMoveStrategy: CanvasStrategy = {
       )
     }
     // Fallback for when the checks above are not satisfied.
-    return failedStrategyApplicationResult
+    return emptyStrategyApplicationResult
   },
 }
 
@@ -174,6 +174,6 @@ export function applyAbsoluteMoveCommon(
     }
   } else {
     // Fallback for when the checks above are not satisfied.
-    return failedStrategyApplicationResult
+    return emptyStrategyApplicationResult
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
@@ -17,9 +17,10 @@ import { determineConstrainedDragAxis } from '../controls/select-mode/move-utils
 import { ConstrainedDragAxis, GuidelineWithSnappingVector } from '../guideline'
 import {
   CanvasStrategy,
-  emptyStrategyApplicationResult,
+  failedStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
+  strategyApplicationResult,
   StrategyApplicationResult,
 } from './canvas-strategy-types'
 import { DragInteractionData, InteractionSession, StrategyState } from './interaction-state'
@@ -110,7 +111,7 @@ export const absoluteMoveStrategy: CanvasStrategy = {
       )
     }
     // Fallback for when the checks above are not satisfied.
-    return emptyStrategyApplicationResult
+    return failedStrategyApplicationResult
   },
 }
 
@@ -134,16 +135,13 @@ export function applyAbsoluteMoveCommon(
     if (cmdKeyPressed) {
       const commandsForSelectedElements = getMoveCommands(drag)
 
-      return {
-        commands: [
-          ...commandsForSelectedElements.commands,
-          pushIntendedBounds(commandsForSelectedElements.intendedBounds),
-          updateHighlightedViews('mid-interaction', []),
-          setElementsToRerenderCommand(selectedElements),
-          setCursorCommand('mid-interaction', CSSCursor.Select),
-        ],
-        customStatePatch: {},
-      }
+      return strategyApplicationResult([
+        ...commandsForSelectedElements.commands,
+        pushIntendedBounds(commandsForSelectedElements.intendedBounds),
+        updateHighlightedViews('mid-interaction', []),
+        setElementsToRerenderCommand(selectedElements),
+        setCursorCommand('mid-interaction', CSSCursor.Select),
+      ])
     } else {
       const constrainedDragAxis =
         shiftKeyPressed && drag != null ? determineConstrainedDragAxis(drag) : null
@@ -165,20 +163,17 @@ export function applyAbsoluteMoveCommon(
         canvasState.scale,
       )
       const commandsForSelectedElements = getMoveCommands(snappedDragVector)
-      return {
-        commands: [
-          ...commandsForSelectedElements.commands,
-          updateHighlightedViews('mid-interaction', []),
-          setSnappingGuidelines('mid-interaction', guidelinesWithSnappingVector),
-          pushIntendedBounds(commandsForSelectedElements.intendedBounds),
-          setElementsToRerenderCommand([...selectedElements, ...targetsForSnapping]),
-          setCursorCommand('mid-interaction', CSSCursor.Select),
-        ],
-        customStatePatch: {},
-      }
+      return strategyApplicationResult([
+        ...commandsForSelectedElements.commands,
+        updateHighlightedViews('mid-interaction', []),
+        setSnappingGuidelines('mid-interaction', guidelinesWithSnappingVector),
+        pushIntendedBounds(commandsForSelectedElements.intendedBounds),
+        setElementsToRerenderCommand([...selectedElements, ...targetsForSnapping]),
+        setCursorCommand('mid-interaction', CSSCursor.Select),
+      ])
     }
   } else {
     // Fallback for when the checks above are not satisfied.
-    return emptyStrategyApplicationResult
+    return failedStrategyApplicationResult
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
@@ -142,7 +142,7 @@ export function applyAbsoluteMoveCommon(
           setElementsToRerenderCommand(selectedElements),
           setCursorCommand('mid-interaction', CSSCursor.Select),
         ],
-        customState: null,
+        customStatePatch: {},
       }
     } else {
       const constrainedDragAxis =
@@ -174,7 +174,7 @@ export function applyAbsoluteMoveCommon(
           setElementsToRerenderCommand([...selectedElements, ...targetsForSnapping]),
           setCursorCommand('mid-interaction', CSSCursor.Select),
         ],
-        customState: null,
+        customStatePatch: {},
       }
     }
   } else {

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
@@ -141,6 +141,7 @@ function reparentElement(
   )
 
   expect(strategyResult.customStatePatch).toEqual({})
+  expect(strategyResult.status).toEqual('success')
 
   // Check if there are set SetElementsToRerenderCommands with the new parent path
   expect(

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
@@ -74,6 +74,7 @@ function reparentElement(
       accumulatedPatches: null as any, // the strategy does not use this
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
+      status: 'success',
       startingMetadata: {
         'scene-aaa/app-entity:aaa': {
           elementPath: EP.elementPath([['scene-aaa', 'app-entity'], ['aaa']]),
@@ -139,7 +140,7 @@ function reparentElement(
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customStatePatch).toEqual({})
 
   // Check if there are set SetElementsToRerenderCommands with the new parent path
   expect(

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
@@ -90,6 +90,7 @@ function dragByPixels(
   )
 
   expect(strategyResult.customStatePatch).toEqual({})
+  expect(strategyResult.status).toEqual('success')
 
   const finalEditor = foldAndApplyCommands(
     editorState,

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
@@ -71,6 +71,7 @@ function dragByPixels(
       accumulatedPatches: null as any, // the strategy does not use this
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
+      status: 'success',
       startingMetadata: {
         'scene-aaa/app-entity:aaa/bbb': {
           elementPath: elementPath([
@@ -88,7 +89,7 @@ function dragByPixels(
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customStatePatch).toEqual({})
 
   const finalEditor = foldAndApplyCommands(
     editorState,

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -71,6 +71,7 @@ function reparentElement(
       accumulatedPatches: null as any, // the strategy does not use this
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
+      status: 'success',
       startingMetadata: {
         sb: {
           elementPath: EP.elementPath([['sb']]),
@@ -204,7 +205,7 @@ function reparentElement(
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customStatePatch).toEqual({})
 
   // Check if there are set SetElementsToRerenderCommands with the new parent path
   expect(

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -206,6 +206,7 @@ function reparentElement(
   )
 
   expect(strategyResult.customStatePatch).toEqual({})
+  expect(strategyResult.status).toEqual('success')
 
   // Check if there are set SetElementsToRerenderCommands with the new parent path
   expect(

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -9,7 +9,7 @@ import { ParentOutlines } from '../controls/parent-outlines'
 import { absoluteMoveStrategy } from './absolute-move-strategy'
 import {
   CanvasStrategy,
-  failedStrategyApplicationResult,
+  emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   strategyApplicationResult,
 } from './canvas-strategy-types'
@@ -79,7 +79,7 @@ export const absoluteReparentStrategy: CanvasStrategy = {
       interactionState.interactionData.type != 'DRAG' ||
       interactionState.interactionData.drag == null
     ) {
-      return failedStrategyApplicationResult
+      return emptyStrategyApplicationResult
     }
 
     const { interactionTarget, projectContents, openFile, nodeModules } = canvasState

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -9,8 +9,9 @@ import { ParentOutlines } from '../controls/parent-outlines'
 import { absoluteMoveStrategy } from './absolute-move-strategy'
 import {
   CanvasStrategy,
-  emptyStrategyApplicationResult,
+  failedStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
+  strategyApplicationResult,
 } from './canvas-strategy-types'
 import { getDragTargets } from './shared-absolute-move-strategy-helpers'
 import { ifAllowedToReparent, isAllowedToReparent } from './reparent-helpers'
@@ -78,7 +79,7 @@ export const absoluteReparentStrategy: CanvasStrategy = {
       interactionState.interactionData.type != 'DRAG' ||
       interactionState.interactionData.drag == null
     ) {
-      return emptyStrategyApplicationResult
+      return failedStrategyApplicationResult
     }
 
     const { interactionTarget, projectContents, openFile, nodeModules } = canvasState
@@ -167,23 +168,17 @@ export const absoluteReparentStrategy: CanvasStrategy = {
         strategyState,
       )
 
-      return {
-        commands: [
-          ...moveCommands.commands,
-          ...commands.flatMap((c) => c.commands),
-          updateSelectedViews('always', newPaths),
-          setElementsToRerenderCommand([...newPaths, ...filteredSelectedElements]),
-          setCursorCommand('mid-interaction', CSSCursor.Move),
-        ],
-        customStatePatch: {},
-      }
+      return strategyApplicationResult([
+        ...moveCommands.commands,
+        ...commands.flatMap((c) => c.commands),
+        updateSelectedViews('always', newPaths),
+        setElementsToRerenderCommand([...newPaths, ...filteredSelectedElements]),
+        setCursorCommand('mid-interaction', CSSCursor.Move),
+      ])
     } else {
       const moveCommands = absoluteMoveStrategy.apply(canvasState, interactionState, strategyState)
 
-      return {
-        commands: moveCommands.commands,
-        customStatePatch: {},
-      }
+      return strategyApplicationResult(moveCommands.commands)
     }
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -175,14 +175,14 @@ export const absoluteReparentStrategy: CanvasStrategy = {
           setElementsToRerenderCommand([...newPaths, ...filteredSelectedElements]),
           setCursorCommand('mid-interaction', CSSCursor.Move),
         ],
-        customState: null,
+        customStatePatch: {},
       }
     } else {
       const moveCommands = absoluteMoveStrategy.apply(canvasState, interactionState, strategyState)
 
       return {
         commands: moveCommands.commands,
-        customState: null,
+        customStatePatch: {},
       }
     }
   },

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -70,6 +70,7 @@ function multiselectResizeElements(
   )
 
   expect(strategyResult.customStatePatch).toEqual({})
+  expect(strategyResult.status).toEqual('success')
 
   return foldAndApplyCommands(
     initialEditor,

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -69,7 +69,7 @@ function multiselectResizeElements(
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customStatePatch).toEqual({})
 
   return foldAndApplyCommands(
     initialEditor,

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -29,7 +29,7 @@ import { AbsoluteResizeControl } from '../controls/select-mode/absolute-resize-c
 import { AbsolutePin, ensureAtLeastTwoPinsForEdgePosition } from './absolute-resize-helpers'
 import {
   CanvasStrategy,
-  failedStrategyApplicationResult,
+  emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   strategyApplicationResult,
 } from './canvas-strategy-types'
@@ -186,7 +186,7 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
       }
     }
     // Fallback for when the checks above are not satisfied.
-    return failedStrategyApplicationResult
+    return emptyStrategyApplicationResult
   },
 }
 

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -29,8 +29,9 @@ import { AbsoluteResizeControl } from '../controls/select-mode/absolute-resize-c
 import { AbsolutePin, ensureAtLeastTwoPinsForEdgePosition } from './absolute-resize-helpers'
 import {
   CanvasStrategy,
-  emptyStrategyApplicationResult,
+  failedStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
+  strategyApplicationResult,
 } from './canvas-strategy-types'
 import { getDragTargets, getMultiselectBounds } from './shared-absolute-move-strategy-helpers'
 import {
@@ -170,28 +171,22 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
               ]
             },
           )
-          return {
-            commands: [
-              ...commandsForSelectedElements,
-              updateHighlightedViews('mid-interaction', []),
-              setCursorCommand('mid-interaction', pickCursorFromEdgePosition(edgePosition)),
-              setElementsToRerenderCommand(selectedElements),
-            ],
-            customStatePatch: {},
-          }
+          return strategyApplicationResult([
+            ...commandsForSelectedElements,
+            updateHighlightedViews('mid-interaction', []),
+            setCursorCommand('mid-interaction', pickCursorFromEdgePosition(edgePosition)),
+            setElementsToRerenderCommand(selectedElements),
+          ])
         }
       } else {
-        return {
-          commands: [
-            setCursorCommand('mid-interaction', pickCursorFromEdgePosition(edgePosition)),
-            updateHighlightedViews('mid-interaction', []),
-          ],
-          customStatePatch: {},
-        }
+        return strategyApplicationResult([
+          setCursorCommand('mid-interaction', pickCursorFromEdgePosition(edgePosition)),
+          updateHighlightedViews('mid-interaction', []),
+        ])
       }
     }
     // Fallback for when the checks above are not satisfied.
-    return emptyStrategyApplicationResult
+    return failedStrategyApplicationResult
   },
 }
 

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -177,7 +177,7 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
               setCursorCommand('mid-interaction', pickCursorFromEdgePosition(edgePosition)),
               setElementsToRerenderCommand(selectedElements),
             ],
-            customState: null,
+            customStatePatch: {},
           }
         }
       } else {
@@ -186,7 +186,7 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
             setCursorCommand('mid-interaction', pickCursorFromEdgePosition(edgePosition)),
             updateHighlightedViews('mid-interaction', []),
           ],
-          customState: null,
+          customStatePatch: {},
         }
       }
     }

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -6,7 +6,7 @@ import { ElementPath, NodeModules } from '../../../core/shared/project-file-type
 import { ProjectContentTreeRoot } from '../../assets'
 import { InsertionSubject } from '../../editor/editor-modes'
 import { CanvasCommand } from '../commands/commands'
-import { InteractionSession, StrategyState } from './interaction-state'
+import { InteractionSession, StrategyApplicationStatus, StrategyState } from './interaction-state'
 
 // TODO: fill this in, maybe make it an ADT for different strategies
 export interface CustomStrategyState {
@@ -28,12 +28,25 @@ export function defaultCustomStrategyState(): CustomStrategyState {
 export interface StrategyApplicationResult {
   commands: Array<CanvasCommand>
   customStatePatch: CustomStrategyStatePatch
-  hasFailed?: boolean
+  status: StrategyApplicationStatus
 }
 
-export const emptyStrategyApplicationResult: StrategyApplicationResult = {
+export const failedStrategyApplicationResult: StrategyApplicationResult = {
   commands: [],
   customStatePatch: {},
+  status: 'failure',
+}
+
+export function strategyApplicationResult(
+  commands: Array<CanvasCommand>,
+  customStatePatch: CustomStrategyStatePatch = {},
+  status: StrategyApplicationStatus = 'success',
+): StrategyApplicationResult {
+  return {
+    commands: commands,
+    customStatePatch: customStatePatch,
+    status: status,
+  }
 }
 
 export interface ControlWithKey {

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -31,10 +31,10 @@ export interface StrategyApplicationResult {
   status: StrategyApplicationStatus
 }
 
-export const failedStrategyApplicationResult: StrategyApplicationResult = {
+export const emptyStrategyApplicationResult: StrategyApplicationResult = {
   commands: [],
   customStatePatch: {},
-  status: 'failure',
+  status: 'success',
 }
 
 export function strategyApplicationResult(

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -13,26 +13,27 @@ export interface CustomStrategyState {
   escapeHatchActivated: boolean
   lastReorderIdx: number | null
   duplicatedElementNewUids: { [elementPath: string]: string }
-  success: 'success' | 'failure'
 }
+
+export type CustomStrategyStatePatch = Partial<CustomStrategyState>
 
 export function defaultCustomStrategyState(): CustomStrategyState {
   return {
     escapeHatchActivated: false,
     lastReorderIdx: null,
     duplicatedElementNewUids: {},
-    success: 'success',
   }
 }
 
 export interface StrategyApplicationResult {
   commands: Array<CanvasCommand>
-  customState: CustomStrategyState | null // null means the previous custom strategy state should be kept
+  customStatePatch: CustomStrategyStatePatch
+  hasFailed?: boolean
 }
 
-export const emptyStrategyApplicationResult = {
+export const emptyStrategyApplicationResult: StrategyApplicationResult = {
   commands: [],
-  customState: null,
+  customStatePatch: {},
 }
 
 export interface ControlWithKey {

--- a/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
@@ -2,7 +2,7 @@ import { ParentBounds } from '../controls/parent-bounds'
 import { ParentOutlines } from '../controls/parent-outlines'
 import {
   CanvasStrategy,
-  failedStrategyApplicationResult,
+  emptyStrategyApplicationResult,
   getInsertionSubjectsFromInteractionTarget,
   InteractionCanvasState,
   strategyApplicationResult,
@@ -121,7 +121,7 @@ export const dragToInsertStrategy: CanvasStrategy = {
       ])
     }
     // Fallback for when the checks above are not satisfied.
-    return failedStrategyApplicationResult
+    return emptyStrategyApplicationResult
   },
 }
 

--- a/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
@@ -116,7 +116,7 @@ export const dragToInsertStrategy: CanvasStrategy = {
 
       return {
         commands: [...insertionCommands.map((c) => c.command), reparentCommand],
-        customState: null,
+        customStatePatch: {},
       }
     }
     // Fallback for when the checks above are not satisfied.

--- a/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
@@ -2,9 +2,10 @@ import { ParentBounds } from '../controls/parent-bounds'
 import { ParentOutlines } from '../controls/parent-outlines'
 import {
   CanvasStrategy,
-  emptyStrategyApplicationResult,
+  failedStrategyApplicationResult,
   getInsertionSubjectsFromInteractionTarget,
   InteractionCanvasState,
+  strategyApplicationResult,
   targetPaths,
 } from './canvas-strategy-types'
 import { InteractionSession, StrategyState } from './interaction-state'
@@ -114,13 +115,13 @@ export const dragToInsertStrategy: CanvasStrategy = {
         },
       )
 
-      return {
-        commands: [...insertionCommands.map((c) => c.command), reparentCommand],
-        customStatePatch: {},
-      }
+      return strategyApplicationResult([
+        ...insertionCommands.map((c) => c.command),
+        reparentCommand,
+      ])
     }
     // Fallback for when the checks above are not satisfied.
-    return emptyStrategyApplicationResult
+    return failedStrategyApplicationResult
   },
 }
 

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -147,16 +147,14 @@ export const escapeHatchStrategy: CanvasStrategy = {
 
         return {
           commands: absoluteMoveApplyResult.commands,
-          customState: {
-            ...strategyState.customStrategyState,
+          customStatePatch: {
             escapeHatchActivated,
-            success: 'success',
           },
         }
       } else {
         return {
           commands: [setCursorCommand('mid-interaction', CSSCursor.Move)],
-          customState: null,
+          customStatePatch: {},
         }
       }
     }

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -44,7 +44,7 @@ import { ZeroSizeResizeControlWrapper } from '../controls/zero-sized-element-con
 import { applyAbsoluteMoveCommon } from './absolute-move-strategy'
 import {
   CanvasStrategy,
-  failedStrategyApplicationResult,
+  emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
   strategyApplicationResult,
@@ -154,7 +154,7 @@ export const escapeHatchStrategy: CanvasStrategy = {
       }
     }
     // Fallback for when the checks above are not satisfied.
-    return failedStrategyApplicationResult
+    return emptyStrategyApplicationResult
   },
 }
 

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -44,9 +44,10 @@ import { ZeroSizeResizeControlWrapper } from '../controls/zero-sized-element-con
 import { applyAbsoluteMoveCommon } from './absolute-move-strategy'
 import {
   CanvasStrategy,
-  emptyStrategyApplicationResult,
+  failedStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
+  strategyApplicationResult,
 } from './canvas-strategy-types'
 import { DragInteractionData, InteractionSession, StrategyState } from './interaction-state'
 import { getReparentOutcome, pathToReparent } from './reparent-utils'
@@ -145,21 +146,15 @@ export const escapeHatchStrategy: CanvasStrategy = {
           getConversionAndMoveCommands,
         )
 
-        return {
-          commands: absoluteMoveApplyResult.commands,
-          customStatePatch: {
-            escapeHatchActivated,
-          },
-        }
+        return strategyApplicationResult(absoluteMoveApplyResult.commands, {
+          escapeHatchActivated,
+        })
       } else {
-        return {
-          commands: [setCursorCommand('mid-interaction', CSSCursor.Move)],
-          customStatePatch: {},
-        }
+        return strategyApplicationResult([setCursorCommand('mid-interaction', CSSCursor.Move)])
       }
     }
     // Fallback for when the checks above are not satisfied.
-    return emptyStrategyApplicationResult
+    return failedStrategyApplicationResult
   },
 }
 

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
@@ -203,7 +203,7 @@ function reorderElement(
     } as StrategyState,
   )
 
-  expect(strategyResult.customState?.lastReorderIdx).toEqual(newIndex)
+  expect(strategyResult.customStatePatch?.lastReorderIdx).toEqual(newIndex)
 
   const finalEditor = foldAndApplyCommands(
     editorState,

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -5,7 +5,7 @@ import { ElementPath } from '../../../core/shared/project-file-types'
 import { reorderElement } from '../commands/reorder-element-command'
 import {
   CanvasStrategy,
-  failedStrategyApplicationResult,
+  emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   strategyApplicationResult,
 } from './canvas-strategy-types'
@@ -65,7 +65,7 @@ export const flexReorderStrategy: CanvasStrategy = {
   },
   apply: (canvasState, interactionState, strategyState) => {
     if (interactionState.interactionData.type !== 'DRAG') {
-      return failedStrategyApplicationResult
+      return emptyStrategyApplicationResult
     }
     if (interactionState.interactionData.drag != null) {
       const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -5,8 +5,9 @@ import { ElementPath } from '../../../core/shared/project-file-types'
 import { reorderElement } from '../commands/reorder-element-command'
 import {
   CanvasStrategy,
-  emptyStrategyApplicationResult,
+  failedStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
+  strategyApplicationResult,
 } from './canvas-strategy-types'
 import * as EP from '../../../core/shared/element-path'
 import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
@@ -64,7 +65,7 @@ export const flexReorderStrategy: CanvasStrategy = {
   },
   apply: (canvasState, interactionState, strategyState) => {
     if (interactionState.interactionData.type !== 'DRAG') {
-      return emptyStrategyApplicationResult
+      return failedStrategyApplicationResult
     }
     if (interactionState.interactionData.drag != null) {
       const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
@@ -76,11 +77,11 @@ export const flexReorderStrategy: CanvasStrategy = {
       ).map((element) => element.elementPath)
 
       if (!isReorderAllowed(siblingsOfTarget)) {
-        return {
-          commands: [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
-          customStatePatch: {},
-          hasFailed: true,
-        }
+        return strategyApplicationResult(
+          [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
+          {},
+          'failure',
+        )
       }
 
       const pointOnCanvas = offsetPoint(
@@ -100,34 +101,31 @@ export const flexReorderStrategy: CanvasStrategy = {
       const realNewIndex = newIndex > -1 ? newIndex : lastReorderIdx
 
       if (realNewIndex === unpatchedIndex) {
-        return {
-          commands: [
+        return strategyApplicationResult(
+          [
             updateHighlightedViews('mid-interaction', []),
             setCursorCommand('mid-interaction', CSSCursor.Move),
           ],
-          customStatePatch: {
+          {
             lastReorderIdx: realNewIndex,
           },
-        }
+        )
       } else {
-        return {
-          commands: [
+        return strategyApplicationResult(
+          [
             reorderElement('always', target, absolute(realNewIndex)),
             setElementsToRerenderCommand([target]),
             updateHighlightedViews('mid-interaction', []),
             setCursorCommand('mid-interaction', CSSCursor.Move),
           ],
-          customStatePatch: {
+          {
             lastReorderIdx: realNewIndex,
           },
-        }
+        )
       }
     } else {
       // Fallback for when the checks above are not satisfied.
-      return {
-        commands: [setCursorCommand('mid-interaction', CSSCursor.Move)],
-        customStatePatch: {},
-      }
+      return strategyApplicationResult([setCursorCommand('mid-interaction', CSSCursor.Move)])
     }
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -78,10 +78,8 @@ export const flexReorderStrategy: CanvasStrategy = {
       if (!isReorderAllowed(siblingsOfTarget)) {
         return {
           commands: [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
-          customState: {
-            ...strategyState.customStrategyState,
-            success: 'failure',
-          },
+          customStatePatch: {},
+          hasFailed: true,
         }
       }
 
@@ -107,10 +105,8 @@ export const flexReorderStrategy: CanvasStrategy = {
             updateHighlightedViews('mid-interaction', []),
             setCursorCommand('mid-interaction', CSSCursor.Move),
           ],
-          customState: {
-            ...strategyState.customStrategyState,
+          customStatePatch: {
             lastReorderIdx: realNewIndex,
-            success: 'success',
           },
         }
       } else {
@@ -121,10 +117,8 @@ export const flexReorderStrategy: CanvasStrategy = {
             updateHighlightedViews('mid-interaction', []),
             setCursorCommand('mid-interaction', CSSCursor.Move),
           ],
-          customState: {
-            ...strategyState.customStrategyState,
+          customStatePatch: {
             lastReorderIdx: realNewIndex,
-            success: 'success',
           },
         }
       }
@@ -132,7 +126,7 @@ export const flexReorderStrategy: CanvasStrategy = {
       // Fallback for when the checks above are not satisfied.
       return {
         commands: [setCursorCommand('mid-interaction', CSSCursor.Move)],
-        customState: null,
+        customStatePatch: {},
       }
     }
   },

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
@@ -20,7 +20,7 @@ import { absoluteReparentStrategy } from './absolute-reparent-strategy'
 import { pickCanvasStateFromEditorState } from './canvas-strategies'
 import {
   CanvasStrategy,
-  failedStrategyApplicationResult,
+  emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
   strategyApplicationResult,
@@ -83,7 +83,7 @@ export const flexReparentToAbsoluteStrategy: CanvasStrategy = {
         interactionState.interactionData.type !== 'DRAG' ||
         interactionState.interactionData.drag == null
       ) {
-        return failedStrategyApplicationResult
+        return emptyStrategyApplicationResult
       }
 
       const pointOnCanvas = offsetPoint(

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
@@ -20,9 +20,10 @@ import { absoluteReparentStrategy } from './absolute-reparent-strategy'
 import { pickCanvasStateFromEditorState } from './canvas-strategies'
 import {
   CanvasStrategy,
-  emptyStrategyApplicationResult,
+  failedStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
+  strategyApplicationResult,
   StrategyApplicationResult,
 } from './canvas-strategy-types'
 import { getEscapeHatchCommands } from './escape-hatch-strategy'
@@ -82,7 +83,7 @@ export const flexReparentToAbsoluteStrategy: CanvasStrategy = {
         interactionState.interactionData.type !== 'DRAG' ||
         interactionState.interactionData.drag == null
       ) {
-        return emptyStrategyApplicationResult
+        return failedStrategyApplicationResult
       }
 
       const pointOnCanvas = offsetPoint(
@@ -135,22 +136,19 @@ export const flexReparentToAbsoluteStrategy: CanvasStrategy = {
         canvasPoint({ x: 0, y: 0 }),
       ).commands
 
-      return {
-        commands: [
-          ...placeholderCloneCommands,
-          ...escapeHatchCommands,
-          updateFunctionCommand('always', (editorState, lifecycle): Array<EditorStatePatch> => {
-            return runAbsoluteReparentStrategyForFreshlyConvertedElement(
-              canvasState.builtInDependencies,
-              editorState,
-              strategyState,
-              interactionState,
-              lifecycle,
-            )
-          }),
-        ],
-        customStatePatch: {},
-      }
+      return strategyApplicationResult([
+        ...placeholderCloneCommands,
+        ...escapeHatchCommands,
+        updateFunctionCommand('always', (editorState, lifecycle): Array<EditorStatePatch> => {
+          return runAbsoluteReparentStrategyForFreshlyConvertedElement(
+            canvasState.builtInDependencies,
+            editorState,
+            strategyState,
+            interactionState,
+            lifecycle,
+          )
+        }),
+      ])
     })
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
@@ -149,7 +149,7 @@ export const flexReparentToAbsoluteStrategy: CanvasStrategy = {
             )
           }),
         ],
-        customState: null,
+        customStatePatch: {},
       }
     })
   },

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
@@ -10,7 +10,7 @@ import { ParentBounds } from '../controls/parent-bounds'
 import { ParentOutlines } from '../controls/parent-outlines'
 import {
   CanvasStrategy,
-  failedStrategyApplicationResult,
+  emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
   strategyApplicationResult,
@@ -68,7 +68,7 @@ function flowReorderApplyCommon(
   displayTypeFiltering: 'allow-mixed-display-type' | 'same-display-type-only',
 ): StrategyApplicationResult {
   if (interactionState.interactionData.type !== 'DRAG') {
-    return failedStrategyApplicationResult
+    return emptyStrategyApplicationResult
   }
 
   if (interactionState.interactionData.drag != null) {

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
@@ -81,10 +81,8 @@ function flowReorderApplyCommon(
     if (!isReorderAllowed(siblingsOfTarget)) {
       return {
         commands: [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
-        customState: {
-          ...strategyState.customStrategyState,
-          success: 'failure',
-        },
+        customStatePatch: {},
+        hasFailed: true,
       }
     }
 
@@ -116,10 +114,8 @@ function flowReorderApplyCommon(
           updateHighlightedViews('mid-interaction', []),
           setCursorCommand('mid-interaction', CSSCursor.Move),
         ],
-        customState: {
-          ...strategyState.customStrategyState,
+        customStatePatch: {
           lastReorderIdx: realNewIndex,
-          success: 'success',
         },
       }
     } else {
@@ -131,10 +127,8 @@ function flowReorderApplyCommon(
           setCursorCommand('mid-interaction', CSSCursor.Move),
           ...getOptionalDisplayPropCommands(target, newDisplayType, withAutoConversion),
         ],
-        customState: {
-          ...strategyState.customStrategyState,
+        customStatePatch: {
           lastReorderIdx: realNewIndex,
-          success: 'success',
         },
       }
     }
@@ -142,7 +136,7 @@ function flowReorderApplyCommon(
     // Fallback for when the checks above are not satisfied.
     return {
       commands: [setCursorCommand('mid-interaction', CSSCursor.Move)],
-      customState: null,
+      customStatePatch: {},
     }
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -112,6 +112,8 @@ export interface CommandDescription {
   transient: boolean
 }
 
+export type StrategyApplicationStatus = 'success' | 'failure'
+
 export interface StrategyState {
   // Need to track here which strategy is being applied.
   currentStrategy: CanvasStrategyId | null
@@ -120,6 +122,7 @@ export interface StrategyState {
   accumulatedPatches: Array<EditorStatePatch>
   commandDescriptions: Array<CommandDescription>
   sortedApplicableStrategies: Array<CanvasStrategy> | null
+  status: StrategyApplicationStatus
 
   // Checkpointed metadata at the point at which a strategy change has occurred.
   startingMetadata: ElementInstanceMetadataMap
@@ -138,6 +141,7 @@ export function createEmptyStrategyState(
     accumulatedPatches: [],
     commandDescriptions: [],
     sortedApplicableStrategies: null,
+    status: 'success',
     startingMetadata: metadata,
     customStrategyState: defaultCustomStrategyState(),
     startingAllElementProps: allElementProps,

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
@@ -2,7 +2,7 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { Keyboard, KeyCharacter } from '../../../utils/keyboard'
 import {
   CanvasStrategy,
-  failedStrategyApplicationResult,
+  emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
   strategyApplicationResult,
@@ -138,7 +138,7 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
       commands.push(setElementsToRerenderCommand(selectedElements))
       return strategyApplicationResult(commands)
     } else {
-      return failedStrategyApplicationResult
+      return emptyStrategyApplicationResult
     }
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
@@ -2,9 +2,10 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { Keyboard, KeyCharacter } from '../../../utils/keyboard'
 import {
   CanvasStrategy,
-  emptyStrategyApplicationResult,
+  failedStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
+  strategyApplicationResult,
 } from './canvas-strategy-types'
 import {
   CanvasRectangle,
@@ -135,12 +136,9 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
       commands.push(setSnappingGuidelines('mid-interaction', guidelines))
       commands.push(pushIntendedBounds(intendedBounds))
       commands.push(setElementsToRerenderCommand(selectedElements))
-      return {
-        commands: commands,
-        customStatePatch: {},
-      }
+      return strategyApplicationResult(commands)
     } else {
-      return emptyStrategyApplicationResult
+      return failedStrategyApplicationResult
     }
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
@@ -137,7 +137,7 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
       commands.push(setElementsToRerenderCommand(selectedElements))
       return {
         commands: commands,
-        customState: null,
+        customStatePatch: {},
       }
     } else {
       return emptyStrategyApplicationResult

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
@@ -2,7 +2,7 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { Keyboard, KeyCharacter } from '../../../utils/keyboard'
 import {
   CanvasStrategy,
-  failedStrategyApplicationResult,
+  emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   strategyApplicationResult,
 } from './canvas-strategy-types'
@@ -193,7 +193,7 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
       commands.push(setElementsToRerenderCommand(selectedElements))
       return strategyApplicationResult(commands)
     } else {
-      return failedStrategyApplicationResult
+      return emptyStrategyApplicationResult
     }
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
@@ -192,7 +192,7 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
       commands.push(setElementsToRerenderCommand(selectedElements))
       return {
         commands: commands,
-        customState: null,
+        customStatePatch: {},
       }
     } else {
       return emptyStrategyApplicationResult

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
@@ -2,8 +2,9 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { Keyboard, KeyCharacter } from '../../../utils/keyboard'
 import {
   CanvasStrategy,
-  emptyStrategyApplicationResult,
+  failedStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
+  strategyApplicationResult,
 } from './canvas-strategy-types'
 import { Modifiers } from '../../../utils/modifiers'
 import {
@@ -190,12 +191,9 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
       commands.push(setSnappingGuidelines('mid-interaction', guidelines))
       commands.push(pushIntendedBounds(intendedBounds))
       commands.push(setElementsToRerenderCommand(selectedElements))
-      return {
-        commands: commands,
-        customStatePatch: {},
-      }
+      return strategyApplicationResult(commands)
     } else {
-      return emptyStrategyApplicationResult
+      return failedStrategyApplicationResult
     }
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
@@ -65,6 +65,7 @@ export function pressKeys(
   )
 
   expect(strategyResult.customStatePatch).toEqual({})
+  expect(strategyResult.status).toEqual('success')
 
   const finalEditor = foldAndApplyCommands(
     editorState,

--- a/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
@@ -57,13 +57,14 @@ export function pressKeys(
       accumulatedPatches: null as any, // the strategy does not use this
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
+      status: 'success',
       startingMetadata: metadata,
       startingAllElementProps: { 'scene-aaa/app-entity:aaa/bbb': {} },
       customStrategyState: defaultCustomStrategyState(),
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customStatePatch).toEqual({})
 
   const finalEditor = foldAndApplyCommands(
     editorState,

--- a/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
@@ -7,7 +7,11 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { CSSCursor } from '../canvas-types'
 import { setCursorCommand } from '../commands/set-cursor-command'
-import { InteractionCanvasState, StrategyApplicationResult } from './canvas-strategy-types'
+import {
+  InteractionCanvasState,
+  strategyApplicationResult,
+  StrategyApplicationResult,
+} from './canvas-strategy-types'
 import { StrategyState } from './interaction-state'
 import { ProjectContentTreeRoot } from '../../../components/assets'
 
@@ -65,10 +69,10 @@ export function ifAllowedToReparent(
   if (allowed) {
     return ifAllowed()
   } else {
-    return {
-      commands: [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
-      customStatePatch: {},
-      hasFailed: true,
-    }
+    return strategyApplicationResult(
+      [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
+      {},
+      'failure',
+    )
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
@@ -67,10 +67,8 @@ export function ifAllowedToReparent(
   } else {
     return {
       commands: [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
-      customState: {
-        ...strategyState.customStrategyState,
-        success: 'failure',
-      },
+      customStatePatch: {},
+      hasFailed: true,
     }
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -36,7 +36,7 @@ import { updateSelectedViews } from '../commands/update-selected-views-command'
 import { wildcardPatch } from '../commands/wildcard-patch-command'
 import { getAllTargetsAtPointAABB } from '../dom-lookup'
 import {
-  failedStrategyApplicationResult,
+  emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
   StrategyApplicationResult,
@@ -698,7 +698,7 @@ export function applyFlexReparent(
         }
       }
     }
-    return failedStrategyApplicationResult
+    return emptyStrategyApplicationResult
   })
 }
 

--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -36,7 +36,7 @@ import { updateSelectedViews } from '../commands/update-selected-views-command'
 import { wildcardPatch } from '../commands/wildcard-patch-command'
 import { getAllTargetsAtPointAABB } from '../dom-lookup'
 import {
-  emptyStrategyApplicationResult,
+  failedStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
   StrategyApplicationResult,
@@ -693,11 +693,12 @@ export function applyFlexReparent(
           return {
             commands: [...midInteractionCommands, ...interactionFinishCommands],
             customStatePatch: {},
+            status: 'success',
           }
         }
       }
     }
-    return emptyStrategyApplicationResult
+    return failedStrategyApplicationResult
   })
 }
 

--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -692,10 +692,7 @@ export function applyFlexReparent(
 
           return {
             commands: [...midInteractionCommands, ...interactionFinishCommands],
-            customState: {
-              ...strategyState.customStrategyState,
-              success: 'success',
-            },
+            customStatePatch: {},
           }
         }
       }

--- a/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.tsx
@@ -18,7 +18,7 @@ export const CanvasStrategyPicker = React.memo(() => {
   const activeStrategy = useDelayedCurrentStrategy()
   const isStrategyFailure = useEditorState(
     (store) => store.strategyState?.status === 'failure',
-    'Strategy success',
+    'Strategy failure',
   )
 
   const onTabPressed = React.useCallback(

--- a/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.tsx
@@ -17,7 +17,7 @@ export const CanvasStrategyPicker = React.memo(() => {
   )
   const activeStrategy = useDelayedCurrentStrategy()
   const isStrategyFailure = useEditorState(
-    (store) => store.strategyState?.customStrategyState.success === 'failure',
+    (store) => store.strategyState?.status === 'failure',
     'Strategy success',
   )
 

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -235,7 +235,7 @@ describe('interactionStart', () => {
         ],
         "startingAllElementProps": Object {},
         "startingMetadata": Object {},
-        "status": "failure",
+        "status": "success",
       }
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)
@@ -516,7 +516,7 @@ describe('interactionHardReset', () => {
         ],
         "startingAllElementProps": Object {},
         "startingMetadata": Object {},
-        "status": "failure",
+        "status": "success",
       }
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)
@@ -737,7 +737,7 @@ describe('interactionUpdate with user changed strategy', () => {
         ],
         "startingAllElementProps": Object {},
         "startingMetadata": Object {},
-        "status": "failure",
+        "status": "success",
       }
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -169,7 +169,7 @@ const testStrategy: CanvasStrategy = {
   ): StrategyApplicationResult {
     return {
       commands: [wildcardPatch('always', { canvas: { scale: { $set: 100 } } })],
-      customState: defaultCustomStrategyState(),
+      customStatePatch: defaultCustomStrategyState(),
     }
   },
 }
@@ -222,7 +222,6 @@ describe('interactionStart', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
-          "success": "success",
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -236,6 +235,7 @@ describe('interactionStart', () => {
         ],
         "startingAllElementProps": Object {},
         "startingMetadata": Object {},
+        "status": "success",
       }
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)
@@ -283,11 +283,11 @@ describe('interactionStart', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
-          "success": "success",
         },
         "sortedApplicableStrategies": null,
         "startingAllElementProps": Object {},
         "startingMetadata": Object {},
+        "status": "success",
       }
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(1)
@@ -348,7 +348,6 @@ describe('interactionUpdatex', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
-          "success": "success",
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -362,6 +361,7 @@ describe('interactionUpdatex', () => {
         ],
         "startingAllElementProps": Object {},
         "startingMetadata": Object {},
+        "status": "success",
       }
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)
@@ -410,11 +410,11 @@ describe('interactionUpdatex', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
-          "success": "success",
         },
         "sortedApplicableStrategies": null,
         "startingAllElementProps": Object {},
         "startingMetadata": Object {},
+        "status": "success",
       }
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(1)
@@ -503,7 +503,6 @@ describe('interactionHardReset', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
-          "success": "success",
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -517,6 +516,7 @@ describe('interactionHardReset', () => {
         ],
         "startingAllElementProps": Object {},
         "startingMetadata": Object {},
+        "status": "success",
       }
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)
@@ -570,11 +570,11 @@ describe('interactionHardReset', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
-          "success": "success",
         },
         "sortedApplicableStrategies": null,
         "startingAllElementProps": Object {},
         "startingMetadata": Object {},
+        "status": "success",
       }
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(1)
@@ -724,7 +724,6 @@ describe('interactionUpdate with user changed strategy', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
-          "success": "success",
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -738,6 +737,7 @@ describe('interactionUpdate with user changed strategy', () => {
         ],
         "startingAllElementProps": Object {},
         "startingMetadata": Object {},
+        "status": "success",
       }
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)
@@ -792,11 +792,11 @@ describe('interactionUpdate with user changed strategy', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
-          "success": "success",
         },
         "sortedApplicableStrategies": null,
         "startingAllElementProps": Object {},
         "startingMetadata": Object {},
+        "status": "success",
       }
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(1)

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -361,7 +361,7 @@ describe('interactionUpdatex', () => {
         ],
         "startingAllElementProps": Object {},
         "startingMetadata": Object {},
-        "status": "failure",
+        "status": "success",
       }
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -44,6 +44,7 @@ import {
   CanvasStrategyId,
   defaultCustomStrategyState,
   InteractionCanvasState,
+  strategyApplicationResult,
   StrategyApplicationResult,
 } from '../../canvas/canvas-strategies/canvas-strategy-types'
 import { canvasPoint } from '../../../core/shared/math-utils'
@@ -167,10 +168,9 @@ const testStrategy: CanvasStrategy = {
     interactionSession: InteractionSession,
     strategyState: StrategyState,
   ): StrategyApplicationResult {
-    return {
-      commands: [wildcardPatch('always', { canvas: { scale: { $set: 100 } } })],
-      customStatePatch: defaultCustomStrategyState(),
-    }
+    return strategyApplicationResult([
+      wildcardPatch('always', { canvas: { scale: { $set: 100 } } }),
+    ])
   },
 }
 
@@ -235,7 +235,7 @@ describe('interactionStart', () => {
         ],
         "startingAllElementProps": Object {},
         "startingMetadata": Object {},
-        "status": "success",
+        "status": "failure",
       }
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)
@@ -361,7 +361,7 @@ describe('interactionUpdatex', () => {
         ],
         "startingAllElementProps": Object {},
         "startingMetadata": Object {},
-        "status": "success",
+        "status": "failure",
       }
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)
@@ -516,7 +516,7 @@ describe('interactionHardReset', () => {
         ],
         "startingAllElementProps": Object {},
         "startingMetadata": Object {},
-        "status": "success",
+        "status": "failure",
       }
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)
@@ -737,7 +737,7 @@ describe('interactionUpdate with user changed strategy', () => {
         ],
         "startingAllElementProps": Object {},
         "startingMetadata": Object {},
-        "status": "success",
+        "status": "failure",
       }
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -550,7 +550,7 @@ function handleUpdate(
       accumulatedPatches: strategyState.accumulatedPatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
-      status: strategyResult.status ? 'failure' : 'success',
+      status: strategyResult.status,
       startingMetadata: strategyState.startingMetadata,
       customStrategyState: patchCustomStrategyState(
         strategyState.customStrategyState,

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -162,7 +162,7 @@ export function interactionHardReset(
         accumulatedPatches: [],
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
-        status: getStatusFromStrategyResult(strategyResult),
+        status: strategyResult.status,
         startingMetadata: resetStrategyState.startingMetadata,
         customStrategyState: patchCustomStrategyState(
           result.strategyState.customStrategyState,
@@ -313,7 +313,7 @@ export function interactionStart(
         accumulatedPatches: [],
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
-        status: getStatusFromStrategyResult(strategyResult),
+        status: strategyResult.status,
         startingMetadata: newEditorState.canvas.interactionSession.metadata,
         customStrategyState: patchCustomStrategyState(
           result.strategyState.customStrategyState,
@@ -408,7 +408,7 @@ function handleUserChangedStrategy(
       accumulatedPatches: commandResult.accumulatedPatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
-      status: getStatusFromStrategyResult(strategyResult),
+      status: strategyResult.status,
       startingMetadata: strategyState.startingMetadata,
       customStrategyState: patchCustomStrategyState(
         strategyState.customStrategyState,
@@ -488,7 +488,7 @@ function handleAccumulatingKeypresses(
         accumulatedPatches: commandResult.accumulatedPatches,
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
-        status: getStatusFromStrategyResult(strategyResult),
+        status: strategyResult.status,
         startingMetadata: strategyState.startingMetadata,
         customStrategyState: patchCustomStrategyState(
           strategyState.customStrategyState,
@@ -741,10 +741,4 @@ function patchCustomStrategyState(
     ...existingState,
     ...patch,
   }
-}
-
-function getStatusFromStrategyResult(
-  strategyResult: StrategyApplicationResult,
-): StrategyApplicationStatus {
-  return strategyResult.status ? 'failure' : 'success'
 }

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -28,8 +28,8 @@ import {
   CanvasStrategy,
   CustomStrategyState,
   CustomStrategyStatePatch,
-  emptyStrategyApplicationResult,
   InteractionCanvasState,
+  strategyApplicationResult,
   StrategyApplicationResult,
 } from '../../canvas/canvas-strategies/canvas-strategy-types'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
@@ -472,7 +472,7 @@ function handleAccumulatingKeypresses(
               updatedInteractionSession,
               strategyState,
             )
-          : emptyStrategyApplicationResult
+          : strategyApplicationResult([])
       const commandResult = foldAndApplyCommands(
         updatedEditorState,
         storedEditorState,
@@ -534,7 +534,7 @@ function handleUpdate(
             newEditorState.canvas.interactionSession,
             strategyState,
           )
-        : emptyStrategyApplicationResult
+        : strategyApplicationResult([])
     const commandResult = foldAndApplyCommands(
       newEditorState,
       storedEditorState,
@@ -550,7 +550,7 @@ function handleUpdate(
       accumulatedPatches: strategyState.accumulatedPatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
-      status: strategyResult.hasFailed ? 'failure' : 'success',
+      status: strategyResult.status ? 'failure' : 'success',
       startingMetadata: strategyState.startingMetadata,
       customStrategyState: patchCustomStrategyState(
         strategyState.customStrategyState,
@@ -746,5 +746,5 @@ function patchCustomStrategyState(
 function getStatusFromStrategyResult(
   strategyResult: StrategyApplicationResult,
 ): StrategyApplicationStatus {
-  return strategyResult.hasFailed ? 'failure' : 'success'
+  return strategyResult.status ? 'failure' : 'success'
 }

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -11,6 +11,7 @@ import {
   interactionSessionHardReset,
   isKeyboardInteractionData,
   KeyboardInteractionData,
+  StrategyApplicationStatus,
   StrategyState,
 } from '../../canvas/canvas-strategies/interaction-state'
 import { foldAndApplyCommands } from '../../canvas/commands/commands'
@@ -25,7 +26,11 @@ import { InnerDispatchResult } from './dispatch'
 import { DerivedState, deriveState, EditorState, EditorStoreFull } from './editor-state'
 import {
   CanvasStrategy,
+  CustomStrategyState,
+  CustomStrategyStatePatch,
+  emptyStrategyApplicationResult,
   InteractionCanvasState,
+  StrategyApplicationResult,
 } from '../../canvas/canvas-strategies/canvas-strategy-types'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { PERFORMANCE_MARKS_ALLOWED } from '../../../common/env-vars'
@@ -157,11 +162,12 @@ export function interactionHardReset(
         accumulatedPatches: [],
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
+        status: getStatusFromStrategyResult(strategyResult),
         startingMetadata: resetStrategyState.startingMetadata,
-        customStrategyState: strategyResult.customState ?? {
-          ...result.strategyState.customStrategyState,
-          success: 'success',
-        },
+        customStrategyState: patchCustomStrategyState(
+          result.strategyState.customStrategyState,
+          strategyResult.customStatePatch,
+        ),
         startingAllElementProps: resetStrategyState.startingAllElementProps,
       }
 
@@ -307,11 +313,12 @@ export function interactionStart(
         accumulatedPatches: [],
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
+        status: getStatusFromStrategyResult(strategyResult),
         startingMetadata: newEditorState.canvas.interactionSession.metadata,
-        customStrategyState: strategyResult.customState ?? {
-          ...result.strategyState.customStrategyState,
-          success: 'success',
-        },
+        customStrategyState: patchCustomStrategyState(
+          result.strategyState.customStrategyState,
+          strategyResult.customStatePatch,
+        ),
         startingAllElementProps: newEditorState.canvas.interactionSession.allElementProps,
       }
 
@@ -401,11 +408,12 @@ function handleUserChangedStrategy(
       accumulatedPatches: commandResult.accumulatedPatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
+      status: getStatusFromStrategyResult(strategyResult),
       startingMetadata: strategyState.startingMetadata,
-      customStrategyState: strategyResult.customState ?? {
-        ...strategyState.customStrategyState,
-        success: 'success',
-      },
+      customStrategyState: patchCustomStrategyState(
+        strategyState.customStrategyState,
+        strategyResult.customStatePatch,
+      ),
       startingAllElementProps: strategyState.startingAllElementProps,
     }
 
@@ -464,10 +472,7 @@ function handleAccumulatingKeypresses(
               updatedInteractionSession,
               strategyState,
             )
-          : {
-              commands: [],
-              customState: strategyState.customStrategyState,
-            }
+          : emptyStrategyApplicationResult
       const commandResult = foldAndApplyCommands(
         updatedEditorState,
         storedEditorState,
@@ -483,11 +488,12 @@ function handleAccumulatingKeypresses(
         accumulatedPatches: commandResult.accumulatedPatches,
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
+        status: getStatusFromStrategyResult(strategyResult),
         startingMetadata: strategyState.startingMetadata,
-        customStrategyState: strategyResult.customState ?? {
-          ...strategyState.customStrategyState,
-          success: 'success',
-        },
+        customStrategyState: patchCustomStrategyState(
+          strategyState.customStrategyState,
+          strategyResult.customStatePatch,
+        ),
         startingAllElementProps: strategyState.startingAllElementProps,
       }
 
@@ -528,10 +534,7 @@ function handleUpdate(
             newEditorState.canvas.interactionSession,
             strategyState,
           )
-        : {
-            commands: [],
-            customState: strategyState.customStrategyState,
-          }
+        : emptyStrategyApplicationResult
     const commandResult = foldAndApplyCommands(
       newEditorState,
       storedEditorState,
@@ -547,11 +550,12 @@ function handleUpdate(
       accumulatedPatches: strategyState.accumulatedPatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
+      status: strategyResult.hasFailed ? 'failure' : 'success',
       startingMetadata: strategyState.startingMetadata,
-      customStrategyState: strategyResult.customState ?? {
-        ...strategyState.customStrategyState,
-        success: 'success',
-      },
+      customStrategyState: patchCustomStrategyState(
+        strategyState.customStrategyState,
+        strategyResult.customStatePatch,
+      ),
       startingAllElementProps: strategyState.startingAllElementProps,
     }
     return {
@@ -727,4 +731,20 @@ function handleStrategiesInner(
       }
     }
   }
+}
+
+function patchCustomStrategyState(
+  existingState: CustomStrategyState,
+  patch: CustomStrategyStatePatch,
+): CustomStrategyState {
+  return {
+    ...existingState,
+    ...patch,
+  }
+}
+
+function getStatusFromStrategyResult(
+  strategyResult: StrategyApplicationResult,
+): StrategyApplicationStatus {
+  return strategyResult.hasFailed ? 'failure' : 'success'
 }


### PR DESCRIPTION
Strategies can store state in `StrategyState.customStrategyState`
To make this possible `StrategyApplicationResult` contains a `customState` field, which can be `null`, to express that the strategy doesn't want to change the custom state. That is an ugly pattern, its goal was to not force strategies to always return the previous custom state.

This PR introduces a new way to solve this problem: strategies can just return a patch to the state, so they only have to return with the fields what they want to change.

At the same time I removed the `success` field from `CustomStrategyState`: it was not a good place for that, because `success` is not something what we ever want to keep: this should be always the result of the last application of the current strategy.

I added a constructor function for `StrategyApplicationResult` to make it easier to create results in the apply functions and in the helpers. Mostly we just return an array of commands, so the other parameters are optional.

We had this `emptyStrategyApplicationResult` which were always used in error cases, so I decided to just call that `failedStrategyApplicationResult` and set the `status` in it to `failure`
