### PR TITLE
Fix/inspector color picker should close when opening other color picker

### DIFF
--- a/editor/src/components/inspector/controls/background-solid-or-gradient-thumbnail-control.tsx
+++ b/editor/src/components/inspector/controls/background-solid-or-gradient-thumbnail-control.tsx
@@ -160,7 +160,6 @@ export const BackgroundSolidOrGradientThumbnailControl = React.memo(
     const backgroundIndex = props.backgroundIndex
     const onMouseDown: React.MouseEventHandler<HTMLDivElement> = React.useCallback(
       (e) => {
-        e.stopPropagation()
         setOpenPopup((openPopup) => {
           if (openPopup != null) {
             return undefined
@@ -176,7 +175,11 @@ export const BackgroundSolidOrGradientThumbnailControl = React.memo(
       <div
         key={props.id}
         id={`trigger-${props.id}`}
-        className={` hexField ${Utils.pathOr('', ['controlClassName'], props)}`}
+        className={` hexField ${Utils.pathOr(
+          '',
+          ['controlClassName'],
+          props,
+        )} ignore-react-onclickoutside-${props.id}`}
         style={props.style}
       >
         {picker}

--- a/editor/src/components/inspector/controls/color-control.tsx
+++ b/editor/src/components/inspector/controls/color-control.tsx
@@ -101,7 +101,11 @@ export const ColorControl = React.memo((props: ColorControlProps) => {
     <div
       key={props.id}
       id={`trigger-${props.id}`}
-      className={` hexField ${Utils.pathOr('', ['controlClassName'], props)}`}
+      className={` hexField ${Utils.pathOr(
+        '',
+        ['controlClassName'],
+        props,
+      )} ignore-react-onclickoutside-${props.id}`}
       style={props.style}
     >
       {picker}
@@ -128,7 +132,6 @@ export const ColorControl = React.memo((props: ColorControlProps) => {
             margin: 1,
           }}
           onMouseDown={(e) => {
-            e.stopPropagation()
             if (props.controlStyles.interactive) {
               setPopupOpen((value) => !value)
             }

--- a/editor/src/components/inspector/controls/color-picker.tsx
+++ b/editor/src/components/inspector/controls/color-picker.tsx
@@ -188,9 +188,12 @@ export class ColorPickerInner extends React.Component<
   }
 
   componentDidMount() {
-    if (this.RefFirstControl.current != null) {
-      this.RefFirstControl.current.focus()
-    }
+    setTimeout(() => {
+      // wrapping in a setTimeout so we don't dispatch from inside React lifecycle
+      if (this.RefFirstControl.current != null) {
+        this.RefFirstControl.current.focus()
+      }
+    }, 0)
   }
 
   componentWillUnmount() {

--- a/editor/src/components/inspector/controls/color-picker.tsx
+++ b/editor/src/components/inspector/controls/color-picker.tsx
@@ -42,6 +42,7 @@ export const ColorPicker: React.FunctionComponent<React.PropsWithChildren<ColorP
       offsetX={props.offsetX - colorPickerWidth}
       offsetY={props.offsetY}
       closePopup={closePopup}
+      outsideClickIgnoreClass={`ignore-react-onclickoutside-${props.id}`}
     >
       <div
         id={props.id}

--- a/editor/src/components/inspector/sections/style-section/background-subsection/background-picker.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/background-picker.tsx
@@ -515,6 +515,7 @@ export const BackgroundPicker: React.FunctionComponent<
         zIndex: 1,
       }}
       closePopupOnUnmount={false}
+      outsideClickIgnoreClass={`ignore-react-onclickoutside-${props.id}`}
     >
       <div
         id={props.id}

--- a/editor/src/components/inspector/widgets/inspector-modal.tsx
+++ b/editor/src/components/inspector/widgets/inspector-modal.tsx
@@ -13,6 +13,7 @@ export type InspectorModalProps = {
   children: JSX.Element
   style?: React.CSSProperties
   closePopupOnUnmount?: boolean
+  outsideClickIgnoreClass?: string
 }
 
 const padding = 16
@@ -26,6 +27,7 @@ export const InspectorModal: React.FunctionComponent<
   closePopup,
   children,
   style,
+  outsideClickIgnoreClass,
   closePopupOnUnmount = true,
 }) => {
   useHandleCloseOnESCOrEnter(closePopup)
@@ -86,7 +88,10 @@ export const InspectorModal: React.FunctionComponent<
   return (
     <div ref={outerElementRef}>
       {ReactDOM.createPortal(
-        <OnClickOutsideHOC onClickOutside={closePopup}>
+        <OnClickOutsideHOC
+          onClickOutside={closePopup}
+          outsideClickIgnoreClass={outsideClickIgnoreClass}
+        >
           <div
             style={{
               position: 'absolute',

--- a/editor/src/uuiui/utilities/on-click-outside-hoc.tsx
+++ b/editor/src/uuiui/utilities/on-click-outside-hoc.tsx
@@ -6,6 +6,7 @@ import onClickOutside from 'react-onclickoutside'
 
 export interface OnClickOutsideHOCProps {
   onClickOutside?: (e: MouseEvent) => void
+  outsideClickIgnoreClass?: string
 }
 
 class OnClickOutsideHOCUnenhanced extends React.Component<


### PR DESCRIPTION
**Problem:**
Color picker should close when opening other color picker in the inspector.

**Fix:**
Removing all the `stopPropagations` from the color picker widgets as they prevented closing other pickers, the events never reached the OnClickOutsideHOC. But with the removal each picker is immediately closed on open, fixed it with the `outsideClickIgnoreClass` property available for the OnClickOutsideHOC.
Minor fix: there was a react flush sync error, fixed it with a setTimeout 0.

**Commit Details:**
- remove stopPropagation from color picker widgets
- added a classname to ignore to color picker widgets
- pass the new classnames to their own OnClickOutsideHOC
