### PR TITLE
Shortcut to insert div

### DIFF
--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -32,6 +32,7 @@ import { EditorAction, EditorDispatch, SwitchEditorMode } from './action-types'
 import * as EditorActions from './actions/action-creators'
 import * as MetaActions from './actions/meta-actions'
 import {
+  defaultDivElement,
   defaultEllipseElement,
   defaultRectangleElement,
   defaultTextElement,
@@ -110,6 +111,7 @@ import {
   GROUP_ELEMENT_DEFAULT_SHORTCUT,
   TOGGLE_FOCUSED_OMNIBOX_TAB,
   FOCUS_CLASS_NAME_INPUT,
+  INSERT_DIV_SHORTCUT,
 } from './shortcut-definitions'
 import { DerivedState, EditorState, getOpenFile, RightMenuTab } from './store/editor-state'
 import { CanvasMousePositionRaw, WindowMousePositionRaw } from '../../utils/global-positions'
@@ -681,6 +683,17 @@ export function handleKeyDown(
         } else {
           return []
         }
+      },
+      [INSERT_DIV_SHORTCUT]: () => {
+        if (!isSelectMode(editor.mode) && !isInsertMode(editor.mode)) {
+          return []
+        }
+
+        const newUID = generateUidWithExistingComponents(editor.projectContents)
+        return addCreateHoverInteractionActionToSwitchModeAction(
+          EditorActions.enableInsertModeForJSXElement(defaultDivElement(newUID), newUID, {}, null),
+          modifiers,
+        )
       },
       [CUT_SELECTION_SHORTCUT]: () => {
         return isSelectMode(editor.mode)

--- a/editor/src/components/editor/shortcut-definitions.ts
+++ b/editor/src/components/editor/shortcut-definitions.ts
@@ -76,6 +76,7 @@ export const SAVE_CURRENT_FILE_SHORTCUT = 'save-current-file'
 export const TOGGLE_SHADOW_SHORTCUT = 'toggle-shadow'
 export const INSERT_TEXT_SHORTCUT = 'insert-text'
 export const INSERT_VIEW_SHORTCUT = 'insert-view'
+export const INSERT_DIV_SHORTCUT = 'insert-div'
 export const CUT_SELECTION_SHORTCUT = 'cut-selection'
 export const UNDO_CHANGES_SHORTCUT = 'undo-changes'
 export const REDO_CHANGES_SHORTCUT = 'redo-changes'
@@ -234,6 +235,7 @@ const shortcutDetailsWithDefaults: ShortcutDetails = {
   ),
   [INSERT_TEXT_SHORTCUT]: shortcut('Insert a text element.', key('t', [])),
   [INSERT_VIEW_SHORTCUT]: shortcut('Insert a view.', key('v', [])),
+  [INSERT_DIV_SHORTCUT]: shortcut('Insert a div.', key('d', [])),
   [CUT_SELECTION_SHORTCUT]: shortcut(
     'Cut the current selection to the clipboard.',
     key('x', 'cmd'),


### PR DESCRIPTION
## Problem:
There is no shortcut to quickly jump into insert mode, inserting a `div`.

## Fix:
Adds `d` as a shortcut to quickly jump into insert mode, inserting a `div`. The div looks the same as `View` from `utopia-api`.

**Commit Details:**
- added shortcut and handler