### PR TITLE
Fix drag target feedback in utfb

### DIFF
--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -954,6 +954,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
                 boundingArea(),
               ),
             ),
+            EditorActions.setFilebrowserDropTarget(null),
           ])
         },
 

--- a/editor/src/templates/image-dnd.spec.browser2.tsx
+++ b/editor/src/templates/image-dnd.spec.browser2.tsx
@@ -279,6 +279,7 @@ describe('image dnd', () => {
 
       await editor.getDispatchFollowUpActionsFinished()
 
+      expect(editor.getEditorState().editor.fileBrowser.dropTarget).toBeNull()
       expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
         formatTestProjectCode(`
       import * as React from 'react'


### PR DESCRIPTION
Fixes https://github.com/concrete-utopia/utopia/issues/2670

**Problem:**
If you drag over a folder and then drag it out from UTFB to the right (staying on top of the folder while you are in the UTFB), the folder stays in the hovered state forever, and you can even make multiple folders hovered. https://screenshot.click/14-16-7w8kg-j9nur.mp4 

**Fix:**
In fileitem.tsx internal and external file drag was handled separately, internal in EditorState, external in a local state with a counter. However, since the new image dnd, even external files set the dropTarget in EditorState, so I could just fully remove the whole local logic, which just caused trouble.
I still needed to solve the problem to clear the dropTarget when dragging over the canvas, so I set the dropTarget to null at the same time when we create the canvas interaction for the dragging. (I also added an except about this in the relevant test)
