### PR TITLE
remove aspect ratio locked prop instead of setting it to false

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -52,6 +52,7 @@ import {
 } from '../../../core/shared/either'
 import * as EP from '../../../core/shared/element-path'
 import {
+  deleteJSXAttribute,
   DetectedLayoutSystem,
   ElementInstanceMetadataMap,
   emptyComments,
@@ -4157,10 +4158,12 @@ export const UPDATE_FNS = {
     return modifyOpenJsxElementAtPath(
       action.target,
       (element) => {
-        const locked = jsxAttributeValue(action.locked, emptyComments)
-        const updatedProps = eitherToMaybe(
-          setJSXValueAtPath(element.props, PP.create(['data-aspect-ratio-locked']), locked),
-        )
+        const path = PP.create(['data-aspect-ratio-locked'])
+        const updatedProps = action.locked
+          ? eitherToMaybe(
+              setJSXValueAtPath(element.props, path, jsxAttributeValue(true, emptyComments)),
+            )
+          : deleteJSXAttribute(element.props, 'data-aspect-ratio-locked')
         return {
           ...element,
           props: updatedProps ?? element.props,

--- a/editor/src/components/inspector/inspector.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector.spec.browser2.tsx
@@ -1,5 +1,6 @@
 import { r } from 'tar'
 import { elementPath } from '../../core/shared/element-path'
+import { assertNever } from '../../core/shared/utils'
 import { mouseClickAtPoint } from '../canvas/event-helpers.test-utils'
 import { getPrintedUiJsCode, renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
 import { selectComponents } from '../editor/actions/action-creators'
@@ -7,7 +8,7 @@ import { AspectRatioLockButtonTestId } from './sections/layout-section/self-layo
 
 describe('inspector', () => {
   it('toggle aspect ratio lock off', async () => {
-    const codeAfterToggle = await runToggleAspectRatioLockTest(true)
+    const codeAfterToggle = await runToggleAspectRatioLockTest('locked')
     expect(codeAfterToggle).toEqual(`import * as React from 'react'
 import { Scene, Storyboard } from 'utopia-api'
 
@@ -30,7 +31,7 @@ export var storyboard = (
   })
 
   it('toggle aspect ratio lock on', async () => {
-    const codeAfterToggle = await runToggleAspectRatioLockTest(false)
+    const codeAfterToggle = await runToggleAspectRatioLockTest('not-locked')
     expect(codeAfterToggle).toEqual(`import * as React from 'react'
 import { Scene, Storyboard } from 'utopia-api'
 
@@ -54,7 +55,9 @@ export var storyboard = (
   })
 })
 
-async function runToggleAspectRatioLockTest(aspectRatioLocked: boolean): Promise<string> {
+async function runToggleAspectRatioLockTest(
+  aspectRatioLocked: AspectRatioLockedState,
+): Promise<string> {
   const editor = await renderTestEditorWithCode(
     projectSource(aspectRatioLocked),
     'await-first-dom-report',
@@ -75,7 +78,20 @@ async function runToggleAspectRatioLockTest(aspectRatioLocked: boolean): Promise
   return getPrintedUiJsCode(editor.getEditorState())
 }
 
-function projectSource(aspectRatioLocked: boolean) {
+type AspectRatioLockedState = 'locked' | 'not-locked'
+
+const isAspectRatioLocked = (state: AspectRatioLockedState): boolean => {
+  switch (state) {
+    case 'locked':
+      return true
+    case 'not-locked':
+      return false
+    default:
+      assertNever(state)
+  }
+}
+
+function projectSource(aspectRatioLockedState: AspectRatioLockedState) {
   return `import * as React from 'react'
 import { Scene, Storyboard } from 'utopia-api'
 
@@ -91,7 +107,7 @@ export var storyboard = (
         height: 426,
       }}
       data-uid='7a0'
-      data-aspect-ratio-locked${aspectRatioLocked ? `` : `={false}`}
+      data-aspect-ratio-locked${isAspectRatioLocked(aspectRatioLockedState) ? `` : `={false}`}
     />
   </Storyboard>
 )

--- a/editor/src/components/inspector/inspector.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector.spec.browser2.tsx
@@ -1,0 +1,99 @@
+import { r } from 'tar'
+import { elementPath } from '../../core/shared/element-path'
+import { mouseClickAtPoint } from '../canvas/event-helpers.test-utils'
+import { getPrintedUiJsCode, renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
+import { selectComponents } from '../editor/actions/action-creators'
+import { AspectRatioLockButtonTestId } from './sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection'
+
+describe('inspector', () => {
+  it('toggle aspect ratio lock off', async () => {
+    const codeAfterToggle = await runToggleAspectRatioLockTest(true)
+    expect(codeAfterToggle).toEqual(`import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='0cd'>
+    <div
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 33,
+        top: 307,
+        width: 363,
+        height: 426,
+      }}
+      data-uid='7a0'
+    />
+  </Storyboard>
+)
+`)
+  })
+
+  it('toggle aspect ratio lock on', async () => {
+    const codeAfterToggle = await runToggleAspectRatioLockTest(false)
+    expect(codeAfterToggle).toEqual(`import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='0cd'>
+    <div
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 33,
+        top: 307,
+        width: 363,
+        height: 426,
+      }}
+      data-uid='7a0'
+      data-aspect-ratio-locked
+    />
+  </Storyboard>
+)
+`)
+  })
+})
+
+async function runToggleAspectRatioLockTest(aspectRatioLocked: boolean): Promise<string> {
+  const editor = await renderTestEditorWithCode(
+    projectSource(aspectRatioLocked),
+    'await-first-dom-report',
+  )
+  const target = elementPath([['0cd', '7a0']])
+
+  await editor.dispatch([selectComponents([target], false)], true)
+  await editor.getDispatchFollowUpActionsFinished()
+
+  const aspectRatioLockButton = editor.renderedDOM.getByTestId(AspectRatioLockButtonTestId)
+  const aspectRatioLockButtonBounds = aspectRatioLockButton.getBoundingClientRect()
+  mouseClickAtPoint(aspectRatioLockButton, {
+    x: aspectRatioLockButtonBounds.x + 1,
+    y: aspectRatioLockButtonBounds.y + 1,
+  })
+
+  await editor.getDispatchFollowUpActionsFinished()
+  return getPrintedUiJsCode(editor.getEditorState())
+}
+
+function projectSource(aspectRatioLocked: boolean) {
+  return `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='0cd'>
+    <div
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 33,
+        top: 307,
+        width: 363,
+        height: 426,
+      }}
+      data-uid='7a0'
+      data-aspect-ratio-locked${aspectRatioLocked ? `` : `={false}`}
+    />
+  </Storyboard>
+)
+`
+}

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -28,6 +28,7 @@ import {
   alignSelectedViews,
   distributeSelectedViews,
   setAspectRatioLock,
+  setProperty,
   setProp_UNSAFE,
   transientActions,
   unsetProperty,
@@ -312,8 +313,15 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
   )
 
   const toggleAspectRatioLock = React.useCallback(() => {
-    const actions = selectedViews.map((path) => {
-      return setAspectRatioLock(path, !aspectRatioLocked)
+    const aspectRatioLockPropPath = PP.create(['data-aspect-ratio-locked'])
+    const actions: EditorAction[] = selectedViews.flatMap((path): EditorAction[] => {
+      if (aspectRatioLocked) {
+        return [unsetProperty(path, aspectRatioLockPropPath)]
+      }
+      return [
+        setProperty(path, aspectRatioLockPropPath, jsxAttributeValue(true, emptyComments)),
+        setAspectRatioLock(path, true),
+      ]
     })
     dispatch(actions, 'everyone')
   }, [dispatch, selectedViews, aspectRatioLocked])

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -313,16 +313,9 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
   )
 
   const toggleAspectRatioLock = React.useCallback(() => {
-    const aspectRatioLockPropPath = PP.create(['data-aspect-ratio-locked'])
-    const actions: EditorAction[] = selectedViews.flatMap((path): EditorAction[] => {
-      if (aspectRatioLocked) {
-        return [unsetProperty(path, aspectRatioLockPropPath)]
-      }
-      return [
-        setProperty(path, aspectRatioLockPropPath, jsxAttributeValue(true, emptyComments)),
-        setAspectRatioLock(path, true),
-      ]
-    })
+    const actions: EditorAction[] = selectedViews.map((path) =>
+      setAspectRatioLock(path, !aspectRatioLocked),
+    )
     dispatch(actions, 'everyone')
   }, [dispatch, selectedViews, aspectRatioLocked])
 

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -324,6 +324,8 @@ function flexStyleNumberControl(label: string, styleProp: StyleLayoutNumberProp)
 
 const spacingButton = <SquareButton />
 
+export const AspectRatioLockButtonTestId = 'AspectRatioLockButton'
+
 interface WidthHeightRowProps {
   layoutType: SelfLayoutTab
   toggleMinMax: () => void
@@ -394,7 +396,11 @@ const WidthHeightRow = React.memo((props: WidthHeightRowProps) => {
       </div>
       <UIGridRow padded={false} variant='|--67px--||16px||--67px--||16px|'>
         {widthControl}
-        <SquareButton onClick={toggleAspectRatioLock} style={{ width: 16, height: 16 }}>
+        <SquareButton
+          data-testid={AspectRatioLockButtonTestId}
+          onClick={toggleAspectRatioLock}
+          style={{ width: 16, height: 16 }}
+        >
           {aspectRatioLocked ? <Icons.LockClosed /> : <Icons.LockOpen />}
         </SquareButton>
         {heightControl}


### PR DESCRIPTION
## Problem
When toggling the aspect ratio lock, it's set to `false` in the JSX markup. Instead, removing the prop would be a slight improvement since it reduces clutter in the JSX markup and removes a utopia-specific artefact from the code.

## Fix 
Remove the aspect ratio lock prop when it's set to `false`