### PR TITLE
Surface tree conflicts.

### DIFF
--- a/editor/src/components/assets.spec.ts
+++ b/editor/src/components/assets.spec.ts
@@ -1,13 +1,7 @@
 import * as FastCheck from 'fast-check'
-import { directory, imageFile, isDirectory } from '../core/model/project-file-utils'
-import {
-  TextFile,
-  Directory,
-  ImageFile,
-  ProjectContents,
-  ProjectFile,
-  codeFile,
-} from '../core/shared/project-file-types'
+import fastDeepEquals from 'fast-deep-equal'
+import { directory, isDirectory } from '../core/model/project-file-utils'
+import { codeFile, ProjectContents } from '../core/shared/project-file-types'
 import {
   contentsToTree,
   projectContentDirectory,
@@ -15,72 +9,7 @@ import {
   ProjectContentTreeRoot,
   treeToContents,
 } from './assets'
-import fastDeepEquals from 'fast-deep-equal'
-
-function codeFileArbitrary(): FastCheck.Arbitrary<TextFile> {
-  return FastCheck.string().map((content) => codeFile(content, null))
-}
-
-function remoteImageFileArbitrary(): FastCheck.Arbitrary<ImageFile> {
-  return FastCheck.constant(imageFile(undefined, undefined, 100, 100, 123456))
-}
-
-function localImageFileArbitrary(): FastCheck.Arbitrary<ImageFile> {
-  return FastCheck.tuple(FastCheck.string(), FastCheck.string()).map(([imageType, base64]) =>
-    imageFile(imageType, base64, 100, 100, 123456),
-  )
-}
-
-function notDirectoryContentFileArbitrary(): FastCheck.Arbitrary<TextFile | ImageFile> {
-  return FastCheck.oneof<TextFile | ImageFile>(
-    codeFileArbitrary(),
-    remoteImageFileArbitrary(),
-    localImageFileArbitrary(),
-  )
-}
-
-function directoryContentFileArbitrary(): FastCheck.Arbitrary<Directory> {
-  return FastCheck.constant(directory())
-}
-
-function pathArbitrary(): FastCheck.Arbitrary<string> {
-  return FastCheck.array(
-    FastCheck.stringOf(
-      FastCheck.char().filter((char) => char !== '/'),
-      1,
-      30,
-    ),
-    1,
-    5,
-  ).map((arr) => {
-    return `/${arr.join('/')}`
-  })
-}
-
-function projectContentsFilter(projectContents: ProjectContents): boolean {
-  const allKeys = Object.keys(projectContents)
-  for (const key of allKeys) {
-    const pathElements = key.split('/')
-    for (let size = 1; size < pathElements.length; size++) {
-      const subPath = pathElements.slice(0, size).join('/')
-      const possibleContent = projectContents[subPath]
-      if (possibleContent != null && !isDirectory(possibleContent)) {
-        return false
-      }
-    }
-  }
-  return true
-}
-
-function projectContentsArbitrary(): FastCheck.Arbitrary<ProjectContents> {
-  return FastCheck.dictionary<ProjectFile>(
-    pathArbitrary(),
-    FastCheck.oneof<ProjectFile>(
-      notDirectoryContentFileArbitrary(),
-      directoryContentFileArbitrary(),
-    ),
-  ).filter(projectContentsFilter)
-}
+import { projectContentsArbitrary } from './assets.test-utils'
 
 function checkContentsToTree(contents: ProjectContents): boolean {
   const result = treeToContents(contentsToTree(contents))

--- a/editor/src/components/assets.test-utils.ts
+++ b/editor/src/components/assets.test-utils.ts
@@ -1,0 +1,139 @@
+import * as FastCheck from 'fast-check'
+import { directory, imageFile, isDirectory } from '../core/model/project-file-utils'
+import {
+  TextFile,
+  Directory,
+  ImageFile,
+  ProjectContents,
+  ProjectFile,
+  codeFile,
+  AssetFile,
+  assetFile,
+} from '../core/shared/project-file-types'
+import {
+  ProjectContentDirectory,
+  projectContentDirectory,
+  ProjectContentFile,
+  projectContentFile,
+  ProjectContentsTree,
+  ProjectContentTreeRoot,
+} from './assets'
+
+export function codeFileArbitrary(): FastCheck.Arbitrary<TextFile> {
+  return FastCheck.string().map((content) => codeFile(content, null))
+}
+
+export function remoteImageFileArbitrary(): FastCheck.Arbitrary<ImageFile> {
+  return FastCheck.constant(imageFile(undefined, undefined, 100, 100, 123456))
+}
+
+export function localImageFileArbitrary(): FastCheck.Arbitrary<ImageFile> {
+  return FastCheck.tuple(FastCheck.string(), FastCheck.string()).map(([imageType, base64]) =>
+    imageFile(imageType, base64, 100, 100, 123456),
+  )
+}
+
+export function assetFileArbitrary(): FastCheck.Arbitrary<AssetFile> {
+  return FastCheck.tuple(
+    FastCheck.oneof<string | undefined>(FastCheck.constant(undefined), FastCheck.asciiString()),
+    FastCheck.oneof<string | undefined>(FastCheck.constant(undefined), FastCheck.asciiString()),
+  ).map(([base64, gitBlobSha]) => {
+    return assetFile(base64, gitBlobSha)
+  })
+}
+
+export function notDirectoryContentFileArbitrary(): FastCheck.Arbitrary<
+  TextFile | ImageFile | AssetFile
+> {
+  return FastCheck.oneof<TextFile | ImageFile | AssetFile>(
+    codeFileArbitrary(),
+    remoteImageFileArbitrary(),
+    localImageFileArbitrary(),
+    assetFileArbitrary(),
+  )
+}
+
+export function directoryContentFileArbitrary(): FastCheck.Arbitrary<Directory> {
+  return FastCheck.constant(directory())
+}
+
+export function pathArbitrary(): FastCheck.Arbitrary<string> {
+  return FastCheck.array(
+    FastCheck.stringOf(
+      FastCheck.char().filter((char) => char !== '/'),
+      1,
+      30,
+    ),
+    1,
+    5,
+  ).map((arr) => {
+    return `/${arr.join('/')}`
+  })
+}
+
+function projectContentsFilter(projectContents: ProjectContents): boolean {
+  const allKeys = Object.keys(projectContents)
+  for (const key of allKeys) {
+    const pathElements = key.split('/')
+    for (let size = 1; size < pathElements.length; size++) {
+      const subPath = pathElements.slice(0, size).join('/')
+      const possibleContent = projectContents[subPath]
+      if (possibleContent != null && !isDirectory(possibleContent)) {
+        return false
+      }
+    }
+  }
+  return true
+}
+
+export function projectContentsArbitrary(): FastCheck.Arbitrary<ProjectContents> {
+  return FastCheck.dictionary<ProjectFile>(
+    pathArbitrary(),
+    FastCheck.oneof<ProjectFile>(
+      notDirectoryContentFileArbitrary(),
+      directoryContentFileArbitrary(),
+    ),
+  ).filter(projectContentsFilter)
+}
+
+export function projectContentFileArbitrary(): FastCheck.Arbitrary<ProjectContentFile> {
+  return FastCheck.tuple(pathArbitrary(), notDirectoryContentFileArbitrary()).map(
+    ([fullPath, content]) => {
+      return projectContentFile(fullPath, content)
+    },
+  )
+}
+
+export function projectContentDirectoryArbitrary(
+  depth: number = 3,
+): FastCheck.Arbitrary<ProjectContentDirectory> {
+  return FastCheck.tuple(
+    pathArbitrary(),
+    directoryContentFileArbitrary(),
+    projectContentTreeRootArbitrary(depth - 1),
+  ).map(([fullPath, dir, children]) => {
+    return projectContentDirectory(fullPath, dir, children)
+  })
+}
+
+export function projectContentTreeRootArbitrary(
+  depth: number = 3,
+): FastCheck.Arbitrary<ProjectContentTreeRoot> {
+  return FastCheck.dictionary<ProjectContentsTree>(
+    pathArbitrary(),
+    projectContentsTreeArbitrary(depth),
+  )
+}
+
+export function projectContentsTreeArbitrary(
+  depth: number = 3,
+): FastCheck.Arbitrary<ProjectContentsTree> {
+  if (depth > 1) {
+    return FastCheck.oneof<ProjectContentsTree>(
+      projectContentDirectoryArbitrary(depth),
+      projectContentFileArbitrary(),
+    )
+  } else {
+    return projectContentFileArbitrary()
+  }
+}

--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -77,9 +77,7 @@ export function deriveGithubFileChanges(
   let untracked: Array<string> = []
   let modified: Array<string> = []
   let deleted: Array<string> = []
-  let conflicted: Array<string> = []
-
-  conflicted = Object.keys(treeConflicts)
+  const conflicted: Array<string> = Object.keys(treeConflicts)
   const conflictedSet = new Set(conflicted)
 
   projectFiles.forEach((f) => {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -5019,17 +5019,27 @@ export const UPDATE_FNS = {
       githubSettings.branchName != null &&
       githubSettings.originCommit != null
     ) {
-      const updatedProjectContents = mergeProjectContents(
+      const mergeResults = mergeProjectContents(
+        Date.now(),
         editor.projectContents,
         action.specificCommitContent,
         action.branchLatestContent,
       )
+      // If there are conflicts, then don't update the origin commit so we can try again.
+      const newOriginCommit =
+        Object.keys(mergeResults.treeConflicts).length > 0
+          ? githubSettings.originCommit
+          : action.latestCommit
       return {
         ...editor,
-        projectContents: updatedProjectContents,
+        projectContents: mergeResults.value,
         githubSettings: {
           ...githubSettings,
-          originCommit: action.latestCommit,
+          originCommit: newOriginCommit,
+        },
+        githubData: {
+          ...editor.githubData,
+          treeConflicts: mergeResults.treeConflicts,
         },
       }
     } else {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -163,7 +163,12 @@ import { GuidelineWithSnappingVectorAndPointsOfRelevance } from '../../canvas/gu
 import { MouseButtonsPressed } from '../../../utils/mouse'
 import { UTOPIA_LABEL_KEY } from '../../../core/model/utopia-constants'
 import { FileResult } from '../../../core/shared/file-utils'
-import { GithubBranch, GithubFileStatus, RepositoryEntry } from '../../../core/shared/github'
+import {
+  GithubBranch,
+  GithubFileStatus,
+  RepositoryEntry,
+  TreeConflicts,
+} from '../../../core/shared/github'
 
 const ObjectPathImmutable: any = OPI
 
@@ -1049,12 +1054,14 @@ export function projectGithubSettings(
 export interface GithubData {
   branches: Array<GithubBranch>
   publicRepositories: Array<RepositoryEntry>
+  treeConflicts: TreeConflicts
 }
 
 export function emptyGithubData(): GithubData {
   return {
     branches: [],
     publicRepositories: [],
+    treeConflicts: {},
   }
 }
 

--- a/editor/src/core/shared/github.spec.ts
+++ b/editor/src/core/shared/github.spec.ts
@@ -9,6 +9,7 @@ import {
 import * as FastCheck from 'fast-check'
 import { projectContentFile, ProjectContentsTree } from '../../components/assets'
 import {
+  codeFile,
   imageFile,
   RevisionsState,
   textFile,
@@ -106,41 +107,15 @@ describe('mergeProjectContentsTree', () => {
     FastCheck.assert(property, { verbose: true })
   })
   it('should return the current contents when a change only exists for that', () => {
-    const originContents = projectContentFile(
-      '/myfile.txt',
-      textFile(
-        textFileContents('origin code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
-    )
+    const originContents = projectContentFile('/myfile.txt', codeFile('origin code', null, 1000000))
     const currentContents = projectContentFile(
       '/myfile.txt',
-      textFile(
-        textFileContents('current code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
+      codeFile('current code', null, 1000000),
     )
-    const branchContents = projectContentFile(
-      '/myfile.txt',
-      textFile(
-        textFileContents('origin code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
-    )
+    const branchContents = projectContentFile('/myfile.txt', codeFile('origin code', null, 1000000))
     const mergedContents = projectContentFile(
       '/myfile.txt',
-      textFile(
-        textFileContents('current code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        2000000,
-      ),
+      codeFile('current code', null, 2000000),
     )
     const actualResult = mergeProjectContentsTree(
       2000000,
@@ -153,42 +128,13 @@ describe('mergeProjectContentsTree', () => {
     expect(actualResult.treeConflicts).toEqual({})
   })
   it('should return the branch contents when a change only exists for that', () => {
-    const originContents = projectContentFile(
-      '/myfile.txt',
-      textFile(
-        textFileContents('origin code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
-    )
+    const originContents = projectContentFile('/myfile.txt', codeFile('origin code', null, 1000000))
     const currentContents = projectContentFile(
       '/myfile.txt',
-      textFile(
-        textFileContents('origin code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
+      codeFile('origin code', null, 1000000),
     )
-    const branchContents = projectContentFile(
-      '/myfile.txt',
-      textFile(
-        textFileContents('branch code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
-    )
-    const mergedContents = projectContentFile(
-      '/myfile.txt',
-      textFile(
-        textFileContents('branch code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        2000000,
-      ),
-    )
+    const branchContents = projectContentFile('/myfile.txt', codeFile('branch code', null, 1000000))
+    const mergedContents = projectContentFile('/myfile.txt', codeFile('branch code', null, 2000000))
     const actualResult = mergeProjectContentsTree(
       2000000,
       '/myfile.txt',
@@ -200,25 +146,9 @@ describe('mergeProjectContentsTree', () => {
     expect(actualResult.treeConflicts).toEqual({})
   })
   it('should return the current contents when it is null', () => {
-    const originContents = projectContentFile(
-      '/myfile.txt',
-      textFile(
-        textFileContents('origin code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
-    )
+    const originContents = projectContentFile('/myfile.txt', codeFile('origin code', null, 1000000))
     const currentContents = null
-    const branchContents = projectContentFile(
-      '/myfile.txt',
-      textFile(
-        textFileContents('origin code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
-    )
+    const branchContents = projectContentFile('/myfile.txt', codeFile('origin code', null, 1000000))
     const actualResult = mergeProjectContentsTree(
       2000000,
       '/myfile.txt',
@@ -230,23 +160,10 @@ describe('mergeProjectContentsTree', () => {
     expect(actualResult.treeConflicts).toEqual({})
   })
   it('should return the branch contents when it is null', () => {
-    const originContents = projectContentFile(
-      '/myfile.txt',
-      textFile(
-        textFileContents('origin code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
-    )
+    const originContents = projectContentFile('/myfile.txt', codeFile('origin code', null, 1000000))
     const currentContents = projectContentFile(
       '/myfile.txt',
-      textFile(
-        textFileContents('origin code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
+      codeFile('origin code', null, 1000000),
     )
     const branchContents = null
     const actualResult = mergeProjectContentsTree(
@@ -260,33 +177,12 @@ describe('mergeProjectContentsTree', () => {
     expect(actualResult.treeConflicts).toEqual({})
   })
   it('should return merged contents when a change exists in both cases', () => {
-    const originContents = projectContentFile(
-      '/myfile.txt',
-      textFile(
-        textFileContents('origin code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
-    )
+    const originContents = projectContentFile('/myfile.txt', codeFile('origin code', null, 1000000))
     const currentContents = projectContentFile(
       '/myfile.txt',
-      textFile(
-        textFileContents('current code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
+      codeFile('current code', null, 1000000),
     )
-    const branchContents = projectContentFile(
-      '/myfile.txt',
-      textFile(
-        textFileContents('branch code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
-    )
+    const branchContents = projectContentFile('/myfile.txt', codeFile('branch code', null, 1000000))
     const mergedCode = `<<<<<<< Your Changes
 current code
 ||||||| Original
@@ -294,15 +190,7 @@ origin code
 =======
 branch code
 >>>>>>> Branch Changes`
-    const mergedContents = projectContentFile(
-      '/myfile.txt',
-      textFile(
-        textFileContents(mergedCode, unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        2000000,
-      ),
-    )
+    const mergedContents = projectContentFile('/myfile.txt', codeFile(mergedCode, null, 2000000))
     const actualResult = mergeProjectContentsTree(
       2000000,
       '/myfile.txt',
@@ -314,23 +202,10 @@ branch code
     expect(actualResult.treeConflicts).toEqual({})
   })
   it('should return a tree conflict if the current contents has changed and the branch contents has changed file type', () => {
-    const originContents = projectContentFile(
-      '/myfile.txt',
-      textFile(
-        textFileContents('origin code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
-    )
+    const originContents = projectContentFile('/myfile.txt', codeFile('origin code', null, 1000000))
     const currentContents = projectContentFile(
       '/myfile.txt',
-      textFile(
-        textFileContents('current code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
+      codeFile('current code', null, 1000000),
     )
     const branchContents = projectContentFile(
       '/myfile.txt',
@@ -349,27 +224,14 @@ branch code
     })
   })
   it('should return a tree conflict if the branch contents has changed and the current contents has changed file type', () => {
-    const originContents = projectContentFile(
-      '/myfile.txt',
-      textFile(
-        textFileContents('origin code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
-    )
+    const originContents = projectContentFile('/myfile.txt', codeFile('origin code', null, 1000000))
     const currentContents = projectContentFile(
       '/myfile.txt',
       imageFile('jpg', undefined, undefined, undefined, 0, undefined),
     )
     const branchContents = projectContentFile(
       '/myfile.txt',
-      textFile(
-        textFileContents('current code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
+      codeFile('current code', null, 1000000),
     )
     const actualResult = mergeProjectContentsTree(
       2000000,
@@ -384,23 +246,10 @@ branch code
     })
   })
   it('should return a tree conflict if the current contents has changed and the branch contents has been deleted', () => {
-    const originContents = projectContentFile(
-      '/myfile.txt',
-      textFile(
-        textFileContents('origin code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
-    )
+    const originContents = projectContentFile('/myfile.txt', codeFile('origin code', null, 1000000))
     const currentContents = projectContentFile(
       '/myfile.txt',
-      textFile(
-        textFileContents('current code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
+      codeFile('current code', null, 1000000),
     )
     const branchContents = null
     const actualResult = mergeProjectContentsTree(
@@ -416,24 +265,11 @@ branch code
     })
   })
   it('should return a tree conflict if the branch contents has changed and the current contents has been deleted', () => {
-    const originContents = projectContentFile(
-      '/myfile.txt',
-      textFile(
-        textFileContents('origin code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
-    )
+    const originContents = projectContentFile('/myfile.txt', codeFile('origin code', null, 1000000))
     const currentContents = null
     const branchContents = projectContentFile(
       '/myfile.txt',
-      textFile(
-        textFileContents('current code', unparsed, RevisionsState.CodeAhead),
-        null,
-        null,
-        1000000,
-      ),
+      codeFile('current code', null, 1000000),
     )
     const actualResult = mergeProjectContentsTree(
       2000000,

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -41,7 +41,14 @@ import { emptySet } from './set-utils'
 import { trimUpToAndIncluding } from './string-utils'
 import { arrayEquals } from './utils'
 import { merge, mergeDiff3 } from 'node-diff3'
-import { isTextFile, RevisionsState, textFile, textFileContents } from './project-file-types'
+import {
+  isTextFile,
+  ProjectFile,
+  RevisionsState,
+  textFile,
+  textFileContents,
+  unparsed,
+} from './project-file-types'
 
 export function parseGithubProjectString(maybeProject: string): GithubRepo | null {
   const withoutGithubPrefix = trimUpToAndIncluding('github.com/', maybeProject)
@@ -480,28 +487,40 @@ export const githubFileChangesSelector = createSelector(
   (store: EditorStorePatched) => store.editor.projectContents,
   (store) => store.userState.githubState.authenticated,
   (store) => store.editor.githubChecksums,
-  (projectContents, githubAuthenticated, githubChecksums): GithubFileChanges | null => {
+  (store) => store.editor.githubData.treeConflicts,
+  (
+    projectContents,
+    githubAuthenticated,
+    githubChecksums,
+    treeConflicts,
+  ): GithubFileChanges | null => {
     if (!githubAuthenticated) {
       return null
     }
     const checksums = getProjectContentsChecksums(projectContents)
-    return deriveGithubFileChanges(checksums, githubChecksums)
+    return deriveGithubFileChanges(checksums, githubChecksums, treeConflicts)
   },
 )
 
-export type GithubFileStatus = 'modified' | 'deleted' | 'untracked' | 'conflict'
+export type GithubFileStatus = 'modified' | 'deleted' | 'untracked' | 'conflicted'
 
 export interface GithubFileChanges {
   untracked: Array<string>
   modified: Array<string>
   deleted: Array<string>
+  conflicted: Array<string>
 }
 
 export function getGithubFileChangesCount(changes: GithubFileChanges | null): number {
   if (changes == null) {
     return 0
   }
-  return changes.untracked.length + changes.modified.length + changes.deleted.length
+  return (
+    changes.untracked.length +
+    changes.modified.length +
+    changes.deleted.length +
+    changes.conflicted.length
+  )
 }
 
 export function githubFileChangesEquals(
@@ -517,7 +536,8 @@ export function githubFileChangesEquals(
   return (
     arrayEquals(a.untracked, b.untracked) &&
     arrayEquals(a.modified, b.modified) &&
-    arrayEquals(a.deleted, b.deleted)
+    arrayEquals(a.deleted, b.deleted) &&
+    arrayEquals(a.conflicted, b.conflicted)
   )
 }
 
@@ -543,6 +563,7 @@ export function githubFileChangesToList(
     ...toItem('untracked', changes.untracked),
     ...toItem('modified', changes.modified),
     ...toItem('deleted', changes.deleted),
+    ...toItem('conflicted', changes.conflicted),
   ].sort(sortByFilename)
 }
 
@@ -581,17 +602,92 @@ export function revertGithubFile(
   return actions
 }
 
+export interface DifferingTypesConflict {
+  type: 'DIFFERING_TYPES'
+  currentContents: ProjectContentsTree
+  originContents: ProjectContentsTree | null
+  branchContents: ProjectContentsTree
+}
+
+export function differingTypesConflict(
+  currentContents: ProjectContentsTree,
+  originContents: ProjectContentsTree | null,
+  branchContents: ProjectContentsTree,
+): DifferingTypesConflict {
+  return {
+    type: 'DIFFERING_TYPES',
+    currentContents: currentContents,
+    originContents: originContents,
+    branchContents: branchContents,
+  }
+}
+
+export interface CurrentChangedBranchDeleted {
+  type: 'CURRENT_CHANGED_BRANCH_DELETED'
+  currentContents: ProjectContentsTree
+  originContents: ProjectContentsTree
+}
+
+export function currentChangedBranchDeleted(
+  currentContents: ProjectContentsTree,
+  originContents: ProjectContentsTree,
+): CurrentChangedBranchDeleted {
+  return {
+    type: 'CURRENT_CHANGED_BRANCH_DELETED',
+    currentContents: currentContents,
+    originContents: originContents,
+  }
+}
+
+export interface CurrentDeletedBranchChanged {
+  type: 'CURRENT_DELETED_BRANCH_CHANGED'
+  originContents: ProjectContentsTree
+  branchContents: ProjectContentsTree
+}
+
+export function currentDeletedBranchChanged(
+  originContents: ProjectContentsTree,
+  branchContents: ProjectContentsTree,
+): CurrentDeletedBranchChanged {
+  return {
+    type: 'CURRENT_DELETED_BRANCH_CHANGED',
+    originContents: originContents,
+    branchContents: branchContents,
+  }
+}
+
+export type Conflict =
+  | DifferingTypesConflict
+  | CurrentChangedBranchDeleted
+  | CurrentDeletedBranchChanged
+
+export type TreeConflicts = { [path: string]: Conflict }
+
+export interface WithTreeConflicts<T> {
+  value: T
+  treeConflicts: TreeConflicts
+}
+
+export function withTreeConflicts<T>(value: T, treeConflicts: TreeConflicts): WithTreeConflicts<T> {
+  return {
+    value: value,
+    treeConflicts: treeConflicts,
+  }
+}
+
 export function mergeProjectContents(
+  currentTime: number,
   currentTree: ProjectContentTreeRoot,
   originTree: ProjectContentTreeRoot,
   branchTree: ProjectContentTreeRoot,
-): ProjectContentTreeRoot {
+): WithTreeConflicts<ProjectContentTreeRoot> {
   let keys: Set<string> = emptySet()
   Object.keys(currentTree).forEach(keys.add, keys)
   Object.keys(originTree).forEach(keys.add, keys)
   Object.keys(branchTree).forEach(keys.add, keys)
 
   let result: ProjectContentTreeRoot = {}
+  let treeConflicts: TreeConflicts = {}
   for (const key of keys) {
     const currentContents = propOrNull(key, currentTree)
     const originContents = propOrNull(key, originTree)
@@ -602,18 +698,62 @@ export function mergeProjectContents(
       throw new Error(`Invalid state of the elements being null reached.`)
     } else {
       const combinedElement = mergeProjectContentsTree(
+        currentTime,
         fullPath,
         currentContents,
         originContents,
         branchContents,
       )
-      if (combinedElement != null) {
-        result[key] = combinedElement
+      treeConflicts = {
+        ...treeConflicts,
+        ...combinedElement.treeConflicts,
+      }
+      if (combinedElement.value != null) {
+        result[key] = combinedElement.value
       }
     }
   }
 
-  return result
+  return withTreeConflicts(result, treeConflicts)
+}
+
+export function projectFileContentOrTypeChanged(first: ProjectFile, second: ProjectFile): boolean {
+  if (first.type === second.type) {
+    if (first.type === 'TEXT_FILE' && second.type === 'TEXT_FILE') {
+      return first.fileContents.code !== second.fileContents.code
+    } else if (first.type === 'IMAGE_FILE' && second.type === 'IMAGE_FILE') {
+      return first.hash !== second.hash
+    } else if (
+      first.type === 'ASSET_FILE' &&
+      second.type === 'ASSET_FILE' &&
+      first.gitBlobSha !== null &&
+      second.gitBlobSha != null
+    ) {
+      return first.gitBlobSha !== second.gitBlobSha
+    } else if (first.type === 'DIRECTORY' && second.type === 'DIRECTORY') {
+      return false
+    } else {
+      return false
+    }
+  } else {
+    return true
+  }
+}
+
+export function projectContentsTreeContentOrTypeChange(
+  first: ProjectContentsTree | null,
+  second: ProjectContentsTree | null,
+): boolean {
+  if (first?.type === 'PROJECT_CONTENT_FILE' && second?.type === 'PROJECT_CONTENT_FILE') {
+    return projectFileContentOrTypeChanged(first.content, second.content)
+  } else if (
+    first?.type === 'PROJECT_CONTENT_DIRECTORY' &&
+    second?.type === 'PROJECT_CONTENT_DIRECTORY'
+  ) {
+    return projectFileContentOrTypeChanged(first.directory, second.directory)
+  } else {
+    return first?.type !== second?.type
+  }
 }
 
 /*
@@ -625,18 +765,13 @@ export function mergeProjectContents(
  *       \-->branch
  */
 export function mergeProjectContentsTree(
+  currentTime: number,
   fullPath: string,
   currentContents: ProjectContentsTree | null,
   originContents: ProjectContentsTree | null,
   branchContents: ProjectContentsTree | null,
-): ProjectContentsTree | null {
-  if (originContents == null && branchContents == null) {
-    // Origin and branch lack an entry, so go with whatever the Utopia project contains.
-    return currentContents
-  } else if (originContents == null && currentContents == null) {
-    // Origin and Utopia project lack an entry, so go with whatever the branch contains.
-    return branchContents
-  } else if (
+): WithTreeConflicts<ProjectContentsTree | null> {
+  if (
     isProjectContentFile(currentContents) &&
     isTextFile(currentContents.content) &&
     isProjectContentFile(originContents) &&
@@ -644,28 +779,28 @@ export function mergeProjectContentsTree(
     isProjectContentFile(branchContents) &&
     isTextFile(branchContents.content)
   ) {
-    // All 3 branches are a file.
-    const mergedResult = mergeDiff3(
-      currentContents.content.fileContents.code,
-      originContents.content.fileContents.code,
-      branchContents.content.fileContents.code,
-      {
+    // At this path it was and in Utopia and in the branch is a text file.
+    const currentCode = currentContents.content.fileContents.code
+    const originCode = originContents.content.fileContents.code
+    const branchCode = branchContents.content.fileContents.code
+    if (currentCode === originCode && branchCode === originCode) {
+      // Code is the same in all 3 places, skip any merging activity.
+      return withTreeConflicts(originContents, {})
+    } else {
+      // There's a code change between the 3 places, perform a merge of the changes.
+      const mergedResult = mergeDiff3(currentCode, originCode, branchCode, {
         label: { a: 'Your Changes', o: 'Original', b: 'Branch Changes' },
         stringSeparator: /\r?\n/,
-      },
-    ).result.join('\n')
-    const updatedTextFile = textFile(
-      textFileContents(
-        mergedResult,
-        originContents.content.fileContents.parsed,
-        RevisionsState.CodeAhead,
-      ),
-      originContents.content.lastSavedContents,
-      originContents.content.lastParseSuccess,
-      Date.now(),
-    )
+      }).result.join('\n')
+      const updatedTextFile = textFile(
+        textFileContents(mergedResult, unparsed, RevisionsState.CodeAhead),
+        null,
+        null,
+        currentTime,
+      )
 
-    return projectContentFile(fullPath, updatedTextFile)
+      return withTreeConflicts(projectContentFile(fullPath, updatedTextFile), {})
+    }
   } else if (
     isProjectContentDirectory(currentContents) &&
     isProjectContentDirectory(originContents) &&
@@ -673,15 +808,95 @@ export function mergeProjectContentsTree(
   ) {
     // All 3 branches are directories.
     const mergedResult = mergeProjectContents(
+      currentTime,
       currentContents.children,
       originContents.children,
       branchContents.children,
     )
-    return projectContentDirectory(fullPath, currentContents.directory, mergedResult)
+    return withTreeConflicts(
+      projectContentDirectory(fullPath, currentContents.directory, mergedResult.value),
+      mergedResult.treeConflicts,
+    )
   } else {
-    // More cases in the future needed for tree conflicts at the least.
-    // For now go with whatever the editor has.
-    return currentContents
+    // Check what changes have been made against the origin and potentially between Utopia and the branch.
+    const currentContentsToOriginChanged = projectContentsTreeContentOrTypeChange(
+      originContents,
+      currentContents,
+    )
+    const branchContentsToOriginChanged = projectContentsTreeContentOrTypeChange(
+      originContents,
+      branchContents,
+    )
+    const branchContentsToCurrentChanged = projectContentsTreeContentOrTypeChange(
+      currentContents,
+      branchContents,
+    )
+
+    if (currentContentsToOriginChanged && !branchContentsToOriginChanged) {
+      // Utopia has changed from the origin, but the branch has not.
+      return withTreeConflicts(currentContents, {})
+    } else if (!currentContentsToOriginChanged && branchContentsToOriginChanged) {
+      // The branch has changed from the origin, but Utopia has not.
+      return withTreeConflicts(branchContents, {})
+      // Neither Utopia nor the branch have changed from the origin.
+    } else if (!currentContentsToOriginChanged && !branchContentsToOriginChanged) {
+      return withTreeConflicts(originContents, {})
+    } else if (
+      currentContentsToOriginChanged &&
+      branchContentsToOriginChanged &&
+      !branchContentsToCurrentChanged
+    ) {
+      // Utopia has changed from the origin, the branch has changed from the origin but Utopia and the branch are compatible values.
+      return withTreeConflicts(currentContents, {})
+    } else if (
+      currentContentsToOriginChanged &&
+      branchContentsToOriginChanged &&
+      branchContentsToCurrentChanged
+    ) {
+      // Utopia has changed from the origin, the branch has changed from the origin and Utopia and the branch are incompatible.
+      if (currentContents == null) {
+        if (originContents == null) {
+          // Origin and Utopia project lack an entry, so go with whatever the branch contains.
+          return withTreeConflicts(branchContents, {})
+        } else {
+          if (branchContents == null) {
+            // Both Utopia and the branch have deleted this.
+            return withTreeConflicts(branchContents, {})
+          } else {
+            // Utopia deleted this, but it changed in the branch.
+            return withTreeConflicts(currentContents, {
+              [fullPath]: currentDeletedBranchChanged(originContents, branchContents),
+            })
+          }
+        }
+      } else {
+        if (originContents == null) {
+          if (branchContents == null) {
+            // Created in Utopia, didn't exist before.
+            return withTreeConflicts(currentContents, {})
+          } else {
+            // Didn't exist previously, created in both the branch and Utopia.
+            return withTreeConflicts(currentContents, {
+              [fullPath]: differingTypesConflict(currentContents, originContents, branchContents),
+            })
+          }
+        } else {
+          if (branchContents == null) {
+            // Deleted on the branch, but changed in Utopia.
+            return withTreeConflicts(currentContents, {
+              [fullPath]: currentChangedBranchDeleted(currentContents, originContents),
+            })
+          } else {
+            // Existed previously, but changed incompatibly in both Utopia and the branch.
+            return withTreeConflicts(currentContents, {
+              [fullPath]: differingTypesConflict(currentContents, originContents, branchContents),
+            })
+          }
+        }
+      }
+    } else {
+      throw new Error(`Unhandled case reached.`)
+    }
   }
 }
 

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -571,14 +571,18 @@ export function textFile(
   }
 }
 
-export function codeFile(fileContents: string, lastSavedContents: string | null): TextFile {
+export function codeFile(
+  fileContents: string,
+  lastSavedContents: string | null,
+  lastRevisedTime: number = 0,
+): TextFile {
   return textFile(
     textFileContents(fileContents, unparsed, RevisionsState.CodeAhead),
     lastSavedContents == null
       ? null
       : textFileContents(lastSavedContents, unparsed, RevisionsState.CodeAhead),
     null,
-    0,
+    lastRevisedTime,
   )
 }
 


### PR DESCRIPTION
Fixes #2789

**Problem:**
Currently when updating the project against Github it's possible for tree conflicts to occur, but we completely ignore them.

**Fix:**
The previous merge conflict identifying code has now been extended to identify tree conflicts, recording their results in a separate structure so they can be resolved later and potentially to see either side of the conflict.

**Limitations:**
- This does not currently provide any functionality to resolve those conflicts.

**Commit Details:**
- Separated out some arbitrary instances into `assets.test-utils.ts` so they can be imported from elsewhere.
- `deriveGithubFileChanges` now takes account of any tree conflicts which have been passed in.
- `mergeProjectContents` now takes the current time so that changes are against a single time and also to make testing easier.
- `UPDATE_AGAINST_GITHUB` action now takes account of any tree conflicts that have arisen, potentially not updating the origin commit.
- Added `GithubData.treeConflicts` field.
- `mergeProjectContentsTree` reworked to capture tree conflicts.
- Added `Conflict` sum type to capture the different types of conflict which can arise.
- Added `GithubFileChanges.conflicted` field.
