### PR TITLE
`borderRadiusEquals.areEqual` instead of `borderRadiusEquals`

### DIFF
--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1219,7 +1219,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
     const closestOffsetParentPathResult = ElementPathKeepDeepEquality(
       oldSize.closestOffsetParentPath,
       newSize.closestOffsetParentPath,
-    )
+    ).areEqual
     const usesParentBoundsResult = oldSize.usesParentBounds === newSize.usesParentBounds
     const parentLayoutSystemResult = oldSize.parentLayoutSystem === newSize.parentLayoutSystem
     const layoutSystemForChildrenResult =
@@ -1256,7 +1256,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
       coordinateSystemBoundsResult.areEqual &&
       immediateParentBoundsResult.areEqual &&
       immediateParentProvidesLayoutResult &&
-      closestOffsetParentPathResult.areEqual &&
+      closestOffsetParentPathResult &&
       usesParentBoundsResult &&
       parentLayoutSystemResult &&
       layoutSystemForChildrenResult &&
@@ -1279,7 +1279,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
       hasPositionOffsetEquals &&
       textDirectionEquals &&
       hasTransformEquals &&
-      borderRadiusEquals.areEqual
+      borderRadiusEquals
     if (areEqual) {
       return keepDeepEqualityResult(oldSize, true)
     } else {

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1279,7 +1279,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
       hasPositionOffsetEquals &&
       textDirectionEquals &&
       hasTransformEquals &&
-      borderRadiusEquals
+      borderRadiusEquals.areEqual
     if (areEqual) {
       return keepDeepEqualityResult(oldSize, true)
     } else {

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1250,7 +1250,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
     const borderRadiusEquals = nullableDeepEquality(SidesKeepDeepEquality)(
       oldSize.borderRadius,
       newSize.borderRadius,
-    )
+    ).areEqual
     const areEqual =
       offsetResult.areEqual &&
       coordinateSystemBoundsResult.areEqual &&


### PR DESCRIPTION
## Problem:
`borderRadiusEquals` was used in `SpecialSizeMeasurementsKeepDeepEquality` instead of `borderRadiusEquals.areEqual`

## Fix:
Use `borderRadiusEquals.areEqual` instead of `borderRadiusEquals`