### PR TITLE
Restore flex insertion 'hack' and fix the outline controls

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.tsx
@@ -20,7 +20,6 @@ import { getDragTargets } from './shared-move-strategies-helpers'
 export function baseAbsoluteReparentToFlexStrategy(
   reparentTarget: ReparentTarget,
   fitness: number,
-  showTargetOrReorderIndicator: 'show-reorder-indicator' | 'show-flex-target',
 ): CanvasStrategyFactory {
   return (
     canvasState: InteractionCanvasState,
@@ -81,7 +80,6 @@ export function baseAbsoluteReparentToFlexStrategy(
           canvasState,
           interactionSession,
           reparentTarget,
-          showTargetOrReorderIndicator,
         )
       },
     }

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
@@ -89,7 +89,6 @@ export const dragToInsertMetaStrategy: MetaCanvasStrategy = (
     pointOnCanvas,
     cmdPressed,
     true,
-    'show-reorder-indicator',
   )
 
   return mapDropNulls((result): CanvasStrategy | null => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -16,7 +16,6 @@ import {
   CanvasRectangle,
   Size,
 } from '../../../../core/shared/math-utils'
-import { maybeToArray } from '../../../../core/shared/optional-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import { cmdModifier } from '../../../../utils/modifiers'
 import { InsertionSubject } from '../../../editor/editor-modes'
@@ -29,8 +28,8 @@ import {
 import { showReorderIndicator } from '../../commands/show-reorder-indicator-command'
 import { updateFunctionCommand } from '../../commands/update-function-command'
 import { updateHighlightedViews } from '../../commands/update-highlighted-views-command'
-import { ParentBoundsForInsertion } from '../../controls/parent-bounds'
-import { ImmediateParentOutlines } from '../../controls/parent-outlines'
+import { ParentBounds } from '../../controls/parent-bounds'
+import { ParentOutlines } from '../../controls/parent-outlines'
 import {
   DragOutlineControl,
   dragTargetsElementPaths,
@@ -83,7 +82,6 @@ export const drawToInsertMetaStrategy: MetaCanvasStrategy = (
     pointOnCanvas,
     true, // Draw to insert should always disregard the size of the potential target parent
     true,
-    'show-flex-target',
   )
 
   return mapDropNulls((result): CanvasStrategy | null => {
@@ -139,14 +137,14 @@ function drawToInsertStrategyFactory(
     name: name,
     controlsToRender: [
       controlWithProps({
-        control: ImmediateParentOutlines,
-        props: { targets: [targetParent] },
+        control: ParentOutlines,
+        props: { targetParent: targetParent },
         key: 'parent-outlines-control',
         show: 'visible-only-while-active',
       }),
       controlWithProps({
-        control: ParentBoundsForInsertion,
-        props: { targetParents: [targetParent] },
+        control: ParentBounds,
+        props: { targetParent: targetParent },
         key: 'parent-bounds-control',
         show: 'visible-only-while-active',
       }),
@@ -446,7 +444,8 @@ function runTargetStrategiesForFreshlyInsertedElementToReparent(
   }
   const reparentCommands = strategy.apply(strategyLifecycle).commands
 
-  return foldAndApplyCommandsInner(editorState, [], reparentCommands, strategyLifecycle)
+  // We only want the commands that are applied at the end of the reparent, as we'll be resizing afterwards
+  return foldAndApplyCommandsInner(editorState, [], reparentCommands, 'end-interaction')
     .statePatches
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flex-strategy.tsx
@@ -20,7 +20,6 @@ import { applyFlexReparent, ReparentTarget } from './reparent-strategy-helpers'
 export function baseFlexReparentToFlexStrategy(
   reparentTarget: ReparentTarget,
   fitness: number,
-  showTargetOrReorderIndicator: 'show-reorder-indicator' | 'show-flex-target',
 ): CanvasStrategyFactory {
   return (
     canvasState: InteractionCanvasState,
@@ -70,13 +69,7 @@ export function baseFlexReparentToFlexStrategy(
       apply: () => {
         return interactionSession == null
           ? emptyStrategyApplicationResult
-          : applyFlexReparent(
-              'do-not-strip-props',
-              canvasState,
-              interactionSession,
-              reparentTarget,
-              showTargetOrReorderIndicator,
-            )
+          : applyFlexReparent('do-not-strip-props', canvasState, interactionSession, reparentTarget)
       },
     }
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -36,7 +36,6 @@ export function getApplicableReparentFactories(
   pointOnCanvas: CanvasPoint,
   cmdPressed: boolean,
   allDraggedElementsAbsolute: boolean,
-  showFlexTargetOrReorderIndicator: 'show-reorder-indicator' | 'show-flex-target',
 ): Array<ReparentFactoryAndDetails> {
   const reparentStrategies = findReparentStrategies(canvasState, cmdPressed, pointOnCanvas)
 
@@ -79,11 +78,7 @@ export function getApplicableReparentFactories(
             strategyType: result.strategy,
             missingBoundsHandling: result.missingBoundsHandling,
             fitness: fitness,
-            factory: baseAbsoluteReparentToFlexStrategy(
-              result.target,
-              fitness,
-              showFlexTargetOrReorderIndicator,
-            ),
+            factory: baseAbsoluteReparentToFlexStrategy(result.target, fitness),
           }
         } else {
           return {
@@ -92,11 +87,7 @@ export function getApplicableReparentFactories(
             strategyType: result.strategy,
             missingBoundsHandling: result.missingBoundsHandling,
             fitness: fitness,
-            factory: baseFlexReparentToFlexStrategy(
-              result.target,
-              fitness,
-              showFlexTargetOrReorderIndicator,
-            ),
+            factory: baseFlexReparentToFlexStrategy(result.target, fitness),
           }
         }
       }
@@ -161,7 +152,6 @@ export const reparentMetaStrategy: MetaCanvasStrategy = (
     pointOnCanvas,
     cmdPressed,
     allDraggedElementsAbsolute,
-    'show-reorder-indicator',
   )
 
   const targetIsValid = (

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -633,7 +633,6 @@ export function applyFlexReparent(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession,
   reparentResult: ReparentTarget,
-  showTargetOrReorderIndicator: 'show-reorder-indicator' | 'show-flex-target',
 ): StrategyApplicationResult {
   const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
   const filteredSelectedElements = getDragTargets(selectedElements)
@@ -697,8 +696,11 @@ export function applyFlexReparent(
               setCursorCommand('mid-interaction', CSSCursor.Move),
             ]
 
-            function showReorderIndicatorCommands(): Array<CanvasCommand> {
+            function midInteractionCommandsForTarget(): Array<CanvasCommand> {
               return [
+                wildcardPatch('mid-interaction', {
+                  canvas: { controls: { parentHighlightPaths: { $set: [newParent] } } },
+                }),
                 showReorderIndicator(newParent, newIndex),
                 newParentADescendantOfCurrentParent
                   ? wildcardPatch('mid-interaction', {
@@ -709,18 +711,6 @@ export function applyFlexReparent(
                     }),
                 wildcardPatch('mid-interaction', { displayNoneInstances: { $push: [newPath] } }),
               ]
-            }
-
-            function midInteractionCommandsForTarget(): Array<CanvasCommand> {
-              const commandsForTarget: Array<CanvasCommand> = [
-                wildcardPatch('mid-interaction', {
-                  canvas: { controls: { parentHighlightPaths: { $set: [newParent] } } },
-                }),
-              ]
-
-              return showTargetOrReorderIndicator === 'show-reorder-indicator'
-                ? commandsForTarget.concat(showReorderIndicatorCommands())
-                : commandsForTarget
             }
 
             let interactionFinishCommands: Array<CanvasCommand>

--- a/editor/src/components/canvas/controls/parent-bounds.tsx
+++ b/editor/src/components/canvas/controls/parent-bounds.tsx
@@ -59,36 +59,6 @@ export const ParentBounds = controlForStrategyMemoized(({ targetParent }: Parent
   return parentFrame == null ? null : drawBounds(parentFrame, scale)
 })
 
-interface ParentBoundsForInsertionProps {
-  targetParents: Array<ElementPath>
-}
-export const ParentBoundsForInsertion = controlForStrategyMemoized(
-  ({ targetParents }: ParentBoundsForInsertionProps) => {
-    const scale = useEditorState(
-      (store) => store.editor.canvas.scale,
-      'ParentBoundsForInsertion canvas scale',
-    )
-    const parentFrame = useEditorState((store) => {
-      const parentHighlightPaths = store.editor.canvas.controls.parentHighlightPaths
-      if (parentHighlightPaths != null && parentHighlightPaths.length === 1) {
-        return MetadataUtils.getFrameInCanvasCoords(
-          parentHighlightPaths[0],
-          store.editor.jsxMetadata,
-        )
-      }
-
-      if (!isInsertMode(store.editor.mode)) {
-        if (targetParents.length === 1 && !EP.isStoryboardPath(targetParents[0])) {
-          return MetadataUtils.getFrameInCanvasCoords(targetParents[0], store.editor.jsxMetadata)
-        }
-      }
-      return null
-    }, 'ParentBoundsForInsertion frame')
-
-    return parentFrame == null ? null : drawBounds(parentFrame, scale)
-  },
-)
-
 function drawBounds(parentFrame: CanvasRectangle, scale: number) {
   return (
     <CanvasOffsetWrapper key={`parent-bounds`}>


### PR DESCRIPTION
**Problem:**
A flex insertion "hack" was removed in #2691, but that inadvertently broke the guideline control rendering, as it would mean zero sized intended bounds were being pushed (via the `'mid-interaction'` commands of the reparenting stage).

**Fix:**
The real issue here is that actually we don't want any of the `'mid-interaction'` commands from the reparenting stage to be run during a draw to insert, as in most cases they will clash with those from the resizing stage that comes immediately after. To fix that I have reverted the changes from the previous PR and updated the comment.

Reverting these changes alone caused a separate issue, as during a flex insertion those `mid-interaction` commands were setting the parent highlight paths used for rendering the outline and bounds controls. This was only an issue because the draw-to-insert strategy was using the incorrect controls here, so I have updated that to use the correct `ParentOutlines` and `ParentBounds` controls (which we are using in drag-to-insert).
