### PR TITLE
Pull stored config and github auth status on polled login

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -58,6 +58,7 @@ import {
   GithubOperation,
   GithubChecksums,
   GithubData,
+  UserConfiguration,
 } from './store/editor-state'
 import { Notice } from '../common/notice'
 import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
@@ -913,6 +914,11 @@ export interface SetGithubState {
   githubState: GithubState
 }
 
+export interface SetUserConfiguration {
+  action: 'SET_USER_CONFIGURATION'
+  userConfiguration: UserConfiguration
+}
+
 export interface UpdateGithubOperations {
   action: 'UPDATE_GITHUB_OPERATIONS'
   operation: GithubOperation
@@ -1188,6 +1194,7 @@ export type EditorAction =
   | UpdateConfigFromVSCode
   | SetLoginState
   | SetGithubState
+  | SetUserConfiguration
   | ResetCanvas
   | SetFilebrowserDropTarget
   | SetCurrentTheme

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -217,6 +217,7 @@ import type {
   UpdateGithubData,
   RemoveFileConflict,
   SetRefreshingDependencies,
+  SetUserConfiguration,
 } from '../action-types'
 import { EditorModes, insertionSubject, Mode } from '../editor-modes'
 import type {
@@ -235,6 +236,7 @@ import type {
   GithubOperation,
   GithubChecksums,
   GithubData,
+  UserConfiguration,
 } from '../store/editor-state'
 
 export function clearSelection(): EditorAction {
@@ -1458,6 +1460,13 @@ export function setGithubState(githubState: GithubState): SetGithubState {
   return {
     action: 'SET_GITHUB_STATE',
     githubState: githubState,
+  }
+}
+
+export function setUserConfiguration(userConfiguration: UserConfiguration): SetUserConfiguration {
+  return {
+    action: 'SET_USER_CONFIGURATION',
+    userConfiguration: userConfiguration,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -90,6 +90,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_CONFIG_FROM_VSCODE':
     case 'SET_LOGIN_STATE':
     case 'SET_GITHUB_STATE':
+    case 'SET_USER_CONFIGURATION':
     case 'RESET_CANVAS':
     case 'SET_FILEBROWSER_DROPTARGET':
     case 'SET_FORKED_FROM_PROJECT_ID':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -313,6 +313,7 @@ import {
   UpdateGithubData,
   RemoveFileConflict,
   SetRefreshingDependencies,
+  SetUserConfiguration,
 } from '../action-types'
 import { defaultSceneElement, defaultTransparentViewElement } from '../defaults'
 import { EditorModes, isLiveMode, isSelectMode, Mode } from '../editor-modes'
@@ -4562,6 +4563,15 @@ export const UPDATE_FNS = {
     return {
       ...userState,
       githubState: action.githubState,
+    }
+  },
+  SET_USER_CONFIGURATION: (action: SetUserConfiguration, userState: UserState): UserState => {
+    // Side effect - update the theme setting in VS Code
+    void sendSetVSCodeTheme(getCurrentTheme(action.userConfiguration))
+
+    return {
+      ...userState,
+      ...action.userConfiguration,
     }
   },
   RESET_CANVAS: (action: ResetCanvas, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -127,6 +127,11 @@ function processAction(
       ...working,
       userState: UPDATE_FNS.SET_GITHUB_STATE(action, working.userState),
     }
+  } else if (action.action === 'SET_USER_CONFIGURATION') {
+    return {
+      ...working,
+      userState: UPDATE_FNS.SET_USER_CONFIGURATION(action, working.userState),
+    }
   } else {
     // Process action on the JS side.
     const editorAfterUpdateFunction = runLocalEditorAction(

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -3073,8 +3073,8 @@ export function getElementFromProjectContents(
   return withUnderlyingTarget(target, projectContents, {}, openFile, null, (_, element) => element)
 }
 
-export function getCurrentTheme(userState: UserState): Theme {
-  return userState.themeConfig ?? DefaultTheme
+export function getCurrentTheme(userConfiguration: UserConfiguration): Theme {
+  return userConfiguration.themeConfig ?? DefaultTheme
 }
 
 export function getNewSceneName(editor: EditorState): string {


### PR DESCRIPTION
**Problem:**
When opening the app as a logged in user we would pull down the user's stored config, and update their github authentication status in `editor.tsx` [here](https://github.com/concrete-utopia/utopia/blob/master/editor/src/templates/editor.tsx#L299). However, if the user isn't logged in when first opening the app, but logs in via the "Sign in" button in the title bar, we will update the login status via a polled check in `server.ts` [here](https://github.com/concrete-utopia/utopia/blob/master/editor/src/components/editor/server.ts#L372-L403), without then pulling the stored config or github auth status

**Fix:**
Inside the polled check, if the login state has changed, and the user is now logged in, we fire off two fetch requests to pull the stored config and github auth status, dispatched actions that update the `UserState` on the results of those. Those requests are fired immediately (but not `await`ed) so that we can update with the results as soon as possible.