### PR TITLE
tests(performance) - eliminate small deltas from automated PR annotations

### DIFF
--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -128,7 +128,7 @@ export const testPerformance = async function () {
         spacerLine,
       ]
     } else {
-      return [titleLine, spacerLine]
+      return null
     }
   })
 


### PR DESCRIPTION
**Problem:**
Our perf tests show all results, and we suppress details if the absolute percentage difference is less than 5. This generates a spammy level of lines. We already show all results in the perf graph anyway (though maybe even that is overkill)

**Fix:**
Only show lines where abs delta is > 5%

_NB: rage fix. Also, Gresham's Law stimulus for a / a better solution_