### PR TITLE
Flex resize use resizeBoundingBox

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -42,13 +42,11 @@ import {
   AbsolutePin,
   ensureAtLeastTwoPinsForEdgePosition,
   getLockedAspectRatio,
-  supportsAbsoluteResize,
-} from './resize-helpers'
-import {
   pickCursorFromEdgePosition,
   resizeBoundingBox,
-  runLegacyAbsoluteResizeSnapping,
-} from './shared-absolute-resize-strategy-helpers'
+  supportsAbsoluteResize,
+} from './resize-helpers'
+import { runLegacyAbsoluteResizeSnapping } from './shared-absolute-resize-strategy-helpers'
 import { getDragTargets, getMultiselectBounds } from './shared-move-strategies-helpers'
 
 export function absoluteResizeBoundingBoxStrategy(

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -1983,119 +1983,174 @@ describe('Inserting into flex column', () => {
 })
 
 describe('Inserting an image', () => {
-  const inputCode = makeTestProjectCodeWithSnippet(`
-    <div
-      data-uid='aaa'
-      style={{
-        width: '100%',
-        height: '100%',
-        backgroundColor: '#FFFFFF',
-        position: 'relative',
-      }}
-    >
-      <div
-        data-uid='bbb'
-        data-testid='bbb'
-        style={{
-          position: 'absolute',
-          left: 10,
-          top: 10,
-          width: 380,
-          height: 180,
-          backgroundColor: '#d3d3d3',
-        }}
-      />
-      <div
-        data-uid='ccc'
-        style={{
-          position: 'absolute',
-          left: 10,
-          top: 200,
-          width: 380,
-          height: 190,
-          backgroundColor: '#FF0000',
-        }}
-      />
-    </div>
-  `)
-
   it('Draw to insert to an absolute layout keeps aspect ratio', async () => {
-    const renderResult = await setupInsertTest(inputCode)
-    await enterInsertModeFromInsertMenu(renderResult, 'img')
-
-    const targetElement = renderResult.renderedDOM.getByTestId('bbb')
-    const targetElementBounds = targetElement.getBoundingClientRect()
-    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
-
-    const startPoint = slightlyOffsetWindowPointBecauseVeryWeirdIssue({
-      x: targetElementBounds.x + 5,
-      y: targetElementBounds.y + 5,
-    })
-    const endPoint = slightlyOffsetWindowPointBecauseVeryWeirdIssue({
-      x: targetElementBounds.x + 15, // with aspect ratio lock this 10px with should be ignored
-      y: targetElementBounds.y + 305,
-    })
-
-    // Move before starting dragging
-    mouseMoveToPoint(canvasControlsLayer, startPoint)
-
-    // Highlight should show the candidate parent
-    expect(renderResult.getEditorState().editor.highlightedViews.map(EP.toUid)).toEqual(['bbb'])
-
-    // Drag from inside bbb to inside ccc
-    mouseDragFromPointToPoint(canvasControlsLayer, startPoint, endPoint)
-
-    await renderResult.getDispatchFollowUpActionsFinished()
-
-    // Check that the inserted element is a child of bbb
-    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
-      makeTestProjectCodeWithSnippet(`
+    const inputCode = `
+      <div
+        data-uid='aaa'
+        style={{
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+          position: 'relative',
+        }}
+      >
         <div
-          data-uid='aaa'
+          data-uid='bbb'
+          data-testid='bbb'
           style={{
-            width: '100%',
-            height: '100%',
-            backgroundColor: '#FFFFFF',
-            position: 'relative',
+            position: 'absolute',
+            left: 10,
+            top: 10,
+            width: 380,
+            height: 180,
+            backgroundColor: '#d3d3d3',
+          }}
+        />
+        <div
+          data-uid='ccc'
+          style={{
+            position: 'absolute',
+            left: 10,
+            top: 200,
+            width: 380,
+            height: 190,
+            backgroundColor: '#FF0000',
+          }}
+        />
+      </div>
+    `
+    const expectedCode = `
+      <div
+        data-uid='aaa'
+        style={{
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+          position: 'relative',
+        }}
+      >
+        <div
+          data-uid='bbb'
+          data-testid='bbb'
+          style={{
+            position: 'absolute',
+            left: 10,
+            top: 10,
+            width: 380,
+            height: 180,
+            backgroundColor: '#d3d3d3',
           }}
         >
-          <div
-            data-uid='bbb'
-            data-testid='bbb'
+          <img
             style={{
+              width: 300,
+              height: 300,
               position: 'absolute',
-              left: 10,
-              top: 10,
-              width: 380,
-              height: 180,
-              backgroundColor: '#d3d3d3',
+              left: 5,
+              top: 5,
             }}
-          >
-            <img              
-              style={{
-                width: 300,
-                height: 300,
-                position: 'absolute',
-                left: 5,
-                top: 5,
-              }}
-              src='/editor/icons/favicons/favicon-128.png?hash=nocommit'
-              data-uid='ddd'
-            />
-          </div>
-          <div
-            data-uid='ccc'
-            style={{
-              position: 'absolute',
-              left: 10,
-              top: 200,
-              width: 380,
-              height: 190,
-              backgroundColor: '#FF0000',
-            }}
+            src='/editor/icons/favicons/favicon-128.png?hash=nocommit'
+            data-uid='ddd'
           />
         </div>
-      `),
-    )
+        <div
+          data-uid='ccc'
+          style={{
+            position: 'absolute',
+            left: 10,
+            top: 200,
+            width: 380,
+            height: 190,
+            backgroundColor: '#FF0000',
+          }}
+        />
+      </div>
+    `
+    await testDragToInsertImageAspectRatio(inputCode, expectedCode)
+  })
+
+  it('Draw to insert to a flex layout keeps aspect ratio', async () => {
+    const inputCode = `
+      <div
+        data-uid='aaa'
+        style={{
+          width: '100%',
+          height: '100%',
+        }}
+      >
+        <div
+          data-uid='bbb'
+          data-testid='bbb'
+          style={{
+            backgroundColor: '#f09',
+            display: 'flex',
+            width: 400,
+            height: 400
+          }}
+        />
+      </div>
+    `
+    const expectedCode = `
+      <div
+        data-uid='aaa'
+        style={{ width: '100%', height: '100%' }}
+      >
+        <div
+          data-uid='bbb'
+          data-testid='bbb'
+          style={{
+            backgroundColor: '#f09',
+            display: 'flex',
+            width: 400,
+            height: 400
+          }}
+        >
+          <img
+            style={{
+              width: 300,
+              height: 300,
+              position: 'relative'
+            }}
+            src='/editor/icons/favicons/favicon-128.png?hash=nocommit'
+            data-uid='ddd'
+          />
+        </div>
+      </div>
+    `
+    await testDragToInsertImageAspectRatio(inputCode, expectedCode)
   })
 })
+
+const testDragToInsertImageAspectRatio = async (inputCode: string, expectedCode: string) => {
+  const renderResult = await setupInsertTest(makeTestProjectCodeWithSnippet(inputCode))
+  await enterInsertModeFromInsertMenu(renderResult, 'img')
+
+  const targetElement = renderResult.renderedDOM.getByTestId('bbb')
+  const targetElementBounds = targetElement.getBoundingClientRect()
+  const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+  const startPoint = slightlyOffsetWindowPointBecauseVeryWeirdIssue({
+    x: targetElementBounds.x + 5,
+    y: targetElementBounds.y + 5,
+  })
+  const endPoint = slightlyOffsetWindowPointBecauseVeryWeirdIssue({
+    x: targetElementBounds.x + 15, // with aspect ratio lock this 10px with should be ignored
+    y: targetElementBounds.y + 305,
+  })
+
+  // Move before starting dragging
+  mouseMoveToPoint(canvasControlsLayer, startPoint)
+
+  // Highlight should show the candidate parent
+  expect(renderResult.getEditorState().editor.highlightedViews.map(EP.toUid)).toEqual(['bbb'])
+
+  // Drag from inside bbb to inside ccc
+  mouseDragFromPointToPoint(canvasControlsLayer, startPoint, endPoint)
+
+  await renderResult.getDispatchFollowUpActionsFinished()
+
+  // Check that the inserted element is a child of bbb
+  expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+    makeTestProjectCodeWithSnippet(expectedCode),
+  )
+}

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.spec.browser2.tsx
@@ -437,18 +437,6 @@ describe('Flex Resize', () => {
       })
     })
   })
