### PR TITLE
feature(canvas) pressing space during an interaction is the escape hatch

### DIFF
--- a/editor/src/components/canvas/canvas-panning.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-panning.spec.browser2.tsx
@@ -40,7 +40,7 @@ describe(`pan while 'space' is held down`, () => {
     expect(endingCanvasPosition.x - startingCanvasPosition.x).toEqual(100)
     expect(endingCanvasPosition.y - startingCanvasPosition.y).toEqual(100)
   })
-  it(`start drag first`, async () => {
+  it(`start drag first, the drag interaction is still active`, async () => {
     const renderResult = await createExampleProject()
     const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
     const controlsBounds = canvasControlsLayer.getBoundingClientRect()
@@ -67,7 +67,10 @@ describe(`pan while 'space' is held down`, () => {
     )
 
     const endingCanvasPosition = renderResult.getEditorState().editor.canvas.roundedCanvasOffset
-    expect(endingCanvasPosition.x - startingCanvasPosition.x).toEqual(100)
-    expect(endingCanvasPosition.y - startingCanvasPosition.y).toEqual(100)
+    expect(endingCanvasPosition.x - startingCanvasPosition.x).toEqual(0)
+    expect(endingCanvasPosition.y - startingCanvasPosition.y).toEqual(0)
+
+    const interactionSession = renderResult.getEditorState().editor.canvas.interactionSession
+    expect(interactionSession).toBeDefined()
   })
 })

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -35,6 +35,7 @@ export interface DragInteractionData {
   globalTime: number
   hasMouseMoved: boolean
   _accumulatedMovement: CanvasVector
+  spacePressed: boolean
 }
 
 export interface HoverInteractionData {
@@ -176,6 +177,7 @@ export function createInteractionViaMouse(
       globalTime: Date.now(),
       hasMouseMoved: false,
       _accumulatedMovement: zeroCanvasPoint,
+      spacePressed: false,
     },
     activeControl: activeControl,
     lastInteractionTime: Date.now(),
@@ -235,6 +237,7 @@ export function updateInteractionViaDragDelta(
         globalTime: Date.now(),
         hasMouseMoved: true,
         _accumulatedMovement: accumulatedMovement,
+        spacePressed: currentState.interactionData.spacePressed,
       },
       activeControl: sourceOfUpdate ?? currentState.activeControl,
       lastInteractionTime: Date.now(),
@@ -306,6 +309,7 @@ function updateInteractionDataViaMouse(
             globalTime: Date.now(),
             hasMouseMoved: true,
             _accumulatedMovement: currentData._accumulatedMovement,
+            spacePressed: currentData.spacePressed,
           }
         case 'HOVER':
           return {
@@ -318,6 +322,7 @@ function updateInteractionDataViaMouse(
             globalTime: Date.now(),
             hasMouseMoved: false,
             _accumulatedMovement: zeroCanvasPoint,
+            spacePressed: false,
           }
         default:
           assertNever(currentData)
@@ -392,6 +397,11 @@ export function updateInteractionViaKeyboard(
       }
     }
     case 'DRAG': {
+      const isSpacePressed =
+        (currentState.interactionData.spacePressed ||
+          addedKeysPressed.some((key) => key === 'space')) &&
+        !keysReleased.some((key) => key === 'space')
+
       return {
         interactionData: {
           type: 'DRAG',
@@ -403,6 +413,7 @@ export function updateInteractionViaKeyboard(
           globalTime: Date.now(),
           hasMouseMoved: currentState.interactionData.hasMouseMoved,
           _accumulatedMovement: currentState.interactionData._accumulatedMovement,
+          spacePressed: isSpacePressed,
         },
         activeControl: currentState.activeControl,
         lastInteractionTime: Date.now(),
@@ -573,3 +584,10 @@ export type CanvasControlType =
   | KeyboardCatcherControl
   | ReorderSlider
   | BorderRadiusResizeHandle
+
+export function isDragToPan(
+  interaction: InteractionSession | null,
+  spacePressed: boolean | undefined,
+): boolean {
+  return spacePressed === true && interaction == null
+}

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -93,7 +93,9 @@ export function convertToAbsoluteAndMoveStrategy(
       interactionSession != null &&
       interactionSession.interactionData.type === 'DRAG' &&
       interactionSession.activeControl.type === 'BOUNDING_AREA'
-        ? 0.5
+        ? interactionSession.interactionData.spacePressed
+          ? 5
+          : 0.5
         : 0,
     apply: () => {
       if (

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-move-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-move-metastrategy.tsx
@@ -70,7 +70,7 @@ export const dragToMoveMetaStrategy: MetaCanvasStrategy = (
     baseMoveStrategyFactories,
   )
   if (reparentStrategies.length > 0 || dragStrategies.length > 0) {
-    return [
+    const dragToMoveStrategies = [
       ...reparentStrategies,
       ...dragStrategies.map((strategy) => {
         const indicatorCommand = wildcardPatch('mid-interaction', {
@@ -93,8 +93,25 @@ export const dragToMoveMetaStrategy: MetaCanvasStrategy = (
         }
       }),
     ]
+    return filterStrategiesWhileSpacePressed(
+      interactionSession.interactionData.spacePressed,
+      dragToMoveStrategies,
+    )
   } else {
-    return [doNothingStrategy(canvasState, interactionSession, customStrategyState)]
+    return filterStrategiesWhileSpacePressed(interactionSession.interactionData.spacePressed, [
+      doNothingStrategy(canvasState, interactionSession, customStrategyState),
+    ])
+  }
+}
+
+export function filterStrategiesWhileSpacePressed(
+  spacePressed: boolean,
+  strategies: Array<CanvasStrategy>,
+): Array<CanvasStrategy> {
+  if (spacePressed) {
+    return strategies.filter((strat) => strat.id === 'ABSOLUTE_MOVE')
+  } else {
+    return strategies
   }
 }
 

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -42,6 +42,7 @@ import { isFeatureEnabled } from '../../../../utils/feature-switches'
 import {
   boundingArea,
   createInteractionViaMouse,
+  isDragToPan,
   KeyboardInteractionTimeout,
 } from '../../canvas-strategies/interaction-state'
 import { Modifier } from '../../../../utils/modifiers'
@@ -605,7 +606,10 @@ function useSelectOrLiveModeSelectAndHover(
     (event: React.MouseEvent<HTMLDivElement>) => {
       // Do not handle the mouse move in the regular style if 'space' is pressed.
       const isDragIntention =
-        editorStoreRef.current.editor.keysPressed['space'] || event.buttons === 4
+        isDragToPan(
+          editorStoreRef.current.editor.canvas.interactionSession,
+          editorStoreRef.current.editor.keysPressed['space'],
+        ) || event.buttons === 4
       if (isDragIntention) {
         return
       }

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -146,16 +146,10 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
 
         // TODO: maybe we should not whitelist keys, just check if Keyboard.keyIsModifer(key) is false
         const existingInteractionSession = editorStoreRef.current.editor.canvas.interactionSession
-        if (key === 'space') {
-          if (existingInteractionSession != null) {
-            editorStoreRef.current.dispatch(
-              [CanvasActions.clearInteractionSession(false)],
-              'everyone',
-            )
-          }
-          event.preventDefault()
-          event.stopPropagation()
-        } else if (Keyboard.keyIsModifier(key) && existingInteractionSession != null) {
+        if (
+          (Keyboard.keyIsModifier(key) || key === 'space') &&
+          existingInteractionSession != null
+        ) {
           editorStoreRef.current.dispatch(
             [
               CanvasActions.createInteractionSession(

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1649,7 +1649,7 @@ export const ModifiersKeepDeepEquality: KeepDeepEqualityCall<Modifiers> = combin
 )
 
 export const DragInteractionDataKeepDeepEquality: KeepDeepEqualityCall<DragInteractionData> =
-  combine8EqualityCalls(
+  combine9EqualityCalls(
     (data) => data.dragStart,
     CanvasPointKeepDeepEquality,
     (data) => data.drag,
@@ -1666,6 +1666,8 @@ export const DragInteractionDataKeepDeepEquality: KeepDeepEqualityCall<DragInter
     BooleanKeepDeepEquality,
     (data) => data._accumulatedMovement,
     CanvasPointKeepDeepEquality,
+    (data) => data.spacePressed,
+    BooleanKeepDeepEquality,
     (
       dragStart,
       drag,
@@ -1675,6 +1677,7 @@ export const DragInteractionDataKeepDeepEquality: KeepDeepEqualityCall<DragInter
       globalTime,
       hasMouseMoved,
       accumulatedMovement,
+      spacePressed,
     ) => {
       return {
         type: 'DRAG',
@@ -1686,6 +1689,7 @@ export const DragInteractionDataKeepDeepEquality: KeepDeepEqualityCall<DragInter
         globalTime: globalTime,
         hasMouseMoved: hasMouseMoved,
         _accumulatedMovement: accumulatedMovement,
+        spacePressed: spacePressed,
       }
     },
   )

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -7,6 +7,7 @@ import { CanvasComponentEntry } from '../components/canvas/canvas-component-entr
 import {
   boundingArea,
   createInteractionViaMouse,
+  isDragToPan,
   updateInteractionViaDragDelta,
   updateInteractionViaMouse,
 } from '../components/canvas/canvas-strategies/interaction-state'
@@ -304,7 +305,7 @@ function on(
     ]
   }
 
-  if (canvas.keysPressed['space']) {
+  if (isDragToPan(canvas.editorState.canvas.interactionSession, canvas.keysPressed['space'])) {
     if (event.event === 'MOVE' && event.nativeEvent.buttons === 1) {
       return [
         CanvasActions.scrollCanvas(
@@ -1280,7 +1281,13 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
   handleMouseMove = (event: MouseEvent) => {
     if (this.canvasSelected()) {
       const canvasPositions = this.getPosition(event)
-      if (this.props.model.keysPressed['space'] || event.buttons === 4) {
+      if (
+        isDragToPan(
+          this.props.editor.canvas.interactionSession,
+          this.props.model.keysPressed['space'],
+        ) ||
+        event.buttons === 4
+      ) {
         this.handleEvent({
           ...canvasPositions,
           event: 'MOVE',


### PR DESCRIPTION
Fixes #2884

**Fix:**
Pressing space while dragging elements should activate the absolute move escape hatch and filter the list of available move strategies. I added space pressed status to the drag interaction data and updated the strategies.
Drag to pan can be active only when not in an interaction.

**Commit Details:**
- extend interaction data
- update escape hatch strategy to higher fitness
- filter drag-to-move metastrategies, since the escape hatch is not active during regular absolute move, that one will be kept while pressing space
- update tests for drag to pan and escape hatch
