### PR TITLE
canvas toolbar goes behind the error overlays

### DIFF
--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -33,6 +33,7 @@ import { CanvasStrategyPicker } from './controls/select-mode/canvas-strategy-pic
 import { when } from '../../utils/react-conditionals'
 import { isFeatureEnabled } from '../../utils/feature-switches'
 import { StrategyIndicator } from './controls/select-mode/strategy-indicator'
+import { CanvasToolbar } from '../editor/canvas-toolbar'
 
 export function filterOldPasses(errorMessages: Array<ErrorMessage>): Array<ErrorMessage> {
   let passTimes: { [key: string]: number } = {}
@@ -125,9 +126,12 @@ export const CanvasWrapperComponent = React.memo(() => {
             position: 'relative',
           }}
         >
-          {safeMode ? <SafeModeErrorOverlay /> : <ErrorOverlayComponent />}
           {when(isFeatureEnabled('Canvas Strategies'), <CanvasStrategyPicker />)}
           <StrategyIndicator />
+          <CanvasToolbar />
+
+          {/* The error overlays are deliberately the last here so they hide other canvas UI */}
+          {safeMode ? <SafeModeErrorOverlay /> : <ErrorOverlayComponent />}
         </FlexColumn>
       </FlexRow>
     </FlexColumn>

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -331,7 +331,6 @@ const DesignPanelRootInner = React.memo(() => {
               </div>
             ) : null}
             <CanvasWrapperComponent />
-            <CanvasToolbar />
             <FloatingInsertMenu />
           </SimpleFlexColumn>
         ) : null}

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -41,15 +41,6 @@ export const CanvasToolbar = React.memo(() => {
 
   const selectedViewsRef = useRefEditorState((store) => store.editor.selectedViews)
 
-  const navigatorWidth = usePubSubAtomReadOnly(NavigatorWidthAtom, AlwaysTrue)
-  const navigatorVisible = useEditorState(
-    (store) => !store.editor.navigator.minimised,
-    'CanvasToolbar navigatorVisible',
-  )
-  const effectiveNavigatorWidth = navigatorVisible ? navigatorWidth : 0
-
-  const topMenuHeight = UtopiaTheme.layout.rowHeight.normal
-
   const divInsertion = useCheckInsertModeForElementType('div')
   const insertDivCallback = useEnterDrawToInsertForDiv()
   const imgInsertion = useCheckInsertModeForElementType('img')
@@ -146,8 +137,8 @@ export const CanvasToolbar = React.memo(() => {
     <FlexColumn
       style={{
         position: 'absolute',
-        top: topMenuHeight + 8,
-        left: effectiveNavigatorWidth + 8,
+        top: 8,
+        left: 8,
         alignItems: 'stretch',
         width: 64,
         borderRadius: 4,

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`406`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`408`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`395`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`397`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`671`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`672`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`743`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`744`)
   })
 })

--- a/editor/src/third-party/react-error-overlay/components/ErrorOverlay.tsx
+++ b/editor/src/third-party/react-error-overlay/components/ErrorOverlay.tsx
@@ -8,6 +8,7 @@
 /* @flow */
 import React from 'react'
 import { Component, ReactNode } from 'react'
+import { colorTheme } from '../../../uuiui'
 import { black } from '../styles'
 
 const overlayStyle = {
@@ -73,7 +74,7 @@ class ErrorOverlay extends Component<Props, State> {
   render() {
     return (
       <div
-        style={overlayStyle}
+        style={{ ...overlayStyle, backgroundColor: colorTheme.neutralBackground.value }}
         className='react-error-overlay-allow-text-selection'
         ref={this.getIframeWindow}
       >


### PR DESCRIPTION
**Problem:**
<img width="545" alt="image" src="https://user-images.githubusercontent.com/2226774/202574910-dc20a145-2c99-4474-884a-d329ea3ee14f.png">

**Fix:**
I moved the CanvasToolbar next to the StrategyIndicator and the CanvasStrategyPicker. 
I also shuffled SafeModeErrorOverlay and ErrorOverlayComponent to be the last siblings in CanvasWrapperComponent, so they always cover the other canvas UI elements. 
I added a background color to SafeModeErrorOverlay.

**Details:**
The CanvasWrapperComponent is already navigator-aware, so I got to simplify the code of CanvasToolbar too. yay!
