### PR TITLE
Remove the whenToRun param from setCursorCommand

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.tsx
@@ -112,7 +112,7 @@ export function absoluteDuplicateStrategy(
                 withDuplicatedMetadata,
               ),
             ),
-            setCursorCommand('mid-interaction', CSSCursor.Duplicate),
+            setCursorCommand(CSSCursor.Duplicate),
           ],
           {
             duplicatedElementNewUids: duplicatedElementNewUids,
@@ -120,7 +120,7 @@ export function absoluteDuplicateStrategy(
         )
       } else {
         // Fallback for when the checks above are not satisfied.
-        return strategyApplicationResult([setCursorCommand('mid-interaction', CSSCursor.Duplicate)])
+        return strategyApplicationResult([setCursorCommand(CSSCursor.Duplicate)])
       }
     },
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
@@ -158,7 +158,7 @@ export function baseAbsoluteReparentStrategy(
                 ...commands.flatMap((c) => c.commands),
                 updateSelectedViews('always', newPaths),
                 setElementsToRerenderCommand([...newPaths, ...filteredSelectedElements]),
-                setCursorCommand('mid-interaction', CSSCursor.Move),
+                setCursorCommand(CSSCursor.Move),
               ])
             } else {
               const moveCommands =

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -189,13 +189,13 @@ export function absoluteResizeBoundingBoxStrategy(
             return strategyApplicationResult([
               ...commandsForSelectedElements,
               updateHighlightedViews('mid-interaction', []),
-              setCursorCommand('mid-interaction', pickCursorFromEdgePosition(edgePosition)),
+              setCursorCommand(pickCursorFromEdgePosition(edgePosition)),
               setElementsToRerenderCommand(selectedElements),
             ])
           }
         } else {
           return strategyApplicationResult([
-            setCursorCommand('mid-interaction', pickCursorFromEdgePosition(edgePosition)),
+            setCursorCommand(pickCursorFromEdgePosition(edgePosition)),
             updateHighlightedViews('mid-interaction', []),
           ])
         }

