### PR TITLE
Fix/inspector slider number widget

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -541,7 +541,7 @@ describe('inspector tests with real metadata', () => {
       'padding-R',
     )) as HTMLInputElement
     const opacityControl = (await renderResult.renderedDOM.findByTestId(
-      'opacity-number-control',
+      'opacity-number-input',
     )) as HTMLInputElement
 
     matchInlineSnapshotBrowser(metadata.computedStyle?.['width'], `"203px"`)
@@ -636,7 +636,7 @@ describe('inspector tests with real metadata', () => {
       'radius-all-number-input',
     )) as HTMLInputElement
     const opacityControl = (await renderResult.renderedDOM.findByTestId(
-      'opacity-number-control',
+      'opacity-number-input',
     )) as HTMLInputElement
     const minWidthControl = (await renderResult.renderedDOM.findByTestId(
       'position-minWidth-number-input',
@@ -1193,7 +1193,7 @@ describe('inspector tests with real metadata', () => {
       'radius-all-number-input',
     )) as HTMLInputElement
     const opacityControl = (await renderResult.renderedDOM.findByTestId(
-      'opacity-number-control',
+      'opacity-number-input',
     )) as HTMLInputElement
 
     matchInlineSnapshotBrowser(widthControl.value, `"100"`)
@@ -1293,7 +1293,7 @@ describe('inspector tests with real metadata', () => {
       'padding-R',
     )) as HTMLInputElement
     const earlyOpacityControl = (await renderResult.renderedDOM.findByTestId(
-      'opacity-number-control',
+      'opacity-number-input',
     )) as HTMLInputElement
 
     matchInlineSnapshotBrowser(earlyMetadata.computedStyle?.['width'], `"203px"`)
@@ -1351,7 +1351,7 @@ describe('inspector tests with real metadata', () => {
       'padding-R',
     )) as HTMLInputElement
     const laterOpacityControl = (await renderResult.renderedDOM.findByTestId(
-      'opacity-number-control',
+      'opacity-number-input',
     )) as HTMLInputElement
 
     matchInlineSnapshotBrowser(laterMetadata.computedStyle?.['width'], `"203px"`)
@@ -1446,7 +1446,7 @@ describe('inspector tests with real metadata', () => {
       'radius-all-number-input',
     )) as HTMLInputElement
     const opacityControl = (await renderResult.renderedDOM.findByTestId(
-      'opacity-number-control',
+      'opacity-number-input',
     )) as HTMLInputElement
 
     matchInlineSnapshotBrowser(widthControl.value, `"0"`)
@@ -1559,7 +1559,7 @@ describe('inspector tests with real metadata', () => {
       'radius-all-number-input',
     )) as HTMLInputElement
     const opacityControl = (await renderResult.renderedDOM.findByTestId(
-      'opacity-number-control',
+      'opacity-number-input',
     )) as HTMLInputElement
 
     matchInlineSnapshotBrowser(metadata.computedStyle?.['width'], `"250px"`)
@@ -1679,7 +1679,7 @@ describe('inspector tests with real metadata', () => {
       'radius-all-number-input',
     )) as HTMLInputElement
     const opacityControl = (await renderResult.renderedDOM.findByTestId(
-      'opacity-number-control',
+      'opacity-number-input',
     )) as HTMLInputElement
 
     matchInlineSnapshotBrowser(metadata.computedStyle?.['minWidth'], `"0px"`)
@@ -1788,7 +1788,7 @@ describe('inspector tests with real metadata', () => {
       'radius-all-number-input',
     )) as HTMLInputElement
     const opacityControl = (await renderResult.renderedDOM.findByTestId(
-      'opacity-number-control',
+      'opacity-number-input',
     )) as HTMLInputElement
 
     matchInlineSnapshotBrowser(metadata.computedStyle?.['minWidth'], `"0px"`)
@@ -2216,12 +2216,12 @@ describe('Undo behavior in inspector', () => {
     })
 
     const opacityControl = (await renderResult.renderedDOM.findByTestId(
-      'opacity-number-control',
+      'opacity-number-input',
     )) as HTMLInputElement
     matchInlineSnapshotBrowser(opacityControl.value, `"0.5"`)
 
     // change the opacity of the selected element
-    await setControlValue('opacity-number-control', '0.6', renderResult.renderedDOM)
+    await setControlValue('opacity-number-input', '0.6', renderResult.renderedDOM)
 
     matchInlineSnapshotBrowser(opacityControl.value, `"0.6"`)
     matchInlineSnapshotBrowser(
@@ -2247,7 +2247,7 @@ describe('Undo behavior in inspector', () => {
 
     // the control's value should now be undone
     matchInlineSnapshotBrowser(
-      ((await renderResult.renderedDOM.findByTestId('opacity-number-control')) as HTMLInputElement)
+      ((await renderResult.renderedDOM.findByTestId('opacity-number-input')) as HTMLInputElement)
         .value,
       `"0.5"`,
     )

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -168,25 +168,6 @@ export interface InspectorInfo<T> {
   useSubmitValueFactory: UseSubmitValueFactory<T>
 }
 
-export function useMapInspectorInfoFromCSSNumberToNumber(
-  info: InspectorInfo<CSSNumber>,
-): InspectorInfo<number> {
-  const onSubmitValue = (rawNumber: number, transient?: boolean) =>
-    info.onSubmitValue({ value: rawNumber, unit: info.value.unit }, transient)
-
-  return {
-    value: info.value.value,
-    controlStatus: info.controlStatus,
-    propertyStatus: info.propertyStatus,
-    controlStyles: info.controlStyles,
-    onUnsetValues: info.onUnsetValues,
-    onSubmitValue: onSubmitValue,
-    onTransientSubmitValue: (rawNumber) =>
-      info.onTransientSubmitValue({ value: rawNumber, unit: info.value.unit }),
-    useSubmitValueFactory: useCallbackFactory(info.value.value, onSubmitValue),
-  }
-}
-
 function getSpiedValues<P extends string | number>(
   key: P,
   selectedProps: { [keyValue in P]: ReadonlyArray<any> },

--- a/editor/src/components/inspector/controls/control.ts
+++ b/editor/src/components/inspector/controls/control.ts
@@ -47,6 +47,8 @@ export interface DEPRECATEDControlProps<T> {
   style?: React.CSSProperties
   onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void
+  onDragStart?: () => void
+  onDragEnd?: () => void
 }
 
 export interface InspectorControlProps {

--- a/editor/src/components/inspector/controls/slider-control.tsx
+++ b/editor/src/components/inspector/controls/slider-control.tsx
@@ -25,13 +25,7 @@ export const SliderControl: React.FunctionComponent<React.PropsWithChildren<Slid
 ) => {
   const { onTransientSubmitValue, value, onDragStart, onDragEnd, onDrag } = props
   const [isSliding, setIsSliding] = React.useState(false)
-  const [displayValue, setDisplayValue] = React.useState(0)
-
-  React.useEffect(() => {
-    if (!isSliding) {
-      setDisplayValue(value)
-    }
-  }, [isSliding, value])
+  const [slidingValue, setSlidingValue] = React.useState(0)
 
   const handleBeforeChange = React.useCallback(() => {
     setIsSliding(true)
@@ -43,7 +37,7 @@ export const SliderControl: React.FunctionComponent<React.PropsWithChildren<Slid
   const handleDragging = React.useCallback(
     (newValue: number) => {
       onTransientSubmitValue!(newValue, true)
-      setDisplayValue(newValue)
+      setSlidingValue(newValue)
       if (onDrag != null) {
         onDrag(newValue)
       }
@@ -114,7 +108,7 @@ export const SliderControl: React.FunctionComponent<React.PropsWithChildren<Slid
     >
       <Slider
         disabled={!props.controlStyles.interactive}
-        value={displayValue}
+        value={isSliding ? slidingValue : value}
         onBeforeChange={handleBeforeChange}
         onChange={handleDragging}
         onAfterChange={handleOnAfterChange}

--- a/editor/src/components/inspector/controls/slider-number-control.tsx
+++ b/editor/src/components/inspector/controls/slider-number-control.tsx
@@ -22,13 +22,7 @@ export const SliderNumberControl: React.FunctionComponent<
 > = React.memo((props) => {
   const { value, transformSliderValueToCSSNumber, numberType } = props
   const [isDragging, setIsDragging] = React.useState(false)
-  const [displayValue, setDisplayValue] = React.useState<CSSNumber>(value)
-
-  React.useEffect(() => {
-    if (!isDragging) {
-      setDisplayValue(value)
-    }
-  }, [isDragging, value])
+  const [dragValue, setDragValue] = React.useState<CSSNumber>(value)
 
   const onDragStart = React.useCallback(() => {
     setIsDragging(true)
@@ -39,19 +33,20 @@ export const SliderNumberControl: React.FunctionComponent<
 
   const onSliderDrag = React.useCallback(
     (newValue: number) => {
-      setDisplayValue(transformSliderValueToCSSNumber(newValue))
+      setDragValue(transformSliderValueToCSSNumber(newValue))
     },
-    [transformSliderValueToCSSNumber, setDisplayValue],
+    [transformSliderValueToCSSNumber, setDragValue],
   )
 
   const transformCSSNumberToSliderValue = React.useCallback(() => {
+    const valueToUse = isDragging ? dragValue : value
     if (numberType === 'UnitlessPercent' || numberType === 'Percent') {
-      const scale = displayValue.unit === '%' ? 100 : 1
-      return displayValue.value / scale
+      const scale = valueToUse.unit === '%' ? 100 : 1
+      return valueToUse.value / scale
     } else {
-      return displayValue.value
+      return valueToUse.value
     }
-  }, [numberType, displayValue])
+  }, [numberType, isDragging, dragValue, value])
 
   return (
     <UIGridRow padded={false} variant='<--------auto-------->|--45px--|'>
@@ -70,7 +65,7 @@ export const SliderNumberControl: React.FunctionComponent<
         onDrag={onSliderDrag}
       />
       <NumberInput
-        value={displayValue}
+        value={isDragging ? dragValue : value}
         id={`${props.id}-number-input`}
         testId={`${props.id}-number-input`}
         onSubmitValue={props.onSubmitValue}

--- a/editor/src/components/inspector/controls/slider-number-control.tsx
+++ b/editor/src/components/inspector/controls/slider-number-control.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { NumberInput, NumberInputProps } from '../../../uuiui'
+import { CSSNumber } from '../common/css-utils'
+import { UIGridRow } from '../widgets/ui-grid-row'
+import { OnSubmitValue } from './control'
+import { SliderControl, SliderControlProps } from './slider-control'
+
+interface SliderNumberControlProps {
+  value: CSSNumber
+  onSliderSubmitValue: OnSubmitValue<number>
+  onSliderTransientSubmitValue: OnSubmitValue<number>
+  transformSliderValueToCSSNumber: (value: number) => CSSNumber
+  transformCSSNumberToSliderValue: (value: CSSNumber) => number
+}
+
+type FilteredSliderProps = Omit<
+  SliderControlProps,
+  'onSubmitValue' | 'onTransientSubmitValue' | 'value'
+>
+
+// Slider + Number combo control
+export const SliderNumberControl: React.FunctionComponent<
+  React.PropsWithChildren<NumberInputProps & FilteredSliderProps & SliderNumberControlProps>
+> = React.memo((props) => {
+  const { value, transformSliderValueToCSSNumber, transformCSSNumberToSliderValue } = props
+  const [isDragging, setIsDragging] = React.useState(false)
+  const [displayValue, setDisplayValue] = React.useState<CSSNumber>(value)
+
+  React.useEffect(() => {
+    if (!isDragging) {
+      setDisplayValue(value)
+    }
+  }, [isDragging, value])
+
+  const onDragStart = React.useCallback(() => {
+    setIsDragging(true)
+  }, [setIsDragging])
+  const onDragEnd = React.useCallback(() => {
+    setIsDragging(false)
+  }, [setIsDragging])
+
+  const onSliderDrag = React.useCallback(
+    (newValue: number) => {
+      setDisplayValue(transformSliderValueToCSSNumber(newValue))
+    },
+    [transformSliderValueToCSSNumber, setDisplayValue],
+  )
+
+  return (
+    <UIGridRow padded={false} variant='<--------auto-------->|--45px--|'>
+      <SliderControl
+        id={`${props.id}-slider`}
+        key={`${props.id}-slider`}
+        testId={`${props.id}-slider`}
+        value={transformCSSNumberToSliderValue(displayValue)}
+        DEPRECATED_controlOptions={props.DEPRECATED_controlOptions}
+        onSubmitValue={props.onSliderSubmitValue}
+        onTransientSubmitValue={props.onSliderTransientSubmitValue}
+        controlStatus={props.controlStatus}
+        controlStyles={props.controlStyles}
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+        onDrag={onSliderDrag}
+      />
+      <NumberInput
+        value={displayValue}
+        id={`${props.id}-number-input`}
+        testId={`${props.id}-number-input`}
+        onSubmitValue={props.onSubmitValue}
+        onTransientSubmitValue={props.onTransientSubmitValue}
+        controlStatus={props.controlStatus}
+        minimum={props.minimum}
+        maximum={props.maximum}
+        stepSize={props.stepSize}
+        numberType={props.numberType}
+        defaultUnitToHide={props.defaultUnitToHide}
+      />
+    </UIGridRow>
+  )
+})

--- a/editor/src/components/inspector/controls/slider-number-control.tsx
+++ b/editor/src/components/inspector/controls/slider-number-control.tsx
@@ -15,7 +15,7 @@ interface SliderNumberControlProps {
 
 type FilteredSliderProps = Omit<
   SliderControlProps,
-  'onSubmitValue' | 'onTransientSubmitValue' | 'value'
+  'onSubmitValue' | 'onTransientSubmitValue' | 'onForcedSubmitValue' | 'value'
 >
 
 // Slider + Number combo control

--- a/editor/src/components/inspector/controls/slider-number-control.tsx
+++ b/editor/src/components/inspector/controls/slider-number-control.tsx
@@ -4,13 +4,11 @@ import { CSSNumber } from '../common/css-utils'
 import { UIGridRow } from '../widgets/ui-grid-row'
 import { OnSubmitValue } from './control'
 import { SliderControl, SliderControlProps } from './slider-control'
-
 interface SliderNumberControlProps {
   value: CSSNumber
   onSliderSubmitValue: OnSubmitValue<number>
   onSliderTransientSubmitValue: OnSubmitValue<number>
   transformSliderValueToCSSNumber: (value: number) => CSSNumber
-  transformCSSNumberToSliderValue: (value: CSSNumber) => number
 }
 
 type FilteredSliderProps = Omit<
@@ -22,7 +20,7 @@ type FilteredSliderProps = Omit<
 export const SliderNumberControl: React.FunctionComponent<
   React.PropsWithChildren<NumberInputProps & FilteredSliderProps & SliderNumberControlProps>
 > = React.memo((props) => {
-  const { value, transformSliderValueToCSSNumber, transformCSSNumberToSliderValue } = props
+  const { value, transformSliderValueToCSSNumber, numberType } = props
   const [isDragging, setIsDragging] = React.useState(false)
   const [displayValue, setDisplayValue] = React.useState<CSSNumber>(value)
 
@@ -46,13 +44,22 @@ export const SliderNumberControl: React.FunctionComponent<
     [transformSliderValueToCSSNumber, setDisplayValue],
   )
 
+  const transformCSSNumberToSliderValue = React.useCallback(() => {
+    if (numberType === 'UnitlessPercent' || numberType === 'Percent') {
+      const scale = displayValue.unit === '%' ? 100 : 1
+      return displayValue.value / scale
+    } else {
+      return displayValue.value
+    }
+  }, [numberType, displayValue])
+
   return (
     <UIGridRow padded={false} variant='<--------auto-------->|--45px--|'>
       <SliderControl
         id={`${props.id}-slider`}
         key={`${props.id}-slider`}
         testId={`${props.id}-slider`}
-        value={transformCSSNumberToSliderValue(displayValue)}
+        value={transformCSSNumberToSliderValue()}
         DEPRECATED_controlOptions={props.DEPRECATED_controlOptions}
         onSubmitValue={props.onSliderSubmitValue}
         onTransientSubmitValue={props.onSliderTransientSubmitValue}

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
@@ -260,10 +260,6 @@ export const FlexGapControl = React.memo(() => {
   const [sliderSubmitValue, sliderTransientSubmitValue] = useSubmitValueFactory(
     transformNumberToCSSNumber,
   )
-  const transformCSSNumberToNumber = React.useCallback(
-    (valueAsCSSNumber: CSSNumber) => valueAsCSSNumber.value,
-    [],
-  )
 
   const targetPath = useContextSelector(InspectorPropsContext, (contextData) => {
     return contextData.targetPath
@@ -303,7 +299,6 @@ export const FlexGapControl = React.memo(() => {
           onSliderSubmitValue={sliderSubmitValue}
           onSliderTransientSubmitValue={sliderTransientSubmitValue}
           transformSliderValueToCSSNumber={transformNumberToCSSNumber}
-          transformCSSNumberToSliderValue={transformCSSNumberToNumber}
         />
       </UIGridRow>
     </InspectorContextMenuWrapper>

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-subsection.tsx
@@ -1,10 +1,7 @@
 import React from 'react'
 import { FlexWrap } from 'utopia-api/core'
 import { ControlStatus, ControlStyles, getControlStyles } from '../../../common/control-status'
-import {
-  useInspectorLayoutInfo,
-  useMapInspectorInfoFromCSSNumberToNumber,
-} from '../../../common/property-path-hooks'
+import { useInspectorLayoutInfo } from '../../../common/property-path-hooks'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import {
   FlexAlignContentControl,
@@ -15,7 +12,6 @@ import {
   FlexDirectionControl,
   getDirectionAwareLabels,
 } from './flex-container-controls'
-import { useWrappedEmptyOrUnknownOnSubmitValue } from '../../../../../uuiui'
 
 export const FlexContainerControls = React.memo<{ seeMoreVisible: boolean }>((props) => {
   // Right now flex layout isn't supported on groups, so just don't show the controls if a group is selected
@@ -24,7 +20,6 @@ export const FlexContainerControls = React.memo<{ seeMoreVisible: boolean }>((pr
   const alignItems = useInspectorLayoutInfo('alignItems')
   const alignContent = useInspectorLayoutInfo('alignContent')
   const justifyContent = useInspectorLayoutInfo('justifyContent')
-  const gap = useMapInspectorInfoFromCSSNumberToNumber(useInspectorLayoutInfo('gap'))
 
   const {
     justifyFlexStart,
@@ -40,15 +35,6 @@ export const FlexContainerControls = React.memo<{ seeMoreVisible: boolean }>((pr
     flexWrap.value === FlexWrap.NoWrap ? 'disabled' : alignItems.controlStatus
   const alignItemsControlStyles: ControlStyles =
     flexWrap.value === FlexWrap.NoWrap ? getControlStyles('disabled') : alignItems.controlStyles
-
-  const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-    gap.onSubmitValue,
-    gap.onUnsetValues,
-  )
-  const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-    gap.onSubmitValue,
-    gap.onUnsetValues,
-  )
 
   return (
     <>
@@ -72,14 +58,7 @@ export const FlexContainerControls = React.memo<{ seeMoreVisible: boolean }>((pr
           justifyFlexEnd={justifyFlexEnd}
         />
       </UIGridRow>
-      <FlexGapControl
-        value={gap.value}
-        onSubmitValue={wrappedOnSubmitValue}
-        onTransientSubmitValue={wrappedOnTransientSubmitValue}
-        onUnset={gap.onUnsetValues}
-        controlStatus={gap.controlStatus}
-        controlStyles={gap.controlStyles}
-      />
+      <FlexGapControl />
       <FlexAlignItemsControl
         value={alignItems.value}
         controlStatus={alignItems.controlStatus}

--- a/editor/src/components/inspector/sections/style-section/background-subsection/gradient-stop-editor.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/gradient-stop-editor.tsx
@@ -80,6 +80,8 @@ const GradientStop = React.memo<GradientStopProps>(
       [dragScreenOrigin, valueAtDragOrigin, indexedUpdateStop, stop],
     )
 
+    // TODO ez nem mukodik!
+
     const onMouseUp = React.useCallback(
       (e: MouseEvent) => {
         if (valueAtDragOrigin.current != null && dragScreenOrigin.current != null) {

--- a/editor/src/components/inspector/sections/style-section/background-subsection/gradient-stop-editor.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/gradient-stop-editor.tsx
@@ -80,8 +80,6 @@ const GradientStop = React.memo<GradientStopProps>(
       [dragScreenOrigin, valueAtDragOrigin, indexedUpdateStop, stop],
     )
 
-    // TODO ez nem mukodik!
-
     const onMouseUp = React.useCallback(
       (e: MouseEvent) => {
         if (valueAtDragOrigin.current != null && dragScreenOrigin.current != null) {

--- a/editor/src/components/inspector/sections/style-section/container-subsection/opacity-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/opacity-row.tsx
@@ -45,10 +45,6 @@ export const OpacityRow = React.memo(() => {
     (newValue) => updateScaledValue(newValue, opacity),
     [updateScaledValue, opacity],
   )
-  const transformValueToScaled = React.useCallback<(opacity: CSSNumber) => number>(
-    (value) => value.value / scale,
-    [scale],
-  )
 
   const opacityContextMenuItems = InspectorContextMenuItems.optionalAddOnUnsetValues(
     opacity != null,
@@ -95,7 +91,6 @@ export const OpacityRow = React.memo(() => {
           onSliderSubmitValue={onScaledSubmit}
           onSliderTransientSubmitValue={onScaledTransientSubmit}
           transformSliderValueToCSSNumber={transformNewScaledValue}
-          transformCSSNumberToSliderValue={transformValueToScaled}
         />
       </UIGridRow>
     </InspectorContextMenuWrapper>

--- a/editor/src/components/inspector/sections/style-section/container-subsection/opacity-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/opacity-row.tsx
@@ -10,6 +10,8 @@ import {
   InspectorContextMenuWrapper,
   SliderControl,
 } from '../../../../../uuiui-deps'
+import { SliderNumberControl } from '../../../controls/slider-number-control'
+import { CSSNumber, setCSSNumberValue } from '../../../common/css-utils'
 
 const sliderControlOptions = {
   minimum: 0,
@@ -27,13 +29,25 @@ export const OpacityRow = React.memo(() => {
 
   const opacity = opacityMetadata.value
   const scale = opacity.unit === '%' ? 100 : 1
-  const scaledOpacity = opacity.value / scale
 
   const isVisible = useIsSubSectionVisible('opacity')
-  const [onScaledSubmit, onScaledTransientSubmit] = opacityMetadata.useSubmitValueFactory(
-    (newValue: number, oldValue) => {
-      return CSSUtils.setCSSNumberValue(oldValue, newValue * scale)
+  const updateScaledValue = React.useCallback(
+    (newValue: number, oldValue: CSSNumber) => {
+      return setCSSNumberValue(oldValue, newValue * scale)
     },
+    [scale],
+  )
+  const [onScaledSubmit, onScaledTransientSubmit] =
+    opacityMetadata.useSubmitValueFactory(updateScaledValue)
+
+  // slider conversion functions
+  const transformNewScaledValue = React.useCallback<(newValue: number) => CSSNumber>(
+    (newValue) => updateScaledValue(newValue, opacity),
+    [updateScaledValue, opacity],
+  )
+  const transformValueToScaled = React.useCallback<(opacity: CSSNumber) => number>(
+    (value) => value.value / scale,
+    [scale],
   )
 
   const opacityContextMenuItems = InspectorContextMenuItems.optionalAddOnUnsetValues(
@@ -63,33 +77,26 @@ export const OpacityRow = React.memo(() => {
     >
       <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
         <PropertyLabel target={opacityProp}>Opacity</PropertyLabel>
-        <UIGridRow padded={false} variant='<--------auto-------->|--45px--|'>
-          <SliderControl
-            DEPRECATED_controlOptions={sliderControlOptions}
-            id={`opacity-slider`}
-            key={`opacity-slider`}
-            testId={`opacity-slider`}
-            value={scaledOpacity}
-            controlStatus={opacityMetadata.controlStatus}
-            controlStyles={opacityMetadata.controlStyles}
-            onSubmitValue={onScaledSubmit}
-            onTransientSubmitValue={onScaledTransientSubmit}
-            onForcedSubmitValue={onScaledSubmit}
-          />
-          <NumberInput
-            value={opacity}
-            minimum={0}
-            maximum={1}
-            stepSize={0.01}
-            id='opacity-number-control'
-            testId='opacity-number-control'
-            onSubmitValue={wrappedOnSubmitValue}
-            onTransientSubmitValue={wrappedOnTransientSubmitValue}
-            controlStatus={opacityMetadata.controlStatus}
-            numberType='UnitlessPercent'
-            defaultUnitToHide={null}
-          />
-        </UIGridRow>
+        <SliderNumberControl
+          id='opacity'
+          key='opacity'
+          testId='opacity'
+          value={opacity}
+          DEPRECATED_controlOptions={sliderControlOptions}
+          controlStatus={opacityMetadata.controlStatus}
+          controlStyles={opacityMetadata.controlStyles}
+          minimum={0}
+          maximum={1}
+          stepSize={0.01}
+          numberType='UnitlessPercent'
+          defaultUnitToHide={null}
+          onSubmitValue={wrappedOnSubmitValue}
+          onTransientSubmitValue={wrappedOnTransientSubmitValue}
+          onSliderSubmitValue={onScaledSubmit}
+          onSliderTransientSubmitValue={onScaledTransientSubmit}
+          transformSliderValueToCSSNumber={transformNewScaledValue}
+          transformCSSNumberToSliderValue={transformValueToScaled}
+        />
       </UIGridRow>
     </InspectorContextMenuWrapper>
   )

--- a/editor/src/components/inspector/sections/style-section/container-subsection/radius-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/radius-row.tsx
@@ -227,10 +227,6 @@ export const RadiusRow = React.memo(() => {
     },
     [borderRadiusValue],
   )
-  const transformBorderRadiusToSliderValue = React.useCallback(
-    (value: CSSNumber) => value.value,
-    [],
-  )
 
   return (
     <InspectorContextMenuWrapper
@@ -319,7 +315,6 @@ export const RadiusRow = React.memo(() => {
             onSliderSubmitValue={onBorderRadiusAllSubmitValue}
             onSliderTransientSubmitValue={onBorderRadiusAllTransientSubmitValue}
             transformSliderValueToCSSNumber={transformBorderRadiusAllNumberToCSSNumber}
-            transformCSSNumberToSliderValue={transformBorderRadiusToSliderValue}
           />
         )}
       </UIGridRow>

--- a/editor/src/components/inspector/sections/style-section/container-subsection/radius-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/radius-row.tsx
@@ -29,6 +29,7 @@ import {
   NumberInput,
 } from '../../../../../uuiui'
 import { InspectorContextMenuItems } from '../../../../../uuiui-deps'
+import { SliderNumberControl } from '../../../controls/slider-number-control'
 
 function updateRadiusType(
   newRadiusTypeValue: SelectOption,
@@ -212,6 +213,25 @@ export const RadiusRow = React.memo(() => {
     onUnsetValues,
   )
 
+  // slider conversion functions
+  const transformBorderRadiusAllNumberToCSSNumber = React.useCallback<
+    (newValue: number) => CSSNumber
+  >(
+    (newValue) => {
+      const updatedValue = updateBorderRadiusAll(newValue, borderRadiusValue)
+      if (isLeft(updatedValue)) {
+        return updatedValue.value
+      } else {
+        return updatedValue.value.tr
+      }
+    },
+    [borderRadiusValue],
+  )
+  const transformBorderRadiusToSliderValue = React.useCallback(
+    (value: CSSNumber) => value.value,
+    [],
+  )
+
   return (
     <InspectorContextMenuWrapper
       id='borderRadius-subsection-context-menu'
@@ -279,34 +299,28 @@ export const RadiusRow = React.memo(() => {
             />
           </div>
         ) : (
-          <UIGridRow padded={false} variant='<--------auto-------->|--45px--|'>
-            <SliderControl
-              id='radius-all-slider'
-              key='radius-all-slider'
-              testId='radius-all-slider'
-              value={borderRadiusValue.value.value}
-              DEPRECATED_controlOptions={{
-                minimum: 0,
-                maximum: sliderMax / 2,
-                stepSize: 0.5,
-              }}
-              onSubmitValue={onBorderRadiusAllSubmitValue}
-              onTransientSubmitValue={onBorderRadiusAllTransientSubmitValue}
-              controlStatus={controlStatus}
-              controlStyles={controlStyles}
-            />
-            <NumberInput
-              value={borderRadiusValue.value}
-              id='radius-all-number-input'
-              testId='radius-all-number-input'
-              onSubmitValue={wrappedOnSubmitValue}
-              onTransientSubmitValue={wrappedOnTransientSubmitValue}
-              controlStatus={controlStatus}
-              minimum={0}
-              numberType='Length'
-              defaultUnitToHide={'px'}
-            />
-          </UIGridRow>
+          <SliderNumberControl
+            id='radius-all'
+            key='radius-all'
+            testId='radius-all'
+            value={borderRadiusValue.value}
+            DEPRECATED_controlOptions={{
+              minimum: 0,
+              maximum: sliderMax / 2,
+              stepSize: 0.5,
+            }}
+            controlStatus={controlStatus}
+            controlStyles={controlStyles}
+            minimum={0}
+            numberType='Length'
+            defaultUnitToHide={'px'}
+            onSubmitValue={wrappedOnSubmitValue}
+            onTransientSubmitValue={wrappedOnTransientSubmitValue}
+            onSliderSubmitValue={onBorderRadiusAllSubmitValue}
+            onSliderTransientSubmitValue={onBorderRadiusAllTransientSubmitValue}
+            transformSliderValueToCSSNumber={transformBorderRadiusAllNumberToCSSNumber}
+            transformCSSNumberToSliderValue={transformBorderRadiusToSliderValue}
+          />
         )}
       </UIGridRow>
     </InspectorContextMenuWrapper>

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`408`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`407`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`397`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`396`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`662`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`658`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`734`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`730`)
   })
 })


### PR DESCRIPTION
**Problem:**
Performance optimization was too good, now the slider control doesn't update while dragging.

**Fix:**
Fix slider control, and since it's usually followed by a number control displaying the value both should update while dragging. Added a new inspector control combining the slider and number control that uses react state for fresh values during interactions. Supports percent and number values too (for opacity).
Slider control keeps their own state while dragging too in case it's used without the combined number + slider control.
Also fixed flex gap control, it was using simple 'number' value type but it's actually parsed as a 'CSSNumber'.

**Commit Details:**
- changed slider control
- added new component `SliderNumberControl`
- border radius, flex gap and opacity controls are updated to use this new control
