### PR TITLE
Disable flex resize for missing dimensions

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.spec.browser2.tsx
@@ -253,53 +253,33 @@ describe('Flex Resize', () => {
   describe('when the element has missing dimensions', () => {
     describe('both missing', () => {
       describe('horizontal movement', () => {
-        it('adds only the width', async () => {
-          await resizeWithoutDimensions(
-            edgePosition(1, 0),
-            canvasPoint({ x: 15, y: 0 }),
-            {},
-            { width: 15 },
-          )
+        it('does nothing', async () => {
+          await resizeWithoutDimensions(edgePosition(1, 0), canvasPoint({ x: 15, y: 0 }), {}, {})
         })
       })
 
       describe('vertical movement', () => {
-        it('adds only the height', async () => {
-          await resizeWithoutDimensions(
-            edgePosition(0, 0),
-            canvasPoint({ x: 0, y: 15 }),
-            {},
-            { height: 385 },
-          )
+        it('does nothing', async () => {
+          await resizeWithoutDimensions(edgePosition(0, 0), canvasPoint({ x: 0, y: 15 }), {}, {})
         })
       })
 
       describe('diagonal movement', () => {
-        it('adds width and height', async () => {
-          await resizeWithoutDimensions(
-            edgePosition(0, 0),
-            canvasPoint({ x: 10, y: 15 }),
-            {},
-            { width: 10, height: 385 },
-          )
+        it('does nothing', async () => {
+          await resizeWithoutDimensions(edgePosition(0, 0), canvasPoint({ x: 10, y: 15 }), {}, {})
         })
       })
     })
 
     describe('width missing', () => {
       describe('horizontal movement', () => {
-        it('updates only the width', async () => {
-          await resizeWithoutDimensions(
-            edgePosition(1, 0),
-            canvasPoint({ x: 15, y: 0 }),
-            { height: 10 },
-            { height: 10, width: 15 },
-          )
+        it('does nothing', async () => {
+          await resizeWithoutDimensions(edgePosition(1, 0), canvasPoint({ x: 15, y: 0 }), {}, {})
         })
       })
 
       describe('vertical movement', () => {
-        it('does not add the width', async () => {
+        it('adds the height, does not add the width', async () => {
           await resizeWithoutDimensions(
             edgePosition(0, 0),
             canvasPoint({ x: 0, y: 15 }),
@@ -310,12 +290,12 @@ describe('Flex Resize', () => {
       })
 
       describe('diagonal movement', () => {
-        it('adds the width and updates height', async () => {
+        it('updates the height, does not add the width', async () => {
           await resizeWithoutDimensions(
             edgePosition(0, 0),
             canvasPoint({ x: 10, y: 15 }),
             { height: 20 },
-            { height: 5, width: 10 },
+            { height: 5 },
           )
         })
       })
@@ -334,23 +314,23 @@ describe('Flex Resize', () => {
       })
 
       describe('vertical movement', () => {
-        it('does not change the width', async () => {
+        it('does nothing', async () => {
           await resizeWithoutDimensions(
             edgePosition(0, 0),
             canvasPoint({ x: 0, y: 15 }),
             { width: 15 },
-            { width: 15, height: 385 },
+            { width: 15 },
           )
         })
       })
 
       describe('diagonal movement', () => {
-        it('adds the height and updates width', async () => {
+        it('does not add the height and updates width', async () => {
           await resizeWithoutDimensions(
             edgePosition(0, 0),
             canvasPoint({ x: 10, y: 15 }),
             { width: 15 },
-            { width: 5, height: 385 },
+            { width: 5 },
           )
         })
       })

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
@@ -64,9 +64,14 @@ export function flexResizeBasicStrategy(
     selectedElements[0],
   )
   const elementDimensions = metadata != null ? getElementDimensions(metadata) : null
+  const elementParentBounds = metadata?.specialSizeMeasurements.immediateParentBounds ?? null
+
   const hasDimensions =
     elementDimensions != null &&
     (elementDimensions.width != null || elementDimensions.height != null)
+  const hasSizedParent =
+    elementParentBounds != null &&
+    (elementParentBounds.width !== 0 || elementParentBounds.height !== 0)
 
   return {
     id: 'FLEX_RESIZE_BASIC',
@@ -101,7 +106,7 @@ export function flexResizeBasicStrategy(
       interactionSession != null &&
       interactionSession.interactionData.type === 'DRAG' &&
       interactionSession.activeControl.type === 'RESIZE_HANDLE' &&
-      hasDimensions
+      (hasDimensions || !hasSizedParent)
         ? 1
         : 0,
     apply: (_strategyLifecycle: InteractionLifecycle) => {
@@ -139,8 +144,6 @@ export function flexResizeBasicStrategy(
             ),
             'non-center-based',
           )
-          const elementParentBounds =
-            metadata?.specialSizeMeasurements.immediateParentBounds ?? null
 
           const makeResizeCommand = (
             name: 'width' | 'height',
@@ -149,7 +152,7 @@ export function flexResizeBasicStrategy(
             resized: number,
             parent: number | undefined,
           ): AdjustCssLengthProperty[] => {
-            if (elementDimension == null || original === resized) {
+            if (elementDimension == null && (original === resized || hasSizedParent)) {
               return []
             }
             return [

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
@@ -8,7 +8,6 @@ import {
   CanvasRectangle,
   offsetPoint,
 } from '../../../../core/shared/math-utils'
-import { Modifiers } from '../../../../utils/modifiers'
 import { stylePropPathMappingFn } from '../../../inspector/common/property-path-hooks'
 import { EdgePosition, oppositeEdgePosition } from '../../canvas-types'
 import {
@@ -60,6 +59,14 @@ export function flexResizeBasicStrategy(
   ) {
     return null
   }
+  const metadata = MetadataUtils.findElementByElementPath(
+    canvasState.startingMetadata,
+    selectedElements[0],
+  )
+  const elementDimensions = metadata != null ? getElementDimensions(metadata) : null
+  const hasDimensions =
+    elementDimensions != null &&
+    (elementDimensions.width != null || elementDimensions.height != null)
 
   return {
     id: 'FLEX_RESIZE_BASIC',
@@ -93,7 +100,8 @@ export function flexResizeBasicStrategy(
     fitness:
       interactionSession != null &&
       interactionSession.interactionData.type === 'DRAG' &&
-      interactionSession.activeControl.type === 'RESIZE_HANDLE'
+      interactionSession.activeControl.type === 'RESIZE_HANDLE' &&
+      hasDimensions
         ? 1
         : 0,
     apply: (_strategyLifecycle: InteractionLifecycle) => {
@@ -116,10 +124,6 @@ export function flexResizeBasicStrategy(
             return emptyStrategyApplicationResult
           }
 
-          const metadata = MetadataUtils.findElementByElementPath(
-            canvasState.startingMetadata,
-            selectedElement,
-          )
           if (!metadata) {
             return emptyStrategyApplicationResult
           }
@@ -137,7 +141,6 @@ export function flexResizeBasicStrategy(
           )
           const elementParentBounds =
             metadata?.specialSizeMeasurements.immediateParentBounds ?? null
-          const elementDimensions = getElementDimensions(metadata)
 
           const makeResizeCommand = (
             name: 'width' | 'height',
@@ -146,7 +149,7 @@ export function flexResizeBasicStrategy(
             resized: number,
             parent: number | undefined,
           ): AdjustCssLengthProperty[] => {
-            if (elementDimension == null && original === resized) {
+            if (elementDimension == null || original === resized) {
               return []
             }
             return [


### PR DESCRIPTION
**Problem:**

The current flex resize can set missing dimensions, even in situations when it would not be correct to do so (e.g. when there's `flexBasis` set).

**Fix:**

This PR disables the resizing completely if dimensions are missing, and only allows resizing dimensions which are explicitly set already.

**Notes:**
- @balazsbajorics I also thought about hiding the controls at all, but _probably_ they should be there anyways and do nothing, which _seems_ to me it's less confusing. Feel free to disagree of course and lmk if you prefer otherwise.