### PR TITLE
Use `ProjectFile` in place of `Directory` to get the right JSON.

### DIFF
--- a/clientmodel/lib/src/Utopia/ClientModel.hs
+++ b/clientmodel/lib/src/Utopia/ClientModel.hs
@@ -256,7 +256,7 @@ type ProjectContentTreeRoot = M.HashMap Text ProjectContentsTree
 
 data ProjectContentDirectory = ProjectContentDirectory
                              { fullPath  :: Text
-                             , directory :: Directory
+                             , directory :: ProjectFile
                              , children  :: ProjectContentTreeRoot
                              }
                              deriving (Eq, Show, Generic, Data, Typeable)
@@ -278,7 +278,7 @@ generateProjectContentDirectory :: Int -> Gen ProjectContentDirectory
 generateProjectContentDirectory depth = do
   fullPath <- arbitrary
   children <- liftArbitrary $ generateProjectContentsTree (depth - 1)
-  let directory = Directory
+  let directory = ProjectDirectory Directory
   pure ProjectContentDirectory{..}
 
 instance Arbitrary ProjectContentDirectory where

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -344,7 +344,7 @@ addProjectContentFromGitEntry treeRoot treeContent (filenamePart : filenameRemai
         Nothing -> do
           subTree <- addProjectContentFromGitEntry M.empty treeContent filenameRemainder newPathSoFar
           let fullPath = "/" <> T.intercalate "/" newPathSoFar
-          let newEntry = ProjectContentsTreeDirectory $ ProjectContentDirectory fullPath Directory subTree
+          let newEntry = ProjectContentsTreeDirectory $ ProjectContentDirectory fullPath (ProjectDirectory Directory) subTree
           Right $ M.insert filenamePart newEntry treeRoot
 
 getRecursiveGitTreeAsContent :: (MonadBaseControl IO m, MonadIO m) => AccessToken -> SaveAsset -> Text -> Text -> Text -> Text -> ExceptT Text m ProjectContentTreeRoot


### PR DESCRIPTION
**Problem:**
The JSON for `ProjectContentDirectory` produced by the server was slightly out of sync with the values expected by the frontend as the `directory` field was typed to `Directory`. As that type has no fields of its own it was producing an empty object, whereas the JSON produced by the `ProjectDirectory` case of `ProjectFile` inserts a `type` field which is needed by the frontend.

**Fix:**
Change the type of the `directory` field to be `ProjectFile`, which results in the correct JSON being produced.

**Commit Details:**
- Changed the type of `directory` on `ProjectContentDirectory` to be `ProjectFile` to match up with `ProjectContentFile`.