### PR TITLE
Reparenting out from the containing component

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -349,6 +349,20 @@ export function getReparentTargetUnified(
         (path) => MetadataUtils.findElementByElementPath(metadata, path),
         reparentSubjects.elements,
       )
+      const containingComponents = selectedElementsMetadata.map((e) =>
+        EP.getContainingComponent(e.elementPath),
+      )
+
+      const containingComponentsUnderMouse = containingComponents.filter((c) =>
+        allElementsUnderPoint.find((p) => EP.pathsEqual(c, p)),
+      )
+
+      const isTargetOutsideOfContainingComponentUnderMouse = containingComponentsUnderMouse.some(
+        (c) => EP.isDescendantOf(c, target),
+      )
+      if (isTargetOutsideOfContainingComponentUnderMouse) {
+        return false
+      }
 
       // TODO BEFORE MERGE consider multiselect!!!!!
       // the current parent should be included in the array of valid targets

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -1003,3 +1003,7 @@ export function getOrderedPathsByDepth(elementPaths: Array<ElementPath>): Array<
 export function emptyStaticElementPathPart(): StaticElementPathPart {
   return [] as unknown as StaticElementPathPart
 }
+
+export function getContainingComponent(path: ElementPath): ElementPath {
+  return dropLastPathPart(path)
+}


### PR DESCRIPTION
Fixes https://github.com/concrete-utopia/utopia/issues/2769

**Problem:**
Make sure that if the drag doesn’t leave the bounds of the original containing component, but we don’t find a suitable target parent, we should never accidentally reparent to ancestor component  / canvas root.

**Fix:**
Added this check to `getReparentTargetUnified` and updated the tests.