### PR TITLE
Only send selection changed messages if vscode isn't focused

### DIFF
--- a/editor/src/components/code-editor/code-editor-container.tsx
+++ b/editor/src/components/code-editor/code-editor-container.tsx
@@ -5,8 +5,7 @@ import { createIframeUrl } from '../../core/shared/utils'
 import { getUnderlyingVSCodeBridgeID } from '../editor/store/editor-state'
 import { VSCodeLoadingScreen } from './vscode-editor-loading-screen'
 import { getEditorBranchNameFromURL, setBranchNameFromURL } from '../../utils/branches'
-
-export const VSCODE_EDITOR_IFRAME_ID = 'vscode-editor'
+import { VSCODE_EDITOR_IFRAME_ID } from '../../core/vscode/vscode-bridge'
 
 const VSCodeIframeContainer = React.memo((props: { projectID: string }) => {
   const projectID = props.projectID

--- a/editor/src/components/code-editor/code-editor-container.tsx
+++ b/editor/src/components/code-editor/code-editor-container.tsx
@@ -6,6 +6,8 @@ import { getUnderlyingVSCodeBridgeID } from '../editor/store/editor-state'
 import { VSCodeLoadingScreen } from './vscode-editor-loading-screen'
 import { getEditorBranchNameFromURL, setBranchNameFromURL } from '../../utils/branches'
 
+export const VSCODE_EDITOR_IFRAME_ID = 'vscode-editor'
+
 const VSCodeIframeContainer = React.memo((props: { projectID: string }) => {
   const projectID = props.projectID
   const baseIframeSrc = createIframeUrl(
@@ -28,7 +30,7 @@ const VSCodeIframeContainer = React.memo((props: { projectID: string }) => {
       {window.KarmaTestEnvironment ? null : (
         <iframe
           key={'vscode-editor'}
-          id={'vscode-editor'}
+          id={VSCODE_EDITOR_IFRAME_ID}
           src={url.toString()}
           allow='autoplay'
           style={{

--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -66,7 +66,8 @@ import {
   Theme,
 } from '../../components/editor/store/editor-state'
 import { ProjectFileChange } from '../../components/editor/store/vscode-changes'
-import { VSCODE_EDITOR_IFRAME_ID } from '../../components/code-editor/code-editor-container'
+
+export const VSCODE_EDITOR_IFRAME_ID = 'vscode-editor'
 
 const Scheme = 'utopia'
 const RootDir = `/${Scheme}`

--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -66,6 +66,7 @@ import {
   Theme,
 } from '../../components/editor/store/editor-state'
 import { ProjectFileChange } from '../../components/editor/store/vscode-changes'
+import { VSCODE_EDITOR_IFRAME_ID } from '../../components/code-editor/code-editor-container'
 
 const Scheme = 'utopia'
 const RootDir = `/${Scheme}`
@@ -234,12 +235,6 @@ export async function sendUpdateDecorationsMessage(
   return sendMessage(updateDecorationsMessage(decorations))
 }
 
-export async function sendSelectedElementChangedMessage(
-  boundsForFile: BoundsInFile,
-): Promise<void> {
-  return sendMessage(selectedElementChanged(boundsForFile))
-}
-
 export async function sendSetFollowSelectionEnabledMessage(enabled: boolean): Promise<void> {
   return sendMessage(setFollowSelectionConfig(enabled))
 }
@@ -317,15 +312,21 @@ export function getSelectedElementChangedMessage(
   if (highlightBounds == null) {
     return null
   } else {
-    return selectedElementChanged(
-      boundsInFile(
-        highlightBounds.filePath,
-        highlightBounds.startLine,
-        highlightBounds.startCol,
-        highlightBounds.endLine,
-        highlightBounds.endCol,
-      ),
-    )
+    if (document.activeElement?.id === VSCODE_EDITOR_IFRAME_ID) {
+      // If the code editor is active, we don't want to inform it of selection changes as that
+      // would then update the user's cursor in VS Code
+      return null
+    } else {
+      return selectedElementChanged(
+        boundsInFile(
+          highlightBounds.filePath,
+          highlightBounds.startLine,
+          highlightBounds.startCol,
+          highlightBounds.endLine,
+          highlightBounds.endCol,
+        ),
+      )
+    }
   }
 }
 

--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -454,21 +454,17 @@ function cursorPositionChanged(event: vscode.TextEditorSelectionChangeEvent): vo
 async function revealRangeIfPossible(
   workspaceRootUri: vscode.Uri,
   boundsInFile: BoundsInFile,
-  forceIfFocused: boolean = false,
 ): Promise<void> {
-  const focused = vscode.window.state.focused
-  if (forceIfFocused || !focused) {
-    const visibleEditor = vscode.window.visibleTextEditors.find(
-      (editor) => editor.document.uri.path === boundsInFile.filePath,
-    )
-    if (visibleEditor == null) {
-      const opened = await openFile(vscode.Uri.joinPath(workspaceRootUri, boundsInFile.filePath))
-      if (opened) {
-        revealRangeIfPossibleInVisibleEditor(boundsInFile)
-      }
-    } else {
+  const visibleEditor = vscode.window.visibleTextEditors.find(
+    (editor) => editor.document.uri.path === boundsInFile.filePath,
+  )
+  if (visibleEditor == null) {
+    const opened = await openFile(vscode.Uri.joinPath(workspaceRootUri, boundsInFile.filePath))
+    if (opened) {
       revealRangeIfPossibleInVisibleEditor(boundsInFile)
     }
+  } else {
+    revealRangeIfPossibleInVisibleEditor(boundsInFile)
   }
 }
 


### PR DESCRIPTION
Fixes #2926 

**Problem:**
Loading a branch or repo from github that doesn't contain the file(s) currently open in the code editor will break selection following temporarily (provided the code editor doesn't have _any_ files open that exist in the loaded branch / repo)

**Fix:**
The problem here was that as part of removing those files, VS Code will throw an error complaining that it can no longer read the open file, and then close that file. If this happens and there is no remaining valid open file, VS Code will then believe that it is focused (which we check in the extension via `vscode.window.state.focused`).

The reason we check if VS Code is focused before updating the selection in the VS Code extension is because we don't want selection changes coming from the code editor to then update the user's cursor in the code editor.

To counter this, we now instead perform the focus check on the Utopia side, checking if the iframe used to load VS Code is the `document.activeElement`. We use that to prevent sending `selectedElementChanged` messages, meaning we can now remove the focus check on the VS Code side.

I've also deleted an unused function `sendSelectedElementChangedMessage` so that only one place ever constructs these messages.