### PR TITLE
Cleanup/bars and borders

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
@@ -2219,7 +2219,7 @@ describe('Reparent indicators', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     // Check the indicator presence and position.
-    await checkReparentIndicator(renderResult, 388, 645, 2, 123)
+    await checkReparentIndicator(renderResult, 388, 610, 2, 123)
   })
 
   it(`shows the reparent indicator before all the elements in a 'row-reverse' container`, async () => {
@@ -2255,7 +2255,7 @@ describe('Reparent indicators', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     // Check the indicator presence and position.
-    await checkReparentIndicator(renderResult, 788, 645, 2, 123)
+    await checkReparentIndicator(renderResult, 788, 610, 2, 123)
   })
 
   it(`shows the reparent indicator between two elements in a 'row' container`, async () => {
@@ -2291,7 +2291,7 @@ describe('Reparent indicators', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     // Check the indicator presence and position.
-    await checkReparentIndicator(renderResult, 522, 645, 2, 123)
+    await checkReparentIndicator(renderResult, 522, 610, 2, 123)
   })
 
   it(`shows the reparent indicator between two elements in a 'row-reverse' container`, async () => {
@@ -2327,7 +2327,7 @@ describe('Reparent indicators', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     // Check the indicator presence and position.
-    await checkReparentIndicator(renderResult, 654, 645, 2, 123)
+    await checkReparentIndicator(renderResult, 654, 610, 2, 123)
   })
   it(`shows the reparent indicator between the parent and the first element in a 'row' container with absolute siblings`, async () => {
     const renderResult = await renderTestEditorWithCode(
@@ -2371,7 +2371,7 @@ describe('Reparent indicators', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     // Check the indicator presence and position.
-    await checkReparentIndicator(renderResult, 388, 145, 2, 40)
+    await checkReparentIndicator(renderResult, 388, 110, 2, 40)
   })
   it(`shows the reparent indicator between the parent and the last element in a 'row' container with absolute siblings`, async () => {
     const renderResult = await renderTestEditorWithCode(
@@ -2415,7 +2415,7 @@ describe('Reparent indicators', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     // Check the indicator presence and position.
-    await checkReparentIndicator(renderResult, 438, 145, 2, 40)
+    await checkReparentIndicator(renderResult, 438, 110, 2, 40)
   })
   it(`shows the reparent indicator between the parent and the first element in a 'row-reverse' container with absolute siblings`, async () => {
     const renderResult = await renderTestEditorWithCode(
@@ -2459,6 +2459,6 @@ describe('Reparent indicators', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     // Check the indicator presence and position.
-    await checkReparentIndicator(renderResult, 788, 145, 2, 40)
+    await checkReparentIndicator(renderResult, 788, 110, 2, 40)
   })
 })

--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -34,6 +34,7 @@ import { when } from '../../utils/react-conditionals'
 import { isFeatureEnabled } from '../../utils/feature-switches'
 import { StrategyIndicator } from './controls/select-mode/strategy-indicator'
 import { CanvasToolbar } from '../editor/canvas-toolbar'
+import { TopMenu } from '../editor/top-menu'
 
 export function filterOldPasses(errorMessages: Array<ErrorMessage>): Array<ErrorMessage> {
   let passTimes: { [key: string]: number } = {}
@@ -124,8 +125,11 @@ export const CanvasWrapperComponent = React.memo(() => {
             alignSelf: 'stretch',
             flexGrow: 1,
             position: 'relative',
+            alignItems: 'flex-start',
+            justifyContent: 'flex-start',
           }}
         >
+          <TopMenu />
           {when(isFeatureEnabled('Canvas Strategies'), <CanvasStrategyPicker />)}
           <StrategyIndicator />
           <CanvasToolbar />

--- a/editor/src/components/canvas/controls/formula-bar.tsx
+++ b/editor/src/components/canvas/controls/formula-bar.tsx
@@ -3,19 +3,10 @@
 import React from 'react'
 import { jsx } from '@emotion/react'
 import * as EditorActions from '../../editor/actions/action-creators'
-import { useColorTheme, SimpleFlexRow, UtopiaTheme, HeadlessStringInput } from '../../../uuiui'
+import { useColorTheme, SimpleFlexRow, HeadlessStringInput } from '../../../uuiui'
 import { useEditorState, useRefEditorState } from '../../editor/store/store-hook'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { isRight } from '../../../core/shared/either'
-import {
-  isJSXArbitraryBlock,
-  isJSXElement,
-  isJSXTextBlock,
-} from '../../../core/shared/element-template'
-import { optionalMap } from '../../../core/shared/optional-utils'
-import { ModeToggleButton } from './mode-toggle-button'
-import { ClassNameSelect } from './classname-select'
-import { isFeatureEnabled } from '../../../utils/feature-switches'
+
 import {
   applyShortcutConfigurationToDefaults,
   handleShortcuts,
@@ -145,15 +136,15 @@ export const FormulaBar = React.memo<FormulaBarProps>((props) => {
         paddingRight: 4,
         gap: 4,
         borderRadius: 4,
-        backgroundColor: colorTheme.inverted.bg2.value,
-        color: colorTheme.inverted.fg1.value,
+        backgroundColor: colorTheme.bg1.value,
+        color: colorTheme.border1.value,
         cursor: 'pointer',
         border: '1px solid transparent',
         '&:hover': {
           outline: 'none',
         },
         '&:focus-within': {
-          background: colorTheme.inverted.bg1.value,
+          background: colorTheme.bg1.value,
         },
       }}
       onKeyDown={onKeyDown}
@@ -162,7 +153,7 @@ export const FormulaBar = React.memo<FormulaBarProps>((props) => {
         <HeadlessStringInput
           ref={inputRef}
           type='text'
-          placeholder={disabled ? '(Unavailable)' : '(empty)'}
+          placeholder=''
           css={{
             paddingLeft: 4,
             paddingRight: 4,

--- a/editor/src/components/canvas/controls/formula-bar.tsx
+++ b/editor/src/components/canvas/controls/formula-bar.tsx
@@ -138,7 +138,6 @@ export const FormulaBar = React.memo<FormulaBarProps>((props) => {
         borderRadius: 4,
         backgroundColor: colorTheme.bg1.value,
         color: colorTheme.border1.value,
-        cursor: 'pointer',
         border: '1px solid transparent',
         '&:hover': {
           outline: 'none',

--- a/editor/src/components/canvas/controls/insertion-plus-button.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.spec.browser2.tsx
@@ -279,9 +279,9 @@ describe('Insertion Plus Button', () => {
       expect(bounds.top).toEqual(expectedTop)
     }
 
-    await checkInsertButtonPosition('blue-dot-control-0', 385.5, 631.5)
-    await checkInsertButtonPosition('blue-dot-control-1', 519.5, 631.5)
-    await checkInsertButtonPosition('blue-dot-control-2', 712.5, 631.5)
+    await checkInsertButtonPosition('blue-dot-control-0', 385.5, 596.5)
+    await checkInsertButtonPosition('blue-dot-control-1', 519.5, 596.5)
+    await checkInsertButtonPosition('blue-dot-control-2', 712.5, 596.5)
   })
 
   it(`shows the buttons in the correct places for a flex container with a direction of 'row-reverse' that already has children`, async () => {
@@ -305,9 +305,9 @@ describe('Insertion Plus Button', () => {
       expect(bounds.top).toEqual(expectedTop)
     }
 
-    await checkInsertButtonPosition('blue-dot-control-0', 785.5, 631.5)
-    await checkInsertButtonPosition('blue-dot-control-1', 651.5, 631.5)
-    await checkInsertButtonPosition('blue-dot-control-2', 458.5, 631.5)
+    await checkInsertButtonPosition('blue-dot-control-0', 785.5, 596.5)
+    await checkInsertButtonPosition('blue-dot-control-1', 651.5, 596.5)
+    await checkInsertButtonPosition('blue-dot-control-2', 458.5, 596.5)
   })
 
   it(`shows the buttons in the correct places for a flex container with a direction of 'column' that already has children`, async () => {
@@ -331,9 +331,9 @@ describe('Insertion Plus Button', () => {
       expect(bounds.top).toEqual(expectedTop)
     }
 
-    await checkInsertButtonPosition('blue-dot-control-0', 375.5, 641.5)
-    await checkInsertButtonPosition('blue-dot-control-1', 375.5, 741.5)
-    await checkInsertButtonPosition('blue-dot-control-2', 375.5, 841.5)
+    await checkInsertButtonPosition('blue-dot-control-0', 375.5, 606.5)
+    await checkInsertButtonPosition('blue-dot-control-1', 375.5, 706.5)
+    await checkInsertButtonPosition('blue-dot-control-2', 375.5, 806.5)
   })
 
   it(`shows the buttons in the correct places for a flex container with a direction of 'column-reverse' that already has children`, async () => {
@@ -357,9 +357,9 @@ describe('Insertion Plus Button', () => {
       expect(bounds.top).toEqual(expectedTop)
     }
 
-    await checkInsertButtonPosition('blue-dot-control-0', 375.5, 841.5)
-    await checkInsertButtonPosition('blue-dot-control-1', 375.5, 741.5)
-    await checkInsertButtonPosition('blue-dot-control-2', 375.5, 641.5)
+    await checkInsertButtonPosition('blue-dot-control-0', 375.5, 806.5)
+    await checkInsertButtonPosition('blue-dot-control-1', 375.5, 706.5)
+    await checkInsertButtonPosition('blue-dot-control-2', 375.5, 606.5)
   })
 
   it('shows the buttons in the correct places for a flex container that has no children', async () => {
@@ -383,6 +383,6 @@ describe('Insertion Plus Button', () => {
       expect(bounds.top).toEqual(expectedTop)
     }
 
-    await checkInsertButtonPosition('blue-dot-control-0', 385.5, 631.5)
+    await checkInsertButtonPosition('blue-dot-control-0', 385.5, 596.5)
   })
 })

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -27,7 +27,7 @@ import {
   LargerIcons,
   ResizableFlexColumn,
 } from '../../uuiui'
-import { TopMenu } from '../editor/top-menu'
+
 import { ConsoleAndErrorsPane } from '../code-editor/console-and-errors-pane'
 import { FloatingInsertMenu } from './ui/floating-insert-menu'
 import { usePubSubAtom } from '../../core/shared/atom-with-pub-sub'
@@ -289,29 +289,17 @@ const DesignPanelRootInner = React.memo(() => {
               position: 'relative',
             }}
           >
-            <SimpleFlexRow
-              className='topMenu'
-              style={{
-                minHeight: TopMenuHeight,
-                height: TopMenuHeight,
-                borderBottom: `1px solid ${colorTheme.border0.value}`,
-                alignItems: 'stretch',
-                justifyContent: 'stretch',
-                backgroundColor: 'transparent',
-              }}
-            >
-              <TopMenu />
-            </SimpleFlexRow>
-
             {isCanvasVisible && navigatorVisible ? (
               <div
                 style={{
-                  height: `calc(100% - ${TopMenuHeight}px)`,
+                  height: '100%',
                   position: 'absolute',
-                  top: TopMenuHeight,
+                  top: 0,
                   left: 0,
                   zIndex: 20,
                   overflow: 'hidden',
+                  borderLeft: `1px solid ${colorTheme.subduedBorder.value}`,
+                  borderRight: `1px solid ${colorTheme.subduedBorder.value}`,
                 }}
               >
                 <ResizableFlexColumn
@@ -330,6 +318,7 @@ const DesignPanelRootInner = React.memo(() => {
                 </ResizableFlexColumn>
               </div>
             ) : null}
+
             <CanvasWrapperComponent />
             <FloatingInsertMenu />
           </SimpleFlexColumn>

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -137,8 +137,8 @@ export const CanvasToolbar = React.memo(() => {
     <FlexColumn
       style={{
         position: 'absolute',
-        top: 8,
-        left: 8,
+        top: 48,
+        left: 12,
         alignItems: 'stretch',
         width: 64,
         borderRadius: 4,

--- a/editor/src/components/editor/top-menu.tsx
+++ b/editor/src/components/editor/top-menu.tsx
@@ -20,6 +20,7 @@ import { RightMenuTab, NavigatorWidthAtom } from './store/editor-state'
 import { CanvasVector } from '../../core/shared/math-utils'
 import { AlwaysTrue, usePubSubAtomReadOnly } from '../../core/shared/atom-with-pub-sub'
 import { toString } from '../../core/shared/element-path'
+import { stopPropagation } from '../inspector/common/inspector-utils'
 
 const TopMenuLeftControls = React.memo(() => {
   const dispatch = useEditorState((store) => store.dispatch, 'TopMenuLeftControls dispatch')
@@ -120,7 +121,11 @@ export const TopMenu = React.memo(() => {
         height: UtopiaTheme.layout.rowHeight.normal,
         background: colorTheme.bg1.value,
         borderBottom: `1px solid ${colorTheme.subduedBorder.value}`,
+        pointerEvents: 'initial',
       }}
+      onMouseDown={stopPropagation}
+      onMouseUp={stopPropagation}
+      onClick={stopPropagation}
     >
       <TopMenuLeftControls />
       <FlexRow style={{ border: 1, flexGrow: 1 }}>

--- a/editor/src/components/editor/top-menu.tsx
+++ b/editor/src/components/editor/top-menu.tsx
@@ -118,6 +118,7 @@ export const TopMenu = React.memo(() => {
         paddingLeft: 8,
         paddingRight: 4,
         height: UtopiaTheme.layout.rowHeight.normal,
+        background: colorTheme.bg1.value,
         borderBottom: `1px solid ${colorTheme.subduedBorder.value}`,
       }}
     >

--- a/editor/src/components/editor/top-menu.tsx
+++ b/editor/src/components/editor/top-menu.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import {
+  colorTheme,
   FlexRow,
   LargerIcons,
   MenuIcons,
   SimpleFlexRow,
   SquareButton,
   Tooltip,
-  UNSAFE_getIconURL,
   UtopiaTheme,
 } from '../../uuiui'
 import { useEditorState } from './store/store-hook'
@@ -16,24 +16,10 @@ import { FormulaBar } from '../canvas/controls/formula-bar'
 import CanvasActions from '../canvas/canvas-actions'
 import { EditorAction } from './action-types'
 import { ComponentOrInstanceIndicator } from '../editor/component-button'
-import { IconToggleButton } from '../../uuiui/icon-toggle-button'
-import { LeftPaneDefaultWidth, RightMenuTab, NavigatorWidthAtom } from './store/editor-state'
+import { RightMenuTab, NavigatorWidthAtom } from './store/editor-state'
 import { CanvasVector } from '../../core/shared/math-utils'
 import { AlwaysTrue, usePubSubAtomReadOnly } from '../../core/shared/atom-with-pub-sub'
-import { EditorModes } from './editor-modes'
 import { toString } from '../../core/shared/element-path'
-
-function useShouldResetCanvas(invalidateCount: number): [boolean, (value: boolean) => void] {
-  const [shouldResetCanvas, setShouldResetCanvas] = React.useState(false)
-  const previousCanvasContentInvalidateCount = React.useRef(invalidateCount)
-
-  if (previousCanvasContentInvalidateCount.current !== invalidateCount) {
-    setShouldResetCanvas(true)
-    previousCanvasContentInvalidateCount.current = invalidateCount
-  }
-
-  return [shouldResetCanvas, setShouldResetCanvas]
-}
 
 const TopMenuLeftControls = React.memo(() => {
   const dispatch = useEditorState((store) => store.dispatch, 'TopMenuLeftControls dispatch')
@@ -54,14 +40,6 @@ const TopMenuLeftControls = React.memo(() => {
     dispatch(actions)
   }, [dispatch, navigatorVisible, navigatorWidth])
 
-  const followSelection = useEditorState(
-    (store) => store.editor.config.followSelection,
-    'TopMenu followSelection',
-  )
-  const onToggleFollow = React.useCallback(() => {
-    dispatch([EditorActions.setFollowSelectionEnabled(!followSelection.enabled)])
-  }, [dispatch, followSelection])
-
   return (
     <React.Fragment>
       <Tooltip title={'Toggle outline'} placement={'bottom'}>
@@ -69,55 +47,13 @@ const TopMenuLeftControls = React.memo(() => {
           <MenuIcons.Navigator />
         </SquareButton>
       </Tooltip>
-      <Tooltip title='Mirror selection between canvas and code editor' placement='bottom'>
-        <IconToggleButton
-          onToggle={onToggleFollow}
-          value={followSelection.enabled}
-          srcOn={UNSAFE_getIconURL('bracketed-pointer', 'blue', 'semantic', 18, 18)}
-          srcOff={UNSAFE_getIconURL('bracketed-pointer', 'darkgray', 'semantic', 18, 18)}
-        />
-      </Tooltip>
-      <ComponentOrInstanceIndicator />
     </React.Fragment>
   )
 })
 
 const TopMenuRightControls = React.memo(() => {
   const dispatch = useEditorState((store) => store.dispatch, 'TopMenuRightControls dispatch')
-  const canvasContentInvalidateCount = useEditorState(
-    (store) => store.editor.canvas.canvasContentInvalidateCount,
-    'RightMenu canvasContentInvalidateCount',
-  )
-
   const zoomLevel = useEditorState((store) => store.editor.canvas.scale, 'RightMenu zoomLevel')
-  const zoomIn = React.useCallback(
-    () => dispatch([CanvasActions.zoom(Utils.increaseScale(zoomLevel))]),
-    [dispatch, zoomLevel],
-  )
-  const zoomOut = React.useCallback(
-    () => dispatch([CanvasActions.zoom(Utils.decreaseScale(zoomLevel))]),
-    [dispatch, zoomLevel],
-  )
-  const [shouldResetCanvas, setShouldResetCanvas] = useShouldResetCanvas(
-    canvasContentInvalidateCount,
-  )
-  const resetCanvas = React.useCallback(() => {
-    dispatch([EditorActions.resetCanvas()])
-    setShouldResetCanvas(false)
-  }, [dispatch, setShouldResetCanvas])
-
-  const isLiveMode = useEditorState(
-    (store) => store.editor.mode.type === 'live',
-    'TopMenu isLiveMode',
-  )
-  const toggleLiveMode = React.useCallback(() => {
-    if (isLiveMode) {
-      dispatch([EditorActions.switchEditorMode(EditorModes.selectMode())])
-    } else {
-      dispatch([EditorActions.switchEditorMode(EditorModes.liveMode())])
-    }
-  }, [dispatch, isLiveMode])
-
   const zoom100pct = React.useCallback(() => dispatch([CanvasActions.zoom(1)]), [dispatch])
 
   const rightMenuSelectedTab = useEditorState(
@@ -125,7 +61,6 @@ const TopMenuRightControls = React.memo(() => {
     'RightMenu rightMenuSelectedTab',
   )
 
-  const isInsertMenuSelected = rightMenuSelectedTab === RightMenuTab.Insert
   const isInspectorSelected = rightMenuSelectedTab === RightMenuTab.Inspector
 
   const onShow = React.useCallback(
@@ -140,10 +75,6 @@ const TopMenuRightControls = React.memo(() => {
     [dispatch, rightMenuSelectedTab],
   )
 
-  const onShowInsertTab = React.useCallback(() => {
-    onShow(RightMenuTab.Insert)
-  }, [onShow])
-
   const onShowInspectorTab = React.useCallback(() => {
     dispatch([EditorActions.togglePanel('rightmenu')])
 
@@ -153,13 +84,6 @@ const TopMenuRightControls = React.memo(() => {
   return (
     <React.Fragment>
       <FlexRow>
-        <Tooltip title='Zoom out' placement='left'>
-          <span>
-            <SquareButton highlight onClick={zoomOut}>
-              <LargerIcons.MagnifyingGlassMinus />
-            </SquareButton>
-          </span>
-        </Tooltip>
         <SquareButton
           highlight
           style={{ fontSize: 9, textAlign: 'center', width: 32 }}
@@ -167,37 +91,7 @@ const TopMenuRightControls = React.memo(() => {
         >
           {zoomLevel}x
         </SquareButton>
-        <Tooltip title='Zoom in' placement='left'>
-          <span>
-            <SquareButton highlight onClick={zoomIn}>
-              <LargerIcons.MagnifyingGlassPlus />
-            </SquareButton>
-          </span>
-        </Tooltip>
       </FlexRow>
-      <Tooltip title='Reset canvas' placement='left'>
-        <span>
-          <SquareButton highlight onClick={resetCanvas}>
-            <LargerIcons.Refresh />
-          </SquareButton>
-        </span>
-      </Tooltip>
-      <Tooltip title='Toggle between Live and Edit mode' placement='left'>
-        <IconToggleButton
-          onToggle={toggleLiveMode}
-          value={isLiveMode}
-          srcOn={UNSAFE_getIconURL('playbutton-larger', 'blue', 'semantic', 18, 18)}
-          srcOff={UNSAFE_getIconURL('playbutton-larger', 'darkgray', 'semantic', 18, 18)}
-        />
-      </Tooltip>
-
-      <Tooltip title={'Insert'} placement='left'>
-        <span>
-          <SquareButton highlight onClick={onShowInsertTab}>
-            <LargerIcons.PlusButton color={isInsertMenuSelected ? 'primary' : 'main'} />
-          </SquareButton>
-        </span>
-      </Tooltip>
 
       <Tooltip title={'Inspector'} placement='left'>
         <span>
@@ -219,11 +113,12 @@ export const TopMenu = React.memo(() => {
   return (
     <SimpleFlexRow
       style={{
-        flexGrow: 1,
+        width: '100%',
         gap: 12,
         paddingLeft: 8,
         paddingRight: 4,
         height: UtopiaTheme.layout.rowHeight.normal,
+        borderBottom: `1px solid ${colorTheme.subduedBorder.value}`,
       }}
     >
       <TopMenuLeftControls />

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -69,7 +69,8 @@ const TitleBar = React.memo(() => {
     <SimpleFlexRow
       style={{
         backgroundColor: colorTheme.bg0.value,
-        padding: '0 10px 0 10px',
+        borderBottom: `1px solid ${colorTheme.subduedBorder.value}`,
+        padding: 0,
         flexGrow: 0,
         height: 40,
         fontWeight: 600,
@@ -78,7 +79,7 @@ const TitleBar = React.memo(() => {
         justifyContent: 'space-between',
       }}
     >
-      <div style={{ display: 'flex', height: '100%', alignItems: 'center' }}>
+      <div style={{ display: 'flex', height: '100%', alignItems: 'center', paddingLeft: 10 }}>
         <AppLogo onClick={toggleLeftPanel} />
         {loggedIn ? (
           <>
@@ -108,7 +109,7 @@ const TitleBar = React.memo(() => {
       </div>
 
       <div style={{ display: 'flex', height: '100%' }}>
-        <div style={{ display: 'flex', alignItems: 'center' }}>
+        <div style={{ display: 'flex', alignItems: 'center', paddingRight: 24 }}>
           <TestMenu />
         </div>
         {/* <TextButton onClick={exportToGithub}>Fork</TextButton> */}

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`408`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`410`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`397`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`399`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`672`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`663`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`744`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`735`)
   })
 })


### PR DESCRIPTION
**Problem:**
- With the new toolbar especially, we started duplicating a bunch of functionality, which added clutter to the editor
- We have more panels in the editor that sometimes didn't use borders to subdivide from each other
- the formula bar wants a lot of attention, but in its current incarnation doesn't merit it

**Fix:**
- Moved things about
- Slimmed down the topmenu (but didn't rename it) and moved it into the canvas root
- tidied up some spacing and added borders where there used to be
- gave the formula bar a very light look, and removed the distracting placeholder text (however: it has issues).

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/2945037/202872434-f4b0b4ec-eec4-477b-b827-4e0a7d864c9b.png">


(It's a draft PR because the omnibar passes clicks through, but I subsequently realised _all_ of our on-canvas menus do that - including the toolbar)
