### PR TITLE
Detect upstream changes and potential conflicts

### DIFF
--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -997,11 +997,13 @@ export function updateGithubSettings(settings: ProjectGithubSettings): UpdateGit
     settings: settings,
   }
 }
-
 export function updateGithubData(data: Partial<GithubData>): UpdateGithubData {
   return {
     action: 'UPDATE_GITHUB_DATA',
-    data: data,
+    data: {
+      lastUpdatedAt: Date.now(),
+      ...data,
+    },
   }
 }
 

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -401,18 +401,26 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
 
 const useGithubData = (): void => {
   const dispatch = useEditorState((store) => store.dispatch, 'Dispatch')
-  const { githubAuthenticated, githubRepo, githubOperations } = useEditorState(
-    (store) => ({
-      githubAuthenticated: store.userState.githubState.authenticated,
-      githubRepo: store.editor.githubSettings.targetRepository,
-      githubOperations: store.editor.githubOperations,
-    }),
-    'Github data',
-  )
+  const { githubAuthenticated, githubRepo, githubOperations, branchName, githubChecksums } =
+    useEditorState(
+      (store) => ({
+        githubAuthenticated: store.userState.githubState.authenticated,
+        githubRepo: store.editor.githubSettings.targetRepository,
+        githubOperations: store.editor.githubOperations,
+        branchName: store.editor.githubSettings.branchName,
+        githubChecksums: store.editor.githubChecksums,
+      }),
+      'Github data',
+    )
 
   const refresh = React.useCallback(() => {
-    void refreshGithubData(dispatch, { githubAuthenticated, githubRepo })
-  }, [dispatch, githubAuthenticated, githubRepo])
+    void refreshGithubData(dispatch, {
+      githubAuthenticated,
+      githubRepo,
+      branchName,
+      branchChecksums: githubChecksums,
+    })
+  }, [dispatch, githubAuthenticated, githubRepo, branchName, githubChecksums])
 
   // perform a straight refresh then the repo or the auth change
   React.useEffect(() => refresh(), [refresh])

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -163,7 +163,12 @@ import { GuidelineWithSnappingVectorAndPointsOfRelevance } from '../../canvas/gu
 import { MouseButtonsPressed } from '../../../utils/mouse'
 import { UTOPIA_LABEL_KEY } from '../../../core/model/utopia-constants'
 import { FileResult } from '../../../core/shared/file-utils'
-import { GithubBranch, GithubFileStatus, RepositoryEntry } from '../../../core/shared/github'
+import {
+  GithubBranch,
+  GithubFileChanges,
+  GithubFileStatus,
+  RepositoryEntry,
+} from '../../../core/shared/github'
 
 const ObjectPathImmutable: any = OPI
 
