### PR TITLE
Click to insert as a strategy

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
@@ -19,6 +19,7 @@ import { pickCanvasStateFromEditorState } from './canvas-strategies'
 import {
   CanvasStrategy,
   getTargetPathsFromInteractionTarget,
+  InteractionLifecycle,
   strategyApplicationResult,
 } from './canvas-strategy-types'
 import { InteractionSession, StrategyState } from './interaction-state'
@@ -149,8 +150,8 @@ function runMoveStrategyForFreshlyDuplicatedElements(
   editorState: EditorState,
   strategyState: StrategyState,
   interactionState: InteractionSession,
-  commandLifecycle: 'mid-interaction' | 'end-interaction',
-  strategyLifecycle: 'mid-interaction' | 'end-interaction',
+  commandLifecycle: InteractionLifecycle,
+  strategyLifecycle: InteractionLifecycle,
 ): Array<EditorStatePatch> {
   const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
 

--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
@@ -81,7 +81,7 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
     }
     return 0
   },
-  apply: (canvasState, interactionState, strategyState, lifecycle) => {
+  apply: (canvasState, interactionState, strategyState, strategyLifecycle) => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     if (
       interactionState.interactionData.type === 'DRAG' &&
@@ -129,7 +129,7 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
               },
               interactionState,
               commandLifecycle,
-              lifecycle,
+              strategyLifecycle,
             ),
           ),
           setCursorCommand('mid-interaction', CSSCursor.Duplicate),

--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
@@ -80,7 +80,7 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
     }
     return 0
   },
-  apply: (canvasState, interactionState, strategyState) => {
+  apply: (canvasState, interactionState, strategyState, lifecycle) => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     if (
       interactionState.interactionData.type === 'DRAG' &&
@@ -118,7 +118,7 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
           ...duplicateCommands,
           setElementsToRerenderCommand([...selectedElements, ...newPaths]),
           updateSelectedViews('always', newPaths),
-          updateFunctionCommand('always', (editorState, lifecycle) =>
+          updateFunctionCommand('always', (editorState, commandLifecycle) =>
             runMoveStrategyForFreshlyDuplicatedElements(
               canvasState.builtInDependencies,
               editorState,
@@ -127,6 +127,7 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
                 startingMetadata: withDuplicatedMetadata,
               },
               interactionState,
+              commandLifecycle,
               lifecycle,
             ),
           ),
@@ -149,6 +150,7 @@ function runMoveStrategyForFreshlyDuplicatedElements(
   strategyState: StrategyState,
   interactionState: InteractionSession,
   commandLifecycle: 'mid-interaction' | 'end-interaction',
+  strategyLifecycle: 'mid-interaction' | 'end-interaction',
 ): Array<EditorStatePatch> {
   const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
 
@@ -156,6 +158,7 @@ function runMoveStrategyForFreshlyDuplicatedElements(
     canvasState,
     interactionState,
     strategyState,
+    strategyLifecycle,
   ).commands
 
   return foldAndApplyCommandsInner(editorState, [], [], moveCommands, commandLifecycle).statePatches

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -126,6 +126,7 @@ function dragByPixels(
       startingAllElementProps: {},
       customStrategyState: defaultCustomStrategyState(),
     } as StrategyState,
+    'end-interaction',
   )
 
   expect(strategyResult.customStatePatch).toEqual({})

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
@@ -138,6 +138,7 @@ function reparentElement(
       startingAllElementProps: {},
       customStrategyState: defaultCustomStrategyState(),
     } as StrategyState,
+    'end-interaction',
   )
 
   expect(strategyResult.customStatePatch).toEqual({})

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
@@ -87,6 +87,7 @@ function dragByPixels(
       startingAllElementProps: {},
       customStrategyState: defaultCustomStrategyState(),
     } as StrategyState,
+    'end-interaction',
   )
 
   expect(strategyResult.customStatePatch).toEqual({})

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -203,6 +203,7 @@ function reparentElement(
       startingAllElementProps: {},
       customStrategyState: defaultCustomStrategyState(),
     } as StrategyState,
+    'end-interaction',
   )
 
   expect(strategyResult.customStatePatch).toEqual({})

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -76,7 +76,7 @@ function getAbsoluteReparentStrategy(
         missingBoundsHandling,
       )
     },
