### PR TITLE
Fix updating interaction from hover to drag

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/interaction-state.test-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.test-utils.ts
@@ -15,6 +15,7 @@ export function createMouseInteractionForTests(
 ): InteractionSessionWithoutMetadata {
   return updateInteractionViaMouse(
     createInteractionViaMouse(mouseDownPoint, modifiers, activeControl),
+    'DRAG',
     drag,
     modifiers,
     null,

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -9,6 +9,7 @@ import {
   zeroCanvasPoint,
 } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
+import { assertNever } from '../../../core/shared/utils'
 import { KeyCharacter } from '../../../utils/keyboard'
 import { Modifiers } from '../../../utils/modifiers'
 import { AllElementProps, EditorStatePatch } from '../../editor/store/editor-state'
@@ -51,7 +52,9 @@ export interface KeyboardInteractionData {
   keyStates: Array<KeyState>
 }
 
-export type InputData = KeyboardInteractionData | DragInteractionData | HoverInteractionData
+export type InputData = KeyboardInteractionData | MouseInteractionData
+
+export type MouseInteractionData = DragInteractionData | HoverInteractionData
 
 export function isDragInteractionData(inputData: InputData): inputData is DragInteractionData {
   return inputData.type === 'DRAG'
@@ -90,7 +93,6 @@ export interface InteractionSession {
   // This represents an actual interaction that has started as the result of a key press or a drag
   interactionData: InputData
   activeControl: CanvasControlType
-  sourceOfUpdate: CanvasControlType
   lastInteractionTime: number
   latestMetadata: ElementInstanceMetadataMap
   latestAllElementProps: AllElementProps
@@ -108,7 +110,6 @@ export interface InteractionSession {
 export function interactionSession(
   interactionData: InputData,
   activeControl: CanvasControlType,
-  sourceOfUpdate: CanvasControlType,
   lastInteractionTime: number,
   metadata: ElementInstanceMetadataMap,
   userPreferredStrategy: CanvasStrategyId | null,
@@ -121,7 +122,6 @@ export function interactionSession(
   return {
     interactionData: interactionData,
     activeControl: activeControl,
-    sourceOfUpdate: sourceOfUpdate,
     lastInteractionTime: lastInteractionTime,
     latestMetadata: metadata,
     userPreferredStrategy: userPreferredStrategy,
@@ -195,7 +195,6 @@ export function createInteractionViaMouse(
       _accumulatedMovement: zeroCanvasPoint,
     },
     activeControl: activeControl,
-    sourceOfUpdate: activeControl,
     lastInteractionTime: Date.now(),
     userPreferredStrategy: null,
     startedAt: Date.now(),
@@ -216,7 +215,6 @@ export function createHoverInteractionViaMouse(
       modifiers: modifiers,
     },
     activeControl: activeControl,
-    sourceOfUpdate: activeControl,
     lastInteractionTime: Date.now(),
     userPreferredStrategy: null,
     startedAt: Date.now(),
@@ -255,8 +253,7 @@ export function updateInteractionViaDragDelta(
         hasMouseMoved: true,
         _accumulatedMovement: accumulatedMovement,
       },
-      activeControl: currentState.activeControl,
-      sourceOfUpdate: sourceOfUpdate ?? currentState.activeControl,
+      activeControl: sourceOfUpdate ?? currentState.activeControl,
       lastInteractionTime: Date.now(),
       userPreferredStrategy: currentState.userPreferredStrategy,
       startedAt: currentState.startedAt,
@@ -270,27 +267,23 @@ export function updateInteractionViaDragDelta(
 
 export function updateInteractionViaMouse(
   currentState: InteractionSessionWithoutMetadata,
+  newInteractionType: 'HOVER' | 'DRAG',
   drag: CanvasVector,
   modifiers: Modifiers,
   sourceOfUpdate: CanvasControlType | null, // If null it means the active control is the source
 ): InteractionSessionWithoutMetadata {
-  if (currentState.interactionData.type === 'DRAG') {
-    const dragThresholdPassed =
-      currentState.interactionData.drag != null || dragExceededThreshold(drag)
+  if (
+    currentState.interactionData.type === 'DRAG' ||
+    currentState.interactionData.type === 'HOVER'
+  ) {
     return {
-      interactionData: {
-        type: 'DRAG',
-        dragStart: currentState.interactionData.dragStart,
-        drag: dragThresholdPassed ? drag : null,
-        prevDrag: currentState.interactionData.drag,
-        originalDragStart: currentState.interactionData.originalDragStart,
-        modifiers: modifiers,
-        globalTime: Date.now(),
-        hasMouseMoved: true,
-        _accumulatedMovement: currentState.interactionData._accumulatedMovement,
-      },
-      activeControl: currentState.activeControl,
-      sourceOfUpdate: sourceOfUpdate ?? currentState.activeControl,
+      interactionData: updateInteractionDataViaMouse(
+        currentState.interactionData,
+        newInteractionType,
+        drag,
+        modifiers,
+      ),
+      activeControl: sourceOfUpdate ?? currentState.activeControl,
       lastInteractionTime: Date.now(),
       userPreferredStrategy: currentState.userPreferredStrategy,
       startedAt: currentState.startedAt,
@@ -302,29 +295,53 @@ export function updateInteractionViaMouse(
   }
 }
 
-export function updateHoverInteractionViaMouse(
-  currentState: InteractionSessionWithoutMetadata,
+function updateInteractionDataViaMouse(
+  currentData: MouseInteractionData,
+  newInteractionType: 'HOVER' | 'DRAG',
   mousePoint: CanvasVector,
   modifiers: Modifiers,
-  sourceOfUpdate: CanvasControlType | null, // If null it means the active control is the source
-): InteractionSessionWithoutMetadata {
-  if (currentState.interactionData.type === 'HOVER') {
-    return {
-      interactionData: {
+): MouseInteractionData {
+  switch (newInteractionType) {
+    case 'HOVER':
+      return {
         type: 'HOVER',
         point: mousePoint,
         modifiers: modifiers,
-      },
-      activeControl: currentState.activeControl,
-      sourceOfUpdate: sourceOfUpdate ?? currentState.activeControl,
-      lastInteractionTime: Date.now(),
-      userPreferredStrategy: currentState.userPreferredStrategy,
-      startedAt: currentState.startedAt,
-      updatedTargetPaths: currentState.updatedTargetPaths,
-      aspectRatioLock: currentState.aspectRatioLock,
-    }
-  } else {
-    return currentState
+      }
+
+    case 'DRAG':
+      switch (currentData.type) {
+        case 'DRAG':
+          const dragThresholdPassed = currentData.drag != null || dragExceededThreshold(mousePoint)
+          return {
+            type: 'DRAG',
+            dragStart: currentData.dragStart,
+            drag: dragThresholdPassed ? mousePoint : null,
+            prevDrag: currentData.drag,
+            originalDragStart: currentData.originalDragStart,
+            modifiers: modifiers,
+            globalTime: Date.now(),
+            hasMouseMoved: true,
+            _accumulatedMovement: currentData._accumulatedMovement,
+          }
+        case 'HOVER':
+          return {
+            type: 'DRAG',
+            dragStart: mousePoint,
+            drag: null,
+            prevDrag: null,
+            originalDragStart: mousePoint,
+            modifiers: modifiers,
+            globalTime: Date.now(),
+            hasMouseMoved: false,
+            _accumulatedMovement: zeroCanvasPoint,
+          }
+        default:
+          assertNever(currentData)
+      }
+      break
+    default:
+      assertNever(newInteractionType)
   }
 }
 
@@ -344,7 +361,6 @@ export function createInteractionViaKeyboard(
       ],
     },
     activeControl: activeControl,
-    sourceOfUpdate: activeControl,
     lastInteractionTime: Date.now(),
     userPreferredStrategy: null,
     startedAt: Date.now(),
@@ -358,7 +374,7 @@ export function updateInteractionViaKeyboard(
   addedKeysPressed: Array<KeyCharacter>,
   keysReleased: Array<KeyCharacter>,
   modifiers: Modifiers,
-  sourceOfUpdate: CanvasControlType,
+  activeControl: CanvasControlType | null,
 ): InteractionSessionWithoutMetadata {
   switch (currentState.interactionData.type) {
     case 'KEYBOARD': {
@@ -384,8 +400,7 @@ export function updateInteractionViaKeyboard(
           type: 'KEYBOARD',
           keyStates: [...currentState.interactionData.keyStates, newKeyState],
         },
-        activeControl: currentState.activeControl,
-        sourceOfUpdate: sourceOfUpdate,
+        activeControl: activeControl ?? currentState.activeControl,
         lastInteractionTime: Date.now(),
         userPreferredStrategy: currentState.userPreferredStrategy,
         startedAt: currentState.startedAt,
@@ -407,7 +422,6 @@ export function updateInteractionViaKeyboard(
           _accumulatedMovement: currentState.interactionData._accumulatedMovement,
         },
         activeControl: currentState.activeControl,
-        sourceOfUpdate: currentState.activeControl,
         lastInteractionTime: Date.now(),
         userPreferredStrategy: currentState.userPreferredStrategy,
         startedAt: currentState.startedAt,
@@ -423,7 +437,6 @@ export function updateInteractionViaKeyboard(
           modifiers: modifiers,
         },
         activeControl: currentState.activeControl,
-        sourceOfUpdate: currentState.activeControl,
         lastInteractionTime: Date.now(),
         userPreferredStrategy: currentState.userPreferredStrategy,
         startedAt: currentState.startedAt,

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
@@ -80,6 +80,7 @@ async function startDragUsingActions(
       CanvasActions.updateInteractionSession(
         updateInteractionViaMouse(
           startInteractionSession,
+          'DRAG',
           dragDelta,
           emptyModifiers,
           boundingArea(),

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -76,7 +76,7 @@ async function startDragUsingActions(
   await renderResult.dispatch(
     [
       CanvasActions.updateInteractionSession(
-        updateInteractionViaMouse(startInteractionSession, dragDelta, emptyModifiers, {
+        updateInteractionViaMouse(startInteractionSession, 'DRAG', dragDelta, emptyModifiers, {
           type: 'RESIZE_HANDLE',
           edgePosition: edgePosition,
         }),

--- a/editor/src/components/canvas/canvas-strategies/strategies/look-for-applicable-parent.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/look-for-applicable-parent.spec.browser2.tsx
@@ -296,6 +296,7 @@ async function startDragUsingActions(
       CanvasActions.updateInteractionSession(
         updateInteractionViaMouse(
           startInteractionSession,
+          'DRAG',
           dragDelta,
           emptyModifiers,
           boundingArea(),

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1807,12 +1807,10 @@ const ReparentTargetsToFilterKeepDeepEquality: KeepDeepEqualityCall<ReparentTarg
   )
 
 export const InteractionSessionKeepDeepEquality: KeepDeepEqualityCall<InteractionSession> =
-  combine11EqualityCalls(
+  combine10EqualityCalls(
     (session) => session.interactionData,
     InputDataKeepDeepEquality,
     (session) => session.activeControl,
-    CanvasControlTypeKeepDeepEquality,
-    (session) => session.sourceOfUpdate,
     CanvasControlTypeKeepDeepEquality,
     (session) => session.lastInteractionTime,
     createCallWithTripleEquals(),

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -90,7 +90,6 @@ import {
   createInteractionViaMouse,
   reparentTargetsToFilter,
   ReparentTargetsToFilter,
-  updateHoverInteractionViaMouse,
   updateInteractionViaDragDelta,
   updateInteractionViaMouse,
 } from '../components/canvas/canvas-strategies/interaction-state'
@@ -205,14 +204,34 @@ function handleCanvasEvent(
 
       optionalDragStateAction = cancelInsertModeActions(shouldApplyChanges)
     } else if (event.event === 'MOUSE_DOWN') {
-      optionalDragStateAction = [
-        CanvasActions.createInteractionSession(
-          createInteractionViaMouse(event.canvasPositionRounded, event.modifiers, {
-            type: 'RESIZE_HANDLE',
-            edgePosition: { x: 1, y: 1 },
-          }),
-        ),
-      ]
+      if (model.editorState.canvas.interactionSession == null) {
+        optionalDragStateAction = [
+          CanvasActions.createInteractionSession(
+            createInteractionViaMouse(event.canvasPositionRounded, event.modifiers, {
+              type: 'RESIZE_HANDLE',
+              edgePosition: { x: 1, y: 1 },
+            }),
+          ),
+        ]
+      } else if (
+        model.editorState.canvas.interactionSession.interactionData.type === 'DRAG' ||
+        model.editorState.canvas.interactionSession.interactionData.type === 'HOVER'
+      ) {
+        optionalDragStateAction = [
+          CanvasActions.updateInteractionSession(
+            updateInteractionViaMouse(
+              model.editorState.canvas.interactionSession,
+              'DRAG',
+              event.canvasPositionRounded,
+              event.modifiers,
+              {
+                type: 'RESIZE_HANDLE',
+                edgePosition: { x: 1, y: 1 },
+              },
+            ),
+          ),
+        ]
+      }
     }
   } else if (!(insertMode && isOpenFileUiJs(model.editorState))) {
     switch (event.event) {
@@ -1290,8 +1309,9 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
             modifiers: Modifier.modifiersForEvent(event),
             cursor: null,
             nativeEvent: event,
-            interactionSession: updateHoverInteractionViaMouse(
+            interactionSession: updateInteractionViaMouse(
               this.props.editor.canvas.interactionSession,
+              'HOVER',
               canvasPositions.canvasPositionRounded,
               Modifier.modifiersForEvent(event),
               null,
@@ -1331,6 +1351,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
               nativeEvent: event,
               interactionSession: updateInteractionViaMouse(
                 this.props.editor.canvas.interactionSession,
+                'DRAG',
                 newDrag,
                 Modifier.modifiersForEvent(event),
                 null,


### PR DESCRIPTION
Fixes https://github.com/concrete-utopia/utopia/issues/2685

**Problem:**
Manual strategy selection during draw-to-insert hover is reverted when you press the mouse and start to draw

**Fix:**
The problem was that we created a new interaction session on mouse down, so the `userPreferredStrategy` was lost from the hover session.
We have to update the hover session to a drag session, but we don't have interaction session update functions which change the interaction type.
So I made it possible to switch from hover interaction to drag interaction with an update.
I also removed the `sourceOfUpdate` property (which is not used), and instead of that made it possible to update the `activeControl` of the interaction session.

**Missing**
I wanted to add a new test for this case, but for some mysterious reasons I could not trigger a keyboard event in the tests during the hover.
So I'm going to add that in a separate PR.