### PR TITLE
Fix/reorder indicator

### DIFF
--- a/editor/src/components/canvas/controls/reorder-slider-control.tsx
+++ b/editor/src/components/canvas/controls/reorder-slider-control.tsx
@@ -263,7 +263,7 @@ const ReorderControl = React.memo(({ controlPosition }: { controlPosition: Canva
           boxShadow: `0px ${1 / scale}px ${2 / scale}px 0px ${
             colorTheme.canvasControlReorderSliderBoxShadowPrimary.value
           }, 0px 0px 0px ${0.5 / scale}px ${
-            colorTheme.canvasControlReorderSliderBoxShadowSecondary
+            colorTheme.canvasControlReorderSliderBoxShadowSecondary.value
           }`,
         }}
       ></div>

--- a/editor/src/templates/index.html
+++ b/editor/src/templates/index.html
@@ -150,7 +150,6 @@
             flex-direction: column;
             align-items: center;
             justify-content: center;
-            border: 1px solid beige;
           "
         >
           <img

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -123,7 +123,7 @@ export const light = {
   canvasControlsSizeBoxShadowColor: createUtopiColor('black'),
   canvasControlsSizeBoxBorder: createUtopiColor('hsl(0,0%,15%)'),
   canvasControlReorderSliderBoxShadowPrimary: createUtopiColor('rgba(52,52,52,0.35)'),
-  canvasControlReorderSliderBoxShadowSecondary: createUtopiColor('rgba(166,166,166,0.82)'),
+  canvasControlReorderSliderBoxShadowSecondary: createUtopiColor('hsl(0,0%,0%,0.5)'),
   canvasControlsCoordinateSystemMarks: base.neonpink,
   canvasControlsImmediateParentMarks: createUtopiColor('rgba(0, 0, 0, 0.25)'),
   canvasControlsInlineIndicatorInactive: createUtopiColor('rgba(179,215,255,1)'),


### PR DESCRIPTION
**Problem:**
Our reorder indicator is really hard to see, because Chrome still isn't capable of interpreting `object Object`
Bonus problem: had a beige border on our loading screen that was noticeable in our dark theme load

**Fix:**
Render the shadow and tweak the value
Bonus fix: remove the beige border

<img width="85" alt="image" src="https://user-images.githubusercontent.com/2945037/202921056-22f1c22d-fcb8-40eb-b280-56f838b4eb49.png">