### PR TITLE
Chore: mass renaming interactionState to interactionSession

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
@@ -32,13 +32,13 @@ import { getDragTargets } from './shared-move-strategies-helpers'
 export const absoluteDuplicateStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_DUPLICATE',
   name: () => 'Duplicate',
-  isApplicable: (canvasState, interactionState, metadata) => {
+  isApplicable: (canvasState, interactionSession, metadata) => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     if (
       selectedElements.length > 0 &&
-      interactionState != null &&
-      interactionState.interactionData.type === 'DRAG' &&
-      interactionState.interactionData.modifiers.alt
+      interactionSession != null &&
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.interactionData.modifiers.alt
     ) {
       const filteredSelectedElements = getDragTargets(selectedElements)
       return filteredSelectedElements.every((element) => {
@@ -73,23 +73,23 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
       show: 'visible-only-while-active',
     },
   ],
-  fitness: (canvasState, interactionState) => {
+  fitness: (canvasState, interactionSession) => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     if (
       selectedElements.length > 0 &&
-      interactionState.interactionData.type === 'DRAG' &&
-      interactionState.activeControl.type === 'BOUNDING_AREA' &&
-      interactionState.interactionData.modifiers.alt
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.activeControl.type === 'BOUNDING_AREA' &&
+      interactionSession.interactionData.modifiers.alt
     ) {
       return 2
     }
     return 0
   },
-  apply: (canvasState, interactionState, customStrategyState, strategyLifecycle) => {
+  apply: (canvasState, interactionSession, customStrategyState, strategyLifecycle) => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     if (
-      interactionState.interactionData.type === 'DRAG' &&
-      interactionState.interactionData.drag != null
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.interactionData.drag != null
     ) {
       const filteredSelectedElements = getDragTargets(selectedElements)
 
@@ -130,7 +130,7 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
               canvasState.builtInDependencies,
               editorState,
               customStrategyState,
-              interactionState,
+              interactionSession,
               commandLifecycle,
               strategyLifecycle,
               withDuplicatedMetadata,
@@ -153,7 +153,7 @@ function runMoveStrategyForFreshlyDuplicatedElements(
   builtInDependencies: BuiltInDependencies,
   editorState: EditorState,
   customStrategyState: CustomStrategyState,
-  interactionState: InteractionSession,
+  interactionSession: InteractionSession,
   commandLifecycle: InteractionLifecycle,
   strategyLifecycle: InteractionLifecycle,
   metadata: ElementInstanceMetadataMap,
@@ -166,7 +166,7 @@ function runMoveStrategyForFreshlyDuplicatedElements(
 
   const moveCommands = absoluteMoveStrategy.apply(
     canvasState,
-    interactionState,
+    interactionSession,
     customStrategyState,
     strategyLifecycle,
   ).commands

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
@@ -17,7 +17,7 @@ import {
 export const absoluteMoveStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_MOVE',
   name: () => 'Move',
-  isApplicable: (canvasState, _interactionState, metadata) => {
+  isApplicable: (canvasState, interactionSession, metadata) => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     if (selectedElements.length > 0) {
       const filteredSelectedElements = getDragTargets(selectedElements)
@@ -44,27 +44,27 @@ export const absoluteMoveStrategy: CanvasStrategy = {
       show: 'visible-only-while-active',
     },
   ], // Uses existing hooks in select-mode-hooks.tsx
-  fitness: (canvasState, interactionState, customStrategyState) => {
+  fitness: (canvasState, interactionSession, customStrategyState) => {
     return absoluteMoveStrategy.isApplicable(
       canvasState,
-      interactionState,
+      interactionSession,
       canvasState.startingMetadata,
       canvasState.startingAllElementProps,
     ) &&
-      interactionState.interactionData.type === 'DRAG' &&
-      interactionState.activeControl.type === 'BOUNDING_AREA'
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.activeControl.type === 'BOUNDING_AREA'
       ? 1
       : 0
   },
-  apply: (canvasState, interactionState, customStrategyState) => {
+  apply: (canvasState, interactionSession, customStrategyState) => {
     if (
-      interactionState.interactionData.type === 'DRAG' &&
-      interactionState.interactionData.drag != null
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.interactionData.drag != null
     ) {
       return applyMoveCommon(
         canvasState,
-        interactionState,
-        getAdjustMoveCommands(canvasState, interactionState),
+        interactionSession,
+        getAdjustMoveCommands(canvasState, interactionSession),
       )
     }
     // Fallback for when the checks above are not satisfied.

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -36,12 +36,12 @@ function getAbsoluteReparentStrategy(
   return {
     id: id,
     name: () => name,
-    isApplicable: (canvasState, interactionState, metadata) => {
+    isApplicable: (canvasState, interactionSession, metadata) => {
       const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
       if (
         selectedElements.length > 0 &&
-        interactionState != null &&
-        interactionState.interactionData.type === 'DRAG'
+        interactionSession != null &&
+        interactionSession.interactionData.type === 'DRAG'
       ) {
         const filteredSelectedElements = getDragTargets(selectedElements)
         return filteredSelectedElements.every((element) => {
@@ -67,16 +67,16 @@ function getAbsoluteReparentStrategy(
         show: 'visible-only-while-active',
       },
     ],
-    fitness: (canvasState, interactionState, customStrategyState) => {
+    fitness: (canvasState, interactionSession, customStrategyState) => {
       // All 4 reparent strategies use the same fitness function getFitnessForReparentStrategy
       return getFitnessForReparentStrategy(
         'ABSOLUTE_REPARENT_TO_ABSOLUTE',
         canvasState,
-        interactionState,
+        interactionSession,
         missingBoundsHandling,
       )
     },
-    apply: (canvasState, interactionState, customStrategyState, strategyLifecycle) => {
+    apply: (canvasState, interactionSession, customStrategyState, strategyLifecycle) => {
       const { interactionTarget, projectContents, openFile, nodeModules } = canvasState
       const selectedElements = getTargetPathsFromInteractionTarget(interactionTarget)
       const filteredSelectedElements = getDragTargets(selectedElements)
@@ -87,21 +87,21 @@ function getAbsoluteReparentStrategy(
         filteredSelectedElements,
         () => {
           if (
-            interactionState.interactionData.type != 'DRAG' ||
-            interactionState.interactionData.drag == null
+            interactionSession.interactionData.type != 'DRAG' ||
+            interactionSession.interactionData.drag == null
           ) {
             return emptyStrategyApplicationResult
           }
 
           const pointOnCanvas = offsetPoint(
-            interactionState.interactionData.originalDragStart,
-            interactionState.interactionData.drag,
+            interactionSession.interactionData.originalDragStart,
+            interactionSession.interactionData.drag,
           )
 
           const reparentTarget = getReparentTargetUnified(
             existingReparentSubjects(filteredSelectedElements),
             pointOnCanvas,
-            interactionState.interactionData.modifiers.cmd,
+            interactionSession.interactionData.modifiers.cmd,
             canvasState,
             canvasState.startingMetadata,
             canvasState.startingAllElementProps,
@@ -161,7 +161,7 @@ function getAbsoluteReparentStrategy(
             const moveCommands = absoluteMoveStrategy.apply(
               canvasState,
               {
-                ...interactionState,
+                ...interactionSession,
                 updatedTargetPaths: updatedTargetPaths,
               },
               customStrategyState,
@@ -178,7 +178,7 @@ function getAbsoluteReparentStrategy(
           } else {
             const moveCommands = absoluteMoveStrategy.apply(
               canvasState,
-              interactionState,
+              interactionSession,
               customStrategyState,
               strategyLifecycle,
             )

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
@@ -67,14 +67,14 @@ export const absoluteReparentToFlexStrategy: CanvasStrategy = {
   ],
   fitness: function (
     canvasState: InteractionCanvasState,
-    interactionState: InteractionSession,
+    interactionSession: InteractionSession,
     customStrategyState: CustomStrategyState,
   ): number {
     // All 4 reparent strategies use the same fitness function getFitnessForReparentStrategy
     return getFitnessForReparentStrategy(
       'ABSOLUTE_REPARENT_TO_FLEX',
       canvasState,
-      interactionState,
+      interactionSession,
       'use-strict-bounds',
     )
   },

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -51,7 +51,7 @@ import { pushIntendedBounds } from '../commands/push-intended-bounds-command'
 export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_RESIZE_BOUNDING_BOX',
   name: () => 'Resize',
-  isApplicable: (canvasState, interactionState, metadata, allElementProps) => {
+  isApplicable: (canvasState, interactionSession, metadata, allElementProps) => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     if (selectedElements.length > 0) {
       const filteredSelectedElements = getDragTargets(selectedElements)
@@ -76,38 +76,38 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
     { control: ParentOutlines, key: 'parent-outlines-control', show: 'visible-only-while-active' },
     { control: ParentBounds, key: 'parent-bounds-control', show: 'visible-only-while-active' },
   ],
-  fitness: (canvasState, interactionState, customStrategyState) => {
+  fitness: (canvasState, interactionSession, customStrategyState) => {
     return absoluteResizeBoundingBoxStrategy.isApplicable(
       canvasState,
-      interactionState,
+      interactionSession,
       canvasState.startingMetadata,
       canvasState.startingAllElementProps,
     ) &&
-      interactionState.interactionData.type === 'DRAG' &&
-      interactionState.activeControl.type === 'RESIZE_HANDLE'
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.activeControl.type === 'RESIZE_HANDLE'
       ? 1
       : 0
   },
-  apply: (canvasState, interactionState, customStrategyState) => {
+  apply: (canvasState, interactionSession, customStrategyState) => {
     if (
-      interactionState.interactionData.type === 'DRAG' &&
-      interactionState.activeControl.type === 'RESIZE_HANDLE'
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.activeControl.type === 'RESIZE_HANDLE'
     ) {
-      const edgePosition = interactionState.activeControl.edgePosition
+      const edgePosition = interactionSession.activeControl.edgePosition
       const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
-      if (interactionState.interactionData.drag != null) {
-        const drag = interactionState.interactionData.drag
+      if (interactionSession.interactionData.drag != null) {
+        const drag = interactionSession.interactionData.drag
         const filteredSelectedElements = getDragTargets(selectedElements)
         const originalBoundingBox = getMultiselectBounds(
           canvasState.startingMetadata,
           filteredSelectedElements,
         )
         if (originalBoundingBox != null) {
-          const keepAspectRatio = interactionState.interactionData.modifiers.shift
+          const keepAspectRatio = interactionSession.interactionData.modifiers.shift
           const lockedAspectRatio = keepAspectRatio
             ? originalBoundingBox.width / originalBoundingBox.height
             : null
-          const centerBased = interactionState.interactionData.modifiers.alt
+          const centerBased = interactionSession.interactionData.modifiers.alt
             ? 'center-based'
             : 'non-center-based'
           const newBoundingBox = resizeBoundingBox(

--- a/editor/src/components/canvas/canvas-strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/convert-to-absolute-and-move-strategy.tsx
@@ -47,7 +47,7 @@ import { applyMoveCommon, getDragTargets } from './shared-move-strategies-helper
 export const convertToAbsoluteAndMoveStrategy: CanvasStrategy = {
   id: 'CONVERT_TO_ABSOLUTE_AND_MOVE_STRATEGY',
   name: () => 'Move (Abs)',
-  isApplicable: (canvasState, _interactionState, metadata) => {
+  isApplicable: (canvasState, interactionSession, metadata) => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     if (selectedElements.length > 0) {
       const filteredSelectedElements = getDragTargets(selectedElements)
@@ -74,22 +74,22 @@ export const convertToAbsoluteAndMoveStrategy: CanvasStrategy = {
       show: 'visible-only-while-active',
     },
   ], // Uses existing hooks in select-mode-hooks.tsx
-  fitness: (canvasState, interactionState, customStrategyState) => {
+  fitness: (canvasState, interactionSession, customStrategyState) => {
     return convertToAbsoluteAndMoveStrategy.isApplicable(
       canvasState,
-      interactionState,
+      interactionSession,
       canvasState.startingMetadata,
       canvasState.startingAllElementProps,
     ) &&
-      interactionState.interactionData.type === 'DRAG' &&
-      interactionState.activeControl.type === 'BOUNDING_AREA'
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.activeControl.type === 'BOUNDING_AREA'
       ? 0.5
       : 0
   },
-  apply: (canvasState, interactionState, customStrategyState) => {
+  apply: (canvasState, interactionSession, customStrategyState) => {
     if (
-      interactionState.interactionData.type === 'DRAG' &&
-      interactionState.interactionData.drag != null
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.interactionData.drag != null
     ) {
       const getConversionAndMoveCommands = (
         snappedDragVector: CanvasPoint,
@@ -106,7 +106,7 @@ export const convertToAbsoluteAndMoveStrategy: CanvasStrategy = {
       }
       const absoluteMoveApplyResult = applyMoveCommon(
         canvasState,
-        interactionState,
+        interactionSession,
         getConversionAndMoveCommands,
       )
 

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -8,7 +8,7 @@ import { applyReorderCommon } from './reorder-utils'
 export const flexReorderStrategy: CanvasStrategy = {
   id: 'FLEX_REORDER',
   name: () => 'Reorder (Flex)',
-  isApplicable: (canvasState, _interactionState, metadata) => {
+  isApplicable: (canvasState, interactionSession, metadata) => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     if (selectedElements.length == 1) {
       return MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
@@ -36,22 +36,22 @@ export const flexReorderStrategy: CanvasStrategy = {
       show: 'visible-only-while-active',
     },
   ],
-  fitness: (canvasState, interactionState, customStrategyState) => {
+  fitness: (canvasState, interactionSession, customStrategyState) => {
     return flexReorderStrategy.isApplicable(
       canvasState,
-      interactionState,
+      interactionSession,
       canvasState.startingMetadata,
       canvasState.startingAllElementProps,
     ) &&
-      interactionState.interactionData.type === 'DRAG' &&
-      interactionState.activeControl.type === 'BOUNDING_AREA'
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.activeControl.type === 'BOUNDING_AREA'
       ? 1
       : 0
   },
-  apply: (canvasState, interactionState, customStrategyState) => {
+  apply: (canvasState, interactionSession, customStrategyState) => {
     return applyReorderCommon(
       canvasState,
-      interactionState,
+      interactionSession,
       customStrategyState,
       MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout,
     )

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
@@ -47,7 +47,7 @@ function getFlexReparentToAbsoluteStrategy(
   return {
     id: id,
     name: () => name,
-    isApplicable: (canvasState, _interactionState, metadata) => {
+    isApplicable: (canvasState, interactionSession, metadata) => {
       const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
       if (selectedElements.length == 1) {
         return MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
@@ -75,16 +75,16 @@ function getFlexReparentToAbsoluteStrategy(
         show: 'visible-only-while-active',
       },
     ],
-    fitness: (canvasState, interactionState, customStrategyState) => {
+    fitness: (canvasState, interactionSession, customStrategyState) => {
       // All 4 reparent strategies use the same fitness function getFitnessForReparentStrategy
       return getFitnessForReparentStrategy(
         'FLEX_REPARENT_TO_ABSOLUTE',
         canvasState,
-        interactionState,
+        interactionSession,
         missingBoundsHandling,
       )
     },
-    apply: (canvasState, interactionState, customStrategyState, strategyLifecycle) => {
+    apply: (canvasState, interactionSession, customStrategyState, strategyLifecycle) => {
       const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
       const filteredSelectedElements = getDragTargets(selectedElements)
       return ifAllowedToReparent(
@@ -93,21 +93,21 @@ function getFlexReparentToAbsoluteStrategy(
         filteredSelectedElements,
         () => {
           if (
-            interactionState.interactionData.type !== 'DRAG' ||
-            interactionState.interactionData.drag == null
+            interactionSession.interactionData.type !== 'DRAG' ||
+            interactionSession.interactionData.drag == null
           ) {
             return emptyStrategyApplicationResult
           }
 
           const pointOnCanvas = offsetPoint(
-            interactionState.interactionData.originalDragStart,
-            interactionState.interactionData.drag,
+            interactionSession.interactionData.originalDragStart,
+            interactionSession.interactionData.drag,
           )
 
           const { newParent } = getReparentTargetUnified(
             existingReparentSubjects(filteredSelectedElements),
             pointOnCanvas,
-            interactionState.interactionData.modifiers.cmd,
+            interactionSession.interactionData.modifiers.cmd,
             canvasState,
             canvasState.startingMetadata,
             canvasState.startingAllElementProps,
@@ -160,7 +160,7 @@ function getFlexReparentToAbsoluteStrategy(
                   canvasState.builtInDependencies,
                   editorState,
                   customStrategyState,
-                  interactionState,
+                  interactionSession,
                   commandLifecycle,
                   missingBoundsHandling,
                   strategyLifecycle,
@@ -178,7 +178,7 @@ function runAbsoluteReparentStrategyForFreshlyConvertedElement(
   builtInDependencies: BuiltInDependencies,
   editorState: EditorState,
   customStrategyState: CustomStrategyState,
-  interactionState: InteractionSession,
+  interactionSession: InteractionSession,
   commandLifecycle: InteractionLifecycle,
   missingBoundsHandling: MissingBoundsHandling,
   strategyLifeCycle: InteractionLifecycle,
@@ -191,7 +191,7 @@ function runAbsoluteReparentStrategyForFreshlyConvertedElement(
     : absoluteReparentStrategy
   const reparentCommands = absoluteReparentStrategyToUse.apply(
     canvasState,
-    interactionState,
+    interactionSession,
     customStrategyState,
     strategyLifeCycle,
   ).commands

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.tsx
@@ -9,7 +9,7 @@ import { applyFlexReparent, getFitnessForReparentStrategy } from './reparent-str
 export const flexReparentToFlexStrategy: CanvasStrategy = {
   id: 'FLEX_REPARENT_TO_FLEX',
   name: () => 'Reparent (Flex)',
-  isApplicable: (canvasState, _interactionState, metadata) => {
+  isApplicable: (canvasState, interactionSession, metadata) => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     if (selectedElements.length == 1) {
       return MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
@@ -42,12 +42,12 @@ export const flexReparentToFlexStrategy: CanvasStrategy = {
       show: 'visible-only-while-active',
     },
   ],
-  fitness: (canvasState, interactionState, customStrategyState) => {
+  fitness: (canvasState, interactionSession, customStrategyState) => {
     // All 4 reparent strategies use the same fitness function getFitnessForReparentStrategy
     return getFitnessForReparentStrategy(
       'FLEX_REPARENT_TO_FLEX',
       canvasState,
-      interactionState,
+      interactionSession,
       'use-strict-bounds',
     )
   },

--- a/editor/src/components/canvas/canvas-strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-resize-basic-strategy.tsx
@@ -32,7 +32,7 @@ import { pickCursorFromEdgePosition } from './shared-absolute-resize-strategy-he
 export const flexResizeBasicStrategy: CanvasStrategy = {
   id: 'FLEX_RESIZE_BASIC',
   name: () => 'Flex Resize (Basic)',
-  isApplicable: (canvasState, interactionState, metadata) => {
+  isApplicable: (canvasState, interactionSession, metadata) => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     // no multiselection support yet
     if (selectedElements.length === 1) {
@@ -56,29 +56,29 @@ export const flexResizeBasicStrategy: CanvasStrategy = {
     { control: ParentOutlines, key: 'parent-outlines-control', show: 'visible-only-while-active' },
     { control: ParentBounds, key: 'parent-bounds-control', show: 'visible-only-while-active' },
   ],
-  fitness: (canvasState, interactionState, customStrategyState) => {
+  fitness: (canvasState, interactionSession, customStrategyState) => {
     return flexResizeBasicStrategy.isApplicable(
       canvasState,
-      interactionState,
+      interactionSession,
       canvasState.startingMetadata,
       canvasState.startingAllElementProps,
     ) &&
-      interactionState.interactionData.type === 'DRAG' &&
-      interactionState.activeControl.type === 'RESIZE_HANDLE'
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.activeControl.type === 'RESIZE_HANDLE'
       ? 1
       : 0
   },
-  apply: (canvasState, interactionState, customStrategyState) => {
+  apply: (canvasState, interactionSession, customStrategyState) => {
     if (
-      interactionState.interactionData.type === 'DRAG' &&
-      interactionState.activeControl.type === 'RESIZE_HANDLE'
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.activeControl.type === 'RESIZE_HANDLE'
     ) {
       const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
       // no multiselection support yet
       const selectedElement = selectedElements[0]
-      const edgePosition = interactionState.activeControl.edgePosition
-      if (interactionState.interactionData.drag != null) {
-        const drag = interactionState.interactionData.drag
+      const edgePosition = interactionSession.activeControl.edgePosition
+      if (interactionSession.interactionData.drag != null) {
+        const drag = interactionSession.interactionData.drag
         const originalBounds = MetadataUtils.getFrameInCanvasCoords(
           selectedElement,
           canvasState.startingMetadata,

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-slider-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-slider-strategy.tsx
@@ -38,20 +38,20 @@ export const flowReorderSliderStategy: CanvasStrategy = {
       show: 'always-visible',
     },
   ],
-  fitness: (canvasState, interactionState, customStrategyState) => {
+  fitness: (canvasState, interactionSession, customStrategyState) => {
     return flowReorderSliderStategy.isApplicable(
       canvasState,
-      interactionState,
+      interactionSession,
       canvasState.startingMetadata,
       canvasState.startingAllElementProps,
     ) &&
-      interactionState.interactionData.type === 'DRAG' &&
-      interactionState.activeControl.type === 'FLOW_SLIDER'
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.activeControl.type === 'FLOW_SLIDER'
       ? 100
       : 0
   },
-  apply: (canvasState, interactionState, customStrategyState) => {
-    if (interactionState.interactionData.type !== 'DRAG') {
+  apply: (canvasState, interactionSession, customStrategyState) => {
+    if (interactionSession.interactionData.type !== 'DRAG') {
       return emptyStrategyApplicationResult
     }
 
@@ -70,12 +70,12 @@ export const flowReorderSliderStategy: CanvasStrategy = {
       )
     }
 
-    if (interactionState.interactionData.drag != null) {
+    if (interactionSession.interactionData.drag != null) {
       const unpatchedIndex = siblingsOfTarget.findIndex((sibling) => EP.pathsEqual(sibling, target))
 
       const newIndex = findNewIndex(
         unpatchedIndex,
-        interactionState.interactionData.drag,
+        interactionSession.interactionData.drag,
         siblingsOfTarget,
         'rounded-value',
       )

--- a/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flow-reorder-strategy.tsx
@@ -54,22 +54,22 @@ export const flowReorderStrategy: CanvasStrategy = {
       show: 'visible-only-while-active',
     },
   ], // Uses existing hooks in select-mode-hooks.tsx
-  fitness: (canvasState, interactionState, customStrategyState) => {
+  fitness: (canvasState, interactionSession, customStrategyState) => {
     return flowReorderStrategy.isApplicable(
       canvasState,
-      interactionState,
+      interactionSession,
       canvasState.startingMetadata,
       canvasState.startingAllElementProps,
     ) &&
-      interactionState.interactionData.type === 'DRAG' &&
-      interactionState.activeControl.type === 'BOUNDING_AREA'
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.activeControl.type === 'BOUNDING_AREA'
       ? 3
       : 0
   },
-  apply: (canvasState, interactionState, customStrategyState) => {
+  apply: (canvasState, interactionSession, customStrategyState) => {
     return applyReorderCommon(
       canvasState,
-      interactionState,
+      interactionSession,
       customStrategyState,
       isValidFlowReorderTarget,
     )

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
@@ -39,7 +39,7 @@ import { honoursPropsPosition } from './absolute-utils'
 export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
   id: 'KEYBOARD_ABSOLUTE_MOVE',
   name: () => 'Move',
-  isApplicable: (canvasState, _interactionState, metadata) => {
+  isApplicable: (canvasState, interactionSession, metadata) => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     if (selectedElements.length > 0) {
       return selectedElements.every((element) => {
@@ -54,17 +54,17 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
     }
   },
   controlsToRender: [], // Uses existing hooks in select-mode-hooks.tsx
-  fitness: (canvasState, interactionState, customStrategyState) => {
+  fitness: (canvasState, interactionSession, customStrategyState) => {
     if (
       keyboardAbsoluteMoveStrategy.isApplicable(
         canvasState,
-        interactionState,
+        interactionSession,
         canvasState.startingMetadata,
         canvasState.startingAllElementProps,
       ) &&
-      interactionState.interactionData.type === 'KEYBOARD'
+      interactionSession.interactionData.type === 'KEYBOARD'
     ) {
-      const { interactionData } = interactionState
+      const { interactionData } = interactionSession
 
       const lastKeyState = getLastKeyPressState(interactionData.keyStates)
       if (lastKeyState != null) {
@@ -78,10 +78,10 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
     }
     return 0
   },
-  apply: (canvasState, interactionState, customStrategyState) => {
+  apply: (canvasState, interactionSession, customStrategyState) => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
-    if (interactionState.interactionData.type === 'KEYBOARD') {
-      const accumulatedPresses = accumulatePresses(interactionState.interactionData.keyStates)
+    if (interactionSession.interactionData.type === 'KEYBOARD') {
+      const accumulatedPresses = accumulatePresses(interactionSession.interactionData.keyStates)
       let commands: Array<CanvasCommand> = []
       let intendedBounds: Array<CanvasFrameAndTarget> = []
       let keyboardMovement: CanvasVector = zeroCanvasPoint
@@ -100,7 +100,7 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
             selectedElement,
             keyboardMovement,
             canvasState,
-            interactionState,
+            interactionSession,
           )
           commands.push(...elementResult.commands)
           intendedBounds.push(...elementResult.intendedBounds)
@@ -112,7 +112,7 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
         keyboardMovement,
       )
 
-      const guidelines = getKeyboardStrategyGuidelines(canvasState, interactionState, newFrame)
+      const guidelines = getKeyboardStrategyGuidelines(canvasState, interactionSession, newFrame)
 
       commands.push(updateHighlightedViews('mid-interaction', []))
       commands.push(setSnappingGuidelines('mid-interaction', guidelines))

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
@@ -73,7 +73,7 @@ function pressesToVectorAndEdges(
 export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
   id: 'KEYBOARD_ABSOLUTE_RESIZE',
   name: () => 'Resize',
-  isApplicable: (canvasState, interactionState, metadata) => {
+  isApplicable: (canvasState, interactionSession, metadata) => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     if (selectedElements.length > 0) {
       return selectedElements.every((element) => {
@@ -90,17 +90,17 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
       show: 'visible-except-when-other-strategy-is-active',
     },
   ],
-  fitness: (canvasState, interactionState, customStrategyState) => {
+  fitness: (canvasState, interactionSession, customStrategyState) => {
     if (
       keyboardAbsoluteResizeStrategy.isApplicable(
         canvasState,
-        interactionState,
+        interactionSession,
         canvasState.startingMetadata,
         canvasState.startingAllElementProps,
       ) &&
-      interactionState.interactionData.type === 'KEYBOARD'
+      interactionSession.interactionData.type === 'KEYBOARD'
     ) {
-      const { interactionData } = interactionState
+      const { interactionData } = interactionSession
       const lastKeyPress = getLastKeyPressState(interactionData.keyStates)
       if (lastKeyPress != null) {
         const cmdAndOptionallyShiftModifier =
@@ -113,10 +113,10 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
     }
     return 0
   },
-  apply: (canvasState, interactionState, customStrategyState) => {
+  apply: (canvasState, interactionSession, customStrategyState) => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
-    if (interactionState.interactionData.type === 'KEYBOARD') {
-      const accumulatedPresses = accumulatePresses(interactionState.interactionData.keyStates)
+    if (interactionSession.interactionData.type === 'KEYBOARD') {
+      const accumulatedPresses = accumulatePresses(interactionSession.interactionData.keyStates)
       const movementsWithEdges = pressesToVectorAndEdges(accumulatedPresses)
 
       // Start with the frame as it is at the start of the interaction.
@@ -171,7 +171,7 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
           })
         }
       })
-      const guidelines = getKeyboardStrategyGuidelines(canvasState, interactionState, newFrame)
+      const guidelines = getKeyboardStrategyGuidelines(canvasState, interactionSession, newFrame)
       commands.push(setSnappingGuidelines('mid-interaction', guidelines))
       commands.push(pushIntendedBounds(intendedBounds))
       commands.push(setElementsToRerenderCommand(selectedElements))

--- a/editor/src/components/canvas/canvas-strategies/relative-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/relative-move-strategy.tsx
@@ -20,7 +20,7 @@ export const relativeMoveStrategy: CanvasStrategy = {
 
   name: () => 'Move (Relative)',
 
-  isApplicable: (canvasState, _interactionState, instanceMetadata) => {
+  isApplicable: (canvasState, interactionSession, instanceMetadata) => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     if (selectedElements.length === 0) {
       return false
@@ -50,8 +50,8 @@ export const relativeMoveStrategy: CanvasStrategy = {
     },
   ],
 
-  fitness: (canvasState, interactionState, _sessionState) => {
-    const { interactionData, activeControl } = interactionState
+  fitness: (canvasState, interactionSession, _sessionState) => {
+    const { interactionData, activeControl } = interactionSession
     if (!(interactionData.type === 'DRAG' && interactionData.drag != null)) {
       return 0
     }
@@ -65,7 +65,7 @@ export const relativeMoveStrategy: CanvasStrategy = {
     }
     const filteredSelectedElements = getDragTargets(selectedElements)
     const last = filteredSelectedElements[filteredSelectedElements.length - 1]
-    const metadata = MetadataUtils.findElementByElementPath(interactionState.latestMetadata, last)
+    const metadata = MetadataUtils.findElementByElementPath(interactionSession.latestMetadata, last)
     if (!metadata) {
       return 0
     }
@@ -82,17 +82,17 @@ export const relativeMoveStrategy: CanvasStrategy = {
       : 1 // there should be a more structured way to define priorities (:
   },
 
-  apply: (canvasState, interactionState, customStrategyState) => {
+  apply: (canvasState, interactionSession, customStrategyState) => {
     const isFitting =
-      relativeMoveStrategy.fitness(canvasState, interactionState, customStrategyState) > 0
+      relativeMoveStrategy.fitness(canvasState, interactionSession, customStrategyState) > 0
     if (!isFitting) {
       return emptyStrategyApplicationResult
     }
 
     return applyMoveCommon(
       canvasState,
-      interactionState,
-      getAdjustMoveCommands(canvasState, interactionState, {
+      interactionSession,
+      getAdjustMoveCommands(canvasState, interactionSession, {
         ignoreLocalFrame: true,
       }),
     )

--- a/editor/src/components/canvas/canvas-strategies/reorder-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/reorder-utils.ts
@@ -31,15 +31,15 @@ function isRootOfGeneratedElement(target: ElementPath): boolean {
 
 export function applyReorderCommon(
   canvasState: InteractionCanvasState,
-  interactionState: InteractionSession,
+  interactionSession: InteractionSession,
   customStrategyState: CustomStrategyState,
   isValidTarget: (path: ElementPath, metadata: ElementInstanceMetadataMap) => boolean,
 ): StrategyApplicationResult {
-  if (interactionState.interactionData.type !== 'DRAG') {
+  if (interactionSession.interactionData.type !== 'DRAG') {
     return emptyStrategyApplicationResult
   }
 
-  if (interactionState.interactionData.drag != null) {
+  if (interactionSession.interactionData.drag != null) {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     const target = selectedElements[0]
 
@@ -56,8 +56,8 @@ export function applyReorderCommon(
     }
 
     const pointOnCanvas = offsetPoint(
-      interactionState.interactionData.dragStart,
-      interactionState.interactionData.drag,
+      interactionSession.interactionData.dragStart,
+      interactionSession.interactionData.drag,
     )
 
     const unpatchedIndex = siblings.findIndex((sibling) => EP.pathsEqual(sibling, target))

--- a/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-strategy-helpers.ts
@@ -151,7 +151,7 @@ function isReparentToAbsoluteStrategy(reparentStrategy: ReparentStrategy): boole
 export function getFitnessForReparentStrategy(
   reparentStrategy: ReparentStrategy,
   canvasState: InteractionCanvasState,
-  interactionState: InteractionSession,
+  interactionSession: InteractionSession,
   missingBoundsHandling: MissingBoundsHandling,
 ): number {
   const isForced = missingBoundsHandling === 'allow-missing-bounds'
@@ -159,7 +159,7 @@ export function getFitnessForReparentStrategy(
 
   const foundReparentStrategy = findReparentStrategy(
     canvasState,
-    interactionState,
+    interactionSession,
     missingBoundsHandling,
   )
   if (
@@ -189,16 +189,16 @@ function targetIsValid(
 
 function findReparentStrategy(
   canvasState: InteractionCanvasState,
-  interactionState: InteractionSession,
+  interactionSession: InteractionSession,
   missingBoundsHandling: MissingBoundsHandling,
 ): FindReparentStrategyResult {
   const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
   if (
     selectedElements.length === 0 ||
-    interactionState.activeControl.type !== 'BOUNDING_AREA' ||
-    interactionState.interactionData.type !== 'DRAG' ||
-    interactionState.interactionData.drag == null || // TODO delete this drag nullcheck? do we start the reparent on mouse down or mouse move beyond threshold?
-    interactionState.interactionData.modifiers.alt
+    interactionSession.activeControl.type !== 'BOUNDING_AREA' ||
+    interactionSession.interactionData.type !== 'DRAG' ||
+    interactionSession.interactionData.drag == null || // TODO delete this drag nullcheck? do we start the reparent on mouse down or mouse move beyond threshold?
+    interactionSession.interactionData.modifiers.alt
   ) {
     return { strategy: 'do-not-reparent' }
   }
@@ -206,11 +206,11 @@ function findReparentStrategy(
   const filteredSelectedElements = getDragTargets(selectedElements)
 
   const pointOnCanvas = offsetPoint(
-    interactionState.interactionData.originalDragStart,
-    interactionState.interactionData.drag,
+    interactionSession.interactionData.originalDragStart,
+    interactionSession.interactionData.drag,
   )
 
-  const cmdPressed = interactionState.interactionData.modifiers.cmd
+  const cmdPressed = interactionSession.interactionData.modifiers.cmd
 
   const reparentResult = getReparentTargetUnified(
     existingReparentSubjects(filteredSelectedElements),
@@ -233,7 +233,7 @@ function findReparentStrategy(
     newParentPath != null &&
     targetIsValid(
       newParentPath,
-      interactionState.startingTargetParentsToFilterOut,
+      interactionSession.startingTargetParentsToFilterOut,
       missingBoundsHandling,
     ) &&
     !parentStayedTheSame

--- a/editor/src/components/canvas/canvas-strategies/shared-keyboard-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-keyboard-strategy-helpers.ts
@@ -90,12 +90,12 @@ export function getMovementDeltaFromKey(key: KeyCharacter, modifiers: Modifiers)
 
 export function getKeyboardStrategyGuidelines(
   canvasState: InteractionCanvasState,
-  interactionState: InteractionSession,
+  interactionSession: InteractionSession,
   draggedFrame: CanvasRectangle,
 ): Array<GuidelineWithSnappingVectorAndPointsOfRelevance> {
   const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
   const moveGuidelines = collectParentAndSiblingGuidelines(
-    interactionState.latestMetadata,
+    interactionSession.latestMetadata,
     selectedElements,
   ).map((g) => g.guideline)
 

--- a/editor/src/components/canvas/canvas-strategies/shared-move-strategies-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-move-strategies-helpers.ts
@@ -62,7 +62,7 @@ export interface MoveCommandsOptions {
 export const getAdjustMoveCommands =
   (
     canvasState: InteractionCanvasState,
-    interactionState: InteractionSession,
+    interactionSession: InteractionSession,
     options?: MoveCommandsOptions,
   ) =>
   (
@@ -80,7 +80,7 @@ export const getAdjustMoveCommands =
         selectedElement,
         snappedDragVector,
         canvasState,
-        interactionState,
+        interactionSession,
         options,
       )
       commands.push(...elementResult.commands)
@@ -91,19 +91,19 @@ export const getAdjustMoveCommands =
 
 export function applyMoveCommon(
   canvasState: InteractionCanvasState,
-  interactionState: InteractionSession,
+  interactionSession: InteractionSession,
   getMoveCommands: (snappedDragVector: CanvasPoint) => {
     commands: Array<CanvasCommand>
     intendedBounds: Array<CanvasFrameAndTarget>
   },
 ): StrategyApplicationResult {
   if (
-    interactionState.interactionData.type === 'DRAG' &&
-    interactionState.interactionData.drag != null
+    interactionSession.interactionData.type === 'DRAG' &&
+    interactionSession.interactionData.drag != null
   ) {
-    const drag = interactionState.interactionData.drag
-    const shiftKeyPressed = interactionState.interactionData.modifiers.shift
-    const cmdKeyPressed = interactionState.interactionData.modifiers.cmd
+    const drag = interactionSession.interactionData.drag
+    const shiftKeyPressed = interactionSession.interactionData.modifiers.shift
+    const cmdKeyPressed = interactionSession.interactionData.modifiers.cmd
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
     if (cmdKeyPressed) {
       const commandsForSelectedElements = getMoveCommands(drag)
@@ -120,7 +120,7 @@ export function applyMoveCommon(
         shiftKeyPressed && drag != null ? determineConstrainedDragAxis(drag) : null
 
       const targetsForSnapping = selectedElements.map(
-        (path) => interactionState.updatedTargetPaths[EP.toString(path)] ?? path,
+        (path) => interactionSession.updatedTargetPaths[EP.toString(path)] ?? path,
       )
       const moveGuidelines = collectParentAndSiblingGuidelines(
         canvasState.startingMetadata,
@@ -155,7 +155,7 @@ export function getMoveCommandsForSelectedElement(
   selectedElement: ElementPath,
   drag: CanvasVector,
   canvasState: InteractionCanvasState,
-  interactionState: InteractionSession,
+  interactionSession: InteractionSession,
   options?: MoveCommandsOptions,
 ): {
   commands: Array<AdjustCssLengthProperty>
@@ -192,7 +192,7 @@ export function getMoveCommandsForSelectedElement(
   }
 
   const mappedPath =
-    interactionState.updatedTargetPaths[EP.toString(selectedElement)] ?? selectedElement
+    interactionSession.updatedTargetPaths[EP.toString(selectedElement)] ?? selectedElement
 
   return createMoveCommandsForElement(
     element,


### PR DESCRIPTION
**Problem:**
In the strategy API there is a parameter called `interactionSession: InteractionSession` which is a pointer to `EditorState.canvas.interactionSession`. However, in a ton of places many functions use the parameter name `interactionState` for this. This is a result of a rename that we didn't quite enforce, and then it got copy-pasted to most new strategies. I think the name `interactionSession` makes more sense, as this is the place where we store input data about the ongoing interaction. The mouse position, timer, etc live here.

**Fix:**
Mass rename `interactionState` to `interactionSession`

