### PR TITLE
Only flag serious performance regressions in discord

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -161,6 +161,7 @@ jobs:
             Performance test results:
             ${{ steps.run-performance-test.outputs.perf-result }}
       - name: Build Discord Message
+        if: ${{ steps.run-performance-test.outputs.perf-serious-regression-found == 'true' }}
         env:
           TEMPLATE: >-
             [
@@ -198,6 +199,7 @@ jobs:
           echo "DISCORD_EMBEDS=$(jq -nc --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" --arg result_frames_chart "$RESULT_FRAMES_CHART" --arg result_interactions_chart "$RESULT_INTERACTIONS_CHART" "$TEMPLATE")" | sed 's/\\\\n/\\n/g' >> $GITHUB_ENV
       - name: Send Discord Notification
         uses: Ilshidur/action-discord@0.3.2
+        if: ${{ steps.run-performance-test.outputs.perf-serious-regression-found == 'true' }}
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_PRS_WEBHOOK }}
           DISCORD_USERNAME: 'Puppeteer'

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -113,11 +113,20 @@ export const testPerformance = async function () {
   const combinedStagingResult = { ...stagingResult.frameTests, ...stagingResult.interactionTests }
   const combinedMasterResult = { ...masterResult.frameTests, ...masterResult.interactionTests }
 
+  // Explicitly flag any serious regressions found
+  const seriousRegressionThresholdPercent = 20
+  let seriousRegressionFound = false
+
   const messageParts = Object.entries(combinedStagingResult).flatMap(([k, result]) => {
     const targetResult = combinedMasterResult[k]
     const beforeMedian = targetResult.analytics.percentile50 ?? 1
     const afterMedian = result.analytics.percentile50 ?? 1
     const change = ((afterMedian - beforeMedian) / beforeMedian) * 100
+
+    if (change > seriousRegressionThresholdPercent) {
+      seriousRegressionFound = true
+    }
+
     const titleLine = `**${result.title} (${Math.round(change)}%)**`
     const spacerLine = ''
     if (Math.abs(change) > 5) {
@@ -132,17 +141,18 @@ export const testPerformance = async function () {
     }
   })
 
-  const message = messageParts.join('<br />')
+  const message = seriousRegressionFound ? `${messageParts.join('<br />')} <br />` : ''
   const discordMessage = messageParts.join('\\n')
 
   console.info(
-    `::set-output name=perf-result:: ${message} <br /> ![(Chart1)](${framesSummaryImage}) <br /> ![(Chart2)](${interactionsSummaryImage})`,
+    `::set-output name=perf-result:: ${message} ![(Chart1)](${framesSummaryImage}) <br /> ![(Chart2)](${interactionsSummaryImage})`,
   )
 
   // Output the individual parts for building a discord message
   console.info(`::set-output name=perf-discord-message:: ${discordMessage}`)
   console.info(`::set-output name=perf-frames-chart:: ${framesSummaryImage}`)
   console.info(`::set-output name=perf-interactions-chart:: ${interactionsSummaryImage}`)
+  console.info(`::set-output name=perf-serious-regression-found:: ${seriousRegressionFound}`)
 }
 
 type PageToPromiseResult<T> = (page: puppeteer.Page) => Promise<T>


### PR DESCRIPTION
**Problem:**
Our automated performance tests have too much variance, and cause far too much noise in Discord, but we still want to keep the charts for posterity.

**Fix:**
Only post to discord if there is a major regression in one of the tests, and use the same logic to restrict the github comment.