### PR TITLE
Hide set padding strategy during other interactions

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -43,7 +43,20 @@ const IndividualPaddingProps: Array<keyof ParsedCSSProperties> = [
   'paddingRight',
 ]
 
+export const SetPaddingStrategyName = 'Set Padding'
+
 export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interactionSession) => {
+  if (
+    interactionSession != null &&
+    !(
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.activeControl.type === 'PADDING_RESIZE_HANDLE'
+    )
+  ) {
+    // We don't want to include this in the strategy picker if any other interaction is active
+    return null
+  }
+
   const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
   if (selectedElements.length !== 1) {
     return null
@@ -81,7 +94,7 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
 
   return {
     id: 'SET_PADDING_STRATEGY',
-    name: 'Set Padding',
+    name: SetPaddingStrategyName,
     controlsToRender: controlsToRender,
     fitness: 1,
     apply: () => {


### PR DESCRIPTION
**Problem:**
The "Set Padding" strategy is still applicable when performing other interactions (e.g. dragging to move an element), meaning it shows up in the strategy picker even though picking it would do nothing.

**Fix:**
Add a filter to the strategy factory that returns `null` if any unrelated interaction is active, plus a test to check this.