### PR TITLE
Fix/inspector submitvalue hook

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -730,7 +730,7 @@ function editorDispatchInner(
       frozenDerivedState = optionalDeepFreeze(derivedState)
     }
 
-    const actionNames = dispatchedActions.map((action) => action.action).join(',')
+    const actionNames = simpleStringifyActions(dispatchedActions)
     getAllUniqueUids(frozenEditorState.projectContents, actionNames)
 
     if (MeasureDispatchTime) {

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -207,6 +207,8 @@ function callPropertyControlsHook(selectedViews: ElementPath[]) {
     selectedViewsRef: { current: selectedViews },
     onSubmitValue: null as any,
     onUnsetValue: null as any,
+    collectActionsToSubmitValue: null as any,
+    collectActionsToUnsetValue: null as any,
   }
 
   const contextProvider = ({ children }: any) => (

--- a/editor/src/components/inspector/common/property-path-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-path-hooks.spec.tsx
@@ -1,5 +1,10 @@
 import { render, renderHook } from '@testing-library/react'
 import React from 'react'
+
+jest.mock('../../editor/store/store-hook', () => ({
+  useRefEditorState: jest.fn(() => ({ current: jest.fn(() => {}) })),
+}))
+
 import { isRight } from '../../../core/shared/either'
 import {
   isJSXElement,
@@ -191,6 +196,8 @@ describe('useInspectorMetadataForPropsObject memoization', () => {
   const callbackData = {
     onSubmitValue: utils.NO_OP,
     onUnsetValue: utils.NO_OP,
+    collectActionsToSubmitValue: () => [],
+    collectActionsToUnsetValue: () => [],
     selectedViewsRef: { current: [] },
   }
 

--- a/editor/src/components/inspector/common/property-path-hooks.test-utils.tsx
+++ b/editor/src/components/inspector/common/property-path-hooks.test-utils.tsx
@@ -34,6 +34,8 @@ export const makeInspectorHookContextProvider =
           selectedViewsRef: { current: selectedViews },
           onSubmitValue: NO_OP,
           onUnsetValue: NO_OP,
+          collectActionsToSubmitValue: () => [],
+          collectActionsToUnsetValue: () => [],
         }}
       >
         <InspectorPropsContext.Provider

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -6,7 +6,7 @@ import {
   forUnderlyingTargetFromEditorState,
   withUnderlyingTarget,
 } from '../../../components/editor/store/editor-state'
-import { useEditorState } from '../../../components/editor/store/store-hook'
+import { useEditorState, useRefEditorState } from '../../../components/editor/store/store-hook'
 import {
   calculateMultiPropertyStatusForSelection,
   calculateMultiStringPropertyStatusForSelection,
@@ -94,6 +94,7 @@ import { omitWithPredicate } from '../../../core/shared/object-utils'
 import { UtopiaKeys } from '../../../core/model/utopia-constants'
 import fastDeepEquals from 'fast-deep-equal'
 import { getPropertyControlNames } from '../../../core/property-controls/property-control-values'
+import { EditorAction } from '../../editor/action-types'
 
 export interface InspectorPropsContextData {
   selectedViews: Array<ElementPath>
@@ -108,6 +109,15 @@ export interface InspectorCallbackContextData {
   selectedViewsRef: ReadonlyRef<Array<ElementPath>>
   onSubmitValue: (newValue: any, propertyPath: PropertyPath, transient: boolean) => void
   onUnsetValue: (propertyPath: PropertyPath | Array<PropertyPath>, transient: boolean) => void
+  collectActionsToSubmitValue: (
+    newValue: any,
+    propertyPath: PropertyPath,
+    transient: boolean,
+  ) => Array<EditorAction>
+  collectActionsToUnsetValue: (
+    propertyPath: PropertyPath | Array<PropertyPath>,
+    transient: boolean,
+  ) => Array<EditorAction>
 }
 
 export const InspectorPropsContext = createContext<InspectorPropsContextData>({
@@ -119,10 +129,13 @@ export const InspectorPropsContext = createContext<InspectorPropsContextData>({
   selectedAttributeMetadatas: [],
 })
 
+const emptyCollectActionsFn = () => []
 export const InspectorCallbackContext = React.createContext<InspectorCallbackContextData>({
   selectedViewsRef: { current: [] },
   onSubmitValue: Utils.NO_OP,
   onUnsetValue: Utils.NO_OP,
+  collectActionsToSubmitValue: emptyCollectActionsFn,
+  collectActionsToUnsetValue: emptyCollectActionsFn,
 })
 InspectorCallbackContext.displayName = 'InspectorCallbackContext'
 
@@ -382,16 +395,38 @@ export function useInspectorContext(): {
     propertyPath: PropertyPath | Array<PropertyPath>,
     transient: boolean,
   ) => void
+  collectActionsToSubmitValue: (
+    newValue: any,
+    propertyPath: PropertyPath,
+    transient: boolean,
+  ) => Array<EditorAction>
+  collectActionsToUnsetValue: (
+    propertyPath: PropertyPath | Array<PropertyPath>,
+    transient: boolean,
+  ) => Array<EditorAction>
 } {
-  const { onSubmitValue, onUnsetValue, selectedViewsRef } =
-    React.useContext(InspectorCallbackContext)
+  const {
+    onSubmitValue,
+    onUnsetValue,
+    collectActionsToSubmitValue,
+    collectActionsToUnsetValue,
+    selectedViewsRef,
+  } = React.useContext(InspectorCallbackContext)
   return React.useMemo(() => {
     return {
       onContextSubmitValue: onSubmitValue,
       onContextUnsetValue: onUnsetValue,
+      collectActionsToSubmitValue: collectActionsToSubmitValue,
+      collectActionsToUnsetValue: collectActionsToUnsetValue,
       selectedViewsRef: selectedViewsRef,
     }
-  }, [onSubmitValue, onUnsetValue, selectedViewsRef])
+  }, [
+    onSubmitValue,
+    onUnsetValue,
+    collectActionsToSubmitValue,
+    collectActionsToUnsetValue,
+    selectedViewsRef,
+  ])
 }
 
 function parseFinalValue<PropertiesToControl extends ParsedPropertiesKeys>(
@@ -521,8 +556,12 @@ export function useInspectorInfo<P extends ParsedPropertiesKeys, T = ParsedPrope
 
   const controlStatus = calculateControlStatusWithUnknown(propertyStatus, isUnknown)
 
-  const { onContextSubmitValue: onSingleSubmitValue, onContextUnsetValue: onUnsetValue } =
-    useInspectorContext()
+  const {
+    onContextSubmitValue: onSingleSubmitValue,
+    onContextUnsetValue: onUnsetValue,
+    collectActionsToSubmitValue,
+    collectActionsToUnsetValue,
+  } = useInspectorContext()
 
   const target = useKeepReferenceEqualityIfPossible(
     useContextSelector(InspectorPropsContext, (contextData) => contextData.targetPath, deepEqual),
@@ -535,13 +574,14 @@ export function useInspectorInfo<P extends ParsedPropertiesKeys, T = ParsedPrope
   }, [onUnsetValue, propKeys, pathMappingFn, target])
 
   const transformedValue = transformValue(values)
+
   const onSubmitValue: (newValue: T, transient?: boolean) => void = useCreateOnSubmitValue<P, T>(
     untransformValue,
     propKeys,
     pathMappingFn,
     target,
-    onSingleSubmitValue,
-    onUnsetValue,
+    collectActionsToSubmitValue,
+    collectActionsToUnsetValue,
   )
 
   const onTransientSubmitValue: (newValue: T) => void = React.useCallback(
@@ -571,24 +611,43 @@ function useCreateOnSubmitValue<P extends ParsedPropertiesKeys, T = ParsedProper
   propKeys: P[],
   pathMappingFn: PathMappingFn<P>,
   target: readonly string[],
-  onSingleSubmitValue: (newValue: any, propertyPath: PropertyPath, transient: boolean) => void,
-  onUnsetValue: (propertyPath: PropertyPath | Array<PropertyPath>, transient: boolean) => void,
+  collectActionsToSubmitValue: (
+    newValue: any,
+    propertyPath: PropertyPath,
+    transient: boolean,
+  ) => Array<EditorAction>,
+  collectActionsToUnsetValue: (
+    propertyPath: PropertyPath | Array<PropertyPath>,
+    transient: boolean,
+  ) => Array<EditorAction>,
 ): (newValue: T, transient?: boolean | undefined) => void {
+  const dispatch = useRefEditorState((store) => store.dispatch)
   return React.useCallback(
     (newValue, transient = false) => {
       const untransformedValue = untransformValue(newValue)
+      let actions: Array<EditorAction> = []
       propKeys.forEach((propKey) => {
         const propertyPath = pathMappingFn(propKey, target)
         const valueToPrint = untransformedValue[propKey]
         if (valueToPrint != null) {
           const printedProperty = printCSSValue(propKey, valueToPrint as ParsedProperties[P])
-          onSingleSubmitValue(printedProperty, propertyPath, transient)
+          actions.push(...collectActionsToSubmitValue(printedProperty, propertyPath, transient))
         } else {
-          onUnsetValue(propertyPath, transient)
+          actions.push(...collectActionsToUnsetValue(propertyPath, transient))
         }
       })
+
+      dispatch.current(actions)
     },
-    [onSingleSubmitValue, untransformValue, propKeys, onUnsetValue, pathMappingFn, target],
+    [
+      collectActionsToSubmitValue,
+      collectActionsToUnsetValue,
+      untransformValue,
+      propKeys,
+      pathMappingFn,
+      target,
+      dispatch,
+    ],
   )
 }
 

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -666,9 +666,41 @@ export const InspectorContextProvider = React.memo<{
     [dispatch, refElementsToTargetForUpdates],
   )
 
+  const collectActionsToSubmitValue = React.useCallback(
+    (newValue: JSXAttribute, path: PropertyPath, transient: boolean): Array<EditorAction> => {
+      const actionsArray = [
+        ...refElementsToTargetForUpdates.current.map((elem) => {
+          return setProp_UNSAFE(elem, path, newValue)
+        }),
+      ]
+      return transient ? [transientActions(actionsArray)] : actionsArray
+    },
+    [refElementsToTargetForUpdates],
+  )
+
+  const collectActionsToUnsetValue = React.useCallback(
+    (property: PropertyPath | Array<PropertyPath>, transient: boolean): Array<EditorAction> => {
+      let actionsArray: Array<EditorAction> = []
+      Utils.fastForEach(refElementsToTargetForUpdates.current, (elem) => {
+        if (Array.isArray(property)) {
+          Utils.fastForEach(property, (p) => {
+            actionsArray.push(unsetProperty(elem, p))
+          })
+        } else {
+          actionsArray.push(unsetProperty(elem, property))
+        }
+      })
+
+      return transient ? [transientActions(actionsArray)] : actionsArray
+    },
+    [refElementsToTargetForUpdates],
+  )
+
   const callbackContextValueMemoized = useKeepShallowReferenceEquality({
     onSubmitValue: onSubmitValueForHooks,
     onUnsetValue: onUnsetValue,
+    collectActionsToSubmitValue: collectActionsToSubmitValue,
+    collectActionsToUnsetValue: collectActionsToUnsetValue,
     selectedViewsRef: selectedViewsRef,
   })
 


### PR DESCRIPTION
**Problem:**
Color picker is slow.

**Fix:**
One of the problems with the background color picker is that it modifies 3 property-paths (backgroundColor, backgroundImage, backgroundSize)  and inside the `onSubmitValue` it means 3 different editor dispatches. I rewrote the main submit value hook to dispatch only once.
I didn't change the original 2 callbacks as they are still used in other special hooks.

**Commit Details:**
- extended inspector context with 2 extra callback functions to create the set and unset actions
- modified `useCreateOnSubmitValue`
- mock dispatch in tests
- minor fix for perf measurements: flatten transient action names
