### PR TITLE
Disable performance test feature flags in staging by default

### DIFF
--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -1,5 +1,5 @@
 import localforage from 'localforage'
-import { IS_TEST_ENVIRONMENT, PRODUCTION_CONFIG } from '../common/env-vars'
+import { IS_TEST_ENVIRONMENT, PRODUCTION_OR_STAGING_CONFIG } from '../common/env-vars'
 import { fastForEach, isBrowserEnvironment } from '../core/shared/utils'
 
 export type FeatureName =
@@ -43,8 +43,8 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Dragging Reparents By Default': false,
   'Dragging Shows Overlay': false,
   'Advanced Resize Box': false,
-  'Re-parse Project Button': !(PRODUCTION_CONFIG as boolean),
-  'Performance Test Triggers': !(PRODUCTION_CONFIG as boolean),
+  'Re-parse Project Button': !(PRODUCTION_OR_STAGING_CONFIG as boolean),
+  'Performance Test Triggers': !(PRODUCTION_OR_STAGING_CONFIG as boolean),
   'Click on empty canvas unfocuses': true,
   'Insertion Plus Button': true,
   'Canvas Strategies': true,

--- a/website-next/components/common/env-vars.ts
+++ b/website-next/components/common/env-vars.ts
@@ -8,7 +8,7 @@ export const BASE_URL: string = `${SCHEME}//${HOST}/`
 export const PRODUCTION_ENV: boolean = process.env.NODE_ENV === 'production'
 export const PRODUCTION_CONFIG: boolean = process.env.REACT_APP_ENVIRONMENT_CONFIG === 'production'
 const STAGING_CONFIG: boolean = process.env.REACT_APP_ENVIRONMENT_CONFIG === 'staging'
-const PRODUCTION_OR_STAGING_CONFIG = PRODUCTION_CONFIG || STAGING_CONFIG
+export const PRODUCTION_OR_STAGING_CONFIG = PRODUCTION_CONFIG || STAGING_CONFIG
 const SECONDARY_BASE_URL: string = PRODUCTION_CONFIG
   ? `https://utopia.fm/`
   : STAGING_CONFIG


### PR DESCRIPTION
**Problem:**
We rely on some sample projects in staging when developing new features, but it is extremely easy to accidentally overwrite a project by accident by clicking one of the performance test triggers

**Fix:**
Disable those feature flags by default in staging, meaning the buttons won't be rendered unless they are explicitly enabled