### PR TITLE
Use the same position: absolute setting in all types of insertion

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
@@ -193,29 +193,7 @@ function getStyleAttributesForFrameInAbsolutePosition(
     throw new Error(`Problem setting drag frame on an element we just created.`)
   }
 
-  // we need to add position absolute, so in the storyboard root the element can be absolutely positioned initially
-  const styleAttributes = getJSXAttribute(updatedAttributes.value, 'style')
-
-  if (styleAttributes == null) {
-    throw new Error(`Problem getting style props from element we just created`)
-  }
-
-  const updatedStyleAttrs = setJSXValueInAttributeAtPath(
-    styleAttributes,
-    PP.fromString('position'),
-    jsxAttributeValue('absolute', emptyComments),
-  )
-
-  if (isLeft(updatedStyleAttrs)) {
-    throw new Error(`Problem setting position absolute on an element we just created.`)
-  }
-
-  const updatedAttributesWithPosition = setJSXAttributesAttribute(
-    updatedAttributes.value,
-    'style',
-    updatedStyleAttrs.value,
-  )
-  return updatedAttributesWithPosition
+  return updatedAttributes.value
 }
 
 function runTargetStrategiesForFreshlyInsertedElement(

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -1450,7 +1450,7 @@ describe('INSERT_INSERTABLE', () => {
           export var Card = (props) => {
             return (
               <div style={{ ...props.style }}>
-                <div style={{ position: 'absolute' }}>
+                <div>
                   <div
                     style={{
                       position: 'absolute',

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -14,7 +14,6 @@ import {
   JSXAttributesPart,
   isJSXAttributesEntry,
   getJSXAttribute,
-  simpleAttribute,
 } from '../../core/shared/element-template'
 import { generateUID } from '../../core/shared/uid-utils'
 import {

--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -52,26 +52,7 @@ Array [
               "propertyElements": Array [],
             },
           },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "value": Object {
-                  "position": "absolute",
-                },
-              },
-            },
-          ],
+          "props": Array [],
         },
         "importsToAdd": Object {
           "react": Object {
@@ -119,26 +100,7 @@ Array [
               "propertyElements": Array [],
             },
           },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "value": Object {
-                  "position": "absolute",
-                },
-              },
-            },
-          ],
+          "props": Array [],
         },
         "importsToAdd": Object {
           "react": Object {
@@ -162,26 +124,7 @@ Array [
               "propertyElements": Array [],
             },
           },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "value": Object {
-                  "position": "absolute",
-                },
-              },
-            },
-          ],
+          "props": Array [],
         },
         "importsToAdd": Object {
           "react": Object {
@@ -229,26 +172,7 @@ Array [
               "propertyElements": Array [],
             },
           },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "value": Object {
-                  "position": "absolute",
-                },
-              },
-            },
-          ],
+          "props": Array [],
         },
         "importsToAdd": Object {
           "react": Object {
@@ -272,26 +196,7 @@ Array [
               "propertyElements": Array [],
             },
           },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "value": Object {
-                  "position": "absolute",
-                },
-              },
-            },
-          ],
+          "props": Array [],
         },
         "importsToAdd": Object {
           "react": Object {
@@ -544,26 +449,7 @@ Array [
               "propertyElements": Array [],
             },
           },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "value": Object {
-                  "position": "absolute",
-                },
-              },
-            },
-          ],
+          "props": Array [],
         },
         "importsToAdd": Object {
           "react": Object {
@@ -611,26 +497,7 @@ Array [
               "propertyElements": Array [],
             },
           },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "value": Object {
-                  "position": "absolute",
-                },
-              },
-            },
-          ],
+          "props": Array [],
         },
         "importsToAdd": Object {
           "react": Object {
@@ -654,26 +521,7 @@ Array [
               "propertyElements": Array [],
             },
           },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "value": Object {
-                  "position": "absolute",
-                },
-              },
-            },
-          ],
+          "props": Array [],
         },
         "importsToAdd": Object {
           "react": Object {
@@ -721,26 +569,7 @@ Array [
               "propertyElements": Array [],
             },
           },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "value": Object {
-                  "position": "absolute",
-                },
-              },
-            },
-          ],
+          "props": Array [],
         },
         "importsToAdd": Object {
           "react": Object {
@@ -764,26 +593,7 @@ Array [
               "propertyElements": Array [],
             },
           },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "value": Object {
-                  "position": "absolute",
-                },
-              },
-            },
-          ],
+          "props": Array [],
         },
         "importsToAdd": Object {
           "react": Object {

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -14,7 +14,6 @@ import {
   right,
 } from '../../core/shared/either'
 import {
-  absolutePositionStyle,
   emptyComments,
   isIntrinsicElementFromString,
   JSXAttributes,
@@ -229,13 +228,13 @@ function makeHTMLDescriptor(
 }
 
 const basicHTMLElementsDescriptors = {
-  div: makeHTMLDescriptor('div', {}, absolutePositionStyle),
+  div: makeHTMLDescriptor('div', {}),
   span: makeHTMLDescriptor('span', {}),
-  h1: makeHTMLDescriptor('h1', {}, absolutePositionStyle),
-  h2: makeHTMLDescriptor('h2', {}, absolutePositionStyle),
+  h1: makeHTMLDescriptor('h1', {}),
+  h2: makeHTMLDescriptor('h2', {}),
   p: makeHTMLDescriptor('p', {}),
-  button: makeHTMLDescriptor('button', {}, absolutePositionStyle),
-  input: makeHTMLDescriptor('input', {}, absolutePositionStyle),
+  button: makeHTMLDescriptor('button', {}),
+  input: makeHTMLDescriptor('input', {}),
   video: makeHTMLDescriptor(
     'video',
     {

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -36,10 +36,6 @@ export const emptyComments: ParsedComments = {
   trailingComments: [],
 }
 
-export const absolutePositionStyle: JSXAttributes = [
-  simpleAttribute('style', { position: 'absolute' }),
-]
-
 export function isParsedCommentsEmpty(comments: ParsedComments): boolean {
   return comments.leadingComments.length === 0 && comments.trailingComments.length === 0
 }


### PR DESCRIPTION
Adding `position: absolute` to the insertion subject when it is initialized in the insert menu and added to the editor mode in editor state.
With this change, we don't need to set it when dragging to insert, or when we create the jsx elements from html elements.

Note: when we drag into a flex component, this will be overridden. This is just a better default than nothing, but it can be changed during the actual insertion.