### PR TITLE
Remove startingTargetParentsToFilterOut from InteractionSession

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
@@ -99,7 +99,6 @@ async function getGuidelineRenderResult(scale: number) {
     ),
     latestMetadata: renderResult.getEditorState().editor.jsxMetadata,
     latestAllElementProps: renderResult.getEditorState().editor.allElementProps,
-    startingTargetParentsToFilterOut: null,
   }
 
   await act(async () => {
@@ -163,7 +162,6 @@ describe('Strategy Fitness', () => {
       ),
       latestMetadata: renderResult.getEditorState().editor.jsxMetadata,
       latestAllElementProps: renderResult.getEditorState().editor.allElementProps,
-      startingTargetParentsToFilterOut: null,
     }
 
     const canvasStrategy = findCanvasStrategy(
@@ -212,7 +210,6 @@ describe('Strategy Fitness', () => {
       ),
       latestMetadata: renderResult.getEditorState().editor.jsxMetadata,
       latestAllElementProps: renderResult.getEditorState().editor.allElementProps,
-      startingTargetParentsToFilterOut: null,
     }
 
     const canvasStrategy = findCanvasStrategy(
@@ -297,7 +294,6 @@ describe('Strategy Fitness', () => {
       ),
       latestMetadata: renderResult.getEditorState().editor.jsxMetadata,
       latestAllElementProps: renderResult.getEditorState().editor.allElementProps,
-      startingTargetParentsToFilterOut: null,
     }
 
     const canvasStrategy = findCanvasStrategy(
@@ -346,7 +342,6 @@ describe('Strategy Fitness', () => {
       ),
       latestMetadata: renderResult.getEditorState().editor.jsxMetadata,
       latestAllElementProps: renderResult.getEditorState().editor.allElementProps,
-      startingTargetParentsToFilterOut: null,
     }
 
     const canvasStrategy = findCanvasStrategy(
@@ -395,7 +390,6 @@ describe('Strategy Fitness', () => {
       ),
       latestMetadata: renderResult.getEditorState().editor.jsxMetadata,
       latestAllElementProps: renderResult.getEditorState().editor.allElementProps,
-      startingTargetParentsToFilterOut: null,
     }
 
     const canvasStrategy = findCanvasStrategy(

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -103,7 +103,6 @@ export interface InteractionSession {
 
   startedAt: number
 
-  startingTargetParentsToFilterOut: ReparentTargetsToFilter | null // FIXME Delete in a follow up PR
   updatedTargetPaths: UpdatedPathMap
   aspectRatioLock: number | null
 }
@@ -116,7 +115,6 @@ export function interactionSession(
   userPreferredStrategy: CanvasStrategyId | null,
   startedAt: number,
   allElementProps: AllElementProps,
-  startingTargetParentsToFilterOut: ReparentTargetsToFilter | null,
   updatedTargetPaths: UpdatedPathMap,
   aspectRatioLock: number | null,
 ): InteractionSession {
@@ -128,7 +126,6 @@ export function interactionSession(
     userPreferredStrategy: userPreferredStrategy,
     startedAt: startedAt,
     latestAllElementProps: allElementProps,
-    startingTargetParentsToFilterOut: startingTargetParentsToFilterOut,
     updatedTargetPaths: updatedTargetPaths,
     aspectRatioLock: aspectRatioLock,
   }
@@ -136,7 +133,7 @@ export function interactionSession(
 
 export type InteractionSessionWithoutMetadata = Omit<
   InteractionSession,
-  'latestMetadata' | 'latestAllElementProps' | 'startingTargetParentsToFilterOut'
+  'latestMetadata' | 'latestAllElementProps'
 >
 
 export interface CommandDescription {

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.spec.tsx
@@ -73,7 +73,6 @@ function dragByPixelsIsApplicable(
     ),
     latestMetadata: null as any, // the strategy does not use this
     latestAllElementProps: null as any, // the strategy does not use this
-    startingTargetParentsToFilterOut: null,
   }
 
   return (

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.tsx
@@ -132,7 +132,6 @@ function dragByPixels(
     ),
     latestMetadata: null as any, // the strategy does not use this
     latestAllElementProps: null as any, // the strategy does not use this
-    startingTargetParentsToFilterOut: null,
   }
 
   const strategyResult = absoluteMoveStrategy(

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-canvas.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-canvas.spec.tsx
@@ -124,7 +124,6 @@ function reparentElement(
     ),
     latestMetadata: null as any, // the strategy does not use this
     latestAllElementProps: null as any, // the strategy does not use this
-    startingTargetParentsToFilterOut: null,
   }
 
   const canvasState = pickCanvasStateFromEditorStateWithMetadata(

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-only-move.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-only-move.spec.tsx
@@ -85,7 +85,6 @@ function dragByPixels(
     ),
     latestMetadata: null as any, // the strategy does not use this
     latestAllElementProps: null as any, // the strategy does not use this
-    startingTargetParentsToFilterOut: null,
   }
 
   const strategyResult = absoluteMoveStrategy(

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.tsx
@@ -191,7 +191,6 @@ function reparentElement(
     ),
     latestMetadata: null as any, // the strategy does not use this
     latestAllElementProps: null as any, // the strategy does not use this
-    startingTargetParentsToFilterOut: null,
   }
 
   const canvasState = pickCanvasStateFromEditorStateWithMetadata(

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -62,7 +62,6 @@ function multiselectResizeElements(
       ...interactionSessionWithoutMetadata,
       latestMetadata: {},
       latestAllElementProps: {},
-      startingTargetParentsToFilterOut: null,
     },
   )!.apply('end-interaction')
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.tsx
@@ -180,7 +180,6 @@ function dragByPixels(
     ),
     latestMetadata: null as any, // the strategy does not use this
     latestAllElementProps: null as any, // the strategy does not use this
-    startingTargetParentsToFilterOut: null,
   }
 
   const strategyResultCommands =

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
@@ -345,14 +345,9 @@ function runTargetStrategiesForFreshlyInsertedElement(
     ),
   }
 
-  const patchedInteractionSession: InteractionSession = {
-    ...interactionSession,
-    startingTargetParentsToFilterOut: null,
-  }
-
   const strategy = reparentStrategyToUse(
     patchedCanvasState,
-    patchedInteractionSession,
+    interactionSession,
     customStrategyState,
   )
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -434,7 +434,6 @@ function runTargetStrategiesForFreshlyInsertedElementToReparent(
     ...interactionSession,
     activeControl: boundingArea(),
     interactionData: patchedInteractionData,
-    startingTargetParentsToFilterOut: null,
   }
 
   const patchedCanvasState: InteractionCanvasState = {
@@ -480,7 +479,6 @@ function runTargetStrategiesForFreshlyInsertedElementToResize(
 
   const patchedInteractionSession: InteractionSession = {
     ...interactionSession,
-    startingTargetParentsToFilterOut: null,
     aspectRatioLock: isImg(insertionSubject.element.name)
       ? insertionSubject.defaultSize.width / insertionSubject.defaultSize.height
       : null,

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-interaction.test-utils.tsx
@@ -57,7 +57,6 @@ export function pressKeys(
     ),
     latestMetadata: metadata,
     latestAllElementProps: null as any,
-    startingTargetParentsToFilterOut: null,
   }
 
   const strategy = strategyFactoryFunction(

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -78,7 +78,6 @@ function createEditorStore(
       ...interactionSession,
       latestMetadata: {},
       latestAllElementProps: {},
-      startingTargetParentsToFilterOut: null,
     }
   }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -206,6 +206,7 @@ import {
   NullableStringKeepDeepEquality,
   NumberKeepDeepEquality,
   NullableNumberKeepDeepEquality,
+  combine9EqualityCalls,
 } from '../../../utils/deep-equality'
 import {
   ElementPathArrayKeepDeepEquality,
@@ -1820,30 +1821,8 @@ export const CanvasControlTypeKeepDeepEquality: KeepDeepEqualityCall<CanvasContr
   return keepDeepEqualityResult(newValue, false)
 }
 
-export const ReparentTargetKeepDeepEquality: KeepDeepEqualityCall<ReparentTarget> =
-  combine4EqualityCalls(
-    (target) => target.shouldReparent,
-    BooleanKeepDeepEquality,
-    (target) => target.newParent,
-    ElementPathKeepDeepEquality,
-    (target) => target.shouldReorder,
-    BooleanKeepDeepEquality,
-    (target) => target.newIndex,
-    NumberKeepDeepEquality,
-    reparentTarget,
-  )
-
-const ReparentTargetsToFilterKeepDeepEquality: KeepDeepEqualityCall<ReparentTargetsToFilter> =
-  combine2EqualityCalls(
-    (target) => target['use-strict-bounds'],
-    nullableDeepEquality(ReparentTargetKeepDeepEquality),
-    (target) => target['allow-missing-bounds'],
-    nullableDeepEquality(ReparentTargetKeepDeepEquality),
-    reparentTargetsToFilter,
-  )
-
 export const InteractionSessionKeepDeepEquality: KeepDeepEqualityCall<InteractionSession> =
-  combine10EqualityCalls(
+  combine9EqualityCalls(
     (session) => session.interactionData,
     InputDataKeepDeepEquality,
     (session) => session.activeControl,
@@ -1858,8 +1837,6 @@ export const InteractionSessionKeepDeepEquality: KeepDeepEqualityCall<Interactio
     createCallWithTripleEquals(),
     (session) => session.latestAllElementProps,
     createCallFromIntrospectiveKeepDeep(),
-    (session) => session.startingTargetParentsToFilterOut,
-    nullableDeepEquality(ReparentTargetsToFilterKeepDeepEquality),
     (session) => session.updatedTargetPaths,
     objectDeepEquality(ElementPathKeepDeepEquality),
     (session) => session.aspectRatioLock,

--- a/editor/src/core/shared/redux-devtools.ts
+++ b/editor/src/core/shared/redux-devtools.ts
@@ -95,8 +95,6 @@ function sanitizeEditor(editor: EditorState) {
         latestMetadata: simplifiedMetadataMap(
           editor.canvas.interactionSession?.latestMetadata ?? {},
         ) as any,
-        startingTargetParentsToFilterOut:
-          editor.canvas.interactionSession?.startingTargetParentsToFilterOut,
       },
     } as Partial<EditorState['canvas']>,
     jsxMetadata: simplifiedMetadataMap(editor.jsxMetadata) as any,

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -472,46 +472,6 @@ export function runLocalCanvasAction(
       const allElementProps =
         model.canvas.interactionSession?.latestAllElementProps ?? model.allElementProps
 
-      const startingTargetParentsToFilterOut: ReparentTargetsToFilter | null =
-        model.canvas.interactionSession?.startingTargetParentsToFilterOut ??
-        (() => {
-          if (action.interactionSession.interactionData.type !== 'DRAG') {
-            return null
-          }
-          const pointOnCanvas = offsetPoint(
-            action.interactionSession.interactionData.originalDragStart,
-            action.interactionSession.interactionData.drag ?? zeroCanvasPoint,
-          )
-
-          const allowSmallerParent = action.interactionSession.interactionData.modifiers.cmd
-            ? 'allow-smaller-parent'
-            : 'disallow-smaller-parent'
-
-          const strictBoundsResult = getReparentTargetUnified(
-            existingReparentSubjects(getDragTargets(model.selectedViews)),
-            pointOnCanvas,
-            action.interactionSession.interactionData.modifiers.cmd,
-            pickCanvasStateFromEditorState(model, builtinDependencies),
-            metadata,
-            allElementProps,
-            'use-strict-bounds',
-            allowSmallerParent,
-          )
-
-          const missingBoundsResult = getReparentTargetUnified(
-            existingReparentSubjects(getDragTargets(model.selectedViews)),
-            pointOnCanvas,
-            action.interactionSession.interactionData.modifiers.cmd,
-            pickCanvasStateFromEditorState(model, builtinDependencies),
-            metadata,
-            allElementProps,
-            'allow-missing-bounds',
-            allowSmallerParent,
-          )
-
-          return reparentTargetsToFilter(strictBoundsResult, missingBoundsResult)
-        })()
-
       return {
         ...model,
         canvas: {
@@ -520,7 +480,6 @@ export function runLocalCanvasAction(
             ...action.interactionSession,
             latestMetadata: metadata,
             latestAllElementProps: allElementProps,
-            startingTargetParentsToFilterOut: startingTargetParentsToFilterOut,
           },
         },
       }


### PR DESCRIPTION
Follow up from #2721 

This PR simply removes the now defunct `startingTargetParentsToFilterOut`