### PR TITLE
Save To Github

### DIFF
--- a/clientmodel/lib/package.yaml
+++ b/clientmodel/lib/package.yaml
@@ -26,6 +26,7 @@ default-extensions:
   - TypeOperators
   - DeriveDataTypeable
   - DataKinds
+  - DeriveAnyClass
 
 dependencies:
   - base
@@ -37,7 +38,26 @@ dependencies:
   - tasty
   - unordered-containers
   - text
+  - QuickCheck
+  - generic-arbitrary
+  - quickcheck-instances
 
 library:
   source-dirs:
     - src
+
+tests:
+  clientmodel-test:
+    main: Main.hs
+    source-dirs:
+      - test
+      - src
+    dependencies:
+      - hspec
+      - hedgehog
+      - tasty
+      - tasty-hedgehog
+      - tasty-hspec
+      - tasty-hunit
+      - tasty-quickcheck
+      - hedgehog-quickcheck

--- a/clientmodel/lib/src/Utopia/ClientModel.hs
+++ b/clientmodel/lib/src/Utopia/ClientModel.hs
@@ -3,7 +3,7 @@
 -}
 module Utopia.ClientModel where
 
-import           Control.Lens
+import           Control.Lens                                  hiding (children)
 import           Control.Monad.Fail
 import           Data.Aeson
 import           Data.Aeson.Lens
@@ -11,10 +11,19 @@ import           Data.Aeson.Types
 import           Data.Data
 import           Data.Generics.Product
 import           Data.Generics.Sum
