### PR TITLE
handle 4-value syntax in `borderRadius`

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.spec.browser2.tsx
@@ -69,6 +69,19 @@ describe('set border radius strategy', () => {
     expect(paddingControls).toEqual([])
   })
 
+  it('can handle 4-value syntax', async () => {
+    const editor = await renderTestEditorWithCode(
+      codeForDragTest(`borderRadius: '4px 5px 6px 7px'`),
+      'await-first-dom-report',
+    )
+
+    await doDragTest(editor, 'tl', 10, emptyModifiers)
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      codeForDragTest(`borderRadius: '4px 5px 6px 7px',
+                       borderTopLeftRadius: '14px',`),
+    )
+  })
+
   it('can only adjust border radius to 50% at most', async () => {
     const { width, height } = size(600, 400)
     const editor = await renderTestEditorWithCode(

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -40,6 +40,7 @@ import { setElementsToRerenderCommand } from '../../commands/set-elements-to-rer
 import { setProperty } from '../../commands/set-property-command'
 import { BorderRadiusControl } from '../../controls/select-mode/border-radius-control'
 import {
+  cssNumberEqual,
   cssNumberWithRenderedValue,
   CSSNumberWithRenderedValue,
   measurementBasedOnOtherMeasurement,
@@ -259,8 +260,11 @@ function borderRadiusFromProps(props: JSXAttributes): BorderRadiusFromProps | nu
   }
 
   if (simpleBorderRadius != null) {
+    const { tl, tr, bl, br } = simpleBorderRadius
+    const allSidesEqual = [tr, bl, br].every((c) => cssNumberEqual(tl, c))
+
     return {
-      type: 'borderRadius',
+      type: allSidesEqual ? 'borderRadius' : 'sides',
       sides: simpleBorderRadius,
     }
   }

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -171,3 +171,7 @@ export function indicatorMessage(
 
   return Emdash // emdash
 }
+
+export function cssNumberEqual(left: CSSNumber, right: CSSNumber): boolean {
+  return left.unit === right.unit && left.value === right.value
+}


### PR DESCRIPTION
## Problem:
Border radius controls cannot recognize the 4-value syntax in the `borderRadius` prop

## Fix:
When only `borderRadius` is defined, check if all 4 border radius values are equal. If they are, the border radius controls adjust all corners, otherwise the border radius controls adjust the corners individually.