### PR TITLE
Move #canvas-root css rule to inline style

### DIFF
--- a/editor/resources/editor/css/canvas.css
+++ b/editor/resources/editor/css/canvas.css
@@ -1,9 +1,3 @@
-#canvas-root {
-  position: relative;
-  overflow: hidden;
-  height: 100%;
-}
-
 .canvas-text.canvas-text-editable,
 .canvas-text.canvas-text-editable * {
   user-select: text;

--- a/editor/src/components/canvas/canvas-strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
@@ -1379,7 +1379,7 @@ describe('Reparent indicators', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     // Check the indicator presence and position.
-    await checkReparentIndicator(renderResult, 431, 636, 2, 161.5)
+    await checkReparentIndicator(renderResult, 432, 637, 2, 161.5)
   })
 
   it(`shows the reparent indicator before all the elements in a 'row-reverse' container`, async () => {
@@ -1415,7 +1415,7 @@ describe('Reparent indicators', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     // Check the indicator presence and position.
-    await checkReparentIndicator(renderResult, 831, 636, 2, 161.5)
+    await checkReparentIndicator(renderResult, 832, 637, 2, 161.5)
   })
 
   it(`shows the reparent indicator between two elements in a 'row' container`, async () => {
@@ -1451,7 +1451,7 @@ describe('Reparent indicators', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     // Check the indicator presence and position.
-    await checkReparentIndicator(renderResult, 565, 636, 2, 123)
+    await checkReparentIndicator(renderResult, 566, 637, 2, 123)
   })
 
   it(`shows the reparent indicator between two elements in a 'row-reverse' container`, async () => {
@@ -1487,6 +1487,6 @@ describe('Reparent indicators', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     // Check the indicator presence and position.
-    await checkReparentIndicator(renderResult, 697, 636, 2, 123)
+    await checkReparentIndicator(renderResult, 698, 637, 2, 123)
   })
 })

--- a/editor/src/components/canvas/controls/insertion-plus-button.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.spec.browser2.tsx
@@ -279,9 +279,9 @@ describe('Insertion Plus Button', () => {
       expect(bounds.top).toEqual(expectedTop)
     }
 
-    await checkInsertButtonPosition('blue-dot-control-0', 428.5, 622.5)
-    await checkInsertButtonPosition('blue-dot-control-1', 562.5, 622.5)
-    await checkInsertButtonPosition('blue-dot-control-2', 767, 622.5)
+    await checkInsertButtonPosition('blue-dot-control-0', 429.5, 623.5)
+    await checkInsertButtonPosition('blue-dot-control-1', 563.5, 623.5)
+    await checkInsertButtonPosition('blue-dot-control-2', 768, 623.5)
   })
 
   it(`shows the buttons in the correct places for a flex container with a direction of 'row-reverse' that already has children`, async () => {
@@ -305,9 +305,9 @@ describe('Insertion Plus Button', () => {
       expect(bounds.top).toEqual(expectedTop)
     }
 
-    await checkInsertButtonPosition('blue-dot-control-0', 490, 622.5)
-    await checkInsertButtonPosition('blue-dot-control-1', 694.5, 622.5)
-    await checkInsertButtonPosition('blue-dot-control-2', 828.5, 622.5)
+    await checkInsertButtonPosition('blue-dot-control-0', 491, 623.5)
+    await checkInsertButtonPosition('blue-dot-control-1', 695.5, 623.5)
+    await checkInsertButtonPosition('blue-dot-control-2', 829.5, 623.5)
   })
 
   it(`shows the buttons in the correct places for a flex container with a direction of 'column' that already has children`, async () => {
@@ -331,9 +331,9 @@ describe('Insertion Plus Button', () => {
       expect(bounds.top).toEqual(expectedTop)
     }
 
-    await checkInsertButtonPosition('blue-dot-control-0', 418.5, 632.5)
-    await checkInsertButtonPosition('blue-dot-control-1', 418.5, 732.5)
-    await checkInsertButtonPosition('blue-dot-control-2', 418.5, 832.5)
+    await checkInsertButtonPosition('blue-dot-control-0', 419.5, 633.5)
+    await checkInsertButtonPosition('blue-dot-control-1', 419.5, 733.5)
+    await checkInsertButtonPosition('blue-dot-control-2', 419.5, 833.5)
   })
 
   it(`shows the buttons in the correct places for a flex container with a direction of 'column-reverse' that already has children`, async () => {
@@ -357,9 +357,9 @@ describe('Insertion Plus Button', () => {
       expect(bounds.top).toEqual(expectedTop)
     }
 
-    await checkInsertButtonPosition('blue-dot-control-0', 418.5, 632.5)
-    await checkInsertButtonPosition('blue-dot-control-1', 418.5, 732.5)
-    await checkInsertButtonPosition('blue-dot-control-2', 418.5, 832.5)
+    await checkInsertButtonPosition('blue-dot-control-0', 419.5, 633.5)
+    await checkInsertButtonPosition('blue-dot-control-1', 419.5, 733.5)
+    await checkInsertButtonPosition('blue-dot-control-2', 419.5, 833.5)
   })
 
   it('shows the buttons in the correct places for a flex container that has no children', async () => {
@@ -383,6 +383,6 @@ describe('Insertion Plus Button', () => {
       expect(bounds.top).toEqual(expectedTop)
     }
 
-    await checkInsertButtonPosition('blue-dot-control-0', 428.5, 622.5)
+    await checkInsertButtonPosition('blue-dot-control-0', 429.5, 623.5)
   })
 })

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -888,6 +888,9 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
         style: {
           ...canvasLiveEditingStyle,
           transition: 'all .2s linear',
+          position: 'relative',
+          overflow: 'hidden',
+          height: '100%',
         },
         ref: (ref: HTMLElement | null) => {
           this.canvasWrapperRef = ref


### PR DESCRIPTION
**Problem:**
In the browser tests we don't load css files. Unfortunately the canvas receives important style props from `canvas.css`:

```css
#canvas-root {
  position: relative;
  overflow: hidden;
  height: 100%;
}
```

Without `height: 100%` the canvas doesn't have a height, which surprisingly did not cause problems until now (but it actually makes it impossible to test most of the mouse handlers in `editor-canvas`)

**Fix:**
I moved these style props to inline style in `EditorCanvas`.
Some tests were failing after this with a single pixel size differences. I believe the missing style props slightly changed how the canvas is rendered.