### PR TITLE
Image density control doesn't always show correct values

### DIFF
--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -1089,7 +1089,7 @@ export function useInspectorWarningStatus(): boolean {
   }, 'useInspectorWarningStatus')
 }
 
-export function useSelectedViews() {
+export function useSelectedViews(): ElementPath[] {
   const selectedViews = useContextSelector(
     InspectorPropsContext,
     (context) => context.selectedViews,
@@ -1097,7 +1097,7 @@ export function useSelectedViews() {
   return selectedViews
 }
 
-export function useRefSelectedViews() {
+export function useRefSelectedViews(): ReadonlyRef<ElementPath[]> {
   const { selectedViewsRef } = React.useContext(InspectorCallbackContext)
   return selectedViewsRef
 }

--- a/editor/src/components/inspector/sections/image-section/image-density-control.tsx
+++ b/editor/src/components/inspector/sections/image-section/image-density-control.tsx
@@ -5,6 +5,7 @@ import { showToast, updateFrameDimensions } from '../../../editor/actions/action
 import { OptionChainControl } from '../../controls/option-chain-control'
 import { getControlStyles } from '../../common/control-status'
 import { notice } from '../../../common/notice'
+import { parseImageMultiplier } from '../../../images'
 
 interface ImageDensityControl {
   dispatch: EditorDispatch
@@ -13,6 +14,7 @@ interface ImageDensityControl {
   naturalHeight: number | null
   clientWidth: number
   clientHeight: number
+  src: string
 }
 
 export const ImageDensityControl = React.memo(
@@ -23,17 +25,18 @@ export const ImageDensityControl = React.memo(
     clientHeight,
     dispatch,
     selectedViews,
+    src,
   }: ImageDensityControl) => {
-    const dimensionMultiplier: number | null = React.useMemo(() => {
-      if (naturalWidth != null && naturalHeight != null) {
-        const widthMultiplier = naturalWidth / clientWidth
-        const heightMultiplier = naturalHeight / clientHeight
-        if (widthMultiplier === heightMultiplier) {
-          return widthMultiplier
-        }
-      }
-      return null
-    }, [clientWidth, naturalWidth, clientHeight, naturalHeight])
+    const dimensionMultiplier: number = React.useMemo(
+      () =>
+        imageMultiplierFromSizeMeasurements({
+          clientHeight,
+          clientWidth,
+          naturalHeight,
+          naturalWidth,
+        }) ?? imageMultiplierFromSrc(src),
+      [clientHeight, clientWidth, naturalHeight, naturalWidth, src],
+    )
 
     const onSubmitValue = React.useCallback(
       (value: number) => {
@@ -87,3 +90,26 @@ export const ImageDensityControl = React.memo(
     )
   },
 )
+
+interface SizeMeasurements {
+  naturalWidth: number | null
+  naturalHeight: number | null
+  clientWidth: number
+  clientHeight: number
+}
+
+function imageMultiplierFromSizeMeasurements(measurements: SizeMeasurements): number | null {
+  const { naturalHeight, naturalWidth, clientHeight, clientWidth } = measurements
+  if (naturalWidth != null && naturalHeight != null) {
+    const widthMultiplier = naturalWidth / clientWidth
+    const heightMultiplier = naturalHeight / clientHeight
+    if (widthMultiplier === heightMultiplier) {
+      return widthMultiplier
+    }
+  }
+  return null
+}
+
+function imageMultiplierFromSrc(src: string): number {
+  return parseImageMultiplier(src)
+}

--- a/editor/src/components/inspector/sections/image-section/image-density-control.tsx
+++ b/editor/src/components/inspector/sections/image-section/image-density-control.tsx
@@ -6,6 +6,7 @@ import { OptionChainControl } from '../../controls/option-chain-control'
 import { getControlStyles } from '../../common/control-status'
 import { notice } from '../../../common/notice'
 import { parseImageMultiplier } from '../../../images'
+import { size, Size } from '../../../../core/shared/math-utils'
 
 interface ImageDensityControl {
   dispatch: EditorDispatch
@@ -99,15 +100,25 @@ interface SizeMeasurements {
 }
 
 function imageMultiplierFromSizeMeasurements(measurements: SizeMeasurements): number | null {
-  const { naturalHeight, naturalWidth, clientHeight, clientWidth } = measurements
-  if (naturalWidth != null && naturalHeight != null) {
-    const widthMultiplier = naturalWidth / clientWidth
-    const heightMultiplier = naturalHeight / clientHeight
-    if (widthMultiplier === heightMultiplier) {
-      return widthMultiplier
-    }
+  const naturalSize = size(measurements.naturalWidth ?? 0, measurements.naturalHeight ?? 0)
+  const clientSize = size(measurements.clientWidth, measurements.clientHeight)
+
+  if (isZeroSize(naturalSize) || isZeroSize(clientSize)) {
+    return null
   }
+
+  const widthMultiplier = naturalSize.width / clientSize.width
+  const heightMultiplier = naturalSize.height / clientSize.height
+
+  if (widthMultiplier === heightMultiplier) {
+    return widthMultiplier
+  }
+
   return null
+}
+
+function isZeroSize(s: Size): boolean {
+  return s.width === 0 && s.height === 0
 }
 
 function imageMultiplierFromSrc(src: string): number {

--- a/editor/src/components/inspector/sections/image-section/image-section.tsx
+++ b/editor/src/components/inspector/sections/image-section/image-section.tsx
@@ -117,6 +117,7 @@ export const ImgSection = React.memo(() => {
           naturalHeight={naturalHeight}
           clientWidth={clientWidth}
           clientHeight={clientHeight}
+          src={srcValue}
         />
       </UIGridRow>
     </>


### PR DESCRIPTION
## Problem
The image density control (`Image` section on the right sidebar) in some cases fails to detect the image multiplier (`@2x` from `stuff@2x.png`). This info is read from `ElementInstanceMetadata.specialSizeMeasurements`, which is updated multiple time during image drag and drop.

## Fix
Add a fallback that checks the image file name for the multiplier.

### The control in question
<img width="249" alt="image" src="https://user-images.githubusercontent.com/16385508/197509938-314826c9-0f9f-4fa9-983f-49b56ba223bf.png">