-    apply: (canvasState, interactionState, strategyState, lifecycle) => {
+    apply: (canvasState, interactionState, strategyState, strategyLifecycle) => {
       const { interactionTarget, projectContents, openFile, nodeModules } = canvasState
       const selectedElements = getTargetPathsFromInteractionTarget(interactionTarget)
       const filteredSelectedElements = getDragTargets(selectedElements)
@@ -161,7 +161,7 @@ function getAbsoluteReparentStrategy(
               updatedTargetPaths: updatedTargetPaths,
             },
             strategyState,
-            lifecycle,
+            strategyLifecycle,
           )
 
           return strategyApplicationResult([
@@ -176,7 +176,7 @@ function getAbsoluteReparentStrategy(
             canvasState,
             interactionState,
             strategyState,
-            lifecycle,
+            strategyLifecycle,
           )
 
           return strategyApplicationResult(moveCommands.commands)

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -76,7 +76,7 @@ function getAbsoluteReparentStrategy(
         missingBoundsHandling,
       )
     },
-    apply: (canvasState, interactionState, strategyState) => {
+    apply: (canvasState, interactionState, strategyState, lifecycle) => {
       const { interactionTarget, projectContents, openFile, nodeModules } = canvasState
       const selectedElements = getTargetPathsFromInteractionTarget(interactionTarget)
       const filteredSelectedElements = getDragTargets(selectedElements)
@@ -161,6 +161,7 @@ function getAbsoluteReparentStrategy(
               updatedTargetPaths: updatedTargetPaths,
             },
             strategyState,
+            lifecycle,
           )
 
           return strategyApplicationResult([
@@ -175,6 +176,7 @@ function getAbsoluteReparentStrategy(
             canvasState,
             interactionState,
             strategyState,
+            lifecycle,
           )
 
           return strategyApplicationResult(moveCommands.commands)

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -67,6 +67,7 @@ function multiselectResizeElements(
       startingMetadata: metadata,
       customStrategyState: defaultCustomStrategyState(),
     } as StrategyState,
+    'end-interaction',
   )
 
   expect(strategyResult.customStatePatch).toEqual({})

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -248,8 +248,9 @@ export function applyCanvasStrategy(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession,
   strategyState: StrategyState,
+  lifecycle?: 'mid-interaction' | 'end-interaction',
 ): StrategyApplicationResult {
-  return strategy.apply(canvasState, interactionSession, strategyState)
+  return strategy.apply(canvasState, interactionSession, strategyState, lifecycle)
 }
 
 export function useDelayedEditorState<T>(

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -20,6 +20,7 @@ import {
   InteractionTarget,
   targetPaths,
   StrategyApplicationResult,
+  InteractionLifecycle,
 } from './canvas-strategy-types'
 import { InteractionSession, StrategyState } from './interaction-state'
 import { keyboardAbsoluteMoveStrategy } from './keyboard-absolute-move-strategy'
@@ -260,7 +261,7 @@ export function applyCanvasStrategy(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession,
   strategyState: StrategyState,
-  lifecycle: 'mid-interaction' | 'end-interaction',
+  lifecycle: InteractionLifecycle,
 ): StrategyApplicationResult {
   return strategy.apply(canvasState, interactionSession, strategyState, lifecycle)
 }

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -261,9 +261,9 @@ export function applyCanvasStrategy(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession,
   strategyState: StrategyState,
-  lifecycle: InteractionLifecycle,
+  strategyLifecycle: InteractionLifecycle,
 ): StrategyApplicationResult {
-  return strategy.apply(canvasState, interactionSession, strategyState, lifecycle)
+  return strategy.apply(canvasState, interactionSession, strategyState, strategyLifecycle)
 }
 
 export function useDelayedEditorState<T>(

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -260,7 +260,7 @@ export function applyCanvasStrategy(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession,
   strategyState: StrategyState,
-  lifecycle?: 'mid-interaction' | 'end-interaction',
+  lifecycle: 'mid-interaction' | 'end-interaction',
 ): StrategyApplicationResult {
   return strategy.apply(canvasState, interactionSession, strategyState, lifecycle)
 }

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -160,6 +160,7 @@ export interface CanvasStrategy {
     canvasState: InteractionCanvasState,
     interactionSession: InteractionSession,
     strategyState: StrategyState,
+    lifecycle?: 'mid-interaction' | 'end-interaction',
   ) => StrategyApplicationResult
 }
 

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -133,6 +133,8 @@ export type CanvasStrategyId =
   | 'DRAW_TO_INSERT'
   | 'FLEX_RESIZE_BASIC'
 
+export type InteractionLifecycle = 'mid-interaction' | 'end-interaction'
+
 export interface CanvasStrategy {
   id: CanvasStrategyId // We'd need to do something to guarantee uniqueness here if using this for the commands' reason
 
@@ -165,7 +167,7 @@ export interface CanvasStrategy {
     canvasState: InteractionCanvasState,
     interactionSession: InteractionSession,
     strategyState: StrategyState,
-    lifecycle: 'mid-interaction' | 'end-interaction',
+    lifecycle: InteractionLifecycle,
   ) => StrategyApplicationResult
 }
 

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -167,7 +167,7 @@ export interface CanvasStrategy {
     canvasState: InteractionCanvasState,
     interactionSession: InteractionSession,
     strategyState: StrategyState,
-    lifecycle: InteractionLifecycle,
+    strategyLifecycle: InteractionLifecycle,
   ) => StrategyApplicationResult
 }
 

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -165,7 +165,7 @@ export interface CanvasStrategy {
     canvasState: InteractionCanvasState,
     interactionSession: InteractionSession,
     strategyState: StrategyState,
-    lifecycle?: 'mid-interaction' | 'end-interaction',
+    lifecycle: 'mid-interaction' | 'end-interaction',
   ) => StrategyApplicationResult
 }
 

--- a/editor/src/components/canvas/canvas-strategies/convert-to-absolute-and-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/convert-to-absolute-and-move-strategy.spec.tsx
@@ -194,6 +194,7 @@ function dragByPixels(
         escapeHatchActivated: true,
       },
     } as StrategyState,
+    'end-interaction',
   )
 
   const finalEditor = foldAndApplyCommands(

--- a/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
@@ -83,7 +83,7 @@ export const dragToInsertStrategy: CanvasStrategy = {
       ? 1
       : 0
   },
-  apply: (canvasState, interactionState, strategyState, lifecycle) => {
+  apply: (canvasState, interactionState, strategyState, strategyLifecycle) => {
     const insertionSubjects = getInsertionSubjectsFromInteractionTarget(
       canvasState.interactionTarget,
     )
@@ -105,7 +105,7 @@ export const dragToInsertStrategy: CanvasStrategy = {
             interactionState,
             transient,
             insertionCommands,
-            lifecycle,
+            strategyLifecycle,
           )
         },
       )

--- a/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
@@ -82,7 +82,7 @@ export const dragToInsertStrategy: CanvasStrategy = {
       ? 1
       : 0
   },
-  apply: (canvasState, interactionState, strategyState) => {
+  apply: (canvasState, interactionState, strategyState, lifecycle) => {
     const insertionSubjects = getInsertionSubjectsFromInteractionTarget(
       canvasState.interactionTarget,
     )
@@ -104,6 +104,7 @@ export const dragToInsertStrategy: CanvasStrategy = {
             interactionState,
             transient,
             insertionCommands,
+            lifecycle,
           )
         },
       )
@@ -196,6 +197,7 @@ function runTargetStrategiesForFreshlyInsertedElement(
   interactionState: InteractionSession,
   commandLifecycle: 'mid-interaction' | 'end-interaction',
   insertionSubjects: Array<{ command: InsertElementInsertionSubject; frame: CanvasRectangle }>,
+  strategyLifeCycle: 'mid-interaction' | 'end-interaction',
 ): Array<EditorStatePatch> {
   const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
 
@@ -264,6 +266,7 @@ function runTargetStrategiesForFreshlyInsertedElement(
       patchedCanvasState,
       interactionState,
       patchedStrategyState,
+      strategyLifeCycle,
     ).commands
 
     return foldAndApplyCommandsInner(editorState, [], [], reparentCommands, commandLifecycle)

--- a/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
@@ -5,6 +5,7 @@ import {
   emptyStrategyApplicationResult,
   getInsertionSubjectsFromInteractionTarget,
   InteractionCanvasState,
+  InteractionLifecycle,
   strategyApplicationResult,
   targetPaths,
 } from './canvas-strategy-types'
@@ -195,9 +196,9 @@ function runTargetStrategiesForFreshlyInsertedElement(
   editorState: EditorState,
   strategyState: StrategyState,
   interactionState: InteractionSession,
-  commandLifecycle: 'mid-interaction' | 'end-interaction',
+  commandLifecycle: InteractionLifecycle,
   insertionSubjects: Array<{ command: InsertElementInsertionSubject; frame: CanvasRectangle }>,
-  strategyLifeCycle: 'mid-interaction' | 'end-interaction',
+  strategyLifeCycle: InteractionLifecycle,
 ): Array<EditorStatePatch> {
   const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
 

--- a/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -81,6 +81,16 @@ async function fireClickEvent(canvasControlsLayer: HTMLElement, point: WindowPoi
         clientY: point.y,
       }),
     )
+
+    fireEvent(
+      canvasControlsLayer,
+      new MouseEvent('mouseclick', {
+        bubbles: true,
+        cancelable: true,
+        clientX: point.x,
+        clientY: point.y,
+      }),
+    )
   })
 }
 