-
-  describe('when the resized element is an image', () => {
-    it('keeps the aspect ratio locked (horizontal)', async () => {
-      await resizeImage(edgePosition(1, 0.5), canvasPoint({ x: 20, y: 5 }), 80, 100)
-    })
-    it('keeps the aspect ratio locked (vertical)', async () => {
-      await resizeImage(edgePosition(0.5, 1), canvasPoint({ x: 20, y: 5 }), 64, 80)
-    })
-    it('keeps the aspect ratio locked (diagonal)', async () => {
-      await resizeImage(edgePosition(1, 1), canvasPoint({ x: 20, y: 5 }), 80, 100)
-    })
-  })
 })
 
 async function resizeTestRow(
@@ -789,58 +777,5 @@ async function resizeWithModifiers(
         />
       </div>
       `),
-  )
-}
-
-const resizeImage = async (
-  pos: EdgePosition,
-  dragVector: CanvasVector,
-  expectWidth: number,
-  expectHeight: number,
-) => {
-  const cat =
-    'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wCEAAsICAoIBwsKCQoNDAsNERwSEQ8PESIZGhQcKSQrKigkJyctMkA3LTA9MCcnOEw5PUNFSElIKzZPVU5GVEBHSEUBDA0NEQ8RIRISIUUuJy5FRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRf/AABEIADwAMgMBIgACEQEDEQH/xABxAAADAQEBAQAAAAAAAAAAAAAABQYEAwECEAACAQMDBAECBQUAAAAAAAABAgMABBEFEiETMUFRYQZxFBUjgZEiMkKh8AEBAQEBAAAAAAAAAAAAAAAAAgEAAxEBAQEBAQEAAAAAAAAAAAAAAAECESFB/9oADAMBAAIRAxEAPwCMkP6UjUy+mVAuYQVB3HH80sn4tyPZptooWOeAsSNpB4qRTjXpkntUSRNskWeQfHqphb4QuI41FU99Al1LBGzgtK/TY/4j7n9xUrqOnCxuGy5yrFf+/wBfyKSHNvqUMFoyMmN5yWz3rhkOcrnB9jFKkuniwiMpDdz6rdaNIysZMZ3HtWZpxRXtFZiW4OVjHs00sDm6iGCcEcClTjdJGPVN9MIFyPfmgtV8eiJKJLyNl6m3IRgMcDg5OcH5qJu4Li/na6WNVWdjsVmDFPn4zVzbX8en3HRmWRCeQ55Uik31FeW46j2oQFT+phcEg+adGIuW3dHO/ls8sOxpxap04VX4pdNO8sm1XV1PbYMYpnCf6Bn1Uiu1FeZopIWRy28rgmMg/FONHihF4p3MqseSfApW9zbxyLJGg2g809sdStreRLkrviI2njOK5ZxZ7101qX4tbuC2e1Vy4aPvk9sVHa1HbI522ygEZXaTufP7U3t76O8WSG2kDIgDrzxg+KT3txcz2RfopLCGOSO4P2phEfO/TZsZU57HxTOzkLQKSaWXkfJIj6WTnBOTW2zIFuACCcdq3V40Gfk0ViZzuP3oqoz3dpK90I0RiufHYVU2bR6bp6xl0YFeVxnBrlKoW3uSBgjAB9VPtdSrFKgbg5oZvi2etNpffhL6bpu0aSDweAO9PUk1KHRVli6CwOSV3/3Nyc1D7mJOWPIqv1ORvyuxtwxEYhU4B+M0olTd0zNKQcbmOWNZhNJDJ3IrvKAJ2A8V9FFkXDDNDVPIGpccqKKyGIAkZNFHhdf/2Q=='
-  const inputCode = makeTestProjectCodeWithSnippet(`
-    <div
-      data-uid='aaa'
-      style={{
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-      }}
-    >
-      <img
-        data-uid='ccc'
-        style={{
-          width: 60,
-          height: 75,
-        }}
-        src="${cat}"
-      />
-    </div>
-  `)
-
-  const renderResult = await renderTestEditorWithCode(inputCode, 'await-first-dom-report')
-  const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/ccc`)
-
-  await dragResizeControl(renderResult, target, pos, dragVector)
-
-  expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
-    makeTestProjectCodeWithSnippet(`
-      <div
-        data-uid='aaa'
-        style={{
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-        }}
-      >
-        <img
-          data-uid='ccc'
-          style={{ width: ${expectWidth}, height: ${expectHeight} }}
-          src="${cat}"
-        />
-      </div>
-    `),
   )
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.spec.browser2.tsx
@@ -364,7 +364,7 @@ describe('Flex Resize', () => {
           edgePosition(1, 0.5),
           canvasPoint({ x: 15, y: 20 }),
           { width: 100, height: 200 },
-          { width: 115, height: 207.5 },
+          { width: 115, height: 230 },
           shiftModifier,
         )
       })
