### PR TITLE
Canvas Performance Quick Fix

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -358,7 +358,9 @@ export const UiJsxCanvas = React.memo<UiJsxCanvasPropsWithErrorCallback>((props)
   const cssImports = useKeepReferenceEqualityIfPossible(
     normalizedCssImportsFromImports(uiFilePath, imports),
   )
-  unimportAllButTheseCSSFiles(cssImports) // TODO this needs to support more than just the storyboard file!!!!!
+  if (props.elementsToRerender === 'rerender-all-elements') {
+    unimportAllButTheseCSSFiles(cssImports) // TODO this needs to support more than just the storyboard file!!!!!
+  }
 
   let mutableContextRef = React.useRef<MutableUtopiaCtxRefData>({})
 


### PR DESCRIPTION
**Problem:**
ui-jsx-canvas has a broken line of code:
```typescript
unimportAllButTheseCSSFiles(cssImports) // TODO this needs to support more than just the storyboard file!!!!!
```
Every single frame, this call removes all css stylesheets coming from source files that are not storyboard.js. Then every single frame, the css importer will re-add these stylesheets. Because we append these style sheets globally, and the canvas is not a shadow root or iframe, these re-appended stylesheets then cause a gigantic re-layouting of all the user's canvas content, and also all of Utopia's UI. 

**The Real Fix Would Be:**
We should fix the TODO and only call unimportAllButTheseCSSFiles for css files that are really unimported across the project, not just use storyboard.js as the source of truth here.

**The Quick Fix:**
The canvas already has a selective re-render flag for interactions, if the selective re-render is enabled, we shouldn't -ever- call `unimportAllButTheseCSSFiles` anyways, because we know the user is doing an interaction on the canvas, and definitely not updating css source code in VSCode. (CSS unimporting doesn't need to happen on a frame-by-frame basis anyways, it can be a polling update)

**Commit Details:**
- Only call (the still broken) unimportAllButTheseCSSFiles when we are in 'rerender-all-elements' mode
