### PR TITLE
reset drop target on drag end

### DIFF
--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -35,6 +35,7 @@ import {
 import { notice } from '../common/notice'
 import { appendToPath, getParentDirectory } from '../../utils/path-utils'
 import { AddingFile, applyAddingFile } from './filepath-utils'
+import { useEditorState } from '../editor/store/store-hook'
 
 export interface FileBrowserItemProps extends FileBrowserItemInfo {
   isSelected: boolean
@@ -761,12 +762,8 @@ class FileBrowserItemInner extends React.PureComponent<
   }
 }
 
-interface FilebrowserDragItem {
-  type: 'filebrowser'
-  props: FileBrowserItemProps
-}
-
 export function FileBrowserItem(props: FileBrowserItemProps) {
+  const dispatch = useEditorState((store) => store.dispatch, 'FileBrowserItem dispatch')
   const [{ isDragging }, drag, dragPreview] = useDrag(
     () => ({
       type: 'files',
@@ -782,6 +779,7 @@ export function FileBrowserItem(props: FileBrowserItemProps) {
         ])
         return props
       },
+      end: () => dispatch([EditorActions.setFilebrowserDropTarget(null)]),
     }),
     [props],
   )


### PR DESCRIPTION
## Problem
When a file browser dnd session ends outside the file browser, the drop target highlight doesn't get reset, and gives the impression of getting "stuck".

## Solution
Use the `end` callback from React DnD to reset the drop target at the end of each drop session.

## Commit details
- Add the `end` callback to the React DnD drag specification to reset the drop target to null