### PR TITLE
Turn `gap` into a `CSSNumber`

### DIFF
--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -4086,7 +4086,7 @@ export interface ParsedCSSProperties {
   width: CSSNumber | undefined
   height: CSSNumber | undefined
   flexBasis: CSSNumber | undefined
-  gap: number
+  gap: CSSNumber
 }
 
 export type ParsedCSSPropertiesKeys = keyof ParsedCSSProperties
@@ -4260,7 +4260,10 @@ export const cssEmptyValues: ParsedCSSProperties = {
   flexGrow: 0,
   flexShrink: 1,
   display: 'block',
-  gap: 0,
+  gap: {
+    value: 0,
+    unit: null,
+  },
   width: {
     value: 0,
     unit: null,
@@ -4336,7 +4339,7 @@ export const cssParsers: CSSParsers = {
   flexGrow: parseCSSUnitlessAsNumber,
   flexShrink: parseCSSUnitlessAsNumber,
   display: parseDisplay,
-  gap: parseCSSUnitlessAsNumber,
+  gap: parseCSSLengthPercent,
   width: parseCSSLengthPercent,
   height: parseCSSLengthPercent,
   flexBasis: parseCSSLengthPercent,
@@ -4656,7 +4659,7 @@ interface ParsedLayoutProperties {
   pinBottom: CSSNumber | undefined
   centerY: CSSNumber | undefined
   height: CSSNumber | undefined
-  gapMain: number
+  gapMain: CSSNumber
   flexBasis: CSSNumber | undefined
 }
 
@@ -4669,7 +4672,7 @@ export const layoutEmptyValues: ParsedLayoutProperties = {
   pinBottom: undefined,
   centerY: undefined,
   height: undefined,
-  gapMain: 0,
+  gapMain: { value: 0, unit: null },
   flexBasis: undefined,
 }
 
@@ -4686,7 +4689,7 @@ const layoutParsers: LayoutParsers = {
   pinBottom: parseFramePin,
   centerY: parseFramePin,
   height: parseFramePin,
-  gapMain: isNumberParser,
+  gapMain: parseCSSLengthPercent,
   flexBasis: parseFramePin,
 }
 
@@ -4711,7 +4714,7 @@ const layoutEmptyValuesNew: LayoutPropertyTypes = {
   width: undefined,
   height: undefined,
 
-  gap: 0,
+  gap: { value: 0, unit: null },
   flexBasis: undefined,
 
   left: undefined,
@@ -4728,7 +4731,7 @@ const layoutParsersNew: LayoutParsersNew = {
   width: parseFramePin,
   height: parseFramePin,
 
-  gap: isNumberParser,
+  gap: parseCSSLengthPercent,
   flexBasis: parseFramePin,
 
   left: parseFramePin,
@@ -4745,7 +4748,7 @@ const layoutPrintersNew: LayoutPrintersNew = {
   width: printCSSNumberOrUndefinedAsAttributeValue('px'),
   height: printCSSNumberOrUndefinedAsAttributeValue('px'),
 
-  gap: jsxAttributeValueWithNoComments,
+  gap: printCSSNumberOrUndefinedAsAttributeValue('px'),
   flexBasis: printCSSNumberOrUndefinedAsAttributeValue('px'),
 
   left: printCSSNumberOrUndefinedAsAttributeValue('px'),
@@ -5086,10 +5089,10 @@ export const trivialDefaultValues: ParsedPropertiesWithNonTrivial = {
   pinBottom: undefined,
   centerY: undefined,
   height: undefined,
-  gapMain: 0,
+  gapMain: { value: 0, unit: null },
   flexBasis: undefined,
 
-  gap: 0,
+  gap: { value: 0, unit: null },
 }
 
 export function isTrivialDefaultValue(

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -33,6 +33,7 @@ import {
   printCSSValue,
   cssNumber,
   isTrivialDefaultValue,
+  CSSNumber,
 } from '../../../components/inspector/common/css-utils'
 import { StyleLayoutProp } from '../../../core/layout/layout-helpers-new'
 import { findElementAtPath, MetadataUtils } from '../../../core/model/element-metadata-utils'
@@ -152,6 +153,25 @@ export interface InspectorInfo<T> {
   onSubmitValue: (newTransformedValues: T, transient?: boolean) => void
   onTransientSubmitValue: (newTransformedValues: T) => void
   useSubmitValueFactory: UseSubmitValueFactory<T>
+}
+
+export function useMapInspectorInfoFromCSSNumberToNumber(
+  info: InspectorInfo<CSSNumber>,
+): InspectorInfo<number> {
+  const onSubmitValue = (rawNumber: number, transient?: boolean) =>
+    info.onSubmitValue({ value: rawNumber, unit: info.value.unit }, transient)
+
+  return {
+    value: info.value.value,
+    controlStatus: info.controlStatus,
+    propertyStatus: info.propertyStatus,
+    controlStyles: info.controlStyles,
+    onUnsetValues: info.onUnsetValues,
+    onSubmitValue: onSubmitValue,
+    onTransientSubmitValue: (rawNumber) =>
+      info.onTransientSubmitValue({ value: rawNumber, unit: info.value.unit }),
+    useSubmitValueFactory: useCallbackFactory(info.value.value, onSubmitValue),
+  }
 }
 
 function getSpiedValues<P extends string | number>(

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-subsection.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
 import { FlexWrap } from 'utopia-api/core'
 import { ControlStatus, ControlStyles, getControlStyles } from '../../../common/control-status'
-import { useInspectorLayoutInfo, useInspectorStyleInfo } from '../../../common/property-path-hooks'
+import {
+  useInspectorLayoutInfo,
+  useMapInspectorInfoFromCSSNumberToNumber,
+} from '../../../common/property-path-hooks'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import {
   FlexAlignContentControl,
@@ -12,7 +15,6 @@ import {
   FlexDirectionControl,
   getDirectionAwareLabels,
 } from './flex-container-controls'
-import { PropertyLabel } from '../../../widgets/property-label'
 import { useWrappedEmptyOrUnknownOnSubmitValue } from '../../../../../uuiui'
 
 export const FlexContainerControls = React.memo<{ seeMoreVisible: boolean }>((props) => {
@@ -22,7 +24,7 @@ export const FlexContainerControls = React.memo<{ seeMoreVisible: boolean }>((pr
   const alignItems = useInspectorLayoutInfo('alignItems')
   const alignContent = useInspectorLayoutInfo('alignContent')
   const justifyContent = useInspectorLayoutInfo('justifyContent')
-  const gap = useInspectorLayoutInfo('gap')
+  const gap = useMapInspectorInfoFromCSSNumberToNumber(useInspectorLayoutInfo('gap'))
 
   const {
     justifyFlexStart,

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -133,7 +133,7 @@ export interface LayoutPropertyTypes {
   width: CSSNumber | undefined
   height: CSSNumber | undefined
 
-  gap: number
+  gap: CSSNumber
   flexBasis: CSSNumber | undefined
 
   left: CSSNumber | undefined


### PR DESCRIPTION
## Problem:
We parse `gap` as a `number`, although it has the same grammar as `paddingTop`, `paddingBottom`, `paddingLeft`, `paddingRight` which we represent as `CSSNumber`.

Reference on MDN: [gap](https://developer.mozilla.org/en-US/docs/Web/CSS/gap), [padding](https://developer.mozilla.org/en-US/docs/Web/CSS/padding)

This PR is factored out from https://github.com/concrete-utopia/utopia/pull/2755/, where these changes are necessary to adjust gap values specified in different units (the same way padding controls can be).

## Fix:
Turn `gap` into `CSSNumber` in `ParsedCSSProperties`, and fix the assiciated parsing/printing machinery.

## Commit Details:
- Turn `gap` into `CSSNumber` in `ParsedCSSProperties`
- Update the inspector so it can handle `CSSNumber` valued gap values with the existing controls.
