### PR TITLE
Determine the mime type from the content not the filename.

### DIFF
--- a/clientmodel/lib/src/Utopia/ClientModel.hs
+++ b/clientmodel/lib/src/Utopia/ClientModel.hs
@@ -181,11 +181,11 @@ instance Arbitrary TextFile where
   shrink = genericShrink
 
 data ImageFile = ImageFile
-               { imageType :: Maybe Text
-               , base64    :: Maybe Text
-               , width     :: Maybe Double
-               , height    :: Maybe Double
-               , hash      :: Int
+               { imageType  :: Maybe Text
+               , base64     :: Maybe Text
+               , width      :: Maybe Double
+               , height     :: Maybe Double
+               , hash       :: Int
                , gitBlobSha :: Maybe Text
                }
                deriving (Eq, Show, Generic, Data, Typeable)

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -65,6 +65,7 @@ dependencies:
   - lens-aeson <1.2
   - lifted-async
   - lifted-base
+  - magic
   - mime
   - mime-types
   - modern-uri

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -684,7 +684,7 @@ getGithubBranchContentEndpoint cookie owner repository branchName possibleCommit
 
 getGithubUsersRepositoriesEndpoint :: Maybe Text -> ServerMonad GetUsersPublicRepositoriesResponse
 getGithubUsersRepositoriesEndpoint cookie = requireUser cookie $ \sessionUser -> do
-  getUsersRepositories (view (field @"_id") sessionUser) 
+  getUsersRepositories (view (field @"_id") sessionUser)
 
 saveGithubAssetEndpoint :: Maybe Text -> Text -> Text -> Text -> Text -> Text -> ServerMonad GithubSaveAssetResponse
 saveGithubAssetEndpoint cookie owner repository assetSha projectId fullPath = requireUser cookie $ \sessionUser -> do

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -11,7 +11,6 @@
 
 module Utopia.Web.Executors.Common where
 
-import qualified Data.ByteString.Lazy.Base64     as BLB64
 import           Conduit
 import           Control.Concurrent.Async.Lifted
 import           Control.Concurrent.ReadWriteLock
@@ -23,6 +22,7 @@ import           Control.Monad.Trans.Maybe
 import           Data.Aeson
 import           Data.Bifoldable
 import qualified Data.ByteString.Lazy             as BL
+import qualified Data.ByteString.Lazy.Base64      as BLB64
 import qualified Data.Conduit                     as C
 import qualified Data.Conduit.Combinators         as C hiding (concatMap)
 import qualified Data.Conduit.List                as C hiding (map)
@@ -39,8 +39,8 @@ import           Network.OAuth.OAuth2
 import           Network.Wai
 import qualified Network.Wreq                     as WR
 import           Protolude                        hiding (Handler, concatMap,
-                                                   intersperse, map, yield,
-                                                   (<.>), getField)
+                                                   getField, intersperse, map,
+                                                   yield, (<.>))
 import           Servant
 import           Servant.Client                   hiding (Response)
 import           System.Directory
@@ -464,7 +464,7 @@ getGithubUsersPublicRepositories githubResources logger metrics pool userID = do
   result <- runExceptT $ do
     repositories <- useAccessToken githubResources logger metrics pool userID $ \accessToken -> do
       -- Gives us a function that just takes the page.
-      let getPage = getUsersPublicRepositories accessToken 
+      let getPage = getUsersPublicRepositories accessToken
       -- Now we have a function compatible with `unfoldM`.
       let getUnfoldStep (Just page) = fmap (\result -> convertUsersRepositoriesResultToUnfold page result) $ getPage page
           getUnfoldStep Nothing = pure Nothing
@@ -493,5 +493,5 @@ saveGithubAssetToProject githubResources awsResource logger metrics pool userID 
       blobResult <- getGitBlob accessToken owner repository assetSha
       pure $ BLB64.decodeBase64Lenient $ BL.fromStrict $ encodeUtf8 $ view (field @"content") blobResult
     liftIO $ saveAsset awsResource projectID path assetBytes
