### PR TITLE
When dragging a padding control handle, the padding indicator is under the cursor

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -21,6 +21,7 @@ import {
   deltaFromEdge,
   offsetPaddingByEdge,
   paddingForEdge,
+  PaddingIndictorOffset,
   paddingMeasurementForEdge,
   paddingToPaddingString,
   simplePaddingFromMetadata,
@@ -238,7 +239,7 @@ function paddingValueIndicatorProps(
 
   const updatedPaddingMeasurement = offsetMeasurementByDelta(
     currentPadding,
-    deltaFromEdge(drag, edgePiece),
+    deltaFromEdge(drag, edgePiece) + PaddingIndictorOffset(canvasState.scale),
     precisionFromModifiers(interactionSession.interactionData.modifiers),
   )
 

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { roundTo } from '../../../../core/shared/math-utils'
+import { CanvasVector, roundTo } from '../../../../core/shared/math-utils'
 import { Modifiers } from '../../../../utils/modifiers'
 import { CSSNumber, CSSNumberUnit, printCSSNumber } from '../../../inspector/common/css-utils'
 

--- a/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../canvas-strategies/interaction-state'
 import { CSSCursor, EdgePiece } from '../../canvas-types'
 import { windowToCanvasCoordinates } from '../../dom-lookup'
-import { simplePaddingFromMetadata } from '../../padding-utils'
+import { PaddingIndictorOffset, simplePaddingFromMetadata } from '../../padding-utils'
 import { useBoundingBox } from '../bounding-box-hooks'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 import { isZeroSizedElement } from '../outline-utils'
@@ -61,7 +61,6 @@ const PaddingResizeControlHeight = 12
 const PaddingResizeControlBorder = 0.5
 const PaddingResizeDragBorder = 1
 const PaddingResizeControlHitAreaWidth = 10
-const PaddingIndicatorOffset = 10
 
 type StoreSelector<T> = (s: EditorStorePatched) => T
 
@@ -133,11 +132,10 @@ const PaddingResizeControlI = React.memo(
       size(PaddingResizeControlWidth / scale, PaddingResizeControlHeight / scale),
     )
 
-    const [hitAreaWidth, borderWidth, dragBorderWidth, paddingIndicatorOffset] = [
+    const [hitAreaWidth, borderWidth, dragBorderWidth] = [
       PaddingResizeControlHitAreaWidth,
       PaddingResizeControlBorder,
       PaddingResizeDragBorder,
-      PaddingIndicatorOffset,
     ].map((v) => v / scale)
 
     const stripeColor = colorTheme.brandNeonPink.o(StripeOpacity).value
@@ -175,8 +173,8 @@ const PaddingResizeControlI = React.memo(
             <div
               style={{
                 position: 'absolute',
-                paddingTop: paddingIndicatorOffset,
-                paddingLeft: paddingIndicatorOffset,
+                paddingTop: PaddingIndictorOffset(scale),
+                paddingLeft: PaddingIndictorOffset(scale),
               }}
             >
               <CSSNumberLabel value={props.paddingValue.value} scale={scale} color={color} />

--- a/editor/src/components/canvas/padding-utils.tsx
+++ b/editor/src/components/canvas/padding-utils.tsx
@@ -226,3 +226,5 @@ export function deltaFromEdge(delta: CanvasVector, edgePiece: EdgePiece): number
       assertNever(edgePiece)
   }
 }
+
+export const PaddingIndictorOffset = (scale: number): number => 10 / scale


### PR DESCRIPTION
## Problem:
When dragging a padding control handle, the padding indicator (that shows the current padding value (e.g. `22px`) is under the cursor.

## Fix:
Add extra offset to the indicator position