### PR TITLE
Don't overlay buttons over the file name in UTFB

### DIFF
--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -777,9 +777,7 @@ class FileBrowserItemInner extends React.PureComponent<
               <div
                 style={{
                   ...flexRowStyle,
-                  overflowX: 'hidden',
-                  whiteSpace: 'nowrap',
-                  textOverflow: 'ellipsis',
+                  overflow: 'hidden',
                 }}
               >
                 {this.renderIcon()}

--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -1,5 +1,6 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
+/** @jsxFrag */
 import { jsx } from '@emotion/react'
 import * as Path from 'path'
 import pathParse from 'path-parse'
@@ -29,6 +30,7 @@ import {
   UtopiaTheme,
   SimpleFlexRow,
   Button,
+  FlexRow,
 } from '../../uuiui'
 import { notice } from '../common/notice'
 import { appendToPath, getParentDirectory } from '../../utils/path-utils'
@@ -414,17 +416,24 @@ class FileBrowserItemInner extends React.PureComponent<
         labelColor = colorTheme.primary.value
       }
       return (
-        <div
-          style={{
-            ...flexRowStyle,
-            marginLeft: 6,
-            color: labelColor,
-          }}
-          onDoubleClick={this.onDoubleClickFilename}
-        >
-          <span>{this.state.filename}</span>
-          {this.props.typeInformation != null ? <span>: {this.props.typeInformation}</span> : null}
-        </div>
+        <>
+          <span
+            onDoubleClick={this.onDoubleClickFilename}
+            style={{
+              marginLeft: 6,
+              display: 'inline-block',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              color: labelColor,
+            }}
+          >
+            {this.state.filename}
+          </span>
+          {this.props.typeInformation != null ? (
+            <span style={{ color: labelColor }}>: {this.props.typeInformation}</span>
+          ) : null}
+        </>
       )
     }
   }
@@ -739,35 +748,56 @@ class FileBrowserItemInner extends React.PureComponent<
             height: UtopiaTheme.layout.rowHeight.smaller,
             display: 'flex',
             alignItems: 'center',
+            justifyContent: 'space-between',
             opacity: this.props.isDragging ? 0.5 : undefined,
             backgroundColor: getBackground(),
             borderRadius: 2,
             position: 'relative',
           }}
         >
-          <ExpandableIndicator
-            key='expandable-indicator'
-            visible={
-              this.props.type === 'file' &&
-              this.props.fileType != null &&
-              this.props.fileType === 'DIRECTORY'
-            }
-            collapsed={this.props.collapsed}
-            selected={false}
-            onMouseDown={this.toggleCollapse}
-          />
-          {this.props.connectDragPreview(
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              overflow: 'hidden',
+            }}
+          >
+            <ExpandableIndicator
+              key='expandable-indicator'
+              visible={
+                this.props.type === 'file' &&
+                this.props.fileType != null &&
+                this.props.fileType === 'DIRECTORY'
+              }
+              collapsed={this.props.collapsed}
+              selected={false}
+              onMouseDown={this.toggleCollapse}
+            />
+            {this.props.connectDragPreview(
+              <div
+                style={{
+                  ...flexRowStyle,
+                  overflowX: 'hidden',
+                  whiteSpace: 'nowrap',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {this.renderIcon()}
+                {this.renderLabel()}
+                {this.renderModifiedIcon()}
+              </div>,
+            )}
+          </div>
+          {this.props.type === 'file' ? (
             <div
               style={{
-                ...flexRowStyle,
-                overflowX: 'hidden',
-                whiteSpace: 'nowrap',
-                textOverflow: 'ellipsis',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '2px',
+                flexDirection: 'row',
+                marginRight: '2px',
               }}
             >
-              {this.renderIcon()}
-              {this.renderLabel()}
-              {this.renderModifiedIcon()}
               {this.props.isUploadedAssetFile ? (
                 <span
                   style={{
@@ -780,22 +810,18 @@ class FileBrowserItemInner extends React.PureComponent<
                   S3
                 </span>
               ) : null}
-            </div>,
-          )}
-          {this.props.type === 'file' ? (
-            <SimpleFlexRow style={{ position: 'absolute', right: '0px' }}>
               {displayAddFolder ? (
-                <Button style={{ marginRight: '2px' }} onClick={this.showAddingFolderRow}>
+                <Button onClick={this.showAddingFolderRow}>
                   <Icons.NewFolder style={fileIconStyle} tooltipText='Add New Folder' />
                 </Button>
               ) : null}
               {displayAddTextFile ? (
-                <Button style={{ marginRight: '2px' }} onClick={this.showAddingFileRow}>
+                <Button onClick={this.showAddingFileRow}>
                   <Icons.NewTextFile style={fileIconStyle} tooltipText='Add Code File' />
                 </Button>
               ) : null}
               {displayDelete ? (
-                <Button style={{ marginRight: '2px' }} onClick={this.delete}>
+                <Button onClick={this.delete}>
                   <Icons.Cross tooltipText='Delete' />
                 </Button>
               ) : null}
@@ -813,7 +839,7 @@ class FileBrowserItemInner extends React.PureComponent<
                 </span>
               ) : null}
               {this.renderGithubStatus()}
-            </SimpleFlexRow>
+            </div>
           ) : null}
         </div>
         {this.state.adding == null

--- a/editor/src/components/navigator/navigator-item/expandable-indicator.tsx
+++ b/editor/src/components/navigator/navigator-item/expandable-indicator.tsx
@@ -25,7 +25,7 @@ export const ExpandableIndicator: React.FunctionComponent<
         color={props.selected ? 'on-highlight-main' : 'main'}
         style={{
           pointerEvents: props.visible ? 'all' : 'none',
-          opacity: props.visible ? 1 : 0,
+          visibility: props.visible ? 'visible' : 'hidden',
           cursor: 'pointer',
         }}
         onMouseDown={props.onMouseDown}

--- a/editor/src/components/navigator/navigator-item/expandable-indicator.tsx
+++ b/editor/src/components/navigator/navigator-item/expandable-indicator.tsx
@@ -19,15 +19,18 @@ export const ExpandableIndicator: React.FunctionComponent<
 > = React.memo((props) => {
   return (
     <div data-testid={props.testId} style={{ width: 16, height: 16, ...props.style }}>
-      {props.visible ? (
-        <Icn
-          category='semantic'
-          type={`expansionarrow-${props.collapsed ? 'right' : 'down'}`}
-          color={props.selected ? 'on-highlight-main' : 'main'}
-          onMouseDown={props.onMouseDown}
-          onClick={props.onClick}
-        />
-      ) : null}
+      <Icn
+        category='semantic'
+        type={`expansionarrow-${props.collapsed ? 'right' : 'down'}`}
+        color={props.selected ? 'on-highlight-main' : 'main'}
+        style={{
+          pointerEvents: props.visible ? 'all' : 'none',
+          opacity: props.visible ? 1 : 0,
+          cursor: 'pointer',
+        }}
+        onMouseDown={props.onMouseDown}
+        onClick={props.onClick}
+      />
     </div>
   )
 })


### PR DESCRIPTION
## After
<img width="326" alt="image" src="https://user-images.githubusercontent.com/16385508/203988233-35d31c1c-8dd8-48bd-a4c3-af1242c8a1c1.png">

[Video](https://screenshot.click/05-57-80tg2-lf3a6.mp4)

## Before
<img width="272" alt="image" src="https://user-images.githubusercontent.com/16385508/203988324-46f34c52-3544-4af8-a86a-9e2ef9026c54.png">
(note that the `S3` marker is pushed out as well)