### PR TITLE
Fix missing drag outline

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
@@ -18,6 +18,10 @@ import {
   getDragTargets,
 } from './shared-move-strategies-helpers'
 import { ZeroSizedElementControls } from '../../controls/zero-sized-element-controls'
+import {
+  DragOutlineControl,
+  dragTargetsElementPaths,
+} from '../../controls/select-mode/drag-outline-control'
 
 export function absoluteMoveStrategy(
   canvasState: InteractionCanvasState,
@@ -63,6 +67,12 @@ export function absoluteMoveStrategy(
           key: 'zero-size-control',
           show: 'visible-only-while-active',
         }),
+        {
+          control: DragOutlineControl,
+          props: dragTargetsElementPaths(selectedElements),
+          key: 'ghost-outline-control',
+          show: 'visible-only-while-active',
+        },
       ], // Uses existing hooks in select-mode-hooks.tsx
       fitness:
         interactionSession?.interactionData.type === 'DRAG' &&


### PR DESCRIPTION
**Problem:**

When absolute move strategy is running for an ancestor, it is not visible on the canvas that the ancestor is dragged and not the element itself.

**Fix:**
I added DragOutlineControl to the absolute move strategy. We did not add this earlier because in the absolute case the element moves together with the mouse, so we just haven't realized it is necessary. But for the ancestor case, it is clearly needed.