### PR TITLE
Z-click should not select, only zoom

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -584,9 +584,12 @@ function useSelectOrLiveModeSelectAndHover(
 } {
   const dispatch = useEditorState((store) => store.dispatch, 'useSelectAndHover dispatch')
   const selectedViewsRef = useRefEditorState((store) => store.editor.selectedViews)
+  const isZoomMode = useEditorState(
+    (store) => store.editor.keysPressed['z'] ?? false,
+    'useSelectAndHover isZoomMode',
+  )
   const findValidTarget = useFindValidTarget()
   const getSelectableViewsForSelectMode = useGetSelectableViewsForSelectMode()
-  const startDragStateAfterDragExceedsThreshold = useStartDragStateAfterDragExceedsThreshold()
   const windowToCanvasCoordinates = useWindowToCanvasCoordinates()
   const interactionSessionHappened = React.useRef(false)
 
@@ -649,8 +652,8 @@ function useSelectOrLiveModeSelectAndHover(
         }
       }
 
-      if (isDragIntention || hasInteractionSessionWithMouseMoved) {
-        // Skip all of this handling if 'space' is pressed or a mousemove happened in an interaction
+      if (isDragIntention || hasInteractionSessionWithMouseMoved || isZoomMode) {
+        // Skip all of this handling if 'space' or 'z' is pressed or a mousemove happened in an interaction
         return
       }
 
@@ -729,6 +732,7 @@ function useSelectOrLiveModeSelectAndHover(
       editorStoreRef,
       draggingAllowed,
       windowToCanvasCoordinates,
+      isZoomMode,
     ],
   )
 

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -584,10 +584,6 @@ function useSelectOrLiveModeSelectAndHover(
 } {
   const dispatch = useEditorState((store) => store.dispatch, 'useSelectAndHover dispatch')
   const selectedViewsRef = useRefEditorState((store) => store.editor.selectedViews)
-  const isZoomMode = useEditorState(
-    (store) => store.editor.keysPressed['z'] ?? false,
-    'useSelectAndHover isZoomMode',
-  )
   const findValidTarget = useFindValidTarget()
   const getSelectableViewsForSelectMode = useGetSelectableViewsForSelectMode()
   const windowToCanvasCoordinates = useWindowToCanvasCoordinates()
@@ -652,8 +648,8 @@ function useSelectOrLiveModeSelectAndHover(
         }
       }
 
-      if (isDragIntention || hasInteractionSessionWithMouseMoved || isZoomMode) {
-        // Skip all of this handling if 'space' or 'z' is pressed or a mousemove happened in an interaction
+      if (isDragIntention || hasInteractionSessionWithMouseMoved || !active) {
+        // Skip all of this handling if 'space' is pressed or a mousemove happened in an interaction, or the hook is not active
         return
       }
 
@@ -732,7 +728,7 @@ function useSelectOrLiveModeSelectAndHover(
       editorStoreRef,
       draggingAllowed,
       windowToCanvasCoordinates,
-      isZoomMode,
+      active,
     ],
   )
 


### PR DESCRIPTION
**Problem:**
Z-click should not select or focus the element under the mouse

**Fix:**
Check in select-mode-hooks whether we are in zoom mode in the mouse handler.
