### PR TITLE
Don't upload assets when the user isn't logged in

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3220,6 +3220,14 @@ export const UPDATE_FNS = {
     dispatch: EditorDispatch,
     userState: UserState,
   ): EditorModel => {
+    if (!isLoggedIn(userState.loginState) || editor.id == null) {
+      return UPDATE_FNS.ADD_TOAST(
+        showToast(notice(`Please log in to upload assets`, 'ERROR', true)),
+        editor,
+        dispatch,
+      )
+    }
+
     const replaceImage = action.imageDetails?.afterSave.type === 'SAVE_IMAGE_REPLACE'
     const assetFilename = replaceImage
       ? action.fileName
@@ -3280,27 +3288,19 @@ export const UPDATE_FNS = {
 
     // Side effects.
     let editorWithToast = editor
-    if (isLoggedIn(userState.loginState) && editor.id != null) {
-      saveAssetToServer(notNullProjectID, action.fileType, action.base64, assetFilename)
-        .then(() => {
-          dispatch(
-            [
-              ...actionsToRunAfterSave,
-              showToast(notice(`Succesfully uploaded ${assetFilename}`, 'INFO')),
-            ],
-            'everyone',
-          )
-        })
-        .catch(() => {
-          dispatch([showToast(notice(`Failed to upload ${assetFilename}`, 'ERROR'))])
-        })
-    } else {
-      editorWithToast = UPDATE_FNS.ADD_TOAST(
-        showToast(notice(`Please log in to upload assets`, 'ERROR', true)),
-        editor,
-        dispatch,
-      )
-    }
+    void saveAssetToServer(notNullProjectID, action.fileType, action.base64, assetFilename)
+      .then(() => {
+        dispatch(
+          [
+            ...actionsToRunAfterSave,
+            showToast(notice(`Succesfully uploaded ${assetFilename}`, 'INFO')),
+          ],
+          'everyone',
+        )
+      })
+      .catch(() => {
+        dispatch([showToast(notice(`Failed to upload ${assetFilename}`, 'ERROR'))])
+      })
 
     const updatedProjectContents = addFileToProjectContents(
       editor.projectContents,


### PR DESCRIPTION
## Problem:
When inserting assets without the user being logged in, we don't upload the asset, and put the base64 content of the asset into the image src.

This way the navigator shows the base64 contents instead of the path to the asset (since there's not path to show).

**Fix:**
When the `SAVE_ASSET` action is executed, it is checked right at the start of the function whether the user is logged in, and if not, the action does an early return with no modifications made (besides displaying a toast).

**Commit Details:**
- Implement early return