### PR TITLE
Flex reparent should add contain: layout and not position: relative

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
@@ -278,13 +278,13 @@ describe('Absolute Reparent To Flex Strategy', () => {
       />
       <div
         style={{
-          position: 'relative',
           width: 100,
           height: 100,
           borderWidth: 10,
           borderColor: 'black',
           borderStyle: 'solid',
           backgroundColor: 'yellow',
+          contain: 'layout',
         }}
         data-uid='absolutechild'
         data-testid='absolutechild'
@@ -391,13 +391,13 @@ describe('Absolute Reparent To Flex Strategy', () => {
       />
       <div
         style={{
-          position: 'relative',
           width: 100,
           height: 100,
           borderWidth: 10,
           borderColor: 'black',
           borderStyle: 'solid',
           backgroundColor: 'yellow',
+          contain: 'layout',
         }}
         data-uid='absolutechild'
         data-testid='absolutechild'

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.spec.browser2.tsx
@@ -310,9 +310,9 @@ describe('Dragging from the insert menu into a flex layout', () => {
           <div
             style={{
               backgroundColor: '#0091FFAA',
-              position: 'relative',
               width: 100,
               height: 100,
+              contain: 'layout',
             }}
             data-uid='ddd'
           />
@@ -511,9 +511,9 @@ describe('Dragging from the insert menu into a flex layout', () => {
           <div
             style={{
               backgroundColor: '#0091FFAA',
-              position: 'relative',
               width: 100,
               height: 100,
+              contain: 'layout',
             }}
             data-uid='ddd'
           />

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -1049,9 +1049,9 @@ describe('Inserting into flex row', () => {
           <div
             style={{
               backgroundColor: '#0091FFAA',
-              position: 'relative',
               width: 20,
               height: 300,
+              contain: 'layout',
             }}
             data-uid='ddd'
           />
@@ -1128,9 +1128,9 @@ describe('Inserting into flex row', () => {
           <div
             style={{
               backgroundColor: '#0091FFAA',
-              position: 'relative',
               width: 100,
               height: 100,
+              contain: 'layout',
             }}
             data-uid='ddd'
           />
@@ -1222,9 +1222,9 @@ describe('Inserting into flex row', () => {
           <div
             style={{
               backgroundColor: '#0091FFAA',
-              position: 'relative',
               width: 20,
               height: 300,
+              contain: 'layout',
             }}
             data-uid='ddd'
           />
@@ -1300,9 +1300,9 @@ describe('Inserting into flex row', () => {
           <div
             style={{
               backgroundColor: '#0091FFAA',
-              position: 'relative',
               width: 100,
               height: 100,
+              contain: 'layout',
             }}
             data-uid='ddd'
           />
@@ -1385,9 +1385,9 @@ describe('Inserting into flex row', () => {
           <div
             style={{
               backgroundColor: '#0091FFAA',
-              position: 'relative',
               width: 20,
               height: 300,
+              contain: 'layout',
             }}
             data-uid='ddd'
           />
@@ -1609,9 +1609,9 @@ describe('Inserting into flex row', () => {
         <div
           style={{
             backgroundColor: '#0091FFAA',
-            position: 'relative',
             width: 20,
             height: 30,
+            contain: 'layout',
           }}
           data-uid='ddd'
         />
@@ -1689,9 +1689,9 @@ describe('Inserting into flex row', () => {
         <div
           style={{
             backgroundColor: '#0091FFAA',
-            position: 'relative',
             width: 100,
             height: 100,
+            contain: 'layout',
           }}
           data-uid='ddd'
         />
@@ -1810,9 +1810,9 @@ describe('Inserting into flex column', () => {
           <div
             style={{
               backgroundColor: '#0091FFAA',
-              position: 'relative',
               width: 300,
               height: 20,
+              contain: 'layout',
             }}
             data-uid='ddd'
           />
@@ -1891,9 +1891,9 @@ describe('Inserting into flex column', () => {
           <div
             style={{
               backgroundColor: '#0091FFAA',
-              position: 'relative',
               width: 100,
               height: 100,
+              contain: 'layout',
             }}
             data-uid='ddd'
           />
@@ -1987,9 +1987,9 @@ describe('Inserting into flex column', () => {
           <div
             style={{
               backgroundColor: '#0091FFAA',
-              position: 'relative',
               width: 300,
               height: 20,
+              contain: 'layout',
             }}
             data-uid='ddd'
           />
@@ -2068,9 +2068,9 @@ describe('Inserting into flex column', () => {
           <div
             style={{
               backgroundColor: '#0091FFAA',
-              position: 'relative',
               width: 100,
               height: 100,
+              contain: 'layout',
             }}
             data-uid='ddd'
           />
@@ -2153,9 +2153,9 @@ describe('Inserting into flex column', () => {
           <div
             style={{
               backgroundColor: '#0091FFAA',
-              position: 'relative',
               width: 300,
               height: 20,
+              contain: 'layout',
             }}
             data-uid='ddd'
           />
@@ -2300,7 +2300,7 @@ describe('Inserting an image', () => {
             style={{
               width: 300,
               height: 300,
-              position: 'relative'
+              contain: 'layout',
             }}
             src='/editor/icons/favicons/favicon-128.png?hash=nocommit'
             data-uid='ddd'

--- a/editor/src/components/canvas/canvas-strategies/strategies/forced-absolute-reparent-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/forced-absolute-reparent-strategies.spec.browser2.tsx
@@ -506,10 +506,10 @@ describe('Forced Absolute Reparent Strategies', () => {
       />
       <div
         style={{
-          position: 'relative',
           width: 100,
           height: 100,
           backgroundColor: 'yellow',
+          contain: 'layout',
         }}
         data-uid='absolutechild'
         data-testid='absolutechild'

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -859,7 +859,7 @@ export function getFlexReparentPropertyChanges(
     return []
   }
 
-  if (targetOriginalStylePosition !== 'absolute') {
+  if (targetOriginalStylePosition !== 'absolute' && targetOriginalStylePosition !== 'relative') {
     return [deleteProperties('always', newPath, propertiesToRemove)]
   }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -15,13 +15,16 @@ import { getStoryboardElementPath } from '../../../../core/model/scene-utils'
 import { mapDropNulls, reverse, stripNulls } from '../../../../core/shared/array-utils'
 import { isRight, right } from '../../../../core/shared/either'
 import * as EP from '../../../../core/shared/element-path'
-import { ElementInstanceMetadataMap, JSXElement } from '../../../../core/shared/element-template'
+import {
+  ElementInstanceMetadata,
+  ElementInstanceMetadataMap,
+  JSXElement,
+} from '../../../../core/shared/element-template'
 import {
   canvasPoint,
   CanvasPoint,
   CanvasRectangle,
   canvasRectangle,
-  offsetPoint,
   pointDifference,
   rectContainsPoint,
   rectContainsPointInclusive,
@@ -37,6 +40,7 @@ import * as PP from '../../../../core/shared/property-path'
 import { absolute } from '../../../../utils/utils'
 import { ProjectContentTreeRoot } from '../../../assets'
 import { AllElementProps, getElementFromProjectContents } from '../../../editor/store/editor-state'
+import { CSSPosition } from '../../../inspector/common/css-utils'
 import { stylePropPathMappingFn } from '../../../inspector/common/property-path-hooks'
 import { CSSCursor } from '../../canvas-types'
 import {
@@ -48,9 +52,9 @@ import { deleteProperties } from '../../commands/delete-properties-command'
 import { reorderElement } from '../../commands/reorder-element-command'
 import { setCursorCommand } from '../../commands/set-cursor-command'
 import { setElementsToRerenderCommand } from '../../commands/set-elements-to-rerender-command'
+import { setProperty } from '../../commands/set-property-command'
 import { showReorderIndicator } from '../../commands/show-reorder-indicator-command'
 import { updateHighlightedViews } from '../../commands/update-highlighted-views-command'
-import { updatePropIfExists } from '../../commands/update-prop-if-exists-command'
 import { updateSelectedViews } from '../../commands/update-selected-views-command'
 import { wildcardPatch } from '../../commands/wildcard-patch-command'
 import { getAllTargetsAtPointAABB } from '../../dom-lookup'
@@ -382,6 +386,7 @@ const propertiesToRemove: Array<PropertyPath> = [
   PP.create(['style', 'top']),
   PP.create(['style', 'right']),
   PP.create(['style', 'bottom']),
+  PP.create(['style', 'position']),
 ]
 
 function drawTargetRectanglesForChildrenOfElement(
@@ -678,10 +683,16 @@ export function applyFlexReparent(
           if (outcomeResult != null) {
             const { commands: reparentCommands, newPath } = outcomeResult
 
+            const targetMetadata = MetadataUtils.findElementByElementPath(
+              canvasState.startingMetadata,
+              target,
+            )
+
             // Strip the `position`, positional and dimension properties.
             const propertyChangeCommands = getFlexReparentPropertyChanges(
               stripAbsoluteProperties,
               newPath,
+              targetMetadata?.specialSizeMeasurements.position ?? null,
             )
 
             const commandsBeforeReorder = [
@@ -843,13 +854,22 @@ export function getAbsoluteReparentPropertyChanges(
 export function getFlexReparentPropertyChanges(
   stripAbsoluteProperties: StripAbsoluteProperties,
   newPath: ElementPath,
-) {
-  return stripAbsoluteProperties
-    ? [
-        deleteProperties('always', newPath, propertiesToRemove),
-        updatePropIfExists('always', newPath, PP.create(['style', 'position']), 'relative'), // SPIKE TODO only insert position: relative if there was a position nonstatic prop before
-      ]
-    : []
+  targetOriginalStylePosition: CSSPosition | null,
+): Array<CanvasCommand> {
+  if (!stripAbsoluteProperties) {
+    return []
+  }
+
+  const deletePropertiesCommand = deleteProperties('always', newPath, propertiesToRemove)
+
+  if (targetOriginalStylePosition === 'absolute') {
+    return [
+      deletePropertiesCommand,
+      setProperty('always', newPath, PP.create(['style', 'contain']), 'layout'),
+    ]
+  }
+
+  return [deletePropertiesCommand]
 }
 
 export function getReparentPropertyChanges(
@@ -860,6 +880,7 @@ export function getReparentPropertyChanges(
   newParentStartingMetadata: ElementInstanceMetadataMap,
   projectContents: ProjectContentTreeRoot,
   openFile: string | null | undefined,
+  targetOriginalStylePosition: CSSPosition | null,
 ): Array<CanvasCommand> {
   switch (reparentStrategy) {
     case 'REPARENT_TO_ABSOLUTE':
@@ -873,6 +894,10 @@ export function getReparentPropertyChanges(
       )
     case 'REPARENT_TO_FLEX':
       const newPath = EP.appendToPath(newParent, EP.toUid(target))
-      return getFlexReparentPropertyChanges('strip-absolute-props', newPath)
+      return getFlexReparentPropertyChanges(
+        'strip-absolute-props',
+        newPath,
+        targetOriginalStylePosition,
+      )
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -386,7 +386,6 @@ const propertiesToRemove: Array<PropertyPath> = [
   PP.create(['style', 'top']),
   PP.create(['style', 'right']),
   PP.create(['style', 'bottom']),
-  PP.create(['style', 'position']),
 ]
 
 function drawTargetRectanglesForChildrenOfElement(
@@ -860,16 +859,14 @@ export function getFlexReparentPropertyChanges(
     return []
   }
 
-  const deletePropertiesCommand = deleteProperties('always', newPath, propertiesToRemove)
-
-  if (targetOriginalStylePosition === 'absolute') {
-    return [
-      deletePropertiesCommand,
-      setProperty('always', newPath, PP.create(['style', 'contain']), 'layout'),
-    ]
+  if (targetOriginalStylePosition !== 'absolute') {
+    return [deleteProperties('always', newPath, propertiesToRemove)]
   }
 
-  return [deletePropertiesCommand]
+  return [
+    deleteProperties('always', newPath, [...propertiesToRemove, PP.create(['style', 'position'])]),
+    setProperty('always', newPath, PP.create(['style', 'contain']), 'layout'),
+  ]
 }
 
 export function getReparentPropertyChanges(

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-to-flex-strategy.tsx
@@ -10,7 +10,6 @@ import { CanvasStrategyFactory } from '../canvas-strategies'
 import {
   CanvasStrategy,
   controlWithProps,
-  emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
 } from '../canvas-strategy-types'

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2776,12 +2776,12 @@ export const UPDATE_FNS = {
               currentValue.originalElementPath,
               action.targetOriginalContextMetadata,
             )
-          const pastedElementIsAbsolute = MetadataUtils.isPositionAbsolute(
-            MetadataUtils.findElementByElementPath(
-              action.targetOriginalContextMetadata,
-              currentValue.originalElementPath,
-            ),
+
+          const pastedElementMetadata = MetadataUtils.findElementByElementPath(
+            action.targetOriginalContextMetadata,
+            currentValue.originalElementPath,
           )
+          const pastedElementIsAbsolute = MetadataUtils.isPositionAbsolute(pastedElementMetadata)
 
           if (!(pastedElementIsAbsolute || pastedElementIsFlex)) {
             return workingEditorState
@@ -2794,6 +2794,7 @@ export const UPDATE_FNS = {
               workingEditorState.jsxMetadata,
               workingEditorState.projectContents,
               workingEditorState.canvas.openFile?.filename,
+              pastedElementMetadata?.specialSizeMeasurements.position ?? null,
             )
 
             const allCommands = [...reparentCommands, ...propertyChangeCommands]

--- a/editor/src/core/layout/layout-utils.spec.browser2.tsx
+++ b/editor/src/core/layout/layout-utils.spec.browser2.tsx
@@ -84,7 +84,7 @@ describe('pasteJSXElements', () => {
             style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: 256, height: 202, display: 'flex' }}
             data-uid='bbb'
           >
-            <View style={{ width: 100, height: 100, position: 'relative' }} data-uid='catdog' />
+            <View style={{ width: 100, height: 100, contain: 'layout' }} data-uid='catdog' />
           </View>
         </View>`,
       ),
@@ -107,6 +107,7 @@ async function createStarterEditor() {
   return renderResult
 }
 
+// TODO: copy from the document, and then we don't need a fake metadata
 function createPasteElementAction(
   positionProp: 'element-with-position-absolute' | 'element-with-no-position',
 ) {
@@ -160,11 +161,11 @@ function createPasteElementAction(
         true,
         EP.emptyElementPath,
         true,
-        'none',
+        positionProp === 'element-with-no-position' ? 'flex' : 'none',
         'none',
         false,
         'block',
-        'absolute',
+        positionProp === 'element-with-position-absolute' ? 'absolute' : 'static',
         sides(undefined, undefined, undefined, undefined),
         sides(undefined, undefined, undefined, undefined),
         null,


### PR DESCRIPTION
Fixes https://github.com/concrete-utopia/utopia/issues/2703

**Problem:**
We decided to use `contain: layout` instead of `position: relative`, when originally `position` was `absolute`

**Fix:**
- I needed to get the original positioning, I get that from the metadata
- I replace `position: relative` or `position: absolute` with `contain: layout`
- If position is relative or absolute, I remove `top`/`left`/`bottom`/`right` properties