### PR TITLE
No reorder indicator when there are no siblings

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
@@ -2170,6 +2170,40 @@ const TestProjectFlexAndAbsoluteSiblings = (flexDirection: 'row' | 'row-reverse'
 </div>
 `
 
+const TestProjectNoSiblings = (flexDirection: 'row' | 'row-reverse') => `
+<div
+  style={{
+    position: 'absolute',
+    width: 600,
+    height: 600,
+  }}
+  data-uid='container'
+  data-testid='container'
+>
+  <div
+    style={{
+      position: 'absolute',
+      width: 50,
+      height: 50,
+      top: -50,
+    }}
+    data-uid='absolutechild'
+    data-testid='absolutechild'
+  />
+  <div
+    style={{
+      position: 'absolute',
+      width: 400,
+      height: 400,
+      display: 'flex',
+      flexDirection: '${flexDirection}',
+    }}
+    data-uid='flexcontainer'
+    data-testid='flexcontainer'
+  />
+</div>
+`
+
 async function checkReparentIndicator(
   renderResult: EditorRenderResult,
   expectedLeft: number,
@@ -2460,5 +2494,51 @@ describe('Reparent indicators', () => {
 
     // Check the indicator presence and position.
     await checkReparentIndicator(renderResult, 788, 110, 2, 40)
+  })
+  it(`doesn't show the reparent indicator when there are no siblings`, async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(TestProjectNoSiblings('row')),
+      'await-first-dom-report',
+    )
+
+    // Select the target first.
+    const targetPath = EP.fromString(
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/absolutechild',
+    )
+    await act(() => renderResult.dispatch([selectComponents([targetPath], false)], false))
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Start dragging the target.
+    const targetElement = renderResult.renderedDOM.getByTestId('absolutechild')
+    const targetElementBounds = targetElement.getBoundingClientRect()
+
+    const flexContainer = renderResult.renderedDOM.getByTestId('flexcontainer')
+    const flexContainerBounds = flexContainer.getBoundingClientRect()
+
+    const startPoint = { x: targetElementBounds.x + 20, y: targetElementBounds.y + 20 }
+    const endPoint = {
+      x: flexContainerBounds.x + flexContainerBounds.width - 20,
+      y: flexContainerBounds.y + flexContainerBounds.height / 2,
+    }
+    const dragDelta = windowPoint({
+      x: endPoint.x - startPoint.x,
+      y: endPoint.y - startPoint.y,
+    })
+
+    dragElement(
+      renderResult,
+      'absolutechild',
+      defaultMouseDownOffset,
+      dragDelta,
+      emptyModifiers,
+      false,
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Check that the indicator is not there.
+    await expect(
+      async () => await renderResult.renderedDOM.findByTestId('flex-reparent-indicator-0'),
+    ).rejects.toThrow()
   })
 })

--- a/editor/src/components/canvas/commands/show-reorder-indicator-command.ts
+++ b/editor/src/components/canvas/commands/show-reorder-indicator-command.ts
@@ -61,6 +61,13 @@ export const runShowReorderIndicator: CommandFunction<ShowReorderIndicator> = (
     (sibling) => sibling.elementPath,
   )
 
