### PR TITLE
Fix containing block detection for `contain` prop

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -123,7 +123,13 @@ function isElementAContainingBlockForAbsolute(computedStyle: CSSStyleDeclaration
   if (computedStyle.filter != null && computedStyle.filter !== 'none') {
     return true
   }
-  if (computedStyle.contain === 'paint') {
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/contain
+  if (
+    computedStyle.contain.includes('layout') ||
+    computedStyle.contain.includes('paint') ||
+    computedStyle.contain.includes('strict') ||
+    computedStyle.contain.includes('content')
+  ) {
     return true
   }
   return false


### PR DESCRIPTION
**Problem:**
Previously `isElementAContainingBlockForAbsolute` would only return true if `computedStyle.contain` was equal to `paint`.  This comes from point 4. iv. [of this MDN article.](https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block)

But the [Contain MDN Article](https://developer.mozilla.org/en-US/docs/Web/CSS/contain) has a broader definition:
> If applied (with value: layout, paint, strict or content), this property creates:
> A new [containing block](https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block) (for the descendants whose [position](https://developer.mozilla.org/en-US/docs/Web/CSS/position) property is absolute or fixed).
> [...]

Moreover, the contain prop can take a list of words, so we need to replace the strict equality check with a  String.includes().

**Fix:**
`isElementAContainingBlockForAbsolute` returns true if `computedStyle.contain` contains any of `layout`, `paint`, `strict` or `content`
