### PR TITLE
Fix keyboard reorder for flex reverse and rtl text direcion

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-reorder-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-reorder-strategy.spec.browser2.tsx
@@ -4,7 +4,7 @@ import * as EP from '../../../../core/shared/element-path'
 import { KeyboardInteractionTimeout } from '../interaction-state'
 import sinon, { SinonFakeTimers } from 'sinon'
 import { selectComponents } from '../../../editor/actions/action-creators'
-s
+
 const TestProject = (
   display: 'block' | 'inline-block',
   parentDisplay: 'flex' | 'block',

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-reorder-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-reorder-strategy.ts
@@ -1,5 +1,7 @@
+import { flexDirectionToFlexForwardsOrBackwards } from '../../../../core/layout/layout-utils'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
+import { ElementInstanceMetadata } from '../../../../core/shared/element-template'
 import { KeyCharacter } from '../../../../utils/keyboard'
 import { absolute } from '../../../../utils/utils'
 import { reorderElement } from '../../commands/reorder-element-command'
@@ -15,7 +17,7 @@ import {
 } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
 import { getOptionalDisplayPropCommandsForFlow } from './flow-reorder-helpers'
-import { getDirectionFlexOrFlow, isReorderAllowed } from './reorder-utils'
+import { isReorderAllowed } from './reorder-utils'
 import { accumulatePresses } from './shared-keyboard-strategy-helpers'
 
 export function keyboardReorderStrategy(
@@ -48,8 +50,6 @@ export function keyboardReorderStrategy(
     return null
   }
 
-  const { shouldReverse } = getDirectionFlexOrFlow(target, canvasState.startingMetadata)
-
   return {
     id: 'KEYBOARD_REORDER',
     name: 'Reorder',
@@ -61,13 +61,17 @@ export function keyboardReorderStrategy(
         let keyboardResult: number = 0
         accumulatedPresses.forEach((accumulatedPress) => {
           accumulatedPress.keysPressed.forEach((key) => {
-            const keyPressIndexChange = getIndexChangeDeltaFromKey(key, accumulatedPress.count)
+            const keyPressIndexChange = getIndexChangeDeltaFromKey(
+              key,
+              accumulatedPress.count,
+              elementMetadata,
+            )
             keyboardResult = keyboardResult + keyPressIndexChange
           })
         })
 
         const unpatchedIndex = siblings.findIndex((sibling) => EP.pathsEqual(sibling, target))
-        const result = unpatchedIndex + keyboardResult * (shouldReverse ? -1 : 1)
+        const result = unpatchedIndex + keyboardResult
         const newIndex = Math.min(Math.max(0, result), siblings.length - 1)
 
         if (newIndex === unpatchedIndex) {
@@ -101,15 +105,59 @@ export function keyboardReorderStrategy(
   }
 }
 
-function getIndexChangeDeltaFromKey(key: KeyCharacter, delta: number): number {
-  switch (key) {
-    case 'left':
-    case 'up':
-      return -delta
-    case 'right':
-    case 'down':
-      return delta
-    default:
-      return 0
-  }
+// This function creates the map which describes which keyboard cursor button should move the index which way.
+// In standard layouts keyboard up and left moves backward and keyboard down and right moves forward.
+// In flex reverse layouts this is fully reversed: keyboard up and left moves forward and keyboard down and right moves backward.
+// If you have rtl text direction on top of any layouts, that should switch the effect of the left and right keys (but leave up and down as it is)
+function getIndexChangesForArrowKeys(element: ElementInstanceMetadata | null): {
+  [key: string]: number
+} {
+  const textDirection = element?.specialSizeMeasurements.parentTextDirection ?? 'ltr'
+
+  const deltasForKeypresses = (() => {
+    if (
+      MetadataUtils.isParentYogaLayoutedContainerForElementAndElementParticipatesInLayout(element)
+    ) {
+      const flexDirection = element?.specialSizeMeasurements.parentFlexDirection ?? null
+      const forwardsOrBackwards = flexDirectionToFlexForwardsOrBackwards(flexDirection)
+
+      // when flex is reversed we need to move the opposite way in the indexes as in the screen
+      if (forwardsOrBackwards === 'reverse') {
+        return {
+          left: 1,
+          up: 1,
+          right: -1,
+          down: -1,
+        }
+      }
+    }
+    return {
+      left: -1,
+      up: -1,
+      right: 1,
+      down: 1,
+    }
+  })()
+
+  // when text direction is ltr, up and left keys should go backwards, down and right keys should go forward
+  // when text direction is rtl, up and right keys should go backwards, down and left keys should go forward
+  const deltasForKeypressesWithTextDirection =
+    textDirection === 'ltr'
+      ? deltasForKeypresses
+      : {
+          ...deltasForKeypresses,
+          left: deltasForKeypresses['right'],
+          right: deltasForKeypresses['left'],
+        }
+
+  return deltasForKeypressesWithTextDirection
+}
+
+function getIndexChangeDeltaFromKey(
+  key: KeyCharacter,
+  delta: number,
+  element: ElementInstanceMetadata | null,
+): number {
+  const indexChanges = getIndexChangesForArrowKeys(element)
+  return delta * (indexChanges[key] ?? 0)
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-reorder-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-reorder-strategy.ts
@@ -20,6 +20,8 @@ import { getOptionalDisplayPropCommandsForFlow } from './flow-reorder-helpers'
 import { isReorderAllowed } from './reorder-utils'
 import { accumulatePresses } from './shared-keyboard-strategy-helpers'
 
+type ArrowKey = 'left' | 'right' | 'up' | 'down'
+
 export function keyboardReorderStrategy(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
@@ -61,12 +63,14 @@ export function keyboardReorderStrategy(
         let keyboardResult: number = 0
         accumulatedPresses.forEach((accumulatedPress) => {
           accumulatedPress.keysPressed.forEach((key) => {
-            const keyPressIndexChange = getIndexChangeDeltaFromKey(
-              key,
-              accumulatedPress.count,
-              elementMetadata,
-            )
-            keyboardResult = keyboardResult + keyPressIndexChange
+            if (key === 'left' || key === 'right' || key === 'up' || key === 'down') {
+              const keyPressIndexChange = getIndexChangeDeltaFromKey(
+                key,
+                accumulatedPress.count,
+                elementMetadata,
+              )
+              keyboardResult = keyboardResult + keyPressIndexChange
+            }
           })
         })
 
@@ -110,7 +114,10 @@ export function keyboardReorderStrategy(
 // In flex reverse layouts this is fully reversed: keyboard up and left moves forward and keyboard down and right moves backward.
 // If you have rtl text direction on top of any layouts, that should switch the effect of the left and right keys (but leave up and down as it is)
 function getIndexChangesForArrowKeys(element: ElementInstanceMetadata | null): {
-  [key: string]: number
+  left: number
+  up: number
+  right: number
+  down: number
 } {
   const textDirection = element?.specialSizeMeasurements.parentTextDirection ?? 'ltr'
 
@@ -154,7 +161,7 @@ function getIndexChangesForArrowKeys(element: ElementInstanceMetadata | null): {
 }
 
 function getIndexChangeDeltaFromKey(
-  key: KeyCharacter,
+  key: ArrowKey,
   delta: number,
   element: ElementInstanceMetadata | null,
 ): number {

--- a/editor/src/core/layout/layout-utils.ts
+++ b/editor/src/core/layout/layout-utils.ts
@@ -1006,7 +1006,7 @@ export function roundJSXElementLayoutValues(
 export type SimpleFlexDirection = 'row' | 'column'
 
 export function flexDirectionToSimpleFlexDirection(
-  flexDirection: string,
+  flexDirection: string | null,
 ): SimpleFlexDirection | null {
   switch (flexDirection) {
     case 'row':
@@ -1016,14 +1016,14 @@ export function flexDirectionToSimpleFlexDirection(
     case 'column-reverse':
       return 'column'
     default:
-      return null
+      return 'row'
   }
 }
 
 export type FlexForwardsOrBackwards = 'forward' | 'reverse'
 
 export function flexDirectionToFlexForwardsOrBackwards(
-  flexDirection: string,
+  flexDirection: string | null,
 ): FlexForwardsOrBackwards | null {
   switch (flexDirection) {
     case 'row':
@@ -1033,6 +1033,6 @@ export function flexDirectionToFlexForwardsOrBackwards(
     case 'column-reverse':
       return 'reverse'
     default:
-      return null
+      return 'forward'
   }
 }


### PR DESCRIPTION
**Problem:**
This was started as a refactor, because `getDirectionFlexOrFlow` was very similar to `singleAxisAutoLayoutContainerDirections`, and I wanted to unify them.

However, it turned out we also have some bugs.

Until now we treated `reverse` for flex layouts and `rtl`/`inline` for flow layouts as something as similar concepts. We thought we just have two cases, the forward and the reverse case.

However, the situation is way more complex than that:
- `rtl` works in flex too, and switches horizontal direction for rows, but doesn't affect columns. It still switches the order of wrapped columns!
- in flow parents, `rtl` switches the direction of `inline-block` rows, but leaves the direction of everything which is in a vertical layout! So it can actually create a permutation of the original order which is neither forward nor reverse.
- flex `reverse` changes the order in columns and rows too!
- Fun fact: having a `row-reverse` and `rtl` reverses the direction twice, so it remains the original

Another important note:
- if you have `rtl` layout, you expect the `right` key to go backward in order and the `left` key to go forward in order, even if you have a column layout. This is a mindset difference if you have `rtl` text direction.

**Fix:**
Instead of trying to find out if we should reverse the direction or not (`shouldReverse`), I added a new function which creates an `arrow button` -> `index change` map depending on the layout. This is necessary because we don't have just 2 options (reverse or not reverse).

In non-reverse flex and in flow:
- `up` and `left` moves backward
- `down` and `right` moves forward

In reverse flex everything is the opposite:
- `up` and `left` moves forward
- `down` and `right` moves backward

If you have `rtl` text direction on top of any layouts, you have to switch the effect of the `left` and `right` keys (but leave `up` and `down` as it is).

I added new test cases for the new logic.