### PR TITLE
Creating a reparenting metastrategy

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -8,13 +8,9 @@ import {
 } from '../../../core/shared/array-utils'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
 import { arrayEquals, assertNever } from '../../../core/shared/utils'
-import { AllElementProps, EditorState, EditorStorePatched } from '../../editor/store/editor-state'
+import { EditorState, EditorStorePatched } from '../../editor/store/editor-state'
 import { useEditorState, useSelectorWithCallback } from '../../editor/store/store-hook'
 import { absoluteMoveStrategy } from './strategies/absolute-move-strategy'
-import {
-  absoluteReparentStrategy,
-  forcedAbsoluteReparentStrategy,
-} from './strategies/absolute-reparent-strategy'
 import {
   CanvasStrategy,
   CanvasStrategyId,
@@ -28,7 +24,6 @@ import {
   InteractionLifecycle,
   CustomStrategyState,
   controlWithProps,
-  InsertionSubjects,
 } from './canvas-strategy-types'
 import { InteractionSession, StrategyState } from './interaction-state'
 import { keyboardAbsoluteMoveStrategy } from './strategies/keyboard-absolute-move-strategy'
@@ -37,15 +32,8 @@ import { keyboardAbsoluteResizeStrategy } from './strategies/keyboard-absolute-r
 import { convertToAbsoluteAndMoveStrategy } from './strategies/convert-to-absolute-and-move-strategy'
 import { flexReorderStrategy } from './strategies/flex-reorder-strategy'
 import { absoluteDuplicateStrategy } from './strategies/absolute-duplicate-strategy'
-import { absoluteReparentToFlexStrategy } from './strategies/absolute-reparent-to-flex-strategy'
-import {
-  flexReparentToAbsoluteStrategy,
-  forcedFlexReparentToAbsoluteStrategy,
-} from './strategies/flex-reparent-to-absolute-strategy'
-import { flexReparentToFlexStrategy } from './strategies/flex-reparent-to-flex-strategy'
 import { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { flowReorderStrategy } from './strategies/flow-reorder-strategy'
-import { InsertionSubject } from '../../editor/editor-modes'
 import { dragToInsertStrategy } from './strategies/drag-to-insert-strategy'
 import { StateSelector } from 'zustand'
 import { flowReorderSliderStategy } from './strategies/flow-reorder-slider-strategy'
@@ -55,6 +43,7 @@ import { flexResizeBasicStrategy } from './strategies/flex-resize-basic-strategy
 import { optionalMap } from '../../../core/shared/optional-utils'
 import { lookForApplicableParentStrategy } from './strategies/look-for-applicable-parent-strategy'
 import { relativeMoveStrategy } from './strategies/relative-move-strategy'
+import { reparentMetaStrategy } from './strategies/reparent-metastrategy'
 
 export type CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
@@ -70,18 +59,12 @@ export type MetaCanvasStrategy = (
 
 const existingStrategyFactories: Array<CanvasStrategyFactory> = [
   absoluteMoveStrategy,
-  absoluteReparentStrategy,
-  forcedAbsoluteReparentStrategy,
   absoluteDuplicateStrategy,
   keyboardAbsoluteMoveStrategy,
   keyboardAbsoluteResizeStrategy,
   absoluteResizeBoundingBoxStrategy,
   flexReorderStrategy,
-  flexReparentToAbsoluteStrategy,
-  forcedFlexReparentToAbsoluteStrategy,
-  flexReparentToFlexStrategy,
   convertToAbsoluteAndMoveStrategy,
-  absoluteReparentToFlexStrategy,
   dragToInsertStrategy,
   drawToInsertStrategy,
   flowReorderStrategy,
@@ -104,6 +87,7 @@ export const existingStrategies: MetaCanvasStrategy = (
 export const RegisteredCanvasStrategies: Array<MetaCanvasStrategy> = [
   existingStrategies,
   lookForApplicableParentStrategy,
+  reparentMetaStrategy,
 ]
 
 export function pickCanvasStateFromEditorState(

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -70,15 +70,15 @@ export function isHoverInteractionData(inputData: InputData): inputData is Hover
 export type UpdatedPathMap = { [oldPathString: string]: ElementPath }
 
 export interface ReparentTargetsToFilter {
-  'use-strict-bounds': ReparentTarget
-  'allow-missing-bounds': ReparentTarget
+  'use-strict-bounds': ReparentTarget | null
+  'allow-missing-bounds': ReparentTarget | null
 }
 
 export type MissingBoundsHandling = 'use-strict-bounds' | 'allow-missing-bounds'
 
 export function reparentTargetsToFilter(
-  strictBoundsTarget: ReparentTarget,
-  missingBoundsTarget: ReparentTarget,
+  strictBoundsTarget: ReparentTarget | null,
+  missingBoundsTarget: ReparentTarget | null,
 ): ReparentTargetsToFilter {
   return {
     'use-strict-bounds': strictBoundsTarget,

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-canvas.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-canvas.spec.tsx
@@ -1,3 +1,12 @@
+import * as Prettier from 'prettier/standalone'
+import { PrettierConfig } from 'utopia-vscode-common'
+import { createBuiltInDependenciesList } from '../../../../core/es-modules/package-manager/built-in-dependencies-list'
+import {
+  BakedInStoryboardUID,
+  BakedInStoryboardVariableName,
+} from '../../../../core/model/scene-utils'
+import { right } from '../../../../core/shared/either'
+import * as EP from '../../../../core/shared/element-path'
 import {
   ElementInstanceMetadata,
   emptyComments,
@@ -17,24 +26,11 @@ import {
   testPrintCodeFromEditorState,
   TestSceneUID,
 } from '../../ui-jsx.test-utils'
-import { absoluteReparentStrategy } from './absolute-reparent-strategy'
-import {
-  pickCanvasStateFromEditorState,
-  pickCanvasStateFromEditorStateWithMetadata,
-} from '../canvas-strategies'
+import { pickCanvasStateFromEditorStateWithMetadata } from '../canvas-strategies'
 import { defaultCustomStrategyState } from '../canvas-strategy-types'
-import { boundingArea, InteractionSession, StrategyState } from '../interaction-state'
+import { boundingArea, InteractionSession } from '../interaction-state'
 import { createMouseInteractionForTests } from '../interaction-state.test-utils'
-import * as EP from '../../../../core/shared/element-path'
-import { ElementPath } from '../../../../core/shared/project-file-types'
-import {
-  BakedInStoryboardUID,
-  BakedInStoryboardVariableName,
-} from '../../../../core/model/scene-utils'
-import { PrettierConfig } from 'utopia-vscode-common'
-import * as Prettier from 'prettier/standalone'
-import { right } from '../../../../core/shared/either'
-import { createBuiltInDependenciesList } from '../../../../core/es-modules/package-manager/built-in-dependencies-list'
+import { baseAbsoluteReparentStrategy } from './absolute-reparent-strategy'
 
 jest.mock('../../canvas-utils', () => ({
   ...jest.requireActual('../../canvas-utils'),
@@ -130,13 +126,14 @@ function reparentElement(
     startingTargetParentsToFilterOut: null,
   }
 
-  const strategyResult = absoluteReparentStrategy(
+  const strategyResult = baseAbsoluteReparentStrategy('use-strict-bounds')(
     pickCanvasStateFromEditorStateWithMetadata(
       editorState,
       createBuiltInDependenciesList(null),
       startingMetadata,
     ),
     interactionSession,
+    defaultCustomStrategyState(),
   )!.apply('end-interaction')
 
   expect(strategyResult.customStatePatch).toEqual({})

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-canvas.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-canvas.spec.tsx
@@ -126,7 +126,7 @@ function reparentElement(
     startingTargetParentsToFilterOut: null,
   }
 
-  const strategyResult = baseAbsoluteReparentStrategy('use-strict-bounds')(
+  const strategyResult = baseAbsoluteReparentStrategy('use-strict-bounds', false)(
     pickCanvasStateFromEditorStateWithMetadata(
       editorState,
       createBuiltInDependenciesList(null),

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.tsx
@@ -1,3 +1,6 @@
+import { createBuiltInDependenciesList } from '../../../../core/es-modules/package-manager/built-in-dependencies-list'
+import { left, right } from '../../../../core/shared/either'
+import * as EP from '../../../../core/shared/element-path'
 import {
   ElementInstanceMetadata,
   emptyComments,
@@ -15,17 +18,11 @@ import {
   makeTestProjectCodeWithSnippet,
   testPrintCodeFromEditorState,
 } from '../../ui-jsx.test-utils'
-import {
-  pickCanvasStateFromEditorState,
-  pickCanvasStateFromEditorStateWithMetadata,
-} from '../canvas-strategies'
+import { pickCanvasStateFromEditorStateWithMetadata } from '../canvas-strategies'
 import { defaultCustomStrategyState } from '../canvas-strategy-types'
-import { boundingArea, InteractionSession, StrategyState } from '../interaction-state'
+import { boundingArea, InteractionSession } from '../interaction-state'
 import { createMouseInteractionForTests } from '../interaction-state.test-utils'
-import * as EP from '../../../../core/shared/element-path'
-import { left, right } from '../../../../core/shared/either'
-import { createBuiltInDependenciesList } from '../../../../core/es-modules/package-manager/built-in-dependencies-list'
-import { baseAbsoluteReparentStrategy } from './absolute-reparent-strategy'
+import { reparentMetaStrategy } from './reparent-metastrategy'
 
 jest.mock('../../canvas-utils', () => ({
   ...jest.requireActual('../../canvas-utils'),
@@ -183,9 +180,11 @@ function reparentElement(
     } as ElementInstanceMetadata,
   }
 
+  const startPoint = canvasPoint({ x: 95, y: 80 })
+
   const interactionSession: InteractionSession = {
     ...createMouseInteractionForTests(
-      canvasPoint({ x: 95, y: 80 }),
+      startPoint,
       { cmd: true, alt: false, shift: false, ctrl: false },
       boundingArea(),
       dragVector,
@@ -195,39 +194,46 @@ function reparentElement(
     startingTargetParentsToFilterOut: null,
   }
 
-  const strategyResult = baseAbsoluteReparentStrategy('use-strict-bounds', false)(
-    pickCanvasStateFromEditorStateWithMetadata(
-      editorState,
-      createBuiltInDependenciesList(null),
-      startingMetadata,
-    ),
+  const canvasState = pickCanvasStateFromEditorStateWithMetadata(
+    editorState,
+    createBuiltInDependenciesList(null),
+    startingMetadata,
+  )
+
+  const reparentStrategies = reparentMetaStrategy(
+    canvasState,
     interactionSession,
     defaultCustomStrategyState(),
-  )!.apply('end-interaction')
+  )
 
-  expect(strategyResult.customStatePatch).toEqual({})
-  expect(strategyResult.status).toEqual('success')
+  if (reparentStrategies.length === 0) {
+    return editorState
+  } else {
+    const defaultReparentStrategy = reparentStrategies[0]
+    const strategyResult = defaultReparentStrategy.apply('end-interaction')
 
-  // Check if there are set SetElementsToRerenderCommands with the new parent path
-  expect(
-    strategyResult.commands.find(
-      (c) =>
-        c.type === 'SET_ELEMENTS_TO_RERENDER_COMMAND' &&
-        c.value !== 'rerender-all-elements' &&
-        c.value.every((p) => EP.pathsEqual(EP.parentPath(p), newParent)),
-    ),
-  ).not.toBeNull()
+    expect(strategyResult.customStatePatch).toEqual({})
+    expect(strategyResult.status).toEqual('success')
 
-  const finalEditor = foldAndApplyCommands(
-    editorState,
-    editorState,
-    [],
-    [],
-    strategyResult.commands,
-    'end-interaction',
-  ).editorState
+    // Check if there are set SetElementsToRerenderCommands with the new parent path
+    expect(
+      strategyResult.commands.find(
+        (c) =>
+          c.type === 'SET_ELEMENTS_TO_RERENDER_COMMAND' &&
+          c.value !== 'rerender-all-elements' &&
+          c.value.every((p) => EP.pathsEqual(EP.parentPath(p), newParent)),
+      ),
+    ).not.toBeNull()
 
-  return finalEditor
+    return foldAndApplyCommands(
+      editorState,
+      editorState,
+      [],
+      [],
+      strategyResult.commands,
+      'end-interaction',
+    ).editorState
+  }
 }
 
 describe('Absolute Reparent Strategy', () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.tsx
@@ -195,7 +195,7 @@ function reparentElement(
     startingTargetParentsToFilterOut: null,
   }
 
-  const strategyResult = baseAbsoluteReparentStrategy('use-strict-bounds')(
+  const strategyResult = baseAbsoluteReparentStrategy('use-strict-bounds', false)(
     pickCanvasStateFromEditorStateWithMetadata(
       editorState,
       createBuiltInDependenciesList(null),

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.tsx
@@ -15,7 +15,6 @@ import {
   makeTestProjectCodeWithSnippet,
   testPrintCodeFromEditorState,
 } from '../../ui-jsx.test-utils'
-import { absoluteReparentStrategy } from './absolute-reparent-strategy'
 import {
   pickCanvasStateFromEditorState,
   pickCanvasStateFromEditorStateWithMetadata,
@@ -26,6 +25,7 @@ import { createMouseInteractionForTests } from '../interaction-state.test-utils'
 import * as EP from '../../../../core/shared/element-path'
 import { left, right } from '../../../../core/shared/either'
 import { createBuiltInDependenciesList } from '../../../../core/es-modules/package-manager/built-in-dependencies-list'
+import { baseAbsoluteReparentStrategy } from './absolute-reparent-strategy'
 
 jest.mock('../../canvas-utils', () => ({
   ...jest.requireActual('../../canvas-utils'),
@@ -195,13 +195,14 @@ function reparentElement(
     startingTargetParentsToFilterOut: null,
   }
 
-  const strategyResult = absoluteReparentStrategy(
+  const strategyResult = baseAbsoluteReparentStrategy('use-strict-bounds')(
     pickCanvasStateFromEditorStateWithMetadata(
       editorState,
       createBuiltInDependenciesList(null),
       startingMetadata,
     ),
     interactionSession,
+    defaultCustomStrategyState(),
   )!.apply('end-interaction')
 
   expect(strategyResult.customStatePatch).toEqual({})

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
@@ -1,7 +1,6 @@
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../../core/shared/array-utils'
 import * as EP from '../../../../core/shared/element-path'
-import { offsetPoint } from '../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import { CSSCursor } from '../../canvas-types'
 import { setCursorCommand } from '../../commands/set-cursor-command'
@@ -22,15 +21,12 @@ import { InteractionSession, MissingBoundsHandling, UpdatedPathMap } from '../in
 import { absoluteMoveStrategy } from './absolute-move-strategy'
 import { honoursPropsPosition } from './absolute-utils'
 import { ifAllowedToReparent, isAllowedToReparent } from './reparent-helpers'
-import {
-  existingReparentSubjects,
-  getAbsoluteReparentPropertyChanges,
-  getReparentTargetUnified,
-} from './reparent-strategy-helpers'
+import { getAbsoluteReparentPropertyChanges, ReparentTarget } from './reparent-strategy-helpers'
 import { getReparentOutcome, pathToReparent } from './reparent-utils'
 import { getDragTargets } from './shared-move-strategies-helpers'
 
 export function baseAbsoluteReparentStrategy(
+  reparentTarget: ReparentTarget,
   missingBoundsHandling: MissingBoundsHandling,
   isFallback: boolean,
 ): CanvasStrategyFactory {
@@ -93,20 +89,6 @@ export function baseAbsoluteReparentStrategy(
               return emptyStrategyApplicationResult
             }
 
-            const pointOnCanvas = offsetPoint(
-              dragInteractionData.originalDragStart,
-              dragInteractionData.drag,
-            )
-
-            const reparentTarget = getReparentTargetUnified(
-              existingReparentSubjects(filteredSelectedElements),
-              pointOnCanvas,
-              dragInteractionData.modifiers.cmd,
-              canvasState,
-              canvasState.startingMetadata,
-              canvasState.startingAllElementProps,
-              missingBoundsHandling,
-            )
             const newParent = reparentTarget.newParent
             const allowedToReparent = filteredSelectedElements.every((selectedElement) => {
               return isAllowedToReparent(
@@ -117,7 +99,7 @@ export function baseAbsoluteReparentStrategy(
               )
             })
 
-            if (reparentTarget.shouldReparent && newParent != null && allowedToReparent) {
+            if (reparentTarget.shouldReparent && allowedToReparent) {
               const commands = mapDropNulls((selectedElement) => {
                 const reparentResult = getReparentOutcome(
                   canvasState.builtInDependencies,

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
@@ -30,184 +30,163 @@ import { mapDropNulls } from '../../../../core/shared/array-utils'
 import { honoursPropsPosition } from './absolute-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import { InteractionSession, MissingBoundsHandling, UpdatedPathMap } from '../interaction-state'
+import { CanvasStrategyFactory } from '../canvas-strategies'
 
-function baseAbsoluteReparentStrategy(
-  id: 'ABSOLUTE_REPARENT' | 'FORCED_ABSOLUTE_REPARENT',
-  name: string,
+export function baseAbsoluteReparentStrategy(
   missingBoundsHandling: MissingBoundsHandling,
-  canvasState: InteractionCanvasState,
-  interactionSession: InteractionSession | null,
-): CanvasStrategy | null {
-  const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
-  if (
-    selectedElements.length === 0 ||
-    interactionSession == null ||
-    interactionSession.interactionData.type !== 'DRAG'
-  ) {
-    return null
-  }
+): CanvasStrategyFactory {
+  const forced = missingBoundsHandling === 'allow-missing-bounds'
+  return (
+    canvasState: InteractionCanvasState,
+    interactionSession: InteractionSession | null,
+  ): CanvasStrategy | null => {
+    const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
+    if (
+      selectedElements.length === 0 ||
+      interactionSession == null ||
+      interactionSession.interactionData.type !== 'DRAG'
+    ) {
+      return null
+    }
 
-  const dragInteractionData = interactionSession.interactionData // Why TypeScript?!
-  const filteredSelectedElements = getDragTargets(selectedElements)
-  const isApplicable = filteredSelectedElements.every((element) => {
-    const elementMetadata = MetadataUtils.findElementByElementPath(
-      canvasState.startingMetadata,
-      element,
-    )
-
-    return (
-      elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
-      honoursPropsPosition(canvasState, element)
-    )
-  })
-  if (!isApplicable) {
-    return null
-  }
-  return {
-    id: id,
-    name: name,
-    controlsToRender: [
-      controlWithProps({
-        control: ParentOutlines,
-        props: {},
-        key: 'parent-outlines-control',
-        show: 'visible-only-while-active',
-      }),
-      controlWithProps({
-        control: ParentBounds,
-        props: {},
-        key: 'parent-bounds-control',
-        show: 'visible-only-while-active',
-      }),
-    ],
-    fitness: getFitnessForReparentStrategy(
-      'ABSOLUTE_REPARENT_TO_ABSOLUTE',
-      canvasState,
-      interactionSession,
-      missingBoundsHandling,
-    ),
-    apply: (strategyLifecycle) => {
-      const { projectContents, openFile, nodeModules } = canvasState
-      return ifAllowedToReparent(
-        canvasState,
+    const dragInteractionData = interactionSession.interactionData // Why TypeScript?!
+    const filteredSelectedElements = getDragTargets(selectedElements)
+    const isApplicable = filteredSelectedElements.every((element) => {
+      const elementMetadata = MetadataUtils.findElementByElementPath(
         canvasState.startingMetadata,
-        filteredSelectedElements,
-        () => {
-          if (dragInteractionData.drag == null) {
-            return emptyStrategyApplicationResult
-          }
+        element,
+      )
 
-          const pointOnCanvas = offsetPoint(
-            dragInteractionData.originalDragStart,
-            dragInteractionData.drag,
-          )
+      return (
+        elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
+        honoursPropsPosition(canvasState, element)
+      )
+    })
+    if (!isApplicable) {
+      return null
+    }
+    return {
+      id: `${forced ? 'FORCED_' : ''}ABSOLUTE_REPARENT`,
+      name: `Reparent (Abs${forced ? ', Force' : ''})`,
+      controlsToRender: [
+        controlWithProps({
+          control: ParentOutlines,
+          props: {},
+          key: 'parent-outlines-control',
+          show: 'visible-only-while-active',
+        }),
+        controlWithProps({
+          control: ParentBounds,
+          props: {},
+          key: 'parent-bounds-control',
+          show: 'visible-only-while-active',
+        }),
+      ],
+      fitness: getFitnessForReparentStrategy(
+        'ABSOLUTE_REPARENT_TO_ABSOLUTE',
+        canvasState,
+        interactionSession,
+        missingBoundsHandling,
+      ),
+      apply: (strategyLifecycle) => {
+        const { projectContents, openFile, nodeModules } = canvasState
+        return ifAllowedToReparent(
+          canvasState,
+          canvasState.startingMetadata,
+          filteredSelectedElements,
+          () => {
+            if (dragInteractionData.drag == null) {
+              return emptyStrategyApplicationResult
+            }
 
-          const reparentTarget = getReparentTargetUnified(
-            existingReparentSubjects(filteredSelectedElements),
-            pointOnCanvas,
-            dragInteractionData.modifiers.cmd,
-            canvasState,
-            canvasState.startingMetadata,
-            canvasState.startingAllElementProps,
-            missingBoundsHandling,
-          )
-          const newParent = reparentTarget.newParent
-          const allowedToReparent = filteredSelectedElements.every((selectedElement) => {
-            return isAllowedToReparent(
-              canvasState.projectContents,
-              canvasState.openFile,
-              canvasState.startingMetadata,
-              selectedElement,
+            const pointOnCanvas = offsetPoint(
+              dragInteractionData.originalDragStart,
+              dragInteractionData.drag,
             )
-          })
 
-          if (reparentTarget.shouldReparent && newParent != null && allowedToReparent) {
-            const commands = mapDropNulls((selectedElement) => {
-              const reparentResult = getReparentOutcome(
-                canvasState.builtInDependencies,
-                projectContents,
-                nodeModules,
-                openFile,
-                pathToReparent(selectedElement),
-                newParent,
-                'always',
+            const reparentTarget = getReparentTargetUnified(
+              existingReparentSubjects(filteredSelectedElements),
+              pointOnCanvas,
+              dragInteractionData.modifiers.cmd,
+              canvasState,
+              canvasState.startingMetadata,
+              canvasState.startingAllElementProps,
+              missingBoundsHandling,
+            )
+            const newParent = reparentTarget.newParent
+            const allowedToReparent = filteredSelectedElements.every((selectedElement) => {
+              return isAllowedToReparent(
+                canvasState.projectContents,
+                canvasState.openFile,
+                canvasState.startingMetadata,
+                selectedElement,
               )
-
-              if (reparentResult == null) {
-                return null
-              } else {
-                const offsetCommands = getAbsoluteReparentPropertyChanges(
-                  selectedElement,
-                  newParent,
-                  canvasState.startingMetadata,
-                  canvasState.startingMetadata,
-                  canvasState.projectContents,
-                  canvasState.openFile,
-                )
-
-                const { commands: reparentCommands, newPath } = reparentResult
-                return {
-                  oldPath: selectedElement,
-                  newPath: newPath,
-                  commands: [...offsetCommands, ...reparentCommands],
-                }
-              }
-            }, filteredSelectedElements)
-
-            let newPaths: Array<ElementPath> = []
-            let updatedTargetPaths: UpdatedPathMap = {}
-
-            commands.forEach((c) => {
-              newPaths.push(c.newPath)
-              updatedTargetPaths[EP.toString(c.oldPath)] = c.newPath
             })
 
-            const moveCommands =
-              absoluteMoveStrategy(canvasState, {
-                ...interactionSession,
-                updatedTargetPaths: updatedTargetPaths,
-              })?.apply(strategyLifecycle).commands ?? []
+            if (reparentTarget.shouldReparent && newParent != null && allowedToReparent) {
+              const commands = mapDropNulls((selectedElement) => {
+                const reparentResult = getReparentOutcome(
+                  canvasState.builtInDependencies,
+                  projectContents,
+                  nodeModules,
+                  openFile,
+                  pathToReparent(selectedElement),
+                  newParent,
+                  'always',
+                )
 
-            return strategyApplicationResult([
-              ...moveCommands,
-              ...commands.flatMap((c) => c.commands),
-              updateSelectedViews('always', newPaths),
-              setElementsToRerenderCommand([...newPaths, ...filteredSelectedElements]),
-              setCursorCommand('mid-interaction', CSSCursor.Move),
-            ])
-          } else {
-            const moveCommands =
-              absoluteMoveStrategy(canvasState, interactionSession)?.apply(strategyLifecycle)
-                .commands ?? []
+                if (reparentResult == null) {
+                  return null
+                } else {
+                  const offsetCommands = getAbsoluteReparentPropertyChanges(
+                    selectedElement,
+                    newParent,
+                    canvasState.startingMetadata,
+                    canvasState.startingMetadata,
+                    canvasState.projectContents,
+                    canvasState.openFile,
+                  )
 
-            return strategyApplicationResult(moveCommands)
-          }
-        },
-      )
-    },
+                  const { commands: reparentCommands, newPath } = reparentResult
+                  return {
+                    oldPath: selectedElement,
+                    newPath: newPath,
+                    commands: [...offsetCommands, ...reparentCommands],
+                  }
+                }
+              }, filteredSelectedElements)
+
+              let newPaths: Array<ElementPath> = []
+              let updatedTargetPaths: UpdatedPathMap = {}
+
+              commands.forEach((c) => {
+                newPaths.push(c.newPath)
+                updatedTargetPaths[EP.toString(c.oldPath)] = c.newPath
+              })
+
+              const moveCommands =
+                absoluteMoveStrategy(canvasState, {
+                  ...interactionSession,
+                  updatedTargetPaths: updatedTargetPaths,
+                })?.apply(strategyLifecycle).commands ?? []
+
+              return strategyApplicationResult([
+                ...moveCommands,
+                ...commands.flatMap((c) => c.commands),
+                updateSelectedViews('always', newPaths),
+                setElementsToRerenderCommand([...newPaths, ...filteredSelectedElements]),
+                setCursorCommand('mid-interaction', CSSCursor.Move),
+              ])
+            } else {
+              const moveCommands =
+                absoluteMoveStrategy(canvasState, interactionSession)?.apply(strategyLifecycle)
+                  .commands ?? []
+
+              return strategyApplicationResult(moveCommands)
+            }
+          },
+        )
+      },
+    }
   }
 }
-
-export const absoluteReparentStrategy = (
-  canvasState: InteractionCanvasState,
-  interactionSession: InteractionSession | null,
-): CanvasStrategy | null =>
-  baseAbsoluteReparentStrategy(
-    'ABSOLUTE_REPARENT',
-    'Reparent (Abs)',
-    'use-strict-bounds',
-    canvasState,
-    interactionSession,
-  )
-
-export const forcedAbsoluteReparentStrategy = (
-  canvasState: InteractionCanvasState,
-  interactionSession: InteractionSession | null,
-): CanvasStrategy | null =>
-  baseAbsoluteReparentStrategy(
-    'FORCED_ABSOLUTE_REPARENT',
-    'Reparent (Abs, Force)',
-    'allow-missing-bounds',
-    canvasState,
-    interactionSession,
-  )

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.tsx
@@ -10,7 +10,7 @@ import {
   InteractionCanvasState,
 } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
-import { applyFlexReparent, getFitnessForReparentStrategy } from './reparent-strategy-helpers'
+import { applyFlexReparent } from './reparent-strategy-helpers'
 import { getDragTargets } from './shared-move-strategies-helpers'
 
 export function absoluteReparentToFlexStrategy(
@@ -65,12 +65,7 @@ export function absoluteReparentToFlexStrategy(
         show: 'visible-only-while-active',
       }),
     ],
-    fitness: getFitnessForReparentStrategy(
-      'ABSOLUTE_REPARENT_TO_FLEX',
-      canvasState,
-      interactionSession,
-      'use-strict-bounds',
-    ),
+    fitness: 3,
     apply: () => {
       return applyFlexReparent('strip-absolute-props', canvasState, interactionSession)
     },

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.tsx
@@ -3,6 +3,7 @@ import { ParentBounds } from '../../controls/parent-bounds'
 import { ParentOutlines } from '../../controls/parent-outlines'
 import { DragOutlineControl } from '../../controls/select-mode/drag-outline-control'
 import { FlexReparentTargetIndicator } from '../../controls/select-mode/flex-reparent-target-indicator'
+import { CanvasStrategyFactory } from '../canvas-strategies'
 import {
   CanvasStrategy,
   controlWithProps,
@@ -10,64 +11,73 @@ import {
   InteractionCanvasState,
 } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
-import { applyFlexReparent } from './reparent-strategy-helpers'
+import { applyFlexReparent, ReparentTarget } from './reparent-strategy-helpers'
 import { getDragTargets } from './shared-move-strategies-helpers'
 
-export function absoluteReparentToFlexStrategy(
-  canvasState: InteractionCanvasState,
-  interactionSession: InteractionSession | null,
-): CanvasStrategy | null {
-  const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
-  const filteredSelectedElements = getDragTargets(selectedElements)
-  if (
-    filteredSelectedElements.length !== 1 ||
-    interactionSession == null ||
-    interactionSession.interactionData.type !== 'DRAG'
-  ) {
-    return null
-  }
+export function baseAbsoluteReparentToFlexStrategy(
+  reparentTarget: ReparentTarget,
+): CanvasStrategyFactory {
+  return (
+    canvasState: InteractionCanvasState,
+    interactionSession: InteractionSession | null,
+  ): CanvasStrategy | null => {
+    const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
+    const filteredSelectedElements = getDragTargets(selectedElements)
+    if (
+      filteredSelectedElements.length !== 1 ||
+      interactionSession == null ||
+      interactionSession.interactionData.type !== 'DRAG'
+    ) {
+      return null
+    }
 
-  if (
-    MetadataUtils.findElementByElementPath(
-      canvasState.startingMetadata,
-      filteredSelectedElements[0],
-    )?.specialSizeMeasurements.position !== 'absolute'
-  ) {
-    return null
-  }
+    if (
+      MetadataUtils.findElementByElementPath(
+        canvasState.startingMetadata,
+        filteredSelectedElements[0],
+      )?.specialSizeMeasurements.position !== 'absolute'
+    ) {
+      return null
+    }
 
-  return {
-    id: 'ABSOLUTE_REPARENT_TO_FLEX',
-    name: 'Reparent (Flex)',
-    controlsToRender: [
-      controlWithProps({
-        control: DragOutlineControl,
-        props: {},
-        key: 'ghost-outline-control',
-        show: 'visible-only-while-active',
-      }),
-      controlWithProps({
-        control: ParentOutlines,
-        props: {},
-        key: 'parent-outlines-control',
-        show: 'visible-only-while-active',
-      }),
-      controlWithProps({
-        control: ParentBounds,
-        props: {},
-        key: 'parent-bounds-control',
-        show: 'visible-only-while-active',
-      }),
-      controlWithProps({
-        control: FlexReparentTargetIndicator,
-        props: {},
-        key: 'flex-reparent-target-indicator',
-        show: 'visible-only-while-active',
-      }),
-    ],
-    fitness: 3,
-    apply: () => {
-      return applyFlexReparent('strip-absolute-props', canvasState, interactionSession)
-    },
+    return {
+      id: 'ABSOLUTE_REPARENT_TO_FLEX',
+      name: 'Reparent (Flex)',
+      controlsToRender: [
+        controlWithProps({
+          control: DragOutlineControl,
+          props: {},
+          key: 'ghost-outline-control',
+          show: 'visible-only-while-active',
+        }),
+        controlWithProps({
+          control: ParentOutlines,
+          props: {},
+          key: 'parent-outlines-control',
+          show: 'visible-only-while-active',
+        }),
+        controlWithProps({
+          control: ParentBounds,
+          props: {},
+          key: 'parent-bounds-control',
+          show: 'visible-only-while-active',
+        }),
+        controlWithProps({
+          control: FlexReparentTargetIndicator,
+          props: {},
+          key: 'flex-reparent-target-indicator',
+          show: 'visible-only-while-active',
+        }),
+      ],
+      fitness: 3,
+      apply: () => {
+        return applyFlexReparent(
+          'strip-absolute-props',
+          canvasState,
+          interactionSession,
+          reparentTarget,
+        )
+      },
+    }
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.tsx
@@ -209,7 +209,7 @@ function getHighlightAndReorderIndicatorCommands(
     'allow-missing-bounds',
   )
 
-  if (parent != null && parent.shouldReparent && parent.newParent != null) {
+  if (parent != null && parent.shouldReparent) {
     const highlightParentCommand = updateHighlightedViews('mid-interaction', [parent.newParent])
 
     if (parent.newIndex !== -1) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
@@ -15,11 +15,8 @@ import { wildcardPatch } from '../../commands/wildcard-patch-command'
 import { ParentBounds } from '../../controls/parent-bounds'
 import { ParentOutlines } from '../../controls/parent-outlines'
 import { DragOutlineControl } from '../../controls/select-mode/drag-outline-control'
-import {
-  absoluteReparentStrategy,
-  forcedAbsoluteReparentStrategy,
-} from './absolute-reparent-strategy'
-import { pickCanvasStateFromEditorState } from '../canvas-strategies'
+import { baseAbsoluteReparentStrategy } from './absolute-reparent-strategy'
+import { CanvasStrategyFactory, pickCanvasStateFromEditorState } from '../canvas-strategies'
 import {
   CanvasStrategy,
   controlWithProps,
@@ -39,183 +36,157 @@ import {
 } from './reparent-strategy-helpers'
 import { getDragTargets } from './shared-move-strategies-helpers'
 
-function baseFlexReparentToAbsoluteStrategy(
-  id: 'FLEX_REPARENT_TO_ABSOLUTE' | 'FORCED_FLEX_REPARENT_TO_ABSOLUTE',
-  name: string,
+export function baseFlexReparentToAbsoluteStrategy(
   missingBoundsHandling: MissingBoundsHandling,
-  canvasState: InteractionCanvasState,
-  interactionSession: InteractionSession | null,
-  customStrategyState: CustomStrategyState,
-): CanvasStrategy | null {
-  const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
-  if (
-    selectedElements.length !== 1 ||
-    !MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
-      selectedElements[0],
-      canvasState.startingMetadata,
-    )
-  ) {
-    return null
-  }
-
-  return {
-    id: id,
-    name: name,
-    controlsToRender: [
-      controlWithProps({
-        control: DragOutlineControl,
-        props: {},
-        key: 'ghost-outline-control',
-        show: 'visible-only-while-active',
-      }),
-      controlWithProps({
-        control: ParentOutlines,
-        props: {},
-        key: 'parent-outlines-control',
-        show: 'visible-only-while-active',
-      }),
-      controlWithProps({
-        control: ParentBounds,
-        props: {},
-        key: 'parent-bounds-control',
-        show: 'visible-only-while-active',
-      }),
-    ],
-    fitness:
-      interactionSession == null
-        ? 0
-        : // All 4 reparent strategies use the same fitness function getFitnessForReparentStrategy
-          getFitnessForReparentStrategy(
-            'FLEX_REPARENT_TO_ABSOLUTE',
-            canvasState,
-            interactionSession,
-            missingBoundsHandling,
-          ),
-    apply: (strategyLifecycle) => {
-      const filteredSelectedElements = getDragTargets(selectedElements)
-      return ifAllowedToReparent(
-        canvasState,
+): CanvasStrategyFactory {
+  const forced = missingBoundsHandling === 'allow-missing-bounds'
+  return (
+    canvasState: InteractionCanvasState,
+    interactionSession: InteractionSession | null,
+    customStrategyState: CustomStrategyState,
+  ): CanvasStrategy | null => {
+    const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
+    if (
+      selectedElements.length !== 1 ||
+      !MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
+        selectedElements[0],
         canvasState.startingMetadata,
-        filteredSelectedElements,
-        () => {
-          if (
-            interactionSession == null ||
-            interactionSession.interactionData.type !== 'DRAG' ||
-            interactionSession.interactionData.drag == null
-          ) {
-            return emptyStrategyApplicationResult
-          }
-
-          const pointOnCanvas = offsetPoint(
-            interactionSession.interactionData.originalDragStart,
-            interactionSession.interactionData.drag,
-          )
-
-          const { newParent } = getReparentTargetUnified(
-            existingReparentSubjects(filteredSelectedElements),
-            pointOnCanvas,
-            interactionSession.interactionData.modifiers.cmd,
-            canvasState,
-            canvasState.startingMetadata,
-            canvasState.startingAllElementProps,
-            missingBoundsHandling,
-          )
-
-          let duplicatedElementNewUids = {
-            ...customStrategyState.duplicatedElementNewUids,
-          }
-
-          const placeholderCloneCommands = filteredSelectedElements.flatMap((element) => {
-            const newParentADescendantOfCurrentParent =
-              newParent != null && isDescendantOf(newParent, parentPath(element))
-
-            if (newParentADescendantOfCurrentParent) {
-              // if the new parent a descendant of the current parent, it means we want to keep a placeholder element where the original dragged element was, to avoid the new parent shifting around on the screen
-              const selectedElementString = toString(element)
-              const newUid =
-                duplicatedElementNewUids[selectedElementString] ??
-                generateUidWithExistingComponents(canvasState.projectContents)
-              duplicatedElementNewUids[selectedElementString] = newUid
-
-              const newPath = appendToPath(parentPath(element), newUid)
-
-              return [
-                duplicateElement('mid-interaction', element, newUid),
-                wildcardPatch('mid-interaction', {
-                  hiddenInstances: { $push: [newPath] },
-                }),
-              ]
-            } else {
-              return []
-            }
-          })
-
-          const escapeHatchCommands = getEscapeHatchCommands(
-            filteredSelectedElements,
-            canvasState.startingMetadata,
-            canvasState,
-            canvasPoint({ x: 0, y: 0 }),
-          ).commands
-
-          return strategyApplicationResult([
-            ...placeholderCloneCommands,
-            ...escapeHatchCommands,
-            updateFunctionCommand(
-              'always',
-              (editorState, commandLifecycle): Array<EditorStatePatch> => {
-                const updatedCanvasState = pickCanvasStateFromEditorState(
-                  editorState,
-                  canvasState.builtInDependencies,
-                )
-                const isForced = missingBoundsHandling === 'allow-missing-bounds'
-
-                const absoluteReparentStrategyToUse = isForced
-                  ? forcedAbsoluteReparentStrategy
-                  : absoluteReparentStrategy
-                const reparentCommands =
-                  absoluteReparentStrategyToUse(updatedCanvasState, interactionSession)?.apply(
-                    strategyLifecycle,
-                  ).commands ?? []
-
-                return foldAndApplyCommandsInner(
-                  editorState,
-                  [],
-                  [],
-                  reparentCommands,
-                  commandLifecycle,
-                ).statePatches
-              },
-            ),
-          ])
-        },
       )
-    },
+    ) {
+      return null
+    }
+
+    return {
+      id: `${forced ? 'FORCED_' : ''}FLEX_REPARENT_TO_ABSOLUTE`,
+      name: `Reparent (Abs${forced ? ', Force' : ''})`,
+      controlsToRender: [
+        controlWithProps({
+          control: DragOutlineControl,
+          props: {},
+          key: 'ghost-outline-control',
+          show: 'visible-only-while-active',
+        }),
+        controlWithProps({
+          control: ParentOutlines,
+          props: {},
+          key: 'parent-outlines-control',
+          show: 'visible-only-while-active',
+        }),
+        controlWithProps({
+          control: ParentBounds,
+          props: {},
+          key: 'parent-bounds-control',
+          show: 'visible-only-while-active',
+        }),
+      ],
+      fitness:
+        interactionSession == null
+          ? 0
+          : // All 4 reparent strategies use the same fitness function getFitnessForReparentStrategy
+            getFitnessForReparentStrategy(
+              'FLEX_REPARENT_TO_ABSOLUTE',
+              canvasState,
+              interactionSession,
+              missingBoundsHandling,
+            ),
+      apply: (strategyLifecycle) => {
+        const filteredSelectedElements = getDragTargets(selectedElements)
+        return ifAllowedToReparent(
+          canvasState,
+          canvasState.startingMetadata,
+          filteredSelectedElements,
+          () => {
+            if (
+              interactionSession == null ||
+              interactionSession.interactionData.type !== 'DRAG' ||
+              interactionSession.interactionData.drag == null
+            ) {
+              return emptyStrategyApplicationResult
+            }
+
+            const pointOnCanvas = offsetPoint(
+              interactionSession.interactionData.originalDragStart,
+              interactionSession.interactionData.drag,
+            )
+
+            const { newParent } = getReparentTargetUnified(
+              existingReparentSubjects(filteredSelectedElements),
+              pointOnCanvas,
+              interactionSession.interactionData.modifiers.cmd,
+              canvasState,
+              canvasState.startingMetadata,
+              canvasState.startingAllElementProps,
+              missingBoundsHandling,
+            )
+
+            let duplicatedElementNewUids = {
+              ...customStrategyState.duplicatedElementNewUids,
+            }
+
+            const placeholderCloneCommands = filteredSelectedElements.flatMap((element) => {
+              const newParentADescendantOfCurrentParent =
+                newParent != null && isDescendantOf(newParent, parentPath(element))
+
+              if (newParentADescendantOfCurrentParent) {
+                // if the new parent a descendant of the current parent, it means we want to keep a placeholder element where the original dragged element was, to avoid the new parent shifting around on the screen
+                const selectedElementString = toString(element)
+                const newUid =
+                  duplicatedElementNewUids[selectedElementString] ??
+                  generateUidWithExistingComponents(canvasState.projectContents)
+                duplicatedElementNewUids[selectedElementString] = newUid
+
+                const newPath = appendToPath(parentPath(element), newUid)
+
+                return [
+                  duplicateElement('mid-interaction', element, newUid),
+                  wildcardPatch('mid-interaction', {
+                    hiddenInstances: { $push: [newPath] },
+                  }),
+                ]
+              } else {
+                return []
+              }
+            })
+
+            const escapeHatchCommands = getEscapeHatchCommands(
+              filteredSelectedElements,
+              canvasState.startingMetadata,
+              canvasState,
+              canvasPoint({ x: 0, y: 0 }),
+            ).commands
+
+            return strategyApplicationResult([
+              ...placeholderCloneCommands,
+              ...escapeHatchCommands,
+              updateFunctionCommand(
+                'always',
+                (editorState, commandLifecycle): Array<EditorStatePatch> => {
+                  const updatedCanvasState = pickCanvasStateFromEditorState(
+                    editorState,
+                    canvasState.builtInDependencies,
+                  )
+                  const absoluteReparentStrategyToUse =
+                    baseAbsoluteReparentStrategy(missingBoundsHandling)
+                  const reparentCommands =
+                    absoluteReparentStrategyToUse(
+                      updatedCanvasState,
+                      interactionSession,
+                      customStrategyState,
+                    )?.apply(strategyLifecycle).commands ?? []
+
+                  return foldAndApplyCommandsInner(
+                    editorState,
+                    [],
+                    [],
+                    reparentCommands,
+                    commandLifecycle,
+                  ).statePatches
+                },
+              ),
+            ])
+          },
+        )
+      },
+    }
   }
 }
-
-export const flexReparentToAbsoluteStrategy = (
-  canvasState: InteractionCanvasState,
-  interactionSession: InteractionSession | null,
-  customStrategyState: CustomStrategyState,
-) =>
-  baseFlexReparentToAbsoluteStrategy(
-    'FLEX_REPARENT_TO_ABSOLUTE',
-    'Reparent (Abs)',
-    'use-strict-bounds',
-    canvasState,
-    interactionSession,
-    customStrategyState,
-  )
-export const forcedFlexReparentToAbsoluteStrategy = (
-  canvasState: InteractionCanvasState,
-  interactionSession: InteractionSession | null,
-  customStrategyState: CustomStrategyState,
-) =>
-  baseFlexReparentToAbsoluteStrategy(
-    'FORCED_FLEX_REPARENT_TO_ABSOLUTE',
-    'Reparent (Abs, Force)',
-    'allow-missing-bounds',
-    canvasState,
-    interactionSession,
-    customStrategyState,
-  )

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flex-strategy.tsx
@@ -11,7 +11,7 @@ import {
   InteractionCanvasState,
 } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
-import { applyFlexReparent, getFitnessForReparentStrategy } from './reparent-strategy-helpers'
+import { applyFlexReparent } from './reparent-strategy-helpers'
 
 export function flexReparentToFlexStrategy(
   canvasState: InteractionCanvasState,
@@ -57,16 +57,7 @@ export function flexReparentToFlexStrategy(
         show: 'visible-only-while-active',
       }),
     ],
-    fitness:
-      // All 4 reparent strategies use the same fitness function getFitnessForReparentStrategy
-      interactionSession == null
-        ? 0
-        : getFitnessForReparentStrategy(
-            'FLEX_REPARENT_TO_FLEX',
-            canvasState,
-            interactionSession,
-            'use-strict-bounds',
-          ),
+    fitness: 3,
     apply: () => {
       return interactionSession == null
         ? emptyStrategyApplicationResult

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flex-strategy.tsx
@@ -3,6 +3,7 @@ import { ParentBounds } from '../../controls/parent-bounds'
 import { ParentOutlines } from '../../controls/parent-outlines'
 import { DragOutlineControl } from '../../controls/select-mode/drag-outline-control'
 import { FlexReparentTargetIndicator } from '../../controls/select-mode/flex-reparent-target-indicator'
+import { CanvasStrategyFactory } from '../canvas-strategies'
 import {
   CanvasStrategy,
   controlWithProps,
@@ -11,57 +12,61 @@ import {
   InteractionCanvasState,
 } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
-import { applyFlexReparent } from './reparent-strategy-helpers'
+import { applyFlexReparent, ReparentTarget } from './reparent-strategy-helpers'
 
-export function flexReparentToFlexStrategy(
-  canvasState: InteractionCanvasState,
-  interactionSession: InteractionSession | null,
-): CanvasStrategy | null {
-  const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
-  if (
-    selectedElements.length !== 1 ||
-    !MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
-      selectedElements[0],
-      canvasState.startingMetadata,
-    )
-  ) {
-    return null
-  }
+export function baseFlexReparentToFlexStrategy(
+  reparentTarget: ReparentTarget,
+): CanvasStrategyFactory {
+  return (
+    canvasState: InteractionCanvasState,
+    interactionSession: InteractionSession | null,
+  ): CanvasStrategy | null => {
+    const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
+    if (
+      selectedElements.length !== 1 ||
+      !MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
+        selectedElements[0],
+        canvasState.startingMetadata,
+      )
+    ) {
+      return null
+    }
 
-  return {
-    id: 'FLEX_REPARENT_TO_FLEX',
-    name: 'Reparent (Flex)',
-    controlsToRender: [
-      controlWithProps({
-        control: DragOutlineControl,
-        props: {},
-        key: 'ghost-outline-control',
-        show: 'visible-only-while-active',
-      }),
-      controlWithProps({
-        control: ParentOutlines,
-        props: {},
-        key: 'parent-outlines-control',
-        show: 'visible-only-while-active',
-      }),
-      controlWithProps({
-        control: ParentBounds,
-        props: {},
-        key: 'parent-bounds-control',
-        show: 'visible-only-while-active',
-      }),
-      controlWithProps({
-        control: FlexReparentTargetIndicator,
-        props: {},
-        key: 'flex-reparent-target-indicator',
-        show: 'visible-only-while-active',
-      }),
-    ],
-    fitness: 3,
-    apply: () => {
-      return interactionSession == null
-        ? emptyStrategyApplicationResult
-        : applyFlexReparent('do-not-strip-props', canvasState, interactionSession)
-    },
+    return {
+      id: 'FLEX_REPARENT_TO_FLEX',
+      name: 'Reparent (Flex)',
+      controlsToRender: [
+        controlWithProps({
+          control: DragOutlineControl,
+          props: {},
+          key: 'ghost-outline-control',
+          show: 'visible-only-while-active',
+        }),
+        controlWithProps({
+          control: ParentOutlines,
+          props: {},
+          key: 'parent-outlines-control',
+          show: 'visible-only-while-active',
+        }),
+        controlWithProps({
+          control: ParentBounds,
+          props: {},
+          key: 'parent-bounds-control',
+          show: 'visible-only-while-active',
+        }),
+        controlWithProps({
+          control: FlexReparentTargetIndicator,
+          props: {},
+          key: 'flex-reparent-target-indicator',
+          show: 'visible-only-while-active',
+        }),
+      ],
+      fitness: 3,
+      apply: () => {
+        return interactionSession == null
+          ? emptyStrategyApplicationResult
+          : applyFlexReparent('do-not-strip-props', canvasState, interactionSession, reparentTarget)
+      },
+    }
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/forced-absolute-reparent-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/forced-absolute-reparent-strategies.spec.browser2.tsx
@@ -1,4 +1,13 @@
 import {
+  BakedInStoryboardUID,
+  BakedInStoryboardVariableName,
+} from '../../../../core/model/scene-utils'
+import { stripNulls } from '../../../../core/shared/array-utils'
+import { windowPoint, WindowPoint } from '../../../../core/shared/math-utils'
+import { cmdModifier, Modifiers } from '../../../../utils/modifiers'
+import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
+import { mouseClickAtPoint, mouseDragFromPointWithDelta } from '../../event-helpers.test-utils'
+import {
   EditorRenderResult,
   formatTestProjectCode,
   getPrintedUiJsCode,
@@ -6,32 +15,12 @@ import {
   TestAppUID,
   TestSceneUID,
 } from '../../ui-jsx.test-utils'
-import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
-import { offsetPoint, windowPoint, WindowPoint } from '../../../../core/shared/math-utils'
-import { cmdModifier, Modifiers } from '../../../../utils/modifiers'
-import {
-  BakedInStoryboardVariableName,
-  BakedInStoryboardUID,
-} from '../../../../core/model/scene-utils'
-import {
-  absoluteReparentStrategy,
-  forcedAbsoluteReparentStrategy,
-} from './absolute-reparent-strategy'
-import {
-  flexReparentToAbsoluteStrategy,
-  forcedFlexReparentToAbsoluteStrategy,
-} from './flex-reparent-to-absolute-strategy'
-import { absoluteReparentToFlexStrategy } from './absolute-reparent-to-flex-strategy'
-import { flexReparentToFlexStrategy } from './flex-reparent-to-flex-strategy'
-import { mouseClickAtPoint, mouseDragFromPointWithDelta } from '../../event-helpers.test-utils'
-import {
-  CanvasStrategy,
-  CustomStrategyState,
-  InteractionCanvasState,
-} from '../canvas-strategy-types'
-import { InteractionSession } from '../interaction-state'
-import { stripNulls } from '../../../../core/shared/array-utils'
 import { CanvasStrategyFactory, MetaCanvasStrategy } from '../canvas-strategies'
+import { CustomStrategyState, InteractionCanvasState } from '../canvas-strategy-types'
+import { InteractionSession } from '../interaction-state'
+import { baseAbsoluteReparentStrategy } from './absolute-reparent-strategy'
+import { baseFlexReparentToAbsoluteStrategy } from './flex-reparent-to-absolute-strategy'
+import { reparentMetaStrategy } from './reparent-metastrategy'
 
 async function dragElement(
   renderResult: EditorRenderResult,
@@ -181,21 +170,12 @@ function metaStrategyForFactories(factories: Array<CanvasStrategyFactory>): Meta
     )
 }
 
-const allReparentStrategies = metaStrategyForFactories([
-  absoluteReparentStrategy,
-  absoluteReparentToFlexStrategy,
-  forcedAbsoluteReparentStrategy,
-  flexReparentToAbsoluteStrategy,
-  forcedFlexReparentToAbsoluteStrategy,
-  flexReparentToFlexStrategy,
-])
-
 describe('Forced Absolute Reparent Strategies', () => {
   it('Absolute to forced absolute can be applied', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(defaultTestCode),
       'await-first-dom-report',
-      [metaStrategyForFactories([forcedAbsoluteReparentStrategy])],
+      [metaStrategyForFactories([baseAbsoluteReparentStrategy('allow-missing-bounds')])],
     )
 
     const absoluteChild = await renderResult.renderedDOM.findByTestId('absolutechild')
@@ -306,7 +286,7 @@ describe('Forced Absolute Reparent Strategies', () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(defaultTestCode),
       'await-first-dom-report',
-      [allReparentStrategies],
+      [reparentMetaStrategy],
     )
 
     const absoluteChild = await renderResult.renderedDOM.findByTestId('absolutechild')
@@ -414,7 +394,7 @@ describe('Forced Absolute Reparent Strategies', () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(defaultTestCode),
       'await-first-dom-report',
-      [metaStrategyForFactories([forcedFlexReparentToAbsoluteStrategy])],
+      [metaStrategyForFactories([baseFlexReparentToAbsoluteStrategy('allow-missing-bounds')])],
     )
     const firstFlexChild = await renderResult.renderedDOM.findByTestId('flexchild1')
     const firstFlexChildRect = firstFlexChild.getBoundingClientRect()
@@ -529,7 +509,7 @@ describe('Forced Absolute Reparent Strategies', () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(defaultTestCode),
       'await-first-dom-report',
-      [allReparentStrategies],
+      [reparentMetaStrategy],
     )
     const firstFlexChild = await renderResult.renderedDOM.findByTestId('flexchild1')
     const firstFlexChildRect = firstFlexChild.getBoundingClientRect()
@@ -672,7 +652,7 @@ describe('Forced Absolute Reparent Strategies', () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(testCode),
       'await-first-dom-report',
-      [allReparentStrategies],
+      [reparentMetaStrategy],
     )
 
     await renderResult.getDispatchFollowUpActionsFinished()

--- a/editor/src/components/canvas/canvas-strategies/strategies/forced-absolute-reparent-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/forced-absolute-reparent-strategies.spec.browser2.tsx
@@ -175,7 +175,7 @@ describe('Forced Absolute Reparent Strategies', () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(defaultTestCode),
       'await-first-dom-report',
-      [metaStrategyForFactories([baseAbsoluteReparentStrategy('allow-missing-bounds')])],
+      [metaStrategyForFactories([baseAbsoluteReparentStrategy('allow-missing-bounds', false)])],
     )
 
     const absoluteChild = await renderResult.renderedDOM.findByTestId('absolutechild')
@@ -394,7 +394,11 @@ describe('Forced Absolute Reparent Strategies', () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(defaultTestCode),
       'await-first-dom-report',
-      [metaStrategyForFactories([baseFlexReparentToAbsoluteStrategy('allow-missing-bounds')])],
+      [
+        metaStrategyForFactories([
+          baseFlexReparentToAbsoluteStrategy('allow-missing-bounds', false),
+        ]),
+      ],
     )
     const firstFlexChild = await renderResult.renderedDOM.findByTestId('flexchild1')
     const firstFlexChildRect = firstFlexChild.getBoundingClientRect()

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -1,0 +1,87 @@
+import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import { mapDropNulls } from '../../../../core/shared/array-utils'
+import { offsetPoint } from '../../../../core/shared/math-utils'
+import { assertNever } from '../../../../core/shared/utils'
+import { MetaCanvasStrategy } from '../canvas-strategies'
+import {
+  CustomStrategyState,
+  getTargetPathsFromInteractionTarget,
+  InteractionCanvasState,
+} from '../canvas-strategy-types'
+import { InteractionSession, MissingBoundsHandling } from '../interaction-state'
+import { baseAbsoluteReparentStrategy } from './absolute-reparent-strategy'
+import { absoluteReparentToFlexStrategy } from './absolute-reparent-to-flex-strategy'
+import { baseFlexReparentToAbsoluteStrategy } from './flex-reparent-to-absolute-strategy'
+import { flexReparentToFlexStrategy } from './flex-reparent-to-flex-strategy'
+import { findPartialReparentStrategies } from './reparent-strategy-helpers'
+import { getDragTargets } from './shared-move-strategies-helpers'
+
+export const reparentMetaStrategy: MetaCanvasStrategy = (
+  canvasState: InteractionCanvasState,
+  interactionSession: InteractionSession | null,
+  customStrategyState: CustomStrategyState,
+) => {
+  if (
+    interactionSession == null ||
+    interactionSession.interactionData.type !== 'DRAG' ||
+    interactionSession.interactionData.drag == null
+  ) {
+    return []
+  }
+
+  const reparentSubjects = getDragTargets(
+    getTargetPathsFromInteractionTarget(canvasState.interactionTarget),
+  )
+
+  const allDraggedElementsAbsolute = reparentSubjects.every((element) =>
+    MetadataUtils.isPositionAbsolute(
+      MetadataUtils.findElementByElementPath(canvasState.startingMetadata, element),
+    ),
+  )
+
+  const allDraggedElementsFlex = reparentSubjects.every((element) =>
+    MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
+      element,
+      canvasState.startingMetadata,
+    ),
+  )
+
+  if (!allDraggedElementsAbsolute && !allDraggedElementsFlex) {
+    return []
+  }
+
+  const pointOnCanvas = offsetPoint(
+    interactionSession.interactionData.originalDragStart,
+    interactionSession.interactionData.drag,
+  )
+
+  const cmdPressed = interactionSession.interactionData.modifiers.cmd
+  const factories = findPartialReparentStrategies(canvasState, cmdPressed, pointOnCanvas).map(
+    (result) => {
+      const missingBoundsHandling: MissingBoundsHandling = result.forcingRequired
+        ? 'allow-missing-bounds'
+        : 'use-strict-bounds'
+      switch (result.strategy) {
+        case 'REPARENT_TO_ABSOLUTE':
+          if (allDraggedElementsAbsolute) {
+            return baseAbsoluteReparentStrategy(missingBoundsHandling)
+          } else {
+            return baseFlexReparentToAbsoluteStrategy(missingBoundsHandling)
+          }
+        case 'REPARENT_TO_FLEX':
+          if (allDraggedElementsAbsolute) {
+            return absoluteReparentToFlexStrategy
+          } else {
+            return flexReparentToFlexStrategy
+          }
+        default:
+          assertNever(result.strategy)
+      }
+    },
+  )
+
+  return mapDropNulls(
+    (factory) => factory(canvasState, interactionSession, customStrategyState),
+    factories,
+  )
+}

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -15,7 +15,7 @@ import { baseAbsoluteReparentStrategy } from './absolute-reparent-strategy'
 import { baseAbsoluteReparentToFlexStrategy } from './absolute-reparent-to-flex-strategy'
 import { baseFlexReparentToAbsoluteStrategy } from './flex-reparent-to-absolute-strategy'
 import { baseFlexReparentToFlexStrategy } from './flex-reparent-to-flex-strategy'
-import { findPartialReparentStrategies } from './reparent-strategy-helpers'
+import { findReparentStrategies } from './reparent-strategy-helpers'
 import { getDragTargets } from './shared-move-strategies-helpers'
 
 export const reparentMetaStrategy: MetaCanvasStrategy = (
@@ -78,12 +78,12 @@ export const reparentMetaStrategy: MetaCanvasStrategy = (
   )
 
   const cmdPressed = interactionSession.interactionData.modifiers.cmd
-  const partialStrategies = findPartialReparentStrategies(canvasState, cmdPressed, pointOnCanvas)
-  const filteredPartialStrategies = partialStrategies.filter((partialStrategy) =>
-    targetIsValid(partialStrategy.target.newParent, partialStrategy.missingBoundsHandling),
+  const reparentStrategies = findReparentStrategies(canvasState, cmdPressed, pointOnCanvas)
+  const filteredReparentStrategies = reparentStrategies.filter((reparentStrategy) =>
+    targetIsValid(reparentStrategy.target.newParent, reparentStrategy.missingBoundsHandling),
   )
 
-  const factories = filteredPartialStrategies.map((result) => {
+  const factories = filteredReparentStrategies.map((result) => {
     const missingBoundsHandling: MissingBoundsHandling = result.missingBoundsHandling
     switch (result.strategy) {
       case 'REPARENT_TO_ABSOLUTE':

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -73,16 +73,6 @@ export type FindPartialReparentStrategyResult = {
   isFallback: boolean
 }
 
-export type ReparentStrategy =
-  | 'FLEX_REPARENT_TO_ABSOLUTE'
-  | 'FLEX_REPARENT_TO_FLEX'
-  | 'ABSOLUTE_REPARENT_TO_ABSOLUTE'
-  | 'ABSOLUTE_REPARENT_TO_FLEX'
-
-export type FindReparentStrategyResult =
-  | { strategy: ReparentStrategy; newParent: ElementPath; forcingRequired: boolean }
-  | { strategy: 'do-not-reparent' }
-
 export function partialReparentStrategyForParent(
   targetMetadata: ElementInstanceMetadataMap,
   newParent: ElementPath,
@@ -863,7 +853,7 @@ export function getFlexReparentPropertyChanges(
 }
 
 export function getReparentPropertyChanges(
-  reparentStrategy: ReparentStrategy,
+  reparentStrategy: PartialReparentStrategy,
   target: ElementPath,
   newParent: ElementPath,
   targetStartingMetadata: ElementInstanceMetadataMap,
@@ -872,8 +862,7 @@ export function getReparentPropertyChanges(
   openFile: string | null | undefined,
 ): Array<CanvasCommand> {
   switch (reparentStrategy) {
-    case 'FLEX_REPARENT_TO_ABSOLUTE':
-    case 'ABSOLUTE_REPARENT_TO_ABSOLUTE':
+    case 'REPARENT_TO_ABSOLUTE':
       return getAbsoluteReparentPropertyChanges(
         target,
         newParent,
@@ -882,8 +871,7 @@ export function getReparentPropertyChanges(
         projectContents,
         openFile,
       )
-    case 'ABSOLUTE_REPARENT_TO_FLEX':
-    case 'FLEX_REPARENT_TO_FLEX':
+    case 'REPARENT_TO_FLEX':
       const newPath = EP.appendToPath(newParent, EP.toUid(target))
       return getFlexReparentPropertyChanges('strip-absolute-props', newPath)
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -157,59 +157,6 @@ export function findPartialReparentStrategies(
   return stripNulls([strictStrategy, forcedStrategy])
 }
 
-export function reparentStrategyForParent(
-  originalMetadata: ElementInstanceMetadataMap,
-  targetMetadata: ElementInstanceMetadataMap,
-  elements: Array<ElementPath>,
-  newParent: ElementPath,
-): FindReparentStrategyResult {
-  const allDraggedElementsFlex = elements.every((element) =>
-    MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
-      element,
-      originalMetadata,
-    ),
-  )
-  const allDraggedElementsAbsolute = elements.every((element) =>
-    MetadataUtils.isPositionAbsolute(
-      MetadataUtils.findElementByElementPath(originalMetadata, element),
-    ),
-  )
-
-  const newParentMetadata = MetadataUtils.findElementByElementPath(targetMetadata, newParent)
-  const parentIsFlexLayout = MetadataUtils.isFlexLayoutedContainer(newParentMetadata)
-
-  const parentProvidesBoundsForAbsoluteChildren =
-    newParentMetadata?.specialSizeMeasurements.providesBoundsForAbsoluteChildren ?? false
-
-  const parentIsStoryboard = EP.isStoryboardPath(newParent)
-  const isAbsoluteFriendlyParent = parentProvidesBoundsForAbsoluteChildren || parentIsStoryboard
-  const forcingRequiredForAbsoluteReparent = !isAbsoluteFriendlyParent
-
-  if (allDraggedElementsAbsolute) {
-    if (parentIsFlexLayout) {
-      return { strategy: 'ABSOLUTE_REPARENT_TO_FLEX', newParent: newParent, forcingRequired: false }
-    } else {
-      return {
-        strategy: 'ABSOLUTE_REPARENT_TO_ABSOLUTE',
-        newParent: newParent,
-        forcingRequired: forcingRequiredForAbsoluteReparent,
-      }
-    }
-  }
-  if (allDraggedElementsFlex) {
-    if (parentIsFlexLayout) {
-      return { strategy: 'FLEX_REPARENT_TO_FLEX', newParent: newParent, forcingRequired: false }
-    } else {
-      return {
-        strategy: 'FLEX_REPARENT_TO_ABSOLUTE',
-        newParent: newParent,
-        forcingRequired: forcingRequiredForAbsoluteReparent,
-      }
-    }
-  }
-  return { strategy: 'do-not-reparent' }
-}
-
 export interface ReparentTarget {
   shouldReparent: boolean
   newParent: ElementPath | null

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -65,23 +65,23 @@ import { ifAllowedToReparent } from './reparent-helpers'
 import { getReparentOutcome, pathToReparent } from './reparent-utils'
 import { getDragTargets } from './shared-move-strategies-helpers'
 
-export type PartialReparentStrategy = 'REPARENT_TO_ABSOLUTE' | 'REPARENT_TO_FLEX'
+export type ReparentStrategy = 'REPARENT_TO_ABSOLUTE' | 'REPARENT_TO_FLEX'
 
-export type PartialReparentStrategyForParent = {
-  strategy: PartialReparentStrategy
+export type ReparentStrategyForParent = {
+  strategy: ReparentStrategy
   missingBoundsHandling: MissingBoundsHandling
   isFallback: boolean
 }
 
-export type FindPartialReparentStrategyResult = PartialReparentStrategyForParent & {
+export type FindReparentStrategyResult = ReparentStrategyForParent & {
   target: ReparentTarget
 }
 
-export function partialReparentStrategyForParent(
+export function reparentStrategyForParent(
   targetMetadata: ElementInstanceMetadataMap,
   parent: ElementPath,
   convertToAbsolute: boolean,
-): PartialReparentStrategyForParent {
+): ReparentStrategyForParent {
   const newParentMetadata = MetadataUtils.findElementByElementPath(targetMetadata, parent)
   const parentIsFlexLayout =
     !convertToAbsolute && MetadataUtils.isFlexLayoutedContainer(newParentMetadata)
@@ -108,22 +108,22 @@ export function partialReparentStrategyForParent(
       }
 }
 
-function partialReparentStrategyForReparentTarget(
+function reparentStrategyForReparentTarget(
   targetMetadata: ElementInstanceMetadataMap,
   target: ReparentTarget,
   convertToAbsolute: boolean,
-): FindPartialReparentStrategyResult {
+): FindReparentStrategyResult {
   return {
-    ...partialReparentStrategyForParent(targetMetadata, target.newParent, convertToAbsolute),
+    ...reparentStrategyForParent(targetMetadata, target.newParent, convertToAbsolute),
     target: target,
   }
 }
 
-export function findPartialReparentStrategies(
+export function findReparentStrategies(
   canvasState: InteractionCanvasState,
   cmdPressed: boolean,
   pointOnCanvas: CanvasPoint,
-): Array<FindPartialReparentStrategyResult> {
+): Array<FindReparentStrategyResult> {
   const metadata = canvasState.startingMetadata
 
   const reparentSubjects =
@@ -146,9 +146,7 @@ export function findPartialReparentStrategies(
 
   const strictTarget = getReparentTargetInner('use-strict-bounds')
   const strictStrategy =
-    strictTarget == null
-      ? null
-      : partialReparentStrategyForReparentTarget(metadata, strictTarget, false)
+    strictTarget == null ? null : reparentStrategyForReparentTarget(metadata, strictTarget, false)
 
   const forcedTarget = getReparentTargetInner('allow-missing-bounds')
   const sameTargets =
@@ -160,7 +158,7 @@ export function findPartialReparentStrategies(
   const forcedStrategy =
     forcedTarget == null || skipForcedTarget
       ? null
-      : partialReparentStrategyForReparentTarget(metadata, forcedTarget, convertToAbsolute)
+      : reparentStrategyForReparentTarget(metadata, forcedTarget, convertToAbsolute)
 
   return stripNulls([strictStrategy, forcedStrategy])
 }
@@ -851,7 +849,7 @@ export function getFlexReparentPropertyChanges(
 }
 
 export function getReparentPropertyChanges(
-  reparentStrategy: PartialReparentStrategy,
+  reparentStrategy: ReparentStrategy,
   target: ElementPath,
   newParent: ElementPath,
   targetStartingMetadata: ElementInstanceMetadataMap,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -67,13 +67,10 @@ import { getDragTargets } from './shared-move-strategies-helpers'
 
 export type ReparentStrategy = 'REPARENT_TO_ABSOLUTE' | 'REPARENT_TO_FLEX'
 
-export type ReparentStrategyForParent = {
+export type FindReparentStrategyResult = {
   strategy: ReparentStrategy
   missingBoundsHandling: MissingBoundsHandling
   isFallback: boolean
-}
-
-export type FindReparentStrategyResult = ReparentStrategyForParent & {
   target: ReparentTarget
 }
 
@@ -81,7 +78,11 @@ export function reparentStrategyForParent(
   targetMetadata: ElementInstanceMetadataMap,
   parent: ElementPath,
   convertToAbsolute: boolean,
-): ReparentStrategyForParent {
+): {
+  strategy: ReparentStrategy
+  missingBoundsHandling: MissingBoundsHandling
+  isFallback: boolean
+} {
   const newParentMetadata = MetadataUtils.findElementByElementPath(targetMetadata, parent)
   const parentIsFlexLayout =
     !convertToAbsolute && MetadataUtils.isFlexLayoutedContainer(newParentMetadata)

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -406,7 +406,7 @@ import { getEscapeHatchCommands } from '../../canvas/canvas-strategies/strategie
 import { isAllowedToReparent } from '../../canvas/canvas-strategies/strategies/reparent-helpers'
 import {
   getReparentPropertyChanges,
-  partialReparentStrategyForParent,
+  reparentStrategyForParent,
   reparentTarget,
 } from '../../canvas/canvas-strategies/strategies/reparent-strategy-helpers'
 import {
@@ -2764,7 +2764,7 @@ export const UPDATE_FNS = {
         } else {
           const { commands: reparentCommands, newPath } = outcomeResult
 
-          const partialReparentStrategy = partialReparentStrategyForParent(
+          const reparentStrategy = reparentStrategyForParent(
             workingEditorState.jsxMetadata,
             action.pasteInto,
             false,
@@ -2785,7 +2785,7 @@ export const UPDATE_FNS = {
             return workingEditorState
           } else {
             const propertyChangeCommands = getReparentPropertyChanges(
-              partialReparentStrategy.strategy,
+              reparentStrategy.strategy,
               newPath,
               action.pasteInto,
               action.targetOriginalContextMetadata,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2766,7 +2766,7 @@ export const UPDATE_FNS = {
 
           const partialReparentStrategy = partialReparentStrategyForParent(
             workingEditorState.jsxMetadata,
-            reparentTarget(true, action.pasteInto, false, -1), // FIXME We shouldn't be doing this here
+            action.pasteInto,
             false,
           )
           const pastedElementIsFlex =

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -407,6 +407,7 @@ import { isAllowedToReparent } from '../../canvas/canvas-strategies/strategies/r
 import {
   getReparentPropertyChanges,
   partialReparentStrategyForParent,
+  reparentTarget,
 } from '../../canvas/canvas-strategies/strategies/reparent-strategy-helpers'
 import {
   elementToReparent,
@@ -2765,7 +2766,7 @@ export const UPDATE_FNS = {
 
           const partialReparentStrategy = partialReparentStrategyForParent(
             workingEditorState.jsxMetadata,
-            action.pasteInto,
+            reparentTarget(true, action.pasteInto, false, -1), // FIXME We shouldn't be doing this here
             false,
           )
           const pastedElementIsFlex =

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -407,7 +407,6 @@ import { isAllowedToReparent } from '../../canvas/canvas-strategies/strategies/r
 import {
   getReparentPropertyChanges,
   partialReparentStrategyForParent,
-  ReparentStrategy,
 } from '../../canvas/canvas-strategies/strategies/reparent-strategy-helpers'
 import {
   elementToReparent,
@@ -2784,11 +2783,8 @@ export const UPDATE_FNS = {
           if (!(pastedElementIsAbsolute || pastedElementIsFlex)) {
             return workingEditorState
           } else {
-            const strategyPrefix = pastedElementIsAbsolute ? 'ABSOLUTE' : 'FLEX'
-            const strategyToUse: ReparentStrategy = `${strategyPrefix}_${partialReparentStrategy.strategy}`
-
             const propertyChangeCommands = getReparentPropertyChanges(
-              strategyToUse,
+              partialReparentStrategy.strategy,
               newPath,
               action.pasteInto,
               action.targetOriginalContextMetadata,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1770,7 +1770,7 @@ export const ReparentTargetKeepDeepEquality: KeepDeepEqualityCall<ReparentTarget
     (target) => target.shouldReparent,
     BooleanKeepDeepEquality,
     (target) => target.newParent,
-    nullableDeepEquality(ElementPathKeepDeepEquality),
+    ElementPathKeepDeepEquality,
     (target) => target.shouldReorder,
     BooleanKeepDeepEquality,
     (target) => target.newIndex,
@@ -1781,9 +1781,9 @@ export const ReparentTargetKeepDeepEquality: KeepDeepEqualityCall<ReparentTarget
 const ReparentTargetsToFilterKeepDeepEquality: KeepDeepEqualityCall<ReparentTargetsToFilter> =
   combine2EqualityCalls(
     (target) => target['use-strict-bounds'],
-    ReparentTargetKeepDeepEquality,
+    nullableDeepEquality(ReparentTargetKeepDeepEquality),
     (target) => target['allow-missing-bounds'],
-    ReparentTargetKeepDeepEquality,
+    nullableDeepEquality(ReparentTargetKeepDeepEquality),
     reparentTargetsToFilter,
   )
 


### PR DESCRIPTION
**Problem:**
Reparenting strategies shared a lot of duplicated code, which was called multiple times during each strategy's lifecycle (to determine if it was applicable, what its fitness was, and how to apply it), and which is also heavily relied upon by insertion. On top of this, since the insertion strategies are currently having to find the reparenting strategy with the highest fitness, it means there is currently no way to select different types of insertion (e.g. to insert an absolute positioned element into a flex container).

**Fix:**
The fix here is to introduce a reparenting meta strategy, which performs the task of finding which types of reparent are available for a given point on the canvas, and then generate all of the reparent strategies for that.

This is achieved via a new function in `reparent-strategy-helpers.ts` called `findPartialReparentStrategies`, which determines what available parents are at that point, what context you would be reparenting into (currently just "absolute" or "flex"), and whether or not that reparenting action would require `'allow-missing-bounds'`.

Because we now capture all of this information upfront in the metastrategy (we were previously already calling the same logic, but then just not capturing all of the results, meaning we'd be calling pieces of it repeatedly), it means we can determine the fitness of each of the possible strategies, as well as shortcut parts of their `apply` function (since we don't need to find the target parent again).

I've updated all of the tests, but note that the non-browser tests with faked metadata are just getting worse and worse, so we should take a pitstop in the very near future to turn those into browser tests.