### PR TITLE
When `shift` is held, padding and gap is resized in increments of 10

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -1,8 +1,9 @@
 import { assertNever } from '../../../../core/shared/utils'
-import { cmdModifier } from '../../../../utils/modifiers'
+import { cmdModifier, shiftModifier } from '../../../../utils/modifiers'
 import { wait } from '../../../../utils/utils.test-utils'
 import { EdgePiece } from '../../canvas-types'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
+import { AdjustPrecision } from '../../controls/select-mode/controls-common'
 import {
   paddingControlHandleTestId,
   paddingControlTestId,
@@ -231,27 +232,39 @@ describe('Padding resize strategy', () => {
       'await-first-dom-report',
     )
 
-    await testPaddingResizeForEdge(editor, dragDelta, 'top')
+    await testPaddingResizeForEdge(editor, dragDelta, 'top', 'precise')
     await editor.getDispatchFollowUpActionsFinished()
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
       makeTestProjectCodeWithStringPaddingValues('8.3em 1em 3em 2em'),
     )
   })
 
-  describe('Adjusting individual padding values', () => {
+  describe('Adjusting individual padding values, precise', () => {
     // the expect is in `testAdjustIndividualPaddingValue`
     // eslint-disable-next-line jest/expect-expect
-    it('top', async () => testAdjustIndividualPaddingValue('top'))
+    it('top', async () => testAdjustIndividualPaddingValue('top', 'precise'))
     // eslint-disable-next-line jest/expect-expect
-    it('bottom', async () => testAdjustIndividualPaddingValue('top'))
+    it('bottom', async () => testAdjustIndividualPaddingValue('top', 'precise'))
     // eslint-disable-next-line jest/expect-expect
-    it('left', async () => testAdjustIndividualPaddingValue('top'))
+    it('left', async () => testAdjustIndividualPaddingValue('top', 'precise'))
     // eslint-disable-next-line jest/expect-expect
-    it('right', async () => testAdjustIndividualPaddingValue('top'))
+    it('right', async () => testAdjustIndividualPaddingValue('top', 'precise'))
+  })
+
+  describe('Adjusting individual padding values, coarse', () => {
+    // the expect is in `testAdjustIndividualPaddingValue`
+    // eslint-disable-next-line jest/expect-expect
+    it('top', async () => testAdjustIndividualPaddingValue('top', 'coarse'))
+    // eslint-disable-next-line jest/expect-expect
+    it('bottom', async () => testAdjustIndividualPaddingValue('top', 'coarse'))
+    // eslint-disable-next-line jest/expect-expect
+    it('left', async () => testAdjustIndividualPaddingValue('top', 'coarse'))
+    // eslint-disable-next-line jest/expect-expect
+    it('right', async () => testAdjustIndividualPaddingValue('top', 'coarse'))
   })
 })
 
