### PR TITLE
Change scene label mouse up handling.

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/scene-label.tsx
@@ -110,8 +110,18 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
     }
   }, [dispatch, isHighlighted])
 
+  const onMouseUp = React.useCallback(
+    (event: MouseEvent) => {
+      event.stopPropagation()
+      window.removeEventListener('mouseup', onMouseUp, true)
+      dispatch([CanvasActions.clearInteractionSession(true)], 'canvas')
+    },
+    [dispatch],
+  )
+
   const onMouseDown = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
+      window.addEventListener('mouseup', onMouseUp, true)
       if (event.buttons === 1 && event.button !== 2) {
         event.stopPropagation()
 
@@ -133,16 +143,14 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
         dispatch([selectAction, dragAction], 'canvas')
       }
     },
-    [dispatch, scale, canvasOffset, props.target],
+    [dispatch, scale, canvasOffset, props.target, onMouseUp],
   )
 
-  const onMouseUp = React.useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
-      event.stopPropagation()
-      dispatch([CanvasActions.clearInteractionSession(true)], 'canvas')
-    },
-    [dispatch],
-  )
+  React.useEffect(() => {
+    return () => {
+      window.removeEventListener('mouseup', onMouseUp, true)
+    }
+  }, [onMouseUp])
 
   const highlightColor = colorTheme.fg9.value
   const selectedColor = colorTheme.verySubduedForeground.value
@@ -157,7 +165,6 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
           onMouseOver={labelSelectable ? onMouseOver : NO_OP}
           onMouseOut={labelSelectable ? onMouseLeave : NO_OP}
           onMouseDown={labelSelectable ? onMouseDown : NO_OP}
-          onMouseUp={labelSelectable ? onMouseUp : NO_OP}
           onMouseMove={labelSelectable ? onMouseMove : NO_OP}
           data-testid={SceneLabelTestID}
           className='roleComponentName'


### PR DESCRIPTION
**Problem:**
As a result of the cursor overlay causing the mouse up on the scene label to not fire (in turn as a result of a canvas strategy changing the cursor), the mouse up was falling through to the canvas which ended up clearing the selection created by the mouse down in the same "click" operation because it isn't targeting anything.

**Fix:**
Similarly to a few other places, this implements the pattern of having the mouse up added to the window event listeners by the mouse down so that it will always be fired.

**Commit Details:**
- Remove `onMouseUp` handler from the div that makes up the scene label.
- `onMouseDown` function now adds `onMouseUp` to the window event listeners.
- `onMouseUp` function now removes itself from the window event listeners.
- Added a `React.useEffect` call that removes `onMouseUp` from the window event listeners in the cleanup callback that it returns.