### PR TITLE
File browser context menu items for resolving conflicts.

### DIFF
--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -10,7 +10,12 @@ import { ProjectContentTreeRoot, walkContentsTree } from '../assets'
 import { setFocus } from '../common/actions'
 import { CodeResultCache, isJavascriptOrTypescript } from '../custom-code/code-file'
 import * as EditorActions from '../editor/actions/action-creators'
-import { getAllCodeEditorErrors, getOpenFilename } from '../editor/store/editor-state'
+import {
+  getAllCodeEditorErrors,
+  getOpenFilename,
+  GithubChecksums,
+  GithubRepo,
+} from '../editor/store/editor-state'
 import { useEditorState } from '../editor/store/store-hook'
 import { addingChildElement, FileBrowserItem } from './fileitem'
 import {
@@ -27,9 +32,11 @@ import { unless } from '../../utils/react-conditionals'
 import { AddingFile, applyAddingFile } from './filepath-utils'
 import { generateUidWithExistingComponents } from '../../core/model/element-template-utils'
 import {
+  Conflict,
   GithubFileChanges,
   githubFileChangesSelector,
   GithubFileStatus,
+  TreeConflicts,
 } from '../../core/shared/github'
 
 export type FileBrowserItemType = 'file' | 'export'
@@ -47,6 +54,9 @@ export interface FileBrowserItemInfo {
   imageFile: ImageFile | null
   projectContents: ProjectContentTreeRoot
   githubStatus?: GithubFileStatus
+  conflict: Conflict | null
+  githubRepo: GithubRepo | null
+  projectID: string | null
 }
 
 export function filterErrorMessages(
@@ -66,6 +76,9 @@ function collectFileBrowserItems(
   codeResultCache: CodeResultCache | null,
   errorMessages: ErrorMessage[] | null,
   githubChanges: GithubFileChanges | null,
+  projectID: string | null,
+  conflicts: TreeConflicts,
+  githubRepo: GithubRepo | null,
 ): FileBrowserItemInfo[] {
   const getGithubStatus = (filename: string) => {
     if (githubChanges?.untracked.includes(filename)) {
@@ -96,6 +109,9 @@ function collectFileBrowserItems(
         imageFile: element.type === 'IMAGE_FILE' ? element : null,
         projectContents: projectContents,
         githubStatus: getGithubStatus(fullPath),
+        githubRepo: githubRepo,
+        conflict: conflicts[fullPath] ?? null,
+        projectID: projectID,
       })
       if (
         element.type === 'TEXT_FILE' &&
@@ -119,6 +135,9 @@ function collectFileBrowserItems(
                 isUploadedAssetFile: false,
                 imageFile: null,
                 projectContents: projectContents,
+                githubRepo: githubRepo,
+                conflict: conflicts[fullPath] ?? null,
+                projectID: projectID,
               })
             }
           })
@@ -237,6 +256,9 @@ const FileBrowserItems = React.memo(() => {
     codeResultCache,
     renamingTarget,
     dropTarget,
+    conflicts,
+    githubRepo,
+    projectID,
   } = useEditorState((store) => {
     return {
       dispatch: store.dispatch,
@@ -247,6 +269,9 @@ const FileBrowserItems = React.memo(() => {
       propertyControlsInfo: store.editor.propertyControlsInfo,
       renamingTarget: store.editor.fileBrowser.renamingTarget,
       dropTarget: store.editor.fileBrowser.dropTarget,
+      conflicts: store.editor.githubData.treeConflicts,
+      githubRepo: store.editor.githubSettings.targetRepository,
+      projectID: store.editor.id,
     }
   }, 'FileBrowserItems')
 
@@ -287,8 +312,20 @@ const FileBrowserItems = React.memo(() => {
       codeResultCache,
       errorMessages,
       githubFileChanges,
+      projectID,
+      conflicts,
+      githubRepo,
     )
-  }, [projectContents, collapsedPaths, codeResultCache, errorMessages, githubFileChanges])
+  }, [
+    projectContents,
+    collapsedPaths,
+    codeResultCache,
+    errorMessages,
+    githubFileChanges,
+    projectID,
+    conflicts,
+    githubRepo,
+  ])
 
   const generateNewUid = React.useCallback(
     () => generateUidWithExistingComponents(projectContents),

--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -48,6 +48,7 @@ import { fileOverwriteModal, FileUploadInfo } from '../editor/store/editor-state
 import { optionalMap } from '../../core/shared/optional-utils'
 import { GithubFileStatus } from '../../core/shared/github'
 import { getFilenameParts } from '../images'
+import { getConflictMenuItems } from '../../core/shared/github-ui'
 
 export interface FileBrowserItemProps extends FileBrowserItemInfo {
   isSelected: boolean
@@ -310,6 +311,9 @@ class FileBrowserItemInner extends React.PureComponent<
   toggleCollapse = () => this.props.toggleCollapse(this.props.path)
 
   renderGithubStatus = () => {
+    if (this.props.conflict != null) {
+      return <GithubFileStatusLetter status={'conflicted'} />
+    }
     if (this.props.githubStatus != undefined) {
       return <GithubFileStatusLetter status={this.props.githubStatus} />
     }
@@ -831,6 +835,22 @@ class FileBrowserItemInner extends React.PureComponent<
       const items = [this.deleteContextMenuItem(), this.renameContextMenuItem()]
       if (this.props.githubStatus != undefined) {
         items.push(this.revertContextMenuItem())
+      }
+      if (
+        this.props.conflict != null &&
+        this.props.githubRepo != null &&
+        this.props.projectID != null
+      ) {
+        items.push(
+          ...getConflictMenuItems(
+            this.props.githubRepo,
+            this.props.projectID,
+            this.props.dispatch,
+            this.props.path,
+            this.props.conflict,
+            'Resolve Conflict',
+          ),
+        )
       }
       fileBrowserItem = (
         <div

--- a/editor/src/components/navigator/left-pane/github-pane/github-file-changes-list.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/github-file-changes-list.tsx
@@ -10,7 +10,6 @@ import {
   GithubFileChanges,
   GithubFileChangesListItem,
   githubFileChangesToList,
-  resolveConflict,
 } from '../../../../core/shared/github'
 import { Button, FlexRow } from '../../../../uuiui'
 import * as EditorActions from '../../../editor/actions/action-creators'
@@ -18,12 +17,10 @@ import { useEditorState } from '../../../editor/store/store-hook'
 import { GithubFileStatusLetter } from '../../../filebrowser/fileitem'
 import { UIGridRow } from '../../../inspector/widgets/ui-grid-row'
 import { when } from '../../../../utils/react-conditionals'
-import { ContextMenuItem } from '../../../../components/context-menu-items'
 import { MenuProvider, MomentumContextMenu } from '../../../../components/context-menu-wrapper'
-import { EditorDispatch } from '../../../../components/editor/action-types'
 import { NO_OP } from '../../../../core/shared/utils'
-import { GithubRepo } from '../../../../components/editor/store/editor-state'
-import { contextMenu, useContextMenu } from 'react-contexify'
+import { useContextMenu } from 'react-contexify'
+import { getConflictMenuItems } from '../../../../core/shared/github-ui'
 
 export const Ellipsis: React.FC<{
   children: any
@@ -73,76 +70,6 @@ interface ConflictButtonProps {
   disabled: boolean
 }
 
-function getConflictMenuItems(
-  githubRepo: GithubRepo,
-  projectID: string,
-  dispatch: EditorDispatch,
-  path: string,
-  conflict: Conflict,
-): Array<ContextMenuItem<unknown>> {
-  function applyChange(whichChange: 'utopia' | 'branch'): void {
-    void resolveConflict(githubRepo, projectID, path, conflict, whichChange, dispatch)
-  }
-  switch (conflict.type) {
-    case 'DIFFERING_TYPES':
-      return [
-        {
-          name: 'Accept what is in Utopia.',
-          enabled: true,
-          action: () => {
-            applyChange('utopia')
-          },
-        },
-        {
-          name: 'Apply what is in Github.',
-          enabled: true,
-          action: () => {
-            applyChange('branch')
-          },
-        },
-      ]
-    case 'CURRENT_DELETED_BRANCH_CHANGED':
-      return [
-        {
-          name: 'Delete the file.',
-          enabled: true,
-          action: () => {
-            applyChange('utopia')
-          },
-        },
-        {
-          name: 'Restore the file from Github.',
-          enabled: true,
-          action: () => {
-            applyChange('branch')
-          },
-        },
-      ]
-
-    case 'CURRENT_CHANGED_BRANCH_DELETED':
-      return [
-        {
-          name: 'Keep the file in Utopia.',
-          enabled: true,
-          action: () => {
-            applyChange('utopia')
-          },
-        },
-        {
-          name: 'Delete the file.',
-          enabled: true,
-          action: () => {
-            applyChange('branch')
-          },
-        },
-      ]
-
-    default:
-      const _exhaustiveCheck: never = conflict
-      throw new Error(`Unhandled conflict type ${JSON.stringify(conflict)}`)
-  }
-}
-
 const ConflictButton = React.memo((props: ConflictButtonProps) => {
   const menuId = `conflict-context-menu-${props.fullPath}`
   const dispatch = useEditorState((store) => {
@@ -156,7 +83,14 @@ const ConflictButton = React.memo((props: ConflictButtonProps) => {
   }, 'ConflictButton projectID')
   const menuItems = React.useMemo(() => {
     if (githubRepo != null && projectID != null) {
-      return getConflictMenuItems(githubRepo, projectID, dispatch, props.fullPath, props.conflict)
+      return getConflictMenuItems(
+        githubRepo,
+        projectID,
+        dispatch,
+        props.fullPath,
+        props.conflict,
+        undefined,
+      )
     } else {
       return []
     }

--- a/editor/src/core/shared/github-ui.tsx
+++ b/editor/src/core/shared/github-ui.tsx
@@ -1,0 +1,81 @@
+import { ContextMenuItem } from '../../components/context-menu-items'
+import { EditorDispatch } from '../../components/editor/action-types'
+import { GithubRepo } from '../../components/editor/store/editor-state'
+import { Conflict, resolveConflict } from './github'
+
+export function getConflictMenuItems(
+  githubRepo: GithubRepo,
+  projectID: string,
+  dispatch: EditorDispatch,
+  path: string,
+  conflict: Conflict,
+  submenuName: string | undefined,
+): Array<ContextMenuItem<unknown>> {
+  function applyChange(whichChange: 'utopia' | 'branch'): void {
+    void resolveConflict(githubRepo, projectID, path, conflict, whichChange, dispatch)
+  }
+  switch (conflict.type) {
+    case 'DIFFERING_TYPES':
+      return [
+        {
+          name: 'Accept what is in Utopia.',
+          enabled: true,
+          action: () => {
+            applyChange('utopia')
+          },
+          submenuName: submenuName,
+        },
+        {
+          name: 'Apply what is in Github.',
+          enabled: true,
+          action: () => {
+            applyChange('branch')
+          },
+          submenuName: submenuName,
+        },
+      ]
+    case 'CURRENT_DELETED_BRANCH_CHANGED':
+      return [
+        {
+          name: 'Delete the file.',
+          enabled: true,
+          action: () => {
+            applyChange('utopia')
+          },
+          submenuName: submenuName,
+        },
+        {
+          name: 'Restore the file from Github.',
+          enabled: true,
+          action: () => {
+            applyChange('branch')
+          },
+          submenuName: submenuName,
+        },
+      ]
+
+    case 'CURRENT_CHANGED_BRANCH_DELETED':
+      return [
+        {
+          name: 'Keep the file in Utopia.',
+          enabled: true,
+          action: () => {
+            applyChange('utopia')
+          },
+          submenuName: submenuName,
+        },
+        {
+          name: 'Delete the file.',
+          enabled: true,
+          action: () => {
+            applyChange('branch')
+          },
+          submenuName: submenuName,
+        },
+      ]
+
+    default:
+      const _exhaustiveCheck: never = conflict
+      throw new Error(`Unhandled conflict type ${JSON.stringify(conflict)}`)
+  }
+}


### PR DESCRIPTION
**Problem:**
Previously the context menu items for resolving conflicts were added to the Github tab, but we also desire those context menu items to be present in the file browser.

**Fix:**
Re-used the code that generates context menu items and included those context menu items in the existing context menu for file items.

Example:
![image](https://user-images.githubusercontent.com/217400/201735693-3168b445-d811-4ee2-91dc-28858f4eee4c.png)


**Commit Details:**
- Added `conflict`, `githubRepo` and `projectID` to `FileBrowserItemInfo`.
- `collectFileBrowserItems` now requires the tree conflicts as well as the project ID and target repository.
- Moved `getConflictMenuItems` out of `github-file-changes-list.tsx`, so it can be reused.
- `getConflictMenuItems` now supports a `submenuName` parameter.
- `FileBrowserItemInner` shows the conflict status letter if a conflict is present on this item.
- Include the conflict menu items if a conflict is present in `FileBrowserItemInner`.