### PR TITLE
Non-resizable controls on elements that can't be resized.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -26,7 +26,11 @@ import { updateHighlightedViews } from '../commands/update-highlighted-views-com
 import { ParentBounds } from '../controls/parent-bounds'
 import { ParentOutlines } from '../controls/parent-outlines'
 import { AbsoluteResizeControl } from '../controls/select-mode/absolute-resize-control'
-import { AbsolutePin, ensureAtLeastTwoPinsForEdgePosition } from './absolute-resize-helpers'
+import {
+  AbsolutePin,
+  ensureAtLeastTwoPinsForEdgePosition,
+  supportsAbsoluteResize,
+} from './absolute-resize-helpers'
 import {
   CanvasStrategy,
   emptyStrategyApplicationResult,
@@ -43,7 +47,6 @@ import * as EP from '../../../core/shared/element-path'
 import { ZeroSizeResizeControlWrapper } from '../controls/zero-sized-element-controls'
 import { SetCssLengthProperty, setCssLengthProperty } from '../commands/set-css-length-command'
 import { pushIntendedBounds } from '../commands/push-intended-bounds-command'
-import { honoursPropsPosition, honoursPropsSize } from './absolute-utils'
 
 export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_RESIZE_BOUNDING_BOX',
@@ -53,12 +56,7 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
     if (selectedElements.length > 0) {
       const filteredSelectedElements = getDragTargets(selectedElements)
       return filteredSelectedElements.every((element) => {
-        const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
-        return (
-          elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
-          honoursPropsPosition(canvasState, element) &&
-          honoursPropsSize(canvasState, element)
-        )
+        return supportsAbsoluteResize(metadata, element, canvasState)
       })
     } else {
       return false

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-helpers.ts
@@ -1,7 +1,11 @@
+import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
+import { ElementPath } from '../../../core/shared/project-file-types'
 import { getLayoutProperty } from '../../../core/layout/getLayoutProperty'
-import { PropsOrJSXAttributes } from '../../../core/model/element-metadata-utils'
+import { MetadataUtils, PropsOrJSXAttributes } from '../../../core/model/element-metadata-utils'
 import { isRight } from '../../../core/shared/either'
 import { EdgePosition } from '../canvas-types'
+import { honoursPropsPosition, honoursPropsSize } from './absolute-utils'
+import { InteractionCanvasState } from './canvas-strategy-types'
 
 export type AbsolutePin = 'left' | 'top' | 'right' | 'bottom' | 'width' | 'height'
 
@@ -57,4 +61,17 @@ export function ensureAtLeastTwoPinsForEdgePosition(
   }
 
   return [...horizontalPinsToAdd, ...verticalPinsToAdd]
+}
+
+export function supportsAbsoluteResize(
+  metadata: ElementInstanceMetadataMap,
+  element: ElementPath,
+  canvasState: InteractionCanvasState,
+) {
+  const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
+  return (
+    elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
+    honoursPropsPosition(canvasState, element) &&
+    honoursPropsSize(canvasState, element)
+  )
 }

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
@@ -19,6 +19,8 @@ import { selectComponents } from '../../editor/actions/action-creators'
 import CanvasActions from '../canvas-actions'
 import { AllElementProps } from '../../editor/store/editor-state'
 import { CanvasControlsContainerID } from '../controls/new-canvas-controls'
+import { PrettierConfig } from 'utopia-vscode-common'
+import * as Prettier from 'prettier/standalone'
 
 const baseStrategyState = (
   metadata: ElementInstanceMetadataMap,
@@ -695,5 +697,224 @@ describe('Snapping guidelines for absolutely moved element', () => {
         ],
       },
     ])
