### PR TITLE
Padding controls can show up on elements that have no business having a padding 

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -47,16 +47,7 @@ describe('Padding resize strategy', () => {
         height: 461,
       }}
       data-uid='24a'
-    >
-      <div
-        style={{
-          backgroundColor: '#0091FFAA',
-          width: 22,
-          height: 22,
-        }}
-        data-uid='002'
-      />
-    </div>`),
+    />`),
       'await-first-dom-report',
     )
 
@@ -78,7 +69,7 @@ describe('Padding resize strategy', () => {
     expect(paddingControls).toEqual([])
   })
 
-  it('Padding resize handle is present for elements that are dimensioned and have no children', async () => {
+  it('Padding resize handle is present for elements that are dimensioned and have children', async () => {
     const editor = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`<div
       data-testid='mydiv'
@@ -91,7 +82,16 @@ describe('Padding resize strategy', () => {
         height: 461,
       }}
       data-uid='24a'
-    />`),
+    >
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          width: 22,
+          height: 22,
+        }}
+        data-uid='002'
+      />
+    </div>`),
       'await-first-dom-report',
     )
 
@@ -99,8 +99,8 @@ describe('Padding resize strategy', () => {
     const div = editor.renderedDOM.getByTestId('mydiv')
     const divBounds = div.getBoundingClientRect()
     const divCorner = {
-      x: divBounds.x + 5,
-      y: divBounds.y + 4,
+      x: divBounds.x + 25,
+      y: divBounds.y + 24,
     }
 
     mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -185,9 +185,15 @@ function supportsPaddingControls(metadata: ElementInstanceMetadataMap, path: Ele
     return false
   }
 
+  const { top, right, bottom, left } = element.specialSizeMeasurements.padding
+  const elementHasNonzeroPadding = [top, right, bottom, left].some((s) => s != null && s > 0)
+  if (elementHasNonzeroPadding) {
+    return true
+  }
+
   const children = MetadataUtils.getChildren(metadata, path)
   if (children.length === 0) {
-    return true
+    return false
   }
 
   const childrenNotPositionedAbsoluteOrSticky = MetadataUtils.getChildren(metadata, path).filter(
@@ -196,17 +202,11 @@ function supportsPaddingControls(metadata: ElementInstanceMetadataMap, path: Ele
       child.specialSizeMeasurements.position !== 'sticky',
   )
 
-  if (childrenNotPositionedAbsoluteOrSticky.length < 1) {
-    return false
+  if (childrenNotPositionedAbsoluteOrSticky.length > 0) {
+    return true
   }
 
-  const { top, right, bottom, left } = element.specialSizeMeasurements.padding
-  const elementHasNonzeroPadding = [top, right, bottom, left].some((s) => s != null && s > 0)
-  if (!elementHasNonzeroPadding) {
-    return false
-  }
-
-  return true
+  return false
 }
 
 function paddingValueIndicatorProps(

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`406`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`404`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`395`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`393`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`691`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`670`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`763`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`742`)
   })
 })


### PR DESCRIPTION
## Problem:
Padding controls can show up on elements that have no business having a padding (such as `img`).

## Fix:
Tweak the rules so that
1. if the element has a non-zero padding value, we show the padding controls
2. if the element has any children that are not positioned `absolute` or `sticky` we show the padding controls
3. otherwise, we don't show the padding controls

