### PR TITLE
Performance regression fix

### DIFF
--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -244,7 +244,7 @@ export async function renderTestEditorWithModel(
     }
 
     flushSync(() => {
-      canvasStoreHook.setState(patchedStoreFromFullStore(workingEditorState))
+      canvasStoreHook.setState(patchedStoreFromFullStore(workingEditorState, 'canvas-store'))
     })
 
     // run dom walker
@@ -280,9 +280,11 @@ export async function renderTestEditorWithModel(
     // update state with new metadata
 
     flushSync(() => {
-      storeHook.setState(patchedStoreFromFullStore(workingEditorState))
+      storeHook.setState(patchedStoreFromFullStore(workingEditorState, 'editor-store'))
       if (shouldInspectorUpdate(workingEditorState.strategyState)) {
-        lowPriorityStoreHook.setState(patchedStoreFromFullStore(workingEditorState))
+        lowPriorityStoreHook.setState(
+          patchedStoreFromFullStore(workingEditorState, 'low-priority-store'),
+        )
       }
     })
   }
@@ -324,7 +326,7 @@ export async function renderTestEditorWithModel(
     SetState<EditorStorePatched>,
     GetState<EditorStorePatched>,
     Mutate<StoreApi<EditorStorePatched>, [['zustand/subscribeWithSelector', never]]>
-  >(subscribeWithSelector((set) => patchedStoreFromFullStore(initialEditorStore)))
+  >(subscribeWithSelector((set) => patchedStoreFromFullStore(initialEditorStore, 'canvas-store')))
 
   const domWalkerMutableState = createDomWalkerMutableState(canvasStoreHook)
 
@@ -333,14 +335,18 @@ export async function renderTestEditorWithModel(
     SetState<EditorStorePatched>,
     GetState<EditorStorePatched>,
     Mutate<StoreApi<EditorStorePatched>, [['zustand/subscribeWithSelector', never]]>
-  >(subscribeWithSelector((set) => patchedStoreFromFullStore(initialEditorStore)))
+  >(
+    subscribeWithSelector((set) =>
+      patchedStoreFromFullStore(initialEditorStore, 'low-priority-store'),
+    ),
+  )
 
   const storeHook = create<
     EditorStorePatched,
     SetState<EditorStorePatched>,
     GetState<EditorStorePatched>,
     Mutate<StoreApi<EditorStorePatched>, [['zustand/subscribeWithSelector', never]]>
-  >(subscribeWithSelector((set) => patchedStoreFromFullStore(initialEditorStore)))
+  >(subscribeWithSelector((set) => patchedStoreFromFullStore(initialEditorStore, 'editor-store')))
 
   // initializing the local editor state
   workingEditorState = initialEditorStore

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -47,6 +47,7 @@ import { useEditorState, useRefEditorState } from './store/store-hook'
 import { refreshGithubData } from '../../core/shared/github'
 import { ConfirmDisconnectBranchDialog } from '../filebrowser/confirm-branch-disconnect'
 import { when } from '../../utils/react-conditionals'
+import { LowPriorityStoreProvider } from './store/low-priority-store'
 
 function pushProjectURLToBrowserHistory(projectId: string, projectName: string): void {
   // Make sure we don't replace the query params
@@ -309,9 +310,11 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
             width: '100%',
           }}
         >
-          {(isChrome as boolean) ? null : <BrowserInfoBar />}
-          <LoginStatusBar />
-          <TitleBar />
+          <LowPriorityStoreProvider>
+            {(isChrome as boolean) ? null : <BrowserInfoBar />}
+            <LoginStatusBar />
+            <TitleBar />
+          </LowPriorityStoreProvider>
 
           <SimpleFlexRow
             className='editor-main-horizontal'

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -388,16 +388,23 @@ export type EditorStoreFull = EditorStoreShared & {
   patchedDerived: DerivedState
 }
 
+type StoreName = 'editor-store' | 'canvas-store' | 'low-priority-store'
+
 export type EditorStorePatched = EditorStoreShared & {
+  storeName: StoreName
   editor: EditorState
   derived: DerivedState
 }
 
 export type EditorStoreUnpatched = Omit<EditorStoreFull, 'patchedEditor' | 'patchedDerived'>
 
-export function patchedStoreFromFullStore(store: EditorStoreFull): EditorStorePatched {
+export function patchedStoreFromFullStore(
+  store: EditorStoreFull,
+  name: StoreName,
+): EditorStorePatched {
   return {
     ...store,
+    storeName: name,
     editor: store.patchedEditor,
     derived: store.patchedDerived,
   }

--- a/editor/src/components/editor/store/store-hook.spec.tsx
+++ b/editor/src/components/editor/store/store-hook.spec.tsx
@@ -23,6 +23,7 @@ function createEmptyEditorStoreHook() {
     dispatch: null as any,
     alreadySaved: false,
     builtInDependencies: createBuiltInDependenciesList(null),
+    storeName: 'editor-store',
   }
 
   const storeHook = create<

--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -34,9 +34,9 @@ import { generateUidWithExistingComponents } from '../../core/model/element-temp
 import {
   Conflict,
   GithubFileChanges,
-  githubFileChangesSelector,
   GithubFileStatus,
   TreeConflicts,
+  useGithubFileChanges,
 } from '../../core/shared/github'
 
 export type FileBrowserItemType = 'file' | 'export'
@@ -303,7 +303,7 @@ const FileBrowserItems = React.memo(() => {
     }
   }, [])
 
-  const githubFileChanges = useEditorState(githubFileChangesSelector, 'Github file changes')
+  const githubFileChanges = useGithubFileChanges()
 
   const fileBrowserItems = React.useMemo(() => {
     return collectFileBrowserItems(

--- a/editor/src/components/inspector/common/inspector.test-utils.tsx
+++ b/editor/src/components/inspector/common/inspector.test-utils.tsx
@@ -46,6 +46,7 @@ export function getStoreHook(
     EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa', 'bbb']),
   ])
   const defaultState: EditorStorePatched = {
+    storeName: 'editor-store',
     editor: editor.editor,
     derived: editor.derivedState,
     strategyState: editor.strategyState,

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -59,6 +59,7 @@ function getPaddingHookResult<P extends ParsedPropertiesKeys, S extends ParsedPr
       dispatch: mockDispatch,
       alreadySaved: false,
       builtInDependencies: [],
+      storeName: 'editor-store',
     }
 
     const storeHook = create<

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -193,6 +193,7 @@ function callPropertyControlsHook(selectedViews: ElementPath[]) {
     dispatch: null as any,
     alreadySaved: null as any,
     builtInDependencies: [],
+    storeName: 'editor-store',
   }
 
   const storeHook = create<

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -8,10 +8,10 @@ import { projectDependenciesSelector } from '../../../../core/shared/dependencie
 import {
   getBranchesForGithubRepository,
   getGithubFileChangesCount,
-  githubFileChangesSelector,
   githubFileChangesToList,
   updateProjectAgainstGithub,
   updateProjectWithBranchContent,
+  useGithubFileChanges,
 } from '../../../../core/shared/github'
 import { startGithubAuthentication } from '../../../../utils/github-auth'
 import { unless, when } from '../../../../utils/react-conditionals'
@@ -382,7 +382,7 @@ const RemoteChangesBlock = () => {
     () => getGithubFileChangesCount(upstreamChanges) > 0,
     [upstreamChanges],
   )
-  const githubFileChanges = useEditorState(githubFileChangesSelector, 'Github file changes')
+  const githubFileChanges = useGithubFileChanges()
   const bothModified = React.useMemo(() => {
     const upstreamList = githubFileChangesToList(upstreamChanges)
     const localList = githubFileChangesToList(githubFileChanges)
@@ -501,7 +501,7 @@ const PushIcon = () => {
 }
 
 const LocalChangesBlock = () => {
-  const githubFileChanges = useEditorState(githubFileChangesSelector, 'Github file changes')
+  const githubFileChanges = useGithubFileChanges()
   const changesCount = React.useMemo(
     () => getGithubFileChangesCount(githubFileChanges),
     [githubFileChanges],
@@ -677,7 +677,7 @@ const PullRequestButton = () => {
     }),
     'GH repo and branch',
   )
-  const githubFileChanges = useEditorState(githubFileChangesSelector, 'Github file changes')
+  const githubFileChanges = useGithubFileChanges()
   const changesCount = React.useMemo(
     () => getGithubFileChangesCount(githubFileChanges),
     [githubFileChanges],

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react'
 import { createSelector } from 'reselect'
 import { auth0Url } from '../../common/env-vars'
 import { getUserPicture } from '../../common/user'
-import { getGithubFileChangesCount, githubFileChangesSelector } from '../../core/shared/github'
+import { getGithubFileChangesCount, useGithubFileChanges } from '../../core/shared/github'
 import { unless, when } from '../../utils/react-conditionals'
 import { Avatar, Button, colorTheme, SimpleFlexRow } from '../../uuiui'
 import { LoginState } from '../../uuiui-deps'
@@ -45,7 +45,7 @@ const TitleBar = React.memo(() => {
     [upstreamChanges],
   )
 
-  const githubFileChanges = useEditorState(githubFileChangesSelector, 'Github file changes')
+  const githubFileChanges = useGithubFileChanges()
   const hasDownstreamChanges = React.useMemo(
     () => getGithubFileChangesCount(githubFileChanges) > 0,
     [githubFileChanges],

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -756,6 +756,10 @@ const githubFileChangesSelector = createSelector(
 )
 
 export function useGithubFileChanges(): GithubFileChanges | null {
+  const storeType = useEditorState((store) => store.storeName, 'useGithubFileChanges storeName')
+  if (storeType !== 'low-priority-store') {
+    throw new Error('useGithubFileChanges hook must only be used inside the low-priority-store!')
+  }
   return useEditorState(githubFileChangesSelector, 'useGithubFileChanges')
 }
 

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -46,6 +46,7 @@ import {
   projectGithubSettings,
   PullRequest,
 } from '../../components/editor/store/editor-state'
+import { useEditorState } from '../../components/editor/store/store-hook'
 import { BuiltInDependencies } from '../es-modules/package-manager/built-in-dependencies-list'
 import { refreshDependencies } from './dependencies'
 import { RequestedNpmDependency } from './npm-dependency-types'
@@ -735,7 +736,7 @@ export async function getUsersPublicGithubRepositories(dispatch: EditorDispatch)
   dispatch([updateGithubOperations(operation, 'remove')], 'everyone')
 }
 
-export const githubFileChangesSelector = createSelector(
+const githubFileChangesSelector = createSelector(
   (store: EditorStorePatched) => store.editor.projectContents,
   (store) => store.userState.githubState.authenticated,
   (store) => store.editor.githubChecksums,
@@ -753,6 +754,10 @@ export const githubFileChangesSelector = createSelector(
     return deriveGithubFileChanges(checksums, githubChecksums, treeConflicts)
   },
 )
+
+export function useGithubFileChanges(): GithubFileChanges | null {
+  return useEditorState(githubFileChangesSelector, 'useGithubFileChanges')
+}
 
 export type GithubFileStatus = 'modified' | 'deleted' | 'untracked' | 'conflicted'
 

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -235,21 +235,25 @@ export class Editor {
       SetState<EditorStorePatched>,
       GetState<EditorStorePatched>,
       Mutate<StoreApi<EditorStorePatched>, [['zustand/subscribeWithSelector', never]]>
-    >(subscribeWithSelector((set) => patchedStoreFromFullStore(this.storedState)))
+    >(subscribeWithSelector((set) => patchedStoreFromFullStore(this.storedState, 'editor-store')))
 
     const canvasStoreHook = create<
       EditorStorePatched,
       SetState<EditorStorePatched>,
       GetState<EditorStorePatched>,
       Mutate<StoreApi<EditorStorePatched>, [['zustand/subscribeWithSelector', never]]>
-    >(subscribeWithSelector((set) => patchedStoreFromFullStore(this.storedState)))
+    >(subscribeWithSelector((set) => patchedStoreFromFullStore(this.storedState, 'canvas-store')))
 
     const lowPriorityStoreHook = create<
       EditorStorePatched,
       SetState<EditorStorePatched>,
       GetState<EditorStorePatched>,
       Mutate<StoreApi<EditorStorePatched>, [['zustand/subscribeWithSelector', never]]>
-    >(subscribeWithSelector((set) => patchedStoreFromFullStore(this.storedState)))
+    >(
+      subscribeWithSelector((set) =>
+        patchedStoreFromFullStore(this.storedState, 'low-priority-store'),
+      ),
+    )
 
     this.utopiaStoreHook = storeHook
     this.updateStore = storeHook.setState
@@ -436,7 +440,7 @@ export class Editor {
         ElementsToRerenderGLOBAL.current = currentElementsToRender // Mutation!
         ReactDOM.flushSync(() => {
           ReactDOM.unstable_batchedUpdates(() => {
-            this.updateCanvasStore(patchedStoreFromFullStore(this.storedState))
+            this.updateCanvasStore(patchedStoreFromFullStore(this.storedState, 'canvas-store'))
           })
         })
         if (PerformanceMarks) {
@@ -489,9 +493,11 @@ export class Editor {
         }
         ReactDOM.flushSync(() => {
           ReactDOM.unstable_batchedUpdates(() => {
-            this.updateStore(patchedStoreFromFullStore(this.storedState))
+            this.updateStore(patchedStoreFromFullStore(this.storedState, 'editor-store'))
             if (shouldUpdateLowPriorityUI(this.storedState.strategyState)) {
-              this.updateLowPriorityStore(patchedStoreFromFullStore(this.storedState))
+              this.updateLowPriorityStore(
+                patchedStoreFromFullStore(this.storedState, 'low-priority-store'),
+              )
             }
           })
         })


### PR DESCRIPTION
**Problem:**
The `TitleBar` regressed performance by using getProjectContentsChecksums without the Low Priority Store.

**Fix:**
I made sure it's impossible to accidentally use this without the low priority store ever again:
<img width="1870" alt="image" src="https://user-images.githubusercontent.com/2226774/203129948-e3ec3a93-8912-4b3c-bcc3-fa5cf2ae2691.png">


**Commit Details:**
- The stores have a storeName field
- getProjectContentsChecksums -> useGithubFileChanges hook to be reused in the codebase
- useGithubFileChanges explicitly throws an error if it's called from outside the low-priority-store
- wrap the TitleBar in a LowPriorityStoreProvider
