### PR TITLE
Remove feature switches from UI

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -301,8 +301,8 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
       <SimpleFlexRow
         className='editor-main-vertical-and-modals'
         style={{
-          height: '100%',
-          width: '100%',
+          height: '100vh',
+          width: '100vw',
           overscrollBehaviorX: 'contain',
           color: colorTheme.fg1.value,
         }}

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -24,17 +24,9 @@ export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Shows Overlay', // Removing this option so that we can experiment on this later
   'Debug mode – Redux Devtools',
   'Debug mode – Performance Marks',
-  'Advanced Resize Box',
   'Re-parse Project Button',
   'Performance Test Triggers',
-  'Click on empty canvas unfocuses',
-  'Insertion Plus Button',
-  'Canvas Strategies',
   'Canvas Strategies Debug Panel',
-  'Keyboard up clears interaction',
-  'Canvas Selective Rerender',
-  'Single child, contiguous parent: move parent',
-  'Single child, zero sized parent: move parent',
 ]
 
 let FeatureSwitches: { [feature in FeatureName]: boolean } = {


### PR DESCRIPTION
**Problem:**
See https://github.com/concrete-utopia/utopia/pull/2908

**Fix:**
Because some tests were broken when I removed the feature switches, as a first step I'm just removing them from the feature switch panel.
