### PR TITLE
Remove arbitrary wait from test code

### DIFF
--- a/editor/src/components/canvas/canvas-panning.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-panning.spec.browser2.tsx
@@ -7,12 +7,17 @@ import {
   mouseDragFromPointToPoint,
   mouseMoveToPoint,
 } from './event-helpers.test-utils'
-import { EditorRenderResult, renderTestEditorWithProjectContent } from './ui-jsx.test-utils'
+import {
+  EditorRenderResult,
+  renderTestEditorWithProjectContent,
+  testEditorContext,
+} from './ui-jsx.test-utils'
 
 function createExampleProject(): Promise<EditorRenderResult> {
   return renderTestEditorWithProjectContent(
     contentsToTree(createComplexDefaultProjectContents()),
     'await-first-dom-report',
+    testEditorContext({}),
   )
 }
 

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-multi-file.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-multi-file.spec.browser2.tsx
@@ -10,7 +10,11 @@ import { cmdModifier } from '../../../utils/modifiers'
 import { selectComponents, setFocusedElement } from '../../editor/actions/action-creators'
 import { CanvasControlsContainerID } from '../controls/new-canvas-controls'
 import { mouseDragFromPointToPoint } from '../event-helpers.test-utils'
-import { EditorRenderResult, renderTestEditorWithProjectContent } from '../ui-jsx.test-utils'
+import {
+  EditorRenderResult,
+  renderTestEditorWithProjectContent,
+  testEditorContext,
+} from '../ui-jsx.test-utils'
 
 const defaultAbsoluteChildCode = `
 import * as React from 'react'
@@ -217,6 +221,7 @@ describe('Absolute Reparent Strategy (Multi-File)', () => {
     const renderResult = await renderTestEditorWithProjectContent(
       makeTestProjectContents(),
       'await-first-dom-report',
+      testEditorContext({}),
     )
 
     await act(() => {

--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -57,12 +57,13 @@ export function filterOldPasses(errorMessages: Array<ErrorMessage>): Array<Error
 }
 
 export const CanvasWrapperComponent = React.memo(() => {
-  const { dispatch, editorState, derivedState, userState } = useEditorState(
+  const { dispatch, editorState, derivedState, userState, effects } = useEditorState(
     (store) => ({
       dispatch: store.dispatch,
       editorState: store.editor,
       derivedState: store.derived,
       userState: store.userState,
+      effects: store.effects,
     }),
     'CanvasWrapperComponent',
   )
@@ -100,6 +101,7 @@ export const CanvasWrapperComponent = React.memo(() => {
           userState={userState}
           editor={editorState}
           model={createCanvasModelKILLME(editorState, derivedState)}
+          effects={effects}
           dispatch={dispatch}
         />
       ) : null}

--- a/editor/src/components/canvas/dom-walker-caching.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker-caching.spec.browser2.tsx
@@ -6,7 +6,7 @@ import { SaveDOMReport } from '../editor/action-types'
 import { setCanvasFrames } from '../editor/actions/action-creators'
 import CanvasActions from './canvas-actions'
 import { pinFrameChange } from './canvas-types'
-import { renderTestEditorWithProjectContent } from './ui-jsx.test-utils'
+import { renderTestEditorWithProjectContent, testEditorContext } from './ui-jsx.test-utils'
 import { act } from '@testing-library/react'
 import { wait } from '../../utils/utils.test-utils'
 
@@ -18,6 +18,7 @@ describe('Dom-walker Caching', () => {
     const renderResult = await renderTestEditorWithProjectContent(
       projectContentsTreeRoot,
       'await-first-dom-report',
+      testEditorContext({}),
     )
     // unfortunately we have to dispatch a non-action to allow the dom-walker to run for a second time.
     // It needs to run for a second time to "settle".

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -105,7 +105,6 @@ import {
 import { flushSync } from 'react-dom'
 import { shouldInspectorUpdate } from '../inspector/inspector'
 import { SampleNodeModules } from '../custom-code/code-file.test-utils'
-import { CanvasStrategy } from './canvas-strategies/canvas-strategy-types'
 import {
   MetaCanvasStrategy,
   RegisteredCanvasStrategies,
@@ -226,7 +225,12 @@ export async function renderTestEditorWithModel(
 
   const augmentedEffects: EditorEffects = {
     parseClipboardData: async (data) => {
-      editorDispatchPromises.push(new Promise((resolve) => resolve()))
+      editorDispatchPromises.push(
+        new Promise((r) => {
+          // console.log('here')
+          r()
+        }),
+      )
       return await context.effects.parseClipboardData(data)
     },
   }

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -224,6 +224,13 @@ export async function renderTestEditorWithModel(
 
   const spyCollector = emptyUiJsxCanvasContextData()
 
+  const augmentedEffects: EditorEffects = {
+    parseClipboardData: async (data) => {
+      editorDispatchPromises.push(new Promise((resolve) => resolve()))
+      return await context.effects.parseClipboardData(data)
+    },
+  }
+
   // Reset canvas globals
   resetDispatchGlobals()
   clearAllRegisteredControls()
@@ -238,6 +245,7 @@ export async function renderTestEditorWithModel(
     recordedActions.push(...actions)
     const result = editorDispatch(
       asyncTestDispatch,
+      augmentedEffects,
       actions,
       workingEditorState,
       spyCollector,
@@ -286,6 +294,7 @@ export async function renderTestEditorWithModel(
       recordedActions.push(saveDomReportAction)
       const editorWithNewMetadata = editorDispatch(
         asyncTestDispatch,
+        augmentedEffects,
         [saveDomReportAction],
         workingEditorState,
         spyCollector,
@@ -332,7 +341,7 @@ export async function renderTestEditorWithModel(
     dispatch: asyncTestDispatch,
     alreadySaved: false,
     builtInDependencies: builtInDependencies,
-    effects: context.effects,
+    effects: augmentedEffects,
   }
 
   const canvasStoreHook = create<

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -15,11 +15,10 @@ import {
 import { runLocalCanvasAction } from '../../../templates/editor-canvas'
 import { runLocalNavigatorAction } from '../../../templates/editor-navigator'
 import { optionalDeepFreeze } from '../../../utils/deep-freeze'
-import Utils from '../../../utils/utils'
 import { CanvasAction } from '../../canvas/canvas-types'
 import { LocalNavigatorAction } from '../../navigator/actions'
 import { PreviewIframeId, projectContentsUpdateMessage } from '../../preview/preview-pane'
-import { EditorAction, EditorDispatch, isLoggedIn, LoginState } from '../action-types'
+import { EditorAction, EditorDispatch, isLoggedIn } from '../action-types'
 import { isTransientAction, isUndoOrRedo, isFromVSCode } from '../actions/action-utils'
 import * as EditorActions from '../actions/action-creators'
 import * as History from '../history'
@@ -62,7 +61,7 @@ import {
   RegisteredCanvasStrategies,
 } from '../../canvas/canvas-strategies/canvas-strategies'
 import { removePathsWithDeadUIDs } from '../../../core/shared/element-path'
-import { CanvasStrategy } from '../../canvas/canvas-strategies/canvas-strategy-types'
+import { parseClipboardData } from '../../../utils/clipboard'
 
 type DispatchResultFields = {
   nothingChanged: boolean
@@ -177,6 +176,7 @@ function processAction(
       dispatch: dispatchEvent,
       alreadySaved: working.alreadySaved,
       builtInDependencies: working.builtInDependencies,
+      effects: { parseClipboardData: parseClipboardData },
     }
   }
 }
@@ -499,6 +499,7 @@ export function editorDispatch(
     ]),
     alreadySaved: alreadySaved || shouldSave,
     builtInDependencies: storedState.builtInDependencies,
+    effects: { parseClipboardData: parseClipboardData },
   }
 
   reduxDevtoolsSendActions(actionGroupsToProcess, finalStore, allTransient)
@@ -773,6 +774,7 @@ function editorDispatchInner(
       entireUpdateFinished: Promise.all([storedState.entireUpdateFinished]),
       alreadySaved: storedState.alreadySaved,
       builtInDependencies: storedState.builtInDependencies,
+      effects: { parseClipboardData: parseClipboardData },
     }
   } else {
     //empty return

--- a/editor/src/components/editor/store/editor-update.spec.tsx
+++ b/editor/src/components/editor/store/editor-update.spec.tsx
@@ -79,6 +79,7 @@ import {
   getPrintedUiJsCode,
   renderTestEditorWithProjectContent,
   TestAppUID,
+  testEditorContext,
   TestScenePath,
   TestSceneUID,
 } from '../../canvas/ui-jsx.test-utils'
@@ -622,6 +623,7 @@ describe('action DELETE_SELECTED', () => {
     const renderResult = await renderTestEditorWithProjectContent(
       contentsToTree(projectContents),
       'dont-await-first-dom-report',
+      testEditorContext({}),
     )
     const targetPath = EP.appendNewElementPath(TestScenePath, [
       'app-outer-div',

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -14,6 +14,7 @@ import {
   renderTestEditorWithCode,
   renderTestEditorWithProjectContent,
   TestAppUID,
+  testEditorContext,
   TestScenePath,
   TestSceneUID,
 } from '../../canvas/ui-jsx.test-utils'
@@ -2037,6 +2038,7 @@ describe('inspector tests with real metadata', () => {
     const renderResult = await renderTestEditorWithProjectContent(
       contentsToTree(projectContents),
       'await-first-dom-report',
+      testEditorContext({}),
     )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['app-outer-div', 'app-inner-div'])

--- a/editor/src/core/workers/parser-printer/parser-printer-uids.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-uids.spec.tsx
@@ -38,7 +38,10 @@ import {
 } from '../../../components/editor/store/editor-state'
 import { emptySet } from '../../shared/set-utils'
 import { createCodeFile } from '../../../components/custom-code/code-file.test-utils'
-import { renderTestEditorWithProjectContent } from '../../../components/canvas/ui-jsx.test-utils'
+import {
+  renderTestEditorWithProjectContent,
+  testEditorContext,
+} from '../../../components/canvas/ui-jsx.test-utils'
 import { updateFile } from '../../../components/editor/actions/action-creators'
 
 function addCodeFileToProjectContents(
@@ -221,6 +224,7 @@ describe('parseCode', () => {
     const renderResult = await renderTestEditorWithProjectContent(
       contentsToTree(projectContents),
       'dont-await-first-dom-report',
+      testEditorContext({}),
     )
 
     const uniqueIDs = getAllUniqueUids(
@@ -283,6 +287,7 @@ describe('parseCode', () => {
     const renderResult = await renderTestEditorWithProjectContent(
       contentsToTree(projectContents),
       'dont-await-first-dom-report',
+      testEditorContext({}),
     )
 
     const uniqueIDsBefore = getAllUniqueUids(

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -47,12 +47,12 @@ import {
   ElementInsertionSubject,
   elementInsertionSubject,
   elementInsertionSubjects,
-  InsertionSubject,
 } from '../components/editor/editor-modes'
 import {
   BaseSnappingThreshold,
   CanvasCursor,
   DerivedState,
+  EditorEffects,
   EditorState,
   editorStateCanvasControls,
   isOpenFileUiJs,
@@ -67,13 +67,9 @@ import {
 } from '../components/mouse-move'
 import * as EP from '../core/shared/element-path'
 import { MetadataUtils } from '../core/model/element-metadata-utils'
-import { ElementInstanceMetadataMap, JSXElement } from '../core/shared/element-template'
+import { ElementInstanceMetadataMap } from '../core/shared/element-template'
 import { ElementPath } from '../core/shared/project-file-types'
-import {
-  getActionsForClipboardItems,
-  parseClipboardData,
-  createDirectInsertImageActions,
-} from '../utils/clipboard'
+import { getActionsForClipboardItems, createDirectInsertImageActions } from '../utils/clipboard'
 import Keyboard, { KeyCharacter, KeysPressed } from '../utils/keyboard'
 import { emptyModifiers, Modifier } from '../utils/modifiers'
 import RU from '../utils/react-utils'
@@ -759,6 +755,7 @@ interface EditorCanvasProps {
   model: CanvasModel
   editor: EditorState
   userState: UserState
+  effects: EditorEffects
   dispatch: EditorDispatch
 }
 
@@ -979,7 +976,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
           const mousePosition = this.getPosition(event.nativeEvent)
 
           const getPastedImages = async () => {
-            const result = await parseClipboardData(event.dataTransfer)
+            const result = await this.props.effects.parseClipboardData(event.dataTransfer)
             // Snip out the images only from the result.
             let pastedImages: Array<ImageResult> = []
             fastForEach(result.files, (pastedFile) => {
@@ -1001,7 +998,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
               ],
               'everyone',
             )
-            const result = await parseClipboardData(event.dataTransfer)
+            const result = await this.props.effects.parseClipboardData(event.dataTransfer)
             const pastedImages = await getPastedImages()
 
             const actions = createDirectInsertImageActions(
@@ -1580,7 +1577,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
         // on macOS it seems like alt prevents the 'paste' event from being ever fired, so this is dead code here
         // needs testing if it's any help for other platforms
       } else {
-        void parseClipboardData(event.clipboardData).then((result) => {
+        void this.props.effects.parseClipboardData(event.clipboardData).then((result) => {
           const actions = getActionsForClipboardItems(
             editor.projectContents,
             editor.canvas.openFile?.filename ?? null,

--- a/editor/src/templates/image-dnd.spec.browser2.tsx
+++ b/editor/src/templates/image-dnd.spec.browser2.tsx
@@ -374,8 +374,6 @@ export var storyboard = (
   it('dragging multiple images from the "finder" works', async () => {
     FOR_TESTS_setNextGeneratedUids(['1', '2', '3'])
 
-    let dankPromise = new Promise<void>((resolve) => resolve())
-
     const files = [
       await makeImageFile(imgBase64, 'chucknorris.png'),
       await makeImageFile(imgBase64, 'budspencer.png'),
@@ -387,11 +385,7 @@ export var storyboard = (
       'await-first-dom-report',
       testEditorContext({
         effects: {
-          parseClipboardData: async (dataTransfer) => {
-            const result = await parseClipboardData(dataTransfer)
-            await dankPromise
-            return result
-          },
+          parseClipboardData: parseClipboardData,
         },
       }),
     )
@@ -415,8 +409,6 @@ export var storyboard = (
     fireEvent(canvasControlsLayer, makeDragEvent('drop', canvasControlsLayer, endPoint, files))
 
     await editor.getDispatchFollowUpActionsFinished()
-
-    await dankPromise
 
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(`import * as React from 'react'
 import { Scene, Storyboard } from 'utopia-api'

