### PR TITLE
Feature/relative move

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -46,6 +46,7 @@ import { drawToInsertStrategy } from './draw-to-insert-strategy'
 import { flexResizeBasicStrategy } from './flex-resize-basic-strategy'
 import { optionalMap } from '../../../core/shared/optional-utils'
 import { lookForApplicableParentStrategy } from './look-for-applicable-parent-strategy'
+import { relativeMoveStrategy } from './relative-move-strategy'
 
 export type MetaCanvasStrategy = (
   canvasState: InteractionCanvasState,
@@ -73,6 +74,7 @@ export const existingStrategies: MetaCanvasStrategy = () => [
   flowReorderStrategy,
   flowReorderSliderStategy,
   flexResizeBasicStrategy,
+  relativeMoveStrategy,
 ]
 
 export const RegisteredCanvasStrategies: Array<MetaCanvasStrategy> = [

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -132,6 +132,7 @@ export type CanvasStrategyId =
   | 'LOOK_FOR_APPLICABLE_PARENT_ID'
   | 'DRAW_TO_INSERT'
   | 'FLEX_RESIZE_BASIC'
+  | 'RELATIVE_MOVE'
 
 export type InteractionLifecycle = 'mid-interaction' | 'end-interaction'
 

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-helpers.ts
@@ -17,8 +17,6 @@ export function isValidFlowReorderTarget(elementMetadata: ElementInstanceMetadat
     return false
   } else if (elementMetadata?.specialSizeMeasurements.float !== 'none') {
     return false
-  } else if (MetadataUtils.isPositionRelative(elementMetadata) && elementMetadata != null) {
-    return !elementMetadata.specialSizeMeasurements.hasPositionOffset
   } else {
     return true
   }

--- a/editor/src/components/canvas/canvas-strategies/relative-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/relative-move-strategy.spec.browser2.tsx
@@ -1,0 +1,393 @@
+import React from 'react'
+import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
+import { elementPath } from '../../../core/shared/element-path'
+import {
+  ElementInstanceMetadata,
+  ElementInstanceMetadataMap,
+  SpecialSizeMeasurements,
+} from '../../../core/shared/element-template'
+import {
+  canvasPoint,
+  canvasRectangle,
+  CanvasVector,
+  localRectangle,
+} from '../../../core/shared/math-utils'
+import { ElementPath } from '../../../core/shared/project-file-types'
+import { emptyModifiers } from '../../../utils/modifiers'
+import { EditorState } from '../../editor/store/editor-state'
+import { foldAndApplyCommands } from '../commands/commands'
+import {
+  getEditorState,
+  makeTestProjectCodeWithSnippet,
+  testPrintCodeFromEditorState,
+} from '../ui-jsx.test-utils'
+import { absoluteMoveStrategy } from './absolute-move-strategy'
+import { pickCanvasStateFromEditorState } from './canvas-strategies'
+import { defaultCustomStrategyState } from './canvas-strategy-types'
+import { InteractionSession, StrategyState } from './interaction-state'
+import { createMouseInteractionForTests } from './interaction-state.test-utils'
+
+const prepareEditorState = (
+  codeSnippet: string,
+  selectedViews: Array<ElementPath>,
+): EditorState => {
+  return {
+    ...getEditorState(makeTestProjectCodeWithSnippet(codeSnippet)),
+    selectedViews: selectedViews,
+  }
+}
+
+const defaultMetadata: ElementInstanceMetadataMap = {
+  'scene-aaa': {
+    elementPath: elementPath([['scene-aaa']]),
+  } as ElementInstanceMetadata,
+  'scene-aaa/app-entity': {
+    elementPath: elementPath([['scene-aaa', 'app-entity']]),
+  } as ElementInstanceMetadata,
+  'scene-aaa/app-entity:aaa': {
+    elementPath: elementPath([['scene-aaa', 'app-entity'], ['aaa']]),
+  } as ElementInstanceMetadata,
+  'scene-aaa/app-entity:aaa/bbb': {
+    elementPath: elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ]),
+    specialSizeMeasurements: {
+      immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+    } as SpecialSizeMeasurements,
+    globalFrame: canvasRectangle({ x: 50, y: 50, width: 250, height: 300 }),
+    localFrame: localRectangle({ x: 50, y: 50, width: 250, height: 300 }),
+  } as ElementInstanceMetadata,
+}
+
+function dragByPixels(
+  editorState: EditorState,
+  vector: CanvasVector,
+  metadata: ElementInstanceMetadataMap = defaultMetadata,
+): EditorState {
+  const interactionSession: InteractionSession = {
+    ...createMouseInteractionForTests(
+      null as any, // the strategy does not use this
+      emptyModifiers, // the strategy does not use this
+      null as any, // the strategy does not use this
+      vector,
+    ),
+    latestMetadata: null as any, // the strategy does not use this
+    latestAllElementProps: null as any, // the strategy does not use this
+    startingTargetParentsToFilterOut: null,
+  }
+
+  const strategyResult = absoluteMoveStrategy.apply(
+    pickCanvasStateFromEditorState(editorState, createBuiltInDependenciesList(null)),
+    interactionSession,
+    {
+      currentStrategy: null as any, // the strategy does not use this
+      currentStrategyFitness: null as any, // the strategy does not use this
+      currentStrategyCommands: null as any, // the strategy does not use this
+      accumulatedPatches: null as any, // the strategy does not use this
+      commandDescriptions: null as any, // the strategy does not use this
+      sortedApplicableStrategies: null as any, // the strategy does not use this
+      startingMetadata: metadata ?? defaultMetadata,
+      startingAllElementProps: {},
+      customStrategyState: defaultCustomStrategyState(),
+    } as StrategyState,
+    'end-interaction',
+  )
+
+  expect(strategyResult.customStatePatch).toEqual({})
+  expect(strategyResult.status).toEqual('success')
+
+  const finalEditor = foldAndApplyCommands(
+    editorState,
+    editorState,
+    [],
+    [],
+    strategyResult.commands,
+    'end-interaction',
+  ).editorState
+
+  return finalEditor
+}
+
+const makeParentView = (uid: string, children: (() => string)[]) => {
+  return `
+    <View data-uid='${uid}'>
+      ${children.map((c) => c()).join('\n')}
+    </View>
+  `
+}
+
+const makeView = (uid: string, style: React.CSSProperties) => () => {
+  const defaultStyle: React.CSSProperties = {
+    backgroundColor: '#f0f',
+    width: 200,
+    height: 200,
+  }
+  return `
+    <View
+      data-uid='${uid}'
+      style={${JSON.stringify({
+        ...defaultStyle,
+        ...style,
+      }).replace(/"/g, "'")}}
+    />
+  `
+}
+
+describe('Relative move', () => {
+  describe('when the element position is relative', () => {
+    it('does not trigger when the threshold is not met', async () => {
+      const targetElement = elementPath([
+        ['scene-foo', 'app-entity'],
+        ['foo', 'bar'],
+      ])
+
+      const initialEditor = prepareEditorState(
+        makeParentView('foo', [
+          makeView('bar', {
+            position: 'relative',
+          }),
+        ]),
+        [targetElement],
+      )
+
+      const finalEditor = dragByPixels(initialEditor, canvasPoint({ x: 1, y: 1 }))
+      expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+        makeTestProjectCodeWithSnippet(
+          makeParentView('foo', [
+            makeView('bar', {
+              position: 'relative',
+            }),
+          ]),
+        ),
+      )
+    })
+
+    describe('when the element has no offsets', () => {
+      it('sets the TL offsets', async () => {
+        const targetElement = elementPath([
+          ['scene-foo', 'app-entity'],
+          ['foo', 'bar'],
+        ])
+
+        const initialEditor = prepareEditorState(
+          makeParentView('foo', [
+            makeView('bar', {
+              position: 'relative',
+            }),
+          ]),
+          [targetElement],
+        )
+
+        const finalEditor = dragByPixels(initialEditor, canvasPoint({ x: 15, y: 15 }))
+        expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+          makeTestProjectCodeWithSnippet(
+            makeParentView('foo', [
+              makeView('bar', {
+                position: 'relative',
+                left: 15,
+                top: 15,
+              }),
+            ]),
+          ),
+        )
+      })
+    })
+
+    describe('when the element has offsets', () => {
+      it('updates the offsets', async () => {
+        const targetElement = elementPath([
+          ['scene-foo', 'app-entity'],
+          ['foo', 'bar'],
+        ])
+
+        const initialEditor = prepareEditorState(
+          makeParentView('foo', [
+            makeView('bar', {
+              position: 'relative',
+              left: 10,
+              top: 10,
+            }),
+          ]),
+          [targetElement],
+        )
+
+        const finalEditor = dragByPixels(initialEditor, canvasPoint({ x: 15, y: 15 }))
+        expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+          makeTestProjectCodeWithSnippet(
+            makeParentView('foo', [
+              makeView('bar', {
+                position: 'relative',
+                left: 25,
+                top: 25,
+              }),
+            ]),
+          ),
+        )
+      })
+
+      describe('when vertical or horizontal offsets are missing', () => {
+        it('sets the missing offset', async () => {
+          const targetElement = elementPath([
+            ['scene-foo', 'app-entity'],
+            ['foo', 'bar'],
+          ])
+
+          const initialEditor = prepareEditorState(
+            makeParentView('foo', [
+              makeView('bar', {
+                position: 'relative',
+                top: 10,
+              }),
+            ]),
+            [targetElement],
+          )
+
+          const finalEditor = dragByPixels(initialEditor, canvasPoint({ x: 15, y: 15 }))
+          expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+            makeTestProjectCodeWithSnippet(
+              makeParentView('foo', [
+                makeView('bar', {
+                  position: 'relative',
+                  top: 25,
+                  left: 15,
+                }),
+              ]),
+            ),
+          )
+        })
+      })
+
+      describe('tlbr behavior', () => {
+        describe('honoring explicitly defined properties', () => {
+          it('right', async () => {
+            const targetElement = elementPath([
+              ['scene-foo', 'app-entity'],
+              ['foo', 'bar'],
+            ])
+
+            const initialEditor = prepareEditorState(
+              makeParentView('foo', [
+                makeView('bar', {
+                  position: 'relative',
+                  top: 100,
+                  right: 25,
+                }),
+              ]),
+              [targetElement],
+            )
+
+            const finalEditor = dragByPixels(initialEditor, canvasPoint({ x: 15, y: 15 }))
+            expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+              makeTestProjectCodeWithSnippet(
+                makeParentView('foo', [
+                  makeView('bar', {
+                    position: 'relative',
+                    top: 115,
+                    right: 10,
+                  }),
+                ]),
+              ),
+            )
+          })
+
+          it('bottom', async () => {
+            const targetElement = elementPath([
+              ['scene-foo', 'app-entity'],
+              ['foo', 'bar'],
+            ])
+
+            const initialEditor = prepareEditorState(
+              makeParentView('foo', [
+                makeView('bar', {
+                  position: 'relative',
+                  bottom: 10,
+                  left: 25,
+                }),
+              ]),
+              [targetElement],
+            )
+
+            const finalEditor = dragByPixels(initialEditor, canvasPoint({ x: 15, y: 15 }))
+            expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+              makeTestProjectCodeWithSnippet(
+                makeParentView('foo', [
+                  makeView('bar', {
+                    position: 'relative',
+                    bottom: -5,
+                    left: 40,
+                  }),
+                ]),
+              ),
+            )
+          })
+
+          it('mixed', async () => {
+            const targetElement = elementPath([
+              ['scene-foo', 'app-entity'],
+              ['foo', 'bar'],
+            ])
+
+            const initialEditor = prepareEditorState(
+              makeParentView('foo', [
+                makeView('bar', {
+                  position: 'relative',
+                  bottom: 10,
+                  left: 25,
+                  top: 10,
+                }),
+              ]),
+              [targetElement],
+            )
+
+            const finalEditor = dragByPixels(initialEditor, canvasPoint({ x: 15, y: 15 }))
+            expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+              makeTestProjectCodeWithSnippet(
+                makeParentView('foo', [
+                  makeView('bar', {
+                    position: 'relative',
+                    bottom: -5,
+                    left: 40,
+                    top: 25,
+                  }),
+                ]),
+              ),
+            )
+          })
+        })
+      })
+    })
+  })
+
+  describe('when the element position is absolute', () => {
+    it('does not change it', async () => {
+      const targetElement = elementPath([
+        ['scene-foo', 'app-entity'],
+        ['foo', 'bar'],
+      ])
+
+      const initialEditor = prepareEditorState(
+        makeParentView('foo', [
+          makeView('bar', {
+            position: 'absolute',
+          }),
+        ]),
+        [targetElement],
+      )
+
+      const finalEditor = dragByPixels(initialEditor, canvasPoint({ x: 15, y: 15 }))
+      expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+        makeTestProjectCodeWithSnippet(
+          makeParentView('foo', [
+            makeView('bar', {
+              position: 'absolute',
+              left: 15,
+              top: 15,
+            }),
+          ]),
+        ),
+      )
+    })
+  })
+})

