### PR TITLE
Clipboard now captures only the required imports

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/reparent-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-utils.ts
@@ -17,7 +17,11 @@ import {
   walkElement,
 } from '../../../core/shared/element-template'
 import * as EP from '../../../core/shared/element-path'
-import { getImportsFor, importedFromWhere } from '../../../components/editor/import-utils'
+import {
+  getImportsFor,
+  getRequiredImportsForElement,
+  importedFromWhere,
+} from '../../../components/editor/import-utils'
 import { forceNotNull } from '../../../core/shared/optional-utils'
 import { addImportsToFile } from '../commands/add-imports-to-file-command'
 import { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
@@ -114,7 +118,7 @@ export function getReparentOutcome(
 
   switch (toReparent.type) {
     case 'PATH_TO_REPARENT':
-      const importsToAdd = getReparentImports(
+      const importsToAdd = getRequiredImportsForElement(
         toReparent.target,
         projectContents,
         nodeModules,
@@ -144,87 +148,6 @@ export function getReparentOutcome(
     commands: commands,
     newPath: newPath,
   }
-}
-
-function getReparentImports(
-  target: ElementPath,
-  projectContents: ProjectContentTreeRoot,
-  nodeModules: NodeModules,
-  openFile: string | null | undefined,
-  newTargetFilePath: string,
-  builtInDependencies: BuiltInDependencies,
-): Imports {
-  return withUnderlyingTarget<Imports>(
-    target,
-    projectContents,
-    nodeModules,
-    openFile,
-    emptyImports(),
-    (success, element, underlyingTarget, underlyingFilePath) => {
-      const importsInOriginFile = success.imports
-      const topLevelElementsInOriginFile = success.topLevelElements
-      const lastPathPart =
-        EP.lastElementPathForPath(underlyingTarget) ?? EP.emptyStaticElementPathPart()
-
-      let importsToAdd: Imports = emptyImports()
-      // Walk down through the elements as elements within the element being reparented might also be imported.
-      walkElement(element, lastPathPart, 0, (elem, subPath, depth) => {
-        if (isJSXElement(elem)) {
-          // Straight up ignore intrinsic elements as they wont be imported.
-          if (!isIntrinsicElement(elem.name)) {
-            const importedFromResult = importedFromWhere(
-              underlyingFilePath,
-              elem.name.baseVariable,
-              topLevelElementsInOriginFile,
-              importsInOriginFile,
-            )
-
-            if (importedFromResult != null) {
-              switch (importedFromResult.type) {
-                case 'SAME_FILE_ORIGIN':
-                  importsToAdd = mergeImports(
-                    newTargetFilePath,
-                    importsToAdd,
-                    getImportsFor(
-                      builtInDependencies,
-                      importsInOriginFile,
-                      projectContents,
-                      nodeModules,
-                      underlyingFilePath,
-                      elem.name.baseVariable,
-                    ),
-                  )
-                  break
-                case 'IMPORTED_ORIGIN':
-                  if (importedFromResult.exportedName != null) {
-                    importsToAdd = mergeImports(
-                      newTargetFilePath,
-                      importsToAdd,
-                      getImportsFor(
-                        builtInDependencies,
-                        importsInOriginFile,
-                        projectContents,
-                        nodeModules,
-                        underlyingFilePath,
-                        importedFromResult.exportedName,
-                      ),
-                    )
-                  }
-                  break
-                default:
-                  const _exhaustiveCheck: never = importedFromResult
-                  throw new Error(
-                    `Unhandled imported from result ${JSON.stringify(importedFromResult)}`,
-                  )
-              }
-            }
-          }
-        }
-      })
-
-      return importsToAdd
-    },
-  )
 }
 
 export function cursorForMissingReparentedItems(

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2871,6 +2871,7 @@ export const UPDATE_FNS = {
     action: CopySelectionToClipboard,
     editorForAction: EditorModel,
     dispatch: EditorDispatch,
+    builtInDependencies: BuiltInDependencies,
   ): EditorModel => {
     return toastOnUncopyableElementsSelected(
       'Cannot copy these elements.',
@@ -2878,7 +2879,7 @@ export const UPDATE_FNS = {
       false,
       (editor) => {
         // side effect 😟
-        setClipboardData(createClipboardDataFromSelection(editorForAction))
+        setClipboardData(createClipboardDataFromSelection(editorForAction, builtInDependencies))
         return {
           ...editor,
           pasteTargetsToIgnore: editor.selectedViews,

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -3,7 +3,6 @@ import { EditorAction, EditorDispatch } from '../action-types'
 import { UPDATE_FNS } from '../actions/actions'
 
 import { StateHistory } from '../history'
-import { setClipboardData, createClipboardDataFromSelection } from '../../../utils/clipboard'
 import { UtopiaTsWorkers } from '../../../core/workers/common/worker-types'
 import { UiJsxCanvasContextData } from '../../canvas/ui-jsx-canvas'
 import type { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
@@ -118,7 +117,7 @@ export function runSimpleLocalEditorAction(
     case 'PASTE_JSX_ELEMENTS':
       return UPDATE_FNS.PASTE_JSX_ELEMENTS(action, state, dispatch, builtInDependencies)
     case 'COPY_SELECTION_TO_CLIPBOARD':
-      return UPDATE_FNS.COPY_SELECTION_TO_CLIPBOARD(action, state, dispatch)
+      return UPDATE_FNS.COPY_SELECTION_TO_CLIPBOARD(action, state, dispatch, builtInDependencies)
     case 'OPEN_TEXT_EDITOR':
       return UPDATE_FNS.OPEN_TEXT_EDITOR(action, state)
     case 'CLOSE_TEXT_EDITOR':

--- a/editor/src/utils/clipboard.spec.tsx
+++ b/editor/src/utils/clipboard.spec.tsx
@@ -19,10 +19,12 @@ import {
 } from '../core/shared/project-file-types'
 import * as EP from '../core/shared/element-path'
 import { createClipboardDataFromSelection } from './clipboard'
+import json5 from 'json5'
 
 describe('copy to clipboard', () => {
   it('creates copy data multifile elements', async () => {
     const appFilePath = '/src/app.js'
+    const cardFilePath = '/src/card.js'
     let projectContents: ProjectContents = {
       '/package.json': textFile(
         textFileContents(
@@ -61,10 +63,19 @@ export var storyboard = (
         appFilePath,
         `
 import React from 'react'
+import { Card } from '/src/card.js'
 export var App = (props) => {
   return <div data-uid='app-outer-div' style={{position: 'relative', width: '100%', height: '100%', backgroundColor: '#FFFFFF'}}>
-    <div data-uid='app-inner-div-to-copy'/>
+    <Card data-uid='card-element-to-copy'/>
   </div>
+}`,
+      ),
+      [cardFilePath]: createCodeFile(
+        cardFilePath,
+        `
+import React from 'react'
+export var Card = (props) => {
+  return <div data-uid='card-outer-div'/>
 }`,
       ),
     }
@@ -74,16 +85,79 @@ export var App = (props) => {
     )
     const targetPath1 = EP.appendNewElementPath(TestScenePath, [
       'app-outer-div',
-      'app-inner-div-to-copy',
+      'card-element-to-copy',
     ])
 
     await renderResult.dispatch([selectComponents([targetPath1], false)], false)
-    const clipboardData = createClipboardDataFromSelection(renderResult.getEditorState().editor)
+    const clipboardData = createClipboardDataFromSelection(
+      renderResult.getEditorState().editor,
+      renderResult.getEditorState().builtInDependencies,
+    )
 
     expect(clipboardData?.data.length).toEqual(1)
     expect(clipboardData?.data[0].type).toEqual('ELEMENT_COPY')
-    expect(clipboardData?.data[0].elements).toMatchInlineSnapshot(
-      `"[{element:{type:\\"JSX_ELEMENT\\",name:{baseVariable:\\"div\\",propertyPath:{propertyElements:[]}},uid:\\"app-inner-div-to-copy\\",props:[{type:\\"JSX_ATTRIBUTES_ENTRY\\",key:\\"data-uid\\",value:{type:\\"ATTRIBUTE_VALUE\\",value:\\"app-inner-div-to-copy\\",comments:{leadingComments:[],trailingComments:[]}},comments:{leadingComments:[],trailingComments:[]}}],children:[]},importsToAdd:{react:{importedWithName:\\"React\\",importedFromWithin:[],importedAs:null}},originalElementPath:{type:\\"elementpath\\",parts:[[\\"utopia-storyboard-uid\\",\\"scene-aaa\\",\\"app-entity\\"],[\\"app-outer-div\\",\\"app-inner-div-to-copy\\"]]}}]"`,
-    )
+    expect(clipboardData?.data[0].elements).not.toBeNull()
+    const elements = json5.parse(clipboardData?.data[0].elements ?? '')
+    expect(json5.stringify(elements, null, 2)).toMatchInlineSnapshot(`
+      "[
+        {
+          element: {
+            type: \\"JSX_ELEMENT\\",
+            name: {
+              baseVariable: \\"Card\\",
+              propertyPath: {
+                propertyElements: []
+              }
+            },
+            uid: \\"card-element-to-copy\\",
+            props: [
+              {
+                type: \\"JSX_ATTRIBUTES_ENTRY\\",
+                key: \\"data-uid\\",
+                value: {
+                  type: \\"ATTRIBUTE_VALUE\\",
+                  value: \\"card-element-to-copy\\",
+                  comments: {
+                    leadingComments: [],
+                    trailingComments: []
+                  }
+                },
+                comments: {
+                  leadingComments: [],
+                  trailingComments: []
+                }
+              }
+            ],
+            children: []
+          },
+          importsToAdd: {
+            \\"/src/card.js\\": {
+              importedWithName: null,
+              importedFromWithin: [
+                {
+                  name: \\"Card\\",
+                  alias: \\"Card\\"
+                }
+              ],
+              importedAs: null
+            }
+          },
+          originalElementPath: {
+            type: \\"elementpath\\",
+            parts: [
+              [
+                \\"utopia-storyboard-uid\\",
+                \\"scene-aaa\\",
+                \\"app-entity\\"
+              ],
+              [
+                \\"app-outer-div\\",
+                \\"card-element-to-copy\\"
+              ]
+            ]
+          }
+        }
+      ]"
+    `)
   })
 })


### PR DESCRIPTION
**Problem:**
When copying (or cutting) an element, the clipboard would capture all imports from the source file, meaning pasting could result in cyclic imports

**Fix:**
We were already capturing only the required imports as part of a helper function used by canvas reparenting, so I have extracted that function and moved it into `import-utils.ts` and reused it as part of the element copying.