### PR TITLE
Support branches not existing when querying for them.

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1176,7 +1176,7 @@ export interface GithubUser {
 }
 
 export interface GithubData {
-  branches: Array<GithubBranch>
+  branches: Array<GithubBranch> | null
   publicRepositories: Array<RepositoryEntry>
   treeConflicts: TreeConflicts
   lastUpdatedAt: number | null
@@ -1187,7 +1187,7 @@ export interface GithubData {
 
 export function emptyGithubData(): GithubData {
   return {
-    branches: [],
+    branches: null,
     publicRepositories: [],
     treeConflicts: {},
     lastUpdatedAt: null,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -3264,7 +3264,7 @@ export const RepositoryEntryKeepDeepEquality: KeepDeepEqualityCall<RepositoryEnt
     (r) => r.updatedAt,
     NullableStringKeepDeepEquality,
     (r) => r.defaultBranch,
-    NullableStringKeepDeepEquality,
+    StringKeepDeepEquality,
     (r) => r.permissions,
     RepositoryEntryPermissionsKeepDeepEquality,
     repositoryEntry,
@@ -3296,7 +3296,7 @@ export const GithubFileChangesKeepDeepEquality: KeepDeepEqualityCall<GithubFileC
 
 export const GithubDataKeepDeepEquality: KeepDeepEqualityCall<GithubData> = combine4EqualityCalls(
   (data) => data.branches,
-  arrayDeepEquality(GithubBranchKeepDeepEquality),
+  nullableDeepEquality(arrayDeepEquality(GithubBranchKeepDeepEquality)),
   (data) => data.publicRepositories,
   arrayDeepEquality(RepositoryEntryKeepDeepEquality),
   (data) => data.lastUpdatedAt,

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -76,15 +76,11 @@ const AccountBlock = () => {
 const RepositoryBlock = () => {
   const repo = useEditorState(
     (store) => store.editor.githubSettings.targetRepository,
-    'Github repo',
+    'RepositoryBlock repo',
   )
   const githubAuthenticated = useEditorState(
     (store) => store.userState.githubState.authenticated,
-    'Github authenticated',
-  )
-  const storedTargetGithubRepo = useEditorState(
-    (store) => store.editor.githubSettings.targetRepository,
-    'Github repo',
+    'RepositoryBlock authenticated',
   )
   const repoName = React.useMemo(() => githubRepoFullName(repo) || undefined, [repo])
   const hasRepo = React.useMemo(() => repo != null, [repo])
@@ -116,7 +112,7 @@ const RepositoryBlock = () => {
         </UIGridRow>
         <RepositoryListing
           githubAuthenticated={githubAuthenticated}
-          storedTargetGithubRepo={storedTargetGithubRepo}
+          storedTargetGithubRepo={repo}
         />
       </FlexColumn>
     </Block>
@@ -141,7 +137,7 @@ const BranchBlock = () => {
   }, 'GithubPane storedTargetGithubRepo')
   const branchesForRepository = useEditorState(
     (store) => store.editor.githubData.branches,
-    'Github repo branches',
+    'BranchBlock branchesForRepository',
   )
   const isLoadingBranches = React.useMemo(
     () => githubOperations.some((op) => op.name === 'listBranches'),
@@ -153,10 +149,13 @@ const BranchBlock = () => {
     }
   }, [dispatch, storedTargetGithubRepo])
 
-  const [expanded, setExpanded] = React.useState(false)
-  const toggleExpanded = React.useCallback(() => setExpanded(!expanded), [expanded])
+  const [expandedFlag, setExpandedFlag] = React.useState(false)
+  const expanded = React.useMemo(() => {
+    return expandedFlag && branchesForRepository != null
+  }, [expandedFlag, branchesForRepository])
+  const toggleExpanded = React.useCallback(() => setExpandedFlag(!expanded), [expanded])
   React.useEffect(() => {
-    setExpanded(currentBranch == null)
+    setExpandedFlag(currentBranch == null)
   }, [currentBranch])
 
   const [branchFilter, setBranchFilter] = React.useState('')
@@ -167,9 +166,13 @@ const BranchBlock = () => {
     [setBranchFilter],
   )
   const filteredBranches = React.useMemo(() => {
-    return branchesForRepository.filter(
-      (b) => branchFilter.length === 0 || b.name.includes(branchFilter),
-    )
+    if (branchesForRepository == null) {
+      return []
+    } else {
+      return branchesForRepository.filter(
+        (b) => branchFilter.length === 0 || b.name.includes(branchFilter),
+      )
+    }
   }, [branchesForRepository, branchFilter])
   const builtInDependencies = useEditorState(
     (store) => store.builtInDependencies,
@@ -227,7 +230,7 @@ const BranchBlock = () => {
                   false,
                   currentDependencies,
                   builtInDependencies,
-                ).then(() => setExpanded(false))
+                ).then(() => setExpandedFlag(false))
               }
             }
             const loadingThisBranch = isGithubLoadingBranch(
@@ -278,7 +281,7 @@ const BranchBlock = () => {
     refreshBranches,
     branchFilter,
     updateBranchFilter,
-    setExpanded,
+    setExpandedFlag,
     filteredBranches,
     builtInDependencies,
     currentDependencies,

--- a/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
@@ -228,7 +228,7 @@ export const RepositoryListing = React.memo(
               private: true,
               description: null,
               updatedAt: null,
-              defaultBranch: null,
+              defaultBranch: 'main',
               importPermitted: false,
               permissions: {
                 admin: false,

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -106,10 +106,14 @@ export interface GetBranchesSuccess {
 
 export type GetBranchesResponse = GetBranchesSuccess | GithubFailure
 
-export interface GetBranchContentSuccess {
-  type: 'SUCCESS'
+export interface BranchContent {
   content: ProjectContentTreeRoot
   originCommit: string
+}
+
+export interface GetBranchContentSuccess {
+  type: 'SUCCESS'
+  branch: BranchContent | null
 }
 
 export type GetBranchContentResponse = GetBranchContentSuccess | GithubFailure
@@ -138,7 +142,7 @@ export interface RepositoryEntry {
   private: boolean
   description: string | null
   updatedAt: string | null
-  defaultBranch: string | null
+  defaultBranch: string
   permissions: RepositoryEntryPermissions
 }
 
@@ -148,7 +152,7 @@ export function repositoryEntry(
   fullName: string,
   description: string | null,
   updatedAt: string | null,
-  defaultBranch: string | null,
+  defaultBranch: string,
   permissions: RepositoryEntryPermissions,
 ): RepositoryEntry {
   return {
@@ -437,23 +441,35 @@ export async function updateProjectAgainstGithub(
     }
 
     if (branchLatestContent.type === 'SUCCESS') {
-      if (specificCommitContent.type === 'SUCCESS') {
-        dispatch(
-          [
-            updateGithubChecksums(getProjectContentsChecksums(branchLatestContent.content)),
-            updateBranchContents(branchLatestContent.content),
-            updateAgainstGithub(
-              branchLatestContent.content,
-              specificCommitContent.content,
-              branchLatestContent.originCommit,
-            ),
-            updateGithubData({ upstreamChanges: null }),
-            showToast(notice(`Updated the project against the branch ${branchName}.`, 'SUCCESS')),
-          ],
-          'everyone',
-        )
+      if (branchLatestContent.branch == null) {
+        failWithReason(`Could not find latest code for branch ${branchName}`)
       } else {
-        failWithReason(specificCommitContent.failureReason)
+        if (specificCommitContent.type === 'SUCCESS') {
+          if (specificCommitContent.branch == null) {
+            failWithReason(`Could not find commit ${commitSha} for branch ${branchName}`)
+          } else {
+            dispatch(
+              [
+                updateGithubChecksums(
+                  getProjectContentsChecksums(branchLatestContent.branch.content),
+                ),
+                updateBranchContents(branchLatestContent.branch.content),
+                updateAgainstGithub(
+                  branchLatestContent.branch.content,
+                  specificCommitContent.branch.content,
+                  branchLatestContent.branch.originCommit,
+                ),
+                updateGithubData({ upstreamChanges: null }),
+                showToast(
+                  notice(`Updated the project against the branch ${branchName}.`, 'SUCCESS'),
+                ),
+              ],
+              'everyone',
+            )
+          }
+        } else {
+          failWithReason(specificCommitContent.failureReason)
+        }
       }
     } else {
       failWithReason(branchLatestContent.failureReason)
@@ -504,42 +520,48 @@ export async function updateProjectWithBranchContent(
         )
         break
       case 'SUCCESS':
-        const newGithubData: Partial<GithubData> = {
-          upstreamChanges: null,
-        }
-        if (resetBranches) {
-          newGithubData.branches = []
-        }
+        if (responseBody.branch == null) {
+          dispatch([showToast(notice(`Could not find branch ${branchName}.`, 'ERROR'))], 'everyone')
+        } else {
+          const newGithubData: Partial<GithubData> = {
+            upstreamChanges: null,
+          }
+          if (resetBranches) {
+            newGithubData.branches = null
+          }
 
-        const packageJson = packageJsonFileFromProjectContents(responseBody.content)
-        if (packageJson != null && isTextFile(packageJson)) {
-          await refreshDependencies(
-            dispatch,
-            packageJson.fileContents.code,
-            currentDeps,
-            builtInDependencies,
-            {},
+          const packageJson = packageJsonFileFromProjectContents(responseBody.branch.content)
+          if (packageJson != null && isTextFile(packageJson)) {
+            await refreshDependencies(
+              dispatch,
+              packageJson.fileContents.code,
+              currentDeps,
+              builtInDependencies,
+              {},
+            )
+          }
+
+          dispatch(
+            [
+              updateGithubChecksums(getProjectContentsChecksums(responseBody.branch.content)),
+              updateProjectContents(responseBody.branch.content),
+              updateBranchContents(responseBody.branch.content),
+              updateGithubSettings(
+                projectGithubSettings(
+                  githubRepo,
+                  responseBody.branch.originCommit,
+                  branchName,
+                  responseBody.branch.originCommit,
+                ),
+              ),
+              updateGithubData(newGithubData),
+              showToast(
+                notice(`Updated the project with the content from ${branchName}`, 'SUCCESS'),
+              ),
+            ],
+            'everyone',
           )
         }
-
-        dispatch(
-          [
-            updateGithubChecksums(getProjectContentsChecksums(responseBody.content)),
-            updateProjectContents(responseBody.content),
-            updateBranchContents(responseBody.content),
-            updateGithubSettings(
-              projectGithubSettings(
-                githubRepo,
-                responseBody.originCommit,
-                branchName,
-                responseBody.originCommit,
-              ),
-            ),
-            updateGithubData(newGithubData),
-            showToast(notice(`Updated the project with the content from ${branchName}`, 'SUCCESS')),
-          ],
-          'everyone',
-        )
         break
       default:
         const _exhaustiveCheck: never = responseBody
@@ -1142,9 +1164,11 @@ export async function refreshGithubData(
         const branchContentResponse = await getBranchContentFromServer(githubRepo, branchName, null)
         if (branchContentResponse.ok) {
           const branchLatestContent: GetBranchContentResponse = await branchContentResponse.json()
-          if (branchLatestContent.type === 'SUCCESS') {
+          if (branchLatestContent.type === 'SUCCESS' && branchLatestContent.branch != null) {
             upstreamChangesSuccess = true
-            const upstreamChecksums = getProjectContentsChecksums(branchLatestContent.content)
+            const upstreamChecksums = getProjectContentsChecksums(
+              branchLatestContent.branch.content,
+            )
             const upstreamChanges = deriveGithubFileChanges(branchChecksums, upstreamChecksums, {})
             dispatch([updateGithubData({ upstreamChanges: upstreamChanges })], 'everyone')
           }
@@ -1154,7 +1178,7 @@ export async function refreshGithubData(
         dispatch([updateGithubData({ upstreamChanges: null })], 'everyone')
       }
     } else {
-      dispatch([updateGithubData({ branches: [] })], 'everyone')
+      dispatch([updateGithubData({ branches: null })], 'everyone')
     }
   } else {
     dispatch([updateGithubData(emptyGithubData())], 'everyone')


### PR DESCRIPTION
**Problem:**
If a repository is completely empty, then querying the endpoint for the branches of a repository will return the default branch. However if an attempt is made to retrieve that branch then the Github API will return a 404.

**Fix:**
The function in the server for getting a branch now returns a `Nothing` for the case when the branch could not be found. The remaining changes flow from there, like retrieving the branch content will return a `null` in the place of a newly wrapped `BranchContent` value. There are also some changes in the frontend to distinguish between zero branches returned and the branches have not been retrieved.

**Commit Details:**
- Changed `GetBranchContentSuccess` to hold an optional case of `BranchContent`.
- Made `RepositoryEntry.defaultBranch` be non-optional.
- Modified `getGithubBranches` to handle `getBranch` returning a `Nothing`.
- `GithubData.branches` can now be `null`.
- In `RepositoryListing`, default the `defaultBranch` value to `main`.
- `callGithub` slightly tweaked so that the error case handler can return a value as well as record error cases.