+  })
+})
+
+const projectWithNonResizableElement = `
+import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export const ChildrenHider = (props) => {
+  return <div data-uid='33d' style={{ ...props.style }} />
+}
+
+export const Button = () => {
+  return (
+    <div
+      data-uid='buttondiv'
+      data-testid='buttondiv'
+      data-label='buttondiv'
+      style={{
+        width: 100,
+        height: 30,
+        backgroundColor: 'pink',
+      }}
+    >
+      BUTTON
+    </div>
+  )
+}
+
+const unmoveableColour = 'orange'
+
+export var storyboard = (
+  <Storyboard data-uid='storyboard'>
+    <Scene
+      style={{
+        backgroundColor: 'white',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 700,
+      }}
+      data-uid='scene'
+    >
+      <div
+        style={{
+          backgroundColor: 'white',
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: 400,
+          height: 500,
+        }}
+        data-uid='sceneroot'
+      >
+        <ChildrenHider
+          style={{
+            backgroundColor: 'teal',
+            position: 'absolute',
+            left: 150,
+            top: 200,
+            height: 50,
+            width: 50,
+          }}
+          data-uid='d75'
+        />
+        <div
+          style={{
+            backgroundColor: 'purple',
+            position: 'absolute',
+            left: 21,
+            top: 215.5,
+            width: 123,
+            height: 100,
+          }}
+          data-uid='seconddiv'
+          data-testid='seconddiv'
+          data-label='seconddiv'
+        />
+        <div
+          style={{
+            backgroundColor: unmoveableColour,
+            height: 65,
+            width: 66,
+            position: 'absolute',
+            left: 265,
+            top: 300,
+          }}
+          data-uid='notdrag'
+          data-testid='notdrag'
+          data-label='notdrag'
+        >
+          not drag
+        </div>
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            height: 111,
+            width: 140,
+            position: 'absolute',
+            left: 197,
+            top: 376,
+          }}
+          data-uid='dragme'
+          data-testid='dragme'
+          data-label='dragme'
+        >
+          <Button
+            data-uid='button'
+            data-testid='button'
+            data-label='button'
+          />
+        </div>
+      </div>
+      <div
+        style={{
+          backgroundColor: 'grey',
+          position: 'absolute',
+          display: 'flex',
+          left: 0,
+          top: 500,
+          width: 400,
+          height: 200,
+        }}
+        data-uid='parentsibling'
+        data-testid='parentsibling'
+        data-label='parentsibling'
+      >
+        <div
+          style={{
+            backgroundColor: 'teal',
+            position: 'relative',
+            width: 109,
+            height: 123,
+          }}
+          data-uid='firstdiv'
+          data-testid='firstdiv'
+          data-label='firstdiv'
+        />
+        <div
+          style={{
+            backgroundColor: 'green',
+            position: 'relative',
+            width: 118,
+            height: 123,
+          }}
+          data-uid='thirddiv'
+          data-testid='thirddiv'
+          data-label='thirddiv'
+        />
+      </div>
+    </Scene>
+  </Storyboard>
+)
+`
+
+describe('special case controls', () => {
+  it('non-resizable corner controls show for an element that is not resizable', async () => {
+    const targetElement = elementPath([['storyboard', 'scene', 'sceneroot', 'dragme', 'button']])
+
+    const renderResult = await renderTestEditorWithCode(
+      projectWithNonResizableElement,
+      'await-first-dom-report',
+    )
+
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      await renderResult.dispatch([selectComponents([targetElement], false)], false)
+      await dispatchDone
+    })
+
+    const nonResizableControl = await renderResult.renderedDOM.findByTestId('non-resizable-control')
+    expect(Prettier.format(nonResizableControl.outerHTML, PrettierConfig)).toEqual(`;<div
+  data-testid='non-resizable-control'
+  style='position: absolute; display: block; left: 197px; top: 376px; width: 100px; height: 30px;'
+>
+  <div style='position: absolute; pointer-events: none;'>
+    <div
+      data-testid='non-resizable-0-0'
+      style='position: relative; width: 6px; height: 6px; top: -3px; left: -3px; background: rgb(255, 255, 255); border: 1px solid rgba(0, 0, 0, 0.5); border-radius: 50%;'
+    ></div>
+  </div>
+  <div style='position: absolute; pointer-events: none; left: 100px;'>
+    <div
+      data-testid='non-resizable-1-0'
+      style='position: relative; width: 6px; height: 6px; top: -3px; left: -3px; background: rgb(255, 255, 255); border: 1px solid rgba(0, 0, 0, 0.5); border-radius: 50%;'
+    ></div>
+  </div>
+  <div style='position: absolute; pointer-events: none; top: 30px;'>
+    <div
+      data-testid='non-resizable-0-1'
+      style='position: relative; width: 6px; height: 6px; top: -3px; left: -3px; background: rgb(255, 255, 255); border: 1px solid rgba(0, 0, 0, 0.5); border-radius: 50%;'
+    ></div>
+  </div>
+  <div style='position: absolute; pointer-events: none; left: 100px; top: 30px;'>
+    <div
+      data-testid='non-resizable-1-1'
+      style='position: relative; width: 6px; height: 6px; top: -3px; left: -3px; background: rgb(255, 255, 255); border: 1px solid rgba(0, 0, 0, 0.5); border-radius: 50%;'
+    ></div>
+  </div>
+</div>
+`)
+  })
+
+  it('no non-resizable corner controls show for an element that is resizable', async () => {
+    const targetElement = elementPath([['storyboard', 'scene', 'sceneroot', 'dragme']])
+
+    const renderResult = await renderTestEditorWithCode(
+      projectWithNonResizableElement,
+      'await-first-dom-report',
+    )
+
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      await renderResult.dispatch([selectComponents([targetElement], false)], false)
+      await dispatchDone
+    })
+
+    const nonResizableControl = renderResult.renderedDOM.queryByTestId('non-resizable-control')
+    expect(nonResizableControl).toEqual(null)
   })
 })

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
@@ -21,6 +21,7 @@ import { AllElementProps } from '../../editor/store/editor-state'
 import { CanvasControlsContainerID } from '../controls/new-canvas-controls'
 import { PrettierConfig } from 'utopia-vscode-common'
 import * as Prettier from 'prettier/standalone'
