### PR TITLE
Fix/low priority UI update store

### DIFF
--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -282,7 +282,7 @@ export async function renderTestEditorWithModel(
     flushSync(() => {
       storeHook.setState(patchedStoreFromFullStore(workingEditorState))
       if (shouldInspectorUpdate(workingEditorState.strategyState)) {
-        inspectorStoreHook.setState(patchedStoreFromFullStore(workingEditorState))
+        lowPriorityStoreHook.setState(patchedStoreFromFullStore(workingEditorState))
       }
     })
   }
@@ -328,7 +328,7 @@ export async function renderTestEditorWithModel(
 
   const domWalkerMutableState = createDomWalkerMutableState(canvasStoreHook)
 
-  const inspectorStoreHook = create<
+  const lowPriorityStoreHook = create<
     EditorStorePatched,
     SetState<EditorStorePatched>,
     GetState<EditorStorePatched>,
@@ -361,7 +361,7 @@ export async function renderTestEditorWithModel(
         useStore={storeHook}
         canvasStore={canvasStoreHook}
         spyCollector={spyCollector}
-        inspectorStore={inspectorStoreHook}
+        lowPriorityStore={lowPriorityStoreHook}
         domWalkerMutableState={domWalkerMutableState}
       />
     </React.Profiler>,

--- a/editor/src/components/editor/store/low-priority-store.tsx
+++ b/editor/src/components/editor/store/low-priority-store.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { EditorStateContext, LowPriorityStateContext } from './store-hook'
+
+export const LowPriorityStoreProvider = React.memo<React.PropsWithChildren<unknown>>((props) => {
+  const lowPriorityStore = React.useContext(LowPriorityStateContext)?.useStore
+  return (
+    <EditorStateContext.Provider
+      value={
+        lowPriorityStore == null ? null : { api: lowPriorityStore, useStore: lowPriorityStore }
+      }
+    >
+      {props.children}
+    </EditorStateContext.Provider>
+  )
+})

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -143,8 +143,8 @@ export const EditorStateContext = React.createContext<EditorStateContextData | n
 EditorStateContext.displayName = 'EditorStateContext'
 export const CanvasStateContext = React.createContext<EditorStateContextData | null>(null)
 CanvasStateContext.displayName = 'CanvasStateContext'
-export const InspectorStateContext = React.createContext<EditorStateContextData | null>(null)
-InspectorStateContext.displayName = 'InspectorStateContext'
+export const LowPriorityStateContext = React.createContext<EditorStateContextData | null>(null)
+LowPriorityStateContext.displayName = 'LowPriorityStateContext'
 
 export function useSelectorWithCallback<U>(
   selector: StateSelector<EditorStorePatched, U>,

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -381,17 +381,25 @@ Inspector.displayName = 'Inspector'
 
 const DefaultStyleTargets: Array<CSSTarget> = [cssTarget(['style'], 0), cssTarget(['css'], 0)]
 
+export const LowPriorityStoreProvider = React.memo<React.PropsWithChildren<unknown>>((props) => {
+  const lowPriorityStore = React.useContext(LowPriorityStateContext)?.useStore
+  return (
+    <EditorStateContext.Provider
+      value={
+        lowPriorityStore == null ? null : { api: lowPriorityStore, useStore: lowPriorityStore }
+      }
+    >
+      {props.children}
+    </EditorStateContext.Provider>
+  )
+})
+
 export const InspectorEntryPoint: React.FunctionComponent<React.PropsWithChildren<unknown>> =
   React.memo(() => {
-    const lowPriorityStore = React.useContext(LowPriorityStateContext)?.useStore
     return (
-      <EditorStateContext.Provider
-        value={
-          lowPriorityStore == null ? null : { api: lowPriorityStore, useStore: lowPriorityStore }
-        }
-      >
+      <LowPriorityStoreProvider>
         <MultiselectInspector />
-      </EditorStateContext.Provider>
+      </LowPriorityStoreProvider>
     )
   })
 

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -40,11 +40,7 @@ import {
   getOpenUtopiaJSXComponentsFromStateMultifile,
   isOpenFileUiJs,
 } from '../editor/store/editor-state'
-import {
-  EditorStateContext,
-  LowPriorityStateContext,
-  useEditorState,
-} from '../editor/store/store-hook'
+import { useEditorState } from '../editor/store/store-hook'
 import {
   InspectorCallbackContext,
   InspectorPropsContext,
@@ -88,6 +84,7 @@ import { createSelector } from 'reselect'
 import { isTwindEnabled } from '../../core/tailwind/tailwind'
 import { isStrategyActive } from '../canvas/canvas-strategies/canvas-strategies'
 import type { StrategyState } from '../canvas/canvas-strategies/interaction-state'
+import { LowPriorityStoreProvider } from '../editor/store/low-priority-store'
 
 export interface ElementPathElement {
   name?: string
@@ -380,19 +377,6 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
 Inspector.displayName = 'Inspector'
 
 const DefaultStyleTargets: Array<CSSTarget> = [cssTarget(['style'], 0), cssTarget(['css'], 0)]
-
-export const LowPriorityStoreProvider = React.memo<React.PropsWithChildren<unknown>>((props) => {
-  const lowPriorityStore = React.useContext(LowPriorityStateContext)?.useStore
-  return (
-    <EditorStateContext.Provider
-      value={
-        lowPriorityStore == null ? null : { api: lowPriorityStore, useStore: lowPriorityStore }
-      }
-    >
-      {props.children}
-    </EditorStateContext.Provider>
-  )
-})
 
 export const InspectorEntryPoint: React.FunctionComponent<React.PropsWithChildren<unknown>> =
   React.memo(() => {

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -42,7 +42,7 @@ import {
 } from '../editor/store/editor-state'
 import {
   EditorStateContext,
-  InspectorStateContext,
+  LowPriorityStateContext,
   useEditorState,
 } from '../editor/store/store-hook'
 import {
@@ -383,10 +383,12 @@ const DefaultStyleTargets: Array<CSSTarget> = [cssTarget(['style'], 0), cssTarge
 
 export const InspectorEntryPoint: React.FunctionComponent<React.PropsWithChildren<unknown>> =
   React.memo(() => {
-    const inspectorStore = React.useContext(InspectorStateContext)?.useStore
+    const lowPriorityStore = React.useContext(LowPriorityStateContext)?.useStore
     return (
       <EditorStateContext.Provider
-        value={inspectorStore == null ? null : { api: inspectorStore, useStore: inspectorStore }}
+        value={
+          lowPriorityStore == null ? null : { api: lowPriorityStore, useStore: lowPriorityStore }
+        }
       >
         <MultiselectInspector />
       </EditorStateContext.Provider>

--- a/editor/src/components/navigator/left-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/index.tsx
@@ -15,6 +15,7 @@ import {
   LeftMenuTab,
   LeftPaneDefaultWidth,
 } from '../../editor/store/editor-state'
+import { LowPriorityStoreProvider } from '../../editor/store/low-priority-store'
 import { useEditorState } from '../../editor/store/store-hook'
 import { UIGridRow } from '../../inspector/widgets/ui-grid-row'
 import { ContentsPane } from './contents-pane'
@@ -69,56 +70,62 @@ export const LeftPaneComponent = React.memo(() => {
   }, [onClickTab])
 
   return (
-    <div
-      id={LeftPaneComponentId}
-      className='leftPane'
-      style={{
-        height: '100%',
-        position: 'relative',
-        backgroundColor: colorTheme.leftPaneBackground.value,
-        color: colorTheme.fg1.value,
-        paddingLeft: 4,
-        width: LeftPaneDefaultWidth,
-      }}
-    >
+    <LowPriorityStoreProvider>
       <div
-        id={LeftPaneOverflowScrollId}
-        className='overflow-y-scroll'
+        id={LeftPaneComponentId}
+        className='leftPane'
         style={{
           height: '100%',
-          flexGrow: 1,
-        }}
-        onMouseDown={(mouseEvent: React.MouseEvent<HTMLDivElement>) => {
-          if (mouseEvent.target instanceof HTMLDivElement) {
-            if (mouseEvent.target.id === LeftPaneOverflowScrollId) {
-              dispatch([clearSelection()])
-            }
-          }
+          position: 'relative',
+          backgroundColor: colorTheme.leftPaneBackground.value,
+          color: colorTheme.fg1.value,
+          paddingLeft: 4,
+          width: LeftPaneDefaultWidth,
         }}
       >
-        <UIGridRow variant='<--1fr--><--1fr--><--1fr-->' padded={false} css={{ gridColumnGap: 0 }}>
-          <MenuTab
-            label={'Project'}
-            selected={selectedTab === LeftMenuTab.Project}
-            onClick={onClickProjectTab}
-          />
-          <MenuTab
-            label={'Settings'}
-            selected={selectedTab === LeftMenuTab.Settings}
-            onClick={onClickSettingsTab}
-          />
-          <MenuTab
-            label={'Github'}
-            selected={selectedTab === LeftMenuTab.Github}
-            onClick={onClickGithubTab}
-          />
-        </UIGridRow>
+        <div
+          id={LeftPaneOverflowScrollId}
+          className='overflow-y-scroll'
+          style={{
+            height: '100%',
+            flexGrow: 1,
+          }}
+          onMouseDown={(mouseEvent: React.MouseEvent<HTMLDivElement>) => {
+            if (mouseEvent.target instanceof HTMLDivElement) {
+              if (mouseEvent.target.id === LeftPaneOverflowScrollId) {
+                dispatch([clearSelection()])
+              }
+            }
+          }}
+        >
+          <UIGridRow
+            variant='<--1fr--><--1fr--><--1fr-->'
+            padded={false}
+            css={{ gridColumnGap: 0 }}
+          >
+            <MenuTab
+              label={'Project'}
+              selected={selectedTab === LeftMenuTab.Project}
+              onClick={onClickProjectTab}
+            />
+            <MenuTab
+              label={'Settings'}
+              selected={selectedTab === LeftMenuTab.Settings}
+              onClick={onClickSettingsTab}
+            />
+            <MenuTab
+              label={'Github'}
+              selected={selectedTab === LeftMenuTab.Github}
+              onClick={onClickGithubTab}
+            />
+          </UIGridRow>
 
-        {selectedTab === LeftMenuTab.Project ? <ContentsPane /> : null}
-        {selectedTab === LeftMenuTab.Settings ? <SettingsPane /> : null}
-        {selectedTab === LeftMenuTab.Github ? <GithubPane /> : null}
-        {loggedIn ? null : <LoggedOutPane />}
+          {selectedTab === LeftMenuTab.Project ? <ContentsPane /> : null}
+          {selectedTab === LeftMenuTab.Settings ? <SettingsPane /> : null}
+          {selectedTab === LeftMenuTab.Github ? <GithubPane /> : null}
+          {loggedIn ? null : <LoggedOutPane />}
+        </div>
       </div>
-    </div>
+    </LowPriorityStoreProvider>
   )
 })


### PR DESCRIPTION
**Problem:**
When the github pane is open (and maybe under other circumstances too), every update to projectContents will execute the function `getProjectContentsChecksums`. For the "Before I go" demo project, it takes ~25ms, severly affecting dragging performance.

**Fix:**
Wrap the entire LeftPane in a `LowPriorityStoreProvider` which only updates the editorState values for the subtree when there is No active canvas interaction session.

[Try me here!](https://utopia.pizza/p/88dde564-before-i-go-basic-(forked)/?branch_name=fix-low-priority-ui-update-store)
<img width="1342" alt="image" src="https://user-images.githubusercontent.com/2226774/202769128-4c9f31e1-93cd-4ed4-bc84-7093d68a1036.png">

**Commit Details:**
- Renamed InspectorStore to LowPriorityStore
- Turned LowPriorityStateProvider into a react component that can just be dropped in anywhere in the render tree
- Wrap LeftPaneComponent in LowPriorityStateProvider
- Bonus fix: when the utopia file browser (UTFB) was open, it also re-rendered for every canvas interaction frame. that is also fixed now!

**Notes:**
- You can see on the attached screenshot that on mouse up we still run getProjectContentsChecksums for 25ms, the next lowest hanging fruit is that we should fix the actual function to only re-calculate the checksum for a project content file that actually changed, instead of always recalculating for every file.
