### PR TITLE
Use reparent position logic for the flex insertion indicators

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -460,6 +460,45 @@ function drawTargetRectanglesForChildrenOfElement(
 
 export type StripAbsoluteProperties = 'strip-absolute-props' | 'do-not-strip-props'
 
+export function getSiblingMidPointPosition(
+  precedingSiblingPosition: CanvasRectangle,
+  succeedingSiblingPosition: CanvasRectangle,
+  direction: 'row' | 'column',
+  indicatorSize: number,
+): number {
+  let getSiblingPosition: (rect: CanvasRectangle) => number
+  let getSiblingSize: (rect: CanvasRectangle) => number
+  switch (direction) {
+    case 'row':
+      getSiblingPosition = (rect: CanvasRectangle) => {
+        return rect.x
+      }
+      getSiblingSize = (rect: CanvasRectangle) => {
+        return rect.width
+      }
+      break
+    case 'column':
+      getSiblingPosition = (rect: CanvasRectangle) => {
+        return rect.y
+      }
+      getSiblingSize = (rect: CanvasRectangle) => {
+        return rect.height
+      }
+      break
+    default:
+      const _exhaustiveCheck: never = direction
+      throw new Error(`Unhandled direction of ${JSON.stringify(direction)}`)
+  }
+
+  return (
+    (getSiblingPosition(precedingSiblingPosition) +
+      getSiblingSize(precedingSiblingPosition) +
+      getSiblingPosition(succeedingSiblingPosition) +
+      indicatorSize) /
+    2
+  )
+}
+
 export function applyFlexReparent(
   stripAbsoluteProperties: StripAbsoluteProperties,
   canvasState: InteractionCanvasState,
@@ -602,12 +641,12 @@ export function applyFlexReparent(
             const targetLineBeforeSibling: CanvasRectangle =
               newParentFlexDirection === 'row'
                 ? canvasRectangle({
-                    x:
-                      (precedingSiblingPosition.x +
-                        precedingSiblingPosition.width +
-                        succeedingSiblingPosition.x -
-                        FlexReparentIndicatorSize) /
-                      2,
+                    x: getSiblingMidPointPosition(
+                      precedingSiblingPosition,
+                      succeedingSiblingPosition,
+                      'row',
+                      FlexReparentIndicatorSize,
+                    ),
                     y: (precedingSiblingPosition.y + succeedingSiblingPosition.y) / 2,
                     height:
                       (precedingSiblingPosition.height + succeedingSiblingPosition.height) / 2,
@@ -615,12 +654,12 @@ export function applyFlexReparent(
                   })
                 : canvasRectangle({
                     x: (precedingSiblingPosition.x + succeedingSiblingPosition.x) / 2,
-                    y:
-                      (precedingSiblingPosition.y +
-                        precedingSiblingPosition.height +
-                        succeedingSiblingPosition.y -
-                        FlexReparentIndicatorSize) /
-                      2,
+                    y: getSiblingMidPointPosition(
+                      precedingSiblingPosition,
+                      succeedingSiblingPosition,
+                      'column',
+                      FlexReparentIndicatorSize,
+                    ),
                     width: (precedingSiblingPosition.width + succeedingSiblingPosition.width) / 2,
                     height: FlexReparentIndicatorSize,
                   })

--- a/editor/src/components/canvas/controls/insertion-plus-button.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.spec.browser2.tsx
@@ -1,0 +1,179 @@
+import { act } from '@testing-library/react'
+import { selectComponents } from '../../../components/editor/actions/action-creators'
+import { renderTestEditorWithCode } from '../ui-jsx.test-utils'
+import * as EP from '../../../core/shared/element-path'
+
+function getProjectCode(): string {
+  return `
+import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export var Button = () => {
+  return (
+    <div
+      data-uid='buttondiv'
+      data-testid='buttondiv'
+      data-label='buttondiv'
+      style={{
+        width: 100,
+        height: 30,
+        backgroundColor: 'pink',
+      }}
+    >
+      BUTTON
+    </div>
+  )
+}
+
+export var storyboard = (
+  <Storyboard data-uid='storyboard'>
+    <Scene
+      style={{
+        backgroundColor: 'white',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 700,
+      }}
+      data-uid='scene'
+    >
+      <div
+        style={{
+          backgroundColor: 'white',
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: 400,
+          height: 500,
+        }}
+        data-uid='sceneroot'
+      >
+        <div
+          style={{
+            backgroundColor: 'purple',
+            position: 'absolute',
+            left: 21,
+            top: 215.5,
+            width: 123,
+            height: 100,
+          }}
+          data-uid='seconddiv'
+          data-testid='seconddiv'
+          data-label='seconddiv'
+        />
+        <div
+          style={{
+            backgroundColor: 'green',
+            height: 65,
+            width: 66,
+            position: 'absolute',
+            left: 241,
+            top: 142,
+          }}
+          data-uid='notdrag'
+          data-testid='notdrag'
+          data-label='notdrag'
+        >
+          not drag
+        </div>
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            height: 111,
+            width: 140,
+            position: 'absolute',
+            left: 210,
+            top: 346,
+          }}
+          data-uid='dragme'
+          data-testid='dragme'
+          data-label='dragme'
+        >
+          <Button
+            data-uid='button'
+            data-testid='button'
+            data-label='button'
+          />
+        </div>
+      </div>
+      <div
+        style={{
+          backgroundColor: 'grey',
+          position: 'absolute',
+          display: 'flex',
+          gap: '50px',
+          left: 0,
+          top: 500,
+          width: 400,
+          height: 200,
+        }}
+        data-uid='parentsibling'
+        data-testid='parentsibling'
+        data-label='parentsibling'
+      >
+        <div
+          style={{
+            backgroundColor: 'teal',
+            position: 'relative',
+            width: 109,
+            height: 123,
+          }}
+          data-uid='firstdiv'
+          data-testid='firstdiv'
+          data-label='firstdiv'
+        />
+        <div
+          style={{
+            backgroundColor: 'green',
+            position: 'relative',
+            width: 118,
+            height: 123,
+          }}
+          data-uid='thirddiv'
+          data-testid='thirddiv'
+          data-label='thirddiv'
+        />
+      </div>
+    </Scene>
+  </Storyboard>
+)
+`
+}
+
+describe('Insertion Plus Button', () => {
+  it('shows the buttons in the correct places for a flex container', async () => {
+    const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
+
+    const targetPath = EP.fromString('storyboard/scene/parentsibling')
+    await act(() => renderResult.dispatch([selectComponents([targetPath], false)], false))
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    async function checkInsertButtonPosition(
+      buttonTestId: string,
+      expectedLeft: number,
+      expectedTop: number,
+    ): Promise<void> {
+      const element = await renderResult.renderedDOM.findByTestId(buttonTestId)
+      const bounds = element.getBoundingClientRect()
+      expect(bounds.left).toEqual(expectedLeft)
+      expect(bounds.top).toEqual(expectedTop)
+    }
+
+    await checkInsertButtonPosition(
+      'blue-dot-storyboard/scene/parentsibling/firstdiv',
+      562.5,
+      622.5,
+    )
+    await checkInsertButtonPosition(
+      'blue-dot-storyboard/scene/parentsibling/firstdiv-0',
+      428.5,
+      622.5,
+    )
+    await checkInsertButtonPosition(
+      'blue-dot-storyboard/scene/parentsibling/thirddiv',
+      705.5,
+      622.5,
+    )
+  })
+})

--- a/editor/src/components/canvas/controls/insertion-plus-button.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.spec.browser2.tsx
@@ -141,8 +141,123 @@ export var storyboard = (
 `
 }
 
+function getProjectCodeForEmptyFlexContainer(): string {
+  return `
+import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export var Button = () => {
+  return (
+    <div
+      data-uid='buttondiv'
+      data-testid='buttondiv'
+      data-label='buttondiv'
+      style={{
+        width: 100,
+        height: 30,
+        backgroundColor: 'pink',
+      }}
+    >
+      BUTTON
+    </div>
+  )
+}
+
+export var storyboard = (
+  <Storyboard data-uid='storyboard'>
+    <Scene
+      style={{
+        backgroundColor: 'white',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 700,
+      }}
+      data-uid='scene'
+    >
+      <div
+        style={{
+          backgroundColor: 'white',
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: 400,
+          height: 500,
+        }}
+        data-uid='sceneroot'
+      >
+        <div
+          style={{
+            backgroundColor: 'purple',
+            position: 'absolute',
+            left: 21,
+            top: 215.5,
+            width: 123,
+            height: 100,
+          }}
+          data-uid='seconddiv'
+          data-testid='seconddiv'
+          data-label='seconddiv'
+        />
+        <div
+          style={{
+            backgroundColor: 'green',
+            height: 65,
+            width: 66,
+            position: 'absolute',
+            left: 241,
+            top: 142,
+          }}
+          data-uid='notdrag'
+          data-testid='notdrag'
+          data-label='notdrag'
+        >
+          not drag
+        </div>
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            height: 111,
+            width: 140,
+            position: 'absolute',
+            left: 210,
+            top: 346,
+          }}
+          data-uid='dragme'
+          data-testid='dragme'
+          data-label='dragme'
+        >
+          <Button
+            data-uid='button'
+            data-testid='button'
+            data-label='button'
+          />
+        </div>
+      </div>
+      <div
+        style={{
+          backgroundColor: 'grey',
+          position: 'absolute',
+          display: 'flex',
+          gap: '50px',
+          left: 0,
+          top: 500,
+          width: 400,
+          height: 200,
+        }}
+        data-uid='parentsibling'
+        data-testid='parentsibling'
+        data-label='parentsibling'
+      />
+    </Scene>
+  </Storyboard>
+)
+`
+}
+
 describe('Insertion Plus Button', () => {
-  it('shows the buttons in the correct places for a flex container', async () => {
+  it('shows the buttons in the correct places for a flex container that already has children', async () => {
     const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
 
     const targetPath = EP.fromString('storyboard/scene/parentsibling')
@@ -160,20 +275,32 @@ describe('Insertion Plus Button', () => {
       expect(bounds.top).toEqual(expectedTop)
     }
 
-    await checkInsertButtonPosition(
-      'blue-dot-storyboard/scene/parentsibling/firstdiv',
-      562.5,
-      622.5,
+    await checkInsertButtonPosition('blue-dot-control-0', 428.5, 622.5)
+    await checkInsertButtonPosition('blue-dot-control-1', 562.5, 622.5)
+    await checkInsertButtonPosition('blue-dot-control-2', 767, 622.5)
+  })
+
+  it('shows the buttons in the correct places for a flex container that has no children', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      getProjectCodeForEmptyFlexContainer(),
+      'await-first-dom-report',
     )
-    await checkInsertButtonPosition(
-      'blue-dot-storyboard/scene/parentsibling/firstdiv-0',
-      428.5,
-      622.5,
-    )
-    await checkInsertButtonPosition(
-      'blue-dot-storyboard/scene/parentsibling/thirddiv',
-      705.5,
-      622.5,
-    )
+
+    const targetPath = EP.fromString('storyboard/scene/parentsibling')
+    await act(() => renderResult.dispatch([selectComponents([targetPath], false)], false))
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    async function checkInsertButtonPosition(
+      buttonTestId: string,
+      expectedLeft: number,
+      expectedTop: number,
+    ): Promise<void> {
+      const element = await renderResult.renderedDOM.findByTestId(buttonTestId)
+      const bounds = element.getBoundingClientRect()
+      expect(bounds.left).toEqual(expectedLeft)
+      expect(bounds.top).toEqual(expectedTop)
+    }
+
+    await checkInsertButtonPosition('blue-dot-control-0', 428.5, 622.5)
   })
 })

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`402`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`400`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`391`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`389`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`668`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`666`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`740`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`738`)
   })
 })


### PR DESCRIPTION
**Problem:**
The logic for the flex insertion indicators works differently to the reparent/reorder logic and we really want those to be consistent.

**Fix:**
The calculations utilised in the reparent/reorder logic were extracted out as far as reasonably possible into two functions `getSiblingMidPointPosition` and `siblingAndPseudoPositions`, which have then been used in the flex insertion indicators.

Alongside this some tweaks needed to be made to the indicators as their new positions resulted in them either being inconsistent with each other or were offset from where they needed to be visually.

**Limitations:**
Some of the existing logic does not currently handle `row-reverse` and `column-reverse`, which has been carried forward into this. This should be addressed in a later PR.

**Screenshots:**
New positions:
![image](https://user-images.githubusercontent.com/217400/189908396-8cd39415-931b-4126-abd3-83c72f861522.png)

**Commit Details:**
- Pulled out `getSiblingMidPointPosition` refactoring the position logic out
  of `applyFlexReparent`.
- Changed `ButtonControlProps.key` to be `ButtonControlProps.identifier, as the old
  name conflicted a bit with the React `key` and could end up getting removed
  from the props.
- `InsertionControls` uses `getBetweenChildrenPosition`, which in turn calls
  `getSiblingMidPointPosition` for those cases where it is calculating the position
  between flex elements, as opposed to the opposite axis.
- Changed `BlueDot` to match `PlusButton` as closely as it can so that it gets rendered
  in the same position as the latter.
- Corrected the positioning slightly of the `Line` component as it was rendering one
  pixel out from where it shoould be.
- Added more `data-testid` values for easier debugging.
- Extracted out `siblingAndPseudoPositions` so that
  the bounds can be easily calculated for the positions
  either side of the child elements.
- Slight refactor to extract `midInteractionCommandsForTarget`
  so that the near identical code in two places can be collapsed.
- `InsertionControls` now uses `siblingAndPseudoPositions`
  to construct the frames, looping over those instead of the children.