+  if (siblings.length === 0) {
+    return {
+      editorStatePatches: [],
+      commandDescription: `Show Reorder Indicator without children`,
+    }
+  }
+
   const siblingPositions: Array<SiblingPosition> = siblingAndPseudoPositions(
     newParentDirection,
     forwardsOrBackwards,
@@ -69,84 +76,56 @@ export const runShowReorderIndicator: CommandFunction<ShowReorderIndicator> = (
     editor.jsxMetadata,
   )
 
-  if (siblings.length > 0) {
-    const closestPreviousSiblingPositionIndex = findLastIndex(
-      (siblingPosition) => siblingPosition.index <= command.index,
-      siblingPositions,
-    )
-    const closestPreviousSiblingPosition = forceNotNull(
-      'no sibling found for reorder indicator',
-      siblingPositions[closestPreviousSiblingPositionIndex],
-    )
-    const closestNextSiblingPosition = forceNotNull(
-      'no sibling found for reorder indicator',
-      siblingPositions.find((siblingPosition) => siblingPosition.index > command.index),
-    )
+  const closestPreviousSiblingPositionIndex = findLastIndex(
+    (siblingPosition) => siblingPosition.index <= command.index,
+    siblingPositions,
+  )
+  const closestPreviousSiblingPosition = forceNotNull(
+    'no sibling found for reorder indicator',
+    siblingPositions[closestPreviousSiblingPositionIndex],
+  )
+  const closestNextSiblingPosition = forceNotNull(
+    'no sibling found for reorder indicator',
+    siblingPositions.find((siblingPosition) => siblingPosition.index > command.index),
+  )
 
-    const precedingSiblingPosition: CanvasRectangle = closestPreviousSiblingPosition.frame
-    const succeedingSiblingPosition: CanvasRectangle = closestNextSiblingPosition.frame
+  const precedingSiblingPosition: CanvasRectangle = closestPreviousSiblingPosition.frame
+  const succeedingSiblingPosition: CanvasRectangle = closestNextSiblingPosition.frame
 
-    const targetLineBeforeSibling: CanvasRectangle =
-      newParentDirection === 'horizontal'
-        ? canvasRectangle({
-            x: getSiblingMidPointPosition(
-              precedingSiblingPosition,
-              succeedingSiblingPosition,
-              'horizontal',
-              forwardsOrBackwards,
-            ),
-            y: (precedingSiblingPosition.y + succeedingSiblingPosition.y) / 2,
-            height: (precedingSiblingPosition.height + succeedingSiblingPosition.height) / 2,
-            width: 0,
-          })
-        : canvasRectangle({
-            x: (precedingSiblingPosition.x + succeedingSiblingPosition.x) / 2,
-            y: getSiblingMidPointPosition(
-              precedingSiblingPosition,
-              succeedingSiblingPosition,
-              'vertical',
-              forwardsOrBackwards,
-            ),
-            width: (precedingSiblingPosition.width + succeedingSiblingPosition.width) / 2,
-            height: 0,
-          })
+  const targetLineBeforeSibling: CanvasRectangle =
+    newParentDirection === 'horizontal'
+      ? canvasRectangle({
+          x: getSiblingMidPointPosition(
+            precedingSiblingPosition,
+            succeedingSiblingPosition,
+            'horizontal',
+            forwardsOrBackwards,
+          ),
+          y: (precedingSiblingPosition.y + succeedingSiblingPosition.y) / 2,
+          height: (precedingSiblingPosition.height + succeedingSiblingPosition.height) / 2,
+          width: 0,
+        })
+      : canvasRectangle({
+          x: (precedingSiblingPosition.x + succeedingSiblingPosition.x) / 2,
+          y: getSiblingMidPointPosition(
+            precedingSiblingPosition,
+            succeedingSiblingPosition,
+            'vertical',
+            forwardsOrBackwards,
+          ),
+          width: (precedingSiblingPosition.width + succeedingSiblingPosition.width) / 2,
+          height: 0,
+        })
 
-    const editorStatePatch: EditorStatePatch = {
-      canvas: {
-        controls: {
-          flexReparentTargetLines: { $set: [targetLineBeforeSibling] },
-        },
+  const editorStatePatch: EditorStatePatch = {
+    canvas: {
+      controls: {
+        flexReparentTargetLines: { $set: [targetLineBeforeSibling] },
       },
-    }
-    return {
-      editorStatePatches: [editorStatePatch],
-      commandDescription: `Show Reorder Indicator at index ${command.index}`,
-    }
-  } else {
-    const targetLineBeginningOfParent: CanvasRectangle =
-      newParentDirection === 'horizontal'
-        ? canvasRectangle({
-            x: parentFrame.x,
-            y: parentFrame.y,
-            height: parentFrame.height,
-            width: 0,
-          })
-        : canvasRectangle({
-            x: parentFrame.x,
-            y: parentFrame.y,
-            width: parentFrame.width,
-            height: 0,
-          })
-    const editorStatePatch: EditorStatePatch = {
-      canvas: {
-        controls: {
-          flexReparentTargetLines: { $set: [targetLineBeginningOfParent] },
-        },
-      },
-    }
-    return {
-      editorStatePatches: [editorStatePatch],
-      commandDescription: `Show Reorder Indicator at beginning of parent`,
-    }
+    },
+  }
+  return {
+    editorStatePatches: [editorStatePatch],
+    commandDescription: `Show Reorder Indicator at index ${command.index}`,
   }
 }


### PR DESCRIPTION
**Problem:**
When you reparent into an empty flex container, we show a reorder indicator, which is a blue line on the top or in the left, but it doesn't make much sense visually what is that.

**Fix:**
Do not show reorder indicator when there are no siblings.