### PR TITLE
Use isFallback in flow reparenting fitness

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -78,7 +78,7 @@ export function getApplicableReparentFactories(
         }
       }
       case 'REPARENT_AS_STATIC': {
-        const fitness = 3
+        const fitness = result.isFallback ? 2 : 3
 
         const targetParentDisplayType =
           MetadataUtils.findElementByElementPath(


### PR DESCRIPTION
**Problem:**
Since both absolute and flow reparenting can both be applicable in certain cases, one needs to be the "fallback" option and have a lower weight, otherwise the last used option will persist even if it is the less desirable one.

**Fix:**
Use `result.isFallback` when calculating the fitness for flex / flow reparenting (which we already do when calculating the fitness for absolute reparenting)