### PR TITLE
Added documentation for setting up Github on the server.

### DIFF
--- a/server/readme.md
+++ b/server/readme.md
@@ -40,3 +40,23 @@ Once all of these environment variables are set then S3 will be used to store as
 - `AWS_ACCESS_KEY_ID` - Access key for AWS to use with S3 when storing assets.
 - `AWS_SECRET_ACCESS_KEY` - Secret key for AWS to use with S3 when storing assets.
 - `AWS_BUCKET_NAME` - Bucket name in S3 to use when storing assets.
+
+### Github
+
+First of all, you will need to create an OAuth app in Github by going to "Settings" -> "Developer settings" -> "OAuth Apps" and selecting "New OAuth App" and setting the following fields:
+
+- "Application name": Whatever name you want to see it referred to by.
+- "Homepage URL": Just put `http://localhost:8000`, this is mostly for the UI that Github presents.
+- "Authorization callback URL": Set this to `http://localhost:8000/v1/github/authentication/finish` for local development or whatever appropriate URL for deployment, this is the URL that Github redirects the page to when completing the authorization.
+
+Then hit the "Register application" button to complete the setup. In the page that follows there will be a "Client ID" value and when you press the "Generate a new client secret" button also a client secret value,
+make a note of these.
+
+In your `.envrc` file if locally developing or wherever environment variables are set when deploying, set the following variables:
+
+- `GITHUB_OAUTH_CLIENT_ID` - Set this to the client ID from the OAuth app just created.
+- `GITHUB_OAUTH_CLIENT_SECRET` - Set this to match the client secret just generated.
+- `GITHUB_OAUTH_REDIRECT_URL` - Set this to `http://localhost:8000/v1/github/authentication/finish` for local development or whatever appropriate URL for deployment.
+
+Finally restart your environment, which if running locally might mean running something like `direnv allow` to permit the new settings to apply before rerunning `start-minimal` for instance to start your local environment.
+

--- a/server/readme.md
+++ b/server/readme.md
@@ -43,7 +43,7 @@ Once all of these environment variables are set then S3 will be used to store as
 
 ### Github
 
-First of all, you will need to create an OAuth app in Github by going to "Settings" -> "Developer settings" -> "OAuth Apps" and selecting "New OAuth App" and setting the following fields:
+First of all, you will need to create an OAuth app in Github by going to ["Settings" -> "Developer settings" -> "OAuth Apps"](https://github.com/settings/applications/new) and selecting "New OAuth App" and setting the following fields:
 
 - "Application name": Whatever name you want to see it referred to by.
 - "Homepage URL": Just put `http://localhost:8000`, this is mostly for the UI that Github presents.


### PR DESCRIPTION
**Problem:**
There is no documentation for setting up Github integration on the server.

**Fix:**
Added documentation to the server readme file.

**Commit Details:**
- Added documentation to `server/readme.md`.