### PR TITLE
Fix/reparent filter siblings

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
@@ -2107,6 +2107,69 @@ export var storyboard = (
 `
 }
 
+const TestProjectFlexAndAbsoluteSiblings = (flexDirection: 'row' | 'row-reverse') => `
+<div
+  style={{
+    position: 'absolute',
+    width: 600,
+    height: 600,
+  }}
+  data-uid='container'
+  data-testid='container'
+>
+  <div
+    style={{
+      position: 'absolute',
+      width: 50,
+      height: 50,
+      top: -50,
+    }}
+    data-uid='absolutechild'
+    data-testid='absolutechild'
+  />
+  <div
+    style={{
+      position: 'absolute',
+      width: 400,
+      height: 400,
+      display: 'flex',
+      flexDirection: '${flexDirection}',
+    }}
+    data-uid='flexcontainer'
+    data-testid='flexcontainer'
+  >
+    <div
+      style={{
+        position: 'absolute',
+        width: 100,
+        height: 50,
+        left: 100,
+        top: 50,
+      }}
+      data-uid='absolute1'
+    />
+    <div
+      style={{
+        width: 50,
+        height: 40
+      }}
+      data-uid='flexchild1'
+      data-testid='flexchild1'
+    />
+    <div
+      style={{
+        position: 'absolute',
+        width: 100,
+        height: 50,
+        left: 100,
+        top: 50,
+      }}
+    data-uid='absolute2'
+    />
+  </div>
+</div>
+`
+
 async function checkReparentIndicator(
   renderResult: EditorRenderResult,
   expectedLeft: number,
@@ -2265,5 +2328,137 @@ describe('Reparent indicators', () => {
 
     // Check the indicator presence and position.
     await checkReparentIndicator(renderResult, 654, 645, 2, 123)
+  })
+  it(`shows the reparent indicator between the parent and the first element in a 'row' container with absolute siblings`, async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(TestProjectFlexAndAbsoluteSiblings('row')),
+      'await-first-dom-report',
+    )
+
+    // Select the target first.
+    const targetPath = EP.fromString(
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/absolutechild',
+    )
+    await act(() => renderResult.dispatch([selectComponents([targetPath], false)], false))
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Start dragging the target.
+    const targetElement = renderResult.renderedDOM.getByTestId('absolutechild')
+    const targetElementBounds = targetElement.getBoundingClientRect()
+
+    const flexContainer = renderResult.renderedDOM.getByTestId('flexcontainer')
+    const flexContainerBounds = flexContainer.getBoundingClientRect()
+
+    const startPoint = { x: targetElementBounds.x + 20, y: targetElementBounds.y + 20 }
+    const endPoint = {
+      x: flexContainerBounds.x + 20,
+      y: flexContainerBounds.y + flexContainerBounds.height / 2,
+    }
+    const dragDelta = windowPoint({
+      x: endPoint.x - startPoint.x,
+      y: endPoint.y - startPoint.y,
+    })
+
+    dragElement(
+      renderResult,
+      'absolutechild',
+      defaultMouseDownOffset,
+      dragDelta,
+      emptyModifiers,
+      false,
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Check the indicator presence and position.
+    await checkReparentIndicator(renderResult, 388, 145, 2, 40)
+  })
+  it(`shows the reparent indicator between the parent and the last element in a 'row' container with absolute siblings`, async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(TestProjectFlexAndAbsoluteSiblings('row')),
+      'await-first-dom-report',
+    )
+
+    // Select the target first.
+    const targetPath = EP.fromString(
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/absolutechild',
+    )
+    await act(() => renderResult.dispatch([selectComponents([targetPath], false)], false))
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Start dragging the target.
+    const targetElement = renderResult.renderedDOM.getByTestId('absolutechild')
+    const targetElementBounds = targetElement.getBoundingClientRect()
+
+    const flexContainer = renderResult.renderedDOM.getByTestId('flexcontainer')
+    const flexContainerBounds = flexContainer.getBoundingClientRect()
+
+    const startPoint = { x: targetElementBounds.x + 20, y: targetElementBounds.y + 20 }
+    const endPoint = {
+      x: flexContainerBounds.x + flexContainerBounds.width - 20,
+      y: flexContainerBounds.y + flexContainerBounds.height / 2,
+    }
+    const dragDelta = windowPoint({
+      x: endPoint.x - startPoint.x,
+      y: endPoint.y - startPoint.y,
+    })
+
+    dragElement(
+      renderResult,
+      'absolutechild',
+      defaultMouseDownOffset,
+      dragDelta,
+      emptyModifiers,
+      false,
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Check the indicator presence and position.
+    await checkReparentIndicator(renderResult, 438, 145, 2, 40)
+  })
+  it(`shows the reparent indicator between the parent and the first element in a 'row-reverse' container with absolute siblings`, async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(TestProjectFlexAndAbsoluteSiblings('row-reverse')),
+      'await-first-dom-report',
+    )
+
+    // Select the target first.
+    const targetPath = EP.fromString(
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/absolutechild',
+    )
+    await act(() => renderResult.dispatch([selectComponents([targetPath], false)], false))
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Start dragging the target.
+    const targetElement = renderResult.renderedDOM.getByTestId('absolutechild')
+    const targetElementBounds = targetElement.getBoundingClientRect()
+
+    const flexContainer = renderResult.renderedDOM.getByTestId('flexcontainer')
+    const flexContainerBounds = flexContainer.getBoundingClientRect()
+
+    const startPoint = { x: targetElementBounds.x + 20, y: targetElementBounds.y + 20 }
+    const endPoint = {
+      x: flexContainerBounds.x + flexContainerBounds.width - 20,
+      y: flexContainerBounds.y + flexContainerBounds.height / 2,
+    }
+    const dragDelta = windowPoint({
+      x: endPoint.x - startPoint.x,
+      y: endPoint.y - startPoint.y,
+    })
+
+    dragElement(
+      renderResult,
+      'absolutechild',
+      defaultMouseDownOffset,
+      dragDelta,
+      emptyModifiers,
+      false,
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Check the indicator presence and position.
+    await checkReparentIndicator(renderResult, 778, 145, 2, 40)
   })
 })

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
@@ -2459,6 +2459,6 @@ describe('Reparent indicators', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     // Check the indicator presence and position.
-    await checkReparentIndicator(renderResult, 778, 145, 2, 40)
+    await checkReparentIndicator(renderResult, 788, 145, 2, 40)
   })
 })

--- a/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-helpers.ts
@@ -57,7 +57,7 @@ export function singleAxisAutoLayoutContainerDirections(
   metadata: ElementInstanceMetadataMap,
 ): SingleAxisAutolayoutContainerDirections | 'non-single-axis-autolayout' {
   const containerElement = MetadataUtils.findElementByElementPath(metadata, container)
-  const children = MetadataUtils.getChildrenParticipateInAutoLayout(metadata, container)
+  const children = MetadataUtils.getChildrenParticipatingInAutoLayout(metadata, container)
   if (containerElement == null) {
     return 'non-single-axis-autolayout'
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-helpers.ts
@@ -57,7 +57,7 @@ export function singleAxisAutoLayoutContainerDirections(
   metadata: ElementInstanceMetadataMap,
 ): SingleAxisAutolayoutContainerDirections | 'non-single-axis-autolayout' {
   const containerElement = MetadataUtils.findElementByElementPath(metadata, container)
-  const children = MetadataUtils.getChildren(metadata, container)
+  const children = MetadataUtils.getChildrenParticipateInAutoLayout(metadata, container)
   if (containerElement == null) {
     return 'non-single-axis-autolayout'
   }
@@ -106,13 +106,11 @@ export function singleAxisAutoLayoutContainerDirections(
 
     // TODO turn this into a loop with early return
     fastForEach(children, (child) => {
-      if (isValidFlowReorderTarget(child.elementPath, metadata)) {
-        if (getElementDirection(child) !== targetDirection) {
-          allHorizontalOrVertical = false
-        }
-        if (child.globalFrame != null) {
-          childrenFrames.push(child.globalFrame)
-        }
+      if (getElementDirection(child) !== targetDirection) {
+        allHorizontalOrVertical = false
+      }
+      if (child.globalFrame != null) {
+        childrenFrames.push(child.globalFrame)
       }
     })
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -522,10 +522,7 @@ function drawTargetRectanglesForChildrenOfElement(
   }
 
   const childrenBounds: Array<ElemBounds> = mapDropNulls((childPath, index) => {
-    if (
-      // TODO make a MetadataUtils.elementParticipatesInLayout helper function and use it in Flow Reorder, Flex Reorder too
-      MetadataUtils.isPositionAbsolute(MetadataUtils.findElementByElementPath(metadata, childPath))
-    ) {
+    if (!MetadataUtils.targetParticipatesInAutoLayout(metadata, childPath)) {
       return null
     }
 
@@ -657,16 +654,22 @@ export function getSiblingMidPointPosition(
 
   return value
 }
-
+export interface SiblingPosition {
+  frame: CanvasRectangle
+  index: number
+}
 export function siblingAndPseudoPositions(
   parentFlexDirection: SimpleFlexDirection,
   forwardsOrBackwards: FlexForwardsOrBackwards,
   parentRect: CanvasRectangle,
   siblingsOfTarget: Array<ElementPath>,
   metadata: ElementInstanceMetadataMap,
-): Array<CanvasRectangle> {
+): Array<SiblingPosition> {
+  const siblingsFiltered = siblingsOfTarget.filter((sibling) =>
+    MetadataUtils.targetParticipatesInAutoLayout(metadata, sibling),
+  )
   const siblingsPossiblyReversed =
-    forwardsOrBackwards === 'forward' ? siblingsOfTarget : reverse(siblingsOfTarget)
+    forwardsOrBackwards === 'forward' ? siblingsFiltered : reverse(siblingsFiltered)
 
   const pseudoElements = createPseudoElements(
     siblingsPossiblyReversed,
@@ -675,14 +678,44 @@ export function siblingAndPseudoPositions(
     metadata,
   )
 
-  const siblingPositions: Array<CanvasRectangle> = [
-    pseudoElements.before,
-    ...siblingsPossiblyReversed.map((sibling) => {
-      return MetadataUtils.getFrameInCanvasCoords(sibling, metadata) ?? zeroCanvasRect
-    }),
-    pseudoElements.after,
-  ]
-  return forwardsOrBackwards === 'forward' ? siblingPositions : reverse(siblingPositions)
+  const siblingFramesAndIndexFiltered = mapDropNulls((sibling, index) => {
+    if (MetadataUtils.targetParticipatesInAutoLayout(metadata, sibling)) {
+      return {
+        frame: MetadataUtils.getFrameInCanvasCoords(sibling, metadata) ?? zeroCanvasRect,
+        index: index + 1,
+      }
+    } else {
+      return null
+    }
+  }, siblingsOfTarget)
+
+  if (forwardsOrBackwards === 'forward') {
+    return [
+      {
+        frame: pseudoElements.before,
+        index: 0,
+      },
+      ...siblingFramesAndIndexFiltered,
+      {
+        frame: pseudoElements.after,
+        index: siblingsOfTarget.length + 1,
+      },
+    ]
+  } else {
+    return [
+      {
+        frame: pseudoElements.after,
+        index: 0,
+      },
+      ...siblingFramesAndIndexFiltered,
+      {
+        frame: pseudoElements.before,
+        index: siblingsOfTarget.length + 1,
+      },
+    ]
+  }
+
+  // return forwardsOrBackwards === 'forward' ? siblingPositions : reverse(siblingPositions)
 }
 
 function createPseudoElements(
@@ -1056,9 +1089,7 @@ function getDirectionsForSingleAxisAutoLayoutTarget(
     return 'non-single-axis-autolayout'
   }
   const isFlow = elementMetadata.specialSizeMeasurements.layoutSystemForChildren === 'flow'
-  const flowChildren = MetadataUtils.getChildren(metadata, path).filter(
-    (child) => child.specialSizeMeasurements.position !== 'absolute',
-  )
+  const flowChildren = MetadataUtils.getChildrenParticipateInAutoLayout(metadata, path)
   if (isFlow && flowChildren.length < 2) {
     // TODO !!!!!!!!! this check should not be here!! we are mixing responsibilities!!!! the container dimensions don't depend on the number
     // we should probably (re) use the rules from flowParentAbsoluteOrStatic instead of putting rules here

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -714,8 +714,6 @@ export function siblingAndPseudoPositions(
       },
     ]
   }
-
-  // return forwardsOrBackwards === 'forward' ? siblingPositions : reverse(siblingPositions)
 }
 
 function createPseudoElements(

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -1087,7 +1087,7 @@ function getDirectionsForSingleAxisAutoLayoutTarget(
     return 'non-single-axis-autolayout'
   }
   const isFlow = elementMetadata.specialSizeMeasurements.layoutSystemForChildren === 'flow'
-  const flowChildren = MetadataUtils.getChildrenParticipateInAutoLayout(metadata, path)
+  const flowChildren = MetadataUtils.getChildrenParticipatingInAutoLayout(metadata, path)
   if (isFlow && flowChildren.length < 2) {
     // TODO !!!!!!!!! this check should not be here!! we are mixing responsibilities!!!! the container dimensions don't depend on the number
     // we should probably (re) use the rules from flowParentAbsoluteOrStatic instead of putting rules here

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-strategy-helpers.ts
@@ -678,7 +678,7 @@ export function siblingAndPseudoPositions(
     metadata,
   )
 
-  const siblingFramesAndIndexFiltered = mapDropNulls((sibling, index) => {
+  const siblingFramesAndIndexInAutoLayout = mapDropNulls((sibling, index) => {
     if (MetadataUtils.targetParticipatesInAutoLayout(metadata, sibling)) {
       return {
         frame: MetadataUtils.getFrameInCanvasCoords(sibling, metadata) ?? zeroCanvasRect,
@@ -695,7 +695,7 @@ export function siblingAndPseudoPositions(
         frame: pseudoElements.before,
         index: 0,
       },
-      ...siblingFramesAndIndexFiltered,
+      ...siblingFramesAndIndexInAutoLayout,
       {
         frame: pseudoElements.after,
         index: siblingsOfTarget.length + 1,
@@ -707,7 +707,7 @@ export function siblingAndPseudoPositions(
         frame: pseudoElements.after,
         index: 0,
       },
-      ...siblingFramesAndIndexFiltered,
+      ...siblingFramesAndIndexInAutoLayout,
       {
         frame: pseudoElements.before,
         index: siblingsOfTarget.length + 1,

--- a/editor/src/components/canvas/commands/show-reorder-indicator-command.ts
+++ b/editor/src/components/canvas/commands/show-reorder-indicator-command.ts
@@ -11,6 +11,7 @@ import { singleAxisAutoLayoutContainerDirections } from '../canvas-strategies/st
 import {
   getSiblingMidPointPosition,
   siblingAndPseudoPositions,
+  SiblingPosition,
 } from '../canvas-strategies/strategies/reparent-strategy-helpers'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
@@ -63,7 +64,7 @@ export const runShowReorderIndicator: CommandFunction<ShowReorderIndicator> = (
     (sibling) => sibling.elementPath,
   )
 
-  const siblingPositions: Array<CanvasRectangle> = siblingAndPseudoPositions(
+  const siblingPositions: Array<SiblingPosition> = siblingAndPseudoPositions(
     newParentDirection,
     forwardsOrBackwards,
     parentFrame,
@@ -72,8 +73,8 @@ export const runShowReorderIndicator: CommandFunction<ShowReorderIndicator> = (
   )
 
   if (siblings.length > 0) {
-    const precedingSiblingPosition: CanvasRectangle = siblingPositions[command.index]
-    const succeedingSiblingPosition: CanvasRectangle = siblingPositions[command.index + 1]
+    const precedingSiblingPosition: CanvasRectangle = siblingPositions[command.index].frame
+    const succeedingSiblingPosition: CanvasRectangle = siblingPositions[command.index + 1].frame
 
     const targetLineBeforeSibling: CanvasRectangle =
       newParentDirection === 'row'

--- a/editor/src/components/canvas/commands/show-reorder-indicator-command.ts
+++ b/editor/src/components/canvas/commands/show-reorder-indicator-command.ts
@@ -3,6 +3,7 @@ import {
   flexDirectionToSimpleFlexDirection,
 } from '../../../core/layout/layout-utils'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { reverse } from '../../../core/shared/array-utils'
 import { canvasRectangle, CanvasRectangle, zeroCanvasRect } from '../../../core/shared/math-utils'
 import { forceNotNull } from '../../../core/shared/optional-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
@@ -73,8 +74,17 @@ export const runShowReorderIndicator: CommandFunction<ShowReorderIndicator> = (
   )
 
   if (siblings.length > 0) {
-    const precedingSiblingPosition: CanvasRectangle = siblingPositions[command.index].frame
-    const succeedingSiblingPosition: CanvasRectangle = siblingPositions[command.index + 1].frame
+    const closestPreviousSiblingPosition = forceNotNull(
+      'no sibling found for reorder indicator',
+      reverse(siblingPositions).find((siblingPosition) => siblingPosition.index <= command.index),
+    )
+    const closestNextSiblingPosition = forceNotNull(
+      'no sibling found for reorder indicator',
+      siblingPositions.find((siblingPosition) => siblingPosition.index > command.index),
+    )
+
+    const precedingSiblingPosition: CanvasRectangle = closestPreviousSiblingPosition.frame
+    const succeedingSiblingPosition: CanvasRectangle = closestNextSiblingPosition.frame
 
     const targetLineBeforeSibling: CanvasRectangle =
       newParentDirection === 'row'

--- a/editor/src/components/canvas/commands/show-reorder-indicator-command.ts
+++ b/editor/src/components/canvas/commands/show-reorder-indicator-command.ts
@@ -3,7 +3,7 @@ import {
   flexDirectionToSimpleFlexDirection,
 } from '../../../core/layout/layout-utils'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { reverse } from '../../../core/shared/array-utils'
+import { findLastIndex, reverse } from '../../../core/shared/array-utils'
 import { canvasRectangle, CanvasRectangle, zeroCanvasRect } from '../../../core/shared/math-utils'
 import { forceNotNull } from '../../../core/shared/optional-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
@@ -74,9 +74,13 @@ export const runShowReorderIndicator: CommandFunction<ShowReorderIndicator> = (
   )
 
   if (siblings.length > 0) {
+    const closestPreviousSiblingPositionIndex = findLastIndex(
+      (siblingPosition) => siblingPosition.index <= command.index,
+      siblingPositions,
+    )
     const closestPreviousSiblingPosition = forceNotNull(
       'no sibling found for reorder indicator',
-      reverse(siblingPositions).find((siblingPosition) => siblingPosition.index <= command.index),
+      siblingPositions[closestPreviousSiblingPositionIndex],
     )
     const closestNextSiblingPosition = forceNotNull(
       'no sibling found for reorder indicator',

--- a/editor/src/components/canvas/controls/insertion-plus-button.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.tsx
@@ -12,6 +12,7 @@ import { CanvasRectangle } from '../../../core/shared/math-utils'
 import {
   getSiblingMidPointPosition,
   siblingAndPseudoPositions,
+  SiblingPosition,
 } from '../canvas-strategies/strategies/reparent-strategy-helpers'
 import {
   flexDirectionToFlexForwardsOrBackwards,
@@ -84,7 +85,7 @@ export const InsertionControls: React.FunctionComponent = React.memo(
     const children = MetadataUtils.getChildren(jsxMetadata, parentPath)
     let controlProps: ButtonControlProps[] = []
 
-    const siblingPositions: Array<CanvasRectangle> = siblingAndPseudoPositions(
+    const siblingPositions: Array<SiblingPosition> = siblingAndPseudoPositions(
       direction,
       forwardsOrBackwards,
       parentFrame,
@@ -96,8 +97,8 @@ export const InsertionControls: React.FunctionComponent = React.memo(
     const nonNullForwardsOrBackwards: FlexForwardsOrBackwards = forwardsOrBackwards
 
     function getBetweenChildrenPosition(index: number): number {
-      const precedingSiblingPosition: CanvasRectangle = siblingPositions[index]
-      const succeedingSiblingPosition: CanvasRectangle = siblingPositions[index + 1]
+      const precedingSiblingPosition: CanvasRectangle = siblingPositions[index].frame
+      const succeedingSiblingPosition: CanvasRectangle = siblingPositions[index + 1].frame
       return getSiblingMidPointPosition(
         precedingSiblingPosition,
         succeedingSiblingPosition,
@@ -108,9 +109,7 @@ export const InsertionControls: React.FunctionComponent = React.memo(
 
     if (children.length > 0) {
       for (let index = 0; index < siblingPositions.length - 1; index++) {
-        // Cater for row-reverse and column-reverse cases by "inverting" the index that
-        // elements are inserted at.
-        const insertionIndex = index
+        const insertionIndex = siblingPositions[index].index
         const positionX =
           direction == 'column'
             ? parentFrame.x - InsertionButtonOffset

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -293,6 +293,25 @@ export const MetadataUtils = {
       position === 'relative' || position === 'static' || position === 'sticky'
     return containerLayoutSystem === 'flow' && participatesInFlow
   },
+  elementParticipatesInAutoLayout(element: ElementInstanceMetadata | null): boolean {
+    return !MetadataUtils.isPositionAbsolute(element)
+  },
+  targetParticipatesInAutoLayout(
+    elements: ElementInstanceMetadataMap,
+    target: ElementPath,
+  ): boolean {
+    return MetadataUtils.elementParticipatesInAutoLayout(
+      MetadataUtils.findElementByElementPath(elements, target),
+    )
+  },
+  getChildrenParticipateInAutoLayout(
+    elements: ElementInstanceMetadataMap,
+    target: ElementPath,
+  ): Array<ElementInstanceMetadata> {
+    return MetadataUtils.getChildren(elements, target).filter(
+      MetadataUtils.elementParticipatesInAutoLayout,
+    )
+  },
   isButtonFromMetadata(element: ElementInstanceMetadata | null): boolean {
     const elementName = MetadataUtils.getJSXElementName(maybeEitherToMaybe(element?.element))
     if (

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -294,6 +294,8 @@ export const MetadataUtils = {
     return containerLayoutSystem === 'flow' && participatesInFlow
   },
   elementParticipatesInAutoLayout(element: ElementInstanceMetadata | null): boolean {
+    // this contains the ruleset about style properties that make an element autolayouted
+    // TODO extend with transform: translate, relative offset etc.
     return !MetadataUtils.isPositionAbsolute(element)
   },
   targetParticipatesInAutoLayout(

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -304,7 +304,7 @@ export const MetadataUtils = {
       MetadataUtils.findElementByElementPath(elements, target),
     )
   },
-  getChildrenParticipateInAutoLayout(
+  getChildrenParticipatingInAutoLayout(
     elements: ElementInstanceMetadataMap,
     target: ElementPath,
   ): Array<ElementInstanceMetadata> {


### PR DESCRIPTION
**Problem:**
Bugs: with absolute siblings in a flex layout the reorder indicators and the insertion plus button are incorrect.

**Fix:**
Added new helpers to metadatautils to filter children and elements that are not part of an autolayout. Now this checks only absolute siblings but later can be extended to `transform: translate` etc.

**Commit Details:**
- use new helper in reorder and reparent target helpers
- update `siblingAndPseudoPositions` to filter non auto-layout children and return their original sibling index, this fixes insertion plus button and reorder indicators
- new tests for reorder indicators using flex layout with absolute siblings
