### PR TITLE
Scale gap resize drag delta depending on the gap control being manipulated

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -513,11 +513,13 @@ export function resizeHandle(edgePosition: EdgePosition): ResizeHandle {
 
 export interface FlexGapHandle {
   type: 'FLEX_GAP_HANDLE'
+  offset: number
 }
 
-export function flexGapHandle(): FlexGapHandle {
+export function flexGapHandle(offset: number): FlexGapHandle {
   return {
     type: 'FLEX_GAP_HANDLE',
+    offset: offset,
   }
 }
 

--- a/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
@@ -90,8 +90,8 @@ export const FlexGapControl = controlForStrategyMemoized<FlexGapControlProps>((p
   )
 
   const onMouseDown = React.useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      startInteraction(e, dispatch, canvasOffset.current, scale)
+    (offset: number) => (e: React.MouseEvent<HTMLDivElement>) => {
+      startInteraction(e, dispatch, canvasOffset.current, scale, offset)
     },
     [canvasOffset, dispatch, scale],
   )
@@ -99,7 +99,7 @@ export const FlexGapControl = controlForStrategyMemoized<FlexGapControlProps>((p
   return (
     <CanvasOffsetWrapper>
       <div data-testid={FlexGapControlTestId} ref={controlRef}>
-        {controlBounds.map(({ bounds, path: p }) => {
+        {controlBounds.map(({ bounds, path: p }, offset) => {
           const path = EP.toString(p)
           return (
             <GapControlSegment
@@ -108,7 +108,7 @@ export const FlexGapControl = controlForStrategyMemoized<FlexGapControlProps>((p
               hoverEnd={controlHoverEnd}
               handleHoverStart={handleHoverStart}
               handleHoverEnd={handleHoverEnd}
-              onMouseDown={onMouseDown}
+              onMouseDown={onMouseDown(offset + 1)}
               indicatorShown={indicatorShown}
               path={path}
               bounds={bounds}
@@ -270,6 +270,7 @@ function startInteraction(
   dispatch: EditorDispatch,
   canvasOffset: CanvasVector,
   scale: number,
+  offset: number,
 ) {
   event.stopPropagation()
   if (event.buttons === 1 && event.button !== 2) {
@@ -283,7 +284,7 @@ function startInteraction(
         createInteractionViaMouse(
           canvasPositions.canvasPositionRaw,
           Modifier.modifiersForEvent(event),
-          flexGapHandle(),
+          flexGapHandle(offset),
         ),
       ),
     ])

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1742,14 +1742,8 @@ export const BoundingAreaKeepDeepEquality: KeepDeepEqualityCall<BoundingArea> = 
 export const ResizeHandleKeepDeepEquality: KeepDeepEqualityCall<ResizeHandle> =
   combine1EqualityCall((handle) => handle.edgePosition, EdgePositionKeepDeepEquality, resizeHandle)
 
-// This will break should the definition of `FlexGapHandle` change.
-flexGapHandle()
-export const FlexGapHandleKeepDeepEquality: KeepDeepEqualityCall<FlexGapHandle> = (
-  oldValue,
-  newValue,
-) => {
-  return keepDeepEqualityResult(oldValue, true)
-}
+export const FlexGapHandleKeepDeepEquality: KeepDeepEqualityCall<FlexGapHandle> =
+  combine1EqualityCall((handle) => handle.offset, NumberKeepDeepEquality, flexGapHandle)
 
 // This will break should the definition of `KeyboardCatcherControl` change.
 keyboardCatcherControl()


### PR DESCRIPTION
## `EXPERIMENTAL`

## Problem:
All gap control handles scale the gap value exactly by the drag delta. The problem with this is that the cursor will not follow the gap resize handle (or where it would be), and that Figma can do this.

## Fix
This is an experiment with a simple approach to emulating Figma's behaviour by scaling the drag delta by `n`, where `n` is the `n`th gap handle.

## Limitations
This is only implemented for left-to-right `flex-row` (to make prototying easy)