### PR TITLE
Set `cursor: 'pointer'` on `FormButton`

### DIFF
--- a/editor/src/uuiui/button.tsx
+++ b/editor/src/uuiui/button.tsx
@@ -95,6 +95,7 @@ export const FormButton = styled.button<ButtonProps>((props: ButtonProps) => ({
   outline: 'none',
   opacity: props.disabled ? 0.5 : 1,
   pointerEvents: props.disabled ? 'none' : 'initial',
+  cursor: 'pointer',
 
   // slightly subdued colors in default state
   backgroundColor: props.primary


### PR DESCRIPTION
## Problem:
`Formbutton` (used in `confirm-delete-dialog.tsx`) doesn't have a cursor set.

## Fix:
Set `cursor: 'pointer'` on `FormButton`