### PR TITLE
fix(canvas) reparent helper check if frame is null

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-sibling-position-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-sibling-position-helpers.ts
@@ -63,7 +63,10 @@ export function drawTargetRectanglesForChildrenOfElement(
       return null
     }
 
-    const bounds = MetadataUtils.getFrameInCanvasCoords(childPath, metadata)!
+    const bounds = MetadataUtils.getFrameInCanvasCoords(childPath, metadata)
+    if (bounds == null) {
+      return null
+    }
     return {
       start: bounds[leftOrTop],
       size: bounds[widthOrHeight],


### PR DESCRIPTION
**Problem:**
Double clicking repeatedly on the Stamp component center in the Before I Go Basic project throws errors.

**Fix:**
I checked the project, actually the middle element has no globalFrame because there is no dom metadata collected for svg elements. Added missing null-check.

**Commit Details:**
- update `drawTargetRectanglesForChildrenOfElement`
