### PR TITLE
After clearInteractionSession we have to apply the strategy

### DIFF
--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -24,7 +24,13 @@ import {
   shouldApplyClearInteractionSessionResult,
 } from '../actions/action-utils'
 import { InnerDispatchResult } from './dispatch'
-import { DerivedState, deriveState, EditorState, EditorStoreFull } from './editor-state'
+import {
+  DerivedState,
+  deriveState,
+  EditorState,
+  EditorStoreFull,
+  EditorStoreUnpatched,
+} from './editor-state'
 import {
   CanvasStrategy,
   CustomStrategyState,
@@ -48,7 +54,7 @@ interface HandleStrategiesResult {
 export function interactionFinished(
   strategies: Array<CanvasStrategy>,
   storedState: EditorStoreFull,
-  result: InnerDispatchResult,
+  result: EditorStoreUnpatched,
 ): HandleStrategiesResult {
   const newEditorState = result.unpatchedEditor
   const withClearedSession = createEmptyStrategyState(
@@ -108,7 +114,7 @@ export function interactionFinished(
 export function interactionHardReset(
   strategies: Array<CanvasStrategy>,
   storedState: EditorStoreFull,
-  result: InnerDispatchResult,
+  result: EditorStoreUnpatched,
 ): HandleStrategiesResult {
   const newEditorState = result.unpatchedEditor
   const withClearedSession = {
@@ -191,7 +197,7 @@ export function interactionHardReset(
 export function interactionUpdate(
   strategies: Array<CanvasStrategy>,
   storedState: EditorStoreFull,
-  result: InnerDispatchResult,
+  result: EditorStoreUnpatched,
   actionType: 'interaction-create-or-update' | 'non-interaction',
 ): HandleStrategiesResult {
   const newEditorState = result.unpatchedEditor
@@ -263,7 +269,7 @@ export function interactionUpdate(
 export function interactionStart(
   strategies: Array<CanvasStrategy>,
   storedState: EditorStoreFull,
-  result: InnerDispatchResult,
+  result: EditorStoreUnpatched,
 ): HandleStrategiesResult {
   const newEditorState = result.unpatchedEditor
   const withClearedSession = createEmptyStrategyState(
@@ -342,7 +348,7 @@ export function interactionStart(
 
 export function interactionCancel(
   storedState: EditorStoreFull,
-  result: InnerDispatchResult,
+  result: EditorStoreUnpatched,
 ): HandleStrategiesResult {
   const updatedEditorState: EditorState = {
     ...result.unpatchedEditor,
@@ -583,7 +589,7 @@ export function handleStrategies(
   strategies: Array<CanvasStrategy>,
   dispatchedActions: readonly EditorAction[],
   storedState: EditorStoreFull,
-  result: InnerDispatchResult,
+  result: EditorStoreUnpatched,
   oldDerivedState: DerivedState,
 ): HandleStrategiesResult & { patchedDerivedState: DerivedState } {
   const MeasureDispatchTime =
@@ -688,7 +694,7 @@ function handleStrategiesInner(
   strategies: Array<CanvasStrategy>,
   dispatchedActions: readonly EditorAction[],
   storedState: EditorStoreFull,
-  result: InnerDispatchResult,
+  result: EditorStoreUnpatched,
 ): HandleStrategiesResult {
   const isSaveDomReport = dispatchedActions.some((a) => a.action === 'SAVE_DOM_REPORT')
 

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -380,6 +380,10 @@ export function editorDispatch(
         EditorActions.transientActions(actionGroup),
       ])
       return [...actionGroups, ...wrappedTransientActionGroups]
+    } else if (currentAction.action === 'CLEAR_INTERACTION_SESSION') {
+      // CLEAR_INTERACTION_SESSION must be the last action for a given action group, so we push it and then create a new empty action group for follow-up actions
+      actionGroups[actionGroups.length - 1].push(currentAction)
+      return [...actionGroups, []]
     } else {
       // if this action does not need a rebuilt derived state we can just push it into the last action group to dispatch them together
       let updatedGroups = actionGroups

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -60,7 +60,6 @@ import { emptySet } from '../../../core/shared/set-utils'
 import { RegisteredCanvasStrategies } from '../../canvas/canvas-strategies/canvas-strategies'
 import { removePathsWithDeadUIDs } from '../../../core/shared/element-path'
 import { CanvasStrategy } from '../../canvas/canvas-strategies/canvas-strategy-types'
-import { last } from '../../../core/shared/array-utils'
 
 type DispatchResultFields = {
   nothingChanged: boolean

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -273,6 +273,8 @@ export type EditorStorePatched = EditorStoreShared & {
   derived: DerivedState
 }
 
+export type EditorStoreUnpatched = Omit<EditorStoreFull, 'patchedEditor' | 'patchedDerived'>
+
 export function patchedStoreFromFullStore(store: EditorStoreFull): EditorStorePatched {
   return {
     ...store,

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -827,19 +827,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
     const transientActions = actions.filter((action) => action.action === 'TRANSIENT_ACTIONS')
 
     if (realActions.length > 0) {
-      // if there is a clearInteractionSession action, dispatch the later actions separately
-      const clearInteractionSessionIdx = realActions.findIndex(
-        (a) => a.action === 'CLEAR_INTERACTION_SESSION',
-      )
-      if (
-        clearInteractionSessionIdx === -1 ||
-        clearInteractionSessionIdx === realActions.length - 1
-      ) {
-        this.props.dispatch(realActions, 'canvas')
-      } else {
-        this.props.dispatch(realActions.slice(0, clearInteractionSessionIdx + 1), 'canvas')
-        this.props.dispatch(realActions.slice(clearInteractionSessionIdx), 'canvas')
-      }
+      this.props.dispatch(realActions, 'canvas')
     }
 
     if (transientActions.length > 0) {


### PR DESCRIPTION
## Issue

When we call clearInteractionSession(true) because we want to apply the changes, then it is not really the action reducer what applies the changes. The changes are applied by `handleStrategies` in the `dispatch` function after all the actions are reduced. Why is this important? Because the strategies will be picked and applied after all the changes of all the actions, even the ones after the clearInteractionSession, which you potentially meant as actions which should run after the interaction is applied.

Example scenario:  You want to apply a strategy and then remove the selection. So you call `dispatch(clearInteractionSession, removeSelection)`. What you will see that all the interaction changes are reverted: on the final `handleStrategies` there will be no selected element (because of the second action), so none of the strategies will be applicable.

## Solution

We already have action groups in the dispatch function, so if we guarantee these 2 things:
- we always start a new action group after a `clearInteractionSession` action
- we apply the strategies after each action group.

Closes https://github.com/concrete-utopia/utopia/issues/2497

