### PR TITLE
sanitize branch name

### DIFF
--- a/editor/src/components/navigator/left-pane/github-pane/helpers.spec.ts
+++ b/editor/src/components/navigator/left-pane/github-pane/helpers.spec.ts
@@ -37,4 +37,7 @@ describe('cleanupBranchName', () => {
       'to-be-or-not_to_be-th-t-is-THE-question-test-yes',
     )
   })
+  it('removes backslashes', async () => {
+    expect(cleanupBranchName('hey\\this')).toEqual('hey-this')
+  })
 })

--- a/editor/src/components/navigator/left-pane/github-pane/helpers.spec.ts
+++ b/editor/src/components/navigator/left-pane/github-pane/helpers.spec.ts
@@ -1,0 +1,40 @@
+import { cleanupBranchName } from './helpers'
+
+describe('cleanupBranchName', () => {
+  it('lowercase', async () => {
+    expect(cleanupBranchName('something')).toEqual('something')
+  })
+  it('mixed case', async () => {
+    expect(cleanupBranchName('SoMeThinG')).toEqual('SoMeThinG')
+  })
+  it('with spaces', async () => {
+    expect(cleanupBranchName('foo bar baz')).toEqual('foo-bar-baz')
+  })
+  it('with spaces and extra allowed chars', async () => {
+    expect(cleanupBranchName('feat/foo bar baz')).toEqual('feat/foo-bar-baz')
+  })
+  it('removes trailing .lock', async () => {
+    expect(cleanupBranchName('feat/foo bar baz.lock')).toEqual('feat/foo-bar-baz')
+  })
+  it('with dots', async () => {
+    expect(cleanupBranchName('feat.one')).toEqual('feat.one')
+  })
+  it('removes double dots', async () => {
+    expect(cleanupBranchName('feat..one')).toEqual('feat-one')
+  })
+  it('removes trailing spaces/slashes/dots', async () => {
+    expect(cleanupBranchName('feat one            ')).toEqual('feat-one')
+    expect(cleanupBranchName('feat one.')).toEqual('feat-one')
+    expect(cleanupBranchName('feat one/')).toEqual('feat-one')
+  })
+  it('removes starting spaces/slashes/dots', async () => {
+    expect(cleanupBranchName('            feat one')).toEqual('feat-one')
+    expect(cleanupBranchName('.feat one')).toEqual('feat-one')
+    expect(cleanupBranchName('/feat one')).toEqual('feat-one')
+  })
+  it('with unsupported chars', async () => {
+    expect(cleanupBranchName('to be, or not_to_be, th@t is THE question: test? yes.')).toEqual(
+      'to-be-or-not_to_be-th-t-is-THE-question-test-yes',
+    )
+  })
+})

--- a/editor/src/components/navigator/left-pane/github-pane/helpers.ts
+++ b/editor/src/components/navigator/left-pane/github-pane/helpers.ts
@@ -1,0 +1,9 @@
+export function cleanupBranchName(branchName: string): string {
+  return branchName
+    .split(/[^0-9a-z\/_.]+/i)
+    .join('-')
+    .replace(/[-.\/]+$/, '') // does not end with a dash, a slash, or a dot
+    .replace(/^[-.\/]+/, '') // does not start with a dash, a slash, or a dot
+    .replace(/\.lock$/i, '') // does not end with .lock
+    .replace(/\.{2,}/, '-') // does not contain two or more consecutive dots
+}

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -38,6 +38,7 @@ import { UIGridRow } from '../../../inspector/widgets/ui-grid-row'
 import { Block } from './block'
 import { Ellipsis, GithubFileChangesList } from './github-file-changes-list'
 import { GithubSpinner } from './github-spinner'
+import { cleanupBranchName } from './helpers'
 import { PullRequestPane } from './pull-request-pane'
 import { RefreshIcon } from './refresh-icon'
 import { RepositoryListing } from './repository-listing'
@@ -493,12 +494,7 @@ const LocalChangesBlock = () => {
     if (rawCommitBranchName == null) {
       return null
     }
-    return rawCommitBranchName
-      .toLowerCase()
-      .split(/[^0-9a-z\/_]+/)
-      .join('-')
-      .replace(/-+$/, '')
-      .replace(/^-+/, '')
+    return cleanupBranchName(rawCommitBranchName)
   }, [rawCommitBranchName])
 
   const [commitMessage, setCommitMessage] = React.useState<string | null>(null)

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -481,18 +481,25 @@ const LocalChangesBlock = () => {
   }, [pushToNewBranch])
 
   React.useEffect(() => {
-    if (!pushToNewBranch) {
-      setCommitBranchName(branch)
-    } else {
-      setCommitBranchName(null)
-    }
+    setRawCommitBranchName(pushToNewBranch ? null : branch)
   }, [pushToNewBranch, branch])
 
