### PR TITLE
Store Github branches and repos, refresh with buttons

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -57,6 +57,7 @@ import {
   Theme,
   GithubOperation,
   GithubChecksums,
+  GithubData,
 } from './store/editor-state'
 import { Notice } from '../common/notice'
 import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
@@ -622,6 +623,11 @@ export interface UpdateGithubSettings {
   settings: Partial<ProjectGithubSettings>
 }
 
+export interface UpdateGithubData {
+  action: 'UPDATE_GITHUB_DATA'
+  data: Partial<GithubData>
+}
+
 export interface WorkerCodeUpdate {
   type: 'WORKER_CODE_UPDATE'
   filePath: string
@@ -1113,6 +1119,7 @@ export type EditorAction =
   | UpdateFile
   | UpdateProjectContents
   | UpdateGithubSettings
+  | UpdateGithubData
   | UpdateFromWorker
   | UpdateFromCodeEditor
   | ClearParseOrPrintInFlight

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -619,7 +619,7 @@ export interface UpdateBranchContents {
 
 export interface UpdateGithubSettings {
   action: 'UPDATE_GITHUB_SETTINGS'
-  settings: ProjectGithubSettings
+  settings: Partial<ProjectGithubSettings>
 }
 
 export interface WorkerCodeUpdate {

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -620,7 +620,7 @@ export interface UpdateBranchContents {
 
 export interface UpdateGithubSettings {
   action: 'UPDATE_GITHUB_SETTINGS'
-  settings: Partial<ProjectGithubSettings>
+  settings: ProjectGithubSettings
 }
 
 export interface UpdateGithubData {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -213,6 +213,7 @@ import type {
   UpdateGithubOperations,
   UpdateGithubChecksums,
   UpdateBranchContents,
+  UpdateGithubData,
 } from '../action-types'
 import { EditorModes, insertionSubject, Mode } from '../editor-modes'
 import type {
@@ -230,6 +231,7 @@ import type {
   Theme,
   GithubOperation,
   GithubChecksums,
+  GithubData,
 } from '../store/editor-state'
 
 export function clearSelection(): EditorAction {
@@ -994,6 +996,13 @@ export function updateGithubSettings(
   return {
     action: 'UPDATE_GITHUB_SETTINGS',
     settings: settings,
+  }
+}
+
+export function updateGithubData(data: Partial<GithubData>): UpdateGithubData {
+  return {
+    action: 'UPDATE_GITHUB_DATA',
+    data: data,
   }
 }
 

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -990,9 +990,7 @@ export function updateBranchContents(
   }
 }
 
-export function updateGithubSettings(
-  settings: Partial<ProjectGithubSettings>,
-): UpdateGithubSettings {
+export function updateGithubSettings(settings: ProjectGithubSettings): UpdateGithubSettings {
   return {
     action: 'UPDATE_GITHUB_SETTINGS',
     settings: settings,

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -988,7 +988,9 @@ export function updateBranchContents(
   }
 }
 
-export function updateGithubSettings(settings: ProjectGithubSettings): UpdateGithubSettings {
+export function updateGithubSettings(
+  settings: Partial<ProjectGithubSettings>,
+): UpdateGithubSettings {
   return {
     action: 'UPDATE_GITHUB_SETTINGS',
     settings: settings,

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -118,6 +118,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SAVE_TO_GITHUB':
     case 'UPDATE_GITHUB_OPERATIONS':
     case 'UPDATE_GITHUB_CHECKSUMS':
+    case 'UPDATE_GITHUB_DATA':
       return true
 
     case 'NEW':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3739,10 +3739,7 @@ export const UPDATE_FNS = {
   UPDATE_GITHUB_SETTINGS: (action: UpdateGithubSettings, editor: EditorModel): EditorModel => {
     return {
       ...editor,
-      githubSettings: {
-        ...editor.githubSettings,
-        ...action.settings,
-      },
+      githubSettings: action.settings,
     }
   },
   UPDATE_GITHUB_DATA: (action: UpdateGithubData, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -306,6 +306,7 @@ import {
   UpdateGithubOperations,
   UpdateGithubChecksums,
   UpdateBranchContents,
+  UpdateGithubData,
 } from '../action-types'
 import { defaultSceneElement, defaultTransparentViewElement } from '../defaults'
 import { EditorModes, isLiveMode, isSelectMode, Mode } from '../editor-modes'
@@ -983,6 +984,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
     githubOperations: currentEditor.githubOperations,
     githubChecksums: currentEditor.githubChecksums,
     branchContents: currentEditor.branchContents,
+    githubData: currentEditor.githubData,
   }
 }
 
@@ -3740,6 +3742,15 @@ export const UPDATE_FNS = {
       githubSettings: {
         ...editor.githubSettings,
         ...action.settings,
+      },
+    }
+  },
+  UPDATE_GITHUB_DATA: (action: UpdateGithubData, editor: EditorModel): EditorModel => {
+    return {
+      ...editor,
+      githubData: {
+        ...editor.githubData,
+        ...action.data,
       },
     }
   },

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3737,7 +3737,10 @@ export const UPDATE_FNS = {
   UPDATE_GITHUB_SETTINGS: (action: UpdateGithubSettings, editor: EditorModel): EditorModel => {
     return {
       ...editor,
-      githubSettings: action.settings,
+      githubSettings: {
+        ...editor.githubSettings,
+        ...action.settings,
+      },
     }
   },
   UPDATE_FROM_WORKER: (action: UpdateFromWorker, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/actions/migrations/migrations.ts
+++ b/editor/src/components/editor/actions/migrations/migrations.ts
@@ -30,7 +30,7 @@ import {
 } from '../../../assets'
 import { isUtopiaJSXComponent } from '../../../../core/shared/element-template'
 
-export const CURRENT_PROJECT_VERSION = 10
+export const CURRENT_PROJECT_VERSION = 11
 
 export function applyMigrations(
   persistentModel: PersistentModel,
@@ -45,7 +45,8 @@ export function applyMigrations(
   const version8 = migrateFromVersion7(version7)
   const version9 = migrateFromVersion8(version8)
   const version10 = migrateFromVersion9(version9)
-  return version10
+  const version11 = migrateFromVersion10(version10)
+  return version11
 }
 
 function migrateFromVersion0(
@@ -379,6 +380,24 @@ function migrateFromVersion9(
       },
       githubChecksums: null,
       branchContents: null,
+    }
+  }
+}
+
+function migrateFromVersion10(
+  persistentModel: PersistentModel,
+): PersistentModel & { projectVersion: 11 } {
+  if (persistentModel.projectVersion != null && persistentModel.projectVersion !== 10) {
+    return persistentModel as any
+  } else {
+    return {
+      ...persistentModel,
+      projectVersion: 11,
+      githubSettings: {
+        ...persistentModel.githubSettings,
+        branches: [],
+        publicRepositories: [],
+      },
     }
   }
 }

--- a/editor/src/components/editor/actions/migrations/migrations.ts
+++ b/editor/src/components/editor/actions/migrations/migrations.ts
@@ -30,7 +30,7 @@ import {
 } from '../../../assets'
 import { isUtopiaJSXComponent } from '../../../../core/shared/element-template'
 
-export const CURRENT_PROJECT_VERSION = 11
+export const CURRENT_PROJECT_VERSION = 10
 
 export function applyMigrations(
   persistentModel: PersistentModel,
@@ -45,8 +45,7 @@ export function applyMigrations(
   const version8 = migrateFromVersion7(version7)
   const version9 = migrateFromVersion8(version8)
   const version10 = migrateFromVersion9(version9)
-  const version11 = migrateFromVersion10(version10)
-  return version11
+  return version10
 }
 
 function migrateFromVersion0(
@@ -380,24 +379,6 @@ function migrateFromVersion9(
       },
       githubChecksums: null,
       branchContents: null,
-    }
-  }
-}
-
-function migrateFromVersion10(
-  persistentModel: PersistentModel,
-): PersistentModel & { projectVersion: 11 } {
-  if (persistentModel.projectVersion != null && persistentModel.projectVersion !== 10) {
-    return persistentModel as any
-  } else {
-    return {
-      ...persistentModel,
-      projectVersion: 11,
-      githubSettings: {
-        ...persistentModel.githubSettings,
-        branches: [],
-        publicRepositories: [],
-      },
     }
   }
 }

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -42,8 +42,14 @@ import { FatalIndexedDBErrorComponent } from './fatal-indexeddb-error-component'
 import { editorIsTarget, handleKeyDown, handleKeyUp } from './global-shortcuts'
 import { BrowserInfoBar, LoginStatusBar } from './notification-bar'
 import { applyShortcutConfigurationToDefaults } from './shortcut-definitions'
-import { LeftMenuTab, LeftPaneDefaultWidth, MenuBarWidth } from './store/editor-state'
+import {
+  githubOperationLocksEditor,
+  LeftMenuTab,
+  LeftPaneDefaultWidth,
+  MenuBarWidth,
+} from './store/editor-state'
 import { useEditorState, useRefEditorState } from './store/store-hook'
+import { refreshGithubSettings } from '../../core/shared/github'
 
 function pushProjectURLToBrowserHistory(projectId: string, projectName: string): void {
   // Make sure we don't replace the query params
@@ -288,6 +294,18 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
     [dispatch],
   )
 
+  const githubAuthenticated = useEditorState(
+    (store) => store.userState.githubState.authenticated,
+    'Github authentication',
+  )
+  const githubRepo = useEditorState(
+    (store) => store.editor.githubSettings.targetRepository,
+    'Github repository',
+  )
+  React.useEffect(() => {
+    void refreshGithubSettings(dispatch, { githubAuthenticated, githubRepo })
+  }, [githubAuthenticated, githubRepo, dispatch])
+
   return (
     <>
       <SimpleFlexRow
@@ -489,7 +507,7 @@ const LockedOverlay = React.memo(() => {
   )
 
   const editorLocked = useEditorState(
-    (store) => store.editor.githubOperations.length > 0,
+    (store) => store.editor.githubOperations.some((op) => githubOperationLocksEditor(op)),
     'EditorComponentInner editorLocked',
   )
 

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -49,7 +49,7 @@ import {
   MenuBarWidth,
 } from './store/editor-state'
 import { useEditorState, useRefEditorState } from './store/store-hook'
-import { refreshGithubSettings } from '../../core/shared/github'
+import { refreshGithubData } from '../../core/shared/github'
 
 function pushProjectURLToBrowserHistory(projectId: string, projectName: string): void {
   // Make sure we don't replace the query params
@@ -303,7 +303,7 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
     'Github repository',
   )
   React.useEffect(() => {
-    void refreshGithubSettings(dispatch, { githubAuthenticated, githubRepo })
+    void refreshGithubData(dispatch, { githubAuthenticated, githubRepo })
   }, [githubAuthenticated, githubRepo, dispatch])
 
   return (

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1019,18 +1019,8 @@ export function githubRepo(owner: string, repository: string): GithubRepo {
   }
 }
 
-function githubRepoName(repo: GithubRepo): string {
-  return `${repo.owner}/${repo.repository}`
-}
-
 export function githubRepoEquals(a: GithubRepo | null, b: GithubRepo | null): boolean {
-  if (a == null && b == null) {
-    return true
-  }
-  if (a == null || b == null) {
-    return false
-  }
-  return githubRepoName(a) === githubRepoName(b)
+  return a?.owner === b?.owner && a?.repository === b?.repository
 }
 
 export interface ProjectGithubSettings {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1039,11 +1039,15 @@ export interface ProjectGithubSettings {
   branchName: string | null
 }
 
-export function emptyProjectGithubSettings(): ProjectGithubSettings {
+export function projectGithubSettings(
+  targetRepository: GithubRepo | null,
+  originCommit: string | null,
+  branchName: string | null,
+): ProjectGithubSettings {
   return {
-    targetRepository: null,
-    originCommit: null,
-    branchName: null,
+    targetRepository: targetRepository,
+    originCommit: originCommit,
+    branchName: branchName,
   }
 }
 
@@ -2091,7 +2095,11 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     forceParseFiles: [],
     allElementProps: {},
     _currentAllElementProps_KILLME: {},
-    githubSettings: emptyProjectGithubSettings(),
+    githubSettings: {
+      targetRepository: null,
+      originCommit: null,
+      branchName: null,
+    },
     imageDragSessionState: notDragging(),
     githubOperations: [],
     githubChecksums: null,
@@ -2465,7 +2473,11 @@ export function persistentModelForProjectContents(
     navigator: {
       minimised: false,
     },
-    githubSettings: emptyProjectGithubSettings(),
+    githubSettings: {
+      targetRepository: null,
+      originCommit: null,
+      branchName: null,
+    },
     githubChecksums: null,
     branchContents: null,
   }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1037,8 +1037,6 @@ export interface ProjectGithubSettings {
   targetRepository: GithubRepo | null
   originCommit: string | null
   branchName: string | null
-  branches: Array<GithubBranch>
-  publicRepositories: Array<RepositoryEntry>
 }
 
 export function emptyProjectGithubSettings(): ProjectGithubSettings {
@@ -1046,8 +1044,18 @@ export function emptyProjectGithubSettings(): ProjectGithubSettings {
     targetRepository: null,
     originCommit: null,
     branchName: null,
-    publicRepositories: [],
+  }
+}
+
+export interface GithubData {
+  branches: Array<GithubBranch>
+  publicRepositories: Array<RepositoryEntry>
+}
+
+export function emptyGithubData(): GithubData {
+  return {
     branches: [],
+    publicRepositories: [],
   }
 }
 
@@ -1125,6 +1133,7 @@ export interface EditorState {
   imageDragSessionState: ImageDragSessionState
   githubOperations: Array<GithubOperation>
   githubChecksums: GithubChecksums | null
+  githubData: GithubData
 }
 
 export function editorState(
@@ -1198,6 +1207,7 @@ export function editorState(
   githubOperations: Array<GithubOperation>,
   githubChecksums: GithubChecksums | null,
   branchContents: ProjectContentTreeRoot | null,
+  githubData: GithubData,
 ): EditorState {
   return {
     id: id,
@@ -1270,6 +1280,7 @@ export function editorState(
     imageDragSessionState: imageDragSessionState,
     githubOperations: githubOperations,
     githubChecksums: githubChecksums,
+    githubData: githubData,
   }
 }
 
@@ -2085,6 +2096,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     githubOperations: [],
     githubChecksums: null,
     branchContents: null,
+    githubData: emptyGithubData(),
   }
 }
 
@@ -2383,6 +2395,7 @@ export function editorModelFromPersistentModel(
     githubOperations: [],
     githubChecksums: persistentModel.githubChecksums,
     branchContents: persistentModel.branchContents,
+    githubData: emptyGithubData(),
   }
   return editor
 }

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -205,6 +205,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.UPDATE_BRANCH_CONTENTS(action, state)
     case 'UPDATE_GITHUB_SETTINGS':
       return UPDATE_FNS.UPDATE_GITHUB_SETTINGS(action, state)
+    case 'UPDATE_GITHUB_DATA':
+      return UPDATE_FNS.UPDATE_GITHUB_DATA(action, state)
     case 'UPDATE_FROM_WORKER':
       return UPDATE_FNS.UPDATE_FROM_WORKER(action, state)
     case 'UPDATE_FROM_CODE_EDITOR':

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -306,7 +306,6 @@ import {
   ProjectGithubSettings,
   GithubRepo,
   githubRepo,
-  projectGithubSettings,
   DraggedImageProperties,
   draggedImageProperties,
   ImageDragSessionState,
@@ -319,6 +318,7 @@ import {
   GithubChecksums,
   FileRevertModal,
   fileRevertModal,
+  emptyProjectGithubSettings,
 } from './editor-state'
 import {
   CornerGuideline,
@@ -450,7 +450,12 @@ import {
   TextResult,
   textResult,
 } from '../../../core/shared/file-utils'
-import { GithubFileStatus } from '../../../core/shared/github'
+import {
+  GithubBranch,
+  GithubFileStatus,
+  RepositoryEntry,
+  RepositoryEntryPermissions,
+} from '../../../core/shared/github'
 
 export function TransientCanvasStateFilesStateKeepDeepEquality(
   oldValue: TransientFilesState,
@@ -3200,15 +3205,80 @@ export const GithubRepoKeepDeepEquality: KeepDeepEqualityCall<GithubRepo> = comb
   githubRepo,
 )
 
-export const ProjectGithubSettingsKeepDeepEquality: KeepDeepEqualityCall<ProjectGithubSettings> =
+export const GithubBranchKeepDeepEquality: KeepDeepEqualityCall<GithubBranch> =
+  combine1EqualityCall(
+    (branch) => branch.name,
+    StringKeepDeepEquality,
+    (name: string): GithubBranch => ({ name }),
+  )
+
+export const RepositoryEntryPermissionsKeepDeepEquality: KeepDeepEqualityCall<RepositoryEntryPermissions> =
   combine3EqualityCalls(
+    (p) => p.admin,
+    BooleanKeepDeepEquality,
+    (p) => p.pull,
+    BooleanKeepDeepEquality,
+    (p) => p.push,
+    BooleanKeepDeepEquality,
+    (admin: boolean, push: boolean, pull: boolean): RepositoryEntryPermissions => ({
+      admin,
+      push,
+      pull,
+    }),
+  )
+
+export const RepositoryEntryKeepDeepEquality: KeepDeepEqualityCall<RepositoryEntry> =
+  combine8EqualityCalls(
+    (r) => r.avatarUrl,
+    NullableStringKeepDeepEquality,
+    (r) => r.private,
+    BooleanKeepDeepEquality,
+    (r) => r.fullName,
+    StringKeepDeepEquality,
+    (r) => r.description,
+    NullableStringKeepDeepEquality,
+    (r) => r.name,
+    NullableStringKeepDeepEquality,
+    (r) => r.updatedAt,
+    NullableStringKeepDeepEquality,
+    (r) => r.defaultBranch,
+    NullableStringKeepDeepEquality,
+    (r) => r.permissions,
+    RepositoryEntryPermissionsKeepDeepEquality,
+    (
+      avatarUrl: string | null,
+      priv: boolean,
+      fullName: string,
+      description: string | null,
+      name: string | null,
+      updatedAt: string | null,
+      defaultBranch: string | null,
+      permissions: RepositoryEntryPermissions,
+    ): RepositoryEntry => ({
+      avatarUrl,
+      private: priv,
+      fullName,
+      description,
+      name,
+      updatedAt,
+      defaultBranch,
+      permissions,
+    }),
+  )
+
+export const ProjectGithubSettingsKeepDeepEquality: KeepDeepEqualityCall<ProjectGithubSettings> =
+  combine5EqualityCalls(
     (settings) => settings.targetRepository,
     nullableDeepEquality(GithubRepoKeepDeepEquality),
     (settings) => settings.originCommit,
     nullableDeepEquality(createCallWithTripleEquals<string>()),
     (settings) => settings.branchName,
     nullableDeepEquality(createCallWithTripleEquals<string>()),
-    projectGithubSettings,
+    (settings) => settings.branches,
+    arrayDeepEquality(GithubBranchKeepDeepEquality),
+    (settings) => settings.publicRepositories,
+    arrayDeepEquality(RepositoryEntryKeepDeepEquality),
+    emptyProjectGithubSettings,
   )
 
 export const GithubOperationKeepDeepEquality: KeepDeepEqualityCall<GithubOperation> = (

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -318,9 +318,9 @@ import {
   GithubChecksums,
   FileRevertModal,
   fileRevertModal,
-  emptyProjectGithubSettings,
   GithubData,
   emptyGithubData,
+  projectGithubSettings,
 } from './editor-state'
 import {
   CornerGuideline,
@@ -3276,7 +3276,7 @@ export const ProjectGithubSettingsKeepDeepEquality: KeepDeepEqualityCall<Project
     nullableDeepEquality(createCallWithTripleEquals<string>()),
     (settings) => settings.branchName,
     nullableDeepEquality(createCallWithTripleEquals<string>()),
-    emptyProjectGithubSettings,
+    projectGithubSettings,
   )
 
 export const GithubDataKeepDeepEquality: KeepDeepEqualityCall<GithubData> = combine2EqualityCalls(

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -319,6 +319,8 @@ import {
   FileRevertModal,
   fileRevertModal,
   emptyProjectGithubSettings,
+  GithubData,
+  emptyGithubData,
 } from './editor-state'
 import {
   CornerGuideline,
@@ -3267,19 +3269,23 @@ export const RepositoryEntryKeepDeepEquality: KeepDeepEqualityCall<RepositoryEnt
   )
 
 export const ProjectGithubSettingsKeepDeepEquality: KeepDeepEqualityCall<ProjectGithubSettings> =
-  combine5EqualityCalls(
+  combine3EqualityCalls(
     (settings) => settings.targetRepository,
     nullableDeepEquality(GithubRepoKeepDeepEquality),
     (settings) => settings.originCommit,
     nullableDeepEquality(createCallWithTripleEquals<string>()),
     (settings) => settings.branchName,
     nullableDeepEquality(createCallWithTripleEquals<string>()),
-    (settings) => settings.branches,
-    arrayDeepEquality(GithubBranchKeepDeepEquality),
-    (settings) => settings.publicRepositories,
-    arrayDeepEquality(RepositoryEntryKeepDeepEquality),
     emptyProjectGithubSettings,
   )
+
+export const GithubDataKeepDeepEquality: KeepDeepEqualityCall<GithubData> = combine2EqualityCalls(
+  (data) => data.branches,
+  arrayDeepEquality(GithubBranchKeepDeepEquality),
+  (data) => data.publicRepositories,
+  arrayDeepEquality(RepositoryEntryKeepDeepEquality),
+  emptyGithubData,
+)
 
 export const GithubOperationKeepDeepEquality: KeepDeepEqualityCall<GithubOperation> = (
   oldValue,
@@ -3542,6 +3548,8 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     newValue.branchContents,
   )
 
+  const githubDataResults = GithubDataKeepDeepEquality(oldValue.githubData, newValue.githubData)
+
   const areEqual =
     idResult.areEqual &&
     vscodeBridgeIdResult.areEqual &&
@@ -3612,7 +3620,8 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     imageDragSessionStateEqual.areEqual &&
     githubOperationsResults.areEqual &&
     githubChecksumsResults.areEqual &&
-    branchContentsResults.areEqual
+    branchContentsResults.areEqual &&
+    githubDataResults.areEqual
 
   if (areEqual) {
     return keepDeepEqualityResult(oldValue, true)
@@ -3688,6 +3697,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
       githubOperationsResults.value,
       githubChecksumsResults.value,
       branchContentsResults.value,
+      githubDataResults.value,
     )
 
     return keepDeepEqualityResult(newEditorState, false)

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -455,7 +455,9 @@ import {
 import {
   GithubBranch,
   GithubFileStatus,
+  repositoryEntry,
   RepositoryEntry,
+  repositoryEntryPermissions,
   RepositoryEntryPermissions,
 } from '../../../core/shared/github'
 
@@ -3222,11 +3224,7 @@ export const RepositoryEntryPermissionsKeepDeepEquality: KeepDeepEqualityCall<Re
     BooleanKeepDeepEquality,
     (p) => p.push,
     BooleanKeepDeepEquality,
-    (admin: boolean, push: boolean, pull: boolean): RepositoryEntryPermissions => ({
-      admin,
-      push,
-      pull,
-    }),
+    repositoryEntryPermissions,
   )
 
 export const RepositoryEntryKeepDeepEquality: KeepDeepEqualityCall<RepositoryEntry> =
@@ -3247,25 +3245,7 @@ export const RepositoryEntryKeepDeepEquality: KeepDeepEqualityCall<RepositoryEnt
     NullableStringKeepDeepEquality,
     (r) => r.permissions,
     RepositoryEntryPermissionsKeepDeepEquality,
-    (
-      avatarUrl: string | null,
-      priv: boolean,
-      fullName: string,
-      description: string | null,
-      name: string | null,
-      updatedAt: string | null,
-      defaultBranch: string | null,
-      permissions: RepositoryEntryPermissions,
-    ): RepositoryEntry => ({
-      avatarUrl,
-      private: priv,
-      fullName,
-      description,
-      name,
-      updatedAt,
-      defaultBranch,
-      permissions,
-    }),
+    repositoryEntry,
   )
 
 export const ProjectGithubSettingsKeepDeepEquality: KeepDeepEqualityCall<ProjectGithubSettings> =

--- a/editor/src/components/navigator/left-pane/github-pane/github-spinner.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/github-spinner.tsx
@@ -19,8 +19,8 @@ export const GithubSpinner: React.FC = () => {
     <FlexColumn>
       <svg
         xmlns='http://www.w3.org/2000/svg'
-        width='16'
-        height='16'
+        width='12'
+        height='12'
         viewBox='0 0 24 24'
         fill='none'
         stroke='#999'

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -144,7 +144,7 @@ export const GithubPane = React.memo(() => {
   }, [dispatch, storedTargetGithubRepo])
 
   const branchesForRepository = useEditorState(
-    (store) => store.editor.githubSettings.branches,
+    (store) => store.editor.githubData.branches,
     'Github repo branches',
   )
 

--- a/editor/src/components/navigator/left-pane/github-pane/refresh-icon.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/refresh-icon.tsx
@@ -1,0 +1,28 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+/** @jsxFrag React.Fragment */
+import { jsx } from '@emotion/react'
+import React from 'react'
+import { FlexColumn } from '../../../../uuiui'
+
+export const RefreshIcon: React.FC = () => {
+  return (
+    <FlexColumn>
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        width='12'
+        height='12'
+        viewBox='0 0 24 24'
+        fill='none'
+        stroke='#262626'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      >
+        <polyline points='23 4 23 10 17 10'></polyline>
+        <polyline points='1 20 1 14 7 14'></polyline>
+        <path d='M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15'></path>
+      </svg>{' '}
+    </FlexColumn>
+  )
+}

--- a/editor/src/components/navigator/left-pane/github-pane/refresh-icon.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/refresh-icon.tsx
@@ -22,7 +22,7 @@ export const RefreshIcon: React.FC = () => {
         <polyline points='23 4 23 10 17 10'></polyline>
         <polyline points='1 20 1 14 7 14'></polyline>
         <path d='M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15'></path>
-      </svg>{' '}
+      </svg>
     </FlexColumn>
   )
 }

--- a/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
@@ -193,7 +193,7 @@ export const RepositoryListing = React.memo(
     )
 
     const usersRepositories = useEditorState(
-      (store) => store.editor.githubSettings.publicRepositories,
+      (store) => store.editor.githubData.publicRepositories,
       'Github repositories',
     )
 

--- a/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
@@ -2,7 +2,11 @@ import React from 'react'
 import TimeAgo from 'react-timeago'
 import { notice } from '../../../../components/common/notice'
 import { showToast } from '../../../../components/editor/actions/action-creators'
-import { GithubRepo, isGithubLoadingBranch } from '../../../../components/editor/store/editor-state'
+import {
+  GithubRepo,
+  githubRepoEquals,
+  isGithubLoadingBranch,
+} from '../../../../components/editor/store/editor-state'
 import {
   getBranchContent,
   getUsersPublicGithubRepositories,
@@ -14,6 +18,7 @@ import { useColorTheme, Button, StringInput } from '../../../../uuiui'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { UIGridRow } from '../../../inspector/widgets/ui-grid-row'
 import { GithubSpinner } from './github-spinner'
+import { RefreshIcon } from './refresh-icon'
 
 interface RepositoryRowProps extends RepositoryEntry {
   importPermitted: boolean
@@ -56,6 +61,11 @@ const RepositoryRow = (props: RepositoryRowProps) => {
     }
   }
 
+  const currentRepo = useEditorState(
+    (store) => store.editor.githubSettings.targetRepository,
+    'Current Github repository',
+  )
+
   const importRepository = React.useCallback(() => {
     const parsedTargetRepository = parseGithubProjectString(props.fullName)
     if (parsedTargetRepository == null || props.defaultBranch == null) {
@@ -71,15 +81,17 @@ const RepositoryRow = (props: RepositoryRowProps) => {
         'everyone',
       )
     } else {
+      const isAnotherRepo = !githubRepoEquals(parsedTargetRepository, currentRepo)
       void getBranchContent(
         dispatch,
         parsedTargetRepository,
         forceNotNull('Should have a project ID.', projectID),
         props.defaultBranch,
+        isAnotherRepo,
       )
       setImporting(true)
     }
-  }, [dispatch, projectID, props.fullName, props.defaultBranch])
+  }, [dispatch, projectID, props.fullName, props.defaultBranch, currentRepo])
 
   return (
     <div
@@ -173,25 +185,6 @@ export const RepositoryListing = React.memo(
       setPreviousStoredTarget(storedTargetGithubRepoAsText)
     }
 
-    const dispatch = useEditorState((store) => store.dispatch, 'RepositoryListing dispatch')
-
-    const [usersRepositories, setUsersRepositories] = React.useState<Array<RepositoryEntry> | null>(
-      null,
-    )
-
-    const setUsersRepositoriesCallback = React.useCallback(
-      (repositories: Array<RepositoryEntry>) => {
-        setUsersRepositories(repositories)
-      },
-      [setUsersRepositories],
-    )
-
-    React.useEffect(() => {
-      if (githubAuthenticated) {
-        void getUsersPublicGithubRepositories(dispatch, setUsersRepositoriesCallback)
-      }
-    }, [githubAuthenticated, dispatch, setUsersRepositoriesCallback])
-
     const onInputChangeTargetRepository = React.useCallback(
       (event: React.ChangeEvent<HTMLInputElement>) => {
         setTargetRepository(event.currentTarget.value)
@@ -199,30 +192,31 @@ export const RepositoryListing = React.memo(
       [setTargetRepository],
     )
 
+    const usersRepositories = useEditorState(
+      (store) => store.editor.githubSettings.publicRepositories,
+      'Github repositories',
+    )
+
     const filteredRepositories = React.useMemo(() => {
-      if (usersRepositories == null) {
-        return null
-      } else {
-        let filteredResult: Array<RepositoryRowProps> = []
-        for (const repository of usersRepositories) {
-          // Only include a repository if the user can push to it.
-          if (repository.permissions.push) {
-            filteredResult.push({
-              ...repository,
-              importPermitted: true,
-            })
-          }
-        }
-        if (targetRepository != null) {
-          filteredResult = filteredResult.filter((repository) => {
-            return (
-              repository.fullName.includes(targetRepository) ||
-              repository.name?.includes(targetRepository)
-            )
+      let filteredResult: Array<RepositoryRowProps> = []
+      for (const repository of usersRepositories) {
+        // Only include a repository if the user can push to it.
+        if (repository.permissions.push) {
+          filteredResult.push({
+            ...repository,
+            importPermitted: true,
           })
         }
-        return filteredResult
       }
+      if (targetRepository != null) {
+        filteredResult = filteredResult.filter((repository) => {
+          return (
+            repository.fullName.includes(targetRepository) ||
+            repository.name?.includes(targetRepository)
+          )
+        })
+      }
+      return filteredResult
     }, [usersRepositories, targetRepository])
 
     const filteredRepositoriesWithSpecialCases = React.useMemo(() => {
@@ -261,9 +255,28 @@ export const RepositoryListing = React.memo(
       }
     }, [filteredRepositories, targetRepository])
 
+    const githubOperations = useEditorState(
+      (store) => store.editor.githubOperations,
+      'Github operations',
+    )
+    const githubWorking = React.useMemo(() => githubOperations.length > 0, [githubOperations])
+    const isLoadingRepositories = React.useMemo(
+      () => githubOperations.some((op) => op.name === 'loadRepositories'),
+      [githubOperations],
+    )
+    const dispatch = useEditorState((store) => store.dispatch, 'dispatch')
+
+    const refreshRepos = React.useCallback(() => {
+      void getUsersPublicGithubRepositories(dispatch)
+    }, [dispatch])
+
+    if (!githubAuthenticated) {
+      return null
+    }
+
     return (
       <>
-        <UIGridRow padded variant={'<-------------1fr------------->'}>
+        <UIGridRow padded variant={'<----------1fr---------><-auto->'}>
           <StringInput
             placeholder={
               filteredRepositoriesWithSpecialCases == null
@@ -277,6 +290,15 @@ export const RepositoryListing = React.memo(
             name={'repositories-input'}
             value={targetRepository}
           />
+          <Button
+            spotlight
+            highlight
+            style={{ padding: '0 6px' }}
+            disabled={githubWorking}
+            onMouseDown={refreshRepos}
+          >
+            {isLoadingRepositories ? <GithubSpinner /> : <RefreshIcon />}
+          </Button>
         </UIGridRow>
 
         <UIGridRow padded variant='<-------------1fr------------->'>

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -27,6 +27,7 @@ import {
   GithubOperation,
   GithubRepo,
   PersistentModel,
+  projectGithubSettings,
 } from '../../components/editor/store/editor-state'
 import { trimUpToAndIncluding } from './string-utils'
 import { arrayEquals } from './utils'
@@ -177,11 +178,13 @@ export async function saveProjectToGithub(
         dispatch(
           [
             updateGithubChecksums(getProjectContentsChecksums(persistentModel.projectContents)),
-            updateGithubSettings({
-              targetRepository: persistentModel.githubSettings.targetRepository,
-              originCommit: responseBody.newCommit,
-              branchName: responseBody.branchName,
-            }),
+            updateGithubSettings(
+              projectGithubSettings(
+                persistentModel.githubSettings.targetRepository,
+                responseBody.newCommit,
+                responseBody.branchName,
+              ),
+            ),
             updateBranchContents(persistentModel.projectContents),
             showToast(notice(`Saved to branch ${responseBody.branchName}.`, 'INFO')),
           ],
@@ -310,11 +313,9 @@ export async function getBranchContent(
           updateGithubChecksums(getProjectContentsChecksums(responseBody.content)),
           updateProjectContents(responseBody.content),
           updateBranchContents(responseBody.content),
-          updateGithubSettings({
-            targetRepository: githubRepo,
-            originCommit: responseBody.originCommit,
-            branchName: branchName,
-          }),
+          updateGithubSettings(
+            projectGithubSettings(githubRepo, responseBody.originCommit, branchName),
+          ),
           showToast(notice(`Updated the project with the content from ${branchName}`, 'SUCCESS')),
         ]
         if (resetBranches) {

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -89,6 +89,18 @@ export interface RepositoryEntryPermissions {
   pull: boolean
 }
 
+export function repositoryEntryPermissions(
+  admin: boolean,
+  push: boolean,
+  pull: boolean,
+): RepositoryEntryPermissions {
+  return {
+    admin: admin,
+    push: push,
+    pull: pull,
+  }
+}
+
 export interface RepositoryEntry {
   fullName: string
   avatarUrl: string | null
@@ -98,6 +110,28 @@ export interface RepositoryEntry {
   updatedAt: string | null
   defaultBranch: string | null
   permissions: RepositoryEntryPermissions
+}
+
+export function repositoryEntry(
+  avatarUrl: string | null,
+  priv: boolean,
+  fullName: string,
+  description: string | null,
+  name: string | null,
+  updatedAt: string | null,
+  defaultBranch: string | null,
+  permissions: RepositoryEntryPermissions,
+): RepositoryEntry {
+  return {
+    avatarUrl,
+    private: priv,
+    fullName,
+    description,
+    name,
+    updatedAt,
+    defaultBranch,
+    permissions,
+  }
 }
 
 export interface GetUsersPublicRepositoriesSuccess {


### PR DESCRIPTION
Fixes #2757 

**Context:**

After the initial exploration work, I'm splitting the work for the GH background refresh (#2758) in incremental PRs. This is the first one that lays the groundwork for the background refreshing.

**Fix:**

1. Store the user's public repos list and the repos branches in the editor state **(not persisted),** so that they can be retrieved and updated independently. This will be used later for the background refresh.
2. When the authentication state changes, refresh the repos list.
3. When the imported repo changes, refresh the branches list.
4. When the contents are pushed to GH, refresh the branches list.
5. Do not lock the editor when refreshing repos and/or branches.
6. Add the ability to refresh the repos manually with a refresh button
![refresh-repo](https://user-images.githubusercontent.com/1081051/199717442-45ae2be5-2cf5-4ed1-9091-22d0c4d3ccf3.gif)
7. Add the ability to refresh the branches manually with a refresh button
![refresh-branches](https://user-images.githubusercontent.com/1081051/199717452-b9e87678-be69-45a3-ae02-f732d3f28f4d.gif)