@@ -1049,12 +1054,16 @@ export function projectGithubSettings(
 export interface GithubData {
   branches: Array<GithubBranch>
   publicRepositories: Array<RepositoryEntry>
+  lastUpdatedAt: number | null
+  upstreamChanges: GithubFileChanges | null
 }
 
 export function emptyGithubData(): GithubData {
   return {
     branches: [],
     publicRepositories: [],
+    lastUpdatedAt: null,
+    upstreamChanges: null,
   }
 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -453,7 +453,9 @@ import {
   textResult,
 } from '../../../core/shared/file-utils'
 import {
+  emptyGithubFileChanges,
   GithubBranch,
+  GithubFileChanges,
   GithubFileStatus,
   repositoryEntry,
   RepositoryEntry,
@@ -3266,11 +3268,26 @@ export const ProjectGithubSettingsKeepDeepEquality: KeepDeepEqualityCall<Project
     projectGithubSettings,
   )
 
-export const GithubDataKeepDeepEquality: KeepDeepEqualityCall<GithubData> = combine2EqualityCalls(
+export const GithubFileChangesKeepDeepEquality: KeepDeepEqualityCall<GithubFileChanges> =
+  combine3EqualityCalls(
+    (settings) => settings.modified,
+    arrayDeepEquality(StringKeepDeepEquality),
+    (settings) => settings.untracked,
+    arrayDeepEquality(StringKeepDeepEquality),
+    (settings) => settings.deleted,
+    arrayDeepEquality(StringKeepDeepEquality),
+    emptyGithubFileChanges,
+  )
+
+export const GithubDataKeepDeepEquality: KeepDeepEqualityCall<GithubData> = combine4EqualityCalls(
   (data) => data.branches,
   arrayDeepEquality(GithubBranchKeepDeepEquality),
   (data) => data.publicRepositories,
   arrayDeepEquality(RepositoryEntryKeepDeepEquality),
+  (data) => data.lastUpdatedAt,
+  NullableNumberKeepDeepEquality,
+  (data) => data.upstreamChanges,
+  nullableDeepEquality(GithubFileChangesKeepDeepEquality),
   emptyGithubData,
 )
 

--- a/editor/src/components/navigator/left-pane/github-pane/github-file-changes-list.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/github-file-changes-list.tsx
@@ -15,6 +15,7 @@ import * as EditorActions from '../../../editor/actions/action-creators'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { GithubFileStatusLetter } from '../../../filebrowser/fileitem'
 import { UIGridRow } from '../../../inspector/widgets/ui-grid-row'
+import { when } from '../../../../utils/react-conditionals'
 
 export const Ellipsis: React.FC<{
   children: any
@@ -128,20 +129,25 @@ export const GithubFileChangesList: React.FC<{
               cursor: conflicting ? 'help' : 'default',
             }}
           >
-            <UIGridRow padded variant='|--16px--|<--------auto-------->'>
-              <GithubFileStatusLetter status={i.status} />
-              <FlexRow style={{ gap: 2 }}>
-                <Ellipsis>{i.filename}</Ellipsis>
-                {conflicting && <WarningIcon color='error' />}
-              </FlexRow>
-            </UIGridRow>
-            {revertable && (
-              <RevertButton
-                disabled={githubWorking}
-                text='Revert'
-                onMouseUp={handleClickRevertFile(i)}
-              />
-            )}
+            <>
+              <UIGridRow padded variant='|--16px--|<--------auto-------->'>
+                <GithubFileStatusLetter status={i.status} />
+                <FlexRow style={{ gap: 2 }}>
+                  <>
+                    <Ellipsis>{i.filename}</Ellipsis>
+                    {when(conflicting, <WarningIcon color='error' />)}
+                  </>
+                </FlexRow>
+              </UIGridRow>
+              {when(
+                revertable,
+                <RevertButton
+                  disabled={githubWorking}
+                  text='Revert'
+                  onMouseUp={handleClickRevertFile(i)}
+                />,
+              )}
+            </>
           </UIGridRow>
         )
       })}
@@ -157,12 +163,15 @@ const Header: React.FC<{
 }> = ({ count, revertable, githubWorking, onClickRevertAll }) => {
   return (
     <UIGridRow padded variant='<----------1fr---------><-auto->'>
-      <div>
-        {count} file{count !== 1 ? 's' : ''} changed
-      </div>
-      {revertable && (
-        <RevertButton disabled={githubWorking} text='Revert all' onMouseUp={onClickRevertAll} />
-      )}
+      <>
+        <div>
+          {count} file{count !== 1 ? 's' : ''} changed
+        </div>
+        {when(
+          revertable,
+          <RevertButton disabled={githubWorking} text='Revert all' onMouseUp={onClickRevertAll} />,
+        )}
+      </>
     </UIGridRow>
   )
 }

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../../../core/shared/github'
 import { NO_OP } from '../../../../core/shared/utils'
 import { startGithubAuthentication } from '../../../../utils/github-auth'
