### PR TITLE
early return in canvas drag events if live mode is active

### DIFF
--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -892,6 +892,10 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
         },
 
         onDragOver: (event) => {
+          if (this.props.editor.mode.type === 'live') {
+            return
+          }
+
           event.preventDefault()
 
           if (this.props.editor.canvas.interactionSession != null) {
@@ -958,6 +962,9 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
         },
 
         onDragLeave: () => {
+          if (this.props.editor.mode.type === 'live') {
+            return
+          }
           this.props.dispatch([
             CanvasActions.clearInteractionSession(false),
             EditorActions.switchEditorMode(EditorModes.selectMode(null)),


### PR DESCRIPTION
Fixes #[ticket_number]

## Problem:
When dragging an element in live mode, select mode kicked in

## Fix:
Check the editor mode in canvas drag event handlers, and do nothing if live mode is active