### PR TITLE
Prevent unintended truthiness via eslint

### DIFF
--- a/editor/.eslintrc.js
+++ b/editor/.eslintrc.js
@@ -6,5 +6,14 @@ module.exports = {
   },
   rules: {
     '@typescript-eslint/no-floating-promises': 'error',
+    '@typescript-eslint/strict-boolean-expressions': [
+      'error',
+      {
+        allowString: false,
+        allowNumber: false,
+        allowNullableObject: false,
+        allowNullableBoolean: true,
+      },
+    ],
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
@@ -130,7 +130,7 @@ export function flexResizeBasicStrategy(
             return emptyStrategyApplicationResult
           }
 
-          if (metadata != null) {
+          if (metadata == null) {
             return emptyStrategyApplicationResult
           }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
@@ -130,7 +130,7 @@ export function flexResizeBasicStrategy(
             return emptyStrategyApplicationResult
           }
 
-          if (!metadata) {
+          if (metadata != null) {
             return emptyStrategyApplicationResult
           }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/resize-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/resize-helpers.ts
@@ -118,7 +118,7 @@ export function getLockedAspectRatio(
   }
 
   if (anySelectedElementAspectRatioLocked || modifiers.shift) {
-    return originalBoundingBox.width / (originalBoundingBox.height || 1)
+    return originalBoundingBox.width / (originalBoundingBox.height ?? 1)
   }
 
   return null

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.spec.browser2.tsx
@@ -515,7 +515,11 @@ function projectWithComponentThatDefinesBorderRadiusInternally(
             width: '300px',
             height: '400px',
             backgroundColor: 'green',
-            ${props.internalBorderRadius ? `borderRadius: '${props.internalBorderRadius}',` : ''}
+            ${
+              props.internalBorderRadius != null
+                ? `borderRadius: '${props.internalBorderRadius}',`
+                : ''
+            }
             ...props.style,
           }}
           data-uid='RootDiv'
@@ -530,7 +534,11 @@ function projectWithComponentThatDefinesBorderRadiusInternally(
             position: 'absolute',
             left: 420,
             top: 420,
-            ${props.externalBorderRadius ? `borderRadius: '${props.externalBorderRadius}',` : ''}
+            ${
+              props.externalBorderRadius != null
+                ? `borderRadius: '${props.externalBorderRadius}',`
+                : ''
+            }
           }}
           data-uid='Horrible'
         />

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -743,7 +743,7 @@ function projectWithComponentThatDefinesPaddingInternally(props: HorribleCompone
           width: '300px',
           height: '400px',
           backgroundColor: 'green',
-          ${props.internalPadding ? `padding: '${props.internalPadding}',` : ''}
+          ${props.internalPadding != null ? `padding: '${props.internalPadding}',` : ''}
           ...props.style,
         }}
         data-uid='8bc'
@@ -758,7 +758,7 @@ function projectWithComponentThatDefinesPaddingInternally(props: HorribleCompone
           position: 'absolute',
           left: 420,
           top: 420,
-          ${props.externalPadding ? `padding: '${props.externalPadding}',` : ''}
+          ${props.externalPadding != null ? `padding: '${props.externalPadding}',` : ''}
         }}
         data-uid='ca3'
       />

--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -282,7 +282,7 @@ export const ClassNameSelect = React.memo(
             height: 18,
             border: `1px solid ${theme.inverted.primary.value}`,
             borderRadius: UtopiaTheme.inputBorderRadius,
-            backgroundColor: state.isFocused
+            backgroundColor: (state.isFocused as boolean)
               ? theme.inverted.primary.value
               : theme.inverted.bg1.value,
           }
