### PR TITLE
Performance improvement for getAllTargetsAtPoint and getValidTargetAtPoint

### DIFF
--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -20,6 +20,7 @@ import Canvas, { TargetSearchType } from './canvas'
 import { CanvasPositions } from './canvas-types'
 import { AllElementProps } from '../editor/store/editor-state'
 import Utils from '../../utils/utils'
+import { memoize } from '../../core/shared/memoize'
 
 export function findParentSceneValidPaths(target: Element): Array<ElementPath> | null {
   const validPaths = getDOMAttribute(target, 'data-utopia-valid-paths')
@@ -149,6 +150,20 @@ export function getAllTargetsAtPoint(
     return []
   }
   const elementsUnderPoint = document.elementsFromPoint(point.x, point.y)
+  const elementsFromDOM = findFirstParentsWithValidElementPath(
+    validElementPathsForLookup,
+    elementsUnderPoint,
+  )
+  // TODO FIXME we should take the zero-sized elements from Canvas.getAllTargetsAtPoint, and insert them (in a correct-enough order) here. See PR for context https://github.com/concrete-utopia/utopia/pull/2345
+  return elementsFromDOM
+}
+
+const findFirstParentsWithValidElementPath = memoize(findFirstParentsWithValidElementPathUncached)
+
+function findFirstParentsWithValidElementPathUncached(
+  validElementPathsForLookup: Array<ElementPath> | 'no-filter',
+  elementsUnderPoint: Array<Element>,
+) {
   const validPathsSet =
     validElementPathsForLookup == 'no-filter'
       ? 'no-filter'
@@ -165,8 +180,6 @@ export function getAllTargetsAtPoint(
       }
     }),
   )
-
-  // TODO FIXME we should take the zero-sized elements from Canvas.getAllTargetsAtPoint, and insert them (in a correct-enough order) here. See PR for context https://github.com/concrete-utopia/utopia/pull/2345
   return elementsFromDOM
 }
 

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -158,7 +158,9 @@ export function getAllTargetsAtPoint(
   return elementsFromDOM
 }
 
-const findFirstParentsWithValidElementPath = memoize(findFirstParentsWithValidElementPathUncached)
+const findFirstParentsWithValidElementPath = memoize(findFirstParentsWithValidElementPathUncached, {
+  maxSize: 30,
+})
 
 function findFirstParentsWithValidElementPathUncached(
   validElementPathsForLookup: Array<ElementPath> | 'no-filter',


### PR DESCRIPTION
**Problem:**
`getValidTargetAtPoint`, which is used for highlight and selection, uses `getAllTargetsAtPoint` to get the element under the mouse. `getAllTargetsAtPoint` get the html elements under a point from the browser, and then maps them to valid element paths. This calculation is quite cheap (~1ms), but it runs a lot, especially for highlight on mouse hover.

**Fix:**

1. When we only need the topmost element (`getValidTargetAtPoint`), it is unnecessary to calculate the closest valid element paths to all elements under point.
2. After we have the elements we are doing the calculation to get the valid element paths for all mouse events, but mostly we just calculate the same thing again and again (except when we move the mouse from an element to a different one). So it makes sense to memoize this calculation. The list of elements under a point is the same a lot of times (when we are hovering over the same top element), and even if we leave an element, sometimes we go back later. And in between these mouse move events nothing changes in the document. So it makes sense to use a `>1` maxsize, because we can go back and forth over elements with the mouse.

Measurements before the fix for the calculation:
<img width="264" alt="Screenshot 2022-11-24 at 19 30 42" src="https://user-images.githubusercontent.com/127662/203853244-48e05830-fa5a-41c5-a9b4-a60aeb76167a.png">

Measurements after the fix:

<img width="247" alt="Screenshot 2022-11-24 at 19 28 07" src="https://user-images.githubusercontent.com/127662/203853326-a727af0e-cf0f-48ec-b86a-5601ab5de021.png">
