### PR TITLE
Return await eslint rule

### DIFF
--- a/editor/.eslintrc.js
+++ b/editor/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
         allowNullableBoolean: true,
       },
     ],
+    // Note: Required by the return-await rule, you must disable the base rule as it can report incorrect errors
     'no-return-await': 'off',
     '@typescript-eslint/return-await': 'error',
   },

--- a/editor/.eslintrc.js
+++ b/editor/.eslintrc.js
@@ -15,5 +15,7 @@ module.exports = {
         allowNullableBoolean: true,
       },
     ],
+    'no-return-await': 'off',
+    '@typescript-eslint/return-await': 'error',
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
@@ -2537,8 +2537,8 @@ describe('Reparent indicators', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     // Check that the indicator is not there.
-    await expect(
-      async () => await renderResult.renderedDOM.findByTestId('flex-reparent-indicator-0'),
+    await expect(async () =>
+      renderResult.renderedDOM.findByTestId('flex-reparent-indicator-0'),
     ).rejects.toThrow()
   })
 })

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -415,9 +415,7 @@ export async function renderTestEditorWithModel(
       waitForDOMReport: boolean,
       innerStrategiesToUse: Array<MetaCanvasStrategy> = strategiesToUse,
     ) => {
-      return await act(async () => {
-        await asyncTestDispatch(actions, 'everyone', true, innerStrategiesToUse)
-      })
+      return act(async () => asyncTestDispatch(actions, 'everyone', true, innerStrategiesToUse))
     },
     getDispatchFollowUpActionsFinished: getDispatchFollowUpActionsFinished,
     getEditorState: () => storeHook.getState(),

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -259,7 +259,7 @@ export async function saveAsset(
   imageId: string,
 ): Promise<void> {
   try {
-    return saveAssetRequest(projectId, fileType, base64, imageId)
+    return await saveAssetRequest(projectId, fileType, base64, imageId)
   } catch (e) {
     // FIXME Client should show an error if server requests fail
     console.error(e)

--- a/editor/src/core/es-modules/package-manager/fetch-packages.ts
+++ b/editor/src/core/es-modules/package-manager/fetch-packages.ts
@@ -212,7 +212,7 @@ async function fetchPackagerResponseWithRetry(
     }
   }
 
-  return await fetchPackagerResponseWithRetryInner(NR_RETRIES, RETRY_FREQ_MS)
+  return fetchPackagerResponseWithRetryInner(NR_RETRIES, RETRY_FREQ_MS)
 }
 
 async function fetchPackagerResponse(


### PR DESCRIPTION
**Problem:**
Returning an awaited promise can make sense for better stack trace information as well as for consistent error handling (returned promises will not be caught in an async function try/catch).

**Fix:**
Add the corresponding eslint rule: https://typescript-eslint.io/rules/return-await/
And fix the existing errors in the code

