### PR TITLE
Reparent to flow strategy

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -15,11 +15,7 @@ import { getStoryboardElementPath } from '../../../../core/model/scene-utils'
 import { mapDropNulls, reverse, stripNulls } from '../../../../core/shared/array-utils'
 import { isRight, right } from '../../../../core/shared/either'
 import * as EP from '../../../../core/shared/element-path'
-import {
-  ElementInstanceMetadata,
-  ElementInstanceMetadataMap,
-  JSXElement,
-} from '../../../../core/shared/element-template'
+import { ElementInstanceMetadataMap, JSXElement } from '../../../../core/shared/element-template'
 import {
   canvasPoint,
   CanvasPoint,
@@ -632,7 +628,7 @@ function createPseudoElements(
   }
 }
 
-export function applyFlexReparent(
+export function applyStaticReparent(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession,
   reparentResult: ReparentTarget,
@@ -688,7 +684,7 @@ export function applyFlexReparent(
             )
 
             // Strip the `position`, positional and dimension properties.
-            const propertyChangeCommands = getFlexReparentPropertyChanges(
+            const propertyChangeCommands = getStaticReparentPropertyChanges(
               newPath,
               targetMetadata?.specialSizeMeasurements.position ?? null,
             )
@@ -861,7 +857,7 @@ export function getAbsoluteReparentPropertyChanges(
   ]
 }
 
-export function getFlexReparentPropertyChanges(
+export function getStaticReparentPropertyChanges(
   newPath: ElementPath,
   targetOriginalStylePosition: CSSPosition | null,
 ): Array<CanvasCommand> {
@@ -897,6 +893,6 @@ export function getReparentPropertyChanges(
       )
     case 'REPARENT_TO_FLEX':
       const newPath = EP.appendToPath(newParent, EP.toUid(target))
-      return getFlexReparentPropertyChanges(newPath, targetOriginalStylePosition)
+      return getStaticReparentPropertyChanges(newPath, targetOriginalStylePosition)
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-to-flex-strategy.tsx
@@ -14,7 +14,7 @@ import {
   InteractionCanvasState,
 } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
-import { applyFlexReparent, ReparentTarget } from './reparent-strategy-helpers'
+import { applyStaticReparent, ReparentTarget } from './reparent-strategy-helpers'
 import { getDragTargets } from './shared-move-strategies-helpers'
 
 export function baseReparentToFlexStrategy(
@@ -83,7 +83,7 @@ export function baseReparentToFlexStrategy(
       ],
       fitness: fitness,
       apply: () => {
-        return applyFlexReparent(canvasState, interactionSession, reparentTarget, 'flex')
+        return applyStaticReparent(canvasState, interactionSession, reparentTarget, 'flex')
       },
     }
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-to-flow-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-to-flow-strategy.tsx
@@ -14,7 +14,7 @@ import {
   InteractionCanvasState,
 } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
-import { applyFlexReparent, ReparentTarget } from './reparent-strategy-helpers'
+import { applyStaticReparent, ReparentTarget } from './reparent-strategy-helpers'
 import { getDragTargets } from './shared-move-strategies-helpers'
 
 export function baseReparentToFlowStrategy(
@@ -83,7 +83,7 @@ export function baseReparentToFlowStrategy(
       ],
       fitness: fitness,
       apply: () => {
-        return applyFlexReparent(canvasState, interactionSession, reparentTarget, 'flow')
+        return applyStaticReparent(canvasState, interactionSession, reparentTarget, 'flow')
       },
     }
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-to-flow-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-to-flow-strategy.tsx
@@ -17,7 +17,7 @@ import { InteractionSession } from '../interaction-state'
 import { applyFlexReparent, ReparentTarget } from './reparent-strategy-helpers'
 import { getDragTargets } from './shared-move-strategies-helpers'
 
-export function baseReparentToFlexStrategy(
+export function baseReparentToFlowStrategy(
   reparentTarget: ReparentTarget,
   fitness: number,
 ): CanvasStrategyFactory {
@@ -53,8 +53,8 @@ export function baseReparentToFlexStrategy(
     }
 
     return {
-      id: 'REPARENT_TO_FLEX',
-      name: 'Reparent (Flex)',
+      id: 'REPARENT_TO_FLOW',
+      name: 'Reparent (Flow)',
       controlsToRender: [
         controlWithProps({
           control: DragOutlineControl,
@@ -83,7 +83,7 @@ export function baseReparentToFlexStrategy(
       ],
       fitness: fitness,
       apply: () => {
-        return applyFlexReparent(canvasState, interactionSession, reparentTarget, 'flex')
+        return applyFlexReparent(canvasState, interactionSession, reparentTarget, 'flow')
       },
     }
   }


### PR DESCRIPTION
Fixes https://github.com/concrete-utopia/utopia/issues/2702

**Problem:**
We need a new reparent to flow strategy which is really similar to reparent to flex.
The only difference is that we should not show reorder indicators, but render the full element.

**Fix:**
I was actually ambiguous whether I should create a new strategy or just make the reparent-to-flex strategy parameterized to support flow too.
I decided to duplicate the strategies because in the future we will probably have more flex specific logic, e.g. setting `flex-gap`, `flex-shrink`, `flex-grow`, etc.
The two strategies still share the `applyFlexReparent` helper, because it really did not change much to support flow (I just renamed it to `applyStaticReparent`

**Notes**
- This is not used yet, we need the new flow reparent metastrategy for that (coming soon).
- No tests yet, because this code never runs.