### PR TITLE
make border radius not overlap with resize controls

### DIFF
--- a/editor/src/components/canvas/border-radius-control-utils.tsx
+++ b/editor/src/components/canvas/border-radius-control-utils.tsx
@@ -8,6 +8,8 @@ export const BorderRadiusCorners: BorderRadiusCorner[] = ['tl', 'tr', 'bl', 'br'
 
 export type BorderRadiusSides<T> = { [key in BorderRadiusCorner]: T }
 
+export const BorderRadiusControlMinimumForDisplay = 10
+
 export type BorderRadiusAdjustMode = 'individual' | 'all'
 
 export const BorderRadiusHandleSize = (scale: number): number => 12 / scale

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.spec.browser2.tsx
@@ -93,7 +93,7 @@ describe('set border radius strategy', () => {
     expect(paddingControls).toEqual([])
   })
 
-  describe('Border radius controls on compoenent instances', () => {
+  describe('Border radius controls on component instances', () => {
     it('controls are shown if border radius is specified on the component instance', async () => {
       const editor = await renderTestEditorWithCode(
         projectWithComponentThatDefinesBorderRadiusInternally({
@@ -144,21 +144,21 @@ describe('set border radius strategy', () => {
 
   it('can handle 4-value syntax', async () => {
     const editor = await renderTestEditorWithCode(
-      codeForDragTest(`borderRadius: '4px 5px 6px 7px'`),
+      codeForDragTest(`borderRadius: '14px 15px 16px 17px'`),
       'await-first-dom-report',
     )
 
     await doDragTest(editor, 'tl', 10, emptyModifiers)
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-      codeForDragTest(`borderRadius: '4px 5px 6px 7px',
-                       borderTopLeftRadius: '14px',`),
+      codeForDragTest(`borderRadius: '14px 15px 16px 17px',
+                       borderTopLeftRadius: '24px',`),
     )
   })
 
   it('can only adjust border radius to 50% at most', async () => {
     const { width, height } = size(600, 400)
     const editor = await renderTestEditorWithCode(
-      codeForDragTest(`borderRadius: '4px'`),
+      codeForDragTest(`borderRadius: '24px'`),
       'await-first-dom-report',
     )
 
@@ -172,10 +172,10 @@ describe('set border radius strategy', () => {
 
   it('can only adjust border radius to 0 at min', async () => {
     const editor = await renderTestEditorWithCode(
-      codeForDragTest(`borderRadius: '4px'`),
+      codeForDragTest(`borderRadius: '14px'`),
       'await-first-dom-report',
     )
-    await doDragTest(editor, 'tl', -10, emptyModifiers)
+    await doDragTest(editor, 'tl', -20, emptyModifiers)
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
       codeForDragTest(`borderRadius: '0px'`),
     )
@@ -237,48 +237,59 @@ describe('set border radius strategy', () => {
     )
   })
 
+  it('when resize starts from below 10px, delta is applied as if border radius was 10px', async () => {
+    const editor = await renderTestEditorWithCode(
+      codeForDragTest(`borderRadius: '4px'`),
+      'await-first-dom-report',
+    )
+    await doDragTest(editor, 'tl', 10, emptyModifiers)
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      codeForDragTest(`borderRadius: '20px'`),
+    )
+  })
+
   describe('adjust border radius via handles', () => {
     it('top left', async () => {
       const editor = await renderTestEditorWithCode(
-        codeForDragTest(`borderRadius: '4px'`),
+        codeForDragTest(`borderRadius: '14px'`),
         'await-first-dom-report',
       )
       await doDragTest(editor, 'tl', 10, emptyModifiers)
       expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-        codeForDragTest(`borderRadius: '14px'`),
+        codeForDragTest(`borderRadius: '24px'`),
       )
     })
 
     it('top right', async () => {
       const editor = await renderTestEditorWithCode(
-        codeForDragTest(`borderRadius: '4px'`),
+        codeForDragTest(`borderRadius: '14px'`),
         'await-first-dom-report',
       )
       await doDragTest(editor, 'tr', 10, emptyModifiers)
       expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-        codeForDragTest(`borderRadius: '14px'`),
+        codeForDragTest(`borderRadius: '24px'`),
       )
     })
 
     it('bottom left', async () => {
       const editor = await renderTestEditorWithCode(
-        codeForDragTest(`borderRadius: '4px'`),
+        codeForDragTest(`borderRadius: '14px'`),
         'await-first-dom-report',
       )
       await doDragTest(editor, 'bl', 10, emptyModifiers)
       expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-        codeForDragTest(`borderRadius: '14px'`),
+        codeForDragTest(`borderRadius: '24px'`),
       )
     })
 
     it('bottom right', async () => {
       const editor = await renderTestEditorWithCode(
-        codeForDragTest(`borderRadius: '4px'`),
+        codeForDragTest(`borderRadius: '14px'`),
         'await-first-dom-report',
       )
       await doDragTest(editor, 'br', 10, emptyModifiers)
       expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-        codeForDragTest(`borderRadius: '14px'`),
+        codeForDragTest(`borderRadius: '24px'`),
       )
     })
   })
@@ -286,49 +297,49 @@ describe('set border radius strategy', () => {
   describe('adjust border radius via handles, individually', () => {
     it('top left', async () => {
       const editor = await renderTestEditorWithCode(
-        codeForDragTest(`borderRadius: '4px',`),
+        codeForDragTest(`borderRadius: '14px',`),
         'await-first-dom-report',
       )
       await doDragTest(editor, 'tl', 10, cmdModifier)
       expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-        codeForDragTest(`borderRadius: '4px',
-                         borderTopLeftRadius: '14px',`),
+        codeForDragTest(`borderRadius: '14px',
+                         borderTopLeftRadius: '24px',`),
       )
     })
 
     it('top right', async () => {
       const editor = await renderTestEditorWithCode(
-        codeForDragTest(`borderRadius: '4px'`),
+        codeForDragTest(`borderRadius: '14px'`),
         'await-first-dom-report',
       )
       await doDragTest(editor, 'tr', 10, cmdModifier)
       expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-        codeForDragTest(`borderRadius: '4px',
-                         borderTopRightRadius: '14px',`),
+        codeForDragTest(`borderRadius: '14px',
+                         borderTopRightRadius: '24px',`),
       )
     })
 
     it('bottom left', async () => {
       const editor = await renderTestEditorWithCode(
-        codeForDragTest(`borderRadius: '4px'`),
+        codeForDragTest(`borderRadius: '14px'`),
         'await-first-dom-report',
       )
       await doDragTest(editor, 'bl', 10, cmdModifier)
       expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-        codeForDragTest(`borderRadius: '4px',
-                         borderBottomLeftRadius: '14px',`),
+        codeForDragTest(`borderRadius: '14px',
+                         borderBottomLeftRadius: '24px',`),
       )
     })
 
     it('bottom right', async () => {
       const editor = await renderTestEditorWithCode(
-        codeForDragTest(`borderRadius: '4px'`),
+        codeForDragTest(`borderRadius: '14px'`),
         'await-first-dom-report',
       )
       await doDragTest(editor, 'br', 10, cmdModifier)
       expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-        codeForDragTest(`borderRadius: '4px',
-                         borderBottomRightRadius: '14px',`),
+        codeForDragTest(`borderRadius: '14px',
+                         borderBottomRightRadius: '24px',`),
       )
     })
   })

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -35,6 +35,7 @@ import {
 import { stylePropPathMappingFn } from '../../../inspector/common/property-path-hooks'
 import {
   BorderRadiusAdjustMode,
+  BorderRadiusControlMinimumForDisplay,
   BorderRadiusCorner,
   BorderRadiusSides,
   maxBorderRadius,
@@ -452,13 +453,20 @@ function updateBorderRadiusFn(
   borderRadiusAdjustData: BorderRadiusAdjustData | null,
 ) {
   return (borderRadius: CSSNumberWithRenderedValue) => {
+    const borderRadiusMaxed = Math.max(
+      borderRadius.renderedValuePx,
+      BorderRadiusControlMinimumForDisplay,
+    )
+    const borderRadiusValue =
+      borderRadiusAdjustData == null ? borderRadius.renderedValuePx : borderRadiusMaxed
+
     const dragDelta = clamp(
-      -borderRadius.renderedValuePx,
-      maxBorderRadius(elementSize) - borderRadius.renderedValuePx,
+      -borderRadiusValue,
+      maxBorderRadius(elementSize) - borderRadiusValue,
       optionalMap(({ drag, corner }) => deltaFromDrag(drag, corner), borderRadiusAdjustData) ?? 0,
     )
 
-    const borderRadiusOffset = borderRadius.renderedValuePx + dragDelta
+    const borderRadiusOffset = borderRadiusValue + dragDelta
 
     const precision =
       optionalMap(({ modifiers }) => precisionFromModifiers(modifiers), borderRadiusAdjustData) ??

--- a/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
@@ -9,6 +9,7 @@ import { useEditorState, useRefEditorState } from '../../../editor/store/store-h
 import { printCSSNumber } from '../../../inspector/common/css-utils'
 import {
   BorderRadiusAdjustMode,
+  BorderRadiusControlMinimumForDisplay,
   BorderRadiusCorner,
   BorderRadiusCorners,
   BorderRadiusHandleBorderWidth,
@@ -160,7 +161,14 @@ const CircularHandle = React.memo((props: CircularHandleProp) => {
   const shouldShowHandle = isDragging || backgroundShown
 
   const size = BorderRadiusHandleSize(scale)
-  const position = handlePosition(borderRadius.renderedValuePx, elementSize, corner, scale)
+  const position = handlePosition(
+    isDragging
+      ? borderRadius.renderedValuePx
+      : Math.max(borderRadius.renderedValuePx, BorderRadiusControlMinimumForDisplay),
+    elementSize,
+    corner,
+    scale,
+  )
 
   return (
     <div


### PR DESCRIPTION
## Problem:
Border radius controls might overlap with resize controls

## Fix:
Position border radius controls at a minimum offset of 10px from the corner

**Commit Details:**
- Renamed `thing` to `otherThing`
- Removed `cake` from `fridge-contents.ts`
- Did [other things]
