### PR TITLE
hide non-resizable control on deselect

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/non-resizable-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/non-resizable-control.tsx
@@ -34,6 +34,10 @@ export const NonResizableControl = React.memo(() => {
     ref.current.style.top = boundingBox.height + 'px'
   })
 
+  if (selectedElements.length === 0) {
+    return null
+  }
+
   return (
     <CanvasOffsetWrapper>
       <div


### PR DESCRIPTION
**Problem:**
When changing selection to nothing, the non-resizable element indicators would linger on the screen

**Fix:**
If the selectedViews becomes empty, do not render the non-resizable element indicators