-import qualified Data.HashMap.Strict   as M
-import           Data.Text             hiding (foldl', reverse)
+import qualified Data.HashMap.Strict                           as M
+import           Data.Text                                     hiding (foldl',
+                                                                reverse)
 import           Data.Typeable
 import           Relude
+import           Test.QuickCheck
+import           Test.QuickCheck.Arbitrary.Generic
+import           Test.QuickCheck.Instances.Text
+import           Test.QuickCheck.Instances.UnorderedContainers
+
+-- Slightly nonsense Arbitrary instance, but one that suffices for our needs.
+instance Arbitrary Value where
+  arbitrary = fmap (toJSON :: Text -> Value) arbitrary
 
 textToJSON :: Text -> Value
 textToJSON = toJSON
@@ -31,6 +40,10 @@ instance FromJSON ElementPath where
 
 instance ToJSON ElementPath where
   toJSON = genericToJSON defaultOptions
+
+instance Arbitrary ElementPath where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
 
 data RevisionsState = ParsedAhead
                     | CodeAhead
@@ -52,6 +65,10 @@ instance ToJSON RevisionsState where
   toJSON CodeAhead   = textToJSON "CODE_AHEAD"
   toJSON BothMatch   = textToJSON "BOTH_MATCH"
 
+instance Arbitrary RevisionsState where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
+
 data ParseFailure = ParseFailure
                   { diagnostics   :: Maybe [Value]
                   , parsedJSON    :: Maybe Value
@@ -65,6 +82,10 @@ instance FromJSON ParseFailure where
 
 instance ToJSON ParseFailure where
   toJSON = genericToJSON defaultOptions
+
+instance Arbitrary ParseFailure where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
 
 data ParseSuccess = ParseSuccess
                   { imports                        :: Value
@@ -82,6 +103,10 @@ instance FromJSON ParseSuccess where
 instance ToJSON ParseSuccess where
   toJSON = genericToJSON defaultOptions
 
+instance Arbitrary ParseSuccess where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
+
 data Unparsed = Unparsed
               deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -90,6 +115,10 @@ instance FromJSON Unparsed where
 
 instance ToJSON Unparsed where
   toJSON = const $ object []
+
+instance Arbitrary Unparsed where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
 
 data ParsedTextFile = ParsedTextFileFailure ParseFailure
                     | ParsedTextFileSuccess ParseSuccess
@@ -111,6 +140,10 @@ instance ToJSON ParsedTextFile where
   toJSON (ParsedTextFileSuccess parseSuccess) = over _Object (M.insert "type" "PARSE_SUCCESS") $ toJSON parseSuccess
   toJSON (ParsedTextFileUnparsed unparsed) = over _Object (M.insert "type" "UNPARSED") $ toJSON unparsed
 
+instance Arbitrary ParsedTextFile where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
+
 -- This for the moment excludes the `parsed` field as
 -- that is a very deep and wide structure.
 data TextFileContents = TextFileContents
@@ -126,6 +159,10 @@ instance FromJSON TextFileContents where
 instance ToJSON TextFileContents where
   toJSON = genericToJSON defaultOptions
 
+instance Arbitrary TextFileContents where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
+
 data TextFile = TextFile
               { fileContents      :: TextFileContents
               , lastSavedContents :: Maybe TextFileContents
@@ -138,6 +175,10 @@ instance FromJSON TextFile where
 
 instance ToJSON TextFile where
   toJSON = genericToJSON defaultOptions
+
+instance Arbitrary TextFile where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
 
 data ImageFile = ImageFile
                { imageType :: Maybe Text
@@ -154,6 +195,10 @@ instance FromJSON ImageFile where
 instance ToJSON ImageFile where
   toJSON = genericToJSON defaultOptions
 
+instance Arbitrary ImageFile where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
+
 data AssetFile = AssetFile
                  deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -161,11 +206,29 @@ instance FromJSON AssetFile where
   parseJSON = const $ pure AssetFile
 
 instance ToJSON AssetFile where
-  toJSON = genericToJSON defaultOptions
+  toJSON _ = object []
+
+instance Arbitrary AssetFile where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
+
+data Directory = Directory
+                 deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON Directory where
+  parseJSON = const $ pure Directory
+
+instance ToJSON Directory where
+  toJSON _ = object []
+
+instance Arbitrary Directory where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
 
 data ProjectFile = ProjectTextFile TextFile
                  | ProjectImageFile ImageFile
                  | ProjectAssetFile AssetFile
+                 | ProjectDirectory Directory
                  deriving (Eq, Show, Generic, Data, Typeable)
 
 instance FromJSON ProjectFile where
@@ -175,6 +238,7 @@ instance FromJSON ProjectFile where
           (Just "TEXT_FILE")  -> fmap ProjectTextFile $ parseJSON value
           (Just "IMAGE_FILE") -> fmap ProjectImageFile $ parseJSON value
           (Just "ASSET_FILE") -> fmap ProjectAssetFile $ parseJSON value
+          (Just "DIRECTORY")  -> fmap ProjectDirectory $ parseJSON value
           (Just unknownType)  -> fail ("Unknown type: " <> unpack unknownType)
           _                   -> fail "No type for ProjectFile specified."
 
@@ -182,12 +246,18 @@ instance ToJSON ProjectFile where
   toJSON (ProjectTextFile textFile) = over _Object (M.insert "type" "TEXT_FILE") $ toJSON textFile
   toJSON (ProjectImageFile imageFile) = over _Object (M.insert "type" "IMAGE_FILE") $ toJSON imageFile
   toJSON (ProjectAssetFile assetFile) = over _Object (M.insert "type" "ASSET_FILE") $ toJSON assetFile
+  toJSON (ProjectDirectory assetFile) = over _Object (M.insert "type" "DIRECTORY") $ toJSON assetFile
+
+instance Arbitrary ProjectFile where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
 
 type ProjectContentTreeRoot = M.HashMap Text ProjectContentsTree
 
 data ProjectContentDirectory = ProjectContentDirectory
-                             { fullPath :: Text
-                             , children :: ProjectContentTreeRoot
+                             { fullPath   :: Text
+                             , directory  :: Directory
+                             , children   :: ProjectContentTreeRoot
                              }
                              deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -196,6 +266,24 @@ instance FromJSON ProjectContentDirectory where
 
 instance ToJSON ProjectContentDirectory where
   toJSON = genericToJSON defaultOptions
+
+generateProjectContentsTree :: Int -> Gen ProjectContentsTree
+generateProjectContentsTree 0 = fmap ProjectContentsTreeFile arbitrary
+generateProjectContentsTree depth = oneof
+  [ fmap ProjectContentsTreeDirectory $ resize 3 $ generateProjectContentDirectory depth
+  , fmap ProjectContentsTreeFile arbitrary
+  ]
+
+generateProjectContentDirectory :: Int -> Gen ProjectContentDirectory
+generateProjectContentDirectory depth = do
+  fullPath <- arbitrary
+  children <- liftArbitrary $ generateProjectContentsTree (depth - 1)
+  let directory = Directory
+  pure ProjectContentDirectory{..}
+
+instance Arbitrary ProjectContentDirectory where
+  arbitrary = generateProjectContentDirectory 2
+  shrink = genericShrink
 
 data ProjectContentFile = ProjectContentFile
                         { fullPath :: Text
@@ -208,6 +296,10 @@ instance FromJSON ProjectContentFile where
 
 instance ToJSON ProjectContentFile where
   toJSON = genericToJSON defaultOptions
+
+instance Arbitrary ProjectContentFile where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
 
 data ProjectContentsTree = ProjectContentsTreeDirectory ProjectContentDirectory
                          | ProjectContentsTreeFile ProjectContentFile
@@ -226,30 +318,82 @@ instance ToJSON ProjectContentsTree where
   toJSON (ProjectContentsTreeDirectory dirEntry) = over _Object (M.insert "type" "PROJECT_CONTENT_DIRECTORY") $ toJSON dirEntry
   toJSON (ProjectContentsTreeFile fileEntry) = over _Object (M.insert "type" "PROJECT_CONTENT_FILE") $ toJSON fileEntry
 
--- This is currently not a comprehensive definition for the persistent model the
--- front-end can supply, so round tripping via this type is guaranteed to lose data.
-data PartialPersistentModel = PartialPersistentModel
-                            { projectContents :: ProjectContentTreeRoot
+instance Arbitrary ProjectContentsTree where
+  arbitrary = generateProjectContentsTree 2
+  shrink = genericShrink
+
+data GithubRepo = GithubRepo
+                { owner      :: Text
+                , repository :: Text
+                }
+                deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON GithubRepo where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON GithubRepo where
+  toJSON = genericToJSON defaultOptions
+
+instance Arbitrary GithubRepo where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
+
+data ProjectGithubSettings = ProjectGithubSettings
+                           { targetRepository     :: Maybe GithubRepo
+                           }
+                           deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON ProjectGithubSettings where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON ProjectGithubSettings where
+  toJSON = genericToJSON defaultOptions
+
+instance Arbitrary ProjectGithubSettings where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
+
+data PersistentModel = PersistentModel
+                            { appID               :: Maybe Text
+                            , forkedFromProjectId :: Maybe Text
+                            , projectVersion      :: Integer
+                            , projectDescription  :: Text
+                            , projectContents     :: ProjectContentTreeRoot
+                            , exportsInfo         :: [Value]
+                            , lastUsedFont        :: Maybe Value
+                            , hiddenInstances     :: [ElementPath]
+                            , codeEditorErrors    :: Value
+                            , fileBrowser         :: Value
+                            , dependencyList      :: Value
+                            , projectSettings     :: Value
+                            , navigator           :: Value
+                            , githubSettings      :: ProjectGithubSettings
                             }
                             deriving (Eq, Show, Generic, Data, Typeable)
 
-instance FromJSON PartialPersistentModel where
+instance FromJSON PersistentModel where
   parseJSON = genericParseJSON defaultOptions
 
-instance ToJSON PartialPersistentModel where
+instance ToJSON PersistentModel where
   toJSON = genericToJSON defaultOptions
 
-getProjectContentsTreeFile :: ProjectContentTreeRoot -> [Text] -> Maybe ProjectFile
-getProjectContentsTreeFile _ [] = Nothing
-getProjectContentsTreeFile projectContentsTree pathElements =
-  let directoryContentLens filename = ix filename . _Ctor @"ProjectContentsTreeDirectory" . field @"children"
-      fileLens filename = ix filename . _Ctor @"ProjectContentsTreeFile" . field @"content"
-      finalPathElement : remainingPathElements = reverse pathElements
-      -- Construct the lens from the leaf up to the root.
-      lookupLens = foldl' (\soFar filename -> directoryContentLens filename . soFar) (fileLens finalPathElement) remainingPathElements
-   in firstOf lookupLens projectContentsTree
+instance Arbitrary PersistentModel where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
 
-persistentModelFromJSON :: Value -> Either Text PartialPersistentModel
-persistentModelFromJSON value = first pack $ parseEither parseJSON value
+getProjectContentsTreeFile :: ProjectContentTreeRoot -> [Text] -> Maybe ProjectFile
+getProjectContentsTreeFile _ [] =
+  Nothing
+getProjectContentsTreeFile treeRoot [lastPart] =
+  firstOf (at lastPart . _Just . _Ctor @"ProjectContentsTreeFile" . field @"content") treeRoot
+getProjectContentsTreeFile treeRoot (firstPart : restOfParts) = do
+  nextRoot <- firstOf (at firstPart . _Just . _Ctor @"ProjectContentsTreeDirectory" . field @"children") treeRoot
+  getProjectContentsTreeFile nextRoot restOfParts
+
+
+
+
+
+
 
 

--- a/clientmodel/lib/test/Main.hs
+++ b/clientmodel/lib/test/Main.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE CPP #-}
+
+module Main where
+
+import           Relude
+import           Test.Tasty
+import           Test.Tasty.Hspec
+import           Utopia.ClientModelTest
+
+tests :: IO TestTree
+tests = do
+  return $
+    localOption TreatPendingAsSuccess $
+      testGroup "Tests" [clientModelTestTree]
+
+main :: IO ()
+main = do
+  tree <- tests
+  defaultMain tree
+

--- a/clientmodel/lib/test/Utopia/ClientModelTest.hs
+++ b/clientmodel/lib/test/Utopia/ClientModelTest.hs
@@ -1,0 +1,32 @@
+module Utopia.ClientModelTest where
+
+import           Data.Aeson
+import           Hedgehog
+import qualified Hedgehog.Gen            as Gen
+import qualified Hedgehog.Gen.QuickCheck as Gen
+import           Relude
+import           Test.Tasty
+import           Test.Tasty.Hedgehog
+import           Test.Tasty.Hspec
+import           Utopia.ClientModel
+
+
+clientModelTestTree :: TestTree
+clientModelTestTree = do
+  testGroup "toJSON/fromJSON"
+    [ testProperty "ProjectFile produces the same value when transformed to and back from JSON" $
+        property $ do
+          projectFile <- forAll (Gen.arbitrary :: Gen ProjectFile)
+          let convertedToJSON = toJSON projectFile
+          footnoteShow ("convertedToJSON" :: Text, convertedToJSON)
+          let actualResult = fromJSON convertedToJSON
+          actualResult === pure projectFile
+    , testProperty "PersistentModel produces the same value when transformed to and back from JSON" $
+        property $ do
+          persistentModel <- forAll (Gen.arbitrary :: Gen PersistentModel)
+          let convertedToJSON = toJSON persistentModel
+          footnoteShow ("convertedToJSON" :: Text, convertedToJSON)
+          let actualResult = fromJSON convertedToJSON
+          actualResult === pure persistentModel
+    ]
+

--- a/clientmodel/lib/utopia-clientmodel.cabal
+++ b/clientmodel/lib/utopia-clientmodel.cabal
@@ -33,15 +33,68 @@ library
       TypeOperators
       DeriveDataTypeable
       DataKinds
+      DeriveAnyClass
   ghc-options: -Wall -Werror -threaded -fno-warn-orphans -Wno-unused-imports
   build-depends:
-      aeson <2.1
+      QuickCheck
+    , aeson <2.1
     , base
+    , generic-arbitrary
     , generic-lens
     , lens
     , lens-aeson <1.2
+    , quickcheck-instances
     , relude
     , tasty
+    , text
+    , unordered-containers
+  default-language: Haskell2010
+
+test-suite clientmodel-test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Utopia.ClientModelTest
+      Utopia.ClientModel
+      Paths_utopia_clientmodel
+  hs-source-dirs:
+      test
+      src
+  default-extensions:
+      NoImplicitPrelude
+      OverloadedStrings
+      DeriveGeneric
+      DuplicateRecordFields
+      FlexibleContexts
+      MonoLocalBinds
+      OverloadedStrings
+      RankNTypes
+      RecordWildCards
+      TemplateHaskell
+      TypeApplications
+      TypeOperators
+      DeriveDataTypeable
+      DataKinds
+      DeriveAnyClass
+  ghc-options: -Wall -Werror -threaded -fno-warn-orphans -Wno-unused-imports
+  build-depends:
+      QuickCheck
+    , aeson <2.1
+    , base
+    , generic-arbitrary
+    , generic-lens
+    , hedgehog
+    , hedgehog-quickcheck
+    , hspec
+    , lens
+    , lens-aeson <1.2
+    , quickcheck-instances
+    , relude
+    , tasty
+    , tasty-hedgehog
+    , tasty-hspec
+    , tasty-hunit
+    , tasty-quickcheck
     , text
     , unordered-containers
   default-language: Haskell2010

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -974,6 +974,11 @@ export type ToggleSelectionLock = {
   newValue: SelectionLocked
 }
 
+export interface SaveToGithub {
+  action: 'SAVE_TO_GITHUB'
+  targetRepository: string
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertScene
@@ -1131,6 +1136,7 @@ export type EditorAction =
   | RunEscapeHatch
   | SetElementsToRerender
   | ToggleSelectionLock
+  | SaveToGithub
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -213,6 +213,7 @@ import type {
   ToggleSelectionLock,
   ElementPaste,
   SetGithubState,
+  SaveToGithub,
 } from '../action-types'
 import {
   EditorModes,
@@ -1532,5 +1533,12 @@ export function toggleSelectionLock(
     action: 'TOGGLE_SELECTION_LOCK',
     targets: targets,
     newValue: newValue,
+  }
+}
+
+export function saveToGithub(targetRepository: string): SaveToGithub {
+  return {
+    action: 'SAVE_TO_GITHUB',
+    targetRepository: targetRepository,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -115,6 +115,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SET_USERS_PREFERRED_STRATEGY':
     case 'SET_ELEMENTS_TO_RERENDER':
     case 'TOGGLE_SELECTION_LOCK':
+    case 'SAVE_TO_GITHUB':
       return true
 
     case 'NEW':

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -933,6 +933,9 @@ describe('LOAD', () => {
       navigator: {
         minimised: false,
       },
+      githubSettings: {
+        targetRepository: null,
+      },
     }
 
     const action = {

--- a/editor/src/components/editor/actions/migrations/migrations.ts
+++ b/editor/src/components/editor/actions/migrations/migrations.ts
@@ -30,7 +30,7 @@ import {
 } from '../../../assets'
 import { isUtopiaJSXComponent } from '../../../../core/shared/element-template'
 
-export const CURRENT_PROJECT_VERSION = 7
+export const CURRENT_PROJECT_VERSION = 8
 
 export function applyMigrations(
   persistentModel: PersistentModel,
@@ -42,7 +42,8 @@ export function applyMigrations(
   const version5 = migrateFromVersion4(version4)
   const version6 = migrateFromVersion5(version5)
   const version7 = migrateFromVersion6(version6)
-  return version7
+  const version8 = migrateFromVersion7(version7)
+  return version8
 }
 
 function migrateFromVersion0(
@@ -323,6 +324,22 @@ function migrateFromVersion6(
       ...persistentModel,
       projectVersion: 7,
       projectContents: updatedProjectContents,
+    }
+  }
+}
+
+function migrateFromVersion7(
+  persistentModel: PersistentModel,
+): PersistentModel & { projectVersion: 8 } {
+  if (persistentModel.projectVersion != null && persistentModel.projectVersion !== 7) {
+    return persistentModel as any
+  } else {
+    return {
+      ...persistentModel,
+      projectVersion: 8,
+      githubSettings: {
+        targetRepository: null,
+      },
     }
   }
 }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -850,6 +850,28 @@ export type LockedElements = {
   hierarchyLock: Array<ElementPath>
 }
 
+export interface GithubRepo {
+  owner: string
+  repository: string
+}
+
+export function githubRepo(owner: string, repository: string): GithubRepo {
+  return {
+    owner: owner,
+    repository: repository,
+  }
+}
+
+export interface ProjectGithubSettings {
+  targetRepository: GithubRepo | null
+}
+
+export function projectGithubSettings(targetRepository: GithubRepo | null): ProjectGithubSettings {
+  return {
+    targetRepository: targetRepository,
+  }
+}
+
 // FIXME We need to pull out ProjectState from here
 export interface EditorState {
   id: string | null
@@ -916,6 +938,7 @@ export interface EditorState {
   indexedDBFailed: boolean
   forceParseFiles: Array<string>
   allElementProps: AllElementProps // the final, resolved, static props value for each element.
+  githubSettings: ProjectGithubSettings
 }
 
 export function editorState(
@@ -983,6 +1006,7 @@ export function editorState(
   indexedDBFailed: boolean,
   forceParseFiles: Array<string>,
   allElementProps: AllElementProps,
+  githubSettings: ProjectGithubSettings,
 ): EditorState {
   return {
     id: id,
@@ -1049,6 +1073,7 @@ export function editorState(
     indexedDBFailed: indexedDBFailed,
     forceParseFiles: forceParseFiles,
     allElementProps: allElementProps,
+    githubSettings: githubSettings,
   }
 }
 
@@ -1609,7 +1634,7 @@ function emptyDerivedState(editor: EditorState): DerivedState {
 }
 
 export interface PersistentModel {
-  appID?: string | null
+  appID: string | null
   forkedFromProjectId: string | null
   projectVersion: number
   projectDescription: string
@@ -1633,6 +1658,7 @@ export interface PersistentModel {
   navigator: {
     minimised: boolean
   }
+  githubSettings: ProjectGithubSettings
 }
 
 export function isPersistentModel(data: any): data is PersistentModel {
@@ -1672,6 +1698,7 @@ export function mergePersistentModel(
     navigator: {
       minimised: second.navigator.minimised,
     },
+    githubSettings: second.githubSettings,
   }
 }
 
@@ -1852,6 +1879,9 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     indexedDBFailed: false,
     forceParseFiles: [],
     allElementProps: {},
+    githubSettings: {
+      targetRepository: null,
+    },
   }
 }
 
@@ -2144,6 +2174,7 @@ export function editorModelFromPersistentModel(
     indexedDBFailed: false,
     forceParseFiles: [],
     allElementProps: {},
+    githubSettings: persistentModel.githubSettings,
   }
   return editor
 }
@@ -2179,6 +2210,7 @@ export function persistentModelFromEditorModel(editor: EditorState): PersistentM
     navigator: {
       minimised: editor.navigator.minimised,
     },
+    githubSettings: editor.githubSettings,
   }
 }
 
@@ -2209,6 +2241,9 @@ export function persistentModelForProjectContents(
     },
     navigator: {
       minimised: false,
+    },
+    githubSettings: {
+      targetRepository: null,
     },
   }
 }

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -343,6 +343,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.RUN_ESCAPE_HATCH(action, state, builtInDependencies)
     case 'TOGGLE_SELECTION_LOCK':
       return UPDATE_FNS.TOGGLE_SELECTION_LOCK(action, state)
+    case 'SAVE_TO_GITHUB':
+      return UPDATE_FNS.SAVE_TO_GITHUB(action, state)
     default:
       return state
   }

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -309,6 +309,10 @@ import {
   editorState,
   AllElementProps,
   LockedElements,
+  ProjectGithubSettings,
+  GithubRepo,
+  githubRepo,
+  projectGithubSettings,
 } from './editor-state'
 import {
   CornerGuideline,
@@ -2988,6 +2992,21 @@ export const UtopiaVSCodeConfigKeepDeepEquality: KeepDeepEqualityCall<UtopiaVSCo
     },
   )
 
+export const GithubRepoKeepDeepEquality: KeepDeepEqualityCall<GithubRepo> = combine2EqualityCalls(
+  (repo) => repo.owner,
+  createCallWithTripleEquals(),
+  (repo) => repo.repository,
+  createCallWithTripleEquals(),
+  githubRepo,
+)
+
+export const ProjectGithubSettingsKeepDeepEquality: KeepDeepEqualityCall<ProjectGithubSettings> =
+  combine1EqualityCall(
+    (settings) => settings.targetRepository,
+    nullableDeepEquality(GithubRepoKeepDeepEquality),
+    projectGithubSettings,
+  )
+
 export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
   oldValue,
   newValue,
@@ -3206,6 +3225,10 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     oldValue.allElementProps,
     newValue.allElementProps,
   )
+  const githubSettingsResults = ProjectGithubSettingsKeepDeepEquality(
+    oldValue.githubSettings,
+    newValue.githubSettings,
+  )
 
   const areEqual =
     idResult.areEqual &&
@@ -3271,7 +3294,8 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     vscodeLoadingScreenVisibleResults.areEqual &&
     indexedDBFailedResults.areEqual &&
     forceParseFilesResults.areEqual &&
-    allElementPropsResults.areEqual
+    allElementPropsResults.areEqual &&
+    githubSettingsResults.areEqual
 
   if (areEqual) {
     return keepDeepEqualityResult(oldValue, true)
@@ -3341,6 +3365,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
       indexedDBFailedResults.value,
       forceParseFilesResults.value,
       allElementPropsResults.value,
+      githubSettingsResults.value,
     )
 
     return keepDeepEqualityResult(newEditorState, false)

--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -716,15 +716,22 @@ const GithubPane = React.memo(() => {
   const [githubRepoStr, setGithubRepoStr] = React.useState('')
   const parsedRepo = parseGithubProjectString(githubRepoStr)
   const dispatch = useEditorState((store) => store.dispatch, 'GithubPane dispatch')
-  const persistence = useEditorState((store) => store.persistence, 'GithubPane persistence')
+  const storedTargetGithubRepo = useEditorState((store) => {
+    const repo = store.editor.githubSettings.targetRepository
+    if (repo == null) {
+      return undefined
+    } else {
+      return `https://github.com/${repo.owner}/${repo.repository}`
+    }
+  }, 'GithubPane storedTargetGithubRepo')
 
   const onStartImport = React.useCallback(() => {
     if (parsedRepo != null) {
-      const { owner, repo } = parsedRepo
+      const { owner, repository } = parsedRepo
 
       const url = new URL(urljoin(BASE_URL, 'p'))
       url.searchParams.set('github_owner', owner)
-      url.searchParams.set('github_repo', repo)
+      url.searchParams.set('github_repo', repository)
 
       window.open(url.toString())
     }
@@ -769,6 +776,23 @@ const GithubPane = React.memo(() => {
     },
     [dispatch],
   )
+
+  const [githubRepoToSaveTo, setGithubRepoToSaveTo] = React.useState<string | undefined>(
+    storedTargetGithubRepo,
+  )
+
+  const onChangeGithubRepoToSaveTo = React.useCallback(
+    (changeEvent: React.ChangeEvent<HTMLInputElement>) => {
+      setGithubRepoToSaveTo(changeEvent.currentTarget.value)
+    },
+    [setGithubRepoToSaveTo],
+  )
+
+  const triggerSaveToGithub = React.useCallback(() => {
+    if (githubRepoToSaveTo != null) {
+      dispatch([EditorActions.saveToGithub(githubRepoToSaveTo)], 'everyone')
+    }
+  }, [dispatch, githubRepoToSaveTo])
 
   return (
     <FlexColumn
@@ -835,6 +859,34 @@ const GithubPane = React.memo(() => {
             <StringInput testId='importProject' value={githubRepoStr} onChange={onChange} />
             <Button spotlight highlight disabled={parsedRepo == null} onMouseUp={onStartImport}>
               Start
+            </Button>
+          </UIGridRow>
+
+          <div
+            style={{
+              height: 'initial',
+              minHeight: 34,
+              alignItems: 'flex-start',
+              paddingTop: 8,
+              paddingLeft: 8,
+              paddingRight: 8,
+              paddingBottom: 8,
+              whiteSpace: 'pre-wrap',
+              letterSpacing: 0.1,
+              lineHeight: '17px',
+              fontSize: '11px',
+            }}
+          >
+            Save to a Github repo if you have access to it.
+          </div>
+          <UIGridRow padded variant='<--------auto-------->|--45px--|'>
+            <StringInput
+              testId='saveToGithubInput'
+              value={githubRepoToSaveTo}
+              onChange={onChangeGithubRepoToSaveTo}
+            />
+            <Button spotlight highlight onMouseUp={triggerSaveToGithub}>
+              Save
             </Button>
           </UIGridRow>
         </SectionBodyArea>

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -91,6 +91,7 @@ async function loadProject(
   projectContents: ProjectContentTreeRoot,
 ): Promise<boolean> {
   const persistentModel: PersistentModel = {
+    appID: null,
     forkedFromProjectId: null,
     projectVersion: CURRENT_PROJECT_VERSION,
     projectDescription: 'Performance Test Project',
@@ -113,6 +114,9 @@ async function loadProject(
     },
     navigator: {
       minimised: false,
+    },
+    githubSettings: {
+      targetRepository: null,
     },
   }
 

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -1,9 +1,8 @@
+import { UTOPIA_BACKEND } from '../../common/env-vars'
+import urljoin from 'url-join'
+import { GithubRepo, PersistentModel } from '../../components/editor/store/editor-state'
 import { trimUpToAndIncluding } from './string-utils'
-
-export interface GithubRepo {
-  owner: string
-  repo: string
-}
+import { HEADERS, MODE } from '../../common/server'
 
 export function parseGithubProjectString(maybeProject: string): GithubRepo | null {
   const withoutGithubPrefix = trimUpToAndIncluding('github.com/', maybeProject)
@@ -17,7 +16,23 @@ export function parseGithubProjectString(maybeProject: string): GithubRepo | nul
   } else {
     return {
       owner: owner,
-      repo: repo,
+      repository: repo,
     }
+  }
+}
+
+export async function saveProjectToGithub(persistentModel: PersistentModel): Promise<void> {
+  const url = urljoin(UTOPIA_BACKEND, 'github', 'save')
+
+  const postBody = JSON.stringify(persistentModel)
+  const response = await fetch(url, {
+    method: 'POST',
+    credentials: 'include',
+    headers: HEADERS,
+    mode: MODE,
+    body: postBody,
+  })
+  if (!response.ok) {
+    throw new Error(`Unexpected status returned from endpoint: ${response.status}`)
   }
 }

--- a/server/migrations/002.sql
+++ b/server/migrations/002.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ONLY "public"."github_authentication"
+    ALTER COLUMN "refresh_token" DROP NOT NULL;
+
+ALTER TABLE ONLY "public"."github_authentication"
+    ALTER COLUMN "expires_at" DROP NOT NULL;

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -19,6 +19,7 @@ dependencies:
   - amazonka-s3 ==1.6.1
   - base >= 4.7 && < 5
   - base16-bytestring
+  - base64
   - binary
   - blaze-html
   - bytestring
@@ -28,6 +29,7 @@ dependencies:
   - conduit
   - cookie
   - cryptohash-sha256
+  - cryptonite
   - data-default
   - directory
   - exceptions
@@ -35,13 +37,14 @@ dependencies:
   - filepath
   - free
   - zlib
-  - hoauth2
+  - hoauth2 ==1.16.0
   - http-api-data
   - http-client
   - http-client-tls
   - http-media
   - http-types
   - generic-lens
+  - github 
   - lens
   - lens-aeson <1.2
   - lifted-base
@@ -73,6 +76,7 @@ dependencies:
   - servant-websockets ==2.0.0
   - serversession ==1.0.2
   - split
+  - string-conversions
   - tagsoup
   - tar
   - temporary
@@ -109,6 +113,7 @@ tests:
       else:
         cpp-options: -DENABLE_EXTERNAL_TESTS=False
     main: Main.hs
+    ghc-options: +RTS -N1 -RTS
     source-dirs:
       - test
       - src

--- a/server/src/Main.hs
+++ b/server/src/Main.hs
@@ -43,3 +43,4 @@ main = do
   stop <- runServer environment
   ignoreError $ threadDelay (1000 * 1000 * 60 * 60 * 24 * 365) -- Run for a year.
   stop
+

--- a/server/src/Utopia/Web/Database.hs
+++ b/server/src/Utopia/Web/Database.hs
@@ -18,6 +18,7 @@ import           Control.Lens                    hiding ((.>))
 import           Control.Monad.Catch
 import           Control.Monad.Fail
 import           Data.Aeson
+import           Data.Aeson.Lens
 import qualified Data.ByteString.Lazy            as BL
 import           Data.Generics.Product
 import           Data.Generics.Sum
@@ -388,8 +389,13 @@ checkIfProjectIDReserved metrics pool projectId = invokeAndMeasure (_checkIfProj
 
 projectContentTreeFromDecodedProject :: DecodedProject -> Either Text ProjectContentTreeRoot
 projectContentTreeFromDecodedProject decodedProject = do
-  let contentOfProject = view (field @"content") decodedProject
-  fmap (view (field @"projectContents")) $ persistentModelFromJSON contentOfProject
+  let possibleContentOfProject = firstOf (field @"content" . key "projectContents") decodedProject
+  case possibleContentOfProject of
+    Nothing               -> Left "No projectContents found."
+    Just contentOfProject -> do
+      case fromJSON contentOfProject of
+        Error err         -> Left $ toS err
+        Success result    -> Right result
 
 updateGithubAuthenticationDetails :: DatabaseMetrics -> DBPool -> GithubAuthenticationDetails -> IO ()
 updateGithubAuthenticationDetails metrics pool GithubAuthenticationDetails{..} = invokeAndMeasure (_updateGithubAuthenticationDetailsMetrics metrics) $ usePool pool $ \connection -> do
@@ -406,7 +412,7 @@ updateGithubAuthenticationDetails metrics pool GithubAuthenticationDetails{..} =
                                , iOnConflict = Nothing
                                }
 
-githubAuthenticationDetailsFromRow :: (Text, Text, Text, UTCTime) -> GithubAuthenticationDetails
+githubAuthenticationDetailsFromRow :: (Text, Text, Maybe Text, Maybe UTCTime) -> GithubAuthenticationDetails
 githubAuthenticationDetailsFromRow (userId, accessToken, refreshToken, expiresAt) = GithubAuthenticationDetails{..}
 
 lookupGithubAuthenticationDetails :: DatabaseMetrics -> DBPool -> Text -> IO (Maybe GithubAuthenticationDetails)

--- a/server/src/Utopia/Web/Database/Migrations.hs
+++ b/server/src/Utopia/Web/Database/Migrations.hs
@@ -22,7 +22,9 @@ import           Protolude                            hiding (get)
 
 migrateDatabase :: Bool -> Bool -> Pool Connection -> IO ()
 migrateDatabase verbose includeInitial pool = withResource pool $ \connection -> do
-  let mainMigrationCommands = [MigrationFile "001.sql" "./migrations/001.sql"]
+  let mainMigrationCommands = [ MigrationFile "001.sql" "./migrations/001.sql"
+                              , MigrationFile "002.sql" "./migrations/002.sql"
+                              ]
   let initialMigrationCommand = if includeInitial
                                    then [MigrationFile "initial.sql" "./migrations/initial.sql"]
                                    else []

--- a/server/src/Utopia/Web/Database/Types.hs
+++ b/server/src/Utopia/Web/Database/Types.hs
@@ -120,7 +120,7 @@ data DecodedUserConfiguration = DecodedUserConfiguration
 type DBPool = Pool Connection
 
 
-type GithubAuthenticationFields = (Field SqlText, Field SqlText, Field SqlText, Field SqlTimestamptz)
+type GithubAuthenticationFields = (Field SqlText, Field SqlText, FieldNullable SqlText, FieldNullable SqlTimestamptz)
 
 githubAuthenticationTable :: Table GithubAuthenticationFields GithubAuthenticationFields
 githubAuthenticationTable = table "github_authentication" (p4
@@ -137,6 +137,6 @@ githubAuthenticationSelect = selectTable githubAuthenticationTable
 data GithubAuthenticationDetails = GithubAuthenticationDetails
                  { userId       :: Text
                  , accessToken  :: Text
-                 , refreshToken :: Text
-                 , expiresAt    :: UTCTime
+                 , refreshToken :: Maybe Text
+                 , expiresAt    :: Maybe UTCTime
                  } deriving (Eq, Show, Generic)

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -13,8 +13,10 @@
   All the endpoints defined in "Utopia.Web.Types" are implemented here.
 -}
 module Utopia.Web.Endpoints where
+
 import           Control.Arrow                   ((&&&))
 import           Control.Lens
+import           Control.Monad.Trans.Maybe
 import           Data.Aeson
 import           Data.Aeson.Lens
 import qualified Data.ByteString.Lazy            as BL
@@ -56,14 +58,16 @@ import           Utopia.Web.Types
 import           Utopia.Web.Utils.Files
 import           WaiAppStatic.Storage.Filesystem
 import           WaiAppStatic.Types
+import Utopia.Web.Github
 
 type TagSoupTags = [Tag Text]
 
 projectContentTreeFromSaveProjectRequest :: SaveProjectRequest -> Maybe (Either Text ProjectContentTreeRoot)
-projectContentTreeFromSaveProjectRequest saveProjectRequest =
-  let possiblePersistentModel = firstOf (field @"_content" . _Just) saveProjectRequest
-      possibleParsedPersistentModel = fmap persistentModelFromJSON possiblePersistentModel
-   in over (_Just . _Right) (view (field @"projectContents")) possibleParsedPersistentModel
+projectContentTreeFromSaveProjectRequest saveProjectRequest = do
+  projectContent <- firstOf (field @"_content" . _Just . key "projectContents") saveProjectRequest
+  Just $ case fromJSON projectContent of
+    Error err         -> Left $ toS err
+    Success result    -> Right result
 
 validateSaveRequest :: SaveProjectRequest -> Bool
 validateSaveRequest saveProjectRequest =
@@ -137,9 +141,9 @@ thumbnailUrl siteRoot projectID = siteRoot <> "/v1/thumbnail/" <> projectID
 projectUrl :: Text -> Text -> Text
 projectUrl siteRoot projectID = siteRoot <> "/project/" <> projectID
 
-projectDescription :: Maybe Text -> Text
-projectDescription (Just projectOwner) = "Made by " <> projectOwner <> " with Utopia"
-projectDescription Nothing = "A Utopia project"
+descriptionFromOwner :: Maybe Text -> Text
+descriptionFromOwner (Just projectOwner) = "Made by " <> projectOwner <> " with Utopia"
+descriptionFromOwner Nothing = "A Utopia project"
 
 isoFormatTime :: FormatTime t => t -> String
 isoFormatTime = formatTime defaultTimeLocale "%s"
@@ -150,7 +154,7 @@ twitterCardMetadata projectMetadata siteRoot =
   , TagOpen "meta" [("name", "twitter:site"), ("content", "@UtopiaApp")], TagClose "meta"
   , TagOpen "meta" [("name", "twitter:title"), ("content", view (field @"title") projectMetadata)], TagClose "meta"
   , TagOpen "meta" [("name", "twitter:image"), ("content", thumbnailUrl siteRoot $ view (field @"id") projectMetadata)], TagClose "meta"
-  , TagOpen "meta" [("name", "twitter:description"), ("content", projectDescription $ view (field @"ownerName") projectMetadata)], TagClose "meta"
+  , TagOpen "meta" [("name", "twitter:description"), ("content", descriptionFromOwner $ view (field @"ownerName") projectMetadata)], TagClose "meta"
   ]
 
 facebookCardMetadata :: ProjectMetadata -> Text -> TagSoupTags
@@ -164,7 +168,7 @@ facebookCardMetadata projectMetadata siteRoot =
   , TagOpen "meta" [("property", "og:url"), ("content", projectUrl siteRoot $ view (field @"id") projectMetadata)], TagClose "meta"
   , TagOpen "meta" [("property", "og:updated_time"), ("content", toS $ isoFormatTime $ view (field @"modifiedAt") projectMetadata)], TagClose "meta"
   , TagOpen "meta" [("property", "og:site_name"), ("content", "Utopia")], TagClose "meta"
-  , TagOpen "meta" [("property", "og:description"), ("content", projectDescription $ view (field @"ownerName") projectMetadata)], TagClose "meta"
+  , TagOpen "meta" [("property", "og:description"), ("content", descriptionFromOwner $ view (field @"ownerName") projectMetadata)], TagClose "meta"
   ]
 
 projectTitleMetadata :: ProjectMetadata -> TagSoupTags
@@ -373,12 +377,17 @@ projectChangedSince projectID lastChangedDate = do
 
 downloadProjectEndpoint :: ProjectIdWithSuffix -> [Text] -> ServerMonad DownloadProjectResponse
 downloadProjectEndpoint (ProjectIdWithSuffix projectID _) pathIntoContent = do
-  possibleProject <- loadProject projectID
-  let contentLookup = foldl' (\ lensSoFar pathPart -> lensSoFar . key pathPart) (field @"content") pathIntoContent
-  fromMaybe notFound $ do
-    project <- possibleProject
-    contentFromLookup <- firstOf contentLookup project
-    pure $ pure $ addHeader "*" contentFromLookup
+  possibleContent <- runMaybeT $ do
+    project <- MaybeT $ loadProject projectID
+    projectContents <- MaybeT $ pure $ firstOf (field @"content" . key "projectContents") project
+    decodedProjectContents <- MaybeT $ pure $ case fromJSON projectContents of
+                                Error _         -> Nothing
+                                Success result  -> Just result
+    contentAsJSON <- if null pathIntoContent
+                     then pure projectContents
+                     else MaybeT $ pure $ fmap toJSON $ getProjectContentsTreeFile decodedProjectContents pathIntoContent
+    pure $ pure $ addHeader "*" contentAsJSON
+  fromMaybe notFound possibleContent
 
 loadProjectEndpoint :: ProjectIdWithSuffix -> Maybe UTCTime -> ServerMonad LoadProjectResponse
 loadProjectEndpoint projectID Nothing = actuallyLoadProject projectID
@@ -425,9 +434,11 @@ forkProject sessionUser sourceProject projectTitle = do
 
 saveProjectEndpoint :: Maybe Text -> ProjectIdWithSuffix -> SaveProjectRequest -> ServerMonad SaveProjectResponse
 saveProjectEndpoint cookie (ProjectIdWithSuffix projectID _) saveRequest = requireUser cookie $ \sessionUser -> do
-  let projectValid = validateSaveRequest saveRequest
-  unless projectValid badRequest
-  saveProject sessionUser projectID (view (field @"_name") saveRequest) (view (field @"_content") saveRequest)
+  let saveRequestValid = validateSaveRequest saveRequest
+  unless saveRequestValid $
+    badRequest
+  when saveRequestValid $
+    saveProject sessionUser projectID (view (field @"_name") saveRequest) (view (field @"_content") saveRequest)
   return $ SaveProjectResponse projectID (view (field @"_id") sessionUser)
 
 deleteProjectEndpoint :: Maybe Text -> ProjectIdWithSuffix -> ServerMonad NoContent
@@ -659,6 +670,11 @@ githubAuthenticatedEndpoint cookie = requireUser cookie $ \sessionUser -> do
   possibleAuthDetails <- getGithubAuthentication (view (field @"_id") sessionUser)
   pure $ isJust possibleAuthDetails
 
+githubSaveEndpoint :: Maybe Text -> PersistentModel -> ServerMonad CreateGitBranchResult
+githubSaveEndpoint cookie persistentModel = requireUser cookie $ \sessionUser -> do
+  result <- saveToGithubRepo (view (field @"_id") sessionUser) persistentModel
+  maybe badRequest pure result
+
 {-|
   Compose together all the individual endpoints into a definition for the whole server.
 -}
@@ -681,6 +697,7 @@ protected authCookie = logoutPage authCookie
                   :<|> githubStartAuthenticationEndpoint authCookie
                   :<|> githubFinishAuthenticationEndpoint authCookie
                   :<|> githubAuthenticatedEndpoint authCookie
+                  :<|> githubSaveEndpoint authCookie
 
 unprotected :: ServerT Unprotected ServerMonad
 unprotected = authenticate

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -11,6 +11,8 @@
 
 module Utopia.Web.Executors.Common where
 
+import           Control.Monad.Trans.Maybe
+import           Data.Time
 import           Conduit
 import           Control.Concurrent.ReadWriteLock
 import           Control.Lens                     hiding ((.=), (<.>))
@@ -42,6 +44,7 @@ import           System.Environment
 import           System.FilePath
 import           System.Log.FastLogger
 import qualified Text.Blaze.Html5                 as H
+import           Utopia.ClientModel
 import           Utopia.Web.Assets
 import           Utopia.Web.Auth                  (getUserDetailsFromCode)
 import           Utopia.Web.Auth.Github
@@ -49,6 +52,7 @@ import           Utopia.Web.Auth.Session
 import           Utopia.Web.Auth.Types            (Auth0Resources)
 import qualified Utopia.Web.Database              as DB
 import           Utopia.Web.Database.Types
+import           Utopia.Web.Github
 import           Utopia.Web.Logging
 import           Utopia.Web.Metrics
 import           Utopia.Web.Packager.Locking
@@ -57,6 +61,9 @@ import           Utopia.Web.ServiceTypes
 import           Utopia.Web.Types
 import           Utopia.Web.Utils.Files
 import           Web.Cookie
+
+import           Data.Generics.Product
+import           Data.Generics.Sum
 
 
 {-|
@@ -330,12 +337,47 @@ getProjectDetailsWithDBPool metrics pool projectID = do
             (True, _)          -> ReservedProjectID projectID
             (False, _)         -> UnknownProject
 
-getAndHandleGithubAccessToken :: (MonadIO m) => GithubAuthResources -> FastLogger -> DB.DatabaseMetrics -> DBPool -> Text -> ExchangeToken -> m (Maybe OAuth2Token)
-getAndHandleGithubAccessToken githubResources logger metrics pool userID exchangeToken = do
-  tokenResult <- liftIO $ getAccessToken githubResources exchangeToken
+saveNewOAuth2Token :: (MonadIO m) => FastLogger -> DB.DatabaseMetrics -> DBPool -> Text -> (Either Text OAuth2Token) -> m (Maybe AccessToken)
+saveNewOAuth2Token logger metrics pool userID tokenResult = do
   let logError err = loggerLn logger ("Access Token Error: " <> toLogStr err)
   let saveToken oAuth2Token = do
                           authDetails <- oauth2TokenToGithubAuthenticationDetails oAuth2Token userID
                           DB.updateGithubAuthenticationDetails metrics pool authDetails
   liftIO $ bifoldMap logError saveToken tokenResult
-  pure $ either (const Nothing) Just tokenResult
+  pure $ either (const Nothing) (\result -> Just $ view (field @"accessToken") result) tokenResult
+
+getAndHandleGithubAccessToken :: (MonadIO m) => GithubAuthResources -> FastLogger -> DB.DatabaseMetrics -> DBPool -> Text -> ExchangeToken -> m (Maybe AccessToken)
+getAndHandleGithubAccessToken githubResources logger metrics pool userID exchangeToken = do
+  tokenResult <- liftIO $ getAccessToken githubResources exchangeToken
+  saveNewOAuth2Token logger metrics pool userID tokenResult
+
+useAccessToken :: (MonadIO m) => GithubAuthResources -> FastLogger -> DB.DatabaseMetrics -> DBPool -> Text -> (AccessToken -> m (Maybe a)) -> m (Maybe a)
+useAccessToken githubResources logger metrics pool userID action = do
+  possibleAuthDetails <- liftIO $ DB.lookupGithubAuthenticationDetails metrics pool userID
+  case possibleAuthDetails of
+    Nothing           -> pure Nothing
+    Just authDetails  -> do
+      let currentPossibleRefreshToken = fmap RefreshToken $ view (field @"refreshToken") authDetails
+      let currentAccessToken = AccessToken $ view (field @"accessToken") authDetails
+      let refreshTheToken = do
+            currentRefreshToken <- liftIO $ maybe (fail "No refresh token available.") pure currentPossibleRefreshToken
+            tokenResult <- liftIO $ accessTokenFromRefreshToken githubResources currentRefreshToken
+            saveNewOAuth2Token logger metrics pool userID tokenResult
+      now <- liftIO getCurrentTime
+      let expired = (fmap (< now) $ expiresAt authDetails) == Just True
+      accessTokenToUse <- if expired then refreshTheToken else (pure $ Just currentAccessToken)
+      case accessTokenToUse of
+        Nothing -> pure Nothing
+        Just token -> action token
+
+createTreeAndSaveToGithub :: (MonadIO m) => GithubAuthResources -> FastLogger -> DB.DatabaseMetrics -> DBPool -> Text -> PersistentModel -> m (Maybe CreateGitBranchResult)
+createTreeAndSaveToGithub githubResources logger metrics pool userID model = runMaybeT $ do
+  treeResult <- MaybeT $ useAccessToken githubResources logger metrics pool userID $ \accessToken -> do
+    liftIO $ createGitTreeFromModel accessToken model
+  commitResult <- MaybeT $ useAccessToken githubResources logger metrics pool userID $ \accessToken -> do
+    liftIO $ createGitCommitForTree accessToken model $ view (field @"sha") treeResult
+  now <- liftIO getCurrentTime
+  let branchName = toS $ formatTime defaultTimeLocale "utopia-branch-%0Y%m%d-%H%M%S" now
+  branchResult <- MaybeT $ useAccessToken githubResources logger metrics pool userID $ \accessToken -> do
+    liftIO $ createGitBranchForCommit accessToken model (view (field @"sha") commitResult) branchName
+  pure branchResult

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -339,6 +339,16 @@ innerServerExecutor (GetGithubAuthentication user action) = do
   pool <- fmap _projectPool ask
   result <- liftIO $ DB.lookupGithubAuthenticationDetails metrics pool user
   pure $ action result
+innerServerExecutor (SaveToGithubRepo user model action) = do
+  possibleGithubResources <- fmap _githubResources ask
+  metrics <- fmap _databaseMetrics ask
+  logger <- fmap _logger ask
+  pool <- fmap _projectPool ask
+  case possibleGithubResources of
+    Nothing -> throwError err501
+    Just githubResources -> do
+      result <- createTreeAndSaveToGithub githubResources logger metrics pool user model
+      pure $ action result
 
 {-|
   Invokes a service call using the supplied resources.

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -263,6 +263,14 @@ innerServerExecutor (GetGithubAuthentication user action) = do
   pool <- fmap _projectPool ask
   result <- liftIO $ DB.lookupGithubAuthenticationDetails metrics pool user
   pure $ action result
+innerServerExecutor (SaveToGithubRepo user model action) = do
+  githubResources <- fmap _githubResources ask
+  metrics <- fmap _databaseMetrics ask
+  logger <- fmap _logger ask
+  pool <- fmap _projectPool ask
+  result <- createTreeAndSaveToGithub githubResources logger metrics pool user model
+  pure $ action result
+
 
 readEditorContentFromDisk :: Maybe BranchDownloads -> Maybe Text -> Text -> IO Text
 readEditorContentFromDisk (Just downloads) (Just branchName) fileName = do

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -1,12 +1,30 @@
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 
 module Utopia.Web.Github where
 
-import           Control.Lens         hiding ((.=), (<.>))
-import qualified Data.ByteString.Lazy as BL
-import qualified Network.Wreq         as WR
+import Data.Aeson.Encode.Pretty
+import           Control.Lens              hiding (children, (.=), (<.>))
+import           Control.Monad
+import           Data.Aeson
+import qualified Data.ByteString.Lazy      as BL
+import           Data.Data
+import           Data.Foldable
+import           Data.Text.Encoding.Base64
+import Data.Text.Encoding
+import qualified Data.Text as T
+import           Data.Typeable
+import           Network.OAuth.OAuth2
+import qualified Network.Wreq              as WR
 import           Protolude
+import           Utopia.ClientModel
+import Prelude (String)
+import Crypto.Hash
+import qualified Crypto.Hash as C
 
 fetchRepoArchive :: Text -> Text -> IO (Maybe BL.ByteString)
 fetchRepoArchive owner repo = do
@@ -19,3 +37,186 @@ fetchRepoArchive owner repo = do
   if responseStatus == 200
     then return $ Just $ repoResult ^. WR.responseBody
     else return $ Nothing
+
+dropLastUnderscore :: String -> String
+dropLastUnderscore [] = []
+dropLastUnderscore (last : []) = if last == '_' then [] else [last]
+dropLastUnderscore (first : rest) = first : dropLastUnderscore rest
+
+data GitTreeEntry = GitTreeEntry
+                  { path    :: Text
+                  , mode    :: Text
+                  , type_   :: Text
+                  , content :: Maybe Text
+                  , sha     :: Maybe Text
+                  }
+                  deriving (Eq, Show, Generic, Data, Typeable)
+
+gitTreeEntryOptions :: Options
+gitTreeEntryOptions = defaultOptions { fieldLabelModifier = dropLastUnderscore, omitNothingFields = True }
+
+instance FromJSON GitTreeEntry where
+  parseJSON = genericParseJSON gitTreeEntryOptions
+
+instance ToJSON GitTreeEntry where
+  toJSON = genericToJSON gitTreeEntryOptions
+
+data CreateGitTree = CreateGitTree
+                   { baseTree ::  Maybe Text
+                   , tree     :: [GitTreeEntry]
+                   }
+                   deriving (Eq, Show, Generic, Data, Typeable)
+
+createGitTreeOptions :: Options
+createGitTreeOptions = defaultOptions { fieldLabelModifier = camelTo2 '_', omitNothingFields = True }
+
+instance FromJSON CreateGitTree where
+  parseJSON = genericParseJSON createGitTreeOptions
+
+instance ToJSON CreateGitTree where
+  toJSON = genericToJSON createGitTreeOptions
+
+data CreateGitTreeResult = CreateGitTreeResult
+                         { sha :: Text
+                         , url :: Text
+                         }
+                         deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON CreateGitTreeResult where
+  parseJSON = genericParseJSON defaultOptions 
+
+instance ToJSON CreateGitTreeResult where
+  toJSON = genericToJSON defaultOptions
+
+data CreateGitCommit = CreateGitCommit
+                     { message   :: Text
+                     , tree      :: Text
+                     }
+                     deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON CreateGitCommit where
+  parseJSON = genericParseJSON defaultOptions 
+
+instance ToJSON CreateGitCommit where
+  toJSON = genericToJSON defaultOptions
+
+data CreateGitCommitResult = CreateGitCommitResult
+                           { sha :: Text
+                           , url :: Text
+                           }
+                           deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON CreateGitCommitResult where
+  parseJSON = genericParseJSON defaultOptions 
+
+instance ToJSON CreateGitCommitResult where
+  toJSON = genericToJSON defaultOptions
+
+data CreateGitBranch = CreateGitBranch
+                     { ref    :: Text
+                     , sha    :: Text
+                     }
+                     deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON CreateGitBranch where
+  parseJSON = genericParseJSON defaultOptions 
+
+instance ToJSON CreateGitBranch where
+  toJSON = genericToJSON defaultOptions
+
+data CreateGitBranchResult = CreateGitBranchResult
+                           { ref   :: Text
+                           , url   :: Text
+                           }
+                           deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON CreateGitBranchResult where
+  parseJSON = genericParseJSON defaultOptions 
+
+instance ToJSON CreateGitBranchResult where
+  toJSON = genericToJSON defaultOptions
+
+stripPreceedingSlash :: Text -> Text
+stripPreceedingSlash text =
+  case T.uncons text of
+    Just (first, rest) -> if first == '/' then rest else text
+    Nothing -> text
+
+shaTextFromText :: Text -> Text
+shaTextFromText text = T.pack $ show (C.hash $ encodeUtf8 text :: Digest SHA1)
+
+directoryGitTreeEntry :: ProjectContentDirectory -> Maybe GitTreeEntry
+directoryGitTreeEntry ProjectContentDirectory{..} =
+  Nothing --Just $ GitTreeEntry (stripPreceedingSlash fullPath) "040000" "tree" Nothing Nothing 
+
+projectFileGitTreeEntry :: Text -> ProjectFile -> Maybe GitTreeEntry
+projectFileGitTreeEntry fullPath (ProjectTextFile TextFile{..}) =
+  Just $ GitTreeEntry (stripPreceedingSlash fullPath) "100644" "blob" (Just $ code fileContents) Nothing
+projectFileGitTreeEntry fullPath (ProjectImageFile _) =
+  Nothing
+projectFileGitTreeEntry fullPath (ProjectAssetFile _) =
+  Nothing
+
+fileGitTreeEntry :: ProjectContentFile -> Maybe GitTreeEntry
+fileGitTreeEntry ProjectContentFile{..} = projectFileGitTreeEntry fullPath content
+
+gitTreeEntriesFromProjectContentsTree :: ProjectContentsTree -> [GitTreeEntry]
+gitTreeEntriesFromProjectContentsTree (ProjectContentsTreeDirectory dir) =
+  (gitTreeEntriesFromProjectContent $ children dir) <> (maybeToList $ directoryGitTreeEntry dir)
+gitTreeEntriesFromProjectContentsTree (ProjectContentsTreeFile file) =
+  maybeToList $ fileGitTreeEntry file
+
+gitTreeEntriesFromProjectContent :: ProjectContentTreeRoot -> [GitTreeEntry]
+gitTreeEntriesFromProjectContent projectContents = foldMap' gitTreeEntriesFromProjectContentsTree projectContents
+
+createGitTreeFromProjectContent :: ProjectContentTreeRoot -> CreateGitTree
+createGitTreeFromProjectContent projectContents = CreateGitTree Nothing $ gitTreeEntriesFromProjectContent projectContents
+
+callGithub :: (ToJSON request, FromJSON response) => AccessToken -> Text -> request -> IO (Maybe response)
+callGithub accessToken restURL request = do
+  let options = WR.defaults
+              & WR.header "User-Agent" .~ ["concrete-utopia/utopia"]
+              & WR.header "Accept" .~ ["application/vnd.github.v3+json"]
+              & WR.header "Authorization" .~ ["Bearer " <> (encodeUtf8 $ atoken accessToken)]
+  let body = toJSON request
+  result <- WR.asJSON =<< WR.postWith options (toS restURL) body
+  pure $ firstOf (WR.responseBody . _Just) result
+
+createGitTree :: AccessToken -> GithubRepo -> ProjectContentTreeRoot -> IO (Maybe CreateGitTreeResult)
+createGitTree accessToken GithubRepo{..} projectContents = do
+  let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/trees"
+  let request = createGitTreeFromProjectContent projectContents
+  callGithub accessToken repoUrl request
+
+createGitTreeFromModel :: AccessToken -> PersistentModel -> IO (Maybe CreateGitTreeResult)
+createGitTreeFromModel accessToken PersistentModel{..} = do
+  let possibleGithubRepo = targetRepository githubSettings
+  case possibleGithubRepo of
+    Just repo -> createGitTree accessToken repo projectContents
+    Nothing   -> pure Nothing
+
+createGitCommit :: AccessToken -> GithubRepo -> Text -> IO (Maybe CreateGitCommitResult)
+createGitCommit accessToken GithubRepo{..} treeSha = do
+  let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/commits"
+  let request = CreateGitCommit "Committed automatically." treeSha
+  callGithub accessToken repoUrl request
+
+createGitCommitForTree :: AccessToken -> PersistentModel -> Text -> IO (Maybe CreateGitCommitResult)
+createGitCommitForTree accessToken PersistentModel{..} treeSha = do
+  let possibleGithubRepo = targetRepository githubSettings
+  case possibleGithubRepo of
+    Just repo -> createGitCommit accessToken repo treeSha
+    Nothing   -> pure Nothing
+
+createGitBranch :: AccessToken -> GithubRepo -> Text -> Text -> IO (Maybe CreateGitBranchResult)
+createGitBranch accessToken GithubRepo{..} commitSha branchName = do
+  let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/refs"
+  let request = CreateGitBranch ("refs/heads/" <> branchName) commitSha
+  callGithub accessToken repoUrl request
+
+createGitBranchForCommit :: AccessToken -> PersistentModel -> Text -> Text -> IO (Maybe CreateGitBranchResult)
+createGitBranchForCommit accessToken PersistentModel{..} commitSha branchName = do
+  let possibleGithubRepo = targetRepository githubSettings
+  case possibleGithubRepo of
+    Just repo -> createGitBranch accessToken repo commitSha branchName
+    Nothing   -> pure Nothing

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -29,9 +29,11 @@ import           Protolude
 import           Servant                   hiding (URI)
 import qualified Text.Blaze.Html5          as H
 import           URI.ByteString
+import           Utopia.ClientModel
 import           Utopia.Web.Assets
 import           Utopia.Web.Database.Types
 import           Utopia.Web.JSON
+import Utopia.Web.Github
 import           Web.Cookie
 
 type SessionCookie = Text
@@ -131,8 +133,9 @@ data ServiceCallsF a = NotFound
                      | ClearBranchCache Text a
                      | GetDownloadBranchFolders ([FilePath] -> a)
                      | GetGithubAuthorizationURI (URI -> a)
-                     | GetGithubAccessToken Text ExchangeToken (Maybe OAuth2Token -> a)
+                     | GetGithubAccessToken Text ExchangeToken (Maybe AccessToken -> a)
                      | GetGithubAuthentication Text (Maybe GithubAuthenticationDetails -> a)
+                     | SaveToGithubRepo Text PersistentModel (Maybe CreateGitBranchResult -> a)
                      deriving Functor
 
 {-

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -21,9 +21,11 @@ import           Servant
 import           Servant.HTML.Blaze
 import           Servant.RawM.Server
 import qualified Text.Blaze.Html5        as H
+import           Utopia.ClientModel
 import           Utopia.Web.JSON
 import           Utopia.Web.Servant
 import           Utopia.Web.ServiceTypes
+import Utopia.Web.Github
 
 {-
   'deriveJSON' as used here creates 'Data.Aeson.FromJSON' and 'Data.Aeson.ToJSON' instances
@@ -127,6 +129,8 @@ type GithubStartAuthenticationAPI = "v1" :> "github" :> "authentication" :> "sta
 
 type GithubFinishAuthenticationAPI = "v1" :> "github" :> "authentication" :> "finish" :> QueryParam "code" ExchangeToken :> Get '[HTML] H.Html
 
+type GithubSaveAPI = "v1" :> "github" :> "save" :> ReqBody '[JSON] PersistentModel :> Post '[JSON] CreateGitBranchResult
+
 type PackagePackagerResponse = Headers '[Header "Cache-Control" Text, Header "Last-Modified" LastModifiedTime, Header "Access-Control-Allow-Origin" Text] (ConduitT () ByteString (ResourceT IO) ())
 
 type PackagePackagerAPI = "v1" :> "javascript" :> "packager"
@@ -179,6 +183,7 @@ type Protected = LogoutAPI
             :<|> GithubStartAuthenticationAPI
             :<|> GithubFinishAuthenticationAPI
             :<|> GithubAuthenticatedAPI
+            :<|> GithubSaveAPI
 
 type Unprotected = AuthenticateAPI H.Html
               :<|> EmptyProjectPageAPI

--- a/server/test/Test/Utopia/Web/Executors/Test.hs
+++ b/server/test/Test/Utopia/Web/Executors/Test.hs
@@ -68,6 +68,7 @@ initialiseTestResources pool = do
          , _proxyManager = Just proxyHttpManager
          , _auth0Resources = Nothing
          , _awsResources = Nothing
+         , _githubResources = Nothing
          , _sessionState = sessionStore
          , _storeForMetrics = store
          , _databaseMetrics = dbMetrics

--- a/server/test/Test/Utopia/Web/SampleProject.json
+++ b/server/test/Test/Utopia/Web/SampleProject.json
@@ -1,6 +1,7 @@
 {
   "appID": null,
-  "projectVersion": 6,
+  "projectVersion": 8,
+  "projectDescription": "",
   "projectContents": {
     "package.json": {
       "type": "PROJECT_CONTENT_FILE",
@@ -230,6 +231,9 @@
   "fileBrowser": { "minimised": false },
   "dependencyList": { "minimised": false },
   "projectSettings": { "minimised": false },
-  "navigator": { "minimised": false }
+  "navigator": { "minimised": false },
+  "githubSettings": {
+    "targetRepository": null
+  }
 }
 

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -69,6 +69,7 @@ executable utopia-web
     , amazonka-s3 ==1.6.1
     , base >=4.7 && <5
     , base16-bytestring
+    , base64
     , binary
     , blaze-html
     , bytestring
@@ -78,6 +79,7 @@ executable utopia-web
     , conduit
     , cookie
     , cryptohash-sha256
+    , cryptonite
     , data-default
     , directory
     , exceptions
@@ -85,7 +87,8 @@ executable utopia-web
     , filepath
     , free
     , generic-lens
-    , hoauth2
+    , github
+    , hoauth2 ==1.16.0
     , http-api-data
     , http-client
     , http-client-tls
@@ -122,6 +125,7 @@ executable utopia-web
     , servant-websockets ==2.0.0
     , serversession ==1.0.2
     , split
+    , string-conversions
     , tagsoup
     , tar
     , temporary
@@ -187,7 +191,7 @@ test-suite utopia-web-test
       src
   default-extensions:
       NoImplicitPrelude
-  ghc-options: -Wall -threaded -rtsopts
+  ghc-options: -Wall -threaded -rtsopts +RTS -N1 -RTS
   extra-libraries:
       z
   build-depends:
@@ -198,6 +202,7 @@ test-suite utopia-web-test
     , amazonka-s3 ==1.6.1
     , base >=4.7 && <5
     , base16-bytestring
+    , base64
     , binary
     , blaze-html
     , bytestring
@@ -207,6 +212,7 @@ test-suite utopia-web-test
     , conduit
     , cookie
     , cryptohash-sha256
+    , cryptonite
     , data-default
     , directory
     , exceptions
@@ -214,8 +220,9 @@ test-suite utopia-web-test
     , filepath
     , free
     , generic-lens
+    , github
     , hedgehog
-    , hoauth2
+    , hoauth2 ==1.16.0
     , hspec
     , http-api-data
     , http-client
@@ -256,6 +263,7 @@ test-suite utopia-web-test
     , servant-websockets ==2.0.0
     , serversession ==1.0.2
     , split
+    , string-conversions
     , tagsoup
     , tar
     , tasty

--- a/shell.nix
+++ b/shell.nix
@@ -346,6 +346,8 @@ let
       find . -name '*.hs' | xargs ${pkgs.haskellPackages.stylish-haskell}/bin/stylish-haskell -i
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/clientmodel/lib/src
       find . -name '*.hs' | xargs ${pkgs.haskellPackages.stylish-haskell}/bin/stylish-haskell -i
+      cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/clientmodel/lib/test
+      find . -name '*.hs' | xargs ${pkgs.haskellPackages.stylish-haskell}/bin/stylish-haskell -i
     '')
     (pkgs.writeScriptBin "run-server-inner" ''
       #!/usr/bin/env bash


### PR DESCRIPTION
**Problem:**
Currently projects are held solely inside the Utopia server and can't be easily retrieved without a lot of manual copying and pasting should the user want to use their project outside our editor.

**Fix:**
We now provide a field and button which when filled in and triggered respectively will create a branch in the repository containing the current content of the project.

The steps taken are as follows:
- Create a git tree containing the files within the project.
- Create a git commit which references the git tree created.
- Create a git ref (the real name of a branch) which references the git commit created.

**Commit Details:**
- Added tests for the `clientmodel` package.
- Replaced `PartialPersistentModel` with `PersistentModel` in `clientmodel` so that it can full cycle the representation.
- Simplified `getProjectContentsTreeFile`.
- Created `SaveToGithub` action in the frontend that triggers the side effecting action of saving to Github.
- Added `githubSettings` field to `PersistentModel`.
- Added model migration to add the `githubSettings` field.
- Added section to `GithubPane` for adding the target repository to save to.
- Made `EditorState.appID` not possible to omit as a field.
- Added `002.sql` database migration which makes `refresh_token` and `expires_at` nullable as the OAuth apps do not supply these at all.
- `getAuthorizationURI` now includes the scope to request the access token with.
- Modified `oauth2TokenToGithubAuthenticationDetails` now caters for the refresh token and expiry fields being optional.
- Added `accessTokenFromRefreshToken`.
- Some functions have been reworked as it makes more sense to parse `ProjectContentsTreeRoot` out from the model JSON rather than decoding to `PersistentModel` and extracting the project contents from that.
- Added `githubSaveEndpoint` as the entry to the calls for the logic that creates the Github branch.
- Created `callGithub` utility function for the REST API which does the common functionality for all the REST calls which is invoked by the specific functions like `createGitTree`.
- Added `useAccessToken` for handling the potential need for getting a new access token from the refresh token, which is done transparently to the action passed into it.