### PR TITLE
Prevent Github errors on load from breaking editor.

### DIFF
--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -662,8 +662,13 @@ export async function updateUserDetailsWhenAuthenticated(
 ): Promise<boolean> {
   const authenticationResult = await authenticationCheck
   if (authenticationResult) {
-    const userDetails = await getUserDetailsFromServer()
-    dispatch([updateGithubData({ githubUserDetails: userDetails })], 'everyone')
+    await getUserDetailsFromServer()
+      .then((userDetails) => {
+        dispatch([updateGithubData({ githubUserDetails: userDetails })], 'everyone')
+      })
+      .catch((error) => {
+        console.error(`Error while attempting to retrieve Github user details: ${error}`)
+      })
   }
   return authenticationResult
 }


### PR DESCRIPTION
**Problem:**
If the Github rate limiting has kicked in or Github has gone down, then the startup flow will throw an exception for users authenticated with Github.

**Fix:**
Failures when attempting to get the user details from Github are now just logged to the console.

**Commit Details:**
- `updateUserDetailsWhenAuthenticated` now handles `getUserDetailsFromServer` failing internally, rather than letting the exception bubble up.