### PR TITLE
Editor theme selection is persisted on the user between sessions

### DIFF
--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -307,7 +307,7 @@ export async function renderTestEditorWithModel(
     userState: {
       loginState: loginState,
       shortcutConfig: {},
-      themeConfig: null,
+      themeConfig: 'light',
       githubState: {
         authenticated: false,
       },

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -307,6 +307,7 @@ export async function renderTestEditorWithModel(
     userState: {
       loginState: loginState,
       shortcutConfig: {},
+      themeConfig: null,
       githubState: {
         authenticated: false,
       },

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4621,7 +4621,7 @@ export const UPDATE_FNS = {
     }
     // Side effect.
     void saveUserConfiguration(updatedUserConfiguration)
-    return { ...userState, themeConfig: action.theme }
+    return { ...userState, ...updatedUserConfiguration }
   },
   FOCUS_CLASS_NAME_INPUT: (editor: EditorModel): EditorModel => {
     return {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -974,7 +974,6 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
     vscodeReady: currentEditor.vscodeReady,
     focusedElementPath: currentEditor.focusedElementPath,
     config: defaultConfig(),
-    theme: currentEditor.theme,
     vscodeLoadingScreenVisible: currentEditor.vscodeLoadingScreenVisible,
     indexedDBFailed: currentEditor.indexedDBFailed,
     forceParseFiles: currentEditor.forceParseFiles,
@@ -4368,6 +4367,7 @@ export const UPDATE_FNS = {
     updatedShortcutConfig[action.shortcutName] = [action.newKey]
     const updatedUserConfiguration: UserConfiguration = {
       shortcutConfig: updatedShortcutConfig,
+      themeConfig: userState.themeConfig,
     }
     // Side effect.
     void saveUserConfiguration(updatedUserConfiguration)
@@ -4614,11 +4614,14 @@ export const UPDATE_FNS = {
       forkedFromProjectId: action.id,
     }
   },
-  SET_CURRENT_THEME: (action: SetCurrentTheme, editor: EditorModel): EditorModel => {
-    return {
-      ...editor,
-      theme: action.theme,
+  SET_CURRENT_THEME: (action: SetCurrentTheme, userState: UserState): UserState => {
+    const updatedUserConfiguration: UserConfiguration = {
+      shortcutConfig: userState.shortcutConfig,
+      themeConfig: action.theme,
     }
+    // Side effect.
+    void saveUserConfiguration(updatedUserConfiguration)
+    return { ...userState, themeConfig: action.theme }
   },
   FOCUS_CLASS_NAME_INPUT: (editor: EditorModel): EditorModel => {
     return {

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -102,7 +102,7 @@ function createEditorStore(
     userState: {
       loginState: notLoggedIn,
       shortcutConfig: {},
-      themeConfig: null,
+      themeConfig: 'light',
       githubState: {
         authenticated: false,
       },

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -102,6 +102,7 @@ function createEditorStore(
     userState: {
       loginState: notLoggedIn,
       shortcutConfig: {},
+      themeConfig: null,
       githubState: {
         authenticated: false,
       },

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -112,6 +112,11 @@ function processAction(
       ...working,
       userState: UPDATE_FNS.SET_SHORTCUT(action, working.userState),
     }
+  } else if (action.action === 'SET_CURRENT_THEME') {
+    return {
+      ...working,
+      userState: UPDATE_FNS.SET_CURRENT_THEME(action, working.userState),
+    }
   } else if (action.action === 'SET_LOGIN_STATE') {
     return {
       ...working,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -235,13 +235,13 @@ export function originalPath(originalTP: ElementPath, currentTP: ElementPath): O
 
 export interface UserConfiguration {
   shortcutConfig: ShortcutConfiguration | null
-  themeConfig: Theme | null
+  themeConfig: Theme
 }
 
 export function emptyUserConfiguration(): UserConfiguration {
   return {
     shortcutConfig: null,
-    themeConfig: null,
+    themeConfig: 'light',
   }
 }
 
@@ -1206,7 +1206,6 @@ export function editorState(
   vscodeReady: boolean,
   focusedElementPath: ElementPath | null,
   config: UtopiaVSCodeConfig,
-  theme: Theme,
   vscodeLoadingScreenVisible: boolean,
   indexedDBFailed: boolean,
   forceParseFiles: Array<string>,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -3050,7 +3050,7 @@ export function getElementFromProjectContents(
 }
 
 export function getCurrentTheme(userState: UserState): Theme {
-  return userState.themeConfig === null ? 'light' : userState.themeConfig
+  return userState.themeConfig
 }
 
 export function getNewSceneName(editor: EditorState): string {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -235,11 +235,13 @@ export function originalPath(originalTP: ElementPath, currentTP: ElementPath): O
 
 export interface UserConfiguration {
   shortcutConfig: ShortcutConfiguration | null
+  themeConfig: Theme | null
 }
 
 export function emptyUserConfiguration(): UserConfiguration {
   return {
     shortcutConfig: null,
+    themeConfig: null,
   }
 }
 
@@ -315,6 +317,7 @@ export function isGithubUpdating(operations: Array<GithubOperation>): boolean {
 export const defaultUserState: UserState = {
   loginState: loginNotYetKnown,
   shortcutConfig: {},
+  themeConfig: 'light',
   githubState: {
     authenticated: false,
   },
@@ -1131,7 +1134,6 @@ export interface EditorState {
   vscodeReady: boolean
   focusedElementPath: ElementPath | null
   config: UtopiaVSCodeConfig
-  theme: Theme
   vscodeLoadingScreenVisible: boolean
   indexedDBFailed: boolean
   forceParseFiles: Array<string>
@@ -1278,7 +1280,6 @@ export function editorState(
     vscodeReady: vscodeReady,
     focusedElementPath: focusedElementPath,
     config: config,
-    theme: theme,
     vscodeLoadingScreenVisible: vscodeLoadingScreenVisible,
     indexedDBFailed: indexedDBFailed,
     forceParseFiles: forceParseFiles,
@@ -2093,7 +2094,6 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     vscodeReady: false,
     focusedElementPath: null,
     config: defaultConfig(),
-    theme: 'light',
     vscodeLoadingScreenVisible: true,
     indexedDBFailed: false,
     forceParseFiles: [],
@@ -2396,7 +2396,6 @@ export function editorModelFromPersistentModel(
     vscodeReady: false,
     focusedElementPath: null,
     config: defaultConfig(),
-    theme: 'light',
     vscodeLoadingScreenVisible: true,
     indexedDBFailed: false,
     forceParseFiles: [],
@@ -3051,8 +3050,8 @@ export function getElementFromProjectContents(
   return withUnderlyingTarget(target, projectContents, {}, openFile, null, (_, element) => element)
 }
 
-export function getCurrentTheme(editor: EditorState): Theme {
-  return editor.theme
+export function getCurrentTheme(userState: UserState): Theme {
+  return userState.themeConfig === null ? 'light' : userState.themeConfig
 }
 
 export function getNewSceneName(editor: EditorState): string {

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -320,8 +320,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.SET_FILEBROWSER_DROPTARGET(action, state)
     case 'SET_FORKED_FROM_PROJECT_ID':
       return UPDATE_FNS.SET_FORKED_FROM_PROJECT_ID(action, state)
-    case 'SET_CURRENT_THEME':
-      return UPDATE_FNS.SET_CURRENT_THEME(action, state)
+    // case 'SET_CURRENT_THEME':
+    //   return UPDATE_FNS.SET_CURRENT_THEME(action, state)
     case 'FOCUS_CLASS_NAME_INPUT':
       return UPDATE_FNS.FOCUS_CLASS_NAME_INPUT(state)
     case 'FOCUS_FORMULA_BAR':

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -320,8 +320,6 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.SET_FILEBROWSER_DROPTARGET(action, state)
     case 'SET_FORKED_FROM_PROJECT_ID':
       return UPDATE_FNS.SET_FORKED_FROM_PROJECT_ID(action, state)
-    // case 'SET_CURRENT_THEME':
-    //   return UPDATE_FNS.SET_CURRENT_THEME(action, state)
     case 'FOCUS_CLASS_NAME_INPUT':
       return UPDATE_FNS.FOCUS_CLASS_NAME_INPUT(state)
     case 'FOCUS_FORMULA_BAR':

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -3480,7 +3480,6 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     newValue.focusedElementPath,
   )
   const configResults = UtopiaVSCodeConfigKeepDeepEquality(oldValue.config, newValue.config)
-  const themeResults = createCallWithTripleEquals<Theme>()(oldValue.theme, newValue.theme)
   const vscodeLoadingScreenVisibleResults = BooleanKeepDeepEquality(
     oldValue.vscodeLoadingScreenVisible,
     newValue.vscodeLoadingScreenVisible,
@@ -3589,7 +3588,6 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     vscodeReadyResults.areEqual &&
     focusedElementPathResults.areEqual &&
     configResults.areEqual &&
-    themeResults.areEqual &&
     vscodeLoadingScreenVisibleResults.areEqual &&
     indexedDBFailedResults.areEqual &&
     forceParseFilesResults.areEqual &&
@@ -3665,7 +3663,6 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
       vscodeReadyResults.value,
       focusedElementPathResults.value,
       configResults.value,
-      themeResults.value,
       vscodeLoadingScreenVisibleResults.value,
       indexedDBFailedResults.value,
       forceParseFilesResults.value,

--- a/editor/src/components/navigator/left-pane/settings-pane.tsx
+++ b/editor/src/components/navigator/left-pane/settings-pane.tsx
@@ -36,26 +36,26 @@ const themeOptions = [
   },
 ]
 
+const defaultTheme = themeOptions[1]
+
 export const SettingsPane = React.memo(() => {
-  const { dispatch, userState, projectId, projectName, projectDescription } = useEditorState(
-    (store) => {
+  const { dispatch, userState, projectId, projectName, projectDescription, themeConfig } =
+    useEditorState((store) => {
       return {
         dispatch: store.dispatch,
         userState: store.userState,
         projectId: store.editor.id,
         projectName: store.editor.projectName,
         projectDescription: store.editor.projectDescription,
+        themeConfig: store.userState.themeConfig,
       }
-    },
-    'SettingsPane',
-  )
+    }, 'SettingsPane')
 
   const isMyProject = useIsMyProject(projectId)
 
-  const [theme, setTheme] = React.useState<SelectOption>({
-    label: 'Light',
-    value: 'light',
-  })
+  const [theme, setTheme] = React.useState<SelectOption>(
+    themeOptions.find((option) => option.value === themeConfig) || defaultTheme,
+  )
 
   const handleSubmitValueTheme = React.useCallback(
     (option: SelectOption) => {

--- a/editor/src/components/navigator/left-pane/settings-pane.tsx
+++ b/editor/src/components/navigator/left-pane/settings-pane.tsx
@@ -54,7 +54,7 @@ export const SettingsPane = React.memo(() => {
   const isMyProject = useIsMyProject(projectId)
 
   const [theme, setTheme] = React.useState<SelectOption>(
-    themeOptions.find((option) => option.value === themeConfig) || defaultTheme,
+    themeOptions.find((option) => option.value === themeConfig) ?? defaultTheme,
   )
 
   const handleSubmitValueTheme = React.useCallback(

--- a/editor/src/uuiui/icn.tsx
+++ b/editor/src/uuiui/icn.tsx
@@ -29,7 +29,7 @@ export type IcnResultingColor =
   | 'colourful'
 
 function useIconColor(intent: IcnColor): IcnResultingColor {
-  const currentTheme: Theme = useEditorState((store) => store.editor.theme, 'currentTheme')
+  const currentTheme: Theme = useEditorState((store) => store.userState.themeConfig, 'currentTheme')
   if (currentTheme === 'light') {
     switch (intent) {
       case 'main':

--- a/editor/src/uuiui/styles/theme.ts
+++ b/editor/src/uuiui/styles/theme.ts
@@ -312,7 +312,7 @@ export type ColorTheme = typeof colorTheme
 // TODO: don't export colorTheme anymore and just export useUtopiaTheme() hook
 // prerequisites: no class components and usage of UtopiaTheme.color instead of colorTheme
 export const useColorTheme = (): ColorTheme => {
-  const currentTheme: Theme = useEditorState((store) => store.editor.theme, 'currentTheme')
+  const currentTheme: Theme = useEditorState((store) => store.userState.themeConfig, 'currentTheme')
   return currentTheme === 'dark' ? darkColorTheme : colorTheme
 }
 

--- a/server/migrations/003.sql
+++ b/server/migrations/003.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ONLY "public"."user_configuration"
+    ADD COLUMN "theme" CHARACTER VARYING;

--- a/server/src/Utopia/Web/Database/Migrations.hs
+++ b/server/src/Utopia/Web/Database/Migrations.hs
@@ -24,6 +24,7 @@ migrateDatabase :: Bool -> Bool -> Pool Connection -> IO ()
 migrateDatabase verbose includeInitial pool = withResource pool $ \connection -> do
   let mainMigrationCommands = [ MigrationFile "001.sql" "./migrations/001.sql"
                               , MigrationFile "002.sql" "./migrations/002.sql"
+                              , MigrationFile "003.sql" "./migrations/003.sql"
                               ]
   let initialMigrationCommand = if includeInitial
                                    then [MigrationFile "initial.sql" "./migrations/initial.sql"]

--- a/server/src/Utopia/Web/Database/Types.hs
+++ b/server/src/Utopia/Web/Database/Types.hs
@@ -78,12 +78,12 @@ data UserDetails = UserDetails
                  , picture :: Maybe Text
                  } deriving (Eq, Show, Generic)
 
-type UserConfigurationFields = (Field SqlText, FieldNullable SqlText)
+type UserConfigurationFields = (Field SqlText, FieldNullable SqlText, FieldNullable SqlText)
 
-type UserConfiguration = (Text, Maybe Text)
+type UserConfiguration = (Text, Maybe Text, Maybe Text)
 
 userConfigurationTable :: Table UserConfigurationFields UserConfigurationFields
-userConfigurationTable = table "user_configuration" (p2 (tableField "user_id", tableField "shortcut_config"))
+userConfigurationTable = table "user_configuration" (p3 (tableField "user_id", tableField "shortcut_config", tableField "theme"))
 
 userConfigurationSelect :: Select UserConfigurationFields
 userConfigurationSelect = selectTable userConfigurationTable
@@ -114,6 +114,7 @@ data ProjectMetadata = ProjectMetadata
 data DecodedUserConfiguration = DecodedUserConfiguration
                          { id             :: Text
                          , shortcutConfig :: Maybe Value
+                         , theme          :: Maybe Value
                          } deriving (Eq, Show, Generic)
 
 

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -635,10 +635,10 @@ packagePackagerEndpoint versionedPackageName ifModifiedSince possibleOrigin = do
   pure $ addHeader packagerCacheControl $ addHeader (LastModifiedTime lastModified) $ applyOriginHeader packagerContent
 
 emptyUserConfigurationResponse :: UserConfigurationResponse
-emptyUserConfigurationResponse = UserConfigurationResponse { _shortcutConfig = Nothing }
+emptyUserConfigurationResponse = UserConfigurationResponse { _shortcutConfig = Nothing, _theme = Nothing }
 
 decodedUserConfigurationToResponse :: DecodedUserConfiguration -> UserConfigurationResponse
-decodedUserConfigurationToResponse userConf = UserConfigurationResponse { _shortcutConfig = view (field @"shortcutConfig") userConf }
+decodedUserConfigurationToResponse userConf = UserConfigurationResponse { _shortcutConfig = view (field @"shortcutConfig") userConf, _theme = view (field @"theme") userConf }
 
 getUserConfigurationEndpoint :: Maybe Text -> ServerMonad UserConfigurationResponse
 getUserConfigurationEndpoint cookie = requireUser cookie $ \sessionUser -> do
@@ -647,7 +647,7 @@ getUserConfigurationEndpoint cookie = requireUser cookie $ \sessionUser -> do
 
 saveUserConfigurationEndpoint :: Maybe Text -> UserConfigurationRequest -> ServerMonad NoContent
 saveUserConfigurationEndpoint cookie UserConfigurationRequest{..} = requireUser cookie $ \sessionUser -> do
-  saveUserConfiguration (view (field @"_id") sessionUser) _shortcutConfig
+  saveUserConfiguration (view (field @"_id") sessionUser) _shortcutConfig _theme
   return NoContent
 
 githubStartAuthenticationEndpoint :: Maybe Text -> ServerMonad H.Html

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -635,10 +635,10 @@ packagePackagerEndpoint versionedPackageName ifModifiedSince possibleOrigin = do
   pure $ addHeader packagerCacheControl $ addHeader (LastModifiedTime lastModified) $ applyOriginHeader packagerContent
 
 emptyUserConfigurationResponse :: UserConfigurationResponse
-emptyUserConfigurationResponse = UserConfigurationResponse { _shortcutConfig = Nothing, _theme = Nothing }
+emptyUserConfigurationResponse = UserConfigurationResponse { _shortcutConfig = Nothing, _themeConfig = Nothing }
 
 decodedUserConfigurationToResponse :: DecodedUserConfiguration -> UserConfigurationResponse
-decodedUserConfigurationToResponse userConf = UserConfigurationResponse { _shortcutConfig = view (field @"shortcutConfig") userConf, _theme = view (field @"theme") userConf }
+decodedUserConfigurationToResponse userConf = UserConfigurationResponse { _shortcutConfig = view (field @"shortcutConfig") userConf, _themeConfig = view (field @"theme") userConf }
 
 getUserConfigurationEndpoint :: Maybe Text -> ServerMonad UserConfigurationResponse
 getUserConfigurationEndpoint cookie = requireUser cookie $ \sessionUser -> do
@@ -647,7 +647,7 @@ getUserConfigurationEndpoint cookie = requireUser cookie $ \sessionUser -> do
 
 saveUserConfigurationEndpoint :: Maybe Text -> UserConfigurationRequest -> ServerMonad NoContent
 saveUserConfigurationEndpoint cookie UserConfigurationRequest{..} = requireUser cookie $ \sessionUser -> do
-  saveUserConfiguration (view (field @"_id") sessionUser) _shortcutConfig _theme
+  saveUserConfiguration (view (field @"_id") sessionUser) _shortcutConfig _themeConfig
   return NoContent
 
 githubStartAuthenticationEndpoint :: Maybe Text -> ServerMonad H.Html

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -328,9 +328,9 @@ getUserConfigurationWithDBPool metrics pool userID action = do
   possibleUserConfiguration <- liftIO $ DB.getUserConfiguration metrics pool userID
   return $ action possibleUserConfiguration
 
-saveUserConfigurationWithDBPool :: (MonadIO m) => DB.DatabaseMetrics -> DBPool -> Text -> Maybe Value -> m ()
-saveUserConfigurationWithDBPool metrics pool userID possibleShortcutConfig = do
-  liftIO $ DB.saveUserConfiguration metrics pool userID possibleShortcutConfig
+saveUserConfigurationWithDBPool :: (MonadIO m) => DB.DatabaseMetrics -> DBPool -> Text -> Maybe Value -> Maybe Value -> m ()
+saveUserConfigurationWithDBPool metrics pool userID possibleShortcutConfig possibleTheme = do
+  liftIO $ DB.saveUserConfiguration metrics pool userID possibleShortcutConfig possibleTheme
 
 getProjectDetailsWithDBPool :: (MonadIO m) => DB.DatabaseMetrics -> DBPool -> Text -> m ProjectDetails
 getProjectDetailsWithDBPool metrics pool projectID = do

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -303,10 +303,10 @@ innerServerExecutor (GetUserConfiguration user action) = do
   pool <- fmap _projectPool ask
   metrics <- fmap _databaseMetrics ask
   getUserConfigurationWithDBPool metrics pool user action
-innerServerExecutor (SaveUserConfiguration user possibleShortcutConfig action) = do
+innerServerExecutor (SaveUserConfiguration user possibleShortcutConfig possibleTheme action) = do
   pool <- fmap _projectPool ask
   metrics <- fmap _databaseMetrics ask
-  saveUserConfigurationWithDBPool metrics pool user possibleShortcutConfig
+  saveUserConfigurationWithDBPool metrics pool user possibleShortcutConfig possibleTheme
   return action
 innerServerExecutor (ClearBranchCache branchName action) = do
   possibleDownloads <- fmap _branchDownloads ask

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -235,10 +235,10 @@ innerServerExecutor (GetUserConfiguration user action) = do
   pool <- fmap _projectPool ask
   metrics <- fmap _databaseMetrics ask
   getUserConfigurationWithDBPool metrics pool user action
-innerServerExecutor (SaveUserConfiguration user possibleShortcutConfig action) = do
+innerServerExecutor (SaveUserConfiguration user possibleShortcutConfig possibleTheme action) = do
   pool <- fmap _projectPool ask
   metrics <- fmap _databaseMetrics ask
-  saveUserConfigurationWithDBPool metrics pool user possibleShortcutConfig
+  saveUserConfigurationWithDBPool metrics pool user possibleShortcutConfig possibleTheme
   return action
 innerServerExecutor (ClearBranchCache branchName action) = do
   possibleDownloads <- fmap _branchDownloads ask

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -222,14 +222,14 @@ instance ToJSON UserResponse where
 
 data UserConfigurationResponse = UserConfigurationResponse
                                { _shortcutConfig :: Maybe Value,
-                                _theme :: Maybe Value
+                                _themeConfig :: Maybe Value
                                } deriving (Eq, Show, Generic)
 
 $(makeFieldsNoPrefix ''UserConfigurationResponse)
 
 data UserConfigurationRequest = UserConfigurationRequest
                               { _shortcutConfig :: Maybe Value,
-                                _theme :: Maybe Value
+                                _themeConfig :: Maybe Value
                               } deriving (Eq, Show, Generic)
 
 $(makeFieldsNoPrefix ''UserConfigurationRequest)

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -129,7 +129,7 @@ data ServiceCallsF a = NotFound
                      | GetPathToServe FilePath (Maybe Text) (FilePath -> a)
                      | GetVSCodeAssetRoot (FilePath -> a)
                      | GetUserConfiguration Text (Maybe DecodedUserConfiguration -> a)
-                     | SaveUserConfiguration Text (Maybe Value) a
+                     | SaveUserConfiguration Text (Maybe Value) (Maybe Value) a
                      | ClearBranchCache Text a
                      | GetDownloadBranchFolders ([FilePath] -> a)
                      | GetGithubAuthorizationURI (URI -> a)
@@ -221,13 +221,15 @@ instance ToJSON UserResponse where
   toJSON (LoggedInUser user) = object ["type" .= loggedIn, "user" .= user]
 
 data UserConfigurationResponse = UserConfigurationResponse
-                               { _shortcutConfig :: Maybe Value
+                               { _shortcutConfig :: Maybe Value,
+                                _theme :: Maybe Value
                                } deriving (Eq, Show, Generic)
 
 $(makeFieldsNoPrefix ''UserConfigurationResponse)
 
 data UserConfigurationRequest = UserConfigurationRequest
-                              { _shortcutConfig :: Maybe Value
+                              { _shortcutConfig :: Maybe Value,
+                                _theme :: Maybe Value
                               } deriving (Eq, Show, Generic)
 
 $(makeFieldsNoPrefix ''UserConfigurationRequest)


### PR DESCRIPTION
Editor theme selection is persisted on the user between sessions

**Problem:**
After the user selects a color theme (light or dark), leaves Utopia, then returns, the theme selection is not persisted.

**Fix:**
Theme selection is now persisted on the `UserConfiguration` and stored on the server.

**Commit Details:**
- Moved `theme` from `editorState` to `UserConfiguration` and renamed `themeConfig`
- Added functionality on the server to receive updated `UserConfiguration` and store values in the database
