### PR TITLE
wrapping the flow reorder indicator

### DIFF
--- a/editor/src/components/canvas/controls/flow-slider-control.tsx
+++ b/editor/src/components/canvas/controls/flow-slider-control.tsx
@@ -116,7 +116,7 @@ export const FlowSliderControl = React.memo(() => {
               width: siblings.length * IndicatorSize(scale),
               height: MenuHeight(scale),
               borderRadius: 4 / scale,
-              opacity: '50%',
+              opacity: '60%',
               background: colorTheme.bg0.value,
               boxShadow: `inset 0px 0px 0px ${0.5 / scale}px ${colorTheme.border3.value} , 0px ${
                 2 / scale

--- a/editor/src/components/canvas/controls/flow-slider-control.tsx
+++ b/editor/src/components/canvas/controls/flow-slider-control.tsx
@@ -28,7 +28,7 @@ import { findNewIndex } from '../canvas-strategies/flow-reorder-helpers'
 export const IconSize = 16
 const IndicatorSize = (scale: number) => IconSize / scale
 const MenuHeight = (scale: number) => 22 / scale
-const AnimatedIndicatorOffset = (scale: number) => 2 / scale
+const IndicatorOffset = (scale: number) => 2 / scale
 const ControlSize = (scale: number) => 10 / scale
 
 export const FlowSliderControl = React.memo(() => {
@@ -98,7 +98,7 @@ export const FlowSliderControl = React.memo(() => {
 
   const controlTopLeft = React.useMemo(() => {
     return {
-      x: controlAreaTopLeft.x + latestIndex * IndicatorSize(scale) + AnimatedIndicatorOffset(scale),
+      x: controlAreaTopLeft.x + latestIndex * IndicatorSize(scale) + IndicatorOffset(scale),
       y: getRectCenter(startingFrame ?? zeroCanvasRect).y - ControlSize(scale) / 2,
     } as CanvasPoint
   }, [startingFrame, controlAreaTopLeft, latestIndex, scale])
@@ -190,9 +190,9 @@ const ReorderIndicator = React.memo(({ style }: { style: React.CSSProperties }) 
     <div
       style={{
         position: 'absolute',
-        top: AnimatedIndicatorOffset(scale),
-        width: IndicatorSize(scale) - AnimatedIndicatorOffset(scale),
-        height: MenuHeight(scale) - AnimatedIndicatorOffset(scale) * 2,
+        top: IndicatorOffset(scale),
+        width: IndicatorSize(scale) - IndicatorOffset(scale),
+        height: MenuHeight(scale) - IndicatorOffset(scale) * 2,
         borderRadius: 4 / scale,
         background: colorTheme.primary.value,
         ...style,


### PR DESCRIPTION
**Problem:**
The flow reorder indicator is not that accurate, when reaching the end of the slider it will restart from the beginning and it's not visible from the UI.

**Fix:**
Show 2 reorder indicators on the edges in this case, with overflow set to hidden.

**Commit Details:**
- updating the flow slider control with optionally showing 2 indicators
- rename variables as there are no more Animations
