### PR TITLE
Added "System" theme option

### DIFF
--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -314,7 +314,7 @@ export async function renderTestEditorWithModel(
     userState: {
       loginState: loginState,
       shortcutConfig: {},
-      themeConfig: 'light',
+      themeConfig: 'system',
       githubState: {
         authenticated: false,
       },

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -54,11 +54,11 @@ import {
   ProjectGithubSettings,
   RightMenuTab,
   StoredEditorState,
-  Theme,
   GithubOperation,
   FileChecksums,
   GithubData,
   UserConfiguration,
+  ThemeSetting,
 } from './store/editor-state'
 import { Notice } from '../common/notice'
 import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
@@ -961,7 +961,7 @@ export interface SetFilebrowserDropTarget {
 
 export interface SetCurrentTheme {
   action: 'SET_CURRENT_THEME'
-  theme: Theme
+  theme: ThemeSetting
 }
 
 export interface FocusClassNameInput {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -235,11 +235,11 @@ import type {
   OriginalFrame,
   ProjectGithubSettings,
   RightMenuTab,
-  Theme,
   GithubOperation,
   FileChecksums,
   GithubData,
   UserConfiguration,
+  ThemeSetting,
 } from '../store/editor-state'
 
 export function clearSelection(): EditorAction {
@@ -1537,7 +1537,7 @@ export function setFilebrowserDropTarget(target: string | null): SetFilebrowserD
   }
 }
 
-export function setCurrentTheme(theme: Theme): SetCurrentTheme {
+export function setCurrentTheme(theme: ThemeSetting): SetCurrentTheme {
   return {
     action: 'SET_CURRENT_THEME',
     theme: theme,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4713,7 +4713,7 @@ export const UPDATE_FNS = {
     }
 
     // Side effect - update the setting in VS Code
-    void sendSetVSCodeTheme(action.theme)
+    void sendSetVSCodeTheme(getCurrentTheme(updatedUserConfiguration))
 
     // Side effect - store the setting on the server
     void saveUserConfiguration(updatedUserConfiguration)

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -170,7 +170,7 @@ import {
   RepositoryEntry,
   TreeConflicts,
 } from '../../../core/shared/github'
-import { getPreferredColorScheme, Theme } from '../../../uuiui'
+import { getPreferredColorScheme, Theme } from '../../../uuiui/styles/theme'
 
 const ObjectPathImmutable: any = OPI
 

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -170,6 +170,7 @@ import {
   RepositoryEntry,
   TreeConflicts,
 } from '../../../core/shared/github'
+import { getPreferredColorScheme, Theme } from '../../../uuiui'
 
 const ObjectPathImmutable: any = OPI
 
@@ -236,7 +237,7 @@ export function originalPath(originalTP: ElementPath, currentTP: ElementPath): O
 
 export interface UserConfiguration {
   shortcutConfig: ShortcutConfiguration | null
-  themeConfig: Theme | null
+  themeConfig: ThemeSetting | null
 }
 
 export function emptyUserConfiguration(): UserConfiguration {
@@ -373,7 +374,7 @@ export function isGithubListingPullRequestsForBranch(
 export const defaultUserState: UserState = {
   loginState: loginNotYetKnown,
   shortcutConfig: {},
-  themeConfig: 'light',
+  themeConfig: 'system',
   githubState: {
     authenticated: false,
   },
@@ -570,8 +571,8 @@ export function designerFile(filename: string): DesignerFile {
   }
 }
 
-export type Theme = 'light' | 'dark'
-export const DefaultTheme: Theme = 'light'
+export type ThemeSetting = 'light' | 'dark' | 'system'
+export const DefaultTheme: ThemeSetting = 'system'
 
 export type DropTargetType = 'before' | 'after' | 'reparent' | null
 
@@ -3215,7 +3216,12 @@ export function getElementFromProjectContents(
 }
 
 export function getCurrentTheme(userConfiguration: UserConfiguration): Theme {
-  return userConfiguration.themeConfig ?? DefaultTheme
+  const currentTheme = userConfiguration.themeConfig ?? DefaultTheme
+  if (currentTheme === 'system') {
+    return getPreferredColorScheme()
+  } else {
+    return currentTheme
+  }
 }
 
 export function getNewSceneName(editor: EditorState): string {

--- a/editor/src/components/navigator/left-pane/settings-pane.tsx
+++ b/editor/src/components/navigator/left-pane/settings-pane.tsx
@@ -28,6 +28,10 @@ import { ForksGiven } from './forks-given'
 
 const themeOptions = [
   {
+    label: 'System',
+    value: 'system',
+  },
+  {
     label: 'Dark',
     value: 'dark',
   },
@@ -37,7 +41,7 @@ const themeOptions = [
   },
 ]
 
-const defaultTheme = themeOptions[1]
+const defaultTheme = themeOptions[0]
 
 export const SettingsPane = React.memo(() => {
   const { dispatch, userState, projectId, projectName, projectDescription, themeConfig } =

--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -63,9 +63,9 @@ import {
   EditorState,
   getHighlightBoundsForElementPath,
   getOpenTextFileKey,
-  Theme,
 } from '../../components/editor/store/editor-state'
 import { ProjectFileChange } from '../../components/editor/store/vscode-changes'
+import { Theme } from '../../uuiui'
 
 export const VSCODE_EDITOR_IFRAME_ID = 'vscode-editor'
 

--- a/editor/src/uuiui/icn.tsx
+++ b/editor/src/uuiui/icn.tsx
@@ -3,7 +3,8 @@ import React from 'react'
 import { getPossiblyHashedURL } from '../utils/hashed-assets'
 import { Tooltip } from './tooltip'
 import { useEditorState } from '../components/editor/store/store-hook'
-import { getCurrentTheme, Theme } from '../components/editor/store/editor-state'
+import { getCurrentTheme } from '../components/editor/store/editor-state'
+import { Theme } from './styles/theme'
 
 export type IcnColor =
   | 'main'

--- a/editor/src/uuiui/styles/css-vars.tsx
+++ b/editor/src/uuiui/styles/css-vars.tsx
@@ -5,28 +5,13 @@ import { sendSetVSCodeTheme } from '../../core/vscode/vscode-bridge'
 import { getPreferredColorScheme, Theme } from './theme'
 import { colorThemeCssVariables, darkColorThemeCssVariables } from './theme/utopia-theme'
 
-export const useColorThemeVariables = (): any => {
-  const currentTheme: Theme = useEditorState(
-    (store) => getCurrentTheme(store.userState),
-    'currentTheme',
-  )
-
-  return currentTheme === 'dark' ? darkColorThemeCssVariables : colorThemeCssVariables
-}
-
-export const useColorThemeAlternateVariables = (): any => {
-  const currentTheme: Theme = useEditorState(
-    (store) => getCurrentTheme(store.userState),
-    'currentTheme',
-  )
-  return currentTheme === 'light' ? darkColorThemeCssVariables : colorThemeCssVariables
-}
-
-// TODO: Include alternate themes for the given primary theme
-// and include CSS classes/variables for those
 export const ColorThemeComponent = React.memo(() => {
   const themeSetting = useEditorState((store) => store.userState.themeConfig, 'currentTheme')
-  const colorTheme = useColorThemeVariables()
+  const currentTheme: Theme = useEditorState(
+    (store) => getCurrentTheme(store.userState),
+    'currentTheme',
+  )
+  const colorTheme = currentTheme === 'dark' ? darkColorThemeCssVariables : colorThemeCssVariables
 
   // a dummy state used to force a re-render when the system preferred color scheme
   // change event fires
@@ -39,13 +24,13 @@ export const ColorThemeComponent = React.memo(() => {
       setTheme(preferredColorScheme)
     }
 
+    const colorSchemeQuery = window.matchMedia('(prefers-color-scheme: dark)')
+
     if (themeSetting === 'system') {
-      const colorSchemeQuery = window.matchMedia('(prefers-color-scheme: dark)')
       colorSchemeQuery.addEventListener('change', handlePreferredColorSchemeChange)
-      return () => colorSchemeQuery.removeEventListener('change', handlePreferredColorSchemeChange)
-    } else {
-      return
     }
+
+    return () => colorSchemeQuery.removeEventListener('change', handlePreferredColorSchemeChange)
   }, [themeSetting, theme])
 
   return (

--- a/editor/src/uuiui/styles/css-vars.tsx
+++ b/editor/src/uuiui/styles/css-vars.tsx
@@ -1,10 +1,52 @@
-import { useColorThemeVariables } from './theme'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { getCurrentTheme } from '../../components/editor/store/editor-state'
+import { useEditorState } from '../../components/editor/store/store-hook'
+import { sendSetVSCodeTheme } from '../../core/vscode/vscode-bridge'
+import { getPreferredColorScheme, Theme } from './theme'
+import { colorThemeCssVariables, darkColorThemeCssVariables } from './theme/utopia-theme'
+
+export const useColorThemeVariables = (): any => {
+  const currentTheme: Theme = useEditorState(
+    (store) => getCurrentTheme(store.userState),
+    'currentTheme',
+  )
+
+  return currentTheme === 'dark' ? darkColorThemeCssVariables : colorThemeCssVariables
+}
+
+export const useColorThemeAlternateVariables = (): any => {
+  const currentTheme: Theme = useEditorState(
+    (store) => getCurrentTheme(store.userState),
+    'currentTheme',
+  )
+  return currentTheme === 'light' ? darkColorThemeCssVariables : colorThemeCssVariables
+}
 
 // TODO: Include alternate themes for the given primary theme
 // and include CSS classes/variables for those
 export const ColorThemeComponent = React.memo(() => {
+  const themeSetting = useEditorState((store) => store.userState.themeConfig, 'currentTheme')
   const colorTheme = useColorThemeVariables()
+
+  // a dummy state used to force a re-render when the system preferred color scheme
+  // change event fires
+  const [theme, setTheme] = useState('')
+
+  useEffect(() => {
+    const handlePreferredColorSchemeChange = () => {
+      const preferredColorScheme = getPreferredColorScheme()
+      void sendSetVSCodeTheme(preferredColorScheme)
+      setTheme(preferredColorScheme)
+    }
+
+    if (themeSetting === 'system') {
+      const colorSchemeQuery = window.matchMedia('(prefers-color-scheme: dark)')
+      colorSchemeQuery.addEventListener('change', handlePreferredColorSchemeChange)
+      return () => colorSchemeQuery.removeEventListener('change', handlePreferredColorSchemeChange)
+    } else {
+      return
+    }
+  }, [themeSetting, theme])
 
   return (
     <style>

--- a/editor/src/uuiui/styles/css-vars.tsx
+++ b/editor/src/uuiui/styles/css-vars.tsx
@@ -24,13 +24,15 @@ export const ColorThemeComponent = React.memo(() => {
       setTheme(preferredColorScheme)
     }
 
-    const colorSchemeQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    const colorSchemeQuery = window?.matchMedia?.('(prefers-color-scheme: dark)')
 
     if (themeSetting === 'system') {
-      colorSchemeQuery.addEventListener('change', handlePreferredColorSchemeChange)
+      colorSchemeQuery?.addEventListener('change', handlePreferredColorSchemeChange)
     }
 
-    return () => colorSchemeQuery.removeEventListener('change', handlePreferredColorSchemeChange)
+    return function cleanup() {
+      colorSchemeQuery?.removeEventListener('change', handlePreferredColorSchemeChange)
+    }
   }, [themeSetting, theme])
 
   return (

--- a/editor/src/uuiui/styles/theme/index.ts
+++ b/editor/src/uuiui/styles/theme/index.ts
@@ -8,7 +8,7 @@ export const useColorTheme = (): ThemeObject => {
 }
 
 export function getPreferredColorScheme(): Theme {
-  if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+  if (window?.matchMedia?.('(prefers-color-scheme: dark)').matches) {
     return 'dark'
   } else {
     return 'light'

--- a/editor/src/uuiui/styles/theme/index.ts
+++ b/editor/src/uuiui/styles/theme/index.ts
@@ -1,26 +1,18 @@
-import { Theme } from '../../../components/editor/store/editor-state'
-import { useEditorState } from '../../../components/editor/store/store-hook'
 import { ThemeObject } from './theme-helpers'
-import { colorTheme, colorThemeCssVariables, darkColorThemeCssVariables } from './utopia-theme'
+import { colorTheme } from './utopia-theme'
+
+export type Theme = 'light' | 'dark'
 
 export const useColorTheme = (): ThemeObject => {
   return colorTheme
 }
 
-export const useColorThemeVariables = (): any => {
-  const currentTheme: Theme = useEditorState(
-    (store) => store.userState.themeConfig ?? 'light',
-    'currentTheme',
-  )
-  return currentTheme === 'dark' ? darkColorThemeCssVariables : colorThemeCssVariables
-}
-
-export const useColorThemeAlternateVariables = (): any => {
-  const currentTheme: Theme = useEditorState(
-    (store) => store.userState.themeConfig ?? 'light',
-    'currentTheme',
-  )
-  return currentTheme === 'light' ? darkColorThemeCssVariables : colorThemeCssVariables
+export function getPreferredColorScheme(): Theme {
+  if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    return 'dark'
+  } else {
+    return 'light'
+  }
 }
 
 export { colorTheme, UtopiaStyles, UtopiaTheme } from './utopia-theme'


### PR DESCRIPTION
NOTE: This PR depends on a previous PR - https://github.com/concrete-utopia/utopia/pull/2947

**Problem:**
Users could choose "Light" or "Dark" themes, for the editor, but there was no setting for their system's preferred theme.

**Fix:**
Added "System" theme option, sets the theme based on the user's current system setting (dark/light)

**Commit Details:**
- Added "System" option in theme dropdown
- Added `ThemeSetting` type to differentiate between the theme setting and the actual current theme
- Modified `getCurrentTheme` to return the actual current theme based on the theme setting and the current system setting
- Modified `ColorThemeComponent` to use system setting correctly

https://user-images.githubusercontent.com/5056789/205116688-15c68917-3547-4473-940c-987fb86159d6.mov


