### PR TITLE
Turn off automatic image resize

### DIFF
--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -55,7 +55,7 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Canvas Selective Rerender': true,
   'Single child, contiguous parent: move parent': true,
   'Single child, zero sized parent: move parent': true,
-  'Resize image on drop': true,
+  'Resize image on drop': false,
 }
 
 function settingKeyForName(featureName: FeatureName): string {


### PR DESCRIPTION
## Problem:
Images dropped on the canvas do not respect the `Resize image on drop` feature flag.

## Fix:
Check `Resize image on drop` in `onDrop`
