### PR TITLE
Feat/decouple branch selection

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -629,7 +629,7 @@ export interface UpdateBranchContents {
 
 export interface UpdateGithubSettings {
   action: 'UPDATE_GITHUB_SETTINGS'
-  settings: ProjectGithubSettings
+  settings: Partial<ProjectGithubSettings>
 }
 
 export interface UpdateGithubData {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -1010,7 +1010,9 @@ export function updateBranchContents(
   }
 }
 
-export function updateGithubSettings(settings: ProjectGithubSettings): UpdateGithubSettings {
+export function updateGithubSettings(
+  settings: Partial<ProjectGithubSettings>,
+): UpdateGithubSettings {
   return {
     action: 'UPDATE_GITHUB_SETTINGS',
     settings: settings,

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -938,6 +938,7 @@ describe('LOAD', () => {
         originCommit: null,
         branchName: null,
         pendingCommit: null,
+        branchLoaded: false,
       },
       githubChecksums: null,
       branchContents: null,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3720,7 +3720,10 @@ export const UPDATE_FNS = {
   UPDATE_GITHUB_SETTINGS: (action: UpdateGithubSettings, editor: EditorModel): EditorModel => {
     return {
       ...editor,
-      githubSettings: action.settings,
+      githubSettings: {
+        ...editor.githubSettings,
+        ...action.settings,
+      },
     }
   },
   UPDATE_GITHUB_DATA: (action: UpdateGithubData, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/actions/migrations/migrations.ts
+++ b/editor/src/components/editor/actions/migrations/migrations.ts
@@ -10,7 +10,6 @@ import {
   textFileContents,
   unparsed,
   RevisionsState,
-  isParsedTextFile,
 } from '../../../../core/shared/project-file-types'
 import { isRight, right } from '../../../../core/shared/either'
 import {
@@ -30,7 +29,7 @@ import {
 } from '../../../assets'
 import { isUtopiaJSXComponent } from '../../../../core/shared/element-template'
 
-export const CURRENT_PROJECT_VERSION = 10
+export const CURRENT_PROJECT_VERSION = 11
 
 export function applyMigrations(
   persistentModel: PersistentModel,
@@ -45,7 +44,8 @@ export function applyMigrations(
   const version8 = migrateFromVersion7(version7)
   const version9 = migrateFromVersion8(version8)
   const version10 = migrateFromVersion9(version9)
-  return version10
+  const version11 = migrateFromVersion10(version10)
+  return version11
 }
 
 function migrateFromVersion0(
@@ -376,6 +376,27 @@ function migrateFromVersion9(
         ...persistentModel.githubSettings,
         originCommit: null,
         branchName: null,
+      },
+      githubChecksums: null,
+      branchContents: null,
+    }
+  }
+}
+
+function migrateFromVersion10(
+  persistentModel: PersistentModel,
+): PersistentModel & { projectVersion: 11 } {
+  if (persistentModel.projectVersion != null && persistentModel.projectVersion !== 10) {
+    return persistentModel as any
+  } else {
+    return {
+      ...persistentModel,
+      projectVersion: 11,
+      githubSettings: {
+        ...persistentModel.githubSettings,
+        originCommit: null,
+        branchName: null,
+        branchLoaded: false,
       },
       githubChecksums: null,
       branchContents: null,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1146,6 +1146,22 @@ export interface ProjectGithubSettings {
   branchLoaded: boolean
 }
 
+export function projectGithubSettings(
+  targetRepository: GithubRepo | null,
+  originCommit: string | null,
+  branchName: string | null,
+  pendingCommit: string | null,
+  branchLoaded: boolean,
+): ProjectGithubSettings {
+  return {
+    targetRepository: targetRepository,
+    originCommit: originCommit,
+    branchName: branchName,
+    pendingCommit: pendingCommit,
+    branchLoaded: branchLoaded,
+  }
+}
+
 export function emptyGithubSettings(): ProjectGithubSettings {
   return {
     targetRepository: null,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1143,20 +1143,7 @@ export interface ProjectGithubSettings {
   originCommit: string | null
   branchName: string | null
   pendingCommit: string | null
-}
-
-export function projectGithubSettings(
-  targetRepository: GithubRepo | null,
-  originCommit: string | null,
-  branchName: string | null,
-  pendingCommit: string | null,
-): ProjectGithubSettings {
-  return {
-    targetRepository: targetRepository,
-    originCommit: originCommit,
-    branchName: branchName,
-    pendingCommit: pendingCommit,
-  }
+  branchLoaded: boolean
 }
 
 export function emptyGithubSettings(): ProjectGithubSettings {
@@ -1165,6 +1152,7 @@ export function emptyGithubSettings(): ProjectGithubSettings {
     originCommit: null,
     branchName: null,
     pendingCommit: null,
+    branchLoaded: false,
   }
 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -300,7 +300,6 @@ import {
   EditorStateCodeEditorErrors,
   ErrorMessages,
   editorStateCodeEditorErrors,
-  Theme,
   editorState,
   AllElementProps,
   LockedElements,
@@ -323,7 +322,7 @@ import {
   emptyGithubData,
   DragToMoveIndicatorFlags,
   dragToMoveIndicatorFlags,
-  emptyGithubSettings,
+  projectGithubSettings,
 } from './editor-state'
 import {
   CornerGuideline,
@@ -356,8 +355,6 @@ import {
   PaddingResizeHandle,
   resizeHandle,
   ResizeHandle,
-  paddingResizeHandle,
-  borderRadiusResizeHandle,
   BorderRadiusResizeHandle,
 } from '../../canvas/canvas-strategies/interaction-state'
 import { Modifiers } from '../../../utils/modifiers'
@@ -3290,19 +3287,7 @@ export const ProjectGithubSettingsKeepDeepEquality: KeepDeepEqualityCall<Project
     nullableDeepEquality(createCallWithTripleEquals<string>()),
     (settings) => settings.branchLoaded,
     BooleanKeepDeepEquality,
-    (
-      targetRepository: GithubRepo | null,
-      originCommit: string | null,
-      branchName: string | null,
-      pendingCommit: string | null,
-      branchLoaded: boolean,
-    ): ProjectGithubSettings => ({
-      targetRepository,
-      originCommit,
-      branchName,
-      pendingCommit,
-      branchLoaded,
-    }),
+    projectGithubSettings,
   )
 
 export const GithubFileChangesKeepDeepEquality: KeepDeepEqualityCall<GithubFileChanges> =

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -321,9 +321,9 @@ import {
   fileRevertModal,
   GithubData,
   emptyGithubData,
-  projectGithubSettings,
   DragToMoveIndicatorFlags,
   dragToMoveIndicatorFlags,
+  emptyGithubSettings,
 } from './editor-state'
 import {
   CornerGuideline,
@@ -3273,7 +3273,7 @@ export const RepositoryEntryKeepDeepEquality: KeepDeepEqualityCall<RepositoryEnt
   )
 
 export const ProjectGithubSettingsKeepDeepEquality: KeepDeepEqualityCall<ProjectGithubSettings> =
-  combine4EqualityCalls(
+  combine5EqualityCalls(
     (settings) => settings.targetRepository,
     nullableDeepEquality(GithubRepoKeepDeepEquality),
     (settings) => settings.originCommit,
@@ -3282,7 +3282,21 @@ export const ProjectGithubSettingsKeepDeepEquality: KeepDeepEqualityCall<Project
     nullableDeepEquality(createCallWithTripleEquals<string>()),
     (settings) => settings.pendingCommit,
     nullableDeepEquality(createCallWithTripleEquals<string>()),
-    projectGithubSettings,
+    (settings) => settings.branchLoaded,
+    BooleanKeepDeepEquality,
+    (
+      targetRepository: GithubRepo | null,
+      originCommit: string | null,
+      branchName: string | null,
+      pendingCommit: string | null,
+      branchLoaded: boolean,
+    ): ProjectGithubSettings => ({
+      targetRepository,
+      originCommit,
+      branchName,
+      pendingCommit,
+      branchLoaded,
+    }),
   )
 
 export const GithubFileChangesKeepDeepEquality: KeepDeepEqualityCall<GithubFileChanges> =

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -858,7 +858,7 @@ const BranchNotLoadedBlock = () => {
                 <StringInput
                   testId='commit-message-input'
                   placeholder='Commit message'
-                  value={commitMessage || ''}
+                  value={commitMessage ?? ''}
                   onChange={updateCommitMessage}
                 />
                 <Button

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -608,7 +608,7 @@ const LocalChangesBlock = () => {
           <StringInput
             testId='commit-message-input'
             placeholder='Commit message'
-            value={commitMessage || ''}
+            value={commitMessage ?? ''}
             onChange={updateCommitMessage}
           />
           {when(
@@ -879,7 +879,7 @@ const BranchNotLoadedBlock = () => {
                 <StringInput
                   testId='commit-message-input'
                   placeholder='Commit message'
-                  value={commitMessage || ''}
+                  value={commitMessage ?? ''}
                   onChange={updateCommitMessage}
                 />
                 <Button

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -205,7 +205,7 @@ const BranchBlock = () => {
       })
     } else {
       const newBranchName = cleanupBranchName(branchFilter)
-      if (newBranchName.length > 1) {
+      if (newBranchName.length > 1 && !filtered.some((b) => b.name === newBranchName)) {
         filtered.push({
           name: newBranchName,
           new: true,

--- a/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
@@ -20,7 +20,7 @@ import {
   RepositoryEntry,
 } from '../../../../core/shared/github'
 import { when } from '../../../../utils/react-conditionals'
-import { Button, colorTheme, FlexColumn, StringInput } from '../../../../uuiui'
+import { Button, colorTheme, FlexColumn, FlexRow, StringInput } from '../../../../uuiui'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { Ellipsis } from './github-file-changes-list'
 import { GithubSpinner } from './github-spinner'
@@ -241,7 +241,7 @@ export const RepositoryListing = React.memo(
 
     return (
       <FlexColumn style={{ gap: 4 }}>
-        <UIGridRow padded={false} variant={'<----------1fr---------><-auto->'}>
+        <UIGridRow padded={false} variant='<-------------1fr------------->'>
           <StringInput
             placeholder={
               filteredRepositoriesWithSpecialCases == null
@@ -255,15 +255,6 @@ export const RepositoryListing = React.memo(
             name={'repositories-input'}
             value={targetRepository}
           />
-          <Button
-            spotlight
-            highlight
-            style={{ padding: '0 6px' }}
-            disabled={githubWorking}
-            onMouseDown={refreshRepos}
-          >
-            {isLoadingRepositories ? <GithubSpinner /> : <RefreshIcon />}
-          </Button>
         </UIGridRow>
         <FlexColumn
           style={{
@@ -285,6 +276,21 @@ export const RepositoryListing = React.memo(
             })
           )}
         </FlexColumn>
+        <Button
+          spotlight
+          highlight
+          style={{ padding: '0 6px' }}
+          disabled={githubWorking}
+          onMouseDown={refreshRepos}
+        >
+          {isLoadingRepositories ? (
+            <GithubSpinner />
+          ) : (
+            <FlexRow style={{ gap: 4 }}>
+              <RefreshIcon /> Refresh list
+            </FlexRow>
+          )}
+        </Button>
         <UIGridRow padded={false} variant='<-------------1fr------------->'>
           <a href='https://github.com/new' target='_blank' rel='noopener noreferrer'>
             Create new repository on Github.

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -120,6 +120,7 @@ async function loadProject(
       originCommit: null,
       branchName: null,
       pendingCommit: null,
+      branchLoaded: false,
     },
     githubChecksums: null,
     branchContents: null,

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -509,6 +509,7 @@ export function connectRepo(
       originCommit: originCommit,
       branchName: branchName,
       pendingCommit: originCommit,
+      branchLoaded: false,
     }),
     updateGithubData(newGithubData),
   ]
@@ -576,7 +577,6 @@ export async function updateProjectWithBranchContent(
                 responseBody.branch.originCommit,
                 branchName,
               ),
-              updateGithubSettings({ branchLoaded: true }),
               updateGithubChecksums(getProjectContentsChecksums(responseBody.branch.content)),
               updateProjectContents(responseBody.branch.content),
               updateBranchContents(responseBody.branch.content),

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -252,6 +252,7 @@ export async function saveProjectToGithub(
               originCommit: responseBody.newCommit,
               branchName: responseBody.branchName,
               pendingCommit: responseBody.newCommit,
+              branchLoaded: true,
             }),
             updateBranchContents(persistentModel.projectContents),
             showToast(notice(`Saved to branch ${responseBody.branchName}.`, 'INFO')),

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -43,6 +43,7 @@ import {
   GithubUser,
   packageJsonFileFromProjectContents,
   PersistentModel,
+  projectGithubSettings,
   PullRequest,
 } from '../../components/editor/store/editor-state'
 import { BuiltInDependencies } from '../es-modules/package-manager/built-in-dependencies-list'
@@ -246,14 +247,15 @@ export async function saveProjectToGithub(
         dispatch(
           [
             updateGithubChecksums(getProjectContentsChecksums(persistentModel.projectContents)),
-            updateGithubSettings({
-              ...emptyGithubSettings(),
-              targetRepository: persistentModel.githubSettings.targetRepository,
-              originCommit: responseBody.newCommit,
-              branchName: responseBody.branchName,
-              pendingCommit: responseBody.newCommit,
-              branchLoaded: true,
-            }),
+            updateGithubSettings(
+              projectGithubSettings(
+                persistentModel.githubSettings.targetRepository,
+                responseBody.newCommit,
+                responseBody.branchName,
+                responseBody.newCommit,
+                true,
+              ),
+            ),
             updateBranchContents(persistentModel.projectContents),
             showToast(notice(`Saved to branch ${responseBody.branchName}.`, 'INFO')),
           ],
@@ -503,14 +505,9 @@ export function connectRepo(
     newGithubData.branches = []
   }
   return [
-    updateGithubSettings({
-      ...emptyGithubSettings(),
-      targetRepository: githubRepo,
-      originCommit: originCommit,
-      branchName: branchName,
-      pendingCommit: originCommit,
-      branchLoaded: false,
-    }),
+    updateGithubSettings(
+      projectGithubSettings(githubRepo, originCommit, branchName, originCommit, false),
+    ),
     updateGithubData(newGithubData),
   ]
 }

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -134,7 +134,7 @@ callGithub makeRequest queryParameters handleErrorCases accessToken restURL requ
   -- Make the request.
   result <- liftIO $ makeRequest options (toS restURL) request
   -- Uncomment the next line if you want to see the headers.
-  -- liftIO $ print $ view WR.responseHeaders result
+  liftIO $ print (restURL, view WR.responseHeaders result)
   let status = view WR.responseStatus result
   -- Check the rate limiting.
   let rateLimitRemaining = firstOf (WR.responseHeader "X-RateLimit-Remaining" . unpackedChars . decimal) result :: Maybe Int


### PR DESCRIPTION
Fixes #2891 

**Problem:**

The branch selection currently loads the branch contents replacing the current project contents. No bueno, if you want to just save your work to a GH branch/repo.

**Fix:**

Decouple selecting a branch from loading it (like https://github.com/concrete-utopia/utopia/pull/2866), and add a new block to choose what to do with the newly-selected branch:

![branch flow full](https://user-images.githubusercontent.com/1081051/203061620-e4ce849b-c2a0-4b9c-83fb-4d14b10220e8.gif)