### PR TITLE
Do not allow duplicate values in elementsToRerender

### DIFF
--- a/editor/src/components/canvas/commands/set-elements-to-rerender-command.ts
+++ b/editor/src/components/canvas/commands/set-elements-to-rerender-command.ts
@@ -1,6 +1,7 @@
 import * as EP from '../../../core/shared/element-path'
+import { ElementPath } from '../../../core/shared/project-file-types'
 import { EditorState, EditorStatePatch, ElementsToRerender } from '../../editor/store/editor-state'
-import { BaseCommand, CommandFunction, WhenToRun } from './commands'
+import { BaseCommand, CommandFunction } from './commands'
 
 export interface SetElementsToRerenderCommand extends BaseCommand {
   type: 'SET_ELEMENTS_TO_RERENDER_COMMAND'
@@ -10,10 +11,11 @@ export interface SetElementsToRerenderCommand extends BaseCommand {
 export function setElementsToRerenderCommand(
   value: ElementsToRerender,
 ): SetElementsToRerenderCommand {
+  const uniqueValues = value === 'rerender-all-elements' ? value : uniqueElementPaths(value)
   return {
     type: 'SET_ELEMENTS_TO_RERENDER_COMMAND',
     whenToRun: 'mid-interaction',
-    value: value,
+    value: uniqueValues,
   }
 }
 
@@ -77,4 +79,9 @@ export const runAppendElementsToRerender: CommandFunction<AppendElementsToRerend
       typeof command.value === 'string' ? command.value : command.value.map(EP.toString).join(', ')
     }]`,
   }
+}
+
+function uniqueElementPaths(paths: Array<ElementPath>) {
+  const pathSet = new Set(paths.map(EP.toString))
+  return Array.from(pathSet).map(EP.fromString)
 }


### PR DESCRIPTION
**Problem:**
During dragging the parent bounds control shrink down into zero point of the canvas

**Fix:**
Root cause: during dragging the specialSizeMeasurements.immediateParentBounds is a zero rectangle in the zero point.

Why: In the dom-walker if we visit the same element path multiple times, we expect it to be a fragment (fragments are visited multiple times), and we wipe their specialsizemeasurements. However, with selective rerendering, we visit the same element multiple times if the element is present multiple times in the elementsToRerender array. And this is exactly what happened in this case,  the absolute move strategy added the same element twice, once because it was the selected element, and then we also added the updated version of it according to the updatedPaths in interactionSession. But if it was not updated, we added the same paths twice.

Instead of fixing the move strategy (which maybe we should do anyway), I filtered out duplicate elements in the constructor function of SetElementsToRerender command, to make sure we won't make the same mistake again.

