### PR TITLE
Saving to Github now potentially refers to a parent commit.

### DIFF
--- a/clientmodel/lib/src/Utopia/ClientModel.hs
+++ b/clientmodel/lib/src/Utopia/ClientModel.hs
@@ -343,7 +343,8 @@ instance Arbitrary GithubRepo where
   shrink = genericShrink
 
 data ProjectGithubSettings = ProjectGithubSettings
-                           { targetRepository     :: Maybe GithubRepo
+                           { targetRepository :: Maybe GithubRepo
+                           , originCommit     :: Maybe Text
                            }
                            deriving (Eq, Show, Generic, Data, Typeable)
 

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -51,6 +51,7 @@ import {
   ModalDialog,
   OriginalFrame,
   PersistentModel,
+  ProjectGithubSettings,
   RightMenuTab,
   StoredEditorState,
   Theme,
@@ -602,6 +603,11 @@ export interface UpdateProjectContents {
   contents: ProjectContentTreeRoot
 }
 
+export interface UpdateGithubSettings {
+  action: 'UPDATE_GITHUB_SETTINGS'
+  settings: ProjectGithubSettings
+}
+
 export interface WorkerCodeUpdate {
   type: 'WORKER_CODE_UPDATE'
   filePath: string
@@ -1074,6 +1080,7 @@ export type EditorAction =
   | CloseDesignerFile
   | UpdateFile
   | UpdateProjectContents
+  | UpdateGithubSettings
   | UpdateFromWorker
   | UpdateFromCodeEditor
   | ClearParseOrPrintInFlight

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -215,6 +215,7 @@ import type {
   SetGithubState,
   SaveToGithub,
   UpdateProjectContents,
+  UpdateGithubSettings,
 } from '../action-types'
 import { EditorModes, elementInsertionSubject, Mode } from '../editor-modes'
 import type {
@@ -226,6 +227,7 @@ import type {
   LeftMenuTab,
   ModalDialog,
   OriginalFrame,
+  ProjectGithubSettings,
   RightMenuTab,
   Theme,
 } from '../store/editor-state'
@@ -961,6 +963,13 @@ export function updateProjectContents(contents: ProjectContentTreeRoot): UpdateP
   return {
     action: 'UPDATE_PROJECT_CONTENTS',
     contents: contents,
+  }
+}
+
+export function updateGithubSettings(settings: ProjectGithubSettings): UpdateGithubSettings {
+  return {
+    action: 'UPDATE_GITHUB_SETTINGS',
+    settings: settings,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -156,6 +156,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'ADD_TEXT_FILE':
     case 'UPDATE_FILE':
     case 'UPDATE_PROJECT_CONTENTS':
+    case 'UPDATE_GITHUB_SETTINGS':
     case 'UPDATE_FROM_CODE_EDITOR':
     case 'SET_MAIN_UI_FILE':
     case 'SET_PROP':

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -935,6 +935,7 @@ describe('LOAD', () => {
       },
       githubSettings: {
         targetRepository: null,
+        originCommit: null,
       },
     }
 

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -376,6 +376,7 @@ import {
   SetGithubState,
   SaveToGithub,
   UpdateProjectContents,
+  UpdateGithubSettings,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import { EditorModes, Mode, isSelectMode, isLiveMode } from '../editor-modes'
@@ -3774,6 +3775,12 @@ export const UPDATE_FNS = {
     return {
       ...editor,
       projectContents: action.contents,
+    }
+  },
+  UPDATE_GITHUB_SETTINGS: (action: UpdateGithubSettings, editor: EditorModel): EditorModel => {
+    return {
+      ...editor,
+      githubSettings: action.settings,
     }
   },
   UPDATE_FROM_WORKER: (action: UpdateFromWorker, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/actions/migrations/migrations.ts
+++ b/editor/src/components/editor/actions/migrations/migrations.ts
@@ -30,7 +30,7 @@ import {
 } from '../../../assets'
 import { isUtopiaJSXComponent } from '../../../../core/shared/element-template'
 
-export const CURRENT_PROJECT_VERSION = 8
+export const CURRENT_PROJECT_VERSION = 9
 
 export function applyMigrations(
   persistentModel: PersistentModel,
@@ -43,7 +43,8 @@ export function applyMigrations(
   const version6 = migrateFromVersion5(version5)
   const version7 = migrateFromVersion6(version6)
   const version8 = migrateFromVersion7(version7)
-  return version8
+  const version9 = migrateFromVersion8(version8)
+  return version9
 }
 
 function migrateFromVersion0(
@@ -339,6 +340,23 @@ function migrateFromVersion7(
       projectVersion: 8,
       githubSettings: {
         targetRepository: null,
+      } as any,
+    }
+  }
+}
+
+function migrateFromVersion8(
+  persistentModel: PersistentModel,
+): PersistentModel & { projectVersion: 9 } {
+  if (persistentModel.projectVersion != null && persistentModel.projectVersion !== 8) {
+    return persistentModel as any
+  } else {
+    return {
+      ...persistentModel,
+      projectVersion: 9,
+      githubSettings: {
+        ...persistentModel.githubSettings,
+        originCommit: null,
       },
     }
   }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -864,11 +864,16 @@ export function githubRepo(owner: string, repository: string): GithubRepo {
 
 export interface ProjectGithubSettings {
   targetRepository: GithubRepo | null
+  originCommit: string | null
 }
 
-export function projectGithubSettings(targetRepository: GithubRepo | null): ProjectGithubSettings {
+export function projectGithubSettings(
+  targetRepository: GithubRepo | null,
+  originCommit: string | null,
+): ProjectGithubSettings {
   return {
     targetRepository: targetRepository,
+    originCommit: originCommit,
   }
 }
 
@@ -1885,6 +1890,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     _currentAllElementProps_KILLME: {},
     githubSettings: {
       targetRepository: null,
+      originCommit: null,
     },
   }
 }
@@ -2249,6 +2255,7 @@ export function persistentModelForProjectContents(
     },
     githubSettings: {
       targetRepository: null,
+      originCommit: null,
     },
   }
 }

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -194,6 +194,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.UPDATE_FILE(action, state, dispatch, builtInDependencies)
     case 'UPDATE_PROJECT_CONTENTS':
       return UPDATE_FNS.UPDATE_PROJECT_CONTENTS(action, state)
+    case 'UPDATE_GITHUB_SETTINGS':
+      return UPDATE_FNS.UPDATE_GITHUB_SETTINGS(action, state)
     case 'UPDATE_FROM_WORKER':
       return UPDATE_FNS.UPDATE_FROM_WORKER(action, state)
     case 'UPDATE_FROM_CODE_EDITOR':

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -3010,9 +3010,11 @@ export const GithubRepoKeepDeepEquality: KeepDeepEqualityCall<GithubRepo> = comb
 )
 
 export const ProjectGithubSettingsKeepDeepEquality: KeepDeepEqualityCall<ProjectGithubSettings> =
-  combine1EqualityCall(
+  combine2EqualityCalls(
     (settings) => settings.targetRepository,
     nullableDeepEquality(GithubRepoKeepDeepEquality),
+    (settings) => settings.originCommit,
+    nullableDeepEquality(createCallWithTripleEquals<string>()),
     projectGithubSettings,
   )
 

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -117,6 +117,7 @@ async function loadProject(
     },
     githubSettings: {
       targetRepository: null,
+      originCommit: null,
     },
   }
 

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -1,11 +1,19 @@
 import { UTOPIA_BACKEND } from '../../common/env-vars'
 import urljoin from 'url-join'
-import { GithubRepo, PersistentModel } from '../../components/editor/store/editor-state'
+import {
+  GithubRepo,
+  PersistentModel,
+  projectGithubSettings,
+} from '../../components/editor/store/editor-state'
 import { trimUpToAndIncluding } from './string-utils'
 import { HEADERS, MODE } from '../../common/server'
 import { EditorDispatch } from '../../components/editor/action-types'
 import { notice } from '../../components/common/notice'
-import { showToast, updateProjectContents } from '../../components/editor/actions/action-creators'
+import {
+  showToast,
+  updateGithubSettings,
+  updateProjectContents,
+} from '../../components/editor/actions/action-creators'
 import { ProjectContentTreeRoot } from '../../components/assets'
 
 export function parseGithubProjectString(maybeProject: string): GithubRepo | null {
@@ -54,6 +62,7 @@ export type GetBranchesResponse = GetBranchesSuccess | GithubFailure
 export interface GetBranchContentSuccess {
   type: 'SUCCESS'
   content: ProjectContentTreeRoot
+  originCommit: string
 }
 
 export type GetBranchContentResponse = GetBranchContentSuccess | GithubFailure
@@ -162,6 +171,7 @@ export async function getBranchContent(
         dispatch(
           [
             updateProjectContents(responseBody.content),
+            updateGithubSettings(projectGithubSettings(githubRepo, responseBody.originCommit)),
             showToast(notice(`Updated the project with the content from ${branchName}`, 'SUCCESS')),
           ],
           'everyone',

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -37,6 +37,7 @@ export interface SaveToGithubSuccess {
   type: 'SUCCESS'
   branchName: string
   url: string
+  newCommit: string
 }
 
 export interface GithubFailure {
@@ -96,7 +97,15 @@ export async function saveProjectToGithub(
         break
       case 'SUCCESS':
         dispatch(
-          [showToast(notice(`Saved to branch ${responseBody.branchName}.`, 'INFO'))],
+          [
+            updateGithubSettings(
+              projectGithubSettings(
+                persistentModel.githubSettings.targetRepository,
+                responseBody.newCommit,
+              ),
+            ),
+            showToast(notice(`Saved to branch ${responseBody.branchName}.`, 'INFO')),
+          ],
           'everyone',
         )
         break

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -382,9 +382,10 @@ createTreeAndSaveToGithub githubResources logger metrics pool userID model = do
       createGitCommitForTree accessToken model (view (field @"sha") treeResult) parentCommits
     now <- liftIO getCurrentTime
     let branchName = toS $ formatTime defaultTimeLocale "utopia-branch-%0Y%m%d-%H%M%S" now
+    let commitSha = view (field @"sha") commitResult
     branchResult <- useAccessToken githubResources logger metrics pool userID $ \accessToken -> do
-      createGitBranchForCommit accessToken model (view (field @"sha") commitResult) branchName
-    pure (branchName, view (field @"url") branchResult)
+      createGitBranchForCommit accessToken model commitSha branchName
+    pure (branchName, view (field @"url") branchResult, commitSha)
   pure $ either responseFailureFromReason responseSuccessFromBranchNameAndURL result
 
 getGithubBranches :: (MonadIO m) => GithubAuthResources -> FastLogger -> DB.DatabaseMetrics -> DBPool -> Text -> Text -> Text -> m GetBranchesResponse

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -133,17 +133,17 @@ createCommitHandleErrorCases status | status == notFound404             = throwE
                                     | status == unprocessableEntity422  = liftIO $ fail "Unprocessable entity returned when creating tree."
                                     | otherwise                         = throwE "Unexpected error."
 
-createGitCommit :: (MonadIO m) => AccessToken -> GithubRepo -> Text -> ExceptT Text m CreateGitCommitResult
-createGitCommit accessToken GithubRepo{..} treeSha = do
+createGitCommit :: (MonadIO m) => AccessToken -> GithubRepo -> Text -> [Text] -> ExceptT Text m CreateGitCommitResult
+createGitCommit accessToken GithubRepo{..} treeSha parentCommits = do
   let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/commits"
-  let request = CreateGitCommit "Committed automatically." treeSha
+  let request = CreateGitCommit "Committed automatically." treeSha parentCommits
   callGithub postToGithub [] createCommitHandleErrorCases accessToken repoUrl request
 
-createGitCommitForTree :: (MonadIO m) => AccessToken -> PersistentModel -> Text -> ExceptT Text m CreateGitCommitResult
-createGitCommitForTree accessToken PersistentModel{..} treeSha = do
+createGitCommitForTree :: (MonadIO m) => AccessToken -> PersistentModel -> Text -> [Text] -> ExceptT Text m CreateGitCommitResult
+createGitCommitForTree accessToken PersistentModel{..} treeSha parentCommits = do
   let possibleGithubRepo = targetRepository githubSettings
   case possibleGithubRepo of
-    Just repo -> createGitCommit accessToken repo treeSha
+    Just repo -> createGitCommit accessToken repo treeSha parentCommits
     Nothing   -> throwE "No repository set on project."
 
 createBranchHandleErrorCases :: (MonadIO m) => Status -> ExceptT Text m a

--- a/server/src/Utopia/Web/Github/Types.hs
+++ b/server/src/Utopia/Web/Github/Types.hs
@@ -86,6 +86,7 @@ instance ToJSON CreateGitTreeResult where
 data CreateGitCommit = CreateGitCommit
                      { message :: Text
                      , tree    :: Text
+                     , parents :: [Text]
                      }
                      deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -248,7 +249,8 @@ instance ToJSON GitCommit where
   toJSON = genericToJSON defaultOptions
 
 data GitBranchCommit = GitBranchCommit
-                     { commit  :: GitCommit
+                     { commit :: GitCommit
+                     , sha    :: Text
                      }
                deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -313,7 +315,8 @@ instance ToJSON GetBlobResult where
 
 
 data GetBranchContentSuccess = GetBranchContentSuccess
-                         { content :: ProjectContentTreeRoot
+                         { content      :: ProjectContentTreeRoot
+                         , originCommit :: Text
                          }
                          deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -330,8 +333,8 @@ data GetBranchContentResponse = GetBranchContentResponseSuccess GetBranchContent
 getBranchContentFailureFromReason :: Text -> GetBranchContentResponse
 getBranchContentFailureFromReason failureReason = GetBranchContentResponseFailure GithubFailure{..}
 
-getBranchContentSuccessFromContent :: ProjectContentTreeRoot -> GetBranchContentResponse
-getBranchContentSuccessFromContent content = GetBranchContentResponseSuccess GetBranchContentSuccess{..}
+getBranchContentSuccessFromContent :: (ProjectContentTreeRoot, Text) -> GetBranchContentResponse
+getBranchContentSuccessFromContent (content, originCommit) = GetBranchContentResponseSuccess GetBranchContentSuccess{..}
 
 instance FromJSON GetBranchContentResponse where
   parseJSON value =

--- a/server/src/Utopia/Web/Github/Types.hs
+++ b/server/src/Utopia/Web/Github/Types.hs
@@ -135,6 +135,7 @@ instance ToJSON CreateGitBranchResult where
 data SaveToGithubSuccess = SaveToGithubSuccess
                          { branchName :: Text
                          , url        :: Text
+                         , newCommit  :: Text
                          }
                          deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -175,8 +176,8 @@ instance ToJSON SaveToGithubResponse where
 responseFailureFromReason :: Text -> SaveToGithubResponse
 responseFailureFromReason failureReason = SaveToGithubResponseFailure GithubFailure{..}
 
-responseSuccessFromBranchNameAndURL :: (Text, Text) -> SaveToGithubResponse
-responseSuccessFromBranchNameAndURL (branchName, url) = SaveToGithubResponseSuccess SaveToGithubSuccess{..}
+responseSuccessFromBranchNameAndURL :: (Text, Text, Text) -> SaveToGithubResponse
+responseSuccessFromBranchNameAndURL (branchName, url, newCommit) = SaveToGithubResponseSuccess SaveToGithubSuccess{..}
 
 data GetBranchesBranch = GetBranchesBranch
                        { name :: Text


### PR DESCRIPTION
**Problem:**
As currently implemented the save to Github functionality creates an entirely new tree with no history to it each time, which isn't particularly how git should be used and means old changes cannot be referred to.

**Fix:**
When loading from Github we store the commit that is being loaded so that if the user saves back to Github again, that commit is set as the parent when creating the new commit.

**Commit Details:**
- `originCommit` added to `ProjectGithubSettings`.
- Added `UPDATE_GITHUB_SETTINGS` editor action.
- Added migration to add the `originCommit` field.
- `originCommit` added to `GetBranchContentSuccess`.
- `createTreeAndSaveToGithub` now retrieves the possible origin commit from the model and sets it as the parent commit when creating the commit.
- `getGithubBranch` pulls the commit SHA from the branch and returns it as part of the response to the client.
- `parents` added to `CreateGitCommit` data type.
- `sha` added to `GitBranchCommit` data type.
- Added `newCommit` to `SaveToGithubSuccess`.
- `saveProjectToGithub` also dispatches `updateGithubSettings` to
  update the origin commit.
- `createTreeAndSaveToGithub` now includes the new commit SHA in the
  response