### PR TITLE
Remove redundant stripAbsoluteProperties

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -503,8 +503,6 @@ function drawTargetRectanglesForChildrenOfElement(
   return flexInsertionTargets
 }
 
-export type StripAbsoluteProperties = 'strip-absolute-props' | 'do-not-strip-props'
-
 export function getSiblingMidPointPosition(
   precedingSiblingPosition: CanvasRectangle,
   succeedingSiblingPosition: CanvasRectangle,
@@ -633,7 +631,6 @@ function createPseudoElements(
 }
 
 export function applyFlexReparent(
-  stripAbsoluteProperties: StripAbsoluteProperties,
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession,
   reparentResult: ReparentTarget,
@@ -689,7 +686,6 @@ export function applyFlexReparent(
 
             // Strip the `position`, positional and dimension properties.
             const propertyChangeCommands = getFlexReparentPropertyChanges(
-              stripAbsoluteProperties,
               newPath,
               targetMetadata?.specialSizeMeasurements.position ?? null,
             )
@@ -851,14 +847,9 @@ export function getAbsoluteReparentPropertyChanges(
 }
 
 export function getFlexReparentPropertyChanges(
-  stripAbsoluteProperties: StripAbsoluteProperties,
   newPath: ElementPath,
   targetOriginalStylePosition: CSSPosition | null,
 ): Array<CanvasCommand> {
-  if (!stripAbsoluteProperties) {
-    return []
-  }
-
   if (targetOriginalStylePosition !== 'absolute' && targetOriginalStylePosition !== 'relative') {
     return [deleteProperties('always', newPath, propertiesToRemove)]
   }
@@ -891,10 +882,6 @@ export function getReparentPropertyChanges(
       )
     case 'REPARENT_TO_FLEX':
       const newPath = EP.appendToPath(newParent, EP.toUid(target))
-      return getFlexReparentPropertyChanges(
-        'strip-absolute-props',
-        newPath,
-        targetOriginalStylePosition,
-      )
+      return getFlexReparentPropertyChanges(newPath, targetOriginalStylePosition)
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-to-flow-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-to-flow-strategy.tsx
@@ -17,7 +17,7 @@ import { InteractionSession } from '../interaction-state'
 import { applyFlexReparent, ReparentTarget } from './reparent-strategy-helpers'
 import { getDragTargets } from './shared-move-strategies-helpers'
 
-export function baseReparentToFlexStrategy(
+export function baseReparentToFlowStrategy(
   reparentTarget: ReparentTarget,
   fitness: number,
 ): CanvasStrategyFactory {
@@ -53,8 +53,8 @@ export function baseReparentToFlexStrategy(
     }
 
     return {
-      id: 'REPARENT_TO_FLEX',
-      name: 'Reparent (Flex)',
+      id: 'REPARENT_TO_FLOW',
+      name: 'Reparent (Flow)',
       controlsToRender: [
         controlWithProps({
           control: DragOutlineControl,


### PR DESCRIPTION
**Problem:**
This is a followup PR to https://github.com/concrete-utopia/utopia/pull/2705/
I realized that the `stripAbsoluteProperties` parameter is redundant and unnecessary. Now we decide whether we need to strip the properties or not inside `getFlexReparentPropertyChanges`.

Note: the code was buggy anyway, because it checked the truthiness of `stripAbsoluteProperties`, and that is not a boolean but a union type, so the condition was always false.

**Fix:**
Remove it!