### PR TITLE
Restore scene insertion

### DIFF
--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -215,13 +215,7 @@ import type {
   SetGithubState,
   SaveToGithub,
 } from '../action-types'
-import {
-  EditorModes,
-  elementInsertionSubject,
-  Mode,
-  sceneInsertionSubject,
-  SceneInsertionSubject,
-} from '../editor-modes'
+import { EditorModes, elementInsertionSubject, Mode } from '../editor-modes'
 import type {
   DuplicationState,
   ErrorMessages,
@@ -456,10 +450,6 @@ export function enableInsertModeForJSXElement(
   return switchEditorMode(
     EditorModes.insertMode(elementInsertionSubject(uid, element, size, importsToAdd, null)),
   )
-}
-
-export function enableInsertModeForScene(name: JSXElementName | 'scene'): SwitchEditorMode {
-  return switchEditorMode(EditorModes.insertMode(sceneInsertionSubject()))
 }
 
 export function addToast(toastContent: Notice): AddToast {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -377,14 +377,7 @@ import {
   SaveToGithub,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
-import {
-  EditorModes,
-  elementInsertionSubject,
-  Mode,
-  SceneInsertionSubject,
-  isSelectMode,
-  isLiveMode,
-} from '../editor-modes'
+import { EditorModes, Mode, isSelectMode, isLiveMode } from '../editor-modes'
 import * as History from '../history'
 import { StateHistory } from '../history'
 import {

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -16,10 +16,6 @@ export interface ElementInsertionSubject {
   parent: InsertionParent
 }
 
-export interface SceneInsertionSubject {
-  type: 'Scene'
-}
-
 export interface DragAndDropInsertionSubject {
   type: 'DragAndDrop'
   imageAssets: Array<string> | null
@@ -42,12 +38,6 @@ export function elementInsertionSubject(
   }
 }
 
-export function sceneInsertionSubject(): SceneInsertionSubject {
-  return {
-    type: 'Scene',
-  }
-}
-
 export function dragAndDropInsertionSubject(
   imageAssets: Array<string> | null,
 ): DragAndDropInsertionSubject {
@@ -57,21 +47,12 @@ export function dragAndDropInsertionSubject(
   }
 }
 
-export type InsertionSubject =
-  | ElementInsertionSubject
-  | SceneInsertionSubject
-  | DragAndDropInsertionSubject
+export type InsertionSubject = ElementInsertionSubject | DragAndDropInsertionSubject
 
 export function insertionSubjectIsJSXElement(
   insertionSubject: InsertionSubject,
 ): insertionSubject is ElementInsertionSubject {
   return insertionSubject.type === 'Element'
-}
-
-export function insertionSubjectIsScene(
-  insertionSubject: InsertionSubject,
-): insertionSubject is SceneInsertionSubject {
-  return insertionSubject.type === 'Scene'
 }
 
 export function insertionSubjectIsDragAndDrop(

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -51,7 +51,7 @@ import {
   getInsertableGroupLabel,
   getInsertableGroupPackageStatus,
   getNonEmptyComponentGroups,
-  moveSceneToTheBeginning,
+  moveSceneToTheBeginningAndSetDefaultSize,
 } from '../shared/project-components'
 import { ProjectContentTreeRoot } from '../assets'
 import { generateUidWithExistingComponents } from '../../core/model/element-template-utils'
@@ -199,7 +199,7 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
     const insertableGroups =
       this.props.currentlyOpenFilename == null
         ? []
-        : moveSceneToTheBeginning(
+        : moveSceneToTheBeginningAndSetDefaultSize(
             getNonEmptyComponentGroups(
               this.props.packageStatus,
               this.props.propertyControlsInfo,
@@ -242,7 +242,12 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
                 )
                 this.props.editorDispatch(
                   [
-                    enableInsertModeForJSXElement(newElement, newUID, component.importsToAdd, null),
+                    enableInsertModeForJSXElement(
+                      newElement,
+                      newUID,
+                      component.importsToAdd,
+                      component.defaultSize,
+                    ),
                     CanvasActions.createInteractionSession(
                       createInteractionViaMouse(
                         mousePoint,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -397,8 +397,6 @@ import {
   InsertMode,
   LiveCanvasMode,
   Mode,
-  sceneInsertionSubject,
-  SceneInsertionSubject,
   SelectMode,
   targetedInsertionParent,
   TargetedInsertionParent,
@@ -2556,15 +2554,6 @@ export const ElementInsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<Eleme
     elementInsertionSubject,
   )
 
-// Here to trigger failure in the case of `SceneInsertionSubject` changing it's definition.
-sceneInsertionSubject()
-export const SceneInsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<SceneInsertionSubject> = (
-  oldValue,
-  newValue,
-) => {
-  return keepDeepEqualityResult(oldValue, true)
-}
-
 export const DragAndDropInsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<DragAndDropInsertionSubject> =
   combine1EqualityCall(
     (subject) => subject.imageAssets,
@@ -2580,11 +2569,6 @@ export const InsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<InsertionSub
     case 'Element':
       if (newValue.type === oldValue.type) {
         return ElementInsertionSubjectKeepDeepEquality(oldValue, newValue)
-      }
-      break
-    case 'Scene':
-      if (newValue.type === oldValue.type) {
-        return SceneInsertionSubjectKeepDeepEquality(oldValue, newValue)
       }
       break
     case 'DragAndDrop':

--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -5,6 +5,7 @@ Array [
   Object {
     "insertableComponents": Array [
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -44,6 +45,7 @@ Array [
   Object {
     "insertableComponents": Array [
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -68,6 +70,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -92,6 +95,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -116,6 +120,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -140,6 +145,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -164,6 +170,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -188,6 +195,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -212,6 +220,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -321,6 +330,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -402,6 +412,7 @@ Array [
   Object {
     "insertableComponents": Array [
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -441,6 +452,7 @@ Array [
   Object {
     "insertableComponents": Array [
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -465,6 +477,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -489,6 +502,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -513,6 +527,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -537,6 +552,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -561,6 +577,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -585,6 +602,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -609,6 +627,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -718,6 +737,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -786,6 +806,7 @@ Array [
   Object {
     "insertableComponents": Array [
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -820,6 +841,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -983,6 +1005,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -1017,6 +1040,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -1100,6 +1124,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -1311,6 +1336,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -1394,6 +1420,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -1573,6 +1600,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -1642,6 +1670,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -1695,6 +1724,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {
@@ -1731,6 +1761,7 @@ Array [
         ],
       },
       Object {
+        "defaultSize": null,
         "element": Object {
           "children": Array [],
           "name": Object {

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -26,7 +26,7 @@ import {
   simpleAttribute,
 } from '../../core/shared/element-template'
 import { dropFileExtension } from '../../core/shared/file-utils'
-import { Size } from '../../core/shared/math-utils'
+import { size, Size } from '../../core/shared/math-utils'
 import {
   isResolvedNpmDependency,
   PackageStatus,
@@ -61,6 +61,7 @@ export interface InsertableComponent {
   element: JSXElementWithoutUID
   name: string
   stylePropOptions: Array<StylePropOption>
+  defaultSize: Size | null
 }
 
 export function insertableComponent(
@@ -68,12 +69,14 @@ export function insertableComponent(
   element: JSXElementWithoutUID,
   name: string,
   stylePropOptions: Array<StylePropOption>,
+  defaultSize: Size | null,
 ): InsertableComponent {
   return {
     importsToAdd: importsToAdd,
     element: element,
     name: name,
     stylePropOptions: stylePropOptions,
+    defaultSize: defaultSize,
   }
 }
 
@@ -317,7 +320,12 @@ export function getNonEmptyComponentGroups(
   })
 }
 
-export function moveSceneToTheBeginning(
+const SceneDefaultWidth = 325
+const SceneDefaultHeight = 350
+
+// We would like to treat Scene components from utopia-api specially: they should appear as the first insertable component, and
+// has a custom default size
+export function moveSceneToTheBeginningAndSetDefaultSize(
   groups: Array<InsertableComponentGroup>,
 ): Array<InsertableComponentGroup> {
   const utopiaApiGroupIdx = groups.findIndex(
@@ -338,7 +346,15 @@ export function moveSceneToTheBeginning(
       ]
       const newSceneGroup = insertableComponentGroup(
         insertableComponentGroupProjectComponent('Storyboard'),
-        [scene],
+        [
+          insertableComponent(
+            scene.importsToAdd,
+            scene.element,
+            scene.name,
+            scene.stylePropOptions,
+            size(SceneDefaultWidth, SceneDefaultHeight),
+          ),
+        ],
       )
       return [newSceneGroup, ...groupsWithoutUtopiaApi, utopiaApiGroupWithoutScene]
     }
@@ -391,6 +407,7 @@ export function getComponentGroups(
                   insertOption.elementToInsert,
                   insertOption.insertMenuLabel,
                   stylePropOptions,
+                  null,
                 ),
               )
             })
@@ -401,6 +418,7 @@ export function getComponentGroups(
                 jsxElementWithoutUID(exportedComponent.listingName, [], []),
                 exportedComponent.listingName,
                 stylePropOptions,
+                null,
               ),
             )
           }
@@ -436,6 +454,7 @@ export function getComponentGroups(
             insertOption.elementToInsert,
             insertOption.insertMenuLabel,
             stylePropOptions,
+            null,
           ),
         )
       })

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -26,6 +26,7 @@ import {
   simpleAttribute,
 } from '../../core/shared/element-template'
 import { dropFileExtension } from '../../core/shared/file-utils'
+import { Size } from '../../core/shared/math-utils'
 import {
   isResolvedNpmDependency,
   PackageStatus,
@@ -314,6 +315,35 @@ export function getNonEmptyComponentGroups(
   return groups.filter((group) => {
     return group.insertableComponents.length > 0
   })
+}
+
+export function moveSceneToTheBeginning(
+  groups: Array<InsertableComponentGroup>,
+): Array<InsertableComponentGroup> {
+  const utopiaApiGroupIdx = groups.findIndex(
+    (group) => getInsertableGroupLabel(group.source) === 'utopia-api',
+  )
+  if (utopiaApiGroupIdx > -1) {
+    const utopiaApiGroup = groups[utopiaApiGroupIdx]
+    const sceneIdx = utopiaApiGroup.insertableComponents.findIndex((comp) => comp.name === 'Scene')
+    if (sceneIdx > -1) {
+      const scene = utopiaApiGroup.insertableComponents[sceneIdx]
+      const utopiaApiGroupWithoutScene = insertableComponentGroup(utopiaApiGroup.source, [
+        ...utopiaApiGroup.insertableComponents.slice(0, sceneIdx),
+        ...utopiaApiGroup.insertableComponents.slice(sceneIdx + 1),
+      ])
+      const groupsWithoutUtopiaApi = [
+        ...groups.slice(0, utopiaApiGroupIdx),
+        ...groups.slice(utopiaApiGroupIdx + 1),
+      ]
+      const newSceneGroup = insertableComponentGroup(
+        insertableComponentGroupProjectComponent('Storyboard'),
+        [scene],
+      )
+      return [newSceneGroup, ...groupsWithoutUtopiaApi, utopiaApiGroupWithoutScene]
+    }
+  }
+  return groups
 }
 
 export function getComponentGroups(


### PR DESCRIPTION
**Problem:**
The new insert mode code did not handle scenes.

**Fix:**
In the old way scenes were handled as special insertion subjects. However, I don't think that is necessary anymore, Scene is just a component from utopia-api, and there are only 2 special properties of scene insertion:
- Scene should appear on the top in the insert menu
- scenes has a special default size

I use the recent PR to set the custom default size: https://github.com/concrete-utopia/utopia/pull/2618

