### PR TITLE
Don't show all canvas controls on small elements

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -31,14 +31,12 @@ import { reorderSliderStategy } from './strategies/reorder-slider-strategy'
 import { NonResizableControl } from '../controls/select-mode/non-resizable-control'
 import { flexResizeBasicStrategy } from './strategies/flex-resize-basic-strategy'
 import { optionalMap } from '../../../core/shared/optional-utils'
-import { setPaddingStrategy } from './strategies/set-padding-strategy'
 import { drawToInsertMetaStrategy } from './strategies/draw-to-insert-metastrategy'
 import { dragToInsertMetaStrategy } from './strategies/drag-to-insert-metastrategy'
 import { dragToMoveMetaStrategy } from './strategies/drag-to-move-metastrategy'
 import { ancestorMetaStrategy } from './strategies/ancestor-metastrategy'
 import { keyboardReorderStrategy } from './strategies/keyboard-reorder-strategy'
-import { setFlexGapStrategy } from './strategies/set-flex-gap-strategy'
-import { setBorderRadiusStrategy } from './strategies/set-border-radius-strategy'
+import { stylePropHandlesMetaStrategy } from './strategies/style-prop-handles-metastrategy'
 
 export type CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
@@ -80,9 +78,7 @@ const resizeStrategies: MetaCanvasStrategy = (
       keyboardAbsoluteResizeStrategy,
       absoluteResizeBoundingBoxStrategy,
       flexResizeBasicStrategy,
-      setPaddingStrategy,
-      setFlexGapStrategy,
-      setBorderRadiusStrategy,
+      stylePropHandlesMetaStrategy,
     ],
   )
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -40,6 +40,7 @@ import { setElementsToRerenderCommand } from '../../commands/set-elements-to-rer
 import { setProperty } from '../../commands/set-property-command'
 import { BorderRadiusControl } from '../../controls/select-mode/border-radius-control'
 import {
+  canShowCanvasPropControl,
   cssNumberWithRenderedValue,
   CSSNumberWithRenderedValue,
   measurementBasedOnOtherMeasurement,
@@ -82,6 +83,15 @@ export const setBorderRadiusStrategy: CanvasStrategyFactory = (
     selectedElement,
   )
   if (element == null) {
+    return null
+  }
+
+  const canShowPadding = canShowCanvasPropControl(
+    canvasState.projectContents,
+    canvasState.openFile ?? null,
+    element,
+  ).has('borderRadius')
+  if (!canShowPadding) {
     return null
   }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -90,6 +90,7 @@ export const setBorderRadiusStrategy: CanvasStrategyFactory = (
     canvasState.projectContents,
     canvasState.openFile ?? null,
     element,
+    canvasState.scale,
   ).has('borderRadius')
   if (!canShowPadding) {
     return null

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -86,6 +86,7 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
     canvasState.projectContents,
     canvasState.openFile ?? null,
     element,
+    canvasState.scale,
   ).has('padding')
   if (!canShowPadding) {
     return null

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -38,7 +38,7 @@ import { InteractionSession } from '../interaction-state'
 import { getDragTargets, getMultiselectBounds } from './shared-move-strategies-helpers'
 import { canvasPoint, CanvasPoint, CanvasVector } from '../../../../core/shared/math-utils'
 import {
-  Emdash,
+  canShowCanvasPropControl,
   indicatorMessage,
   offsetMeasurementByDelta,
   precisionFromModifiers,
@@ -71,6 +71,23 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
 
   const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
   if (selectedElements.length !== 1) {
+    return null
+  }
+
+  const element = MetadataUtils.findElementByElementPath(
+    canvasState.startingMetadata,
+    selectedElements[0],
+  )
+  if (element == null) {
+    return null
+  }
+
+  const canShowPadding = canShowCanvasPropControl(
+    canvasState.projectContents,
+    canvasState.openFile ?? null,
+    element,
+  ).has('padding')
+  if (!canShowPadding) {
     return null
   }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/style-prop-handles-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/style-prop-handles-metastrategy.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import { stripNulls } from '../../../../core/shared/array-utils'
+import { RenderControlMemoized } from '../../controls/new-canvas-controls'
+import { ShowHideControl } from '../../controls/select-mode/show-hide-control'
+import { CanvasStrategyFactory } from '../canvas-strategies'
+import {
+  controlWithProps,
+  CustomStrategyState,
+  emptyStrategyApplicationResult,
+  getTargetPathsFromInteractionTarget,
+  InteractionCanvasState,
+} from '../canvas-strategy-types'
+import { InteractionSession } from '../interaction-state'
+import { setBorderRadiusStrategy } from './set-border-radius-strategy'
+import { setFlexGapStrategy } from './set-flex-gap-strategy'
+import { setPaddingStrategy } from './set-padding-strategy'
+
+export const stylePropHandlesMetaStrategy: CanvasStrategyFactory = (
+  canvasState: InteractionCanvasState,
+  interactionSession: InteractionSession | null,
+  customStrategyState: CustomStrategyState,
+) => {
+  const setPaddingStrategyResult = setPaddingStrategy(
+    canvasState,
+    interactionSession,
+    customStrategyState,
+  )
+  const setFlexGapStrategyResult = setFlexGapStrategy(
+    canvasState,
+    interactionSession,
+    customStrategyState,
+  )
+  const setBorderRadiusStrategyResult = setBorderRadiusStrategy(
+    canvasState,
+    interactionSession,
+    customStrategyState,
+  )
+
+  if (
+    setPaddingStrategyResult == null &&
+    setFlexGapStrategyResult == null &&
+    setBorderRadiusStrategyResult == null
+  ) {
+    return null
+  }
+
+  if (interactionSession?.activeControl.type === 'PADDING_RESIZE_HANDLE') {
+    return setPaddingStrategyResult
+  }
+
+  if (interactionSession?.activeControl.type === 'FLEX_GAP_HANDLE') {
+    return setFlexGapStrategyResult
+  }
+
+  if (interactionSession?.activeControl.type === 'BORDER_RADIUS_RESIZE_HANDLE') {
+    return setBorderRadiusStrategyResult
+  }
+
+  const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
+
+  const applicableControls: React.ReactNode[] = stripNulls([
+    setPaddingStrategyResult,
+    setFlexGapStrategyResult,
+    setBorderRadiusStrategyResult,
+  ])
+    .flatMap((s) => s.controlsToRender)
+    .map((c) => (
+      <RenderControlMemoized key={c.key} control={c.control.control} propsForControl={c.props} />
+    ))
+
+  return {
+    id: 'ADJUST_PROPS',
+    name: 'Adjust properties',
+    controlsToRender: [
+      controlWithProps({
+        control: ShowHideControl,
+        props: { children: applicableControls, selectedElements: selectedElements },
+        key: 'show-hide-control',
+        show: 'visible-except-when-other-strategy-is-active',
+      }),
+    ],
+    fitness: 1,
+    apply: () => emptyStrategyApplicationResult,
+  }
+}

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -471,7 +471,7 @@ interface RenderControlMemoizedProps {
   propsForControl: any
 }
 
-const RenderControlMemoized = React.memo(
+export const RenderControlMemoized = React.memo(
   ({ control, propsForControl }: RenderControlMemoizedProps) => {
     const ControlToRender = control
 

--- a/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
@@ -28,7 +28,7 @@ import { windowToCanvasCoordinates } from '../../dom-lookup'
 import { useBoundingBox } from '../bounding-box-hooks'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 import { isZeroSizedElement } from '../outline-utils'
-import { CanvasLabel, CSSNumberWithRenderedValue, useHoverWithDelay } from './controls-common'
+import { CanvasLabel, CSSNumberWithRenderedValue } from './controls-common'
 
 export const CircularHandleTestId = (corner: BorderRadiusCorner): string =>
   `circular-handle-${corner}`
@@ -65,10 +65,6 @@ export const BorderRadiusControl = controlForStrategyMemoized<BorderRadiusContro
 
   const colorTheme = useColorTheme()
 
-  const [backgroundShown, setBackgroundShown] = React.useState<boolean>(false)
-
-  const [controlHoverStart, controlHoverEnd] = useHoverWithDelay(200, setBackgroundShown)
-
   const controlRef = useBoundingBox([selectedElement], (ref, boundingBox) => {
     if (isZeroSizedElement(boundingBox)) {
       ref.current.style.display = 'none'
@@ -83,18 +79,12 @@ export const BorderRadiusControl = controlForStrategyMemoized<BorderRadiusContro
 
   return (
     <CanvasOffsetWrapper>
-      <div
-        onMouseEnter={controlHoverStart}
-        onMouseLeave={controlHoverEnd}
-        ref={controlRef}
-        style={{ position: 'absolute' }}
-      >
+      <div ref={controlRef} style={{ position: 'absolute', pointerEvents: 'none' }}>
         {BorderRadiusCorners.map((corner) => (
           <CircularHandle
             key={CircularHandleTestId(corner)}
             borderRadius={borderRadius[corner]}
             isDragging={isDragging}
-            backgroundShown={backgroundShown}
             scale={scale}
             color={colorTheme.brandNeonPink.value}
             canvasOffsetRef={canvasOffset}
@@ -116,7 +106,6 @@ interface CircularHandleProp {
   dispatch: EditorDispatch
   corner: BorderRadiusCorner
   isDragging: boolean
-  backgroundShown: boolean
   scale: number
   color: string
   elementSize: Size
@@ -128,7 +117,6 @@ const CircularHandle = React.memo((props: CircularHandleProp) => {
   const {
     borderRadius,
     isDragging,
-    backgroundShown,
     scale,
     color,
     canvasOffsetRef,
@@ -151,7 +139,6 @@ const CircularHandle = React.memo((props: CircularHandleProp) => {
   )
 
   const shouldShowIndicator = (!isDragging && hovered) || showIndicatorFromParent
-  const shouldShowHandle = isDragging || backgroundShown
 
   const size = BorderRadiusHandleSize(scale)
   const position = handlePosition(borderRadius.renderedValuePx, elementSize, corner, scale)
@@ -188,7 +175,6 @@ const CircularHandle = React.memo((props: CircularHandleProp) => {
         )}
         <div
           style={{
-            visibility: shouldShowHandle ? 'visible' : 'hidden',
             width: size,
             height: size,
             backgroundColor: 'white',
@@ -201,7 +187,7 @@ const CircularHandle = React.memo((props: CircularHandleProp) => {
         >
           <div
             style={{
-              visibility: shouldShowHandle && showDot ? 'visible' : 'hidden',
+              // visibility: isDragging && showDot ? 'visible' : 'hidden',
               width: BorderRadiusHandleDotSize(scale),
               height: BorderRadiusHandleDotSize(scale),
               backgroundColor: 'blue',

--- a/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
@@ -42,13 +42,7 @@ export interface BorderRadiusControlProps {
 }
 
 export const BorderRadiusControl = controlForStrategyMemoized<BorderRadiusControlProps>((props) => {
-  const {
-    selectedElement,
-    borderRadius,
-    elementSize,
-    showIndicatorOnCorner: showIndicatorOnEdge,
-    mode,
-  } = props
+  const { borderRadius, elementSize, showIndicatorOnCorner: showIndicatorOnEdge, mode } = props
 
   const canvasOffset = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
   const { dispatch, scale, isDragging } = useEditorState(
@@ -65,38 +59,24 @@ export const BorderRadiusControl = controlForStrategyMemoized<BorderRadiusContro
 
   const colorTheme = useColorTheme()
 
-  const controlRef = useBoundingBox([selectedElement], (ref, boundingBox) => {
-    if (isZeroSizedElement(boundingBox)) {
-      ref.current.style.display = 'none'
-    } else {
-      ref.current.style.display = 'block'
-      ref.current.style.left = boundingBox.x + 'px'
-      ref.current.style.top = boundingBox.y + 'px'
-      ref.current.style.width = boundingBox.width + 'px'
-      ref.current.style.height = boundingBox.height + 'px'
-    }
-  })
-
   return (
-    <CanvasOffsetWrapper>
-      <div ref={controlRef} style={{ position: 'absolute', pointerEvents: 'none' }}>
-        {BorderRadiusCorners.map((corner) => (
-          <CircularHandle
-            key={CircularHandleTestId(corner)}
-            borderRadius={borderRadius[corner]}
-            isDragging={isDragging}
-            scale={scale}
-            color={colorTheme.brandNeonPink.value}
-            canvasOffsetRef={canvasOffset}
-            dispatch={dispatch}
-            corner={corner}
-            elementSize={elementSize}
-            showIndicatorFromParent={showIndicatorOnEdge === corner}
-            showDot={mode === 'individual'}
-          />
-        ))}
-      </div>
-    </CanvasOffsetWrapper>
+    <>
+      {BorderRadiusCorners.map((corner) => (
+        <CircularHandle
+          key={CircularHandleTestId(corner)}
+          borderRadius={borderRadius[corner]}
+          isDragging={isDragging}
+          scale={scale}
+          color={colorTheme.brandNeonPink.value}
+          canvasOffsetRef={canvasOffset}
+          dispatch={dispatch}
+          corner={corner}
+          elementSize={elementSize}
+          showIndicatorFromParent={showIndicatorOnEdge === corner}
+          showDot={mode === 'individual'}
+        />
+      ))}
+    </>
   )
 })
 

--- a/editor/src/components/canvas/controls/select-mode/canvas-controls-show-hide.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-controls-show-hide.spec.browser2.tsx
@@ -1,0 +1,15 @@
+describe('Hide canvas controls when element is small', () => {
+  it('No controls are shown when either width or height is less than 40px', () => {
+    expect(0).toEqual(1)
+  })
+
+  it('All controls are shown when both width and height is greater than than 80px', () => {
+    expect(0).toEqual(1)
+  })
+
+  describe('Some controls are shown when both width and height are between 40px and 80px', () => {
+    it('no tests', () => {
+      expect(0).toEqual(1)
+    })
+  })
+})

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { ElementInstanceMetadata } from '../../../../core/shared/element-template'
 import { roundTo } from '../../../../core/shared/math-utils'
 import { Modifiers } from '../../../../utils/modifiers'
 import { CSSNumber, CSSNumberUnit, printCSSNumber } from '../../../inspector/common/css-utils'
@@ -158,4 +159,12 @@ export function indicatorMessage(
   }
 
   return Emdash // emdash
+}
+
+type CanvasPropControl = 'padding' | 'borderRadius' | 'gap'
+
+export function getShownCanvasPropControl(
+  element: ElementInstanceMetadata,
+): Set<CanvasPropControl> {
+  return new Set()
 }

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { ElementInstanceMetadata } from '../../../../core/shared/element-template'
-import { roundTo } from '../../../../core/shared/math-utils'
+import { roundTo, size } from '../../../../core/shared/math-utils'
 import { Modifiers } from '../../../../utils/modifiers'
 import { ProjectContentTreeRoot } from '../../../assets'
 import { CSSNumber, CSSNumberUnit, printCSSNumber } from '../../../inspector/common/css-utils'
@@ -77,6 +77,7 @@ export function measurementBasedOnOtherMeasurement(
 
 const FontSize = 12
 const Padding = 4
+const BorderRadius = 2
 
 interface CanvasLabelProps {
   scale: number
@@ -95,7 +96,7 @@ export const CanvasLabel = React.memo((props: CanvasLabelProps): JSX.Element => 
         padding: padding,
         backgroundColor: color,
         color: 'white',
-        borderRadius: 2,
+        borderRadius: BorderRadius / scale,
       }}
     >
       {value}
@@ -174,20 +175,18 @@ export function canShowCanvasPropControl(
   projectContents: ProjectContentTreeRoot,
   openFile: string | null,
   element: ElementInstanceMetadata,
+  scale: number,
 ): Set<CanvasPropControl> {
-  if (
-    element.specialSizeMeasurements.clientWidth > 80 &&
-    element.specialSizeMeasurements.clientHeight > 80
-  ) {
+  const { width, height } = size(
+    element.specialSizeMeasurements.clientWidth * scale,
+    element.specialSizeMeasurements.clientHeight * scale,
+  )
+
+  if (width > 80 && height > 80) {
     return new Set<CanvasPropControl>(['borderRadius', 'padding', 'gap'])
   }
 
-  if (
-    Math.min(
-      element.specialSizeMeasurements.clientWidth,
-      element.specialSizeMeasurements.clientHeight,
-    ) < 40
-  ) {
+  if (Math.min(width, height) < 40) {
     return new Set<CanvasPropControl>([])
   }
 

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
+import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { ElementInstanceMetadata } from '../../../../core/shared/element-template'
 import { roundTo } from '../../../../core/shared/math-utils'
 import { Modifiers } from '../../../../utils/modifiers'
+import { ProjectContentTreeRoot } from '../../../assets'
 import { CSSNumber, CSSNumberUnit, printCSSNumber } from '../../../inspector/common/css-utils'
 
 export const Emdash: string = '\u2014'
@@ -168,8 +170,30 @@ export function indicatorMessage(
 
 type CanvasPropControl = 'padding' | 'borderRadius' | 'gap'
 
-export function getShownCanvasPropControl(
+export function canShowCanvasPropControl(
+  projectContents: ProjectContentTreeRoot,
+  openFile: string | null,
   element: ElementInstanceMetadata,
 ): Set<CanvasPropControl> {
-  return new Set()
+  if (
+    element.specialSizeMeasurements.clientWidth > 80 &&
+    element.specialSizeMeasurements.clientHeight > 80
+  ) {
+    return new Set<CanvasPropControl>(['borderRadius', 'padding', 'gap'])
+  }
+
+  if (
+    Math.min(
+      element.specialSizeMeasurements.clientWidth,
+      element.specialSizeMeasurements.clientHeight,
+    ) < 40
+  ) {
+    return new Set<CanvasPropControl>([])
+  }
+
+  if (!MetadataUtils.targetElementSupportsChildren(projectContents, openFile, element)) {
+    return new Set<CanvasPropControl>(['borderRadius', 'gap'])
+  }
+
+  return new Set<CanvasPropControl>(['padding', 'gap'])
 }

--- a/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { CanvasVector, size, Size, windowPoint } from '../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import { assertNever } from '../../../../core/shared/utils'
@@ -199,18 +200,6 @@ export const PaddingResizeControl = controlForStrategyMemoized((props: PaddingCo
 
   const numberToPxValue = (n: number) => n + 'px'
 
-  const controlRef = useBoundingBox(selectedElements, (ref, boundingBox) => {
-    if (isZeroSizedElement(boundingBox)) {
-      ref.current.style.display = 'none'
-    } else {
-      ref.current.style.display = 'block'
-      ref.current.style.left = boundingBox.x + 'px'
-      ref.current.style.top = boundingBox.y + 'px'
-      ref.current.style.width = boundingBox.width + 'px'
-      ref.current.style.height = boundingBox.height + 'px'
-    }
-  })
-
   const currentPadding = simplePaddingFromMetadata(elementMetadata.current, selectedElements[0])
 
   const leftRef = useBoundingBox(selectedElements, (ref, boundingBox) => {
@@ -244,33 +233,24 @@ export const PaddingResizeControl = controlForStrategyMemoized((props: PaddingCo
   })
 
   return (
-    <CanvasOffsetWrapper>
-      <div
-        data-testid={PaddingResizeControlContainerTestId}
-        ref={controlRef}
-        style={{
-          position: 'absolute',
-          pointerEvents: 'none',
-        }}
-      >
-        <PaddingResizeControlI
-          ref={rightRef}
-          edge={'right'}
-          paddingValue={currentPadding.paddingRight}
-        />
-        <PaddingResizeControlI
-          ref={bottomRef}
-          edge={'bottom'}
-          paddingValue={currentPadding.paddingBottom}
-        />
-        <PaddingResizeControlI
-          ref={leftRef}
-          edge={'left'}
-          paddingValue={currentPadding.paddingLeft}
-        />
-        <PaddingResizeControlI ref={topRef} edge={'top'} paddingValue={currentPadding.paddingTop} />
-      </div>
-    </CanvasOffsetWrapper>
+    <>
+      <PaddingResizeControlI
+        ref={rightRef}
+        edge={'right'}
+        paddingValue={currentPadding.paddingRight}
+      />
+      <PaddingResizeControlI
+        ref={bottomRef}
+        edge={'bottom'}
+        paddingValue={currentPadding.paddingBottom}
+      />
+      <PaddingResizeControlI
+        ref={leftRef}
+        edge={'left'}
+        paddingValue={currentPadding.paddingLeft}
+      />
+      <PaddingResizeControlI ref={topRef} edge={'top'} paddingValue={currentPadding.paddingTop} />
+    </>
   )
 })
 

--- a/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
@@ -40,7 +40,6 @@ type Orientation = 'vertical' | 'horizontal'
 
 interface ResizeContolProps {
   edge: EdgePiece
-  hiddenByParent: boolean
   paddingValue: CSSNumberWithRenderedValue
 }
 
@@ -126,8 +125,6 @@ const PaddingResizeControlI = React.memo(
 
     const { cursor, orientation } = edgePieceDerivedProps(props.edge)
 
-    const shown = !(props.hiddenByParent && hidden)
-
     const { width, height } = sizeFromOrientation(
       orientation,
       size(PaddingResizeControlWidth / scale, PaddingResizeControlHeight / scale),
@@ -164,7 +161,7 @@ const PaddingResizeControlI = React.memo(
           onMouseLeave={hoverEnd}
           onMouseUp={onMouseUp}
           style={{
-            visibility: shown ? 'visible' : 'hidden',
+            // visibility: hidden ? 'hidden' : 'visible',
             position: 'absolute',
             padding: hitAreaWidth,
             cursor: cursor,
@@ -246,46 +243,32 @@ export const PaddingResizeControl = controlForStrategyMemoized((props: PaddingCo
     ref.current.style.height = numberToPxValue(padding.paddingBottom.renderedValuePx)
   })
 
-  const [hoverHidden, setHoverHidden] = React.useState<boolean>(true)
-  const [hoverStart, hoverEnd] = useHoverWithDelay(PaddingResizeControlHoverTimeout, (h) =>
-    setHoverHidden(!h),
-  )
-
   return (
     <CanvasOffsetWrapper>
       <div
         data-testid={PaddingResizeControlContainerTestId}
-        onMouseEnter={hoverStart}
-        onMouseLeave={hoverEnd}
         ref={controlRef}
         style={{
           position: 'absolute',
+          pointerEvents: 'none',
         }}
       >
         <PaddingResizeControlI
           ref={rightRef}
           edge={'right'}
-          hiddenByParent={hoverHidden}
           paddingValue={currentPadding.paddingRight}
         />
         <PaddingResizeControlI
           ref={bottomRef}
           edge={'bottom'}
-          hiddenByParent={hoverHidden}
           paddingValue={currentPadding.paddingBottom}
         />
         <PaddingResizeControlI
           ref={leftRef}
           edge={'left'}
-          hiddenByParent={hoverHidden}
           paddingValue={currentPadding.paddingLeft}
         />
-        <PaddingResizeControlI
-          ref={topRef}
-          edge={'top'}
-          hiddenByParent={hoverHidden}
-          paddingValue={currentPadding.paddingTop}
-        />
+        <PaddingResizeControlI ref={topRef} edge={'top'} paddingValue={currentPadding.paddingTop} />
       </div>
     </CanvasOffsetWrapper>
   )

--- a/editor/src/components/canvas/controls/select-mode/show-hide-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/show-hide-control.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { ElementPath } from '../../../../core/shared/project-file-types'
+import { controlForStrategyMemoized } from '../../canvas-strategies/canvas-strategy-types'
+import { useBoundingBox } from '../bounding-box-hooks'
+import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
+import { isZeroSizedElement } from '../outline-utils'
+import { useHoverWithDelay } from './controls-common'
+
+type ShowHideControlProps = React.PropsWithChildren<{ selectedElements: ElementPath[] }>
+
+export const ShowHideControl = controlForStrategyMemoized<ShowHideControlProps>((props) => {
+  const [hoverHidden, setHoverHidden] = React.useState<boolean>(true)
+  const [hoverStart, hoverEnd] = useHoverWithDelay(200, (h) => {
+    setHoverHidden(!h)
+  })
+
+  const controlRef = useBoundingBox(props.selectedElements, (ref, boundingBox) => {
+    if (isZeroSizedElement(boundingBox)) {
+      ref.current.style.display = 'none'
+    } else {
+      ref.current.style.display = 'block'
+      ref.current.style.left = boundingBox.x + 'px'
+      ref.current.style.top = boundingBox.y + 'px'
+      ref.current.style.width = boundingBox.width + 'px'
+      ref.current.style.height = boundingBox.height + 'px'
+    }
+  })
+
+  return (
+    <CanvasOffsetWrapper>
+      <div
+        ref={controlRef}
+        style={{ position: 'absolute', visibility: hoverHidden ? 'hidden' : 'visible' }}
+        onMouseEnter={(e) => {
+          hoverStart(e)
+        }}
+        onMouseLeave={hoverEnd}
+      >
+        {props.children}
+      </div>
+    </CanvasOffsetWrapper>
+  )
+})

--- a/editor/src/components/canvas/controls/select-mode/show-hide-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/show-hide-control.tsx
@@ -9,8 +9,8 @@ import { useHoverWithDelay } from './controls-common'
 type ShowHideControlProps = React.PropsWithChildren<{ selectedElements: ElementPath[] }>
 
 export const ShowHideControl = controlForStrategyMemoized<ShowHideControlProps>((props) => {
-  const [hoverHidden, setHoverHidden] = React.useState<boolean>(true)
-  const [hoverStart, hoverEnd] = useHoverWithDelay(200, (h) => {
+  const [hoverHidden, setHoverHidden] = React.useState<boolean>(false)
+  const [hoverStart, hoverEnd] = useHoverWithDelay(0, (h) => {
     setHoverHidden(!h)
   })
 
@@ -29,8 +29,12 @@ export const ShowHideControl = controlForStrategyMemoized<ShowHideControlProps>(
   return (
     <CanvasOffsetWrapper>
       <div
+        data-testId='show-hide-control'
         ref={controlRef}
-        style={{ position: 'absolute', visibility: hoverHidden ? 'hidden' : 'visible' }}
+        style={{
+          position: 'absolute',
+          visibility: hoverHidden ? 'hidden' : 'visible',
+        }}
         onMouseEnter={(e) => {
           hoverStart(e)
         }}


### PR DESCRIPTION
## Problem
On small element, canvas controls can be "clutter" that overshadow the actual element

## Fix
Only show control that are the "most" important based on the actual selected element