+import { forceNotNull } from '../../..//core/shared/optional-utils'
 
 const baseStrategyState = (
   metadata: ElementInstanceMetadataMap,
@@ -867,37 +868,24 @@ describe('special case controls', () => {
       await dispatchDone
     })
 
-    const nonResizableControl = await renderResult.renderedDOM.findByTestId('non-resizable-control')
-    expect(Prettier.format(nonResizableControl.outerHTML, PrettierConfig)).toEqual(`;<div
-  data-testid='non-resizable-control'
-  style='position: absolute; display: block; left: 197px; top: 376px; width: 100px; height: 30px;'
->
-  <div style='position: absolute; pointer-events: none;'>
-    <div
-      data-testid='non-resizable-0-0'
-      style='position: relative; width: 6px; height: 6px; top: -3px; left: -3px; background: rgb(255, 255, 255); border: 1px solid rgba(0, 0, 0, 0.5); border-radius: 50%;'
-    ></div>
-  </div>
-  <div style='position: absolute; pointer-events: none; left: 100px;'>
-    <div
-      data-testid='non-resizable-1-0'
-      style='position: relative; width: 6px; height: 6px; top: -3px; left: -3px; background: rgb(255, 255, 255); border: 1px solid rgba(0, 0, 0, 0.5); border-radius: 50%;'
-    ></div>
-  </div>
-  <div style='position: absolute; pointer-events: none; top: 30px;'>
-    <div
-      data-testid='non-resizable-0-1'
-      style='position: relative; width: 6px; height: 6px; top: -3px; left: -3px; background: rgb(255, 255, 255); border: 1px solid rgba(0, 0, 0, 0.5); border-radius: 50%;'
-    ></div>
-  </div>
-  <div style='position: absolute; pointer-events: none; left: 100px; top: 30px;'>
-    <div
-      data-testid='non-resizable-1-1'
-      style='position: relative; width: 6px; height: 6px; top: -3px; left: -3px; background: rgb(255, 255, 255); border: 1px solid rgba(0, 0, 0, 0.5); border-radius: 50%;'
-    ></div>
-  </div>
-</div>
-`)
+    async function checkResizableControl(
+      controlTestId: string,
+      expectedLeft: string,
+      expectedTop: string,
+    ): Promise<void> {
+      const nonResizableControl = await renderResult.renderedDOM.findByTestId(controlTestId)
+      const nonResizableControlParent = forceNotNull(
+        'Should be able to find the parent.',
+        nonResizableControl.parentElement,
+      )
+      expect(nonResizableControlParent.style.left).toEqual(expectedLeft)
+      expect(nonResizableControlParent.style.top).toEqual(expectedTop)
+    }
+
+    await checkResizableControl('non-resizable-0-0', '', '')
+    await checkResizableControl('non-resizable-1-0', '100px', '')
+    await checkResizableControl('non-resizable-0-1', '', '30px')
+    await checkResizableControl('non-resizable-1-1', '100px', '30px')
   })
 
   it('no non-resizable corner controls show for an element that is resizable', async () => {

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.tsx
@@ -1,0 +1,87 @@
+import { absoluteDuplicateStrategy } from './absolute-duplicate-strategy'
+import { absoluteMoveStrategy } from './absolute-move-strategy'
+import { absoluteReparentStrategy } from './absolute-reparent-strategy'
+import { absoluteReparentToFlexStrategy } from './absolute-reparent-to-flex-strategy'
+import { absoluteResizeBoundingBoxStrategy } from './absolute-resize-bounding-box-strategy'
+import { getApplicableControls, isResizableStrategy } from './canvas-strategies'
+import { CanvasStrategy, CanvasStrategyId, ControlWithKey } from './canvas-strategy-types'
+import { dragToInsertStrategy } from './drag-to-insert-strategy'
+import { escapeHatchStrategy } from './escape-hatch-strategy'
+import { flexReorderStrategy } from './flex-reorder-strategy'
+import { flexReparentToAbsoluteStrategy } from './flex-reparent-to-absolute-strategy'
+import { flexReparentToFlexStrategy } from './flex-reparent-to-flex-strategy'
+import {
+  flowReorderAutoConversionStrategy,
+  flowReorderNoConversionStrategy,
+  flowReorderSameTypeOnlyStrategy,
+} from './flow-reorder-strategy'
+import { keyboardAbsoluteMoveStrategy } from './keyboard-absolute-move-strategy'
+import { keyboardAbsoluteResizeStrategy } from './keyboard-absolute-resize-strategy'
+
+const isResizableStrategyAndResults: Array<[CanvasStrategy, boolean]> = [
+  [absoluteMoveStrategy, false],
+  [absoluteReparentStrategy, false],
+  [absoluteDuplicateStrategy, false],
+  [keyboardAbsoluteMoveStrategy, false],
+  [keyboardAbsoluteResizeStrategy, true],
+  [absoluteResizeBoundingBoxStrategy, true],
+  [flexReorderStrategy, false],
+  [flexReparentToAbsoluteStrategy, false],
+  [flexReparentToFlexStrategy, false],
+  [escapeHatchStrategy, false],
+  [absoluteReparentToFlexStrategy, false],
+  [dragToInsertStrategy, false],
+  [flowReorderAutoConversionStrategy, false],
+  [flowReorderNoConversionStrategy, false],
+  [flowReorderSameTypeOnlyStrategy, false],
+]
+
+const isResizableExpectedResults: Array<[boolean, CanvasStrategyId, CanvasStrategy]> =
+  isResizableStrategyAndResults.map((entry) => {
+    return [entry[1], entry[0].id, entry[0]]
+  })
+
+describe('isResizableStrategy', () => {
+  it.each(isResizableExpectedResults)(
+    'returns %s for the strategy %s',
+    (expectedResult, strategyId, strategy) => {
+      const actualResult = isResizableStrategy(strategy)
+      expect(actualResult).toEqual(expectedResult)
+    },
+  )
+})
+
+const getApplicableControlsExpectedResults: Array<
+  [CanvasStrategy, CanvasStrategyId | null, Array<string>]
+> = [
+  [absoluteMoveStrategy, null, []],
+  [
+    absoluteResizeBoundingBoxStrategy,
+    null,
+    ['absolute-resize-control', 'zero-size-resize-control'],
+  ],
+  [absoluteResizeBoundingBoxStrategy, absoluteMoveStrategy.id, []],
+  [flowReorderAutoConversionStrategy, null, []],
+  [
+    flowReorderAutoConversionStrategy,
+    flowReorderAutoConversionStrategy.id,
+    ['parent-outlines-control', 'parent-bounds-control', 'flow-reorder-drag-outline'],
+  ],
+  [flowReorderAutoConversionStrategy, absoluteMoveStrategy.id, []],
+]
+
+const getApplicableControlsExpectedResultsForTest: Array<
+  [Array<string>, CanvasStrategyId, CanvasStrategyId | null, CanvasStrategy]
+> = getApplicableControlsExpectedResults.map((entry) => {
+  return [entry[2], entry[0].id, entry[1], entry[0]]
+})
+
+describe('getApplicableControls', () => {
+  it.each(getApplicableControlsExpectedResultsForTest)(
+    'return %s against strategy %s with the current strategy %s',
+    (expectedResult, strategyId, currentStrategyId, strategy) => {
+      const actualResult = getApplicableControls(currentStrategyId, strategy).map((c) => c.key)
+      expect(actualResult).toEqual(expectedResult)
+    },
+  )
+})

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -331,9 +331,28 @@ export function isResizableStrategy(canvasStrategy: CanvasStrategy): boolean {
   }
 }
 
+export function interactionInProgress(interactionSession: InteractionSession | null): boolean {
+  if (interactionSession == null) {
+    return false
+  } else {
+    switch (interactionSession.interactionData.type) {
+      case 'DRAG':
+        return true
+      case 'KEYBOARD':
+        return true
+      default:
+        const _exhaustiveCheck: never = interactionSession.interactionData
+        throw new Error(`Unhandled interaction data type: ${interactionSession.interactionData}`)
+    }
+  }
+}
+
 export function useGetApplicableStrategyControls(): Array<ControlWithKey> {
   const applicableStrategies = useGetApplicableStrategies()
   const currentStrategy = useDelayedCurrentStrategy()
+  const currentlyInProgress = useEditorState((store) => {
+    return interactionInProgress(store.editor.canvas.interactionSession)
+  }, 'useGetApplicableStrategyControls currentlyInProgress')
   return React.useMemo(() => {
     let applicableControls: Array<ControlWithKey> = []
     let isResizable: boolean = false
@@ -350,11 +369,11 @@ export function useGetApplicableStrategyControls(): Array<ControlWithKey> {
       )
     }
     // Special case controls.
-    if (!isResizable) {
+    if (!isResizable && !currentlyInProgress) {
       applicableControls.push(notResizableControls)
     }
     return applicableControls
-  }, [applicableStrategies, currentStrategy])
+  }, [applicableStrategies, currentStrategy, currentlyInProgress])
 }
 
 export function isStrategyActive(strategyState: StrategyState): boolean {

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
@@ -139,7 +139,7 @@ function flowReorderApplyCommon(
   }
 }
 
