### PR TITLE
Switch between creating or updating a reference appropriately.

### DIFF
--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -3258,12 +3258,14 @@ export const RepositoryEntryPermissionsKeepDeepEquality: KeepDeepEqualityCall<Re
   )
 
 export const RepositoryEntryKeepDeepEquality: KeepDeepEqualityCall<RepositoryEntry> =
-  combine7EqualityCalls(
+  combine8EqualityCalls(
     (r) => r.avatarUrl,
     NullableStringKeepDeepEquality,
-    (r) => r.private,
+    (r) => r.isPrivate,
     BooleanKeepDeepEquality,
     (r) => r.fullName,
+    StringKeepDeepEquality,
+    (r) => r.name,
     StringKeepDeepEquality,
     (r) => r.description,
     NullableStringKeepDeepEquality,

--- a/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
@@ -114,7 +114,7 @@ const RepositoryRow = (props: RepositoryRowProps) => {
       <div>
         <Ellipsis style={{ maxWidth: 140 }}>{props.fullName}</Ellipsis>
         <span style={{ fontSize: 10, opacity: 0.5 }}>
-          {props.private ? 'private' : 'public'}
+          {props.isPrivate ? 'private' : 'public'}
           {props.updatedAt == null ? null : (
             <>
               {' '}
@@ -202,8 +202,9 @@ export const RepositoryListing = React.memo(
           } else {
             const additionalEntry: RepositoryRowProps = {
               fullName: parsedRepo.repository,
+              name: parsedRepo.repository,
               avatarUrl: null,
-              private: true,
+              isPrivate: true,
               description: null,
               updatedAt: null,
               defaultBranch: 'main',

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -139,8 +139,9 @@ export function repositoryEntryPermissions(
 
 export interface RepositoryEntry {
   fullName: string
+  name: string
   avatarUrl: string | null
-  private: boolean
+  isPrivate: boolean
   description: string | null
   updatedAt: string | null
   defaultBranch: string
@@ -149,8 +150,9 @@ export interface RepositoryEntry {
 
 export function repositoryEntry(
   avatarUrl: string | null,
-  priv: boolean,
+  isPrivate: boolean,
   fullName: string,
+  name: string,
   description: string | null,
   updatedAt: string | null,
   defaultBranch: string,
@@ -158,8 +160,9 @@ export function repositoryEntry(
 ): RepositoryEntry {
   return {
     avatarUrl,
-    private: priv,
+    isPrivate,
     fullName,
+    name,
     description,
     updatedAt,
     defaultBranch,
@@ -702,7 +705,7 @@ export async function getUsersPublicGithubRepositories(dispatch: EditorDispatch)
         dispatch(
           [
             updateGithubData({
-              publicRepositories: responseBody.repositories.filter((repo) => !repo.private),
+              publicRepositories: responseBody.repositories.filter((repo) => !repo.isPrivate),
             }),
           ],
           'everyone',

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -383,7 +383,7 @@ createInitialCommitIfNecessary accessToken owner repository = do
   possibleBranch <- getGitBranch accessToken owner repository defaultBranch
   let createTheCommit = do
         -- Create this dummy file which is needed to create the default branch.
-        updateGitFileResult <- updateGitFile accessToken owner repository defaultBranch "/README" "Basic README added to initialise the repo." "This space intentionally left blank."
+        updateGitFileResult <- updateGitFile accessToken owner repository defaultBranch "/README.md" "Basic README added to initialise the repo." "This space intentionally left blank."
         let commitSha = view (field @"commit" . field @"sha") updateGitFileResult
         pure $ Just commitSha
   if isNothing possibleBranch then createTheCommit else pure Nothing

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -383,7 +383,7 @@ createInitialCommitIfNecessary accessToken owner repository = do
   possibleBranch <- getGitBranch accessToken owner repository defaultBranch
   let createTheCommit = do
         -- Create this dummy file which is needed to create the default branch.
-        updateGitFileResult <- updateGitFile accessToken owner repository defaultBranch "/dummy" "Dummy file to initialise the repo." "This space intentionally left blank."
+        updateGitFileResult <- updateGitFile accessToken owner repository defaultBranch "/README" "Basic README added to initialise the repo." "This space intentionally left blank."
         let commitSha = view (field @"commit" . field @"sha") updateGitFileResult
         pure $ Just commitSha
   if isNothing possibleBranch then createTheCommit else pure Nothing

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -375,20 +375,46 @@ useAccessToken githubResources logger metrics pool userID action = do
         Nothing    -> throwE "User not authenticated with Github."
         Just token -> action token
 
+createInitialCommitIfNecessary :: (MonadBaseControl IO m, MonadIO m) => AccessToken -> Text -> Text -> ExceptT Text m (Maybe Text)
+createInitialCommitIfNecessary accessToken owner repository = do
+  possibleRepo <- getRepository accessToken owner repository
+  usersRepository <- maybe (throwE ("Repository " <> repository <> " not found.")) pure possibleRepo
+  let defaultBranch = view (field @"default_branch") usersRepository
+  possibleBranch <- getGitBranch accessToken owner repository defaultBranch
+  let createTheCommit = do
+        -- Create this dummy file which is needed to create the default branch.
+        updateGitFileResult <- updateGitFile accessToken owner repository defaultBranch "/dummy" "Dummy file to initialise the repo." "This space intentionally left blank."
+        let commitSha = view (field @"commit" . field @"sha") updateGitFileResult
+        pure $ Just commitSha
+  if isNothing possibleBranch then createTheCommit else pure Nothing
+
 createTreeAndSaveToGithub :: (MonadBaseControl IO m, MonadIO m) => GithubAuthResources -> Maybe AWSResources -> FastLogger -> DB.DatabaseMetrics -> DBPool -> Text -> Text -> (Maybe Text) -> (Maybe Text) -> PersistentModel -> m SaveToGithubResponse
 createTreeAndSaveToGithub githubResources awsResource logger metrics pool userID projectID possibleBranchName possibleCommitMessage model = do
-  let parentCommits = toListOf (field @"githubSettings" . field @"originCommit" . _Just) model
+  let possibleParentCommit = firstOf (field @"githubSettings" . field @"originCommit" . _Just) model
+  let possibleTargetRepository = firstOf (field @"githubSettings" . field @"targetRepository" . _Just) model
   result <- runExceptT $ do
-    treeResult <- useAccessToken githubResources logger metrics pool userID $ \accessToken -> do
-      createGitTreeFromModel (loadAsset awsResource) projectID accessToken model
-    commitResult <- useAccessToken githubResources logger metrics pool userID $ \accessToken -> do
-      createGitCommitForTree accessToken model (view (field @"sha") treeResult) possibleCommitMessage parentCommits
-    now <- liftIO getCurrentTime
-    let branchName = fromMaybe (toS $ formatTime defaultTimeLocale "utopia-branch-%0Y%m%d-%H%M%S" now) possibleBranchName
-    let commitSha = view (field @"sha") commitResult
-    branchResult <- useAccessToken githubResources logger metrics pool userID $ \accessToken -> do
-      createGitBranchForCommit accessToken model commitSha branchName
-    pure (branchName, view (field @"url") branchResult, commitSha)
+    -- Resolve the repository in the project model.
+    GithubRepo{..} <- maybe (throwE "No repository set on project.") pure possibleTargetRepository
+    useAccessToken githubResources logger metrics pool userID $ \accessToken -> do
+      -- This should handle empty repositories, as weirdly it's impossible to create a reference for one.
+      initialCommitSha <- createInitialCommitIfNecessary accessToken owner repository
+      let parentCommits = maybeToList (possibleParentCommit <|> initialCommitSha)
+      treeResult <- createGitTreeFromModel (loadAsset awsResource) projectID accessToken model
+      commitResult <- createGitCommitForTree accessToken model (view (field @"sha") treeResult) possibleCommitMessage parentCommits
+      now <- liftIO getCurrentTime
+      let branchName = fromMaybe (toS $ formatTime defaultTimeLocale "utopia-branch-%0Y%m%d-%H%M%S" now) possibleBranchName
+      let commitSha = view (field @"sha") commitResult
+      let updateBranch = do
+            branchResult <- updateGitBranchForCommit accessToken model commitSha branchName
+            pure $ view (field @"url") branchResult
+      let createBranch = do
+            branchResult <- createGitBranchForCommit accessToken model commitSha branchName
+            pure $ view (field @"url") branchResult
+      referenceResult <- getReference accessToken owner repository ("heads/" <> branchName)
+      liftIO $ print referenceResult
+      let doesBranchExist = isJust referenceResult
+      treeURL <- if doesBranchExist then updateBranch else createBranch
+      pure (branchName, treeURL, commitSha)
   pure $ either responseFailureFromReason responseSuccessFromBranchNameAndURL result
 
 convertBranchesResultToUnfold :: Int -> GetBranchesResult -> Maybe (GetBranchesResult, Maybe Int)
@@ -460,10 +486,10 @@ publicRepoToRepositoryEntry :: UsersRepository -> RepositoryEntry
 publicRepoToRepositoryEntry publicRepository = RepositoryEntry
                                              { fullName = view (field @"full_name") publicRepository
                                              , avatarUrl = Just $ view (field @"owner" . field @"avatar_url") publicRepository
-                                             , private = view (field @"private") publicRepository
+                                             , isPrivate = view (field @"private") publicRepository
                                              , description = view (field @"description") publicRepository
                                              , name = view (field @"name") publicRepository
-                                             , updatedAt = Just $ view (field @"updated_at") publicRepository
+                                             , updatedAt = view (field @"updated_at") publicRepository
                                              , defaultBranch = view (field @"default_branch") publicRepository
                                              , permissions = view (field @"permissions") publicRepository
                                              }

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -112,13 +112,19 @@ gitTreeEntriesFromProjectContent loadAsset createBlob projectContents = do
   entries <- mapConcurrently (gitTreeEntriesFromProjectContentsTree loadAsset createBlob) $ M.elems projectContents
   pure $ join entries
 
-createGitTreeFromProjectContent :: (MonadIO m, MonadBaseControl IO m) => LoadAsset -> SimpleCreateBlob m -> ProjectContentTreeRoot -> ExceptT Text m CreateGitTree
-createGitTreeFromProjectContent loadAsset createBlob projectContents = fmap (CreateGitTree Nothing) $ gitTreeEntriesFromProjectContent loadAsset createBlob projectContents
+gitTreeFromProjectContent :: (MonadIO m, MonadBaseControl IO m) => LoadAsset -> SimpleCreateBlob m -> ProjectContentTreeRoot -> ExceptT Text m CreateGitTree
+gitTreeFromProjectContent loadAsset createBlob projectContents = fmap (CreateGitTree Nothing) $ gitTreeEntriesFromProjectContent loadAsset createBlob projectContents
 
 type MakeGithubRequest a = WR.Options -> String -> a -> IO (WR.Response BL.ByteString)
 
 postToGithub :: (ToJSON a) => MakeGithubRequest a
 postToGithub options url content = WR.postWith options url (toJSON content)
+
+putToGithub :: (ToJSON a) => MakeGithubRequest a
+putToGithub options url content = WR.putWith options url (toJSON content)
+
+patchToGithub :: (ToJSON a) => MakeGithubRequest a
+patchToGithub options url content = WR.customPayloadMethodWith "PATCH" options url (toJSON content)
 
 getFromGithub :: MakeGithubRequest ()
 getFromGithub options url _ = WR.getWith options url
@@ -133,9 +139,9 @@ callGithub makeRequest queryParameters handleErrorCases accessToken restURL requ
               & WR.params .~ queryParameters
   -- Make the request.
   result <- liftIO $ makeRequest options (toS restURL) request
-  -- Uncomment the next line if you want to see the headers.
-  -- liftIO $ print $ view WR.responseHeaders result
   let status = view WR.responseStatus result
+  -- Uncomment the next line if you want to see the headers.
+  let logStuffForErrors = liftIO $ print (restURL, status, view WR.responseHeaders result, view WR.responseBody result)
   -- Check the rate limiting.
   let rateLimitRemaining = firstOf (WR.responseHeader "X-RateLimit-Remaining" . unpackedChars . decimal) result :: Maybe Int
   when (rateLimitRemaining == Just 0 || status == tooManyRequests429) $ do
@@ -144,7 +150,7 @@ callGithub makeRequest queryParameters handleErrorCases accessToken restURL requ
   if statusIsSuccessful status
   -- Parse the response contents.
   then except $ bimap show (\r -> view WR.responseBody r) (WR.asJSON result)
-  else handleErrorCases status
+  else logStuffForErrors >> handleErrorCases status
   
 
 createTreeHandleErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
@@ -153,20 +159,24 @@ createTreeHandleErrorCases status | status == forbidden403            = throwE "
                                   | status == unprocessableEntity422  = liftIO $ fail "Unprocessable entity returned when creating tree."
                                   | otherwise                         = throwE "Unexpected error."
 
-createGitTree :: (MonadIO m, MonadBaseControl IO m) => LoadAsset -> AccessToken -> GithubRepo -> ProjectContentTreeRoot -> ExceptT Text m CreateGitTreeResult
-createGitTree loadAsset accessToken repo@GithubRepo{..} projectContents = do
+createGitTree :: (MonadIO m, MonadBaseControl IO m) => AccessToken -> Text -> Text -> CreateGitTree -> ExceptT Text m CreateGitTreeResult
+createGitTree accessToken owner repository gitTree = do
   let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/trees"
+  callGithub postToGithub [] createTreeHandleErrorCases accessToken repoUrl gitTree 
+
+createGitTreeFromProjectContents :: (MonadIO m, MonadBaseControl IO m) => LoadAsset -> AccessToken -> GithubRepo -> ProjectContentTreeRoot -> ExceptT Text m CreateGitTreeResult
+createGitTreeFromProjectContents loadAsset accessToken repo@GithubRepo{..} projectContents = do
   -- Create a simpler function for creating a git blob.
   let createBlob = createGitBlob accessToken repo
-  request <- createGitTreeFromProjectContent loadAsset createBlob projectContents
-  callGithub postToGithub [] createTreeHandleErrorCases accessToken repoUrl request
+  request <- gitTreeFromProjectContent loadAsset createBlob projectContents
+  createGitTree accessToken owner repository request 
 
 createGitTreeFromModel :: (MonadIO m, MonadBaseControl IO m) => LoadAsset -> Text -> AccessToken -> PersistentModel -> ExceptT Text m CreateGitTreeResult
 createGitTreeFromModel loadAsset projectID accessToken PersistentModel{..} = do
   let possibleGithubRepo = targetRepository githubSettings
   let loadAssetForProject projectPath possibleETag = loadAsset (projectID : projectPath) possibleETag
   case possibleGithubRepo of
-    Just repo -> createGitTree loadAssetForProject accessToken repo projectContents
+    Just repo -> createGitTreeFromProjectContents loadAssetForProject accessToken repo projectContents
     Nothing   -> throwE "No repository set on project."
 
 createBlobHandleErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
@@ -187,8 +197,8 @@ createCommitHandleErrorCases status | status == notFound404             = throwE
                                     | status == unprocessableEntity422  = liftIO $ fail "Unprocessable entity returned when creating tree."
                                     | otherwise                         = throwE "Unexpected error."
 
-createGitCommit :: (MonadIO m) => AccessToken -> GithubRepo -> Text -> Maybe Text -> [Text] -> ExceptT Text m CreateGitCommitResult
-createGitCommit accessToken GithubRepo{..} treeSha possibleCommitMessage parentCommits = do
+createGitCommit :: (MonadIO m) => AccessToken -> Text -> Text -> Text -> Maybe Text -> [Text] -> ExceptT Text m CreateGitCommitResult
+createGitCommit accessToken owner repository treeSha possibleCommitMessage parentCommits = do
   let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/commits"
   let request = CreateGitCommit (fromMaybe "Committed automatically." possibleCommitMessage) treeSha parentCommits
   callGithub postToGithub [] createCommitHandleErrorCases accessToken repoUrl request
@@ -197,7 +207,46 @@ createGitCommitForTree :: (MonadIO m) => AccessToken -> PersistentModel -> Text 
 createGitCommitForTree accessToken PersistentModel{..} treeSha possibleCommitMessage parentCommits = do
   let possibleGithubRepo = targetRepository githubSettings
   case possibleGithubRepo of
-    Just repo -> createGitCommit accessToken repo treeSha possibleCommitMessage parentCommits
+    Just GithubRepo{..} -> createGitCommit accessToken owner repository treeSha possibleCommitMessage parentCommits
+    Nothing   -> throwE "No repository set on project."
+
+updateGitFileHandleErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
+updateGitFileHandleErrorCases status | status == notFound404             = throwE "Repository or tree not found."
+                                     | status == conflict409             = throwE "Conflict when updating file."
+                                     | status == unprocessableEntity422  = liftIO $ fail "Unprocessable entity returned when creating tree."
+                                     | otherwise                         = throwE "Unexpected error."
+
+updateGitFile :: (MonadIO m) => AccessToken -> Text -> Text -> Text -> Text -> Text -> BL.ByteString -> ExceptT Text m UpdateGitFileResult
+updateGitFile accessToken owner repository branchName path commitMessage content = do
+  let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/contents" <> path
+  let encodedContent = toS $ BLB64.encodeBase64 content
+  let request = UpdateGitFile commitMessage branchName encodedContent
+  callGithub putToGithub [] updateGitFileHandleErrorCases accessToken repoUrl request
+
+getReferenceHandleErrorCases :: (MonadIO m) => Status -> ExceptT Text m (Maybe GetReferenceResult)
+getReferenceHandleErrorCases status | status == notFound404       = pure Nothing
+                                    | otherwise                   = throwE "Unexpected error."
+
+getReference :: (MonadIO m) => AccessToken -> Text -> Text -> Text -> ExceptT Text m (Maybe GetReferenceResult)
+getReference accessToken owner repository reference = do
+  let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/ref/" <> reference
+  callGithub getFromGithub [] getReferenceHandleErrorCases accessToken repoUrl ()
+
+updateBranchHandleErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
+updateBranchHandleErrorCases status | status == unprocessableEntity422  = liftIO $ fail "Unprocessable entity returned when creating tree."
+                                    | otherwise                         = throwE "Unexpected error."
+
+updateGitBranch :: (MonadIO m) => AccessToken -> Text -> Text -> Text -> Text -> Bool -> ExceptT Text m UpdateGitBranchResult
+updateGitBranch accessToken owner repository commitSha branchName forceUpdate = do
+  let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/refs/heads/" <> branchName
+  let request = UpdateGitBranch commitSha forceUpdate
+  callGithub patchToGithub [] updateBranchHandleErrorCases accessToken repoUrl request
+
+updateGitBranchForCommit :: (MonadIO m) => AccessToken -> PersistentModel -> Text -> Text -> ExceptT Text m UpdateGitBranchResult
+updateGitBranchForCommit accessToken PersistentModel{..} commitSha branchName = do
+  let possibleGithubRepo = targetRepository githubSettings
+  case possibleGithubRepo of
+    Just GithubRepo{..} -> updateGitBranch accessToken owner repository commitSha branchName False
     Nothing   -> throwE "No repository set on project."
 
 createBranchHandleErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
@@ -273,6 +322,17 @@ getUsersPublicRepositories :: (MonadIO m) => AccessToken -> Int -> ExceptT Text 
 getUsersPublicRepositories accessToken page = do
   let repoUrl = "https://api.github.com/user/repos"
   callGithub getFromGithub [("per_page", show userRepositoriesPerPage), ("page", show page), ("visibility", "public")] getUsersPublicRepositoriesErrorCases accessToken repoUrl ()
+
+getRepositoryErrorCases :: (MonadIO m) => Status -> ExceptT Text m (Maybe UsersRepository)
+getRepositoryErrorCases status | status == movedPermanently301      = throwE "Repository moved elsewhere."
+                               | status == forbidden403             = throwE "Forbidden from loading repository."
+                               | status == notFound404              = pure Nothing
+                               | otherwise                          = throwE "Unexpected error."
+
+getRepository :: (MonadIO m) => AccessToken -> Text -> Text -> ExceptT Text m (Maybe UsersRepository)
+getRepository accessToken owner repository = do
+  let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository
+  callGithub getFromGithub [] getRepositoryErrorCases accessToken repoUrl ()
 
 getGitCommitErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
 getGitCommitErrorCases status | status == notFound404          = throwE "Commit does not exist."

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -140,7 +140,6 @@ callGithub makeRequest queryParameters handleErrorCases accessToken restURL requ
   -- Make the request.
   result <- liftIO $ makeRequest options (toS restURL) request
   let status = view WR.responseStatus result
-  -- Uncomment the next line if you want to see the headers.
   let logStuffForErrors = liftIO $ print (restURL, status, view WR.responseHeaders result, view WR.responseBody result)
   -- Check the rate limiting.
   let rateLimitRemaining = firstOf (WR.responseHeader "X-RateLimit-Remaining" . unpackedChars . decimal) result :: Maybe Int

--- a/server/src/Utopia/Web/Github/Types.hs
+++ b/server/src/Utopia/Web/Github/Types.hs
@@ -133,6 +133,41 @@ instance FromJSON CreateGitCommitResult where
 instance ToJSON CreateGitCommitResult where
   toJSON = genericToJSON defaultOptions
 
+data GetReferenceResult = GetReferenceResult
+                        { ref    :: Text
+                        }
+                        deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON GetReferenceResult where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON GetReferenceResult where
+  toJSON = genericToJSON defaultOptions
+
+data UpdateGitBranch = UpdateGitBranch
+                     { sha :: Text
+                     , force :: Bool
+                     }
+                     deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON UpdateGitBranch where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON UpdateGitBranch where
+  toJSON = genericToJSON defaultOptions
+
+data UpdateGitBranchResult = UpdateGitBranchResult
+                           { ref :: Text
+                           , url :: Text
+                           }
+                           deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON UpdateGitBranchResult where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON UpdateGitBranchResult where
+  toJSON = genericToJSON defaultOptions
+
 data CreateGitBranch = CreateGitBranch
                      { ref :: Text
                      , sha :: Text
@@ -155,6 +190,42 @@ instance FromJSON CreateGitBranchResult where
   parseJSON = genericParseJSON defaultOptions
 
 instance ToJSON CreateGitBranchResult where
+  toJSON = genericToJSON defaultOptions
+
+data UpdateGitFile = UpdateGitFile
+                     { message :: Text
+                     , branch  :: Text
+                     , content :: Text
+                     }
+                     deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON UpdateGitFile where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON UpdateGitFile where
+  toJSON = genericToJSON defaultOptions
+
+data UpdateGitFileResultCommit = UpdateGitFileResultCommit
+                               { sha   :: Text
+                               , url   :: Text
+                               }
+                               deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON UpdateGitFileResultCommit where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON UpdateGitFileResultCommit where
+  toJSON = genericToJSON defaultOptions
+
+data UpdateGitFileResult = UpdateGitFileResult
+                           { commit :: UpdateGitFileResultCommit
+                           }
+                           deriving (Eq, Show, Generic, Data, Typeable)
+
+instance FromJSON UpdateGitFileResult where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON UpdateGitFileResult where
   toJSON = genericToJSON defaultOptions
 
 data SaveToGithubSuccess = SaveToGithubSuccess
@@ -474,6 +545,7 @@ instance ToJSON GetBranchContentResponse where
 
 data RepositoryOwner = RepositoryOwner
                      { avatar_url   :: Text
+                     , login        :: Text
                      }
                      deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -501,8 +573,9 @@ data UsersRepository = UsersRepository
                      , owner          :: RepositoryOwner
                      , private        :: Bool
                      , description    :: Maybe Text
-                     , name           :: Maybe Text
-                     , updated_at     :: UTCTime
+                     , name           :: Text
+                     , updated_at     :: Maybe UTCTime
+                     , pushed_at      :: Maybe UTCTime
                      , default_branch :: Text
                      , permissions    :: UsersRepositoryPermissions
                      }
@@ -519,9 +592,9 @@ type GetUsersPublicRepositoriesResult = [UsersRepository]
 data RepositoryEntry = RepositoryEntry
                      { fullName      :: Text
                      , avatarUrl     :: Maybe Text
-                     , private       :: Bool
+                     , isPrivate     :: Bool
                      , description   :: Maybe Text
-                     , name          :: Maybe Text
+                     , name          :: Text
                      , updatedAt     :: Maybe UTCTime
                      , defaultBranch :: Text
                      , permissions   :: UsersRepositoryPermissions


### PR DESCRIPTION
**Problem:**
The Github APIs are sensitive to two things during our existing saving flow:
a) The repository being completely empty causes some endpoints to just outright fail.
b) There are distinct create and update endpoints for references which fail if the reference does or does not exist respectively.

**Fix:**
The above issues are fixed in the following ways:
a) An initial commit is pushed to the default branch of the repository if the repository appears to be completely empty.
b) The existence of the reference is checked for and the appropriate create or update reference endpoint is called.

**Commit Details:**
- Added `name` to `RepositoryEntry`.
- Change `private` to `isPrivate` on `RepositoryEntry` to avoid keyword collision.
- Modify `callGithub` to log errors when a non-2XX response comes back.
- Renamed some functions in `Github.hs` which are prefixed with `createGitTree` to make them more consistent with others that have the same prefix.
- Added `updateGitFile`, `getReference`, `updateGitBranch` and `getRepository` functions for calling Github API endpoints.
- Added `createInitialCommitIfNecessary` to handle the empty repository case of creating a pointless commit in a way that seems to work for Github.
- `updated_at` is now required in `RepositoryEntry`.
- `createTreeAndSaveToGithub` now triggers the initial commit creation and switches between the create and update endpoints depending on the existence of the reference.