### PR TITLE
Tweak dimension detection for basic flex resize

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/flex-resize-basic-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-resize-basic-strategy.spec.browser2.tsx
@@ -45,205 +45,314 @@ async function dragResizeControl(
   await renderResult.getDispatchFollowUpActionsFinished()
 }
 
-describe('Flex resize in row', () => {
-  // Corner tests
-  it('resizes a flex element from edgePosition 0, 0 with drag vector (15, 25)', async () => {
-    await resizeTestRow(edgePosition(0, 0), canvasPoint({ x: 15, y: 25 }), 65, 165)
+describe('Flex Resize', () => {
+  describe('Flex resize in row', () => {
+    // Corner tests
+    it('resizes a flex element from edgePosition 0, 0 with drag vector (15, 25)', async () => {
+      await resizeTestRow(edgePosition(0, 0), canvasPoint({ x: 15, y: 25 }), 65, 165)
+    })
+    it('resizes a flex element from edgePosition 0, 0 with drag vector (15, -25)', async () => {
+      await resizeTestRow(edgePosition(0, 0), canvasPoint({ x: 15, y: -25 }), 65, 215)
+    })
+    it('resizes a flex element from edgePosition 0, 0 with drag vector (-15, 25)', async () => {
+      await resizeTestRow(edgePosition(0, 0), canvasPoint({ x: -15, y: 25 }), 95, 165)
+    })
+    it('resizes a flex element from edgePosition 0, 0 with drag vector (-15, -25)', async () => {
+      await resizeTestRow(edgePosition(0, 0), canvasPoint({ x: -15, y: -25 }), 95, 215)
+    })
+    it('resizes a flex element from edgePosition 0, 1 with drag vector (15, 25)', async () => {
+      await resizeTestRow(edgePosition(0, 1), canvasPoint({ x: 15, y: 25 }), 65, 215)
+    })
+    it('resizes a flex element from edgePosition 0, 1 with drag vector (15, -25)', async () => {
+      await resizeTestRow(edgePosition(0, 1), canvasPoint({ x: 15, y: -25 }), 65, 165)
+    })
+    it('resizes a flex element from edgePosition 0, 1 with drag vector (-15, 25)', async () => {
+      await resizeTestRow(edgePosition(0, 1), canvasPoint({ x: -15, y: 25 }), 95, 215)
+    })
+    it('resizes a flex element from edgePosition 0, 1 with drag vector (-15, -25)', async () => {
+      await resizeTestRow(edgePosition(0, 1), canvasPoint({ x: -15, y: -25 }), 95, 165)
+    })
+    it('resizes a flex element from edgePosition 1, 0 with drag vector (15, 25)', async () => {
+      await resizeTestRow(edgePosition(1, 0), canvasPoint({ x: 15, y: 25 }), 95, 165)
+    })
+    it('resizes a flex element from edgePosition 1, 0 with drag vector (15, -25)', async () => {
+      await resizeTestRow(edgePosition(1, 0), canvasPoint({ x: 15, y: -25 }), 95, 215)
+    })
+    it('resizes a flex element from edgePosition 1, 0 with drag vector (-15, 25)', async () => {
+      await resizeTestRow(edgePosition(1, 0), canvasPoint({ x: -15, y: 25 }), 65, 165)
+    })
+    it('resizes a flex element from edgePosition 1, 0 with drag vector (-15, -25)', async () => {
+      await resizeTestRow(edgePosition(1, 0), canvasPoint({ x: -15, y: -25 }), 65, 215)
+    })
+    it('resizes a flex element from edgePosition 1, 1 with drag vector (15, 25)', async () => {
+      await resizeTestRow(edgePosition(1, 1), canvasPoint({ x: 15, y: 25 }), 95, 215)
+    })
+    it('resizes a flex element from edgePosition 1, 1 with drag vector (15, -25)', async () => {
+      await resizeTestRow(edgePosition(1, 1), canvasPoint({ x: 15, y: -25 }), 95, 165)
+    })
+    it('resizes a flex element from edgePosition 1, 1 with drag vector (-15, 25)', async () => {
+      await resizeTestRow(edgePosition(1, 1), canvasPoint({ x: -15, y: 25 }), 65, 215)
+    })
+    it('resizes a flex element from edgePosition 1, 1 with drag vector (-15, -25)', async () => {
+      await resizeTestRow(edgePosition(1, 1), canvasPoint({ x: -15, y: -25 }), 65, 165)
+    })
+    // Edge tests
+    it('resizes a flex element from edgePosition 0, 0.5 with drag vector (15, 25)', async () => {
+      await resizeTestRow(edgePosition(0, 0.5), canvasPoint({ x: 15, y: 25 }), 65, 190)
+    })
+    it('resizes a flex element from edgePosition 0, 0.5 with drag vector (15, -25)', async () => {
+      await resizeTestRow(edgePosition(0, 0.5), canvasPoint({ x: 15, y: -25 }), 65, 190)
+    })
+    it('resizes a flex element from edgePosition 0, 0.5 with drag vector (-15, 25)', async () => {
+      await resizeTestRow(edgePosition(0, 0.5), canvasPoint({ x: -15, y: 25 }), 95, 190)
+    })
+    it('resizes a flex element from edgePosition 0, 0.5 with drag vector (-15, -25)', async () => {
+      await resizeTestRow(edgePosition(0, 0.5), canvasPoint({ x: -15, y: -25 }), 95, 190)
+    })
+    it('resizes a flex element from edgePosition 0.5, 0 with drag vector (15, 25)', async () => {
+      await resizeTestRow(edgePosition(0.5, 0), canvasPoint({ x: 15, y: 25 }), 80, 165)
+    })
+    it('resizes a flex element from edgePosition 0.5, 0 with drag vector (15, -25)', async () => {
+      await resizeTestRow(edgePosition(0.5, 0), canvasPoint({ x: 15, y: -25 }), 80, 215)
+    })
+    it('resizes a flex element from edgePosition 0.5, 0 with drag vector (-15, 25)', async () => {
+      await resizeTestRow(edgePosition(0.5, 0), canvasPoint({ x: -15, y: 25 }), 80, 165)
+    })
+    it('resizes a flex element from edgePosition 0.5, 0 with drag vector (-15, -25)', async () => {
+      await resizeTestRow(edgePosition(0.5, 0), canvasPoint({ x: -15, y: -25 }), 80, 215)
+    })
+    it('resizes a flex element from edgePosition 1, 0.5 with drag vector (15, 25)', async () => {
+      await resizeTestRow(edgePosition(1, 0.5), canvasPoint({ x: 15, y: 25 }), 95, 190)
+    })
+    it('resizes a flex element from edgePosition 1, 0.5 with drag vector (15, -25)', async () => {
+      await resizeTestRow(edgePosition(1, 0.5), canvasPoint({ x: 15, y: -25 }), 95, 190)
+    })
+    it('resizes a flex element from edgePosition 1, 0.5 with drag vector (-15, 25)', async () => {
+      await resizeTestRow(edgePosition(1, 0.5), canvasPoint({ x: -15, y: 25 }), 65, 190)
+    })
+    it('resizes a flex element from edgePosition 1, 0.5 with drag vector (-15, -25)', async () => {
+      await resizeTestRow(edgePosition(1, 0.5), canvasPoint({ x: -15, y: -25 }), 65, 190)
+    })
+    it('resizes a flex element from edgePosition 0.5, 1 with drag vector (15, 25)', async () => {
+      await resizeTestRow(edgePosition(0.5, 1), canvasPoint({ x: 15, y: 25 }), 80, 215)
+    })
+    it('resizes a flex element from edgePosition 0.5, 1 with drag vector (15, -25)', async () => {
+      await resizeTestRow(edgePosition(0.5, 1), canvasPoint({ x: 15, y: -25 }), 80, 165)
+    })
+    it('resizes a flex element from edgePosition 0.5, 1 with drag vector (-15, 25)', async () => {
+      await resizeTestRow(edgePosition(0.5, 1), canvasPoint({ x: -15, y: 25 }), 80, 215)
+    })
+    it('resizes a flex element from edgePosition 0.5, 1 with drag vector (-15, -25)', async () => {
+      await resizeTestRow(edgePosition(0.5, 1), canvasPoint({ x: -15, y: -25 }), 80, 165)
+    })
   })
-  it('resizes a flex element from edgePosition 0, 0 with drag vector (15, -25)', async () => {
-    await resizeTestRow(edgePosition(0, 0), canvasPoint({ x: 15, y: -25 }), 65, 215)
-  })
-  it('resizes a flex element from edgePosition 0, 0 with drag vector (-15, 25)', async () => {
-    await resizeTestRow(edgePosition(0, 0), canvasPoint({ x: -15, y: 25 }), 95, 165)
-  })
-  it('resizes a flex element from edgePosition 0, 0 with drag vector (-15, -25)', async () => {
-    await resizeTestRow(edgePosition(0, 0), canvasPoint({ x: -15, y: -25 }), 95, 215)
-  })
-  it('resizes a flex element from edgePosition 0, 1 with drag vector (15, 25)', async () => {
-    await resizeTestRow(edgePosition(0, 1), canvasPoint({ x: 15, y: 25 }), 65, 215)
-  })
-  it('resizes a flex element from edgePosition 0, 1 with drag vector (15, -25)', async () => {
-    await resizeTestRow(edgePosition(0, 1), canvasPoint({ x: 15, y: -25 }), 65, 165)
-  })
-  it('resizes a flex element from edgePosition 0, 1 with drag vector (-15, 25)', async () => {
-    await resizeTestRow(edgePosition(0, 1), canvasPoint({ x: -15, y: 25 }), 95, 215)
-  })
-  it('resizes a flex element from edgePosition 0, 1 with drag vector (-15, -25)', async () => {
-    await resizeTestRow(edgePosition(0, 1), canvasPoint({ x: -15, y: -25 }), 95, 165)
-  })
-  it('resizes a flex element from edgePosition 1, 0 with drag vector (15, 25)', async () => {
-    await resizeTestRow(edgePosition(1, 0), canvasPoint({ x: 15, y: 25 }), 95, 165)
-  })
-  it('resizes a flex element from edgePosition 1, 0 with drag vector (15, -25)', async () => {
-    await resizeTestRow(edgePosition(1, 0), canvasPoint({ x: 15, y: -25 }), 95, 215)
-  })
-  it('resizes a flex element from edgePosition 1, 0 with drag vector (-15, 25)', async () => {
-    await resizeTestRow(edgePosition(1, 0), canvasPoint({ x: -15, y: 25 }), 65, 165)
-  })
-  it('resizes a flex element from edgePosition 1, 0 with drag vector (-15, -25)', async () => {
-    await resizeTestRow(edgePosition(1, 0), canvasPoint({ x: -15, y: -25 }), 65, 215)
-  })
-  it('resizes a flex element from edgePosition 1, 1 with drag vector (15, 25)', async () => {
-    await resizeTestRow(edgePosition(1, 1), canvasPoint({ x: 15, y: 25 }), 95, 215)
-  })
-  it('resizes a flex element from edgePosition 1, 1 with drag vector (15, -25)', async () => {
-    await resizeTestRow(edgePosition(1, 1), canvasPoint({ x: 15, y: -25 }), 95, 165)
-  })
-  it('resizes a flex element from edgePosition 1, 1 with drag vector (-15, 25)', async () => {
-    await resizeTestRow(edgePosition(1, 1), canvasPoint({ x: -15, y: 25 }), 65, 215)
-  })
-  it('resizes a flex element from edgePosition 1, 1 with drag vector (-15, -25)', async () => {
-    await resizeTestRow(edgePosition(1, 1), canvasPoint({ x: -15, y: -25 }), 65, 165)
-  })
-  // Edge tests
-  it('resizes a flex element from edgePosition 0, 0.5 with drag vector (15, 25)', async () => {
-    await resizeTestRow(edgePosition(0, 0.5), canvasPoint({ x: 15, y: 25 }), 65, 190)
-  })
-  it('resizes a flex element from edgePosition 0, 0.5 with drag vector (15, -25)', async () => {
-    await resizeTestRow(edgePosition(0, 0.5), canvasPoint({ x: 15, y: -25 }), 65, 190)
-  })
-  it('resizes a flex element from edgePosition 0, 0.5 with drag vector (-15, 25)', async () => {
-    await resizeTestRow(edgePosition(0, 0.5), canvasPoint({ x: -15, y: 25 }), 95, 190)
-  })
-  it('resizes a flex element from edgePosition 0, 0.5 with drag vector (-15, -25)', async () => {
-    await resizeTestRow(edgePosition(0, 0.5), canvasPoint({ x: -15, y: -25 }), 95, 190)
-  })
-  it('resizes a flex element from edgePosition 0.5, 0 with drag vector (15, 25)', async () => {
-    await resizeTestRow(edgePosition(0.5, 0), canvasPoint({ x: 15, y: 25 }), 80, 165)
-  })
-  it('resizes a flex element from edgePosition 0.5, 0 with drag vector (15, -25)', async () => {
-    await resizeTestRow(edgePosition(0.5, 0), canvasPoint({ x: 15, y: -25 }), 80, 215)
-  })
-  it('resizes a flex element from edgePosition 0.5, 0 with drag vector (-15, 25)', async () => {
-    await resizeTestRow(edgePosition(0.5, 0), canvasPoint({ x: -15, y: 25 }), 80, 165)
-  })
-  it('resizes a flex element from edgePosition 0.5, 0 with drag vector (-15, -25)', async () => {
-    await resizeTestRow(edgePosition(0.5, 0), canvasPoint({ x: -15, y: -25 }), 80, 215)
-  })
-  it('resizes a flex element from edgePosition 1, 0.5 with drag vector (15, 25)', async () => {
-    await resizeTestRow(edgePosition(1, 0.5), canvasPoint({ x: 15, y: 25 }), 95, 190)
-  })
-  it('resizes a flex element from edgePosition 1, 0.5 with drag vector (15, -25)', async () => {
-    await resizeTestRow(edgePosition(1, 0.5), canvasPoint({ x: 15, y: -25 }), 95, 190)
-  })
-  it('resizes a flex element from edgePosition 1, 0.5 with drag vector (-15, 25)', async () => {
-    await resizeTestRow(edgePosition(1, 0.5), canvasPoint({ x: -15, y: 25 }), 65, 190)
-  })
-  it('resizes a flex element from edgePosition 1, 0.5 with drag vector (-15, -25)', async () => {
-    await resizeTestRow(edgePosition(1, 0.5), canvasPoint({ x: -15, y: -25 }), 65, 190)
-  })
-  it('resizes a flex element from edgePosition 0.5, 1 with drag vector (15, 25)', async () => {
-    await resizeTestRow(edgePosition(0.5, 1), canvasPoint({ x: 15, y: 25 }), 80, 215)
-  })
-  it('resizes a flex element from edgePosition 0.5, 1 with drag vector (15, -25)', async () => {
-    await resizeTestRow(edgePosition(0.5, 1), canvasPoint({ x: 15, y: -25 }), 80, 165)
-  })
-  it('resizes a flex element from edgePosition 0.5, 1 with drag vector (-15, 25)', async () => {
-    await resizeTestRow(edgePosition(0.5, 1), canvasPoint({ x: -15, y: 25 }), 80, 215)
-  })
-  it('resizes a flex element from edgePosition 0.5, 1 with drag vector (-15, -25)', async () => {
-    await resizeTestRow(edgePosition(0.5, 1), canvasPoint({ x: -15, y: -25 }), 80, 165)
-  })
-})
 
-describe('Flex resize in column', () => {
-  // Corner tests
-  it('resizes a flex element from edgePosition 0, 0 with drag vector (15, 25)', async () => {
-    await resizeTestColumn(edgePosition(0, 0), canvasPoint({ x: 15, y: 25 }), 65, 165)
+  describe('Flex resize in column', () => {
+    // Corner tests
+    it('resizes a flex element from edgePosition 0, 0 with drag vector (15, 25)', async () => {
+      await resizeTestColumn(edgePosition(0, 0), canvasPoint({ x: 15, y: 25 }), 65, 165)
+    })
+    it('resizes a flex element from edgePosition 0, 0 with drag vector (15, -25)', async () => {
+      await resizeTestColumn(edgePosition(0, 0), canvasPoint({ x: 15, y: -25 }), 65, 215)
+    })
+    it('resizes a flex element from edgePosition 0, 0 with drag vector (-15, 25)', async () => {
+      await resizeTestColumn(edgePosition(0, 0), canvasPoint({ x: -15, y: 25 }), 95, 165)
+    })
+    it('resizes a flex element from edgePosition 0, 0 with drag vector (-15, -25)', async () => {
+      await resizeTestColumn(edgePosition(0, 0), canvasPoint({ x: -15, y: -25 }), 95, 215)
+    })
+    it('resizes a flex element from edgePosition 0, 1 with drag vector (15, 25)', async () => {
+      await resizeTestColumn(edgePosition(0, 1), canvasPoint({ x: 15, y: 25 }), 65, 215)
+    })
+    it('resizes a flex element from edgePosition 0, 1 with drag vector (15, -25)', async () => {
+      await resizeTestColumn(edgePosition(0, 1), canvasPoint({ x: 15, y: -25 }), 65, 165)
+    })
+    it('resizes a flex element from edgePosition 0, 1 with drag vector (-15, 25)', async () => {
+      await resizeTestColumn(edgePosition(0, 1), canvasPoint({ x: -15, y: 25 }), 95, 215)
+    })
+    it('resizes a flex element from edgePosition 0, 1 with drag vector (-15, -25)', async () => {
+      await resizeTestColumn(edgePosition(0, 1), canvasPoint({ x: -15, y: -25 }), 95, 165)
+    })
+    it('resizes a flex element from edgePosition 1, 0 with drag vector (15, 25)', async () => {
+      await resizeTestColumn(edgePosition(1, 0), canvasPoint({ x: 15, y: 25 }), 95, 165)
+    })
+    it('resizes a flex element from edgePosition 1, 0 with drag vector (15, -25)', async () => {
+      await resizeTestColumn(edgePosition(1, 0), canvasPoint({ x: 15, y: -25 }), 95, 215)
+    })
+    it('resizes a flex element from edgePosition 1, 0 with drag vector (-15, 25)', async () => {
+      await resizeTestColumn(edgePosition(1, 0), canvasPoint({ x: -15, y: 25 }), 65, 165)
+    })
+    it('resizes a flex element from edgePosition 1, 0 with drag vector (-15, -25)', async () => {
+      await resizeTestColumn(edgePosition(1, 0), canvasPoint({ x: -15, y: -25 }), 65, 215)
+    })
+    // Edge tests
+    it('resizes a flex element from edgePosition 1, 1 with drag vector (15, 25)', async () => {
+      await resizeTestColumn(edgePosition(1, 1), canvasPoint({ x: 15, y: 25 }), 95, 215)
+    })
+    it('resizes a flex element from edgePosition 1, 1 with drag vector (15, -25)', async () => {
+      await resizeTestColumn(edgePosition(1, 1), canvasPoint({ x: 15, y: -25 }), 95, 165)
+    })
+    it('resizes a flex element from edgePosition 1, 1 with drag vector (-15, 25)', async () => {
+      await resizeTestColumn(edgePosition(1, 1), canvasPoint({ x: -15, y: 25 }), 65, 215)
+    })
+    it('resizes a flex element from edgePosition 1, 1 with drag vector (-15, -25)', async () => {
+      await resizeTestColumn(edgePosition(1, 1), canvasPoint({ x: -15, y: -25 }), 65, 165)
+    })
+    it('resizes a flex element from edgePosition 0, 0.5 with drag vector (15, 25)', async () => {
+      await resizeTestColumn(edgePosition(0, 0.5), canvasPoint({ x: 15, y: 25 }), 65, 190)
+    })
+    it('resizes a flex element from edgePosition 0, 0.5 with drag vector (15, -25)', async () => {
+      await resizeTestColumn(edgePosition(0, 0.5), canvasPoint({ x: 15, y: -25 }), 65, 190)
+    })
+    it('resizes a flex element from edgePosition 0, 0.5 with drag vector (-15, 25)', async () => {
+      await resizeTestColumn(edgePosition(0, 0.5), canvasPoint({ x: -15, y: 25 }), 95, 190)
+    })
+    it('resizes a flex element from edgePosition 0, 0.5 with drag vector (-15, -25)', async () => {
+      await resizeTestColumn(edgePosition(0, 0.5), canvasPoint({ x: -15, y: -25 }), 95, 190)
+    })
+    it('resizes a flex element from edgePosition 0.5, 0 with drag vector (15, 25)', async () => {
+      await resizeTestColumn(edgePosition(0.5, 0), canvasPoint({ x: 15, y: 25 }), 80, 165)
+    })
+    it('resizes a flex element from edgePosition 0.5, 0 with drag vector (15, -25)', async () => {
+      await resizeTestColumn(edgePosition(0.5, 0), canvasPoint({ x: 15, y: -25 }), 80, 215)
+    })
+    it('resizes a flex element from edgePosition 0.5, 0 with drag vector (-15, 25)', async () => {
+      await resizeTestColumn(edgePosition(0.5, 0), canvasPoint({ x: -15, y: 25 }), 80, 165)
+    })
+    it('resizes a flex element from edgePosition 0.5, 0 with drag vector (-15, -25)', async () => {
+      await resizeTestColumn(edgePosition(0.5, 0), canvasPoint({ x: -15, y: -25 }), 80, 215)
+    })
+    it('resizes a flex element from edgePosition 1, 0.5 with drag vector (15, 25)', async () => {
+      await resizeTestColumn(edgePosition(1, 0.5), canvasPoint({ x: 15, y: 25 }), 95, 190)
+    })
+    it('resizes a flex element from edgePosition 1, 0.5 with drag vector (15, -25)', async () => {
+      await resizeTestColumn(edgePosition(1, 0.5), canvasPoint({ x: 15, y: -25 }), 95, 190)
+    })
+    it('resizes a flex element from edgePosition 1, 0.5 with drag vector (-15, 25)', async () => {
+      await resizeTestColumn(edgePosition(1, 0.5), canvasPoint({ x: -15, y: 25 }), 65, 190)
+    })
+    it('resizes a flex element from edgePosition 1, 0.5 with drag vector (-15, -25)', async () => {
+      await resizeTestColumn(edgePosition(1, 0.5), canvasPoint({ x: -15, y: -25 }), 65, 190)
+    })
+    it('resizes a flex element from edgePosition 0.5, 1 with drag vector (15, 25)', async () => {
+      await resizeTestColumn(edgePosition(0.5, 1), canvasPoint({ x: 15, y: 25 }), 80, 215)
+    })
+    it('resizes a flex element from edgePosition 0.5, 1 with drag vector (15, -25)', async () => {
+      await resizeTestColumn(edgePosition(0.5, 1), canvasPoint({ x: 15, y: -25 }), 80, 165)
+    })
+    it('resizes a flex element from edgePosition 0.5, 1 with drag vector (-15, 25)', async () => {
+      await resizeTestColumn(edgePosition(0.5, 1), canvasPoint({ x: -15, y: 25 }), 80, 215)
+    })
+    it('resizes a flex element from edgePosition 0.5, 1 with drag vector (-15, -25)', async () => {
+      await resizeTestColumn(edgePosition(0.5, 1), canvasPoint({ x: -15, y: -25 }), 80, 165)
+    })
   })
-  it('resizes a flex element from edgePosition 0, 0 with drag vector (15, -25)', async () => {
-    await resizeTestColumn(edgePosition(0, 0), canvasPoint({ x: 15, y: -25 }), 65, 215)
-  })
-  it('resizes a flex element from edgePosition 0, 0 with drag vector (-15, 25)', async () => {
-    await resizeTestColumn(edgePosition(0, 0), canvasPoint({ x: -15, y: 25 }), 95, 165)
-  })
-  it('resizes a flex element from edgePosition 0, 0 with drag vector (-15, -25)', async () => {
-    await resizeTestColumn(edgePosition(0, 0), canvasPoint({ x: -15, y: -25 }), 95, 215)
-  })
-  it('resizes a flex element from edgePosition 0, 1 with drag vector (15, 25)', async () => {
-    await resizeTestColumn(edgePosition(0, 1), canvasPoint({ x: 15, y: 25 }), 65, 215)
-  })
-  it('resizes a flex element from edgePosition 0, 1 with drag vector (15, -25)', async () => {
-    await resizeTestColumn(edgePosition(0, 1), canvasPoint({ x: 15, y: -25 }), 65, 165)
-  })
-  it('resizes a flex element from edgePosition 0, 1 with drag vector (-15, 25)', async () => {
-    await resizeTestColumn(edgePosition(0, 1), canvasPoint({ x: -15, y: 25 }), 95, 215)
-  })
-  it('resizes a flex element from edgePosition 0, 1 with drag vector (-15, -25)', async () => {
-    await resizeTestColumn(edgePosition(0, 1), canvasPoint({ x: -15, y: -25 }), 95, 165)
-  })
-  it('resizes a flex element from edgePosition 1, 0 with drag vector (15, 25)', async () => {
-    await resizeTestColumn(edgePosition(1, 0), canvasPoint({ x: 15, y: 25 }), 95, 165)
-  })
-  it('resizes a flex element from edgePosition 1, 0 with drag vector (15, -25)', async () => {
-    await resizeTestColumn(edgePosition(1, 0), canvasPoint({ x: 15, y: -25 }), 95, 215)
-  })
-  it('resizes a flex element from edgePosition 1, 0 with drag vector (-15, 25)', async () => {
-    await resizeTestColumn(edgePosition(1, 0), canvasPoint({ x: -15, y: 25 }), 65, 165)
-  })
-  it('resizes a flex element from edgePosition 1, 0 with drag vector (-15, -25)', async () => {
-    await resizeTestColumn(edgePosition(1, 0), canvasPoint({ x: -15, y: -25 }), 65, 215)
-  })
-  // Edge tests
-  it('resizes a flex element from edgePosition 1, 1 with drag vector (15, 25)', async () => {
-    await resizeTestColumn(edgePosition(1, 1), canvasPoint({ x: 15, y: 25 }), 95, 215)
-  })
-  it('resizes a flex element from edgePosition 1, 1 with drag vector (15, -25)', async () => {
-    await resizeTestColumn(edgePosition(1, 1), canvasPoint({ x: 15, y: -25 }), 95, 165)
-  })
-  it('resizes a flex element from edgePosition 1, 1 with drag vector (-15, 25)', async () => {
-    await resizeTestColumn(edgePosition(1, 1), canvasPoint({ x: -15, y: 25 }), 65, 215)
-  })
-  it('resizes a flex element from edgePosition 1, 1 with drag vector (-15, -25)', async () => {
-    await resizeTestColumn(edgePosition(1, 1), canvasPoint({ x: -15, y: -25 }), 65, 165)
-  })
-  it('resizes a flex element from edgePosition 0, 0.5 with drag vector (15, 25)', async () => {
-    await resizeTestColumn(edgePosition(0, 0.5), canvasPoint({ x: 15, y: 25 }), 65, 190)
-  })
-  it('resizes a flex element from edgePosition 0, 0.5 with drag vector (15, -25)', async () => {
-    await resizeTestColumn(edgePosition(0, 0.5), canvasPoint({ x: 15, y: -25 }), 65, 190)
-  })
-  it('resizes a flex element from edgePosition 0, 0.5 with drag vector (-15, 25)', async () => {
-    await resizeTestColumn(edgePosition(0, 0.5), canvasPoint({ x: -15, y: 25 }), 95, 190)
-  })
-  it('resizes a flex element from edgePosition 0, 0.5 with drag vector (-15, -25)', async () => {
-    await resizeTestColumn(edgePosition(0, 0.5), canvasPoint({ x: -15, y: -25 }), 95, 190)
-  })
-  it('resizes a flex element from edgePosition 0.5, 0 with drag vector (15, 25)', async () => {
-    await resizeTestColumn(edgePosition(0.5, 0), canvasPoint({ x: 15, y: 25 }), 80, 165)
-  })
-  it('resizes a flex element from edgePosition 0.5, 0 with drag vector (15, -25)', async () => {
-    await resizeTestColumn(edgePosition(0.5, 0), canvasPoint({ x: 15, y: -25 }), 80, 215)
-  })
-  it('resizes a flex element from edgePosition 0.5, 0 with drag vector (-15, 25)', async () => {
-    await resizeTestColumn(edgePosition(0.5, 0), canvasPoint({ x: -15, y: 25 }), 80, 165)
-  })
-  it('resizes a flex element from edgePosition 0.5, 0 with drag vector (-15, -25)', async () => {
-    await resizeTestColumn(edgePosition(0.5, 0), canvasPoint({ x: -15, y: -25 }), 80, 215)
-  })
-  it('resizes a flex element from edgePosition 1, 0.5 with drag vector (15, 25)', async () => {
-    await resizeTestColumn(edgePosition(1, 0.5), canvasPoint({ x: 15, y: 25 }), 95, 190)
-  })
-  it('resizes a flex element from edgePosition 1, 0.5 with drag vector (15, -25)', async () => {
-    await resizeTestColumn(edgePosition(1, 0.5), canvasPoint({ x: 15, y: -25 }), 95, 190)
-  })
-  it('resizes a flex element from edgePosition 1, 0.5 with drag vector (-15, 25)', async () => {
-    await resizeTestColumn(edgePosition(1, 0.5), canvasPoint({ x: -15, y: 25 }), 65, 190)
-  })
-  it('resizes a flex element from edgePosition 1, 0.5 with drag vector (-15, -25)', async () => {
-    await resizeTestColumn(edgePosition(1, 0.5), canvasPoint({ x: -15, y: -25 }), 65, 190)
-  })
-  it('resizes a flex element from edgePosition 0.5, 1 with drag vector (15, 25)', async () => {
-    await resizeTestColumn(edgePosition(0.5, 1), canvasPoint({ x: 15, y: 25 }), 80, 215)
-  })
-  it('resizes a flex element from edgePosition 0.5, 1 with drag vector (15, -25)', async () => {
-    await resizeTestColumn(edgePosition(0.5, 1), canvasPoint({ x: 15, y: -25 }), 80, 165)
-  })
-  it('resizes a flex element from edgePosition 0.5, 1 with drag vector (-15, 25)', async () => {
-    await resizeTestColumn(edgePosition(0.5, 1), canvasPoint({ x: -15, y: 25 }), 80, 215)
-  })
-  it('resizes a flex element from edgePosition 0.5, 1 with drag vector (-15, -25)', async () => {
-    await resizeTestColumn(edgePosition(0.5, 1), canvasPoint({ x: -15, y: -25 }), 80, 165)
+
+  describe('when the element has missing dimensions', () => {
+    describe('both missing', () => {
+      describe('horizontal movement', () => {
+        it('adds only the width', async () => {
+          await resizeWithoutDimensions(
+            edgePosition(1, 0),
+            canvasPoint({ x: 15, y: 0 }),
+            {},
+            { width: 15 },
+          )
+        })
+      })
+
+      describe('vertical movement', () => {
+        it('adds only the height', async () => {
+          await resizeWithoutDimensions(
+            edgePosition(0, 0),
+            canvasPoint({ x: 0, y: 15 }),
+            {},
+            { height: 385 },
+          )
+        })
+      })
+
+      describe('diagonal movement', () => {
+        it('adds width and height', async () => {
+          await resizeWithoutDimensions(
+            edgePosition(0, 0),
+            canvasPoint({ x: 10, y: 15 }),
+            {},
+            { width: 10, height: 385 },
+          )
+        })
+      })
+    })
+
+    describe('width missing', () => {
+      describe('horizontal movement', () => {
+        it('updates only the width', async () => {
+          await resizeWithoutDimensions(
+            edgePosition(1, 0),
+            canvasPoint({ x: 15, y: 0 }),
+            { height: 10 },
+            { height: 10, width: 15 },
+          )
+        })
+      })
+
+      describe('vertical movement', () => {
+        it('does not add the width', async () => {
+          await resizeWithoutDimensions(
+            edgePosition(0, 0),
+            canvasPoint({ x: 0, y: 15 }),
+            { height: 20 },
+            { height: 5 },
+          )
+        })
+      })
+
+      describe('diagonal movement', () => {
+        it('adds the width and updates height', async () => {
+          await resizeWithoutDimensions(
+            edgePosition(0, 0),
+            canvasPoint({ x: 10, y: 15 }),
+            { height: 20 },
+            { height: 5, width: 10 },
+          )
+        })
+      })
+    })
+
+    describe('height missing', () => {
+      describe('horizontal movement', () => {
+        it('updates only the width', async () => {
+          await resizeWithoutDimensions(
+            edgePosition(1, 0),
+            canvasPoint({ x: 15, y: 0 }),
+            { width: 15 },
+            { width: 30 },
+          )
+        })
+      })
+
+      describe('vertical movement', () => {
+        it('does not change the width', async () => {
+          await resizeWithoutDimensions(
+            edgePosition(0, 0),
+            canvasPoint({ x: 0, y: 15 }),
+            { width: 15 },
+            { width: 15, height: 385 },
+          )
+        })
+      })
+
+      describe('diagonal movement', () => {
+        it('adds the height and updates width', async () => {
+          await resizeWithoutDimensions(
+            edgePosition(0, 0),
+            canvasPoint({ x: 10, y: 15 }),
+            { width: 15 },
+            { width: 5, height: 385 },
+          )
+        })
+      })
+    })
   })
 })
 
@@ -427,6 +536,98 @@ async function resizeTestColumn(
             height: ${expextedHeight},
             backgroundColor: '#FF0000',
           }}
+        />
+        <div
+          data-uid='ddd'
+          style={{
+            width: 50,
+            height: 110,
+            backgroundColor: '#FF0000',
+          }}
+        />
+      </div>
+      `),
+  )
+}
+
+const resizeWithoutDimensions = async (
+  pos: EdgePosition,
+  dragVector: CanvasVector,
+  initialDimensions: { width?: number; height?: number },
+  expectDimensions: { width?: number; height?: number },
+) => {
+  const inputCode = makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+          position: 'relative',
+          display: 'flex',
+          gap: 10,
+        }}
+      >
+        <div
+          data-uid='bbb'
+          data-testid='bbb'
+          style={{
+            position: 'relative',
+            width: 180,
+            height: 180,
+            backgroundColor: '#d3d3d3',
+          }}
+        />
+        <div
+          data-uid='ccc'
+          style={
+            ${JSON.stringify({ backgroundColor: '#f0f', ...initialDimensions })}
+          }
+        />
+        <div
+          data-uid='ddd'
+          style={{
+            width: 50,
+            height: 110,
+            backgroundColor: '#FF0000',
+          }}
+        />
+      </div>
+    `)
+
+  const renderResult = await renderTestEditorWithCode(inputCode, 'await-first-dom-report')
+  const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/ccc`)
+
+  await dragResizeControl(renderResult, target, pos, dragVector)
+
+  expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+    makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+          position: 'relative',
+          display: 'flex',
+          gap: 10,
+        }}
+      >
+        <div
+          data-uid='bbb'
+          data-testid='bbb'
+          style={{
+            position: 'relative',
+            width: 180,
+            height: 180,
+            backgroundColor: '#d3d3d3',
+          }}
+        />
+        <div
+          data-uid='ccc'
+          style={
+            ${JSON.stringify({ backgroundColor: '#f0f', ...expectDimensions })}
+          }
         />
         <div
           data-uid='ddd'

--- a/editor/src/components/canvas/canvas-strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-resize-basic-strategy.tsx
@@ -125,47 +125,42 @@ export const flexResizeBasicStrategy: CanvasStrategy = {
 
         const makeResizeCommand = (
           name: 'width' | 'height',
-          original: number,
-          resized: number,
           parent: number | undefined,
-          dimension: number | null,
+          value: number,
         ) => {
-          const newValue = resized - (dimension != null ? original : 0)
           return adjustCssLengthProperty(
             'always',
             selectedElement,
             stylePropPathMappingFn(name, ['style']),
-            newValue,
+            value,
             parent,
             true,
           )
         }
 
+        const makeNewDimension = (original: number, resized: number, dimension?: number | null) =>
+          resized - (dimension != null ? original : 0)
+
         const resizeCommands: Array<AdjustCssLengthProperty> = []
 
-        if (edgePosition.x === 1) {
+        const newWidth = makeNewDimension(
+          originalBounds.width,
+          resizedBounds.width,
+          dimensions?.width,
+        )
+        if (dimensions?.width != null || originalBounds.width !== newWidth) {
           // it moves horizontally
-          resizeCommands.push(
-            makeResizeCommand(
-              'width',
-              originalBounds.width,
-              resizedBounds.width,
-              elementParentBounds?.width,
-              dimensions?.width || null,
-            ),
-          )
+          resizeCommands.push(makeResizeCommand('width', elementParentBounds?.width, newWidth))
         }
-        if (edgePosition.y === 1) {
+
+        const newHeight = makeNewDimension(
+          originalBounds.height,
+          resizedBounds.height,
+          dimensions?.height,
+        )
+        if (dimensions?.height != null || originalBounds.height !== newHeight) {
           // it moves vertically
-          resizeCommands.push(
-            makeResizeCommand(
-              'height',
-              originalBounds.height,
-              resizedBounds.height,
-              elementParentBounds?.height,
-              dimensions?.height || null,
-            ),
-          )
+          resizeCommands.push(makeResizeCommand('height', elementParentBounds?.height, newHeight))
         }
 
         return strategyApplicationResult([

--- a/editor/src/components/canvas/canvas-strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-resize-basic-strategy.tsx
@@ -244,7 +244,7 @@ const getDimensions = (
   ): number | null => {
     return foldEither(
       (_) => null,
-      (v) => (v != null ? v.value : null),
+      (v) => v?.value ?? null,
       getLayoutProperty(name, attrs, ['style']),
     )
   }

--- a/editor/src/components/canvas/canvas-strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-resize-basic-strategy.tsx
@@ -237,7 +237,12 @@ export function resizeWidthHeight(
   }
 }
 
-const getDimensions = (metadata: ElementInstanceMetadata) => {
+const getDimensions = (
+  metadata: ElementInstanceMetadata,
+): {
+  width: number | null
+  height: number | null
+} | null => {
   const getOffsetPropValue = (
     name: 'width' | 'height',
     attrs: PropsOrJSXAttributes,


### PR DESCRIPTION
~**Note ⚠️** there are no automated tests for this because @gbalint is already doing that work separately~ added the tests after merging master.

## Problem

The current basic flex resize messes with the dimensions if they're not defined explicitly.

## Solution

This PR does two things:
1. if the resize does not involve directly an axis, don't update its value
2. if it does, but the property is not defined for the element, use as a basis the new bounds directly so that the dimension will not either go negative when it shouldn't nor jump to `0` resulting in confusion.

Before:

https://user-images.githubusercontent.com/1081051/194295784-1c9602a2-3485-404d-b352-da160725fd33.mov

After:

https://user-images.githubusercontent.com/1081051/194295813-2b0e0de7-713a-4b52-bcbc-249fd1f0f810.mov
