### PR TITLE
Authenticate With Github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ utopia-db
 
 # Nix builds.
 server-build-result
+
+# Local custom setups.
+custom-shell.nix

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -301,6 +301,9 @@ export async function renderTestEditorWithModel(
     userState: {
       loginState: notLoggedIn,
       shortcutConfig: {},
+      githubState: {
+        authenticated: false,
+      },
     },
     workers: workers,
     persistence: DummyPersistenceMachine,

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -45,6 +45,7 @@ import {
   ElementsToRerender,
   ErrorMessages,
   FloatingInsertMenuState,
+  GithubState,
   LeftMenuTab,
   ModalDialog,
   OriginalFrame,
@@ -868,6 +869,11 @@ export interface SetLoginState {
   loginState: LoginState
 }
 
+export interface SetGithubState {
+  action: 'SET_GITHUB_STATE'
+  githubState: GithubState
+}
+
 export interface ResetCanvas {
   action: 'RESET_CANVAS'
 }
@@ -1104,6 +1110,7 @@ export type EditorAction =
   | SetFollowSelectionEnabled
   | UpdateConfigFromVSCode
   | SetLoginState
+  | SetGithubState
   | ResetCanvas
   | SetFilebrowserDropTarget
   | SetCurrentTheme

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -212,6 +212,7 @@ import type {
   UpdateMouseButtonsPressed,
   ToggleSelectionLock,
   ElementPaste,
+  SetGithubState,
 } from '../action-types'
 import {
   EditorModes,
@@ -224,6 +225,7 @@ import type {
   DuplicationState,
   ErrorMessages,
   FloatingInsertMenuState,
+  GithubState,
   LeftMenuTab,
   ModalDialog,
   OriginalFrame,
@@ -1392,6 +1394,13 @@ export function setLoginState(loginState: LoginState): SetLoginState {
   return {
     action: 'SET_LOGIN_STATE',
     loginState: loginState,
+  }
+}
+
+export function setGithubState(githubState: GithubState): SetGithubState {
+  return {
+    action: 'SET_GITHUB_STATE',
+    githubState: githubState,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -89,6 +89,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SET_FOLLOW_SELECTION_ENABLED':
     case 'UPDATE_CONFIG_FROM_VSCODE':
     case 'SET_LOGIN_STATE':
+    case 'SET_GITHUB_STATE':
     case 'RESET_CANVAS':
     case 'SET_FILEBROWSER_DROPTARGET':
     case 'SET_FORKED_FROM_PROJECT_ID':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -373,6 +373,7 @@ import {
   SetElementsToRerender,
   UpdateMouseButtonsPressed,
   ToggleSelectionLock,
+  SetGithubState,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -4390,6 +4391,7 @@ export const UPDATE_FNS = {
     return {
       ...updatedUserConfiguration,
       loginState: userState.loginState,
+      githubState: userState.githubState,
     }
   },
   UPDATE_PROPERTY_CONTROLS_INFO: (
@@ -4590,6 +4592,12 @@ export const UPDATE_FNS = {
     return {
       ...userState,
       loginState: action.loginState,
+    }
+  },
+  SET_GITHUB_STATE: (action: SetGithubState, userState: UserState): UserState => {
+    return {
+      ...userState,
+      githubState: action.githubState,
     }
   },
   RESET_CANVAS: (action: ResetCanvas, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -349,7 +349,7 @@ export async function downloadGithubRepo(
   owner: string,
   repo: string,
 ): Promise<ServerResponse<JSZip>> {
-  const url = urljoin(UTOPIA_BACKEND, 'github', owner, repo)
+  const url = urljoin(UTOPIA_BACKEND, 'github', 'import', owner, repo)
   const response = await fetch(url, {
     method: 'GET',
     credentials: 'include',

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -111,6 +111,9 @@ function createEditorStore(
     userState: {
       loginState: notLoggedIn,
       shortcutConfig: {},
+      githubState: {
+        authenticated: false,
+      },
     },
     workers: new UtopiaTsWorkersImplementation(
       new FakeParserPrinterWorker(),

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -115,6 +115,11 @@ function processAction(
       ...working,
       userState: UPDATE_FNS.SET_LOGIN_STATE(action, working.userState),
     }
+  } else if (action.action === 'SET_GITHUB_STATE') {
+    return {
+      ...working,
+      userState: UPDATE_FNS.SET_GITHUB_STATE(action, working.userState),
+    }
   } else {
     // Process action on the JS side.
     const editorAfterUpdateFunction = runLocalEditorAction(

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -241,13 +241,21 @@ export function emptyUserConfiguration(): UserConfiguration {
   }
 }
 
+export interface GithubState {
+  authenticated: boolean
+}
+
 export interface UserState extends UserConfiguration {
   loginState: LoginState
+  githubState: GithubState
 }
 
 export const defaultUserState: UserState = {
   loginState: loginNotYetKnown,
   shortcutConfig: {},
+  githubState: {
+    authenticated: false,
+  },
 }
 
 type EditorStoreShared = {

--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -781,49 +781,38 @@ const GithubPane = React.memo(() => {
       }}
       onFocus={onFocus}
     >
-      <UIRow style={{ paddingLeft: 8, paddingRight: 8 }}>
-        <Title>Github</Title>
-      </UIRow>
-      <UIGridRow padded variant='<--------auto-------->|--45px--|'>
-        {githubAuthenticated ? 'Authenticated With Github' : 'Not Authenticated With Github'}
-        <Button
-          spotlight
-          highlight
-          disabled={githubAuthenticated}
-          onMouseUp={triggerAuthentication}
-        >
-          Authenticate With Github
-        </Button>
-      </UIGridRow>
-      <div
-        style={{
-          height: 'initial',
-          minHeight: 34,
-          alignItems: 'flex-start',
-          paddingTop: 8,
-          paddingLeft: 8,
-          paddingRight: 8,
-          paddingBottom: 8,
-          whiteSpace: 'pre-wrap',
-          letterSpacing: 0.1,
-          lineHeight: '17px',
-          fontSize: '11px',
-        }}
-      >
-        You can import a new project from Github. It might take a few minutes, and will show up in a
-        new tab.
-      </div>
-      <UIGridRow padded variant='<--------auto-------->|--45px--|'>
-        <StringInput testId='importProject' value={githubRepoStr} onChange={onChange} />
-        <Button spotlight highlight disabled={parsedRepo == null} onMouseUp={onStartImport}>
-          Start
-        </Button>
-      </UIGridRow>
       <Section>
         <SectionTitleRow minimised={false} toggleMinimised={NO_OP}>
           <Title style={{ flexGrow: 1 }}>Github</Title>
         </SectionTitleRow>
         <SectionBodyArea minimised={false}>
+          <div
+            style={{
+              height: 'initial',
+              minHeight: 34,
+              alignItems: 'flex-start',
+              paddingTop: 8,
+              paddingLeft: 8,
+              paddingRight: 8,
+              paddingBottom: 8,
+              whiteSpace: 'pre-wrap',
+              letterSpacing: 0.1,
+              lineHeight: '17px',
+              fontSize: '11px',
+            }}
+          >
+            {githubAuthenticated ? 'Authenticated With Github' : 'Not Authenticated With Github'}
+          </div>
+          <UIGridRow padded variant='<--------auto-------->|--45px--|'>
+            <Button
+              spotlight
+              highlight
+              disabled={githubAuthenticated}
+              onMouseUp={triggerAuthentication}
+            >
+              Authenticate With Github
+            </Button>
+          </UIGridRow>
           <div
             style={{
               height: 'initial',

--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -60,6 +60,7 @@ import { Link } from '../../uuiui/link'
 import { useTriggerForkProject } from '../editor/persistence-hooks'
 import urljoin from 'url-join'
 import { parseGithubProjectString } from '../../core/shared/github'
+import { startGithubAuthentication } from '../../utils/github-auth'
 
 export interface LeftPaneProps {
   editorState: EditorState
@@ -706,6 +707,9 @@ const SharingPane = React.memo(() => {
 const GithubPane = React.memo(() => {
   const [githubRepoStr, setGithubRepoStr] = React.useState('')
   const parsedRepo = parseGithubProjectString(githubRepoStr)
+  const dispatch = useEditorState((store) => {
+    return store.dispatch
+  }, 'GithubPane dispatch')
 
   const onStartImport = React.useCallback(() => {
     if (parsedRepo != null) {
@@ -726,6 +730,14 @@ const GithubPane = React.memo(() => {
     [setGithubRepoStr],
   )
 
+  const githubAuthenticated = useEditorState((store) => {
+    return store.userState.githubState.authenticated
+  }, 'GithubPane githubAuthenticated')
+
+  const triggerAuthentication = React.useCallback(() => {
+    startGithubAuthentication(dispatch)
+  }, [dispatch])
+
   return (
     <FlexColumn
       id='leftPaneGithub'
@@ -739,6 +751,17 @@ const GithubPane = React.memo(() => {
       <UIRow style={{ paddingLeft: 8, paddingRight: 8 }}>
         <Title>Github</Title>
       </UIRow>
+      <UIGridRow padded variant='<--------auto-------->|--45px--|'>
+        {githubAuthenticated ? 'Authenticated With Github' : 'Not Authenticated With Github'}
+        <Button
+          spotlight
+          highlight
+          disabled={githubAuthenticated}
+          onMouseUp={triggerAuthentication}
+        >
+          Authenticate With Github
+        </Button>
+      </UIGridRow>
       <div
         style={{
           height: 'initial',

--- a/editor/src/utils/github-auth.ts
+++ b/editor/src/utils/github-auth.ts
@@ -1,0 +1,58 @@
+import { UTOPIA_BACKEND } from '../common/env-vars'
+import { MODE } from '../common/server'
+import urljoin from 'url-join'
+import { LoginState } from '../common/user'
+import { EditorDispatch } from '../components/editor/action-types'
+import { setGithubState } from '../components/editor/actions/action-creators'
+
+async function checkIfAuthenticatedWithGithub(): Promise<boolean> {
+  const url = urljoin(UTOPIA_BACKEND, 'github', 'authentication', 'status')
+  const response = await fetch(url, {
+    method: 'GET',
+    credentials: 'include',
+    mode: MODE,
+  })
+  if (response.ok) {
+    return response.json()
+  } else {
+    throw new Error(`Unexpected status returned from endpoint: ${response.status}`)
+  }
+}
+
+export async function isAuthenticatedWithGithub(loginState: LoginState): Promise<boolean> {
+  if (loginState.type === 'LOGGED_IN') {
+    return checkIfAuthenticatedWithGithub()
+  } else {
+    return false
+  }
+}
+
+const timeToWait = 1000 * 5
+
+export async function startGithubAuthentication(dispatch: EditorDispatch): Promise<void> {
+  // Open the window that starts the authentication flow.
+  const url = urljoin(UTOPIA_BACKEND, 'github', 'authentication', 'start')
+  window.open(url)
+
+  async function checkAuthenticatedPeriodically(timeLeftMS: number): Promise<void> {
+    const currentStatus = await checkIfAuthenticatedWithGithub()
+    if (currentStatus) {
+      dispatch([setGithubState({ authenticated: true })], 'everyone')
+    } else {
+      if (timeLeftMS > 0) {
+        // Wait for a bit and try again.
+        const wait = new Promise((resolve) => {
+          setTimeout(resolve, timeToWait)
+        })
+        wait.then(() => {
+          return checkAuthenticatedPeriodically(timeLeftMS - timeToWait)
+        })
+      } else {
+        console.error('Timeout waiting for Github authentication to succeed.')
+      }
+    }
+  }
+
+  // Try this for a maximum of 5 minutes.
+  await checkAuthenticatedPeriodically(1000 * 60 * 5)
+}

--- a/server/migrations/001.sql
+++ b/server/migrations/001.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "public"."github_authentication" (
+    "user_id" character varying NOT NULL,
+    "access_token" character varying NOT NULL,
+    "refresh_token" character varying NOT NULL,
+    "expires_at" timestamp with time zone NOT NULL
+);
+
+ALTER TABLE ONLY "public"."github_authentication"
+    ADD CONSTRAINT "unique_github_authentication" UNIQUE ("user_id");
+

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -35,6 +35,7 @@ dependencies:
   - filepath
   - free
   - zlib
+  - hoauth2
   - http-api-data
   - http-client
   - http-client-tls
@@ -82,6 +83,7 @@ dependencies:
   - unix
   - unordered-containers
   - utopia-clientmodel
+  - uri-bytestring
   - uuid
   - vector
   - wai

--- a/server/src/Utopia/Web/Auth/Github.hs
+++ b/server/src/Utopia/Web/Auth/Github.hs
@@ -1,0 +1,89 @@
+{-# OPTIONS_GHC -fno-warn-orphans   #-}
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE DeriveGeneric          #-}
+{-# LANGUAGE DuplicateRecordFields  #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE OverloadedStrings      #-}
+{-# LANGUAGE RankNTypes             #-}
+{-# LANGUAGE RecordWildCards        #-}
+{-# LANGUAGE TemplateHaskell        #-}
+{-# LANGUAGE TypeOperators          #-}
+{-# LANGUAGE QuasiQuotes            #-}
+{-# LANGUAGE TypeApplications      #-}
+
+
+module Utopia.Web.Auth.Github where
+
+import Network.OAuth.OAuth2
+import URI.ByteString
+import URI.ByteString.QQ
+import           Protolude
+import Data.String
+import           System.Environment
+import Control.Monad
+import qualified Data.ByteString.Char8 as C
+import qualified Data.Text as T
+import Network.HTTP.Client
+import Control.Monad.Trans.Maybe
+import           Network.HTTP.Client.TLS
+import           Data.Generics.Product
+import           Data.Generics.Sum
+import Control.Lens
+import Utopia.Web.Database
+import Utopia.Web.Database.Types
+import Data.Time.Clock
+
+data GithubAuthResources = GithubAuthResources
+                         { _githubAuth      :: OAuth2
+                         , _githubManager   :: Manager
+                         }
+
+getGithubOAuthClientId :: IO (Maybe String)
+getGithubOAuthClientId = lookupEnv "GITHUB_OAUTH_CLIENT_ID"
+
+getGithubOAuthClientSecret :: IO (Maybe String)
+getGithubOAuthClientSecret = lookupEnv "GITHUB_OAUTH_CLIENT_SECRET"
+
+getGithubOAuthRedirectURL :: IO (Maybe String)
+getGithubOAuthRedirectURL = lookupEnv "GITHUB_OAUTH_REDIRECT_URL"
+
+getGithubOAuth2 :: IO (Maybe OAuth2)
+getGithubOAuth2 = do
+  maybeClientId <- getGithubOAuthClientId
+  maybeClientSecret <- getGithubOAuthClientSecret
+  maybeRedirectURL <- getGithubOAuthRedirectURL
+  oauthCallback <- case maybeRedirectURL of
+    Just urlToParse -> either (\err -> fail $ show err) (pure . pure) $ parseURI strictURIParserOptions $ C.pack urlToParse
+    Nothing         -> pure Nothing
+  pure $ do
+    oauthClientId <- fmap T.pack maybeClientId
+    let oauthClientSecret = fmap T.pack maybeClientSecret
+    let oauthOAuthorizeEndpoint = [uri|https://github.com/login/oauth/authorize|]
+    let oauthAccessTokenEndpoint = [uri|https://github.com/login/oauth/access_token|]
+    pure $ OAuth2{..}
+
+getGithubAuthResources :: IO (Maybe GithubAuthResources)
+getGithubAuthResources = runMaybeT $ do
+  _githubAuth <- MaybeT getGithubOAuth2
+  _githubManager <- liftIO $ newManager tlsManagerSettings
+  pure $ GithubAuthResources{..}
+
+getAuthorizationURI :: GithubAuthResources -> URI
+getAuthorizationURI GithubAuthResources{..} = authorizationUrl _githubAuth
+
+getAccessToken :: GithubAuthResources -> ExchangeToken -> IO (Either Text OAuth2Token)
+getAccessToken GithubAuthResources{..} exchangeToken = do
+  result <- fetchAccessToken _githubManager _githubAuth exchangeToken
+  pure $ first show result
+
+oauth2TokenToGithubAuthenticationDetails :: OAuth2Token -> Text -> IO GithubAuthenticationDetails
+oauth2TokenToGithubAuthenticationDetails oauth2Token userId = do
+  now <- getCurrentTime
+  let accessToken = atoken $ view (field @"accessToken" ) oauth2Token
+  let possibleRefreshToken = fmap rtoken $ firstOf (field @"refreshToken" . _Just) oauth2Token
+  refreshToken <- maybe (fail "No refresh token supplied.") pure possibleRefreshToken
+  expiresAt <- maybe (fail "No expiry supplied.") (\expires -> pure $ addUTCTime (fromInteger $ toInteger expires) now) (expiresIn oauth2Token)
+  pure $ GithubAuthenticationDetails{..}
+

--- a/server/src/Utopia/Web/Auth/Github.hs
+++ b/server/src/Utopia/Web/Auth/Github.hs
@@ -6,38 +6,38 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE OverloadedStrings      #-}
+{-# LANGUAGE QuasiQuotes            #-}
 {-# LANGUAGE RankNTypes             #-}
 {-# LANGUAGE RecordWildCards        #-}
 {-# LANGUAGE TemplateHaskell        #-}
+{-# LANGUAGE TypeApplications       #-}
 {-# LANGUAGE TypeOperators          #-}
-{-# LANGUAGE QuasiQuotes            #-}
-{-# LANGUAGE TypeApplications      #-}
 
 
 module Utopia.Web.Auth.Github where
 
-import Network.OAuth.OAuth2
-import URI.ByteString
-import URI.ByteString.QQ
-import           Protolude
-import Data.String
-import           System.Environment
-import Control.Monad
-import qualified Data.ByteString.Char8 as C
-import qualified Data.Text as T
-import Network.HTTP.Client
-import Control.Monad.Trans.Maybe
-import           Network.HTTP.Client.TLS
+import           Control.Lens
+import           Control.Monad
+import           Control.Monad.Trans.Maybe
+import qualified Data.ByteString.Char8     as C
 import           Data.Generics.Product
 import           Data.Generics.Sum
-import Control.Lens
-import Utopia.Web.Database
-import Utopia.Web.Database.Types
-import Data.Time.Clock
+import           Data.String
+import qualified Data.Text                 as T
+import           Data.Time.Clock
+import           Network.HTTP.Client
+import           Network.HTTP.Client.TLS
+import           Network.OAuth.OAuth2
+import           Protolude
+import           System.Environment
+import           URI.ByteString
+import           URI.ByteString.QQ
+import           Utopia.Web.Database
+import           Utopia.Web.Database.Types
 
 data GithubAuthResources = GithubAuthResources
-                         { _githubAuth      :: OAuth2
-                         , _githubManager   :: Manager
+                         { _githubAuth    :: OAuth2
+                         , _githubManager :: Manager
                          }
 
 getGithubOAuthClientId :: IO (Maybe String)

--- a/server/src/Utopia/Web/Database.hs
+++ b/server/src/Utopia/Web/Database.hs
@@ -56,6 +56,8 @@ data DatabaseMetrics = DatabaseMetrics
                      , _getUserConfigurationMetrics     :: InvocationMetric
                      , _saveUserConfigurationMetrics    :: InvocationMetric
                      , _checkIfProjectIDReservedMetrics :: InvocationMetric
+                     , _updateGithubAuthenticationDetailsMetrics ::InvocationMetric
+                     , _getGithubAuthenticationDetailsMetrics :: InvocationMetric
                      }
 
 createDatabaseMetrics :: Store -> IO DatabaseMetrics
@@ -77,6 +79,8 @@ createDatabaseMetrics store = DatabaseMetrics
   <*> createInvocationMetric "utopia.database.getuserconfiguration" store
   <*> createInvocationMetric "utopia.database.saveuserconfiguration" store
   <*> createInvocationMetric "utopia.database.checkifprojectidreserved" store
+  <*> createInvocationMetric "utopia.database.updategithubauthenticationdetails" store
+  <*> createInvocationMetric "utopia.database.lookupgithubauthenticationdetails" store
 
 data UserIDIncorrectException = UserIDIncorrectException
                               deriving (Eq, Show)
@@ -386,3 +390,29 @@ projectContentTreeFromDecodedProject :: DecodedProject -> Either Text ProjectCon
 projectContentTreeFromDecodedProject decodedProject = do
   let contentOfProject = view (field @"content") decodedProject
   fmap (view (field @"projectContents")) $ persistentModelFromJSON contentOfProject
+
+updateGithubAuthenticationDetails :: DatabaseMetrics -> DBPool -> GithubAuthenticationDetails -> IO ()
+updateGithubAuthenticationDetails metrics pool GithubAuthenticationDetails{..} = invokeAndMeasure (_updateGithubAuthenticationDetailsMetrics metrics) $ usePool pool $ \connection -> do
+  let githubAuthenticationDetailsEntry = toFields (userId, accessToken, refreshToken, expiresAt)
+  void $ runDelete_ connection $ Delete
+                               { dTable = githubAuthenticationTable
+                               , dWhere = (\(rowUserId, _, _, _) -> rowUserId .=== toFields userId)
+                               , dReturning = rCount
+                               }
+  void $ runInsert_ connection $ Insert
+                               { iTable = githubAuthenticationTable
+                               , iRows = [githubAuthenticationDetailsEntry]
+                               , iReturning = rCount
+                               , iOnConflict = Nothing
+                               }
+
+githubAuthenticationDetailsFromRow :: (Text, Text, Text, UTCTime) -> GithubAuthenticationDetails
+githubAuthenticationDetailsFromRow (userId, accessToken, refreshToken, expiresAt) = GithubAuthenticationDetails{..}
+
+lookupGithubAuthenticationDetails :: DatabaseMetrics -> DBPool -> Text -> IO (Maybe GithubAuthenticationDetails)
+lookupGithubAuthenticationDetails metrics pool userId = invokeAndMeasure (_getGithubAuthenticationDetailsMetrics metrics) $ usePool pool $ \connection -> do
+  githubAuthenticationDetails <- runSelect connection $ do
+    githubAuthenticationDetailsRow@(rowUserId, _, _, _) <- githubAuthenticationSelect
+    where_ $ rowUserId .== toFields userId
+    pure githubAuthenticationDetailsRow
+  pure $ fmap githubAuthenticationDetailsFromRow $ listToMaybe githubAuthenticationDetails 

--- a/server/src/Utopia/Web/Database.hs
+++ b/server/src/Utopia/Web/Database.hs
@@ -415,4 +415,4 @@ lookupGithubAuthenticationDetails metrics pool userId = invokeAndMeasure (_getGi
     githubAuthenticationDetailsRow@(rowUserId, _, _, _) <- githubAuthenticationSelect
     where_ $ rowUserId .== toFields userId
     pure githubAuthenticationDetailsRow
-  pure $ fmap githubAuthenticationDetailsFromRow $ listToMaybe githubAuthenticationDetails 
+  pure $ fmap githubAuthenticationDetailsFromRow $ listToMaybe githubAuthenticationDetails

--- a/server/src/Utopia/Web/Database/Migrations.hs
+++ b/server/src/Utopia/Web/Database/Migrations.hs
@@ -22,7 +22,7 @@ import           Protolude                            hiding (get)
 
 migrateDatabase :: Bool -> Bool -> Pool Connection -> IO ()
 migrateDatabase verbose includeInitial pool = withResource pool $ \connection -> do
-  let mainMigrationCommands = []
+  let mainMigrationCommands = [MigrationFile "001.sql" "./migrations/001.sql"]
   let initialMigrationCommand = if includeInitial
                                    then [MigrationFile "initial.sql" "./migrations/initial.sql"]
                                    else []

--- a/server/src/Utopia/Web/Database/Types.hs
+++ b/server/src/Utopia/Web/Database/Types.hs
@@ -119,3 +119,24 @@ data DecodedUserConfiguration = DecodedUserConfiguration
 
 type DBPool = Pool Connection
 
+
+type GithubAuthenticationFields = (Field SqlText, Field SqlText, Field SqlText, Field SqlTimestamptz)
+
+githubAuthenticationTable :: Table GithubAuthenticationFields GithubAuthenticationFields 
+githubAuthenticationTable = table "github_authentication" (p4
+                    ( tableField "user_id"
+                    , tableField "access_token"
+                    , tableField "refresh_token"
+                    , tableField "expires_at"
+                    )
+                   )
+
+githubAuthenticationSelect :: Select GithubAuthenticationFields
+githubAuthenticationSelect = selectTable githubAuthenticationTable
+
+data GithubAuthenticationDetails = GithubAuthenticationDetails
+                 { userId       :: Text
+                 , accessToken  :: Text
+                 , refreshToken :: Text
+                 , expiresAt    :: UTCTime
+                 } deriving (Eq, Show, Generic)

--- a/server/src/Utopia/Web/Database/Types.hs
+++ b/server/src/Utopia/Web/Database/Types.hs
@@ -122,7 +122,7 @@ type DBPool = Pool Connection
 
 type GithubAuthenticationFields = (Field SqlText, Field SqlText, Field SqlText, Field SqlTimestamptz)
 
-githubAuthenticationTable :: Table GithubAuthenticationFields GithubAuthenticationFields 
+githubAuthenticationTable :: Table GithubAuthenticationFields GithubAuthenticationFields
 githubAuthenticationTable = table "github_authentication" (p4
                     ( tableField "user_id"
                     , tableField "access_token"

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -26,6 +26,7 @@ import           Data.Text.Encoding
 import           Data.Time
 import           Network.HTTP.Types.Header
 import           Network.HTTP.Types.Status
+import           Network.OAuth.OAuth2
 import           Network.Wai
 import           Network.Wai.Middleware.Gzip
 import           Prelude                         (String)
@@ -55,7 +56,6 @@ import           Utopia.Web.Types
 import           Utopia.Web.Utils.Files
 import           WaiAppStatic.Storage.Filesystem
 import           WaiAppStatic.Types
-import Network.OAuth.OAuth2
 
 type TagSoupTags = [Tag Text]
 
@@ -646,7 +646,7 @@ githubStartAuthenticationEndpoint cookie = requireUser cookie $ \_ -> do
   pure mempty
 
 githubFinishAuthenticationEndpoint :: Maybe Text -> Maybe ExchangeToken -> ServerMonad H.Html
-githubFinishAuthenticationEndpoint _ Nothing = badRequest 
+githubFinishAuthenticationEndpoint _ Nothing = badRequest
 githubFinishAuthenticationEndpoint cookie (Just authCode) = requireUser cookie $ \sessionUser -> do
   _ <- getGithubAccessToken (view (field @"_id") sessionUser) authCode
   pure $

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -55,6 +55,7 @@ import           Utopia.Web.Types
 import           Utopia.Web.Utils.Files
 import           WaiAppStatic.Storage.Filesystem
 import           WaiAppStatic.Types
+import Network.OAuth.OAuth2
 
 type TagSoupTags = [Tag Text]
 
@@ -638,6 +639,26 @@ saveUserConfigurationEndpoint cookie UserConfigurationRequest{..} = requireUser 
   saveUserConfiguration (view (field @"_id") sessionUser) _shortcutConfig
   return NoContent
 
+githubStartAuthenticationEndpoint :: Maybe Text -> ServerMonad H.Html
+githubStartAuthenticationEndpoint cookie = requireUser cookie $ \_ -> do
+  authURI <- getGithubAuthorizationURI
+  _ <- tempRedirect authURI
+  pure mempty
+
+githubFinishAuthenticationEndpoint :: Maybe Text -> Maybe ExchangeToken -> ServerMonad H.Html
+githubFinishAuthenticationEndpoint _ Nothing = badRequest 
+githubFinishAuthenticationEndpoint cookie (Just authCode) = requireUser cookie $ \sessionUser -> do
+  _ <- getGithubAccessToken (view (field @"_id") sessionUser) authCode
+  pure $
+    H.div $ do
+      H.script ! HA.type_ "text/javascript" $ H.toMarkup ("window.close();" :: Text)
+      H.toMarkup ("Auth Successful" :: Text)
+
+githubAuthenticatedEndpoint :: Maybe Text -> ServerMonad Bool
+githubAuthenticatedEndpoint cookie = requireUser cookie $ \sessionUser -> do
+  possibleAuthDetails <- getGithubAuthentication (view (field @"_id") sessionUser)
+  pure $ isJust possibleAuthDetails
+
 {-|
   Compose together all the individual endpoints into a definition for the whole server.
 -}
@@ -657,6 +678,9 @@ protected authCookie = logoutPage authCookie
                   :<|> saveProjectAssetEndpoint authCookie
                   :<|> saveProjectThumbnailEndpoint authCookie
                   :<|> downloadGithubProjectEndpoint authCookie
+                  :<|> githubStartAuthenticationEndpoint authCookie
+                  :<|> githubFinishAuthenticationEndpoint authCookie
+                  :<|> githubAuthenticatedEndpoint authCookie
 
 unprotected :: ServerT Unprotected ServerMonad
 unprotected = authenticate

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -17,6 +17,7 @@ import           Control.Lens                     hiding ((.=), (<.>))
 import           Control.Monad.Catch              hiding (Handler, catch)
 import           Control.Monad.RWS.Strict
 import           Data.Aeson
+import           Data.Bifoldable
 import qualified Data.ByteString.Lazy             as BL
 import           Data.Conduit.Combinators         hiding (encodeUtf8, foldMap)
 import           Data.Generics.Product
@@ -28,6 +29,7 @@ import           Network.HTTP.Client              hiding (Response)
 import           Network.HTTP.Types.Header
 import           Network.HTTP.Types.Status
 import           Network.Mime
+import           Network.OAuth.OAuth2
 import           Network.Wai
 import qualified Network.Wreq                     as WR
 import           Protolude                        hiding (Handler, concatMap,
@@ -42,10 +44,12 @@ import           System.Log.FastLogger
 import qualified Text.Blaze.Html5                 as H
 import           Utopia.Web.Assets
 import           Utopia.Web.Auth                  (getUserDetailsFromCode)
+import           Utopia.Web.Auth.Github
 import           Utopia.Web.Auth.Session
 import           Utopia.Web.Auth.Types            (Auth0Resources)
 import qualified Utopia.Web.Database              as DB
 import           Utopia.Web.Database.Types
+import           Utopia.Web.Logging
 import           Utopia.Web.Metrics
 import           Utopia.Web.Packager.Locking
 import           Utopia.Web.Packager.NPM
@@ -53,10 +57,6 @@ import           Utopia.Web.ServiceTypes
 import           Utopia.Web.Types
 import           Utopia.Web.Utils.Files
 import           Web.Cookie
-import Network.OAuth.OAuth2
-import  Utopia.Web.Auth.Github
-import Data.Bifoldable
-import Utopia.Web.Logging
 
 
 {-|

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -50,6 +50,8 @@ import           Utopia.Web.ServiceTypes
 import           Utopia.Web.Types
 import           Utopia.Web.Utils.Files
 import           Web.Cookie
+import Utopia.Web.Auth.Github
+import URI.ByteString
 
 {-|
   Any long living resources like database pools live in here.
@@ -63,6 +65,7 @@ data DevServerResources = DevServerResources
                         , _proxyManager          :: Maybe Manager
                         , _auth0Resources        :: Maybe Auth0Resources
                         , _awsResources          :: Maybe AWSResources
+                        , _githubResources       :: Maybe GithubAuthResources
                         , _sessionState          :: SessionState
                         , _storeForMetrics       :: Store
                         , _databaseMetrics       :: DB.DatabaseMetrics
@@ -139,6 +142,8 @@ innerServerExecutor BadRequest = do
   throwError err400
 innerServerExecutor NotAuthenticated = do
   throwError err401
+innerServerExecutor (TempRedirect uri) = do
+  throwError err302 { errHeaders = [("Location", serializeURIRef' uri)]}
 innerServerExecutor NotModified = do
   throwError err304
 innerServerExecutor (CheckAuthCode authCode action) = do
@@ -312,6 +317,28 @@ innerServerExecutor (GetDownloadBranchFolders action) = do
   downloads <- fmap _branchDownloads ask
   folders <- liftIO $ maybe (pure []) getDownloadedLocalFolders downloads
   pure $ action folders
+innerServerExecutor (GetGithubAuthorizationURI action) = do
+  possibleGithubResources <- fmap _githubResources ask
+  case possibleGithubResources of
+    Nothing -> throwError err501
+    Just githubResources -> do
+      let uri = getAuthorizationURI githubResources
+      pure $ action uri
+innerServerExecutor (GetGithubAccessToken user authCode action) = do
+  possibleGithubResources <- fmap _githubResources ask
+  logger <- fmap _logger ask
+  metrics <- fmap _databaseMetrics ask
+  pool <- fmap _projectPool ask
+  case possibleGithubResources of
+    Nothing -> throwError err501
+    Just githubResources -> do
+      result <- getAndHandleGithubAccessToken githubResources logger metrics pool user authCode
+      pure $ action result
+innerServerExecutor (GetGithubAuthentication user action) = do
+  metrics <- fmap _databaseMetrics ask
+  pool <- fmap _projectPool ask
+  result <- liftIO $ DB.lookupGithubAuthenticationDetails metrics pool user 
+  pure $ action result
 
 {-|
   Invokes a service call using the supplied resources.
@@ -365,6 +392,7 @@ initialiseResources = do
   _proxyManager <- if shouldProxy then Just <$> newManager defaultManagerSettings else return Nothing
   _auth0Resources <- getAuth0Environment
   _awsResources <- getAmazonResourcesFromEnvironment
+  _githubResources <- getGithubAuthResources
   _sessionState <- createSessionState _projectPool
   _serverPort <- portFromEnvironment
   _storeForMetrics <- newStore

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -31,8 +31,10 @@ import           Servant
 import           Servant.Client
 import           System.Environment
 import           System.Log.FastLogger
+import           URI.ByteString
 import           Utopia.Web.Assets
 import           Utopia.Web.Auth
+import           Utopia.Web.Auth.Github
 import           Utopia.Web.Auth.Session
 import           Utopia.Web.Auth.Types
 import qualified Utopia.Web.Database            as DB
@@ -50,8 +52,6 @@ import           Utopia.Web.ServiceTypes
 import           Utopia.Web.Types
 import           Utopia.Web.Utils.Files
 import           Web.Cookie
-import Utopia.Web.Auth.Github
-import URI.ByteString
 
 {-|
   Any long living resources like database pools live in here.
@@ -337,7 +337,7 @@ innerServerExecutor (GetGithubAccessToken user authCode action) = do
 innerServerExecutor (GetGithubAuthentication user action) = do
   metrics <- fmap _databaseMetrics ask
   pool <- fmap _projectPool ask
-  result <- liftIO $ DB.lookupGithubAuthenticationDetails metrics pool user 
+  result <- liftIO $ DB.lookupGithubAuthenticationDetails metrics pool user
   pure $ action result
 
 {-|

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -41,6 +41,8 @@ import           Utopia.Web.Packager.NPM
 import           Utopia.Web.ServiceTypes
 import           Utopia.Web.Types
 import           Utopia.Web.Utils.Files
+import Utopia.Web.Auth.Github
+import URI.ByteString
 
 {-|
   Any long living resources like database pools live in here.
@@ -50,6 +52,7 @@ data ProductionServerResources = ProductionServerResources
                                , _projectPool             :: DBPool
                                , _auth0Resources          :: Auth0Resources
                                , _awsResources            :: AWSResources
+                               , _githubResources         :: GithubAuthResources
                                , _sessionState            :: SessionState
                                , _serverPort              :: Int
                                , _storeForMetrics         :: Store
@@ -79,6 +82,8 @@ innerServerExecutor BadRequest = do
   throwError err400
 innerServerExecutor NotAuthenticated = do
   throwError err401
+innerServerExecutor (TempRedirect uri) = do
+  throwError err302 { errHeaders = [("Location", serializeURIRef' uri)]}
 innerServerExecutor NotModified = do
   throwError err304
 innerServerExecutor (CheckAuthCode authCode action) = do
@@ -242,6 +247,22 @@ innerServerExecutor (GetDownloadBranchFolders action) = do
   downloads <- fmap _branchDownloads ask
   folders <- liftIO $ maybe (pure []) getDownloadedLocalFolders downloads
   pure $ action folders
+innerServerExecutor (GetGithubAuthorizationURI action) = do
+  githubResources <- fmap _githubResources ask
+  let uri = getAuthorizationURI githubResources
+  pure $ action uri
+innerServerExecutor (GetGithubAccessToken user authCode action) = do
+  githubResources <- fmap _githubResources ask
+  metrics <- fmap _databaseMetrics ask
+  logger <- fmap _logger ask
+  pool <- fmap _projectPool ask
+  result <- getAndHandleGithubAccessToken githubResources logger metrics pool user authCode
+  pure $ action result
+innerServerExecutor (GetGithubAuthentication user action) = do
+  metrics <- fmap _databaseMetrics ask
+  pool <- fmap _projectPool ask
+  result <- liftIO $ DB.lookupGithubAuthenticationDetails metrics pool user 
+  pure $ action result
 
 readEditorContentFromDisk :: Maybe BranchDownloads -> Maybe Text -> Text -> IO Text
 readEditorContentFromDisk (Just downloads) (Just branchName) fileName = do
@@ -278,9 +299,11 @@ initialiseResources = do
   _commitHash <- toS <$> getEnv "UTOPIA_SHA"
   _projectPool <- DB.createDatabasePoolFromEnvironment
   maybeAuth0Resources <- getAuth0Environment
-  _auth0Resources <- maybe (panic "No Auth0 environment configured") return maybeAuth0Resources
+  _auth0Resources <- maybe (panic "No Auth0 environment configured.") pure maybeAuth0Resources
   maybeAws <- getAmazonResourcesFromEnvironment
-  _awsResources <- maybe (panic "No AWS environment configured") return maybeAws
+  _awsResources <- maybe (panic "No AWS environment configured.") pure maybeAws
+  maybeGithubAuthResources <- getGithubAuthResources
+  _githubResources <- maybe (panic "No Github resources configured.") pure maybeGithubAuthResources
   _sessionState <- createSessionState _projectPool
   _serverPort <- portFromEnvironment
   _storeForMetrics <- newStore

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -23,8 +23,10 @@ import           Protolude                      hiding (Handler)
 import           Servant
 import           System.Environment
 import           System.Log.FastLogger
+import           URI.ByteString
 import           Utopia.Web.Assets
 import           Utopia.Web.Auth
+import           Utopia.Web.Auth.Github
 import           Utopia.Web.Auth.Session
 import           Utopia.Web.Auth.Types
 import qualified Utopia.Web.Database            as DB
@@ -41,8 +43,6 @@ import           Utopia.Web.Packager.NPM
 import           Utopia.Web.ServiceTypes
 import           Utopia.Web.Types
 import           Utopia.Web.Utils.Files
-import Utopia.Web.Auth.Github
-import URI.ByteString
 
 {-|
   Any long living resources like database pools live in here.
@@ -261,7 +261,7 @@ innerServerExecutor (GetGithubAccessToken user authCode action) = do
 innerServerExecutor (GetGithubAuthentication user action) = do
   metrics <- fmap _databaseMetrics ask
   pool <- fmap _projectPool ask
-  result <- liftIO $ DB.lookupGithubAuthenticationDetails metrics pool user 
+  result <- liftIO $ DB.lookupGithubAuthenticationDetails metrics pool user
   pure $ action result
 
 readEditorContentFromDisk :: Maybe BranchDownloads -> Maybe Text -> Text -> IO Text

--- a/server/src/Utopia/Web/Servant.hs
+++ b/server/src/Utopia/Web/Servant.hs
@@ -24,11 +24,11 @@ import qualified Data.Text                as T
 import           Data.Time.Clock
 import           Data.Time.Format
 import           Network.HTTP.Media       hiding (Accept)
+import           Network.OAuth.OAuth2
 import           Prelude                  (String)
 import           Protolude
 import           Servant.API
 import           Servant.HTML.Blaze
-import Network.OAuth.OAuth2
 
 data BMP
 

--- a/server/src/Utopia/Web/Servant.hs
+++ b/server/src/Utopia/Web/Servant.hs
@@ -28,6 +28,7 @@ import           Prelude                  (String)
 import           Protolude
 import           Servant.API
 import           Servant.HTML.Blaze
+import Network.OAuth.OAuth2
 
 data BMP
 
@@ -144,3 +145,6 @@ instance FromHttpApiData ProjectIdWithSuffix where
 
 instance ToHttpApiData ProjectIdWithSuffix where
   toUrlPiece (ProjectIdWithSuffix projectId projectSuffix) = projectId <> (if T.null projectSuffix then T.empty else "-" <> projectSuffix)
+
+instance FromHttpApiData ExchangeToken where
+  parseUrlPiece toParse = fmap ExchangeToken $ parseUrlPiece toParse

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -24,15 +24,15 @@ import qualified Data.ByteString.Lazy      as BL
 import           Data.Generics.Product
 import           Data.Time
 import           Network.HTTP.Client       hiding (Cookie)
+import           Network.OAuth.OAuth2
 import           Protolude
-import           Servant hiding (URI)
+import           Servant                   hiding (URI)
 import qualified Text.Blaze.Html5          as H
+import           URI.ByteString
 import           Utopia.Web.Assets
 import           Utopia.Web.Database.Types
 import           Utopia.Web.JSON
 import           Web.Cookie
-import Network.OAuth.OAuth2
-import URI.ByteString
 
 type SessionCookie = Text
 

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -25,12 +25,14 @@ import           Data.Generics.Product
 import           Data.Time
 import           Network.HTTP.Client       hiding (Cookie)
 import           Protolude
-import           Servant
+import           Servant hiding (URI)
 import qualified Text.Blaze.Html5          as H
 import           Utopia.Web.Assets
 import           Utopia.Web.Database.Types
 import           Utopia.Web.JSON
 import           Web.Cookie
+import Network.OAuth.OAuth2
+import URI.ByteString
 
 type SessionCookie = Text
 
@@ -90,6 +92,7 @@ data ServiceCallsF a = NotFound
                      | BadRequest
                      | NotAuthenticated
                      | NotModified
+                     | TempRedirect URI
                      | CheckAuthCode Text (Maybe SetCookie -> a)
                      | Logout Text H.Html (SetSessionCookies H.Html -> a)
                      | ValidateAuth Text (Maybe SessionUser -> a)
@@ -127,6 +130,9 @@ data ServiceCallsF a = NotFound
                      | SaveUserConfiguration Text (Maybe Value) a
                      | ClearBranchCache Text a
                      | GetDownloadBranchFolders ([FilePath] -> a)
+                     | GetGithubAuthorizationURI (URI -> a)
+                     | GetGithubAccessToken Text ExchangeToken (Maybe OAuth2Token -> a)
+                     | GetGithubAuthentication Text (Maybe GithubAuthenticationDetails -> a)
                      deriving Functor
 
 {-

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -23,6 +23,7 @@ import qualified Text.Blaze.Html5        as H
 import           Utopia.Web.JSON
 import           Utopia.Web.Servant
 import           Utopia.Web.ServiceTypes
+import Network.OAuth.OAuth2
 
 {-
   'deriveJSON' as used here creates 'Data.Aeson.FromJSON' and 'Data.Aeson.ToJSON' instances
@@ -116,7 +117,13 @@ type LoadProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" Proje
 
 type SaveProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" ProjectIdWithSuffix :> ReqBody '[BMP, GIF, JPG, PNG, SVG] BL.ByteString :> Post '[JSON] NoContent
 
-type DownloadGithubProjectAPI = "v1" :> "github" :> Capture "owner" Text :> Capture "project" Text :> Get '[ZIP] BL.ByteString
+type DownloadGithubProjectAPI = "v1" :> "github" :> "import" :> Capture "owner" Text :> Capture "project" Text :> Get '[ZIP] BL.ByteString
+
+type GithubAuthenticatedAPI = "v1" :> "github" :> "authentication" :> "status" :> Get '[JSON] Bool
+
+type GithubStartAuthenticationAPI = "v1" :> "github" :> "authentication" :> "start" :> Get '[HTML] H.Html 
+
+type GithubFinishAuthenticationAPI = "v1" :> "github" :> "authentication" :> "finish" :> QueryParam "code" ExchangeToken :> Get '[HTML] H.Html
 
 type PackagePackagerResponse = Headers '[Header "Cache-Control" Text, Header "Last-Modified" LastModifiedTime, Header "Access-Control-Allow-Origin" Text] (ConduitT () ByteString (ResourceT IO) ())
 
@@ -167,6 +174,9 @@ type Protected = LogoutAPI
             :<|> SaveProjectAssetAPI
             :<|> SaveProjectThumbnailAPI
             :<|> DownloadGithubProjectAPI
+            :<|> GithubStartAuthenticationAPI
+            :<|> GithubFinishAuthenticationAPI
+            :<|> GithubAuthenticatedAPI
 
 type Unprotected = AuthenticateAPI H.Html
               :<|> EmptyProjectPageAPI

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -15,6 +15,7 @@ import           Data.Aeson
 import           Data.Aeson.TH
 import qualified Data.ByteString.Lazy    as BL
 import           Data.Time
+import           Network.OAuth.OAuth2
 import           Protolude
 import           Servant
 import           Servant.HTML.Blaze
@@ -23,7 +24,6 @@ import qualified Text.Blaze.Html5        as H
 import           Utopia.Web.JSON
 import           Utopia.Web.Servant
 import           Utopia.Web.ServiceTypes
-import Network.OAuth.OAuth2
 
 {-
   'deriveJSON' as used here creates 'Data.Aeson.FromJSON' and 'Data.Aeson.ToJSON' instances
@@ -123,7 +123,7 @@ type DownloadGithubProjectAPI = "v1" :> "github" :> "import" :> Capture "owner" 
 
 type GithubAuthenticatedAPI = "v1" :> "github" :> "authentication" :> "status" :> Get '[JSON] Bool
 
-type GithubStartAuthenticationAPI = "v1" :> "github" :> "authentication" :> "start" :> Get '[HTML] H.Html 
+type GithubStartAuthenticationAPI = "v1" :> "github" :> "authentication" :> "start" :> Get '[HTML] H.Html
 
 type GithubFinishAuthenticationAPI = "v1" :> "github" :> "authentication" :> "finish" :> QueryParam "code" ExchangeToken :> Get '[HTML] H.Html
 

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -28,6 +28,7 @@ executable utopia-web
   other-modules:
       Utopia.Web.Assets
       Utopia.Web.Auth
+      Utopia.Web.Auth.Github
       Utopia.Web.Auth.Session
       Utopia.Web.Auth.Types
       Utopia.Web.Database
@@ -84,6 +85,7 @@ executable utopia-web
     , filepath
     , free
     , generic-lens
+    , hoauth2
     , http-api-data
     , http-client
     , http-client-tls
@@ -129,6 +131,7 @@ executable utopia-web
     , transformers
     , unix
     , unordered-containers
+    , uri-bytestring
     , utopia-clientmodel
     , uuid
     , vector
@@ -153,6 +156,7 @@ test-suite utopia-web-test
       Main
       Utopia.Web.Assets
       Utopia.Web.Auth
+      Utopia.Web.Auth.Github
       Utopia.Web.Auth.Session
       Utopia.Web.Auth.Types
       Utopia.Web.Database
@@ -211,6 +215,7 @@ test-suite utopia-web-test
     , free
     , generic-lens
     , hedgehog
+    , hoauth2
     , hspec
     , http-api-data
     , http-client
@@ -264,6 +269,7 @@ test-suite utopia-web-test
     , transformers
     , unix
     , unordered-containers
+    , uri-bytestring
     , utopia-clientmodel
     , uuid
     , vector


### PR DESCRIPTION
**Problem:**
As a first step towards having proper Github integration, it is required for the editor to obtain an OAuth access token so that requests can be made against the Github API.

**Changes:**
The somewhat stock OAuth flow for Github has been implemented from a triggering button in the Github side pane is the headline change. This has consisted of adding some storage for the access tokens in the database and maintenance thereof in the backend, and a handful of endpoints for starting and finishing the authentication flow as well as another for checking the authentication status.

**Commit Details:**
- Added `SetGithubState` action with the appropriate action creator function.
- Moved the Github import endpoint to live under `/github/import` to free up the `/github` path for more endpoints.
- Added handler for `SetGithubState` to `processAction`.
- Added `GithubState` to `UserState` in the field `githubState`.
- Added both an indicator of Github authentication and a triggering button to `GithubPane`.
- During startup of the editor, `isAuthenticatedWithGithub` is invoked as part of the chain of similar checks to see if the user has already authenticated with Github.
- Frontend utility functions for handling the various calls necessary implemented in `github-auth.ts`.
- Added a database migration that adds the `github_authentication` table.
- Added `hoauth2` and `uri-bytestring` dependencies to the server.
- Added `Utopia.Web.Auth.Github` module which covers the acquisition of the various environment variables and the calls necessary to obtain the access token.
- Added `updatedGithubAuthenticationDetails` and `lookupGithubAuthenticationDetails` to the database layer for saving and loading the authentication details respectively.
- Added endpoints for starting and finishing the authentication flow as well as another that returns the authentication state.
- Added the `TempRedirect` service type that triggers a 302 targeting a URL.
- Added the `GetGithubAuthorizationURI` service type that gets the URL for the start of the authentication flow.
- Added the `GetGithubAccessToken` service type that handles the receipt of the auth code and then retrieval of the access token.
- Added the `GetGithubAuthentication` service type that does a lookup of the authentication details that a user may have obtained previously.
