### PR TITLE
Save images and assets to Github.

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4941,7 +4941,11 @@ export const UPDATE_FNS = {
     }
     // Side effect - Pushing this to the server to get that to save to Github.
     const persistentModel = persistentModelFromEditorModel(updatedEditor)
-    void saveProjectToGithub(persistentModel, dispatch)
+    void saveProjectToGithub(
+      forceNotNull('Should have a project ID at this point.', editor.id),
+      persistentModel,
+      dispatch,
+    )
 
     return editor
   },

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -69,10 +69,11 @@ export interface GetBranchContentSuccess {
 export type GetBranchContentResponse = GetBranchContentSuccess | GithubFailure
 
 export async function saveProjectToGithub(
+  projectID: string,
   persistentModel: PersistentModel,
   dispatch: EditorDispatch,
 ): Promise<void> {
-  const url = urljoin(UTOPIA_BACKEND, 'github', 'save')
+  const url = urljoin(UTOPIA_BACKEND, 'github', 'save', projectID)
 
   const postBody = JSON.stringify(persistentModel)
   const response = await fetch(url, {

--- a/server/src/Utopia/Web/Assets.hs
+++ b/server/src/Utopia/Web/Assets.hs
@@ -6,6 +6,7 @@ module Utopia.Web.Assets where
 
 import           Conduit
 import           Control.Lens
+import           Control.Monad.Fail
 import           Control.Monad.Trans.AWS
 import qualified Data.ByteString.Lazy    as BL
 import           Data.Generics.Sum
@@ -30,6 +31,11 @@ data AWSResources = AWSResources
 data LoadAssetResult = AssetUnmodified
                      | AssetNotFound
                      | AssetLoaded BL.ByteString (Maybe Text)
+
+assetContentsFromLoadAssetResult :: LoadAssetResult -> IO BL.ByteString
+assetContentsFromLoadAssetResult AssetUnmodified          = fail "Asset is unmodified."
+assetContentsFromLoadAssetResult AssetNotFound            = fail "Asset not found."
+assetContentsFromLoadAssetResult (AssetLoaded content _)  = pure content
 
 type LoadAsset = [Text] -> Maybe Text -> IO LoadAssetResult
 

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -670,9 +670,9 @@ githubAuthenticatedEndpoint cookie = requireUser cookie $ \sessionUser -> do
   possibleAuthDetails <- getGithubAuthentication (view (field @"_id") sessionUser)
   pure $ isJust possibleAuthDetails
 
-githubSaveEndpoint :: Maybe Text -> PersistentModel -> ServerMonad SaveToGithubResponse
-githubSaveEndpoint cookie persistentModel = requireUser cookie $ \sessionUser -> do
-  saveToGithubRepo (view (field @"_id") sessionUser) persistentModel
+githubSaveEndpoint :: Maybe Text -> Text -> PersistentModel -> ServerMonad SaveToGithubResponse
+githubSaveEndpoint cookie projectID persistentModel = requireUser cookie $ \sessionUser -> do
+  saveToGithubRepo (view (field @"_id") sessionUser) projectID persistentModel
 
 getGithubBranchesEndpoint :: Maybe Text -> Text -> Text -> ServerMonad GetBranchesResponse
 getGithubBranchesEndpoint cookie owner repository = requireUser cookie $ \sessionUser -> do

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -222,9 +222,8 @@ responseFromLoadAssetResult assetPath (AssetLoaded bytes possibleETag) =
   let headers = getAssetHeaders (Just assetPath) possibleETag
   in  Just $ responseLBS ok200 headers bytes
 
-loadProjectAssetWithCall :: (MonadIO m, MonadThrow m) => LoadAsset -> [Text] -> Maybe Text -> m (Maybe Application)
-loadProjectAssetWithCall loadCall assetPath possibleETag = do
-  possibleAsset <- liftIO $ loadCall assetPath possibleETag
+loadProjectAssetWithAsset :: (MonadIO m, MonadThrow m) => [Text] -> LoadAssetResult -> m (Maybe Application)
+loadProjectAssetWithAsset assetPath possibleAsset = do
   let possibleResponse = responseFromLoadAssetResult assetPath possibleAsset
   pure $ fmap (\response -> \_ -> \sendResponse -> sendResponse response) possibleResponse
 
@@ -375,12 +374,12 @@ useAccessToken githubResources logger metrics pool userID action = do
         Nothing    -> throwE "User not authenticated with Github."
         Just token -> action token
 
-createTreeAndSaveToGithub :: (MonadIO m) => GithubAuthResources -> FastLogger -> DB.DatabaseMetrics -> DBPool -> Text -> PersistentModel -> m SaveToGithubResponse
-createTreeAndSaveToGithub githubResources logger metrics pool userID model = do
+createTreeAndSaveToGithub :: (MonadBaseControl IO m, MonadIO m) => GithubAuthResources -> Maybe AWSResources -> FastLogger -> DB.DatabaseMetrics -> DBPool -> Text -> Text -> PersistentModel -> m SaveToGithubResponse
+createTreeAndSaveToGithub githubResources awsResource logger metrics pool userID projectID model = do
   let parentCommits = toListOf (field @"githubSettings" . field @"originCommit" . _Just) model
   result <- runExceptT $ do
     treeResult <- useAccessToken githubResources logger metrics pool userID $ \accessToken -> do
-      createGitTreeFromModel accessToken model
+      createGitTreeFromModel (loadAsset awsResource) projectID accessToken model
     commitResult <- useAccessToken githubResources logger metrics pool userID $ \accessToken -> do
       createGitCommitForTree accessToken model (view (field @"sha") treeResult) parentCommits
     now <- liftIO getCurrentTime
@@ -429,3 +428,9 @@ getGithubBranch githubResources logger metrics pool userID owner repository bran
       getRecursiveGitTreeAsContent accessToken owner repository treeSha
     pure (projectContent, commitSha)
   pure $ either getBranchContentFailureFromReason getBranchContentSuccessFromContent result
+
+loadAsset :: Maybe AWSResources -> LoadAsset
+loadAsset awsResource path possibleETag = do
+  let loadCall = maybe loadProjectAssetFromDisk loadProjectAssetFromS3 awsResource
+  loadCall path possibleETag
+

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ApplicativeDo         #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE DeriveGeneric         #-}
@@ -22,6 +23,7 @@ import           Data.Aeson
 import           Data.Aeson.Encode.Pretty
 import           Data.Aeson.Lens
 import qualified Data.ByteString.Lazy            as BL
+import qualified Data.ByteString.Lazy.Base64     as BLB64
 import           Data.Data
 import           Data.Foldable
 import           Data.Generics.Product
@@ -39,6 +41,7 @@ import qualified Network.Wreq.Types              as WR (Postable)
 import           Prelude                         (String)
 import           Protolude
 import           Utopia.ClientModel
+import           Utopia.Web.Assets
 import           Utopia.Web.Github.Types
 
 fetchRepoArchive :: Text -> Text -> IO (Maybe BL.ByteString)
@@ -59,34 +62,49 @@ stripPreceedingSlash text =
     Just (firstChar, rest) -> if firstChar == '/' then rest else text
     Nothing                -> text
 
-directoryGitTreeEntry :: ProjectContentDirectory -> Maybe GitTreeEntry
+type SimpleCreateBlob m = Text -> ExceptT Text m CreateGitBlobResult
+
+directoryGitTreeEntry :: (MonadIO m) => ProjectContentDirectory -> ExceptT Text m (Maybe GitTreeEntry)
 directoryGitTreeEntry _ =
-  Nothing
+  pure Nothing
 
-projectFileGitTreeEntry :: Text -> ProjectFile -> Maybe GitTreeEntry
-projectFileGitTreeEntry fullPath (ProjectTextFile TextFile{..}) =
-  Just $ GitTreeEntry (stripPreceedingSlash fullPath) "100644" "blob" (Just $ code fileContents) Nothing
-projectFileGitTreeEntry _ (ProjectImageFile _) =
-  Nothing
-projectFileGitTreeEntry _ (ProjectAssetFile _) =
-  Nothing
-projectFileGitTreeEntry _ (ProjectDirectory _) =
-  Nothing
+createGitEntryFromAssetOrImage :: (MonadIO m) => LoadAsset -> SimpleCreateBlob m -> Text -> ExceptT Text m (Maybe GitTreeEntry)
+createGitEntryFromAssetOrImage loadAsset createBlob fullPath = do
+  assetResult <- liftIO $ loadAsset (T.splitOn "/" $ T.drop 1 fullPath) Nothing
+  assetContent <- liftIO $ assetContentsFromLoadAssetResult assetResult
+  let encodedContent = toS $ BLB64.encodeBase64 assetContent
+  createResult <- createBlob encodedContent
+  let blobSha = view (field @"sha") createResult
+  pure $ Just $ GitTreeEntry (stripPreceedingSlash fullPath) "100644" "blob" Nothing (Just blobSha)
 
-fileGitTreeEntry :: ProjectContentFile -> Maybe GitTreeEntry
-fileGitTreeEntry ProjectContentFile{..} = projectFileGitTreeEntry fullPath content
+projectFileGitTreeEntry :: (MonadIO m) => LoadAsset -> SimpleCreateBlob m -> Text -> ProjectFile -> ExceptT Text m (Maybe GitTreeEntry)
+projectFileGitTreeEntry _ _ fullPath (ProjectTextFile TextFile{..}) =
+  pure $ Just $ GitTreeEntry (stripPreceedingSlash fullPath) "100644" "blob" (Just $ code fileContents) Nothing
+projectFileGitTreeEntry loadAsset createBlob fullPath (ProjectImageFile _) =
+  createGitEntryFromAssetOrImage loadAsset createBlob fullPath
+projectFileGitTreeEntry loadAsset createBlob fullPath (ProjectAssetFile _) =
+  createGitEntryFromAssetOrImage loadAsset createBlob fullPath
+projectFileGitTreeEntry _ _ _ (ProjectDirectory _) =
+  pure Nothing
 
-gitTreeEntriesFromProjectContentsTree :: ProjectContentsTree -> [GitTreeEntry]
-gitTreeEntriesFromProjectContentsTree (ProjectContentsTreeDirectory dir) =
-  (gitTreeEntriesFromProjectContent $ children dir) <> (maybeToList $ directoryGitTreeEntry dir)
-gitTreeEntriesFromProjectContentsTree (ProjectContentsTreeFile file) =
-  maybeToList $ fileGitTreeEntry file
+fileGitTreeEntry :: (MonadIO m) => LoadAsset -> SimpleCreateBlob m -> ProjectContentFile -> ExceptT Text m (Maybe GitTreeEntry)
+fileGitTreeEntry loadAsset createBlob ProjectContentFile{..} = projectFileGitTreeEntry loadAsset createBlob fullPath content
 
-gitTreeEntriesFromProjectContent :: ProjectContentTreeRoot -> [GitTreeEntry]
-gitTreeEntriesFromProjectContent projectContents = foldMap' gitTreeEntriesFromProjectContentsTree projectContents
+gitTreeEntriesFromProjectContentsTree :: (MonadIO m, MonadBaseControl IO m) => LoadAsset -> SimpleCreateBlob m -> ProjectContentsTree -> ExceptT Text m [GitTreeEntry]
+gitTreeEntriesFromProjectContentsTree loadAsset createBlob (ProjectContentsTreeDirectory dir) = do
+  subEntries <- gitTreeEntriesFromProjectContent loadAsset createBlob $ children dir
+  directoryEntries <- fmap maybeToList $ directoryGitTreeEntry dir
+  pure (subEntries <> directoryEntries)
+gitTreeEntriesFromProjectContentsTree loadAsset createBlob (ProjectContentsTreeFile file) =
+  fmap maybeToList $ fileGitTreeEntry loadAsset createBlob file
 
-createGitTreeFromProjectContent :: ProjectContentTreeRoot -> CreateGitTree
-createGitTreeFromProjectContent projectContents = CreateGitTree Nothing $ gitTreeEntriesFromProjectContent projectContents
+gitTreeEntriesFromProjectContent :: (MonadIO m, MonadBaseControl IO m) => LoadAsset -> SimpleCreateBlob m -> ProjectContentTreeRoot -> ExceptT Text m [GitTreeEntry]
+gitTreeEntriesFromProjectContent loadAsset createBlob projectContents = do
+  entries <- mapConcurrently (gitTreeEntriesFromProjectContentsTree loadAsset createBlob) $ M.elems projectContents
+  pure $ join entries
+
+createGitTreeFromProjectContent :: (MonadIO m, MonadBaseControl IO m) => LoadAsset -> SimpleCreateBlob m -> ProjectContentTreeRoot -> ExceptT Text m CreateGitTree
+createGitTreeFromProjectContent loadAsset createBlob projectContents = fmap (CreateGitTree Nothing) $ gitTreeEntriesFromProjectContent loadAsset createBlob projectContents
 
 type MakeGithubRequest a = WR.Options -> String -> a -> IO (WR.Response BL.ByteString)
 
@@ -115,18 +133,33 @@ createTreeHandleErrorCases status | status == forbidden403            = throwE "
                                   | status == unprocessableEntity422  = liftIO $ fail "Unprocessable entity returned when creating tree."
                                   | otherwise                         = throwE "Unexpected error."
 
-createGitTree :: (MonadIO m) => AccessToken -> GithubRepo -> ProjectContentTreeRoot -> ExceptT Text m CreateGitTreeResult
-createGitTree accessToken GithubRepo{..} projectContents = do
+createGitTree :: (MonadIO m, MonadBaseControl IO m) => LoadAsset -> AccessToken -> GithubRepo -> ProjectContentTreeRoot -> ExceptT Text m CreateGitTreeResult
+createGitTree loadAsset accessToken repo@GithubRepo{..} projectContents = do
   let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/trees"
-  let request = createGitTreeFromProjectContent projectContents
+  let createBlob = createGitBlob accessToken repo
+  request <- createGitTreeFromProjectContent loadAsset createBlob projectContents
   callGithub postToGithub [] createTreeHandleErrorCases accessToken repoUrl request
 
-createGitTreeFromModel :: (MonadIO m) => AccessToken -> PersistentModel -> ExceptT Text m CreateGitTreeResult
-createGitTreeFromModel accessToken PersistentModel{..} = do
+createGitTreeFromModel :: (MonadIO m, MonadBaseControl IO m) => LoadAsset -> Text -> AccessToken -> PersistentModel -> ExceptT Text m CreateGitTreeResult
+createGitTreeFromModel loadAsset projectID accessToken PersistentModel{..} = do
   let possibleGithubRepo = targetRepository githubSettings
+  let loadAssetForProject projectPath possibleETag = loadAsset (projectID : projectPath) possibleETag
   case possibleGithubRepo of
-    Just repo -> createGitTree accessToken repo projectContents
+    Just repo -> createGitTree loadAssetForProject accessToken repo projectContents
     Nothing   -> throwE "No repository set on project."
+
+createBlobHandleErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
+createBlobHandleErrorCases status | status == forbidden403            = throwE "Forbidden from creating blob."
+                                  | status == notFound404             = throwE "Repository or tree not found."
+                                  | status == conflict409             = throwE "Conflict when creating blob."
+                                  | status == unprocessableEntity422  = liftIO $ fail "Unprocessable entity returned when creating tree."
+                                  | otherwise                         = throwE "Unexpected error."
+
+createGitBlob :: (MonadIO m) => AccessToken -> GithubRepo -> Text -> ExceptT Text m CreateGitBlobResult
+createGitBlob accessToken GithubRepo{..} base64EncodedContent = do
+  let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/blobs"
+  let request = CreateGitBlob base64EncodedContent "base64"
+  callGithub postToGithub [] createBlobHandleErrorCases accessToken repoUrl request
 
 createCommitHandleErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
 createCommitHandleErrorCases status | status == notFound404             = throwE "Repository or tree not found."
@@ -164,8 +197,8 @@ createGitBranchForCommit accessToken PersistentModel{..} commitSha branchName = 
     Nothing   -> throwE "No repository set on project."
 
 getGitBranchesErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
-getGitBranchesErrorCases status | status == notFound404  = throwE "Could not find repository."
-                                    | otherwise                         = throwE "Unexpected error."
+getGitBranchesErrorCases status | status == notFound404   = throwE "Could not find repository."
+                                | otherwise               = throwE "Unexpected error."
 
 getGitBranches :: (MonadIO m) => AccessToken -> Text -> Text -> Int -> ExceptT Text m GetBranchesResult
 getGitBranches accessToken owner repository page = do
@@ -173,9 +206,9 @@ getGitBranches accessToken owner repository page = do
   callGithub getFromGithub [("per_page", "100"), ("page", show page)] getGitBranchesErrorCases accessToken repoUrl ()
 
 getGitBranchErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
-getGitBranchErrorCases status | status == notFound404  = throwE "Could not find branch."
-                              | status == movedPermanently301  = throwE "Repository moved elsewhere."
-                              | otherwise                         = throwE "Unexpected error."
+getGitBranchErrorCases status | status == notFound404           = throwE "Could not find branch."
+                              | status == movedPermanently301   = throwE "Repository moved elsewhere."
+                              | otherwise                       = throwE "Unexpected error."
 
 getGitBranch :: (MonadIO m) => AccessToken -> Text -> Text -> Text -> ExceptT Text m GetBranchResult
 getGitBranch accessToken owner repository branchName = do
@@ -183,9 +216,9 @@ getGitBranch accessToken owner repository branchName = do
   callGithub getFromGithub [] getGitBranchErrorCases accessToken repoUrl ()
 
 getGitTreeErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
-getGitTreeErrorCases status | status == notFound404  = throwE "Could not find tree."
-                              | status == unprocessableEntity422  = liftIO $ fail "Unprocessable entity returned when creating tree."
-                              | otherwise                         = throwE "Unexpected error."
+getGitTreeErrorCases status | status == notFound404             = throwE "Could not find tree."
+                            | status == unprocessableEntity422  = liftIO $ fail "Unprocessable entity returned when creating tree."
+                            | otherwise                         = throwE "Unexpected error."
 
 getGitTree :: (MonadIO m) => AccessToken -> Text -> Text -> Text -> ExceptT Text m GetTreeResult
 getGitTree accessToken owner repository treeSha = do
@@ -193,8 +226,8 @@ getGitTree accessToken owner repository treeSha = do
   callGithub getFromGithub [("recursive", "true")] getGitTreeErrorCases accessToken repoUrl ()
 
 getGitBlobErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
-getGitBlobErrorCases status   | status == forbidden403 = throwE "Forbidden from loading blob."
-                              | status == notFound404  = throwE "Could not find blob."
+getGitBlobErrorCases status   | status == forbidden403            = throwE "Forbidden from loading blob."
+                              | status == notFound404             = throwE "Could not find blob."
                               | status == unprocessableEntity422  = liftIO $ fail "Unprocessable entity returned when creating tree."
                               | otherwise                         = throwE "Unexpected error."
 

--- a/server/src/Utopia/Web/Github/Types.hs
+++ b/server/src/Utopia/Web/Github/Types.hs
@@ -84,6 +84,30 @@ instance FromJSON CreateGitTreeResult where
 instance ToJSON CreateGitTreeResult where
   toJSON = genericToJSON defaultOptions
 
+data CreateGitBlob = CreateGitBlob
+                   { content  :: Text
+                   , encoding :: Text
+                   }
+                   deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON CreateGitBlob where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON CreateGitBlob where
+  toJSON = genericToJSON defaultOptions
+
+data CreateGitBlobResult = CreateGitBlobResult
+                         { url :: Text
+                         , sha :: Text
+                         }
+                         deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON CreateGitBlobResult where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON CreateGitBlobResult where
+  toJSON = genericToJSON defaultOptions
+
 data CreateGitCommit = CreateGitCommit
                      { message :: Text
                      , tree    :: Text

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -135,7 +135,7 @@ data ServiceCallsF a = NotFound
                      | GetGithubAuthorizationURI (URI -> a)
                      | GetGithubAccessToken Text ExchangeToken (Maybe AccessToken -> a)
                      | GetGithubAuthentication Text (Maybe GithubAuthenticationDetails -> a)
-                     | SaveToGithubRepo Text PersistentModel (SaveToGithubResponse -> a)
+                     | SaveToGithubRepo Text Text PersistentModel (SaveToGithubResponse -> a)
                      | GetBranchesFromGithubRepo Text Text Text (GetBranchesResponse -> a)
                      | GetBranchContent Text Text Text Text (GetBranchContentResponse -> a)
                      deriving Functor

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -129,7 +129,7 @@ type GithubStartAuthenticationAPI = "v1" :> "github" :> "authentication" :> "sta
 
 type GithubFinishAuthenticationAPI = "v1" :> "github" :> "authentication" :> "finish" :> QueryParam "code" ExchangeToken :> Get '[HTML] H.Html
 
-type GithubSaveAPI = "v1" :> "github" :> "save" :> ReqBody '[JSON] PersistentModel :> Post '[JSON] SaveToGithubResponse
+type GithubSaveAPI = "v1" :> "github" :> "save" :> Capture "project_id" Text :> ReqBody '[JSON] PersistentModel :> Post '[JSON] SaveToGithubResponse
 
 type GithubBranchesAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> Get '[JSON] GetBranchesResponse
 


### PR DESCRIPTION
**Problem:**
Previously the functionality for uploading a project to Github ignored image and asset files completely which meant they wouldn't be included.

**Fix:**
Now when constructing the git tree to upload if an image or asset file is reached the following steps occur:
- Asset contents is loaded from S3 (or potentially local storage in development).
- The contents are base64 encoded.
- A git blob is created via a call to the Github API.
- The sha of the blob is recorded in the entry that goes into the tree that eventually gets uploaded.

**Commit Details:**
- Added `CreateGitBlob` and `CreateGitBlobResult` data types.
- Modified `createGitTreeFromProjectContent` to take additional parameters for loading an asset from wherever Utopia has it stored and for creating a Git blob if necessary. As well as extending the return type to support more detailed failure cases.
- `createGitTree` passes a partly applied version of `createGitBlob` to `createGitTreeFromProjectContent`.
- Added `createGitBlob` function for creating a blob, along with the `createBlobHandleErrorCases` support function.
- `SaveToGithubRepo` now takes the project ID.