### PR TITLE
Draw to insert (forced) tests

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -15,6 +15,7 @@ import {
   mouseDragFromPointToPoint,
   mouseDragFromPointToPointNoMouseDown,
   mouseMoveToPoint,
+  pressKey,
 } from '../../event-helpers.test-utils'
 import { RightMenuTab } from '../../../editor/store/editor-state'
 import { FOR_TESTS_setNextGeneratedUid } from '../../../../core/model/element-template-utils.test-utils'
@@ -764,6 +765,196 @@ describe('Inserting into absolute', () => {
               data-uid='ddd'
             />
           </div>
+        </div>
+      `),
+    )
+  })
+})
+
+describe('Forced inserting into Static', () => {
+  const inputCode = makeTestProjectCodeWithSnippet(`
+    <div
+      data-uid='aaa'
+      style={{
+        width: '100%',
+        height: '100%',
+        backgroundColor: '#FFFFFF',
+        position: 'relative',
+      }}
+    >
+      <div
+        data-uid='bbb'
+        data-testid='bbb'
+        style={{
+          position: 'static',
+          width: 380,
+          height: 180,
+          backgroundColor: '#d3d3d3',
+        }}
+      />
+      <div
+        data-uid='ccc'
+        style={{
+          position: 'static',
+          width: 380,
+          height: 190,
+          backgroundColor: '#FF0000',
+        }}
+      />
+    </div>
+  `)
+
+  it('By default, it refuses to insert into a static element', async () => {
+    const renderResult = await setupInsertTest(inputCode)
+    await enterInsertModeFromInsertMenu(renderResult)
+
+    const targetElement = renderResult.renderedDOM.getByTestId('bbb')
+    const targetElementBounds = targetElement.getBoundingClientRect()
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    const startPoint = slightlyOffsetWindowPointBecauseVeryWeirdIssue({
+      x: targetElementBounds.x + 5,
+      y: targetElementBounds.y + 5,
+    })
+    const endPoint = slightlyOffsetWindowPointBecauseVeryWeirdIssue({
+      x: targetElementBounds.x + 25,
+      y: targetElementBounds.y + 25,
+    })
+
+    // Move before starting dragging
+    mouseMoveToPoint(canvasControlsLayer, startPoint)
+
+    // Highlight should show the candidate parent
+    expect(renderResult.getEditorState().editor.highlightedViews.map(EP.toUid)).toEqual(['aaa'])
+
+    // Drag from inside bbb to inside ccc
+    mouseDragFromPointToPoint(canvasControlsLayer, startPoint, endPoint)
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Check that the inserted element is a child of bbb
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          data-uid='aaa'
+          style={{
+            width: '100%',
+            height: '100%',
+            backgroundColor: '#FFFFFF',
+            position: 'relative',
+          }}
+        >
+          <div
+            data-uid='bbb'
+            data-testid='bbb'
+            style={{
+              position: 'static',
+              width: 380,
+              height: 180,
+              backgroundColor: '#d3d3d3',
+            }}
+          />
+          <div
+            data-uid='ccc'
+            style={{
+              position: 'static',
+              width: 380,
+              height: 190,
+              backgroundColor: '#FF0000',
+            }}
+          />
+          <div
+            style={{
+              backgroundColor: '#0091FFAA',
+              position: 'absolute',
+              left: 5,
+              top: 5,
+              width: 20,
+              height: 20,
+            }}
+            data-uid='ddd'
+          />
+        </div>
+      `),
+    )
+  })
+
+  it('Using the strategy picker, it happily inserts into a static element', async () => {
+    const renderResult = await setupInsertTest(inputCode)
+    await enterInsertModeFromInsertMenu(renderResult)
+
+    const targetElement = renderResult.renderedDOM.getByTestId('bbb')
+    const targetElementBounds = targetElement.getBoundingClientRect()
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    const startPoint = slightlyOffsetWindowPointBecauseVeryWeirdIssue({
+      x: targetElementBounds.x + 5,
+      y: targetElementBounds.y + 5,
+    })
+    const endPoint = slightlyOffsetWindowPointBecauseVeryWeirdIssue({
+      x: targetElementBounds.x + 25,
+      y: targetElementBounds.y + 25,
+    })
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Move before starting dragging
+    mouseMoveToPoint(canvasControlsLayer, startPoint)
+
+    // Highlight should show the candidate parent
+    expect(renderResult.getEditorState().editor.highlightedViews.map(EP.toUid)).toEqual(['aaa'])
+
+    mouseDragFromPointToPoint(canvasControlsLayer, startPoint, endPoint, {
+      midDragCallback: () => {
+        pressKey('2') // this should select the 'Draw to Insert (Abs, Forced)' strategy
+      },
+    })
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Check that the inserted element is a child of bbb
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          data-uid='aaa'
+          style={{
+            width: '100%',
+            height: '100%',
+            backgroundColor: '#FFFFFF',
+            position: 'relative',
+          }}
+        >
+          <div
+            data-uid='bbb'
+            data-testid='bbb'
+            style={{
+              position: 'static',
+              width: 380,
+              height: 180,
+              backgroundColor: '#d3d3d3',
+            }}
+          >
+          <div
+            style={{
+              backgroundColor: '#0091FFAA',
+              position: 'absolute',
+              left: 5,
+              top: 5,
+              width: 20,
+              height: 20,
+            }}
+            data-uid='ddd'
+          />
+          </div>
+          <div
+            data-uid='ccc'
+            style={{
+              position: 'static',
+              width: 380,
+              height: 190,
+              backgroundColor: '#FF0000',
+            }}
+          />
         </div>
       `),
     )

--- a/editor/src/components/canvas/canvas-strategies/strategies/forced-absolute-reparent-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/forced-absolute-reparent-strategies.spec.browser2.tsx
@@ -322,7 +322,7 @@ describe('Forced Absolute Reparent Strategies', () => {
       dragDelta,
       cmdModifier,
       function midDragCallback() {
-        pressKey('3')
+        pressKey('3') // this should select the Reparent (Abs, Forced) strategy
       },
     )
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/forced-absolute-reparent-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/forced-absolute-reparent-strategies.spec.browser2.tsx
@@ -3,9 +3,14 @@ import {
   BakedInStoryboardVariableName,
 } from '../../../../core/model/scene-utils'
 import { windowPoint, WindowPoint } from '../../../../core/shared/math-utils'
-import { cmdModifier, Modifiers } from '../../../../utils/modifiers'
+import { cmdModifier, emptyModifiers, Modifiers } from '../../../../utils/modifiers'
+import { wait } from '../../../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
-import { mouseClickAtPoint, mouseDragFromPointWithDelta } from '../../event-helpers.test-utils'
+import {
+  mouseClickAtPoint,
+  mouseDragFromPointWithDelta,
+  pressKey,
+} from '../../event-helpers.test-utils'
 import {
   EditorRenderResult,
   formatTestProjectCode,
@@ -14,7 +19,7 @@ import {
   TestAppUID,
   TestSceneUID,
 } from '../../ui-jsx.test-utils'
-import { MetaCanvasStrategy } from '../canvas-strategies'
+import { MetaCanvasStrategy, RegisteredCanvasStrategies } from '../canvas-strategies'
 import { CustomStrategyState, InteractionCanvasState } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
 import { reparentMetaStrategy } from './reparent-metastrategy'
@@ -24,6 +29,7 @@ async function dragElement(
   targetTestId: string,
   dragDelta: WindowPoint,
   modifiers: Modifiers,
+  midDragCallback?: () => void,
 ): Promise<void> {
   const targetElement = await renderResult.renderedDOM.getByTestId(targetTestId)
   const targetElementBounds = targetElement.getBoundingClientRect()
@@ -37,6 +43,7 @@ async function dragElement(
   mouseClickAtPoint(canvasControlsLayer, startPoint, { modifiers: cmdModifier })
   mouseDragFromPointWithDelta(canvasControlsLayer, startPoint, dragDelta, {
     modifiers: modifiers,
+    midDragCallback: midDragCallback,
   })
 }
 
@@ -281,6 +288,128 @@ describe('Forced Absolute Reparent Strategies', () => {
   </div>`),
     )
   })
