### PR TITLE
Adjusting gap/padding values when they are set to 0

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -239,6 +239,25 @@ describe('Padding resize strategy', () => {
     )
   })
 
+  it('padding can be set to zero and then resized to a non-zero value', async () => {
+    const dragDeltaToZero = -100
+    const editor = await renderTestEditorWithCode(
+      makeTestProjectCodeWithStringPaddingValues('2em 1em 3em 2em'),
+      'await-first-dom-report',
+    )
+
+    await testPaddingResizeForEdge(editor, dragDeltaToZero, 'top', 'precise')
+    await editor.getDispatchFollowUpActionsFinished()
+
+    const dragDeltaFromZero = 100
+    await testPaddingResizeForEdge(editor, dragDeltaFromZero, 'top', 'precise')
+    await editor.getDispatchFollowUpActionsFinished()
+
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      makeTestProjectCodeWithStringPaddingValues(`${dragDeltaFromZero}px 1em 3em 2em`),
+    )
+  })
+
   describe('Adjusting individual padding values, precise', () => {
     // the expect is in `testAdjustIndividualPaddingValue`
     // eslint-disable-next-line jest/expect-expect
@@ -303,16 +322,16 @@ async function testPaddingResizeForEdge(
   mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
 
   const paddingControl = editor.renderedDOM.getByTestId(paddingControlHandleTestId(edge))
-  const bounds = paddingControl.getBoundingClientRect()
+  const paddingControlBounds = paddingControl.getBoundingClientRect()
 
-  const center = {
-    x: Math.floor(bounds.x + bounds.width / 2),
-    y: Math.floor(bounds.y + bounds.height / 2),
+  const paddingControlCenter = {
+    x: Math.floor(paddingControlBounds.x + paddingControlBounds.width / 2),
+    y: Math.floor(paddingControlBounds.y + paddingControlBounds.height / 2),
   }
-  const endPoint = offsetPointByEdge(edge, delta, center)
+  const endPoint = offsetPointByEdge(edge, delta, paddingControlCenter)
 
   const modifiers = precision === 'coarse' ? shiftModifier : undefined
-  mouseDragFromPointToPoint(paddingControl, center, endPoint, { modifiers })
+  mouseDragFromPointToPoint(paddingControl, paddingControlCenter, endPoint, { modifiers })
   await editor.getDispatchFollowUpActionsFinished()
 }
 


### PR DESCRIPTION
## Problem:
When a padding/gap value goes to 0 (any unit) during adjustment via the padding/gap handles, it cannot be set to any non-zero value after via the handles.

## Background:
The reason for this lies in the way adjusting a `CSSNumber` value with a delta is coded. Since the delta is given is pixels (calculated from mouse move events), we have to find out how many pixels is 1 unit of the `CSSNumber` we want to adjust, and then convert the drag delta into those units.

The code that finds out how many units is one pixel is along the lines of

```
const unitsPerPixel = cssNumber.valueInUnits / cssNumber.renderedValueInPx
const deltaInUnits = dragDelta * unitsPerPixel
```

For example, a gap is set to `3em`, with a rendered value of `48px`. If I want to adjust it by a delta of `32px`,  `pixelsPerUnit` is calculated to be `0.0625em` (`3 / 48`), and then the drag delta is convert to `2em` (`32 * 0.0625`), and the adjustment is made using this value.

The problem with this is that when `cssNumber.valueInUnits` is 0, `pixelsPerUnit` and `deltaInUnits` will be uniformly 0, and the updated CSSNumber will be unchanged, due to the calculated delta being 0. 

## Fix
Simply drop the unit when a padding/gap is set to 0 (any unit), instead of hacking it with side effects/global state.