### PR TITLE
Prevent reparenting when target only contains text

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -235,7 +235,7 @@ export function applyCanvasStrategy(
   return strategy.apply(canvasState, interactionSession, strategyState)
 }
 
-export function useDelayedStrategy<T>(
+export function useDelayedEditorState<T>(
   selector: StateSelector<EditorStorePatched, T | null>,
 ): T | null {
   /**
@@ -292,12 +292,7 @@ export function useDelayedStrategy<T>(
 
 export const useDelayedCurrentStrategy = () => {
   const selector = (store: EditorStorePatched) => store.strategyState.currentStrategy
-  return useDelayedStrategy<CanvasStrategyId | null>(selector)
-}
-
-export const useDelayedStrategyCursor = () => {
-  const selector = (store: EditorStorePatched) => store.editor.canvas.cursor
-  return useDelayedStrategy<CSSCursor | null>(selector)
+  return useDelayedEditorState<CanvasStrategyId | null>(selector)
 }
 
 export function useGetApplicableStrategyControls(): Array<ControlWithKey> {

--- a/editor/src/components/canvas/controls/guideline-controls.tsx
+++ b/editor/src/components/canvas/controls/guideline-controls.tsx
@@ -21,6 +21,7 @@ import {
 import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
 import { Guideline } from '../guideline'
 import { mapDropNulls } from '../../../core/shared/array-utils'
+import { assertNever } from '../../../core/shared/utils'
 
 // STRATEGY GUIDELINE CONTROLS
 export const GuidelineControls = React.memo(() => {
@@ -208,7 +209,7 @@ function guidelineToSegment(guideline: Guideline): CanvasSegment | null {
     case 'CornerGuideline':
       return null
     default:
-      return Utils.assertNever(guideline)
+      return assertNever(guideline)
   }
 }
 

--- a/editor/src/components/canvas/controls/select-mode/cursor-overlay.tsx
+++ b/editor/src/components/canvas/controls/select-mode/cursor-overlay.tsx
@@ -5,8 +5,7 @@ import { useEditorState } from '../../../editor/store/store-hook'
 import { cursorForMissingReparentedItems } from '../../canvas-strategies/reparent-utils'
 import { CSSCursor } from '../../canvas-types'
 import { getCursorFromDragState } from '../../canvas-utils'
-import Utils from '../../../../utils/utils'
-import { useDelayedStrategyCursor } from '../../canvas-strategies/canvas-strategies'
+import { useDelayedEditorState } from '../../canvas-strategies/canvas-strategies'
 
 export function getCursorForOverlay(editorState: EditorState): CSSCursor | null {
   const forMissingReparentedItems = cursorForMissingReparentedItems(
@@ -19,10 +18,9 @@ export function getCursorForOverlay(editorState: EditorState): CSSCursor | null 
 }
 
 export const CursorOverlay = React.memo(() => {
-  const strategyCursor = useDelayedStrategyCursor()
-  const cursor = useEditorState((store) => {
-    return Utils.defaultIfNull(strategyCursor, getCursorFromDragState(store.editor))
-  }, 'CursorOverlay cursor')
+  const cursor = useDelayedEditorState((store) => {
+    return getCursorForOverlay(store.editor)
+  })
 
   const styleProps = React.useMemo(() => {
     let workingStyleProps: React.CSSProperties = {

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -338,16 +338,19 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
       },
       canDrop: (item: NavigatorItemDragAndDropWrapperProps, monitor) => {
         const editorState = editorStateRef.current
-        const supportsChildren = MetadataUtils.targetSupportsChildren(
-          editorState.projectContents,
-          editorState.canvas.openFile?.filename,
-          editorState.jsxMetadata,
-          item.elementPath,
-        )
+        const isReparentTarget = item.appropriateDropTargetHint?.type === 'reparent'
+        const childrenSupportedIfRequired =
+          !isReparentTarget ||
+          MetadataUtils.targetSupportsChildren(
+            editorState.projectContents,
+            editorState.canvas.openFile?.filename,
+            editorState.jsxMetadata,
+            props.elementPath,
+          )
         const notSelectedItem = item.getDragSelections().every((selection) => {
           return canDrop(props, selection.elementPath)
         })
-        return supportsChildren && notSelectedItem
+        return childrenSupportedIfRequired && notSelectedItem
       },
     }),
     [props],

--- a/editor/src/core/model/element-metadata-utils.spec.tsx
+++ b/editor/src/core/model/element-metadata-utils.spec.tsx
@@ -23,12 +23,18 @@ import {
   jsxAttributesFromMap,
   emptyAttributeMetadatada,
   emptyComments,
+  JSXElementChildren,
+  jsxFragment,
+  jsxArbitraryBlock,
+  isJSXElement,
+  JSXElement,
 } from '../shared/element-template'
 import { sampleImportsForTests } from './test-ui-js-file.test-utils'
 import { BakedInStoryboardUID } from './scene-utils'
 import {
   ElementPath,
   isParseSuccess,
+  ParseSuccess,
   ParsedTextFile,
   RevisionsState,
   textFile,
@@ -43,6 +49,8 @@ import { parseCode } from '../workers/parser-printer/parser-printer'
 import { TestAppUID, TestSceneUID } from '../../components/canvas/ui-jsx.test-utils'
 import { contentsToTree } from '../../components/assets'
 import { SampleNodeModules } from '../../components/custom-code/code-file.test-utils'
+import { findJSXElementAtStaticPath } from './element-template-utils'
+import { getUtopiaJSXComponentsFromSuccess } from './project-file-utils'
 
 const TestScenePath = 'scene-aaa'
 
@@ -313,12 +321,13 @@ describe('findElementByElementPath', () => {
 function dummyInstanceDataForElementType(
   elementName: JSXElementName | string,
   elementPath: ElementPath,
+  children: JSXElementChildren = [],
 ): ElementInstanceMetadata {
   return {
     globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
     localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
     elementPath: elementPath,
-    element: right(jsxTestElement(elementName, [], [])),
+    element: right(jsxTestElement(elementName, [], children)),
     componentInstance: false,
     isEmotionOrStyledComponent: false,
     specialSizeMeasurements: emptySpecialSizeMeasurements,
@@ -406,6 +415,194 @@ describe('targetElementSupportsChildren', () => {
         [BakedInStoryboardUID, TestScenePath],
         ['Dummy', 'Element'],
       ]),
+    )
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      StoryboardFilePath,
+      element,
+    )
+    expect(actualResult).toEqual(true)
+  })
+  it('returns false for a parsed div with only a single text child', () => {
+    const element = dummyInstanceDataForElementType(
+      jsxElementName('div', []),
+      EP.elementPath([
+        [BakedInStoryboardUID, TestScenePath],
+        ['Dummy', 'Element'],
+      ]),
+      [jsxTextBlock('Some Dummy Text')],
+    )
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      StoryboardFilePath,
+      element,
+    )
+    expect(actualResult).toEqual(false)
+  })
+  it('returns false for a parsed div with only text children', () => {
+    const element = dummyInstanceDataForElementType(
+      jsxElementName('div', []),
+      EP.elementPath([
+        [BakedInStoryboardUID, TestScenePath],
+        ['Dummy', 'Element'],
+      ]),
+      [jsxTextBlock('Some'), jsxTextBlock('Dummy'), jsxTextBlock('Text')],
+    )
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      StoryboardFilePath,
+      element,
+    )
+    expect(actualResult).toEqual(false)
+  })
+  it('returns true for a parsed div with mixed text and other element children', () => {
+    const element = dummyInstanceDataForElementType(
+      jsxElementName('div', []),
+      EP.elementPath([
+        [BakedInStoryboardUID, TestScenePath],
+        ['Dummy', 'Element'],
+      ]),
+      [
+        jsxTextBlock('Some'),
+        jsxTextBlock('Dummy'),
+        jsxTextBlock('Text'),
+        jsxTestElement('div', [], []),
+      ],
+    )
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      StoryboardFilePath,
+      element,
+    )
+    expect(actualResult).toEqual(true)
+  })
+  it('returns true for a parsed div with an arbitrary jsx block child', () => {
+    const element = dummyInstanceDataForElementType(
+      jsxElementName('div', []),
+      EP.elementPath([
+        [BakedInStoryboardUID, TestScenePath],
+        ['Dummy', 'Element'],
+      ]),
+      [jsxArbitraryBlock('<div />', '<div />;', 'return <div />;', [], null, {})], // Whatever, close enough
+    )
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      StoryboardFilePath,
+      element,
+    )
+    expect(actualResult).toEqual(true)
+  })
+  it('returns true for a parsed div with another parsed div child', () => {
+    const element = dummyInstanceDataForElementType(
+      jsxElementName('div', []),
+      EP.elementPath([
+        [BakedInStoryboardUID, TestScenePath],
+        ['Dummy', 'Element'],
+      ]),
+      [jsxTestElement('div', [], [])],
+    )
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      StoryboardFilePath,
+      element,
+    )
+    expect(actualResult).toEqual(true)
+  })
+  it('returns true for a parsed div with an empty fragment child', () => {
+    const element = dummyInstanceDataForElementType(
+      jsxElementName('div', []),
+      EP.elementPath([
+        [BakedInStoryboardUID, TestScenePath],
+        ['Dummy', 'Element'],
+      ]),
+      [jsxFragment([], false)],
+    )
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      StoryboardFilePath,
+      element,
+    )
+    expect(actualResult).toEqual(true)
+  })
+  it('returns false for a parsed div with only text children inside a fragment', () => {
+    const element = dummyInstanceDataForElementType(
+      jsxElementName('div', []),
+      EP.elementPath([
+        [BakedInStoryboardUID, TestScenePath],
+        ['Dummy', 'Element'],
+      ]),
+      [jsxFragment([jsxTextBlock('Some'), jsxTextBlock('Dummy'), jsxTextBlock('Text')], false)],
+    )
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      StoryboardFilePath,
+      element,
+    )
+    expect(actualResult).toEqual(false)
+  })
+  it('returns true for a parsed div with a fragment child containing another parsed div', () => {
+    const element = dummyInstanceDataForElementType(
+      jsxElementName('div', []),
+      EP.elementPath([
+        [BakedInStoryboardUID, TestScenePath],
+        ['Dummy', 'Element'],
+      ]),
+      [jsxFragment([jsxTestElement('div', [], [])], false)],
+    )
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      StoryboardFilePath,
+      element,
+    )
+    expect(actualResult).toEqual(true)
+  })
+  it('returns true for a parsed div with a fragment child containing an arbitrary jsx block', () => {
+    const element = dummyInstanceDataForElementType(
+      jsxElementName('div', []),
+      EP.elementPath([
+        [BakedInStoryboardUID, TestScenePath],
+        ['Dummy', 'Element'],
+      ]),
+      [
+        jsxFragment(
+          [
+            jsxTestElement(
+              'div',
+              [],
+              [
+                jsxArbitraryBlock('<div />', '<div />;', 'return <div />;', [], null, {}), // Whatever, close enough
+              ],
+            ),
+          ],
+          false,
+        ),
+      ],
+    )
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      StoryboardFilePath,
+      element,
+    )
+    expect(actualResult).toEqual(true)
+  })
+  it('returns false for a parsed div with a fragment containing mixed text and element children', () => {
+    const element = dummyInstanceDataForElementType(
+      jsxElementName('div', []),
+      EP.elementPath([
+        [BakedInStoryboardUID, TestScenePath],
+        ['Dummy', 'Element'],
+      ]),
+      [
+        jsxFragment(
+          [
+            jsxTextBlock('Some'),
+            jsxTextBlock('Dummy'),
+            jsxTextBlock('Text'),
+            jsxTestElement('div', [], []),
+          ],
+          false,
+        ),
+      ],
     )
     const actualResult = MetadataUtils.targetElementSupportsChildren(
       {},
@@ -534,6 +731,67 @@ export const App = (props) => {
       element,
     )
     expect(actualResult).toEqual(true)
+  })
+  it('returns false for a component used from a different file that uses props.children but has only text children', () => {
+    const storyboardCode = `import React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+import { App } from '/src/app.js'
+export var storyboard = (
+  <Storyboard data-uid='${BakedInStoryboardUID}'>
+    <Scene
+      data-uid='${TestSceneUID}'
+      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
+    >
+      <App data-uid='${TestAppUID}'>
+        Some Dummy Text
+      </App>
+    </Scene>
+  </Storyboard>
+`
+    const storyboardJS = parseResultFromCode(StoryboardFilePath, storyboardCode)
+    const appCode = `import React from 'react'
+export const App = (props) => {
+  return <div>{props.children}</div>
+}
+`
+    const appJS = parseResultFromCode('/src/app.js', appCode)
+    const projectContents = contentsToTree({
+      [StoryboardFilePath]: textFile(
+        textFileContents(storyboardCode, storyboardJS, RevisionsState.BothMatch),
+        null,
+        null,
+        Date.now(),
+      ),
+      ['/src/app.js']: textFile(
+        textFileContents(appCode, appJS, RevisionsState.BothMatch),
+        null,
+        null,
+        Date.now(),
+      ),
+    })
+
+    // Painfully pull out the parsed children so that we can add them into the dummy metadata
+    expect(isParseSuccess(storyboardJS)).toBeTruthy()
+    const parsedStoryboard = storyboardJS as ParseSuccess
+    const parsedElement = findJSXElementAtStaticPath(
+      getUtopiaJSXComponentsFromSuccess(parsedStoryboard),
+      EP.elementPath([EP.staticElementPath([BakedInStoryboardUID, TestSceneUID, TestAppUID])]),
+    )
+    expect(parsedElement).toBeDefined()
+    expect(isJSXElement(parsedElement!)).toBeTruthy()
+    const parsedChildren = (parsedElement! as JSXElement).children
+
+    const element = dummyInstanceDataForElementType(
+      jsxElementName('App', []),
+      EP.elementPath([[BakedInStoryboardUID, TestScenePath, TestAppUID]]),
+      parsedChildren,
+    )
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      projectContents,
+      StoryboardFilePath,
+      element,
+    )
+    expect(actualResult).toEqual(false)
   })
   it('returns false for a component used from a different file that does not use props.children', () => {
     const storyboardCode = `import React from 'react'

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -62,6 +62,7 @@ import {
   componentHonoursPropsPosition,
   componentHonoursPropsSize,
   componentUsesProperty,
+  elementOnlyHasTextChildren,
   findJSXElementChildAtPath,
   getUtopiaID,
 } from './element-template-utils'
@@ -619,27 +620,34 @@ export const MetadataUtils = {
     return foldEither(
       (elementString) => intrinsicHTMLElementNamesThatSupportChildren.includes(elementString),
       (element) => {
-        if (isJSXElement(element)) {
-          if (isIntrinsicElement(element.name)) {
-            return intrinsicHTMLElementNamesThatSupportChildren.includes(element.name.baseVariable)
-          } else if (isUtopiaAPIComponentFromMetadata(instance)) {
-            // Explicitly prevent components / elements that we *know* don't support children
-            return (
-              isViewLikeFromMetadata(instance) ||
-              isSceneFromMetadata(instance) ||
-              isGivenUtopiaElementFromMetadata(instance, 'Text')
-            )
-          } else {
-            return MetadataUtils.targetUsesProperty(
-              projectContents,
-              openFile,
-              instance.elementPath,
-              'children',
-            )
+        if (elementOnlyHasTextChildren(element)) {
+          // Prevent re-parenting into an element that only has text children, as that is rarely a desired goal
+          return false
+        } else {
+          if (isJSXElement(element)) {
+            if (isIntrinsicElement(element.name)) {
+              return intrinsicHTMLElementNamesThatSupportChildren.includes(
+                element.name.baseVariable,
+              )
+            } else if (isUtopiaAPIComponentFromMetadata(instance)) {
+              // Explicitly prevent components / elements that we *know* don't support children
+              return (
+                isViewLikeFromMetadata(instance) ||
+                isSceneFromMetadata(instance) ||
+                isGivenUtopiaElementFromMetadata(instance, 'Text')
+              )
+            } else {
+              return MetadataUtils.targetUsesProperty(
+                projectContents,
+                openFile,
+                instance.elementPath,
+                'children',
+              )
+            }
           }
+          // We don't know at this stage
+          return true
         }
-        // We don't know at this stage
-        return true
       },
       instance.element,
     )

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1116,7 +1116,7 @@ export function jsxElement(
 export function jsxTestElement(
   name: JSXElementName | string,
   props: JSXAttributes,
-  children: Array<JSXElement>,
+  children: JSXElementChildren,
   uid: string = 'aaa',
 ): JSXElement {
   return jsxElement(

--- a/editor/src/core/shared/utils.ts
+++ b/editor/src/core/shared/utils.ts
@@ -142,3 +142,7 @@ export function unknownObjectProperty(o: unknown, key: string): any {
 export function createIframeUrl(base: string, assetName: string): string {
   return appendHash(urljoin(base, 'editor', assetName))
 }
+
+export function assertNever(n: never): never {
+  throw new Error(`Expected \`never\`, got ${JSON.stringify(n)}`)
+}

--- a/editor/src/utils/utils.ts
+++ b/editor/src/utils/utils.ts
@@ -626,10 +626,6 @@ function assert(errorMessage: string, predicate: boolean | (() => boolean)): voi
   throw new Error(`Assert failed: ${errorMessage}`)
 }
 
-function assertNever(n: never): never {
-  throw new Error(`Expected \`never\`, got ${JSON.stringify(n)}`)
-}
-
 export interface Annotations {
   _signature: string
   _description: string
@@ -940,7 +936,6 @@ function deduplicateBy<T>(key: (t: T) => string, ts: Array<T>): Array<T> {
 export default {
   generateUUID: generateUUID,
   assert: assert,
-  assertNever: assertNever,
   roundTo: roundTo,
   roundToNearestHalf: roundToNearestHalf,
   roundPointToNearestHalf: roundPointToNearestHalf,


### PR DESCRIPTION
**Problem:**
Elements that only contain text as a child (e.g. `<span>Hello</span>`) are rarely the intended targets of a reparent interaction

**Fix:**
Prevent those elements as reparent targets by adding a check inside `MetadataUtils.targetElementSupportsChildren`. I've also added a number of tests to capture this.

This broke a number of unrelated tests, which exposed a couple of issues in the navigator's restriction of drop targets, and the cursor rendering when a target is invalid. I fixed those as part of this PR because they were blocking this. If absolutely necessary those fixes can be separated from this PR.