### PR TITLE
Make the Github polling more resilient.

### DIFF
--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -1021,10 +1021,7 @@ export function updateGithubSettings(
 export function updateGithubData(data: Partial<GithubData>): UpdateGithubData {
   return {
     action: 'UPDATE_GITHUB_DATA',
-    data: {
-      lastUpdatedAt: Date.now(),
-      ...data,
-    },
+    data: data,
   }
 }
 

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3759,6 +3759,7 @@ export const UPDATE_FNS = {
       ...editor,
       githubData: {
         ...editor.githubData,
+        lastUpdatedAt: Date.now(),
         ...action.data,
       },
     }

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -6,6 +6,7 @@ import React, { useEffect } from 'react'
 import TimeAgo from 'react-timeago'
 import { projectDependenciesSelector } from '../../../../core/shared/dependencies'
 import {
+  dispatchPromiseActions,
   getBranchesForGithubRepository,
   getGithubFileChangesCount,
   githubFileChangesToList,
@@ -170,7 +171,10 @@ const BranchBlock = () => {
 
   const refreshBranches = React.useCallback(() => {
     if (targetRepository != null) {
-      void getBranchesForGithubRepository(dispatch, targetRepository)
+      void dispatchPromiseActions(
+        dispatch,
+        getBranchesForGithubRepository(dispatch, targetRepository),
+      )
     }
   }, [dispatch, targetRepository])
 
@@ -470,7 +474,7 @@ const RemoteChangesBlock = () => {
       subtitle={
         <TimeAgo
           style={{ color: colorTheme.fg7.value }}
-          date={githubLastUpdatedAt || 0}
+          date={githubLastUpdatedAt ?? 0}
           formatter={compactTimeagoFormatter}
         />
       }

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -178,6 +178,10 @@ const BranchBlock = () => {
     }
   }, [dispatch, targetRepository])
 
+  React.useEffect(() => {
+    refreshBranches()
+  }, [refreshBranches])
+
   const [expandedFlag, setExpandedFlag] = React.useState(false)
 
   const expanded = React.useMemo(() => {

--- a/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
@@ -237,7 +237,9 @@ export const RepositoryListing = React.memo(
     const dispatch = useEditorState((store) => store.dispatch, 'dispatch')
 
     const refreshRepos = React.useCallback(() => {
-      void getUsersPublicGithubRepositories(dispatch)
+      void getUsersPublicGithubRepositories(dispatch).then((actions) => {
+        dispatch(actions, 'everyone')
+      })
     }, [dispatch])
 
     const clearRepository = React.useCallback(() => {

--- a/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
@@ -242,6 +242,10 @@ export const RepositoryListing = React.memo(
       })
     }, [dispatch])
 
+    React.useEffect(() => {
+      refreshRepos()
+    }, [refreshRepos])
+
     const clearRepository = React.useCallback(() => {
       dispatch([updateGithubSettings(emptyGithubSettings())], 'everyone')
     }, [dispatch])

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -63,6 +63,13 @@ import { emptySet } from './set-utils'
 import { trimUpToAndIncluding } from './string-utils'
 import { arrayEquals } from './utils'
 
+export function dispatchPromiseActions(
+  dispatch: EditorDispatch,
+  promise: Promise<Array<EditorAction>>,
+): Promise<void> {
+  return promise.then((actions) => dispatch(actions, 'everyone'))
+}
+
 export function parseGithubProjectString(maybeProject: string): GithubRepo | null {
   const withoutGithubPrefix = trimUpToAndIncluding('github.com/', maybeProject)
 
@@ -265,9 +272,12 @@ export async function saveProjectToGithub(
 
         // refresh the branches after the content was saved
         if (persistentModel.githubSettings.targetRepository) {
-          void getBranchesForGithubRepository(
+          void dispatchPromiseActions(
             dispatch,
-            persistentModel.githubSettings.targetRepository,
+            getBranchesForGithubRepository(
+              dispatch,
+              persistentModel.githubSettings.targetRepository,
+            ),
           )
         }
         break
@@ -287,49 +297,51 @@ export async function saveProjectToGithub(
 export async function getBranchesForGithubRepository(
   dispatch: EditorDispatch,
   githubRepo: GithubRepo,
-): Promise<void> {
+): Promise<Array<EditorAction>> {
   const operation: GithubOperation = { name: 'listBranches' }
 
   dispatch([updateGithubOperations(operation, 'add')], 'everyone')
 
-  const url = urljoin(UTOPIA_BACKEND, 'github', 'branches', githubRepo.owner, githubRepo.repository)
+  try {
+    const url = urljoin(
+      UTOPIA_BACKEND,
+      'github',
+      'branches',
+      githubRepo.owner,
+      githubRepo.repository,
+    )
 
-  const response = await fetch(url, {
-    method: 'GET',
-    credentials: 'include',
-    headers: HEADERS,
-    mode: MODE,
-  })
+    const response = await fetch(url, {
+      method: 'GET',
+      credentials: 'include',
+      headers: HEADERS,
+      mode: MODE,
+    })
 
-  if (response.ok) {
-    const responseBody: GetBranchesResponse = await response.json()
+    if (response.ok) {
+      const responseBody: GetBranchesResponse = await response.json()
 
-    switch (responseBody.type) {
-      case 'FAILURE':
-        dispatch(
-          [
+      switch (responseBody.type) {
+        case 'FAILURE':
+          return [
             showToast(
               notice(`Error when listing branches: ${responseBody.failureReason}`, 'ERROR'),
             ),
-          ],
-          'everyone',
-        )
-        break
-      case 'SUCCESS':
-        dispatch([updateGithubData({ branches: responseBody.branches })], 'everyone')
-        break
-      default:
-        const _exhaustiveCheck: never = responseBody
-        throw new Error(`Unhandled response body ${JSON.stringify(responseBody)}`)
+          ]
+        case 'SUCCESS':
+          return [updateGithubData({ branches: responseBody.branches })]
+        default:
+          const _exhaustiveCheck: never = responseBody
+          throw new Error(`Unhandled response body ${JSON.stringify(responseBody)}`)
+      }
+    } else {
+      return [
+        showToast(notice(`Unexpected status returned from endpoint: ${response.status}`, 'ERROR')),
+      ]
     }
-  } else {
-    dispatch(
-      [showToast(notice(`Unexpected status returned from endpoint: ${response.status}`, 'ERROR'))],
-      'everyone',
-    )
+  } finally {
+    dispatch([updateGithubOperations(operation, 'remove')], 'everyone')
   }
-
-  dispatch([updateGithubOperations(operation, 'remove')], 'everyone')
 }
 
 const RE_PULL_REQUEST_URL_NUMBER = /.+\/pull\/([0-9]+).*/
@@ -346,7 +358,7 @@ export async function updatePullRequestsForBranch(
   dispatch: EditorDispatch,
   githubRepo: GithubRepo,
   branchName: string,
-): Promise<void> {
+): Promise<Array<EditorAction>> {
   const operation: GithubOperation = {
     name: 'listPullRequestsForBranch',
     githubRepo: githubRepo,
@@ -355,66 +367,61 @@ export async function updatePullRequestsForBranch(
 
   dispatch([updateGithubOperations(operation, 'add')], 'everyone')
 
-  const url = urljoin(
-    UTOPIA_BACKEND,
-    'github',
-    'branches',
-    githubRepo.owner,
-    githubRepo.repository,
-    'branch',
-    branchName,
-    'pullrequest',
-  )
+  try {
+    const url = urljoin(
+      UTOPIA_BACKEND,
+      'github',
+      'branches',
+      githubRepo.owner,
+      githubRepo.repository,
+      'branch',
+      branchName,
+      'pullrequest',
+    )
 
-  const response = await fetch(url, {
-    method: 'GET',
-    credentials: 'include',
-    headers: HEADERS,
-    mode: MODE,
-  })
+    const response = await fetch(url, {
+      method: 'GET',
+      credentials: 'include',
+      headers: HEADERS,
+      mode: MODE,
+    })
 
-  if (response.ok) {
-    const responseBody: GetBranchPullRequestResponse = await response.json()
+    if (response.ok) {
+      const responseBody: GetBranchPullRequestResponse = await response.json()
 
-    switch (responseBody.type) {
-      case 'FAILURE':
-        dispatch(
-          [
+      switch (responseBody.type) {
+        case 'FAILURE':
+          return [
             showToast(
               notice(
                 `Error when listing pull requests for branch: ${responseBody.failureReason}`,
                 'ERROR',
               ),
             ),
-          ],
-          'everyone',
-        )
-        break
-      case 'SUCCESS':
-        dispatch(
-          [
+          ]
+          break
+        case 'SUCCESS':
+          return [
             updateGithubData({
               currentBranchPullRequests: responseBody.pullRequests.map((pr) => ({
                 ...pr,
                 number: getPullRequestNumberFromUrl(pr.htmlURL),
               })),
             }),
-          ],
-          'everyone',
-        )
-        break
-      default:
-        const _exhaustiveCheck: never = responseBody
-        throw new Error(`Unhandled response body ${JSON.stringify(responseBody)}`)
+          ]
+          break
+        default:
+          const _exhaustiveCheck: never = responseBody
+          throw new Error(`Unhandled response body ${JSON.stringify(responseBody)}`)
+      }
+    } else {
+      return [
+        showToast(notice(`Unexpected status returned from endpoint: ${response.status}`, 'ERROR')),
+      ]
     }
-  } else {
-    dispatch(
-      [showToast(notice(`Unexpected status returned from endpoint: ${response.status}`, 'ERROR'))],
-      'everyone',
-    )
+  } finally {
+    dispatch([updateGithubOperations(operation, 'remove')], 'everyone')
   }
-
-  dispatch([updateGithubOperations(operation, 'remove')], 'everyone')
 }
 
 export async function updateProjectAgainstGithub(
@@ -638,7 +645,7 @@ async function getBranchContentFromServer(
   })
 }
 
-export async function getUserDetailsFromServer(): Promise<GithubUser> {
+export async function getUserDetailsFromServer(): Promise<Array<EditorAction>> {
   const url = urljoin(UTOPIA_BACKEND, 'github', 'user')
 
   const response = await fetch(url, {
@@ -656,7 +663,7 @@ export async function getUserDetailsFromServer(): Promise<GithubUser> {
           `Error when attempting to retrieve the user details: ${responseBody.failureReason}`,
         )
       case 'SUCCESS':
-        return responseBody.user
+        return [updateGithubData({ githubUserDetails: responseBody.user })]
       default:
         const _exhaustiveCheck: never = responseBody
         throw new Error(`Unhandled response body ${JSON.stringify(responseBody)}`)
@@ -673,72 +680,66 @@ export async function updateUserDetailsWhenAuthenticated(
 ): Promise<boolean> {
   const authenticationResult = await authenticationCheck
   if (authenticationResult) {
-    await getUserDetailsFromServer()
-      .then((userDetails) => {
-        dispatch([updateGithubData({ githubUserDetails: userDetails })], 'everyone')
-      })
-      .catch((error) => {
-        console.error(`Error while attempting to retrieve Github user details: ${error}`)
-      })
+    await dispatchPromiseActions(dispatch, getUserDetailsFromServer()).catch((error) => {
+      console.error(`Error while attempting to retrieve Github user details: ${error}`)
+    })
   }
   return authenticationResult
 }
 
-export async function getUsersPublicGithubRepositories(dispatch: EditorDispatch): Promise<void> {
+export async function getUsersPublicGithubRepositories(
+  dispatch: EditorDispatch,
+): Promise<Array<EditorAction>> {
   const operation: GithubOperation = { name: 'loadRepositories' }
 
   dispatch([updateGithubOperations(operation, 'add')], 'everyone')
 
-  const url = urljoin(UTOPIA_BACKEND, 'github', 'user', 'repositories')
+  try {
+    const url = urljoin(UTOPIA_BACKEND, 'github', 'user', 'repositories')
 
-  const response = await fetch(url, {
-    method: 'GET',
-    credentials: 'include',
-    headers: HEADERS,
-    mode: MODE,
-  })
-  if (response.ok) {
-    const responseBody: GetUsersPublicRepositoriesResponse = await response.json()
-    switch (responseBody.type) {
-      case 'FAILURE':
-        const actions: EditorAction[] = [
-          showToast(
-            notice(
-              `Error when getting a user's repositories: ${responseBody.failureReason}`,
-              'ERROR',
+    const response = await fetch(url, {
+      method: 'GET',
+      credentials: 'include',
+      headers: HEADERS,
+      mode: MODE,
+    })
+    if (response.ok) {
+      const responseBody: GetUsersPublicRepositoriesResponse = await response.json()
+      switch (responseBody.type) {
+        case 'FAILURE':
+          const actions: EditorAction[] = [
+            showToast(
+              notice(
+                `Error when getting a user's repositories: ${responseBody.failureReason}`,
+                'ERROR',
+              ),
             ),
-          ),
-        ]
-        if (responseBody.failureReason.includes('Authentication')) {
-          actions.push(
-            updateGithubSettings(emptyGithubSettings()),
-            setGithubState({ authenticated: false }),
-          )
-        }
-        dispatch(actions, 'everyone')
-        break
-      case 'SUCCESS':
-        dispatch(
-          [
+          ]
+          if (responseBody.failureReason.includes('Authentication')) {
+            actions.push(
+              updateGithubSettings(emptyGithubSettings()),
+              setGithubState({ authenticated: false }),
+            )
+          }
+          return actions
+        case 'SUCCESS':
+          return [
             updateGithubData({
               publicRepositories: responseBody.repositories.filter((repo) => !repo.isPrivate),
             }),
-          ],
-          'everyone',
-        )
-        break
-      default:
-        const _exhaustiveCheck: never = responseBody
-        throw new Error(`Unhandled response body ${JSON.stringify(responseBody)}`)
+          ]
+        default:
+          const _exhaustiveCheck: never = responseBody
+          throw new Error(`Unhandled response body ${JSON.stringify(responseBody)}`)
+      }
+    } else {
+      return [
+        showToast(notice(`Unexpected status returned from endpoint: ${response.status}`, 'ERROR')),
+      ]
     }
-  } else {
-    dispatch(
-      [showToast(notice(`Unexpected status returned from endpoint: ${response.status}`, 'ERROR'))],
-      'everyone',
-    )
+  } finally {
+    dispatch([updateGithubOperations(operation, 'remove')], 'everyone')
   }
-
-  dispatch([updateGithubOperations(operation, 'remove')], 'everyone')
 }
 
 const githubFileChangesSelector = createSelector(
@@ -1193,56 +1194,80 @@ export async function refreshGithubData(
   githubUserDetails: GithubUser | null,
   previousCommitSha: string | null,
 ): Promise<void> {
+  // Collect actions which are the results of the various requests,
+  // but not those that show which Github operations are running.
+  const promises: Array<Promise<Array<EditorAction>>> = []
   if (githubAuthenticated) {
     if (githubUserDetails === null) {
-      void getUserDetailsFromServer().then((r) =>
-        dispatch([updateGithubData({ githubUserDetails: r })]),
-      )
+      promises.push(getUserDetailsFromServer())
     }
-    void getUsersPublicGithubRepositories(dispatch)
+    promises.push(getUsersPublicGithubRepositories(dispatch))
     if (githubRepo != null) {
-      let upstreamChangesSuccess = false
-      void getBranchesForGithubRepository(dispatch, githubRepo)
+      promises.push(getBranchesForGithubRepository(dispatch, githubRepo))
+      promises.push(
+        updateUpstreamChanges(branchName, branchChecksums, githubRepo, previousCommitSha),
+      )
       if (branchName != null && branchChecksums != null) {
-        void updatePullRequestsForBranch(dispatch, githubRepo, branchName)
-        const branchContentResponse = await getBranchContentFromServer(
-          githubRepo,
-          branchName,
-          null,
-          previousCommitSha,
-        )
-        if (branchContentResponse.ok) {
-          const branchLatestContent: GetBranchContentResponse = await branchContentResponse.json()
-          if (branchLatestContent.type === 'SUCCESS' && branchLatestContent.branch != null) {
-            upstreamChangesSuccess = true
-            const upstreamChecksums = getProjectContentsChecksums(
-              branchLatestContent.branch.content,
-            )
-            const upstreamChanges = deriveGithubFileChanges(branchChecksums, upstreamChecksums, {})
-            dispatch(
-              [
-                updateGithubData({
-                  upstreamChanges: upstreamChanges,
-                  lastRefreshedCommit: branchLatestContent.branch.originCommit,
-                }),
-              ],
-              'everyone',
-            )
-          }
-        } else if (branchContentResponse.status === 304) {
-          // Not modified status means that the branch has the same commit SHA.
-          upstreamChangesSuccess = true
-        }
-      }
-      if (!upstreamChangesSuccess) {
-        dispatch([updateGithubData({ upstreamChanges: null })], 'everyone')
+        promises.push(updatePullRequestsForBranch(dispatch, githubRepo, branchName))
       }
     } else {
-      dispatch([updateGithubData({ branches: null })], 'everyone')
+      promises.push(Promise.resolve([updateGithubData({ branches: null })]))
     }
   } else {
-    dispatch([updateGithubData(emptyGithubData())], 'everyone')
+    promises.push(Promise.resolve([updateGithubData(emptyGithubData())]))
   }
+
+  // Resolve all the promises.
+  await Promise.all(promises)
+    .then((collatedActions) => {
+      // Dispatch all the actions from all the polling functions.
+      dispatch(
+        collatedActions.flatMap((arr) => arr),
+        'everyone',
+      )
+    })
+    .catch((error) => {
+      console.error(`Error whie polling Github: ${error}`)
+    })
+}
+
+async function updateUpstreamChanges(
+  branchName: string | null,
+  branchChecksums: GithubChecksums | null,
+  githubRepo: GithubRepo,
+  previousCommitSha: string | null,
+): Promise<Array<EditorAction>> {
+  const actions: Array<EditorAction> = []
+  let upstreamChangesSuccess = false
+  if (branchName != null && branchChecksums != null) {
+    const branchContentResponse = await getBranchContentFromServer(
+      githubRepo,
+      branchName,
+      null,
+      previousCommitSha,
+    )
+    if (branchContentResponse.ok) {
+      const branchLatestContent: GetBranchContentResponse = await branchContentResponse.json()
+      if (branchLatestContent.type === 'SUCCESS' && branchLatestContent.branch != null) {
+        upstreamChangesSuccess = true
+        const upstreamChecksums = getProjectContentsChecksums(branchLatestContent.branch.content)
+        const upstreamChanges = deriveGithubFileChanges(branchChecksums, upstreamChecksums, {})
+        actions.push(
+          updateGithubData({
+            upstreamChanges: upstreamChanges,
+            lastRefreshedCommit: branchLatestContent.branch.originCommit,
+          }),
+        )
+      }
+    } else if (branchContentResponse.status === 304) {
+      // Not modified status means that the branch has the same commit SHA.
+      upstreamChangesSuccess = true
+    }
+  }
+  if (!upstreamChangesSuccess) {
+    actions.push(updateGithubData({ upstreamChanges: null }))
+  }
+  return actions
 }
 
 export function disconnectGithubProjectActions(): EditorAction[] {

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -399,7 +399,6 @@ export async function updatePullRequestsForBranch(
               ),
             ),
           ]
-          break
         case 'SUCCESS':
           return [
             updateGithubData({
@@ -409,7 +408,6 @@ export async function updatePullRequestsForBranch(
               })),
             }),
           ]
-          break
         default:
           const _exhaustiveCheck: never = responseBody
           throw new Error(`Unhandled response body ${JSON.stringify(responseBody)}`)

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -172,7 +172,7 @@ export function startGithubPolling(utopiaStoreAPI: UtopiaStoreAPI): void {
       const githubUserDetails = currentState.editor.githubData.githubUserDetails
       const lastRefreshedCommit = currentState.editor.githubData.lastRefreshedCommit
       const dispatch = currentState.dispatch
-      refreshGithubData(
+      void refreshGithubData(
         dispatch,
         githubAuthenticated,
         githubRepo,


### PR DESCRIPTION
**Problem:**
There were a couple of issues with the previous polling:
- It was being (re)triggered through changes in a React `useEffect` call, which could trigger a lot of `clearInterval` and `setInterval` calls as various dependencies of the call changed.
- As multiple parts of the polling were updating a `GithubData` value, they were all setting their own value for `lastUpdatedAt` which resulted in the timer in the UI bouncing around near 0s for a few seconds.
- The various promises triggered in the polling weren't `await`ed or anything like that so in the case of a slow call could dogpile the server.

**Fix:**
The primary part of improving the polling was to have all the various parts of the polling have their results be accumulated in the polled function, which had the following effect:
- With a tweak to the action, all the updates to `GithubData` are now happening in quick succession so the `lastUpdatedAt` value doesn't visibly get bounced about.
- Now they are all effectively being waited on to get their results, the polling function only succeeds once all of the promises have finished.

The triggering of the polling has been changed to live completely outside the sphere of React as well, with it scheduling the next run only once the previous poll job has finished.

**Commit Details:**
- Moved updating of `GithubData.lastUpdatedAt` to the action handler from the action creator so that it should be changing monotonically. As well as that being the exact time it does change.
- Removed React based polling from `editor-component.tsx` and added a new function for polling based on the time when the last poll completed, which now accesses the Zustand store more directly.
- New polling function `startGithubPolling` is triggered from the `Editor` component.
- Added `dispatchPromiseActions` utility function.
- Refactored a lot of the functions called during the polling to return the actions that they previously individually dispatched for the result of processing them. As they are now collated together and dispatched all together.
- Refactored out `updateUpstreamChanges` from the previous polling code.