### PR TITLE
Refactor: simplify insertion subjects

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -145,7 +145,6 @@ function getInsertionSubjectsFromInsertMode(subject: InsertionSubject): Insertio
   switch (subject.type) {
     case 'Elements':
       return insertionSubjects(subject.elements)
-    case 'DragAndDrop':
     case 'Element':
       return insertionSubjects([subject])
     default:

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -141,21 +141,10 @@ export function pickCanvasStateFromEditorStateWithMetadata(
   }
 }
 
-function getInsertionSubjectsFromInsertMode(subject: InsertionSubject): InsertionSubjects {
-  switch (subject.type) {
-    case 'Elements':
-      return insertionSubjects(subject.elements)
-    case 'Element':
-      return insertionSubjects([subject])
-    default:
-      assertNever(subject)
-  }
-}
-
 function getInteractionTargetFromEditorState(editor: EditorState): InteractionTarget {
   switch (editor.mode.type) {
     case 'insert':
-      return getInsertionSubjectsFromInsertMode(editor.mode.subject)
+      return insertionSubjects(editor.mode.subjects)
     case 'live':
     case 'select':
       return targetPaths(editor.selectedViews)

--- a/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/drag-to-insert-strategy.tsx
@@ -11,11 +11,6 @@ import {
   strategyApplicationResult,
   targetPaths,
 } from './canvas-strategy-types'
-import {
-  DefaultInsertSize,
-  ElementInsertionSubject,
-  InsertionSubject,
-} from '../../editor/editor-modes'
 import { InteractionSession } from './interaction-state'
 import { LayoutHelpers } from '../../../core/layout/layout-helpers'
 import { isLeft } from '../../../core/shared/either'
@@ -43,6 +38,7 @@ import { ElementInstanceMetadataMap } from '../../../core/shared/element-templat
 import { cmdModifier } from '../../../utils/modifiers'
 import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
 import { FlexReparentTargetIndicator } from '../controls/select-mode/flex-reparent-target-indicator'
+import { InsertionSubject } from '../../editor/editor-modes'
 
 export function dragToInsertStrategy(
   canvasState: InteractionCanvasState,
@@ -50,8 +46,7 @@ export function dragToInsertStrategy(
   customStrategyState: CustomStrategyState,
 ): CanvasStrategy | null {
   const insertionSubjects = getInsertionSubjectsFromInteractionTarget(canvasState.interactionTarget)
-  const insertionElementSubjects = insertionSubjects.filter((s) => s.type === 'Element')
-  if (insertionElementSubjects.length === 0) {
+  if (insertionSubjects.length === 0) {
     return null
   }
 
@@ -98,7 +93,7 @@ export function dragToInsertStrategy(
         interactionSession.interactionData.drag != null
       ) {
         const insertionCommands = insertionSubjects.flatMap((s) => {
-          const size = s.type === 'Element' ? s.defaultSize : DefaultInsertSize
+          const size = s.defaultSize
           return getInsertionCommands(s, interactionSession, size)
         })
 
@@ -133,10 +128,6 @@ function getInsertionCommands(
   interactionSession: InteractionSession,
   size: Size,
 ): Array<{ command: InsertElementInsertionSubject; frame: CanvasRectangle }> {
-  if (subject.type !== 'Element') {
-    // non-element subjects are not supported
-    return []
-  }
   if (
     interactionSession.interactionData.type === 'DRAG' &&
     interactionSession.interactionData.drag != null
@@ -174,7 +165,7 @@ function getInsertionCommands(
 }
 
 function getStyleAttributesForFrameInAbsolutePosition(
-  subject: ElementInsertionSubject,
+  subject: InsertionSubject,
   frame: CanvasRectangle,
 ) {
   const updatedAttributes = LayoutHelpers.updateLayoutPropsWithFrame(

--- a/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/draw-to-insert-strategy.tsx
@@ -12,7 +12,7 @@ import {
   targetPaths,
 } from './canvas-strategy-types'
 import { boundingArea, InteractionSession } from './interaction-state'
-import { ElementInsertionSubject, insertionSubjectIsJSXElement } from '../../editor/editor-modes'
+import { InsertionSubject } from '../../editor/editor-modes'
 import { LayoutHelpers } from '../../../core/layout/layout-helpers'
 import { foldEither } from '../../../core/shared/either'
 import {
@@ -57,11 +57,10 @@ export function drawToInsertStrategy(
   customStrategyState: CustomStrategyState,
 ): CanvasStrategy | null {
   const insertionSubjects = getInsertionSubjectsFromInteractionTarget(canvasState.interactionTarget)
-  const insertionElementSubjects = insertionSubjects.filter(insertionSubjectIsJSXElement)
-  if (insertionElementSubjects.length !== 1) {
+  if (insertionSubjects.length !== 1) {
     return null
   }
-  const insertionSubject = insertionElementSubjects[0]
+  const insertionSubject = insertionSubjects[0]
   return {
     id: 'DRAW_TO_INSERT',
     name: 'Draw to insert',
@@ -224,7 +223,7 @@ function getHighlightAndReorderIndicatorCommands(
 }
 
 function getInsertionCommands(
-  subject: ElementInsertionSubject,
+  subject: InsertionSubject,
   interactionSession: InteractionSession,
   insertionSubjectSize: Size,
   sizing: 'zero-size' | 'default-size',
@@ -255,7 +254,7 @@ function getInsertionCommands(
       frame,
     )
 
-    const updatedInsertionSubject: ElementInsertionSubject = {
+    const updatedInsertionSubject: InsertionSubject = {
       ...subject,
       parent: subject.parent,
       element: {
@@ -283,7 +282,7 @@ function getInsertionCommands(
       frame,
     )
 
-    const updatedInsertionSubject: ElementInsertionSubject = {
+    const updatedInsertionSubject: InsertionSubject = {
       ...subject,
       parent: subject.parent,
       element: {
@@ -301,7 +300,7 @@ function getInsertionCommands(
 }
 
 function getStyleAttributesForFrameInAbsolutePosition(
-  subject: ElementInsertionSubject,
+  subject: InsertionSubject,
   frame: CanvasRectangle,
 ) {
   return foldEither(
@@ -329,7 +328,7 @@ function runTargetStrategiesForFreshlyInsertedElementToReparent(
   editorState: EditorState,
   customStrategyState: CustomStrategyState,
   interactionSession: InteractionSession,
-  insertionSubject: ElementInsertionSubject,
+  insertionSubject: InsertionSubject,
   frame: CanvasRectangle,
   strategyLifecycle: InteractionLifecycle,
   startingMetadata: ElementInstanceMetadataMap,
@@ -396,7 +395,7 @@ function runTargetStrategiesForFreshlyInsertedElementToResize(
   customStrategyState: CustomStrategyState,
   interactionSession: InteractionSession,
   commandLifecycle: InteractionLifecycle,
-  insertionSubject: ElementInsertionSubject,
+  insertionSubject: InsertionSubject,
   frame: CanvasRectangle,
   strategyLifecycle: InteractionLifecycle,
 ): Array<EditorStatePatch> {

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1874,57 +1874,6 @@ export function produceCanvasTransientState(
     const editorMode = editorState.mode
     switch (editorMode.type) {
       case 'insert':
-        if (
-          insertionSubjectIsJSXElement(editorMode.subject) &&
-          !isFeatureEnabled('Canvas Strategies')
-        ) {
-          const insertionElement = editorMode.subject.element
-          const importsToAdd = editorMode.subject.importsToAdd
-          const insertionParent = editorMode.subject.parent?.target ?? null
-
-          // Not actually modifying the underlying target, but we'll exploit the functionality.
-          modifyUnderlyingTarget(
-            insertionParent,
-            currentOpenFile,
-            editorState,
-            (element) => element,
-            (parseSuccess, underlying, underlyingFilePath) => {
-              const openComponents = getUtopiaJSXComponentsFromSuccess(parseSuccess)
-
-              const updatedComponents = insertJSXElementChild(
-                editorState.projectContents,
-                currentOpenFile,
-                underlying,
-                insertionElement,
-                openComponents,
-                {
-                  type: 'front',
-                },
-              )
-              const updatedImports: Imports = mergeImports(
-                underlyingFilePath,
-                parseSuccess.imports,
-                importsToAdd,
-              )
-
-              // Sync these back up.
-              const topLevelElements = applyUtopiaJSXComponentsChanges(
-                parseSuccess.topLevelElements,
-                updatedComponents,
-              )
-
-              transientState = transientCanvasState(
-                editorState.selectedViews,
-                editorState.highlightedViews,
-                {
-                  [underlyingFilePath]: transientFileState(topLevelElements, updatedImports),
-                },
-                [],
-              )
-              return parseSuccess
-            },
-          )
-        }
         break
       case 'select':
         if (

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1873,6 +1873,9 @@ export function produceCanvasTransientState(
     const editorMode = editorState.mode
     switch (editorMode.type) {
       case 'insert':
+        if (!isFeatureEnabled('Canvas Strategies')) {
+          throw Error('Insert mode is not supported with disabled Canvas Strategies feature switch')
+        }
         break
       case 'select':
         if (

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -123,7 +123,6 @@ import {
   Size,
   vectorDifference,
 } from '../../core/shared/math-utils'
-import { insertionSubjectIsJSXElement } from '../editor/editor-modes'
 import {
   DerivedState,
   EditorState,

--- a/editor/src/components/canvas/commands/insert-element-insertion-subject.ts
+++ b/editor/src/components/canvas/commands/insert-element-insertion-subject.ts
@@ -4,7 +4,7 @@ import * as EP from '../../../core/shared/element-path'
 import { optionalMap } from '../../../core/shared/optional-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { mergeImports } from '../../../core/workers/common/project-file-utils'
-import { ElementInsertionSubject } from '../../editor/editor-modes'
+import { InsertionSubject } from '../../editor/editor-modes'
 import {
   EditorState,
   EditorStatePatch,
@@ -15,12 +15,12 @@ import { BaseCommand, CommandFunction, getPatchForComponentChange, WhenToRun } f
 
 export interface InsertElementInsertionSubject extends BaseCommand {
   type: 'INSERT_ELEMENT_INSERTION_SUBJECT'
-  subject: ElementInsertionSubject
+  subject: InsertionSubject
 }
 
 export function insertElementInsertionSubject(
   whenToRun: WhenToRun,
-  subject: ElementInsertionSubject,
+  subject: InsertionSubject,
 ): InsertElementInsertionSubject {
   return {
     type: 'INSERT_ELEMENT_INSERTION_SUBJECT',

--- a/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.tsx
@@ -25,9 +25,11 @@ function useGetHighlightableViewsForInsertMode() {
     if (isInsertMode(mode)) {
       const allPaths = MetadataUtils.getAllPaths(componentMetadata)
       const insertTargets = allPaths.filter((path) => {
-        return (
-          insertionSubjectIsJSXElement(mode.subject) &&
-          MetadataUtils.targetSupportsChildren(projectContents, openFile, componentMetadata, path)
+        return MetadataUtils.targetSupportsChildren(
+          projectContents,
+          openFile,
+          componentMetadata,
+          path,
         )
       })
       return insertTargets

--- a/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.tsx
@@ -3,7 +3,7 @@ import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
 import { NO_OP } from '../../../../core/shared/utils'
 import { useKeepShallowReferenceEquality } from '../../../../utils/react-performance'
-import { insertionSubjectIsJSXElement, isInsertMode } from '../../../editor/editor-modes'
+import { isInsertMode } from '../../../editor/editor-modes'
 import { useRefEditorState } from '../../../editor/store/store-hook'
 import { useHighlightCallbacks } from './select-mode-hooks'
 

--- a/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.tsx
@@ -3,11 +3,7 @@ import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
 import { NO_OP } from '../../../../core/shared/utils'
 import { useKeepShallowReferenceEquality } from '../../../../utils/react-performance'
-import {
-  insertionSubjectIsDragAndDrop,
-  insertionSubjectIsJSXElement,
-  isInsertMode,
-} from '../../../editor/editor-modes'
+import { insertionSubjectIsJSXElement, isInsertMode } from '../../../editor/editor-modes'
 import { useRefEditorState } from '../../../editor/store/store-hook'
 import { useHighlightCallbacks } from './select-mode-hooks'
 
@@ -30,8 +26,7 @@ function useGetHighlightableViewsForInsertMode() {
       const allPaths = MetadataUtils.getAllPaths(componentMetadata)
       const insertTargets = allPaths.filter((path) => {
         return (
-          (insertionSubjectIsJSXElement(mode.subject) ||
-            insertionSubjectIsDragAndDrop(mode.subject)) &&
+          insertionSubjectIsJSXElement(mode.subject) &&
           MetadataUtils.targetSupportsChildren(projectContents, openFile, componentMetadata, path)
         )
       })

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -458,7 +458,7 @@ export function enableInsertModeForJSXElement(
   size: Size | null,
 ): SwitchEditorMode {
   return switchEditorMode(
-    EditorModes.insertMode(elementInsertionSubject(uid, element, size, importsToAdd, null)),
+    EditorModes.insertMode([elementInsertionSubject(uid, element, size, importsToAdd, null)]),
   )
 }
 

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -210,7 +210,7 @@ import type {
   UpdateProjectContents,
   UpdateGithubSettings,
 } from '../action-types'
-import { EditorModes, elementInsertionSubject, Mode } from '../editor-modes'
+import { EditorModes, insertionSubject, Mode } from '../editor-modes'
 import type {
   DuplicationState,
   ErrorMessages,
@@ -458,7 +458,7 @@ export function enableInsertModeForJSXElement(
   size: Size | null,
 ): SwitchEditorMode {
   return switchEditorMode(
-    EditorModes.insertMode([elementInsertionSubject(uid, element, size, importsToAdd, null)]),
+    EditorModes.insertMode([insertionSubject(uid, element, size, importsToAdd, null)]),
   )
 }
 

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -32,8 +32,6 @@ import {
   StoryboardFilePath,
 } from './store/editor-state'
 import { useEditorState, useRefEditorState } from './store/store-hook'
-import { isParsedTextFile } from '../../core/shared/project-file-types'
-import { isLiveMode, dragAndDropInsertionSubject, EditorModes, isSelectMode } from './editor-modes'
 import { Toast } from '../common/notices'
 import { chrome as isChrome } from 'platform-detect'
 import { applyShortcutConfigurationToDefaults } from './shortcut-definitions'

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -9,8 +9,7 @@ import type { Size } from '../../core/shared/math-utils'
 
 export const DefaultInsertSize: Size = { width: 100, height: 100 }
 
-export interface ElementInsertionSubject {
-  type: 'Element'
+export interface InsertionSubject {
   uid: string
   element: JSXElement
   defaultSize: Size
@@ -18,15 +17,14 @@ export interface ElementInsertionSubject {
   parent: InsertionParent
 }
 
-export function elementInsertionSubject(
+export function insertionSubject(
   uid: string,
   element: JSXElement,
   size: Size | null,
   importsToAdd: Imports,
   parent: InsertionParent,
-): ElementInsertionSubject {
+): InsertionSubject {
   return {
-    type: 'Element',
     uid: uid,
     element: element,
     defaultSize: size ?? DefaultInsertSize,
@@ -45,14 +43,6 @@ export function imageInsertionSubject(file: ImageFile, path: string): ImageInser
     file: file,
     path: path,
   }
-}
-
-export type InsertionSubject = ElementInsertionSubject
-
-export function insertionSubjectIsJSXElement(
-  insertionSubject: InsertionSubject,
-): insertionSubject is ElementInsertionSubject {
-  return insertionSubject.type === 'Element'
 }
 
 export interface TargetedInsertionParent {

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -7,6 +7,8 @@ import type {
 import type { JSXElement } from '../../core/shared/element-template'
 import type { Size } from '../../core/shared/math-utils'
 
+export const DefaultInsertSize: Size = { width: 100, height: 100 }
+
 export interface ElementInsertionSubject {
   type: 'Element'
   uid: string
@@ -15,13 +17,6 @@ export interface ElementInsertionSubject {
   importsToAdd: Imports
   parent: InsertionParent
 }
-
-export interface ElementInsertionSubjects {
-  type: 'Elements'
-  elements: Array<ElementInsertionSubject>
-}
-
-export const DefaultInsertSize: Size = { width: 100, height: 100 }
 
 export function elementInsertionSubject(
   uid: string,
@@ -40,15 +35,6 @@ export function elementInsertionSubject(
   }
 }
 
-export function elementInsertionSubjects(
-  elements: Array<ElementInsertionSubject>,
-): ElementInsertionSubjects {
-  return {
-    type: 'Elements',
-    elements: elements,
-  }
-}
-
 export interface ImageInsertionSubject {
   file: ImageFile
   path: string
@@ -61,7 +47,7 @@ export function imageInsertionSubject(file: ImageFile, path: string): ImageInser
   }
 }
 
-export type InsertionSubject = ElementInsertionSubject | ElementInsertionSubjects
+export type InsertionSubject = ElementInsertionSubject
 
 export function insertionSubjectIsJSXElement(
   insertionSubject: InsertionSubject,
@@ -102,7 +88,7 @@ export function insertionParent(
 
 export interface InsertMode {
   type: 'insert'
-  subject: InsertionSubject
+  subjects: Array<InsertionSubject>
 }
 
 export interface SelectMode {
@@ -119,10 +105,10 @@ export type Mode = InsertMode | SelectMode | LiveCanvasMode
 export type PersistedMode = SelectMode | LiveCanvasMode
 
 export const EditorModes = {
-  insertMode: function (subject: InsertionSubject): InsertMode {
+  insertMode: function (subjects: Array<InsertionSubject>): InsertMode {
     return {
       type: 'insert',
-      subject: subject,
+      subjects: subjects,
     }
   },
   selectMode: function (controlId: string | null = null): SelectMode {

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -21,11 +21,6 @@ export interface ElementInsertionSubjects {
   elements: Array<ElementInsertionSubject>
 }
 
-export interface DragAndDropInsertionSubject {
-  type: 'DragAndDrop'
-  imageAssets: Array<ImageInsertionSubject>
-}
-
 export const DefaultInsertSize: Size = { width: 100, height: 100 }
 
 export function elementInsertionSubject(
@@ -66,30 +61,12 @@ export function imageInsertionSubject(file: ImageFile, path: string): ImageInser
   }
 }
 
-export function dragAndDropInsertionSubject(
-  assets: Array<ImageInsertionSubject>,
-): DragAndDropInsertionSubject {
-  return {
-    type: 'DragAndDrop',
-    imageAssets: assets,
-  }
-}
-
-export type InsertionSubject =
-  | ElementInsertionSubject
-  | ElementInsertionSubjects
-  | DragAndDropInsertionSubject
+export type InsertionSubject = ElementInsertionSubject | ElementInsertionSubjects
 
 export function insertionSubjectIsJSXElement(
   insertionSubject: InsertionSubject,
 ): insertionSubject is ElementInsertionSubject {
   return insertionSubject.type === 'Element'
-}
-
-export function insertionSubjectIsDragAndDrop(
-  insertionSubject: InsertionSubject,
-): insertionSubject is DragAndDropInsertionSubject {
-  return insertionSubject.type === 'DragAndDrop'
 }
 
 export interface TargetedInsertionParent {

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -177,11 +177,8 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
 
   render() {
     let currentlyBeingInserted: ComponentBeingInserted | null = null
-    if (
-      this.props.mode.type === 'insert' &&
-      insertionSubjectIsJSXElement(this.props.mode.subject)
-    ) {
-      const insertionSubject: ElementInsertionSubject = this.props.mode.subject
+    if (this.props.mode.type === 'insert' && this.props.mode.subjects.length === 1) {
+      const insertionSubject: ElementInsertionSubject = this.props.mode.subjects[0]
       currentlyBeingInserted = componentBeingInserted(
         insertionSubject.importsToAdd,
         insertionSubject.element.name,

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -26,8 +26,7 @@ import Utils from '../../utils/utils'
 import { FontSettings } from '../inspector/common/css-utils'
 import { EditorAction, EditorDispatch } from './action-types'
 import { enableInsertModeForJSXElement } from './actions/action-creators'
-import { ElementInsertionSubject, Mode, insertionSubjectIsJSXElement } from './editor-modes'
-import { insertImage } from './image-insert'
+import { InsertionSubject, Mode } from './editor-modes'
 import { getOpenFilename } from './store/editor-state'
 import { useEditorState } from './store/store-hook'
 import { WarningIcon } from '../../uuiui/warning-icon'
@@ -178,7 +177,7 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
   render() {
     let currentlyBeingInserted: ComponentBeingInserted | null = null
     if (this.props.mode.type === 'insert' && this.props.mode.subjects.length === 1) {
-      const insertionSubject: ElementInsertionSubject = this.props.mode.subjects[0]
+      const insertionSubject: InsertionSubject = this.props.mode.subjects[0]
       currentlyBeingInserted = componentBeingInserted(
         insertionSubject.importsToAdd,
         insertionSubject.element.name,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -380,8 +380,6 @@ import {
   FileEvaluationCache,
 } from '../../../core/es-modules/package-manager/package-manager'
 import {
-  dragAndDropInsertionSubject,
-  DragAndDropInsertionSubject,
   ImageInsertionSubject,
   EditorModes,
   elementInsertionSubject,
@@ -2573,13 +2571,6 @@ export const ImageInsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<ImageIn
     imageInsertionSubject,
   )
 
-export const DragAndDropInsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<DragAndDropInsertionSubject> =
-  combine1EqualityCall(
-    (subject) => subject.imageAssets,
-    arrayDeepEquality(ImageInsertionSubjectKeepDeepEquality),
-    dragAndDropInsertionSubject,
-  )
-
 export const InsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<InsertionSubject> = (
   oldValue,
   newValue,
@@ -2588,11 +2579,6 @@ export const InsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<InsertionSub
     case 'Element':
       if (newValue.type === oldValue.type) {
         return ElementInsertionSubjectKeepDeepEquality(oldValue, newValue)
-      }
-      break
-    case 'DragAndDrop':
-      if (newValue.type === oldValue.type) {
-        return DragAndDropInsertionSubjectKeepDeepEquality(oldValue, newValue)
       }
       break
     case 'Elements':

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -392,8 +392,6 @@ import {
   targetedInsertionParent,
   TargetedInsertionParent,
   imageInsertionSubject,
-  ElementInsertionSubjects,
-  elementInsertionSubjects,
 } from '../editor-modes'
 import { EditorPanel } from '../../common/actions'
 import { notice, Notice, NoticeLevel } from '../../common/notice'
@@ -2553,15 +2551,6 @@ export const ElementInsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<Eleme
     elementInsertionSubject,
   )
 
-export const ElementInsertionSubjectsKeepDeepEquality: KeepDeepEqualityCall<ElementInsertionSubjects> =
-  combine2EqualityCalls(
-    (s) => s.elements,
-    arrayDeepEquality(ElementInsertionSubjectKeepDeepEquality),
-    (s) => s.type,
-    StringKeepDeepEquality,
-    elementInsertionSubjects,
-  )
-
 export const ImageInsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<ImageInsertionSubject> =
   combine2EqualityCalls(
     (s) => s.file,
@@ -2581,21 +2570,16 @@ export const InsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<InsertionSub
         return ElementInsertionSubjectKeepDeepEquality(oldValue, newValue)
       }
       break
-    case 'Elements':
-      if (newValue.type === oldValue.type) {
-        return ElementInsertionSubjectsKeepDeepEquality(oldValue, newValue)
-      }
-      break
-    default:
-      const _exhaustiveCheck: never = oldValue
-      throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
+    // default:
+    //   const _exhaustiveCheck: never = oldValue
+    //   throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
   }
   return keepDeepEqualityResult(newValue, false)
 }
 
 export const InsertModeKeepDeepEquality: KeepDeepEqualityCall<InsertMode> = combine1EqualityCall(
-  (mode) => mode.subject,
-  InsertionSubjectKeepDeepEquality,
+  (mode) => mode.subjects,
+  arrayDeepEquality(InsertionSubjectKeepDeepEquality),
   EditorModes.insertMode,
 )
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -382,8 +382,7 @@ import {
 import {
   ImageInsertionSubject,
   EditorModes,
-  elementInsertionSubject,
-  ElementInsertionSubject,
+  insertionSubject,
   InsertionSubject,
   InsertMode,
   LiveCanvasMode,
@@ -2536,7 +2535,7 @@ export const SizeKeepDeepEquality: KeepDeepEqualityCall<Size> = combine2Equality
   size,
 )
 
-export const ElementInsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<ElementInsertionSubject> =
+export const InsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<InsertionSubject> =
   combine5EqualityCalls(
     (subject) => subject.uid,
     StringKeepDeepEquality,
@@ -2548,7 +2547,7 @@ export const ElementInsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<Eleme
     objectDeepEquality(ImportDetailsKeepDeepEquality),
     (subject) => subject.parent,
     nullableDeepEquality(TargetedInsertionParentKeepDeepEquality),
-    elementInsertionSubject,
+    insertionSubject,
   )
 
 export const ImageInsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<ImageInsertionSubject> =
@@ -2559,23 +2558,6 @@ export const ImageInsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<ImageIn
     StringKeepDeepEquality,
     imageInsertionSubject,
   )
-
-export const InsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<InsertionSubject> = (
-  oldValue,
-  newValue,
-) => {
-  switch (oldValue.type) {
-    case 'Element':
-      if (newValue.type === oldValue.type) {
-        return ElementInsertionSubjectKeepDeepEquality(oldValue, newValue)
-      }
-      break
-    // default:
-    //   const _exhaustiveCheck: never = oldValue
-    //   throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
-  }
-  return keepDeepEqualityResult(newValue, false)
-}
 
 export const InsertModeKeepDeepEquality: KeepDeepEqualityCall<InsertMode> = combine1EqualityCall(
   (mode) => mode.subjects,

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -42,10 +42,7 @@ import {
   EditorModes,
   Mode,
   isLiveMode,
-  InsertMode,
-  insertionSubjectIsJSXElement,
-  ElementInsertionSubject,
-  elementInsertionSubject,
+  insertionSubject,
   InsertionSubject,
 } from '../components/editor/editor-modes'
 import {
@@ -1601,7 +1598,7 @@ interface ActionsForDroppedImageContext {
 
 interface ActionForDroppedImageResult {
   actions: EditorAction[]
-  singleSubject: ElementInsertionSubject
+  singleSubject: InsertionSubject
 }
 
 function actionsForDroppedImage(
@@ -1645,12 +1642,12 @@ function actionsForDroppedImage(
   })
   return {
     actions: saveImageActions,
-    singleSubject: elementInsertionSubject(newUID, newElement, elementSize, {}, null),
+    singleSubject: insertionSubject(newUID, newElement, elementSize, {}, null),
   }
 }
 
 interface ActionsForDroppedImagesResult {
-  subjects: Array<ElementInsertionSubject>
+  subjects: Array<InsertionSubject>
   actions: Array<EditorAction>
 }
 
@@ -1667,7 +1664,7 @@ function actionsForDroppedImages(
 ): ActionsForDroppedImagesResult {
   let actions: Array<EditorAction> = []
   let uidsSoFar: Array<string> = []
-  let subjects: Array<ElementInsertionSubject> = []
+  let subjects: Array<InsertionSubject> = []
   for (const image of images) {
     const { actions: actionsForImage, singleSubject } = actionsForDroppedImage(image, {
       generateUid: () =>

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -1019,21 +1019,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
           if (this.props.editor.mode.type === 'select') {
             const insertionTarget = this.props.editor.highlightedViews[0]
             return insertImageFromClipboard(insertionTarget)
-          }
-
-          if (
-            this.props.editor.mode.type === 'insert' &&
-            this.props.editor.mode.subject.type === 'DragAndDrop' &&
-            this.props.editor.mode.subject.imageAssets == null
-          ) {
-            const insertionTarget = this.props.editor.highlightedViews[0]
-            return insertImageFromClipboard(insertionTarget)
-          }
-
-          if (
-            this.props.editor.mode.type === 'insert' &&
-            this.props.editor.mode.subject.type === 'Element'
-          ) {
+          } else if (this.props.editor.mode.type === 'insert') {
             void getPastedImages().then((images) => {
               if (images.length === 0) {
                 return this.props.dispatch([
@@ -1068,25 +1054,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
               this.handleMouseUp(event.nativeEvent)
             })
           }
-
-          if (
-            this.props.editor.mode.type === 'insert' &&
-            this.props.editor.mode.subject.type === 'DragAndDrop' &&
-            this.props.editor.mode.subject.imageAssets != null
-          ) {
-            let actions: Array<EditorAction> = []
-            fastForEach(this.props.editor.mode.subject.imageAssets, (imageAsset) => {
-              actions.push(
-                EditorActions.insertDroppedImage(
-                  imageAsset.file,
-                  imageAsset.path,
-                  mousePosition.canvasPositionRounded,
-                ),
-              )
-            })
-            actions.push(EditorActions.switchEditorMode(EditorModes.selectMode()))
-            return this.props.dispatch(actions, 'everyone')
-          }
+          return
         },
 
         onWheel: (event) => {

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -46,7 +46,6 @@ import {
   insertionSubjectIsJSXElement,
   ElementInsertionSubject,
   elementInsertionSubject,
-  elementInsertionSubjects,
   InsertionSubject,
 } from '../components/editor/editor-modes'
 import {
@@ -227,16 +226,14 @@ function handleCanvasEvent(
 
       optionalDragStateAction = cancelInsertModeActions(shouldApplyChanges)
     } else if (event.event === 'MOUSE_DOWN') {
-      if (insertionSubjectIsJSXElement((model.editorState.mode as InsertMode).subject)) {
-        optionalDragStateAction = [
-          CanvasActions.createInteractionSession(
-            createInteractionViaMouse(event.canvasPositionRounded, event.modifiers, {
-              type: 'RESIZE_HANDLE',
-              edgePosition: { x: 1, y: 1 },
-            }),
-          ),
-        ]
-      }
+      optionalDragStateAction = [
+        CanvasActions.createInteractionSession(
+          createInteractionViaMouse(event.canvasPositionRounded, event.modifiers, {
+            type: 'RESIZE_HANDLE',
+            edgePosition: { x: 1, y: 1 },
+          }),
+        ),
+      ]
     }
   } else if (!(insertMode && isOpenFileUiJs(model.editorState))) {
     switch (event.event) {
@@ -879,14 +876,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
 
   getModeSpecificCursor(): CSSCursor | null {
     if (this.props.editor.mode.type === 'insert') {
-      if (
-        this.props.editor.mode.subject != null &&
-        Utils.path(['superType', 'template'], this.props.editor.mode.subject) === 'text'
-      ) {
-        return CSSCursor.TextInsert
-      } else {
-        return CSSCursor.Insert
-      }
+      return CSSCursor.Insert
     } else {
       return null
     }
@@ -1042,12 +1032,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
               })
 
               this.props.dispatch(
-                [
-                  ...actions,
-                  EditorActions.switchEditorMode(
-                    EditorModes.insertMode(elementInsertionSubjects(subjects)),
-                  ),
-                ],
+                [...actions, EditorActions.switchEditorMode(EditorModes.insertMode(subjects))],
                 'everyone',
               )
               this.handleMouseMove(event.nativeEvent)


### PR DESCRIPTION
With the new insert mode `InsertionSubjects` types can be simplified:

- `DragAndDropInsertionSubject` is not used anymore
- `ElementInsertionSubjects` are just an array of `ElementInsertionSubject` 
- Because only `ElementInsertionSubject` remained in `InsertionSubject` we don't need a union type anymore

Note:
I did not refactor the insert case in `produceCanvasTransientState`, because insert mode without the Canvas strategies feature switch is fully broken anyway.