### PR TITLE
Added a live variant to `DragOutlineControl`

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
@@ -21,6 +21,7 @@ import { ZeroSizedElementControls } from '../../controls/zero-sized-element-cont
 import {
   DragOutlineControl,
   dragTargetsElementPaths,
+  dragTargetsElementPathsLive,
 } from '../../controls/select-mode/drag-outline-control'
 
 export function absoluteMoveStrategy(
@@ -69,7 +70,7 @@ export function absoluteMoveStrategy(
         }),
         {
           control: DragOutlineControl,
-          props: dragTargetsElementPaths(selectedElements),
+          props: dragTargetsElementPathsLive(selectedElements),
           key: 'ghost-outline-control',
           show: 'visible-only-while-active',
         },


### PR DESCRIPTION
**Problem:**
Dragging an absolutely positioned element (eg on the canvas) shows the outline we use for dragging elements in layout systems. The outline usually is very near the element, but sometimes isn’t (eg when snapping, or when dragging really fast). This makes the editor feel laggier than it is.

**Fix:**
The outline was mapped to the starting position offset by the drag, but if any snapping has been applied to the element that position will not line up with where the element is on the canvas.

This PR adds a new setting for `DragOutlineControl`, which makes the frame of the outline track to the current position of the element, wherever that is.

**Commit Details:**
- Added `DragTargetsElementPathsLive` to `DragOutlineControlProps`.
- Modified `useFrameFromProps` to lookup the position of the element from `latestMetadata`.
- Changed `absoluteMoveStrategy` to use `dragTargetsElementPathsLive`.