--- a/editor/src/components/canvas/canvas-strategies/relative-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/relative-move-strategy.tsx
@@ -1,0 +1,152 @@
+import { ParsedCSSProperties } from 'src/components/inspector/common/css-utils'
+import { ElementPath } from 'src/core/shared/project-file-types'
+import { getLayoutProperty } from '../../../core/layout/getLayoutProperty'
+import { MetadataUtils, PropsOrJSXAttributes } from '../../../core/model/element-metadata-utils'
+import { isRight, right } from '../../../core/shared/either'
+import { ElementInstanceMetadata, isJSXElement } from '../../../core/shared/element-template'
+import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
+import { CanvasCommand } from '../commands/commands'
+import { setCssLengthProperty } from '../commands/set-css-length-command'
+import {
+  CanvasStrategy,
+  emptyStrategyApplicationResult,
+  getTargetPathsFromInteractionTarget,
+  strategyApplicationResult,
+} from './canvas-strategy-types'
+import { getDragTargets } from './shared-absolute-move-strategy-helpers'
+
+export const relativeMoveStrategy: CanvasStrategy = {
+  id: 'RELATIVE_MOVE',
+
+  name: () => 'Move (relative)',
+
+  isApplicable: (canvasState, _interactionState, metadata) => {
+    const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
+    if (selectedElements.length === 0) {
+      return false
+    }
+
+    const filteredSelectedElements = getDragTargets(selectedElements)
+    const last = filteredSelectedElements[filteredSelectedElements.length - 1]
+    const meta = MetadataUtils.findElementByElementPath(metadata, last)
+    if (!meta) {
+      return false
+    }
+
+    const { position } = meta.specialSizeMeasurements
+    if (position !== 'relative') {
+      return false
+    }
+
+    const offsets = getStyleOffsets(meta)
+    if (!offsets) {
+      return false
+    }
+
+    return (
+      offsets.left !== null ||
+      offsets.top !== null ||
+      offsets.right !== null ||
+      offsets.bottom !== null
+    )
+  },
+
+  controlsToRender: [],
+
+  fitness: (_canvasState, interactionState, _sessionState) => {
+    // it fits if:
+    // - it's dragging, and
+    // - bounding area is defined, and
+    // - CMD is pressed
+    const { interactionData, activeControl } = interactionState
+    if (!(interactionData.type === 'DRAG' && interactionData.drag !== null)) {
+      return 0
+    }
+    if (activeControl.type !== 'BOUNDING_AREA') {
+      return 0
+    }
+    if (!interactionData.modifiers.cmd) {
+      return 0
+    }
+    return 10 // this is silly, it should be less random
+  },
+
+  apply: (canvasState, interactionState, sessionState) => {
+    const { interactionData } = interactionState
+    if (!(interactionData.type === 'DRAG' && interactionData.drag !== null)) {
+      return emptyStrategyApplicationResult
+    }
+
+    const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
+    if (selectedElements.length === 0) {
+      return emptyStrategyApplicationResult
+    }
+
+    const filteredSelectedElements = getDragTargets(selectedElements)
+    const last = filteredSelectedElements[filteredSelectedElements.length - 1]
+    const meta = MetadataUtils.findElementByElementPath(sessionState.startingMetadata, last)
+    if (!meta) {
+      return emptyStrategyApplicationResult
+    }
+    const offsets = getStyleOffsets(meta)
+    if (!offsets) {
+      return emptyStrategyApplicationResult
+    }
+
+    const { drag } = interactionData
+
+    const commands: Array<CanvasCommand> = []
+    commands.push(applyStyle('left', (offsets.left || 0) + drag.x, last))
+    commands.push(applyStyle('top', (offsets.top || 0) + drag.y, last))
+    commands.push(applyStyle('right', (offsets.right || 0) - drag.x, last))
+    commands.push(applyStyle('bottom', (offsets.bottom || 0) - drag.y, last))
+    return strategyApplicationResult(commands)
+  },
+}
+
+const applyStyle = (
+  name: keyof ParsedCSSProperties,
+  val: number,
+  path: ElementPath,
+): CanvasCommand => {
+  return setCssLengthProperty(
+    'always',
+    path,
+    stylePropPathMappingFn(name, ['style']),
+    val,
+    undefined,
+  )
+}
+
+const getStyleOffsets = (meta: ElementInstanceMetadata) => {
+  const getOffsetPropValue = (
+    name: 'left' | 'top' | 'right' | 'bottom',
+    attrs: PropsOrJSXAttributes,
+  ): number | null => {
+    const prop = getLayoutProperty(name, attrs, ['style'])
+    if (!isRight(prop)) {
+      return null
+    }
+    if (!prop.value) {
+      return null
+    }
+    return prop.value.value
+  }
+
+  if (!isRight(meta.element)) {
+    return null
+  }
+  const { value } = meta.element
+  if (!isJSXElement(value)) {
+    return null
+  }
+
+  const attrs = right(value.props)
+
+  return {
+    left: getOffsetPropValue('left', attrs),
+    top: getOffsetPropValue('top', attrs),
+    right: getOffsetPropValue('right', attrs),
+    bottom: getOffsetPropValue('bottom', attrs),
+  }
+}

