### PR TITLE
Make border radius handles appear instantly on mouseover

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
@@ -34,6 +34,8 @@ import { CanvasLabel, CSSNumberWithRenderedValue } from './controls-common'
 export const CircularHandleTestId = (corner: BorderRadiusCorner): string =>
   `circular-handle-${corner}`
 
+const BorderRadiusHandleAppearDelay: number = 0
+
 export interface BorderRadiusControlProps {
   selectedElement: ElementPath
   elementSize: Size
@@ -75,7 +77,7 @@ export const BorderRadiusControl = controlForStrategyMemoized<BorderRadiusContro
     }
 
     if (hoveredViews.includes(selectedElement)) {
-      timeoutRef.current = setTimeout(() => setBackgroundShown(true), 200)
+      timeoutRef.current = setTimeout(() => setBackgroundShown(true), BorderRadiusHandleAppearDelay)
     } else {
       setBackgroundShown(false)
     }

--- a/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import * as EP from '../../../../core/shared/element-path'
 import { CanvasVector, Size, windowPoint } from '../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import { Modifier } from '../../../../utils/modifiers'
@@ -66,7 +67,7 @@ export const BorderRadiusControl = controlForStrategyMemoized<BorderRadiusContro
 
   const colorTheme = useColorTheme()
 
-  const backgroundShown = hoveredViews.includes(selectedElement)
+  const backgroundShown = hoveredViews.some((p) => EP.pathsEqual(p, selectedElement))
 
   const controlRef = useBoundingBox([selectedElement], (ref, boundingBox) => {
     if (isZeroSizedElement(boundingBox)) {

--- a/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
@@ -34,8 +34,6 @@ import { CanvasLabel, CSSNumberWithRenderedValue } from './controls-common'
 export const CircularHandleTestId = (corner: BorderRadiusCorner): string =>
   `circular-handle-${corner}`
 
-const BorderRadiusHandleAppearDelay: number = 0
-
 export interface BorderRadiusControlProps {
   selectedElement: ElementPath
   elementSize: Size
@@ -68,20 +66,7 @@ export const BorderRadiusControl = controlForStrategyMemoized<BorderRadiusContro
 
   const colorTheme = useColorTheme()
 
-  const timeoutRef = React.useRef<NodeJS.Timeout | null>(null)
-  const [backgroundShown, setBackgroundShown] = React.useState<boolean>(false)
-  React.useEffect(() => {
-    const timeoutHandle = timeoutRef.current
-    if (timeoutHandle != null) {
-      clearTimeout(timeoutHandle)
-    }
-
-    if (hoveredViews.includes(selectedElement)) {
-      timeoutRef.current = setTimeout(() => setBackgroundShown(true), BorderRadiusHandleAppearDelay)
-    } else {
-      setBackgroundShown(false)
-    }
-  }, [hoveredViews, selectedElement])
+  const backgroundShown = hoveredViews.includes(selectedElement)
 
   const controlRef = useBoundingBox([selectedElement], (ref, boundingBox) => {
     if (isZeroSizedElement(boundingBox)) {


### PR DESCRIPTION
## Problem:
Border radius handles appear with a delay

## Fix:
Decrease the delay to 0
