### PR TITLE
Do not overwrite existing files on canvas image drop

### DIFF
--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -1666,14 +1666,14 @@ interface ActionsForDroppedImagesContext {
 function actionsForDroppedImages(
   images: Array<ImageResult>,
   context: ActionsForDroppedImagesContext,
-  overwriteExistingFilename: 'overwrite' | 'autoincrement',
+  overwriteExistingFile: 'overwrite' | 'autoincrement',
 ): ActionsForDroppedImagesResult {
   let actions: Array<EditorAction> = []
   let uidsSoFar: Array<string> = []
   let subjects: Array<InsertionSubject> = []
   for (const image of images) {
     const filename =
-      overwriteExistingFilename === 'autoincrement'
+      overwriteExistingFile === 'autoincrement'
         ? uniqueProjectContentID(image.filename, context.projectContents)
         : image.filename
     const { actions: actionsForImage, singleSubject } = actionsForDroppedImage(

--- a/editor/src/templates/image-dnd.spec.browser2.tsx
+++ b/editor/src/templates/image-dnd.spec.browser2.tsx
@@ -567,60 +567,60 @@ import { View, Rectangle } from 'utopia-api'
 import { FlexRow } from 'utopia-api'
 
 export var storyboard = (
-<Storyboard data-uid='0cd'>
-  <Scene
-    style={{
-      width: 700,
-      height: 759,
-      position: 'absolute',
-      left: 207,
-      top: 126,
-      paddingLeft: 91,
-    }}
-    data-testid='scene'
-    data-label='Playground'
-    data-uid='3fc'
-  />
-  <img
-    alt=''
-    src='./assets/chucknorris.png'
-    style={{
-      position: 'absolute',
-      left: 602.5,
-      top: 505.5,
-      width: 1,
-      height: 1,
-    }}
-    data-uid='1'
-    data-aspect-ratio-locked
-  />
-  <img
-    alt=''
-    src='./assets/chucknorris_2.png'
-    style={{
-      position: 'absolute',
-      left: 602.5,
-      top: 505.5,
-      width: 1,
-      height: 1,
-    }}
-    data-uid='2'
-    data-aspect-ratio-locked
-  />
-  <img
-    alt=''
-    src='./assets/brucelee.png'
-    style={{
-      position: 'absolute',
-      left: 602.5,
-      top: 505.5,
-      width: 1,
-      height: 1,
-    }}
-    data-uid='3'
-    data-aspect-ratio-locked
-  />
-</Storyboard>
+  <Storyboard data-uid='0cd'>
+    <Scene
+      style={{
+        width: 700,
+        height: 759,
+        position: 'absolute',
+        left: 207,
+        top: 126,
+        paddingLeft: 91,
+      }}
+      data-testid='scene'
+      data-label='Playground'
+      data-uid='3fc'
+    />
+    <img
+      alt=''
+      src='./assets/chucknorris.png'
+      style={{
+        position: 'absolute',
+        left: 602.5,
+        top: 505.5,
+        width: 1,
+        height: 1,
+      }}
+      data-uid='1'
+      data-aspect-ratio-locked
+    />
+    <img
+      alt=''
+      src='./assets/chucknorris_2.png'
+      style={{
+        position: 'absolute',
+        left: 602.5,
+        top: 505.5,
+        width: 1,
+        height: 1,
+      }}
+      data-uid='2'
+      data-aspect-ratio-locked
+    />
+    <img
+      alt=''
+      src='./assets/brucelee.png'
+      style={{
+        position: 'absolute',
+        left: 602.5,
+        top: 505.5,
+        width: 1,
+        height: 1,
+      }}
+      data-uid='3'
+      data-aspect-ratio-locked
+    />
+  </Storyboard>
 )
 `)
 })

--- a/editor/src/templates/image-dnd.spec.browser2.tsx
+++ b/editor/src/templates/image-dnd.spec.browser2.tsx
@@ -363,6 +363,74 @@ export var storyboard = (
 `)
   })
 
+  it('dragging existing filename from the "finder" autoincrements filename', async () => {
+    FOR_TESTS_setNextGeneratedUids(['1', '2', '3'])
+
+    const editor = await renderTestEditorWithProjectContent(contents, 'await-first-dom-report')
+    const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    const file = await makeImageFile(imgBase64, 'stuff.png')
+
+    const target = editor.renderedDOM.getByTestId('scene')
+    const targetBounds = target.getBoundingClientRect()
+
+    const endPoint = {
+      x: targetBounds.x + targetBounds.width / 2,
+      y: targetBounds.y + targetBounds.height / 2,
+    }
+
+    fireEvent(
+      canvasControlsLayer,
+      makeDragEvent('drag', canvasControlsLayer, { x: 5, y: 5 }, [file]),
+    )
+
+    fireEvent(canvasControlsLayer, makeDragEvent('drag', canvasControlsLayer, endPoint, [file]))
+
+    fireEvent(canvasControlsLayer, makeDragEvent('drop', canvasControlsLayer, endPoint, [file]))
+
+    await editor.getDispatchFollowUpActionsFinished()
+
+    await wait(250) // read the image
+
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(`import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+import { App } from '/src/app.js'
+import { View, Rectangle } from 'utopia-api'
+import { FlexRow } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='0cd'>
+    <Scene
+      style={{
+        width: 700,
+        height: 759,
+        position: 'absolute',
+        left: 207,
+        top: 126,
+        paddingLeft: 91,
+      }}
+      data-testid='scene'
+      data-label='Playground'
+      data-uid='3fc'
+    />
+    <img
+      alt=''
+      src='./assets/stuff_2.png'
+      style={{
+        position: 'absolute',
+        left: 602.5,
+        top: 505.5,
+        width: 1,
+        height: 1,
+      }}
+      data-uid='1'
+      data-aspect-ratio-locked
+    />
+  </Storyboard>
+)
+`)
+  })
+
   it('dragging multiple images from the "finder" works', async () => {
     FOR_TESTS_setNextGeneratedUids(['1', '2', '3'])
 
@@ -460,6 +528,101 @@ export var storyboard = (
 )
 `)
   })
+})
+
+it('dragging multiple images with the same name from the "finder" works', async () => {
+  FOR_TESTS_setNextGeneratedUids(['1', '2', '3'])
+
+  const editor = await renderTestEditorWithProjectContent(contents, 'await-first-dom-report')
+  const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+  const files = [
+    await makeImageFile(imgBase64, 'chucknorris.png'),
+    await makeImageFile(imgBase64, 'chucknorris.png'),
+    await makeImageFile(imgBase64, 'brucelee.png'),
+  ]
+
+  const target = editor.renderedDOM.getByTestId('scene')
+  const targetBounds = target.getBoundingClientRect()
+
+  const endPoint = {
+    x: targetBounds.x + targetBounds.width / 2,
+    y: targetBounds.y + targetBounds.height / 2,
+  }
+
+  fireEvent(canvasControlsLayer, makeDragEvent('drag', canvasControlsLayer, { x: 5, y: 5 }, files))
+
+  fireEvent(canvasControlsLayer, makeDragEvent('drag', canvasControlsLayer, endPoint, files))
+
+  fireEvent(canvasControlsLayer, makeDragEvent('drop', canvasControlsLayer, endPoint, files))
+
+  await editor.getDispatchFollowUpActionsFinished()
+
+  await wait(250) // read the image
+
+  expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(`import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+import { App } from '/src/app.js'
+import { View, Rectangle } from 'utopia-api'
+import { FlexRow } from 'utopia-api'
+
+export var storyboard = (
+<Storyboard data-uid='0cd'>
+  <Scene
+    style={{
+      width: 700,
+      height: 759,
+      position: 'absolute',
+      left: 207,
+      top: 126,
+      paddingLeft: 91,
+    }}
+    data-testid='scene'
+    data-label='Playground'
+    data-uid='3fc'
+  />
+  <img
+    alt=''
+    src='./assets/chucknorris.png'
+    style={{
+      position: 'absolute',
+      left: 602.5,
+      top: 505.5,
+      width: 1,
+      height: 1,
+    }}
+    data-uid='1'
+    data-aspect-ratio-locked
+  />
+  <img
+    alt=''
+    src='./assets/chucknorris_2.png'
+    style={{
+      position: 'absolute',
+      left: 602.5,
+      top: 505.5,
+      width: 1,
+      height: 1,
+    }}
+    data-uid='2'
+    data-aspect-ratio-locked
+  />
+  <img
+    alt=''
+    src='./assets/brucelee.png'
+    style={{
+      position: 'absolute',
+      left: 602.5,
+      top: 505.5,
+      width: 1,
+      height: 1,
+    }}
+    data-uid='3'
+    data-aspect-ratio-locked
+  />
+</Storyboard>
+)
+`)
 })
 
 // minimal PNG image


### PR DESCRIPTION
**Problem:**
When you drag and drop an image file to the canvas with a filename which already exists in the project, we should not overwrite the existing file, but create a new file with an autoincremented filename.

**Fix:**
I could have used the `saveAssetDoNothing` action instead of the `saveAssetReplace` one to generate a new filename inside the action update function. However, I need to know the filename to add it `src` of the inserted image element, so it just made more sense to generate a unique filename before creating the action.

After we clean up the file upload dialog from the code we can also delete the `saveAssetReplace` action, because we don't use it anymore.