### PR TITLE
Added Import From URL functionality.

### DIFF
--- a/editor/src/components/common/actions/index.ts
+++ b/editor/src/components/common/actions/index.ts
@@ -7,6 +7,7 @@ export type LeftMenuPanel =
   | 'googleFontsResources'
   | 'insertmenu'
   | 'projectsettings'
+  | 'githuboptions'
 
 export type CenterPanel = 'canvas' | 'misccodeeditor'
 
@@ -37,6 +38,8 @@ export function paneForPanel(panel: EditorPanel | null): EditorPane | null {
     case 'genericExternalResources':
       return 'leftmenu'
     case 'googleFontsResources':
+      return 'leftmenu'
+    case 'githuboptions':
       return 'leftmenu'
     case 'insertmenu':
       return 'rightmenu'

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -247,7 +247,7 @@ export type Atomic = {
   actions: Array<EditorAction>
 }
 
-export type NewProject = {
+export interface NewProject {
   action: 'NEW'
   nodeModules: NodeModules
   packageResult: PackageStatusMap

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2635,6 +2635,7 @@ export const UPDATE_FNS = {
       case 'center':
       case 'insertmenu':
       case 'projectsettings':
+      case 'githuboptions':
         return editor
       default:
         const _exhaustiveCheck: never = action.target
@@ -2755,6 +2756,7 @@ export const UPDATE_FNS = {
       case 'misccodeeditor':
       case 'center':
       case 'insertmenu':
+      case 'githuboptions':
         return editor
       default:
         const _exhaustiveCheck: never = action.target

--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -2,7 +2,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/react'
 import styled from '@emotion/styled'
-import React from 'react'
+import React, { ChangeEvent } from 'react'
 import {
   fetchProjectMetadata,
   projectEditorURL,
@@ -47,7 +47,12 @@ import {
   setProjectDescription,
 } from '../editor/actions/action-creators'
 import { InsertMenu } from '../editor/insertmenu'
-import { DerivedState, EditorState, LeftMenuTab } from '../editor/store/editor-state'
+import {
+  createNewProjectName,
+  DerivedState,
+  EditorState,
+  LeftMenuTab,
+} from '../editor/store/editor-state'
 import { useEditorState } from '../editor/store/store-hook'
 import { FileBrowser } from '../filebrowser/filebrowser'
 import { UIGridRow } from '../inspector/widgets/ui-grid-row'
@@ -60,6 +65,9 @@ import { Link } from '../../uuiui/link'
 import { useTriggerForkProject } from '../editor/persistence-hooks'
 import urljoin from 'url-join'
 import { parseGithubProjectString } from '../../core/shared/github'
+import { importFromProjectURL } from '../../core/model/project-import'
+import { forEachLeft, forEachRight } from '../../core/shared/either'
+import { notice } from '../common/notice'
 
 export interface LeftPaneProps {
   editorState: EditorState
@@ -706,6 +714,8 @@ const SharingPane = React.memo(() => {
 const GithubPane = React.memo(() => {
   const [githubRepoStr, setGithubRepoStr] = React.useState('')
   const parsedRepo = parseGithubProjectString(githubRepoStr)
+  const dispatch = useEditorState((store) => store.dispatch, 'GithubPane dispatch')
+  const persistence = useEditorState((store) => store.persistence, 'GithubPane persistence')
 
   const onStartImport = React.useCallback(() => {
     if (parsedRepo != null) {
@@ -726,6 +736,31 @@ const GithubPane = React.memo(() => {
     [setGithubRepoStr],
   )
 
+  const [urlToImportFrom, setURLToImportFrom] = React.useState<string | null>(null)
+
+  const importFromURLChange = React.useCallback(
+    (changeEvent: React.ChangeEvent<HTMLInputElement>) => {
+      setURLToImportFrom(changeEvent.currentTarget.value)
+    },
+    [setURLToImportFrom],
+  )
+
+  const triggerImportFromURL = React.useCallback(() => {
+    if (urlToImportFrom != null) {
+      const url = new URL(urljoin(BASE_URL, 'p'))
+      url.searchParams.set('import_url', urlToImportFrom)
+
+      window.open(url.toString())
+    }
+  }, [urlToImportFrom])
+
+  const onFocus = React.useCallback(
+    (event: React.FocusEvent<HTMLElement>) => {
+      dispatch([setFocus('githuboptions')], 'everyone')
+    },
+    [dispatch],
+  )
+
   return (
     <FlexColumn
       id='leftPaneGithub'
@@ -735,34 +770,72 @@ const GithubPane = React.memo(() => {
         alignItems: 'stretch',
         paddingBottom: 50,
       }}
+      onFocus={onFocus}
     >
-      <UIRow style={{ paddingLeft: 8, paddingRight: 8 }}>
-        <Title>Github</Title>
-      </UIRow>
-      <div
-        style={{
-          height: 'initial',
-          minHeight: 34,
-          alignItems: 'flex-start',
-          paddingTop: 8,
-          paddingLeft: 8,
-          paddingRight: 8,
-          paddingBottom: 8,
-          whiteSpace: 'pre-wrap',
-          letterSpacing: 0.1,
-          lineHeight: '17px',
-          fontSize: '11px',
-        }}
-      >
-        You can import a new project from Github. It might take a few minutes, and will show up in a
-        new tab.
-      </div>
-      <UIGridRow padded variant='<--------auto-------->|--45px--|'>
-        <StringInput testId='importProject' value={githubRepoStr} onChange={onChange} />
-        <Button spotlight highlight disabled={parsedRepo == null} onMouseUp={onStartImport}>
-          Start
-        </Button>
-      </UIGridRow>
+      <Section>
+        <SectionTitleRow minimised={false} toggleMinimised={NO_OP}>
+          <Title style={{ flexGrow: 1 }}>Github</Title>
+        </SectionTitleRow>
+        <SectionBodyArea minimised={false}>
+          <div
+            style={{
+              height: 'initial',
+              minHeight: 34,
+              alignItems: 'flex-start',
+              paddingTop: 8,
+              paddingLeft: 8,
+              paddingRight: 8,
+              paddingBottom: 8,
+              whiteSpace: 'pre-wrap',
+              letterSpacing: 0.1,
+              lineHeight: '17px',
+              fontSize: '11px',
+            }}
+          >
+            You can import a new project from Github. It might take a few minutes, and will show up
+            in a new tab.
+          </div>
+          <UIGridRow padded variant='<--------auto-------->|--45px--|'>
+            <StringInput testId='importProject' value={githubRepoStr} onChange={onChange} />
+            <Button spotlight highlight disabled={parsedRepo == null} onMouseUp={onStartImport}>
+              Start
+            </Button>
+          </UIGridRow>
+        </SectionBodyArea>
+      </Section>
+      <Section>
+        <SectionTitleRow minimised={false} toggleMinimised={NO_OP}>
+          <Title style={{ flexGrow: 1 }}>Import From URL</Title>
+        </SectionTitleRow>
+        <SectionBodyArea minimised={false}>
+          <div
+            style={{
+              height: 'initial',
+              minHeight: UtopiaTheme.layout.rowHeight.normal,
+              alignItems: 'flex-start',
+              paddingTop: 8,
+              paddingLeft: 8,
+              paddingRight: 8,
+              paddingBottom: 8,
+              whiteSpace: 'pre-wrap',
+              letterSpacing: 0.1,
+              lineHeight: '17px',
+              fontSize: '11px',
+            }}
+          >
+            <p style={{ marginTop: 0, marginBottom: 12 }}>
+              Import a project from an existing project based on its URL.
+            </p>
+          </div>
+
+          <UIGridRow variant='<--------auto-------->|--45px--|' padded>
+            <StringInput testId='import-from-url-input' onChange={importFromURLChange} />
+            <Button spotlight highlight onClick={triggerImportFromURL}>
+              Import
+            </Button>
+          </UIGridRow>
+        </SectionBodyArea>
+      </Section>
     </FlexColumn>
   )
 })

--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -65,7 +65,7 @@ import { Link } from '../../uuiui/link'
 import { useTriggerForkProject } from '../editor/persistence-hooks'
 import urljoin from 'url-join'
 import { parseGithubProjectString } from '../../core/shared/github'
-import { importFromProjectURL } from '../../core/model/project-import'
+import { getURLImportDetails } from '../../core/model/project-import'
 import { forEachLeft, forEachRight } from '../../core/shared/either'
 import { notice } from '../common/notice'
 

--- a/editor/src/core/model/project-import.ts
+++ b/editor/src/core/model/project-import.ts
@@ -156,7 +156,7 @@ export interface ImportFromProjectURLSuccess {
   originalProjectRootURL: string
 }
 
-export async function importFromProjectURL(
+export async function getURLImportDetails(
   projectURL: string,
 ): Promise<Either<string, ImportFromProjectURLSuccess>> {
   const possibleContentsURL = contentsJSONURLFromProjectURL(projectURL)

--- a/editor/src/core/model/project-import.ts
+++ b/editor/src/core/model/project-import.ts
@@ -4,7 +4,17 @@ import { isText } from 'istextorbinary'
 import { RevisionsState, textFile, textFileContents, unparsed } from '../shared/project-file-types'
 import { assetFile, directory, fileTypeFromFileName, imageFile } from './project-file-utils'
 import { assetResultForBase64, getFileExtension, imageResultForBase64 } from '../shared/file-utils'
-import { addFileToProjectContents, ProjectContentTreeRoot } from '../../components/assets'
+import {
+  addFileToProjectContents,
+  ProjectContentTreeRoot,
+  walkContentsTreeAsync,
+} from '../../components/assets'
+import { Either, isRight, left, right } from '../shared/either'
+import { EditorState, PersistentModel } from '../../components/editor/store/editor-state'
+import { contentsJSONURLFromProjectURL } from '../shared/utils'
+import { EditorDispatch } from '../../components/editor/action-types'
+import { saveAsset } from '../../components/editor/server'
+import { forceNotNull } from '../shared/optional-utils'
 
 async function attemptedTextFileLoad(fileName: string, file: JSZipObject): Promise<string | null> {
   const fileBuffer = await file.async('nodebuffer')
@@ -139,4 +149,79 @@ export async function importZippedGitProject(
   } else {
     return projectImportSuccess(projectName, loadedProject)
   }
+}
+
+export interface ImportFromProjectURLSuccess {
+  model: PersistentModel
+  originalProjectRootURL: string
+}
+
+export async function importFromProjectURL(
+  projectURL: string,
+): Promise<Either<string, ImportFromProjectURLSuccess>> {
+  const possibleContentsURL = contentsJSONURLFromProjectURL(projectURL)
+  if (isRight(possibleContentsURL)) {
+    const contentsURL = possibleContentsURL.value.contentsURL
+    const response = await fetch(contentsURL, {
+      method: 'GET',
+      credentials: 'include',
+      mode: 'cors',
+    })
+
+    if (response.ok) {
+      const responseJSON = await response.json()
+      return right({
+        model: responseJSON,
+        originalProjectRootURL: possibleContentsURL.value.projectRootURL,
+      })
+    } else if (response.status === 404) {
+      return left(`Unable to find the content.`)
+    } else {
+      return left(`Server responded with ${response.status} ${response.statusText}`)
+    }
+  } else {
+    return possibleContentsURL
+  }
+}
+
+export async function reuploadAsset(
+  originalProjectRootURL: string,
+  editorState: EditorState,
+  assetPath: string,
+): Promise<void> {
+  const response = await fetch(`${originalProjectRootURL}${assetPath}`, {
+    method: 'GET',
+    credentials: 'include',
+    mode: 'cors',
+  })
+  const blobContent = await response.blob()
+  const reader = new window.FileReader()
+  reader.readAsDataURL(blobContent)
+  const base64 = await new Promise((resolve) => {
+    reader.onloadend = () => {
+      resolve(reader.result)
+    }
+  })
+  if (typeof base64 === 'string') {
+    const fileType = getFileExtension(assetPath)
+    await saveAsset(
+      forceNotNull('Should have a project ID.', editorState.id),
+      fileType,
+      base64,
+      assetPath,
+    )
+  } else {
+    throw new Error(`Not able to construct base64 of asset as a string.`)
+  }
+}
+
+export async function reuploadAssets(
+  originalProjectRootURL: string,
+  editorState: EditorState,
+): Promise<void> {
+  walkContentsTreeAsync(editorState.projectContents, async (fullPath, file) => {
+    if (file.type === 'ASSET_FILE' || file.type === 'IMAGE_FILE') {
+      await reuploadAsset(originalProjectRootURL, editorState, fullPath)
+    }
+  })
 }

--- a/editor/src/core/shared/promise-utils.ts
+++ b/editor/src/core/shared/promise-utils.ts
@@ -9,3 +9,17 @@ export function cachedPromise<T>(promiseId: string, constructor: () => Promise<T
     return newPromise
   }
 }
+
+export async function waitUntil(limitMS: number, check: () => boolean): Promise<boolean> {
+  if (check()) {
+    return true
+  } else if (limitMS <= 0) {
+    return false
+  } else {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 5)
+    }).then(() => {
+      return waitUntil(limitMS - 5, check)
+    })
+  }
+}

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -81,7 +81,7 @@ import {
 } from '../components/canvas/ui-jsx-canvas'
 import { foldEither, isLeft } from '../core/shared/either'
 import {
-  importFromProjectURL,
+  getURLImportDetails,
   importZippedGitProject,
   isProjectImportSuccess,
   reuploadAssets,
@@ -503,7 +503,7 @@ export class Editor {
   }
 
   private createNewProjectFromImportURL(importURL: string): void {
-    importFromProjectURL(importURL)
+    getURLImportDetails(importURL)
       .then((importResult) => {
         foldEither(
           (errorMessage) => {

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -70,7 +70,6 @@ import {
   UtopiaTsWorkersImplementation,
 } from '../core/workers/workers'
 import '../utils/react-shim'
-import Utils, { waitUntil } from '../utils/utils'
 import { HeartbeatRequestMessage } from '../core/workers/watchdog-worker'
 import { triggerHashedAssetsUpdate } from '../utils/hashed-assets'
 import {
@@ -109,6 +108,7 @@ import { isFeatureEnabled } from '../utils/feature-switches'
 import { shouldInspectorUpdate } from '../components/inspector/inspector'
 import * as EP from '../core/shared/element-path'
 import { ProjectContentTreeRootKeepDeepEquality } from '../components/editor/store/store-deep-equality-instances'
+import { waitUntil } from '../core/shared/promise-utils'
 
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()

--- a/editor/src/utils/utils.spec.ts
+++ b/editor/src/utils/utils.spec.ts
@@ -1,8 +1,9 @@
 import * as Chai from 'chai'
 import Utils from './utils'
 import { CanvasRectangle, LocalPoint, LocalRectangle } from '../core/shared/math-utils'
-import { longestCommonArray } from '../core/shared/utils'
+import { longestCommonArray, projectIdFromURL } from '../core/shared/utils'
 import fastDeepEquals from 'fast-deep-equal'
+import { left, right } from '../core/shared/either'
 
 // disabling jest/valid-expect because this file uses Chai.expect
 /* eslint-disable jest/valid-expect */
@@ -389,5 +390,34 @@ describe('ObjectFlattenKeys', () => {
     }
     const expected = ['a', 'b', 'cica', 'kutya', 'lo', 'kitty', 'cat', 'loaf']
     expect(Utils.objectFlattenKeys(obj)).deep.equal(expected)
+  })
+})
+
+describe('projectIdFromURL', () => {
+  it.each([
+    ['cake', left(`Invalid value passed that isn't a URL.`)],
+    [
+      'https://utopia.app/something',
+      left(`URL does not appear to have the project ID or be for a project.`),
+    ],
+    ['https://utopia.app/p/abc123/rest/of/the/url', right('abc123')],
+    ['https://utopia.app/p/abc123', right('abc123')],
+    ['https://utopia.app/p/abc123-nice-hat', right('abc123')],
+    ['https://utopia.app/p/abc123-nice-hat/rest-of-the-url', right('abc123')],
+    ['http://localhost:8000/p/abc123/rest/of/the/url', right('abc123')],
+    ['http://localhost:8000/p/abc123', right('abc123')],
+    ['http://localhost:8000/p/abc123-nice-hat', right('abc123')],
+    ['http://localhost:8000/p/abc123-nice-hat/rest-of-the-url', right('abc123')],
+    ['https://utopia.app/project/abc123/rest/of/the/url', right('abc123')],
+    ['https://utopia.app/project/abc123', right('abc123')],
+    ['https://utopia.app/project/abc123-nice-hat', right('abc123')],
+    ['https://utopia.app/project/abc123-nice-hat/rest-of-the-url', right('abc123')],
+    ['http://localhost:8000/project/abc123/rest/of/the/url', right('abc123')],
+    ['http://localhost:8000/project/abc123', right('abc123')],
+    ['http://localhost:8000/project/abc123-nice-hat', right('abc123')],
+    ['http://localhost:8000/project/abc123-nice-hat/rest-of-the-url', right('abc123')],
+  ])('the value %s should produce a %s', (input, expectedResult) => {
+    const actualResult = projectIdFromURL(input)
+    expect(actualResult).deep.equal(expectedResult)
   })
 })

--- a/editor/src/utils/utils.ts
+++ b/editor/src/utils/utils.ts
@@ -933,6 +933,20 @@ function deduplicateBy<T>(key: (t: T) => string, ts: Array<T>): Array<T> {
   return results
 }
 
+export async function waitUntil(limitMS: number, check: () => boolean): Promise<boolean> {
+  if (check()) {
+    return true
+  } else if (limitMS <= 0) {
+    return false
+  } else {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 5)
+    }).then(() => {
+      return waitUntil(limitMS - 5, check)
+    })
+  }
+}
+
 export default {
   generateUUID: generateUUID,
   assert: assert,
@@ -1094,4 +1108,5 @@ export default {
   findLastIndex: findLastIndex,
   timeLimitPromise: timeLimitPromise,
   deduplicateBy: deduplicateBy,
+  waitUntil: waitUntil,
 }

--- a/editor/src/utils/utils.ts
+++ b/editor/src/utils/utils.ts
@@ -933,20 +933,6 @@ function deduplicateBy<T>(key: (t: T) => string, ts: Array<T>): Array<T> {
   return results
 }
 
-export async function waitUntil(limitMS: number, check: () => boolean): Promise<boolean> {
-  if (check()) {
-    return true
-  } else if (limitMS <= 0) {
-    return false
-  } else {
-    return new Promise((resolve) => {
-      setTimeout(resolve, 5)
-    }).then(() => {
-      return waitUntil(limitMS - 5, check)
-    })
-  }
-}
-
 export default {
   generateUUID: generateUUID,
   assert: assert,
@@ -1108,5 +1094,4 @@ export default {
   findLastIndex: findLastIndex,
   timeLimitPromise: timeLimitPromise,
   deduplicateBy: deduplicateBy,
-  waitUntil: waitUntil,
 }

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -370,14 +370,14 @@ projectChangedSince projectID lastChangedDate = do
             (ProjectDetailsMetadata projMeta) -> Just (view (field @"modifiedAt") projMeta > lastChangedDate)
             _ -> Nothing
 
-downloadProjectEndpoint :: ProjectIdWithSuffix -> [Text] -> ServerMonad Value
+downloadProjectEndpoint :: ProjectIdWithSuffix -> [Text] -> ServerMonad DownloadProjectResponse
 downloadProjectEndpoint (ProjectIdWithSuffix projectID _) pathIntoContent = do
   possibleProject <- loadProject projectID
   let contentLookup = foldl' (\ lensSoFar pathPart -> lensSoFar . key pathPart) (field @"content") pathIntoContent
   fromMaybe notFound $ do
     project <- possibleProject
     contentFromLookup <- firstOf contentLookup project
-    return $ return contentFromLookup
+    pure $ pure $ addHeader "*" contentFromLookup
 
 loadProjectEndpoint :: ProjectIdWithSuffix -> Maybe UTCTime -> ServerMonad LoadProjectResponse
 loadProjectEndpoint projectID Nothing = actuallyLoadProject projectID

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -78,7 +78,9 @@ type EmptyPreviewPageAPI = "share" :> BranchNameParam :> Get '[HTML] H.Html
 
 type PreviewPageAPI = "share" :> Capture "project_id" ProjectIdWithSuffix :> BranchNameParam :> Get '[HTML] H.Html
 
-type DownloadProjectAPI = "v1" :> "project" :> Capture "project_id" ProjectIdWithSuffix :> "contents.json" :> CaptureAll "remaining_path" Text :> Get '[PrettyJSON] Value
+type DownloadProjectResponse = Headers '[Header "Access-Control-Allow-Origin" Text] Value
+
+type DownloadProjectAPI = "v1" :> "project" :> Capture "project_id" ProjectIdWithSuffix :> "contents.json" :> CaptureAll "remaining_path" Text :> Get '[PrettyJSON] DownloadProjectResponse
 
 type ProjectOwnerAPI = "v1" :> "project" :> Capture "project_id" ProjectIdWithSuffix :> "owner" :> Get '[JSON] ProjectOwnerResponse
 
@@ -209,4 +211,5 @@ packagerLink :: Text -> Text -> Text
 packagerLink jsPackageName jsPackageVersion =
   let versionedName = jsPackageName <> "@" <> jsPackageVersion
    in toUrlPiece $ safeLink apiProxy packagerAPI versionedName
+
 


### PR DESCRIPTION
**Problem:**
We want to be able to copy projects from one environment to another easily so that sample projects can be created and then migrated across those environments.

**Fix:**
Similar to how the old Github import was implemented, a handler on load of the editor looks for an appropriate query parameter and then initiates the import flow.

The persistent model is pulled from the project via the project download endpoint, then a new project is created with that content and once the project content is available then the assets and images are pulled from the old project and uploaded into the new one.

**Notes:**
Until the code has been deployed to both source and target environments, it will not work across existing deployments due to the `Access-Control-Allow-Origin` header change that was needed.

**Commit Details:**
- Added `githuboptions` to `LeftMenuPanel` so that it can be included in focus checks, which fixes an issue with not being able to paste into the import from URL input field.
- Added the input field and button to hold the URL and trigger the import to `GithubPane`.
- Brought `GithubPane` to be more like the other panes in its use of utility components.
- Added `importFromProjectURL` for handling the lookup of the data involved in importing a project.
- Implemented `reuploadAssets` and `reuploadAsset` utility functions to upload the assets from the old project into the new one.
- Added `waitUntil` utility function.
- Added handling for the presence of the `import_url` query parameter which triggers the import itself.
- Added the `Access-Control-Allow-Origin` header for the endpoint that provides the `content.json` download so that it can be invoked across domains.