### PR TITLE
padding/border radius controls overlap

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.spec.browser2.tsx
@@ -1,6 +1,7 @@
 import {
   canvasVector,
   CanvasVector,
+  Size,
   size,
   windowPoint,
   WindowPoint,
@@ -51,6 +52,29 @@ describe('set border radius strategy', () => {
 
   it("border radius controls don't show up for elements that have don't border radius set", async () => {
     const editor = await renderTestEditorWithCode(codeForDragTest(``), 'await-first-dom-report')
+
+    const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
+    const div = editor.renderedDOM.getByTestId('mydiv')
+    const divBounds = div.getBoundingClientRect()
+    const divCorner = {
+      x: divBounds.x + 50,
+      y: divBounds.y + 40,
+    }
+
+    mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
+
+    const paddingControls = BorderRadiusCorners.flatMap((corner) =>
+      editor.renderedDOM.queryAllByTestId(CircularHandleTestId(corner)),
+    )
+
+    expect(paddingControls).toEqual([])
+  })
+
+  it("border radius controls don't show up for elements that are smaller than 40px", async () => {
+    const editor = await renderTestEditorWithCode(
+      divWithDimensions({ width: 20, height: 20 }),
+      'await-first-dom-report',
+    )
 
     const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
     const div = editor.renderedDOM.getByTestId('mydiv')
@@ -270,6 +294,22 @@ function codeForDragTest(borderRadius: string): string {
       width: 600,
       height: 400,
       ${borderRadius}
+    }}
+    data-uid='24a'
+  />`)
+}
+
+function divWithDimensions(sizee: Size): string {
+  return makeTestProjectCodeWithSnippet(`<div
+    data-testid='mydiv'
+    style={{
+      backgroundColor: '#0091FFAA',
+      position: 'absolute',
+      left: 28,
+      top: 28,
+      width: '${sizee.width}px',
+      height: '${sizee.height}px',
+      borderRadius: '5px',
     }}
     data-uid='24a'
   />`)

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -41,6 +41,7 @@ import { setElementsToRerenderCommand } from '../../commands/set-elements-to-rer
 import { setProperty } from '../../commands/set-property-command'
 import { BorderRadiusControl } from '../../controls/select-mode/border-radius-control'
 import {
+  canShowCanvasPropControl,
   cssNumberEqual,
   cssNumberWithRenderedValue,
   CSSNumberWithRenderedValue,
@@ -84,6 +85,16 @@ export const setBorderRadiusStrategy: CanvasStrategyFactory = (
     selectedElement,
   )
   if (element == null) {
+    return null
+  }
+
+  const canShowBorderRadiusControls = canShowCanvasPropControl(
+    canvasState.projectContents,
+    canvasState.openFile ?? null,
+    element,
+    canvasState.scale,
+  ).has('borderRadius')
+  if (!canShowBorderRadiusControls) {
     return null
   }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -116,6 +116,41 @@ describe('Padding resize strategy', () => {
     })
   })
 
+  it("padding controls don't show up for elements that are smaller than 40px", async () => {
+    const editor = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`<div
+      data-testid='mydiv'
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 28,
+        top: 28,
+        width: 39,
+        height: 39,
+      }}
+      data-uid='24a'
+    />`),
+      'await-first-dom-report',
+    )
+
+    const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
+    const div = editor.renderedDOM.getByTestId('mydiv')
+    const divBounds = div.getBoundingClientRect()
+    const divCorner = {
+      x: divBounds.x + 50,
+      y: divBounds.y + 40,
+    }
+
+    mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
+
+    const paddingControls = EdgePieces.flatMap((edge) => [
+      ...editor.renderedDOM.queryAllByTestId(paddingControlTestId(edge)),
+      ...editor.renderedDOM.queryAllByTestId(paddingControlHandleTestId(edge)),
+    ])
+
+    expect(paddingControls).toEqual([])
+  })
+
   it('Padding resize handles are present and visible after the timeout', async () => {
     const editor = await renderTestEditorWithCode(
       makeTestProjectCodeWithStringPaddingValues(

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -150,7 +150,9 @@ describe('Padding resize strategy', () => {
       y: paddingResizeControlContainerBounds.y + 4,
     }
 
-    mouseEnterAtPoint(paddingResizeControlContainer, paddingResizeControlContainerCorner)
+    mouseMoveToPoint(canvasControlsLayer, paddingResizeControlContainerCorner)
+
+    // mouseEnterAtPoint(paddingResizeControlContainer, paddingResizeControlContainerCorner)
 
     await wait(PaddingResizeControlHoverTimeout + 1)
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -10,14 +10,12 @@ import {
 import {
   paddingControlHandleTestId,
   paddingControlTestId,
-  PaddingResizeControlContainerTestId,
   PaddingResizeControlHoverTimeout,
 } from '../../controls/select-mode/padding-resize-control'
 import {
   mouseClickAtPoint,
   mouseDownAtPoint,
   mouseDragFromPointToPoint,
-  mouseEnterAtPoint,
   mouseMoveToPoint,
 } from '../../event-helpers.test-utils'
 import {
@@ -141,9 +139,6 @@ describe('Padding resize strategy', () => {
 
     mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
 
-    const paddingResizeControlContainer = editor.renderedDOM.getByTestId(
-      PaddingResizeControlContainerTestId,
-    )
     const paddingResizeControlContainerBounds = div.getBoundingClientRect()
     const paddingResizeControlContainerCorner = {
       x: paddingResizeControlContainerBounds.x + 5,
@@ -151,8 +146,6 @@ describe('Padding resize strategy', () => {
     }
 
     mouseMoveToPoint(canvasControlsLayer, paddingResizeControlContainerCorner)
-
-    // mouseEnterAtPoint(paddingResizeControlContainer, paddingResizeControlContainerCorner)
 
     await wait(PaddingResizeControlHoverTimeout + 1)
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -38,6 +38,7 @@ import { InteractionSession } from '../interaction-state'
 import { getDragTargets, getMultiselectBounds } from './shared-move-strategies-helpers'
 import { canvasPoint, CanvasPoint, CanvasVector } from '../../../../core/shared/math-utils'
 import {
+  canShowCanvasPropControl,
   Emdash,
   indicatorMessage,
   offsetMeasurementByDelta,
@@ -72,6 +73,24 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
 
   const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
   if (selectedElements.length !== 1) {
+    return null
+  }
+
+  const element = MetadataUtils.findElementByElementPath(
+    canvasState.startingMetadata,
+    selectedElements[0],
+  )
+  if (element == null) {
+    return null
+  }
+
+  const canShowPadding = canShowCanvasPropControl(
+    canvasState.projectContents,
+    canvasState.openFile ?? null,
+    element,
+    canvasState.scale,
+  ).has('padding')
+  if (!canShowPadding) {
     return null
   }
 

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1688,6 +1688,7 @@ function getTransientCanvasStateFromFrameChanges(
   return transientCanvasState(
     editorState.selectedViews,
     editorState.highlightedViews,
+    [],
     mapValues((success) => {
       return transientFileState(success.topLevelElements, success.imports)
     }, successByFilename),
@@ -1718,7 +1719,13 @@ export function produceResizeCanvasTransientState(
   })
   const boundingBox = Utils.boundingRectangleArray(globalFrames)
   if (boundingBox == null) {
-    return transientCanvasState(dragState.draggedElements, editorState.highlightedViews, null, [])
+    return transientCanvasState(
+      dragState.draggedElements,
+      editorState.highlightedViews,
+      editorState.hoveredViews,
+      null,
+      [],
+    )
   } else {
     Utils.fastForEach(elementsToTarget, (target) => {
       forUnderlyingTargetFromEditorState(
@@ -1792,7 +1799,13 @@ export function produceResizeSingleSelectCanvasTransientState(
     true,
   )
   if (elementsToTarget.length !== 1) {
-    return transientCanvasState(editorState.selectedViews, editorState.highlightedViews, null, [])
+    return transientCanvasState(
+      editorState.selectedViews,
+      editorState.highlightedViews,
+      editorState.hoveredViews,
+      null,
+      [],
+    )
   }
   const elementToTarget = elementsToTarget[0]
 
@@ -1924,7 +1937,13 @@ export function produceCanvasTransientState(
   }
 
   if (transientState == null) {
-    return transientCanvasState(editorState.selectedViews, editorState.highlightedViews, null, [])
+    return transientCanvasState(
+      editorState.selectedViews,
+      editorState.highlightedViews,
+      editorState.hoveredViews,
+      null,
+      [],
+    )
   } else {
     return transientState
   }
@@ -2520,6 +2539,7 @@ function produceMoveTransientCanvasState(
   return transientCanvasState(
     selectedViews,
     workingEditorState.highlightedViews,
+    workingEditorState.hoveredViews,
     transientFilesState,
     workingEditorState.toasts, // TODO Filter for relevant toasts
   )
@@ -3100,6 +3120,7 @@ function createCanvasTransientStateFromProperties(
     return transientCanvasState(
       updatedEditor.selectedViews,
       updatedEditor.highlightedViews,
+      updatedEditor.hoveredViews,
       transientFilesState,
       [],
     )

--- a/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
@@ -65,7 +65,20 @@ export const BorderRadiusControl = controlForStrategyMemoized<BorderRadiusContro
 
   const colorTheme = useColorTheme()
 
-  const backgroundShown = hoveredViews.includes(props.selectedElement)
+  const timeoutRef = React.useRef<NodeJS.Timeout | null>(null)
+  const [backgroundShown, setBackgroundShown] = React.useState<boolean>(false)
+  React.useEffect(() => {
+    const timeoutHandle = timeoutRef.current
+    if (timeoutHandle != null) {
+      clearTimeout(timeoutHandle)
+    }
+
+    if (hoveredViews.includes(selectedElement)) {
+      timeoutRef.current = setTimeout(() => setBackgroundShown(true), 200)
+    } else {
+      setBackgroundShown(false)
+    }
+  }, [hoveredViews, selectedElement])
 
   const controlRef = useBoundingBox([selectedElement], (ref, boundingBox) => {
     if (isZeroSizedElement(boundingBox)) {

--- a/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
@@ -51,11 +51,11 @@ export const BorderRadiusControl = controlForStrategyMemoized<BorderRadiusContro
   } = props
 
   const canvasOffset = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
-  const { dispatch, scale, isDragging } = useEditorState(
+  const { dispatch, scale, hoveredViews, isDragging } = useEditorState(
     (store) => ({
       dispatch: store.dispatch,
       scale: store.editor.canvas.scale,
-
+      hoveredViews: store.editor.hoveredViews,
       isDragging:
         store.editor.canvas.interactionSession?.activeControl.type ===
         'BORDER_RADIUS_RESIZE_HANDLE',
@@ -65,9 +65,7 @@ export const BorderRadiusControl = controlForStrategyMemoized<BorderRadiusContro
 
   const colorTheme = useColorTheme()
 
-  const [backgroundShown, setBackgroundShown] = React.useState<boolean>(false)
-
-  const [controlHoverStart, controlHoverEnd] = useHoverWithDelay(200, setBackgroundShown)
+  const backgroundShown = hoveredViews.includes(props.selectedElement)
 
   const controlRef = useBoundingBox([selectedElement], (ref, boundingBox) => {
     if (isZeroSizedElement(boundingBox)) {
@@ -83,12 +81,7 @@ export const BorderRadiusControl = controlForStrategyMemoized<BorderRadiusContro
 
   return (
     <CanvasOffsetWrapper>
-      <div
-        onMouseEnter={controlHoverStart}
-        onMouseLeave={controlHoverEnd}
-        ref={controlRef}
-        style={{ position: 'absolute' }}
-      >
+      <div ref={controlRef} style={{ position: 'absolute', pointerEvents: 'none' }}>
         {BorderRadiusCorners.map((corner) => (
           <CircularHandle
             key={CircularHandleTestId(corner)}
@@ -188,6 +181,7 @@ const CircularHandle = React.memo((props: CircularHandleProp) => {
         )}
         <div
           style={{
+            pointerEvents: 'all',
             visibility: shouldShowHandle ? 'visible' : 'hidden',
             width: size,
             height: size,

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
-import { roundTo } from '../../../../core/shared/math-utils'
+import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import { ElementInstanceMetadata } from '../../../../core/shared/element-template'
+import { roundTo, size } from '../../../../core/shared/math-utils'
 import { Modifiers } from '../../../../utils/modifiers'
+import { ProjectContentTreeRoot } from '../../../assets'
 import { CSSNumber, CSSNumberUnit, printCSSNumber } from '../../../inspector/common/css-utils'
 
 export const Emdash: string = '\u2014'
@@ -81,6 +84,7 @@ export function measurementBasedOnOtherMeasurement(
 
 const FontSize = 12
 const Padding = 4
+const BorderRadius = 2
 
 interface CanvasLabelProps {
   scale: number
@@ -92,6 +96,7 @@ export const CanvasLabel = React.memo((props: CanvasLabelProps): JSX.Element => 
   const { scale, color, value } = props
   const fontSize = FontSize / scale
   const padding = Padding / scale
+  const borderRadius = BorderRadius / scale
   return (
     <div
       style={{
@@ -99,7 +104,7 @@ export const CanvasLabel = React.memo((props: CanvasLabelProps): JSX.Element => 
         padding: padding,
         backgroundColor: color,
         color: 'white',
-        borderRadius: 2,
+        borderRadius: borderRadius,
       }}
     >
       {value}
@@ -174,4 +179,32 @@ export function indicatorMessage(
 
 export function cssNumberEqual(left: CSSNumber, right: CSSNumber): boolean {
   return left.unit === right.unit && left.value === right.value
+}
+
+type CanvasPropControl = 'padding' | 'borderRadius' | 'gap'
+
+export function canShowCanvasPropControl(
+  projectContents: ProjectContentTreeRoot,
+  openFile: string | null,
+  element: ElementInstanceMetadata,
+  scale: number,
+): Set<CanvasPropControl> {
+  const { width, height } = size(
+    element.specialSizeMeasurements.clientWidth * scale,
+    element.specialSizeMeasurements.clientHeight * scale,
+  )
+
+  if (width > 80 && height > 80) {
+    return new Set<CanvasPropControl>(['borderRadius', 'padding', 'gap'])
+  }
+
+  if (Math.min(width, height) < 40) {
+    return new Set<CanvasPropControl>([])
+  }
+
+  if (!MetadataUtils.targetElementSupportsChildren(projectContents, openFile, element)) {
+    return new Set<CanvasPropControl>(['borderRadius', 'gap'])
+  }
+
+  return new Set<CanvasPropControl>(['padding', 'gap'])
 }

--- a/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
@@ -20,15 +20,12 @@ import { controlForStrategyMemoized } from '../../canvas-strategies/canvas-strat
 import { createInteractionViaMouse, flexGapHandle } from '../../canvas-strategies/interaction-state'
 import { windowToCanvasCoordinates } from '../../dom-lookup'
 import { cursorFromFlexDirection, gapControlBoundsFromMetadata } from '../../gap-utils'
-import { useBoundingBox } from '../bounding-box-hooks'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
-import { isZeroSizedElement } from '../outline-utils'
 import {
   CanvasLabel,
   CSSNumberWithRenderedValue,
   PillHandle,
   StripedBackgroundCSS,
-  StripeOpacity,
   useHoverWithDelay,
 } from './controls-common'
 
@@ -44,12 +41,31 @@ export const FlexGapControlHandleTestId = 'FlexGapControlHandleTestId'
 export const FlexGapControl = controlForStrategyMemoized<FlexGapControlProps>((props) => {
   const { selectedElement, flexDirection, updatedGapValue } = props
   const colorTheme = useColorTheme()
-  const indicatorColor = colorTheme.brandNeonPink30.value
+  const indicatorColor = colorTheme.brandNeonPink.value
+
+  const hoveredViews = useEditorState(
+    (store) => store.editor.hoveredViews,
+    'FlexGapControl hoveredViews',
+  )
 
   const [indicatorShown, setIndicatorShown] = useState<string | null>(null)
-  const [backgroundShown, setBackgroundShown] = useState<boolean>(false)
 
+  const [backgroundShown, setBackgroundShown] = React.useState<boolean>(false)
   const [controlHoverStart, controlHoverEnd] = useHoverWithDelay(0, setBackgroundShown)
+
+  const timeoutRef = React.useRef<NodeJS.Timeout | null>(null)
+  React.useEffect(() => {
+    const timeoutHandle = timeoutRef.current
+    if (timeoutHandle != null) {
+      clearTimeout(timeoutHandle)
+    }
+
+    if (hoveredViews.includes(selectedElement)) {
+      timeoutRef.current = setTimeout(() => setBackgroundShown(true), 200)
+    } else {
+      setBackgroundShown(false)
+    }
+  }, [hoveredViews, selectedElement])
 
   const handleHoverStart = React.useCallback((id: string) => setIndicatorShown(id), [])
   const handleHoverEnd = React.useCallback(() => setIndicatorShown(null), [])
@@ -65,18 +81,6 @@ export const FlexGapControl = controlForStrategyMemoized<FlexGapControlProps>((p
   )
 
   const canvasOffset = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
-
-  const controlRef = useBoundingBox([selectedElement], (ref, boundingBox) => {
-    if (isZeroSizedElement(boundingBox)) {
-      ref.current.style.display = 'none'
-    } else {
-      ref.current.style.display = 'block'
-      ref.current.style.left = boundingBox.x + 'px'
-      ref.current.style.top = boundingBox.y + 'px'
-      ref.current.style.width = boundingBox.width + 'px'
-      ref.current.style.height = boundingBox.height + 'px'
-    }
-  })
 
   const controlBounds = gapControlBoundsFromMetadata(
     metadata,
@@ -94,7 +98,7 @@ export const FlexGapControl = controlForStrategyMemoized<FlexGapControlProps>((p
 
   return (
     <CanvasOffsetWrapper>
-      <div data-testid={FlexGapControlTestId} ref={controlRef}>
+      <div data-testid={FlexGapControlTestId} style={{ pointerEvents: 'none' }}>
         {controlBounds.map(({ bounds, path: p }) => {
           const path = EP.toString(p)
           return (
@@ -205,6 +209,7 @@ const GapControlSegment = React.memo<GapControlSegmentProps>((props) => {
       onMouseEnter={hoverStart}
       onMouseLeave={hoverEnd}
       style={{
+        pointerEvents: 'all',
         position: 'absolute',
         left: bounds.x,
         top: bounds.y,

--- a/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
@@ -186,14 +186,23 @@ const GapControlSegment = React.memo<GapControlSegmentProps>((props) => {
   } = props
 
   const colorTheme = useColorTheme()
+  const [stripesShown, setStripesShown] = React.useState<boolean>(false)
 
   const { dragBorderWidth, hitAreaPadding, paddingIndicatorOffset, borderWidth } =
     gapControlSizeConstants(DefaultGapControlSizeConstants, scale)
   const { width, height } = handleDimensions(flexDirection, scale)
 
-  const handleHoverStartInner = React.useCallback(
-    () => handleHoverStart(path),
-    [handleHoverStart, path],
+  const handleHoverStartInner = React.useCallback(() => {
+    handleHoverStart(path)
+    setStripesShown(true)
+  }, [handleHoverStart, path])
+
+  const handleHoverEndInner = React.useCallback(
+    (e: React.MouseEvent) => {
+      hoverEnd(e)
+      setStripesShown(false)
+    },
+    [hoverEnd],
   )
 
   const shouldShowIndicator = React.useCallback(
@@ -201,13 +210,13 @@ const GapControlSegment = React.memo<GapControlSegmentProps>((props) => {
     [indicatorShown, isDragging],
   )
 
-  const shouldShowBackground = !isDragging && backgroundShown
+  const shouldShowBackground = !isDragging && backgroundShown && stripesShown
 
   return (
     <div
       key={path}
       onMouseEnter={hoverStart}
-      onMouseLeave={hoverEnd}
+      onMouseLeave={handleHoverEndInner}
       style={{
         pointerEvents: 'all',
         position: 'absolute',

--- a/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
@@ -147,7 +147,6 @@ const PaddingResizeControlI = React.memo(
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          zIndex: 0,
           border: isDragging ? `${dragBorderWidth}px solid ${color}` : undefined,
           ...(hidden ? {} : StripedBackgroundCSS(stripeColor, scale)),
         }}
@@ -159,6 +158,7 @@ const PaddingResizeControlI = React.memo(
           onMouseLeave={hoverEnd}
           onMouseUp={onMouseUp}
           style={{
+            pointerEvents: 'all',
             visibility: shown ? 'visible' : 'hidden',
             position: 'absolute',
             padding: hitAreaWidth,

--- a/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
@@ -120,7 +120,7 @@ const PaddingResizeControlI = React.memo(
 
     const { cursor, orientation } = edgePieceDerivedProps(props.edge)
 
-    const shown = !(props.hiddenByParent && hidden)
+    const shown = !isDragging && !(props.hiddenByParent && hidden)
 
     const { width, height } = sizeFromOrientation(
       orientation,
@@ -215,6 +215,22 @@ export const PaddingResizeControl = controlForStrategyMemoized((props: PaddingCo
     }
   })
 
+  const timeoutRef = React.useRef<NodeJS.Timeout | null>(null)
+
+  const [hoverHidden, setHoverHidden] = React.useState<boolean>(false)
+  React.useEffect(() => {
+    const timeoutHandle = timeoutRef.current
+    const shouldBeShown = hoveredViews.includes(selectedElements[0])
+    if (timeoutHandle != null) {
+      clearTimeout(timeoutHandle)
+    }
+    if (shouldBeShown) {
+      timeoutRef.current = setTimeout(() => setHoverHidden(false), PaddingResizeControlHoverTimeout)
+    } else {
+      setHoverHidden(true)
+    }
+  }, [hoveredViews, selectedElements])
+
   const currentPadding = combinePaddings(
     paddingFromSpecialSizeMeasurements(elementMetadata.current, selectedElements[0]),
     simplePaddingFromMetadata(elementMetadata.current, selectedElements[0]),
@@ -250,7 +266,6 @@ export const PaddingResizeControl = controlForStrategyMemoized((props: PaddingCo
     ref.current.style.height = numberToPxValue(padding.paddingBottom?.renderedValuePx ?? 0)
   })
 
-  const hoverHidden = !hoveredViews.includes(selectedElements[0])
   return (
     <CanvasOffsetWrapper>
       <div

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -405,8 +405,16 @@ export interface SetHighlightedView {
   target: ElementPath
 }
 
+export interface SetHoveredView {
+  action: 'SET_HOVERED_VIEW'
+  target: ElementPath
+}
+
 export interface ClearHighlightedViews {
   action: 'CLEAR_HIGHLIGHTED_VIEWS'
+}
+export interface ClearHoveredViews {
+  action: 'CLEAR_HOVERED_VIEWS'
 }
 
 export type UpdateKeysPressed = {
@@ -1104,6 +1112,8 @@ export type EditorAction =
   | RemoveToast
   | SetHighlightedView
   | ClearHighlightedViews
+  | SetHoveredView
+  | ClearHoveredViews
   | UpdateKeysPressed
   | UpdateMouseButtonsPressed
   | HideModal

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -218,6 +218,8 @@ import type {
   RemoveFileConflict,
   SetRefreshingDependencies,
   SetUserConfiguration,
+  SetHoveredView,
+  ClearHoveredViews,
 } from '../action-types'
 import { EditorModes, insertionSubject, Mode } from '../editor-modes'
 import type {
@@ -541,9 +543,22 @@ export function setHighlightedView(target: ElementPath): SetHighlightedView {
   }
 }
 
+export function setHoveredView(target: ElementPath): SetHoveredView {
+  return {
+    action: 'SET_HOVERED_VIEW',
+    target: target,
+  }
+}
+
 export function clearHighlightedViews(): ClearHighlightedViews {
   return {
     action: 'CLEAR_HIGHLIGHTED_VIEWS',
+  }
+}
+
+export function clearHoveredViews(): ClearHoveredViews {
+  return {
+    action: 'CLEAR_HOVERED_VIEWS',
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -43,6 +43,8 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'REMOVE_TOAST':
     case 'SET_HIGHLIGHTED_VIEW':
     case 'CLEAR_HIGHLIGHTED_VIEWS':
+    case 'SET_HOVERED_VIEW':
+    case 'CLEAR_HOVERED_VIEWS':
     case 'HIDE_MODAL':
     case 'SHOW_MODAL':
     case 'RESIZE_INTERFACEDESIGNER_CODEPANE':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -314,6 +314,8 @@ import {
   RemoveFileConflict,
   SetRefreshingDependencies,
   SetUserConfiguration,
+  SetHoveredView,
+  ClearHoveredViews,
 } from '../action-types'
 import { defaultSceneElement, defaultTransparentViewElement } from '../defaults'
 import { EditorModes, isLiveMode, isSelectMode, Mode } from '../editor-modes'
@@ -1541,6 +1543,16 @@ export const UPDATE_FNS = {
       }
     }
   },
+  SET_HOVERED_VIEW: (action: SetHoveredView, editor: EditorModel): EditorModel => {
+    if (editor.hoveredViews.length > 0 && EP.containsPath(action.target, editor.hoveredViews)) {
+      return editor
+    } else {
+      return {
+        ...editor,
+        hoveredViews: [action.target],
+      }
+    }
+  },
   CLEAR_HIGHLIGHTED_VIEWS: (action: ClearHighlightedViews, editor: EditorModel): EditorModel => {
     if (editor.highlightedViews.length === 0) {
       return editor
@@ -1548,6 +1560,15 @@ export const UPDATE_FNS = {
     return {
       ...editor,
       highlightedViews: [],
+    }
+  },
+  CLEAR_HOVERED_VIEWS: (action: ClearHoveredViews, editor: EditorModel): EditorModel => {
+    if (editor.hoveredViews.length === 0) {
+      return editor
+    }
+    return {
+      ...editor,
+      hoveredViews: [],
     }
   },
   UNDO: (editor: EditorModel, stateHistory: StateHistory): EditorModel => {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -875,6 +875,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
     propertyControlsInfo: currentEditor.propertyControlsInfo,
     selectedViews: currentEditor.selectedViews,
     highlightedViews: currentEditor.highlightedViews,
+    hoveredViews: currentEditor.hoveredViews,
     hiddenInstances: poppedEditor.hiddenInstances,
     displayNoneInstances: poppedEditor.displayNoneInstances,
     warnedInstances: poppedEditor.warnedInstances,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1219,6 +1219,7 @@ export interface EditorState {
   nodeModules: EditorStateNodeModules
   selectedViews: Array<ElementPath>
   highlightedViews: Array<ElementPath>
+  hoveredViews: Array<ElementPath>
   hiddenInstances: Array<ElementPath>
   displayNoneInstances: Array<ElementPath>
   warnedInstances: Array<ElementPath>
@@ -1292,6 +1293,7 @@ export function editorState(
   nodeModules: EditorStateNodeModules,
   selectedViews: Array<ElementPath>,
   highlightedViews: Array<ElementPath>,
+  hoveredViews: Array<ElementPath>,
   hiddenInstances: Array<ElementPath>,
   displayNoneInstances: Array<ElementPath>,
   warnedInstances: Array<ElementPath>,
@@ -1366,6 +1368,7 @@ export function editorState(
     nodeModules: nodeModules,
     selectedViews: selectedViews,
     highlightedViews: highlightedViews,
+    hoveredViews: hoveredViews,
     hiddenInstances: hiddenInstances,
     displayNoneInstances: displayNoneInstances,
     warnedInstances: warnedInstances,
@@ -1910,6 +1913,7 @@ export type EditorStatePatch = Spec<EditorState>
 export interface TransientCanvasState {
   selectedViews: Array<ElementPath>
   highlightedViews: Array<ElementPath>
+  hoveredViews: Array<ElementPath>
   filesState: TransientFilesState | null
   toastsToApply: ReadonlyArray<Notice>
 }
@@ -1917,12 +1921,14 @@ export interface TransientCanvasState {
 export function transientCanvasState(
   selectedViews: Array<ElementPath>,
   highlightedViews: Array<ElementPath>,
+  hoveredViews: Array<ElementPath>,
   fileState: TransientFilesState | null,
   toastsToApply: ReadonlyArray<Notice>,
 ): TransientCanvasState {
   return {
     selectedViews: selectedViews,
     highlightedViews: highlightedViews,
+    hoveredViews: hoveredViews,
     filesState: fileState,
     toastsToApply: toastsToApply,
   }
@@ -2090,6 +2096,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     },
     selectedViews: [],
     highlightedViews: [],
+    hoveredViews: [],
     hiddenInstances: [],
     displayNoneInstances: [],
     warnedInstances: [],
@@ -2397,6 +2404,7 @@ export function editorModelFromPersistentModel(
     },
     selectedViews: [],
     highlightedViews: [],
+    hoveredViews: [],
     hiddenInstances: persistentModel.hiddenInstances,
     displayNoneInstances: [],
     warnedInstances: [],

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -147,8 +147,12 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.REMOVE_TOAST(action, state)
     case 'SET_HIGHLIGHTED_VIEW':
       return UPDATE_FNS.SET_HIGHLIGHTED_VIEW(action, state)
+    case 'SET_HOVERED_VIEW':
+      return UPDATE_FNS.SET_HOVERED_VIEW(action, state)
     case 'CLEAR_HIGHLIGHTED_VIEWS':
       return UPDATE_FNS.CLEAR_HIGHLIGHTED_VIEWS(action, state)
+    case 'CLEAR_HOVERED_VIEWS':
+      return UPDATE_FNS.CLEAR_HOVERED_VIEWS(action, state)
     case 'UPDATE_KEYS_PRESSED':
       return UPDATE_FNS.UPDATE_KEYS_PRESSED(action, state)
     case 'UPDATE_MOUSE_BUTTONS_PRESSED':

--- a/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
@@ -58,6 +58,7 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
   const oldValue: TransientCanvasState = transientCanvasState(
     [EP.elementPath([['scene'], ['aaa', 'bbb']])],
     [EP.elementPath([['scene'], ['aaa', 'ccc']])],
+    [EP.elementPath([['scene'], ['aaa', 'ccc']])],
     {
       ['/utopia/app.js']: transientFileState(
         [
@@ -82,6 +83,7 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
   const newSameValue: TransientCanvasState = transientCanvasState(
     [EP.elementPath([['scene'], ['aaa', 'bbb']])],
     [EP.elementPath([['scene'], ['aaa', 'ccc']])],
+    [EP.elementPath([['scene'], ['aaa', 'ccc']])],
     {
       ['/utopia/app.js']: transientFileState(
         [
@@ -105,6 +107,7 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
   )
   const newDifferentValue: TransientCanvasState = transientCanvasState(
     [EP.elementPath([['scene'], ['aaa', 'ddd']])],
+    [EP.elementPath([['scene'], ['aaa', 'ccc']])],
     [EP.elementPath([['scene'], ['aaa', 'ccc']])],
     {
       ['/utopia/app.js']: transientFileState(
@@ -156,6 +159,7 @@ describe('DerivedStateKeepDeepEquality', () => {
     transientState: transientCanvasState(
       [EP.elementPath([['scene'], ['aaa', 'bbb']])],
       [EP.elementPath([['scene'], ['aaa', 'ccc']])],
+      [EP.elementPath([['scene'], ['aaa', 'ccc']])],
       {
         ['/utopia/app.js']: transientFileState(
           [
@@ -191,6 +195,7 @@ describe('DerivedStateKeepDeepEquality', () => {
     transientState: transientCanvasState(
       [EP.elementPath([['scene'], ['aaa', 'bbb']])],
       [EP.elementPath([['scene'], ['aaa', 'ccc']])],
+      [EP.elementPath([['scene'], ['aaa', 'ccc']])],
       {
         ['/utopia/app.js']: transientFileState(
           [
@@ -225,6 +230,7 @@ describe('DerivedStateKeepDeepEquality', () => {
     controls: [],
     transientState: transientCanvasState(
       [EP.elementPath([['scene'], ['aaa', 'bbb']])],
+      [EP.elementPath([['scene'], ['aaa', 'ccc']])],
       [EP.elementPath([['scene'], ['aaa', 'ccc']])],
       {
         ['/utopia/app.js']: transientFileState(

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -471,10 +471,12 @@ export function TransientCanvasStateFilesStateKeepDeepEquality(
 }
 
 export function TransientCanvasStateKeepDeepEquality(): KeepDeepEqualityCall<TransientCanvasState> {
-  return combine4EqualityCalls(
+  return combine5EqualityCalls(
     (state) => state.selectedViews,
     ElementPathArrayKeepDeepEquality,
     (state) => state.highlightedViews,
+    ElementPathArrayKeepDeepEquality,
+    (state) => state.hoveredViews,
     ElementPathArrayKeepDeepEquality,
     (state) => state.filesState,
     nullableDeepEquality(TransientCanvasStateFilesStateKeepDeepEquality),
@@ -3383,6 +3385,10 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     oldValue.highlightedViews,
     newValue.highlightedViews,
   )
+  const hoveredViewsResult = ElementPathArrayKeepDeepEquality(
+    oldValue.highlightedViews,
+    newValue.highlightedViews,
+  )
   const hiddenInstancesResult = ElementPathArrayKeepDeepEquality(
     oldValue.hiddenInstances,
     newValue.hiddenInstances,
@@ -3591,6 +3597,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     nodeModulesResult.areEqual &&
     selectedViewsResult.areEqual &&
     highlightedViewsResult.areEqual &&
+    hoveredViewsResult.areEqual &&
     hiddenInstancesResult.areEqual &&
     displayNoneInstancesResult.areEqual &&
     warnedInstancesResult.areEqual &&
@@ -3667,6 +3674,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
       nodeModulesResult.value,
       selectedViewsResult.value,
       highlightedViewsResult.value,
+      hoveredViewsResult.value,
       hiddenInstancesResult.value,
       displayNoneInstancesResult.value,
       warnedInstancesResult.value,


### PR DESCRIPTION
## Problem
Border radius controls shouldn't render over the resize controls
Padding background can be rendered over other controls, preventing controls under them from being dragged

## Fix
- add a new editorState, `hoveredViews` that contain the views that are being hovered over
- check this in the padding/gap border radius controls, render the controls if the selected element is among the elements being hovered
- padding background: slap a `z-index: 1` on it
