### PR TITLE
Outline control for drag to insert

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.tsx
@@ -1,7 +1,10 @@
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { ParentBounds } from '../../controls/parent-bounds'
 import { ParentOutlines } from '../../controls/parent-outlines'
-import { DragOutlineControl } from '../../controls/select-mode/drag-outline-control'
+import {
+  DragOutlineControl,
+  dragTargetsElementPaths,
+} from '../../controls/select-mode/drag-outline-control'
 import { FlexReparentTargetIndicator } from '../../controls/select-mode/flex-reparent-target-indicator'
 import { CanvasStrategyFactory } from '../canvas-strategies'
 import {
@@ -48,7 +51,7 @@ export function baseAbsoluteReparentToFlexStrategy(
       controlsToRender: [
         controlWithProps({
           control: DragOutlineControl,
-          props: { targets: filteredSelectedElements },
+          props: dragTargetsElementPaths(filteredSelectedElements),
           key: 'ghost-outline-control',
           show: 'visible-only-while-active',
         }),

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.spec.browser2.tsx
@@ -1,6 +1,6 @@
 import { FOR_TESTS_setNextGeneratedUid } from '../../../../core/model/element-template-utils.test-utils'
 import { cmdModifier, emptyModifiers, Modifiers } from '../../../../utils/modifiers'
-import { slightlyOffsetPointBecauseVeryWeirdIssue, wait } from '../../../../utils/utils.test-utils'
+import { slightlyOffsetPointBecauseVeryWeirdIssue } from '../../../../utils/utils.test-utils'
 import { setRightMenuTab } from '../../../editor/actions/action-creators'
 import { RightMenuTab } from '../../../editor/store/editor-state'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.spec.browser2.tsx
@@ -1,9 +1,10 @@
 import { FOR_TESTS_setNextGeneratedUid } from '../../../../core/model/element-template-utils.test-utils'
 import { cmdModifier, emptyModifiers, Modifiers } from '../../../../utils/modifiers'
-import { slightlyOffsetPointBecauseVeryWeirdIssue } from '../../../../utils/utils.test-utils'
+import { slightlyOffsetPointBecauseVeryWeirdIssue, wait } from '../../../../utils/utils.test-utils'
 import { setRightMenuTab } from '../../../editor/actions/action-creators'
 import { RightMenuTab } from '../../../editor/store/editor-state'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
+import { DragOutlineControlTestId } from '../../controls/select-mode/drag-outline-control'
 import {
   mouseDownAtPoint,
   mouseMoveToPoint,
@@ -70,6 +71,8 @@ async function dragFromInsertMenuDivButtonToPoint(
   renderResult: EditorRenderResult,
 ) {
   startDraggingFromInsertMenuDivButtonToPoint(targetPoint, modifiers, renderResult)
+  const dragOutlineControl = renderResult.renderedDOM.getByTestId(DragOutlineControlTestId)
+  expect(dragOutlineControl).not.toBeNull()
   finishDraggingToPoint(targetPoint, modifiers, renderResult)
 
   await renderResult.getDispatchFollowUpActionsFinished()

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -31,7 +31,10 @@ import { updateFunctionCommand } from '../../commands/update-function-command'
 import { updateHighlightedViews } from '../../commands/update-highlighted-views-command'
 import { ParentBoundsForInsertion } from '../../controls/parent-bounds'
 import { ImmediateParentOutlines } from '../../controls/parent-outlines'
-import { DragOutlineControl } from '../../controls/select-mode/drag-outline-control'
+import {
+  DragOutlineControl,
+  dragTargetsElementPaths,
+} from '../../controls/select-mode/drag-outline-control'
 import { FlexReparentTargetIndicator } from '../../controls/select-mode/flex-reparent-target-indicator'
 import {
   CanvasStrategyFactory,
@@ -149,7 +152,7 @@ function drawToInsertStrategyFactory(
       }),
       controlWithProps({
         control: DragOutlineControl,
-        props: { targets: [predictedElementPath] },
+        props: dragTargetsElementPaths([predictedElementPath]),
         key: 'ghost-outline-control',
         show: 'visible-only-while-active',
       }),

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reorder-strategy.tsx
@@ -7,7 +7,10 @@ import {
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
 } from '../canvas-strategy-types'
-import { DragOutlineControl } from '../../controls/select-mode/drag-outline-control'
+import {
+  DragOutlineControl,
+  dragTargetsElementPaths,
+} from '../../controls/select-mode/drag-outline-control'
 import { ImmediateParentOutlines } from '../../controls/parent-outlines'
 import { ImmediateParentBounds } from '../../controls/parent-bounds'
 import { applyReorderCommon } from './reorder-utils'
@@ -34,7 +37,7 @@ export function flexReorderStrategy(
     controlsToRender: [
       controlWithProps({
         control: DragOutlineControl,
-        props: { targets: selectedElements },
+        props: dragTargetsElementPaths(selectedElements),
         key: 'ghost-outline-control',
         show: 'visible-only-while-active',
       }),

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
@@ -14,7 +14,10 @@ import { updateFunctionCommand } from '../../commands/update-function-command'
 import { wildcardPatch } from '../../commands/wildcard-patch-command'
 import { ParentBounds } from '../../controls/parent-bounds'
 import { ParentOutlines } from '../../controls/parent-outlines'
-import { DragOutlineControl } from '../../controls/select-mode/drag-outline-control'
+import {
+  DragOutlineControl,
+  dragTargetsElementPaths,
+} from '../../controls/select-mode/drag-outline-control'
 import { CanvasStrategyFactory, pickCanvasStateFromEditorState } from '../canvas-strategies'
 import {
   CanvasStrategy,
@@ -60,7 +63,7 @@ export function baseFlexReparentToAbsoluteStrategy(
       controlsToRender: [
         controlWithProps({
           control: DragOutlineControl,
-          props: { targets: selectedElements },
+          props: dragTargetsElementPaths(selectedElements),
           key: 'ghost-outline-control',
           show: 'visible-only-while-active',
         }),

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flex-strategy.tsx
@@ -1,7 +1,10 @@
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { ParentBounds } from '../../controls/parent-bounds'
 import { ParentOutlines } from '../../controls/parent-outlines'
-import { DragOutlineControl } from '../../controls/select-mode/drag-outline-control'
+import {
+  DragOutlineControl,
+  dragTargetsElementPaths,
+} from '../../controls/select-mode/drag-outline-control'
 import { FlexReparentTargetIndicator } from '../../controls/select-mode/flex-reparent-target-indicator'
 import { CanvasStrategyFactory } from '../canvas-strategies'
 import {
@@ -40,7 +43,7 @@ export function baseFlexReparentToFlexStrategy(
       controlsToRender: [
         controlWithProps({
           control: DragOutlineControl,
-          props: { targets: selectedElements },
+          props: dragTargetsElementPaths(selectedElements),
           key: 'ghost-outline-control',
           show: 'visible-only-while-active',
         }),

--- a/editor/src/components/canvas/controls/select-mode/drag-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/drag-outline-control.tsx
@@ -1,50 +1,96 @@
 import React from 'react'
+import {
+  boundingRectangleArray,
+  CanvasRectangle,
+  offsetRect,
+} from '../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
+import { assertNever } from '../../../../core/shared/utils'
 import { useColorTheme } from '../../../../uuiui'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { controlForStrategyMemoized } from '../../canvas-strategies/canvas-strategy-types'
 import { getMultiselectBounds } from '../../canvas-strategies/strategies/shared-move-strategies-helpers'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 
-interface DragOutlineControlProps {
+export const DragOutlineControlTestId = 'drag-outline-control'
+
+interface DragTargetsElementPaths {
+  type: 'element-paths'
   targets: Array<ElementPath>
 }
 
-export const DragOutlineControl = controlForStrategyMemoized(
-  ({ targets }: DragOutlineControlProps) => {
-    const scale = useEditorState((store) => store.editor.canvas.scale, 'OutlineControl scale')
-    const frame = useEditorState((store) => {
-      return getMultiselectBounds(store.strategyState.startingMetadata, targets)
-    }, 'GhostOutline frame')
-    const dragVector = useEditorState((store) => {
-      if (store.editor.canvas.interactionSession?.interactionData.type === 'DRAG') {
-        return store.editor.canvas.interactionSession.interactionData.drag
-      } else {
-        return null
-      }
-    }, 'GhostOutline dragVector')
+export function dragTargetsElementPaths(targets: Array<ElementPath>): DragTargetsElementPaths {
+  return {
+    type: 'element-paths',
+    targets: targets,
+  }
+}
 
-    const colorTheme = useColorTheme()
+interface DragTargetsFrames {
+  type: 'frames'
+  frames: Array<CanvasRectangle>
+}
 
-    if (frame == null || dragVector == null) {
-      return null
-    } else {
-      return (
-        <CanvasOffsetWrapper>
-          <div
-            style={{
-              position: 'absolute',
-              top: frame.y + dragVector.y,
-              left: frame.x + dragVector.x,
-              width: frame.width,
-              height: frame.height,
-              boxSizing: 'border-box',
-              boxShadow: `0px 0px 0px ${1 / scale}px  ${colorTheme.canvasSelectionFocusable.value}`,
-              opacity: '50%',
-            }}
-          />
-        </CanvasOffsetWrapper>
-      )
+export function dragTargetsFrame(frames: Array<CanvasRectangle>): DragTargetsFrames {
+  return {
+    type: 'frames',
+    frames: frames,
+  }
+}
+
+type DragOutlineControlProps = DragTargetsElementPaths | DragTargetsFrames
+
+export const DragOutlineControl = controlForStrategyMemoized((props: DragOutlineControlProps) => {
+  const scale = useEditorState((store) => store.editor.canvas.scale, 'OutlineControl scale')
+  const frame = useFrameFromProps(props)
+
+  const colorTheme = useColorTheme()
+
+  if (frame == null) {
+    return null
+  }
+
+  return (
+    <CanvasOffsetWrapper>
+      <div
+        data-testid={DragOutlineControlTestId}
+        style={{
+          position: 'absolute',
+          top: frame.y,
+          left: frame.x,
+          width: frame.width,
+          height: frame.height,
+          boxSizing: 'border-box',
+          boxShadow: `0px 0px 0px ${1 / scale}px  ${colorTheme.canvasSelectionFocusable.value}`,
+          opacity: '50%',
+        }}
+      />
+    </CanvasOffsetWrapper>
+  )
+})
+
+function useFrameFromProps(props: DragOutlineControlProps): CanvasRectangle | null {
+  const bounds = useEditorState((store) => {
+    switch (props.type) {
+      case 'frames':
+        return boundingRectangleArray(props.frames)
+      case 'element-paths':
+        return getMultiselectBounds(store.strategyState.startingMetadata, props.targets)
+      default:
+        assertNever(props)
     }
-  },
-)
+  }, 'GhostOutline frame')
+
+  const dragVector = useEditorState((store) => {
+    if (store.editor.canvas.interactionSession?.interactionData.type !== 'DRAG') {
+      return null
+    }
+    return store.editor.canvas.interactionSession.interactionData.drag
+  }, 'GhostOutline dragVector')
+
+  if (bounds == null || dragVector == null) {
+    return null
+  }
+
+  return offsetRect(bounds, dragVector)
+}


### PR DESCRIPTION
Fixes https://github.com/concrete-utopia/utopia/issues/2689

**Problem:**
Drag outline control is not visible during drag to insert

**Root cause:**
`DragOutlineControl` calculates the bounding box of the target elements using the `startingMetadata`. But that metadata does not contain the element which will be just inserted during this interaction

**Fix:**
`DragOutlineControl` can receive either an array of element paths or an array of frames to render the outline. In the  drag-to-insert strategy we can just pass the frames, so the control does not need to refer to the metadata to get the bounds.
