### PR TITLE
Reset commit message on push

### DIFF
--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -569,14 +569,20 @@ const LocalChangesBlock = () => {
     return cleanupBranchName(rawCommitBranchName)
   }, [rawCommitBranchName])
 
+  const originCommit = useEditorState(
+    (store) => store.editor.githubSettings.originCommit,
+    'Github origin commit',
+  )
   const [commitMessage, setCommitMessage] = React.useState<string | null>(null)
-  React.useEffect(() => {
-    setCommitMessage(null)
-  }, [branch])
   const updateCommitMessage = React.useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => setCommitMessage(e.target.value),
     [],
   )
+
+  React.useEffect(() => {
+    setCommitMessage(null)
+    setRawCommitBranchName(null)
+  }, [branch, originCommit])
 
   const triggerSaveToGithub = React.useCallback(() => {
     if (repo != null && cleanedCommitBranchName != null && commitMessage != null) {

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -581,7 +581,6 @@ const LocalChangesBlock = () => {
 
   React.useEffect(() => {
     setCommitMessage(null)
-    setRawCommitBranchName(null)
   }, [branch, originCommit])
 
   const triggerSaveToGithub = React.useCallback(() => {


### PR DESCRIPTION
Fixes #2954

This PR adjusts the commit message input box so that its content is reset after a successful push (or any other time when the origin commit changes).

<img width="238" alt="Screenshot 2022-11-30 at 6 20 48 PM" src="https://user-images.githubusercontent.com/1081051/204865217-67645cf4-067b-4c9a-ac12-8dd07f66530b.png">