-import { when } from '../../../../utils/react-conditionals'
+import { unless, when } from '../../../../utils/react-conditionals'
 import {
   Button,
   FlexColumn,
@@ -256,7 +256,6 @@ export const GithubPane = React.memo(() => {
   ])
 
   const githubFileChanges = useEditorState(githubFileChangesSelector, 'Github file changes')
-
   const githubLastUpdatedAt = useEditorState(
     (store) => store.editor.githubData.lastUpdatedAt,
     'Github last updated',
@@ -401,73 +400,74 @@ export const GithubPane = React.memo(() => {
                 changes={githubFileChanges}
                 githubWorking={githubWorking}
               />
+              <UIGridRow padded variant='<-------------1fr------------->'>
+                <Button
+                  spotlight
+                  highlight
+                  disabled={!githubAuthenticated || storedTargetGithubRepo == null || githubWorking}
+                  onMouseUp={triggerSaveToGithub}
+                >
+                  {isGithubCommishing(githubOperations) ? <GithubSpinner /> : 'Save To Github'}
+                </Button>
+              </UIGridRow>
+              <UIGridRow padded variant='<-------------1fr------------->'>
+                <div
+                  style={{
+                    padding: '10px 0',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                  }}
+                >
+                  {when(
+                    hasUpstreamChanges,
+                    <div>
+                      <div
+                        style={{
+                          display: 'flex',
+                          gap: 4,
+                          alignItems: 'center',
+                        }}
+                      >
+                        <FlexRow style={{ gap: 2, color: '#f90' }}>
+                          Upstream:
+                          <FlexRow>
+                            {upstreamChangesCount} file{upstreamChangesCount !== 1 ? 's' : ''}{' '}
+                            changed
+                          </FlexRow>
+                        </FlexRow>
+                      </div>
+                      <GithubFileChangesList
+                        showHeader={false}
+                        revertable={false}
+                        conflicts={bothModified}
+                        changes={upstreamChanges}
+                        githubWorking={githubWorking}
+                      />
+                    </div>,
+                  )}
+                  {unless(hasUpstreamChanges, <span>Upstream: up-to-date.</span>)}
+                  <div style={{ color: '#aaa' }}>
+                    <TimeAgo date={githubLastUpdatedAt || 0} formatter={compactTimeagoFormatter} />
+                  </div>
+                </div>
+                <Button
+                  spotlight
+                  highlight
+                  disabled={!githubAuthenticated || storedTargetGithubRepo == null || githubWorking}
+                  onMouseUp={triggerUpdateAgainstGithub}
+                >
+                  {isGithubUpdating(githubOperations) ? (
+                    <GithubSpinner />
+                  ) : (
+                    <>
+                      {bothModified.length > 0 && <WarningIcon />}
+                      Update Against Github
+                    </>
+                  )}
+                </Button>
+              </UIGridRow>
             </>,
           )}
-          <UIGridRow padded variant='<-------------1fr------------->'>
-            <Button
-              spotlight
-              highlight
-              disabled={!githubAuthenticated || storedTargetGithubRepo == null || githubWorking}
-              onMouseUp={triggerSaveToGithub}
-            >
-              {isGithubCommishing(githubOperations) ? <GithubSpinner /> : 'Save To Github'}
-            </Button>
-          </UIGridRow>
-          <UIGridRow padded variant='<-------------1fr------------->'>
-            <div
-              style={{
-                padding: '10px 0',
-                display: 'flex',
-                justifyContent: 'space-between',
-              }}
-            >
-              {hasUpstreamChanges ? (
-                <div>
-                  <div
-                    style={{
-                      display: 'flex',
-                      gap: 4,
-                      alignItems: 'center',
-                    }}
-                  >
-                    <FlexRow style={{ gap: 2, color: '#f90' }}>
-                      Upstream:
-                      <FlexRow>
-                        {upstreamChangesCount} file{upstreamChangesCount !== 1 ? 's' : ''} changed
-                      </FlexRow>
-                    </FlexRow>
-                  </div>
-                  <GithubFileChangesList
-                    showHeader={false}
-                    revertable={false}
-                    conflicts={bothModified}
-                    changes={upstreamChanges}
-                    githubWorking={githubWorking}
-                  />
-                </div>
-              ) : (
-                <span>Upstream: up-to-date.</span>
-              )}
-              <div style={{ color: '#aaa' }}>
-                <TimeAgo date={githubLastUpdatedAt || 0} formatter={compactTimeagoFormatter} />
-              </div>
-            </div>
-            <Button
-              spotlight
-              highlight
-              disabled={!githubAuthenticated || storedTargetGithubRepo == null || githubWorking}
-              onMouseUp={triggerUpdateAgainstGithub}
-            >
-              {isGithubUpdating(githubOperations) ? (
-                <GithubSpinner />
-              ) : (
-                <>
-                  {bothModified.length > 0 && <WarningIcon />}
-                  Update Against Github
-                </>
-              )}
-            </Button>
-          </UIGridRow>
           {loadBranchesUI}
         </SectionBodyArea>
       </Section>

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -31,6 +31,7 @@ import {
   EditorStorePatched,
   emptyGithubData,
   GithubChecksums,
+  GithubData,
   GithubOperation,
   GithubRepo,
   PersistentModel,
@@ -311,6 +312,7 @@ export async function updateProjectAgainstGithub(
               specificCommitContent.content,
               branchLatestContent.originCommit,
             ),
+            updateGithubData({ upstreamChanges: null }),
             showToast(notice(`Updated the project against the branch ${branchName}.`, 'SUCCESS')),
           ],
           'everyone',
@@ -365,19 +367,25 @@ export async function updateProjectWithBranchContent(
         )
         break
       case 'SUCCESS':
-        const actions: Array<EditorAction> = [
-          updateGithubChecksums(getProjectContentsChecksums(responseBody.content)),
-          updateProjectContents(responseBody.content),
-          updateBranchContents(responseBody.content),
-          updateGithubSettings(
-            projectGithubSettings(githubRepo, responseBody.originCommit, branchName),
-          ),
-          showToast(notice(`Updated the project with the content from ${branchName}`, 'SUCCESS')),
-        ]
-        if (resetBranches) {
-          actions.push(updateGithubData({ branches: [] }))
+        const newGithubData: Partial<GithubData> = {
+          upstreamChanges: null,
         }
-        dispatch(actions, 'everyone')
+        if (resetBranches) {
+          newGithubData.branches = []
+        }
+        dispatch(
+          [
+            updateGithubChecksums(getProjectContentsChecksums(responseBody.content)),
+            updateProjectContents(responseBody.content),
+            updateBranchContents(responseBody.content),
+            updateGithubSettings(
+              projectGithubSettings(githubRepo, responseBody.originCommit, branchName),
+            ),
+            updateGithubData(newGithubData),
+            showToast(notice(`Updated the project with the content from ${branchName}`, 'SUCCESS')),
+          ],
+          'everyone',
+        )
         break
       default:
         const _exhaustiveCheck: never = responseBody


### PR DESCRIPTION
Fixes #2777 

**Problem:**

While you're working on your project, connected to a GH branch, upstream changes may have happened and you should be able to know what changed before hitting the `Update Against Github` button.

**Fix:**

1. Detect upstream changes compared to the original branch contents as part of the GH data refresh
2. If there are changes, display them in the GH pane

| No changes | Upstream changes |
|------------|----------------------|
| ![Screenshot 2022-11-07 at 5 16 39 PM](https://user-images.githubusercontent.com/1081051/200360621-39e69b08-c0bf-4187-8c5c-26aa5f22d25f.png) |   ![Screenshot 2022-11-07 at 5 16 47 PM](https://user-images.githubusercontent.com/1081051/200360654-cdc4fe7e-cbe5-4219-99cc-6e9d0e809a3b.png) |

3. If there are conflicting changes (= both ends altered the same file), show a warning icon

| Warning icons | Tooltip on mouse over |
|---------------|------------------------|
| ![Screenshot 2022-11-07 at 5 16 59 PM](https://user-images.githubusercontent.com/1081051/200360686-9f4d0343-7b0a-4525-80f8-a7068d432a53.png) | ![Screenshot 2022-11-07 at 5 17 10 PM](https://user-images.githubusercontent.com/1081051/200360706-9f6f1200-2830-4005-9106-09a9f4f788e2.png) |