### PR TITLE
Less Verbose Karma

### DIFF
--- a/editor/karma.conf.js
+++ b/editor/karma.conf.js
@@ -21,7 +21,7 @@ module.exports = function (config) {
       'karma-mocha-reporter',
       require('./test/karma-custom-reporter/short-console-messages'),
     ],
-    reporters: config.debug ? ['mocha'] : ['mocha', 'utopia'],
+    reporters: config.debug ? ['mocha'] : ['mocha', 'short-console-messages'],
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: '',
 

--- a/editor/test/karma-custom-reporter/short-console-messages.js
+++ b/editor/test/karma-custom-reporter/short-console-messages.js
@@ -1,10 +1,16 @@
 /* eslint-disable */
 var Levels = ['error', 'warn', 'info', 'debug', 'log']
-var UtopiaReporter = function (baseReporterDecorator, formatError, config) {
+var ShortConsoleMessages = function (baseReporterDecorator, formatError, config) {
   baseReporterDecorator(this)
   var self = this
-  var consoleMessagesForSpec = [] // {type: string, log: string }
-  var allConsoleMessages = [] // {type: string, log: string, specName: string}
+  /**
+   * @type Array<{type: string, log: string }>
+   */
+  var consoleMessagesForSpec = []
+  /**
+   * @type Array<{ {type: string, log: string, specName: string}}>
+   */
+  var allConsoleMessages = []
 
   function shortenMessage(message) {
     var truncated = message.length > 200 ? `${message.substring(0, 200)}...` : message
@@ -43,9 +49,20 @@ var UtopiaReporter = function (baseReporterDecorator, formatError, config) {
       }
     })
     Levels.forEach((l) => {
+      const OnlyShowFirstN = 3
       messagesGrouped[l].forEach((message) => {
         self.write(`\n${l.toUpperCase()} (${message.count}) ${message.log}`)
-        self.write(`\nthis console message is from: \n  ${message.specNames.join('\n  ')}\n`)
+        self.write(
+          `\nthis console message is from: \n  ${message.specNames
+            .slice(0, OnlyShowFirstN)
+            .map((n) => `• ${n}`)
+            .join('\n  ')}`,
+        )
+        if (message.count > OnlyShowFirstN) {
+          self.write(`\n ...and ${message.count - OnlyShowFirstN} more\n`)
+        } else {
+          self.write(`\n`)
+        }
       })
     })
     self.write(`\n`)
@@ -72,8 +89,8 @@ var UtopiaReporter = function (baseReporterDecorator, formatError, config) {
   }
 }
 
-UtopiaReporter.$inject = ['baseReporterDecorator', 'formatError', 'config']
+ShortConsoleMessages.$inject = ['baseReporterDecorator', 'formatError', 'config']
 
 module.exports = {
-  'reporter:utopia': ['type', UtopiaReporter],
+  'reporter:short-console-messages': ['type', ShortConsoleMessages],
 }


### PR DESCRIPTION
**Problem:**
We have our own logger for Karma (browser2 tests) which collects each logline, and only prints them once, listing all the tests where that logline was observed.

For example:
```
ERROR (1) 'Warning: %s a style property during rerender (%s) when a conflicting property is set (%s) can lead to styling bugs. To avoid this, don't mix shorthand and non-shorthand properties for the same value;...
this console message is from:
  • updating style properties keeps the original order element with different padding props
```

The problem is that we have a few logged warnings and errors that are logged almost 400 times. And this little custom logger prints all 400 test names after each karma run. Yikes!

**Fix:**
Only print the first 3 test names for each collated logline.

**Commit Details:**
- Renamed the logger from `utopia` to `short-console-messages` because the file and the import is also called `short-console-messages` and it was quite confusing to match the lines ` require('./test/karma-custom-reporter/short-console-messages')` with the line `reporters: config.debug ? ['mocha'] : ['mocha', 'utopia'],`. Now that line says `reporters: config.debug ? ['mocha'] : ['mocha', 'short-console-messages'],` which makes it much easier to figure out where's the source code for the logger (in `short-console-messages.js`)
- Deleted some comments near the top of the file which were denoting types, and instead turned them into JSDoc typescript type annotations
- Changed `printCleanConsoleMessages` so it only prints the first 3 test names, and then a string `...and 379 more` if there's more test names that were cut.
