### PR TITLE
Disconnect project from Github branch

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -44,6 +44,7 @@ import { applyShortcutConfigurationToDefaults } from './shortcut-definitions'
 import { githubOperationLocksEditor, LeftMenuTab, LeftPaneDefaultWidth } from './store/editor-state'
 import { useEditorState, useRefEditorState } from './store/store-hook'
 import { refreshGithubData } from '../../core/shared/github'
+import { ConfirmDisconnectBranchDialog } from '../filebrowser/confirm-branch-disconnect'
 
 function pushProjectURLToBrowserHistory(projectId: string, projectName: string): void {
   // Make sure we don't replace the query params
@@ -440,10 +441,11 @@ const useGithubData = (): void => {
 }
 
 const ModalComponent = React.memo((): React.ReactElement<any> | null => {
-  const { modal, dispatch } = useEditorState((store) => {
+  const { modal, dispatch, currentBranch } = useEditorState((store) => {
     return {
       dispatch: store.dispatch,
       modal: store.editor.modal,
+      currentBranch: store.editor.githubSettings.branchName,
     }
   }, 'ModalComponent')
   if (modal != null) {
@@ -462,6 +464,11 @@ const ModalComponent = React.memo((): React.ReactElement<any> | null => {
         )
       case 'file-revert-all':
         return <ConfirmRevertAllDialogProps dispatch={dispatch} />
+      case 'disconnect-github-project':
+        if (currentBranch != null) {
+          return <ConfirmDisconnectBranchDialog dispatch={dispatch} branchName={currentBranch} />
+        }
+        break
     }
   }
   return null

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -392,6 +392,16 @@ export function fileRevertAllModal(): FileRevertAllModal {
   }
 }
 
+export interface DisconnectGithubProjectModal {
+  type: 'disconnect-github-project'
+}
+
+export function disconnectGithubProjectModal(branchName: string): DisconnectGithubProjectModal {
+  return {
+    type: 'disconnect-github-project',
+  }
+}
+
 export interface FileUploadInfo {
   fileResult: FileResult
   targetPath: string
@@ -421,6 +431,7 @@ export type ModalDialog =
   | FileOverwriteModal
   | FileRevertModal
   | FileRevertAllModal
+  | DisconnectGithubProjectModal
 
 export type CursorImportanceLevel = 'fixed' | 'mouseOver' // only one fixed cursor can exist, mouseover is a bit less important
 export interface CursorStackItem {
@@ -1048,6 +1059,14 @@ export function projectGithubSettings(
     targetRepository: targetRepository,
     originCommit: originCommit,
     branchName: branchName,
+  }
+}
+
+export function emptyGithubSettings(): ProjectGithubSettings {
+  return {
+    targetRepository: null,
+    originCommit: null,
+    branchName: null,
   }
 }
 
@@ -2099,11 +2118,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     forceParseFiles: [],
     allElementProps: {},
     _currentAllElementProps_KILLME: {},
-    githubSettings: {
-      targetRepository: null,
-      originCommit: null,
-      branchName: null,
-    },
+    githubSettings: emptyGithubSettings(),
     imageDragSessionState: notDragging(),
     githubOperations: [],
     githubChecksums: null,
@@ -2477,11 +2492,7 @@ export function persistentModelForProjectContents(
     navigator: {
       minimised: false,
     },
-    githubSettings: {
-      targetRepository: null,
-      originCommit: null,
-      branchName: null,
-    },
+    githubSettings: emptyGithubSettings(),
     githubChecksums: null,
     branchContents: null,
   }

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -322,6 +322,8 @@ import {
   GithubData,
   emptyGithubData,
   projectGithubSettings,
+  DisconnectGithubProjectModal,
+  disconnectGithubProjectModal,
 } from './editor-state'
 import {
   CornerGuideline,
@@ -3107,6 +3109,13 @@ export const FileRevertModalKeepDeepEquality: KeepDeepEqualityCall<FileRevertMod
     fileRevertModal,
   )
 
+export const DisconnectGithubProjectModalKeepDeepEquality: KeepDeepEqualityCall<DisconnectGithubProjectModal> =
+  combine1EqualityCall(
+    (modal) => modal.branchName,
+    StringKeepDeepEquality,
+    disconnectGithubProjectModal,
+  )
+
 export const ModalDialogKeepDeepEquality: KeepDeepEqualityCall<ModalDialog> = (
   oldValue,
   newValue,
@@ -3133,6 +3142,13 @@ export const ModalDialogKeepDeepEquality: KeepDeepEqualityCall<ModalDialog> = (
       } else {
         return keepDeepEqualityResult(oldValue, false)
       }
+    case 'disconnect-github-project':
+      if (newValue.type === oldValue.type) {
+        return keepDeepEqualityResult(newValue, true)
+      } else {
+        return keepDeepEqualityResult(oldValue, false)
+      }
+      break
     default:
       assertNever(oldValue)
   }

--- a/editor/src/components/filebrowser/confirm-branch-disconnect.tsx
+++ b/editor/src/components/filebrowser/confirm-branch-disconnect.tsx
@@ -1,0 +1,66 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { jsx } from '@emotion/react'
+import React from 'react'
+import { disconnectGithubProjectActions } from '../../core/shared/github'
+import { Dialog, FormButton } from '../../uuiui'
+import { EditorDispatch } from '../editor/action-types'
+import * as EditorActions from '../editor/actions/action-creators'
+
+interface ConfirmDisconnectBranchProps {
+  dispatch: EditorDispatch
+  branchName: string
+}
+
+export const ConfirmDisconnectBranchDialog: React.FunctionComponent<
+  React.PropsWithChildren<ConfirmDisconnectBranchProps>
+> = (props) => {
+  const hide = React.useCallback(() => {
+    props.dispatch([EditorActions.hideModal()], 'everyone')
+  }, [props])
+  return (
+    <Dialog
+      title='Disconnect project from branch'
+      content={<DialogBody {...props} />}
+      defaultButton={<AcceptButton {...props} />}
+      secondaryButton={<CancelButton {...props} />}
+      closeCallback={hide}
+    />
+  )
+}
+
+const DialogBody: React.FunctionComponent<React.PropsWithChildren<ConfirmDisconnectBranchProps>> = (
+  props,
+) => (
+  <React.Fragment>
+    <p>
+      Are you sure you want to disconnect this project from the Github branch{' '}
+      <strong>“{props.branchName}”</strong>?
+    </p>
+  </React.Fragment>
+)
+
+const AcceptButton: React.FunctionComponent<
+  React.PropsWithChildren<ConfirmDisconnectBranchProps>
+> = (props) => {
+  const clickButton = React.useCallback(() => {
+    const actions = disconnectGithubProjectActions()
+    props.dispatch(actions)
+  }, [props])
+
+  return (
+    <FormButton primary danger onClick={clickButton}>
+      Disconnect
+    </FormButton>
+  )
+}
+
+const CancelButton: React.FunctionComponent<
+  React.PropsWithChildren<ConfirmDisconnectBranchProps>
+> = (props) => {
+  const clickButton = React.useCallback(() => {
+    props.dispatch([EditorActions.hideModal()], 'everyone')
+  }, [props])
+
+  return <FormButton onClick={clickButton}>Cancel</FormButton>
+}

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -2,7 +2,7 @@
 /** @jsx jsx */
 /** @jsxFrag React.Fragment */
 import { jsx } from '@emotion/react'
-import React from 'react'
+import React, { useCallback } from 'react'
 import urljoin from 'url-join'
 import { BASE_URL } from '../../../../common/env-vars'
 import {
@@ -74,7 +74,6 @@ export const GithubPane = React.memo(() => {
   const [importGithubRepoStr, setImportGithubRepoStr] = React.useState('')
   const parsedImportRepo = parseGithubProjectString(importGithubRepoStr)
   const dispatch = useEditorState((store) => store.dispatch, 'GithubPane dispatch')
-  const projectID = useEditorState((store) => store.editor.id, 'GithubPane projectID')
   const githubOperations = useEditorState(
     (store) => store.editor.githubOperations,
     'Github operations',
@@ -281,6 +280,19 @@ export const GithubPane = React.memo(() => {
     return intersection
   }, [upstreamChanges, githubFileChanges])
 
+  const disconnectFromGithub = useCallback(() => {
+    if (currentBranch != null) {
+      dispatch(
+        [
+          EditorActions.showModal({
+            type: 'disconnect-github-project',
+          }),
+        ],
+        'everyone',
+      )
+    }
+  }, [dispatch, currentBranch])
+
   return (
     <FlexColumn
       id='leftPaneGithub'
@@ -469,6 +481,24 @@ export const GithubPane = React.memo(() => {
             </>,
           )}
           {loadBranchesUI}
+          {when(
+            currentBranch != null,
+            <UIGridRow
+              padded
+              variant='<-------------1fr------------->'
+              style={{ margin: '10px 0' }}
+            >
+              <Button
+                spotlight
+                highlight
+                style={{ backgroundColor: '#fee', border: '1px solid #f00' }}
+                onClick={disconnectFromGithub}
+                disabled={githubWorking}
+              >
+                Disconnect from branch
+              </Button>
+            </UIGridRow>,
+          )}
         </SectionBodyArea>
       </Section>
       <Section>

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -1,3 +1,4 @@
+import { mergeDiff3 } from 'node-diff3'
 import { createSelector } from 'reselect'
 import urljoin from 'url-join'
 import { UTOPIA_BACKEND } from '../../common/env-vars'
@@ -30,6 +31,7 @@ import {
 import {
   EditorStorePatched,
   emptyGithubData,
+  emptyGithubSettings,
   GithubChecksums,
   GithubData,
   GithubOperation,
@@ -38,11 +40,10 @@ import {
   projectGithubSettings,
 } from '../../components/editor/store/editor-state'
 import { propOrNull } from './object-utils'
+import { isTextFile, RevisionsState, textFile, textFileContents } from './project-file-types'
 import { emptySet } from './set-utils'
 import { trimUpToAndIncluding } from './string-utils'
 import { arrayEquals } from './utils'
-import { mergeDiff3 } from 'node-diff3'
-import { isTextFile, RevisionsState, textFile, textFileContents } from './project-file-types'
 
 export function parseGithubProjectString(maybeProject: string): GithubRepo | null {
   const withoutGithubPrefix = trimUpToAndIncluding('github.com/', maybeProject)
@@ -741,4 +742,13 @@ export async function refreshGithubData(
   } else {
     dispatch([updateGithubData(emptyGithubData())], 'everyone')
   }
+}
+
+export function disconnectGithubProjectActions(): EditorAction[] {
+  return [
+    updateGithubData(emptyGithubData()),
+    updateGithubChecksums({}),
+    updateBranchContents(null),
+    updateGithubSettings({ ...emptyGithubSettings() }),
+  ]
 }


### PR DESCRIPTION
Fixes #2793 

**Problem:**

When you connect a project to a GH branch you're stuck with it and you cannot disconnect from it.

**Fix:**

This PR adds a button to wipe all the GH state for the current project, with a confirmation modal.

![Kapture 2022-11-09 at 11 06 16](https://user-images.githubusercontent.com/1081051/200801968-d93fe92e-6825-432d-8251-5bf8f07486e6.gif)