--- a/editor/src/templates/image-dnd.spec.browser2.tsx
+++ b/editor/src/templates/image-dnd.spec.browser2.tsx
@@ -410,6 +410,8 @@ export var storyboard = (
 
     await editor.getDispatchFollowUpActionsFinished()
 
+    // await wait(100000)
+
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(`import * as React from 'react'
 import { Scene, Storyboard } from 'utopia-api'
 import { App } from '/src/app.js'

--- a/editor/src/utils/clipboard.spec.tsx
+++ b/editor/src/utils/clipboard.spec.tsx
@@ -2,6 +2,7 @@ import { contentsToTree } from '../components/assets'
 import {
   renderTestEditorWithProjectContent,
   TestAppUID,
+  testEditorContext,
   TestScenePath,
   TestSceneUID,
 } from '../components/canvas/ui-jsx.test-utils'
@@ -82,6 +83,7 @@ export var Card = (props) => {
     const renderResult = await renderTestEditorWithProjectContent(
       contentsToTree(projectContents),
       'dont-await-first-dom-report',
+      testEditorContext({}),
     )
     const targetPath1 = EP.appendNewElementPath(TestScenePath, [
       'app-outer-div',


### PR DESCRIPTION
Fixes #[ticket_number]

# Problem:
Async functions that are called during event handlers cannot be awaited in test code, so `await wait(...)` has to be called with arbitrary wait times.

# Fix:
Factor out these functions to `EditorEffects`, which can be injected in test setups. The injected function pushes a promise on `editorDispatchPromises` (in `renderTestEditorWithModel`), which can be awaited as part of `getDispatchFollowUpActionsFinished`


**Commit Details:**
- create `EditorEffects` prop on `EditorStoreShared`
- thread `EditorEffects` to call sites
- update `renderTestEditorWithModel` to push a promise to `editorDispatchPromises` when a function on `EditorEffects` is called
