### PR TITLE
Allow `string | number` as property value in `SetPropertyCommand`

### DIFF
--- a/editor/src/components/canvas/commands/set-property-command.ts
+++ b/editor/src/components/canvas/commands/set-property-command.ts
@@ -10,14 +10,14 @@ export interface SetProperty extends BaseCommand {
   type: 'SET_PROPERTY'
   element: ElementPath
   property: PropertyPath
-  value: string
+  value: string | number
 }
 
 export function setProperty(
   whenToRun: WhenToRun,
   element: ElementPath,
   property: PropertyPath,
-  value: string,
+  value: string | number,
 ): SetProperty {
   return {
     type: 'SET_PROPERTY',


### PR DESCRIPTION
## Problem:
`SetPropertyCommand` can only be used to set string-values properties. However, numbers are also valid property values in JSX (such as `width: 22` or `gap: 10`). `SetPropertyCommand` cannot be used to set number-valued properties such as these.

## Fix:
Turn `value` on `SetProperty` into `string | number`. Since value is passed to `jsxAttributeValue`, this is well-typed.