### PR TITLE
Remove flex insert hack for reorder indicators

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.tsx
@@ -17,6 +17,7 @@ import { getDragTargets } from './shared-move-strategies-helpers'
 export function baseAbsoluteReparentToFlexStrategy(
   reparentTarget: ReparentTarget,
   fitness: number,
+  showTargetOrReorderIndicator: 'show-reorder-indicator' | 'show-flex-target',
 ): CanvasStrategyFactory {
   return (
     canvasState: InteractionCanvasState,
@@ -77,6 +78,7 @@ export function baseAbsoluteReparentToFlexStrategy(
           canvasState,
           interactionSession,
           reparentTarget,
+          showTargetOrReorderIndicator,
         )
       },
     }

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
@@ -84,6 +84,7 @@ export const dragToInsertMetaStrategy: MetaCanvasStrategy = (
     pointOnCanvas,
     cmdPressed,
     true,
+    'show-reorder-indicator',
   )
 
   return mapDropNulls((result): CanvasStrategy | null => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -80,6 +80,7 @@ export const drawToInsertMetaStrategy: MetaCanvasStrategy = (
     pointOnCanvas,
     true, // Draw to insert should always disregard the size of the potential target parent
     true,
+    'show-flex-target',
   )
 
   return mapDropNulls((result): CanvasStrategy | null => {
@@ -442,7 +443,7 @@ function runTargetStrategiesForFreshlyInsertedElementToReparent(
   }
   const reparentCommands = strategy.apply(strategyLifecycle).commands
 
-  return foldAndApplyCommandsInner(editorState, [], reparentCommands, 'end-interaction') // TODO HACK-HACK 'end-interaction' is here so it is not just the reorder indicator which is rendered
+  return foldAndApplyCommandsInner(editorState, [], reparentCommands, strategyLifecycle)
     .statePatches
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flex-strategy.tsx
@@ -17,6 +17,7 @@ import { applyFlexReparent, ReparentTarget } from './reparent-strategy-helpers'
 export function baseFlexReparentToFlexStrategy(
   reparentTarget: ReparentTarget,
   fitness: number,
+  showTargetOrReorderIndicator: 'show-reorder-indicator' | 'show-flex-target',
 ): CanvasStrategyFactory {
   return (
     canvasState: InteractionCanvasState,
@@ -66,7 +67,13 @@ export function baseFlexReparentToFlexStrategy(
       apply: () => {
         return interactionSession == null
           ? emptyStrategyApplicationResult
-          : applyFlexReparent('do-not-strip-props', canvasState, interactionSession, reparentTarget)
+          : applyFlexReparent(
+              'do-not-strip-props',
+              canvasState,
+              interactionSession,
+              reparentTarget,
+              showTargetOrReorderIndicator,
+            )
       },
     }
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -36,6 +36,7 @@ export function getApplicableReparentFactories(
   pointOnCanvas: CanvasPoint,
   cmdPressed: boolean,
   allDraggedElementsAbsolute: boolean,
+  showFlexTargetOrReorderIndicator: 'show-reorder-indicator' | 'show-flex-target',
 ): Array<ReparentFactoryAndDetails> {
   const reparentStrategies = findReparentStrategies(canvasState, cmdPressed, pointOnCanvas)
 
@@ -78,7 +79,11 @@ export function getApplicableReparentFactories(
             strategyType: result.strategy,
             missingBoundsHandling: result.missingBoundsHandling,
             fitness: fitness,
-            factory: baseAbsoluteReparentToFlexStrategy(result.target, fitness),
+            factory: baseAbsoluteReparentToFlexStrategy(
+              result.target,
+              fitness,
+              showFlexTargetOrReorderIndicator,
+            ),
           }
         } else {
           return {
@@ -87,7 +92,11 @@ export function getApplicableReparentFactories(
             strategyType: result.strategy,
             missingBoundsHandling: result.missingBoundsHandling,
             fitness: fitness,
-            factory: baseFlexReparentToFlexStrategy(result.target, fitness),
+            factory: baseFlexReparentToFlexStrategy(
+              result.target,
+              fitness,
+              showFlexTargetOrReorderIndicator,
+            ),
           }
         }
       }
@@ -152,6 +161,7 @@ export const reparentMetaStrategy: MetaCanvasStrategy = (
     pointOnCanvas,
     cmdPressed,
     allDraggedElementsAbsolute,
+    'show-reorder-indicator',
   )
 
   const targetIsValid = (

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -633,6 +633,7 @@ export function applyFlexReparent(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession,
   reparentResult: ReparentTarget,
+  showTargetOrReorderIndicator: 'show-reorder-indicator' | 'show-flex-target',
 ): StrategyApplicationResult {
   const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
   const filteredSelectedElements = getDragTargets(selectedElements)
@@ -696,11 +697,8 @@ export function applyFlexReparent(
               setCursorCommand('mid-interaction', CSSCursor.Move),
             ]
 
-            function midInteractionCommandsForTarget(): Array<CanvasCommand> {
+            function showReorderIndicatorCommands(): Array<CanvasCommand> {
               return [
-                wildcardPatch('mid-interaction', {
-                  canvas: { controls: { parentHighlightPaths: { $set: [newParent] } } },
-                }),
                 showReorderIndicator(newParent, newIndex),
                 newParentADescendantOfCurrentParent
                   ? wildcardPatch('mid-interaction', {
@@ -711,6 +709,18 @@ export function applyFlexReparent(
                     }),
                 wildcardPatch('mid-interaction', { displayNoneInstances: { $push: [newPath] } }),
               ]
+            }
+
+            function midInteractionCommandsForTarget(): Array<CanvasCommand> {
+              const commandsForTarget: Array<CanvasCommand> = [
+                wildcardPatch('mid-interaction', {
+                  canvas: { controls: { parentHighlightPaths: { $set: [newParent] } } },
+                }),
+              ]
+
+              return showTargetOrReorderIndicator === 'show-reorder-indicator'
+                ? commandsForTarget.concat(showReorderIndicatorCommands())
+                : commandsForTarget
             }
 
             let interactionFinishCommands: Array<CanvasCommand>


### PR DESCRIPTION
Fixes #2690 

**Problem:**
Re-parenting into a flex container requires us to hide the dragged element so that it doesn't mess up the layout mid-interaction. However, this behaviour is not desired when drawing to insert into a flex container, so we currently have a hack in place to prevent it there.

**Fix:**
Add a param to the flex reparent factories for controlling whether or not the re-parented element should be hidden (and replaced with a marker indicating its new position). When using draw-to-insert, we go with `'show-flex-target'`, but when dragging to insert, or reparent we go with `'show-reorder-indicator'`