### PR TITLE
Load project contents from a Github branch.

### DIFF
--- a/clientmodel/lib/package.yaml
+++ b/clientmodel/lib/package.yaml
@@ -27,6 +27,8 @@ default-extensions:
   - DeriveDataTypeable
   - DataKinds
   - DeriveAnyClass
+  - Strict
+  - StrictData
 
 dependencies:
   - base

--- a/clientmodel/lib/src/Utopia/ClientModel.hs
+++ b/clientmodel/lib/src/Utopia/ClientModel.hs
@@ -305,6 +305,10 @@ data ProjectContentsTree = ProjectContentsTreeDirectory ProjectContentDirectory
                          | ProjectContentsTreeFile ProjectContentFile
                          deriving (Eq, Show, Generic, Data, Typeable)
 
+fullPathFromProjectContentsTree :: ProjectContentsTree -> Text
+fullPathFromProjectContentsTree (ProjectContentsTreeDirectory ProjectContentDirectory{..}) = fullPath
+fullPathFromProjectContentsTree (ProjectContentsTreeFile ProjectContentFile{..}) = fullPath
+
 instance FromJSON ProjectContentsTree where
   parseJSON value =
     let fileType = firstOf (key "type" . _String) value

--- a/clientmodel/lib/utopia-clientmodel.cabal
+++ b/clientmodel/lib/utopia-clientmodel.cabal
@@ -34,6 +34,8 @@ library
       DeriveDataTypeable
       DataKinds
       DeriveAnyClass
+      Strict
+      StrictData
   ghc-options: -Wall -Werror -threaded -fno-warn-orphans -Wno-unused-imports
   build-depends:
       QuickCheck
@@ -76,6 +78,8 @@ test-suite clientmodel-test
       DeriveDataTypeable
       DataKinds
       DeriveAnyClass
