### PR TITLE
Represent padding values that are not defined in `style` as `undefined`

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -3,7 +3,10 @@ import { cmdModifier, shiftModifier } from '../../../../utils/modifiers'
 import { wait } from '../../../../utils/utils.test-utils'
 import { EdgePiece } from '../../canvas-types'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
-import { AdjustPrecision } from '../../controls/select-mode/controls-common'
+import {
+  AdjustPrecision,
+  pureCSSNumberWithRenderedValue,
+} from '../../controls/select-mode/controls-common'
 import {
   paddingControlHandleTestId,
   paddingControlTestId,
@@ -18,11 +21,12 @@ import {
   mouseMoveToPoint,
 } from '../../event-helpers.test-utils'
 import {
-  defaultPaddingMeasurement,
   offsetPaddingByEdge,
   paddingToPaddingString,
   CSSPaddingMeasurements,
   CSSPaddingMappedValues,
+  combinePaddings,
+  paddingPropForEdge,
 } from '../../padding-utils'
 import {
   EditorRenderResult,
@@ -30,7 +34,7 @@ import {
   makeTestProjectCodeWithSnippet,
   renderTestEditorWithCode,
 } from '../../ui-jsx.test-utils'
-import { SetPaddingStrategyName } from './set-padding-strategy'
+import { PaddingTearThreshold, SetPaddingStrategyName } from './set-padding-strategy'
 
 const EdgePieces: Array<EdgePiece> = ['top', 'bottom', 'left', 'right']
 
@@ -118,10 +122,10 @@ describe('Padding resize strategy', () => {
     const editor = await renderTestEditorWithCode(
       makeTestProjectCodeWithStringPaddingValues(
         paddingToPaddingString({
-          paddingTop: defaultPaddingMeasurement(22),
-          paddingBottom: defaultPaddingMeasurement(33),
-          paddingLeft: defaultPaddingMeasurement(44),
-          paddingRight: defaultPaddingMeasurement(55),
+          paddingTop: pureCSSNumberWithRenderedValue(22),
+          paddingBottom: pureCSSNumberWithRenderedValue(33),
+          paddingLeft: pureCSSNumberWithRenderedValue(44),
+          paddingRight: pureCSSNumberWithRenderedValue(55),
         }),
       ),
       'await-first-dom-report',
@@ -163,10 +167,10 @@ describe('Padding resize strategy', () => {
     const editor = await renderTestEditorWithCode(
       makeTestProjectCodeWithStringPaddingValues(
         paddingToPaddingString({
-          paddingTop: defaultPaddingMeasurement(22),
-          paddingBottom: defaultPaddingMeasurement(33),
-          paddingLeft: defaultPaddingMeasurement(44),
-          paddingRight: defaultPaddingMeasurement(55),
+          paddingTop: pureCSSNumberWithRenderedValue(22),
+          paddingBottom: pureCSSNumberWithRenderedValue(33),
+          paddingLeft: pureCSSNumberWithRenderedValue(44),
+          paddingRight: pureCSSNumberWithRenderedValue(55),
         }),
       ),
       'await-first-dom-report',
@@ -194,10 +198,10 @@ describe('Padding resize strategy', () => {
     const editor = await renderTestEditorWithCode(
       makeTestProjectCodeWithStringPaddingValues(
         paddingToPaddingString({
-          paddingTop: defaultPaddingMeasurement(22),
-          paddingBottom: defaultPaddingMeasurement(33),
-          paddingLeft: defaultPaddingMeasurement(44),
-          paddingRight: defaultPaddingMeasurement(55),
+          paddingTop: pureCSSNumberWithRenderedValue(22),
+          paddingBottom: pureCSSNumberWithRenderedValue(33),
+          paddingLeft: pureCSSNumberWithRenderedValue(44),
+          paddingRight: pureCSSNumberWithRenderedValue(55),
         }),
       ),
       'await-first-dom-report',
@@ -256,6 +260,37 @@ describe('Padding resize strategy', () => {
 
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
       makeTestProjectCodeWithStringPaddingValues(`${dragDeltaFromZero}px 1em 3em 2em`),
+    )
+  })
+
+  it('padding can be set to zero without removing the property', async () => {
+    const dragDeltaToZero = -11
+    const editor = await renderTestEditorWithCode(
+      makeTestProjectCodeWithStringPaddingValues('11px 11px 11px 11px'),
+      'await-first-dom-report',
+    )
+
+    await testPaddingResizeForEdge(editor, dragDeltaToZero, 'top', 'precise')
+    await editor.getDispatchFollowUpActionsFinished()
+
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      makeTestProjectCodeWithStringPaddingValues(`0px 11px 11px 11px`),
+    )
+  })
+
+  it('padding can be set below zero, but above the remove threshold without removing the property', async () => {
+    const originalPadding = 11
+    const dragDelta = -originalPadding - Math.abs(PaddingTearThreshold) / 2
+    const editor = await renderTestEditorWithCode(
+      makeTestProjectCodeWithStringPaddingValues(`${originalPadding}px 11px 11px 11px`),
+      'await-first-dom-report',
+    )
+
+    await testPaddingResizeForEdge(editor, dragDelta, 'top', 'precise')
+    await editor.getDispatchFollowUpActionsFinished()
+
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      makeTestProjectCodeWithStringPaddingValues(`0px 11px 11px 11px`),
     )
   })
 
@@ -435,10 +470,10 @@ describe('Padding resize strategy', () => {
 
 async function testAdjustIndividualPaddingValue(edge: EdgePiece, precision: AdjustPrecision) {
   const padding: CSSPaddingMeasurements = {
-    paddingTop: defaultPaddingMeasurement(22),
-    paddingBottom: defaultPaddingMeasurement(33),
-    paddingLeft: defaultPaddingMeasurement(44),
-    paddingRight: defaultPaddingMeasurement(55),
+    paddingTop: pureCSSNumberWithRenderedValue(22),
+    paddingBottom: pureCSSNumberWithRenderedValue(33),
+    paddingLeft: pureCSSNumberWithRenderedValue(44),
+    paddingRight: pureCSSNumberWithRenderedValue(55),
   }
   const dragDelta = 12
   const editor = await renderTestEditorWithCode(
@@ -446,11 +481,23 @@ async function testAdjustIndividualPaddingValue(edge: EdgePiece, precision: Adju
     'await-first-dom-report',
   )
 
+  const defaultPadding: CSSPaddingMappedValues<number> = {
+    paddingTop: 0,
+    paddingRight: 0,
+    paddingBottom: 0,
+    paddingLeft: 0,
+  }
+
   await testPaddingResizeForEdge(editor, dragDelta, edge, precision)
   await editor.getDispatchFollowUpActionsFinished()
   expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
     makeTestProjectCodeWithStringPaddingValues(
-      paddingToPaddingString(offsetPaddingByEdge(edge, dragDelta, padding, precision)),
+      paddingToPaddingString(
+        combinePaddings(
+          defaultPadding,
+          offsetPaddingByEdge(paddingPropForEdge(edge), dragDelta, padding, precision),
+        ),
+      ),
     ),
   )
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -5,7 +5,7 @@ import { EdgePiece } from '../../canvas-types'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import {
   AdjustPrecision,
-  pureCSSNumberWithRenderedValue,
+  unitlessCSSNumberWithRenderedValue,
 } from '../../controls/select-mode/controls-common'
 import {
   paddingControlHandleTestId,
@@ -122,10 +122,10 @@ describe('Padding resize strategy', () => {
     const editor = await renderTestEditorWithCode(
       makeTestProjectCodeWithStringPaddingValues(
         paddingToPaddingString({
-          paddingTop: pureCSSNumberWithRenderedValue(22),
-          paddingBottom: pureCSSNumberWithRenderedValue(33),
-          paddingLeft: pureCSSNumberWithRenderedValue(44),
-          paddingRight: pureCSSNumberWithRenderedValue(55),
+          paddingTop: unitlessCSSNumberWithRenderedValue(22),
+          paddingBottom: unitlessCSSNumberWithRenderedValue(33),
+          paddingLeft: unitlessCSSNumberWithRenderedValue(44),
+          paddingRight: unitlessCSSNumberWithRenderedValue(55),
         }),
       ),
       'await-first-dom-report',
@@ -167,10 +167,10 @@ describe('Padding resize strategy', () => {
     const editor = await renderTestEditorWithCode(
       makeTestProjectCodeWithStringPaddingValues(
         paddingToPaddingString({
-          paddingTop: pureCSSNumberWithRenderedValue(22),
-          paddingBottom: pureCSSNumberWithRenderedValue(33),
-          paddingLeft: pureCSSNumberWithRenderedValue(44),
-          paddingRight: pureCSSNumberWithRenderedValue(55),
+          paddingTop: unitlessCSSNumberWithRenderedValue(22),
+          paddingBottom: unitlessCSSNumberWithRenderedValue(33),
+          paddingLeft: unitlessCSSNumberWithRenderedValue(44),
+          paddingRight: unitlessCSSNumberWithRenderedValue(55),
         }),
       ),
       'await-first-dom-report',
@@ -198,10 +198,10 @@ describe('Padding resize strategy', () => {
     const editor = await renderTestEditorWithCode(
       makeTestProjectCodeWithStringPaddingValues(
         paddingToPaddingString({
-          paddingTop: pureCSSNumberWithRenderedValue(22),
-          paddingBottom: pureCSSNumberWithRenderedValue(33),
-          paddingLeft: pureCSSNumberWithRenderedValue(44),
-          paddingRight: pureCSSNumberWithRenderedValue(55),
+          paddingTop: unitlessCSSNumberWithRenderedValue(22),
+          paddingBottom: unitlessCSSNumberWithRenderedValue(33),
+          paddingLeft: unitlessCSSNumberWithRenderedValue(44),
+          paddingRight: unitlessCSSNumberWithRenderedValue(55),
         }),
       ),
       'await-first-dom-report',
@@ -470,10 +470,10 @@ describe('Padding resize strategy', () => {
 
 async function testAdjustIndividualPaddingValue(edge: EdgePiece, precision: AdjustPrecision) {
   const padding: CSSPaddingMeasurements = {
-    paddingTop: pureCSSNumberWithRenderedValue(22),
-    paddingBottom: pureCSSNumberWithRenderedValue(33),
-    paddingLeft: pureCSSNumberWithRenderedValue(44),
-    paddingRight: pureCSSNumberWithRenderedValue(55),
+    paddingTop: unitlessCSSNumberWithRenderedValue(22),
+    paddingBottom: unitlessCSSNumberWithRenderedValue(33),
+    paddingLeft: unitlessCSSNumberWithRenderedValue(44),
+    paddingRight: unitlessCSSNumberWithRenderedValue(55),
   }
   const dragDelta = 12
   const editor = await renderTestEditorWithCode(

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -42,7 +42,7 @@ import {
   indicatorMessage,
   offsetMeasurementByDelta,
   precisionFromModifiers,
-  pureCSSNumberWithRenderedValue,
+  unitlessCSSNumberWithRenderedValue,
 } from '../../controls/select-mode/controls-common'
 import { CanvasCommand } from '../../commands/commands'
 
@@ -153,7 +153,7 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
       const rawDelta = deltaFromEdge(drag, edgePiece)
       const maxedDelta = Math.max(-currentPadding, rawDelta)
       const newPaddingEdge = offsetMeasurementByDelta(
-        padding[paddingPropInteractedWith] ?? pureCSSNumberWithRenderedValue(maxedDelta),
+        padding[paddingPropInteractedWith] ?? unitlessCSSNumberWithRenderedValue(maxedDelta),
         rawDelta,
         precision,
       )
@@ -295,7 +295,8 @@ function paddingValueIndicatorProps(
     canvasState.startingMetadata,
     filteredSelectedElements[0],
   )
-  const currentPadding = padding[paddingPropForEdge(edgePiece)] ?? pureCSSNumberWithRenderedValue(0)
+  const currentPadding =
+    padding[paddingPropForEdge(edgePiece)] ?? unitlessCSSNumberWithRenderedValue(0)
 
   const delta = deltaFromEdge(drag, edgePiece)
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -19,8 +19,8 @@ import {
 import {
   CSSPaddingKey,
   deltaFromEdge,
+  maybeFullPadding,
   offsetPaddingByEdge,
-  paddingForEdge,
   paddingPropForEdge,
   paddingToPaddingString,
   printCssNumberWithDefaultUnit,
@@ -42,6 +42,7 @@ import {
   indicatorMessage,
   offsetMeasurementByDelta,
   precisionFromModifiers,
+  pureCSSNumberWithRenderedValue,
 } from '../../controls/select-mode/controls-common'
 import { CanvasCommand } from '../../commands/commands'
 
@@ -53,7 +54,7 @@ const IndividualPaddingProps: Array<CSSPaddingKey> = [
   'paddingRight',
 ]
 
-const PaddingTearThreshold: number = -25
+export const PaddingTearThreshold: number = -25
 
 export const SetPaddingStrategyName = 'Set Padding'
 
@@ -144,22 +145,26 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
 
       const selectedElement = filteredSelectedElements[0]
 
+      const paddingPropInteractedWith = paddingPropForEdge(edgePiece)
+      const precision = precisionFromModifiers(interactionSession.interactionData.modifiers)
+
       const padding = simplePaddingFromMetadata(canvasState.startingMetadata, selectedElement)
-      const currentPadding = paddingForEdge(edgePiece, padding)
+      const currentPadding = padding[paddingPropForEdge(edgePiece)]?.renderedValuePx ?? 0
       const rawDelta = deltaFromEdge(drag, edgePiece)
-      const delta = Math.max(-currentPadding, rawDelta)
-      const newPadding = offsetPaddingByEdge(
-        edgePiece,
+      const maxedDelta = Math.max(-currentPadding, rawDelta)
+      const newPaddingEdge = offsetMeasurementByDelta(
+        padding[paddingPropInteractedWith] ?? pureCSSNumberWithRenderedValue(maxedDelta),
         rawDelta,
-        padding,
-        precisionFromModifiers(interactionSession.interactionData.modifiers),
+        precision,
       )
 
+      const delta = newPaddingEdge.renderedValuePx < PaddingTearThreshold ? rawDelta : maxedDelta
+
       const newPaddingMaxed = offsetPaddingByEdge(
-        edgePiece,
+        paddingPropInteractedWith,
         delta,
         padding,
-        precisionFromModifiers(interactionSession.interactionData.modifiers),
+        precision,
       )
 
       const basicCommands: CanvasCommand[] = [
@@ -168,34 +173,33 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
         setElementsToRerenderCommand(selectedElements),
       ]
 
-      if (rawDelta < PaddingTearThreshold) {
-        const paddingPropToBeRemoved = paddingPropForEdge(edgePiece)
-        const nonZeroPropsToAdd = IndividualPaddingProps.filter(
-          (p) => p !== paddingPropToBeRemoved && newPaddingMaxed[p].renderedValuePx > 0,
-        )
+      const nonZeroPropsToAdd = IndividualPaddingProps.flatMap(
+        (p): Array<[CSSPaddingKey, string | number]> => {
+          const value = newPaddingMaxed[p]
+          if (value == null || value.renderedValuePx < 0) {
+            return []
+          }
+          return [[p, printCssNumberWithDefaultUnit(value.value, 'px')]]
+        },
+      )
+
+      if (newPaddingEdge.renderedValuePx < PaddingTearThreshold) {
         return strategyApplicationResult([
           ...basicCommands,
           deleteProperties('always', selectedElement, [
             StylePaddingProp,
-            stylePropPathMappingFn(paddingPropToBeRemoved, ['style']),
+            stylePropPathMappingFn(paddingPropInteractedWith, ['style']),
           ]),
-          ...nonZeroPropsToAdd.map((p) =>
-            setProperty(
-              'always',
-              selectedElement,
-              stylePropPathMappingFn(p, ['style']),
-              printCssNumberWithDefaultUnit(newPaddingMaxed[p].value, 'px'),
-            ),
+          ...nonZeroPropsToAdd.map(([p, value]) =>
+            setProperty('always', selectedElement, stylePropPathMappingFn(p, ['style']), value),
           ),
         ])
       }
 
-      const allPaddingPropsHigherThanZero = IndividualPaddingProps.every(
-        (p) => newPadding[p].renderedValuePx > 0,
-      )
+      const allPaddingPropsDefined = maybeFullPadding(newPaddingMaxed)
 
-      if (allPaddingPropsHigherThanZero) {
-        const paddingString = paddingToPaddingString(newPaddingMaxed)
+      if (allPaddingPropsDefined != null) {
+        const paddingString = paddingToPaddingString(allPaddingPropsDefined)
         return strategyApplicationResult([
           ...basicCommands,
           ...IndividualPaddingProps.map((p) =>
@@ -211,13 +215,8 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
           StylePaddingProp,
           ...IndividualPaddingProps.map((p) => stylePropPathMappingFn(p, ['style'])),
         ]),
-        ...IndividualPaddingProps.filter((p) => newPaddingMaxed[p].renderedValuePx > 0).map((p) =>
-          setProperty(
-            'always',
-            selectedElement,
-            stylePropPathMappingFn(p, ['style']),
-            printCssNumberWithDefaultUnit(newPaddingMaxed[p].value, 'px'),
-          ),
+        ...nonZeroPropsToAdd.map(([p, value]) =>
+          setProperty('always', selectedElement, stylePropPathMappingFn(p, ['style']), value),
         ),
       ])
     },
@@ -296,7 +295,7 @@ function paddingValueIndicatorProps(
     canvasState.startingMetadata,
     filteredSelectedElements[0],
   )
-  const currentPadding = padding[paddingPropForEdge(edgePiece)]
+  const currentPadding = padding[paddingPropForEdge(edgePiece)] ?? pureCSSNumberWithRenderedValue(0)
 
   const delta = deltaFromEdge(drag, edgePiece)
 

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -10,7 +10,7 @@ export interface CSSNumberWithRenderedValue {
   renderedValuePx: number
 }
 
-export const pureCSSNumberWithRenderedValue = (
+export const unitlessCSSNumberWithRenderedValue = (
   renderedValuePx: number,
 ): CSSNumberWithRenderedValue => ({
   value: { value: renderedValuePx, unit: null },

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -10,6 +10,13 @@ export interface CSSNumberWithRenderedValue {
   renderedValuePx: number
 }
 
+export const pureCSSNumberWithRenderedValue = (
+  renderedValuePx: number,
+): CSSNumberWithRenderedValue => ({
+  value: { value: renderedValuePx, unit: null },
+  renderedValuePx,
+})
+
 export const cssNumberWithRenderedValue = (
   value: CSSNumber,
   renderedValuePx: number,

--- a/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
@@ -16,7 +16,12 @@ import {
 } from '../../canvas-strategies/interaction-state'
 import { CSSCursor, EdgePiece } from '../../canvas-types'
 import { windowToCanvasCoordinates } from '../../dom-lookup'
-import { PaddingIndictorOffset, simplePaddingFromMetadata } from '../../padding-utils'
+import {
+  combinePaddings,
+  paddingFromSpecialSizeMeasurements,
+  PaddingIndictorOffset,
+  simplePaddingFromMetadata,
+} from '../../padding-utils'
 import { useBoundingBox } from '../bounding-box-hooks'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 import { isZeroSizedElement } from '../outline-utils'
@@ -214,36 +219,39 @@ export const PaddingResizeControl = controlForStrategyMemoized((props: PaddingCo
     }
   })
 
-  const currentPadding = simplePaddingFromMetadata(elementMetadata.current, selectedElements[0])
+  const currentPadding = combinePaddings(
+    paddingFromSpecialSizeMeasurements(elementMetadata.current, selectedElements[0]),
+    simplePaddingFromMetadata(elementMetadata.current, selectedElements[0]),
+  )
 
   const leftRef = useBoundingBox(selectedElements, (ref, boundingBox) => {
     const padding = simplePaddingFromMetadata(elementMetadata.current, selectedElements[0])
     ref.current.style.height = numberToPxValue(boundingBox.height)
-    ref.current.style.width = numberToPxValue(padding.paddingLeft.renderedValuePx)
+    ref.current.style.width = numberToPxValue(padding.paddingLeft?.renderedValuePx ?? 0)
   })
 
   const topRef = useBoundingBox(selectedElements, (ref, boundingBox) => {
     const padding = simplePaddingFromMetadata(elementMetadata.current, selectedElements[0])
     ref.current.style.width = numberToPxValue(boundingBox.width)
-    ref.current.style.height = numberToPxValue(padding.paddingTop.renderedValuePx)
+    ref.current.style.height = numberToPxValue(padding.paddingTop?.renderedValuePx ?? 0)
   })
 
   const rightRef = useBoundingBox(selectedElements, (ref, boundingBox) => {
     const padding = simplePaddingFromMetadata(elementMetadata.current, selectedElements[0])
     ref.current.style.left = numberToPxValue(
-      boundingBox.width - padding.paddingRight.renderedValuePx,
+      boundingBox.width - (padding.paddingRight?.renderedValuePx ?? 0),
     )
     ref.current.style.height = numberToPxValue(boundingBox.height)
-    ref.current.style.width = numberToPxValue(padding.paddingRight.renderedValuePx)
+    ref.current.style.width = numberToPxValue(padding.paddingRight?.renderedValuePx ?? 0)
   })
 
   const bottomRef = useBoundingBox(selectedElements, (ref, boundingBox) => {
     const padding = simplePaddingFromMetadata(elementMetadata.current, selectedElements[0])
     ref.current.style.top = numberToPxValue(
-      boundingBox.height - padding.paddingBottom.renderedValuePx,
+      boundingBox.height - (padding.paddingBottom?.renderedValuePx ?? 0),
     )
     ref.current.style.width = numberToPxValue(boundingBox.width)
-    ref.current.style.height = numberToPxValue(padding.paddingBottom.renderedValuePx)
+    ref.current.style.height = numberToPxValue(padding.paddingBottom?.renderedValuePx ?? 0)
   })
 
   const [hoverHidden, setHoverHidden] = React.useState<boolean>(true)

--- a/editor/src/components/canvas/padding-utils.tsx
+++ b/editor/src/components/canvas/padding-utils.tsx
@@ -1,31 +1,29 @@
 import { getLayoutProperty } from '../../core/layout/getLayoutProperty'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
-import { Either, isLeft, right } from '../../core/shared/either'
+import { defaultEither, Either, isLeft, right } from '../../core/shared/either'
 import { ElementInstanceMetadataMap, isJSXElement } from '../../core/shared/element-template'
 import { CanvasVector } from '../../core/shared/math-utils'
+import { optionalMap } from '../../core/shared/optional-utils'
 import { ElementPath } from '../../core/shared/project-file-types'
 import { assertNever } from '../../core/shared/utils'
 import { CSSNumber, CSSNumberUnit, CSSPadding, printCSSNumber } from '../inspector/common/css-utils'
 import { EdgePiece } from './canvas-types'
 import {
   AdjustPrecision,
+  cssNumberWithRenderedValue,
   CSSNumberWithRenderedValue,
   offsetMeasurementByDelta,
+  pureCSSNumberWithRenderedValue,
 } from './controls/select-mode/controls-common'
 
 export type CSSPaddingKey = keyof CSSPadding
 export type CSSPaddingMappedValues<T> = { [key in CSSPaddingKey]: T }
 export type CSSPaddingMeasurements = CSSPaddingMappedValues<CSSNumberWithRenderedValue>
 
-export const defaultPaddingMeasurement = (sizePx: number): CSSNumberWithRenderedValue => ({
-  value: { value: sizePx, unit: null },
-  renderedValuePx: sizePx,
-})
-
-export function simplePaddingFromMetadata(
+export function paddingFromSpecialSizeMeasurements(
   metadata: ElementInstanceMetadataMap,
   elementPath: ElementPath,
-): CSSPaddingMeasurements {
+): CSSPaddingMappedValues<number> {
   const element = MetadataUtils.findElementByElementPath(metadata, elementPath)
   const paddingFromMeasurements = element?.specialSizeMeasurements.padding
 
@@ -36,102 +34,106 @@ export function simplePaddingFromMetadata(
     paddingRight: paddingFromMeasurements?.right ?? 0,
   }
 
-  const defaultPadding = {
-    paddingTop: defaultPaddingMeasurement(paddingMappedMeasurements.paddingTop),
-    paddingBottom: defaultPaddingMeasurement(paddingMappedMeasurements.paddingBottom),
-    paddingLeft: defaultPaddingMeasurement(paddingMappedMeasurements.paddingLeft),
-    paddingRight: defaultPaddingMeasurement(paddingMappedMeasurements.paddingRight),
+  return paddingMappedMeasurements
+}
+
+export function simplePaddingFromMetadata(
+  metadata: ElementInstanceMetadataMap,
+  elementPath: ElementPath,
+): CSSPaddingMappedValues<CSSNumberWithRenderedValue | undefined> {
+  const element = MetadataUtils.findElementByElementPath(metadata, elementPath)
+
+  const defaults: CSSPaddingMappedValues<CSSNumber | undefined> = {
+    paddingTop: undefined,
+    paddingRight: undefined,
+    paddingBottom: undefined,
+    paddingLeft: undefined,
   }
 
   if (element == null || isLeft(element.element) || !isJSXElement(element.element.value)) {
-    return defaultPadding
+    return {
+      paddingTop: undefined,
+      paddingRight: undefined,
+      paddingBottom: undefined,
+      paddingLeft: undefined,
+    }
   }
 
-  const padding = cssPaddingToMeasurement(
+  const paddingNumbers = paddingFromSpecialSizeMeasurements(metadata, elementPath)
+
+  const padding: CSSPadding | undefined = defaultEither(
+    undefined,
     getLayoutProperty('padding', right(element.element.value.props), ['style']),
-    paddingMappedMeasurements,
   )
 
-  const paddingTop = paddingMeasurementFromEither(
-    getLayoutProperty('paddingTop', right(element.element.value.props), ['style']),
-    paddingMappedMeasurements.paddingTop,
-  )
+  const paddingLonghands: CSSPaddingMappedValues<CSSNumber | undefined> = {
+    paddingTop: defaultEither(
+      undefined,
+      getLayoutProperty('paddingTop', right(element.element.value.props), ['style']),
+    ),
+    paddingBottom: defaultEither(
+      undefined,
+      getLayoutProperty('paddingBottom', right(element.element.value.props), ['style']),
+    ),
+    paddingLeft: defaultEither(
+      undefined,
+      getLayoutProperty('paddingLeft', right(element.element.value.props), ['style']),
+    ),
+    paddingRight: defaultEither(
+      undefined,
+      getLayoutProperty('paddingRight', right(element.element.value.props), ['style']),
+    ),
+  }
 
-  const paddingBottom = paddingMeasurementFromEither(
-    getLayoutProperty('paddingBottom', right(element.element.value.props), ['style']),
-    paddingMappedMeasurements.paddingBottom,
-  )
+  const make = (prop: CSSPaddingKey): CSSNumberWithRenderedValue | undefined => {
+    return (
+      optionalMap(
+        (p) => cssNumberWithRenderedValue(p, paddingNumbers[prop]),
+        paddingLonghands[prop],
+      ) ??
+      optionalMap(
+        (p) => cssNumberWithRenderedValue(p, paddingNumbers[prop]),
+        padding?.[prop] ?? defaults[prop],
+      ) ??
+      undefined
+    )
+  }
 
-  const paddingLeft = paddingMeasurementFromEither(
-    getLayoutProperty('paddingLeft', right(element.element.value.props), ['style']),
-    paddingMappedMeasurements.paddingLeft,
-  )
-
-  const paddingRight = paddingMeasurementFromEither(
-    getLayoutProperty('paddingRight', right(element.element.value.props), ['style']),
-    paddingMappedMeasurements.paddingRight,
-  )
-
-  return cssPaddingWithDefaults(
-    { paddingTop, paddingBottom, paddingLeft, paddingRight },
-    padding,
-    defaultPadding,
-  )
-}
-
-function cssPaddingWithDefaults(
-  parts: Partial<CSSPaddingMeasurements>,
-  whole: Partial<CSSPaddingMeasurements>,
-  defaults: CSSPaddingMeasurements,
-): CSSPaddingMeasurements {
   return {
-    paddingTop: parts.paddingTop ?? whole.paddingTop ?? defaults.paddingTop,
-    paddingBottom: parts.paddingBottom ?? whole.paddingBottom ?? defaults.paddingBottom,
-    paddingLeft: parts.paddingLeft ?? whole.paddingLeft ?? defaults.paddingLeft,
-    paddingRight: parts.paddingRight ?? whole.paddingRight ?? defaults.paddingRight,
+    paddingTop: make('paddingTop'),
+    paddingRight: make('paddingRight'),
+    paddingBottom: make('paddingBottom'),
+    paddingLeft: make('paddingLeft'),
   }
 }
 
-function paddingMeasurementFromEither(
-  value: Either<string, CSSNumber | undefined>,
-  renderedDimension: number,
-): CSSNumberWithRenderedValue | undefined {
-  if (isLeft(value) || value.value == null) {
+export function combinePaddings(
+  paddingNumber: CSSPaddingMappedValues<number>,
+  paddingRenderedValues: CSSPaddingMappedValues<CSSNumberWithRenderedValue | undefined>,
+): CSSPaddingMappedValues<CSSNumberWithRenderedValue> {
+  return {
+    paddingTop:
+      paddingRenderedValues.paddingTop ?? pureCSSNumberWithRenderedValue(paddingNumber.paddingTop),
+    paddingRight:
+      paddingRenderedValues.paddingRight ??
+      pureCSSNumberWithRenderedValue(paddingNumber.paddingRight),
+    paddingBottom:
+      paddingRenderedValues.paddingBottom ??
+      pureCSSNumberWithRenderedValue(paddingNumber.paddingBottom),
+    paddingLeft:
+      paddingRenderedValues.paddingLeft ??
+      pureCSSNumberWithRenderedValue(paddingNumber.paddingLeft),
+  }
+}
+
+export function maybeFullPadding(
+  padding: CSSPaddingMappedValues<CSSNumberWithRenderedValue | undefined>,
+): CSSPaddingMappedValues<CSSNumberWithRenderedValue> | undefined {
+  const { paddingTop, paddingRight, paddingBottom, paddingLeft } = padding
+  if (paddingTop == null || paddingRight == null || paddingBottom == null || paddingLeft == null) {
     return undefined
   }
-
-  return {
-    renderedValuePx: renderedDimension,
-    value: value.value,
-  }
-}
-
-function cssPaddingToMeasurement(
-  p: Either<string, CSSPadding | undefined>,
-  padding: CSSPaddingMappedValues<number>,
-): Partial<CSSPaddingMeasurements> {
-  if (isLeft(p) || p.value == null) {
-    return {}
-  }
-
-  return {
-    paddingTop: {
-      value: p.value.paddingTop,
-      renderedValuePx: padding.paddingTop,
-    },
-    paddingBottom: {
-      value: p.value.paddingBottom,
-      renderedValuePx: padding.paddingBottom,
-    },
-    paddingLeft: {
-      value: p.value.paddingLeft,
-      renderedValuePx: padding.paddingLeft,
-    },
-    paddingRight: {
-      value: p.value.paddingRight,
-      renderedValuePx: padding.paddingRight,
-    },
-  }
+  return { paddingTop, paddingRight, paddingBottom, paddingLeft }
 }
 
 export function paddingPropForEdge(edgePiece: EdgePiece): CSSPaddingKey {
@@ -154,34 +156,18 @@ export function paddingForEdge(edgePiece: EdgePiece, padding: CSSPaddingMeasurem
 }
 
 export function offsetPaddingByEdge(
-  edge: EdgePiece,
+  prop: CSSPaddingKey,
   delta: number,
-  padding: CSSPaddingMeasurements,
+  padding: CSSPaddingMappedValues<CSSNumberWithRenderedValue | undefined>,
   precision: AdjustPrecision,
-): CSSPaddingMeasurements {
-  switch (edge) {
-    case 'bottom':
-      return {
-        ...padding,
-        paddingBottom: offsetMeasurementByDelta(padding.paddingBottom, delta, precision),
-      }
-    case 'top':
-      return {
-        ...padding,
-        paddingTop: offsetMeasurementByDelta(padding.paddingTop, delta, precision),
-      }
-    case 'left':
-      return {
-        ...padding,
-        paddingLeft: offsetMeasurementByDelta(padding.paddingLeft, delta, precision),
-      }
-    case 'right':
-      return {
-        ...padding,
-        paddingRight: offsetMeasurementByDelta(padding.paddingRight, delta, precision),
-      }
-    default:
-      assertNever(edge)
+): CSSPaddingMappedValues<CSSNumberWithRenderedValue | undefined> {
+  return {
+    ...padding,
+    [prop]: offsetMeasurementByDelta(
+      padding[prop] ?? pureCSSNumberWithRenderedValue(0),
+      delta,
+      precision,
+    ),
   }
 }
 

--- a/editor/src/components/canvas/padding-utils.tsx
+++ b/editor/src/components/canvas/padding-utils.tsx
@@ -13,7 +13,7 @@ import {
   cssNumberWithRenderedValue,
   CSSNumberWithRenderedValue,
   offsetMeasurementByDelta,
-  pureCSSNumberWithRenderedValue,
+  unitlessCSSNumberWithRenderedValue,
 } from './controls/select-mode/controls-common'
 
 export type CSSPaddingKey = keyof CSSPadding
@@ -113,16 +113,17 @@ export function combinePaddings(
 ): CSSPaddingMappedValues<CSSNumberWithRenderedValue> {
   return {
     paddingTop:
-      paddingRenderedValues.paddingTop ?? pureCSSNumberWithRenderedValue(paddingNumber.paddingTop),
+      paddingRenderedValues.paddingTop ??
+      unitlessCSSNumberWithRenderedValue(paddingNumber.paddingTop),
     paddingRight:
       paddingRenderedValues.paddingRight ??
-      pureCSSNumberWithRenderedValue(paddingNumber.paddingRight),
+      unitlessCSSNumberWithRenderedValue(paddingNumber.paddingRight),
     paddingBottom:
       paddingRenderedValues.paddingBottom ??
-      pureCSSNumberWithRenderedValue(paddingNumber.paddingBottom),
+      unitlessCSSNumberWithRenderedValue(paddingNumber.paddingBottom),
     paddingLeft:
       paddingRenderedValues.paddingLeft ??
-      pureCSSNumberWithRenderedValue(paddingNumber.paddingLeft),
+      unitlessCSSNumberWithRenderedValue(paddingNumber.paddingLeft),
   }
 }
 
@@ -164,7 +165,7 @@ export function offsetPaddingByEdge(
   return {
     ...padding,
     [prop]: offsetMeasurementByDelta(
-      padding[prop] ?? pureCSSNumberWithRenderedValue(0),
+      padding[prop] ?? unitlessCSSNumberWithRenderedValue(0),
       delta,
       precision,
     ),


### PR DESCRIPTION
## Problem:
Currently, padding values that are not defined in `style` are treated as if they were 0. Due to this, we can't differentiate between padding values that were set to 0 intentionally, and padding values that are simply not defined. 

So far this has been an edge case, since the padding controls normalised the `padding` prop to the 4-value form (`padding: "top right bottom left"`). Now that we have the capability to fully remove padding from any of the sides, not knowing whether a padding is 0 or has been removed became a problem. For example, if there's only `paddingTop`, `paddingBottom`, and `paddingRight` present in `style`, and `paddingRight` we removed, how do we know if `paddingLeft` is 0 or not there at all (without reading `style` again and again)?

## Fix:
Refactor the function that reads what padding is set for an element to return `undefined` for paddings that are not set.