### PR TITLE
Fix/strategy indicator hook

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/strategy-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/strategy-indicator.tsx
@@ -14,20 +14,20 @@ import {
   NavigatorWidthAtom,
 } from '../../../editor/store/editor-state'
 import { useEditorState } from '../../../editor/store/store-hook'
-import { useDelayedEditorState } from '../../canvas-strategies/canvas-strategies'
-
-const useDelayedDragToMoveIndicatorFlags = () => {
-  const selector = (store: EditorStorePatched) =>
-    !store.editor.canvas.controls.dragToMoveIndicatorFlags.showIndicator
-      ? null
-      : store.editor.canvas.controls.dragToMoveIndicatorFlags
-  return useDelayedEditorState<DragToMoveIndicatorFlags | null>(selector)
-}
 
 const StrategyIndicatorWidth = 240
 export const StrategyIndicator = React.memo(() => {
   const colorTheme = useColorTheme()
-  const indicatorFlags = useDelayedDragToMoveIndicatorFlags()
+  const indicatorFlags = useEditorState((store) => {
+    if (
+      store.editor.canvas.interactionSession?.interactionData.type === 'DRAG' &&
+      store.editor.canvas.interactionSession?.interactionData.hasMouseMoved
+    ) {
+      return store.editor.canvas.controls.dragToMoveIndicatorFlags
+    } else {
+      return null
+    }
+  }, 'StrategyIndicator')
 
   const isNavigatorOpen = useEditorState(
     (store) => !store.editor.navigator.minimised,

--- a/editor/src/components/canvas/controls/select-mode/strategy-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/strategy-indicator.tsx
@@ -1,18 +1,7 @@
 import React from 'react'
 import { AlwaysTrue, usePubSubAtomReadOnly } from '../../../../core/shared/atom-with-pub-sub'
-import {
-  FlexColumn,
-  FlexRow,
-  IcnColor,
-  ModalityIcons,
-  useColorTheme,
-  UtopiaStyles,
-} from '../../../../uuiui'
-import {
-  DragToMoveIndicatorFlags,
-  EditorStorePatched,
-  NavigatorWidthAtom,
-} from '../../../editor/store/editor-state'
+import { FlexColumn, FlexRow, ModalityIcons, useColorTheme, UtopiaStyles } from '../../../../uuiui'
+import { NavigatorWidthAtom } from '../../../editor/store/editor-state'
 import { useEditorState } from '../../../editor/store/store-hook'
 
 const StrategyIndicatorWidth = 240


### PR DESCRIPTION
**Problem:**
The strategy indicator appears after a timer, instead it should be visible only when the element is dragged.

**Fix:**
Fix strategy indicator hook

**Commit Details:**
- update hook
- remove unused imports
