### PR TITLE
fix(inspector) fixing color picker gradient stop

### DIFF
--- a/editor/src/components/inspector/sections/style-section/background-subsection/background-picker.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/background-picker.tsx
@@ -452,14 +452,17 @@ export const BackgroundPicker: React.FunctionComponent<
     (newValue: CSSColor) =>
       onSubmitValueAndUpdateLocalStops(
         setColor(selectedStopUnorderedIndex, newValue, stops),
-        false,
+        'dragEnd',
       ),
     [stops, onSubmitValueAndUpdateLocalStops, selectedStopUnorderedIndex],
   )
 
   const onTransientSubmitValueAndUpdateLocalColor = React.useCallback(
     (newValue: CSSColor) =>
-      onSubmitValueAndUpdateLocalStops(setColor(selectedStopUnorderedIndex, newValue, stops), true),
+      onSubmitValueAndUpdateLocalStops(
+        setColor(selectedStopUnorderedIndex, newValue, stops),
+        'drag',
+      ),
     [stops, onSubmitValueAndUpdateLocalStops, selectedStopUnorderedIndex],
   )
 

--- a/editor/src/components/inspector/sections/style-section/background-subsection/gradient-stop-editor.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/gradient-stop-editor.tsx
@@ -29,7 +29,7 @@ interface GradientStopProps {
   setSelectedIndex: (index: number) => void
   unorderedIndex: number
   focusStopEditor: () => void
-  indexedUpdateStop: (newStop: CSSGradientStop, transient: boolean) => void
+  indexedUpdateStop: (newStop: CSSGradientStop, dragState: 'dragStart' | 'drag' | 'dragEnd') => void
   indexedDeleteStop: () => void
 }
 
@@ -73,7 +73,7 @@ const GradientStop = React.memo<GradientStopProps>(
               dragScreenOrigin.current.x,
               valueAtDragOrigin.current,
             ),
-            true,
+            'drag',
           )
         }
       },
@@ -96,7 +96,7 @@ const GradientStop = React.memo<GradientStopProps>(
                   dragScreenOrigin.current.x,
                   valueAtDragOrigin.current,
                 ),
-                false,
+                'dragEnd',
               )
             }
           }
@@ -300,11 +300,11 @@ function getIndexedUpdateStop(
   index: number,
   oldValue: Array<CSSGradientStop>,
   setStateStops: OnSubmitValueAndUpdateLocalState<Array<CSSGradientStop>>,
-): (newStop: CSSGradientStop, transient: boolean) => void {
-  return function updateStop(newStop, transient) {
+): (newStop: CSSGradientStop, dragState: 'dragStart' | 'drag' | 'dragEnd') => void {
+  return function updateStop(newStop, dragState) {
     const workingValue = [...oldValue]
     workingValue[index] = newStop
-    setStateStops(workingValue, transient)
+    setStateStops(workingValue, dragState)
   }
 }
 
@@ -351,7 +351,7 @@ function deleteStopAndUpdateIndex(
       },
     )
     if (isFinite(lowestDistance) && indexWithLowestDistance >= 0) {
-      setStops(newStops, false)
+      setStops(newStops, false, 'dragEnd')
       setSelectedStopUnorderedIndex(indexWithLowestDistance)
     }
   }
@@ -373,7 +373,7 @@ export const GradientStopsEditor = React.memo<GradientControlProps>(
             Number(((e.nativeEvent.offsetX / GradientPickerWidth) * 100).toFixed(2)),
             stops,
           )
-          setLocalAndEditorStops(newStops, false)
+          setLocalAndEditorStops(newStops, 'dragStart')
           setSelectedStopUnorderedIndex(newStops.length - 1)
         }
       },
@@ -394,14 +394,14 @@ export const GradientStopsEditor = React.memo<GradientControlProps>(
           // TODO: transient actions when holding
           setLocalAndEditorStops(
             incrementSelectedStopPosition(e.shiftKey ? -10 : -1, stops, selectedStopUnorderedIndex),
-            false,
+            'notDragging',
           )
           e.stopPropagation()
         } else if (e.key === 'ArrowRight') {
           // TODO: transient actions when holding
           setLocalAndEditorStops(
             incrementSelectedStopPosition(e.shiftKey ? 10 : 1, stops, selectedStopUnorderedIndex),
-            false,
+            'notDragging',
           )
           e.stopPropagation()
         }


### PR DESCRIPTION
**Problem:**
Dragging gradient stops in the editor doesn't update with the cursor changes only after released.

**Fix:**
Fixing the existing hook to update correctly while dragging, storing values in local state during interaction. Change 'transient' parameter to indicate different interaction states.

**Commit Details:**
- updating gradient stop editor
- color picker also uses this hook