-export const flowReorderAutoConversionStategy: CanvasStrategy = {
+export const flowReorderAutoConversionStrategy: CanvasStrategy = {
   id: 'FLOW_REORDER_AUTO_CONVERSION',
   name: 'Reorder (Flow, Auto)',
   isApplicable: isFlowReorderConversionApplicable,
@@ -161,7 +161,7 @@ export const flowReorderAutoConversionStategy: CanvasStrategy = {
     },
   ], // Uses existing hooks in select-mode-hooks.tsx
   fitness: (canvasState, interactionState, strategyState) => {
-    return flowReorderAutoConversionStategy.isApplicable(
+    return flowReorderAutoConversionStrategy.isApplicable(
       canvasState,
       interactionState,
       strategyState.startingMetadata,
@@ -183,13 +183,13 @@ export const flowReorderAutoConversionStategy: CanvasStrategy = {
   },
 }
 
-export const flowReorderNoConversionStategy: CanvasStrategy = {
+export const flowReorderNoConversionStrategy: CanvasStrategy = {
   id: 'FLOW_REORDER_NO_CONVERSION',
   name: 'Reorder (Flow)',
   isApplicable: isFlowReorderConversionApplicable,
-  controlsToRender: flowReorderAutoConversionStategy.controlsToRender,
+  controlsToRender: flowReorderAutoConversionStrategy.controlsToRender,
   fitness: (canvasState, interactionState, strategyState) => {
-    return flowReorderNoConversionStategy.isApplicable(
+    return flowReorderNoConversionStrategy.isApplicable(
       canvasState,
       interactionState,
       strategyState.startingMetadata,
@@ -211,7 +211,7 @@ export const flowReorderNoConversionStategy: CanvasStrategy = {
   },
 }
 
-export const flowReorderSameTypeOnlyStategy: CanvasStrategy = {
+export const flowReorderSameTypeOnlyStrategy: CanvasStrategy = {
   id: 'FLOW_REORDER_SAME_TYPE_ONLY',
   name: 'Reorder (Same)',
   isApplicable: (canvasState, interactionState, strategyState, allElementProps) => {
@@ -224,7 +224,7 @@ export const flowReorderSameTypeOnlyStategy: CanvasStrategy = {
     )
   },
   controlsToRender: [
-    ...flowReorderAutoConversionStategy.controlsToRender,
+    ...flowReorderAutoConversionStrategy.controlsToRender,
     {
       control: FlowReorderAreaIndicator,
       key: 'flow-reorder-area-indicator',
@@ -232,7 +232,7 @@ export const flowReorderSameTypeOnlyStategy: CanvasStrategy = {
     },
   ],
   fitness: (canvasState, interactionState, strategyState) => {
-    return flowReorderSameTypeOnlyStategy.isApplicable(
+    return flowReorderSameTypeOnlyStrategy.isApplicable(
       canvasState,
       interactionState,
       strategyState.startingMetadata,

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
@@ -4,6 +4,7 @@ import {
   CanvasStrategy,
   emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
+  InteractionCanvasState,
   strategyApplicationResult,
 } from './canvas-strategy-types'
 import { Modifiers } from '../../../utils/modifiers'
@@ -35,7 +36,7 @@ import {
 import { getMultiselectBounds } from './shared-absolute-move-strategy-helpers'
 import { setSnappingGuidelines } from '../commands/set-snapping-guidelines-command'
 import { pushIntendedBounds } from '../commands/push-intended-bounds-command'
-import { honoursPropsPosition, honoursPropsSize } from './absolute-utils'
+import { supportsAbsoluteResize } from './absolute-resize-helpers'
 
 interface VectorAndEdge {
   movement: CanvasVector
@@ -83,12 +84,7 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     if (selectedElements.length > 0) {
       return selectedElements.every((element) => {
-        const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
-        return (
-          elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
-          honoursPropsPosition(canvasState, element) &&
-          honoursPropsSize(canvasState, element)
-        )
+        return supportsAbsoluteResize(metadata, element, canvasState)
       })
     } else {
       return false

--- a/editor/src/components/canvas/controls/select-mode/non-resizable-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/non-resizable-control.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { NO_OP } from '../../../../core/shared/utils'
+import { useColorTheme } from '../../../../uuiui'
+import { EditorStorePatched } from '../../../editor/store/editor-state'
+import { useEditorState } from '../../../editor/store/store-hook'
+import { EdgePosition } from '../../canvas-types'
+import { useBoundingBox } from '../bounding-box-hooks'
+import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
+
+const selectedElementsSelector = (store: EditorStorePatched) => store.editor.selectedViews
+export const NonResizableControl = React.memo(() => {
+  const selectedElements = useEditorState(
+    selectedElementsSelector,
+    'NonResizableControl selectedElements',
+  )
+
+  const controlRef = useBoundingBox(selectedElements, (ref, boundingBox) => {
+    ref.current.style.display = 'block'
+    ref.current.style.left = boundingBox.x + 'px'
+    ref.current.style.top = boundingBox.y + 'px'
+    ref.current.style.width = boundingBox.width + 'px'
+    ref.current.style.height = boundingBox.height + 'px'
+  })
+
+  const topLeftRef = useBoundingBox(selectedElements, NO_OP)
+  const topRightRef = useBoundingBox(selectedElements, (ref, boundingBox) => {
+    ref.current.style.left = boundingBox.width + 'px'
+  })
+  const bottomLeftRef = useBoundingBox(selectedElements, (ref, boundingBox) => {
+    ref.current.style.top = boundingBox.height + 'px'
+  })
+  const bottomRightRef = useBoundingBox(selectedElements, (ref, boundingBox) => {
+    ref.current.style.left = boundingBox.width + 'px'
+    ref.current.style.top = boundingBox.height + 'px'
+  })
+
+  return (
+    <CanvasOffsetWrapper>
+      <div
+        ref={controlRef}
+        style={{
+          position: 'absolute',
+        }}
+        data-testid={'non-resizable-control'}
+      >
+        <NonResizablePoint ref={topLeftRef} position={{ x: 0, y: 0 }} />
+        <NonResizablePoint ref={topRightRef} position={{ x: 1, y: 0 }} />
+        <NonResizablePoint ref={bottomLeftRef} position={{ x: 0, y: 1 }} />
+        <NonResizablePoint ref={bottomRightRef} position={{ x: 1, y: 1 }} />
+      </div>
+    </CanvasOffsetWrapper>
+  )
+})
+
+interface NonResizablePointProps {
+  position: EdgePosition
+}
+
+const NonResizablePointSize = 6
+const NonResizablePointOffset = NonResizablePointSize / 2
+const NonResizablePoint = React.memo(
+  React.forwardRef<HTMLDivElement, NonResizablePointProps>((props, ref) => {
+    const colorTheme = useColorTheme()
+    const scale = useEditorState((store) => store.editor.canvas.scale, 'NonResizablePoint scale')
+
+    return (
+      <div
+        ref={ref}
+        style={{
+          position: 'absolute',
+          pointerEvents: 'none',
+        }}
+      >
+        <div
+          style={{
+            position: 'relative',
+            width: NonResizablePointSize / scale,
+            height: NonResizablePointSize / scale,
+            top: -NonResizablePointOffset / scale,
+            left: -NonResizablePointOffset / scale,
+            background: colorTheme.canvasControlsSizeBoxBackground.value,
+            border: `${1 / scale}px solid ${
+              colorTheme.canvasControlsSizeBoxShadowColor.o(50).value
+            }`,
+            borderRadius: '50%',
+          }}
+          data-testid={`non-resizable-${props.position.x}-${props.position.y}`}
+        />
+      </div>
+    )
+  }),
+)


### PR DESCRIPTION
**Problem:**
Elements that are not resizable just lack the controls for resizing, but don't indicate specifically that they don't allow resizing.

**Fix:**
When the applicable strategies lack a case which supports resizing, a set of non-resizing corner indicator controls are added in.

**Commit Details:**
- Split out some parts of `useGetApplicableStrategyControls` into smaller functions.
- Added `isResizableStrategy` to determine if a strategy means something is resizable.
- `useGetApplicableStrategyControls` now adds in `notResizableControls` if no resizable strategy is currently applicable.
- Added `NonResizableControl` and NonResizablePoint`.
- Corrected some minor typos on flow strategy variable names.