### PR TITLE
Switch CanvasStrategyId type to a string

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -112,27 +112,7 @@ export function getInsertionSubjectsFromInteractionTarget(
   return []
 }
 
-export type CanvasStrategyId =
-  | 'ABSOLUTE_MOVE'
-  | 'ABSOLUTE_REPARENT'
-  | 'FORCED_ABSOLUTE_REPARENT'
-  | 'ABSOLUTE_DUPLICATE'
-  | 'ABSOLUTE_RESIZE_BOUNDING_BOX'
-  | 'KEYBOARD_ABSOLUTE_MOVE'
-  | 'KEYBOARD_ABSOLUTE_RESIZE'
-  | 'CONVERT_TO_ABSOLUTE_AND_MOVE_STRATEGY'
-  | 'FLEX_REORDER'
-  | 'ABSOLUTE_REPARENT_TO_FLEX'
-  | 'FLEX_REPARENT_TO_ABSOLUTE'
-  | 'FORCED_FLEX_REPARENT_TO_ABSOLUTE'
-  | 'FLEX_REPARENT_TO_FLEX'
-  | 'DRAG_TO_INSERT'
-  | 'FLOW_REORDER'
-  | 'FLOW_REORDER_SLIDER'
-  | 'LOOK_FOR_APPLICABLE_PARENT_ID'
-  | 'DRAW_TO_INSERT'
-  | 'FLEX_RESIZE_BASIC'
-  | 'RELATIVE_MOVE'
+export type CanvasStrategyId = string
 
 export type InteractionLifecycle = 'mid-interaction' | 'end-interaction'
 

--- a/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.spec.browser2.tsx
@@ -6,17 +6,15 @@ import {
 } from '../../ui-jsx.test-utils'
 import {
   CanvasStrategy,
-  CanvasStrategyId,
   strategyApplicationResult,
 } from '../../canvas-strategies/canvas-strategy-types'
-import { act } from 'react-dom/test-utils'
 import { CanvasControlsContainerID } from '../new-canvas-controls'
 import { applicableStrategy, ApplicableStrategy } from '../../canvas-strategies/canvas-strategies'
 import { cmdModifier, emptyModifiers, Modifiers, shiftModifier } from '../../../../utils/modifiers'
 import { mouseDownAtPoint, mouseMoveToPoint, pressKey } from '../../event-helpers.test-utils'
 
 const BestStrategy: CanvasStrategy = {
-  id: 'BEST_STRATEGY' as CanvasStrategyId,
+  id: 'BEST_STRATEGY',
   name: () => 'Best Strategy',
   isApplicable: () => true,
   controlsToRender: [],
@@ -25,7 +23,7 @@ const BestStrategy: CanvasStrategy = {
 }
 
 const AverageStrategy: CanvasStrategy = {
-  id: 'AVERAGE_STRATEGY' as CanvasStrategyId,
+  id: 'AVERAGE_STRATEGY',
   name: () => 'Average Strategy',
   isApplicable: () => true,
   controlsToRender: [],
@@ -34,7 +32,7 @@ const AverageStrategy: CanvasStrategy = {
 }
 
 const WorstStrategy: CanvasStrategy = {
-  id: 'WORST_STRATEGY' as CanvasStrategyId,
+  id: 'WORST_STRATEGY',
   name: () => 'Worst Strategy',
   isApplicable: () => true,
   controlsToRender: [],
@@ -43,7 +41,7 @@ const WorstStrategy: CanvasStrategy = {
 }
 
 const UnfitStrategy: CanvasStrategy = {
-  id: 'UNFIT_STRATEGY' as CanvasStrategyId,
+  id: 'UNFIT_STRATEGY',
   name: () => 'Unfit Strategy',
   isApplicable: () => false,
   controlsToRender: [],


### PR DESCRIPTION
**Problem:**
Using statically defined `CanvasStrategyId`s (via a string union type) is no longer suitable given our move towards using meta strategies (which was exposed via the strategy which looks for an applicable ancestor).

**Fix:**
Change the type to be simple an alias of `string`. The type originally existed as a way to highlight what IDs already existed and had been taken (as we have no way of ensuring uniqueness of those IDs at compile time). That use was weak at best, and since we now require dynamic IDs I have simply switched to using a string.

We could perhaps consider some sort of registration function for ensuring uniqueness here at runtime, but I'm deliberately not going to tackle that right now as it will make some upcoming work around meta strategies more tricky.