### PR TITLE
Feature/canvas flow reorder filter

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
@@ -166,6 +166,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -261,6 +262,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
@@ -168,6 +168,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -264,6 +265,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -210,6 +210,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -328,6 +329,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -605,6 +607,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -721,6 +724,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -837,6 +841,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -953,6 +958,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1176,6 +1182,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1294,6 +1301,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1479,6 +1487,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1701,6 +1710,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1819,6 +1829,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1918,6 +1929,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -2158,6 +2170,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -2276,6 +2289,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -2517,6 +2531,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -2668,6 +2683,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -2819,6 +2835,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -2970,6 +2987,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -3261,6 +3279,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -3379,6 +3398,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -3739,6 +3759,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -3994,6 +4015,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4152,6 +4174,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4310,6 +4333,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4468,6 +4492,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4723,6 +4748,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4881,6 +4907,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5039,6 +5066,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5197,6 +5225,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5452,6 +5481,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5610,6 +5640,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5768,6 +5799,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5926,6 +5958,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6160,6 +6193,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6278,6 +6312,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6436,6 +6471,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6536,6 +6572,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6636,6 +6673,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6858,6 +6896,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6976,6 +7015,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -7147,6 +7187,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -7387,6 +7428,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -7505,6 +7547,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -7759,6 +7802,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -7919,6 +7963,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -8079,6 +8124,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -8239,6 +8285,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -8479,6 +8526,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -8597,6 +8645,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -8851,6 +8900,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9011,6 +9061,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9171,6 +9222,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9331,6 +9383,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9565,6 +9618,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9683,6 +9737,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9841,6 +9896,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9941,6 +9997,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10041,6 +10098,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10275,6 +10333,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10393,6 +10452,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10584,6 +10644,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10684,6 +10745,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10784,6 +10846,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -11033,6 +11096,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -11165,6 +11229,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -11481,6 +11546,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -11664,6 +11730,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -11912,6 +11979,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -12044,6 +12112,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -12360,6 +12429,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -12543,6 +12613,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -12792,6 +12863,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -12924,6 +12996,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -13288,6 +13361,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -13519,6 +13593,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -13768,6 +13843,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -13900,6 +13976,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -14264,6 +14341,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -14495,6 +14573,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -14716,6 +14795,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -14834,6 +14914,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -14933,6 +15014,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -15277,6 +15359,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -15395,6 +15478,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -16572,6 +16656,7 @@ export var storyboard = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -17413,6 +17498,7 @@ export var storyboard = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -17762,6 +17848,7 @@ export var storyboard = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -18111,6 +18198,7 @@ export var storyboard = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -18460,6 +18548,7 @@ export var storyboard = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -18845,6 +18934,7 @@ export var storyboard = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -19074,6 +19164,7 @@ export var storyboard = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -19459,6 +19550,7 @@ export var storyboard = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -19688,6 +19780,7 @@ export var storyboard = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -20073,6 +20166,7 @@ export var storyboard = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -20302,6 +20396,7 @@ export var storyboard = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -20546,6 +20641,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -20664,6 +20760,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -20854,6 +20951,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -20970,6 +21068,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21086,6 +21185,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21309,6 +21409,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21427,6 +21528,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21590,6 +21692,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21812,6 +21915,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21930,6 +22034,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -22158,6 +22263,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -22369,6 +22475,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -22465,6 +22572,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -22725,6 +22833,7 @@ export var storyboard = (
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -22929,6 +23038,7 @@ export var storyboard = (
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -23197,6 +23307,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -23315,6 +23426,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -23540,6 +23652,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -23713,6 +23826,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -23840,6 +23954,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -24089,6 +24204,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -24221,6 +24337,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -24477,6 +24594,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -24605,6 +24723,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -24998,6 +25117,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -25130,6 +25250,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -25387,6 +25508,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -25515,6 +25637,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -25849,6 +25972,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -25969,6 +26093,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -26698,6 +26823,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -26802,6 +26928,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -26906,6 +27033,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27010,6 +27138,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27114,6 +27243,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27218,6 +27348,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27322,6 +27453,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27496,6 +27628,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27600,6 +27733,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27704,6 +27838,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27808,6 +27943,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27912,6 +28048,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28016,6 +28153,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28122,6 +28260,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28226,6 +28365,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28330,6 +28470,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28434,6 +28575,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28538,6 +28680,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28642,6 +28785,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28748,6 +28892,7 @@ export var App = (props) => {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28988,6 +29133,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29106,6 +29252,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29360,6 +29507,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29520,6 +29668,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29680,6 +29829,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29840,6 +29990,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -30080,6 +30231,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -30198,6 +30350,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -30453,6 +30606,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -30614,6 +30768,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -30775,6 +30930,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -30936,6 +31092,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -31176,6 +31333,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -31294,6 +31452,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -31555,6 +31714,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -31715,6 +31875,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -31875,6 +32036,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32035,6 +32197,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32280,6 +32443,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32412,6 +32576,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32630,6 +32795,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32758,6 +32924,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32982,6 +33149,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33078,6 +33246,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33183,6 +33352,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33288,6 +33458,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33488,6 +33659,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33584,6 +33756,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33799,6 +33972,7 @@ export var storyboard = (
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33919,6 +34093,7 @@ export var storyboard = (
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34119,6 +34294,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34215,6 +34391,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34314,6 +34491,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34522,6 +34700,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34618,6 +34797,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34795,6 +34975,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34923,6 +35104,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35125,6 +35307,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35221,6 +35404,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35480,6 +35664,7 @@ export var storyboard = (
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35676,6 +35861,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35772,6 +35958,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35887,6 +36074,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -36132,6 +36320,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -36250,6 +36439,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -36666,6 +36856,7 @@ export var storyboard = (
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -36878,6 +37069,7 @@ export var storyboard = (
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -37014,6 +37206,7 @@ export var storyboard = (
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -37120,6 +37313,7 @@ export var storyboard = (
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -37347,6 +37541,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -37465,6 +37660,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -37614,6 +37810,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -37730,6 +37927,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -37955,6 +38153,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38073,6 +38272,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38172,6 +38372,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38427,6 +38628,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38545,6 +38747,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38828,6 +39031,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39012,6 +39216,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39167,6 +39372,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39351,6 +39557,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39506,6 +39713,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39690,6 +39898,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39845,6 +40054,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40069,6 +40279,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40187,6 +40398,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40286,6 +40498,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40520,6 +40733,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40638,6 +40852,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40803,6 +41018,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40939,6 +41155,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -41046,6 +41263,7 @@ Object {
       "flexDirection": null,
       "float": "none",
       "globalContentBox": null,
+      "hasPositionOffset": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -208,6 +208,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -325,6 +326,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -601,6 +603,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -716,6 +719,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -831,6 +835,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -946,6 +951,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -1168,6 +1174,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -1285,6 +1292,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -1469,6 +1477,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -1690,6 +1699,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -1807,6 +1817,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -1905,6 +1916,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -2144,6 +2156,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -2261,6 +2274,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -2501,6 +2515,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -2651,6 +2666,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -2801,6 +2817,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -2951,6 +2968,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -3241,6 +3259,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -3358,6 +3377,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -3717,6 +3737,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -3971,6 +3992,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -4128,6 +4150,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -4285,6 +4308,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -4442,6 +4466,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -4696,6 +4721,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -4853,6 +4879,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -5010,6 +5037,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -5167,6 +5195,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -5421,6 +5450,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -5578,6 +5608,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -5735,6 +5766,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -5892,6 +5924,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -6125,6 +6158,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -6242,6 +6276,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -6399,6 +6434,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -6498,6 +6534,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -6597,6 +6634,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -6818,6 +6856,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -6935,6 +6974,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -7105,6 +7145,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -7344,6 +7385,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -7461,6 +7503,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -7714,6 +7757,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -7873,6 +7917,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -8032,6 +8077,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -8191,6 +8237,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -8430,6 +8477,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -8547,6 +8595,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -8800,6 +8849,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -8959,6 +9009,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -9118,6 +9169,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -9277,6 +9329,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -9510,6 +9563,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -9627,6 +9681,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -9784,6 +9839,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -9883,6 +9939,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -9982,6 +10039,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -10215,6 +10273,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -10332,6 +10391,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -10522,6 +10582,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -10621,6 +10682,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -10720,6 +10782,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -10968,6 +11031,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -11099,6 +11163,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -11414,6 +11479,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -11596,6 +11662,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -11843,6 +11910,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -11974,6 +12042,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -12289,6 +12358,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -12471,6 +12541,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -12719,6 +12790,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -12850,6 +12922,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -13213,6 +13286,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -13443,6 +13517,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -13691,6 +13766,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -13822,6 +13898,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -14185,6 +14262,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -14415,6 +14493,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -14635,6 +14714,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -14752,6 +14832,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -14850,6 +14931,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -15193,6 +15275,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -15310,6 +15393,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -16486,6 +16570,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -17326,6 +17411,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -17674,6 +17760,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -18022,6 +18109,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -18370,6 +18458,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -18754,6 +18843,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -18982,6 +19072,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -19366,6 +19457,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -19594,6 +19686,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -19978,6 +20071,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -20206,6 +20300,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -20449,6 +20544,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -20566,6 +20662,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -20755,6 +20852,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -20870,6 +20968,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -20985,6 +21084,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -21207,6 +21307,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -21324,6 +21425,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -21486,6 +21588,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -21707,6 +21810,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -21824,6 +21928,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -22051,6 +22156,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -22261,6 +22367,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -22356,6 +22463,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -22615,6 +22723,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -22818,6 +22927,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -23085,6 +23195,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -23202,6 +23313,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -23426,6 +23538,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -23598,6 +23711,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -23724,6 +23838,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -23972,6 +24087,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -24103,6 +24219,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -24358,6 +24475,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -24485,6 +24603,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -24877,6 +24996,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -25008,6 +25128,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -25264,6 +25385,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -25391,6 +25513,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -25724,6 +25847,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -25843,6 +25967,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -26571,6 +26696,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -26674,6 +26800,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -26777,6 +26904,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -26880,6 +27008,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -26983,6 +27112,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -27086,6 +27216,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -27189,6 +27320,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -27362,6 +27494,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -27465,6 +27598,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -27568,6 +27702,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -27671,6 +27806,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -27774,6 +27910,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -27877,6 +28014,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -27982,6 +28120,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -28085,6 +28224,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -28188,6 +28328,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -28291,6 +28432,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -28394,6 +28536,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -28497,6 +28640,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -28602,6 +28746,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -28841,6 +28986,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -28958,6 +29104,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -29211,6 +29358,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -29370,6 +29518,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -29529,6 +29678,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -29688,6 +29838,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -29927,6 +30078,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -30044,6 +30196,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -30298,6 +30451,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -30458,6 +30612,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -30618,6 +30773,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -30778,6 +30934,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -31017,6 +31174,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -31134,6 +31292,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -31394,6 +31553,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -31553,6 +31713,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -31712,6 +31873,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -31871,6 +32033,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -32115,6 +32278,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -32246,6 +32410,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -32463,6 +32628,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -32590,6 +32756,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -32813,6 +32980,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -32908,6 +33076,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -33012,6 +33181,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -33116,6 +33286,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -33315,6 +33486,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -33410,6 +33582,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -33624,6 +33797,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -33743,6 +33917,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -33942,6 +34117,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -34037,6 +34213,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -34135,6 +34312,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -34342,6 +34520,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -34437,6 +34616,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -34613,6 +34793,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -34740,6 +34921,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -34941,6 +35123,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -35036,6 +35219,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -35294,6 +35478,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -35489,6 +35674,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -35584,6 +35770,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -35698,6 +35885,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -35942,6 +36130,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -36059,6 +36248,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -36474,6 +36664,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -36685,6 +36876,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -36820,6 +37012,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -36925,6 +37118,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -37151,6 +37345,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -37268,6 +37463,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -37416,6 +37612,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -37531,6 +37728,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -37755,6 +37953,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -37872,6 +38071,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -37970,6 +38170,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -38224,6 +38425,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -38341,6 +38543,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -38623,6 +38826,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -38806,6 +39010,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -38960,6 +39165,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -39143,6 +39349,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -39297,6 +39504,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -39480,6 +39688,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -39634,6 +39843,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -39857,6 +40067,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -39974,6 +40185,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -40072,6 +40284,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -40305,6 +40518,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -40422,6 +40636,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -40586,6 +40801,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -40721,6 +40937,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
@@ -40827,6 +41044,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "float": "none",
       "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-helpers.ts
@@ -12,23 +12,13 @@ import { stylePropPathMappingFn } from '../../inspector/common/property-path-hoo
 import { DeleteProperties, deleteProperties } from '../commands/delete-properties-command'
 import { SetProperty, setProperty } from '../commands/set-property-command'
 
-export function isValidFlowReorderTarget(
-  elementMetadata: ElementInstanceMetadata | null,
-  allElementProps: AllElementProps,
-): boolean {
+export function isValidFlowReorderTarget(elementMetadata: ElementInstanceMetadata | null): boolean {
   if (MetadataUtils.isPositionAbsolute(elementMetadata)) {
     return false
   } else if (elementMetadata?.specialSizeMeasurements.float !== 'none') {
     return false
   } else if (MetadataUtils.isPositionRelative(elementMetadata) && elementMetadata != null) {
-    const styleProps = allElementProps[EP.toString(elementMetadata.elementPath)]?.style
-    return (
-      styleProps == null ||
-      (styleProps.left == null &&
-        styleProps.top == null &&
-        styleProps.right == null &&
-        styleProps.bottom == null)
-    )
+    return !elementMetadata.specialSizeMeasurements.hasPositionOffset
   } else {
     return true
   }
@@ -45,7 +35,7 @@ function findSiblingIndexUnderPoint(
     const siblingMetadata = MetadataUtils.findElementByElementPath(metadata, sibling)
     const frame = MetadataUtils.getFrameInCanvasCoords(sibling, metadata)
     return (
-      isValidFlowReorderTarget(siblingMetadata, allElementProps) &&
+      isValidFlowReorderTarget(siblingMetadata) &&
       frame != null &&
       rectContainsPoint(frame, point) &&
       MetadataUtils.isPositionedByFlow(siblingMetadata) &&

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-helpers.ts
@@ -12,16 +12,16 @@ import { stylePropPathMappingFn } from '../../inspector/common/property-path-hoo
 import { DeleteProperties, deleteProperties } from '../commands/delete-properties-command'
 import { SetProperty, setProperty } from '../commands/set-property-command'
 
-export function isValidSibling(
-  siblingMetadata: ElementInstanceMetadata | null,
+export function isValidFlowReorderTarget(
+  elementMetadata: ElementInstanceMetadata | null,
   allElementProps: AllElementProps,
 ): boolean {
-  if (MetadataUtils.isPositionAbsolute(siblingMetadata)) {
+  if (MetadataUtils.isPositionAbsolute(elementMetadata)) {
     return false
-  } else if (siblingMetadata?.specialSizeMeasurements.float !== 'none') {
+  } else if (elementMetadata?.specialSizeMeasurements.float !== 'none') {
     return false
-  } else if (MetadataUtils.isPositionRelative(siblingMetadata) && siblingMetadata != null) {
-    const styleProps = allElementProps[EP.toString(siblingMetadata.elementPath)].style
+  } else if (MetadataUtils.isPositionRelative(elementMetadata) && elementMetadata != null) {
+    const styleProps = allElementProps[EP.toString(elementMetadata.elementPath)]?.style
     return (
       styleProps == null ||
       (styleProps.left == null &&
@@ -45,7 +45,7 @@ function findSiblingIndexUnderPoint(
     const siblingMetadata = MetadataUtils.findElementByElementPath(metadata, sibling)
     const frame = MetadataUtils.getFrameInCanvasCoords(sibling, metadata)
     return (
-      isValidSibling(siblingMetadata, allElementProps) &&
+      isValidFlowReorderTarget(siblingMetadata, allElementProps) &&
       frame != null &&
       rectContainsPoint(frame, point) &&
       MetadataUtils.isPositionedByFlow(siblingMetadata) &&

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-slider-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-slider-strategy.tsx
@@ -18,19 +18,22 @@ import {
   getNewDisplayTypeForIndex,
   getOptionalDisplayPropCommands,
 } from './flow-reorder-helpers'
-import { isFlowReorderConversionApplicable } from './flow-reorder-strategy'
 import { isReorderAllowed } from './reorder-utils'
 
 export const flowReorderSliderStategy: CanvasStrategy = {
   id: 'FLOW_REORDER_SLIDER',
   name: () => 'Reorder (Slider)',
-  isApplicable: (canvasState, interactionState, metadata, allElementProps) => {
-    return isFlowReorderConversionApplicable(
-      canvasState,
-      interactionState,
-      metadata,
-      allElementProps,
-    )
+  isApplicable: (canvasState, interactionSession, metadata, allElementProps) => {
+    const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
+    if (selectedElements.length === 1) {
+      const target = selectedElements[0]
+      const elementMetadata = MetadataUtils.findElementByElementPath(metadata, target)
+      const siblings = MetadataUtils.getSiblings(metadata, target)
+      if (siblings.length > 1 && MetadataUtils.isPositionedByFlow(elementMetadata)) {
+        return true
+      }
+    }
+    return false
   },
   controlsToRender: [
     {

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.spec.browser2.tsx
@@ -6,9 +6,16 @@ import {
 } from '../ui-jsx.test-utils'
 import { act, fireEvent } from '@testing-library/react'
 import { CanvasControlsContainerID } from '../controls/new-canvas-controls'
-import { offsetPoint, windowPoint, WindowPoint } from '../../../core/shared/math-utils'
+import {
+  offsetPoint,
+  rectangleDifference,
+  windowPoint,
+  WindowPoint,
+} from '../../../core/shared/math-utils'
 import { emptyModifiers, Modifiers } from '../../../utils/modifiers'
 import * as EP from '../../../core/shared/element-path'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { assert } from 'chai'
 
 const TestProject = `
 <div style={{ width: '100%', height: '100%', position: 'absolute' }} data-uid='container'>
@@ -306,5 +313,64 @@ describe('Flow Reorder Strategy (Mixed Display Type)', () => {
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(TestProjectCCCDraggedToSecond),
     )
+  })
+  it('dragging an element over a sibling with float:right will skip reorder', async () => {
+    const TestCodeWithFloat = `
+      <div style={{ width: 100, height: 50, position: 'absolute' }} data-uid='container'>
+        <div
+          style={{
+            width: 50,
+            height: 50,
+            backgroundColor: '#CA1E4C80',
+            float: 'right'
+          }}
+          data-uid='aaa'
+          data-testid='aaa'
+        />
+        <div
+          style={{
+            width: 50,
+            height: 50,
+            backgroundColor: '#FF00FF',
+          }}
+          data-uid='bbb'
+          data-testid='bbb'
+        />
+      </div>
+    `
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(TestCodeWithFloat),
+      'await-first-dom-report',
+    )
+
+    const elementAFrame = MetadataUtils.getFrameInCanvasCoords(
+      EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:container/aaa'),
+      renderResult.getEditorState().editor.jsxMetadata,
+    )
+    const elementBFrame = MetadataUtils.getFrameInCanvasCoords(
+      EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:container/bbb'),
+      renderResult.getEditorState().editor.jsxMetadata,
+    )
+
+    if (elementAFrame == null || elementBFrame == null) {
+      assert.fail()
+    } else {
+      // drag element 'B' over 'A' will skip reorder
+      const dragDelta = windowPoint(rectangleDifference(elementBFrame, elementAFrame))
+      act(() =>
+        dragElement(renderResult, 'bbb', dragDelta, emptyModifiers, [
+          'utopia-storyboard-uid/scene-aaa',
+          'utopia-storyboard-uid/scene-aaa/app-entity',
+          'utopia-storyboard-uid/scene-aaa/app-entity:container',
+          'utopia-storyboard-uid/scene-aaa/app-entity:container/aaa',
+          'utopia-storyboard-uid/scene-aaa/app-entity:container/bbb',
+        ]),
+      )
+
+      await renderResult.getDispatchFollowUpActionsFinished()
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        makeTestProjectCodeWithSnippet(TestCodeWithFloat),
+      )
+    }
   })
 })

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
@@ -46,7 +46,7 @@ function isFlowReorderConversionApplicable(
     if (
       siblings.length > 1 &&
       MetadataUtils.isPositionedByFlow(elementMetadata) &&
-      isValidFlowReorderTarget(elementMetadata, allElementProps)
+      isValidFlowReorderTarget(elementMetadata)
     ) {
       return siblings.some((sibling) => MetadataUtils.isPositionedByFlow(sibling))
     } else {

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
@@ -32,7 +32,7 @@ import {
 import { AllElementProps } from '../../editor/store/editor-state'
 import { isReorderAllowed } from './reorder-utils'
 
-export function isFlowReorderConversionApplicable(
+function isFlowReorderConversionApplicable(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
   metadata: ElementInstanceMetadataMap,

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
@@ -88,6 +88,7 @@ function flowReorderApplyCommon(
 
     const { newIndex, targetSiblingUnderMouse } = getFlowReorderIndex(
       interactionState.latestMetadata,
+      strategyState.startingAllElementProps,
       rawPointOnCanvas,
       target,
     )

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
@@ -23,6 +23,7 @@ import {
   getFlowReorderIndex,
   getNewDisplayTypeForIndex,
   getOptionalDisplayPropCommands,
+  isValidFlowReorderTarget,
 } from './flow-reorder-helpers'
 import {
   FlowReorderAreaIndicator,
@@ -42,7 +43,11 @@ export function isFlowReorderConversionApplicable(
     const target = selectedElements[0]
     const elementMetadata = MetadataUtils.findElementByElementPath(metadata, target)
     const siblings = MetadataUtils.getSiblings(metadata, target)
-    if (siblings.length > 1 && MetadataUtils.isPositionedByFlow(elementMetadata)) {
+    if (
+      siblings.length > 1 &&
+      MetadataUtils.isPositionedByFlow(elementMetadata) &&
+      isValidFlowReorderTarget(elementMetadata, allElementProps)
+    ) {
       return siblings.some((sibling) => MetadataUtils.isPositionedByFlow(sibling))
     } else {
       return false

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -125,6 +125,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "initial",
           "flexDirection": null,
+          "float": "none",
           "globalContentBox": null,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
@@ -210,6 +211,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -307,6 +309,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -411,6 +414,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -520,6 +524,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 124,
             "width": 266,
@@ -631,6 +636,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 70,
             "width": 125,
@@ -777,6 +783,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "initial",
           "flexDirection": null,
+          "float": "none",
           "globalContentBox": null,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
@@ -862,6 +869,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -959,6 +967,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -1059,6 +1068,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -1159,6 +1169,7 @@ describe('DOM Walker tests', () => {
           "coordinateSystemBounds": null,
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 164,
             "width": 306,
@@ -1266,6 +1277,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 70,
             "width": 125,
@@ -1412,6 +1424,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "initial",
           "flexDirection": null,
+          "float": "none",
           "globalContentBox": null,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
@@ -1497,6 +1510,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -1594,6 +1608,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "flex",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -1694,6 +1709,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "flex",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -1794,6 +1810,7 @@ describe('DOM Walker tests', () => {
           "coordinateSystemBounds": null,
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 164,
             "width": 306,
@@ -1901,6 +1918,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 70,
             "width": 125,
@@ -2035,6 +2053,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "initial",
           "flexDirection": null,
+          "float": "none",
           "globalContentBox": null,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
@@ -2120,6 +2139,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -2217,6 +2237,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -2317,6 +2338,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -2455,6 +2477,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "initial",
           "flexDirection": null,
+          "float": "none",
           "globalContentBox": null,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
@@ -2540,6 +2563,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -2637,6 +2661,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -2737,6 +2762,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -2842,6 +2868,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -2947,6 +2974,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,
@@ -3052,6 +3080,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "float": "none",
           "globalContentBox": Object {
             "height": 812,
             "width": 375,

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -535,7 +535,7 @@ describe('DOM Walker tests', () => {
             "x": 55,
             "y": 98,
           },
-          "hasPositionOffset": false,
+          "hasPositionOffset": true,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -648,7 +648,7 @@ describe('DOM Walker tests', () => {
             "x": 126,
             "y": 125,
           },
-          "hasPositionOffset": false,
+          "hasPositionOffset": true,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 124,
@@ -1186,7 +1186,7 @@ describe('DOM Walker tests', () => {
             "x": 55,
             "y": 98,
           },
-          "hasPositionOffset": false,
+          "hasPositionOffset": true,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1295,7 +1295,7 @@ describe('DOM Walker tests', () => {
             "x": 126,
             "y": 125,
           },
-          "hasPositionOffset": false,
+          "hasPositionOffset": true,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 164,
@@ -1833,7 +1833,7 @@ describe('DOM Walker tests', () => {
             "x": 55,
             "y": 98,
           },
-          "hasPositionOffset": false,
+          "hasPositionOffset": true,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1942,7 +1942,7 @@ describe('DOM Walker tests', () => {
             "x": 126,
             "y": 125,
           },
-          "hasPositionOffset": false,
+          "hasPositionOffset": true,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 164,

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -127,6 +127,7 @@ describe('DOM Walker tests', () => {
           "flexDirection": null,
           "float": "none",
           "globalContentBox": null,
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 0,
@@ -218,6 +219,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -316,6 +318,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -421,6 +424,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -531,6 +535,7 @@ describe('DOM Walker tests', () => {
             "x": 55,
             "y": 98,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -643,6 +648,7 @@ describe('DOM Walker tests', () => {
             "x": 126,
             "y": 125,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 124,
@@ -785,6 +791,7 @@ describe('DOM Walker tests', () => {
           "flexDirection": null,
           "float": "none",
           "globalContentBox": null,
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 0,
@@ -876,6 +883,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -974,6 +982,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1075,6 +1084,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1176,6 +1186,7 @@ describe('DOM Walker tests', () => {
             "x": 55,
             "y": 98,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1284,6 +1295,7 @@ describe('DOM Walker tests', () => {
             "x": 126,
             "y": 125,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 164,
@@ -1426,6 +1438,7 @@ describe('DOM Walker tests', () => {
           "flexDirection": null,
           "float": "none",
           "globalContentBox": null,
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 0,
@@ -1517,6 +1530,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1615,6 +1629,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1716,6 +1731,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1817,6 +1833,7 @@ describe('DOM Walker tests', () => {
             "x": 55,
             "y": 98,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1925,6 +1942,7 @@ describe('DOM Walker tests', () => {
             "x": 126,
             "y": 125,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 164,
@@ -2055,6 +2073,7 @@ describe('DOM Walker tests', () => {
           "flexDirection": null,
           "float": "none",
           "globalContentBox": null,
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 0,
@@ -2146,6 +2165,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2244,6 +2264,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2345,6 +2366,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2479,6 +2501,7 @@ describe('DOM Walker tests', () => {
           "flexDirection": null,
           "float": "none",
           "globalContentBox": null,
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 0,
@@ -2570,6 +2593,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2668,6 +2692,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2769,6 +2794,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2875,6 +2901,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2981,6 +3008,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -3087,6 +3115,7 @@ describe('DOM Walker tests', () => {
             "x": 0,
             "y": 0,
           },
+          "hasPositionOffset": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -897,6 +897,16 @@ function getSpecialMeasurements(
     height: globalFrame.height - border.top - border.bottom,
   })
 
+  function positionValueIsDefault(value: string) {
+    return value === 'auto' || value === '0px'
+  }
+
+  const hasPositionOffset =
+    !positionValueIsDefault(elementStyle.top) ||
+    !positionValueIsDefault(elementStyle.right) ||
+    !positionValueIsDefault(elementStyle.bottom) ||
+    !positionValueIsDefault(elementStyle.left)
+
   return specialSizeMeasurements(
     offset,
     coordinateSystemBounds,
@@ -921,6 +931,7 @@ function getSpecialMeasurements(
     childrenCount,
     globalContentBox,
     elementStyle.float,
+    hasPositionOffset,
   )
 }
 

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -920,6 +920,7 @@ function getSpecialMeasurements(
     element.localName,
     childrenCount,
     globalContentBox,
+    elementStyle.float,
   )
 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
@@ -269,6 +269,7 @@ describe('SpecialSizeMeasurementsKeepDeepEquality', () => {
       height: 80,
     }),
     float: 'none',
+    hasPositionOffset: false,
   }
 
   const newDifferentValue: SpecialSizeMeasurements = {
@@ -323,6 +324,7 @@ describe('SpecialSizeMeasurementsKeepDeepEquality', () => {
       height: 0,
     }),
     float: 'none',
+    hasPositionOffset: false,
   }
 
   it('same reference returns the same reference', () => {
@@ -432,6 +434,7 @@ describe('ElementInstanceMetadataKeepDeepEquality', () => {
         height: 80,
       }),
       float: 'none',
+      hasPositionOffset: false,
     },
     computedStyle: {
       a: 'a',
@@ -514,6 +517,7 @@ describe('ElementInstanceMetadataKeepDeepEquality', () => {
         height: 80,
       }),
       float: 'none',
+      hasPositionOffset: false,
     },
     computedStyle: {
       a: 'a',
@@ -622,6 +626,7 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
           height: 80,
         }),
         float: 'none',
+        hasPositionOffset: false,
       },
       computedStyle: {
         a: 'a',
@@ -706,6 +711,7 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
           height: 80,
         }),
         float: 'none',
+        hasPositionOffset: false,
       },
       computedStyle: {
         a: 'a',
@@ -790,6 +796,7 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
           height: 80,
         }),
         float: 'none',
+        hasPositionOffset: false,
       },
       computedStyle: {
         a: 'a',

--- a/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
@@ -268,6 +268,7 @@ describe('SpecialSizeMeasurementsKeepDeepEquality', () => {
       width: 60,
       height: 80,
     }),
+    float: 'none',
   }
 
   const newDifferentValue: SpecialSizeMeasurements = {
@@ -321,6 +322,7 @@ describe('SpecialSizeMeasurementsKeepDeepEquality', () => {
       width: 60,
       height: 0,
     }),
+    float: 'none',
   }
 
   it('same reference returns the same reference', () => {
@@ -429,6 +431,7 @@ describe('ElementInstanceMetadataKeepDeepEquality', () => {
         width: 60,
         height: 80,
       }),
+      float: 'none',
     },
     computedStyle: {
       a: 'a',
@@ -510,6 +513,7 @@ describe('ElementInstanceMetadataKeepDeepEquality', () => {
         width: 60,
         height: 80,
       }),
+      float: 'none',
     },
     computedStyle: {
       a: 'a',
@@ -617,6 +621,7 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
           width: 60,
           height: 80,
         }),
+        float: 'none',
       },
       computedStyle: {
         a: 'a',
@@ -700,6 +705,7 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
           width: 60,
           height: 80,
         }),
+        float: 'none',
       },
       computedStyle: {
         a: 'a',
@@ -783,6 +789,7 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
           width: 60,
           height: 80,
         }),
+        float: 'none',
       },
       computedStyle: {
         a: 'a',

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1214,6 +1214,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
       newSize.globalContentBox,
     ).areEqual
     const floatEquals = oldSize.float === newSize.float
+    const hasPositionOffsetEquals = oldSize.hasPositionOffset === newSize.hasPositionOffset
     const areEqual =
       offsetResult.areEqual &&
       coordinateSystemBoundsResult.areEqual &&
@@ -1237,7 +1238,8 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
       htmlElementNameEquals &&
       renderedChildrenCount &&
       globalContentBoxEquals &&
-      floatEquals
+      floatEquals &&
+      hasPositionOffsetEquals
     if (areEqual) {
       return keepDeepEqualityResult(oldSize, true)
     } else {
@@ -1265,6 +1267,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
         newSize.renderedChildrenCount,
         newSize.globalContentBox,
         newSize.float,
+        newSize.hasPositionOffset,
       )
       return keepDeepEqualityResult(sizeMeasurements, false)
     }

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1213,6 +1213,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
       oldSize.globalContentBox,
       newSize.globalContentBox,
     ).areEqual
+    const floatEquals = oldSize.float === newSize.float
     const areEqual =
       offsetResult.areEqual &&
       coordinateSystemBoundsResult.areEqual &&
@@ -1235,7 +1236,8 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
       displayEquals &&
       htmlElementNameEquals &&
       renderedChildrenCount &&
-      globalContentBoxEquals
+      globalContentBoxEquals &&
+      floatEquals
     if (areEqual) {
       return keepDeepEqualityResult(oldSize, true)
     } else {
@@ -1262,6 +1264,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
         newSize.htmlElementName,
         newSize.renderedChildrenCount,
         newSize.globalContentBox,
+        newSize.float,
       )
       return keepDeepEqualityResult(sizeMeasurements, false)
     }

--- a/editor/src/core/layout/layout-utils.spec.browser2.tsx
+++ b/editor/src/core/layout/layout-utils.spec.browser2.tsx
@@ -177,6 +177,7 @@ function createPasteElementAction(
         0,
         null,
         'none',
+        false,
       ),
       computedStyle: emptyComputedStyle,
       attributeMetadatada: emptyAttributeMetadatada,

--- a/editor/src/core/layout/layout-utils.spec.browser2.tsx
+++ b/editor/src/core/layout/layout-utils.spec.browser2.tsx
@@ -176,6 +176,7 @@ function createPasteElementAction(
         'div',
         0,
         null,
+        'none',
       ),
       computedStyle: emptyComputedStyle,
       attributeMetadatada: emptyAttributeMetadatada,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -266,6 +266,9 @@ export const MetadataUtils = {
   isPositionAbsolute(instance: ElementInstanceMetadata | null): boolean {
     return instance?.specialSizeMeasurements.position === 'absolute'
   },
+  isPositionRelative(instance: ElementInstanceMetadata | null): boolean {
+    return instance?.specialSizeMeasurements.position === 'relative'
+  },
   isPositionedByFlow(instance: ElementInstanceMetadata | null): boolean {
     if (instance === null) {
       return false

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1604,6 +1604,7 @@ export interface SpecialSizeMeasurements {
   renderedChildrenCount: number
   globalContentBox: CanvasRectangle | null
   float: string
+  hasPositionOffset: boolean
 }
 
 export function specialSizeMeasurements(
@@ -1630,6 +1631,7 @@ export function specialSizeMeasurements(
   renderedChildrenCount: number,
   globalContentBox: CanvasRectangle | null,
   float: string,
+  hasPositionOffset: boolean,
 ): SpecialSizeMeasurements {
   return {
     offset,
@@ -1655,6 +1657,7 @@ export function specialSizeMeasurements(
     renderedChildrenCount,
     globalContentBox,
     float,
+    hasPositionOffset,
   }
 }
 
@@ -1685,6 +1688,7 @@ export const emptySpecialSizeMeasurements = specialSizeMeasurements(
   0,
   null,
   'none',
+  false,
 )
 
 export const emptyComputedStyle: ComputedStyle = {}

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1603,6 +1603,7 @@ export interface SpecialSizeMeasurements {
   htmlElementName: string
   renderedChildrenCount: number
   globalContentBox: CanvasRectangle | null
+  float: string
 }
 
 export function specialSizeMeasurements(
@@ -1628,6 +1629,7 @@ export function specialSizeMeasurements(
   htmlElementName: string,
   renderedChildrenCount: number,
   globalContentBox: CanvasRectangle | null,
+  float: string,
 ): SpecialSizeMeasurements {
   return {
     offset,
@@ -1652,6 +1654,7 @@ export function specialSizeMeasurements(
     htmlElementName,
     renderedChildrenCount,
     globalContentBox,
+    float,
   }
 }
 
@@ -1681,6 +1684,7 @@ export const emptySpecialSizeMeasurements = specialSizeMeasurements(
   'div',
   0,
   null,
+  'none',
 )
 
 export const emptyComputedStyle: ComputedStyle = {}


### PR DESCRIPTION
**Fix:**
When reordering static elements we should skip these siblings as they are not a bit standing somewhere outside of the flow layout:
- absolute
- float
- relative with at least one position property set

The fallback strategy still shows the slider control for these (except for absolute)

**Commit Details:**
- added float to specialSizeMeasurements
- filter selected element in `isApplicable`
- filter potential reorder sibling target when dragging an element over these special siblings
- test
