### PR TITLE
removed shade from utopiColor, removed all instances of .shade() and moved actual colors to the light and dark themes

### DIFF
--- a/editor/src/components/canvas/controls/outline-control.tsx
+++ b/editor/src/components/canvas/controls/outline-control.tsx
@@ -39,7 +39,7 @@ export function getSelectionColor(
   } else if (MetadataUtils.isFocusableComponent(path, metadata)) {
     return colorTheme.canvasSelectionFocusable.value
   } else {
-    return colorTheme.CanvasSelectionNotFocusable.value
+    return colorTheme.canvasSelectionNotFocusable.value
   }
 }
 
@@ -364,7 +364,7 @@ export const OutlineControls = (props: OutlineControlsProps) => {
         scale={props.scale}
         color={selectionColor}
         striped={createsYogaLayout}
-        stripedColor={colorTheme.canvasSelectionAlternateOutlineYogaParent.shade(50).value}
+        stripedColor={colorTheme.selectionOutlines.value}
       />,
     )
   })

--- a/editor/src/components/canvas/controls/property-target-selector.tsx
+++ b/editor/src/components/canvas/controls/property-target-selector.tsx
@@ -88,7 +88,7 @@ export const PropertyTargetSelector = React.memo(
       <div
         style={{
           position: 'absolute',
-          backgroundColor: colorTheme.primary.shade(10).value,
+          backgroundColor: colorTheme.canvasElementBackground.value,
           border: `1px solid ${colorTheme.primary.value}`,
           borderRadius: 5,
           top: props.top,

--- a/editor/src/components/canvas/controls/select-mode/flex-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-resize-control.tsx
@@ -248,7 +248,7 @@ const DimensionableControlVertical = React.memo(() => {
       className='label-dimensionableControlVertical'
       style={{
         position: 'relative',
-        backgroundColor: colorTheme.primary.shade(10).value,
+        backgroundColor: colorTheme.canvasElementBackground.value,
         borderRadius: 5 / scale,
         boxShadow: `0px 0px 0px ${0.3 / scale}px ${colorTheme.primary.value}, 0px ${1 / scale}px ${
           3 / scale
@@ -277,7 +277,7 @@ const DimensionableControlHorizontal = React.memo(() => {
       className='label-dimensionableControlVertical'
       style={{
         position: 'relative',
-        backgroundColor: colorTheme.primary.shade(10).value,
+        backgroundColor: colorTheme.canvasElementBackground.value,
         borderRadius: 5 / scale,
         boxShadow: `0px 0px 0px ${0.3 / scale}px ${colorTheme.primary.value}, 0px ${1 / scale}px ${
           3 / scale

--- a/editor/src/components/canvas/controls/size-box.tsx
+++ b/editor/src/components/canvas/controls/size-box.tsx
@@ -442,7 +442,7 @@ const DimensionableControlVertical = (props: DimensionableControlProps) => {
       className='label-dimensionableControlVertical'
       style={{
         position: 'absolute',
-        backgroundColor: colorTheme.primary.shade(10).value,
+        backgroundColor: colorTheme.canvasElementBackground.value,
         borderRadius: `${5 / props.scale}px`,
         // These just about work. I can clean them up afterwards
         boxShadow: `0px 0px 0px ${0.3 / props.scale}px ${colorTheme.primary.value}, 0px ${
@@ -469,7 +469,7 @@ const DimensionableControlHorizontal = (props: DimensionableControlProps) => {
       className='label-dimensionableControlVertical'
       style={{
         position: 'absolute',
-        backgroundColor: colorTheme.primary.shade(10).value,
+        backgroundColor: colorTheme.canvasElementBackground.value,
         borderRadius: `${5 / props.scale}px`,
         // These just about work. I can clean them up afterwards
         boxShadow: `0px 0px 0px ${0.3 / props.scale}px ${colorTheme.primary.value}, 0px ${

--- a/editor/src/components/editor/component-button.tsx
+++ b/editor/src/components/editor/component-button.tsx
@@ -66,12 +66,12 @@ export const ComponentOrInstanceIndicator = React.memo(() => {
       if (isComponent && !isFocused) {
         return {
           color: colorTheme.component.value,
-          backgroundColor: colorTheme.component.shade(10).value,
+          backgroundColor: colorTheme.canvasComponentButtonFocusable.value,
         }
       } else if (isFocused && isComponent) {
         return {
           color: colorTheme.componentChild.value,
-          backgroundColor: colorTheme.componentChild.shade(10).value,
+          backgroundColor: colorTheme.canvasComponentButtonFocused.value,
         }
       } else {
         return {

--- a/editor/src/components/inspector/common/inspector-utils.tsx
+++ b/editor/src/components/inspector/common/inspector-utils.tsx
@@ -9,7 +9,7 @@ import { ControlStatus } from './control-status'
 import { CSSBackgroundLayer, CSSTransformItem, CSSUnknownArrayItem } from './css-utils'
 
 const isControlledStyling = (colorTheme: any) => ({
-  backgroundColor: colorTheme.primary.shade(5).value,
+  backgroundColor: colorTheme.inspectorControlledBackground.value,
   color: colorTheme.primary.value,
 })
 

--- a/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
@@ -144,7 +144,7 @@ const RepositoryRow = (props: RepositoryRowProps) => {
           color:
             props.importPermitted && !githubWorking
               ? colorTheme.inlineButtonColor.value
-              : colorTheme.inlineButtonColor.shade(50).value,
+              : colorTheme.inlineButtonColorDisabled.value,
           borderRadius: 2,
           cursor: 'pointer',
           minWidth: '44px',

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -8,8 +8,6 @@ import { MenuTile } from './menu-tile'
 import { FullHeightButton, RoundedButton, TextButton } from './buttons'
 import { TestMenu } from './test-menu'
 
-interface TitleBarProps {}
-
 const AppLogo: React.FC<{ onClick: () => void }> = ({ onClick }) => (
   <div
     onClick={onClick}
@@ -28,8 +26,8 @@ const ProjectTitle: React.FC<React.PropsWithChildren<ProjectTitleProps>> = ({ ch
   return <div style={{ fontWeight: 400, fontSize: 12, padding: '0 10px' }}>{children}</div>
 }
 
-const TitleBar: React.FC<React.PropsWithChildren<TitleBarProps>> = () => {
-  const { loginState, projectName, isCodeEditorVisible, isPreviewPaneVisible, dispatch } =
+const TitleBar = React.memo(() => {
+  const { dispatch, loginState, projectName, isCodeEditorVisible, isPreviewPaneVisible } =
     useEditorState(
       (store) => ({
         dispatch: store.dispatch,
@@ -115,6 +113,6 @@ const TitleBar: React.FC<React.PropsWithChildren<TitleBarProps>> = () => {
       </div>
     </SimpleFlexRow>
   )
-}
+})
 
 export default TitleBar

--- a/editor/src/uuiui/button.tsx
+++ b/editor/src/uuiui/button.tsx
@@ -100,9 +100,9 @@ export const FormButton = styled.button<ButtonProps>((props: ButtonProps) => ({
   // slightly subdued colors in default state
   backgroundColor: props.primary
     ? props.danger
-      ? colorTheme.errorForeground.shade(90).value
-      : colorTheme.primary.shade(90).value
-    : colorTheme.emphasizedBackground.shade(101).value,
+      ? colorTheme.errorForegroundSubdued.value
+      : colorTheme.primarySubdued.value
+    : colorTheme.emphasizedBackgroundPop.value,
 
   color: props.primary ? 'white' : props.danger ? colorTheme.errorForeground.value : 'inherit',
 
@@ -138,8 +138,8 @@ export const FormButton = styled.button<ButtonProps>((props: ButtonProps) => ({
     // slightly brighter backgrounds while pressed
     backgroundColor: props.primary
       ? props.danger
-        ? colorTheme.errorForeground.shade(103).value
-        : colorTheme.primary.shade(103).value
-      : colorTheme.emphasizedBackground.shade(98).value,
+        ? colorTheme.errorForegroundEmphasized.value
+        : colorTheme.primaryEmphasized.value
+      : colorTheme.emphasizedBackgroundReduced.value,
   },
 }))

--- a/editor/src/uuiui/inline-button.tsx
+++ b/editor/src/uuiui/inline-button.tsx
@@ -34,7 +34,7 @@ export const InlineButton = styled.button({
   position: 'relative',
   '&:hover': {
     borderRadius: 1,
-    background: colorTheme.primary.shade(10).value,
+    background: colorTheme.canvasElementBackground.value,
   },
   '&:focus': {
     outline: 'none',
@@ -56,18 +56,22 @@ export const InlineIndicator = styled.div<{
   outline: 'none',
   paddingLeft: 2,
   paddingRight: 2,
-  color: props.shouldIndicate ? colorTheme.primary.value : colorTheme.primary.shade(30).value,
+  color: props.shouldIndicate
+    ? colorTheme.primary.value
+    : colorTheme.canvasControlsInlineIndicatorInactive.value,
 }))
 
 export const InlineToggleButton = styled(InlineButton)<{
   toggleValue: boolean
 }>((props) => ({
-  color: props.toggleValue ? colorTheme.primary.value : colorTheme.primary.shade(30).value,
+  color: props.toggleValue
+    ? colorTheme.primary.value
+    : colorTheme.canvasControlsInlineToggleUnsetText.value,
   '&:hover': {
-    background: colorTheme.primary.shade(5).value,
-    color: colorTheme.primary.shade(90).value,
+    background: colorTheme.canvasControlsInlineToggleHoverBackground.value,
+    color: colorTheme.canvasControlsInlineToggleHoverText.value,
   },
   '&:active': {
-    background: colorTheme.primary.shade(10).value,
+    background: colorTheme.canvasControlsInlineToggleActiveBackground.value,
   },
 }))

--- a/editor/src/uuiui/styles/theme.ts
+++ b/editor/src/uuiui/styles/theme.ts
@@ -1,6 +1,5 @@
-import { useEditorState } from './../../components/editor/store/store-hook'
-import { Interpolation } from '@emotion/react'
 import { Theme } from './../../components/editor/store/editor-state'
+import { useEditorState } from './../../components/editor/store/store-hook'
 import { createUtopiColor } from './utopi-color-helpers'
 
 const base = {
@@ -19,8 +18,10 @@ const base = {
 }
 
 const lightBase = {
-  darkPrimary: base.blue.shade(150),
+  darkPrimary: createUtopiColor('rgba(0,61,128,1)'),
   primary: base.blue,
+  primarySubdued: createUtopiColor('rgba(0,118,247,1)'),
+  primaryEmphasized: createUtopiColor('rgba(26,135,255,1)'),
   component: base.purple,
   componentChild: base.orange,
   css: base.neongreen,
@@ -55,6 +56,8 @@ const lightBase = {
 const lightPrimitives = {
   // backgrounds
   emphasizedBackground: lightBase.bg0,
+  emphasizedBackgroundPop: createUtopiColor('rgba(252,252,252,1)'),
+  emphasizedBackgroundReduced: createUtopiColor('rgba(255,255,255,1)'),
   neutralBackground: lightBase.bg1,
   secondaryBackground: lightBase.bg2,
   subtleBackground: lightBase.bg3,
@@ -73,10 +76,12 @@ const lightPrimitives = {
 
 const lightErrorStates = {
   errorForeground: base.red,
-  errorBgSolid: base.red.shade(70),
+  errorForegroundSubdued: createUtopiColor('rgba(253,26,79,1)'),
+  errorForegroundEmphasized: createUtopiColor('rgba(245,0,57,1)'),
+  errorBgSolid: createUtopiColor('rgba(254,77,118,1)'),
   warningForeground: base.orange,
   warningBgTranslucent: base.orange.o(20),
-  warningBgSolid: base.orange.shade(70),
+  warningBgSolid: createUtopiColor('rgba(252,142,77,1)'),
 }
 
 const light = {
@@ -91,7 +96,7 @@ const light = {
   leftPaneBackground: lightPrimitives.neutralBackground,
   inspectorBackground: lightPrimitives.neutralBackground,
   canvasBackground: lightPrimitives.secondaryBackground,
-  canvasLiveBackground: lightPrimitives.secondaryBackground.shade(30),
+  canvasLiveBackground: createUtopiColor('rgba(252,252,252,1)'),
   canvasLiveBorder: lightBase.primary,
 
   // tabs. Nb: active tab matches canvasBackground
@@ -107,15 +112,20 @@ const light = {
   canvasControlsSizeBoxBorder: createUtopiColor('hsl(0,0%,15%)'),
   canvasControlsCoordinateSystemMarks: base.neonpink,
   canvasControlsImmediateParentMarks: base.black.o(25),
+  canvasControlsInlineIndicatorInactive: createUtopiColor('rgba(179,215,255,1)'),
+  canvasControlsInlineToggleUnsetText: createUtopiColor('rgba(179,215,255,1)'),
+  canvasControlsInlineToggleHoverBackground: createUtopiColor('rgba(242,248,255,1)'),
+  canvasControlsInlineToggleHoverText: createUtopiColor('rgba(26,135,255,1)'),
+  canvasControlsInlineToggleActiveBackground: createUtopiColor('rgba(230,242,255,1)'),
 
   canvasSelectionPrimaryOutline: lightBase.primary,
   canvasSelectionInstanceOutline: base.purple,
   canvasSelectionSceneOutline: base.purple,
   canvasSelectionRandomDOMElementInstanceOutline: base.darkgray,
   canvasSelectionAlternateOutlineYogaParent: base.neonpink,
-  canvasSelectionAlternateOutlineYogaChild: base.neonpink.shade(80),
+  canvasSelectionAlternateOutlineYogaChild: createUtopiColor('rgba(255,51,255,1)'),
   canvasSelectionSecondaryOutline: base.almostBlack.o(50),
-  CanvasSelectionNotFocusable: base.darkgray,
+  canvasSelectionNotFocusable: base.darkgray,
   canvasDraggingPlaceholderYoga: base.neonpink.o(30),
   canvasDragOutlineBlock: lightBase.primary,
   canvasDragOutlineInline: base.red,
@@ -128,17 +138,24 @@ const light = {
 
   canvasLayoutForeground: base.neonpink,
   canvasLayoutFillSolid: base.neonpink,
-  canvasLayoutFillTranslucent: base.neonpink.shade(10).o(90),
+  canvasLayoutFillTranslucent: createUtopiColor('rgba(255,230,255,0.9)'),
   canvasLayoutStroke: base.neonpink,
 
   paddingForeground: base.neongreen,
   paddingFillSolid: base.neongreen,
-  paddingFillTranslucent: base.neongreen.shade(10).o(70),
+  paddingFillTranslucent: createUtopiColor('rgba(230,248,230,0.7)'),
   paddingStroke: base.neongreen,
+
+  selectionOutlines: createUtopiColor('rgba(255,128,255,1)'),
+  canvasElementBackground: createUtopiColor('rgba(230,242,255,1)'),
+  canvasComponentButtonFocusable: createUtopiColor('rgba(238,237,252,1)'),
+  canvasComponentButtonFocused: createUtopiColor('rgba(255,239,230,1)'),
+  inspectorControlledBackground: createUtopiColor('rgba(242,248,255,1)'),
 
   // interface elements: buttons, segment controls, checkboxes etc
 
   inlineButtonColor: lightBase.primary,
+  inlineButtonColorDisabled: createUtopiColor('rgba(128,189,255,1)'),
   buttonBackground: lightBase.bg2,
   buttonHoverBackground: lightBase.bg3,
 
@@ -163,8 +180,10 @@ const light = {
 
 /** DARK **/
 const darkBase = {
-  darkPrimary: base.blue.shade(150),
+  darkPrimary: createUtopiColor('rgba(0,61,128,1)'),
   primary: base.blue,
+  primarySubdued: createUtopiColor('rgba(0,118,247,1)'),
+  primaryEmphasized: createUtopiColor('rgba(26,135,255,1)'),
   component: base.purple,
   componentChild: base.orange,
   css: base.neongreen,
@@ -199,6 +218,8 @@ const darkBase = {
 const darkPrimitives = {
   // backgrounds
   emphasizedBackground: darkBase.bg0,
+  emphasizedBackgroundPop: createUtopiColor('rgba(0,0,0,1)'),
+  emphasizedBackgroundReduced: createUtopiColor('rgba(5,5,5,1)'),
   neutralBackground: darkBase.bg1,
   secondaryBackground: darkBase.bg2,
   subtleBackground: darkBase.bg3,
@@ -217,10 +238,12 @@ const darkPrimitives = {
 
 const darkErrorStates = {
   errorForeground: base.red,
-  errorBgSolid: base.red.shade(70),
+  errorForegroundSubdued: createUtopiColor('rgba(253,26,79,1)'),
+  errorForegroundEmphasized: createUtopiColor('rgba(245,0,57,1)'),
+  errorBgSolid: createUtopiColor('rgba(254,77,118,1)'),
   warningForeground: base.orange,
   warningBgTranslucent: base.orange.o(20),
-  warningBgSolid: base.orange.shade(70),
+  warningBgSolid: createUtopiColor('rgba(252,142,77,1)'),
 }
 const dark: typeof light = {
   ...darkBase,
@@ -234,7 +257,7 @@ const dark: typeof light = {
   leftPaneBackground: darkPrimitives.neutralBackground,
   inspectorBackground: darkPrimitives.neutralBackground,
   canvasBackground: darkPrimitives.secondaryBackground,
-  canvasLiveBackground: darkPrimitives.secondaryBackground.shade(30),
+  canvasLiveBackground: createUtopiColor('rgba(195,197,201,1)'),
   canvasLiveBorder: darkBase.primary,
 
   // tabs. Nb: active tab matches canvasBackground
@@ -250,15 +273,20 @@ const dark: typeof light = {
   canvasControlsSizeBoxBorder: createUtopiColor('hsl(0,0%,15%)'),
   canvasControlsCoordinateSystemMarks: base.neonpink,
   canvasControlsImmediateParentMarks: base.black.o(25),
+  canvasControlsInlineIndicatorInactive: createUtopiColor('rgba(179,215,255,1)'),
+  canvasControlsInlineToggleUnsetText: createUtopiColor('rgba(179,215,255,1)'),
+  canvasControlsInlineToggleHoverBackground: createUtopiColor('rgba(242,248,255,1)'),
+  canvasControlsInlineToggleHoverText: createUtopiColor('rgba(26,135,255,1)'),
+  canvasControlsInlineToggleActiveBackground: createUtopiColor('rgba(230,242,255,1)'),
 
   canvasSelectionPrimaryOutline: darkBase.primary,
   canvasSelectionInstanceOutline: base.purple,
   canvasSelectionSceneOutline: base.purple,
   canvasSelectionRandomDOMElementInstanceOutline: base.darkgray,
   canvasSelectionAlternateOutlineYogaParent: base.neonpink,
-  canvasSelectionAlternateOutlineYogaChild: base.neonpink.shade(80),
+  canvasSelectionAlternateOutlineYogaChild: createUtopiColor('rgba(255,51,255,1)'),
   canvasSelectionSecondaryOutline: base.almostBlack.o(50),
-  CanvasSelectionNotFocusable: base.darkgray,
+  canvasSelectionNotFocusable: base.darkgray,
   canvasDraggingPlaceholderYoga: base.neonpink.o(30),
   canvasDragOutlineBlock: darkBase.primary,
   canvasDragOutlineInline: base.red,
@@ -271,17 +299,24 @@ const dark: typeof light = {
 
   canvasLayoutForeground: base.neonpink,
   canvasLayoutFillSolid: base.neonpink,
-  canvasLayoutFillTranslucent: base.neonpink.shade(10).o(90),
+  canvasLayoutFillTranslucent: createUtopiColor('rgba(255,230,255,0.9)'),
   canvasLayoutStroke: base.neonpink,
 
   paddingForeground: base.neongreen,
   paddingFillSolid: base.neongreen,
-  paddingFillTranslucent: base.neongreen.shade(10).o(90),
+  paddingFillTranslucent: createUtopiColor('rgba(230,248,230,0.9)'),
   paddingStroke: base.neongreen,
+
+  selectionOutlines: createUtopiColor('rgba(255,128,255,1)'),
+  canvasElementBackground: createUtopiColor('rgba(230,242,255,1)'),
+  canvasComponentButtonFocusable: createUtopiColor('rgba(238,237,252,1)'),
+  canvasComponentButtonFocused: createUtopiColor('rgba(255,239,230,1)'),
+  inspectorControlledBackground: createUtopiColor('rgba(242,248,255,1)'),
 
   // interface elements: buttons, segment controls, checkboxes etc
 
   inlineButtonColor: darkBase.primary,
+  inlineButtonColorDisabled: createUtopiColor('rgba(128,189,255,1)'),
   buttonBackground: darkBase.bg2,
   buttonHoverBackground: darkBase.bg3,
 

--- a/editor/src/uuiui/styles/utopi-color-helpers.ts
+++ b/editor/src/uuiui/styles/utopi-color-helpers.ts
@@ -1,6 +1,4 @@
 import ChromaWrongTypes from 'chroma-js'
-import { clamp } from '../../core/shared/math-utils'
-import { IcnColor } from '../icn'
 const Chroma = ChromaWrongTypes as any
 
 export interface UtopiColor {
@@ -22,24 +20,6 @@ export interface UtopiColor {
 }
 
 type ColorHex = string
-type ColorShades = Array<ColorHex>
-
-const colorShadeCache: { [colorHex: string]: ColorShades } = {}
-function shade(this: UtopiColor, value: number): UtopiColor {
-  if (colorShadeCache[this.value] == null) {
-    const alpha = Chroma(this.value).rgba()[3]
-    const whiteWithOpacity = Chroma('white').alpha(alpha)
-    const blackWithOpacity = Chroma('black').alpha(alpha)
-    // shades go from 0 to 200, so we ask Chroma to create a 201-long color range
-    colorShadeCache[this.value] = Chroma.scale([
-      whiteWithOpacity,
-      this.value,
-      blackWithOpacity,
-    ]).colors(201)
-  }
-  const index = clamp(0, 200, Math.floor(value))
-  return createUtopiColor(colorShadeCache[this.value][index])
-}
 
 const opacitycache: { [colorHex: string]: { [opacity: string]: ColorHex } } = {}
 function opacity(this: UtopiColor, value: number): UtopiColor {
@@ -60,6 +40,7 @@ export function createUtopiColor(baseColor: string): UtopiColor {
   const fromCache = utopiColorCache[key]
   if (fromCache == null) {
     const hexWithAlpha = Chroma(baseColor).css('rgba')
+
     const value = {
       value: hexWithAlpha,
       shade: shade,

--- a/editor/src/uuiui/styles/utopi-color-helpers.ts
+++ b/editor/src/uuiui/styles/utopi-color-helpers.ts
@@ -8,12 +8,6 @@ export interface UtopiColor {
   value: string
 
   /**
-   * The color palette shade of the base color.
-   * @param value 0 is white, 200 is black, 100 is identity
-   */
-  shade: (value: number) => UtopiColor
-
-  /**
    * Opacity or Alpha. Value goes from 0 to 100
    */
   o: (value: number) => UtopiColor
@@ -43,7 +37,6 @@ export function createUtopiColor(baseColor: string): UtopiColor {
 
     const value = {
       value: hexWithAlpha,
-      shade: shade,
       o: opacity,
     }
     utopiColorCache[key] = value

--- a/editor/src/uuiui/styles/utopi-colors.spec.ts
+++ b/editor/src/uuiui/styles/utopi-colors.spec.ts
@@ -12,22 +12,6 @@ describe('UtopiColors', () => {
     expect(colorFromHex.value).toEqual('rgba(0,122,255,1)')
   })
 
-  it('shade 100 is identity function', () => {
-    const babyBlue = createUtopiColor('#007AFF')
-    expect(babyBlue.value).toEqual(babyBlue.shade(100).value)
-    expect(babyBlue.shade(100).value).toEqual(babyBlue.shade(100).shade(100).shade(100).value)
-  })
-
-  it('shade 0 is white', () => {
-    const babyBlue = createUtopiColor('#007AFF')
-    expect('rgba(255,255,255,1)').toEqual(babyBlue.shade(0).value)
-  })
-
-  it('shade 200 is black!', () => {
-    const babyBlue = createUtopiColor('#007AFF')
-    expect('rgba(0,0,0,1)').toEqual(babyBlue.shade(200).value)
-  })
-
   it('opacity 100 is identity', () => {
     const babyBlueAlpha = createUtopiColor('#007AFFFF')
     expect(babyBlueAlpha.value).toEqual(babyBlueAlpha.o(100).value)
@@ -39,11 +23,6 @@ describe('UtopiColors', () => {
     expect('rgba(0,122,255,0)').toEqual(babyBlueAlpha.o(0).value)
   })
 
-  it('call order of opacity and shade is not important', () => {
-    const babyBlue = createUtopiColor('#007AFFFF')
-    expect(babyBlue.shade(50).o(50)).toEqual(babyBlue.o(50).shade(50))
-  })
-
   const TEST_SIZE = 10000
 
   xit('test createUtopiColor performance', () => {
@@ -53,16 +32,6 @@ describe('UtopiColors', () => {
     }
     const endTime = performance.now()
     console.info('CREATE UTOPICOLORS PERFORMANCE MEASURE', (endTime - startTime) / TEST_SIZE)
-  })
-
-  xit('test shade performance', () => {
-    const babyBlue = createUtopiColor('#007AFF')
-    const startTime = performance.now()
-    for (let i = 0; i < TEST_SIZE; i++) {
-      babyBlue.shade(99).value
-    }
-    const endTime = performance.now()
-    console.info('SHADE PERFORMANCE MEASURE', (endTime - startTime) / TEST_SIZE)
   })
 
   xit('test opacity performance', () => {


### PR DESCRIPTION
**Problem:**
UtopiColor.shade() is no longer desirable functionality.

**Fix:**
Removed the .shade() function from UtopiColor and moved all colors created with it that exist outside of `theme.ts` into the `theme.ts`

**Commit Details:**
- Removed `shade` function from `utopi-color-helpers.ts`
- Removed tests using the `shade` function