### PR TITLE
Handle reverse suffixed flex directions in the reparent indicator.

### DIFF
--- a/editor/src/components/canvas/controls/insertion-plus-button.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.spec.browser2.tsx
@@ -3,7 +3,7 @@ import { selectComponents } from '../../../components/editor/actions/action-crea
 import { renderTestEditorWithCode } from '../ui-jsx.test-utils'
 import * as EP from '../../../core/shared/element-path'
 
-function getProjectCode(): string {
+function getProjectCode(flexDirection: string): string {
   return `
 import * as React from 'react'
 import { Scene, Storyboard } from 'utopia-api'
@@ -102,6 +102,7 @@ export var storyboard = (
           backgroundColor: 'grey',
           position: 'absolute',
           display: 'flex',
+          flexDirection: '${flexDirection}',
           gap: '50px',
           left: 0,
           top: 500,
@@ -257,8 +258,15 @@ export var storyboard = (
 }
 
 describe('Insertion Plus Button', () => {
-  it('shows the buttons in the correct places for a flex container that already has children', async () => {
-    const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
+  beforeEach(() => {
+    viewport.set(2200, 1000)
+  })
+
+  it(`shows the buttons in the correct places for a flex container with a direction of 'row' that already has children`, async () => {
+    const renderResult = await renderTestEditorWithCode(
+      getProjectCode('row'),
+      'await-first-dom-report',
+    )
 
     const targetPath = EP.fromString('storyboard/scene/parentsibling')
     await act(() => renderResult.dispatch([selectComponents([targetPath], false)], false))
@@ -278,6 +286,84 @@ describe('Insertion Plus Button', () => {
     await checkInsertButtonPosition('blue-dot-control-0', 428.5, 622.5)
     await checkInsertButtonPosition('blue-dot-control-1', 562.5, 622.5)
     await checkInsertButtonPosition('blue-dot-control-2', 767, 622.5)
+  })
+
+  it(`shows the buttons in the correct places for a flex container with a direction of 'row-reverse' that already has children`, async () => {
+    const renderResult = await renderTestEditorWithCode(
+      getProjectCode('row-reverse'),
+      'await-first-dom-report',
+    )
+
+    const targetPath = EP.fromString('storyboard/scene/parentsibling')
+    await act(() => renderResult.dispatch([selectComponents([targetPath], false)], false))
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    async function checkInsertButtonPosition(
+      buttonTestId: string,
+      expectedLeft: number,
+      expectedTop: number,
+    ): Promise<void> {
+      const element = await renderResult.renderedDOM.findByTestId(buttonTestId)
+      const bounds = element.getBoundingClientRect()
+      expect(bounds.left).toEqual(expectedLeft)
+      expect(bounds.top).toEqual(expectedTop)
+    }
+
+    await checkInsertButtonPosition('blue-dot-control-0', 490, 622.5)
+    await checkInsertButtonPosition('blue-dot-control-1', 694.5, 622.5)
+    await checkInsertButtonPosition('blue-dot-control-2', 828.5, 622.5)
+  })
+
+  it(`shows the buttons in the correct places for a flex container with a direction of 'column' that already has children`, async () => {
+    const renderResult = await renderTestEditorWithCode(
+      getProjectCode('column'),
+      'await-first-dom-report',
+    )
+
+    const targetPath = EP.fromString('storyboard/scene/parentsibling')
+    await act(() => renderResult.dispatch([selectComponents([targetPath], false)], false))
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    async function checkInsertButtonPosition(
+      buttonTestId: string,
+      expectedLeft: number,
+      expectedTop: number,
+    ): Promise<void> {
+      const element = await renderResult.renderedDOM.findByTestId(buttonTestId)
+      const bounds = element.getBoundingClientRect()
+      expect(bounds.left).toEqual(expectedLeft)
+      expect(bounds.top).toEqual(expectedTop)
+    }
+
+    await checkInsertButtonPosition('blue-dot-control-0', 418.5, 632.5)
+    await checkInsertButtonPosition('blue-dot-control-1', 418.5, 732.5)
+    await checkInsertButtonPosition('blue-dot-control-2', 418.5, 832.5)
+  })
+
+  it(`shows the buttons in the correct places for a flex container with a direction of 'column-reverse' that already has children`, async () => {
+    const renderResult = await renderTestEditorWithCode(
+      getProjectCode('column-reverse'),
+      'await-first-dom-report',
+    )
+
+    const targetPath = EP.fromString('storyboard/scene/parentsibling')
+    await act(() => renderResult.dispatch([selectComponents([targetPath], false)], false))
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    async function checkInsertButtonPosition(
+      buttonTestId: string,
+      expectedLeft: number,
+      expectedTop: number,
+    ): Promise<void> {
+      const element = await renderResult.renderedDOM.findByTestId(buttonTestId)
+      const bounds = element.getBoundingClientRect()
+      expect(bounds.left).toEqual(expectedLeft)
+      expect(bounds.top).toEqual(expectedTop)
+    }
+
+    await checkInsertButtonPosition('blue-dot-control-0', 418.5, 632.5)
+    await checkInsertButtonPosition('blue-dot-control-1', 418.5, 732.5)
+    await checkInsertButtonPosition('blue-dot-control-2', 418.5, 832.5)
   })
 
   it('shows the buttons in the correct places for a flex container that has no children', async () => {

--- a/editor/src/components/canvas/controls/select-mode/flex-reparent-target-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-reparent-target-indicator.tsx
@@ -12,6 +12,7 @@ export const FlexReparentTargetIndicator = React.memo(() => {
       <div style={{ display: 'block' }}>
         {reparentTargetLines.map((line, i) => (
           <div
+            data-testid={`flex-reparent-indicator-${i}`}
             key={i}
             style={{
               position: 'absolute',

--- a/editor/src/core/layout/layout-utils.ts
+++ b/editor/src/core/layout/layout-utils.ts
@@ -1002,3 +1002,37 @@ export function roundJSXElementLayoutValues(
     props: roundAttributeLayoutValues(propertyTarget, element.props),
   }
 }
+
+export type SimpleFlexDirection = 'row' | 'column'
+
+export function flexDirectionToSimpleFlexDirection(
+  flexDirection: string,
+): SimpleFlexDirection | null {
+  switch (flexDirection) {
+    case 'row':
+    case 'row-reverse':
+      return 'row'
+    case 'column':
+    case 'column-reverse':
+      return 'column'
+    default:
+      return null
+  }
+}
+
+export type FlexForwardsOrBackwards = 'forward' | 'reverse'
+
+export function flexDirectionToFlexForwardsOrBackwards(
+  flexDirection: string,
+): FlexForwardsOrBackwards | null {
+  switch (flexDirection) {
+    case 'row':
+    case 'column':
+      return 'forward'
+    case 'row-reverse':
+    case 'column-reverse':
+      return 'reverse'
+    default:
+      return null
+  }
+}


### PR DESCRIPTION
**Problem:**
The flex reparent indicator and insertion buttons were not handling the positions relating to `column-reverse` and `row-reverse`.

**Fix:**
Initially two simplified flex types that represent the axis and directionality of the flex direction itself were constructed along with their conversion functions.

Then in a few places those values were used to calculate the reversed bounds primarily of the `-reverse` suffixed flex directions.

**Commit Details:**
- `dragTargetRectanglesForChildrenOfElement` now gets the simplified direction and if the direction is forwards or backwards and utilises those to construct the appropriate sets of bounds.
- `getSiblingMidPointPosition` is slightly simplified and uses the new `SimpleFlexDirection` type for a parameter.
- `indicatorSize` parameter removed from `getSiblingMidPointPosition` as that fixes a bug with the positioning at the mid-point for some usages and makes it a tiny bit clearer.
- `siblingAndPseudoPositions` now takes parameters of `SimpleFlexDirection` and `FlexForwardsOrBackwards` to produce the positions so that the bounds are correctly calculated.
- `applyFlexReparent` slightly tweaked to pass the new types to other functions.
- `InsertionControls` uses the new functions and correctly calculates the insertion index in the case that it is a `-reverse` suffixed flex direction.
- `flexDirectionToSimpleFlexDirection` utility function added.
- `flexDirectionToFlexForwardsOrBackwards` utility function added.