### PR TITLE
Make getReparentTargetUnified work without existing selected elements

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -16,6 +16,7 @@ import {
 import { getDragTargets } from './shared-absolute-move-strategy-helpers'
 import { ifAllowedToReparent, isAllowedToReparent } from './reparent-helpers'
 import {
+  existingReparentSubjects,
   getAbsoluteReparentPropertyChanges,
   getFitnessForReparentStrategy,
   getReparentTargetUnified,
@@ -95,7 +96,7 @@ function getAbsoluteReparentStrategy(
         )
 
         const reparentTarget = getReparentTargetUnified(
-          filteredSelectedElements,
+          existingReparentSubjects(filteredSelectedElements),
           pointOnCanvas,
           interactionState.interactionData.modifiers.cmd,
           canvasState,

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
@@ -32,6 +32,7 @@ import { getEscapeHatchCommands } from './convert-to-absolute-and-move-strategy'
 import { InteractionSession, MissingBoundsHandling, StrategyState } from './interaction-state'
 import { ifAllowedToReparent } from './reparent-helpers'
 import {
+  existingReparentSubjects,
   getFitnessForReparentStrategy,
   getReparentTargetUnified,
 } from './reparent-strategy-helpers'
@@ -100,7 +101,7 @@ function getFlexReparentToAbsoluteStrategy(
         )
 
         const { newParent } = getReparentTargetUnified(
-          filteredSelectedElements,
+          existingReparentSubjects(filteredSelectedElements),
           pointOnCanvas,
           interactionState.interactionData.modifiers.cmd,
           canvasState,

--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -217,7 +217,7 @@ function findReparentStrategy(
   const cmdPressed = interactionState.interactionData.modifiers.cmd
 
   const reparentResult = getReparentTargetUnified(
-    filteredSelectedElements,
+    existingReparentSubjects(filteredSelectedElements),
     pointOnCanvas,
     cmdPressed,
     canvasState,
@@ -276,8 +276,32 @@ export function reparentTarget(
   }
 }
 
+type ReparentSubjects = NewReparentSubjects | ExistingReparentSubjects
+
+export interface NewReparentSubjects {
+  type: 'NEW_ELEMENTS'
+}
+
+export function newReparentSubjects(): NewReparentSubjects {
+  return {
+    type: 'NEW_ELEMENTS',
+  }
+}
+
+export interface ExistingReparentSubjects {
+  type: 'EXISTING_ELEMENTS'
+  elements: Array<ElementPath>
+}
+
+export function existingReparentSubjects(elements: Array<ElementPath>): ExistingReparentSubjects {
+  return {
+    type: 'EXISTING_ELEMENTS',
+    elements: elements,
+  }
+}
+
 export function getReparentTargetUnified(
-  filteredSelectedElements: Array<ElementPath>,
+  reparentSubjects: ReparentSubjects,
   pointOnCanvas: CanvasPoint,
   cmdPressed: boolean,
   canvasState: InteractionCanvasState,
@@ -290,8 +314,9 @@ export function getReparentTargetUnified(
   const canvasScale = canvasState.scale
 
   const multiselectBounds: Size =
-    MetadataUtils.getBoundingRectangleInCanvasCoords(filteredSelectedElements, metadata) ??
-    size(0, 0)
+    (reparentSubjects.type === 'EXISTING_ELEMENTS'
+      ? MetadataUtils.getBoundingRectangleInCanvasCoords(reparentSubjects.elements, metadata)
+      : null) ?? size(0, 0)
 
   const allElementsUnderPoint = getAllTargetsAtPointAABB(
     metadata,
@@ -313,11 +338,6 @@ export function getReparentTargetUnified(
     }
   }
 
-  const filteredSelectedElementsMetadata = mapDropNulls(
-    (path) => MetadataUtils.findElementByElementPath(metadata, path),
-    filteredSelectedElements,
-  )
-
   const filteredElementsUnderPoint = allElementsUnderPoint.filter((target) => {
     let validParentForFlexOrAbsolute = cmdPressed
     if (missingBoundsHandling === 'allow-missing-bounds') {
@@ -332,30 +352,42 @@ export function getReparentTargetUnified(
       validParentForFlexOrAbsolute = isFlex || providesBoundsForAbsoluteChildren
     }
 
-    // TODO BEFORE MERGE consider multiselect!!!!!
-    // the current parent should be included in the array of valid targets
-    return (
-      filteredSelectedElementsMetadata.some((maybeChild) =>
-        EP.isChildOf(maybeChild.elementPath, target),
-      ) ||
-      // any of the dragged elements (or their flex parents) and their descendants are not game for reparenting
-      (!filteredSelectedElementsMetadata.some((maybeAncestorOrEqual) =>
-        !cmdPressed && maybeAncestorOrEqual.specialSizeMeasurements.parentLayoutSystem === 'flex'
-          ? // for Flex children, we also want to filter out all their siblings to force a Flex Reorder strategy
-            EP.isDescendantOf(target, EP.parentPath(maybeAncestorOrEqual.elementPath))
-          : // for non-flex elements, we filter out their descendants and themselves
-            EP.isDescendantOfOrEqualTo(target, maybeAncestorOrEqual.elementPath),
-      ) &&
-        // simply skip elements that do not support children
-        MetadataUtils.targetSupportsChildren(projectContents, openFile, metadata, target) &&
-        // if cmd is not pressed, we only allow reparent to parents that are larger than the multiselect bounds
-        (cmdPressed ||
-          sizeFitsInTarget(
-            multiselectBounds,
-            MetadataUtils.getFrameInCanvasCoords(target, metadata) ?? size(0, 0),
-          )) &&
-        validParentForFlexOrAbsolute)
-    )
+    const canReparent =
+      // simply skip elements that do not support children
+      MetadataUtils.targetSupportsChildren(projectContents, openFile, metadata, target) &&
+      // if cmd is not pressed, we only allow reparent to parents that are larger than the multiselect bounds
+      (cmdPressed ||
+        sizeFitsInTarget(
+          multiselectBounds,
+          MetadataUtils.getFrameInCanvasCoords(target, metadata) ?? size(0, 0),
+        )) &&
+      validParentForFlexOrAbsolute
+
+    if (reparentSubjects.type === 'EXISTING_ELEMENTS') {
+      const selectedElementsMetadata = mapDropNulls(
+        (path) => MetadataUtils.findElementByElementPath(metadata, path),
+        reparentSubjects.elements,
+      )
+
+      // TODO BEFORE MERGE consider multiselect!!!!!
+      // the current parent should be included in the array of valid targets
+      return (
+        selectedElementsMetadata.some((maybeChild) =>
+          EP.isChildOf(maybeChild.elementPath, target),
+        ) ||
+        // any of the dragged elements (or their flex parents) and their descendants are not game for reparenting
+        (!selectedElementsMetadata.some((maybeAncestorOrEqual) =>
+          !cmdPressed && maybeAncestorOrEqual.specialSizeMeasurements.parentLayoutSystem === 'flex'
+            ? // for Flex children, we also want to filter out all their siblings to force a Flex Reorder strategy
+              EP.isDescendantOf(target, EP.parentPath(maybeAncestorOrEqual.elementPath))
+            : // for non-flex elements, we filter out their descendants and themselves
+              EP.isDescendantOfOrEqualTo(target, maybeAncestorOrEqual.elementPath),
+        ) &&
+          canReparent)
+      )
+    } else {
+      return canReparent
+    }
   })
 
   // if the mouse is over the canvas, return the canvas root as the target path
@@ -667,7 +699,7 @@ export function applyFlexReparent(
         interactionSession.interactionData.drag,
       )
       const reparentResult = getReparentTargetUnified(
-        filteredSelectedElements,
+        existingReparentSubjects(filteredSelectedElements),
         pointOnCanvas,
         interactionSession.interactionData.modifiers.cmd,
         canvasState,

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -101,7 +101,10 @@ import {
   updateInteractionViaMouse,
 } from '../components/canvas/canvas-strategies/interaction-state'
 import { MouseButtonsPressed } from '../utils/mouse'
-import { getReparentTargetUnified } from '../components/canvas/canvas-strategies/reparent-strategy-helpers'
+import {
+  existingReparentSubjects,
+  getReparentTargetUnified,
+} from '../components/canvas/canvas-strategies/reparent-strategy-helpers'
 import { getDragTargets } from '../components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers'
 import { pickCanvasStateFromEditorState } from '../components/canvas/canvas-strategies/canvas-strategies'
 import { BuiltInDependencies } from '../core/es-modules/package-manager/built-in-dependencies-list'
@@ -442,7 +445,7 @@ export function runLocalCanvasAction(
           )
 
           const strictBoundsResult = getReparentTargetUnified(
-            getDragTargets(model.selectedViews),
+            existingReparentSubjects(getDragTargets(model.selectedViews)),
             pointOnCanvas,
             action.interactionSession.interactionData.modifiers.cmd,
             pickCanvasStateFromEditorState(model, builtinDependencies),
@@ -452,7 +455,7 @@ export function runLocalCanvasAction(
           )
 
           const missingBoundsResult = getReparentTargetUnified(
-            getDragTargets(model.selectedViews),
+            existingReparentSubjects(getDragTargets(model.selectedViews)),
             pointOnCanvas,
             action.interactionSession.interactionData.modifiers.cmd,
             pickCanvasStateFromEditorState(model, builtinDependencies),


### PR DESCRIPTION
**Problem:**

In insert mode, we highlight the possible parent under the mouse on hover. For that, we need to know which is going to be the parent if we start draw-to-insert at that point.
There is a function which returns the new parent (`getReparentTargetUnified`), but that only works if the elements to reparent are already existing and have metadata.

**Fix:**

We need the metadata in `getReparentTargetUnified` for 2 reasons:
1. get the bounds of the selected elements, so we don't reparent into a smaller target (if it is not forced)
2. check that an element can not be reparented to any of its descendants

None of these are relevant in case of insertion, so we can use this function to get the reparent target for new elements, we just need to change its parameters to allow non-existing reparent targets.


