### PR TITLE
fix(inspector) update component section in time on selection change

### DIFF
--- a/editor/src/components/inspector/common/property-controls-hooks.ts
+++ b/editor/src/components/inspector/common/property-controls-hooks.ts
@@ -215,14 +215,10 @@ type FullPropertyControlsAndTargets = {
 const emptyControls: PropertyControls = {}
 
 export function useGetPropertyControlsForSelectedComponents(): Array<FullPropertyControlsAndTargets> {
-  const selectedViews = useEditorState(
-    (store) => store.editor.selectedViews,
-    'useGetPropertyControlsForSelectedComponents selectedViews',
-  )
   const selectedPropertyControls = useEditorState(
     (store) => {
       let propertyControlsAndTargets: Array<PropertyControlsAndTargets> = []
-      fastForEach(selectedViews, (path) => {
+      fastForEach(store.editor.selectedViews, (path) => {
         const propertyControls = getPropertyControlsForTargetFromEditor(path, store.editor)
         if (propertyControls == null) {
           propertyControlsAndTargets.push({

--- a/editor/src/components/inspector/common/property-controls-hooks.ts
+++ b/editor/src/components/inspector/common/property-controls-hooks.ts
@@ -215,12 +215,14 @@ type FullPropertyControlsAndTargets = {
 const emptyControls: PropertyControls = {}
 
 export function useGetPropertyControlsForSelectedComponents(): Array<FullPropertyControlsAndTargets> {
-  const selectedViews = useRefSelectedViews()
-
+  const selectedViews = useEditorState(
+    (store) => store.editor.selectedViews,
+    'useGetPropertyControlsForSelectedComponents selectedViews',
+  )
   const selectedPropertyControls = useEditorState(
     (store) => {
       let propertyControlsAndTargets: Array<PropertyControlsAndTargets> = []
-      fastForEach(selectedViews.current, (path) => {
+      fastForEach(selectedViews, (path) => {
         const propertyControls = getPropertyControlsForTargetFromEditor(path, store.editor)
         if (propertyControls == null) {
           propertyControlsAndTargets.push({


### PR DESCRIPTION
**Problem:**
Component section shows controls with a delay, and annoyingly at first it shows the previous selected elements control props with empty results for a short time before switching to the new props and values.

**Fix:**
Make sure the hook is running when the selected views are changed. It used the selected views from ref editor state and it is inconsistent, sometimes trying to update the prop controls before the selection was updated. 
With this the component controls are filled at the same time as the style section controls. 

**Commit Details:**
- update `useGetPropertyControlsForSelectedComponents`
