### PR TITLE
Fix/reorder helpers switch displayprop

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-helpers.ts
@@ -224,11 +224,13 @@ export function getOptionalDisplayPropCommandsForFlow(
     lastReorderIdx != null &&
     lastReorderIdx !== siblingsOfTarget.findIndex((sibling) => EP.pathsEqual(sibling, target))
   ) {
-    const newDisplayType = getNewDisplayTypeForIndex(
+    const targetSibling = MetadataUtils.findElementByElementPath(
       startingMetadata,
       siblingsOfTarget[lastReorderIdx],
     )
-    return getNewDisplayTypeCommands(element, newDisplayType) // TODO this is wrong, it will convert a display: flex to block!!!
+    const elementDisplayType = elementMetadata?.specialSizeMeasurements.display ?? null
+    const newDirection = getElementDirection(targetSibling) === 'horizontal' ? 'row' : 'column'
+    return getOptionalCommandToConvertDisplayInlineBlock(target, elementDisplayType, newDirection)
   } else {
     return []
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-helpers.ts
@@ -161,46 +161,7 @@ export function getElementDirection(
   return displayValue?.includes('inline') ? 'horizontal' : 'vertical'
 }
 
-function getNewDisplayTypeForIndex(
-  metadata: ElementInstanceMetadataMap,
-  targetSibling: ElementPath,
-) {
-  const displayType = MetadataUtils.findElementByElementPath(metadata, targetSibling)
-    ?.specialSizeMeasurements.display
-  const displayBlockInlineBlock =
-    displayType === 'block' || displayType === 'inline-block' ? displayType : null
-
-  return displayBlockInlineBlock
-}
-
-function shouldRemoveDisplayProp(
-  element: ElementInstanceMetadata | null,
-  newDisplayValue: 'block' | 'inline-block' | null,
-): boolean {
-  if (element == null || element.specialSizeMeasurements.htmlElementName == null) {
-    return false
-  } else {
-    return (
-      // TODO global css overrides can change these defaults
-      defaultDisplayTypeForHTMLElement(element.specialSizeMeasurements.htmlElementName) ===
-      newDisplayValue
-    )
-  }
-}
-
 const StyleDisplayProp = stylePropPathMappingFn('display', ['style'])
-function getNewDisplayTypeCommands(
-  element: ElementInstanceMetadata,
-  newDisplayValue: 'block' | 'inline-block' | null,
-): Array<SetProperty | DeleteProperties> {
-  if (shouldRemoveDisplayProp(element, newDisplayValue)) {
-    return [deleteProperties('always', element.elementPath, [StyleDisplayProp])]
-  } else if (newDisplayValue != null) {
-    return [setProperty('always', element.elementPath, StyleDisplayProp, newDisplayValue)]
-  } else {
-    return []
-  }
-}
 
 export function getOptionalDisplayPropCommandsForFlow(
   lastReorderIdx: number | null | undefined,


### PR DESCRIPTION
Fixes [#2807](https://github.com/concrete-utopia/utopia/issues/2807)

**Problem:**
When reordering a flow layout from keyboard or slider and inserting into a row of inline elements the element is converted to inline too. The issue is that it always added `display: inline-block`, even if it was `display: flex` before, the flex property was lost.

**Commit Details:**
- added tests to convert between flex and inline-flex, block and inline-block
- using `getOptionalCommandToConvertDisplayInlineBlock` which solved the same problem for reparent
