### PR TITLE
Resolve tree conflicts.

### DIFF
--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -504,6 +504,18 @@ export function addFileToProjectContents(
   return addAtCurrentIndex(tree, 0)
 }
 
+export function getProjectFileFromContents(contents: ProjectContentsTree): ProjectFile {
+  switch (contents.type) {
+    case 'PROJECT_CONTENT_FILE':
+      return contents.content
+    case 'PROJECT_CONTENT_DIRECTORY':
+      return contents.directory
+    default:
+      const _exhaustiveCheck: never = contents
+      throw new Error(`Unhandled contents ${JSON.stringify(contents)}`)
+  }
+}
+
 export function removeFromProjectContents(
   projectContents: ProjectContentTreeRoot,
   path: string,

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -628,6 +628,11 @@ export interface UpdateGithubData {
   data: Partial<GithubData>
 }
 
+export interface RemoveFileConflict {
+  action: 'REMOVE_FILE_CONFLICT'
+  path: string
+}
+
 export interface WorkerCodeUpdate {
   type: 'WORKER_CODE_UPDATE'
   filePath: string
@@ -1127,6 +1132,7 @@ export type EditorAction =
   | UpdateProjectContents
   | UpdateGithubSettings
   | UpdateGithubData
+  | RemoveFileConflict
   | UpdateFromWorker
   | UpdateFromCodeEditor
   | ClearParseOrPrintInFlight

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -215,6 +215,7 @@ import type {
   UpdateBranchContents,
   UpdateAgainstGithub,
   UpdateGithubData,
+  RemoveFileConflict,
 } from '../action-types'
 import { EditorModes, insertionSubject, Mode } from '../editor-modes'
 import type {
@@ -1004,6 +1005,13 @@ export function updateGithubData(data: Partial<GithubData>): UpdateGithubData {
       lastUpdatedAt: Date.now(),
       ...data,
     },
+  }
+}
+
+export function removeFileConflict(path: string): RemoveFileConflict {
+  return {
+    action: 'REMOVE_FILE_CONFLICT',
+    path: path,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -119,6 +119,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_GITHUB_OPERATIONS':
     case 'UPDATE_GITHUB_CHECKSUMS':
     case 'UPDATE_GITHUB_DATA':
+    case 'REMOVE_FILE_CONFLICT':
       return true
 
     case 'NEW':

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -937,6 +937,7 @@ describe('LOAD', () => {
         targetRepository: null,
         originCommit: null,
         branchName: null,
+        pendingCommit: null,
       },
       githubChecksums: null,
       branchContents: null,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1052,17 +1052,20 @@ export interface ProjectGithubSettings {
   targetRepository: GithubRepo | null
   originCommit: string | null
   branchName: string | null
+  pendingCommit: string | null
 }
 
 export function projectGithubSettings(
   targetRepository: GithubRepo | null,
   originCommit: string | null,
   branchName: string | null,
+  pendingCommit: string | null,
 ): ProjectGithubSettings {
   return {
     targetRepository: targetRepository,
     originCommit: originCommit,
     branchName: branchName,
+    pendingCommit: pendingCommit,
   }
 }
 
@@ -1071,6 +1074,7 @@ export function emptyGithubSettings(): ProjectGithubSettings {
     targetRepository: null,
     originCommit: null,
     branchName: null,
+    pendingCommit: null,
   }
 }
 

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -207,6 +207,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.UPDATE_GITHUB_SETTINGS(action, state)
     case 'UPDATE_GITHUB_DATA':
       return UPDATE_FNS.UPDATE_GITHUB_DATA(action, state)
+    case 'REMOVE_FILE_CONFLICT':
+      return UPDATE_FNS.REMOVE_FILE_CONFLICT(action, state)
     case 'UPDATE_FROM_WORKER':
       return UPDATE_FNS.UPDATE_FROM_WORKER(action, state)
     case 'UPDATE_FROM_CODE_EDITOR':

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -3236,12 +3236,14 @@ export const RepositoryEntryKeepDeepEquality: KeepDeepEqualityCall<RepositoryEnt
   )
 
 export const ProjectGithubSettingsKeepDeepEquality: KeepDeepEqualityCall<ProjectGithubSettings> =
-  combine3EqualityCalls(
+  combine4EqualityCalls(
     (settings) => settings.targetRepository,
     nullableDeepEquality(GithubRepoKeepDeepEquality),
     (settings) => settings.originCommit,
     nullableDeepEquality(createCallWithTripleEquals<string>()),
     (settings) => settings.branchName,
+    nullableDeepEquality(createCallWithTripleEquals<string>()),
+    (settings) => settings.pendingCommit,
     nullableDeepEquality(createCallWithTripleEquals<string>()),
     projectGithubSettings,
   )

--- a/editor/src/components/navigator/left-pane/github-pane/github-file-changes-list.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/github-file-changes-list.tsx
@@ -5,10 +5,12 @@ import { jsx } from '@emotion/react'
 import React from 'react'
 import { WarningIcon } from '../../../../uuiui/warning-icon'
 import {
+  Conflict,
   getGithubFileChangesCount,
   GithubFileChanges,
   GithubFileChangesListItem,
   githubFileChangesToList,
+  resolveConflict,
 } from '../../../../core/shared/github'
 import { Button, FlexRow } from '../../../../uuiui'
 import * as EditorActions from '../../../editor/actions/action-creators'
@@ -16,6 +18,12 @@ import { useEditorState } from '../../../editor/store/store-hook'
 import { GithubFileStatusLetter } from '../../../filebrowser/fileitem'
 import { UIGridRow } from '../../../inspector/widgets/ui-grid-row'
 import { when } from '../../../../utils/react-conditionals'
+import { ContextMenuItem } from '../../../../components/context-menu-items'
+import { MenuProvider, MomentumContextMenu } from '../../../../components/context-menu-wrapper'
+import { EditorDispatch } from '../../../../components/editor/action-types'
+import { NO_OP } from '../../../../core/shared/utils'
+import { GithubRepo } from '../../../../components/editor/store/editor-state'
+import { contextMenu, useContextMenu } from 'react-contexify'
 
 export const Ellipsis: React.FC<{
   children: any
@@ -59,6 +67,126 @@ const RevertButton = ({
   )
 }
 
+interface ConflictButtonProps {
+  fullPath: string
+  conflict: Conflict
+  disabled: boolean
+}
+
+function getConflictMenuItems(
+  githubRepo: GithubRepo,
+  projectID: string,
+  dispatch: EditorDispatch,
+  path: string,
+  conflict: Conflict,
+): Array<ContextMenuItem<unknown>> {
+  function applyChange(whichChange: 'utopia' | 'branch'): void {
+    void resolveConflict(githubRepo, projectID, path, conflict, whichChange, dispatch)
+  }
+  switch (conflict.type) {
+    case 'DIFFERING_TYPES':
+      return [
+        {
+          name: 'Accept what is in Utopia.',
+          enabled: true,
+          action: () => {
+            applyChange('utopia')
+          },
+        },
+        {
+          name: 'Apply what is in Github.',
+          enabled: true,
+          action: () => {
+            applyChange('branch')
+          },
+        },
+      ]
+    case 'CURRENT_DELETED_BRANCH_CHANGED':
+      return [
+        {
+          name: 'Delete the file.',
+          enabled: true,
+          action: () => {
+            applyChange('utopia')
+          },
+        },
+        {
+          name: 'Restore the file from Github.',
+          enabled: true,
+          action: () => {
+            applyChange('branch')
+          },
+        },
+      ]
+
+    case 'CURRENT_CHANGED_BRANCH_DELETED':
+      return [
+        {
+          name: 'Keep the file in Utopia.',
+          enabled: true,
+          action: () => {
+            applyChange('utopia')
+          },
+        },
+        {
+          name: 'Delete the file.',
+          enabled: true,
+          action: () => {
+            applyChange('branch')
+          },
+        },
+      ]
+
+    default:
+      const _exhaustiveCheck: never = conflict
+      throw new Error(`Unhandled conflict type ${JSON.stringify(conflict)}`)
+  }
+}
+
+const ConflictButton = React.memo((props: ConflictButtonProps) => {
+  const menuId = `conflict-context-menu-${props.fullPath}`
+  const dispatch = useEditorState((store) => {
+    return store.dispatch
+  }, 'ConflictButton dispatch')
+  const githubRepo = useEditorState((store) => {
+    return store.editor.githubSettings.targetRepository
+  }, 'ConflictButton githubRepo')
+  const projectID = useEditorState((store) => {
+    return store.editor.id
+  }, 'ConflictButton projectID')
+  const menuItems = React.useMemo(() => {
+    if (githubRepo != null && projectID != null) {
+      return getConflictMenuItems(githubRepo, projectID, dispatch, props.fullPath, props.conflict)
+    } else {
+      return []
+    }
+  }, [props.fullPath, props.conflict, dispatch, githubRepo, projectID])
+  const { show } = useContextMenu({
+    id: menuId,
+  })
+  const openContextMenu = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      event.preventDefault()
+      show(event)
+    },
+    [show],
+  )
+  return (
+    <MenuProvider id={menuId} itemsLength={menuItems.length}>
+      <Button
+        style={{ padding: '0 6px' }}
+        spotlight
+        highlight
+        disabled={props.disabled}
+        onClick={openContextMenu}
+      >
+        Action...
+      </Button>
+      <MomentumContextMenu id={menuId} items={menuItems} getData={NO_OP} />
+    </MenuProvider>
+  )
+})
+
 export const GithubFileChangesList: React.FC<{
   changes: GithubFileChanges | null
   githubWorking: boolean
@@ -69,6 +197,10 @@ export const GithubFileChangesList: React.FC<{
   const count = React.useMemo(() => getGithubFileChangesCount(changes), [changes])
   const dispatch = useEditorState((store) => store.dispatch, 'dispatch')
   const list = React.useMemo(() => githubFileChangesToList(changes), [changes])
+  const treeConflicts = useEditorState(
+    (store) => store.editor.githubData.treeConflicts,
+    'GithubFileChangesList treeConflicts',
+  )
 
   const handleClickRevertAllFiles = React.useCallback(
     (e: React.MouseEvent) => {
@@ -116,7 +248,8 @@ export const GithubFileChangesList: React.FC<{
         />
       )}
       {list.map((i) => {
-        const conflicting = conflicts?.includes(i.filename) || false
+        const conflicting = conflicts?.includes(i.filename) ?? false
+        const isTreeConflict = i.filename in treeConflicts
         return (
           <UIGridRow
             key={i.filename}
@@ -140,11 +273,19 @@ export const GithubFileChangesList: React.FC<{
                 </FlexRow>
               </UIGridRow>
               {when(
-                revertable,
+                revertable && !isTreeConflict,
                 <RevertButton
                   disabled={githubWorking}
                   text='Revert'
                   onMouseUp={handleClickRevertFile(i)}
+                />,
+              )}
+              {when(
+                isTreeConflict,
+                <ConflictButton
+                  fullPath={i.filename}
+                  conflict={treeConflicts[i.filename]}
+                  disabled={githubWorking}
                 />,
               )}
             </>

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -119,6 +119,7 @@ async function loadProject(
       targetRepository: null,
       originCommit: null,
       branchName: null,
+      pendingCommit: null,
     },
     githubChecksums: null,
     branchContents: null,

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -686,6 +686,11 @@ getGithubUsersRepositoriesEndpoint :: Maybe Text -> ServerMonad GetUsersPublicRe
 getGithubUsersRepositoriesEndpoint cookie = requireUser cookie $ \sessionUser -> do
   getUsersRepositories (view (field @"_id") sessionUser) 
 
+saveGithubAssetEndpoint :: Maybe Text -> Text -> Text -> Text -> Text -> Text -> ServerMonad GithubSaveAssetResponse
+saveGithubAssetEndpoint cookie owner repository assetSha projectId fullPath = requireUser cookie $ \sessionUser -> do
+  let splitPath = drop 1 $ T.splitOn "/" fullPath
+  saveGithubAsset (view (field @"_id") sessionUser) owner repository assetSha projectId splitPath
+
 {-|
   Compose together all the individual endpoints into a definition for the whole server.
 -}
@@ -712,6 +717,7 @@ protected authCookie = logoutPage authCookie
                   :<|> getGithubBranchesEndpoint authCookie
                   :<|> getGithubBranchContentEndpoint authCookie
                   :<|> getGithubUsersRepositoriesEndpoint authCookie
+                  :<|> saveGithubAssetEndpoint authCookie
 
 unprotected :: ServerT Unprotected ServerMonad
 unprotected = authenticate

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -379,6 +379,17 @@ innerServerExecutor (GetUsersRepositories user action) = do
     Just githubResources -> do
       result <- getGithubUsersPublicRepositories githubResources logger metrics pool user
       pure $ action result
+innerServerExecutor (SaveGithubAsset user owner repository assetSha projectID assetPath action) = do
+  possibleGithubResources <- fmap _githubResources ask
+  awsResource <- fmap _awsResources ask
+  metrics <- fmap _databaseMetrics ask
+  logger <- fmap _logger ask
+  pool <- fmap _projectPool ask
+  case possibleGithubResources of
+    Nothing -> throwError err501
+    Just githubResources -> do
+      result <- saveGithubAssetToProject githubResources awsResource logger metrics pool user owner repository assetSha projectID assetPath
+      pure $ action result
 
 {-|
   Invokes a service call using the supplied resources.

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -293,6 +293,14 @@ innerServerExecutor (GetUsersRepositories user action) = do
   pool <- fmap _projectPool ask
   result <- getGithubUsersPublicRepositories githubResources logger metrics pool user
   pure $ action result
+innerServerExecutor (SaveGithubAsset user owner repository assetSha projectID assetPath action) = do
+  githubResources <- fmap _githubResources ask
+  awsResource <- fmap _awsResources ask
+  metrics <- fmap _databaseMetrics ask
+  logger <- fmap _logger ask
+  pool <- fmap _projectPool ask
+  result <- saveGithubAssetToProject githubResources (Just awsResource) logger metrics pool user owner repository assetSha projectID assetPath 
+  pure $ action result
 
 readEditorContentFromDisk :: Maybe BranchDownloads -> Maybe Text -> Text -> IO Text
 readEditorContentFromDisk (Just downloads) (Just branchName) fileName = do

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -130,6 +130,8 @@ callGithub makeRequest queryParameters handleErrorCases accessToken restURL requ
               & WR.checkResponse .~ (Just $ \_ _ -> return ())
               & WR.params .~ queryParameters
   result <- liftIO $ makeRequest options (toS restURL) request
+  -- Uncomment the next line if you want to see the headers.
+  -- liftIO $ print $ view WR.responseHeaders result
   let status = view WR.responseStatus result
   unless (statusIsSuccessful status) $ handleErrorCases status
   except $ bimap show (\r -> view WR.responseBody r) (WR.asJSON result)

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -139,6 +139,7 @@ data ServiceCallsF a = NotFound
                      | GetBranchesFromGithubRepo Text Text Text (GetBranchesResponse -> a)
                      | GetBranchContent Text Text Text Text (Maybe Text) (GetBranchContentResponse -> a)
                      | GetUsersRepositories Text (GetUsersPublicRepositoriesResponse -> a)
+                     | SaveGithubAsset Text Text Text Text Text [Text] (GithubSaveAssetResponse -> a)
                      deriving Functor
 
 {-

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -133,6 +133,8 @@ type GithubSaveAPI = "v1" :> "github" :> "save" :> Capture "project_id" Text :> 
 
 type GithubBranchesAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> Get '[JSON] GetBranchesResponse
 
+type GithubSaveAssetAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> "asset" :> Capture "asset_sha" Text :> QueryParam' '[Required, Strict] "project_id" Text :> QueryParam' '[Required, Strict] "path" Text :> Post '[JSON] GithubSaveAssetResponse
+
 type GithubBranchLoadAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> Capture "branchName" Text :> QueryParam "commit_sha" Text :> Get '[JSON] GetBranchContentResponse
 
 type GithubUsersRepositoriesAPI = "v1" :> "github" :> "user" :> "repositories" :> Get '[JSON] GetUsersPublicRepositoriesResponse
@@ -193,6 +195,7 @@ type Protected = LogoutAPI
             :<|> GithubBranchesAPI
             :<|> GithubBranchLoadAPI
             :<|> GithubUsersRepositoriesAPI
+            :<|> GithubSaveAssetAPI
 
 type Unprotected = AuthenticateAPI H.Html
               :<|> EmptyProjectPageAPI


### PR DESCRIPTION
**Problem:**
Currently we can surface tree conflicts, but not action those conflicts.

**Fix:**
There are two components to the implementation:
- In the editor, there is now functionality for choosing which option to take for a conflict, usually either the upstream change or the change made in Utopia. This currently takes the place of the revert option, in the Github file change listing.
- Functionality to save an asset into a Utopia project from a specified git blob in the linked repository.

**Limitations:**
- Because of the way that images/assets are separated from text content when pulling them from Github, which by filename, it's currently impossible to create "differing types" conflict.
- There's currently very limited handling of completing the process for the project as a whole, as opposed to for each file, that should be addressed subsequently.

**Commit Details:**
- Added `getProjectFileFromContents` utility function.
- Added `RemoveFileConflict` editor action.
- Added `ConflictButton` control which launches a context menu for actioning the changes.
- Added `saveGithubAsset` to call the endpoint for adding an asset to Utopia which is held in a Github repository.
- Implemented `resolveConflict` to handle the actions triggered from `ConflictButton`.
- Implemented `saveGithubAssetToProject` to save a git blob from Github into a project.
- Added endpoint `saveGithubAssetEndpoint` along with the attendant support code.