### PR TITLE
Do not run produceCanvasTransientState in insert mode

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -208,6 +208,7 @@ import { createStylePostActionToast } from '../../core/layout/layout-notice'
 import { uniqToasts } from '../editor/actions/toast-helpers'
 import { stylePropPathMappingFn } from '../inspector/common/property-path-hooks'
 import { EditorDispatch } from '../editor/action-types'
+import { isFeatureEnabled } from '../../utils/feature-switches'
 
 export function getOriginalFrames(
   selectedViews: Array<ElementPath>,
@@ -1867,6 +1868,9 @@ export function produceCanvasTransientState(
   editorState: EditorState,
   preventAnimations: boolean,
 ): TransientCanvasState {
+  if (isFeatureEnabled('Canvas Strategies')) {
+    return transientCanvasState(editorState.selectedViews, editorState.highlightedViews, null, [])
+  }
   const currentOpenFile = editorState.canvas.openFile?.filename
   let transientState: TransientCanvasState | null = null
   if (currentOpenFile != null) {

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1868,16 +1868,16 @@ export function produceCanvasTransientState(
   editorState: EditorState,
   preventAnimations: boolean,
 ): TransientCanvasState {
-  if (isFeatureEnabled('Canvas Strategies')) {
-    return transientCanvasState(editorState.selectedViews, editorState.highlightedViews, null, [])
-  }
   const currentOpenFile = editorState.canvas.openFile?.filename
   let transientState: TransientCanvasState | null = null
   if (currentOpenFile != null) {
     const editorMode = editorState.mode
     switch (editorMode.type) {
       case 'insert':
-        if (insertionSubjectIsJSXElement(editorMode.subject)) {
+        if (
+          insertionSubjectIsJSXElement(editorMode.subject) &&
+          isFeatureEnabled('Canvas Strategies')
+        ) {
           const insertionElement = editorMode.subject.element
           const importsToAdd = editorMode.subject.importsToAdd
           const insertionParent = editorMode.subject.parent?.target ?? null


### PR DESCRIPTION
**Problem:**
In https://github.com/concrete-utopia/utopia/pull/2607 I introduced a regression. I removed `InsertMode.insertionStarted`, because I did not use it anymore. I forgot about the fact that the non-strategy code is still around, and `produceCanvasTransientState` inserted the new element to the transient state.

**Fix:**
I had several options to fix this:
1. Remove all old interaction code.
2. Put back `InsertMode.interactionStarted`
3. Put the problematic code behind the `Canvas strategies` FS

1 . would be the best, but is a big task and I need a quick fix to eliminate the regression.
2 . would be an unnecessary step back, because the old insert mode is broken anyway
So I just chose the ugly but quick 3., but imho we should do 1 ASAP

