### PR TITLE
Prevent control filtering when no drag active

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -20,7 +20,12 @@ import {
   controlWithProps,
   getTargetPathsFromInteractionTarget,
 } from './canvas-strategy-types'
-import { InteractionSession, StrategyState } from './interaction-state'
+import {
+  CanvasControlType,
+  InteractionSession,
+  isNotYetStartedDragInteraction,
+  StrategyState,
+} from './interaction-state'
 import { keyboardAbsoluteMoveStrategy } from './strategies/keyboard-absolute-move-strategy'
 import { absoluteResizeBoundingBoxStrategy } from './strategies/absolute-resize-bounding-box-strategy'
 import { keyboardAbsoluteResizeStrategy } from './strategies/keyboard-absolute-resize-strategy'
@@ -439,6 +444,7 @@ export function interactionInProgress(interactionSession: InteractionSession | n
   } else {
     switch (interactionSession.interactionData.type) {
       case 'DRAG':
+        return !isNotYetStartedDragInteraction(interactionSession.interactionData)
       case 'KEYBOARD':
       case 'HOVER':
         return true
@@ -480,4 +486,20 @@ export function useGetApplicableStrategyControls(): Array<ControlWithProps<unkno
 
 export function isStrategyActive(strategyState: StrategyState): boolean {
   return strategyState.currentStrategyCommands.length > 0
+}
+
+export function onlyFitWhenDraggingThisControl(
+  interactionSession: InteractionSession | null,
+  controlType: CanvasControlType['type'],
+  fitnessWhenFit: number,
+): number {
+  if (
+    interactionSession != null &&
+    interactionSession.interactionData.type === 'DRAG' &&
+    interactionSession.activeControl.type === controlType
+  ) {
+    return fitnessWhenFit
+  } else {
+    return 0
+  }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -29,6 +29,7 @@ import { ImmediateParentBounds } from '../../controls/parent-bounds'
 import { ImmediateParentOutlines } from '../../controls/parent-outlines'
 import { AbsoluteResizeControl } from '../../controls/select-mode/absolute-resize-control'
 import { ZeroSizeResizeControlWrapper } from '../../controls/zero-sized-element-controls'
+import { onlyFitWhenDraggingThisControl } from '../canvas-strategies'
 import {
   CanvasStrategy,
   controlWithProps,
@@ -94,12 +95,7 @@ export function absoluteResizeBoundingBoxStrategy(
         show: 'visible-only-while-active',
       }),
     ],
-    fitness:
-      interactionSession != null &&
-      interactionSession.interactionData.type === 'DRAG' &&
-      interactionSession.activeControl.type === 'RESIZE_HANDLE'
-        ? 1
-        : 0,
+    fitness: onlyFitWhenDraggingThisControl(interactionSession, 'RESIZE_HANDLE', 1),
     apply: () => {
       if (
         interactionSession != null &&

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -53,7 +53,7 @@ import {
   shouldShowControls,
   unitlessCSSNumberWithRenderedValue,
 } from '../../controls/select-mode/controls-common'
-import { CanvasStrategyFactory } from '../canvas-strategies'
+import { CanvasStrategyFactory, onlyFitWhenDraggingThisControl } from '../canvas-strategies'
 import {
   controlWithProps,
   getTargetPathsFromInteractionTarget,
@@ -70,17 +70,6 @@ export const setBorderRadiusStrategy: CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
 ) => {
-  if (
-    interactionSession != null &&
-    !(
-      interactionSession.interactionData.type === 'DRAG' &&
-      interactionSession.activeControl.type === 'BORDER_RADIUS_RESIZE_HANDLE'
-    )
-  ) {
-    // We don't want to include this in the strategy picker if any other interaction is active
-    return null
-  }
-
   const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
   if (selectedElements.length !== 1) {
     return null
@@ -127,7 +116,7 @@ export const setBorderRadiusStrategy: CanvasStrategyFactory = (
   return {
     id: SetBorderRadiusStrategyId,
     name: 'Set border radius',
-    fitness: 1,
+    fitness: onlyFitWhenDraggingThisControl(interactionSession, 'BORDER_RADIUS_RESIZE_HANDLE', 1),
     controlsToRender: [
       controlWithProps({
         control: BorderRadiusControl,

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
@@ -25,7 +25,7 @@ import {
   FlexGapData,
   maybeFlexGapFromElement,
 } from '../../gap-utils'
-import { CanvasStrategyFactory } from '../canvas-strategies'
+import { CanvasStrategyFactory, onlyFitWhenDraggingThisControl } from '../canvas-strategies'
 import {
   controlWithProps,
   emptyStrategyApplicationResult,
@@ -45,17 +45,6 @@ export const setFlexGapStrategy: CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
 ) => {
-  if (
-    interactionSession != null &&
-    !(
-      interactionSession.interactionData.type === 'DRAG' &&
-      interactionSession.activeControl.type === 'FLEX_GAP_HANDLE'
-    )
-  ) {
-    // We don't want to include this in the strategy picker if any other interaction is active
-    return null
-  }
-
   const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
   if (selectedElements.length !== 1) {
     return null
@@ -123,7 +112,7 @@ export const setFlexGapStrategy: CanvasStrategyFactory = (
     id: SetFlexGapStrategyId,
     name: 'Set flex gap',
     controlsToRender: controlsToRender,
-    fitness: 1,
+    fitness: onlyFitWhenDraggingThisControl(interactionSession, 'FLEX_GAP_HANDLE', 1),
     apply: () => {
       if (
         interactionSession == null ||

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -32,7 +32,7 @@ import {
   printCssNumberWithDefaultUnit,
   simplePaddingFromMetadata,
 } from '../../padding-utils'
-import { CanvasStrategyFactory } from '../canvas-strategies'
+import { CanvasStrategyFactory, onlyFitWhenDraggingThisControl } from '../canvas-strategies'
 import {
   controlWithProps,
   emptyStrategyApplicationResult,
@@ -67,17 +67,6 @@ export const PaddingTearThreshold: number = -25
 export const SetPaddingStrategyName = 'Set Padding'
 
 export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interactionSession) => {
-  if (
-    interactionSession != null &&
-    !(
-      interactionSession.interactionData.type === 'DRAG' &&
-      interactionSession.activeControl.type === 'PADDING_RESIZE_HANDLE'
-    )
-  ) {
-    // We don't want to include this in the strategy picker if any other interaction is active
-    return null
-  }
-
   const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
   if (selectedElements.length !== 1) {
     return null
@@ -135,7 +124,7 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
     id: 'SET_PADDING_STRATEGY',
     name: SetPaddingStrategyName,
     controlsToRender: controlsToRender,
-    fitness: 1,
+    fitness: onlyFitWhenDraggingThisControl(interactionSession, 'PADDING_RESIZE_HANDLE', 1),
     apply: () => {
       if (
         interactionSession == null ||


### PR DESCRIPTION
**Problem:**
We were early returning from certain strategies a bit too eagerly, preventing their controls from rendering

**Fix:**
Rather than early returning at the start in cases where another control might be dragged, use that check in the `fitness` (which is what we were already doing for the absolute resizing strategy). As this is a common pattern I've extracted a function for it.

Also, the non-resizeable controls were being hidden when a drag had started but not passed the threshold, so I've also updated that logic to only hide those once the drag threshold has been passed.