### PR TITLE
rename `ElementInsertionSubject.size` to `defaultSize`

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
@@ -10,7 +10,11 @@ import {
   targetPaths,
 } from './canvas-strategy-types'
 import { InteractionSession, StrategyState } from './interaction-state'
-import { ElementInsertionSubject, InsertionSubject } from '../../editor/editor-modes'
+import {
+  DefaultInsertSize,
+  ElementInsertionSubject,
+  InsertionSubject,
+} from '../../editor/editor-modes'
 import { LayoutHelpers } from '../../../core/layout/layout-helpers'
 import { isLeft } from '../../../core/shared/either'
 import {
@@ -32,12 +36,11 @@ import {
 } from '../../../core/model/element-metadata-utils'
 import { elementPath } from '../../../core/shared/element-path'
 import * as EP from '../../../core/shared/element-path'
-import { CanvasRectangle, canvasRectangle } from '../../../core/shared/math-utils'
+import { CanvasRectangle, canvasRectangle, Size } from '../../../core/shared/math-utils'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
 import { cmdModifier } from '../../../utils/modifiers'
 import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
 import { FlexReparentTargetIndicator } from '../controls/select-mode/flex-reparent-target-indicator'
-import { DefaultInsertHeight, DefaultInsertWidth } from '../insertion-strategy-utils'
 
 export const dragToInsertStrategy: CanvasStrategy = {
   id: 'DRAG_TO_INSERT',
@@ -92,9 +95,10 @@ export const dragToInsertStrategy: CanvasStrategy = {
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.interactionData.drag != null
     ) {
-      const insertionCommands = insertionSubjects.flatMap((s) =>
-        getInsertionCommands(s, interactionState),
-      )
+      const insertionCommands = insertionSubjects.flatMap((s) => {
+        const size = s.type === 'Element' ? s.defaultSize : DefaultInsertSize
+        return getInsertionCommands(s, interactionState, size)
+      })
 
       const reparentCommand = updateFunctionCommand(
         'always',
@@ -124,6 +128,7 @@ export const dragToInsertStrategy: CanvasStrategy = {
 function getInsertionCommands(
   subject: InsertionSubject,
   interactionState: InteractionSession,
+  size: Size,
 ): Array<{ command: InsertElementInsertionSubject; frame: CanvasRectangle }> {
   if (subject.type !== 'Element') {
     // non-element subjects are not supported
@@ -136,10 +141,10 @@ function getInsertionCommands(
     const pointOnCanvas = interactionState.interactionData.dragStart
 
     const frame = canvasRectangle({
-      x: pointOnCanvas.x - DefaultInsertWidth / 2,
-      y: pointOnCanvas.y - DefaultInsertHeight / 2,
-      width: DefaultInsertWidth,
-      height: DefaultInsertHeight,
+      x: pointOnCanvas.x - size.width / 2,
+      y: pointOnCanvas.y - size.height / 2,
+      width: size.width,
+      height: size.height,
     })
 
     const updatedAttributesWithPosition = getStyleAttributesForFrameInAbsolutePosition(

--- a/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.tsx
@@ -32,13 +32,17 @@ import {
 } from '../../../core/model/element-metadata-utils'
 import { elementPath } from '../../../core/shared/element-path'
 import * as EP from '../../../core/shared/element-path'
-import { canvasPoint, CanvasRectangle, canvasRectangle } from '../../../core/shared/math-utils'
+import {
+  canvasPoint,
+  CanvasRectangle,
+  canvasRectangle,
+  Size,
+} from '../../../core/shared/math-utils'
 import { cmdModifier } from '../../../utils/modifiers'
 import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
 import { FlexReparentTargetIndicator } from '../controls/select-mode/flex-reparent-target-indicator'
 import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
 import { getReparentTargetUnified, newReparentSubjects } from './reparent-strategy-helpers'
-import { DefaultInsertHeight, DefaultInsertWidth } from '../insertion-strategy-utils'
 
 export const drawToInsertStrategy: CanvasStrategy = {
   id: 'DRAW_TO_INSERT',
@@ -99,6 +103,7 @@ export const drawToInsertStrategy: CanvasStrategy = {
           const insertionCommand = getInsertionCommands(
             insertionSubject,
             interactionState,
+            insertionSubject.defaultSize,
             'zero-size',
           )
 
@@ -146,6 +151,7 @@ export const drawToInsertStrategy: CanvasStrategy = {
           const insertionCommand = getInsertionCommands(
             insertionSubject,
             interactionState,
+            insertionSubject.defaultSize,
             'default-size',
           )
 
@@ -197,6 +203,7 @@ export const drawToInsertStrategy: CanvasStrategy = {
 function getInsertionCommands(
   subject: ElementInsertionSubject,
   interactionState: InteractionSession,
+  insertionSubjectSize: Size,
   sizing: 'zero-size' | 'default-size',
 ): { command: InsertElementInsertionSubject; frame: CanvasRectangle } | null {
   if (
@@ -214,10 +221,10 @@ function getInsertionCommands(
             height: 0,
           })
         : canvasRectangle({
-            x: pointOnCanvas.x - DefaultInsertWidth / 2,
-            y: pointOnCanvas.y - DefaultInsertHeight / 2,
-            width: DefaultInsertWidth,
-            height: DefaultInsertHeight,
+            x: pointOnCanvas.x - insertionSubjectSize.width / 2,
+            y: pointOnCanvas.y - insertionSubjectSize.height / 2,
+            width: insertionSubjectSize.width,
+            height: insertionSubjectSize.height,
           })
 
     const updatedAttributesWithPosition = getStyleAttributesForFrameInAbsolutePosition(

--- a/editor/src/components/canvas/insertion-strategy-utils.ts
+++ b/editor/src/components/canvas/insertion-strategy-utils.ts
@@ -1,2 +1,0 @@
-export const DefaultInsertWidth = 100
-export const DefaultInsertHeight = 100

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -1,17 +1,12 @@
-import type {
-  ElementPath,
-  id,
-  StaticElementPath,
-  Imports,
-} from '../../core/shared/project-file-types'
-import type { JSXElement, JSXElementName } from '../../core/shared/element-template'
+import type { ElementPath, StaticElementPath, Imports } from '../../core/shared/project-file-types'
+import type { JSXElement } from '../../core/shared/element-template'
 import type { Size } from '../../core/shared/math-utils'
 
 export interface ElementInsertionSubject {
   type: 'Element'
   uid: string
   element: JSXElement
-  size: Size | null
+  defaultSize: Size | null
   importsToAdd: Imports
   parent: InsertionParent
 }
@@ -36,7 +31,7 @@ export function elementInsertionSubject(
     type: 'Element',
     uid: uid,
     element: element,
-    size: size,
+    defaultSize: size,
     importsToAdd: importsToAdd,
     parent: parent,
   }

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -6,7 +6,7 @@ export interface ElementInsertionSubject {
   type: 'Element'
   uid: string
   element: JSXElement
-  defaultSize: Size | null
+  defaultSize: Size
   importsToAdd: Imports
   parent: InsertionParent
 }
@@ -20,6 +20,8 @@ export interface DragAndDropInsertionSubject {
   imageAssets: Array<string> | null
 }
 
+export const DefaultInsertSize: Size = { width: 100, height: 100 }
+
 export function elementInsertionSubject(
   uid: string,
   element: JSXElement,
@@ -31,7 +33,7 @@ export function elementInsertionSubject(
     type: 'Element',
     uid: uid,
     element: element,
-    defaultSize: size,
+    defaultSize: size ?? DefaultInsertSize,
     importsToAdd: importsToAdd,
     parent: parent,
   }

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -2547,7 +2547,7 @@ export const ElementInsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<Eleme
     StringKeepDeepEquality,
     (subject) => subject.element,
     JSXElementKeepDeepEquality,
-    (subject) => subject.size,
+    (subject) => subject.defaultSize,
     nullableDeepEquality(SizeKeepDeepEquality),
     (subject) => subject.importsToAdd,
     objectDeepEquality(ImportDetailsKeepDeepEquality),


### PR DESCRIPTION
## Problem:
`ElementInsertionSubject.size` is misleadingly named, because the size of the inserted element can be modified by the insertion strategies.

## Fix
Rename `ElementInsertionSubject.size` to `ElementInsertionSubject.defaultSize` to signal that this is only a suggested size, which can be overridden later, and make the strategies use `ElementInsertionSubject.defaultSize`, instead of their own defaults.

## Commit Details:
- Renamed `ElementInsertionSubject.size` to `ElementInsertionSubject.defaultSize`
- added the default sizes used by the `{draw | drag}-to-insert` strategies as a default in the `ElementInsertionSubject` constructor
- make the `{draw | drag}-to-insert` strategies use `ElementInsertionSubject.defaultSize` to set default sized
