### PR TITLE
Choose Github repositories from those accessible to the user.

### DIFF
--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -861,7 +861,7 @@ const GithubPane = React.memo(() => {
 
   React.useEffect(() => {
     if (githubAuthenticated) {
-      getUsersPublicGithubRepositories(dispatch, setUsersRepositoriesCallback)
+      void getUsersPublicGithubRepositories(dispatch, setUsersRepositoriesCallback)
     }
   }, [githubAuthenticated, dispatch, setUsersRepositoriesCallback])
 

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -683,6 +683,10 @@ getGithubBranchContentEndpoint _ _ _ _ Nothing = badRequest
 getGithubBranchContentEndpoint cookie owner repository branchName (Just projectID) = requireUser cookie $ \sessionUser -> do
   getBranchContent (view (field @"_id") sessionUser) owner repository branchName projectID
 
+getGithubUsersRepositoriesEndpoint :: Maybe Text -> ServerMonad GetUsersPublicRepositoriesResponse
+getGithubUsersRepositoriesEndpoint cookie = requireUser cookie $ \sessionUser -> do
+  getUsersRepositories (view (field @"_id") sessionUser) 
+
 {-|
   Compose together all the individual endpoints into a definition for the whole server.
 -}
@@ -708,6 +712,7 @@ protected authCookie = logoutPage authCookie
                   :<|> githubSaveEndpoint authCookie
                   :<|> getGithubBranchesEndpoint authCookie
                   :<|> getGithubBranchContentEndpoint authCookie
+                  :<|> getGithubUsersRepositoriesEndpoint authCookie
 
 unprotected :: ServerT Unprotected ServerMonad
 unprotected = authenticate

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -370,6 +370,17 @@ innerServerExecutor (GetBranchContent user owner repository branchName projectID
     Just githubResources -> do
       result <- getGithubBranch githubResources awsResource logger metrics pool user owner repository branchName projectID
       pure $ action result
+innerServerExecutor (GetUsersRepositories user action) = do
+  possibleGithubResources <- fmap _githubResources ask
+  metrics <- fmap _databaseMetrics ask
+  logger <- fmap _logger ask
+  pool <- fmap _projectPool ask
+  case possibleGithubResources of
+    Nothing -> throwError err501
+    Just githubResources -> do
+      result <- getGithubUsersPublicRepositories githubResources logger metrics pool user
+      pure $ action result
+
 {-|
   Invokes a service call using the supplied resources.
 -}

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -287,6 +287,13 @@ innerServerExecutor (GetBranchContent user owner repository branchName projectID
   awsResource <- fmap _awsResources ask
   result <- getGithubBranch githubResources (Just awsResource) logger metrics pool user owner repository branchName projectID
   pure $ action result
+innerServerExecutor (GetUsersRepositories user action) = do
+  githubResources <- fmap _githubResources ask
+  metrics <- fmap _databaseMetrics ask
+  logger <- fmap _logger ask
+  pool <- fmap _projectPool ask
+  result <- getGithubUsersPublicRepositories githubResources logger metrics pool user
+  pure $ action result
 
 readEditorContentFromDisk :: Maybe BranchDownloads -> Maybe Text -> Text -> IO Text
 readEditorContentFromDisk (Just downloads) (Just branchName) fileName = do

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -138,6 +138,7 @@ data ServiceCallsF a = NotFound
                      | SaveToGithubRepo Text Text PersistentModel (SaveToGithubResponse -> a)
                      | GetBranchesFromGithubRepo Text Text Text (GetBranchesResponse -> a)
                      | GetBranchContent Text Text Text Text Text (GetBranchContentResponse -> a)
+                     | GetUsersRepositories Text (GetUsersPublicRepositoriesResponse -> a)
                      deriving Functor
 
 {-

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -135,6 +135,8 @@ type GithubBranchesAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text 
 
 type GithubBranchLoadAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> Capture "branchName" Text :> QueryParam "project_id" Text :> Post '[JSON] GetBranchContentResponse
 
+type GithubUsersRepositoriesAPI = "v1" :> "github" :> "user" :> "repositories" :> Get '[JSON] GetUsersPublicRepositoriesResponse
+
 type PackagePackagerResponse = Headers '[Header "Cache-Control" Text, Header "Last-Modified" LastModifiedTime, Header "Access-Control-Allow-Origin" Text] (ConduitT () ByteString (ResourceT IO) ())
 
 type PackagePackagerAPI = "v1" :> "javascript" :> "packager"
@@ -190,6 +192,7 @@ type Protected = LogoutAPI
             :<|> GithubSaveAPI
             :<|> GithubBranchesAPI
             :<|> GithubBranchLoadAPI
+            :<|> GithubUsersRepositoriesAPI
 
 type Unprotected = AuthenticateAPI H.Html
               :<|> EmptyProjectPageAPI


### PR DESCRIPTION
Fixes #2712

**Problem:**
Currently the user must remember what repositories they have access to and type the URL in of the one they wish to operate on by hand. Which is a somewhat error prone process.

**Fix:**
Now we retrieve the public repositories that the user has access to from Github and provide those in a dropdown for the user to select them from.

**Commit Details:**
- Added call in the backend to get a page of the accessible repositories.
- Added `getGithubUsersPublicRepositories` to the backend which paginates the repository listing and combines them all into one.
- Updated `getGithubBranches` to use a slightly better function with `unfoldM` that avoids making an extra call to the server.
- Added endpoint for retrieving user's repositories.
- Added `getUsersPublicGithubRepositories` to the frontend which handles triggering a callback on a successful result.
- Change the control from a `StringInput` to a `CreatableSelect` to allow the user to choose the repository from the list as well as potentially specify a new one.
