### PR TITLE
fix gap/padding control handle sizes

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -105,7 +105,6 @@ export const PillHandle = React.memo((props: PillHandleProps): JSX.Element => {
   return (
     <div
       style={{
-        boxSizing: 'border-box',
         width: width,
         height: height,
         backgroundColor: pillColor,

--- a/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
@@ -135,7 +135,7 @@ interface GapControlSizeConstants {
 
 const DefaultGapControlSizeConstants: GapControlSizeConstants = {
   dragBorderWidth: 1,
-  borderWidth: 0.5,
+  borderWidth: 1,
   paddingIndicatorOffset: 10,
   hitAreaPadding: 5,
 }
@@ -257,10 +257,10 @@ const GapControlSegment = React.memo<GapControlSegmentProps>((props) => {
 
 function handleDimensions(flexDirection: SimpleFlexDirectionForGap, scale: number): Size {
   if (flexDirection === 'row' || flexDirection === 'row-reverse') {
-    return size(2 / scale, 12 / scale)
+    return size(4 / scale, 12 / scale)
   }
   if (flexDirection === 'column' || flexDirection === 'column-reverse') {
-    return size(12 / scale, 2 / scale)
+    return size(12 / scale, 4 / scale)
   }
   assertNever(flexDirection)
 }

--- a/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
@@ -56,9 +56,9 @@ function sizeFromOrientation(orientation: Orientation, desiredSize: Size): Size 
 
 export const PaddingResizeControlHoverTimeout: number = 200
 
-const PaddingResizeControlWidth = 2
+const PaddingResizeControlWidth = 4
 const PaddingResizeControlHeight = 12
-const PaddingResizeControlBorder = 0.5
+const PaddingResizeControlBorder = 1
 const PaddingResizeDragBorder = 1
 const PaddingResizeControlHitAreaWidth = 10
 


### PR DESCRIPTION
On Saturday, 12 November an attempt was made to finally make padding/gap control handles look good by making them `2px` across on the inside with a 1px border

<img width="607" alt="image" src="https://user-images.githubusercontent.com/16385508/201487581-ca7e0e82-5ed2-4437-bf76-fd00529c7cb8.png">

<img width="606" alt="image" src="https://user-images.githubusercontent.com/16385508/201487607-b5743611-8daf-4e92-87e2-b7ce9b1b9d61.png">
