### PR TITLE
When merging imports, filter any imports of the current file

### DIFF
--- a/editor/src/core/workers/common/project-file-utils.spec.ts
+++ b/editor/src/core/workers/common/project-file-utils.spec.ts
@@ -144,4 +144,22 @@ describe('mergeImports', () => {
       '/src/fileB': importDetails(null, [importAlias('FlexRow')], null),
     })
   })
+
+  it('does not add an import for the current file', () => {
+    const result = mergeImports(
+      '/src/code.js',
+      {
+        '/src/fileA': importDetails(null, [importAlias('Card')], null),
+        './fileA': importDetails(null, [importAlias('OtherCard')], null),
+      },
+      {
+        '/src/code.js': importDetails(null, [importAlias('FlexRow')], null),
+        './code.js': importDetails(null, [importAlias('FlexCol')], null),
+      },
+    )
+
+    expect(result).toEqual({
+      '/src/fileA': importDetails(null, [importAlias('Card'), importAlias('OtherCard')], null),
+    })
+  })
 })

--- a/editor/src/core/workers/common/project-file-utils.spec.ts
+++ b/editor/src/core/workers/common/project-file-utils.spec.ts
@@ -1,5 +1,5 @@
 import { importAlias, importDetails } from '../../shared/project-file-types'
-import { mergeImports } from './project-file-utils'
+import { addImport, mergeImports } from './project-file-utils'
 
 describe('mergeImports', () => {
   it('can merge an empty imports', () => {
@@ -155,6 +155,26 @@ describe('mergeImports', () => {
       {
         '/src/code.js': importDetails(null, [importAlias('FlexRow')], null),
         './code.js': importDetails(null, [importAlias('FlexCol')], null),
+      },
+    )
+
+    expect(result).toEqual({
+      '/src/fileA': importDetails(null, [importAlias('Card'), importAlias('OtherCard')], null),
+    })
+  })
+})
+
+describe('addImport', () => {
+  it('does not add an import for the current file', () => {
+    const result = addImport(
+      '/src/code.js',
+      '/src/code.js',
+      null,
+      [importAlias('FlexRow'), importAlias('FlexCol')],
+      null,
+      {
+        '/src/fileA': importDetails(null, [importAlias('Card')], null),
+        './fileA': importDetails(null, [importAlias('OtherCard')], null),
       },
     )
 

--- a/editor/src/core/workers/common/project-file-utils.ts
+++ b/editor/src/core/workers/common/project-file-utils.ts
@@ -61,7 +61,14 @@ export function mergeImports(fileUri: string, first: Imports, second: Imports): 
   let imports: Imports = {}
   allKeys.forEach((key) => {
     let existingKeyToUse = key
-    const absoluteKey = stripExtension(absolutePathFromRelativePath(fileUri, false, key))
+    const rawAbsolutePath = absolutePathFromRelativePath(fileUri, false, key)
+    if (fileUri === rawAbsolutePath) {
+      // Prevent accidentally importing the current file
+      return
+    }
+
+    const absoluteKey = stripExtension(rawAbsolutePath)
+
     if (absoluteKeysToRelativeKeys[absoluteKey] == null) {
       absoluteKeysToRelativeKeys[absoluteKey] = key
     } else {


### PR DESCRIPTION
**Problem:**
The "Convert to" context menu item will add imports for the target of the conversion, but if that element is in the same file as the target component, the result would be an import of the current file added to the file, causing an error.

**Fix:**
Add a check inside the `mergeImports` function to ensure we never add imports for the current file.