+      Strict
+      StrictData
   ghc-options: -Wall -Werror -threaded -fno-warn-orphans -Wno-unused-imports
   build-depends:
       QuickCheck

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -45,6 +45,7 @@ import {
   ElementsToRerender,
   ErrorMessages,
   FloatingInsertMenuState,
+  GithubRepo,
   GithubState,
   LeftMenuTab,
   ModalDialog,
@@ -65,6 +66,7 @@ import {
 } from '../shared/project-components'
 import { LayoutTargetableProp } from '../../core/layout/layout-helpers-new'
 import { BuildType } from '../../core/workers/common/worker-types'
+import { ProjectContentTreeRoot } from '../assets'
 export { isLoggedIn, loggedInUser, notLoggedIn } from '../../common/user'
 export type { LoginState, UserDetails } from '../../common/user'
 
@@ -595,6 +597,11 @@ export interface UpdateFile {
   addIfNotInFiles: boolean
 }
 
+export interface UpdateProjectContents {
+  action: 'UPDATE_PROJECT_CONTENTS'
+  contents: ProjectContentTreeRoot
+}
+
 export interface WorkerCodeUpdate {
   type: 'WORKER_CODE_UPDATE'
   filePath: string
@@ -976,7 +983,7 @@ export type ToggleSelectionLock = {
 
 export interface SaveToGithub {
   action: 'SAVE_TO_GITHUB'
-  targetRepository: string
+  targetRepository: GithubRepo
 }
 
 export type EditorAction =
@@ -1066,6 +1073,7 @@ export type EditorAction =
   | OpenCodeEditorFile
   | CloseDesignerFile
   | UpdateFile
+  | UpdateProjectContents
   | UpdateFromWorker
   | UpdateFromCodeEditor
   | ClearParseOrPrintInFlight

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -214,6 +214,7 @@ import type {
   ElementPaste,
   SetGithubState,
   SaveToGithub,
+  UpdateProjectContents,
 } from '../action-types'
 import {
   EditorModes,
@@ -226,6 +227,7 @@ import type {
   DuplicationState,
   ErrorMessages,
   FloatingInsertMenuState,
+  GithubRepo,
   GithubState,
   LeftMenuTab,
   ModalDialog,
@@ -965,6 +967,13 @@ export function updateFile(
   }
 }
 
+export function updateProjectContents(contents: ProjectContentTreeRoot): UpdateProjectContents {
+  return {
+    action: 'UPDATE_PROJECT_CONTENTS',
+    contents: contents,
+  }
+}
+
 export function workerCodeUpdate(
   filePath: string,
   code: string,
@@ -1536,7 +1545,7 @@ export function toggleSelectionLock(
   }
 }
 
-export function saveToGithub(targetRepository: string): SaveToGithub {
+export function saveToGithub(targetRepository: GithubRepo): SaveToGithub {
   return {
     action: 'SAVE_TO_GITHUB',
     targetRepository: targetRepository,

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -155,6 +155,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'DELETE_FILE':
     case 'ADD_TEXT_FILE':
     case 'UPDATE_FILE':
+    case 'UPDATE_PROJECT_CONTENTS':
     case 'UPDATE_FROM_CODE_EDITOR':
     case 'SET_MAIN_UI_FILE':
     case 'SET_PROP':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -375,6 +375,7 @@ import {
   ToggleSelectionLock,
   SetGithubState,
   SaveToGithub,
+  UpdateProjectContents,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -3776,6 +3777,12 @@ export const UPDATE_FNS = {
       },
     }
   },
+  UPDATE_PROJECT_CONTENTS: (action: UpdateProjectContents, editor: EditorModel): EditorModel => {
+    return {
+      ...editor,
+      projectContents: action.contents,
+    }
+  },
   UPDATE_FROM_WORKER: (action: UpdateFromWorker, editor: EditorModel): EditorModel => {
     let workingProjectContents: ProjectContentTreeRoot = editor.projectContents
     let anyParsedUpdates: boolean = false
@@ -5020,23 +5027,18 @@ export const UPDATE_FNS = {
     editor: EditorModel,
     dispatch: EditorDispatch,
   ): EditorModel => {
-    const updatedRepo = parseGithubProjectString(action.targetRepository)
-    if (updatedRepo == null) {
-      return editor
-    } else {
-      const updatedEditor = {
-        ...editor,
-        githubSettings: {
-          ...editor.githubSettings,
-          targetRepository: updatedRepo,
-        },
-      }
-      // Side effect - Pushing this to the server to get that to save to Github.
-      const persistentModel = persistentModelFromEditorModel(updatedEditor)
-      void saveProjectToGithub(persistentModel, dispatch)
-
-      return editor
+    const updatedEditor = {
+      ...editor,
+      githubSettings: {
+        ...editor.githubSettings,
+        targetRepository: action.targetRepository,
+      },
     }
+    // Side effect - Pushing this to the server to get that to save to Github.
+    const persistentModel = persistentModelFromEditorModel(updatedEditor)
+    void saveProjectToGithub(persistentModel, dispatch)
+
+    return editor
   },
 }
 

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -192,6 +192,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.OPEN_CODE_EDITOR_FILE(action, state)
     case 'UPDATE_FILE':
       return UPDATE_FNS.UPDATE_FILE(action, state, dispatch, builtInDependencies)
+    case 'UPDATE_PROJECT_CONTENTS':
+      return UPDATE_FNS.UPDATE_PROJECT_CONTENTS(action, state)
     case 'UPDATE_FROM_WORKER':
       return UPDATE_FNS.UPDATE_FROM_WORKER(action, state)
     case 'UPDATE_FROM_CODE_EDITOR':

--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -813,7 +813,7 @@ const GithubPane = React.memo(() => {
 
   React.useEffect(() => {
     if (parsedTargetRepository != null) {
-      getBranchesForGithubRepository(parsedTargetRepository).then((result) => {
+      void getBranchesForGithubRepository(parsedTargetRepository).then((result) => {
         setBranchesForRepository(result)
       })
     }
@@ -838,7 +838,7 @@ const GithubPane = React.memo(() => {
               {branchesForRepository.branches.map((branch, index) => {
                 function loadContentForBranch() {
                   if (parsedTargetRepository != null) {
-                    getBranchContent(dispatch, parsedTargetRepository, branch.name)
+                    void getBranchContent(dispatch, parsedTargetRepository, branch.name)
                   }
                 }
                 return (

--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -1,5 +1,6 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
+/** @jsxFrag React.Fragment */
 import { jsx } from '@emotion/react'
 import styled from '@emotion/styled'
 import React, { ChangeEvent } from 'react'
@@ -64,11 +65,17 @@ import { getContentsTreeFileFromString } from '../assets'
 import { Link } from '../../uuiui/link'
 import { useTriggerForkProject } from '../editor/persistence-hooks'
 import urljoin from 'url-join'
-import { parseGithubProjectString } from '../../core/shared/github'
+import {
+  getBranchContent,
+  getBranchesForGithubRepository,
+  GetBranchesResponse,
+  parseGithubProjectString,
+} from '../../core/shared/github'
 import { startGithubAuthentication } from '../../utils/github-auth'
 import { getURLImportDetails } from '../../core/model/project-import'
 import { forEachLeft, forEachRight } from '../../core/shared/either'
 import { notice } from '../common/notice'
+import { when } from '../../utils/react-conditionals'
 
 export interface LeftPaneProps {
   editorState: EditorState
@@ -713,8 +720,8 @@ const SharingPane = React.memo(() => {
 })
 
 const GithubPane = React.memo(() => {
-  const [githubRepoStr, setGithubRepoStr] = React.useState('')
-  const parsedRepo = parseGithubProjectString(githubRepoStr)
+  const [importGithubRepoStr, setImportGithubRepoStr] = React.useState('')
+  const parsedImportRepo = parseGithubProjectString(importGithubRepoStr)
   const dispatch = useEditorState((store) => store.dispatch, 'GithubPane dispatch')
   const storedTargetGithubRepo = useEditorState((store) => {
     const repo = store.editor.githubSettings.targetRepository
@@ -726,8 +733,8 @@ const GithubPane = React.memo(() => {
   }, 'GithubPane storedTargetGithubRepo')
 
   const onStartImport = React.useCallback(() => {
-    if (parsedRepo != null) {
-      const { owner, repository } = parsedRepo
+    if (parsedImportRepo != null) {
+      const { owner, repository } = parsedImportRepo
 
       const url = new URL(urljoin(BASE_URL, 'p'))
       url.searchParams.set('github_owner', owner)
@@ -735,13 +742,13 @@ const GithubPane = React.memo(() => {
 
       window.open(url.toString())
     }
-  }, [parsedRepo])
+  }, [parsedImportRepo])
 
   const onChange = React.useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      setGithubRepoStr(e.currentTarget.value)
+      setImportGithubRepoStr(e.currentTarget.value)
     },
-    [setGithubRepoStr],
+    [setImportGithubRepoStr],
   )
 
   const githubAuthenticated = useEditorState((store) => {
@@ -777,22 +784,81 @@ const GithubPane = React.memo(() => {
     [dispatch],
   )
 
-  const [githubRepoToSaveTo, setGithubRepoToSaveTo] = React.useState<string | undefined>(
+  const [targetRepository, setTargetRepository] = React.useState<string | undefined>(
     storedTargetGithubRepo,
   )
+  const parsedTargetRepository = React.useMemo(() => {
+    if (targetRepository == null) {
+      return null
+    } else {
+      return parseGithubProjectString(targetRepository)
+    }
+  }, [targetRepository])
 
-  const onChangeGithubRepoToSaveTo = React.useCallback(
+  const onChangeTargetRepository = React.useCallback(
     (changeEvent: React.ChangeEvent<HTMLInputElement>) => {
-      setGithubRepoToSaveTo(changeEvent.currentTarget.value)
+      setTargetRepository(changeEvent.currentTarget.value)
     },
-    [setGithubRepoToSaveTo],
+    [setTargetRepository],
   )
 
   const triggerSaveToGithub = React.useCallback(() => {
-    if (githubRepoToSaveTo != null) {
-      dispatch([EditorActions.saveToGithub(githubRepoToSaveTo)], 'everyone')
+    if (parsedTargetRepository != null) {
+      dispatch([EditorActions.saveToGithub(parsedTargetRepository)], 'everyone')
     }
-  }, [dispatch, githubRepoToSaveTo])
+  }, [dispatch, parsedTargetRepository])
+
+  const [branchesForRepository, setBranchesForRepository] =
+    React.useState<GetBranchesResponse | null>(null)
+
+  React.useEffect(() => {
+    if (parsedTargetRepository != null) {
+      getBranchesForGithubRepository(parsedTargetRepository).then((result) => {
+        setBranchesForRepository(result)
+      })
+    }
+  }, [parsedTargetRepository])
+
+  const getBranchesUI = React.useCallback(() => {
+    if (branchesForRepository == null) {
+      return null
+    } else {
+      switch (branchesForRepository.type) {
+        case 'FAILURE':
+          return <span>{branchesForRepository.failureReason}</span>
+        case 'SUCCESS':
+          return (
+            <>
+              {when(
+                branchesForRepository.branches.length > 0,
+                <UIGridRow padded variant='<--------auto-------->|--45px--|'>
+                  <span>NOTE: These will replace the current project contents.</span>
+                </UIGridRow>,
+              )}
+              {branchesForRepository.branches.map((branch, index) => {
+                function loadContentForBranch() {
+                  if (parsedTargetRepository != null) {
+                    getBranchContent(dispatch, parsedTargetRepository, branch.name)
+                  }
+                }
+                return (
+                  <UIGridRow key={index} padded variant='<--------auto-------->|--45px--|'>
+                    <span>{branch.name}</span>
+                    <Button spotlight highlight onMouseUp={loadContentForBranch}>
+                      Load
+                    </Button>
+                  </UIGridRow>
+                )
+              })}
+            </>
+          )
+
+        default:
+          const _exhaustiveCheck: never = branchesForRepository
+          throw new Error(`Unhandled branches value ${JSON.stringify(branchesForRepository)}`)
+      }
+    }
+  }, [branchesForRepository, parsedTargetRepository, dispatch])
 
   return (
     <FlexColumn
@@ -856,8 +922,13 @@ const GithubPane = React.memo(() => {
             in a new tab.
           </div>
           <UIGridRow padded variant='<--------auto-------->|--45px--|'>
-            <StringInput testId='importProject' value={githubRepoStr} onChange={onChange} />
-            <Button spotlight highlight disabled={parsedRepo == null} onMouseUp={onStartImport}>
+            <StringInput testId='importProject' value={importGithubRepoStr} onChange={onChange} />
+            <Button
+              spotlight
+              highlight
+              disabled={parsedImportRepo == null}
+              onMouseUp={onStartImport}
+            >
               Start
             </Button>
           </UIGridRow>
@@ -877,18 +948,27 @@ const GithubPane = React.memo(() => {
               fontSize: '11px',
             }}
           >
-            Save to a Github repo if you have access to it.
+            Work with a Github repo if you have access to it.
           </div>
-          <UIGridRow padded variant='<--------auto-------->|--45px--|'>
+          <UIGridRow padded variant='<-------------1fr------------->'>
             <StringInput
               testId='saveToGithubInput'
-              value={githubRepoToSaveTo}
-              onChange={onChangeGithubRepoToSaveTo}
+              value={targetRepository}
+              disabled={!githubAuthenticated}
+              onChange={onChangeTargetRepository}
             />
-            <Button spotlight highlight onMouseUp={triggerSaveToGithub}>
-              Save
+          </UIGridRow>
+          <UIGridRow padded variant='<-------------1fr------------->'>
+            <Button
+              spotlight
+              highlight
+              disabled={!githubAuthenticated}
+              onMouseUp={triggerSaveToGithub}
+            >
+              Save To Github
             </Button>
           </UIGridRow>
+          {getBranchesUI()}
         </SectionBodyArea>
       </Section>
       <Section>

--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -819,7 +819,7 @@ const GithubPane = React.memo(() => {
     }
   }, [parsedTargetRepository])
 
-  const getBranchesUI = React.useCallback(() => {
+  const branchesUI = React.useMemo(() => {
     if (branchesForRepository == null) {
       return null
     } else {
@@ -962,13 +962,13 @@ const GithubPane = React.memo(() => {
             <Button
               spotlight
               highlight
-              disabled={!githubAuthenticated}
+              disabled={!githubAuthenticated || parsedTargetRepository == null}
               onMouseUp={triggerSaveToGithub}
             >
               Save To Github
             </Button>
           </UIGridRow>
-          {getBranchesUI()}
+          {branchesUI}
         </SectionBodyArea>
       </Section>
       <Section>

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -5,7 +5,16 @@ description: Utopia Web
 github: concrete-utopia/utopia
 category: Development
 license: MIT
-ghc-options: -Wall -threaded -rtsopts
+
+ghc-options:
+  - -Wall
+  - -Werror
+  - -threaded
+  - -fno-warn-orphans
+  - -Wno-unused-imports
+  - -Wno-deprecations
+  - -rtsopts
+
 flags:
   enable-external-tests:
     description: Enable the external tests.
@@ -47,7 +56,9 @@ dependencies:
   - github 
   - lens
   - lens-aeson <1.2
+  - lifted-async
   - lifted-base
+  - mime
   - mime-types
   - modern-uri
   - monad-control

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -15,6 +15,11 @@ ghc-options:
   - -Wno-deprecations
   - -rtsopts
 
+default-extensions:
+  - Strict
+  - StrictData
+  - NoImplicitPrelude
+
 flags:
   enable-external-tests:
     description: Enable the external tests.
@@ -110,8 +115,6 @@ dependencies:
   - wreq
 extra-libraries:
   - z
-default-extensions:
-  - NoImplicitPrelude
 executable:
   main: Main.hs
   source-dirs: src

--- a/server/src/Utopia/Web/Assets.hs
+++ b/server/src/Utopia/Web/Assets.hs
@@ -141,7 +141,7 @@ loadFileFromS3 bucketName objectKey possibleETag = do
       fileContents <- sinkBody (view gorsBody successfulResponse) sinkLazy
       let etagFromS3 = firstOf (gorsETag . _Just . _Ctor @"ETag" . utf8) successfulResponse
       pure $ AssetLoaded fileContents etagFromS3
-    Left serviceError ->
+    Left _ ->
       pure AssetUnmodified
 
 checkFileExistsInS3 :: BucketName -> ObjectKey -> AWST (ResourceT IO) Bool

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -50,7 +50,7 @@ import           Utopia.Web.Database             (projectContentTreeFromDecodedP
 import           Utopia.Web.Database.Types
 import qualified Utopia.Web.Database.Types       as DB
 import           Utopia.Web.Executors.Common
-import           Utopia.Web.Github
+import           Utopia.Web.Github.Types
 import           Utopia.Web.Packager.NPM
 import           Utopia.Web.Proxy
 import           Utopia.Web.Servant
@@ -674,6 +674,14 @@ githubSaveEndpoint :: Maybe Text -> PersistentModel -> ServerMonad SaveToGithubR
 githubSaveEndpoint cookie persistentModel = requireUser cookie $ \sessionUser -> do
   saveToGithubRepo (view (field @"_id") sessionUser) persistentModel
 
+getGithubBranchesEndpoint :: Maybe Text -> Text -> Text -> ServerMonad GetBranchesResponse
+getGithubBranchesEndpoint cookie owner repository = requireUser cookie $ \sessionUser -> do
+  getBranchesFromGithubRepo (view (field @"_id") sessionUser) owner repository
+
+getGithubBranchContentEndpoint :: Maybe Text -> Text -> Text -> Text -> ServerMonad GetBranchContentResponse
+getGithubBranchContentEndpoint cookie owner repository branchName = requireUser cookie $ \sessionUser -> do
+  getBranchContent (view (field @"_id") sessionUser) owner repository branchName
+
 {-|
   Compose together all the individual endpoints into a definition for the whole server.
 -}
@@ -697,6 +705,8 @@ protected authCookie = logoutPage authCookie
                   :<|> githubFinishAuthenticationEndpoint authCookie
                   :<|> githubAuthenticatedEndpoint authCookie
                   :<|> githubSaveEndpoint authCookie
+                  :<|> getGithubBranchesEndpoint authCookie
+                  :<|> getGithubBranchContentEndpoint authCookie
 
 unprotected :: ServerT Unprotected ServerMonad
 unprotected = authenticate

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -11,12 +11,12 @@
 
 module Utopia.Web.Executors.Common where
 
-import Control.Monad.Trans.Control
 import           Conduit
 import           Control.Concurrent.ReadWriteLock
 import           Control.Lens                     hiding ((.=), (<.>))
 import           Control.Monad.Catch              hiding (Handler, catch)
 import           Control.Monad.RWS.Strict
+import           Control.Monad.Trans.Control
 import           Control.Monad.Trans.Maybe
 import           Data.Aeson
 import           Data.Bifoldable

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -400,5 +400,5 @@ getGithubBranch githubResources logger metrics pool userID owner repository bran
       getGitBranch accessToken owner repository branchName
     let treeSha = view (field @"commit" . field @"commit" . field @"tree" . field @"sha") branch
     useAccessToken githubResources logger metrics pool userID $ \accessToken -> do
-      getRecursiveGitTreeAsContent accessToken owner repository [] treeSha
+      getRecursiveGitTreeAsContent accessToken owner repository treeSha
   pure $ either getBranchContentFailureFromReason getBranchContentSuccessFromContent result

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -11,6 +11,7 @@
 
 module Utopia.Web.Executors.Common where
 
+import Control.Monad.Trans.Control
 import           Conduit
 import           Control.Concurrent.ReadWriteLock
 import           Control.Lens                     hiding ((.=), (<.>))
@@ -52,6 +53,7 @@ import           Utopia.Web.Auth.Types            (Auth0Resources)
 import qualified Utopia.Web.Database              as DB
 import           Utopia.Web.Database.Types
 import           Utopia.Web.Github
+import           Utopia.Web.Github.Types
 import           Utopia.Web.Logging
 import           Utopia.Web.Metrics
 import           Utopia.Web.Packager.Locking
@@ -383,3 +385,20 @@ createTreeAndSaveToGithub githubResources logger metrics pool userID model = do
       createGitBranchForCommit accessToken model (view (field @"sha") commitResult) branchName
     pure (branchName, view (field @"url") branchResult)
   pure $ either responseFailureFromReason responseSuccessFromBranchNameAndURL result
+
+getGithubBranches :: (MonadIO m) => GithubAuthResources -> FastLogger -> DB.DatabaseMetrics -> DBPool -> Text -> Text -> Text -> m GetBranchesResponse
+getGithubBranches githubResources logger metrics pool userID owner repository = do
+  result <- runExceptT $ do
+    useAccessToken githubResources logger metrics pool userID $ \accessToken -> do
+      getGitBranches accessToken owner repository
+  pure $ either getBranchesFailureFromReason getBranchesSuccessFromBranches result
+
+getGithubBranch :: (MonadBaseControl IO m, MonadIO m) => GithubAuthResources -> FastLogger -> DB.DatabaseMetrics -> DBPool -> Text -> Text -> Text -> Text -> m GetBranchContentResponse
+getGithubBranch githubResources logger metrics pool userID owner repository branchName = do
+  result <- runExceptT $ do
+    branch <- useAccessToken githubResources logger metrics pool userID $ \accessToken -> do
+      getGitBranch accessToken owner repository branchName
+    let treeSha = view (field @"commit" . field @"commit" . field @"tree" . field @"sha") branch
+    useAccessToken githubResources logger metrics pool userID $ \accessToken -> do
+      getRecursiveGitTreeAsContent accessToken owner repository [] treeSha
+  pure $ either getBranchContentFailureFromReason getBranchContentSuccessFromContent result

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -349,7 +349,26 @@ innerServerExecutor (SaveToGithubRepo user model action) = do
     Just githubResources -> do
       result <- createTreeAndSaveToGithub githubResources logger metrics pool user model
       pure $ action result
-
+innerServerExecutor (GetBranchesFromGithubRepo user owner repository action) = do
+  possibleGithubResources <- fmap _githubResources ask
+  metrics <- fmap _databaseMetrics ask
+  logger <- fmap _logger ask
+  pool <- fmap _projectPool ask
+  case possibleGithubResources of
+    Nothing -> throwError err501
+    Just githubResources -> do
+      result <- getGithubBranches githubResources logger metrics pool user owner repository
+      pure $ action result
+innerServerExecutor (GetBranchContent user owner repository branchName action) = do
+  possibleGithubResources <- fmap _githubResources ask
+  metrics <- fmap _databaseMetrics ask
+  logger <- fmap _logger ask
+  pool <- fmap _projectPool ask
+  case possibleGithubResources of
+    Nothing -> throwError err501
+    Just githubResources -> do
+      result <- getGithubBranch githubResources logger metrics pool user owner repository branchName
+      pure $ action result
 {-|
   Invokes a service call using the supplied resources.
 -}

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -270,7 +270,20 @@ innerServerExecutor (SaveToGithubRepo user model action) = do
   pool <- fmap _projectPool ask
   result <- createTreeAndSaveToGithub githubResources logger metrics pool user model
   pure $ action result
-
+innerServerExecutor (GetBranchesFromGithubRepo user owner repository action) = do
+  githubResources <- fmap _githubResources ask
+  metrics <- fmap _databaseMetrics ask
+  logger <- fmap _logger ask
+  pool <- fmap _projectPool ask
+  result <- getGithubBranches githubResources logger metrics pool user owner repository
+  pure $ action result
+innerServerExecutor (GetBranchContent user owner repository branchName action) = do
+  githubResources <- fmap _githubResources ask
+  metrics <- fmap _databaseMetrics ask
+  logger <- fmap _logger ask
+  pool <- fmap _projectPool ask
+  result <- getGithubBranch githubResources logger metrics pool user owner repository branchName
+  pure $ action result
 
 readEditorContentFromDisk :: Maybe BranchDownloads -> Maybe Text -> Text -> IO Text
 readEditorContentFromDisk (Just downloads) (Just branchName) fileName = do

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -1,9 +1,11 @@
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE TypeApplications      #-}
 
 module Utopia.Web.Github where
 
@@ -19,17 +21,24 @@ import           Data.Aeson.Lens
 import qualified Data.ByteString.Lazy       as BL
 import           Data.Data
 import           Data.Foldable
+import           Data.Generics.Product
+import           Data.Generics.Sum
 import qualified Data.HashMap.Strict        as M
 import qualified Data.Text                  as T
 import           Data.Text.Encoding
-import           Data.Text.Encoding.Base64
+import           Data.Text.Encoding.Base64.URL
 import           Data.Typeable
 import           Network.HTTP.Types.Status
 import           Network.OAuth.OAuth2
 import qualified Network.Wreq               as WR
+import qualified Network.Wreq.Types         as WR (Postable)
 import           Prelude                    (String)
 import           Protolude
 import           Utopia.ClientModel
+import           Utopia.Web.Github.Types
+import Codec.MIME.Base64
+import Control.Concurrent.Async.Lifted
+import Control.Monad.Trans.Control
 
 fetchRepoArchive :: Text -> Text -> IO (Maybe BL.ByteString)
 fetchRepoArchive owner repo = do
@@ -43,163 +52,15 @@ fetchRepoArchive owner repo = do
     then return $ Just $ repoResult ^. WR.responseBody
     else return $ Nothing
 
-dropLastUnderscore :: String -> String
-dropLastUnderscore []             = []
-dropLastUnderscore (last : [])    = if last == '_' then [] else [last]
-dropLastUnderscore (first : rest) = first : dropLastUnderscore rest
-
-data GitTreeEntry = GitTreeEntry
-                  { path    :: Text
-                  , mode    :: Text
-                  , type_   :: Text
-                  , content :: Maybe Text
-                  , sha     :: Maybe Text
-                  }
-                  deriving (Eq, Show, Generic, Data, Typeable)
-
-gitTreeEntryOptions :: Options
-gitTreeEntryOptions = defaultOptions { fieldLabelModifier = dropLastUnderscore, omitNothingFields = True }
-
-instance FromJSON GitTreeEntry where
-  parseJSON = genericParseJSON gitTreeEntryOptions
-
-instance ToJSON GitTreeEntry where
-  toJSON = genericToJSON gitTreeEntryOptions
-
-data CreateGitTree = CreateGitTree
-                   { baseTree ::  Maybe Text
-                   , tree     :: [GitTreeEntry]
-                   }
-                   deriving (Eq, Show, Generic, Data, Typeable)
-
-createGitTreeOptions :: Options
-createGitTreeOptions = defaultOptions { fieldLabelModifier = camelTo2 '_', omitNothingFields = True }
-
-instance FromJSON CreateGitTree where
-  parseJSON = genericParseJSON createGitTreeOptions
-
-instance ToJSON CreateGitTree where
-  toJSON = genericToJSON createGitTreeOptions
-
-data CreateGitTreeResult = CreateGitTreeResult
-                         { sha :: Text
-                         , url :: Text
-                         }
-                         deriving (Eq, Show, Generic, Data, Typeable)
-
-instance FromJSON CreateGitTreeResult where
-  parseJSON = genericParseJSON defaultOptions
-
-instance ToJSON CreateGitTreeResult where
-  toJSON = genericToJSON defaultOptions
-
-data CreateGitCommit = CreateGitCommit
-                     { message :: Text
-                     , tree    :: Text
-                     }
-                     deriving (Eq, Show, Generic, Data, Typeable)
-
-instance FromJSON CreateGitCommit where
-  parseJSON = genericParseJSON defaultOptions
-
-instance ToJSON CreateGitCommit where
-  toJSON = genericToJSON defaultOptions
-
-data CreateGitCommitResult = CreateGitCommitResult
-                           { sha :: Text
-                           , url :: Text
-                           }
-                           deriving (Eq, Show, Generic, Data, Typeable)
-
-instance FromJSON CreateGitCommitResult where
-  parseJSON = genericParseJSON defaultOptions
-
-instance ToJSON CreateGitCommitResult where
-  toJSON = genericToJSON defaultOptions
-
-data CreateGitBranch = CreateGitBranch
-                     { ref :: Text
-                     , sha :: Text
-                     }
-                     deriving (Eq, Show, Generic, Data, Typeable)
-
-instance FromJSON CreateGitBranch where
-  parseJSON = genericParseJSON defaultOptions
-
-instance ToJSON CreateGitBranch where
-  toJSON = genericToJSON defaultOptions
-
-data CreateGitBranchResult = CreateGitBranchResult
-                           { ref :: Text
-                           , url :: Text
-                           }
-                           deriving (Eq, Show, Generic, Data, Typeable)
-
-instance FromJSON CreateGitBranchResult where
-  parseJSON = genericParseJSON defaultOptions
-
-instance ToJSON CreateGitBranchResult where
-  toJSON = genericToJSON defaultOptions
-
-data SaveToGithubSuccess = SaveToGithubSuccess
-                         { branchName :: Text
-                         , url        :: Text
-                         }
-                         deriving (Eq, Show, Generic, Data, Typeable)
-
-instance FromJSON SaveToGithubSuccess where
-  parseJSON = genericParseJSON defaultOptions
-
-instance ToJSON SaveToGithubSuccess where
-  toJSON = genericToJSON defaultOptions
-
-data SaveToGithubFailure = SaveToGithubFailure
-                         { failureReason  :: Text
-                         }
-                         deriving (Eq, Show, Generic, Data, Typeable)
-
-instance FromJSON SaveToGithubFailure where
-  parseJSON = genericParseJSON defaultOptions
-
-instance ToJSON SaveToGithubFailure where
-  toJSON = genericToJSON defaultOptions
-
-
-data SaveToGithubResponse = SaveToGithubResponseSuccess SaveToGithubSuccess
-                          | SaveToGithubResponseFailure SaveToGithubFailure
-                          deriving (Eq, Show, Generic, Data, Typeable)
-
-responseFailureFromReason :: Text -> SaveToGithubResponse
-responseFailureFromReason failureReason = SaveToGithubResponseFailure SaveToGithubFailure{..}
-
-responseSuccessFromBranchNameAndURL :: (Text, Text) -> SaveToGithubResponse
-responseSuccessFromBranchNameAndURL (branchName, url) = SaveToGithubResponseSuccess SaveToGithubSuccess{..}
-
-instance FromJSON SaveToGithubResponse where
-  parseJSON value =
-    let fileType = firstOf (key "type" . _String) value
-     in case fileType of
-          (Just "SUCCESS")  -> fmap SaveToGithubResponseSuccess $ parseJSON value
-          (Just "FAILURE")  -> fmap SaveToGithubResponseFailure $ parseJSON value
-          (Just unknownType)  -> fail ("Unknown type: " <> T.unpack unknownType)
-          _                   -> fail "No type for SaveToGithubResponse specified."
-
-instance ToJSON SaveToGithubResponse where
-  toJSON (SaveToGithubResponseSuccess success) = over _Object (M.insert "type" "SUCCESS") $ toJSON success
-  toJSON (SaveToGithubResponseFailure failure) = over _Object (M.insert "type" "FAILURE") $ toJSON failure
-
 stripPreceedingSlash :: Text -> Text
 stripPreceedingSlash text =
   case T.uncons text of
-    Just (first, rest) -> if first == '/' then rest else text
-    Nothing            -> text
-
-shaTextFromText :: Text -> Text
-shaTextFromText text = T.pack $ show (C.hash $ encodeUtf8 text :: Digest SHA1)
+    Just (firstChar, rest) -> if firstChar == '/' then rest else text
+    Nothing                -> text
 
 directoryGitTreeEntry :: ProjectContentDirectory -> Maybe GitTreeEntry
-directoryGitTreeEntry ProjectContentDirectory{..} =
-  Nothing --Just $ GitTreeEntry (stripPreceedingSlash fullPath) "040000" "tree" Nothing Nothing
+directoryGitTreeEntry _ =
+  Nothing
 
 projectFileGitTreeEntry :: Text -> ProjectFile -> Maybe GitTreeEntry
 projectFileGitTreeEntry fullPath (ProjectTextFile TextFile{..}) =
@@ -226,19 +87,25 @@ gitTreeEntriesFromProjectContent projectContents = foldMap' gitTreeEntriesFromPr
 createGitTreeFromProjectContent :: ProjectContentTreeRoot -> CreateGitTree
 createGitTreeFromProjectContent projectContents = CreateGitTree Nothing $ gitTreeEntriesFromProjectContent projectContents
 
-callGithub :: (ToJSON request, FromJSON response, MonadIO m) => (Status -> ExceptT Text m ()) -> AccessToken -> Text -> request -> ExceptT Text m response
-callGithub handleErrorCases accessToken restURL request = do
+type MakeGithubRequest a = WR.Options -> String -> a -> IO (WR.Response BL.ByteString)
+
+postToGithub :: (ToJSON a) => MakeGithubRequest a
+postToGithub options url content = WR.postWith options url (toJSON content)
+
+getFromGithub :: MakeGithubRequest ()
+getFromGithub options url _ = WR.getWith options url
+
+callGithub :: (ToJSON request, FromJSON response, MonadIO m) => MakeGithubRequest request -> (Status -> ExceptT Text m ()) -> AccessToken -> Text -> request -> ExceptT Text m response
+callGithub makeRequest handleErrorCases accessToken restURL request = do
   let options = WR.defaults
               & WR.header "User-Agent" .~ ["concrete-utopia/utopia"]
               & WR.header "Accept" .~ ["application/vnd.github.v3+json"]
               & WR.header "Authorization" .~ ["Bearer " <> (encodeUtf8 $ atoken accessToken)]
-  let body = toJSON request
-  result <- liftIO $ do
-    response <- WR.postWith options (toS restURL) body
-    WR.asJSON response
+              & WR.checkResponse .~ (Just $ \_ _ -> return ())
+  result <- liftIO $ makeRequest options (toS restURL) request
   let status = view WR.responseStatus result
   unless (statusIsSuccessful status) $ handleErrorCases status
-  maybe (throwE "No response body from request.") pure $ firstOf (WR.responseBody . _Just) result
+  except $ bimap show (\r -> view WR.responseBody r) (WR.asJSON result)
 
 createTreeHandleErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
 createTreeHandleErrorCases status | status == forbidden403            = throwE "Forbidden from creating tree."
@@ -250,7 +117,7 @@ createGitTree :: (MonadIO m) => AccessToken -> GithubRepo -> ProjectContentTreeR
 createGitTree accessToken GithubRepo{..} projectContents = do
   let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/trees"
   let request = createGitTreeFromProjectContent projectContents
-  callGithub createTreeHandleErrorCases accessToken repoUrl request
+  callGithub postToGithub createTreeHandleErrorCases accessToken repoUrl request
 
 createGitTreeFromModel :: (MonadIO m) => AccessToken -> PersistentModel -> ExceptT Text m CreateGitTreeResult
 createGitTreeFromModel accessToken PersistentModel{..} = do
@@ -268,7 +135,7 @@ createGitCommit :: (MonadIO m) => AccessToken -> GithubRepo -> Text -> ExceptT T
 createGitCommit accessToken GithubRepo{..} treeSha = do
   let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/commits"
   let request = CreateGitCommit "Committed automatically." treeSha
-  callGithub createCommitHandleErrorCases accessToken repoUrl request
+  callGithub postToGithub createCommitHandleErrorCases accessToken repoUrl request
 
 createGitCommitForTree :: (MonadIO m) => AccessToken -> PersistentModel -> Text -> ExceptT Text m CreateGitCommitResult
 createGitCommitForTree accessToken PersistentModel{..} treeSha = do
@@ -285,7 +152,7 @@ createGitBranch :: (MonadIO m) => AccessToken -> GithubRepo -> Text -> Text -> E
 createGitBranch accessToken GithubRepo{..} commitSha branchName = do
   let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/refs"
   let request = CreateGitBranch ("refs/heads/" <> branchName) commitSha
-  callGithub createBranchHandleErrorCases accessToken repoUrl request
+  callGithub postToGithub createBranchHandleErrorCases accessToken repoUrl request
 
 createGitBranchForCommit :: (MonadIO m) => AccessToken -> PersistentModel -> Text -> Text -> ExceptT Text m CreateGitBranchResult
 createGitBranchForCommit accessToken PersistentModel{..} commitSha branchName = do
@@ -293,3 +160,83 @@ createGitBranchForCommit accessToken PersistentModel{..} commitSha branchName = 
   case possibleGithubRepo of
     Just repo -> createGitBranch accessToken repo commitSha branchName
     Nothing   -> throwE "No repository set on project."
+
+getGitBranchesErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
+getGitBranchesErrorCases status | status == notFound404  = throwE "Could not find repository."
+                                    | otherwise                         = throwE "Unexpected error."
+
+getGitBranches :: (MonadIO m) => AccessToken -> Text -> Text -> ExceptT Text m GetBranchesResult
+getGitBranches accessToken owner repository = do
+  let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/branches"
+  callGithub getFromGithub getGitBranchesErrorCases accessToken repoUrl ()
+
+getGitBranchErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
+getGitBranchErrorCases status | status == notFound404  = throwE "Could not find branch."
+                              | status == movedPermanently301  = throwE "Repository moved elsewhere."
+                              | otherwise                         = throwE "Unexpected error."
+
+getGitBranch :: (MonadIO m) => AccessToken -> Text -> Text -> Text -> ExceptT Text m GetBranchResult
+getGitBranch accessToken owner repository branchName = do
+  let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/branches/" <> branchName
+  callGithub getFromGithub getGitBranchErrorCases accessToken repoUrl ()
+
+getGitTreeErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
+getGitTreeErrorCases status | status == notFound404  = throwE "Could not find tree."
+                              | status == unprocessableEntity422  = liftIO $ fail "Unprocessable entity returned when creating tree."
+                              | otherwise                         = throwE "Unexpected error."
+
+getGitTree :: (MonadIO m) => AccessToken -> Text -> Text -> Text -> ExceptT Text m GetTreeResult
+getGitTree accessToken owner repository treeSha = do
+  let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/trees/" <> treeSha
+  callGithub getFromGithub getGitTreeErrorCases accessToken repoUrl ()
+
+getGitBlobErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
+getGitBlobErrorCases status   | status == forbidden403 = throwE "Forbidden from loading blob."
+                              | status == notFound404  = throwE "Could not find blob."
+                              | status == unprocessableEntity422  = liftIO $ fail "Unprocessable entity returned when creating tree."
+                              | otherwise                         = throwE "Unexpected error."
+
+getGitBlob :: (MonadIO m) => AccessToken -> Text -> Text -> Text -> ExceptT Text m GetBlobResult
+getGitBlob accessToken owner repository fileSha = do
+  let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/blobs/" <> fileSha
+  callGithub getFromGithub getGitBlobErrorCases accessToken repoUrl ()
+
+getFullPath :: [Text] -> Text -> Text
+getFullPath pathSoFar latestPathPart = T.cons '/' (T.intercalate "/" (pathSoFar <> [latestPathPart]))
+
+makeProjectContentsTreeEntry :: ReferenceGitTreeEntry -> GetBlobResult -> [Text] -> ProjectContentTreeRoot
+makeProjectContentsTreeEntry gitEntry blobResult pathSoFar = do
+  let decodedContent = toS $ decodeToString $ view (field @"content") blobResult
+  let path = view (field @"path") gitEntry
+  let pathWithForwardSlash = getFullPath pathSoFar path
+  let textFileContents = TextFileContents decodedContent (ParsedTextFileUnparsed Unparsed) CodeAhead
+  let textFile = TextFile textFileContents Nothing 0.0
+  M.singleton path $ ProjectContentsTreeFile $ ProjectContentFile pathWithForwardSlash $ ProjectTextFile textFile
+
+foldExceptContentTreeRoot :: (MonadBaseControl IO m, MonadIO m, Traversable t) => (a -> ExceptT Text m ProjectContentTreeRoot) -> t a -> ExceptT Text m ProjectContentTreeRoot
+foldExceptContentTreeRoot fn traversableValues = do
+  subContents <- mapConcurrently fn traversableValues
+  let subContent = foldMap' (\x -> x) subContents
+  pure subContent
+
+projectContentFromGitTreeEntry :: (MonadBaseControl IO m, MonadIO m) => AccessToken -> Text -> Text -> [Text] -> ReferenceGitTreeEntry -> ExceptT Text m ProjectContentTreeRoot
+projectContentFromGitTreeEntry accessToken owner repository pathSoFar entry = do
+  let entrySha = view (field @"sha") entry
+  case view (field @"type_") entry of
+    "blob" -> do
+      gitBlob <- getGitBlob accessToken owner repository entrySha
+      pure $ makeProjectContentsTreeEntry entry gitBlob pathSoFar
+    "tree" -> do
+      let path = view (field @"path") entry
+      subContent <- getRecursiveGitTreeAsContent accessToken owner repository (pathSoFar <> [path]) entrySha
+      let fullPath = getFullPath pathSoFar path
+      pure $ M.singleton path $ ProjectContentsTreeDirectory $ ProjectContentDirectory fullPath Directory subContent
+    _ -> do
+      pure mempty
+
+getRecursiveGitTreeAsContent :: (MonadBaseControl IO m, MonadIO m) => AccessToken -> Text -> Text -> [Text] -> Text -> ExceptT Text m ProjectContentTreeRoot
+getRecursiveGitTreeAsContent accessToken owner repository pathSoFar treeSha = do
+  treeResult <- getGitTree accessToken owner repository treeSha
+  let treeEntries = view (field @"tree") treeResult
+  foldExceptContentTreeRoot (projectContentFromGitTreeEntry accessToken owner repository pathSoFar) treeEntries
+

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -229,7 +229,6 @@ projectContentFromGitTreeEntry accessToken owner repository entry = do
     "blob" -> do
       -- This entry is a regular file.
       let entrySha = view (field @"sha") entry
-      print $ view (field @"path") entry
       gitBlob <- getGitBlob accessToken owner repository entrySha
       pure $ makeProjectContentsTreeEntry entry gitBlob
     _ -> do

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -9,36 +9,36 @@
 
 module Utopia.Web.Github where
 
-import           Control.Lens               hiding (children, (.=), (<.>))
+import           Codec.MIME.Base64
+import           Control.Concurrent.Async.Lifted
+import           Control.Lens                    hiding (children, (.=), (<.>))
 import           Control.Monad
 import           Control.Monad.Except
+import           Control.Monad.Trans.Control
 import           Control.Monad.Trans.Except
 import           Crypto.Hash
-import qualified Crypto.Hash                as C
+import qualified Crypto.Hash                     as C
 import           Data.Aeson
 import           Data.Aeson.Encode.Pretty
 import           Data.Aeson.Lens
-import qualified Data.ByteString.Lazy       as BL
+import qualified Data.ByteString.Lazy            as BL
 import           Data.Data
 import           Data.Foldable
 import           Data.Generics.Product
 import           Data.Generics.Sum
-import qualified Data.HashMap.Strict        as M
-import qualified Data.Text                  as T
+import qualified Data.HashMap.Strict             as M
+import qualified Data.Text                       as T
 import           Data.Text.Encoding
 import           Data.Text.Encoding.Base64.URL
 import           Data.Typeable
 import           Network.HTTP.Types.Status
 import           Network.OAuth.OAuth2
-import qualified Network.Wreq               as WR
-import qualified Network.Wreq.Types         as WR (Postable)
-import           Prelude                    (String)
+import qualified Network.Wreq                    as WR
+import qualified Network.Wreq.Types              as WR (Postable)
+import           Prelude                         (String)
 import           Protolude
 import           Utopia.ClientModel
 import           Utopia.Web.Github.Types
-import Codec.MIME.Base64
-import Control.Concurrent.Async.Lifted
-import Control.Monad.Trans.Control
 
 fetchRepoArchive :: Text -> Text -> IO (Maybe BL.ByteString)
 fetchRepoArchive owner repo = do

--- a/server/src/Utopia/Web/Github/Types.hs
+++ b/server/src/Utopia/Web/Github/Types.hs
@@ -225,7 +225,7 @@ instance ToJSON GetBranchesResponse where
   toJSON (GetBranchesResponseFailure failure) = over _Object (M.insert "type" "FAILURE") $ toJSON failure
 
 data GitCommitTree = GitCommitTree
-                   { sha  :: Text
+                   { sha :: Text
                    , url :: Text
                    }
                deriving (Eq, Show, Generic, Data, Typeable)

--- a/server/src/Utopia/Web/Github/Types.hs
+++ b/server/src/Utopia/Web/Github/Types.hs
@@ -1,0 +1,349 @@
+
+{-# LANGUAGE DeriveDataTypeable    #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RecordWildCards       #-}
+
+module Utopia.Web.Github.Types where
+
+import           Control.Lens               hiding (children, (.=), (<.>))
+import           Control.Monad
+import           Control.Monad.Except
+import           Control.Monad.Trans.Except
+import           Crypto.Hash
+import qualified Crypto.Hash                as C
+import           Data.Aeson
+import           Data.Aeson.Encode.Pretty
+import           Data.Aeson.Lens
+import qualified Data.ByteString.Lazy       as BL
+import           Data.Data
+import           Data.Foldable
+import qualified Data.HashMap.Strict        as M
+import qualified Data.Text                  as T
+import           Data.Text.Encoding
+import           Data.Text.Encoding.Base64
+import           Data.Typeable
+import           Network.HTTP.Types.Status
+import           Network.OAuth.OAuth2
+import qualified Network.Wreq               as WR
+import qualified Network.Wreq.Types         as WR (Postable)
+import           Prelude                    (String)
+import           Protolude
+import           Utopia.ClientModel
+
+dropLastUnderscore :: String -> String
+dropLastUnderscore []                 = []
+dropLastUnderscore (last : [])        = if last == '_' then [] else [last]
+dropLastUnderscore (firstChar : rest) = firstChar : dropLastUnderscore rest
+
+data GitTreeEntry = GitTreeEntry
+                  { path    :: Text
+                  , mode    :: Text
+                  , type_   :: Text
+                  , content :: Maybe Text
+                  , sha     :: Maybe Text
+                  }
+                  deriving (Eq, Show, Generic, Data, Typeable)
+
+gitTreeEntryOptions :: Options
+gitTreeEntryOptions = defaultOptions { fieldLabelModifier = dropLastUnderscore, omitNothingFields = True }
+
+instance FromJSON GitTreeEntry where
+  parseJSON = genericParseJSON gitTreeEntryOptions
+
+instance ToJSON GitTreeEntry where
+  toJSON = genericToJSON gitTreeEntryOptions
+
+data CreateGitTree = CreateGitTree
+                   { baseTree ::  Maybe Text
+                   , tree     :: [GitTreeEntry]
+                   }
+                   deriving (Eq, Show, Generic, Data, Typeable)
+
+createGitTreeOptions :: Options
+createGitTreeOptions = defaultOptions { fieldLabelModifier = camelTo2 '_', omitNothingFields = True }
+
+instance FromJSON CreateGitTree where
+  parseJSON = genericParseJSON createGitTreeOptions
+
+instance ToJSON CreateGitTree where
+  toJSON = genericToJSON createGitTreeOptions
+
+data CreateGitTreeResult = CreateGitTreeResult
+                         { sha :: Text
+                         , url :: Text
+                         }
+                         deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON CreateGitTreeResult where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON CreateGitTreeResult where
+  toJSON = genericToJSON defaultOptions
+
+data CreateGitCommit = CreateGitCommit
+                     { message :: Text
+                     , tree    :: Text
+                     }
+                     deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON CreateGitCommit where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON CreateGitCommit where
+  toJSON = genericToJSON defaultOptions
+
+data CreateGitCommitResult = CreateGitCommitResult
+                           { sha :: Text
+                           , url :: Text
+                           }
+                           deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON CreateGitCommitResult where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON CreateGitCommitResult where
+  toJSON = genericToJSON defaultOptions
+
+data CreateGitBranch = CreateGitBranch
+                     { ref :: Text
+                     , sha :: Text
+                     }
+                     deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON CreateGitBranch where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON CreateGitBranch where
+  toJSON = genericToJSON defaultOptions
+
+data CreateGitBranchResult = CreateGitBranchResult
+                           { ref :: Text
+                           , url :: Text
+                           }
+                           deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON CreateGitBranchResult where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON CreateGitBranchResult where
+  toJSON = genericToJSON defaultOptions
+
+data SaveToGithubSuccess = SaveToGithubSuccess
+                         { branchName :: Text
+                         , url        :: Text
+                         }
+                         deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON SaveToGithubSuccess where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON SaveToGithubSuccess where
+  toJSON = genericToJSON defaultOptions
+
+data GithubFailure = GithubFailure
+                         { failureReason  :: Text
+                         }
+                         deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON GithubFailure where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON GithubFailure where
+  toJSON = genericToJSON defaultOptions
+
+data SaveToGithubResponse = SaveToGithubResponseSuccess SaveToGithubSuccess
+                          | SaveToGithubResponseFailure GithubFailure
+                          deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON SaveToGithubResponse where
+  parseJSON value =
+    let fileType = firstOf (key "type" . _String) value
+     in case fileType of
+          (Just "SUCCESS")  -> fmap SaveToGithubResponseSuccess $ parseJSON value
+          (Just "FAILURE")  -> fmap SaveToGithubResponseFailure $ parseJSON value
+          (Just unknownType)  -> fail ("Unknown type: " <> T.unpack unknownType)
+          _                   -> fail "No type for SaveToGithubResponse specified."
+
+instance ToJSON SaveToGithubResponse where
+  toJSON (SaveToGithubResponseSuccess success) = over _Object (M.insert "type" "SUCCESS") $ toJSON success
+  toJSON (SaveToGithubResponseFailure failure) = over _Object (M.insert "type" "FAILURE") $ toJSON failure
+
+responseFailureFromReason :: Text -> SaveToGithubResponse
+responseFailureFromReason failureReason = SaveToGithubResponseFailure GithubFailure{..}
+
+responseSuccessFromBranchNameAndURL :: (Text, Text) -> SaveToGithubResponse
+responseSuccessFromBranchNameAndURL (branchName, url) = SaveToGithubResponseSuccess SaveToGithubSuccess{..}
+
+data GetBranchesBranch = GetBranchesBranch
+                       { name :: Text
+                       }
+                       deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON GetBranchesBranch where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON GetBranchesBranch where
+  toJSON = genericToJSON defaultOptions
+
+type GetBranchesResult = [GetBranchesBranch]
+
+data GetBranchesSuccess = GetBranchesSuccess
+                         { branches    :: GetBranchesResult
+                         }
+                         deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON GetBranchesSuccess where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON GetBranchesSuccess where
+  toJSON = genericToJSON defaultOptions
+
+data GetBranchesResponse = GetBranchesResponseSuccess GetBranchesSuccess
+                          | GetBranchesResponseFailure GithubFailure
+                          deriving (Eq, Show, Generic, Data, Typeable)
+
+getBranchesFailureFromReason :: Text -> GetBranchesResponse
+getBranchesFailureFromReason failureReason = GetBranchesResponseFailure GithubFailure{..}
+
+getBranchesSuccessFromBranches :: GetBranchesResult -> GetBranchesResponse
+getBranchesSuccessFromBranches branches = GetBranchesResponseSuccess GetBranchesSuccess{..}
+
+instance FromJSON GetBranchesResponse where
+  parseJSON value =
+    let fileType = firstOf (key "type" . _String) value
+     in case fileType of
+          (Just "SUCCESS")  -> fmap GetBranchesResponseSuccess $ parseJSON value
+          (Just "FAILURE")  -> fmap GetBranchesResponseFailure $ parseJSON value
+          (Just unknownType)  -> fail ("Unknown type: " <> T.unpack unknownType)
+          _                   -> fail "No type for GetBranchesResponse specified."
+
+instance ToJSON GetBranchesResponse where
+  toJSON (GetBranchesResponseSuccess success) = over _Object (M.insert "type" "SUCCESS") $ toJSON success
+  toJSON (GetBranchesResponseFailure failure) = over _Object (M.insert "type" "FAILURE") $ toJSON failure
+
+data GitCommitTree = GitCommitTree
+                   { sha  :: Text
+                   , url :: Text
+                   }
+               deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON GitCommitTree where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON GitCommitTree where
+  toJSON = genericToJSON defaultOptions
+
+data GitCommit = GitCommit
+               { tree  :: GitCommitTree
+               }
+               deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON GitCommit where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON GitCommit where
+  toJSON = genericToJSON defaultOptions
+
+data GitBranchCommit = GitBranchCommit
+                     { commit  :: GitCommit
+                     }
+               deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON GitBranchCommit where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON GitBranchCommit where
+  toJSON = genericToJSON defaultOptions
+
+data GetBranchResult = GetBranchResult
+                     { commit     :: GitBranchCommit
+                     }
+               deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON GetBranchResult where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON GetBranchResult where
+  toJSON = genericToJSON defaultOptions
+
+data ReferenceGitTreeEntry = ReferenceGitTreeEntry
+                           { path  :: Text
+                           , type_ :: Text
+                           , sha   :: Text
+                           }
+               deriving (Eq, Show, Generic, Data, Typeable)
+
+referenceGitTreeEntryOptions :: Options
+referenceGitTreeEntryOptions = defaultOptions { fieldLabelModifier = dropLastUnderscore, omitNothingFields = True }
+
+instance FromJSON ReferenceGitTreeEntry where
+  parseJSON = genericParseJSON referenceGitTreeEntryOptions
+
+instance ToJSON ReferenceGitTreeEntry where
+  toJSON = genericToJSON referenceGitTreeEntryOptions
+
+data GetTreeResult = GetTreeResult
+                     { tree     :: [ReferenceGitTreeEntry]
+                     }
+               deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON GetTreeResult where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON GetTreeResult where
+  toJSON = genericToJSON defaultOptions
+
+data GetBlobResult = GetBlobResult
+                     { content  :: String
+                     , encoding :: Text
+                     , sha      :: Text
+                     , url      :: Text
+                     , size     :: Int
+                     }
+               deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON GetBlobResult where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON GetBlobResult where
+  toJSON = genericToJSON defaultOptions
+
+
+data GetBranchContentSuccess = GetBranchContentSuccess
+                         { content :: ProjectContentTreeRoot
+                         }
+                         deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON GetBranchContentSuccess where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON GetBranchContentSuccess where
+  toJSON = genericToJSON defaultOptions
+
+data GetBranchContentResponse = GetBranchContentResponseSuccess GetBranchContentSuccess
+                          | GetBranchContentResponseFailure GithubFailure
+                          deriving (Eq, Show, Generic, Data, Typeable)
+
+getBranchContentFailureFromReason :: Text -> GetBranchContentResponse
+getBranchContentFailureFromReason failureReason = GetBranchContentResponseFailure GithubFailure{..}
+
+getBranchContentSuccessFromContent :: ProjectContentTreeRoot -> GetBranchContentResponse
+getBranchContentSuccessFromContent content = GetBranchContentResponseSuccess GetBranchContentSuccess{..}
+
+instance FromJSON GetBranchContentResponse where
+  parseJSON value =
+    let fileType = firstOf (key "type" . _String) value
+     in case fileType of
+          (Just "SUCCESS")  -> fmap GetBranchContentResponseSuccess $ parseJSON value
+          (Just "FAILURE")  -> fmap GetBranchContentResponseFailure $ parseJSON value
+          (Just unknownType)  -> fail ("Unknown type: " <> T.unpack unknownType)
+          _                   -> fail "No type for GetBranchContentResponse specified."
+
+instance ToJSON GetBranchContentResponse where
+  toJSON (GetBranchContentResponseSuccess success) = over _Object (M.insert "type" "SUCCESS") $ toJSON success
+  toJSON (GetBranchContentResponseFailure failure) = over _Object (M.insert "type" "FAILURE") $ toJSON failure
+
+

--- a/server/src/Utopia/Web/Github/Types.hs
+++ b/server/src/Utopia/Web/Github/Types.hs
@@ -297,7 +297,7 @@ instance ToJSON GetTreeResult where
   toJSON = genericToJSON defaultOptions
 
 data GetBlobResult = GetBlobResult
-                     { content  :: String
+                     { content  :: Text
                      , encoding :: Text
                      , sha      :: Text
                      , url      :: Text

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -32,7 +32,7 @@ import           URI.ByteString
 import           Utopia.ClientModel
 import           Utopia.Web.Assets
 import           Utopia.Web.Database.Types
-import           Utopia.Web.Github
+import           Utopia.Web.Github.Types
 import           Utopia.Web.JSON
 import           Web.Cookie
 
@@ -136,6 +136,8 @@ data ServiceCallsF a = NotFound
                      | GetGithubAccessToken Text ExchangeToken (Maybe AccessToken -> a)
                      | GetGithubAuthentication Text (Maybe GithubAuthenticationDetails -> a)
                      | SaveToGithubRepo Text PersistentModel (SaveToGithubResponse -> a)
+                     | GetBranchesFromGithubRepo Text Text Text (GetBranchesResponse -> a)
+                     | GetBranchContent Text Text Text Text (GetBranchContentResponse -> a)
                      deriving Functor
 
 {-

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -22,7 +22,7 @@ import           Servant.HTML.Blaze
 import           Servant.RawM.Server
 import qualified Text.Blaze.Html5        as H
 import           Utopia.ClientModel
-import           Utopia.Web.Github
+import           Utopia.Web.Github.Types
 import           Utopia.Web.JSON
 import           Utopia.Web.Servant
 import           Utopia.Web.ServiceTypes
@@ -131,6 +131,10 @@ type GithubFinishAuthenticationAPI = "v1" :> "github" :> "authentication" :> "fi
 
 type GithubSaveAPI = "v1" :> "github" :> "save" :> ReqBody '[JSON] PersistentModel :> Post '[JSON] SaveToGithubResponse
 
+type GithubBranchesAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> Get '[JSON] GetBranchesResponse
+
+type GithubBranchLoadAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> Capture "branchName" Text :> Get '[JSON] GetBranchContentResponse
+
 type PackagePackagerResponse = Headers '[Header "Cache-Control" Text, Header "Last-Modified" LastModifiedTime, Header "Access-Control-Allow-Origin" Text] (ConduitT () ByteString (ResourceT IO) ())
 
 type PackagePackagerAPI = "v1" :> "javascript" :> "packager"
@@ -184,6 +188,8 @@ type Protected = LogoutAPI
             :<|> GithubFinishAuthenticationAPI
             :<|> GithubAuthenticatedAPI
             :<|> GithubSaveAPI
+            :<|> GithubBranchesAPI
+            :<|> GithubBranchLoadAPI
 
 type Unprotected = AuthenticateAPI H.Html
               :<|> EmptyProjectPageAPI

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -58,6 +58,8 @@ executable utopia-web
   hs-source-dirs:
       src
   default-extensions:
+      Strict
+      StrictData
       NoImplicitPrelude
   ghc-options: -Wall -Werror -threaded -fno-warn-orphans -Wno-unused-imports -Wno-deprecations -rtsopts
   extra-libraries:
@@ -194,6 +196,8 @@ test-suite utopia-web-test
       test
       src
   default-extensions:
+      Strict
+      StrictData
       NoImplicitPrelude
   ghc-options: -Wall -Werror -threaded -fno-warn-orphans -Wno-unused-imports -Wno-deprecations -rtsopts +RTS -N1 -RTS
   extra-libraries:

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -41,6 +41,7 @@ executable utopia-web
       Utopia.Web.Executors.Development
       Utopia.Web.Executors.Production
       Utopia.Web.Github
+      Utopia.Web.Github.Types
       Utopia.Web.JSON
       Utopia.Web.Logging
       Utopia.Web.Metrics
@@ -58,7 +59,7 @@ executable utopia-web
       src
   default-extensions:
       NoImplicitPrelude
-  ghc-options: -Wall -threaded -rtsopts
+  ghc-options: -Wall -Werror -threaded -fno-warn-orphans -Wno-unused-imports -Wno-deprecations -rtsopts
   extra-libraries:
       z
   build-depends:
@@ -96,7 +97,9 @@ executable utopia-web
     , http-types
     , lens
     , lens-aeson <1.2
+    , lifted-async
     , lifted-base
+    , mime
     , mime-types
     , modern-uri
     , monad-control
@@ -173,6 +176,7 @@ test-suite utopia-web-test
       Utopia.Web.Executors.Development
       Utopia.Web.Executors.Production
       Utopia.Web.Github
+      Utopia.Web.Github.Types
       Utopia.Web.JSON
       Utopia.Web.Logging
       Utopia.Web.Metrics
@@ -191,7 +195,7 @@ test-suite utopia-web-test
       src
   default-extensions:
       NoImplicitPrelude
-  ghc-options: -Wall -threaded -rtsopts +RTS -N1 -RTS
+  ghc-options: -Wall -Werror -threaded -fno-warn-orphans -Wno-unused-imports -Wno-deprecations -rtsopts +RTS -N1 -RTS
   extra-libraries:
       z
   build-depends:
@@ -231,7 +235,9 @@ test-suite utopia-web-test
     , http-types
     , lens
     , lens-aeson <1.2
+    , lifted-async
     , lifted-base
+    , mime
     , mime-types
     , modern-uri
     , monad-control


### PR DESCRIPTION
**Problem:**
It's possible for us to save to Github, but not currently to retrieve those projects back from Github.

**Fix:**
This implements a flow of listing branches for a given repository, as well as the functionality to load the content from a given branch.

It was found while implementing this that Github use a MIME Base64 encoding, rather than the more regular style of Base64 encoding

When loading the content, in a slight reversal from what is possible when creating a git tree, the tree has to be recursively loaded for each directory in the tree (which is itself another tree). As well as individual files needing to be retrieved by looking up the value of each blob.

**Commit Details:**
- Added `fullPathFromProjectContentsTree` utility function.
- Added `UPDATE_PROJECT_CONTENTS` editor action which replaces the entirety of the project contents in `EditorState`.
- Added server endpoint to retrieve the branches for a given repository
- Added server endpoint that pulls the content for a given branch.
- Moved the types out of `Github.hs` as it was starting to get swamped by them.
- Generalised `callGithub` with a `MakeGithubRequest` parameter which allows us to make `GET` requests without a request body.
- Improved the error handling in `callGithub`, also disabling the default `checkResponse` so that any status code response will return.
- Added service types for getting the branch listing and for retrieving the content of a branch.
- `getRecursiveGitTreeAsContent` fronts the functionality of handling of blobs or being itself invoked for a tree within the tree.