### PR TITLE
currentElementsToRender does not fall back to rerender-all-elements

### DIFF
--- a/editor/src/components/canvas/commands/set-elements-to-rerender-command.ts
+++ b/editor/src/components/canvas/commands/set-elements-to-rerender-command.ts
@@ -1,5 +1,4 @@
 import * as EP from '../../../core/shared/element-path'
-import { ElementPath } from '../../../core/shared/project-file-types'
 import { EditorState, EditorStatePatch, ElementsToRerender } from '../../editor/store/editor-state'
 import { BaseCommand, CommandFunction } from './commands'
 
@@ -11,7 +10,7 @@ export interface SetElementsToRerenderCommand extends BaseCommand {
 export function setElementsToRerenderCommand(
   value: ElementsToRerender,
 ): SetElementsToRerenderCommand {
-  const uniqueValues = value === 'rerender-all-elements' ? value : uniqueElementPaths(value)
+  const uniqueValues = value === 'rerender-all-elements' ? value : EP.uniqueElementPaths(value)
   return {
     type: 'SET_ELEMENTS_TO_RERENDER_COMMAND',
     whenToRun: 'mid-interaction',
@@ -79,9 +78,4 @@ export const runAppendElementsToRerender: CommandFunction<AppendElementsToRerend
       typeof command.value === 'string' ? command.value : command.value.map(EP.toString).join(', ')
     }]`,
   }
-}
-
-function uniqueElementPaths(paths: Array<ElementPath>) {
-  const pathSet = new Set(paths.map(EP.toString))
-  return Array.from(pathSet).map(EP.fromString)
 }

--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -227,7 +227,6 @@ export function renderCanvasReturnResultAndError(
       propertyControlsInfo: {},
       dispatch: NO_OP,
       domWalkerAdditionalElementsToUpdate: [],
-      elementsToRerender: 'rerender-all-elements',
     }
   } else {
     canvasProps = {
@@ -251,7 +250,6 @@ export function renderCanvasReturnResultAndError(
       propertyControlsInfo: {},
       dispatch: NO_OP,
       domWalkerAdditionalElementsToUpdate: [],
-      elementsToRerender: 'rerender-all-elements',
     }
   }
 

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -168,7 +168,6 @@ export interface UiJsxCanvasProps {
   propertyControlsInfo: PropertyControlsInfo
   dispatch: EditorDispatch
   domWalkerAdditionalElementsToUpdate: Array<ElementPath>
-  elementsToRerender: Array<ElementPath> | 'rerender-all-elements'
 }
 
 export interface CanvasReactReportErrorCallback {
@@ -242,7 +241,6 @@ export function pickUiJsxCanvasProps(
       propertyControlsInfo: editor.propertyControlsInfo,
       dispatch: dispatch,
       domWalkerAdditionalElementsToUpdate: editor.canvas.domWalkerAdditionalElementsToUpdate,
-      elementsToRerender: editor.canvas.elementsToRerender,
     }
   }
 }
@@ -358,7 +356,7 @@ export const UiJsxCanvas = React.memo<UiJsxCanvasPropsWithErrorCallback>((props)
   const cssImports = useKeepReferenceEqualityIfPossible(
     normalizedCssImportsFromImports(uiFilePath, imports),
   )
-  if (props.elementsToRerender === 'rerender-all-elements') {
+  if (ElementsToRerenderGLOBAL.current === 'rerender-all-elements') {
     unimportAllButTheseCSSFiles(cssImports) // TODO this needs to support more than just the storyboard file!!!!!
   }
 
@@ -509,7 +507,7 @@ export const UiJsxCanvas = React.memo<UiJsxCanvasPropsWithErrorCallback>((props)
     props.domWalkerInvalidateCount,
     props.mountCount,
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    props.elementsToRerender,
+    ElementsToRerenderGLOBAL.current,
   ])
 
   return (

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -1007,3 +1007,8 @@ export function emptyStaticElementPathPart(): StaticElementPathPart {
 export function getContainingComponent(path: ElementPath): ElementPath {
   return dropLastPathPart(path)
 }
+
+export function uniqueElementPaths(paths: Array<ElementPath>): Array<ElementPath> {
+  const pathSet = new Set(paths.map(toString))
+  return Array.from(pathSet).map(fromString)
+}

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -172,10 +172,10 @@ function fixElementsToRerender(
     lastElementsToRerender !== 'rerender-all-elements'
   ) {
     // if the current elements to rerender array doesn't match the previous elements to rerender array, for a single frame let's use the union of the two arrays
-    fixedElementsToRerender = uniqBy(
-      [...lastElementsToRerender, ...currentOrTransientElementsToRerender],
-      EP.pathsEqual,
-    )
+    fixedElementsToRerender = EP.uniqueElementPaths([
+      ...lastElementsToRerender,
+      ...currentOrTransientElementsToRerender,
+    ])
   }
 
   lastElementsToRerender = currentOrTransientElementsToRerender


### PR DESCRIPTION
**Problem:**
All reparenting runs with selective rerender turned off (set to `rerender-all-elements`). This causes a very visible performance problem. 

**Fix:**
I tweaked `fixedElementsToRerender` to a new behavior: when elementsToRerender changes, we don't fall back to rerender-all-elements (as on master) but instead use the union of the old elementsToRerender array and the new elementsToRerender array.

**Other fix:**
The ui-jsx-canvas.tsx was the only place that consumed EditorState.canvas.elementsToRerender – which is not the same value as the output of fixedElementsToRerender. I changed it so the code in ui-jsx-canvas now uses ElementsToRerenderGLOBAL.current which is the same value as used by the ComponentRendererComponent.
