### PR TITLE
Refresh Github data asynchronously

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -428,7 +428,7 @@ const GithubDataManager = () => {
   // 1. perform a straight refresh then the repo or the auth change
   React.useEffect(() => {
     void refreshGithubData(dispatch, { githubAuthenticated, githubRepo })
-  }, [githubAuthenticated, githubRepo, dispatch])
+  }, [dispatch, githubAuthenticated, githubRepo])
 
   // 2. schedule a repeat refresh every GITHUB_REFRESH_INTERVAL
   React.useEffect(() => {
@@ -443,7 +443,7 @@ const GithubDataManager = () => {
     return function () {
       clearInterval(refreshInterval)
     }
-  }, [githubAuthenticated, githubRepo, dispatch, githubOperations])
+  }, [dispatch, githubAuthenticated, githubRepo, githubOperations])
 
   return null
 }

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -415,7 +415,7 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
   )
 })
 
-const useGithubData = () => {
+const useGithubData = (): void => {
   const dispatch = useEditorState((store) => store.dispatch, 'Dispatch')
   const { githubAuthenticated, githubRepo, githubOperations } = useEditorState(
     (store) => ({
@@ -445,8 +445,6 @@ const useGithubData = () => {
       clearInterval(interval)
     }
   }, [refresh, githubOperations])
-
-  return null
 }
 
 const ModalComponent = React.memo((): React.ReactElement<any> | null => {

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -425,25 +425,25 @@ const GithubDataManager = () => {
     'Github data',
   )
 
-  // 1. perform a straight refresh then the repo or the auth change
-  React.useEffect(() => {
+  const refresh = React.useCallback(() => {
     void refreshGithubData(dispatch, { githubAuthenticated, githubRepo })
   }, [dispatch, githubAuthenticated, githubRepo])
 
-  // 2. schedule a repeat refresh every GITHUB_REFRESH_INTERVAL
+  // perform a straight refresh then the repo or the auth change
+  React.useEffect(() => refresh(), [refresh])
+
+  // schedule a repeat refresh every GITHUB_REFRESH_INTERVAL
   React.useEffect(() => {
-    // ignore scheduling if there are already github operations going on
     if (githubOperations.length > 0) {
+      // ignore scheduling if there are already operations going on
       return
     }
-    let refreshInterval = setInterval(
-      () => refreshGithubData(dispatch, { githubAuthenticated, githubRepo }),
-      GITHUB_REFRESH_INTERVAL_MILLISECONDS,
-    )
+
+    let interval = setInterval(refresh, GITHUB_REFRESH_INTERVAL_MILLISECONDS)
     return function () {
-      clearInterval(refreshInterval)
+      clearInterval(interval)
     }
-  }, [dispatch, githubAuthenticated, githubRepo, githubOperations])
+  }, [refresh, githubOperations])
 
   return null
 }

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -83,6 +83,8 @@ function useDelayedValueHook(inputValue: boolean, delayMs: number): boolean {
 }
 
 export const EditorComponentInner = React.memo((props: EditorProps) => {
+  useGithubData()
+
   const editorStoreRef = useRefEditorState((store) => store)
   const colorTheme = useColorTheme()
   const onWindowMouseUp = React.useCallback(
@@ -408,13 +410,12 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
         <ModalComponent />
         <ToastRenderer />
         <LockedOverlay />
-        <GithubDataManager />
       </SimpleFlexRow>
     </>
   )
 })
 
-const GithubDataManager = () => {
+const useGithubData = () => {
   const dispatch = useEditorState((store) => store.dispatch, 'Dispatch')
   const { githubAuthenticated, githubRepo, githubOperations } = useEditorState(
     (store) => ({

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -162,18 +162,21 @@ export const GithubPane = React.memo(() => {
   const loadBranchesUI = React.useMemo(() => {
     return (
       <>
-        <UIGridRow padded variant='<----------1fr---------><-auto->'>
-          <span style={{ fontWeight: 500 }}>Branches</span>
-          <Button
-            spotlight
-            highlight
-            style={{ padding: '0 6px' }}
-            onMouseUp={refreshBranches}
-            disabled={githubWorking}
-          >
-            {isLoadingBranches ? <GithubSpinner /> : <RefreshIcon />}
-          </Button>
-        </UIGridRow>
+        {when(
+          storedTargetGithubRepo != null,
+          <UIGridRow padded variant='<----------1fr---------><-auto->'>
+            <span style={{ fontWeight: 500 }}>Branches</span>
+            <Button
+              spotlight
+              highlight
+              style={{ padding: '0 6px' }}
+              onMouseUp={refreshBranches}
+              disabled={githubWorking}
+            >
+              {isLoadingBranches ? <GithubSpinner /> : <RefreshIcon />}
+            </Button>
+          </UIGridRow>,
+        )}
         {when(
           branchesForRepository.length > 0,
           <UIGridRow padded variant='<--------auto-------->|--45px--|'>


### PR DESCRIPTION
Fixes #2758 

**Context:**

This is continues from https://github.com/concrete-utopia/utopia/pull/2762 by adding the background refresh functionality for the Github data (repositories and branches).

**Fix:**

Every 30s, refresh the GH data (if there are no other GH operations happening at the same time).

**Notes:**
- This is done with a dummy component to separate the code pieces a bit since the main component is already _huge_.