### PR TITLE
List all branches for a given repository.

### DIFF
--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -835,21 +835,28 @@ const GithubPane = React.memo(() => {
                   <span>NOTE: These will replace the current project contents.</span>
                 </UIGridRow>,
               )}
-              {branchesForRepository.branches.map((branch, index) => {
-                function loadContentForBranch() {
-                  if (parsedTargetRepository != null) {
-                    void getBranchContent(dispatch, parsedTargetRepository, branch.name)
-                  }
-                }
-                return (
-                  <UIGridRow key={index} padded variant='<--------auto-------->|--45px--|'>
-                    <span>{branch.name}</span>
-                    <Button spotlight highlight onMouseUp={loadContentForBranch}>
-                      Load
-                    </Button>
-                  </UIGridRow>
-                )
-              })}
+              {when(
+                branchesForRepository.branches.length > 0,
+                <div
+                  style={{ overflowY: 'auto', height: UtopiaTheme.layout.rowHeight.normal * 11.5 }}
+                >
+                  {branchesForRepository.branches.map((branch, index) => {
+                    function loadContentForBranch() {
+                      if (parsedTargetRepository != null) {
+                        void getBranchContent(dispatch, parsedTargetRepository, branch.name)
+                      }
+                    }
+                    return (
+                      <UIGridRow key={index} padded variant='<--------auto-------->|--45px--|'>
+                        <span>{branch.name}</span>
+                        <Button spotlight highlight onMouseUp={loadContentForBranch}>
+                          Load
+                        </Button>
+                      </UIGridRow>
+                    )
+                  })}
+                </div>,
+              )}
             </>
           )
 

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -167,10 +167,10 @@ getGitBranchesErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
 getGitBranchesErrorCases status | status == notFound404  = throwE "Could not find repository."
                                     | otherwise                         = throwE "Unexpected error."
 
-getGitBranches :: (MonadIO m) => AccessToken -> Text -> Text -> ExceptT Text m GetBranchesResult
-getGitBranches accessToken owner repository = do
+getGitBranches :: (MonadIO m) => AccessToken -> Text -> Text -> Int -> ExceptT Text m GetBranchesResult
+getGitBranches accessToken owner repository page = do
   let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/branches"
-  callGithub getFromGithub [] getGitBranchesErrorCases accessToken repoUrl ()
+  callGithub getFromGithub [("per_page", "100"), ("page", show page)] getGitBranchesErrorCases accessToken repoUrl ()
 
 getGitBranchErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
 getGitBranchErrorCases status | status == notFound404  = throwE "Could not find branch."

--- a/server/src/Utopia/Web/Github/Types.hs
+++ b/server/src/Utopia/Web/Github/Types.hs
@@ -24,6 +24,7 @@ import qualified Data.HashMap.Strict        as M
 import qualified Data.Text                  as T
 import           Data.Text.Encoding
 import           Data.Text.Encoding.Base64
+import           Data.Time.Clock
 import           Data.Typeable
 import           Network.HTTP.Types.Status
 import           Network.OAuth.OAuth2
@@ -238,8 +239,22 @@ instance FromJSON GitCommitTree where
 instance ToJSON GitCommitTree where
   toJSON = genericToJSON defaultOptions
 
+data GitAuthor = GitAuthor
+                   { name  :: Text
+                   , email :: Text
+                   , date  :: UTCTime
+                   }
+               deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON GitAuthor where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON GitAuthor where
+  toJSON = genericToJSON defaultOptions
+
 data GitCommit = GitCommit
-               { tree  :: GitCommitTree
+               { tree   :: GitCommitTree
+               , author :: GitAuthor
                }
                deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -262,7 +277,8 @@ instance ToJSON GitBranchCommit where
   toJSON = genericToJSON defaultOptions
 
 data GetBranchResult = GetBranchResult
-                     { commit     :: GitBranchCommit
+                     { commit :: GitBranchCommit
+                     , name   :: Text
                      }
                deriving (Eq, Show, Generic, Data, Typeable)
 


### PR DESCRIPTION
**Problem:**
Currently the branch listing just gets the first page of branches and no more.

**Fix:**
Retrieve all the branches by making use of the "pagination" built into the list branches API that Github provides.

**Commit Details:**
- `getGitBranches` now supplies the query parameter `per_page` maximum value of 100 and a `page` parameter.
- `getGithubBranches` now creates a `Conduit` of results which are "unfolded" from page 1 until the call returns no entries.
- Branches are now sorted in `getGithubBranches`.
- Wrapped the branch listing in a div, which has a height that isn't a whole multiple of the row height so that it hints at being scrollable.