--- a/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.tsx
@@ -95,7 +95,7 @@ export function ancestorMetaStrategy(
           apply: appendCommandsToApplyResult(s.apply, [
             appendElementsToRerenderCommand([target]),
             highlightElementsCommand([parentPath]),
-            setCursorCommand('mid-interaction', CSSCursor.MovingMagic),
+            setCursorCommand(CSSCursor.MovingMagic),
           ]),
         })),
       )

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
@@ -210,7 +210,7 @@ function dragToInsertStrategyFactory(
       ) {
         if (insertionSubjects.length === 0) {
           return strategyApplicationResult(
-            [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
+            [setCursorCommand(CSSCursor.NotPermitted)],
             {},
             'failure',
           )

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
@@ -194,13 +194,13 @@ export function flexResizeBasicStrategy(
           return strategyApplicationResult([
             ...resizeCommands,
             updateHighlightedViews('mid-interaction', []),
-            setCursorCommand('mid-interaction', pickCursorFromEdgePosition(edgePosition)),
+            setCursorCommand(pickCursorFromEdgePosition(edgePosition)),
             setElementsToRerenderCommand(selectedElements),
           ])
         } else {
           return strategyApplicationResult([
             updateHighlightedViews('mid-interaction', []),
-            setCursorCommand('mid-interaction', pickCursorFromEdgePosition(edgePosition)),
+            setCursorCommand(pickCursorFromEdgePosition(edgePosition)),
           ])
         }
       }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reorder-slider-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reorder-slider-strategy.tsx
@@ -77,7 +77,7 @@ export function reorderSliderStategy(
 
         if (!isReorderAllowed(siblingsOfTarget)) {
           return strategyApplicationResult(
-            [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
+            [setCursorCommand(CSSCursor.NotPermitted)],
             {},
             'failure',
           )
@@ -105,7 +105,7 @@ export function reorderSliderStategy(
                 canvasState.interactionTarget,
                 canvasState.startingMetadata,
               ),
-              setCursorCommand('mid-interaction', CSSCursor.ResizeEW),
+              setCursorCommand(CSSCursor.ResizeEW),
             ],
             {
               lastReorderIdx: newIndex,
@@ -113,9 +113,7 @@ export function reorderSliderStategy(
           )
         } else {
           // Fallback for when the checks above are not satisfied.
-          return strategyApplicationResult([
-            setCursorCommand('mid-interaction', CSSCursor.ResizeEW),
-          ])
+          return strategyApplicationResult([setCursorCommand(CSSCursor.ResizeEW)])
         }
       } else {
         return emptyStrategyApplicationResult

--- a/editor/src/components/canvas/canvas-strategies/strategies/reorder-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reorder-utils.ts
@@ -55,11 +55,7 @@ export function applyReorderCommon(
     )
 
     if (!isReorderAllowed(siblings)) {
-      return strategyApplicationResult(
-        [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
-        {},
-        'failure',
-      )
+      return strategyApplicationResult([setCursorCommand(CSSCursor.NotPermitted)], {}, 'failure')
     }
 
     const pointOnCanvas = offsetPoint(
@@ -86,7 +82,7 @@ export function applyReorderCommon(
         [
           updateHighlightedViews('mid-interaction', []),
           setElementsToRerenderCommand(siblings),
-          setCursorCommand('mid-interaction', CSSCursor.Move),
+          setCursorCommand(CSSCursor.Move),
         ],
         {
           lastReorderIdx: newResultOrLastIndex,
@@ -98,7 +94,7 @@ export function applyReorderCommon(
           reorderElement('always', target, absolute(newResultOrLastIndex)),
           setElementsToRerenderCommand(siblings),
           updateHighlightedViews('mid-interaction', []),
-          setCursorCommand('mid-interaction', CSSCursor.Move),
+          setCursorCommand(CSSCursor.Move),
         ],
         {
           lastReorderIdx: newResultOrLastIndex,
@@ -107,7 +103,7 @@ export function applyReorderCommon(
     }
   } else {
     // Fallback for when the checks above are not satisfied.
-    return strategyApplicationResult([setCursorCommand('mid-interaction', CSSCursor.Move)])
+    return strategyApplicationResult([setCursorCommand(CSSCursor.Move)])
   }
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers.ts
@@ -68,10 +68,6 @@ export function ifAllowedToReparent(
   if (allowed) {
     return ifAllowed()
   } else {
-    return strategyApplicationResult(
-      [setCursorCommand('mid-interaction', CSSCursor.NotPermitted)],
-      {},
-      'failure',
-    )
+    return strategyApplicationResult([setCursorCommand(CSSCursor.NotPermitted)], {}, 'failure')
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -815,7 +815,7 @@ export function applyStaticReparent(
               ...propertyChangeCommands,
               setElementsToRerenderCommand([target, newPath]),
               updateHighlightedViews('mid-interaction', []),
-              setCursorCommand('mid-interaction', CSSCursor.Move),
+              setCursorCommand(CSSCursor.Move),
             ]
 
             function midInteractionCommandsForTarget(): Array<CanvasCommand> {

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
@@ -118,7 +118,7 @@ export const setFlexGapStrategy: CanvasStrategyFactory = (
           StyleGapProp,
           printCSSNumber(updatedFlexGapMeasurement.value, null),
         ),
-        setCursorCommand('always', cursorFromFlexDirection(flexGap.direction)),
+        setCursorCommand(cursorFromFlexDirection(flexGap.direction)),
         setElementsToRerenderCommand([...selectedElements, ...children]),
       ])
     },

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -128,7 +128,7 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
 
       if (originalBoundingBox == null || filteredSelectedElements.length !== 1) {
         return strategyApplicationResult([
-          setCursorCommand('mid-interaction', pickCursorFromEdge(edgePiece)),
+          setCursorCommand(pickCursorFromEdge(edgePiece)),
           updateHighlightedViews('mid-interaction', []),
         ])
       }
@@ -147,7 +147,7 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
         ),
         setProperty('always', selectedElement, StylePaddingProp, paddingString),
         updateHighlightedViews('mid-interaction', []),
-        setCursorCommand('mid-interaction', pickCursorFromEdge(edgePiece)),
+        setCursorCommand(pickCursorFromEdge(edgePiece)),
         setElementsToRerenderCommand(selectedElements),
       ])
     },

--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
@@ -115,7 +115,7 @@ export function applyMoveCommon(
         pushIntendedBounds(commandsForSelectedElements.intendedBounds),
         updateHighlightedViews('mid-interaction', []),
         setElementsToRerenderCommand(selectedElements),
-        setCursorCommand('mid-interaction', CSSCursor.Select),
+        setCursorCommand(CSSCursor.Select),
       ])
     } else {
       const constrainedDragAxis =
@@ -144,7 +144,7 @@ export function applyMoveCommon(
         setSnappingGuidelines('mid-interaction', guidelinesWithSnappingVector),
         pushIntendedBounds(commandsForSelectedElements.intendedBounds),
         setElementsToRerenderCommand([...selectedElements, ...targetsForSnapping]),
-        setCursorCommand('mid-interaction', CSSCursor.Select),
+        setCursorCommand(CSSCursor.Select),
       ])
     }
   } else {

--- a/editor/src/components/canvas/commands/set-cursor-command.ts
+++ b/editor/src/components/canvas/commands/set-cursor-command.ts
@@ -7,10 +7,10 @@ export interface SetCursorCommand extends BaseCommand {
   value: CSSCursor | null
 }
 
-export function setCursorCommand(whenToRun: WhenToRun, value: CSSCursor | null): SetCursorCommand {
+export function setCursorCommand(value: CSSCursor | null): SetCursorCommand {
   return {
     type: 'SET_CURSOR_COMMAND',
-    whenToRun: whenToRun,
+    whenToRun: 'mid-interaction',
     value: value,
   }
 }


### PR DESCRIPTION
Fixes #2786

**Problem:**
The `setCursorCommand` should not support a `whenToRun` param, as it should only be used mid-interaction

**Fix:**
Remove the `whenToRun` param, so that it is only ever run `'mid-interaction'`