-  pure $ either getGithubSaveAssetFailureFromReason getGithubSaveAssetSuccessFromResult result 
+  pure $ either getGithubSaveAssetFailureFromReason getGithubSaveAssetSuccessFromResult result
 

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -299,7 +299,7 @@ innerServerExecutor (SaveGithubAsset user owner repository assetSha projectID as
   metrics <- fmap _databaseMetrics ask
   logger <- fmap _logger ask
   pool <- fmap _projectPool ask
-  result <- saveGithubAssetToProject githubResources (Just awsResource) logger metrics pool user owner repository assetSha projectID assetPath 
+  result <- saveGithubAssetToProject githubResources (Just awsResource) logger metrics pool user owner repository assetSha projectID assetPath
   pure $ action result
 
 readEditorContentFromDisk :: Maybe BranchDownloads -> Maybe Text -> Text -> IO Text

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -11,6 +11,7 @@
 module Utopia.Web.Github where
 
 import           Codec.MIME.Base64
+import           Codec.Picture
 import           Control.Concurrent.Async.Lifted
 import           Control.Lens                    hiding (children, (.=), (<.>))
 import           Control.Monad
@@ -29,6 +30,7 @@ import           Data.Foldable
 import           Data.Generics.Product
 import           Data.Generics.Sum
 import qualified Data.HashMap.Strict             as M
+import qualified Data.Hashable                   as H
 import qualified Data.Text                       as T
 import           Data.Text.Encoding
 import           Data.Text.Encoding.Base64
@@ -43,8 +45,6 @@ import           Protolude
 import           Utopia.ClientModel
 import           Utopia.Web.Assets
 import           Utopia.Web.Github.Types
-import qualified Data.Hashable as H
-import Codec.Picture
 
 fetchRepoArchive :: Text -> Text -> IO (Maybe BL.ByteString)
 fetchRepoArchive owner repo = do
@@ -272,13 +272,13 @@ getGitCommit accessToken owner repository commitSha = do
   let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/commits/" <> commitSha
   callGithub getFromGithub [] getGitCommitErrorCases accessToken repoUrl ()
 
-makeProjectTextFileFromEntry :: (MonadBaseControl IO m, MonadIO m) => ReferenceGitTreeEntry -> GetBlobResult -> ExceptT Text m (ProjectContentsTree, [Text])
-makeProjectTextFileFromEntry gitEntry blobResult = do
-  let decodedContent = decodeBase64Lenient $ view (field @"content") blobResult
+makeProjectTextFileFromEntry :: (MonadBaseControl IO m, MonadIO m) => ReferenceGitTreeEntry -> GetBlobResult -> BL.ByteString -> ExceptT Text m (ProjectContentsTree, [Text])
+makeProjectTextFileFromEntry gitEntry _ decodedContent = do
   let path = view (field @"path") gitEntry
   let pathParts = T.splitOn "/" path
   let pathWithForwardSlash = "/" <> path
-  let textFileContents = TextFileContents decodedContent (ParsedTextFileUnparsed Unparsed) CodeAhead
+  decodedText <- except $ first (\exception -> T.pack $ show exception) $ decodeUtf8' $ BL.toStrict decodedContent
+  let textFileContents = TextFileContents decodedText (ParsedTextFileUnparsed Unparsed) CodeAhead
   let textFile = TextFile textFileContents Nothing 0.0
   let fileResult = ProjectContentsTreeFile $ ProjectContentFile pathWithForwardSlash $ ProjectTextFile textFile
   pure (fileResult, pathParts)
@@ -289,9 +289,8 @@ getImageDimensions decodedContent = do
   decodedImage <- either (const Nothing) pure $ decodeImage strictBytes
   pure $ dynamicMap (\image -> (fromIntegral $ imageWidth image, fromIntegral $ imageHeight image)) decodedImage
 
-makeProjectImageFileFromEntry :: (MonadBaseControl IO m, MonadIO m) => ReferenceGitTreeEntry -> GetBlobResult -> ExceptT Text m (ProjectContentsTree, [Text])
-makeProjectImageFileFromEntry gitEntry blobResult = do
-  let decodedContent = BLB64.decodeBase64Lenient $ BL.fromStrict $ encodeUtf8 $ view (field @"content") blobResult
+makeProjectImageFileFromEntry :: (MonadBaseControl IO m, MonadIO m) => ReferenceGitTreeEntry -> GetBlobResult -> BL.ByteString -> ExceptT Text m (ProjectContentsTree, [Text])
+makeProjectImageFileFromEntry gitEntry blobResult decodedContent = do
   let path = view (field @"path") gitEntry
   let pathParts = T.splitOn "/" path
   let pathWithForwardSlash = "/" <> path
@@ -300,11 +299,11 @@ makeProjectImageFileFromEntry gitEntry blobResult = do
   let possibleHeight = firstOf (_Just . _2) dimensions
   let imageSha = view (field @"sha") blobResult
   let imageFile = ImageFile Nothing Nothing possibleWidth possibleHeight (H.hash decodedContent) (Just imageSha)
-  let fileResult = ProjectContentsTreeFile $ ProjectContentFile pathWithForwardSlash $ ProjectImageFile imageFile 
+  let fileResult = ProjectContentsTreeFile $ ProjectContentFile pathWithForwardSlash $ ProjectImageFile imageFile
   pure (fileResult, pathParts)
 
-makeProjectAssetFileFromEntry :: (MonadBaseControl IO m, MonadIO m) => ReferenceGitTreeEntry -> GetBlobResult -> ExceptT Text m (ProjectContentsTree, [Text])
-makeProjectAssetFileFromEntry gitEntry blobResult = do
+makeProjectAssetFileFromEntry :: (MonadBaseControl IO m, MonadIO m) => ReferenceGitTreeEntry -> GetBlobResult -> BL.ByteString -> ExceptT Text m (ProjectContentsTree, [Text])
+makeProjectAssetFileFromEntry gitEntry blobResult _ = do
   let path = view (field @"path") gitEntry
   let pathParts = T.splitOn "/" path
   let pathWithForwardSlash = "/" <> path
@@ -326,14 +325,16 @@ projectContentFromGitTreeEntry accessToken owner repository entry = do
     "blob" -> do
       let entrySha = view (field @"sha") entry
       gitBlob <- getGitBlob accessToken owner repository entrySha
-      case blobEntryTypeFromFilename (view (field @"path") entry) of
+      let decodedContent = BLB64.decodeBase64Lenient $ BL.fromStrict $ encodeUtf8 $ view (field @"content") gitBlob
+      blobEntryType <- blobEntryTypeFromContents decodedContent
+      case blobEntryType of
         TextEntryType -> do
           -- This entry is a regular file.
-          makeProjectTextFileFromEntry entry gitBlob
+          makeProjectTextFileFromEntry entry gitBlob decodedContent
         ImageEntryType -> do
-          makeProjectImageFileFromEntry entry gitBlob
+          makeProjectImageFileFromEntry entry gitBlob decodedContent
         AssetEntryType -> do
-          makeProjectAssetFileFromEntry entry gitBlob
+          makeProjectAssetFileFromEntry entry gitBlob decodedContent
     _ -> do
       throwError "Not a blob."
 

--- a/server/src/Utopia/Web/Github/Types.hs
+++ b/server/src/Utopia/Web/Github/Types.hs
@@ -412,9 +412,9 @@ instance ToJSON RepositoryOwner where
   toJSON = genericToJSON defaultOptions
 
 data UsersRepositoryPermissions = UsersRepositoryPermissions
-                                { admin       :: Bool
-                                , push        :: Bool
-                                , pull        :: Bool
+                                { admin :: Bool
+                                , push  :: Bool
+                                , pull  :: Bool
                                 }
                                 deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -425,14 +425,14 @@ instance ToJSON UsersRepositoryPermissions where
   toJSON = genericToJSON defaultOptions
 
 data UsersRepository = UsersRepository
-                     { full_name        :: Text
-                     , owner            :: RepositoryOwner
-                     , private          :: Bool
-                     , description      :: Maybe Text
-                     , name             :: Maybe Text
-                     , updated_at       :: UTCTime
-                     , default_branch   :: Text
-                     , permissions      :: UsersRepositoryPermissions
+                     { full_name      :: Text
+                     , owner          :: RepositoryOwner
+                     , private        :: Bool
+                     , description    :: Maybe Text
+                     , name           :: Maybe Text
+                     , updated_at     :: UTCTime
+                     , default_branch :: Text
+                     , permissions    :: UsersRepositoryPermissions
                      }
                      deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -445,14 +445,14 @@ instance ToJSON UsersRepository where
 type GetUsersPublicRepositoriesResult = [UsersRepository]
 
 data RepositoryEntry = RepositoryEntry
-                     { fullName         :: Text
-                     , avatarUrl        :: Maybe Text
-                     , private          :: Bool
-                     , description      :: Maybe Text
-                     , name             :: Maybe Text
-                     , updatedAt        :: Maybe UTCTime
-                     , defaultBranch    :: Maybe Text
-                     , permissions      :: UsersRepositoryPermissions
+                     { fullName      :: Text
+                     , avatarUrl     :: Maybe Text
+                     , private       :: Bool
+                     , description   :: Maybe Text
+                     , name          :: Maybe Text
+                     , updatedAt     :: Maybe UTCTime
+                     , defaultBranch :: Maybe Text
+                     , permissions   :: UsersRepositoryPermissions
                      }
                      deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -501,12 +501,12 @@ data GithubSaveAssetSuccess = GithubSaveAssetSuccess
                             deriving (Eq, Show, Generic, Data, Typeable)
 
 instance FromJSON GithubSaveAssetSuccess where
-  parseJSON = genericParseJSON defaultOptions
+  parseJSON = const $ pure GithubSaveAssetSuccess
 
 instance ToJSON GithubSaveAssetSuccess where
-  toJSON = genericToJSON defaultOptions
+  toJSON = const $ object []
 
-data GithubSaveAssetResponse = GithubSaveAssetResponseSuccess GithubSaveAssetSuccess 
+data GithubSaveAssetResponse = GithubSaveAssetResponseSuccess GithubSaveAssetSuccess
                              | GithubSaveAssetResponseFailure GithubFailure
                              deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -526,6 +526,6 @@ instance ToJSON GithubSaveAssetResponse where
 getGithubSaveAssetFailureFromReason :: Text -> GithubSaveAssetResponse
 getGithubSaveAssetFailureFromReason failureReason = GithubSaveAssetResponseFailure GithubFailure{..}
 
-getGithubSaveAssetSuccessFromResult :: () -> GithubSaveAssetResponse  
-getGithubSaveAssetSuccessFromResult _ = GithubSaveAssetResponseSuccess GithubSaveAssetSuccess 
+getGithubSaveAssetSuccessFromResult :: () -> GithubSaveAssetResponse
+getGithubSaveAssetSuccessFromResult _ = GithubSaveAssetResponseSuccess GithubSaveAssetSuccess
 

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -223,14 +223,14 @@ instance ToJSON UserResponse where
 
 data UserConfigurationResponse = UserConfigurationResponse
                                { _shortcutConfig :: Maybe Value,
-                                _themeConfig :: Maybe Value
+                                _themeConfig     :: Maybe Value
                                } deriving (Eq, Show, Generic)
 
 $(makeFieldsNoPrefix ''UserConfigurationResponse)
 
 data UserConfigurationRequest = UserConfigurationRequest
                               { _shortcutConfig :: Maybe Value,
-                                _themeConfig :: Maybe Value
+                                _themeConfig    :: Maybe Value
                               } deriving (Eq, Show, Generic)
 
 $(makeFieldsNoPrefix ''UserConfigurationRequest)

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -104,6 +104,7 @@ executable utopia-web
     , lens-aeson <1.2
     , lifted-async
     , lifted-base
+    , magic
     , mime
     , mime-types
     , modern-uri
@@ -247,6 +248,7 @@ test-suite utopia-web-test
     , lens-aeson <1.2
     , lifted-async
     , lifted-base
+    , magic
     , mime
     , mime-types
     , modern-uri


### PR DESCRIPTION
**Problem:**
In this PR:
https://github.com/concrete-utopia/utopia/pull/2815
It was observed that as a result of identifying mime types by file extension, it is actually difficult to create a situation where a text file becomes an image causing a conflict.

**Fix:**
Instead of using the file extension, now `libmagic` is used to instead identify the mime type from the content.

**Commit Details:**
- Added `magic` library to the dependencies.
- Replaced `blobEntryTypeFromFilename` with `blobEntryTypeFromContents`.
- Removed `expandedMimeMap` as it's not needed anymore.
- Reformatted some code as `style-project` runs on the whole project.