### PR TITLE
Improve the runtime of createExecutionScope.

### DIFF
--- a/editor/src/utils/path-utils.ts
+++ b/editor/src/utils/path-utils.ts
@@ -1,16 +1,18 @@
 export function normalizePath(path: Array<string>): Array<string> {
-  return path.reduce((pathSoFar: Array<string>, pathElem: string, index: number) => {
-    if (pathElem === '') {
-      return pathSoFar
+  let result: Array<string> = []
+  for (const elem of path) {
+    switch (elem) {
+      case '':
+      case '.':
+        break
+      case '..':
+        result.pop()
+        break
+      default:
+        result.push(elem)
     }
-    if (pathElem === '.') {
-      return pathSoFar
-    }
-    if (pathElem === '..') {
-      return pathSoFar.slice(0, -1)
-    }
-    return [...pathSoFar, pathElem]
-  }, [])
+  }
+  return result
 }
 
 export function stripTrailingSlash(path: string): string {


### PR DESCRIPTION
**Problem:**
Overall `createExecutionScope` seems to be quite expensive for what it does and is on the hot path of canvas renders.

**Fix:**
There are two main improvements made in this PR:
- By adding a `direct` parameter to `FileLookupFn` we can avoid making unnecessary lookups for variants of `package.json` when attempting to resolve that file.
- `normalizePath` is now approximately 16x faster than the previous implementation, which contributes a surprising improvement overall as that function showed up regularly in the profile under `createExecutionScope`.

Together these improvements have brought the runtime of the topmost invocation of `createExecutionScope` from around 5ms to a little over 2ms in my local testing.

**Commit Details:**
- `FileLookupFn` now has an additional parameter of `direct`, which specifies that variants of a path should not be investigated. This was primary done to ensure that `resolvePackageJson` when looking for `package.json` files doesn't also look for `package.json.js` and so on.
- `fallbackLookup` honours the `direct` parameter, avoiding checking for variants if it set to true.
- `normalizePath` is now approximately 16x faster than it was by modifying an array instead of creating new arrays sometimes for each path part.