--- a/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -9,7 +9,6 @@ import {
   getPrintedUiJsCode,
 } from '../ui-jsx.test-utils'
 import { CanvasControlsContainerID } from '../controls/new-canvas-controls'
-import { wait } from '../../../utils/utils.test-utils'
 
 function slightlyOffsetWindowPointBecauseVeryWeirdIssue(point: {
   x: number

--- a/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -191,6 +191,74 @@ describe('Inserting into absolute', () => {
     )
   })
 
+  it('Click to insert with default size', async () => {
+    const renderResult = await renderTestEditorWithCode(inputCode, 'await-first-dom-report')
+    await startInsertMode(renderResult.dispatch)
+
+    const targetElement = renderResult.renderedDOM.getByTestId('bbb')
+    const targetElementBounds = targetElement.getBoundingClientRect()
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    const startPoint = slightlyOffsetWindowPointBecauseVeryWeirdIssue({
+      x: targetElementBounds.x + 65,
+      y: targetElementBounds.y + 55,
+    })
+    const endPoint = startPoint
+
+    // Drag from inside bbb to inside ccc
+    await fireDragEvent(canvasControlsLayer, startPoint, endPoint)
+    await wait(1000000000)
+    // Check that the inserted element is a child of bbb
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          data-uid='aaa'
+          style={{
+            width: '100%',
+            height: '100%',
+            backgroundColor: '#FFFFFF',
+            position: 'relative',
+          }}
+        >
+          <div
+            data-uid='bbb'
+            data-testid='bbb'
+            style={{
+              position: 'absolute',
+              left: 10,
+              top: 10,
+              width: 380,
+              height: 180,
+              backgroundColor: '#d3d3d3',
+            }}
+          >
+            <div
+              data-uid='ddd'
+              style={{
+                position: 'absolute',
+                left: 15,
+                top: 5,
+                width: 100,
+                height: 100,
+              }}
+            />
+          </div>
+          <div
+            data-uid='ccc'
+            style={{
+              position: 'absolute',
+              left: 10,
+              top: 200,
+              width: 380,
+              height: 190,
+              backgroundColor: '#FF0000',
+            }}
+          />
+        </div>
+      `),
+    )
+  })
+
   it('Should not clear the intended target when dragging to insert past the scene boundary', async () => {
     const renderResult = await renderTestEditorWithCode(inputCode, 'await-first-dom-report')
     await startInsertMode(renderResult.dispatch)

--- a/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -519,8 +519,8 @@ describe('Inserting into flex row', () => {
             data-testid='bbb'
             style={{
               position: 'relative',
-              width: 100,
-              height: 100,
+              width: 180,
+              height: 180,
               backgroundColor: '#d3d3d3',
             }}
           /> 
@@ -1222,8 +1222,8 @@ describe('Inserting into flex column', () => {
             data-uid='ddd'
             style={{
               position: 'relative',
-              width: 100,
-              height: 100,
+              width: 300,
+              height: 20,
             }}
           />
           <div

--- a/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -510,8 +510,8 @@ describe('Inserting into flex row', () => {
             data-uid='ddd'
             style={{
               position: 'relative',
-              width: 20,
-              height: 300,
+              width: 100,
+              height: 100,
             }}
           />
           <div
@@ -1222,8 +1222,8 @@ describe('Inserting into flex column', () => {
             data-uid='ddd'
             style={{
               position: 'relative',
-              width: 300,
-              height: 20,
+              width: 100,
+              height: 100,
             }}
           />
           <div

--- a/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -9,6 +9,7 @@ import {
   getPrintedUiJsCode,
 } from '../ui-jsx.test-utils'
 import { CanvasControlsContainerID } from '../controls/new-canvas-controls'
+import * as EP from '../../../core/shared/element-path'
 
 function slightlyOffsetWindowPointBecauseVeryWeirdIssue(point: {
   x: number
@@ -17,6 +18,21 @@ function slightlyOffsetWindowPointBecauseVeryWeirdIssue(point: {
   // FIXME when running in headless chrome, the result of getBoundingClientRect will be slightly
   // offset for some unknown reason, meaning the inserted element will be 1 pixel of in each dimension
   return windowPoint({ x: point.x - 0.001, y: point.y - 0.001 })
+}
+
+async function fireMoveEvent(canvasControlsLayer: HTMLElement, point: WindowPoint) {
+  await act(async () => {
+    fireEvent(
+      canvasControlsLayer,
+      new MouseEvent('mousemove', {
+        bubbles: true,
+        cancelable: true,
+        clientX: point.x,
+        clientY: point.y,
+        buttons: 1,
+      }),
+    )
+  })
 }
 
 async function fireDragEvent(
@@ -170,6 +186,12 @@ describe('Inserting into absolute', () => {
       x: targetElementBounds.x + 25,
       y: targetElementBounds.y + 305,
     })
+
+    // Move before starting dragging
+    await fireMoveEvent(canvasControlsLayer, startPoint)
+
+    // Highlight should drag the candidate parent
+    expect(renderResult.getEditorState().editor.highlightedViews.map(EP.toUid)).toEqual(['bbb'])
 
     // Drag from inside bbb to inside ccc
     await fireDragEvent(canvasControlsLayer, startPoint, endPoint)

--- a/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.tsx
@@ -83,7 +83,7 @@ export const drawToInsertStrategy: CanvasStrategy = {
       ? 1
       : 0
   },
-  apply: (canvasState, interactionState, strategyState, lifecycle) => {
+  apply: (canvasState, interactionState, strategyState, strategyLifecycle) => {
     if (
       canvasState.interactionTarget.type === 'INSERTION_SUBJECTS' &&
       canvasState.interactionTarget.subjects.length === 1 &&
@@ -110,7 +110,7 @@ export const drawToInsertStrategy: CanvasStrategy = {
                 interactionState,
                 insertionSubject,
                 insertionCommand.frame,
-                lifecycle,
+                strategyLifecycle,
               )
             },
           )
@@ -126,7 +126,7 @@ export const drawToInsertStrategy: CanvasStrategy = {
                 commandLifecycle,
                 insertionSubject,
                 insertionCommand.frame,
-                lifecycle,
+                strategyLifecycle,
               )
             },
           )
@@ -137,7 +137,7 @@ export const drawToInsertStrategy: CanvasStrategy = {
             resizeCommand,
           ])
         }
-      } else if (lifecycle === 'end-interaction') {
+      } else if (strategyLifecycle === 'end-interaction') {
         const insertionSubject = canvasState.interactionTarget.subjects[0]
 
         const insertionCommand = getInsertionCommands(
@@ -157,7 +157,7 @@ export const drawToInsertStrategy: CanvasStrategy = {
                 interactionState,
                 insertionSubject,
                 insertionCommand.frame,
-                lifecycle,
+                strategyLifecycle,
               )
             },
           )

--- a/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.tsx
@@ -5,6 +5,7 @@ import {
   emptyStrategyApplicationResult,
   getInsertionSubjectsFromInteractionTarget,
   InteractionCanvasState,
+  InteractionLifecycle,
   strategyApplicationResult,
   targetPaths,
 } from './canvas-strategy-types'
@@ -252,7 +253,7 @@ function runTargetStrategiesForFreshlyInsertedElementToReparent(
   interactionState: InteractionSession,
   insertionSubject: ElementInsertionSubject,
   frame: CanvasRectangle,
-  strategyLifecycle: 'mid-interaction' | 'end-interaction',
+  strategyLifecycle: InteractionLifecycle,
 ): Array<EditorStatePatch> {
   const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
 
@@ -328,10 +329,10 @@ function runTargetStrategiesForFreshlyInsertedElementToResize(
   editorState: EditorState,
   strategyState: StrategyState,
   interactionState: InteractionSession,
-  commandLifecycle: 'mid-interaction' | 'end-interaction',
+  commandLifecycle: InteractionLifecycle,
   insertionSubject: ElementInsertionSubject,
   frame: CanvasRectangle,
-  strategyLifecycle: 'mid-interaction' | 'end-interaction',
+  strategyLifecycle: InteractionLifecycle,
 ): Array<EditorStatePatch> {
   const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
 

--- a/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.tsx
@@ -109,6 +109,7 @@ export const drawToInsertStrategy: CanvasStrategy = {
                 interactionState,
                 insertionSubject,
                 insertionCommand.frame,
+                lifecycle,
               )
             },
           )
@@ -124,6 +125,7 @@ export const drawToInsertStrategy: CanvasStrategy = {
                 commandLifecycle,
                 insertionSubject,
                 insertionCommand.frame,
+                lifecycle,
               )
             },
           )
@@ -154,6 +156,7 @@ export const drawToInsertStrategy: CanvasStrategy = {
                 interactionState,
                 insertionSubject,
                 insertionCommand.frame,
+                lifecycle,
               )
             },
           )
@@ -249,6 +252,7 @@ function runTargetStrategiesForFreshlyInsertedElementToReparent(
   interactionState: InteractionSession,
   insertionSubject: ElementInsertionSubject,
   frame: CanvasRectangle,
+  strategyLifecycle: 'mid-interaction' | 'end-interaction',
 ): Array<EditorStatePatch> {
   const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
 
@@ -312,6 +316,7 @@ function runTargetStrategiesForFreshlyInsertedElementToReparent(
     patchedCanvasState,
     patchedInteractionState,
     patchedStrategyState,
+    strategyLifecycle,
   ).commands
 
   return foldAndApplyCommandsInner(editorState, [], [], reparentCommands, 'end-interaction') // TODO HACK-HACK 'end-interaction' is here so it is not just the reorder indicator which is rendered
@@ -326,6 +331,7 @@ function runTargetStrategiesForFreshlyInsertedElementToResize(
   commandLifecycle: 'mid-interaction' | 'end-interaction',
   insertionSubject: ElementInsertionSubject,
   frame: CanvasRectangle,
+  strategyLifecycle: 'mid-interaction' | 'end-interaction',
 ): Array<EditorStatePatch> {
   const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
 
@@ -364,8 +370,12 @@ function runTargetStrategiesForFreshlyInsertedElementToResize(
 
   const resizeCommands =
     resizeStrategy != null
-      ? resizeStrategy.strategy.apply(patchedCanvasState, interactionState, patchedStrategyState)
-          .commands
+      ? resizeStrategy.strategy.apply(
+          patchedCanvasState,
+          interactionState,
+          patchedStrategyState,
+          strategyLifecycle,
+        ).commands
       : []
 
   return foldAndApplyCommandsInner(editorState, [], [], resizeCommands, commandLifecycle)

--- a/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.tsx
@@ -82,49 +82,56 @@ export const drawToInsertStrategy: CanvasStrategy = {
       ? 1
       : 0
   },
-  apply: (canvasState, interactionState, strategyState) => {
+  apply: (canvasState, interactionState, strategyState, lifecycle) => {
     if (
       canvasState.interactionTarget.type === 'INSERTION_SUBJECTS' &&
       canvasState.interactionTarget.subjects.length === 1 &&
       canvasState.interactionTarget.subjects[0].type === 'Element' &&
-      interactionState.interactionData.type === 'DRAG' &&
-      interactionState.interactionData.drag != null
+      interactionState.interactionData.type === 'DRAG'
     ) {
-      const insertionSubject = canvasState.interactionTarget.subjects[0]
+      if (interactionState.interactionData.drag != null) {
+        const insertionSubject = canvasState.interactionTarget.subjects[0]
 
-      const insertionCommand = getInsertionCommands(insertionSubject, interactionState, null)
+        const insertionCommand = getInsertionCommands(insertionSubject, interactionState, null)
 
-      if (insertionCommand != null) {
-        const reparentCommand = updateFunctionCommand(
-          'always',
-          (editorState): Array<EditorStatePatch> => {
-            return runTargetStrategiesForFreshlyInsertedElementToReparent(
-              canvasState.builtInDependencies,
-              editorState,
-              strategyState,
-              interactionState,
-              insertionSubject,
-              insertionCommand.frame,
-            )
-          },
-        )
+        if (insertionCommand != null) {
+          const reparentCommand = updateFunctionCommand(
+            'always',
+            (editorState): Array<EditorStatePatch> => {
+              return runTargetStrategiesForFreshlyInsertedElementToReparent(
+                canvasState.builtInDependencies,
+                editorState,
+                strategyState,
+                interactionState,
+                insertionSubject,
+                insertionCommand.frame,
+              )
+            },
+          )
 
-        const resizeCommand = updateFunctionCommand(
-          'always',
-          (editorState, commandLifecycle): Array<EditorStatePatch> => {
-            return runTargetStrategiesForFreshlyInsertedElementToResize(
-              canvasState.builtInDependencies,
-              editorState,
-              strategyState,
-              interactionState,
-              commandLifecycle,
-              insertionSubject,
-              insertionCommand.frame,
-            )
-          },
-        )
+          const resizeCommand = updateFunctionCommand(
+            'always',
+            (editorState, commandLifecycle): Array<EditorStatePatch> => {
+              return runTargetStrategiesForFreshlyInsertedElementToResize(
+                canvasState.builtInDependencies,
+                editorState,
+                strategyState,
+                interactionState,
+                commandLifecycle,
+                insertionSubject,
+                insertionCommand.frame,
+              )
+            },
+          )
 
-        return strategyApplicationResult([insertionCommand.command, reparentCommand, resizeCommand])
+          return strategyApplicationResult([
+            insertionCommand.command,
+            reparentCommand,
+            resizeCommand,
+          ])
+        }
+      } else {
+        // just insert a default sized element and no resize
       }
     }
     // Fallback for when the checks above are not satisfied.

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
@@ -201,6 +201,7 @@ function reorderElement(
       startingMetadata: metadata,
       customStrategyState: defaultCustomStrategyState(),
     } as StrategyState,
+    'end-interaction',
   )
 
   expect(strategyResult.customStatePatch?.lastReorderIdx).toEqual(newIndex)

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
@@ -82,7 +82,7 @@ function getFlexReparentToAbsoluteStrategy(
         missingBoundsHandling,
       )
     },
-    apply: (canvasState, interactionState, strategyState) => {
+    apply: (canvasState, interactionState, strategyState, lifecycle) => {
       const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
       const filteredSelectedElements = getDragTargets(selectedElements)
       return ifAllowedToReparent(canvasState, strategyState, filteredSelectedElements, () => {
@@ -147,16 +147,20 @@ function getFlexReparentToAbsoluteStrategy(
         return strategyApplicationResult([
           ...placeholderCloneCommands,
           ...escapeHatchCommands,
-          updateFunctionCommand('always', (editorState, lifecycle): Array<EditorStatePatch> => {
-            return runAbsoluteReparentStrategyForFreshlyConvertedElement(
-              canvasState.builtInDependencies,
-              editorState,
-              strategyState,
-              interactionState,
-              lifecycle,
-              missingBoundsHandling,
-            )
-          }),
+          updateFunctionCommand(
+            'always',
+            (editorState, commandLifecycle): Array<EditorStatePatch> => {
+              return runAbsoluteReparentStrategyForFreshlyConvertedElement(
+                canvasState.builtInDependencies,
+                editorState,
+                strategyState,
+                interactionState,
+                commandLifecycle,
+                missingBoundsHandling,
+                lifecycle,
+              )
+            },
+          ),
         ])
       })
     },
@@ -170,6 +174,7 @@ function runAbsoluteReparentStrategyForFreshlyConvertedElement(
   interactionState: InteractionSession,
   commandLifecycle: 'mid-interaction' | 'end-interaction',
   missingBoundsHandling: MissingBoundsHandling,
+  strategyLifeCycle: 'mid-interaction' | 'end-interaction',
 ): Array<EditorStatePatch> {
   const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
   const isForced = missingBoundsHandling === 'allow-missing-bounds'
@@ -181,6 +186,7 @@ function runAbsoluteReparentStrategyForFreshlyConvertedElement(
     canvasState,
     interactionState,
     strategyState,
+    strategyLifeCycle,
   ).commands
 
   return foldAndApplyCommandsInner(editorState, [], [], reparentCommands, commandLifecycle)

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
@@ -83,7 +83,7 @@ function getFlexReparentToAbsoluteStrategy(
         missingBoundsHandling,
       )
     },
-    apply: (canvasState, interactionState, strategyState, lifecycle) => {
+    apply: (canvasState, interactionState, strategyState, strategyLifecycle) => {
       const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
       const filteredSelectedElements = getDragTargets(selectedElements)
       return ifAllowedToReparent(canvasState, strategyState, filteredSelectedElements, () => {
@@ -158,7 +158,7 @@ function getFlexReparentToAbsoluteStrategy(
                 interactionState,
                 commandLifecycle,
                 missingBoundsHandling,
-                lifecycle,
+                strategyLifecycle,
               )
             },
           ),

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
@@ -25,6 +25,7 @@ import {
   CanvasStrategy,
   emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
+  InteractionLifecycle,
   strategyApplicationResult,
 } from './canvas-strategy-types'
 import { getEscapeHatchCommands } from './convert-to-absolute-and-move-strategy'
@@ -172,9 +173,9 @@ function runAbsoluteReparentStrategyForFreshlyConvertedElement(
   editorState: EditorState,
   strategyState: StrategyState,
   interactionState: InteractionSession,
-  commandLifecycle: 'mid-interaction' | 'end-interaction',
+  commandLifecycle: InteractionLifecycle,
   missingBoundsHandling: MissingBoundsHandling,
-  strategyLifeCycle: 'mid-interaction' | 'end-interaction',
+  strategyLifeCycle: InteractionLifecycle,
 ): Array<EditorStatePatch> {
   const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
   const isForced = missingBoundsHandling === 'allow-missing-bounds'

--- a/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
@@ -62,6 +62,7 @@ export function pressKeys(
       startingAllElementProps: { 'scene-aaa/app-entity:aaa/bbb': {} },
       customStrategyState: defaultCustomStrategyState(),
     } as StrategyState,
+    'end-interaction',
   )
 
   expect(strategyResult.customStatePatch).toEqual({})

--- a/editor/src/components/canvas/canvas-strategies/look-for-applicable-parent.tsx
+++ b/editor/src/components/canvas/canvas-strategies/look-for-applicable-parent.tsx
@@ -103,7 +103,7 @@ export const lookForApplicableParentStrategy: CanvasStrategy = {
       : 0
   },
 
-  apply: (canvasState, interactionSession, strategyState) => {
+  apply: (canvasState, interactionSession, strategyState, lifecycle) => {
     const result = lookForParentApplicableStrategy(
       canvasState,
       interactionSession,
@@ -133,6 +133,7 @@ export const lookForApplicableParentStrategy: CanvasStrategy = {
       patchedCanvasState,
       interactionSession,
       strategyState,
+      lifecycle,
     )
 
     return strategyApplicationResult(

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -51,6 +51,7 @@ import {
 import { AddElement, runAddElement } from './add-element-command'
 import { runUpdatePropIfExists, UpdatePropIfExists } from './update-prop-if-exists-command'
 import { HighlightElementsCommand, runHighlightElementsCommand } from './highlight-element-command'
+import { InteractionLifecycle } from '../canvas-strategies/canvas-strategy-types'
 
 export interface CommandFunctionResult {
   editorStatePatches: Array<EditorStatePatch>
@@ -95,7 +96,7 @@ export type CanvasCommand =
 export const runCanvasCommand = (
   editorState: EditorState,
   command: CanvasCommand,
-  commandLifecycle: 'mid-interaction' | 'end-interaction',
+  commandLifecycle: InteractionLifecycle,
 ): CommandFunctionResult => {
   switch (command.type) {
     case 'WILDCARD_PATCH':
@@ -171,7 +172,7 @@ export function foldAndApplyCommandsInner(
   patches: Array<EditorStatePatch>,
   commandsToAccumulate: Array<CanvasCommand>,
   commands: Array<CanvasCommand>,
-  commandLifecycle: 'mid-interaction' | 'end-interaction',
+  commandLifecycle: InteractionLifecycle,
 ): {
   statePatches: EditorStatePatch[]
   updatedEditorState: EditorState
@@ -233,7 +234,7 @@ export function foldAndApplyCommands(
   patches: Array<EditorStatePatch>,
   commandsToAccumulate: Array<CanvasCommand>,
   commands: Array<CanvasCommand>,
-  commandLifecycle: 'mid-interaction' | 'end-interaction',
+  commandLifecycle: InteractionLifecycle,
 ): {
   editorState: EditorState
   accumulatedPatches: Array<EditorStatePatch>

--- a/editor/src/components/canvas/commands/update-function-command.ts
+++ b/editor/src/components/canvas/commands/update-function-command.ts
@@ -6,6 +6,7 @@ import {
   EditorStatePatch,
   withUnderlyingTargetFromEditorState,
 } from '../../editor/store/editor-state'
+import { InteractionLifecycle } from '../canvas-strategies/canvas-strategy-types'
 import { duplicate } from '../canvas-utils'
 import {
   BaseCommand,
@@ -19,7 +20,7 @@ export interface UpdateFunctionCommand extends BaseCommand {
   type: 'UPDATE_FUNCTION_COMMAND'
   updateFunction: (
     editorState: EditorState,
-    commandLifecycle: 'mid-interaction' | 'end-interaction',
+    commandLifecycle: InteractionLifecycle,
   ) => Array<EditorStatePatch>
 }
 
@@ -27,7 +28,7 @@ export function updateFunctionCommand(
   whenToRun: WhenToRun,
   updateFunction: (
     editorState: EditorState,
-    commandLifecycle: 'mid-interaction' | 'end-interaction',
+    commandLifecycle: InteractionLifecycle,
   ) => Array<EditorStatePatch>,
 ): UpdateFunctionCommand {
   return {
@@ -40,7 +41,7 @@ export function updateFunctionCommand(
 export const runUpdateFunctionCommand = (
   editorState: EditorState,
   command: UpdateFunctionCommand,
-  commandLifecycle: 'mid-interaction' | 'end-interaction',
+  commandLifecycle: InteractionLifecycle,
 ): CommandFunctionResult => {
   return {
     editorStatePatches: command.updateFunction(editorState, commandLifecycle),

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -52,6 +52,7 @@ import {
 import { Modifier, Modifiers } from '../../../../utils/modifiers'
 import { pathsEqual } from '../../../../core/shared/element-path'
 import { EditorAction } from '../../../../components/editor/action-types'
+import { isInsertMode } from '../../../editor/editor-modes'
 
 const DRAG_START_THRESHOLD = 2
 
@@ -667,7 +668,9 @@ function useSelectOrLiveModeSelectAndHover(
             setSelectedViewsForCanvasControlsOnly(updatedSelection)
 
             // In either case cancel insert mode.
-            editorActions.push(...cancelInsertModeActions('ignore-it-completely'))
+            if (isInsertMode(editorStoreRef.current.editor.mode)) {
+              editorActions.push(...cancelInsertModeActions('apply-changes'))
+            }
 
             // then we set the selected views for the editor state, 1 frame later
             if (updatedSelection.length === 0) {

--- a/editor/src/components/editor/actions/meta-actions.ts
+++ b/editor/src/components/editor/actions/meta-actions.ts
@@ -39,7 +39,7 @@ export function selectComponents(
   addToSelection: boolean,
 ): Array<EditorAction> {
   return [
-    ...cancelInsertModeActions('do-not-apply-changes'),
+    ...cancelInsertModeActions('apply-changes'),
     EditorActions.selectComponents(target, addToSelection),
   ]
 }

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -155,6 +155,7 @@ export function interactionHardReset(
         canvasState,
         newEditorState.canvas.interactionSession,
         resetStrategyState,
+        'mid-interaction',
       )
       const commandResult = foldAndApplyCommands(
         newEditorState,
@@ -306,6 +307,7 @@ export function interactionStart(
         canvasState,
         newEditorState.canvas.interactionSession,
         withClearedSession,
+        'mid-interaction',
       )
       const commandResult = foldAndApplyCommands(
         newEditorState,
@@ -406,6 +408,7 @@ function handleUserChangedStrategy(
       canvasState,
       newEditorState.canvas.interactionSession,
       strategyState,
+      'mid-interaction',
     )
     const commandResult = foldAndApplyCommands(
       newEditorState,
@@ -485,6 +488,7 @@ function handleAccumulatingKeypresses(
               canvasState,
               updatedInteractionSession,
               strategyState,
+              'mid-interaction',
             )
           : strategyApplicationResult([])
       const commandResult = foldAndApplyCommands(
@@ -547,6 +551,7 @@ function handleUpdate(
             canvasState,
             newEditorState.canvas.interactionSession,
             strategyState,
+            'mid-interaction',
           )
         : strategyApplicationResult([])
     const commandResult = foldAndApplyCommands(

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -84,6 +84,7 @@ export function interactionFinished(
             canvasState,
             interactionSession,
             result.strategyState,
+            'end-interaction',
           )
         : {
             commands: [],

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`400`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`411`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`389`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`422`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`666`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`699`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`738`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`771`)
   })
 })

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`411`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`400`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`422`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`389`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`699`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`666`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`771`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`738`)
   })
 })

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -185,10 +185,7 @@ function handleCanvasEvent(model: CanvasModel, event: CanvasMouseEvent): Array<E
     event.event === 'MOUSE_UP' &&
     model.editorState.canvas.interactionSession?.interactionData.type === 'DRAG'
   ) {
-    const applyChanges = model.editorState.canvas.interactionSession?.interactionData.drag != null
-    optionalDragStateAction = cancelInsertModeActions(
-      applyChanges ? 'apply-changes' : 'do-not-apply-changes',
-    )
+    optionalDragStateAction = cancelInsertModeActions('apply-changes')
   } else if (!(insertMode && isOpenFileUiJs(model.editorState))) {
     switch (event.event) {
       case 'DRAG':
@@ -209,9 +206,7 @@ function handleCanvasEvent(model: CanvasModel, event: CanvasMouseEvent): Array<E
           ]
         }
         if (model.editorState.canvas.interactionSession?.interactionData.type === 'DRAG') {
-          const applyChanges =
-            model.editorState.canvas.interactionSession?.interactionData.drag != null
-          optionalDragStateAction = [CanvasActions.clearInteractionSession(applyChanges)]
+          optionalDragStateAction = [CanvasActions.clearInteractionSession(true)]
         }
         break
 


### PR DESCRIPTION
**Problem:**
Click to insert was broken after draw to insert was introduced as a strategy. Furthermore, click to insert always inserted with absolute positioning, even into a flex container.

**Fix:**
Extend the draw-to-insert strategy so it can insert with clicking too.

We can detect that a "drag" is a "click" when the drag is null in the interaction, and the interaction is just finished (so a mouse up has happened without move)

To make this possible, we need to know in the `apply` function if it is running when interaction is finished or earlier. To achieve this I added a `lifecycle` parameter to the `apply` function, and I fill that in in `dispatch-strategies`.

This is very similar to the command lifecycle, but not the same. This lifecycle can make it possible to emit different commands from the strategy in the different lifecycle phases. 

Theoretically we could remove lifecycle management from commands, and always only emit the commands which are relevant in that lifecycle.

E.g. instead of 

```typescript
     return strategyApplicationResult([
        ...commandsForSelectedElements.commands,
        pushIntendedBounds(commandsForSelectedElements.intendedBounds),
        updateHighlightedViews('mid-interaction', []),
        setElementsToRerenderCommand(selectedElements),
        setCursorCommand('mid-interaction', CSSCursor.Select),
      ])
```

we could write:

```typescript
   const alwaysCommands = [
        ...commandsForSelectedElements.commands,
        pushIntendedBounds(commandsForSelectedElements.intendedBounds),
        setElementsToRerenderCommand(selectedElements),
        setCursorCommand('mid-interaction', CSSCursor.Select),
      ])

  return lifecycle === 'mid-interaction' ? strategyApplicationResult([
        ...alwaysCommands,
       updateHighlightedViews([]),
    ]) :  strategyApplicationResult(alwaysCommands)
```

But I believe this is just way more complicated to use, so I decided to keep lifecycle management inside commands too.
