### PR TITLE
fix(canvas) show zero size controls on reparent

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
@@ -16,6 +16,7 @@ import {
   getAdjustMoveCommands,
   getDragTargets,
 } from './shared-move-strategies-helpers'
+import { ZeroSizedElementControls } from '../../controls/zero-sized-element-controls'
 
 export function absoluteMoveStrategy(
   canvasState: InteractionCanvasState,
@@ -52,6 +53,12 @@ export function absoluteMoveStrategy(
         control: ImmediateParentBounds,
         props: { targets: selectedElements },
         key: 'parent-bounds-control',
+        show: 'visible-only-while-active',
+      }),
+      controlWithProps({
+        control: ZeroSizedElementControls,
+        props: { showAllPossibleElements: true },
+        key: 'zero-size-control',
         show: 'visible-only-while-active',
       }),
     ], // Uses existing hooks in select-mode-hooks.tsx

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
@@ -8,6 +8,7 @@ import { setElementsToRerenderCommand } from '../../commands/set-elements-to-rer
 import { updateSelectedViews } from '../../commands/update-selected-views-command'
 import { ParentBounds } from '../../controls/parent-bounds'
 import { ParentOutlines } from '../../controls/parent-outlines'
+import { ZeroSizedElementControls } from '../../controls/zero-sized-element-controls'
 import { CanvasStrategyFactory } from '../canvas-strategies'
 import {
   CanvasStrategy,
@@ -74,6 +75,12 @@ export function baseAbsoluteReparentStrategy(
           control: ParentBounds,
           props: { targetParent: reparentTarget.newParent },
           key: 'parent-bounds-control',
+          show: 'visible-only-while-active',
+        }),
+        controlWithProps({
+          control: ZeroSizedElementControls,
+          props: { showAllPossibleElements: true },
+          key: 'zero-size-control',
           show: 'visible-only-while-active',
         }),
       ],

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
@@ -18,6 +18,7 @@ import {
   DragOutlineControl,
   dragTargetsElementPaths,
 } from '../../controls/select-mode/drag-outline-control'
+import { ZeroSizedElementControls } from '../../controls/zero-sized-element-controls'
 import { CanvasStrategyFactory, pickCanvasStateFromEditorState } from '../canvas-strategies'
 import {
   CanvasStrategy,
@@ -68,6 +69,12 @@ export function baseFlexReparentToAbsoluteStrategy(
           control: ParentBounds,
           props: { targetParent: reparentTarget.newParent },
           key: 'parent-bounds-control',
+          show: 'visible-only-while-active',
+        }),
+        controlWithProps({
+          control: ZeroSizedElementControls,
+          props: { showAllPossibleElements: true },
+          key: 'zero-size-control',
           show: 'visible-only-while-active',
         }),
       ],

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -6,6 +6,7 @@ import {
   dragTargetsElementPaths,
 } from '../../controls/select-mode/drag-outline-control'
 import { FlexReparentTargetIndicator } from '../../controls/select-mode/flex-reparent-target-indicator'
+import { ZeroSizedElementControls } from '../../controls/zero-sized-element-controls'
 import { CanvasStrategyFactory } from '../canvas-strategies'
 import {
   CanvasStrategy,
@@ -61,6 +62,12 @@ export function baseReparentAsStaticStrategy(
           control: FlexReparentTargetIndicator,
           props: {},
           key: 'flex-reparent-target-indicator',
+          show: 'visible-only-while-active',
+        }),
+        controlWithProps({
+          control: ZeroSizedElementControls,
+          props: { showAllPossibleElements: true },
+          key: 'zero-size-control',
           show: 'visible-only-while-active',
         }),
       ],

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -54,6 +54,7 @@ import { CursorComponent } from './select-mode/cursor-component'
 import { ControlForStrategy, ControlWithProps } from '../canvas-strategies/canvas-strategy-types'
 import { useKeepShallowReferenceEquality } from '../../../utils/react-performance'
 import { shallowEqual } from '../../../core/shared/equality-utils'