-  const [commitBranchName, setCommitBranchName] = React.useState<string | null>(null)
+  const [rawCommitBranchName, setRawCommitBranchName] = React.useState<string | null>(null)
   const updateCommitBranchName = React.useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => setCommitBranchName(e.target.value),
+    (e: React.ChangeEvent<HTMLInputElement>) => setRawCommitBranchName(e.target.value),
     [],
   )
+  const cleanedCommitBranchName = React.useMemo(() => {
+    if (rawCommitBranchName == null) {
+      return null
+    }
+    return rawCommitBranchName
+      .split(/[^0-9a-zA-Z\/_]+/)
+      .join('-')
+      .replace(/-+$/, '')
+      .replace(/^-+/, '')
+      .toLowerCase()
+  }, [rawCommitBranchName])
 
   const [commitMessage, setCommitMessage] = React.useState<string | null>(null)
   React.useEffect(() => {
@@ -504,10 +511,13 @@ const LocalChangesBlock = () => {
   )
 
   const triggerSaveToGithub = React.useCallback(() => {
-    if (repo != null && commitBranchName != null && commitMessage != null) {
-      dispatch([EditorActions.saveToGithub(repo, commitBranchName, commitMessage)], 'everyone')
+    if (repo != null && cleanedCommitBranchName != null && commitMessage != null) {
+      dispatch(
+        [EditorActions.saveToGithub(repo, cleanedCommitBranchName, commitMessage)],
+        'everyone',
+      )
     }
-  }, [dispatch, repo, commitMessage, commitBranchName])
+  }, [dispatch, repo, commitMessage, cleanedCommitBranchName])
 
   const githubAuthenticated = useEditorState(
     (store) => store.userState.githubState.authenticated,
@@ -531,7 +541,7 @@ const LocalChangesBlock = () => {
     >
       {when(
         hasLocalChanges,
-        <FlexColumn style={{ gap: 10, width: '100%' }}>
+        <FlexColumn style={{ gap: 10, width: '100%', whiteSpace: 'pre-wrap' }}>
           <GithubFileChangesList
             showHeader={true}
             revertable={true}
@@ -547,12 +557,27 @@ const LocalChangesBlock = () => {
           />
           {when(
             pushToNewBranch,
-            <StringInput
-              testId='commit-branch-input'
-              placeholder='New branch name'
-              value={commitBranchName || ''}
-              onChange={updateCommitBranchName}
-            />,
+            <div>
+              <StringInput
+                testId='commit-branch-input'
+                placeholder='New branch name'
+                value={rawCommitBranchName || ''}
+                onChange={updateCommitBranchName}
+              />
+              {when(
+                rawCommitBranchName !== cleanedCommitBranchName,
+                <div
+                  style={{
+                    fontSize: 10,
+                    background: colorTheme.bg1.value,
+                    padding: '2px 6px',
+                    color: colorTheme.fg4.value,
+                  }}
+                >
+                  {cleanedCommitBranchName}
+                </div>,
+              )}
+            </div>,
           )}
           <Button
             disabled={githubWorking}

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -494,11 +494,11 @@ const LocalChangesBlock = () => {
       return null
     }
     return rawCommitBranchName
-      .split(/[^0-9a-zA-Z\/_]+/)
+      .toLowerCase()
+      .split(/[^0-9a-z\/_]+/)
       .join('-')
       .replace(/-+$/, '')
       .replace(/^-+/, '')
-      .toLowerCase()
   }, [rawCommitBranchName])
 
   const [commitMessage, setCommitMessage] = React.useState<string | null>(null)


### PR DESCRIPTION
Fixes #2856 

**Problem:**

Now that we support naming branches, we should make sure to preemptively sanitize the branch names to make the UX more fluid.

**Fix:**

This PR sanitizes the new branch name to lowercase, kebab-case (but preserving underscores and slashes), providing a visual hint about the final result.

![clean branch name](https://user-images.githubusercontent.com/1081051/202670242-9fc8ba20-29a5-4922-adc0-9518a1faa749.gif)
