### PR TITLE
Make padding/gap resize stripes less overwhelming

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -115,14 +115,14 @@ export const PillHandle = React.memo((props: PillHandleProps): JSX.Element => {
   )
 })
 
-export const StripeOpacity: number = 100
+export const StripeOpacity: number = 30
 
 export const StripedBackgroundCSS = (
   stripeColor: string,
   scale: number,
 ): { backgroundImage: string; backgroundSize: string } => ({
-  backgroundImage: `linear-gradient(135deg, ${stripeColor} 12.5%, rgba(255,255,255,0) 12.5%, rgba(255,255,255,0) 50%, ${stripeColor} 50%, ${stripeColor} 62%, rgba(255,255,255,0) 62%, rgba(255,255,255,0) 100%)`,
-  backgroundSize: `${20 / scale}px ${20 / scale}px`,
+  backgroundImage: `linear-gradient(135deg, ${stripeColor} 24.5%, rgba(255,255,255,0) 24.5%, rgba(255,255,255,0) 50%, ${stripeColor} 50%, ${stripeColor} 74%, rgba(255,255,255,0) 74%, rgba(255,255,255,0) 100%)`,
+  backgroundSize: `${4 / scale}px ${4 / scale}px`,
 })
 
 export type Timeout = ReturnType<typeof setTimeout>

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -115,6 +115,8 @@ export const PillHandle = React.memo((props: PillHandleProps): JSX.Element => {
   )
 })
 
+export const StripeOpacity: number = 100
+
 export const StripedBackgroundCSS = (
   stripeColor: string,
   scale: number,

--- a/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
@@ -32,6 +32,7 @@ import {
   CSSNumberWithRenderedValue,
   PillHandle,
   StripedBackgroundCSS,
+  StripeOpacity,
   useHoverWithDelay,
 } from './controls-common'
 
@@ -47,7 +48,7 @@ export const FlexGapControlHandleTestId = 'FlexGapControlHandleTestId'
 export const FlexGapControl = controlForStrategyMemoized<FlexGapControlProps>((props) => {
   const { selectedElement, flexDirection, updatedGapValue } = props
   const colorTheme = useColorTheme()
-  const indicatorColor = colorTheme.brandNeonPink.value
+  const indicatorColor = colorTheme.brandNeonPink.o(StripeOpacity).value
 
   const [indicatorShown, setIndicatorShown] = useState<string | null>(null)
   const [backgroundShown, setBackgroundShown] = useState<boolean>(false)
@@ -184,6 +185,8 @@ const GapControlSegment = React.memo<GapControlSegmentProps>((props) => {
     backgroundShown,
   } = props
 
+  const colorTheme = useColorTheme()
+
   const { dragBorderWidth, hitAreaPadding, paddingIndicatorOffset, borderWidth } =
     gapControlSizeConstants(DefaultGapControlSizeConstants, scale)
   const { width, height } = handleDimensions(flexDirection, scale)
@@ -235,7 +238,7 @@ const GapControlSegment = React.memo<GapControlSegmentProps>((props) => {
               pointerEvents: 'none',
             }}
           >
-            <CSSNumberLabel value={gapValue} scale={scale} color={indicatorColor} />
+            <CSSNumberLabel value={gapValue} scale={scale} color={colorTheme.brandNeonPink.value} />
           </div>,
         )}
         {when(
@@ -243,7 +246,7 @@ const GapControlSegment = React.memo<GapControlSegmentProps>((props) => {
           <PillHandle
             width={width}
             height={height}
-            pillColor={indicatorColor}
+            pillColor={colorTheme.brandNeonPink.value}
             borderWidth={borderWidth}
           />,
         )}

--- a/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
@@ -24,6 +24,7 @@ import {
   CSSNumberWithRenderedValue,
   PillHandle,
   StripedBackgroundCSS,
+  StripeOpacity,
   useHoverWithDelay,
 } from './controls-common'
 import { useMaybeHighlightElement } from './select-mode-hooks'
@@ -139,7 +140,7 @@ const PaddingResizeControlI = React.memo(
       PaddingIndicatorOffset,
     ].map((v) => v / scale)
 
-    const stripeColor = colorTheme.brandNeonPink.o(50).value
+    const stripeColor = colorTheme.brandNeonPink.o(StripeOpacity).value
     const color = colorTheme.brandNeonPink.value
 
     return (


### PR DESCRIPTION
## Try it [here](https://utopia.pizza/p/2783fe14-psychedelic-paint/?branch_name=fix/strips-too-big)

## Problem:
Padding/gap resize stripes are too distracting

## Fix:
space them tighter and make them less opaque

### Before
<img width="617" alt="image" src="https://user-images.githubusercontent.com/16385508/200894940-f23c2333-37be-4c2e-8119-1d7a8a37e22b.png">

### After
<img width="651" alt="image" src="https://user-images.githubusercontent.com/16385508/200895023-11a1ce11-5f23-4023-b810-b6d54e733c3f.png">

