### PR TITLE
remove onAbandonIntent prop

### DIFF
--- a/editor/src/uuiui/isolator.tsx
+++ b/editor/src/uuiui/isolator.tsx
@@ -37,7 +37,6 @@ export const Isolator: React.FunctionComponent<React.PropsWithChildren<IsolatorP
         backdropFilter: 'blur(1px)',
       }}
       onClick={() => props.onAbandonIntent()}
-      {...props}
     />
   )
 }


### PR DESCRIPTION
## Problem:
When opening a modal dialog, a React warning shows up: `Unknown event handler property onAbandonIntent. It will be ignored.`

## Fix:
Remove the unnecessary property spread in `<Isolator />`