### PR TITLE
Detect asset checksums, detect image file changes

### DIFF
--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -74,13 +74,11 @@ export function getProjectContentsChecksums(
         checksums[filename] = getSHA1Checksum(file.fileContents.code)
         break
       case 'ASSET_FILE':
-        if (file.base64 != undefined) {
-          checksums[filename] = getSHA1Checksum(file.base64)
-        }
-        break
       case 'IMAGE_FILE':
-        if (file.gitBlobSha) {
+        if (file.gitBlobSha != null) {
           checksums[filename] = file.gitBlobSha
+        } else if (file.base64 != undefined) {
+          checksums[filename] = getSHA1Checksum(file.base64)
         } else if (Object.keys(assetChecksums).includes(filename)) {
           checksums[filename] = assetChecksums[filename]
         }

--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -46,8 +46,13 @@ function getSHA1Checksum(contents: string | Buffer): string {
   return new sha1().update(contents).digest('hex')
 }
 
-export function inferGitBlobChecksum(buf: Buffer): string {
-  return getSHA1Checksum(Buffer.concat([Buffer.from(`blob ${buf.byteLength}\0`), buf]))
+export function inferGitBlobChecksum(buffer: Buffer): string {
+  // This function returns the same SHA1 checksum string that git would return for the same contents.
+  // Given the contents in the buffer variable, the final checksum is calculated by hashing
+  // a string built as "<prefix><contents>". The prefix looks like "blob <contents_length_in_bytes><null_character>".
+  const prefix = Buffer.from(`blob ${buffer.byteLength}\0`)
+  const wrapped = Buffer.concat([prefix, buffer])
+  return getSHA1Checksum(wrapped)
 }
 
 export function getProjectContentsChecksums(

--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -50,6 +50,7 @@ export function inferGitBlobChecksum(buffer: Buffer): string {
   // This function returns the same SHA1 checksum string that git would return for the same contents.
   // Given the contents in the buffer variable, the final checksum is calculated by hashing
   // a string built as "<prefix><contents>". The prefix looks like "blob <contents_length_in_bytes><null_character>".
+  // Ref: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
   const prefix = Buffer.from(`blob ${buffer.byteLength}\0`)
   const wrapped = Buffer.concat([prefix, buffer])
   return getSHA1Checksum(wrapped)

--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -47,7 +47,7 @@ function getSHA1Checksum(contents: string | Buffer): string {
 }
 
 export function inferGitBlobChecksum(buf: Buffer): string {
-  return getSHA1Checksum(Buffer.concat([Buffer.from(`blob ${buf.byteLength.toString()}\0`), buf]))
+  return getSHA1Checksum(Buffer.concat([Buffer.from(`blob ${buf.byteLength}\0`), buf]))
 }
 
 export function getProjectContentsChecksums(

--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -42,7 +42,7 @@ export function getAllProjectAssetFiles(
   return allProjectAssets
 }
 
-export function getSHA1Checksum(contents: string | Buffer): string {
+function getSHA1Checksum(contents: string | Buffer): string {
   return new sha1().update(contents).digest('hex')
 }
 

--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -65,16 +65,31 @@ export function getProjectContentsChecksums(
   const checksums: GithubChecksums = {}
   Object.keys(contents).forEach((filename) => {
     const file = contents[filename]
-    if (isTextFile(file)) {
-      checksums[filename] = getSHA1Checksum(file.fileContents.code)
-    } else if (isAssetFile(file) && file.base64 != undefined) {
-      checksums[filename] = getSHA1Checksum(file.base64)
-    } else if (isImageFile(file)) {
-      if (file.gitBlobSha) {
-        checksums[filename] = file.gitBlobSha
-      } else if (Object.keys(assetChecksums).includes(filename)) {
-        checksums[filename] = assetChecksums[filename]
-      }
+    if (file == null) {
+      return
+    }
+
+    switch (file.type) {
+      case 'TEXT_FILE':
+        checksums[filename] = getSHA1Checksum(file.fileContents.code)
+        break
+      case 'ASSET_FILE':
+        if (file.base64 != undefined) {
+          checksums[filename] = getSHA1Checksum(file.base64)
+        }
+        break
+      case 'IMAGE_FILE':
+        if (file.gitBlobSha) {
+          checksums[filename] = file.gitBlobSha
+        } else if (Object.keys(assetChecksums).includes(filename)) {
+          checksums[filename] = assetChecksums[filename]
+        }
+        break
+      case 'DIRECTORY':
+        break
+      default:
+        const _exhaustiveCheck: never = file
+        throw new Error(`Invalid file type`)
     }
   })
 

--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -18,7 +18,7 @@ import { mapValues, propOrNull } from '../core/shared/object-utils'
 import { emptySet } from '../core/shared/set-utils'
 import { sha1 } from 'sha.js'
 import { GithubFileChanges, TreeConflicts } from '../core/shared/github'
-import { GithubChecksums } from './editor/store/editor-state'
+import { FileChecksums } from './editor/store/editor-state'
 
 export interface AssetFileWithFileName {
   fileName: string
@@ -58,11 +58,11 @@ export function inferGitBlobChecksum(buffer: Buffer): string {
 
 export function getProjectContentsChecksums(
   tree: ProjectContentTreeRoot,
-  assetChecksums: GithubChecksums,
-): GithubChecksums {
+  assetChecksums: FileChecksums,
+): FileChecksums {
   const contents = treeToContents(tree)
 
-  const checksums: GithubChecksums = {}
+  const checksums: FileChecksums = {}
   Object.keys(contents).forEach((filename) => {
     const file = contents[filename]
     if (file == null) {
@@ -95,8 +95,8 @@ export function getProjectContentsChecksums(
 }
 
 export function deriveGithubFileChanges(
-  projectChecksums: GithubChecksums,
-  githubChecksums: GithubChecksums | null,
+  projectChecksums: FileChecksums,
+  githubChecksums: FileChecksums | null,
   treeConflicts: TreeConflicts,
 ): GithubFileChanges | null {
   if (githubChecksums == null || Object.keys(githubChecksums).length === 0) {

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -56,7 +56,7 @@ import {
   StoredEditorState,
   Theme,
   GithubOperation,
-  GithubChecksums,
+  FileChecksums,
   GithubData,
   UserConfiguration,
 } from './store/editor-state'
@@ -940,7 +940,7 @@ export interface SetRefreshingDependencies {
 
 export interface UpdateGithubChecksums {
   action: 'UPDATE_GITHUB_CHECKSUMS'
-  checksums: GithubChecksums | null
+  checksums: FileChecksums | null
 }
 
 export interface SetAssetChecksum {

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -943,6 +943,12 @@ export interface UpdateGithubChecksums {
   checksums: GithubChecksums | null
 }
 
+export interface SetAssetChecksum {
+  action: 'SET_ASSET_CHECKSUM'
+  filename: string
+  checksum: string | null
+}
+
 export interface ResetCanvas {
   action: 'RESET_CANVAS'
 }
@@ -1234,6 +1240,7 @@ export type EditorAction =
   | UpdateGithubChecksums
   | UpdateBranchContents
   | SetRefreshingDependencies
+  | SetAssetChecksum
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -237,7 +237,7 @@ import type {
   RightMenuTab,
   Theme,
   GithubOperation,
-  GithubChecksums,
+  FileChecksums,
   GithubData,
   UserConfiguration,
 } from '../store/editor-state'
@@ -1505,7 +1505,7 @@ export function setRefreshingDependencies(value: boolean): SetRefreshingDependen
   }
 }
 
-export function updateGithubChecksums(checksums: GithubChecksums | null): UpdateGithubChecksums {
+export function updateGithubChecksums(checksums: FileChecksums | null): UpdateGithubChecksums {
   return {
     action: 'UPDATE_GITHUB_CHECKSUMS',
     checksums: checksums,

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -220,6 +220,7 @@ import type {
   SetUserConfiguration,
   SetHoveredView,
   ClearHoveredViews,
+  SetAssetChecksum,
 } from '../action-types'
 import { EditorModes, insertionSubject, Mode } from '../editor-modes'
 import type {
@@ -1508,6 +1509,14 @@ export function updateGithubChecksums(checksums: GithubChecksums | null): Update
   return {
     action: 'UPDATE_GITHUB_CHECKSUMS',
     checksums: checksums,
+  }
+}
+
+export function setAssetChecksum(filename: string, checksum: string | null): SetAssetChecksum {
+  return {
+    action: 'SET_ASSET_CHECKSUM',
+    filename: filename,
+    checksum: checksum,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -124,6 +124,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_GITHUB_CHECKSUMS':
     case 'UPDATE_GITHUB_DATA':
     case 'REMOVE_FILE_CONFLICT':
+    case 'SET_ASSET_CHECKSUM':
       return true
 
     case 'NEW':

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -942,6 +942,7 @@ describe('LOAD', () => {
       },
       githubChecksums: null,
       branchContents: null,
+      assetChecksums: {},
     }
 
     const action = {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -343,7 +343,6 @@ import {
   DerivedState,
   editorModelFromPersistentModel,
   EditorState,
-  emptyGithubSettings,
   getAllBuildErrors,
   getAllLintErrors,
   getCurrentTheme,
@@ -355,7 +354,7 @@ import {
   getOpenFilename,
   getOpenTextFileKey,
   getOpenUIJSFileKey,
-  GithubChecksums,
+  FileChecksums,
   insertElementAtPath,
   LeftMenuTab,
   LeftPaneDefaultWidth,
@@ -371,7 +370,6 @@ import {
   packageJsonFileFromProjectContents,
   PersistentModel,
   persistentModelFromEditorModel,
-  ProjectGithubSettings,
   removeElementAtPath,
   RightMenuTab,
   SimpleParseSuccess,
@@ -1495,11 +1493,11 @@ function normalizeGithubData(editor: EditorModel): EditorModel {
 
 function pruneAssetChecksums(
   tree: ProjectContentTreeRoot,
-  checksums: GithubChecksums,
-): GithubChecksums {
+  checksums: FileChecksums,
+): FileChecksums {
   // this function removes the asset checksums that reference files that don't exist in the project anymore
   const assetChecksums = checksums != null ? { ...checksums } : {}
-  const keepChecksums: GithubChecksums = {}
+  const keepChecksums: FileChecksums = {}
   Object.keys(assetChecksums).forEach((filename) => {
     const file = getContentsTreeFileFromString(tree, filename)
     if (file != null && (isAssetFile(file) || isImageFile(file))) {
@@ -2044,7 +2042,7 @@ export const UPDATE_FNS = {
     }
   },
   SET_ASSET_CHECKSUM: (action: SetAssetChecksum, editor: EditorModel): EditorModel => {
-    const assetChecksums: GithubChecksums =
+    const assetChecksums: FileChecksums =
       editor.assetChecksums == null ? {} : { ...editor.assetChecksums }
     const absoluteFilename = action.filename.replace(/^\.\//, '/')
     if (action.checksum == null) {

--- a/editor/src/components/editor/actions/migrations/migrations.ts
+++ b/editor/src/components/editor/actions/migrations/migrations.ts
@@ -29,7 +29,7 @@ import {
 } from '../../../assets'
 import { isUtopiaJSXComponent } from '../../../../core/shared/element-template'
 
-export const CURRENT_PROJECT_VERSION = 11
+export const CURRENT_PROJECT_VERSION = 12
 
 export function applyMigrations(
   persistentModel: PersistentModel,
@@ -45,7 +45,8 @@ export function applyMigrations(
   const version9 = migrateFromVersion8(version8)
   const version10 = migrateFromVersion9(version9)
   const version11 = migrateFromVersion10(version10)
-  return version11
+  const version12 = migrateFromVersion11(version11)
+  return version12
 }
 
 function migrateFromVersion0(
@@ -400,6 +401,20 @@ function migrateFromVersion10(
       },
       githubChecksums: null,
       branchContents: null,
+    }
+  }
+}
+
+function migrateFromVersion11(
+  persistentModel: PersistentModel,
+): PersistentModel & { projectVersion: 12 } {
+  if (persistentModel.projectVersion != null && persistentModel.projectVersion !== 11) {
+    return persistentModel as any
+  } else {
+    return {
+      ...persistentModel,
+      projectVersion: 12,
+      assetChecksums: {},
     }
   }
 }

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -14,7 +14,7 @@ import { PersistentModel, UserConfiguration, emptyUserConfiguration } from './st
 import { LoginState } from '../../uuiui-deps'
 import urljoin from 'url-join'
 import JSZip from 'jszip'
-import { addFileToProjectContents, AssetFileWithFileName, walkContentsTree } from '../assets'
+import { AssetFileWithFileName, inferGitBlobChecksum } from '../assets'
 import { isLoginLost, isNotLoggedIn } from '../../common/user'
 import { notice } from '../common/notice'
 import { EditorDispatch, isLoggedIn } from './action-types'
@@ -233,7 +233,7 @@ async function saveAssetRequest(
   fileType: string,
   base64: string,
   fileName: string,
-): Promise<void> {
+): Promise<string> {
   const mimeStrippedBase64 = getMimeStrippedBase64(base64)
   const asset = Buffer.from(mimeStrippedBase64, 'base64')
   const url = assetURL(projectId, fileName)
@@ -246,7 +246,7 @@ async function saveAssetRequest(
     body: asset,
   })
   if (response.ok) {
-    return
+    return inferGitBlobChecksum(asset)
   } else {
     throw new Error(`Save asset request failed (${response.status}): ${response.statusText}`)
   }
@@ -257,13 +257,13 @@ export async function saveAsset(
   fileType: string,
   base64: string,
   imageId: string,
-): Promise<void> {
+): Promise<string | null> {
   try {
     return saveAssetRequest(projectId, fileType, base64, imageId)
   } catch (e) {
     // FIXME Client should show an error if server requests fail
     console.error(e)
-    return
+    return null
   }
 }
 
@@ -281,12 +281,14 @@ export function assetToSave(fileType: string, base64: string, fileName: string):
   }
 }
 
-export async function saveAssets(projectId: string, assets: Array<AssetToSave>): Promise<void> {
+export async function saveAssets(
+  projectId: string,
+  assets: Array<AssetToSave>,
+): Promise<(string | null)[]> {
   const promises = assets.map((asset) =>
     saveAsset(projectId, asset.fileType, asset.base64, asset.fileName),
   )
-  await Promise.all(promises)
-  return
+  return await Promise.all(promises)
 }
 
 export async function saveThumbnail(thumbnail: Buffer, projectId: string): Promise<void> {

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -284,7 +284,7 @@ export function assetToSave(fileType: string, base64: string, fileName: string):
 export async function saveAssets(
   projectId: string,
   assets: Array<AssetToSave>,
-): Promise<(string | null)[]> {
+): Promise<Array<string | null>> {
   const promises = assets.map((asset) =>
     saveAsset(projectId, asset.fileType, asset.base64, asset.fileName),
   )

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1219,7 +1219,7 @@ export function emptyGithubData(): GithubData {
   }
 }
 
-export type GithubChecksums = { [filename: string]: string } // key = filename, value = sha1 hash of the file
+export type FileChecksums = { [filename: string]: string } // key = filename, value = sha1 hash of the file
 
 // FIXME We need to pull out ProjectState from here
 export interface EditorState {
@@ -1292,10 +1292,10 @@ export interface EditorState {
   githubSettings: ProjectGithubSettings
   imageDragSessionState: ImageDragSessionState
   githubOperations: Array<GithubOperation>
-  githubChecksums: GithubChecksums | null
+  githubChecksums: FileChecksums | null
   githubData: GithubData
   refreshingDependencies: boolean
-  assetChecksums: GithubChecksums
+  assetChecksums: FileChecksums
 }
 
 export function editorState(
@@ -1367,11 +1367,11 @@ export function editorState(
   githubSettings: ProjectGithubSettings,
   imageDragSessionState: ImageDragSessionState,
   githubOperations: Array<GithubOperation>,
-  githubChecksums: GithubChecksums | null,
+  githubChecksums: FileChecksums | null,
   branchContents: ProjectContentTreeRoot | null,
   githubData: GithubData,
   refreshingDependencies: boolean,
-  assetChecksums: GithubChecksums,
+  assetChecksums: FileChecksums,
 ): EditorState {
   return {
     id: id,
@@ -2035,9 +2035,9 @@ export interface PersistentModel {
     minimised: boolean
   }
   githubSettings: ProjectGithubSettings
-  githubChecksums: GithubChecksums | null
+  githubChecksums: FileChecksums | null
   branchContents: ProjectContentTreeRoot | null
-  assetChecksums: GithubChecksums
+  assetChecksums: FileChecksums
 }
 
 export function isPersistentModel(data: any): data is PersistentModel {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1295,6 +1295,7 @@ export interface EditorState {
   githubChecksums: GithubChecksums | null
   githubData: GithubData
   refreshingDependencies: boolean
+  assetChecksums: GithubChecksums
 }
 
 export function editorState(
@@ -1370,6 +1371,7 @@ export function editorState(
   branchContents: ProjectContentTreeRoot | null,
   githubData: GithubData,
   refreshingDependencies: boolean,
+  assetChecksums: GithubChecksums,
 ): EditorState {
   return {
     id: id,
@@ -1444,6 +1446,7 @@ export function editorState(
     githubChecksums: githubChecksums,
     githubData: githubData,
     refreshingDependencies: refreshingDependencies,
+    assetChecksums: assetChecksums,
   }
 }
 
@@ -2034,6 +2037,7 @@ export interface PersistentModel {
   githubSettings: ProjectGithubSettings
   githubChecksums: GithubChecksums | null
   branchContents: ProjectContentTreeRoot | null
+  assetChecksums: GithubChecksums
 }
 
 export function isPersistentModel(data: any): data is PersistentModel {
@@ -2076,6 +2080,7 @@ export function mergePersistentModel(
     githubSettings: second.githubSettings,
     githubChecksums: second.githubChecksums,
     branchContents: second.branchContents,
+    assetChecksums: second.assetChecksums,
   }
 }
 
@@ -2265,6 +2270,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     branchContents: null,
     githubData: emptyGithubData(),
     refreshingDependencies: false,
+    assetChecksums: {},
   }
 }
 
@@ -2566,6 +2572,7 @@ export function editorModelFromPersistentModel(
     githubChecksums: persistentModel.githubChecksums,
     branchContents: persistentModel.branchContents,
     githubData: emptyGithubData(),
+    assetChecksums: {},
   }
   return editor
 }
@@ -2604,6 +2611,7 @@ export function persistentModelFromEditorModel(editor: EditorState): PersistentM
     githubSettings: editor.githubSettings,
     githubChecksums: editor.githubChecksums,
     branchContents: editor.branchContents,
+    assetChecksums: editor.assetChecksums,
   }
 }
 
@@ -2638,6 +2646,7 @@ export function persistentModelForProjectContents(
     githubSettings: emptyGithubSettings(),
     githubChecksums: null,
     branchContents: null,
+    assetChecksums: {},
   }
 }
 

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -143,6 +143,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.UPDATE_GITHUB_OPERATIONS(action, state)
     case 'UPDATE_GITHUB_CHECKSUMS':
       return UPDATE_FNS.UPDATE_GITHUB_CHECKSUMS(action, state)
+    case 'SET_ASSET_CHECKSUM':
+      return UPDATE_FNS.SET_ASSET_CHECKSUM(action, state)
     case 'REMOVE_TOAST':
       return UPDATE_FNS.REMOVE_TOAST(action, state)
     case 'SET_HIGHLIGHTED_VIEW':

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -315,7 +315,7 @@ import {
   FileUploadInfo,
   FileOverwriteModal,
   GithubOperation,
-  GithubChecksums,
+  FileChecksums,
   FileRevertModal,
   fileRevertModal,
   GithubData,
@@ -2455,7 +2455,7 @@ export function ProjectContentTreeRootKeepDeepEquality(): KeepDeepEqualityCall<P
   return objectDeepEquality(ProjectContentsTreeKeepDeepEquality())
 }
 
-const GithubChecksumsKeepDeepEquality: KeepDeepEqualityCall<GithubChecksums | null> = (
+const FileChecksumsKeepDeepEquality: KeepDeepEqualityCall<FileChecksums | null> = (
   oldAttribute,
   newAttribute,
 ) => {
@@ -3567,7 +3567,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     newValue.githubOperations,
   )
 
-  const githubChecksumsResults = GithubChecksumsKeepDeepEquality(
+  const githubChecksumsResults = FileChecksumsKeepDeepEquality(
     oldValue.githubChecksums,
     newValue.githubChecksums,
   )

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -3584,6 +3584,11 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     newValue.refreshingDependencies,
   )
 
+  const assetChecksumsResults = objectDeepEquality(StringKeepDeepEquality)(
+    oldValue.assetChecksums,
+    newValue.assetChecksums,
+  )
+
   const areEqual =
     idResult.areEqual &&
     vscodeBridgeIdResult.areEqual &&
@@ -3656,7 +3661,8 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     githubChecksumsResults.areEqual &&
     branchContentsResults.areEqual &&
     githubDataResults.areEqual &&
-    refreshingDependenciesResults.areEqual
+    refreshingDependenciesResults.areEqual &&
+    assetChecksumsResults.areEqual
 
   if (areEqual) {
     return keepDeepEqualityResult(oldValue, true)
@@ -3734,6 +3740,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
       branchContentsResults.value,
       githubDataResults.value,
       refreshingDependenciesResults.value,
+      assetChecksumsResults.value,
     )
 
     return keepDeepEqualityResult(newEditorState, false)

--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -10,12 +10,7 @@ import { ProjectContentTreeRoot, walkContentsTree } from '../assets'
 import { setFocus } from '../common/actions'
 import { CodeResultCache, isJavascriptOrTypescript } from '../custom-code/code-file'
 import * as EditorActions from '../editor/actions/action-creators'
-import {
-  getAllCodeEditorErrors,
-  getOpenFilename,
-  GithubChecksums,
-  GithubRepo,
-} from '../editor/store/editor-state'
+import { getAllCodeEditorErrors, getOpenFilename, GithubRepo } from '../editor/store/editor-state'
 import { useEditorState } from '../editor/store/store-hook'
 import { addingChildElement, FileBrowserItem } from './fileitem'
 import {

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -124,6 +124,7 @@ async function loadProject(
     },
     githubChecksums: null,
     branchContents: null,
+    assetChecksums: {},
   }
 
   // Load the project itself.

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -36,7 +36,7 @@ import {
   EditorStorePatched,
   emptyGithubData,
   emptyGithubSettings,
-  GithubChecksums,
+  FileChecksums,
   GithubData,
   GithubOperation,
   GithubRepo,
@@ -202,7 +202,7 @@ export type GetGithubUserResponse = GetGithubUserSuccess | GithubFailure
 export interface SaveProjectToGithubOptions {
   branchName: string | null
   commitMessage: string | null
-  assetChecksums: GithubChecksums
+  assetChecksums: FileChecksums
 }
 
 export async function saveProjectToGithub(
@@ -1193,7 +1193,7 @@ export async function refreshGithubData(
   githubAuthenticated: boolean,
   githubRepo: GithubRepo | null,
   branchName: string | null,
-  localChecksums: GithubChecksums | null,
+  localChecksums: FileChecksums | null,
   githubUserDetails: GithubUser | null,
   previousCommitSha: string | null,
 ): Promise<void> {
@@ -1241,7 +1241,7 @@ export async function refreshGithubData(
 
 async function updateUpstreamChanges(
   branchName: string | null,
-  localChecksums: GithubChecksums | null,
+  localChecksums: FileChecksums | null,
   githubRepo: GithubRepo,
   previousCommitSha: string | null,
 ): Promise<Array<EditorAction>> {

--- a/editor/src/templates/image-dnd.spec.browser2.tsx
+++ b/editor/src/templates/image-dnd.spec.browser2.tsx
@@ -238,7 +238,10 @@ describe('image drag and drop', () => {
     dropDone = defer()
     const onDropStub = sandbox.stub(ImageDrop.DropHandlers, 'onDrop')
     onDropStub.callsFake((e, f, context) => {
-      const mockContext: ImageDrop.DropContext = { ...context, saveAssets: () => Promise.resolve() }
+      const mockContext: ImageDrop.DropContext = {
+        ...context,
+        saveAssets: () => Promise.resolve([]),
+      }
       return originalOnDrop(e, f, mockContext).then(() => dropDone.resolve())
     })
   })

--- a/editor/src/templates/image-drop.tsx
+++ b/editor/src/templates/image-drop.tsx
@@ -74,7 +74,7 @@ export async function insertImageFromClipboard(
 }
 
 export interface DropContext {
-  saveAssets: (projectId: string, assets: AssetToSave[]) => Promise<(string | null)[]>
+  saveAssets: (projectId: string, assets: AssetToSave[]) => Promise<Array<string | null>>
   mousePosition: CanvasPositions
   editor: () => EditorState
   dispatch: EditorDispatch

--- a/editor/src/templates/image-drop.tsx
+++ b/editor/src/templates/image-drop.tsx
@@ -74,7 +74,7 @@ export async function insertImageFromClipboard(
 }
 
 export interface DropContext {
-  saveAssets: (projectId: string, assets: AssetToSave[]) => Promise<void>
+  saveAssets: (projectId: string, assets: AssetToSave[]) => Promise<(string | null)[]>
   mousePosition: CanvasPositions
   editor: () => EditorState
   dispatch: EditorDispatch
@@ -138,7 +138,7 @@ async function onDrop(
 
     await context
       .saveAssets(projectId, assetInfo)
-      .then(() => {
+      .then((checksums) => {
         const substitutionPaths = stripNulls(
           assetInfo.flatMap((i) =>
             i.projectPath == null ? [] : [{ uid: i.uid, path: i.projectPath }],
@@ -156,6 +156,9 @@ async function onDrop(
 
         context.dispatch([
           ...srcUpdateActions,
+          ...assetInfo.map((i, index) => {
+            return EditorActions.setAssetChecksum(i.fileName, checksums[index])
+          }),
           EditorActions.showToast(notice('Succesfully uploaded assets')),
           ...openFileActions,
         ])


### PR DESCRIPTION
Fixes #2917 

**Problem:**

Image files are not included in the detected GH file changes.

**Fix:**

This PR includes the image files in the github file changes listings (remote and local). A tricky bit was to calculate the _correct_ SHA checksum for the asset, which is now done in the same way `git` will calculate and return it.