### PR TITLE
Load assets and images when loading a project from Github

### DIFF
--- a/clientmodel/lib/src/Utopia/ClientModel.hs
+++ b/clientmodel/lib/src/Utopia/ClientModel.hs
@@ -185,7 +185,7 @@ data ImageFile = ImageFile
                , base64    :: Maybe Text
                , width     :: Maybe Double
                , height    :: Maybe Double
-               , hash      :: Integer
+               , hash      :: Int
                }
                deriving (Eq, Show, Generic, Data, Typeable)
 

--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -72,10 +72,8 @@ import {
   parseGithubProjectString,
 } from '../../core/shared/github'
 import { startGithubAuthentication } from '../../utils/github-auth'
-import { getURLImportDetails } from '../../core/model/project-import'
-import { forEachLeft, forEachRight } from '../../core/shared/either'
-import { notice } from '../common/notice'
 import { when } from '../../utils/react-conditionals'
+import { forceNotNull } from '../../core/shared/optional-utils'
 
 export interface LeftPaneProps {
   editorState: EditorState
@@ -723,6 +721,7 @@ const GithubPane = React.memo(() => {
   const [importGithubRepoStr, setImportGithubRepoStr] = React.useState('')
   const parsedImportRepo = parseGithubProjectString(importGithubRepoStr)
   const dispatch = useEditorState((store) => store.dispatch, 'GithubPane dispatch')
+  const projectID = useEditorState((store) => store.editor.id, 'GithubPane projectID')
   const storedTargetGithubRepo = useEditorState((store) => {
     const repo = store.editor.githubSettings.targetRepository
     if (repo == null) {
@@ -843,7 +842,12 @@ const GithubPane = React.memo(() => {
                   {branchesForRepository.branches.map((branch, index) => {
                     function loadContentForBranch() {
                       if (parsedTargetRepository != null) {
-                        void getBranchContent(dispatch, parsedTargetRepository, branch.name)
+                        void getBranchContent(
+                          dispatch,
+                          parsedTargetRepository,
+                          forceNotNull('Should have a project ID.', projectID),
+                          branch.name,
+                        )
                       }
                     }
                     return (
@@ -865,7 +869,7 @@ const GithubPane = React.memo(() => {
           throw new Error(`Unhandled branches value ${JSON.stringify(branchesForRepository)}`)
       }
     }
-  }, [branchesForRepository, parsedTargetRepository, dispatch])
+  }, [branchesForRepository, parsedTargetRepository, dispatch, projectID])
 
   return (
     <FlexColumn

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -535,6 +535,7 @@ export function isDirectory(projectFile: ProjectFile): projectFile is Directory 
 }
 
 // A layer over the mime-types library which means we can shim in things we need.
+// Keep this in sync with Utopia/Web/Assets.hs.
 export function mimeTypeLookup(filename: string): string | false {
   if (filename.endsWith('.ts')) {
     return 'application/x-typescript'

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -147,6 +147,7 @@ export async function getBranchesForGithubRepository(
 export async function getBranchContent(
   dispatch: EditorDispatch,
   githubRepo: GithubRepo,
+  projectID: string,
   branchName: string,
 ): Promise<void> {
   const url = urljoin(
@@ -157,9 +158,12 @@ export async function getBranchContent(
     githubRepo.repository,
     branchName,
   )
+  const searchParams = new URLSearchParams({
+    project_id: projectID,
+  })
 
-  const response = await fetch(url, {
-    method: 'GET',
+  const response = await fetch(`${url}?${searchParams}`, {
+    method: 'POST',
     credentials: 'include',
     headers: HEADERS,
     mode: MODE,

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -41,6 +41,7 @@ dependencies:
   - cereal
   - concurrent-extra
   - conduit
+  - containers
   - cookie
   - cryptohash-sha256
   - cryptonite
@@ -50,15 +51,16 @@ dependencies:
   - fast-logger
   - filepath
   - free
-  - zlib
+  - generic-lens
+  - github 
+  - hashable
   - hoauth2 ==1.16.0
   - http-api-data
   - http-client
   - http-client-tls
   - http-media
   - http-types
-  - generic-lens
-  - github 
+  - JuicyPixels
   - lens
   - lens-aeson <1.2
   - lifted-async
@@ -102,8 +104,8 @@ dependencies:
   - transformers
   - unix
   - unordered-containers
-  - utopia-clientmodel
   - uri-bytestring
+  - utopia-clientmodel
   - uuid
   - vector
   - wai
@@ -113,6 +115,7 @@ dependencies:
   - warp
   - websockets
   - wreq
+  - zlib
 extra-libraries:
   - z
 executable:
@@ -132,11 +135,11 @@ tests:
       - test
       - src
     dependencies:
-      - servant-client-core
-      - hspec
       - hedgehog
+      - hspec
       - port-utils
       - random
+      - servant-client-core
       - tasty
       - tasty-hedgehog
       - tasty-hspec

--- a/server/src/Utopia/Web/Assets.hs
+++ b/server/src/Utopia/Web/Assets.hs
@@ -207,6 +207,7 @@ data BlobEntryType = TextEntryType
                    | AssetEntryType
                    deriving (Eq, Ord, Show)
 
+-- Keep in sync with core/model/project-file-utils.ts.
 expandedMimeMap :: MimeMap
 expandedMimeMap = defaultMimeMap <> M.fromList
   [ ("ts", "application/typescript")
@@ -214,12 +215,15 @@ expandedMimeMap = defaultMimeMap <> M.fromList
   , ("jsx", "application/javascript")
   ]
 
+-- Keep in sync with core/model/project-file-utils.ts.
 looksLikeJavaScript :: MimeType -> Bool
 looksLikeJavaScript mimeType = B.isSuffixOf "/javascript" mimeType || B.isSuffixOf "/typescript" mimeType
 
+-- Keep in sync with core/model/project-file-utils.ts.
 looksLikeText :: MimeType -> Bool
 looksLikeText mimeType = looksLikeJavaScript mimeType || B.isPrefixOf "text/" mimeType || B.isPrefixOf "application/json" mimeType
 
+-- Keep in sync with core/model/project-file-utils.ts.
 looksLikeImage :: MimeType -> Bool
 looksLikeImage mimeType = B.isPrefixOf "image/" mimeType
 

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -678,9 +678,10 @@ getGithubBranchesEndpoint :: Maybe Text -> Text -> Text -> ServerMonad GetBranch
 getGithubBranchesEndpoint cookie owner repository = requireUser cookie $ \sessionUser -> do
   getBranchesFromGithubRepo (view (field @"_id") sessionUser) owner repository
 
-getGithubBranchContentEndpoint :: Maybe Text -> Text -> Text -> Text -> ServerMonad GetBranchContentResponse
-getGithubBranchContentEndpoint cookie owner repository branchName = requireUser cookie $ \sessionUser -> do
-  getBranchContent (view (field @"_id") sessionUser) owner repository branchName
+getGithubBranchContentEndpoint :: Maybe Text -> Text -> Text -> Text -> Maybe Text -> ServerMonad GetBranchContentResponse
+getGithubBranchContentEndpoint _ _ _ _ Nothing = badRequest
+getGithubBranchContentEndpoint cookie owner repository branchName (Just projectID) = requireUser cookie $ \sessionUser -> do
+  getBranchContent (view (field @"_id") sessionUser) owner repository branchName projectID
 
 {-|
   Compose together all the individual endpoints into a definition for the whole server.

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -150,7 +150,7 @@ innerServerExecutor (SaveProjectAsset user projectID path action) = do
   pool <- fmap _projectPool ask
   awsResource <- fmap _awsResources ask
   metrics <- fmap _databaseMetrics ask
-  application <- saveProjectAssetWithCall metrics pool user projectID path $ saveProjectAssetToS3 awsResource
+  application <- saveProjectAssetWithCall metrics pool user projectID path $ saveAsset $ Just awsResource
   return $ action application
 innerServerExecutor (RenameProjectAsset user projectID oldPath newPath next) = do
   awsResource <- fmap _awsResources ask
@@ -279,12 +279,13 @@ innerServerExecutor (GetBranchesFromGithubRepo user owner repository action) = d
   pool <- fmap _projectPool ask
   result <- getGithubBranches githubResources logger metrics pool user owner repository
   pure $ action result
-innerServerExecutor (GetBranchContent user owner repository branchName action) = do
+innerServerExecutor (GetBranchContent user owner repository branchName projectID action) = do
   githubResources <- fmap _githubResources ask
   metrics <- fmap _databaseMetrics ask
   logger <- fmap _logger ask
   pool <- fmap _projectPool ask
-  result <- getGithubBranch githubResources logger metrics pool user owner repository branchName
+  awsResource <- fmap _awsResources ask
+  result <- getGithubBranch githubResources (Just awsResource) logger metrics pool user owner repository branchName projectID
   pure $ action result
 
 readEditorContentFromDisk :: Maybe BranchDownloads -> Maybe Text -> Text -> IO Text

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -137,7 +137,7 @@ data ServiceCallsF a = NotFound
                      | GetGithubAuthentication Text (Maybe GithubAuthenticationDetails -> a)
                      | SaveToGithubRepo Text Text PersistentModel (SaveToGithubResponse -> a)
                      | GetBranchesFromGithubRepo Text Text Text (GetBranchesResponse -> a)
-                     | GetBranchContent Text Text Text Text (GetBranchContentResponse -> a)
+                     | GetBranchContent Text Text Text Text Text (GetBranchContentResponse -> a)
                      deriving Functor
 
 {-

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -133,7 +133,7 @@ type GithubSaveAPI = "v1" :> "github" :> "save" :> Capture "project_id" Text :> 
 
 type GithubBranchesAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> Get '[JSON] GetBranchesResponse
 
-type GithubBranchLoadAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> Capture "branchName" Text :> Get '[JSON] GetBranchContentResponse
+type GithubBranchLoadAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> Capture "branchName" Text :> QueryParam "project_id" Text :> Post '[JSON] GetBranchContentResponse
 
 type PackagePackagerResponse = Headers '[Header "Cache-Control" Text, Header "Last-Modified" LastModifiedTime, Header "Access-Control-Allow-Origin" Text] (ConduitT () ByteString (ResourceT IO) ())
 

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -65,7 +65,8 @@ executable utopia-web
   extra-libraries:
       z
   build-depends:
-      aeson <2.1
+      JuicyPixels
+    , aeson <2.1
     , aeson-pretty
     , amazonka ==1.6.1
     , amazonka-core ==1.6.1
@@ -80,6 +81,7 @@ executable utopia-web
     , cereal
     , concurrent-extra
     , conduit
+    , containers
     , cookie
     , cryptohash-sha256
     , cryptonite
@@ -91,6 +93,7 @@ executable utopia-web
     , free
     , generic-lens
     , github
+    , hashable
     , hoauth2 ==1.16.0
     , http-api-data
     , http-client
@@ -203,7 +206,8 @@ test-suite utopia-web-test
   extra-libraries:
       z
   build-depends:
-      aeson <2.1
+      JuicyPixels
+    , aeson <2.1
     , aeson-pretty
     , amazonka ==1.6.1
     , amazonka-core ==1.6.1
@@ -218,6 +222,7 @@ test-suite utopia-web-test
     , cereal
     , concurrent-extra
     , conduit
+    , containers
     , cookie
     , cryptohash-sha256
     , cryptonite
@@ -229,6 +234,7 @@ test-suite utopia-web-test
     , free
     , generic-lens
     , github
+    , hashable
     , hedgehog
     , hoauth2 ==1.16.0
     , hspec


### PR DESCRIPTION
**Problem:**
When loading a branch from Github, we want assets and images to be included in the resultant Utopia project, which they aren't currently.

**Fix:**
In almost the exact inverse of what we do when saving to Github, the following flow is triggered when loading the contents of an image that is in a branch:

- Asset contents are loaded from git blob service.
- The contents are base64 decoded.
- The asset is uploaded against the project in S3 (or locally in development)
- An entry is added to the project contents as our indicator of its existance.

**Commit Details:**
- Changed `ImageFile.hash` to be an `Int` instead of `Integer` to make it more amenable to being hashed.
- `getBranchContent` now includes the project ID in a query parameter.
- Created some utility functions mostly fronted by `blobEntryTypeFromFilename` which determine if a blob should fall into one of 3 categories: Text, Image or Asset.
- `getRecursiveGitTreeAsContent` now takes an instance of `SaveAsset` and passes it into `projectContentFromGitEntry` so that images and assets can be uploaded while constructing the project contents.
- For images, the `JuicyPixls` library is used to grab the dimensions of the image so that it can be included in the metadata.