--- a/editor/src/components/canvas/canvas-strategies/relative-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/relative-move-strategy.tsx
@@ -1,4 +1,3 @@
-import { ParsedCSSProperties } from 'src/components/inspector/common/css-utils'
 import { ElementPath } from 'src/core/shared/project-file-types'
 import { getLayoutProperty } from '../../../core/layout/getLayoutProperty'
 import { MetadataUtils, PropsOrJSXAttributes } from '../../../core/model/element-metadata-utils'
@@ -33,6 +32,7 @@ export const relativeMoveStrategy: CanvasStrategy = {
       return false
     }
 
+    // should we also support absolute elements, for which we'll do something like `CONVERT_TO_RELATIVE`?
     return meta.specialSizeMeasurements.position === 'relative'
   },
 


### PR DESCRIPTION
# Problem

Having a strategy to handle the movement of elements with `position: relative`.

# Fix

Added the `RELATIVE_MOVE` strategy.

## Notes & gotchas:

- It only triggers when the element has an explicit `position: "relative"` property. 
- If the element has defined offsets (at least one TLBR), the strategy will have a higher fitness score
- If the element doesn't have defined offsets, the strategy will have a lower fitness score (e.g. it will default to `FLOW_REORDER`)
- the offsets are set with TL priority
  - if the horizontal or vertical offset is missing, it will be added (T or L)
  - if the BR offsets are set, they will be updated as per the movement delta
- ⚠️ the condition to check whether the flow reorder strategy applies are changed to be applicable even if the element has `position: "relative"` so that the two strategies can be used alternatively on the same element. This _should_ be fine, but it'd be great if somebody with more experience on this could double check it's not gonna introduce issues
- ⚠️ I'm not super sure about which controls should be rendered for the strategy, I left it empty for now