### PR TITLE
Disable gap control if children are wrapped

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.spec.browser2.tsx
@@ -180,6 +180,47 @@ export var storyboard = (
     expect(gapControlHandles.length).toEqual(1)
   })
 
+  it('gap controls are not present when elements are wrapped', async () => {
+    const editor = await renderTestEditorWithCode(
+      projectWithWrappedLayout(true),
+      'await-first-dom-report',
+    )
+
+    const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
+    const div = editor.renderedDOM.getByTestId(DivTestId)
+    const divBounds = div.getBoundingClientRect()
+    mouseClickAtPoint(canvasControlsLayer, {
+      x: divBounds.x + 5,
+      y: divBounds.y + 5,
+    })
+
+    const gapControls = [
+      ...editor.renderedDOM.queryAllByTestId(FlexGapControlTestId),
+      ...editor.renderedDOM.queryAllByTestId(FlexGapControlHandleTestId),
+    ]
+
+    expect(gapControls).toEqual([])
+  })
+
+  it('gap controls are present when elements are not wrapped', async () => {
+    const editor = await renderTestEditorWithCode(
+      projectWithWrappedLayout(false),
+      'await-first-dom-report',
+    )
+
+    const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
+    const div = editor.renderedDOM.getByTestId(DivTestId)
+    const divBounds = div.getBoundingClientRect()
+    mouseClickAtPoint(canvasControlsLayer, {
+      x: divBounds.x + 5,
+      y: divBounds.y + 5,
+    })
+
+    const gapControls = [...editor.renderedDOM.queryAllByTestId(FlexGapControlHandleTestId)]
+
+    expect(gapControls.length).toEqual(3)
+  })
+
   it('adjusts gap by dragging the handle', async () => {
     const initialGap = 42
     const dragDelta = 11
@@ -545,4 +586,67 @@ async function doGapResize(editor: EditorRenderResult, delta: CanvasPoint) {
 
   mouseDragFromPointToPoint(gapControlHandle, center, endPoint)
   await editor.getDispatchFollowUpActionsFinished()
+}
+
+function projectWithWrappedLayout(wrap: boolean): string {
+  return `import * as React from 'react'
+  import { Scene, Storyboard } from 'utopia-api'
+  
+  export var storyboard = (
+    <Storyboard data-uid='Storyboard'>
+      <div
+        data-testid='${DivTestId}'
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          width: 307,
+          height: 234,
+          display: 'flex',
+          flexWrap: '${wrap ? 'wrap' : 'nowrap'}',
+          gap: 41,
+          left: 43,
+          top: 201,
+        }}
+        data-uid='cca'
+      >
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            width: 77,
+            height: 51,
+            contain: 'layout',
+          }}
+          data-uid='a58'
+        />
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            width: 51,
+            height: 88,
+            contain: 'layout',
+          }}
+          data-uid='47c'
+        />
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            width: 40,
+            height: 59,
+            contain: 'layout',
+          }}
+          data-uid='121'
+        />
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            width: 36,
+            height: 52,
+            contain: 'layout',
+          }}
+          data-uid='e7f'
+        />
+      </div>
+    </Storyboard>
+  )
+  `
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
@@ -34,6 +34,7 @@ import {
   strategyApplicationResult,
 } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
+import { areAllSiblingsInOneDimensionFlexOrFlow } from './flow-reorder-helpers'
 
 export const SetFlexGapStrategyId = 'SET_FLEX_GAP_STRATEGY'
 
@@ -52,6 +53,14 @@ export const setFlexGapStrategy: CanvasStrategyFactory = (
 
   const selectedElement = selectedElements[0]
   const children = MetadataUtils.getChildrenPaths(canvasState.startingMetadata, selectedElement)
+
+  if (children.length < 2) {
+    return null
+  }
+
+  if (!areAllSiblingsInOneDimensionFlexOrFlow(children[0], canvasState.startingMetadata)) {
+    return null
+  }
 
   const flexGap = maybeFlexGapFromElement(canvasState.startingMetadata, selectedElements[0])
   if (flexGap == null) {


### PR DESCRIPTION
## Problem
Gap controls don't show up correctly when children are wrapped

## Fix
Disable the gap strategy is children are wrapped