### PR TITLE
scoped metadata first try

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -3,9 +3,9 @@ import { getStoryboardElementPath } from '../../../core/model/scene-utils'
 import { mapDropNulls, reverse } from '../../../core/shared/array-utils'
 import * as EP from '../../../core/shared/element-path'
 import {
-  ElementInstanceMetadata,
   ElementInstanceMetadataMap,
   JSXElement,
+  ScopedMetadataMap,
 } from '../../../core/shared/element-template'
 import {
   canvasPoint,
@@ -204,7 +204,10 @@ export function getReparentTargetUnified(
   pointOnCanvas: CanvasPoint,
   cmdPressed: boolean,
   canvasState: InteractionCanvasState,
-  metadata: ElementInstanceMetadataMap,
+  metadata: ScopedMetadataMap<
+    'globalFrame' | 'element' | 'importInfo',
+    'layoutSystemForChildren' | 'flexDirection'
+  >,
   allElementProps: AllElementProps,
 ): ReparentTarget {
   const projectContents = canvasState.projectContents
@@ -352,7 +355,7 @@ const propertiesToRemove: Array<PropertyPath> = [
 ]
 
 function drawTargetRectanglesForChildrenOfElement(
-  metadata: ElementInstanceMetadataMap,
+  metadata: ScopedMetadataMap<'globalFrame', 'flexDirection'>,
   flexElementPath: ElementPath,
   targetRectangleSize: 'padded-edge' | 'full-size',
   canvasScale: number,

--- a/editor/src/components/canvas/canvas.ts
+++ b/editor/src/components/canvas/canvas.ts
@@ -2,6 +2,7 @@ import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
+  ScopedMetadataMap,
 } from '../../core/shared/element-template'
 import { ElementPath } from '../../core/shared/project-file-types'
 import { KeyCharacter } from '../../utils/keyboard'
@@ -48,7 +49,7 @@ const Canvas = {
   ],
   getFramesInCanvasContext(
     allElementProps: AllElementProps,
-    metadata: ElementInstanceMetadataMap,
+    metadata: ScopedMetadataMap<'globalFrame'>,
     useBoundingFrames: boolean,
   ): Array<FrameWithPath> {
     // Note: This will not necessarily be representative of the structured ordering in
@@ -265,7 +266,7 @@ const Canvas = {
     })
   },
   getAllTargetsAtPoint(
-    componentMetadata: ElementInstanceMetadataMap,
+    componentMetadata: ScopedMetadataMap<'globalFrame'>,
     selectedViews: Array<ElementPath>,
     hiddenInstances: Array<ElementPath>,
     canvasPosition: CanvasPoint,

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -1,6 +1,6 @@
 import { intersection, last, mapDropNulls, stripNulls } from '../../core/shared/array-utils'
 import { getDOMAttribute } from '../../core/shared/dom-utils'
-import { ElementInstanceMetadataMap } from '../../core/shared/element-template'
+import { ElementInstanceMetadataMap, ScopedMetadataMap } from '../../core/shared/element-template'
 import {
   boundingRectangleArray,
   CanvasPoint,
@@ -268,7 +268,7 @@ function isPointInSelectionRectangle(
 }
 
 export function getAllTargetsAtPointAABB(
-  componentMetadata: ElementInstanceMetadataMap,
+  componentMetadata: ScopedMetadataMap<'globalFrame'>,
   selectedViews: Array<ElementPath>,
   hiddenInstances: Array<ElementPath>,
   validElementPathsForLookup: Array<ElementPath> | 'no-filter',

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -47,6 +47,7 @@ import {
   isIntrinsicElementFromString,
   isIntrinsicHTMLElement,
   isIntrinsicHTMLElementString,
+  ScopedMetadata,
 } from '../shared/element-template'
 import {
   sceneMetadata as _sceneMetadata,
@@ -86,7 +87,7 @@ export function isUtopiaAPIComponent(elementName: JSXElementName, imports: Impor
 }
 
 export function isUtopiaAPIComponentFromMetadata(
-  elementInstanceMetadata: ElementInstanceMetadata,
+  elementInstanceMetadata: ScopedMetadata<'importInfo'>,
 ): boolean {
   const foundImportInfo = maybeEitherToMaybe(elementInstanceMetadata.importInfo)
   if (foundImportInfo == null) {
@@ -132,7 +133,7 @@ function isGivenUtopiaAPIElementFromName(
 }
 
 export function isGivenUtopiaElementFromMetadata(
-  elementInstanceMetadata: ElementInstanceMetadata,
+  elementInstanceMetadata: ScopedMetadata<'importInfo'>,
   componentName: string,
 ): boolean {
   const foundImportInfo = maybeEitherToMaybe(elementInstanceMetadata.importInfo)
@@ -147,7 +148,9 @@ export function isSceneAgainstImports(element: JSXElementChild, imports: Imports
   return isGivenUtopiaAPIElement(element, imports, 'Scene')
 }
 
-export function isSceneFromMetadata(elementInstanceMetadata: ElementInstanceMetadata): boolean {
+export function isSceneFromMetadata(
+  elementInstanceMetadata: ScopedMetadata<'importInfo'>,
+): boolean {
   return isGivenUtopiaElementFromMetadata(elementInstanceMetadata, 'Scene')
 }
 
@@ -176,7 +179,9 @@ export function isViewAgainstImports(jsxElementName: JSXElementName, imports: Im
   return isGivenUtopiaAPIElementFromName(jsxElementName, imports, 'View')
 }
 
-export function isViewLikeFromMetadata(elementInstanceMetadata: ElementInstanceMetadata): boolean {
+export function isViewLikeFromMetadata(
+  elementInstanceMetadata: ScopedMetadata<'importInfo'>,
+): boolean {
   return (
     isGivenUtopiaElementFromMetadata(elementInstanceMetadata, 'View') ||
     isGivenUtopiaElementFromMetadata(elementInstanceMetadata, 'FlexRow') ||

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1549,6 +1549,22 @@ export interface ElementInstanceMetadata {
   importInfo: ImportInfo | null
 }
 
+export type ScopedMetadata<
+  MetadataPick extends keyof ElementInstanceMetadata = 'globalFrame',
+  SpecialSizeMeasurementsPick extends keyof SpecialSizeMeasurements = 'parentLayoutSystem',
+> = Pick<ElementInstanceMetadata, MetadataPick> & {
+  specialSizeMeasurements: Pick<SpecialSizeMeasurements, SpecialSizeMeasurementsPick>
+} & { elementPath: ElementPath }
+
+export type ElementMap<T extends ScopedMetadata> = { [elementPath: string]: T }
+
+export type ScopedMetadataMap<
+  MetadataPick extends keyof ElementInstanceMetadata = 'globalFrame',
+  SpecialSizeMeasurementsPick extends keyof SpecialSizeMeasurements = 'parentLayoutSystem',
+> = ElementMap<
+  ScopedMetadata<MetadataPick | 'globalFrame', SpecialSizeMeasurementsPick | 'parentLayoutSystem'>
+>
+
 export function elementInstanceMetadata(
   elementPath: ElementPath,
   element: Either<string, JSXElementChild>,


### PR DESCRIPTION
This PR takes `getReparentTargetUnified` and makes it so that it uses a scoped version of the metadata. 

As it turns out, getReparentTargetUnified needs the following things from the metadata: 'globalFrame', 'element', 'importInfo' and from the specialSizeMeasurements it needs  'layoutSystemForChildren' | 'flexDirection'.

This is all expressed like so:
```typescript
export function getReparentTargetUnified(
  filteredSelectedElements: Array<ElementPath>,
  pointOnCanvas: CanvasPoint,
  cmdPressed: boolean,
  canvasState: InteractionCanvasState,
  metadata: ScopedMetadataMap<
    'globalFrame' | 'element' | 'importInfo', // <- first generic parameter lists the keys from metadata
    'layoutSystemForChildren' | 'flexDirection' // second parameter lists the keys from specialSizeMeasurements
  >,
  allElementProps: AllElementProps,
): ReparentTarget {
```

I then went in and fixed up all the helper functions that were used by this function, rippling out into a few helper files. 

I personally don't think this is too bad, except the type declaration for `ScopedMetadataMap` but we could probably improve that. (please ignore that for now, and focus on the actual codebase changes!)