### PR TITLE
Make the saved to branch toast more prominent.

### DIFF
--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -258,7 +258,7 @@ export async function saveProjectToGithub(
               ),
             ),
             updateBranchContents(persistentModel.projectContents),
-            showToast(notice(`Saved to branch ${responseBody.branchName}.`, 'INFO')),
+            showToast(notice(`Saved to branch ${responseBody.branchName}.`, 'SUCCESS')),
           ],
           'everyone',
         )


### PR DESCRIPTION
**Problem:**
The "Saved to branch..." toast isn't very visible because of the grey background.

**Fix:**
Changed the notice level of the toast to make it the green colour that a few others are doing.

**Commit Details:**
- Changed `NoticeLevel` parameter from `INFO` to `SUCCESS`.