### PR TITLE
fix(utopia-api) change rectangle default color

### DIFF
--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -104,12 +104,22 @@ export function defaultTextElementStyle(): JSXAttribute {
   )
 }
 
+export function defaultRectangleElementStyle(): JSXAttribute {
+  return jsxAttributeValue(
+    {
+      backgroundColor: '#FF69B4AB',
+      position: 'absolute',
+    },
+    emptyComments,
+  )
+}
+
 export function defaultRectangleElement(uid: string): JSXElement {
   return jsxElement(
     jsxElementName('Rectangle', []),
     uid,
     jsxAttributesFromMap({
-      style: defaultViewElementStyle(),
+      style: defaultRectangleElementStyle(),
       'data-uid': jsxAttributeValue(uid, emptyComments),
     }),
     [],

--- a/editor/src/core/third-party/utopia-api-components.ts
+++ b/editor/src/core/third-party/utopia-api-components.ts
@@ -4,6 +4,7 @@ import {
 } from '../../components/custom-code/code-file'
 import {
   defaultFlexRowOrColStyle,
+  defaultRectangleElementStyle,
   defaultSceneElementStyle,
   defaultTextElementStyle,
   defaultViewElementStyle,
@@ -52,7 +53,7 @@ const BasicUtopiaComponentDescriptor = (
 
 export const UtopiaApiComponents: ComponentDescriptorsForFile = {
   Ellipse: BasicUtopiaComponentDescriptor('Ellipse', defaultViewElementStyle()),
-  Rectangle: BasicUtopiaComponentDescriptor('Rectangle', defaultViewElementStyle()),
+  Rectangle: BasicUtopiaComponentDescriptor('Rectangle', defaultRectangleElementStyle()),
   View: BasicUtopiaComponentDescriptor('View', defaultViewElementStyle()),
   FlexRow: BasicUtopiaComponentDescriptor('FlexRow', defaultFlexRowOrColStyle()),
   FlexCol: BasicUtopiaComponentDescriptor('FlexCol', defaultFlexRowOrColStyle()),


### PR DESCRIPTION
**Problem:**
Inserted Rectangle, View and div use the same default colors but they behave differently.

**Fix:**
Change default background color for Rectangle.

**Commit Details:**
- add new helper `defaultRectangleElementStyle` and replace component decriptor
- update `defaultRectangleElement` to use different style