-async function testAdjustIndividualPaddingValue(edge: EdgePiece) {
+async function testAdjustIndividualPaddingValue(edge: EdgePiece, precision: AdjustPrecision) {
   const padding: CSSPaddingMeasurements = {
     paddingTop: defaultPaddingMeasurement(22),
     paddingBottom: defaultPaddingMeasurement(33),
@@ -264,11 +277,11 @@ async function testAdjustIndividualPaddingValue(edge: EdgePiece) {
     'await-first-dom-report',
   )
 
-  await testPaddingResizeForEdge(editor, dragDelta, edge)
+  await testPaddingResizeForEdge(editor, dragDelta, edge, precision)
   await editor.getDispatchFollowUpActionsFinished()
   expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
     makeTestProjectCodeWithStringPaddingValues(
-      paddingToPaddingString(offsetPaddingByEdge(edge, dragDelta, padding)),
+      paddingToPaddingString(offsetPaddingByEdge(edge, dragDelta, padding, precision)),
     ),
   )
 }
@@ -277,6 +290,7 @@ async function testPaddingResizeForEdge(
   editor: EditorRenderResult,
   delta: number,
   edge: EdgePiece,
+  precision: AdjustPrecision,
 ) {
   const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
   const div = editor.renderedDOM.getByTestId('mydiv')
@@ -297,7 +311,8 @@ async function testPaddingResizeForEdge(
   }
   const endPoint = offsetPointByEdge(edge, delta, center)
 
-  mouseDragFromPointToPoint(paddingControl, center, endPoint)
+  const modifiers = precision === 'coarse' ? shiftModifier : undefined
+  mouseDragFromPointToPoint(paddingControl, center, endPoint, { modifiers })
   await editor.getDispatchFollowUpActionsFinished()
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -36,7 +36,10 @@ import {
 import { InteractionSession } from '../interaction-state'
 import { getDragTargets, getMultiselectBounds } from './shared-move-strategies-helpers'
 import { canvasPoint, CanvasPoint, CanvasVector } from '../../../../core/shared/math-utils'
-import { offsetMeasurementByDelta } from '../../controls/select-mode/controls-common'
+import {
+  offsetMeasurementByDelta,
+  precisionFromModifiers,
+} from '../../controls/select-mode/controls-common'
 
 const StylePaddingProp = stylePropPathMappingFn('padding', ['style'])
 const IndividualPaddingProps: Array<keyof ParsedCSSProperties> = [
@@ -138,7 +141,12 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
       const padding = simplePaddingFromMetadata(canvasState.startingMetadata, selectedElement)
       const currentPadding = paddingForEdge(edgePiece, padding)
       const delta = Math.max(-currentPadding, deltaFromEdge(drag, edgePiece))
-      const newPadding = offsetPaddingByEdge(edgePiece, delta, padding)
+      const newPadding = offsetPaddingByEdge(
+        edgePiece,
+        delta,
+        padding,
+        precisionFromModifiers(interactionSession.interactionData.modifiers),
+      )
       const paddingString = paddingToPaddingString(newPadding)
 
       return strategyApplicationResult([
@@ -231,6 +239,7 @@ function paddingValueIndicatorProps(
   const updatedPaddingMeasurement = offsetMeasurementByDelta(
     currentPadding,
     deltaFromEdge(drag, edgePiece),
+    precisionFromModifiers(interactionSession.interactionData.modifiers),
   )
 
   return {

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -41,8 +41,13 @@ export const offsetMeasurementByDelta = (
     measurement.value.value + deltaInUnits,
     precision,
   )
+  const newRenderedValuePx = valueWithUnitAppropriatePrecision(
+    'px',
+    newValueInPixels / pixelsPerUnit,
+    precision,
+  )
   return {
-    renderedValuePx: Math.floor(newValueInPixels / pixelsPerUnit),
+    renderedValuePx: newRenderedValuePx,
     value: {
       unit: measurement.value.unit,
       value: newValueRounded,

--- a/editor/src/components/canvas/padding-utils.tsx
+++ b/editor/src/components/canvas/padding-utils.tsx
@@ -8,6 +8,7 @@ import { assertNever } from '../../core/shared/utils'
 import { CSSNumber, CSSPadding } from '../inspector/common/css-utils'
 import { EdgePiece } from './canvas-types'
 import {
+  AdjustPrecision,
   CSSNumberWithRenderedValue,
   offsetMeasurementByDelta,
 } from './controls/select-mode/controls-common'
@@ -170,16 +171,29 @@ export function offsetPaddingByEdge(
   edge: EdgePiece,
   delta: number,
   padding: CSSPaddingMeasurements,
+  precision: AdjustPrecision,
 ): CSSPaddingMeasurements {
   switch (edge) {
     case 'bottom':
-      return { ...padding, paddingBottom: offsetMeasurementByDelta(padding.paddingBottom, delta) }
+      return {
+        ...padding,
+        paddingBottom: offsetMeasurementByDelta(padding.paddingBottom, delta, precision),
+      }
     case 'top':
-      return { ...padding, paddingTop: offsetMeasurementByDelta(padding.paddingTop, delta) }
+      return {
+        ...padding,
+        paddingTop: offsetMeasurementByDelta(padding.paddingTop, delta, precision),
+      }
     case 'left':
-      return { ...padding, paddingLeft: offsetMeasurementByDelta(padding.paddingLeft, delta) }
+      return {
+        ...padding,
+        paddingLeft: offsetMeasurementByDelta(padding.paddingLeft, delta, precision),
+      }
     case 'right':
-      return { ...padding, paddingRight: offsetMeasurementByDelta(padding.paddingRight, delta) }
+      return {
+        ...padding,
+        paddingRight: offsetMeasurementByDelta(padding.paddingRight, delta, precision),
+      }
     default:
       assertNever(edge)
   }


### PR DESCRIPTION
![padd_rounded](https://user-images.githubusercontent.com/16385508/200589078-0f4c50e4-106d-45f5-8a1c-3f0cd0be0a65.gif)


## Problem:
Figma supports adjusting gaps and padding while `shift` is held, in which case the values are adjusted in increments of 10.

## Fix:
Add a new type which signals whether the adjustment is `precise` or `coarse`, and pass this down to the relevant calculations.

**Commit Details:**
- Renamed `thing` to `otherThing`
- Removed `cake` from `fridge-contents.ts`
- Did [other things]
