### PR TITLE
spike: overridden props

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -212,6 +212,7 @@ export function renderCoreElement(
         filePath,
         blockScope,
         element.props,
+        element.overriddenProps ?? [],
         requireResult,
       )
 
@@ -546,6 +547,7 @@ export function renderComponentUsingJsxFactoryFunction(
       throw new Error(`Unable to find factory function ${factoryFunctionName} in scope.`)
     }
   }
+  // console.log(fixedProps)
   return factoryFunction.call(null, type, fixedProps, ...children)
 }
 

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -732,6 +732,13 @@ export interface SetProp {
   value: JSXAttribute
 }
 
+export interface SetOverrideProp {
+  action: 'SET_OVERRIDE_PROP'
+  target: ElementPath
+  propertyPath: PropertyPath
+  value: JSXAttribute
+}
+
 export interface SetPropWithElementPath {
   action: 'SET_PROP_WITH_ELEMENT_PATH'
   target: StaticElementPathPart
@@ -1176,6 +1183,7 @@ export type EditorAction =
   | SendLinterRequestMessage
   | SaveDOMReport
   | SetProp
+  | SetOverrideProp
   | SetPropWithElementPath
   | SetFilebrowserRenamingTarget
   | ToggleProperty

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -221,6 +221,7 @@ import type {
   SetHoveredView,
   ClearHoveredViews,
   SetAssetChecksum,
+  SetOverrideProp,
 } from '../action-types'
 import { EditorModes, insertionSubject, Mode } from '../editor-modes'
 import type {
@@ -1137,6 +1138,19 @@ export function setProp_UNSAFE(
 ): SetProp {
   return {
     action: 'SET_PROP',
+    target: target,
+    propertyPath: propertyPath,
+    value: value,
+  }
+}
+
+export function setOverrideProp(
+  target: ElementPath,
+  propertyPath: PropertyPath,
+  value: JSXAttribute,
+): SetOverrideProp {
+  return {
+    action: 'SET_OVERRIDE_PROP',
     target: target,
     propertyPath: propertyPath,
     value: value,

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -171,6 +171,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_FROM_CODE_EDITOR':
     case 'SET_MAIN_UI_FILE':
     case 'SET_PROP':
+    case 'SET_OVERRIDE_PROP':
     case 'SET_PROP_WITH_ELEMENT_PATH':
     case 'SWITCH_LAYOUT_SYSTEM':
     case 'SAVE_CURRENT_FILE':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -530,7 +530,7 @@ function applyUpdateToJSXElement(
   } else {
     return {
       ...element,
-      props: result.value,
+      overriddenProps: result.value,
     }
   }
 }

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -237,6 +237,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.SET_CODE_EDITOR_LINT_ERRORS(action, state)
     case 'SAVE_DOM_REPORT':
       return UPDATE_FNS.SAVE_DOM_REPORT(action, state, spyCollector)
+    case 'SET_OVERRIDE_PROP':
+      return UPDATE_FNS.SET_OVERRIDE_PROP(action, state)
     case 'SET_PROP':
       return UPDATE_FNS.SET_PROP(action, state)
     case 'SET_PROP_WITH_ELEMENT_PATH':

--- a/editor/src/components/inspector/sections/image-section/image-source-control.tsx
+++ b/editor/src/components/inspector/sections/image-section/image-source-control.tsx
@@ -2,8 +2,11 @@ import React from 'react'
 import { imagePathURL } from '../../../../common/server'
 import { treeToContents } from '../../../../components/assets'
 import { isImageFile } from '../../../../core/model/project-file-utils'
+import { emptyComments, jsxAttributeValue } from '../../../../core/shared/element-template'
 import { ProjectContents } from '../../../../core/shared/project-file-types'
+import { setOverrideProp } from '../../../editor/actions/action-creators'
 import { useEditorState } from '../../../editor/store/store-hook'
+import * as PP from '../../../../core/shared/property-path'
 import { useInspectorElementInfo } from '../../common/property-path-hooks'
 import { OptionChainControl } from '../../controls/option-chain-control'
 import { SelectControl, SelectOption } from '../../controls/select-control'
@@ -34,6 +37,28 @@ export const ImageSourceControl = React.memo(() => {
     controlStatus: srcControlStatus,
     onSubmitValue: srcOnSubmitValue,
   } = useInspectorElementInfo('src')
+
+  const dispatch = useEditorState((store) => store.dispatch, 'ImageSourceControl dispatch')
+  const selectedElements = useEditorState(
+    (store) => store.editor.selectedViews,
+    'ImageSourceControl selectedElements',
+  )
+
+  const dispatchOverrideAction = React.useCallback(
+    (newSrc: string) => {
+      if (selectedElements.length === 0) {
+        return
+      }
+      dispatch([
+        setOverrideProp(
+          selectedElements[0],
+          PP.create(['src']),
+          jsxAttributeValue(newSrc, emptyComments),
+        ),
+      ])
+    },
+    [dispatch, selectedElements],
+  )
 
   const { projectContents } = useEditorState((store) => {
     return {
@@ -83,7 +108,7 @@ export const ImageSourceControl = React.memo(() => {
           testId='image-src-local'
           value={srcValue}
           options={localImageFilesOptions}
-          onSubmitValue={srcOnSubmitValue}
+          onSubmitValue={dispatchOverrideAction}
           controlStyles={srcControlStyles}
           controlStatus={srcControlStatus}
         />
@@ -93,7 +118,7 @@ export const ImageSourceControl = React.memo(() => {
           key='image-src-url'
           testId='image-src-url'
           value={srcValue}
-          onSubmitValue={srcOnSubmitValue}
+          onSubmitValue={dispatchOverrideAction}
           controlStyles={srcControlStyles}
           controlStatus={srcControlStatus}
         />

--- a/editor/src/core/model/jsx-attributes.spec.ts
+++ b/editor/src/core/model/jsx-attributes.spec.ts
@@ -177,6 +177,7 @@ describe('setJSXValueAtPath', () => {
       'test.js',
       { props: sampleParentProps },
       updatedAttributes,
+      [],
       {},
     )
     expect(compiledProps.top).toEqual(55)
@@ -205,6 +206,7 @@ describe('setJSXValueAtPath', () => {
       'test.js',
       { props: sampleParentProps },
       updatedAttributes,
+      [],
       {},
     )
     expect(compiledProps.my.property.path).toEqual('hello')
@@ -222,6 +224,7 @@ describe('setJSXValueAtPath', () => {
       'test.js',
       { props: sampleParentProps },
       updatedAttributes,
+      [],
       {},
     )
     expect(compiledProps.layout.left).toEqual(2000)
@@ -239,6 +242,7 @@ describe('setJSXValueAtPath', () => {
       'test.js',
       { props: sampleParentProps },
       updatedAttributes,
+      [],
       {},
     )
     expect(compiledProps.layout.deep.path).toEqual('easy!')
@@ -256,6 +260,7 @@ describe('setJSXValueAtPath', () => {
       'test.js',
       { props: sampleParentProps },
       updatedAttributes,
+      [],
       {},
     )
     expect(compiledProps.objectWithArray.array).toEqual([0, 1, 'wee'])
@@ -273,6 +278,7 @@ describe('setJSXValueAtPath', () => {
       'test.js',
       { props: sampleParentProps },
       updatedAttributes,
+      [],
       {},
     )
     expect(compiledProps.objectWithNestedArray.array).toEqual([0, 1, 'wee'])
@@ -290,6 +296,7 @@ describe('setJSXValueAtPath', () => {
       'test.js',
       { props: sampleParentProps },
       updatedAttributes,
+      [],
       {},
     )
     expect(compiledProps.objectWithNestedArray.array).toEqual([0, 1, 'wee'])
@@ -307,6 +314,7 @@ describe('setJSXValueAtPath', () => {
       'test.js',
       { props: sampleParentProps },
       updatedAttributes,
+      [],
       {},
     )
     expect(compiledProps.objectWithNestedArray.array).toEqual({ 0: 0, 1: 1, 2: 2, wee: 'wee' })
@@ -325,6 +333,7 @@ describe('setJSXValueAtPath', () => {
         'test.js',
         { props: sampleParentProps },
         updatedAttributes,
+        [],
         {},
       )
     }).toThrow()
@@ -342,6 +351,7 @@ describe('setJSXValueAtPath', () => {
       'test.js',
       { props: sampleParentProps },
       updatedAttributes,
+      [],
       {},
     )
     expect(compiledProps.style.backgroundColor).toEqual('wee')
@@ -366,6 +376,7 @@ describe('setJSXValueAtPath', () => {
       'test.js',
       { props: sampleParentProps },
       updatedAttributes2,
+      [],
       {},
     )
     expect(compiledProps.my.property.path).toEqual('hello')
@@ -384,6 +395,7 @@ describe('setJSXValueAtPath', () => {
       'test.js',
       { props: sampleParentProps },
       updatedAttributes,
+      [],
       {},
     )
     expect(compiledProps.style.backgroundColor).toEqual('blue')
@@ -515,6 +527,7 @@ describe('setJSXValueAtPath', () => {
       'test.js',
       { props: sampleParentProps },
       updatedAttributes,
+      [],
       {},
     )
     expect(compiledProps).toEqual({ top: [55] })
@@ -527,6 +540,7 @@ describe('jsxAttributesToProps', () => {
       'test.js',
       { props: sampleParentProps },
       sampleJsxAttributes(),
+      [],
       {},
     )
     expect(compiledProps).toEqual(expectedCompiledProps)
@@ -548,7 +562,7 @@ describe('jsxAttributesToProps', () => {
         emptyComments,
       ),
     })
-    const compiledProps = jsxAttributesToProps('test.js', {}, attributes, {})
+    const compiledProps = jsxAttributesToProps('test.js', {}, attributes, [], {})
 
     expect(compiledProps).toEqual({ style: { paddingLeft: 23, padding: 5 } })
     expect(Object.entries(compiledProps.style)).toEqual([
@@ -590,7 +604,7 @@ describe('jsxAttributesToProps', () => {
       ),
     })
 
-    const compiledProps = jsxAttributesToProps('test.js', {}, attributes, {})
+    const compiledProps = jsxAttributesToProps('test.js', {}, attributes, [], {})
 
     expect(compiledProps).toEqual({ style: { paddingLeft: 23, padding: 5 } })
     expect(Object.entries(compiledProps.style)).toEqual([

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -970,6 +970,7 @@ export interface JSXElement {
   props: JSXAttributes
   children: JSXElementChildren
   uid: string
+  overriddenProps?: JSXAttributes
 }
 
 export interface JSXElementWithoutUID {
@@ -1103,12 +1104,14 @@ export function jsxElement(
   uid: string,
   props: JSXAttributes,
   children: JSXElementChildren,
+  overriddenProps: JSXAttributes = [],
 ): JSXElement {
   return {
     type: 'JSX_ELEMENT',
     name: typeof name === 'string' ? jsxElementName(name, []) : name,
     uid: uid,
     props: props,
+    overriddenProps: overriddenProps,
     children: children,
   }
 }
@@ -1118,12 +1121,14 @@ export function jsxTestElement(
   props: JSXAttributes,
   children: JSXElementChildren,
   uid: string = 'aaa',
+  overriddenProps: JSXAttributes = [],
 ): JSXElement {
   return jsxElement(
     name,
     uid,
     setJSXAttributesAttribute(props, 'data-uid', jsxAttributeValue(uid, emptyComments)),
     children,
+    overriddenProps,
   )
 }
 

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -238,26 +238,21 @@ export function jsxAttributesToProps(
   requireResult: MapLike<any>,
 ): any {
   let result: any = {}
-  const go = (attrs: JSXAttributes) => {
-    for (const entry of attrs) {
-      switch (entry.type) {
-        case 'JSX_ATTRIBUTES_ENTRY':
-          result[entry.key] = jsxAttributeToValue(filePath, inScope, requireResult, entry.value)
-          break
-        case 'JSX_ATTRIBUTES_SPREAD':
-          result = {
-            ...result,
-            ...jsxAttributeToValue(filePath, inScope, requireResult, entry.spreadValue),
-          }
-          break
-        default:
-          assertNever(entry)
-      }
+  for (const entry of [...attributes, ...overrides]) {
+    switch (entry.type) {
+      case 'JSX_ATTRIBUTES_ENTRY':
+        result[entry.key] = jsxAttributeToValue(filePath, inScope, requireResult, entry.value)
+        break
+      case 'JSX_ATTRIBUTES_SPREAD':
+        result = {
+          ...result,
+          ...jsxAttributeToValue(filePath, inScope, requireResult, entry.spreadValue),
+        }
+        break
+      default:
+        assertNever(entry)
     }
   }
-
-  go(attributes)
-  go(overrides)
 
   return result
 }

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -45,7 +45,7 @@ import {
 import { resolveParamsAndRunJsCode } from './javascript-cache'
 import { PropertyPath } from './project-file-types'
 import * as PP from './property-path'
-import { fastForEach } from './utils'
+import { assertNever, fastForEach } from './utils'
 import { optionalMap } from './optional-utils'
 import { getAllObjectPaths } from './object-utils'
 
@@ -234,25 +234,31 @@ export function jsxAttributesToProps(
   filePath: string,
   inScope: MapLike<any>,
   attributes: JSXAttributes,
+  overrides: JSXAttributes,
   requireResult: MapLike<any>,
 ): any {
   let result: any = {}
-  for (const entry of attributes) {
-    switch (entry.type) {
-      case 'JSX_ATTRIBUTES_ENTRY':
-        result[entry.key] = jsxAttributeToValue(filePath, inScope, requireResult, entry.value)
-        break
-      case 'JSX_ATTRIBUTES_SPREAD':
-        result = {
-          ...result,
-          ...jsxAttributeToValue(filePath, inScope, requireResult, entry.spreadValue),
-        }
-        break
-      default:
-        const _exhaustiveCheck: never = entry
-        throw new Error(`Unhandled entry ${JSON.stringify(entry)}`)
+  const go = (attrs: JSXAttributes) => {
+    for (const entry of attrs) {
+      switch (entry.type) {
+        case 'JSX_ATTRIBUTES_ENTRY':
+          result[entry.key] = jsxAttributeToValue(filePath, inScope, requireResult, entry.value)
+          break
+        case 'JSX_ATTRIBUTES_SPREAD':
+          result = {
+            ...result,
+            ...jsxAttributeToValue(filePath, inScope, requireResult, entry.spreadValue),
+          }
+          break
+        default:
+          assertNever(entry)
+      }
     }
   }
+
+  go(attributes)
+  go(overrides)
+
   return result
 }
 

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -287,7 +287,13 @@ function createFakeMetadataForJSXElement(
       ),
       ...parentScope,
     }
-    const props = jsxAttributesToProps('test.js', inScope, element.props, Utils.NO_OP)
+    const props = jsxAttributesToProps(
+      'test.js',
+      inScope,
+      element.props,
+      element.overriddenProps ?? [],
+      Utils.NO_OP,
+    )
     const children = element.children.flatMap((child) =>
       createFakeMetadataForJSXElement(
         child,


### PR DESCRIPTION
override props in parsed model, don't write them back to source