### PR TITLE
Bugs 

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -606,7 +606,9 @@ export function updateFramesOfScenesAndComponents(
         parentFrame = optionalParentFrame
       }
       const parentOffset =
-        parentFrame == null
+        parentFrame == null ||
+        Math.abs(parentFrame.x) === Infinity ||
+        Math.abs(parentFrame.y) === Infinity
           ? ({ x: 0, y: 0 } as CanvasPoint)
           : ({ x: parentFrame.x, y: parentFrame.y } as CanvasPoint)
 

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -18,8 +18,6 @@ import {
 } from '../../core/layout/layout-helpers-new'
 import {
   maybeSwitchLayoutProps,
-  PinningAndFlexPoints,
-  PinningAndFlexPointsExceptSize,
   roundJSXElementLayoutValues,
   roundAttributeLayoutValues,
 } from '../../core/layout/layout-utils'
@@ -795,24 +793,12 @@ export function updateFramesOfScenesAndComponents(
     }
 
     if (propsToSet.length > 0 || propsToUnset.length > 0) {
-      const propsToNotDelete = [...propsToSet.map((p) => p.path), ...propsToSkip]
-
       workingEditorState = modifyUnderlyingForOpenFile(
         originalTarget,
         workingEditorState,
         (elem) => {
           // Remove the pinning and flex props first...
-          const propsToMaybeRemove: Array<LayoutPinnedProp | 'flexBasis'> =
-            frameAndTarget.type === 'PIN_MOVE_CHANGE'
-              ? PinningAndFlexPointsExceptSize // for PIN_MOVE_CHANGE, we don't want to remove the size props, we just keep them intact
-              : PinningAndFlexPoints
           let propsToRemove: Array<PropertyPath> = [...propsToUnset]
-          fastForEach(propsToMaybeRemove, (prop) => {
-            const propPath = stylePropPathMappingFn(prop, ['style'])
-            if (!PP.contains(propsToNotDelete, propPath)) {
-              propsToRemove.push(propPath)
-            }
-          })
           const layoutPropsRemoved = unsetJSXValuesAtPaths(elem.props, propsToRemove)
           // ...Add in the updated properties.
 

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -604,9 +604,7 @@ export function updateFramesOfScenesAndComponents(
         parentFrame = optionalParentFrame
       }
       const parentOffset =
-        parentFrame == null ||
-        Math.abs(parentFrame.x) === Infinity ||
-        Math.abs(parentFrame.y) === Infinity
+        parentFrame == null || EP.isStoryboardChild(originalTarget)
           ? ({ x: 0, y: 0 } as CanvasPoint)
           : ({ x: parentFrame.x, y: parentFrame.y } as CanvasPoint)
 

--- a/editor/src/core/layout/layout-utils.ts
+++ b/editor/src/core/layout/layout-utils.ts
@@ -284,16 +284,6 @@ function getLayoutFunction(
   }
 }
 
-export const PinningAndFlexPoints: Array<LayoutPinnedProp | 'flexBasis'> = [
-  ...LayoutPinnedProps,
-  // 'flexBasis',
-]
-
-export const PinningAndFlexPointsExceptSize: Array<LayoutPinnedProp | 'flexBasis'> = [
-  ...LayoutPinnedProps.filter((p) => p !== 'width' && p !== 'height'),
-  // 'flexBasis',
-]
-
 function keepLayoutProps(
   target: ElementPath,
   newParentPath: ElementPath,

--- a/editor/src/core/layout/layout-utils.ts
+++ b/editor/src/core/layout/layout-utils.ts
@@ -286,12 +286,12 @@ function getLayoutFunction(
 
 export const PinningAndFlexPoints: Array<LayoutPinnedProp | 'flexBasis'> = [
   ...LayoutPinnedProps,
-  'flexBasis',
+  // 'flexBasis',
 ]
 
 export const PinningAndFlexPointsExceptSize: Array<LayoutPinnedProp | 'flexBasis'> = [
   ...LayoutPinnedProps.filter((p) => p !== 'width' && p !== 'height'),
-  'flexBasis',
+  // 'flexBasis',
 ]
 
 function keepLayoutProps(


### PR DESCRIPTION
## Problems:
When setting the layout system to `flex`...
1. `flexBasis` values are applied
2. `top`/`left` values are set to `infinity` when the element has no parent

## Fix:
1. Remove setting `flexBasis`
2. Check if the parent's frame contain `Infinity` values, and use a fallback frame if they do

## `TODO`
- [ ] Tests