@@ -337,7 +337,7 @@ export const ClassNameSelect = React.memo(
             paddingRight: 8,
             backgroundColor: optionColors.backgroundColor,
             color: optionColors.color,
-            cursor: isDisabled ? 'not-allowed' : 'default',
+            cursor: (isDisabled as boolean) ? 'not-allowed' : 'default',
 
             ':active': {
               ...(styles as any)[':active'],

--- a/editor/src/components/canvas/controls/layout-parent-control.tsx
+++ b/editor/src/components/canvas/controls/layout-parent-control.tsx
@@ -186,7 +186,7 @@ export const LayoutParentControl = React.memo((): JSX.Element | null => {
           {when(
             flexDirectionIcon != null && parentLayout === 'flex',
             <div>
-              {selectedAlignment ? (
+              {selectedAlignment != null ? (
                 <PopupList
                   options={allAlignmentOptions}
                   value={selectedAlignment}

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -143,7 +143,7 @@ export function useHoverWithDelay(
   const fadeInTimeout = React.useRef<Timeout | null>(null)
 
   const onHoverEnd = () => {
-    if (fadeInTimeout.current) {
+    if (fadeInTimeout.current != null) {
       clearTimeout(fadeInTimeout.current)
     }
     fadeInTimeout.current = null

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -253,7 +253,7 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
     if (IS_BROWSER_TEST_DEBUG) {
       return
     }
-    if (projectId) {
+    if (projectId != null) {
       pushProjectURLToBrowserHistory(projectId, projectName)
     }
   }, [projectName, projectId])

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1279,7 +1279,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
       hasPositionOffsetEquals &&
       textDirectionEquals &&
       hasTransformEquals &&
-      borderRadiusEquals.areEqual
+      borderRadiusEquals
     if (areEqual) {
       return keepDeepEqualityResult(oldSize, true)
     } else {

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1279,7 +1279,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
       hasPositionOffsetEquals &&
       textDirectionEquals &&
       hasTransformEquals &&
-      borderRadiusEquals
+      borderRadiusEquals.areEqual
     if (areEqual) {
       return keepDeepEqualityResult(oldSize, true)
     } else {

--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -486,7 +486,7 @@ class FileBrowserItemInner extends React.PureComponent<
             EditorActions.showModal({
               type: 'file-revert',
               filePath: this.props.path,
-              status: this.props.githubStatus || null,
+              status: this.props.githubStatus ?? null,
             }),
           ],
           'everyone',

--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -362,9 +362,13 @@ const ClassNameControl = React.memo(() => {
 
   const multiValueLabel: styleFn = React.useCallback(
     (base, { isFocused }) => {
-      const enabledColor = isFocused ? theme.inverted.textColor.value : theme.inverted.primary.value
+      const enabledColor = (isFocused as boolean)
+        ? theme.inverted.textColor.value
+        : theme.inverted.primary.value
       const color = isMenuEnabled ? enabledColor : theme.fg8.value
-      const backgroundColor = isFocused ? theme.inverted.primary.value : theme.bg1.value
+      const backgroundColor = (isFocused as boolean)
+        ? theme.inverted.primary.value
+        : theme.bg1.value
       return {
         ...base,
         label: 'multiValueLabel',
@@ -409,8 +413,10 @@ const ClassNameControl = React.memo(() => {
 
   const multiValue: styleFn = React.useCallback(
     (base, { isFocused, data }) => {
-      const backgroundColor = isFocused ? theme.inverted.primary.value : theme.bg1.value
-      if (isFocused) {
+      const backgroundColor = (isFocused as boolean)
+        ? theme.inverted.primary.value
+        : theme.bg1.value
+      if (isFocused as boolean) {
         focusedValueRef.current = data.label
       }
 
@@ -426,7 +432,7 @@ const ClassNameControl = React.memo(() => {
         minWidth: 0,
         height: UtopiaTheme.layout.inputHeight.small,
         boxShadow: `inset 0 0 0 1px ${
-          isFocused ? theme.inspectorFocusedColor.value : 'transparent'
+          (isFocused as boolean) ? theme.inspectorFocusedColor.value : 'transparent'
         }`,
         overflow: 'hidden',
         backgroundColor: backgroundColor,
@@ -440,7 +446,7 @@ const ClassNameControl = React.memo(() => {
       if (
         isFocusedRef.current &&
         shouldPreviewOnFocusRef.current &&
-        isFocused &&
+        (isFocused as boolean) &&
         targets.length === 1
       ) {
         const oldClassNameString =
@@ -465,9 +471,11 @@ const ClassNameControl = React.memo(() => {
         updateFocusedOption(value)
       }
 
-      const color = isFocused ? theme.inverted.textColor.value : theme.textColor.value
-      const backgroundColor = isFocused ? theme.inverted.primary.value : theme.bg1.value
-      const borderRadius = isFocused ? 3 : 0
+      const color = (isFocused as boolean) ? theme.inverted.textColor.value : theme.textColor.value
+      const backgroundColor = (isFocused as boolean)
+        ? theme.inverted.primary.value
+        : theme.bg1.value
+      const borderRadius = (isFocused as boolean) ? 3 : 0
 
       return {
         minHeight: 27,
@@ -477,7 +485,7 @@ const ClassNameControl = React.memo(() => {
         paddingRight: 8,
         backgroundColor: backgroundColor,
         color: color,
-        cursor: isDisabled ? 'not-allowed' : 'default',
+        cursor: (isDisabled as boolean) ? 'not-allowed' : 'default',
         borderRadius: borderRadius,
       }
 

--- a/editor/src/components/navigator/dependency-list.tsx
+++ b/editor/src/components/navigator/dependency-list.tsx
@@ -470,8 +470,8 @@ const AddTailwindButton = (props: AddTailwindButtonProps) => {
   }, [dispatch])
 
   const tailwindAlreadyAdded =
-    props.packagesWithStatus.find((p) => p.name === 'tailwindcss') &&
-    props.packagesWithStatus.find((p) => p.name === 'postcss')
+    props.packagesWithStatus.find((p) => p.name === 'tailwindcss') != null &&
+    props.packagesWithStatus.find((p) => p.name === 'postcss') != null
   if (tailwindAlreadyAdded) {
     return null
   }

--- a/editor/src/components/navigator/dependency-list.tsx
+++ b/editor/src/components/navigator/dependency-list.tsx
@@ -470,8 +470,8 @@ const AddTailwindButton = (props: AddTailwindButtonProps) => {
   }, [dispatch])
 
   const tailwindAlreadyAdded =
-    props.packagesWithStatus.find((p) => p.name === 'tailwindcss') != null &&
-    props.packagesWithStatus.find((p) => p.name === 'postcss') != null
+    props.packagesWithStatus.some((p) => p.name === 'tailwindcss') &&
+    props.packagesWithStatus.some((p) => p.name === 'postcss')
   if (tailwindAlreadyAdded) {
     return null
   }

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -101,7 +101,7 @@ const RepositoryBlock = () => {
     (store) => store.userState.githubState.authenticated,
     'RepositoryBlock authenticated',
   )
-  const repoName = React.useMemo(() => githubRepoFullName(repo) || undefined, [repo])
+  const repoName = React.useMemo(() => githubRepoFullName(repo) ?? undefined, [repo])
   const hasRepo = React.useMemo(() => repo != null, [repo])
   const [expanded, setExpanded] = React.useState(false)
   React.useEffect(() => {
@@ -404,7 +404,7 @@ const BranchBlock = () => {
       expanded={expanded}
       onClick={toggleExpanded}
       title={currentBranch != null ? 'Branch' : 'Select Branch'}
-      subtitle={currentBranch || undefined}
+      subtitle={currentBranch ?? undefined}
       status={!expanded && currentBranch != null ? 'successful' : 'incomplete'}
       last={currentBranch == null}
     >
@@ -634,7 +634,7 @@ const LocalChangesBlock = () => {
               <StringInput
                 testId='commit-branch-input'
                 placeholder='New branch name'
-                value={rawCommitBranchName || ''}
+                value={rawCommitBranchName ?? ''}
                 onChange={updateCommitBranchName}
               />
               {when(
@@ -809,7 +809,7 @@ const BranchNotLoadedBlock = () => {
     setFlow(isANewBranch ? 'createBranch' : null)
   }, [branchName, isANewBranch])
 
-  if (!branchName || branchLoaded) {
+  if (branchName == null || branchName === '' || branchLoaded) {
     return null
   }
   return (

--- a/editor/src/components/titlebar/menu-tile.tsx
+++ b/editor/src/components/titlebar/menu-tile.tsx
@@ -96,7 +96,7 @@ export const MenuTile: React.FunctionComponent<React.PropsWithChildren<MenuTileP
         {React.cloneElement(props.icon, {
           color: props.selected ? 'primary' : 'secondary',
         })}
-        {props.badge && <MenuTileBadge text={props.badge} />}
+        {props.badge != null && <MenuTileBadge text={props.badge} />}
       </div>
     </Tile>
   )

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -166,7 +166,7 @@ const TitleBar = React.memo(() => {
           height: 27,
         }}
       >
-        {currentBranch ? (
+        {currentBranch != null ? (
           <SimpleFlexRow style={{ gap: 5 }}>
             {repoName}
             {<Icons.Branch style={{ width: 19, height: 19 }} />}

--- a/editor/src/core/shared/atom-with-pub-sub.ts
+++ b/editor/src/core/shared/atom-with-pub-sub.ts
@@ -7,6 +7,7 @@ import { useForceUpdate } from '../../components/editor/hook-utils'
 // From https://github.com/dai-shi/use-context-selector/blob/2dd334d727fc3b4cbadf7876b6ce64e0c633fd25/src/index.ts#L25
 const isSSR =
   typeof window === 'undefined' ||
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   /ServerSideRendering/.test(window.navigator && window.navigator.userAgent)
 
 export const useIsomorphicLayoutEffect = isSSR ? React.useEffect : React.useLayoutEffect

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -271,7 +271,7 @@ export async function saveProjectToGithub(
         )
 
         // refresh the branches after the content was saved
-        if (persistentModel.githubSettings.targetRepository) {
+        if (persistentModel.githubSettings.targetRepository != null) {
           void dispatchPromiseActions(
             dispatch,
             getBranchesForGithubRepository(

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -709,7 +709,7 @@ async function renderRootComponent(
     // as subsequent updates will be fed through Zustand
     const rootElement = document.getElementById(EditorID)
     if (rootElement != null) {
-      if (process.env.HOT_MODE) {
+      if (process.env.HOT_MODE != null) {
         ReactDOM.render(
           <HotRoot
             api={api}

--- a/editor/src/utils/vite-hmr-config.ts
+++ b/editor/src/utils/vite-hmr-config.ts
@@ -1,6 +1,7 @@
 // TODO we should bump TS to latest (we are 0.4 versions behind!)
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
+// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 if (import.meta.hot) {
   // this is written without the != null part to make sure Webpack (and Vite) recognizes and tree shakes it
   import.meta.hot?.decline() // this _should_ be working but does not for some reason

--- a/editor/src/uuiui/icn.tsx
+++ b/editor/src/uuiui/icn.tsx
@@ -145,7 +145,7 @@ export const Icn = React.memo(
   }: IcnProps) => {
     const disabledStyle = isDisabled ? { opacity: 0.5 } : undefined
 
-    const iconColor = useIconColor(props.color || 'main')
+    const iconColor = useIconColor(props.color ?? 'main')
 
     const { onMouseDown: propsOnMouseDown, onClick } = props
     const onMouseDown = React.useCallback(


### PR DESCRIPTION
**Problem:**
Unintended truthiness checks are the bane of our collective existence, and have bitten us many, many, many times

**Fix:**
Use [`@typescript-eslint/strict-boolean-expressions`](https://typescript-eslint.io/rules/strict-boolean-expressions/) to prevent us accidentally using truthiness checks, and fixed all of the issues that were found by this (they all appeared to be `null` checks)