### PR TITLE
When saving to Github now the branch and commit message can be supplied.

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4988,6 +4988,8 @@ export const UPDATE_FNS = {
       forceNotNull('Should have a project ID at this point.', editor.id),
       persistentModel,
       dispatch,
+      null,
+      null,
     )
 
     return editor

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -173,6 +173,8 @@ export async function saveProjectToGithub(
   projectID: string,
   persistentModel: PersistentModel,
   dispatch: EditorDispatch,
+  branchName: string | null,
+  commitMessage: string | null,
 ): Promise<void> {
   const operation: GithubOperation = { name: 'commish' }
 
@@ -180,8 +182,21 @@ export async function saveProjectToGithub(
 
   const url = urljoin(UTOPIA_BACKEND, 'github', 'save', projectID)
 
+  let includeQueryParams: boolean = false
+  let paramsRecord: Record<string, string> = {}
+  if (branchName != null) {
+    includeQueryParams = true
+    paramsRecord.branch_name = branchName
+  }
+  if (commitMessage != null) {
+    includeQueryParams = true
+    paramsRecord.commit_message = commitMessage
+  }
+  const searchParams = new URLSearchParams(paramsRecord)
+  const urlToUse = includeQueryParams ? `${url}?${searchParams}` : url
+
   const postBody = JSON.stringify(persistentModel)
-  const response = await fetch(url, {
+  const response = await fetch(urlToUse, {
     method: 'POST',
     credentials: 'include',
     headers: HEADERS,

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -670,9 +670,9 @@ githubAuthenticatedEndpoint cookie = requireUser cookie $ \sessionUser -> do
   possibleAuthDetails <- getGithubAuthentication (view (field @"_id") sessionUser)
   pure $ isJust possibleAuthDetails
 
-githubSaveEndpoint :: Maybe Text -> Text -> PersistentModel -> ServerMonad SaveToGithubResponse
-githubSaveEndpoint cookie projectID persistentModel = requireUser cookie $ \sessionUser -> do
-  saveToGithubRepo (view (field @"_id") sessionUser) projectID persistentModel
+githubSaveEndpoint :: Maybe Text -> Text -> Maybe Text -> Maybe Text -> PersistentModel -> ServerMonad SaveToGithubResponse
+githubSaveEndpoint cookie projectID possibleBranchName possibleCommitMessage persistentModel = requireUser cookie $ \sessionUser -> do
+  saveToGithubRepo (view (field @"_id") sessionUser) projectID possibleBranchName possibleCommitMessage persistentModel
 
 getGithubBranchesEndpoint :: Maybe Text -> Text -> Text -> ServerMonad GetBranchesResponse
 getGithubBranchesEndpoint cookie owner repository = requireUser cookie $ \sessionUser -> do

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -338,7 +338,7 @@ innerServerExecutor (GetGithubAuthentication user action) = do
   pool <- fmap _projectPool ask
   result <- liftIO $ DB.lookupGithubAuthenticationDetails metrics pool user
   pure $ action result
-innerServerExecutor (SaveToGithubRepo user projectID model action) = do
+innerServerExecutor (SaveToGithubRepo user projectID possibleBranchName possibleCommitMessage model action) = do
   possibleGithubResources <- fmap _githubResources ask
   awsResource <- fmap _awsResources ask
   metrics <- fmap _databaseMetrics ask
@@ -347,7 +347,7 @@ innerServerExecutor (SaveToGithubRepo user projectID model action) = do
   case possibleGithubResources of
     Nothing -> throwError err501
     Just githubResources -> do
-      result <- createTreeAndSaveToGithub githubResources awsResource logger metrics pool user projectID model
+      result <- createTreeAndSaveToGithub githubResources awsResource logger metrics pool user projectID possibleBranchName possibleCommitMessage model
       pure $ action result
 innerServerExecutor (GetBranchesFromGithubRepo user owner repository action) = do
   possibleGithubResources <- fmap _githubResources ask

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -264,13 +264,13 @@ innerServerExecutor (GetGithubAuthentication user action) = do
   pool <- fmap _projectPool ask
   result <- liftIO $ DB.lookupGithubAuthenticationDetails metrics pool user
   pure $ action result
-innerServerExecutor (SaveToGithubRepo user projectID model action) = do
+innerServerExecutor (SaveToGithubRepo user projectID possibleBranchName possibleCommitMessage model action) = do
   githubResources <- fmap _githubResources ask
   awsResource <- fmap _awsResources ask
   metrics <- fmap _databaseMetrics ask
   logger <- fmap _logger ask
   pool <- fmap _projectPool ask
-  result <- createTreeAndSaveToGithub githubResources (Just awsResource) logger metrics pool user projectID model
+  result <- createTreeAndSaveToGithub githubResources (Just awsResource) logger metrics pool user projectID possibleBranchName possibleCommitMessage model
   pure $ action result
 innerServerExecutor (GetBranchesFromGithubRepo user owner repository action) = do
   githubResources <- fmap _githubResources ask

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -186,17 +186,17 @@ createCommitHandleErrorCases status | status == notFound404             = throwE
                                     | status == unprocessableEntity422  = liftIO $ fail "Unprocessable entity returned when creating tree."
                                     | otherwise                         = throwE "Unexpected error."
 
-createGitCommit :: (MonadIO m) => AccessToken -> GithubRepo -> Text -> [Text] -> ExceptT Text m CreateGitCommitResult
-createGitCommit accessToken GithubRepo{..} treeSha parentCommits = do
+createGitCommit :: (MonadIO m) => AccessToken -> GithubRepo -> Text -> Maybe Text -> [Text] -> ExceptT Text m CreateGitCommitResult
+createGitCommit accessToken GithubRepo{..} treeSha possibleCommitMessage parentCommits = do
   let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/commits"
-  let request = CreateGitCommit "Committed automatically." treeSha parentCommits
+  let request = CreateGitCommit (fromMaybe "Committed automatically." possibleCommitMessage) treeSha parentCommits
   callGithub postToGithub [] createCommitHandleErrorCases accessToken repoUrl request
 
-createGitCommitForTree :: (MonadIO m) => AccessToken -> PersistentModel -> Text -> [Text] -> ExceptT Text m CreateGitCommitResult
-createGitCommitForTree accessToken PersistentModel{..} treeSha parentCommits = do
+createGitCommitForTree :: (MonadIO m) => AccessToken -> PersistentModel -> Text -> Maybe Text -> [Text] -> ExceptT Text m CreateGitCommitResult
+createGitCommitForTree accessToken PersistentModel{..} treeSha possibleCommitMessage parentCommits = do
   let possibleGithubRepo = targetRepository githubSettings
   case possibleGithubRepo of
-    Just repo -> createGitCommit accessToken repo treeSha parentCommits
+    Just repo -> createGitCommit accessToken repo treeSha possibleCommitMessage parentCommits
     Nothing   -> throwE "No repository set on project."
 
 createBranchHandleErrorCases :: (MonadIO m) => Status -> ExceptT Text m a

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -135,7 +135,7 @@ data ServiceCallsF a = NotFound
                      | GetGithubAuthorizationURI (URI -> a)
                      | GetGithubAccessToken Text ExchangeToken (Maybe AccessToken -> a)
                      | GetGithubAuthentication Text (Maybe GithubAuthenticationDetails -> a)
-                     | SaveToGithubRepo Text Text PersistentModel (SaveToGithubResponse -> a)
+                     | SaveToGithubRepo Text Text (Maybe Text) (Maybe Text) PersistentModel (SaveToGithubResponse -> a)
                      | GetBranchesFromGithubRepo Text Text Text (GetBranchesResponse -> a)
                      | GetBranchContent Text Text Text Text (Maybe Text) (GetBranchContentResponse -> a)
                      | GetUsersRepositories Text (GetUsersPublicRepositoriesResponse -> a)

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -129,7 +129,7 @@ type GithubStartAuthenticationAPI = "v1" :> "github" :> "authentication" :> "sta
 
 type GithubFinishAuthenticationAPI = "v1" :> "github" :> "authentication" :> "finish" :> QueryParam "code" ExchangeToken :> Get '[HTML] H.Html
 
-type GithubSaveAPI = "v1" :> "github" :> "save" :> Capture "project_id" Text :> ReqBody '[JSON] PersistentModel :> Post '[JSON] SaveToGithubResponse
+type GithubSaveAPI = "v1" :> "github" :> "save" :> Capture "project_id" Text :> QueryParam "branch_name" Text :> QueryParam "commit_message" Text :> ReqBody '[JSON] PersistentModel :> Post '[JSON] SaveToGithubResponse
 
 type GithubBranchesAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> Get '[JSON] GetBranchesResponse
 


### PR DESCRIPTION
**Problem:**
Previously the branch name and commit messages were dynamic based on the date and a constant respectively, which is not that useful for real world situations.

**Fix:**
The save request endpoint now accepts `branch_name` and `commit_message` query parameters to set the values of those two when making the calls to save the current project.

**Notes:**
This was tested by supplying values to the function `saveProjectToGithub` and afterwards they were replaced with `null`.

**Commit Details:**
- `createGitCommit` now takes an optional branch name and optional commit message.
- `githubSaveEndpoint` now permits the branch name and commit message to be supplied via optional query parameters.
- `saveProjectToGithub` now takes `branchName` and `commitMessage` parameters which then get added to the fetch request as query parameters.