### PR TITLE
Only show padding controls when padding is already set

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -21,7 +21,52 @@ import {
 } from '../../ui-jsx.test-utils'
 import { SetPaddingStrategyName } from './set-padding-strategy'
 
+const edgePieces: Array<EdgePiece> = ['top', 'bottom', 'left', 'right']
+
 describe('Padding resize strategy', () => {
+  it('Padding resize handle is not present for elements that have no padding set', async () => {
+    const editor = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`<div
+      data-testid='mydiv'
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 28,
+        top: 28,
+        width: 612,
+        height: 461,
+      }}
+      data-uid='24a'
+    >
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          width: '100%',
+          height: '100%',
+        }}
+        data-uid='002'
+      />
+    </div>`),
+      'await-first-dom-report',
+    )
+
+    const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
+    const div = editor.renderedDOM.getByTestId('mydiv')
+    const divBounds = div.getBoundingClientRect()
+    const divCorner = {
+      x: divBounds.x + 5,
+      y: divBounds.y + 4,
+    }
+
+    mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
+
+    const paddingControls = edgePieces.flatMap((edge) =>
+      editor.renderedDOM.queryAllByTestId(paddingControlTestId(edge)),
+    )
+
+    expect(paddingControls).toEqual([])
+  })
+
   it('Padding resize is present', async () => {
     const editor = await renderTestEditorWithCode(
       makeTestProjectCodeWithStringPaddingValues(
@@ -45,7 +90,6 @@ describe('Padding resize strategy', () => {
 
     mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
 
-    const edgePieces: Array<EdgePiece> = ['top', 'bottom', 'left', 'right']
     edgePieces.forEach((edge) => {
       const paddingControlOuter = editor.renderedDOM.getByTestId(paddingControlTestId(edge))
       expect(paddingControlOuter).toBeTruthy()

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -41,12 +41,47 @@ describe('Padding resize strategy', () => {
       <div
         style={{
           backgroundColor: '#0091FFAA',
-          width: '100%',
-          height: '100%',
+          width: 22,
+          height: 22,
         }}
         data-uid='002'
       />
     </div>`),
+      'await-first-dom-report',
+    )
+
+    const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
+    const div = editor.renderedDOM.getByTestId('mydiv')
+    const divBounds = div.getBoundingClientRect()
+    const divCorner = {
+      x: divBounds.x + 50,
+      y: divBounds.y + 40,
+    }
+
+    mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
+
+    const paddingControls = edgePieces.flatMap((edge) => [
+      // ...editor.renderedDOM.queryAllByTestId(paddingControlTestId(edge)),
+      ...editor.renderedDOM.queryAllByTestId(paddingControlHandleTestId(edge)),
+    ])
+
+    expect(paddingControls).toEqual([])
+  })
+
+  it('Padding resize handle is present for elements that are dimensioned and have no children', async () => {
+    const editor = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`<div
+      data-testid='mydiv'
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 28,
+        top: 28,
+        width: 612,
+        height: 461,
+      }}
+      data-uid='24a'
+    />`),
       'await-first-dom-report',
     )
 
@@ -60,11 +95,12 @@ describe('Padding resize strategy', () => {
 
     mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
 
-    const paddingControls = edgePieces.flatMap((edge) =>
-      editor.renderedDOM.queryAllByTestId(paddingControlTestId(edge)),
-    )
-
-    expect(paddingControls).toEqual([])
+    edgePieces.forEach((edge) => {
+      const paddingControlOuter = editor.renderedDOM.getByTestId(paddingControlTestId(edge))
+      expect(paddingControlOuter).toBeTruthy()
+      const paddingControlHandle = editor.renderedDOM.getByTestId(paddingControlHandleTestId(edge))
+      expect(paddingControlHandle).toBeTruthy()
+    })
   })
 
   it('Padding resize is present', async () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -21,7 +21,7 @@ import {
 } from '../../ui-jsx.test-utils'
 import { SetPaddingStrategyName } from './set-padding-strategy'
 
-const edgePieces: Array<EdgePiece> = ['top', 'bottom', 'left', 'right']
+const EdgePieces: Array<EdgePiece> = ['top', 'bottom', 'left', 'right']
 
 describe('Padding resize strategy', () => {
   it('Padding resize handle is not present for elements that have no padding set', async () => {
@@ -60,7 +60,7 @@ describe('Padding resize strategy', () => {
 
     mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
 
-    const paddingControls = edgePieces.flatMap((edge) => [
+    const paddingControls = EdgePieces.flatMap((edge) => [
       // ...editor.renderedDOM.queryAllByTestId(paddingControlTestId(edge)),
       ...editor.renderedDOM.queryAllByTestId(paddingControlHandleTestId(edge)),
     ])
@@ -95,7 +95,7 @@ describe('Padding resize strategy', () => {
 
     mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
 
-    edgePieces.forEach((edge) => {
+    EdgePieces.forEach((edge) => {
       const paddingControlOuter = editor.renderedDOM.getByTestId(paddingControlTestId(edge))
       expect(paddingControlOuter).toBeTruthy()
       const paddingControlHandle = editor.renderedDOM.getByTestId(paddingControlHandleTestId(edge))
@@ -126,7 +126,7 @@ describe('Padding resize strategy', () => {
 
     mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
 
-    edgePieces.forEach((edge) => {
+    EdgePieces.forEach((edge) => {
       const paddingControlOuter = editor.renderedDOM.getByTestId(paddingControlTestId(edge))
       expect(paddingControlOuter).toBeTruthy()
       const paddingControlHandle = editor.renderedDOM.getByTestId(paddingControlHandleTestId(edge))

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -61,7 +61,7 @@ describe('Padding resize strategy', () => {
     mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
 
     const paddingControls = EdgePieces.flatMap((edge) => [
-      // ...editor.renderedDOM.queryAllByTestId(paddingControlTestId(edge)),
+      ...editor.renderedDOM.queryAllByTestId(paddingControlTestId(edge)),
       ...editor.renderedDOM.queryAllByTestId(paddingControlHandleTestId(edge)),
     ])
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -1,11 +1,5 @@
-import {
-  getSimpleAttributeAtPath,
-  MetadataUtils,
-} from '../../../../core/model/element-metadata-utils'
-import {
-  ElementInstanceMetadataMap,
-  getJSXAttribute,
-} from '../../../../core/shared/element-template'
+import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
 import { getJSXAttributeAtPath } from '../../../../core/shared/jsx-attributes'
 import * as PP from '../../../../core/shared/property-path'
 import { optionalMap } from '../../../../core/shared/optional-utils'
@@ -13,7 +7,6 @@ import { ElementPath, PropertyPath } from '../../../../core/shared/project-file-
 import { assertNever } from '../../../../core/shared/utils'
 import { CSSPadding, ParsedCSSProperties } from '../../../inspector/common/css-utils'
 import { stylePropPathMappingFn } from '../../../inspector/common/property-path-hooks'
-import { create } from '../../../template-property-path'
 import { CSSCursor, EdgePiece } from '../../canvas-types'
 import { deleteProperties } from '../../commands/delete-properties-command'
 import { setCursorCommand } from '../../commands/set-cursor-command'
@@ -179,12 +172,18 @@ function supportsPaddingControls(metadata: ElementInstanceMetadataMap, path: Ele
     return false
   }
 
-  if (!elementHasPaddingSetFromMetadata(metadata, path)) {
+  if (element.globalFrame == null || isZeroSizedElement(element.globalFrame)) {
     return false
   }
 
-  if (element.globalFrame == null || isZeroSizedElement(element.globalFrame)) {
-    return false
+  if (elementHasPaddingSetFromMetadata(metadata, path)) {
+    return true
+  }
+
+  const children = MetadataUtils.getChildren(metadata, path)
+  if (children.length === 0) {
+    // isZeroSizedElement check omitted, since it's already checked above and we know it's true if we got here
+    return true
   }
 
   const childrenNotPositionAbsoluteOrSticky = MetadataUtils.getChildren(metadata, path).filter(

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -176,23 +176,22 @@ function supportsPaddingControls(metadata: ElementInstanceMetadataMap, path: Ele
     return false
   }
 
-  if (elementHasPaddingSetFromMetadata(metadata, path)) {
-    return true
-  }
-
   const children = MetadataUtils.getChildren(metadata, path)
   if (children.length === 0) {
-    // isZeroSizedElement check omitted, since it's already checked above and we know it's true if we got here
     return true
   }
 
-  const childrenNotPositionAbsoluteOrSticky = MetadataUtils.getChildren(metadata, path).filter(
+  const childrenNotPositionedAbsoluteOrSticky = MetadataUtils.getChildren(metadata, path).filter(
     (child) =>
       child.specialSizeMeasurements.position !== 'absolute' &&
       child.specialSizeMeasurements.position !== 'sticky',
   )
 
-  if (childrenNotPositionAbsoluteOrSticky.length < 1) {
+  if (childrenNotPositionedAbsoluteOrSticky.length < 1) {
+    return false
+  }
+
+  if (!elementHasPaddingSetFromMetadata(metadata, path)) {
     return false
   }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -170,6 +170,12 @@ function supportsPaddingControls(metadata: ElementInstanceMetadataMap, path: Ele
     return false
   }
 
+  const { top, bottom, left, right } = element.specialSizeMeasurements.padding
+  const isPaddingSetForElement = [top, bottom, left, right].some((s) => s != null)
+  if (!isPaddingSetForElement) {
+    return false
+  }
+
   if (element.globalFrame == null || isZeroSizedElement(element.globalFrame)) {
     return false
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -191,34 +191,13 @@ function supportsPaddingControls(metadata: ElementInstanceMetadataMap, path: Ele
     return false
   }
 
-  if (!elementHasPaddingSetFromMetadata(metadata, path)) {
+  const { top, right, bottom, left } = element.specialSizeMeasurements.padding
+  const elementHasNonzeroPadding = [top, right, bottom, left].some((s) => s != null && s > 0)
+  if (!elementHasNonzeroPadding) {
     return false
   }
 
   return true
-}
-
-function elementHasPaddingSetFromMetadata(
-  metadata: ElementInstanceMetadataMap,
-  path: ElementPath,
-): boolean {
-  const element = MetadataUtils.getJSXElementFromMetadata(metadata, path)
-  if (element == null) {
-    return false
-  }
-
-  const jsxAttributeExists = (propertyPath: PropertyPath): boolean =>
-    getJSXAttributeAtPath(element.props, propertyPath).attribute.type !== 'ATTRIBUTE_NOT_FOUND'
-
-  const paddingProps = (p: keyof CSSPadding) => PP.create(['style', p])
-
-  return (
-    jsxAttributeExists(PP.create(['style', 'padding'])) ||
-    jsxAttributeExists(paddingProps('paddingBottom')) ||
-    jsxAttributeExists(paddingProps('paddingTop')) ||
-    jsxAttributeExists(paddingProps('paddingLeft')) ||
-    jsxAttributeExists(paddingProps('paddingRight'))
-  )
 }
 
 function paddingValueIndicatorProps(

--- a/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
@@ -24,6 +24,8 @@ export const paddingControlTestId = (edge: EdgePiece): string => `padding-contro
 export const paddingControlHandleTestId = (edge: EdgePiece): string =>
   `padding-control-handle-${edge}`
 
+export const PaddingResizeControlContainerTestId = 'PaddingResizeControlContainerTestId'
+
 type Orientation = 'vertical' | 'horizontal'
 
 interface ResizeContolProps {
@@ -42,6 +44,8 @@ const transformFromOrientation = (orientation: Orientation) => {
   }
 }
 
+export const PaddingResizeControlHoverTimeout: number = 200
+
 type Timeout = ReturnType<typeof setTimeout>
 
 const PaddingResizeControlWidth = 4
@@ -57,7 +61,9 @@ const PaddingResizeControlI = React.memo(
     const colorTheme = useColorTheme()
 
     const [hidden, setHidden] = React.useState<boolean>(true)
-    const [hoverStart, hoverEnd] = useHoverWithDelay(200, (h) => setHidden(!h))
+    const [hoverStart, hoverEnd] = useHoverWithDelay(PaddingResizeControlHoverTimeout, (h) =>
+      setHidden(!h),
+    )
 
     const onEdgeMouseDown = React.useCallback(
       (event: React.MouseEvent<HTMLDivElement>) => {
@@ -177,11 +183,14 @@ export const PaddingResizeControl = controlForStrategyMemoized(() => {
   })
 
   const [hoverHidden, setHoverHidden] = React.useState<boolean>(true)
-  const [hoverStart, hoverEnd] = useHoverWithDelay(200, (h) => setHoverHidden(!h))
+  const [hoverStart, hoverEnd] = useHoverWithDelay(PaddingResizeControlHoverTimeout, (h) =>
+    setHoverHidden(!h),
+  )
 
   return (
     <CanvasOffsetWrapper>
       <div
+        data-testid={PaddingResizeControlContainerTestId}
         onMouseEnter={hoverStart}
         onMouseLeave={hoverEnd}
         ref={controlRef}

--- a/editor/src/components/canvas/event-helpers.test-utils.tsx
+++ b/editor/src/components/canvas/event-helpers.test-utils.tsx
@@ -82,6 +82,51 @@ export function mouseMoveToPoint(
   resetMouseStatus()
 }
 
+export function mouseEnterAtPoint(
+  eventSourceElement: HTMLElement,
+  point: Point,
+  options: {
+    modifiers?: Modifiers
+    eventOptions?: MouseEventInit
+  } = {},
+): void {
+  const modifiers = options.modifiers ?? emptyModifiers
+  const passedEventOptions = options.eventOptions ?? {}
+  const eventOptions = {
+    ctrlKey: modifiers.ctrl,
+    metaKey: modifiers.cmd,
+    altKey: modifiers.alt,
+    shiftKey: modifiers.shift,
+    ...passedEventOptions,
+  }
+
+  act(() => {
+    fireEvent(
+      eventSourceElement,
+      new MouseEvent('mouseover', {
+        bubbles: true,
+        cancelable: true,
+        clientX: point.x,
+        clientY: point.y,
+        ...eventOptions,
+      }),
+    )
+  })
+
+  act(() => {
+    fireEvent(
+      eventSourceElement,
+      new MouseEvent('mouseenter', {
+        bubbles: true,
+        cancelable: true,
+        clientX: point.x,
+        clientY: point.y,
+        ...eventOptions,
+      }),
+    )
+  })
+}
+
 export function mouseUpAtPoint(
   eventSourceElement: HTMLElement,
   point: Point,

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`402`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`404`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`391`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`393`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`668`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`676`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`740`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`748`)
   })
 })


### PR DESCRIPTION
## Problem:
We currently show padding controls for elements that can have a size and have children that are not positioned absolute or sticky. While this filters all elements to some degree, the padding controls still add visual clutter when shown on an element that doesn't have a padding set in the code (meaning that it might never have padding applied).

## Fix:
check whether padding is already set in some form on the selected element, and only show the padding controls if it is.

## Quirks
This PR uses `element.specialSizeMeasurements.padding` to check if padding is set on an element, but this brings a tradeoff with it:
- on the plus side, using element.specialSizeMeasurements.padding tells us the padding even if it's set in units other than px, or it's set from css
- on the minus side, padding values coming from element.specialSizeMeasurements.padding are 0 if the padding is not set, so to filter this out, we can only show the padding controls if the padding value is > 0. This edge case where padding is set to 0 but the controls are not shown.
The upsides outweigh the downsides here, but I still wanted to call out the behaviour, so that the edge case above will be a known bug

## Also
Also adding a further idea from the discussion from [discord[(https://discord.com/channels/647102474519576589/1026865812864249926/1034858760230944779):
> if they are dimensioned and empty, show padding controls always even if no padding
