### PR TITLE
Still honour startingTargetParentsToFilterOut when holding cmd

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
@@ -15,6 +15,7 @@ import { CanvasControlsContainerID } from '../controls/new-canvas-controls'
 import { getCursorForOverlay } from '../controls/select-mode/cursor-overlay'
 import {
   EditorRenderResult,
+  formatTestProjectCode,
   getPrintedUiJsCode,
   makeTestProjectCodeWithSnippet,
   renderTestEditorWithCode,
@@ -26,6 +27,7 @@ import {
 function dragElement(
   renderResult: EditorRenderResult,
   targetTestId: string,
+  mouseDownOffset: WindowPoint,
   dragDelta: WindowPoint,
   modifiers: Modifiers,
   includeMouseUp: boolean,
@@ -34,7 +36,10 @@ function dragElement(
   const targetElementBounds = targetElement.getBoundingClientRect()
   const canvasControl = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
 
-  const startPoint = windowPoint({ x: targetElementBounds.x + 20, y: targetElementBounds.y + 20 })
+  const startPoint = windowPoint({
+    x: targetElementBounds.x + mouseDownOffset.x,
+    y: targetElementBounds.y + mouseDownOffset.y,
+  })
   const endPoint = offsetPoint(startPoint, dragDelta)
   fireEvent(
     canvasControl,
@@ -79,6 +84,8 @@ function dragElement(
     )
   }
 }
+
+const defaultMouseDownOffset = windowPoint({ x: 20, y: 20 })
 
 describe('Unified Reparent Fitness Function Tests', () => {
   beforeEach(() => {
@@ -130,7 +137,9 @@ describe('Unified Reparent Fitness Function Tests', () => {
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb', 'ccc'])
     await renderResult.dispatch([selectComponents([targetPath], false)], false)
-    act(() => dragElement(renderResult, 'ccc', dragDelta, emptyModifiers, true))
+    act(() =>
+      dragElement(renderResult, 'ccc', defaultMouseDownOffset, dragDelta, emptyModifiers, true),
+    )
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
@@ -218,7 +227,9 @@ describe('Unified Reparent Fitness Function Tests', () => {
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb', 'ccc'])
     await renderResult.dispatch([selectComponents([targetPath], false)], false)
 
-    act(() => dragElement(renderResult, 'ccc', dragDelta, emptyModifiers, true))
+    act(() =>
+      dragElement(renderResult, 'ccc', defaultMouseDownOffset, dragDelta, emptyModifiers, true),
+    )
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
@@ -306,7 +317,16 @@ describe('Unified Reparent Fitness Function Tests', () => {
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'draggedElement'])
     await renderResult.dispatch([selectComponents([targetPath], false)], false)
 
-    act(() => dragElement(renderResult, 'draggedElement', dragDelta, emptyModifiers, true))
+    act(() =>
+      dragElement(
+        renderResult,
+        'draggedElement',
+        defaultMouseDownOffset,
+        dragDelta,
+        emptyModifiers,
+        true,
+      ),
+    )
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
@@ -396,7 +416,16 @@ describe('Unified Reparent Fitness Function Tests', () => {
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'draggedElement'])
     await renderResult.dispatch([selectComponents([targetPath], false)], false)
 
-    act(() => dragElement(renderResult, 'draggedElement', dragDelta, cmdModifier, true))
+    act(() =>
+      dragElement(
+        renderResult,
+        'draggedElement',
+        defaultMouseDownOffset,
+        dragDelta,
+        cmdModifier,
+        true,
+      ),
+    )
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
@@ -487,7 +516,16 @@ describe('Unified Reparent Fitness Function Tests', () => {
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'draggedElement'])
     await renderResult.dispatch([selectComponents([targetPath], false)], false)
 
-    act(() => dragElement(renderResult, 'draggedElement', dragDelta, emptyModifiers, true))
+    act(() =>
+      dragElement(
+        renderResult,
+        'draggedElement',
+        defaultMouseDownOffset,
+        dragDelta,
+        emptyModifiers,
+        true,
+      ),
+    )
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
@@ -576,7 +614,16 @@ describe('Unified Reparent Fitness Function Tests', () => {
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'draggedElement'])
     await renderResult.dispatch([selectComponents([targetPath], false)], false)
 
-    act(() => dragElement(renderResult, 'draggedElement', dragDelta, emptyModifiers, true))
+    act(() =>
+      dragElement(
+        renderResult,
+        'draggedElement',
+        defaultMouseDownOffset,
+        dragDelta,
+        emptyModifiers,
+        true,
+      ),
+    )
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
@@ -663,7 +710,16 @@ describe('Unified Reparent Fitness Function Tests', () => {
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'draggedElement'])
     await renderResult.dispatch([selectComponents([targetPath], false)], false)
 
-    act(() => dragElement(renderResult, 'draggedElement', dragDelta, cmdModifier, true))
+    act(() =>
+      dragElement(
+        renderResult,
+        'draggedElement',
+        defaultMouseDownOffset,
+        dragDelta,
+        cmdModifier,
+        true,
+      ),
+    )
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
@@ -751,7 +807,16 @@ describe('Unified Reparent Fitness Function Tests', () => {
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'draggedElement'])
     await renderResult.dispatch([selectComponents([targetPath], false)], false)
 
-    act(() => dragElement(renderResult, 'draggedElement', dragDelta, cmdModifier, true))
+    act(() =>
+      dragElement(
+        renderResult,
+        'draggedElement',
+        defaultMouseDownOffset,
+        dragDelta,
+        cmdModifier,
+        true,
+      ),
+    )
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
@@ -787,6 +852,394 @@ describe('Unified Reparent Fitness Function Tests', () => {
             data-testid='bbb'
           />
         </div>
+      `),
+    )
+  })
+})
+
+describe('Target parent filtering', () => {
+  beforeEach(() => {
+    viewport.set(2200, 1000)
+  })
+
+  function makeFilteringProjectWithCode(code: string): string {
+    const projectCode = `
+      import * as React from 'react'
+      import { Scene, Storyboard } from 'utopia-api'
+
+      export var ${BakedInStoryboardVariableName} = (
+        <Storyboard data-uid='${BakedInStoryboardUID}'>
+          <Scene
+            style={{
+              width: 350,
+              height: 350,
+              position: 'absolute',
+              left: 0,
+              top: 0,
+            }}
+            data-uid='${TestSceneUID}'
+          >
+            ${code}
+          </Scene>
+        </Storyboard>
+      )
+    `
+
+    return formatTestProjectCode(projectCode)
+  }
+
+  // Target element overlaps both smaller and larger elements, starting 25px to the right and below the top left of the larger,
+  // and 25px to the left and above the smaller
+  const startingCode = makeFilteringProjectWithCode(`
+    <div
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 50,
+        top: 50,
+        width: 250,
+        height: 250,
+      }}
+      data-label='larger sibling'
+      data-uid='large'
+      data-testid='large'
+    >
+      <div
+        style={{
+          backgroundColor: '#11FF00',
+          position: 'absolute',
+          left: 50,
+          top: 50,
+          width: 150,
+          height: 150,
+        }}
+        data-label='smaller element'
+        data-uid='small'
+        data-testid='small'
+      />
+    </div>
+    <div
+      style={{
+        backgroundColor: '#FF0000AB',
+        position: 'absolute',
+        left: 75,
+        top: 75,
+        width: 200,
+        height: 200,
+      }}
+      data-label='drag me'
+      data-uid='dragme'
+      data-testid='dragme'
+    />
+  `)
+
+  it('Dragging with cmd with cursor over the larger element prevents reparenting into the larger element', async () => {
+    const renderResult = await renderTestEditorWithCode(startingCode, 'await-first-dom-report')
+
+    const targetPath = EP.elementPath([[BakedInStoryboardUID, TestSceneUID, 'dragme']])
+    await renderResult.dispatch([selectComponents([targetPath], false)], false)
+
+    // mouse down inside the target, but not in the area over the smaller element
+    const mouseDownOffset = windowPoint({ x: 10, y: 10 })
+    // drag to the left so that the cursor is over the larger element, and no longer over where the target started
+    const dragDelta = windowPoint({ x: -20, y: 0 })
+
+    act(() => dragElement(renderResult, 'dragme', mouseDownOffset, dragDelta, cmdModifier, true))
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // The result should be that we've just moved the element without reparenting it
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeFilteringProjectWithCode(`
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            position: 'absolute',
+            left: 50,
+            top: 50,
+            width: 250,
+            height: 250,
+          }}
+          data-label='larger sibling'
+          data-uid='large'
+          data-testid='large'
+        >
+          <div
+            style={{
+              backgroundColor: '#11FF00',
+              position: 'absolute',
+              left: 50,
+              top: 50,
+              width: 150, 
+              height: 150,
+            }}
+            data-label='smaller element'
+            data-uid='small'
+            data-testid='small'
+          />
+        </div>
+        <div
+          style={{
+            backgroundColor: '#FF0000AB',
+            position: 'absolute',
+            left: 55,
+            top: 75,
+            width: 200,
+            height: 200,
+          }}
+          data-label='drag me'
+          data-uid='dragme'
+          data-testid='dragme'
+        />
+      `),
+    )
+  })
+
+  it('Dragging with cmd with cursor over the larger element allows reparenting into the smaller element', async () => {
+    const renderResult = await renderTestEditorWithCode(startingCode, 'await-first-dom-report')
+
+    const targetPath = EP.elementPath([[BakedInStoryboardUID, TestSceneUID, 'dragme']])
+    await renderResult.dispatch([selectComponents([targetPath], false)], false)
+
+    // mouse down inside the target, but not in the area over the smaller element
+    const mouseDownOffset = windowPoint({ x: 10, y: 10 })
+    // drag to the right so that the cursor is over the smaller element
+    const dragDelta = windowPoint({ x: 20, y: 20 })
+
+    act(() => dragElement(renderResult, 'dragme', mouseDownOffset, dragDelta, cmdModifier, true))
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // The dragged element should have been reparented into the smaller element
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeFilteringProjectWithCode(`
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            position: 'absolute',
+            left: 50,
+            top: 50,
+            width: 250,
+            height: 250,
+          }}
+          data-label='larger sibling'
+          data-uid='large'
+          data-testid='large'
+        >
+          <div
+            style={{
+              backgroundColor: '#11FF00',
+              position: 'absolute',
+              left: 50,
+              top: 50,
+              width: 150, 
+              height: 150,
+            }}
+            data-label='smaller element'
+            data-uid='small'
+            data-testid='small'
+          >
+            <div
+              style={{
+                backgroundColor: '#FF0000AB',
+                position: 'absolute',
+                left: -5,
+                top: -5,
+                width: 200,
+                height: 200,
+              }}
+              data-label='drag me'
+              data-uid='dragme'
+              data-testid='dragme'
+            />
+          </div>
+        </div>
+      `),
+    )
+  })
+
+  it('Dragging with cmd with cursor over the smaller element prevents reparenting into the smaller element', async () => {
+    const renderResult = await renderTestEditorWithCode(startingCode, 'await-first-dom-report')
+
+    const targetPath = EP.elementPath([[BakedInStoryboardUID, TestSceneUID, 'dragme']])
+    await renderResult.dispatch([selectComponents([targetPath], false)], false)
+
+    // mouse down inside the target in the area over the smaller element
+    const mouseDownOffset = windowPoint({ x: 30, y: 30 })
+    // drag to the right so that the cursor remains over the smaller element
+    const dragDelta = windowPoint({ x: 10, y: 10 })
+
+    act(() => dragElement(renderResult, 'dragme', mouseDownOffset, dragDelta, cmdModifier, true))
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // The result should be that we've just moved the element without reparenting it
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeFilteringProjectWithCode(`
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            position: 'absolute',
+            left: 50,
+            top: 50,
+            width: 250,
+            height: 250,
+          }}
+          data-label='larger sibling'
+          data-uid='large'
+          data-testid='large'
+        >
+          <div
+            style={{
+              backgroundColor: '#11FF00',
+              position: 'absolute',
+              left: 50,
+              top: 50,
+              width: 150, 
+              height: 150,
+            }}
+            data-label='smaller element'
+            data-uid='small'
+            data-testid='small'
+          />
+        </div>
+        <div
+          style={{
+            backgroundColor: '#FF0000AB',
+            position: 'absolute',
+            left: 85,
+            top: 85,
+            width: 200,
+            height: 200,
+          }}
+          data-label='drag me'
+          data-uid='dragme'
+          data-testid='dragme'
+        />
+      `),
+    )
+  })
+
+  it('Dragging with cmd with cursor over the smaller element allows reparenting into the larger element', async () => {
+    const renderResult = await renderTestEditorWithCode(startingCode, 'await-first-dom-report')
+
+    const targetPath = EP.elementPath([[BakedInStoryboardUID, TestSceneUID, 'dragme']])
+    await renderResult.dispatch([selectComponents([targetPath], false)], false)
+
+    // mouse down inside the target in the area over the smaller element
+    const mouseDownOffset = windowPoint({ x: 30, y: 30 })
+    // drag to the left so that the cursor is over the larger element
+    const dragDelta = windowPoint({ x: -10, y: -10 })
+
+    act(() => dragElement(renderResult, 'dragme', mouseDownOffset, dragDelta, cmdModifier, true))
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // The dragged element should have been reparented into the larger element
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeFilteringProjectWithCode(`
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            position: 'absolute',
+            left: 50,
+            top: 50,
+            width: 250,
+            height: 250,
+          }}
+          data-label='larger sibling'
+          data-uid='large'
+          data-testid='large'
+        >
+          <div
+            style={{
+              backgroundColor: '#11FF00',
+              position: 'absolute',
+              left: 50,
+              top: 50,
+              width: 150, 
+              height: 150,
+            }}
+            data-label='smaller element'
+            data-uid='small'
+            data-testid='small'
+          />
+          <div
+            style={{
+              backgroundColor: '#FF0000AB',
+              position: 'absolute',
+              left: 15,
+              top: 15,
+              width: 200,
+              height: 200,
+            }}
+            data-label='drag me'
+            data-uid='dragme'
+            data-testid='dragme'
+          />
+        </div>
+      `),
+    )
+  })
+
+  it('Dragging without cmd with cursor over the smaller element prevents reparenting into the larger element', async () => {
+    const renderResult = await renderTestEditorWithCode(startingCode, 'await-first-dom-report')
+
+    const targetPath = EP.elementPath([[BakedInStoryboardUID, TestSceneUID, 'dragme']])
+    await renderResult.dispatch([selectComponents([targetPath], false)], false)
+
+    // mouse down inside the target in the area over the smaller element
+    const mouseDownOffset = windowPoint({ x: 30, y: 30 })
+    // drag to the left so that the cursor is over the larger element
+    const dragDelta = windowPoint({ x: -10, y: -10 })
+
+    act(() => dragElement(renderResult, 'dragme', mouseDownOffset, dragDelta, emptyModifiers, true))
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // The result should be that we've just moved the element without reparenting it
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeFilteringProjectWithCode(`
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            position: 'absolute',
+            left: 50,
+            top: 50,
+            width: 250,
+            height: 250,
+          }}
+          data-label='larger sibling'
+          data-uid='large'
+          data-testid='large'
+        >
+          <div
+            style={{
+              backgroundColor: '#11FF00',
+              position: 'absolute',
+              left: 50,
+              top: 50,
+              width: 150, 
+              height: 150,
+            }}
+            data-label='smaller element'
+            data-uid='small'
+            data-testid='small'
+          />
+        </div>
+        <div
+          style={{
+            backgroundColor: '#FF0000AB',
+            position: 'absolute',
+            left: 65,
+            top: 65,
+            width: 200,
+            height: 200,
+          }}
+          data-label='drag me'
+          data-uid='dragme'
+          data-testid='dragme'
+        />
       `),
     )
   })
@@ -979,7 +1432,16 @@ describe('Reparent indicators', () => {
       y: endPoint.y - startPoint.y,
     })
 
-    act(() => dragElement(renderResult, 'seconddiv', dragDelta, emptyModifiers, false))
+    act(() =>
+      dragElement(
+        renderResult,
+        'seconddiv',
+        defaultMouseDownOffset,
+        dragDelta,
+        emptyModifiers,
+        false,
+      ),
+    )
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
@@ -1015,7 +1477,16 @@ describe('Reparent indicators', () => {
       y: endPoint.y - startPoint.y,
     })
 
-    act(() => dragElement(renderResult, 'seconddiv', dragDelta, emptyModifiers, false))
+    act(() =>
+      dragElement(
+        renderResult,
+        'seconddiv',
+        defaultMouseDownOffset,
+        dragDelta,
+        emptyModifiers,
+        false,
+      ),
+    )
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
@@ -1051,7 +1522,16 @@ describe('Reparent indicators', () => {
       y: endPoint.y - startPoint.y,
     })
 
-    act(() => dragElement(renderResult, 'seconddiv', dragDelta, emptyModifiers, false))
+    act(() =>
+      dragElement(
+        renderResult,
+        'seconddiv',
+        defaultMouseDownOffset,
+        dragDelta,
+        emptyModifiers,
+        false,
+      ),
+    )
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
@@ -1087,7 +1567,16 @@ describe('Reparent indicators', () => {
       y: endPoint.y - startPoint.y,
     })
 
-    act(() => dragElement(renderResult, 'seconddiv', dragDelta, emptyModifiers, false))
+    act(() =>
+      dragElement(
+        renderResult,
+        'seconddiv',
+        defaultMouseDownOffset,
+        dragDelta,
+        emptyModifiers,
+        false,
+      ),
+    )
 
     await renderResult.getDispatchFollowUpActionsFinished()
 

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -94,6 +94,12 @@ export function insertionSubjects(subjects: Array<InsertionSubject>): InsertionS
   }
 }
 
+export function isInsertionSubjects(
+  interactionTarget: InteractionTarget,
+): interactionTarget is InsertionSubjects {
+  return interactionTarget.type === 'INSERTION_SUBJECTS'
+}
+
 export function getTargetPathsFromInteractionTarget(target: InteractionTarget): Array<ElementPath> {
   if (target.type === 'TARGET_PATHS') {
     return target.elements

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -96,12 +96,6 @@ export function insertionSubjects(subjects: Array<InsertionSubject>): InsertionS
   }
 }
 
-export function isInsertionSubjects(
-  interactionTarget: InteractionTarget,
-): interactionTarget is InsertionSubjects {
-  return interactionTarget.type === 'INSERTION_SUBJECTS'
-}
-
 export function getTargetPathsFromInteractionTarget(target: InteractionTarget): Array<ElementPath> {
   if (target.type === 'TARGET_PATHS') {
     return target.elements

--- a/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
@@ -250,6 +250,7 @@ function runTargetStrategiesForFreshlyInsertedElement(
   const patchedInteractionState = {
     ...interactionState,
     interactionData: patchedInteractionData,
+    startingTargetParentsToFilterOut: null,
   }
 
   const { strategy } = findCanvasStrategy(
@@ -265,7 +266,7 @@ function runTargetStrategiesForFreshlyInsertedElement(
   } else {
     const reparentCommands = strategy.strategy.apply(
       patchedCanvasState,
-      interactionState,
+      patchedInteractionState,
       patchedStrategyState,
       strategyLifeCycle,
     ).commands

--- a/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -249,6 +249,77 @@ describe('Inserting into absolute', () => {
     )
   })
 
+  it('Should drag to insert into targets smaller than the element', async () => {
+    const renderResult = await renderTestEditorWithCode(inputCode, 'await-first-dom-report')
+    await startInsertMode(renderResult.dispatch)
+
+    const targetElement = renderResult.renderedDOM.getByTestId('bbb')
+    const targetElementBounds = targetElement.getBoundingClientRect()
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    const startPoint = slightlyOffsetWindowPointBecauseVeryWeirdIssue({
+      x: targetElementBounds.x + 5,
+      y: targetElementBounds.y + 5,
+    })
+    const endPoint = slightlyOffsetWindowPointBecauseVeryWeirdIssue({
+      x: targetElementBounds.x + 1005,
+      y: targetElementBounds.y + 1005,
+    })
+
+    // Drag from inside bbb to inside ccc
+    await fireDragEvent(canvasControlsLayer, startPoint, endPoint)
+
+    // Check that the inserted element is a child of bbb
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          data-uid='aaa'
+          style={{
+            width: '100%',
+            height: '100%',
+            backgroundColor: '#FFFFFF',
+            position: 'relative',
+          }}
+        >
+          <div
+            data-uid='bbb'
+            data-testid='bbb'
+            style={{
+              position: 'absolute',
+              left: 10,
+              top: 10,
+              width: 380,
+              height: 180,
+              backgroundColor: '#d3d3d3',
+            }}
+          >
+            <div
+              data-uid='ddd'
+              style={{
+                position: 'absolute',
+                left: 5,
+                top: 5,
+                width: 1000,
+                height: 1000,
+              }}
+            />
+          </div>
+          <div
+            data-uid='ccc'
+            style={{
+              position: 'absolute',
+              left: 10,
+              top: 200,
+              width: 380,
+              height: 190,
+              backgroundColor: '#FF0000',
+            }}
+          />
+        </div>
+      `),
+    )
+  })
+
   it('Click to insert with default size', async () => {
     const renderResult = await renderTestEditorWithCode(inputCode, 'await-first-dom-report')
     await startInsertMode(renderResult.dispatch)
@@ -311,6 +382,88 @@ describe('Inserting into absolute', () => {
               backgroundColor: '#FF0000',
             }}
           />
+        </div>
+      `),
+    )
+  })
+
+  it('Click to insert into an element smaller than the default size', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          data-uid='aaa'
+          style={{
+            width: '100%',
+            height: '100%',
+            backgroundColor: '#FFFFFF',
+            position: 'relative',
+          }}
+        >
+          <div
+            data-uid='bbb'
+            data-testid='bbb'
+            style={{
+              position: 'absolute',
+              left: 10,
+              top: 10,
+              width: 10,
+              height: 10,
+              backgroundColor: '#d3d3d3',
+            }}
+          />
+        </div>
+    `),
+      'await-first-dom-report',
+    )
+    await startInsertMode(renderResult.dispatch)
+
+    const targetElement = renderResult.renderedDOM.getByTestId('bbb')
+    const targetElementBounds = targetElement.getBoundingClientRect()
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    const point = slightlyOffsetWindowPointBecauseVeryWeirdIssue({
+      x: targetElementBounds.x + 5,
+      y: targetElementBounds.y + 5,
+    })
+
+    // Click in bbb
+    await fireClickEvent(canvasControlsLayer, point)
+
+    // Check that the inserted element is a child of bbb
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          data-uid='aaa'
+          style={{
+            width: '100%',
+            height: '100%',
+            backgroundColor: '#FFFFFF',
+            position: 'relative',
+          }}
+        >
+          <div
+            data-uid='bbb'
+            data-testid='bbb'
+            style={{
+              position: 'absolute',
+              left: 10,
+              top: 10,
+              width: 10,
+              height: 10,
+              backgroundColor: '#d3d3d3',
+            }}
+          >
+            <div
+              data-uid='ddd'
+              style={{
+                position: 'absolute',
+                left: -45,
+                top: -45,
+                width: 100,
+                height: 100,
+              }}
+            />
+          </div>
         </div>
       `),
     )

--- a/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.tsx
@@ -295,6 +295,7 @@ function runTargetStrategiesForFreshlyInsertedElementToReparent(
     ...interactionState,
     activeControl: boundingArea(),
     interactionData: patchedInteractionData,
+    startingTargetParentsToFilterOut: null,
   }
 
   const patchedCanvasState: InteractionCanvasState = {
@@ -335,6 +336,10 @@ function runTargetStrategiesForFreshlyInsertedElementToResize(
   strategyLifecycle: InteractionLifecycle,
 ): Array<EditorStatePatch> {
   const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
+  const patchedInteractionState: InteractionSession = {
+    ...interactionState,
+    startingTargetParentsToFilterOut: null,
+  }
 
   const element = insertionSubject.element
   const path = editorState.selectedViews[0]
@@ -364,7 +369,7 @@ function runTargetStrategiesForFreshlyInsertedElementToResize(
   const { strategy: resizeStrategy } = findCanvasStrategy(
     RegisteredCanvasStrategies,
     patchedCanvasState,
-    interactionState,
+    patchedInteractionState,
     patchedStrategyState,
     null,
   )
@@ -373,7 +378,7 @@ function runTargetStrategiesForFreshlyInsertedElementToResize(
     resizeStrategy != null
       ? resizeStrategy.strategy.apply(
           patchedCanvasState,
-          interactionState,
+          patchedInteractionState,
           patchedStrategyState,
           strategyLifecycle,
         ).commands

--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -41,6 +41,7 @@ import {
   emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
+  isInsertionSubjects,
   StrategyApplicationResult,
 } from './canvas-strategy-types'
 import {
@@ -232,11 +233,12 @@ function findReparentStrategy(
     (e) => EP.parentPath(e) === newParentPath,
   )
 
+  const isInsertion = isInsertionSubjects(canvasState.interactionTarget)
+
   if (
     reparentResult.shouldReparent &&
     newParentPath != null &&
-    // holding cmd forces a reparent even if the target parent was under the mouse at the interaction start
-    (cmdPressed ||
+    (isInsertion ||
       targetIsValid(
         newParentPath,
         interactionState.startingTargetParentsToFilterOut,

--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -41,7 +41,6 @@ import {
   emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
-  isInsertionSubjects,
   StrategyApplicationResult,
 } from './canvas-strategy-types'
 import {
@@ -233,17 +232,14 @@ function findReparentStrategy(
     (e) => EP.parentPath(e) === newParentPath,
   )
 
-  const isInsertion = isInsertionSubjects(canvasState.interactionTarget)
-
   if (
     reparentResult.shouldReparent &&
     newParentPath != null &&
-    (isInsertion ||
-      targetIsValid(
-        newParentPath,
-        interactionState.startingTargetParentsToFilterOut,
-        missingBoundsHandling,
-      )) &&
+    targetIsValid(
+      newParentPath,
+      interactionState.startingTargetParentsToFilterOut,
+      missingBoundsHandling,
+    ) &&
     !parentStayedTheSame
   ) {
     return reparentStrategyForParent(

--- a/editor/src/sample-projects/sample-project-utils.test-utils.ts
+++ b/editor/src/sample-projects/sample-project-utils.test-utils.ts
@@ -13,6 +13,8 @@ import {
   textFile,
   textFileContents,
   ParseFailure,
+  isParseFailure,
+  isUnparsed,
 } from '../core/shared/project-file-types'
 import { emptySet } from '../core/shared/set-utils'
 import { lintAndParse } from '../core/workers/parser-printer/parser-printer'
@@ -71,8 +73,12 @@ export function createTestProjectWithCode(appUiJsFile: string): PersistentModel 
     emptySet(),
   ) as ParsedTextFile
 
-  if (!isParseSuccess(parsedFile)) {
-    throw new Error('The test file parse failed')
+  if (isParseFailure(parsedFile)) {
+    const failure =
+      parsedFile.errorMessage ?? parsedFile.errorMessages.map((m) => m.message).join(`,\n`)
+    throw new Error(`createTestProjectWithCode file parsing failed: ${failure}`)
+  } else if (isUnparsed(parsedFile)) {
+    throw new Error(`createTestProjectWithCode: Unexpected unparsed file.`)
   }
 
   return {


### PR DESCRIPTION
**Problem:**
We were ignoring `startingTargetParentsToFilterOut` during reparenting when `cmd` was held. This was erroneously added logic, and meant that holding `cmd` would immediately reparent an element to whatever was behind it at the start of a drag.

**Fix:**
Remove the logic that was using `cmd` in this way. This did cause an issue with insertion, as that is using the same reparenting logic, so to fix that I have patched the `interactionState` to set `startingTargetParentsToFilterOut` to `null` before calling the reparenting logic during an insertion.

I've also added a number of tests for `startingTargetParentsToFilterOut`, as well as a couple of insertion tests to ensure we can still insert into an element that is smaller than the inserted element.