+import { ZeroSizedElementControls } from './zero-sized-element-controls'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
@@ -437,6 +438,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
           )}
           {when(isFeatureEnabled('Canvas Strategies'), <GuidelineControls />)}
           <OutlineHighlightControl />
+          <ZeroSizedElementControls.control showAllPossibleElements={false} />
           {when(
             isCanvasStrategyOnAndSelectOrInsertMode(props.editor.mode),
             <>

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -496,7 +496,6 @@ export class SelectModeControlContainer extends React.Component<
                   : null
               }
             />
-            <ZeroSizedElementControls targets={this.props.selectedViews} />
           </>
         ) : null}
         {when(isFeatureEnabled('Insertion Plus Button'), <InsertionControls />)}

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -66,19 +66,12 @@ export const ZeroSizedElementControls = controlForStrategyMemoized(
         })
       } else {
         return selectedElements.flatMap((view) => {
-          const siblings = MetadataUtils.getSiblings(store.editor.jsxMetadata, view)
-          return siblings.filter((sibling) => {
-            if (sibling.globalFrame == null) {
+          const children = MetadataUtils.getChildren(store.editor.jsxMetadata, view)
+          return children.filter((child) => {
+            if (child.globalFrame == null) {
               return false
             } else {
-              return (
-                isZeroSizedElement(sibling.globalFrame) &&
-                MetadataUtils.targetElementSupportsChildren(
-                  store.editor.projectContents,
-                  store.editor.canvas.openFile?.filename,
-                  sibling,
-                )
-              )
+              return isZeroSizedElement(child.globalFrame)
             }
           })
         })

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -28,61 +28,83 @@ import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
 import { controlForStrategyMemoized } from '../canvas-strategies/canvas-strategy-types'
 
 interface ZeroSizedElementControlProps {
-  targets: Array<ElementPath>
+  showAllPossibleElements: boolean
 }
 
-const EmptyChildren: ElementInstanceMetadata[] = []
-export const ZeroSizedElementControls = React.memo(({ targets }: ZeroSizedElementControlProps) => {
-  const highlightedViews = useEditorState(
-    (store) => store.editor.highlightedViews,
-    'ZeroSizedElementControls highlightedViews',
-  )
-  const canvasOffset = useEditorState(
-    (store) => store.editor.canvas.realCanvasOffset,
-    'ZeroSizedElementControls canvasOffset',
-  )
-  const scale = useEditorState(
-    (store) => store.editor.canvas.scale,
-    'ZeroSizedElementControls scale',
-  )
-  const dispatch = useEditorState((store) => store.dispatch, 'ZeroSizedElementControls dispatch')
+export const ZeroSizedElementControls = controlForStrategyMemoized(
+  ({ showAllPossibleElements }: ZeroSizedElementControlProps) => {
+    const highlightedViews = useEditorState(
+      (store) => store.editor.highlightedViews,
+      'ZeroSizedElementControls highlightedViews',
+    )
+    const selectedElements = useEditorState(
+      (store) => store.editor.selectedViews,
+      'ZeroSizedElementControls selectedElements',
+    )
+    const canvasOffset = useEditorState(
+      (store) => store.editor.canvas.realCanvasOffset,
+      'ZeroSizedElementControls canvasOffset',
+    )
+    const scale = useEditorState(
+      (store) => store.editor.canvas.scale,
+      'ZeroSizedElementControls scale',
+    )
+    const dispatch = useEditorState((store) => store.dispatch, 'ZeroSizedElementControls dispatch')
 
-  const zeroSizeChildren = useEditorState((store) => {
-    if (store.editor.keysPressed['cmd']) {
-      return targets.flatMap((view) => {
-        const children = MetadataUtils.getChildren(store.editor.jsxMetadata, view)
-        return children.filter((child) => {
-          if (child.globalFrame == null) {
-            return false
-          } else {
-            return isZeroSizedElement(child.globalFrame)
-          }
+    const zeroSizeElements = useEditorState((store) => {
+      if (showAllPossibleElements) {
+        return Object.values(store.editor.jsxMetadata).filter((element) => {
+          return (
+            element.globalFrame != null &&
+            isZeroSizedElement(element.globalFrame) &&
+            MetadataUtils.targetElementSupportsChildren(
+              store.editor.projectContents,
+              store.editor.canvas.openFile?.filename,
+              element,
+            )
+          )
         })
-      })
-    } else {
-      return EmptyChildren
-    }
-  }, 'ZeroSizedElementControls zeroSizeChildren')
+      } else {
+        return selectedElements.flatMap((view) => {
+          const siblings = MetadataUtils.getSiblings(store.editor.jsxMetadata, view)
+          return siblings.filter((sibling) => {
+            if (sibling.globalFrame == null) {
+              return false
+            } else {
+              return (
+                isZeroSizedElement(sibling.globalFrame) &&
+                MetadataUtils.targetElementSupportsChildren(
+                  store.editor.projectContents,
+                  store.editor.canvas.openFile?.filename,
+                  sibling,
+                )
+              )
+            }
+          })
+        })
+      }
+    }, 'ZeroSizedElementControls zeroSizeElements')
 
-  return (
-    <React.Fragment>
-      {zeroSizeChildren.map((element) => {
-        let isHighlighted =
-          highlightedViews.find((view) => EP.pathsEqual(element.elementPath, view)) != null
-        return (
-          <ZeroSizeSelectControl
-            key={`zero-size-element-${EP.toString(element.elementPath)}`}
-            element={element}
-            dispatch={dispatch}
-            canvasOffset={canvasOffset}
-            scale={scale}
-            isHighlighted={isHighlighted}
-          />
-        )
-      })}
-    </React.Fragment>
-  )
-})
+    return (
+      <React.Fragment>
+        {zeroSizeElements.map((element) => {
+          let isHighlighted =
+            highlightedViews.find((view) => EP.pathsEqual(element.elementPath, view)) != null
+          return (
+            <ZeroSizeSelectControl
+              key={`zero-size-element-${EP.toString(element.elementPath)}`}
+              element={element}
+              dispatch={dispatch}
+              canvasOffset={canvasOffset}
+              scale={scale}
+              isHighlighted={isHighlighted}
+            />
+          )
+        })}
+      </React.Fragment>
+    )
+  },
+)
 
 interface ZeroSizeSelectControlProps {
   element: ElementInstanceMetadata
@@ -199,8 +221,12 @@ export const ZeroSizeOutlineControl = React.memo(
   },
 )
 
+interface ZeroSizeResizeControlWrapperProps {
+  targets: Array<ElementPath>
+}
+
 export const ZeroSizeResizeControlWrapper = controlForStrategyMemoized(
-  ({ targets }: ZeroSizedElementControlProps) => {
+  ({ targets }: ZeroSizeResizeControlWrapperProps) => {
     const { maybeHighlightOnHover, maybeClearHighlightsOnHoverEnd } = useMaybeHighlightElement()
     const zeroSizeElements = useEditorState((store) => {
       return mapDropNulls((path) => {

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`404`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`406`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`393`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`395`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`689`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`691`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`761`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`763`)
   })
 })


### PR DESCRIPTION
Fixes #2773

https://utopia.pizza/p/3eb80fb7-shocking-diagnostic/?branch_name=fix-canvas-zero-size-controls

**Problem:**
There is a bug that it's possible to reparent into zero size elements but there are no controls shown before it happens.

**Fix:**
Showing zero size controls on dragging an element and reparenting. All zero size controls are shown that can be reparent targets.

When the element is selected only the children zero size controls are visible.
