### PR TITLE
Only list Github repositories you can push to.

### DIFF
--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -956,12 +956,16 @@ const RepositoryListing = React.memo(
       if (usersRepositories == null) {
         return null
       } else {
-        let filteredResult = usersRepositories.map((repository) => {
-          return {
-            ...repository,
-            importPermitted: true,
+        let filteredResult: Array<RepositoryRowProps> = []
+        for (const repository of usersRepositories) {
+          // Only include a repository if the user can push to it.
+          if (repository.permissions.push) {
+            filteredResult.push({
+              ...repository,
+              importPermitted: true,
+            })
           }
-        })
+        }
         if (targetRepository != null) {
           filteredResult = filteredResult.filter((repository) => {
             return (
@@ -998,6 +1002,11 @@ const RepositoryListing = React.memo(
               updatedAt: null,
               defaultBranch: null,
               importPermitted: false,
+              permissions: {
+                admin: false,
+                push: false,
+                pull: false,
+              },
             }
             return [...filteredRepositories, additionalEntry]
           }

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -78,6 +78,12 @@ export interface GetBranchContentSuccess {
 
 export type GetBranchContentResponse = GetBranchContentSuccess | GithubFailure
 
+export interface RepositoryEntryPermissions {
+  admin: boolean
+  push: boolean
+  pull: boolean
+}
+
 export interface RepositoryEntry {
   fullName: string
   avatarUrl: string | null
@@ -86,6 +92,7 @@ export interface RepositoryEntry {
   name: string | null
   updatedAt: string | null
   defaultBranch: string | null
+  permissions: RepositoryEntryPermissions
 }
 
 export interface GetUsersPublicRepositoriesSuccess {

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -447,6 +447,7 @@ publicRepoToRepositoryEntry publicRepository = RepositoryEntry
                                              , name = view (field @"name") publicRepository
                                              , updatedAt = Just $ view (field @"updated_at") publicRepository
                                              , defaultBranch = Just $ view (field @"default_branch") publicRepository
+                                             , permissions = view (field @"permissions") publicRepository
                                              }
 
 getGithubUsersPublicRepositories :: (MonadBaseControl IO m, MonadIO m, MonadThrow m) => GithubAuthResources -> FastLogger -> DB.DatabaseMetrics -> DBPool -> Text -> m GetUsersPublicRepositoriesResponse

--- a/server/src/Utopia/Web/Github/Types.hs
+++ b/server/src/Utopia/Web/Github/Types.hs
@@ -400,6 +400,19 @@ instance FromJSON RepositoryOwner where
 instance ToJSON RepositoryOwner where
   toJSON = genericToJSON defaultOptions
 
+data UsersRepositoryPermissions = UsersRepositoryPermissions
+                                { admin       :: Bool
+                                , push        :: Bool
+                                , pull        :: Bool
+                                }
+                                deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON UsersRepositoryPermissions where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON UsersRepositoryPermissions where
+  toJSON = genericToJSON defaultOptions
+
 data UsersRepository = UsersRepository
                      { full_name        :: Text
                      , owner            :: RepositoryOwner
@@ -408,6 +421,7 @@ data UsersRepository = UsersRepository
                      , name             :: Maybe Text
                      , updated_at       :: UTCTime
                      , default_branch   :: Text
+                     , permissions      :: UsersRepositoryPermissions
                      }
                      deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -427,6 +441,7 @@ data RepositoryEntry = RepositoryEntry
                      , name             :: Maybe Text
                      , updatedAt        :: Maybe UTCTime
                      , defaultBranch    :: Maybe Text
+                     , permissions      :: UsersRepositoryPermissions
                      }
                      deriving (Eq, Show, Generic, Data, Typeable)
 


### PR DESCRIPTION
**Problem:**
Presenting users with a repository to tie their project to which they cannot push to is a little silly and so ideally those would not be included.

**Fix:**
Those repositories that the user does not have permission to push to are now excluded from the repository listing.

**Commit Details:**
- The `permissions` field from the repository listing is now passed through to the frontend.
- `RepositoryListing` component only includes those repositories that include the `push` permission.
