### PR TITLE
Pull request listing.

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -349,7 +349,6 @@ export function isGithubUpdating(operations: Array<GithubOperation>): boolean {
 
 export function isGithubListingPullRequestsForBranch(
   operations: Array<GithubOperation>,
-
   repo: GithubRepo,
   branchName: string,
 ): boolean {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -255,12 +255,41 @@ export interface UserState extends UserConfiguration {
   githubState: GithubState
 }
 
+export interface GithubCommish {
+  name: 'commish'
+}
+
+export interface GithubListBranches {
+  name: 'listBranches'
+}
+
+export interface GithubLoadBranch {
+  name: 'loadBranch'
+  githubRepo: GithubRepo
+  branchName: string
+}
+
+export interface GithubLoadRepositories {
+  name: 'loadRepositories'
+}
+
+export interface GithubUpdateAgainstBranch {
+  name: 'updateAgainstBranch'
+}
+
+export interface GithubListPullRequestsForBranch {
+  name: 'listPullRequestsForBranch'
+  githubRepo: GithubRepo
+  branchName: string
+}
+
 export type GithubOperation =
-  | { name: 'commish' }
-  | { name: 'listBranches' }
-  | { name: 'loadBranch'; branchName: string; githubRepo: GithubRepo }
-  | { name: 'loadRepositories' }
-  | { name: 'updateAgainstBranch' }
+  | GithubCommish
+  | GithubListBranches
+  | GithubLoadBranch
+  | GithubLoadRepositories
+  | GithubUpdateAgainstBranch
+  | GithubListPullRequestsForBranch
 
 export function githubOperationPrettyName(op: GithubOperation): string {
   switch (op.name) {
@@ -274,6 +303,8 @@ export function githubOperationPrettyName(op: GithubOperation): string {
       return 'Loading Repositories'
     case 'updateAgainstBranch':
       return 'Updating'
+    case 'listPullRequestsForBranch':
+      return 'Listing pull requests'
     default:
       const _exhaustiveCheck: never = op
       return 'Unknown operation' // this should never happen
@@ -284,6 +315,7 @@ export function githubOperationLocksEditor(op: GithubOperation): boolean {
   switch (op.name) {
     case 'listBranches':
     case 'loadRepositories':
+    case 'listPullRequestsForBranch':
       return false
     default:
       return true
@@ -313,6 +345,21 @@ export function isGithubLoadingRepositories(operations: Array<GithubOperation>):
 
 export function isGithubUpdating(operations: Array<GithubOperation>): boolean {
   return operations.some((operation) => operation.name === 'updateAgainstBranch')
+}
+
+export function isGithubListingPullRequestsForBranch(
+  operations: Array<GithubOperation>,
+
+  repo: GithubRepo,
+  branchName: string,
+): boolean {
+  return operations.some((operation) => {
+    return (
+      operation.name === 'listPullRequestsForBranch' &&
+      githubRepoEquals(operation.githubRepo, repo) &&
+      operation.branchName === branchName
+    )
+  })
 }
 
 export const defaultUserState: UserState = {
@@ -1048,6 +1095,11 @@ export function githubRepoEquals(a: GithubRepo | null, b: GithubRepo | null): bo
   return a?.owner === b?.owner && a?.repository === b?.repository
 }
 
+export interface PullRequest {
+  title: string
+  htmlURL: string
+}
+
 export interface ProjectGithubSettings {
   targetRepository: GithubRepo | null
   originCommit: string | null
@@ -1084,6 +1136,7 @@ export interface GithubData {
   treeConflicts: TreeConflicts
   lastUpdatedAt: number | null
   upstreamChanges: GithubFileChanges | null
+  currentBranchPullRequests: Array<PullRequest> | null
 }
 
 export function emptyGithubData(): GithubData {
@@ -1093,6 +1146,7 @@ export function emptyGithubData(): GithubData {
     treeConflicts: {},
     lastUpdatedAt: null,
     upstreamChanges: null,
+    currentBranchPullRequests: null,
   }
 }
 

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -45,6 +45,7 @@ import { RepositoryListing } from './repository-listing'
 import TimeAgo from 'react-timeago'
 import { WarningIcon } from '../../../../uuiui/warning-icon'
 import { projectDependenciesSelector } from '../../../../core/shared/dependencies'
+import { PullRequestPane } from './pull-request-pane'
 
 const GitBranchIcon = () => {
   return (
@@ -251,6 +252,7 @@ export const GithubPane = React.memo(() => {
             })}
           </div>,
         )}
+        <PullRequestPane />
       </>
     )
   }, [

--- a/editor/src/components/navigator/left-pane/github-pane/pull-request-pane.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/pull-request-pane.tsx
@@ -1,0 +1,124 @@
+import React from 'react'
+import { Button } from '../../../../uuiui/button'
+import urljoin from 'url-join'
+import { useEditorState } from '../../../../components/editor/store/store-hook'
+import { UIGridRow } from '../../../../components/inspector/widgets/ui-grid-row'
+import { GithubSpinner } from './github-spinner'
+import { RefreshIcon } from './refresh-icon'
+import { updatePullRequestsForBranch } from '../../../../core/shared/github'
+import {
+  isGithubListingPullRequestsForBranch,
+  PullRequest,
+} from '../../../../components/editor/store/editor-state'
+
+export const PullRequestPane = () => {
+  const dispatch = useEditorState((store) => store.dispatch, 'PullRequestPane dispatch')
+
+  const githubRepo = useEditorState((store) => {
+    return store.editor.githubSettings.targetRepository
+  }, 'PullRequestPane githubRepo')
+
+  const branchName = useEditorState((store) => {
+    return store.editor.githubSettings.branchName
+  }, 'PullRequestPane branch')
+
+  const pullRequests = useEditorState((store) => {
+    return store.editor.githubData.currentBranchPullRequests
+  }, 'PullRequestPane pullRequest')
+
+  const githubOperations = useEditorState(
+    (store) => store.editor.githubOperations,
+    'PullRequestPane githubOperations',
+  )
+
+  const githubWorking = React.useMemo(() => {
+    return githubOperations.length > 0
+  }, [githubOperations])
+
+  const isUpdatingPullRequests = React.useMemo(() => {
+    if (githubRepo != null && branchName != null) {
+      return isGithubListingPullRequestsForBranch(githubOperations, githubRepo, branchName)
+    } else {
+      return false
+    }
+  }, [githubOperations, githubRepo, branchName])
+
+  const refreshPullRequests = React.useCallback(() => {
+    if (githubRepo != null && branchName != null) {
+      void updatePullRequestsForBranch(dispatch, githubRepo, branchName)
+    }
+  }, [dispatch, githubRepo, branchName])
+
+  const pullRequestsWithCreateNew: Array<PullRequest> | null = React.useMemo(() => {
+    if (githubRepo != null && branchName != null) {
+      const createPullRequestURL = urljoin(
+        'https://github.com',
+        githubRepo.owner,
+        githubRepo.repository,
+        'compare',
+        branchName,
+      )
+      const createPullRequestURLWithParams = `${createPullRequestURL}?expand=1`
+      return [
+        ...(pullRequests ?? []),
+        {
+          title: 'Create PR on Github.',
+          htmlURL: createPullRequestURLWithParams,
+        },
+      ]
+    } else {
+      return null
+    }
+  }, [pullRequests, githubRepo, branchName])
+
+  if (pullRequestsWithCreateNew == null) {
+    return null
+  } else {
+    return (
+      <>
+        <UIGridRow padded variant='<----------1fr---------><-auto->'>
+          <span style={{ fontWeight: 500 }}>Pull Requests</span>
+          <Button
+            spotlight
+            highlight
+            style={{ padding: '0 6px' }}
+            disabled={githubWorking}
+            onMouseDown={refreshPullRequests}
+          >
+            {isUpdatingPullRequests ? <GithubSpinner /> : <RefreshIcon />}
+          </Button>
+        </UIGridRow>
+        <UIGridRow padded variant='<----------1fr---------><-auto->'>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
+            {pullRequestsWithCreateNew.map((pr, index) => {
+              return (
+                <div
+                  key={`pull-request-${index}`}
+                  style={{
+                    gap: 8,
+                    paddingLeft: 8,
+                    paddingRight: 8,
+                    paddingBottom: 8,
+                    paddingTop: 8,
+                    width: '100%',
+                    maxHeight: 220,
+                    overflowY: 'scroll',
+                  }}
+                >
+                  <a href={pr.htmlURL} target='_blank' rel='noopener noreferrer'>
+                    {pr.title}
+                  </a>
+                </div>
+              )
+            })}
+          </div>
+        </UIGridRow>
+      </>
+    )
+  }
+}

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -482,7 +482,7 @@ export async function updateProjectWithBranchContent(
         dispatch(
           [
             updateGithubChecksums(getProjectContentsChecksums(responseBody.content)),
-            //updateProjectContents(responseBody.content),
+            updateProjectContents(responseBody.content),
             updateBranchContents(responseBody.content),
             updateGithubSettings(
               projectGithubSettings(

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -42,6 +42,7 @@ import {
   packageJsonFileFromProjectContents,
   PersistentModel,
   projectGithubSettings,
+  PullRequest,
 } from '../../components/editor/store/editor-state'
 import { BuiltInDependencies } from '../es-modules/package-manager/built-in-dependencies-list'
 import { refreshDependencies } from './dependencies'
@@ -169,6 +170,13 @@ export interface GetUsersPublicRepositoriesSuccess {
 
 export type GetUsersPublicRepositoriesResponse = GetUsersPublicRepositoriesSuccess | GithubFailure
 
+export interface GetBranchPullRequestSuccess {
+  type: 'SUCCESS'
+  pullRequests: Array<PullRequest>
+}
+
+export type GetBranchPullRequestResponse = GetBranchPullRequestSuccess | GithubFailure
+
 export async function saveProjectToGithub(
   projectID: string,
   persistentModel: PersistentModel,
@@ -273,6 +281,74 @@ export async function getBranchesForGithubRepository(
         break
       case 'SUCCESS':
         dispatch([updateGithubData({ branches: responseBody.branches })], 'everyone')
+        break
+      default:
+        const _exhaustiveCheck: never = responseBody
+        throw new Error(`Unhandled response body ${JSON.stringify(responseBody)}`)
+    }
+  } else {
+    dispatch(
+      [showToast(notice(`Unexpected status returned from endpoint: ${response.status}`, 'ERROR'))],
+      'everyone',
+    )
+  }
+
+  dispatch([updateGithubOperations(operation, 'remove')], 'everyone')
+}
+
+export async function updatePullRequestsForBranch(
+  dispatch: EditorDispatch,
+  githubRepo: GithubRepo,
+  branchName: string,
+): Promise<void> {
+  const operation: GithubOperation = {
+    name: 'listPullRequestsForBranch',
+    githubRepo: githubRepo,
+    branchName: branchName,
+  }
+
+  dispatch([updateGithubOperations(operation, 'add')], 'everyone')
+
+  const url = urljoin(
+    UTOPIA_BACKEND,
+    'github',
+    'branches',
+    githubRepo.owner,
+    githubRepo.repository,
+    'branch',
+    branchName,
+    'pullrequest',
+  )
+
+  const response = await fetch(url, {
+    method: 'GET',
+    credentials: 'include',
+    headers: HEADERS,
+    mode: MODE,
+  })
+
+  if (response.ok) {
+    const responseBody: GetBranchPullRequestResponse = await response.json()
+
+    switch (responseBody.type) {
+      case 'FAILURE':
+        dispatch(
+          [
+            showToast(
+              notice(
+                `Error when listing pull requests for branch: ${responseBody.failureReason}`,
+                'ERROR',
+              ),
+            ),
+          ],
+          'everyone',
+        )
+        break
+      case 'SUCCESS':
+        dispatch(
+          [updateGithubData({ currentBranchPullRequests: responseBody.pullRequests })],
+          'everyone',
+        )
         break
       default:
         const _exhaustiveCheck: never = responseBody
@@ -406,7 +482,7 @@ export async function updateProjectWithBranchContent(
         dispatch(
           [
             updateGithubChecksums(getProjectContentsChecksums(responseBody.content)),
-            updateProjectContents(responseBody.content),
+            //updateProjectContents(responseBody.content),
             updateBranchContents(responseBody.content),
             updateGithubSettings(
               projectGithubSettings(
@@ -447,6 +523,7 @@ async function getBranchContentFromServer(
     'branches',
     githubRepo.owner,
     githubRepo.repository,
+    'branch',
     branchName,
   )
   let includeQueryParams: boolean = false
@@ -967,6 +1044,7 @@ export async function refreshGithubData(
       let upstreamChangesSuccess = false
       void getBranchesForGithubRepository(dispatch, githubRepo)
       if (branchName != null && branchChecksums != null) {
+        void updatePullRequestsForBranch(dispatch, githubRepo, branchName)
         const branchContentResponse = await getBranchContentFromServer(githubRepo, branchName, null)
         if (branchContentResponse.ok) {
           const branchLatestContent: GetBranchContentResponse = await branchContentResponse.json()

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -691,6 +691,10 @@ saveGithubAssetEndpoint cookie owner repository assetSha projectId fullPath = re
   let splitPath = drop 1 $ T.splitOn "/" fullPath
   saveGithubAsset (view (field @"_id") sessionUser) owner repository assetSha projectId splitPath
 
+getGithubBranchPullRequestEndpoint :: Maybe Text -> Text -> Text -> Text -> ServerMonad GetBranchPullRequestResponse
+getGithubBranchPullRequestEndpoint cookie owner repository branchName = requireUser cookie $ \sessionUser -> do
+  getPullRequestForBranch (view (field @"_id") sessionUser) owner repository branchName
+
 {-|
   Compose together all the individual endpoints into a definition for the whole server.
 -}
@@ -716,6 +720,7 @@ protected authCookie = logoutPage authCookie
                   :<|> githubSaveEndpoint authCookie
                   :<|> getGithubBranchesEndpoint authCookie
                   :<|> getGithubBranchContentEndpoint authCookie
+                  :<|> getGithubBranchPullRequestEndpoint authCookie
                   :<|> getGithubUsersRepositoriesEndpoint authCookie
                   :<|> saveGithubAssetEndpoint authCookie
 

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -390,6 +390,16 @@ innerServerExecutor (SaveGithubAsset user owner repository assetSha projectID as
     Just githubResources -> do
       result <- saveGithubAssetToProject githubResources awsResource logger metrics pool user owner repository assetSha projectID assetPath
       pure $ action result
+innerServerExecutor (GetPullRequestForBranch user owner repository branchName action) = do
+  possibleGithubResources <- fmap _githubResources ask
+  metrics <- fmap _databaseMetrics ask
+  logger <- fmap _logger ask
+  pool <- fmap _projectPool ask
+  case possibleGithubResources of
+    Nothing -> throwError err501
+    Just githubResources -> do
+      result <- getBranchPullRequest githubResources logger metrics pool user owner repository branchName
+      pure $ action result
 
 {-|
   Invokes a service call using the supplied resources.

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -301,6 +301,13 @@ innerServerExecutor (SaveGithubAsset user owner repository assetSha projectID as
   pool <- fmap _projectPool ask
   result <- saveGithubAssetToProject githubResources (Just awsResource) logger metrics pool user owner repository assetSha projectID assetPath
   pure $ action result
+innerServerExecutor (GetPullRequestForBranch user owner repository branchName action) = do
+  githubResources <- fmap _githubResources ask
+  metrics <- fmap _databaseMetrics ask
+  logger <- fmap _logger ask
+  pool <- fmap _projectPool ask
+  result <- getBranchPullRequest githubResources logger metrics pool user owner repository branchName
+  pure $ action result
 
 readEditorContentFromDisk :: Maybe BranchDownloads -> Maybe Text -> Text -> IO Text
 readEditorContentFromDisk (Just downloads) (Just branchName) fileName = do

--- a/server/src/Utopia/Web/Github/Types.hs
+++ b/server/src/Utopia/Web/Github/Types.hs
@@ -365,6 +365,66 @@ instance FromJSON GetGitCommitResult where
 instance ToJSON GetGitCommitResult where
   toJSON = genericToJSON defaultOptions
 
+data ListPullRequestResult = ListPullRequestResult
+                           { html_url :: Text
+                           , title    :: Text
+                           }
+                           deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON ListPullRequestResult where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON ListPullRequestResult where
+  toJSON = genericToJSON defaultOptions
+
+type ListPullRequestsResult = [ListPullRequestResult]
+
+data PullRequest = PullRequest
+                 { title   :: Text
+                 , htmlURL :: Text
+                 }
+                 deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON PullRequest where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON PullRequest where
+  toJSON = genericToJSON defaultOptions
+
+data GetBranchPullRequestSuccess = GetBranchPullRequestSuccess
+                                 { pullRequests :: [PullRequest]
+                                 }
+                                 deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON GetBranchPullRequestSuccess where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON GetBranchPullRequestSuccess where
+  toJSON = genericToJSON defaultOptions
+
+data GetBranchPullRequestResponse = GetBranchPullRequestResponseSuccess GetBranchPullRequestSuccess
+                                  | GetBranchPullRequestResponseFailure GithubFailure
+                                  deriving (Eq, Show, Generic, Data, Typeable)
+
+getBranchPullRequestFailureFromReason  :: Text -> GetBranchPullRequestResponse
+getBranchPullRequestFailureFromReason failureReason = GetBranchPullRequestResponseFailure GithubFailure{..}
+
+getBranchPullRequestSuccessFromContent :: [PullRequest] -> GetBranchPullRequestResponse
+getBranchPullRequestSuccessFromContent pullRequests = GetBranchPullRequestResponseSuccess GetBranchPullRequestSuccess{..}
+
+instance FromJSON GetBranchPullRequestResponse where
+  parseJSON value =
+    let fileType = firstOf (key "type" . _String) value
+     in case fileType of
+          (Just "SUCCESS")  -> fmap GetBranchPullRequestResponseSuccess $ parseJSON value
+          (Just "FAILURE")  -> fmap GetBranchPullRequestResponseFailure $ parseJSON value
+          (Just unknownType)  -> fail ("Unknown type: " <> T.unpack unknownType)
+          _                   -> fail "No type for GetBranchPullRequestResponse specified."
+
+instance ToJSON GetBranchPullRequestResponse where
+  toJSON (GetBranchPullRequestResponseSuccess success) = over _Object (M.insert "type" "SUCCESS") $ toJSON success
+  toJSON (GetBranchPullRequestResponseFailure failure) = over _Object (M.insert "type" "FAILURE") $ toJSON failure
+
 data GetBranchContentSuccess = GetBranchContentSuccess
                          { content      :: ProjectContentTreeRoot
                          , originCommit :: Text
@@ -378,8 +438,8 @@ instance ToJSON GetBranchContentSuccess where
   toJSON = genericToJSON defaultOptions
 
 data GetBranchContentResponse = GetBranchContentResponseSuccess GetBranchContentSuccess
-                          | GetBranchContentResponseFailure GithubFailure
-                          deriving (Eq, Show, Generic, Data, Typeable)
+                              | GetBranchContentResponseFailure GithubFailure
+                              deriving (Eq, Show, Generic, Data, Typeable)
 
 getBranchContentFailureFromReason :: Text -> GetBranchContentResponse
 getBranchContentFailureFromReason failureReason = GetBranchContentResponseFailure GithubFailure{..}

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -140,6 +140,7 @@ data ServiceCallsF a = NotFound
                      | GetBranchContent Text Text Text Text (Maybe Text) (GetBranchContentResponse -> a)
                      | GetUsersRepositories Text (GetUsersPublicRepositoriesResponse -> a)
                      | SaveGithubAsset Text Text Text Text Text [Text] (GithubSaveAssetResponse -> a)
+                     | GetPullRequestForBranch Text Text Text Text (GetBranchPullRequestResponse -> a)
                      deriving Functor
 
 {-

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -135,7 +135,9 @@ type GithubBranchesAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text 
 
 type GithubSaveAssetAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> "asset" :> Capture "asset_sha" Text :> QueryParam' '[Required, Strict] "project_id" Text :> QueryParam' '[Required, Strict] "path" Text :> Post '[JSON] GithubSaveAssetResponse
 
-type GithubBranchLoadAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> Capture "branchName" Text :> QueryParam "commit_sha" Text :> Get '[JSON] GetBranchContentResponse
+type GithubBranchLoadAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> "branch" :> Capture "branchName" Text :> QueryParam "commit_sha" Text :> Get '[JSON] GetBranchContentResponse
+
+type GithubBranchPullRequestAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> "branch" :> Capture "branchName" Text :> "pullrequest" :> Get '[JSON] GetBranchPullRequestResponse
 
 type GithubUsersRepositoriesAPI = "v1" :> "github" :> "user" :> "repositories" :> Get '[JSON] GetUsersPublicRepositoriesResponse
 
@@ -194,6 +196,7 @@ type Protected = LogoutAPI
             :<|> GithubSaveAPI
             :<|> GithubBranchesAPI
             :<|> GithubBranchLoadAPI
+            :<|> GithubBranchPullRequestAPI
             :<|> GithubUsersRepositoriesAPI
             :<|> GithubSaveAssetAPI
 


### PR DESCRIPTION
**Problem:**
Currently there is no support for handling pull requests related to the branch.

**Fix:**
Along with a link to create a new PR, existing PRs for the current branch are listed which can be clicked on to access them.

**Screenshots:**
![image](https://user-images.githubusercontent.com/217400/202209895-9b3fd35a-1b8a-49d5-b58d-19cda3464dc5.png)

**Commit Details:**
- Broke apart `GithubOperation` into separate types.
- Added new `GithubOperation` case of `GithubListPullRequestsForBranch`.
- Added `currentBranchPullRequests` to `GithubData`.
- Added new React component `PullRequestPane` which contains the listing of pull requests.
- Added `updatePullRequestsForBranch` and included a call to it in `refreshGithubData`.
- Slightly tweaked the endpoint URL for loading the content of a branch to make it more consistent with the new endpoint for pulling the PRs for a branch.
- Added endpoint to get the pull requests for a branch.
- Implemented `listPullRequests` to retrieve the pull requests for a branch.