@@ -373,7 +373,7 @@ describe('Flex Resize', () => {
           edgePosition(0, 0.5),
           canvasPoint({ x: 15, y: 20 }),
           { width: 100, height: 200 },
-          { width: 85, height: 192.5 },
+          { width: 85, height: 170 },
           shiftModifier,
         )
       })
@@ -404,7 +404,7 @@ describe('Flex Resize', () => {
           edgePosition(1, 1),
           canvasPoint({ x: 15, y: 20 }),
           { width: 100, height: 200 },
-          { width: 115, height: 207.5 },
+          { width: 115, height: 230 },
           shiftModifier,
         )
       })
@@ -413,7 +413,7 @@ describe('Flex Resize', () => {
           edgePosition(1, 0),
           canvasPoint({ x: 15, y: 20 }),
           { width: 100, height: 200 },
-          { width: 115, height: 207.5 },
+          { width: 115, height: 230 },
           shiftModifier,
         )
       })
@@ -422,7 +422,7 @@ describe('Flex Resize', () => {
           edgePosition(0, 0),
           canvasPoint({ x: 15, y: 20 }),
           { width: 100, height: 200 },
-          { width: 85, height: 192.5 },
+          { width: 90, height: 180 },
           shiftModifier,
         )
       })
@@ -431,7 +431,7 @@ describe('Flex Resize', () => {
           edgePosition(0, 1),
           canvasPoint({ x: 15, y: 20 }),
           { width: 100, height: 200 },
-          { width: 85, height: 192.5 },
+          { width: 110, height: 220 },
           shiftModifier,
         )
       })
@@ -440,13 +440,13 @@ describe('Flex Resize', () => {
 
   describe('when the resized element is an image', () => {
     it('keeps the aspect ratio locked (horizontal)', async () => {
-      await resizeImage(edgePosition(1, 0.5), canvasPoint({ x: 20, y: 5 }), 80, 91)
+      await resizeImage(edgePosition(1, 0.5), canvasPoint({ x: 20, y: 5 }), 80, 100)
     })
     it('keeps the aspect ratio locked (vertical)', async () => {
       await resizeImage(edgePosition(0.5, 1), canvasPoint({ x: 20, y: 5 }), 64, 80)
     })
     it('keeps the aspect ratio locked (diagonal)', async () => {
-      await resizeImage(edgePosition(1, 1), canvasPoint({ x: 20, y: 5 }), 80, 91)
+      await resizeImage(edgePosition(1, 1), canvasPoint({ x: 20, y: 5 }), 80, 100)
     })
   })
 })

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.spec.browser2.tsx
@@ -437,6 +437,18 @@ describe('Flex Resize', () => {
       })
     })
   })
