### PR TITLE
clicking lozenges opens github pane, never closes it

### DIFF
--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -93,10 +93,10 @@ const TitleBar = React.memo(() => {
   }, [dispatch])
 
   const openLeftPaneltoGithubTab = useCallback(() => {
-    let actions: Array<EditorAction> = []
-    actions.push(setPanelVisibility('leftmenu', true))
-    actions.push(setLeftMenuTab(LeftMenuTab.Github))
-    dispatch(actions)
+    dispatch([
+      setPanelVisibility('leftmenu', true),
+      setLeftMenuTab(LeftMenuTab.Github),
+    ])
   }, [dispatch])
 
   const loggedIn = React.useMemo(() => loginState.type === 'LOGGED_IN', [loginState])

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -139,14 +139,20 @@ const TitleBar = React.memo(() => {
           <>
             {when(
               hasUpstreamChanges,
-              <RoundButton color={colorTheme.secondaryOrange.value} onClick={openLeftPaneltoGithubTab}>
+              <RoundButton
+                color={colorTheme.secondaryOrange.value}
+                onClick={openLeftPaneltoGithubTab}
+              >
                 {<Icons.Download style={{ width: 19, height: 19 }} color={'on-light-main'} />}
                 <>Pull Remote</>
               </RoundButton>,
             )}
             {when(
               hasDownstreamChanges,
-              <RoundButton color={colorTheme.secondaryBlue.value} onClick={openLeftPaneltoGithubTab}>
+              <RoundButton
+                color={colorTheme.secondaryBlue.value}
+                onClick={openLeftPaneltoGithubTab}
+              >
                 {<Icons.Upload style={{ width: 19, height: 19 }} color={'on-light-main'} />}
                 <>Push Local</>
               </RoundButton>,

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -16,8 +16,8 @@ import {
 } from '../../uuiui'
 import { LoginState } from '../../uuiui-deps'
 import { EditorAction } from '../editor/action-types'
-import { togglePanel } from '../editor/actions/action-creators'
-import { EditorStorePatched, githubRepoFullName } from '../editor/store/editor-state'
+import { setLeftMenuTab, setPanelVisibility, togglePanel } from '../editor/actions/action-creators'
+import { EditorStorePatched, githubRepoFullName, LeftMenuTab } from '../editor/store/editor-state'
 import { useEditorState } from '../editor/store/store-hook'
 import { RoundButton } from './buttons'
 import { TestMenu } from './test-menu'
@@ -87,6 +87,13 @@ const TitleBar = React.memo(() => {
     dispatch(actions)
   }, [dispatch])
 
+  const openLeftPanel = useCallback(() => {
+    let actions: Array<EditorAction> = []
+    actions.push(setPanelVisibility('leftmenu', true))
+    actions.push(setLeftMenuTab(LeftMenuTab.Github))
+    dispatch(actions)
+  }, [dispatch])
+
   const loggedIn = React.useMemo(() => loginState.type === 'LOGGED_IN', [loginState])
 
   return (
@@ -127,14 +134,14 @@ const TitleBar = React.memo(() => {
           <>
             {when(
               hasUpstreamChanges,
-              <RoundButton color={colorTheme.secondaryOrange.value} onClick={toggleLeftPanel}>
+              <RoundButton color={colorTheme.secondaryOrange.value} onClick={openLeftPanel}>
                 {<Icons.Download style={{ width: 19, height: 19 }} color={'on-light-main'} />}
                 <>Pull Remote</>
               </RoundButton>,
             )}
             {when(
               hasDownstreamChanges,
-              <RoundButton color={colorTheme.secondaryBlue.value} onClick={toggleLeftPanel}>
+              <RoundButton color={colorTheme.secondaryBlue.value} onClick={openLeftPanel}>
                 {<Icons.Upload style={{ width: 19, height: 19 }} color={'on-light-main'} />}
                 <>Push Local</>
               </RoundButton>,

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -81,6 +81,11 @@ const TitleBar = React.memo(() => {
     window.open(auth0Url('auto-close'), '_blank')
   }, [])
 
+  const isLeftMenuExpanded = useEditorState(
+    (store) => store.editor.leftMenu.expanded,
+    'LeftPanelRoot isLeftMenuExpanded',
+  )
+
   const toggleLeftPanel = useCallback(() => {
     let actions: Array<EditorAction> = []
     actions.push(togglePanel('leftmenu'))
@@ -88,6 +93,9 @@ const TitleBar = React.memo(() => {
   }, [dispatch])
 
   const openLeftPanel = useCallback(() => {
+    // {
+    //   isLeftMenuExpanded ? console.log('highlight the CTA') : null
+    // }
     let actions: Array<EditorAction> = []
     actions.push(setPanelVisibility('leftmenu', true))
     actions.push(setLeftMenuTab(LeftMenuTab.Github))

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -93,9 +93,6 @@ const TitleBar = React.memo(() => {
   }, [dispatch])
 
   const openLeftPanel = useCallback(() => {
-    // {
-    //   isLeftMenuExpanded ? console.log('highlight the CTA') : null
-    // }
     let actions: Array<EditorAction> = []
     actions.push(setPanelVisibility('leftmenu', true))
     actions.push(setLeftMenuTab(LeftMenuTab.Github))

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -93,10 +93,7 @@ const TitleBar = React.memo(() => {
   }, [dispatch])
 
   const openLeftPaneltoGithubTab = useCallback(() => {
-    dispatch([
-      setPanelVisibility('leftmenu', true),
-      setLeftMenuTab(LeftMenuTab.Github),
-    ])
+    dispatch([setPanelVisibility('leftmenu', true), setLeftMenuTab(LeftMenuTab.Github)])
   }, [dispatch])
 
   const loggedIn = React.useMemo(() => loginState.type === 'LOGGED_IN', [loginState])

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -92,7 +92,7 @@ const TitleBar = React.memo(() => {
     dispatch(actions)
   }, [dispatch])
 
-  const openLeftPanel = useCallback(() => {
+  const openLeftPaneltoGithubTab = useCallback(() => {
     let actions: Array<EditorAction> = []
     actions.push(setPanelVisibility('leftmenu', true))
     actions.push(setLeftMenuTab(LeftMenuTab.Github))
@@ -139,14 +139,14 @@ const TitleBar = React.memo(() => {
           <>
             {when(
               hasUpstreamChanges,
-              <RoundButton color={colorTheme.secondaryOrange.value} onClick={openLeftPanel}>
+              <RoundButton color={colorTheme.secondaryOrange.value} onClick={openLeftPaneltoGithubTab}>
                 {<Icons.Download style={{ width: 19, height: 19 }} color={'on-light-main'} />}
                 <>Pull Remote</>
               </RoundButton>,
             )}
             {when(
               hasDownstreamChanges,
-              <RoundButton color={colorTheme.secondaryBlue.value} onClick={openLeftPanel}>
+              <RoundButton color={colorTheme.secondaryBlue.value} onClick={openLeftPaneltoGithubTab}>
                 {<Icons.Upload style={{ width: 19, height: 19 }} color={'on-light-main'} />}
                 <>Push Local</>
               </RoundButton>,


### PR DESCRIPTION
**Problem:**
Clicking on the "Pull Remote" and "Push Local" title bar lozenges was toggling the left pane, and not specifically the GitHub tab of the pane.

**Fix:**
Now, clicking on said lozenges will open the GitHub tab of the left pane specifically, never close it. Ideally, if the tab is _already_ open, we would highlight the CTA button somehow. 