+
+  it('Absolute to forced absolute can be accessed by using the strategy selector', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(defaultTestCode),
+      'await-first-dom-report',
+      RegisteredCanvasStrategies,
+    )
+
+    const absoluteChild = await renderResult.renderedDOM.findByTestId('absolutechild')
+    const absoluteChildRect = absoluteChild.getBoundingClientRect()
+    const absoluteChildCenter = {
+      x: absoluteChildRect.x + absoluteChildRect.width / 2,
+      y: absoluteChildRect.y + absoluteChildRect.height / 2,
+    }
+    const secondFlexChild = await renderResult.renderedDOM.findByTestId('flexchild2')
+    const secondFlexChildRect = secondFlexChild.getBoundingClientRect()
+    const secondFlexChildCenter = {
+      x: secondFlexChildRect.x + secondFlexChildRect.width / 2,
+      y: secondFlexChildRect.y + secondFlexChildRect.height / 2,
+    }
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    const dragDelta = windowPoint({
+      x: secondFlexChildCenter.x - absoluteChildCenter.x,
+      y: secondFlexChildCenter.y - absoluteChildCenter.y,
+    })
+
+    await dragElement(
+      renderResult,
+      'absolutechild',
+      dragDelta,
+      cmdModifier,
+      function midDragCallback() {
+        pressKey('3')
+      },
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+  <div
+    style={{
+      position: 'absolute',
+      width: 700,
+      height: 600,
+    }}
+    data-uid='container'
+    data-testid='container'
+  >
+    <div
+      style={{
+        width: 250,
+        height: 500,
+        backgroundColor: 'orange',
+      }}
+      data-uid='staticparent'
+      data-testid='staticparent'
+    />
+    <div
+      style={{
+        position: 'absolute',
+        width: 250,
+        height: 500,
+        left: 250,
+        top: 0,
+        backgroundColor: 'lightblue',
+      }}
+      data-uid='absoluteparent'
+      data-testid='absoluteparent'
+    />
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        position: 'absolute',
+        width: 250,
+        height: 500,
+        left: 500,
+        top: 0,
+        backgroundColor: 'lightgreen',
+      }}
+      data-uid='flexparent'
+      data-testid='flexparent'
+    >
+      <div
+        style={{
+          width: 100,
+          height: 100,
+          backgroundColor: 'teal',
+        }}
+        data-uid='flexchild1'
+        data-testid='flexchild1'
+      />
+      <div
+        style={{
+          width: 100,
+          height: 100,
+          backgroundColor: 'red',
+        }}
+        data-uid='flexchild2'
+        data-testid='flexchild2'
+      >
+        <div
+          style={{
+            position: 'absolute',
+            left: 100,
+            top: 0,
+            width: 100,
+            height: 100,
+            backgroundColor: 'yellow',
+          }}
+          data-uid='absolutechild'
+          data-testid='absolutechild'
+        />
+      </div>
+    </div>
+  </div>`),
+    )
+  })
+
   it('Absolute to forced absolute is not the default choice', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(defaultTestCode),


### PR DESCRIPTION
Fixes #2669 

**Problem:**
I forgot to add test coverage in my PR #2662 

**Commit Details:**
- Added a test to forced-absolute-reparent-strategies.spec.browser2 that uses the full RegisteredCanvasStrategies array and interacts with the strategy picker to trigger the forced strategy
- Added two new tests to draw-to-insert-strategy.spec.browser2 that covers the default and the forced behavior (using the strategy picker in the second test case)
