### PR TITLE
Refresh branch content can avoid loading the branch.

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -407,6 +407,7 @@ const useGithubData = (): void => {
     branchName,
     githubChecksums,
     githubUserDetails,
+    lastRefreshedCommit,
   } = useEditorState(
     (store) => ({
       githubAuthenticated: store.userState.githubState.authenticated,
@@ -415,6 +416,7 @@ const useGithubData = (): void => {
       branchName: store.editor.githubSettings.branchName,
       githubChecksums: store.editor.githubChecksums,
       githubUserDetails: store.editor.githubData.githubUserDetails,
+      lastRefreshedCommit: store.editor.githubData.lastRefreshedCommit,
     }),
     'Github data',
   )
@@ -427,8 +429,17 @@ const useGithubData = (): void => {
       branchName,
       githubChecksums,
       githubUserDetails,
+      lastRefreshedCommit,
     )
-  }, [dispatch, githubAuthenticated, githubRepo, branchName, githubChecksums, githubUserDetails])
+  }, [
+    dispatch,
+    githubAuthenticated,
+    githubRepo,
+    branchName,
+    githubChecksums,
+    githubUserDetails,
+    lastRefreshedCommit,
+  ])
 
   // perform a straight refresh then the repo or the auth change
   React.useEffect(() => refresh(), [refresh])

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1187,6 +1187,7 @@ export interface GithubData {
   upstreamChanges: GithubFileChanges | null
   currentBranchPullRequests: Array<PullRequest> | null
   githubUserDetails: GithubUser | null
+  lastRefreshedCommit: string | null
 }
 
 export function emptyGithubData(): GithubData {
@@ -1198,6 +1199,7 @@ export function emptyGithubData(): GithubData {
     upstreamChanges: null,
     currentBranchPullRequests: null,
     githubUserDetails: null,
+    lastRefreshedCommit: null,
   }
 }
 

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -428,8 +428,8 @@ export async function updateProjectAgainstGithub(
 
   dispatch([updateGithubOperations(operation, 'add')], 'everyone')
 
-  const branchLatestRequest = getBranchContentFromServer(githubRepo, branchName, null)
-  const specificCommitRequest = getBranchContentFromServer(githubRepo, branchName, commitSha)
+  const branchLatestRequest = getBranchContentFromServer(githubRepo, branchName, null, null)
+  const specificCommitRequest = getBranchContentFromServer(githubRepo, branchName, commitSha, null)
 
   const branchLatestResponse = await branchLatestRequest
   const specificCommitResponse = await specificCommitRequest
@@ -528,7 +528,7 @@ export async function updateProjectWithBranchContent(
 
   dispatch([updateGithubOperations(operation, 'add')], 'everyone')
 
-  const response = await getBranchContentFromServer(githubRepo, branchName, null)
+  const response = await getBranchContentFromServer(githubRepo, branchName, null, null)
 
   if (response.ok) {
     const responseBody: GetBranchContentResponse = await response.json()
@@ -603,6 +603,7 @@ async function getBranchContentFromServer(
   githubRepo: GithubRepo,
   branchName: string,
   commitSha: string | null,
+  previousCommitSha: string | null,
 ): Promise<Response> {
   const url = urljoin(
     UTOPIA_BACKEND,
@@ -618,6 +619,10 @@ async function getBranchContentFromServer(
   if (commitSha != null) {
     includeQueryParams = true
     paramsRecord.commit_sha = commitSha
+  }
+  if (previousCommitSha != null) {
+    includeQueryParams = true
+    paramsRecord.previous_commit_sha = previousCommitSha
   }
   const searchParams = new URLSearchParams(paramsRecord)
   const urlToUse = includeQueryParams ? `${url}?${searchParams}` : url
@@ -1175,6 +1180,7 @@ export async function refreshGithubData(
   branchName: string | null,
   branchChecksums: GithubChecksums | null,
   githubUserDetails: GithubUser | null,
+  previousCommitSha: string | null,
 ): Promise<void> {
   if (githubAuthenticated) {
     if (githubUserDetails === null) {
@@ -1188,16 +1194,36 @@ export async function refreshGithubData(
       void getBranchesForGithubRepository(dispatch, githubRepo)
       if (branchName != null && branchChecksums != null) {
         void updatePullRequestsForBranch(dispatch, githubRepo, branchName)
-        const branchContentResponse = await getBranchContentFromServer(githubRepo, branchName, null)
+        const branchContentResponse = await getBranchContentFromServer(
+          githubRepo,
+          branchName,
+          null,
+          previousCommitSha,
+        )
         if (branchContentResponse.ok) {
           const branchLatestContent: GetBranchContentResponse = await branchContentResponse.json()
           if (branchLatestContent.type === 'SUCCESS' && branchLatestContent.branch != null) {
             upstreamChangesSuccess = true
-            const upstreamChecksums = getProjectContentsChecksums(
-              branchLatestContent.branch.content,
-            )
-            const upstreamChanges = deriveGithubFileChanges(branchChecksums, upstreamChecksums, {})
-            dispatch([updateGithubData({ upstreamChanges: upstreamChanges })], 'everyone')
+            // It was a successful call, but we got the same commit as last time.
+            if (previousCommitSha !== branchLatestContent.branch.originCommit) {
+              const upstreamChecksums = getProjectContentsChecksums(
+                branchLatestContent.branch.content,
+              )
+              const upstreamChanges = deriveGithubFileChanges(
+                branchChecksums,
+                upstreamChecksums,
+                {},
+              )
+              dispatch(
+                [
+                  updateGithubData({
+                    upstreamChanges: upstreamChanges,
+                    lastRefreshedCommit: branchLatestContent.branch.originCommit,
+                  }),
+                ],
+                'everyone',
+              )
+            }
           }
         }
       }

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -1204,27 +1204,23 @@ export async function refreshGithubData(
           const branchLatestContent: GetBranchContentResponse = await branchContentResponse.json()
           if (branchLatestContent.type === 'SUCCESS' && branchLatestContent.branch != null) {
             upstreamChangesSuccess = true
-            // It was a successful call, but we got the same commit as last time.
-            if (previousCommitSha !== branchLatestContent.branch.originCommit) {
-              const upstreamChecksums = getProjectContentsChecksums(
-                branchLatestContent.branch.content,
-              )
-              const upstreamChanges = deriveGithubFileChanges(
-                branchChecksums,
-                upstreamChecksums,
-                {},
-              )
-              dispatch(
-                [
-                  updateGithubData({
-                    upstreamChanges: upstreamChanges,
-                    lastRefreshedCommit: branchLatestContent.branch.originCommit,
-                  }),
-                ],
-                'everyone',
-              )
-            }
+            const upstreamChecksums = getProjectContentsChecksums(
+              branchLatestContent.branch.content,
+            )
+            const upstreamChanges = deriveGithubFileChanges(branchChecksums, upstreamChecksums, {})
+            dispatch(
+              [
+                updateGithubData({
+                  upstreamChanges: upstreamChanges,
+                  lastRefreshedCommit: branchLatestContent.branch.originCommit,
+                }),
+              ],
+              'everyone',
+            )
           }
+        } else if (branchContentResponse.status === 304) {
+          // Not modified status means that the branch has the same commit SHA.
+          upstreamChangesSuccess = true
         }
       }
       if (!upstreamChangesSuccess) {

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -22,6 +22,7 @@ import           Data.Aeson.Lens
 import qualified Data.ByteString.Lazy            as BL
 import           Data.CaseInsensitive            hiding (traverse)
 import           Data.Generics.Product
+import           Data.Generics.Sum
 import qualified Data.HashMap.Strict             as M
 import qualified Data.Text                       as T
 import           Data.Text.Encoding
@@ -674,8 +675,18 @@ getGithubBranchesEndpoint cookie owner repository = requireUser cookie $ \sessio
   getBranchesFromGithubRepo (view (field @"_id") sessionUser) owner repository
 
 getGithubBranchContentEndpoint :: Maybe Text -> Text -> Text -> Text -> Maybe Text -> Maybe Text -> ServerMonad GetBranchContentResponse
-getGithubBranchContentEndpoint cookie owner repository branchName possibleCommitSha possiblePreviousCommitSha = requireUser cookie $ \sessionUser -> do
-  getBranchContent (view (field @"_id") sessionUser) owner repository branchName possibleCommitSha possiblePreviousCommitSha
+getGithubBranchContentEndpoint cookie owner repository branchName possibleCommitSha Nothing = requireUser cookie $ \sessionUser -> do
+  -- No previous commit SHA was supplied.
+  getBranchContent (view (field @"_id") sessionUser) owner repository branchName possibleCommitSha Nothing
+getGithubBranchContentEndpoint cookie owner repository branchName possibleCommitSha justPreviousCommitSha@(Just _) = requireUser cookie $ \sessionUser -> do
+  -- A previous commit SHA was supplied, which may mean we want to return a 304.
+  contentResponse <- getBranchContent (view (field @"_id") sessionUser) owner repository branchName possibleCommitSha justPreviousCommitSha
+  -- Check the previous commit SHA against the newly returned content.
+  let possibleNewCommitSha = firstOf (_Ctor @"GetBranchContentResponseSuccess" . field @"branch" . _Just . field @"originCommit") contentResponse
+  -- Return a 304 if the commits match.
+  if possibleNewCommitSha == justPreviousCommitSha
+    then notModified
+    else pure contentResponse
 
 getGithubUsersRepositoriesEndpoint :: Maybe Text -> ServerMonad GetUsersPublicRepositoriesResponse
 getGithubUsersRepositoriesEndpoint cookie = requireUser cookie $ \sessionUser -> do

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -673,9 +673,9 @@ getGithubBranchesEndpoint :: Maybe Text -> Text -> Text -> ServerMonad GetBranch
 getGithubBranchesEndpoint cookie owner repository = requireUser cookie $ \sessionUser -> do
   getBranchesFromGithubRepo (view (field @"_id") sessionUser) owner repository
 
-getGithubBranchContentEndpoint :: Maybe Text -> Text -> Text -> Text -> Maybe Text -> ServerMonad GetBranchContentResponse
-getGithubBranchContentEndpoint cookie owner repository branchName possibleCommitSha = requireUser cookie $ \sessionUser -> do
-  getBranchContent (view (field @"_id") sessionUser) owner repository branchName possibleCommitSha
+getGithubBranchContentEndpoint :: Maybe Text -> Text -> Text -> Text -> Maybe Text -> Maybe Text -> ServerMonad GetBranchContentResponse
+getGithubBranchContentEndpoint cookie owner repository branchName possibleCommitSha possiblePreviousCommitSha = requireUser cookie $ \sessionUser -> do
+  getBranchContent (view (field @"_id") sessionUser) owner repository branchName possibleCommitSha possiblePreviousCommitSha
 
 getGithubUsersRepositoriesEndpoint :: Maybe Text -> ServerMonad GetUsersPublicRepositoriesResponse
 getGithubUsersRepositoriesEndpoint cookie = requireUser cookie $ \sessionUser -> do

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -555,7 +555,7 @@ getDetailsOfGithubUser :: (MonadBaseControl IO m, MonadIO m, MonadThrow m) => Gi
 getDetailsOfGithubUser githubResources logger metrics pool userID = do
   result <- runExceptT $ do
     useAccessToken githubResources logger metrics pool userID $ \accessToken -> do
-      userResult <- getGithubUser accessToken 
+      userResult <- getGithubUser accessToken
       pure $ githubUserFromGithubUserResult userResult
   pure $ either getGithubUserResponseFailureFromReason getGithubUserResponseSuccessFromContent result
 

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -359,7 +359,7 @@ innerServerExecutor (GetBranchesFromGithubRepo user owner repository action) = d
     Just githubResources -> do
       result <- getGithubBranches githubResources logger metrics pool user owner repository
       pure $ action result
-innerServerExecutor (GetBranchContent user owner repository branchName possibleCommitSha action) = do
+innerServerExecutor (GetBranchContent user owner repository branchName possibleCommitSha possiblePreviousCommitSha action) = do
   possibleGithubResources <- fmap _githubResources ask
   metrics <- fmap _databaseMetrics ask
   logger <- fmap _logger ask
@@ -367,7 +367,7 @@ innerServerExecutor (GetBranchContent user owner repository branchName possibleC
   case possibleGithubResources of
     Nothing -> throwError err501
     Just githubResources -> do
-      result <- getGithubBranch githubResources logger metrics pool user owner repository branchName possibleCommitSha
+      result <- getGithubBranch githubResources logger metrics pool user owner repository branchName possibleCommitSha possiblePreviousCommitSha
       pure $ action result
 innerServerExecutor (GetUsersRepositories user action) = do
   possibleGithubResources <- fmap _githubResources ask

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -279,12 +279,12 @@ innerServerExecutor (GetBranchesFromGithubRepo user owner repository action) = d
   pool <- fmap _projectPool ask
   result <- getGithubBranches githubResources logger metrics pool user owner repository
   pure $ action result
-innerServerExecutor (GetBranchContent user owner repository branchName possibleCommitSha action) = do
+innerServerExecutor (GetBranchContent user owner repository branchName possibleCommitSha possiblePreviousCommitSha action) = do
   githubResources <- fmap _githubResources ask
   metrics <- fmap _databaseMetrics ask
   logger <- fmap _logger ask
   pool <- fmap _projectPool ask
-  result <- getGithubBranch githubResources logger metrics pool user owner repository branchName possibleCommitSha
+  result <- getGithubBranch githubResources logger metrics pool user owner repository branchName possibleCommitSha possiblePreviousCommitSha
   pure $ action result
 innerServerExecutor (GetUsersRepositories user action) = do
   githubResources <- fmap _githubResources ask

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -150,7 +150,7 @@ callGithub makeRequest queryParameters handleErrorCases accessToken restURL requ
   -- Parse the response contents.
   then except $ bimap show (\r -> view WR.responseBody r) (WR.asJSON result)
   else logStuffForErrors >> handleErrorCases status
-  
+
 
 createTreeHandleErrorCases :: (MonadIO m) => Status -> ExceptT Text m a
 createTreeHandleErrorCases status | status == forbidden403            = throwE "Forbidden from creating tree."
@@ -161,14 +161,14 @@ createTreeHandleErrorCases status | status == forbidden403            = throwE "
 createGitTree :: (MonadIO m, MonadBaseControl IO m) => AccessToken -> Text -> Text -> CreateGitTree -> ExceptT Text m CreateGitTreeResult
 createGitTree accessToken owner repository gitTree = do
   let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repository <> "/git/trees"
-  callGithub postToGithub [] createTreeHandleErrorCases accessToken repoUrl gitTree 
+  callGithub postToGithub [] createTreeHandleErrorCases accessToken repoUrl gitTree
 
 createGitTreeFromProjectContents :: (MonadIO m, MonadBaseControl IO m) => LoadAsset -> AccessToken -> GithubRepo -> ProjectContentTreeRoot -> ExceptT Text m CreateGitTreeResult
 createGitTreeFromProjectContents loadAsset accessToken repo@GithubRepo{..} projectContents = do
   -- Create a simpler function for creating a git blob.
   let createBlob = createGitBlob accessToken repo
   request <- gitTreeFromProjectContent loadAsset createBlob projectContents
-  createGitTree accessToken owner repository request 
+  createGitTree accessToken owner repository request
 
 createGitTreeFromModel :: (MonadIO m, MonadBaseControl IO m) => LoadAsset -> Text -> AccessToken -> PersistentModel -> ExceptT Text m CreateGitTreeResult
 createGitTreeFromModel loadAsset projectID accessToken PersistentModel{..} = do

--- a/server/src/Utopia/Web/Github/Types.hs
+++ b/server/src/Utopia/Web/Github/Types.hs
@@ -145,7 +145,7 @@ instance ToJSON GetReferenceResult where
   toJSON = genericToJSON defaultOptions
 
 data UpdateGitBranch = UpdateGitBranch
-                     { sha :: Text
+                     { sha   :: Text
                      , force :: Bool
                      }
                      deriving (Eq, Show, Generic, Data, Typeable)
@@ -206,8 +206,8 @@ instance ToJSON UpdateGitFile where
   toJSON = genericToJSON defaultOptions
 
 data UpdateGitFileResultCommit = UpdateGitFileResultCommit
-                               { sha   :: Text
-                               , url   :: Text
+                               { sha :: Text
+                               , url :: Text
                                }
                                deriving (Eq, Show, Generic, Data, Typeable)
 
@@ -544,8 +544,8 @@ instance ToJSON GetBranchContentResponse where
   toJSON (GetBranchContentResponseFailure failure) = over _Object (M.insert "type" "FAILURE") $ toJSON failure
 
 data RepositoryOwner = RepositoryOwner
-                     { avatar_url   :: Text
-                     , login        :: Text
+                     { avatar_url :: Text
+                     , login      :: Text
                      }
                      deriving (Eq, Show, Generic, Data, Typeable)
 

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -137,7 +137,7 @@ data ServiceCallsF a = NotFound
                      | GetGithubAuthentication Text (Maybe GithubAuthenticationDetails -> a)
                      | SaveToGithubRepo Text Text (Maybe Text) (Maybe Text) PersistentModel (SaveToGithubResponse -> a)
                      | GetBranchesFromGithubRepo Text Text Text (GetBranchesResponse -> a)
-                     | GetBranchContent Text Text Text Text (Maybe Text) (GetBranchContentResponse -> a)
+                     | GetBranchContent Text Text Text Text (Maybe Text) (Maybe Text) (GetBranchContentResponse -> a)
                      | GetUsersRepositories Text (GetUsersPublicRepositoriesResponse -> a)
                      | SaveGithubAsset Text Text Text Text Text [Text] (GithubSaveAssetResponse -> a)
                      | GetPullRequestForBranch Text Text Text Text (GetBranchPullRequestResponse -> a)

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -135,7 +135,7 @@ type GithubBranchesAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text 
 
 type GithubSaveAssetAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> "asset" :> Capture "asset_sha" Text :> QueryParam' '[Required, Strict] "project_id" Text :> QueryParam' '[Required, Strict] "path" Text :> Post '[JSON] GithubSaveAssetResponse
 
-type GithubBranchLoadAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> "branch" :> Capture "branchName" Text :> QueryParam "commit_sha" Text :> Get '[JSON] GetBranchContentResponse
+type GithubBranchLoadAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> "branch" :> Capture "branchName" Text :> QueryParam "commit_sha" Text :> QueryParam "previous_commit_sha" Text :> Get '[JSON] GetBranchContentResponse
 
 type GithubBranchPullRequestAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> "branch" :> Capture "branchName" Text :> "pullrequest" :> Get '[JSON] GetBranchPullRequestResponse
 


### PR DESCRIPTION
**Problem:**
The periodic refresh of the branch content loads the entire content of the branch every time it refreshes with a lot of calls to load the blobs of each of the files. Which especially for large repositories might consume a large number of Github's API call limit.

**Fix:**
The refresh now supplies the previously returned commit SHA to the server, so that if the server finds the same commit SHA as the latest on that branch it short circuits the service to return an empty collection of project contents. When the client gets the response and checks the commit SHA that it returns, if that hasn't changed then it wont update the local copy of the branch contents.

**Commit Details:**
- Added `lastRefreshedCommit` to `GithubData` to store what commit was last returned when refreshing the content.
- `getBranchContentFromServer` now may pass the query parameter of `previous_commit_sha` to the branch load endpoint.
- `refreshGithubData` now checks the previous commit SHA against the newly returned one and doesn't update the content if there has been no change.
- Added handling of the `previous_commit_sha` query parameter to the Github branch loading endpoint.
- `getGithubBranch` now prevents the loading of the branch content if the previous and target commit SHAs are the same.