+
+  describe('when the resized element is an image', () => {
+    it('keeps the aspect ratio locked (horizontal)', async () => {
+      await resizeImage(edgePosition(1, 0.5), canvasPoint({ x: 20, y: 5 }), 80, 91)
+    })
+    it('keeps the aspect ratio locked (vertical)', async () => {
+      await resizeImage(edgePosition(0.5, 1), canvasPoint({ x: 20, y: 5 }), 64, 80)
+    })
+    it('keeps the aspect ratio locked (diagonal)', async () => {
+      await resizeImage(edgePosition(1, 1), canvasPoint({ x: 20, y: 5 }), 80, 91)
+    })
+  })
 })
 
 async function resizeTestRow(
@@ -777,5 +789,58 @@ async function resizeWithModifiers(
         />
       </div>
       `),
+  )
+}
+
+const resizeImage = async (
+  pos: EdgePosition,
+  dragVector: CanvasVector,
+  expectWidth: number,
+  expectHeight: number,
+) => {
+  const cat =
+    'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wCEAAsICAoIBwsKCQoNDAsNERwSEQ8PESIZGhQcKSQrKigkJyctMkA3LTA9MCcnOEw5PUNFSElIKzZPVU5GVEBHSEUBDA0NEQ8RIRISIUUuJy5FRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRf/AABEIADwAMgMBIgACEQEDEQH/xABxAAADAQEBAQAAAAAAAAAAAAAABQYEAwECEAACAQMDBAECBQUAAAAAAAABAgMABBEFEiETMUFRYQZxFBUjgZEiMkKh8AEBAQEBAAAAAAAAAAAAAAAAAgEAAxEBAQEBAQEAAAAAAAAAAAAAAAECESFB/9oADAMBAAIRAxEAPwCMkP6UjUy+mVAuYQVB3HH80sn4tyPZptooWOeAsSNpB4qRTjXpkntUSRNskWeQfHqphb4QuI41FU99Al1LBGzgtK/TY/4j7n9xUrqOnCxuGy5yrFf+/wBfyKSHNvqUMFoyMmN5yWz3rhkOcrnB9jFKkuniwiMpDdz6rdaNIysZMZ3HtWZpxRXtFZiW4OVjHs00sDm6iGCcEcClTjdJGPVN9MIFyPfmgtV8eiJKJLyNl6m3IRgMcDg5OcH5qJu4Li/na6WNVWdjsVmDFPn4zVzbX8en3HRmWRCeQ55Uik31FeW46j2oQFT+phcEg+adGIuW3dHO/ls8sOxpxap04VX4pdNO8sm1XV1PbYMYpnCf6Bn1Uiu1FeZopIWRy28rgmMg/FONHihF4p3MqseSfApW9zbxyLJGg2g809sdStreRLkrviI2njOK5ZxZ7101qX4tbuC2e1Vy4aPvk9sVHa1HbI522ygEZXaTufP7U3t76O8WSG2kDIgDrzxg+KT3txcz2RfopLCGOSO4P2phEfO/TZsZU57HxTOzkLQKSaWXkfJIj6WTnBOTW2zIFuACCcdq3V40Gfk0ViZzuP3oqoz3dpK90I0RiufHYVU2bR6bp6xl0YFeVxnBrlKoW3uSBgjAB9VPtdSrFKgbg5oZvi2etNpffhL6bpu0aSDweAO9PUk1KHRVli6CwOSV3/3Nyc1D7mJOWPIqv1ORvyuxtwxEYhU4B+M0olTd0zNKQcbmOWNZhNJDJ3IrvKAJ2A8V9FFkXDDNDVPIGpccqKKyGIAkZNFHhdf/2Q=='
+  const inputCode = makeTestProjectCodeWithSnippet(`
+    <div
+      data-uid='aaa'
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+      }}
+    >
+      <img
+        data-uid='ccc'
+        style={{
+          width: 60,
+          height: 75,
+        }}
+        src="${cat}"
+      />
+    </div>
+  `)
+
+  const renderResult = await renderTestEditorWithCode(inputCode, 'await-first-dom-report')
+  const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/ccc`)
+
+  await dragResizeControl(renderResult, target, pos, dragVector)
+
+  expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+    makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+        }}
+      >
+        <img
+          data-uid='ccc'
+          style={{ width: ${expectWidth}, height: ${expectHeight} }}
+          src="${cat}"
+        />
+      </div>
+    `),
   )
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
@@ -205,11 +205,7 @@ const getSpecializedLockedAspectRatio = (
   rectangle: CanvasRectangle,
   metadata: ElementInstanceMetadata,
 ) => {
-  if (rectangle.width === 0 || rectangle.height === 0) {
-    // if dimensions are missing, there's no point in calculating the ratio
-    return null
-  }
-  if (MetadataUtils.isImg(metadata)) {
+  if (MetadataUtils.isImg(metadata) && rectangle.width !== 0 && rectangle.width !== 0) {
     return rectangle.width / rectangle.height
   }
   return getLockedAspectRatio(interactionSession, modifiers, rectangle)

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
@@ -205,7 +205,7 @@ const getSpecializedLockedAspectRatio = (
   rectangle: CanvasRectangle,
   metadata: ElementInstanceMetadata,
 ) => {
-  if (MetadataUtils.isImg(metadata)) {
+  if (MetadataUtils.isImg(metadata) && rectangle.width !== 0 && rectangle.width !== 0) {
     return rectangle.width / rectangle.height
   }
   return getLockedAspectRatio(interactionSession, modifiers, rectangle)

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
@@ -205,7 +205,11 @@ const getSpecializedLockedAspectRatio = (
   rectangle: CanvasRectangle,
   metadata: ElementInstanceMetadata,
 ) => {
-  if (MetadataUtils.isImg(metadata) && rectangle.width !== 0 && rectangle.width !== 0) {
+  if (rectangle.width === 0 || rectangle.height === 0) {
+    // if dimensions are missing, there's no point in calculating the ratio
+    return null
+  }
+  if (MetadataUtils.isImg(metadata)) {
     return rectangle.width / rectangle.height
   }
   return getLockedAspectRatio(interactionSession, modifiers, rectangle)

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
@@ -205,7 +205,7 @@ const getSpecializedLockedAspectRatio = (
   rectangle: CanvasRectangle,
   metadata: ElementInstanceMetadata,
 ) => {
-  if (MetadataUtils.isImg(metadata) && rectangle.width !== 0 && rectangle.width !== 0) {
+  if (MetadataUtils.isImg(metadata) && rectangle.width !== 0 && rectangle.height !== 0) {
     return rectangle.width / rectangle.height
   }
   return getLockedAspectRatio(interactionSession, modifiers, rectangle)

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
@@ -8,6 +8,7 @@ import {
   CanvasRectangle,
   offsetPoint,
 } from '../../../../core/shared/math-utils'
+import { Modifiers } from '../../../../utils/modifiers'
 import { stylePropPathMappingFn } from '../../../inspector/common/property-path-hooks'
 import { EdgePosition, oppositeEdgePosition } from '../../canvas-types'
 import {
@@ -26,7 +27,6 @@ import { ParentBounds } from '../../controls/parent-bounds'
 import { ParentOutlines } from '../../controls/parent-outlines'
 import { AbsoluteResizeControl } from '../../controls/select-mode/absolute-resize-control'
 import { ZeroSizeResizeControlWrapper } from '../../controls/zero-sized-element-controls'
-import { honoursPropsSize } from './absolute-utils'
 import {
   CanvasStrategy,
   controlWithProps,
@@ -37,6 +37,7 @@ import {
   strategyApplicationResult,
 } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
+import { honoursPropsSize } from './absolute-utils'
 import { getLockedAspectRatio } from './resize-helpers'
 import { pickCursorFromEdgePosition } from './shared-absolute-resize-strategy-helpers'
 
@@ -112,12 +113,6 @@ export function flexResizeBasicStrategy(
             return emptyStrategyApplicationResult
           }
 
-          const resizedBounds = resizeWidthHeight(originalBounds, drag, edgePosition)
-          const lockedAspectRatio = getLockedAspectRatio(
-            interactionSession,
-            interactionSession.interactionData.modifiers,
-            originalBounds,
-          )
           const metadata = MetadataUtils.findElementByElementPath(
             canvasState.startingMetadata,
             selectedElement,
@@ -127,7 +122,23 @@ export function flexResizeBasicStrategy(
           }
           const elementParentBounds =
             metadata?.specialSizeMeasurements.immediateParentBounds ?? null
-          const dimensions = getDimensions(metadata)
+          const dimensions = getElementDimensions(metadata)
+
+          const resizedBounds = resizeWidthHeight(originalBounds, drag, edgePosition)
+          const lockedAspectRatio = getSpecializedLockedAspectRatio(
+            interactionSession,
+            interactionSession.interactionData.modifiers,
+            originalBounds,
+            metadata,
+          )
+
+          const newDimensions = makeNewDimensions(
+            originalBounds,
+            resizedBounds,
+            dimensions,
+            lockedAspectRatio,
+          )
+          const { width: newWidth, height: newHeight } = newDimensions
 
           const makeResizeCommand = (
             name: 'width' | 'height',
@@ -144,33 +155,10 @@ export function flexResizeBasicStrategy(
             )
           }
 
-          const makeNewDimension = (original: number, resized: number, dimension?: number | null) =>
-            resized - (dimension != null ? original : 0)
-
           const resizeCommands: Array<AdjustCssLengthProperty> = []
 
           const parentWidth = elementParentBounds?.width
           const parentHeight = elementParentBounds?.height
-
-          let newWidth = makeNewDimension(
-            originalBounds.width,
-            resizedBounds.width,
-            dimensions?.width,
-          )
-          let newHeight = makeNewDimension(
-            originalBounds.height,
-            resizedBounds.height,
-            dimensions?.height,
-          )
-          if (lockedAspectRatio != null) {
-            if (newWidth !== 0) {
-              // diagonal + horizontal lock
-              newHeight = newWidth * lockedAspectRatio
-            } else if (newHeight !== 0) {
-              // vertical lock
-              newWidth = newHeight * lockedAspectRatio
-            }
-          }
 
           if (dimensions?.width != null || originalBounds.width !== newWidth) {
             // it moves horizontally
@@ -198,6 +186,60 @@ export function flexResizeBasicStrategy(
       return emptyStrategyApplicationResult
     },
   }
+}
+
+interface ResizeDimensions {
+  width: number
+  height: number
+}
+
+const makeNewDimensions = (
+  originalBounds: CanvasRectangle,
+  resizedBounds: CanvasRectangle,
+  elementDimensions: ElementDimensions,
+  lockedAspectRatio: number | null,
+): ResizeDimensions => {
+  const makeNewDimension = (original: number, resized: number, dimension?: number | null) => {
+    return resized - (dimension != null ? original : 0)
+  }
+
+  const width = makeNewDimension(
+    originalBounds.width,
+    resizedBounds.width,
+    elementDimensions?.width,
+  )
+  const height = makeNewDimension(
+    originalBounds.height,
+    resizedBounds.height,
+    elementDimensions?.height,
+  )
+
+  if (lockedAspectRatio != null) {
+    if (width !== 0) {
+      return {
+        width,
+        height: width * lockedAspectRatio,
+      }
+    } else if (height !== 0) {
+      return {
+        width: height * lockedAspectRatio,
+        height,
+      }
+    }
+  }
+  return { width, height }
+}
+
+const getSpecializedLockedAspectRatio = (
+  interactionSession: InteractionSession,
+  modifiers: Modifiers,
+  rectangle: CanvasRectangle,
+  metadata: ElementInstanceMetadata,
+) => {
+  if (MetadataUtils.isImg(metadata)) {
+    return rectangle.width / rectangle.height
+  }
+  return getLockedAspectRatio(interactionSession, modifiers, rectangle)
 }
 
 export function resizeWidthHeight(
@@ -252,12 +294,12 @@ export function resizeWidthHeight(
   }
 }
 
-const getDimensions = (
-  metadata: ElementInstanceMetadata,
-): {
+type ElementDimensions = {
   width: number | null
   height: number | null
-} | null => {
+} | null
+
+const getElementDimensions = (metadata: ElementInstanceMetadata): ElementDimensions => {
   const getOffsetPropValue = (
     name: 'width' | 'height',
     attrs: PropsOrJSXAttributes,

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
@@ -124,17 +124,15 @@ export function flexResizeBasicStrategy(
             return emptyStrategyApplicationResult
           }
 
-          const lockedAspectRatio = getSpecializedLockedAspectRatio(
-            interactionSession,
-            interactionSession.interactionData.modifiers,
-            originalBounds,
-            metadata,
-          )
           const resizedBounds = resizeBoundingBox(
             originalBounds,
             drag,
             edgePosition,
-            lockedAspectRatio,
+            getLockedAspectRatio(
+              interactionSession,
+              interactionSession.interactionData.modifiers,
+              originalBounds,
+            ),
             'non-center-based',
           )
           const elementParentBounds =
@@ -197,18 +195,6 @@ export function flexResizeBasicStrategy(
       return emptyStrategyApplicationResult
     },
   }
-}
-
-const getSpecializedLockedAspectRatio = (
-  interactionSession: InteractionSession,
-  modifiers: Modifiers,
-  rectangle: CanvasRectangle,
-  metadata: ElementInstanceMetadata,
-) => {
-  if (MetadataUtils.isImg(metadata) && rectangle.width !== 0 && rectangle.height !== 0) {
-    return rectangle.width / rectangle.height
-  }
-  return getLockedAspectRatio(interactionSession, modifiers, rectangle)
 }
 
 export function resizeWidthHeight(

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
@@ -23,8 +23,8 @@ import {
   strategyApplicationResult,
 } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
-import { supportsAbsoluteResize } from './resize-helpers'
-import { createResizeCommands, resizeBoundingBox } from './shared-absolute-resize-strategy-helpers'
+import { resizeBoundingBox, supportsAbsoluteResize } from './resize-helpers'
+import { createResizeCommands } from './shared-absolute-resize-strategy-helpers'
 import {
   AccumulatedPresses,
   accumulatePresses,

--- a/editor/src/components/canvas/canvas-strategies/strategies/resize-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/resize-helpers.ts
@@ -2,13 +2,29 @@ import { getLayoutProperty } from '../../../../core/layout/getLayoutProperty'
 import { MetadataUtils, PropsOrJSXAttributes } from '../../../../core/model/element-metadata-utils'
 import { isRight } from '../../../../core/shared/either'
 import { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
-import { CanvasRectangle } from '../../../../core/shared/math-utils'
+import {
+  canvasPoint,
+  CanvasPoint,
+  canvasRectangle,
+  CanvasRectangle,
+  distance,
+  offsetPoint,
+  pointDifference,
+  rectFromTwoPoints,
+  zeroCanvasPoint,
+} from '../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import { Modifiers } from '../../../../utils/modifiers'
-import { EdgePosition } from '../../canvas-types'
-import { honoursPropsPosition, honoursPropsSize } from './absolute-utils'
+import { CSSCursor, EdgePosition } from '../../canvas-types'
+import {
+  isEdgePositionAHorizontalEdge,
+  isEdgePositionAVerticalEdge,
+  isEdgePositionOnSide,
+  pickPointOnRect,
+} from '../../canvas-utils'
 import { InteractionCanvasState } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
+import { honoursPropsPosition, honoursPropsSize } from './absolute-utils'
 
 export type AbsolutePin = 'left' | 'top' | 'right' | 'bottom' | 'width' | 'height'
 
@@ -91,4 +107,257 @@ export function getLockedAspectRatio(
     return originalBoundingBox.width / originalBoundingBox.height
   }
   return null
+}
+
+export function pickCursorFromEdgePosition(edgePosition: EdgePosition) {
+  const isTopLeft = edgePosition.x === 0 && edgePosition.y === 0
+  const isBottomRight = edgePosition.x === 1 && edgePosition.y === 1
+
+  if (isEdgePositionAHorizontalEdge(edgePosition)) {
+    return CSSCursor.ResizeNS
+  } else if (isEdgePositionAVerticalEdge(edgePosition)) {
+    return CSSCursor.ResizeEW
+  } else if (isTopLeft || isBottomRight) {
+    return CSSCursor.ResizeNWSE
+  } else {
+    return CSSCursor.ResizeNESW
+  }
+}
+
+export type IsCenterBased = 'center-based' | 'non-center-based'
+
+export function resizeBoundingBox(
+  boundingBox: CanvasRectangle,
+  drag: CanvasPoint,
+  edgePosition: EdgePosition,
+  lockedAspectRatio: number | null,
+  centerBased: IsCenterBased,
+): CanvasRectangle {
+  if (isEdgePositionOnSide(edgePosition)) {
+    return resizeBoundingBoxFromSide(
+      boundingBox,
+      drag,
+      edgePosition,
+      centerBased,
+      lockedAspectRatio,
+    )
+  } else {
+    return resizeBoundingBoxFromCorner(
+      boundingBox,
+      drag,
+      edgePosition,
+      centerBased,
+      lockedAspectRatio,
+    )
+  }
+}
+
+export function resizeBoundingBoxFromCorner(
+  boundingBox: CanvasRectangle,
+  drag: CanvasPoint,
+  edgePosition: EdgePosition,
+  centerBased: IsCenterBased,
+  lockedAspectRatio: number | null,
+): CanvasRectangle {
+  const startingCornerPosition = {
+    x: 1 - edgePosition.x,
+    y: 1 - edgePosition.y,
+  } as EdgePosition
+
+  let oppositeCorner = pickPointOnRect(boundingBox, startingCornerPosition)
+  const draggedCorner = pickPointOnRect(boundingBox, edgePosition)
+  const newCorner = offsetPoint(draggedCorner, drag)
+
+  let newBoundingBox = boundingBox
+  if (centerBased === 'center-based') {
+    oppositeCorner = offsetPoint(oppositeCorner, pointDifference(drag, zeroCanvasPoint))
+  }
+
+  newBoundingBox = rectFromTwoPoints(oppositeCorner, newCorner)
+  if (lockedAspectRatio != null) {
+    // When aspect ratio is locked we extend the new bounding box in this way:
+    // 1. the extended bounding box should fully contain the bounding box
+    // 2. the extended rectangle should have the correct locked aspect ratio
+    // 3. there is always a fixed point of the bounding box which should not move:
+    //    - when it is a center based resize that fixed point is the center of the rectangle
+    //    - otherwise it is the opposite point than what we drag
+    const fixedEdgePosition = getFixedEdgePositionForAspectRatioLockResize(
+      centerBased,
+      newCorner,
+      oppositeCorner,
+    )
+
+    return extendRectangleToAspectRatio(newBoundingBox, fixedEdgePosition, lockedAspectRatio)
+  } else {
+    return newBoundingBox
+  }
+}
+
+export function resizeBoundingBoxFromSide(
+  boundingBox: CanvasRectangle,
+  drag: CanvasPoint,
+  edgePosition: EdgePosition,
+  centerBased: IsCenterBased,
+  lockedAspectRatio: number | null,
+): CanvasRectangle {
+  const isEdgeHorizontalSide = isEdgePositionAHorizontalEdge(edgePosition)
+
+  const dragToUse = isEdgeHorizontalSide
+    ? canvasPoint({
+        x: 0,
+        y: drag.y,
+      })
+    : canvasPoint({
+        x: drag.x,
+        y: 0,
+      })
+
+  const oppositeSideCenterPosition = isEdgeHorizontalSide
+    ? ({
+        x: edgePosition.x,
+        y: 1 - edgePosition.y,
+      } as EdgePosition)
+    : ({
+        x: 1 - edgePosition.x,
+        y: edgePosition.y,
+      } as EdgePosition)
+
+  const draggedSideCenter = pickPointOnRect(boundingBox, edgePosition)
+  const newSideCenter = offsetPoint(draggedSideCenter, dragToUse)
+
+  let oppositeSideCenter = pickPointOnRect(boundingBox, oppositeSideCenterPosition)
+  if (centerBased === 'center-based') {
+    oppositeSideCenter = offsetPoint(
+      oppositeSideCenter,
+      pointDifference(dragToUse, zeroCanvasPoint),
+    )
+  }
+
+  if (lockedAspectRatio == null) {
+    const newCorner1 = isEdgeHorizontalSide
+      ? canvasPoint({
+          x: oppositeSideCenter.x - boundingBox.width / 2,
+          y: oppositeSideCenter.y,
+        })
+      : canvasPoint({
+          x: oppositeSideCenter.x,
+          y: oppositeSideCenter.y - boundingBox.height / 2,
+        })
+    const newCorner2 = isEdgeHorizontalSide
+      ? canvasPoint({
+          x: newSideCenter.x + boundingBox.width / 2,
+          y: newSideCenter.y,
+        })
+      : canvasPoint({
+          x: newSideCenter.x,
+          y: newSideCenter.y + boundingBox.height / 2,
+        })
+    return rectFromTwoPoints(newCorner1, newCorner2)
+  } else {
+    const dragDistance = distance(newSideCenter, oppositeSideCenter)
+    if (isEdgeHorizontalSide) {
+      const newWidth = dragDistance * lockedAspectRatio
+      const newCorner1 = canvasPoint({
+        x: oppositeSideCenter.x - newWidth / 2,
+        y: oppositeSideCenter.y,
+      })
+      const newCorner2 = canvasPoint({
+        x: newSideCenter.x + newWidth / 2,
+        y: newSideCenter.y,
+      })
+      return rectFromTwoPoints(newCorner1, newCorner2)
+    } else {
+      const newHeight = dragDistance / lockedAspectRatio
+      const newCorner1 = canvasPoint({
+        x: oppositeSideCenter.x,
+        y: oppositeSideCenter.y - newHeight / 2,
+      })
+      const newCorner2 = canvasPoint({
+        x: newSideCenter.x,
+        y: newSideCenter.y + newHeight / 2,
+      })
+      return rectFromTwoPoints(newCorner1, newCorner2)
+    }
+  }
+}
+
+function getFixedEdgePositionForAspectRatioLockResize(
+  centerBased: IsCenterBased,
+  newCorner: CanvasPoint,
+  oppositeCorner: CanvasPoint,
+): EdgePosition {
+  if (centerBased === 'center-based') {
+    return { x: 0.5, y: 0.5 }
+  } else {
+    if (oppositeCorner.x < newCorner.x) {
+      if (oppositeCorner.y < newCorner.y) {
+        return { x: 0, y: 0 }
+      } else {
+        return { x: 0, y: 1 }
+      }
+    } else {
+      if (oppositeCorner.y < newCorner.y) {
+        return { x: 1, y: 0 }
+      } else {
+        return { x: 1, y: 1 }
+      }
+    }
+  }
+}
+
+function extendRectangleToAspectRatio(
+  rectangle: CanvasRectangle,
+  fixedEdgePosition: EdgePosition,
+  aspectRatio: number,
+): CanvasRectangle {
+  const currentAspectRatio = rectangle.width / rectangle.height
+  if (currentAspectRatio < aspectRatio) {
+    const newWidth = rectangle.height * aspectRatio
+    if (fixedEdgePosition.x === 0) {
+      return canvasRectangle({
+        x: rectangle.x,
+        y: rectangle.y,
+        width: newWidth,
+        height: rectangle.height,
+      })
+    } else if (fixedEdgePosition.x === 0.5) {
+      return canvasRectangle({
+        x: rectangle.x + (rectangle.width - newWidth) / 2,
+        y: rectangle.y,
+        width: newWidth,
+        height: rectangle.height,
+      })
+    } else {
+      return canvasRectangle({
+        x: rectangle.x + rectangle.width - newWidth,
+        y: rectangle.y,
+        width: newWidth,
+        height: rectangle.height,
+      })
+    }
+  } else {
+    const newHeight = rectangle.width / aspectRatio
+    if (fixedEdgePosition.y === 0) {
+      return canvasRectangle({
+        x: rectangle.x,
+        y: rectangle.y,
+        width: rectangle.width,
+        height: newHeight,
+      })
+    } else if (fixedEdgePosition.y === 0.5) {
+      return canvasRectangle({
+        x: rectangle.x,
+        y: rectangle.y + (rectangle.height - newHeight) / 2,
+        width: rectangle.width,
+        height: newHeight,
+      })
+    } else {
+      return canvasRectangle({
+        x: rectangle.x,
+        y: rectangle.y + rectangle.height - newHeight,
+        width: rectangle.width,
+        height: newHeight,
+      })
+    }
+  }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-absolute-resize-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-absolute-resize-strategy-helpers.ts
@@ -1,4 +1,3 @@
-import { AllElementProps } from '../../../editor/store/editor-state'
 import { isHorizontalPoint } from 'utopia-api/core'
 import { getLayoutProperty } from '../../../../core/layout/getLayoutProperty'
 import { framePointForPinnedProp } from '../../../../core/layout/layout-helpers-new'
@@ -8,32 +7,22 @@ import { ElementInstanceMetadataMap, JSXElement } from '../../../../core/shared/
 import {
   canvasPoint,
   CanvasPoint,
-  canvasRectangle,
   CanvasRectangle,
   CanvasVector,
-  distance,
-  offsetPoint,
   pointDifference,
-  rectFromTwoPoints,
-  zeroCanvasPoint,
 } from '../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
+import { AllElementProps } from '../../../editor/store/editor-state'
 import { stylePropPathMappingFn } from '../../../inspector/common/property-path-hooks'
-import { CanvasFrameAndTarget, CSSCursor, EdgePosition } from '../../canvas-types'
-import {
-  isEdgePositionAHorizontalEdge,
-  isEdgePositionAVerticalEdge,
-  isEdgePositionOnSide,
-  pickPointOnRect,
-  snapPoint,
-} from '../../canvas-utils'
+import { CanvasFrameAndTarget, EdgePosition } from '../../canvas-types'
+import { pickPointOnRect, snapPoint } from '../../canvas-utils'
 import {
   AdjustCssLengthProperty,
   adjustCssLengthProperty,
 } from '../../commands/adjust-css-length-command'
 import { pointGuidelineToBoundsEdge } from '../../controls/guideline-helpers'
 import { GuidelineWithSnappingVectorAndPointsOfRelevance } from '../../guideline'
-import { AbsolutePin } from './resize-helpers'
+import { AbsolutePin, IsCenterBased, resizeBoundingBox } from './resize-helpers'
 
 export function createResizeCommands(
   element: JSXElement,
@@ -103,163 +92,6 @@ function pinsForEdgePosition(edgePosition: EdgePosition): AbsolutePin[] {
   }
 
   return [...horizontalPins, ...verticalPins]
-}
-
-type IsCenterBased = 'center-based' | 'non-center-based'
-
-export function resizeBoundingBox(
-  boundingBox: CanvasRectangle,
-  drag: CanvasPoint,
-  edgePosition: EdgePosition,
-  lockedAspectRatio: number | null,
-  centerBased: IsCenterBased,
-): CanvasRectangle {
-  if (isEdgePositionOnSide(edgePosition)) {
-    return resizeBoundingBoxFromSide(
-      boundingBox,
-      drag,
-      edgePosition,
-      centerBased,
-      lockedAspectRatio,
-    )
-  } else {
-    return resizeBoundingBoxFromCorner(
-      boundingBox,
-      drag,
-      edgePosition,
-      centerBased,
-      lockedAspectRatio,
-    )
-  }
-}
-
-export function resizeBoundingBoxFromCorner(
-  boundingBox: CanvasRectangle,
-  drag: CanvasPoint,
-  edgePosition: EdgePosition,
-  centerBased: IsCenterBased,
-  lockedAspectRatio: number | null,
-): CanvasRectangle {
-  const startingCornerPosition = {
-    x: 1 - edgePosition.x,
-    y: 1 - edgePosition.y,
-  } as EdgePosition
-
-  let oppositeCorner = pickPointOnRect(boundingBox, startingCornerPosition)
-  const draggedCorner = pickPointOnRect(boundingBox, edgePosition)
-  const newCorner = offsetPoint(draggedCorner, drag)
-
-  let newBoundingBox = boundingBox
-  if (centerBased === 'center-based') {
-    oppositeCorner = offsetPoint(oppositeCorner, pointDifference(drag, zeroCanvasPoint))
-  }
-
-  newBoundingBox = rectFromTwoPoints(oppositeCorner, newCorner)
-  if (lockedAspectRatio != null) {
-    // When aspect ratio is locked we extend the new bounding box in this way:
-    // 1. the extended bounding box should fully contain the bounding box
-    // 2. the extended rectangle should have the correct locked aspect ratio
-    // 3. there is always a fixed point of the bounding box which should not move:
-    //    - when it is a center based resize that fixed point is the center of the rectangle
-    //    - otherwise it is the opposite point than what we drag
-    const fixedEdgePosition = getFixedEdgePositionForAspectRatioLockResize(
-      centerBased,
-      newCorner,
-      oppositeCorner,
-    )
-
-    return extendRectangleToAspectRatio(newBoundingBox, fixedEdgePosition, lockedAspectRatio)
-  } else {
-    return newBoundingBox
-  }
-}
-
-export function resizeBoundingBoxFromSide(
-  boundingBox: CanvasRectangle,
-  drag: CanvasPoint,
-  edgePosition: EdgePosition,
-  centerBased: IsCenterBased,
-  lockedAspectRatio: number | null,
-): CanvasRectangle {
-  const isEdgeHorizontalSide = isEdgePositionAHorizontalEdge(edgePosition)
-
-  const dragToUse = isEdgeHorizontalSide
-    ? canvasPoint({
-        x: 0,
-        y: drag.y,
-      })
-    : canvasPoint({
-        x: drag.x,
-        y: 0,
-      })
-
-  const oppositeSideCenterPosition = isEdgeHorizontalSide
-    ? ({
-        x: edgePosition.x,
-        y: 1 - edgePosition.y,
-      } as EdgePosition)
-    : ({
-        x: 1 - edgePosition.x,
-        y: edgePosition.y,
-      } as EdgePosition)
-
-  const draggedSideCenter = pickPointOnRect(boundingBox, edgePosition)
-  const newSideCenter = offsetPoint(draggedSideCenter, dragToUse)
-
-  let oppositeSideCenter = pickPointOnRect(boundingBox, oppositeSideCenterPosition)
-  if (centerBased === 'center-based') {
-    oppositeSideCenter = offsetPoint(
-      oppositeSideCenter,
-      pointDifference(dragToUse, zeroCanvasPoint),
-    )
-  }
-
-  if (lockedAspectRatio == null) {
-    const newCorner1 = isEdgeHorizontalSide
-      ? canvasPoint({
-          x: oppositeSideCenter.x - boundingBox.width / 2,
-          y: oppositeSideCenter.y,
-        })
-      : canvasPoint({
-          x: oppositeSideCenter.x,
-          y: oppositeSideCenter.y - boundingBox.height / 2,
-        })
-    const newCorner2 = isEdgeHorizontalSide
-      ? canvasPoint({
-          x: newSideCenter.x + boundingBox.width / 2,
-          y: newSideCenter.y,
-        })
-      : canvasPoint({
-          x: newSideCenter.x,
-          y: newSideCenter.y + boundingBox.height / 2,
-        })
-    return rectFromTwoPoints(newCorner1, newCorner2)
-  } else {
-    const dragDistance = distance(newSideCenter, oppositeSideCenter)
-    if (isEdgeHorizontalSide) {
-      const newWidth = dragDistance * lockedAspectRatio
-      const newCorner1 = canvasPoint({
-        x: oppositeSideCenter.x - newWidth / 2,
-        y: oppositeSideCenter.y,
-      })
-      const newCorner2 = canvasPoint({
-        x: newSideCenter.x + newWidth / 2,
-        y: newSideCenter.y,
-      })
-      return rectFromTwoPoints(newCorner1, newCorner2)
-    } else {
-      const newHeight = dragDistance / lockedAspectRatio
-      const newCorner1 = canvasPoint({
-        x: oppositeSideCenter.x,
-        y: oppositeSideCenter.y - newHeight / 2,
-      })
-      const newCorner2 = canvasPoint({
-        x: newSideCenter.x,
-        y: newSideCenter.y + newHeight / 2,
-      })
-      return rectFromTwoPoints(newCorner1, newCorner2)
-    }
-  }
 }
 
 export function runLegacyAbsoluteResizeSnapping(
@@ -377,100 +209,4 @@ function getPointOnDiagonal(
     })
   }
   throw new Error(`Edge position ${edgePosition} is not a corner position`)
-}
-
-export function pickCursorFromEdgePosition(edgePosition: EdgePosition) {
-  const isTopLeft = edgePosition.x === 0 && edgePosition.y === 0
-  const isBottomRight = edgePosition.x === 1 && edgePosition.y === 1
-
-  if (isEdgePositionAHorizontalEdge(edgePosition)) {
-    return CSSCursor.ResizeNS
-  } else if (isEdgePositionAVerticalEdge(edgePosition)) {
-    return CSSCursor.ResizeEW
-  } else if (isTopLeft || isBottomRight) {
-    return CSSCursor.ResizeNWSE
-  } else {
-    return CSSCursor.ResizeNESW
-  }
-}
-
-function getFixedEdgePositionForAspectRatioLockResize(
-  centerBased: IsCenterBased,
-  newCorner: CanvasPoint,
-  oppositeCorner: CanvasPoint,
-): EdgePosition {
-  if (centerBased === 'center-based') {
-    return { x: 0.5, y: 0.5 }
-  } else {
-    if (oppositeCorner.x < newCorner.x) {
-      if (oppositeCorner.y < newCorner.y) {
-        return { x: 0, y: 0 }
-      } else {
-        return { x: 0, y: 1 }
-      }
-    } else {
-      if (oppositeCorner.y < newCorner.y) {
-        return { x: 1, y: 0 }
-      } else {
-        return { x: 1, y: 1 }
-      }
-    }
-  }
-}
-
-function extendRectangleToAspectRatio(
-  rectangle: CanvasRectangle,
-  fixedEdgePosition: EdgePosition,
-  aspectRatio: number,
-): CanvasRectangle {
-  const currentAspectRatio = rectangle.width / rectangle.height
-  if (currentAspectRatio < aspectRatio) {
-    const newWidth = rectangle.height * aspectRatio
-    if (fixedEdgePosition.x === 0) {
-      return canvasRectangle({
-        x: rectangle.x,
-        y: rectangle.y,
-        width: newWidth,
-        height: rectangle.height,
-      })
-    } else if (fixedEdgePosition.x === 0.5) {
-      return canvasRectangle({
-        x: rectangle.x + (rectangle.width - newWidth) / 2,
-        y: rectangle.y,
-        width: newWidth,
-        height: rectangle.height,
-      })
-    } else {
-      return canvasRectangle({
-        x: rectangle.x + rectangle.width - newWidth,
-        y: rectangle.y,
-        width: newWidth,
-        height: rectangle.height,
-      })
-    }
-  } else {
-    const newHeight = rectangle.width / aspectRatio
-    if (fixedEdgePosition.y === 0) {
-      return canvasRectangle({
-        x: rectangle.x,
-        y: rectangle.y,
-        width: rectangle.width,
-        height: newHeight,
-      })
-    } else if (fixedEdgePosition.y === 0.5) {
-      return canvasRectangle({
-        x: rectangle.x,
-        y: rectangle.y + (rectangle.height - newHeight) / 2,
-        width: rectangle.width,
-        height: newHeight,
-      })
-    } else {
-      return canvasRectangle({
-        x: rectangle.x,
-        y: rectangle.y + rectangle.height - newHeight,
-        width: rectangle.width,
-        height: newHeight,
-      })
-    }
-  }
 }


### PR DESCRIPTION
This PR is a followup to https://github.com/concrete-utopia/utopia/pull/2636

⚠️ This PR is only performing a refactor to use `resizeBoundingBox` in the flex resize strategy. The scope has changed, but I'm keeping the old description below for historical purposes.

---

**Problem:**

Images should be resized with a fixed aspect ratio.

**Fix:**

This PR forces the resizing strategy to keep the aspect ratio locked for images.

Notes:
- The same thing could have also been done by faking a `shift` modifier for a quick win when calling `getLockedAspectRatio`, but honestly that would be ugly as hell.
- As a bonus point, got rid of the `let` assignments when calculating the new dimensions ✨ 
