### PR TITLE
repo title + branch in title bar

### DIFF
--- a/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
@@ -117,7 +117,7 @@ const RepositoryRow = (props: RepositoryRowProps) => {
       onClick={importRepository}
     >
       <div>
-        <Ellipsis style={{ maxWidth: 140 }}>{props.fullName}</Ellipsis>
+        <Ellipsis style={{ maxWidth: 170 }}>{props.fullName}</Ellipsis>
         <span style={{ fontSize: 10, opacity: 0.5 }}>
           {props.isPrivate ? 'private' : 'public'}
           {props.updatedAt == null ? null : (

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -17,7 +17,7 @@ import {
 import { LoginState } from '../../uuiui-deps'
 import { EditorAction } from '../editor/action-types'
 import { togglePanel } from '../editor/actions/action-creators'
-import { EditorStorePatched } from '../editor/store/editor-state'
+import { EditorStorePatched, githubRepoFullName } from '../editor/store/editor-state'
 import { useEditorState } from '../editor/store/store-hook'
 import { RoundButton } from './buttons'
 import { TestMenu } from './test-menu'
@@ -40,17 +40,24 @@ const ProjectTitle: React.FC<React.PropsWithChildren<ProjectTitleProps>> = ({ ch
 }
 
 const TitleBar = React.memo(() => {
-  const { dispatch, loginState, projectName, upstreamChanges } = useEditorState(
+  const { dispatch, loginState, projectName, upstreamChanges, currentBranch } = useEditorState(
     (store) => ({
       dispatch: store.dispatch,
       loginState: store.userState.loginState,
       projectName: store.editor.projectName,
       upstreamChanges: store.editor.githubData.upstreamChanges,
+      currentBranch: store.editor.githubSettings.branchName,
     }),
     'TitleBar',
   )
 
   const userPicture = useGetUserPicture()
+
+  const repo = useEditorState(
+    (store) => store.editor.githubSettings.targetRepository,
+    'RepositoryBlock repo',
+  )
+  const repoName = React.useMemo(() => githubRepoFullName(repo) || undefined, [repo])
 
   const hasUpstreamChanges = React.useMemo(
     () => getGithubFileChangesCount(upstreamChanges) > 0,
@@ -145,7 +152,15 @@ const TitleBar = React.memo(() => {
           height: 27,
         }}
       >
-        <ProjectTitle>{projectName}</ProjectTitle>
+        {currentBranch ? (
+          <SimpleFlexRow style={{ gap: 5 }}>
+            {repoName}
+            {<Icons.Branch style={{ width: 19, height: 19 }} />}
+            {currentBranch}
+          </SimpleFlexRow>
+        ) : (
+          <ProjectTitle>{projectName}</ProjectTitle>
+        )}
       </SimpleFlexRow>
       <div style={{ flexGrow: 1 }} />
       <div style={{ flex: '0 0 0px', paddingRight: 8 }}>

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -53,11 +53,10 @@ const TitleBar = React.memo(() => {
 
   const userPicture = useGetUserPicture()
 
-  const repo = useEditorState(
-    (store) => store.editor.githubSettings.targetRepository,
+  const repoName = useEditorState(
+    (store) => githubRepoFullName(store.editor.githubSettings.targetRepository),
     'RepositoryBlock repo',
   )
-  const repoName = React.useMemo(() => githubRepoFullName(repo) || undefined, [repo])
 
   const hasUpstreamChanges = React.useMemo(
     () => getGithubFileChangesCount(upstreamChanges) > 0,

--- a/editor/src/uuiui/icons.tsx
+++ b/editor/src/uuiui/icons.tsx
@@ -252,6 +252,13 @@ export const Icons = {
     height: 18,
     color: 'main',
   }),
+  Branch: makeIcon({
+    category: 'semantic',
+    type: 'branch',
+    width: 18,
+    height: 18,
+    color: 'main',
+  }),
 }
 
 export const FunctionIcons = {


### PR DESCRIPTION
When a project is connected to a github repository, and has a selected branch, the name of the repo and branch are now displayed in the center of the title bar. The utopia-generated project title will be displayed there only when the project is not connected to github.
