### PR TITLE
fix(reorder) elements with transform props are not fit for reorder

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
@@ -169,6 +169,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -268,6 +269,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -211,6 +211,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -332,6 +333,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -612,6 +614,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -731,6 +734,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -850,6 +854,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -969,6 +974,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1195,6 +1201,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1316,6 +1323,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1504,6 +1512,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1729,6 +1738,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1850,6 +1860,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1952,6 +1963,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -2195,6 +2207,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -2316,6 +2329,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -2560,6 +2574,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -2714,6 +2729,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -2868,6 +2884,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -3022,6 +3039,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -3316,6 +3334,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -3437,6 +3456,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -3800,6 +3820,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4058,6 +4079,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4219,6 +4241,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4380,6 +4403,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4541,6 +4565,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4799,6 +4824,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4960,6 +4986,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5121,6 +5148,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5282,6 +5310,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5540,6 +5569,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5701,6 +5731,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5862,6 +5893,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6023,6 +6055,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6260,6 +6293,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6381,6 +6415,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6542,6 +6577,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6645,6 +6681,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6748,6 +6785,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6973,6 +7011,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -7094,6 +7133,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -7268,6 +7308,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -7511,6 +7552,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -7632,6 +7674,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -7889,6 +7932,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -8052,6 +8096,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -8215,6 +8260,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -8378,6 +8424,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -8621,6 +8668,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -8742,6 +8790,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -8999,6 +9048,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9162,6 +9212,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9325,6 +9376,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9488,6 +9540,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9725,6 +9778,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9846,6 +9900,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10007,6 +10062,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10110,6 +10166,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10213,6 +10270,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10450,6 +10508,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10571,6 +10630,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10765,6 +10825,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10868,6 +10929,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10971,6 +11033,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -11223,6 +11286,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -11358,6 +11422,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -11677,6 +11742,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -11863,6 +11929,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -12114,6 +12181,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -12249,6 +12317,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -12568,6 +12637,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -12754,6 +12824,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -13006,6 +13077,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -13141,6 +13213,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -13508,6 +13581,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -13742,6 +13816,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -13994,6 +14069,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -14129,6 +14205,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -14496,6 +14573,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -14730,6 +14808,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -14954,6 +15033,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -15075,6 +15155,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -15177,6 +15258,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -15524,6 +15606,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -15645,6 +15728,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -16825,6 +16909,7 @@ export var storyboard = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -17669,6 +17754,7 @@ export var storyboard = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -18021,6 +18107,7 @@ export var storyboard = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -18373,6 +18460,7 @@ export var storyboard = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -18725,6 +18813,7 @@ export var storyboard = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -19113,6 +19202,7 @@ export var storyboard = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -19345,6 +19435,7 @@ export var storyboard = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -19733,6 +19824,7 @@ export var storyboard = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -19965,6 +20057,7 @@ export var storyboard = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -20353,6 +20446,7 @@ export var storyboard = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -20585,6 +20679,7 @@ export var storyboard = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -20832,6 +20927,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -20953,6 +21049,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21146,6 +21243,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21265,6 +21363,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21384,6 +21483,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21610,6 +21710,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21731,6 +21832,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21897,6 +21999,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -22122,6 +22225,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -22243,6 +22347,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -22474,6 +22579,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -22688,6 +22794,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -22787,6 +22894,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -23050,6 +23158,7 @@ export var storyboard = (
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -23257,6 +23366,7 @@ export var storyboard = (
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -23528,6 +23638,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -23649,6 +23760,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -23877,6 +23989,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -24053,6 +24166,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -24183,6 +24297,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -24435,6 +24550,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -24570,6 +24686,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -24829,6 +24946,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -24960,6 +25078,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -25356,6 +25475,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -25491,6 +25611,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -25751,6 +25872,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -25882,6 +26004,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -26219,6 +26342,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -26342,6 +26466,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27074,6 +27199,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27181,6 +27307,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27288,6 +27415,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27395,6 +27523,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27502,6 +27631,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27609,6 +27739,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27716,6 +27847,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27893,6 +28025,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28000,6 +28133,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28107,6 +28241,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28214,6 +28349,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28321,6 +28457,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28428,6 +28565,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28537,6 +28675,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28644,6 +28783,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28751,6 +28891,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28858,6 +28999,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28965,6 +29107,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29072,6 +29215,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29181,6 +29325,7 @@ export var App = (props) => {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29424,6 +29569,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29545,6 +29691,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29802,6 +29949,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29965,6 +30113,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -30128,6 +30277,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -30291,6 +30441,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -30534,6 +30685,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -30655,6 +30807,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -30913,6 +31066,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -31077,6 +31231,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -31241,6 +31396,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -31405,6 +31561,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -31648,6 +31805,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -31769,6 +31927,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32033,6 +32192,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32196,6 +32356,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32359,6 +32520,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32522,6 +32684,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32770,6 +32933,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32905,6 +33069,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33126,6 +33291,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33257,6 +33423,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33484,6 +33651,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33583,6 +33751,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33691,6 +33860,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33799,6 +33969,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34002,6 +34173,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34101,6 +34273,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34319,6 +34492,7 @@ export var storyboard = (
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34442,6 +34616,7 @@ export var storyboard = (
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34645,6 +34820,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34744,6 +34920,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34846,6 +35023,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35057,6 +35235,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35156,6 +35335,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35336,6 +35516,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35467,6 +35648,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35672,6 +35854,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35771,6 +35954,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -36033,6 +36217,7 @@ export var storyboard = (
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -36232,6 +36417,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -36331,6 +36517,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -36449,6 +36636,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -36697,6 +36885,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -36818,6 +37007,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -37237,6 +37427,7 @@ export var storyboard = (
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -37452,6 +37643,7 @@ export var storyboard = (
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -37591,6 +37783,7 @@ export var storyboard = (
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -37700,6 +37893,7 @@ export var storyboard = (
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -37930,6 +38124,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38051,6 +38246,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38203,6 +38399,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38322,6 +38519,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38550,6 +38748,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38671,6 +38870,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38773,6 +38973,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39031,6 +39232,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39152,6 +39354,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39438,6 +39641,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39625,6 +39829,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39783,6 +39988,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39970,6 +40176,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40128,6 +40335,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40315,6 +40523,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40473,6 +40682,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40700,6 +40910,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40821,6 +41032,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40923,6 +41135,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -41160,6 +41373,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -41281,6 +41495,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -41449,6 +41664,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -41588,6 +41804,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -41698,6 +41915,7 @@ Object {
       "float": "none",
       "globalContentBox": null,
       "hasPositionOffset": false,
+      "hasTransform": false,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reorder-strategy.tsx
@@ -29,11 +29,12 @@ export function flexReorderStrategy(
   )
   if (
     selectedElements.length !== 1 ||
-    (!MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
-      selectedElements[0],
-      canvasState.startingMetadata,
-    ) &&
-      !element?.specialSizeMeasurements.hasTransform)
+    !(
+      MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
+        selectedElements[0],
+        canvasState.startingMetadata,
+      ) && !element?.specialSizeMeasurements.hasTransform
+    )
   ) {
     return null
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reorder-strategy.tsx
@@ -23,12 +23,17 @@ export function flexReorderStrategy(
   customStrategyState: CustomStrategyState,
 ): CanvasStrategy | null {
   const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
+  const element = MetadataUtils.findElementByElementPath(
+    canvasState.startingMetadata,
+    selectedElements[0],
+  )
   if (
     selectedElements.length !== 1 ||
-    !MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
+    (!MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
       selectedElements[0],
       canvasState.startingMetadata,
-    )
+    ) &&
+      !element?.specialSizeMeasurements.hasTransform)
   ) {
     return null
   }
@@ -37,10 +42,6 @@ export function flexReorderStrategy(
     return null
   }
 
-  const element = MetadataUtils.findElementByElementPath(
-    canvasState.startingMetadata,
-    selectedElements[0],
-  )
   const parentFlexDirection = element?.specialSizeMeasurements.parentFlexDirection
   const reorderDirection = parentFlexDirection === 'column' ? 'vertical' : 'horizontal'
   return {

--- a/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-helpers.ts
@@ -21,6 +21,8 @@ export function isValidFlowReorderTarget(
   const elementMetadata = MetadataUtils.findElementByElementPath(metadata, path)
   if (MetadataUtils.isPositionAbsolute(elementMetadata)) {
     return false
+  } else if (elementMetadata?.specialSizeMeasurements.hasTransform) {
+    return false
   } else if (elementMetadata?.specialSizeMeasurements.float !== 'none') {
     return false
   } else {

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -128,6 +128,7 @@ describe('DOM Walker tests', () => {
           "float": "none",
           "globalContentBox": null,
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 0,
@@ -222,6 +223,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -323,6 +325,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -431,6 +434,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -544,6 +548,7 @@ describe('DOM Walker tests', () => {
             "y": 98,
           },
           "hasPositionOffset": true,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -659,6 +664,7 @@ describe('DOM Walker tests', () => {
             "y": 125,
           },
           "hasPositionOffset": true,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 124,
@@ -804,6 +810,7 @@ describe('DOM Walker tests', () => {
           "float": "none",
           "globalContentBox": null,
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 0,
@@ -898,6 +905,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -999,6 +1007,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1103,6 +1112,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1207,6 +1217,7 @@ describe('DOM Walker tests', () => {
             "y": 98,
           },
           "hasPositionOffset": true,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1318,6 +1329,7 @@ describe('DOM Walker tests', () => {
             "y": 125,
           },
           "hasPositionOffset": true,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 164,
@@ -1463,6 +1475,7 @@ describe('DOM Walker tests', () => {
           "float": "none",
           "globalContentBox": null,
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 0,
@@ -1557,6 +1570,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1658,6 +1672,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1762,6 +1777,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1866,6 +1882,7 @@ describe('DOM Walker tests', () => {
             "y": 98,
           },
           "hasPositionOffset": true,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1977,6 +1994,7 @@ describe('DOM Walker tests', () => {
             "y": 125,
           },
           "hasPositionOffset": true,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 164,
@@ -2110,6 +2128,7 @@ describe('DOM Walker tests', () => {
           "float": "none",
           "globalContentBox": null,
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 0,
@@ -2204,6 +2223,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2305,6 +2325,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2409,6 +2430,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2546,6 +2568,7 @@ describe('DOM Walker tests', () => {
           "float": "none",
           "globalContentBox": null,
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 0,
@@ -2640,6 +2663,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2741,6 +2765,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2845,6 +2870,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2954,6 +2980,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -3063,6 +3090,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -3172,6 +3200,7 @@ describe('DOM Walker tests', () => {
             "y": 0,
           },
           "hasPositionOffset": false,
+          "hasTransform": false,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -912,6 +912,7 @@ function getSpecialMeasurements(
     !positionValueIsDefault(elementStyle.right) ||
     !positionValueIsDefault(elementStyle.bottom) ||
     !positionValueIsDefault(elementStyle.left)
+  const hasTransform = elementStyle.transform !== 'none'
 
   const flexGapValue = parseCSSLength(parentElementStyle?.gap)
   const parsedFlexGapValue = isRight(flexGapValue) ? flexGapValue.value.value : 0
@@ -943,6 +944,7 @@ function getSpecialMeasurements(
     elementStyle.float,
     hasPositionOffset,
     elementStyle.direction,
+    hasTransform,
   )
 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
@@ -272,6 +272,7 @@ describe('SpecialSizeMeasurementsKeepDeepEquality', () => {
     float: 'none',
     hasPositionOffset: false,
     textDirection: 'initial',
+    hasTransform: false,
   }
 
   const newDifferentValue: SpecialSizeMeasurements = {
@@ -329,6 +330,7 @@ describe('SpecialSizeMeasurementsKeepDeepEquality', () => {
     float: 'none',
     hasPositionOffset: false,
     textDirection: 'initial',
+    hasTransform: false,
   }
 
   it('same reference returns the same reference', () => {
@@ -441,6 +443,7 @@ describe('ElementInstanceMetadataKeepDeepEquality', () => {
       float: 'none',
       hasPositionOffset: false,
       textDirection: 'initial',
+      hasTransform: false,
     },
     computedStyle: {
       a: 'a',
@@ -526,6 +529,7 @@ describe('ElementInstanceMetadataKeepDeepEquality', () => {
       float: 'none',
       hasPositionOffset: false,
       textDirection: 'initial',
+      hasTransform: false,
     },
     computedStyle: {
       a: 'a',
@@ -637,6 +641,7 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
         float: 'none',
         hasPositionOffset: false,
         textDirection: 'initial',
+        hasTransform: false,
       },
       computedStyle: {
         a: 'a',
@@ -724,6 +729,7 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
         float: 'none',
         hasPositionOffset: false,
         textDirection: 'initial',
+        hasTransform: false,
       },
       computedStyle: {
         a: 'a',
@@ -811,6 +817,7 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
         float: 'none',
         hasPositionOffset: false,
         textDirection: 'initial',
+        hasTransform: false,
       },
       computedStyle: {
         a: 'a',

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1236,6 +1236,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
     const floatEquals = oldSize.float === newSize.float
     const hasPositionOffsetEquals = oldSize.hasPositionOffset === newSize.hasPositionOffset
     const textDirectionEquals = oldSize.textDirection === newSize.textDirection
+    const hasTransformEquals = oldSize.hasTransform === newSize.hasTransform
     const areEqual =
       offsetResult.areEqual &&
       coordinateSystemBoundsResult.areEqual &&
@@ -1262,7 +1263,8 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
       globalContentBoxEquals &&
       floatEquals &&
       hasPositionOffsetEquals &&
-      textDirectionEquals
+      textDirectionEquals &&
+      hasTransformEquals
     if (areEqual) {
       return keepDeepEqualityResult(oldSize, true)
     } else {
@@ -1293,6 +1295,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
         newSize.float,
         newSize.hasPositionOffset,
         newSize.textDirection,
+        newSize.hasTransform,
       )
       return keepDeepEqualityResult(sizeMeasurements, false)
     }

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1607,6 +1607,7 @@ export interface SpecialSizeMeasurements {
   float: string
   hasPositionOffset: boolean
   textDirection: string
+  hasTransform: boolean
 }
 
 export function specialSizeMeasurements(
@@ -1636,6 +1637,7 @@ export function specialSizeMeasurements(
   float: string,
   hasPositionOffset: boolean,
   textDirection: string,
+  hasTransform: boolean,
 ): SpecialSizeMeasurements {
   return {
     offset,
@@ -1664,6 +1666,7 @@ export function specialSizeMeasurements(
     float,
     hasPositionOffset,
     textDirection,
+    hasTransform,
   }
 }
 
@@ -1697,6 +1700,7 @@ export const emptySpecialSizeMeasurements = specialSizeMeasurements(
   'none',
   false,
   'initial',
+  false,
 )
 
 export const emptyComputedStyle: ComputedStyle = {}


### PR DESCRIPTION
**Problem:**
Exclude elements from dragging reorder strategies when they have transform style props as transform: translate can create an offset.

**Fix:**
Added this information to the `specialSizeMeasurements`.

**Commit Details:**
- update tests and snapshots
- extend metadata
- filter in flex and flow reorder strategies
