### PR TITLE
fix(canvas) hide outline after deleting an element

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
@@ -19,7 +19,7 @@ export const MultiSelectOutlineControl = React.memo<MultiSelectOutlineControlPro
     'MultiSelectOutlineControl hiddenInstances',
   )
   const localSelectedElements = props.localSelectedElements.filter(
-    (sv) => !hiddenInstances.includes(sv),
+    (sv) => !hiddenInstances.includes(sv) && !EP.isStoryboardPath(sv),
   )
   return (
     <CanvasOffsetWrapper>

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1739,7 +1739,8 @@ export const UPDATE_FNS = {
         const withElementDeleted = deleteElements(staticSelectedElements, editor)
         const parentsToSelect = uniqBy(
           mapDropNulls((view) => {
-            return EP.parentPath(view)
+            const parentPath = EP.parentPath(view)
+            return EP.isStoryboardPath(parentPath) ? null : parentPath
           }, editor.selectedViews),
           EP.pathsEqual,
         )
@@ -1759,10 +1760,11 @@ export const UPDATE_FNS = {
       false,
       (e) => {
         const updatedEditor = deleteElements([action.target], e)
-        const newSelection = EP.parentPath(action.target)
+        const parentPath = EP.parentPath(action.target)
+        const newSelection = EP.isStoryboardPath(parentPath) ? [] : [parentPath]
         return {
           ...updatedEditor,
-          selectedViews: [newSelection],
+          selectedViews: newSelection,
         }
       },
       dispatch,


### PR DESCRIPTION
**Problem:**
After deleting an element that was directly on the canvas there is a visible ghost outline where the deleted element was before. When we delete an element the parent element becomes selected automatically, in this case it was the storyboard.

**Fix:**
Fix outline control to filter storyboard path as a possible target.
Update `actions.ts` to not allow storyboard path as a parent to be selected after delete.

**Commit Details:**
- update `DELETE_SELECTED` and `DELETE_VIEW` actions
- update outline control
