### PR TITLE
reparent metastrategy: disallow anyDraggedElementsRootElements

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
@@ -805,6 +805,53 @@ describe('Unified Reparent Fitness Function Tests', () => {
       `),
     )
   })
+
+  it('dragging the root element of a component does not activate reparent', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+    <div
+      style={{
+        position: 'absolute',
+        width: '100%',
+        height: '100%',
+        left: 150,
+        top: 150,
+        backgroundColor: '#d3d3d3',
+      }}
+      data-uid='aaa'
+      data-testid='aaa'
+    />
+    `),
+      'await-first-dom-report',
+    )
+
+    // when dragging towards the left and top, we leave the original bounds of the dragged element
+    const dragDelta = windowPoint({ x: -75, y: -75 })
+
+    const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa'])
+    await renderResult.dispatch([selectComponents([targetPath], false)], false)
+
+    dragElement(renderResult, 'aaa', defaultMouseDownOffset, dragDelta, cmdModifier, true)
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+      <div
+        style={{
+          position: 'absolute',
+          width: '100%',
+          height: '100%',
+          left: 75,
+          top: 75,
+          backgroundColor: '#d3d3d3',
+        }}
+        data-uid='aaa'
+        data-testid='aaa'
+      />
+      `),
+    )
+  })
 })
 
 describe('Target parent filtering', () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -1,6 +1,10 @@
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../../core/shared/array-utils'
-import { parentPath, pathsEqual } from '../../../../core/shared/element-path'
+import {
+  isRootElementOfInstance,
+  parentPath,
+  pathsEqual,
+} from '../../../../core/shared/element-path'
 import { CanvasPoint, offsetPoint } from '../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import { assertNever } from '../../../../core/shared/utils'
@@ -128,7 +132,9 @@ export const reparentMetaStrategy: MetaCanvasStrategy = (
     ),
   )
 
-  if (!(allDraggedElementsAbsolute || allDraggedElementsFlex)) {
+  const anyDraggedElementsRootElements = reparentSubjects.some(isRootElementOfInstance)
+
+  if (!(allDraggedElementsAbsolute || allDraggedElementsFlex) || anyDraggedElementsRootElements) {
     return []
   }
 


### PR DESCRIPTION
Fixes #2680 

**Problem:**
When the user is dragging the root element of a component, we let the reparent metastrategy become the most fit one, even though the actual metastrategy behavior will be to show a 🚫 cursor and a greyed out "Reparent" strategy.

In some cases it is desired to allow the reparent metastrategy to win only to disallow a certain parent. But if the dragged element is the root element of a component, we know ahead of time that we will _never_ be able to run the reparent strategy!

**Fix:**
The simple fix (kudos to @Rheeseyb) is to simply never allow the reparent metastrategy to run if a component's root element is dragged.

**Commit Details:**
- Add new check for `anyDraggedElementsRootElements`

**TODO**
- [x] IOU a test!