### PR TITLE
Image drag session state management

### DIFF
--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -824,6 +824,7 @@ export const FileBrowserItem: React.FC<FileBrowserItemProps> = (props: FileBrows
       drop: (item, monitor) => {
         dispatch([
           CanvasActions.clearInteractionSession(false),
+          EditorActions.setImageDragSessionState(notDragging()),
           EditorActions.switchEditorMode(EditorModes.selectMode(null)),
           EditorActions.setFilebrowserDropTarget(null),
         ])

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -981,7 +981,6 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
           this.props.dispatch([
             CanvasActions.clearInteractionSession(false),
             EditorActions.switchEditorMode(EditorModes.selectMode(null)),
-            EditorActions.setImageDragSessionState(notDragging()),
           ])
         },
 


### PR DESCRIPTION
## Problem:
- Image drag session state is cleared when dragging out of the canvas
- Image drag session state is not cleared when dropping on UTFB

## Fix:
- Image drag session state not is cleared when dragging out of the canvas
- Image drag session state is cleared when dropping on UTFB

