### PR TITLE
eye dropper

### DIFF
--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -86,7 +86,7 @@ import {
   TOGGLE_FOCUSED_OMNIBOX_TAB,
   FOCUS_CLASS_NAME_INPUT,
   INSERT_DIV_SHORTCUT,
-  OPEN_EYEDROPPPER,
+  OPEN_EYEDROPPPER as OPEN_EYEDROPPER,
 } from './shortcut-definitions'
 import { DerivedState, EditorState, getOpenFile, RightMenuTab } from './store/editor-state'
 import { CanvasMousePositionRaw, WindowMousePositionRaw } from '../../utils/global-positions'
@@ -642,7 +642,7 @@ export function handleKeyDown(
           return []
         }
       },
-      [OPEN_EYEDROPPPER]: () => {
+      [OPEN_EYEDROPPER]: () => {
         const selectedViews = editor.selectedViews
         if (selectedViews.length === 0) {
           return []

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -647,6 +647,10 @@ export function handleKeyDown(
         if (selectedElement == null) {
           return []
         }
+        if ((window as any).EyeDropper == null) {
+          return []
+        }
+
         ;(new (window as any).EyeDropper() as any).open().then((result: any) => {
           dispatch([
             EditorActions.setProperty(

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -643,8 +643,8 @@ export function handleKeyDown(
         }
       },
       [OPEN_EYEDROPPPER]: () => {
-        const selectedElement = editor.selectedViews.at(0)
-        if (selectedElement == null) {
+        const selectedViews = editor.selectedViews
+        if (selectedViews.length === 0) {
           return []
         }
         const EyeDropper = window.EyeDropper
@@ -653,13 +653,15 @@ export function handleKeyDown(
         }
 
         void new EyeDropper().open().then((result: any) => {
-          dispatch([
-            EditorActions.setProperty(
-              selectedElement,
-              PP.create(['style', 'backgroundColor']),
-              jsxAttributeValue(result.sRGBHex as string, emptyComments),
+          dispatch(
+            selectedViews.map((view) =>
+              EditorActions.setProperty(
+                view,
+                PP.create(['style', 'backgroundColor']),
+                jsxAttributeValue(result.sRGBHex as string, emptyComments),
+              ),
             ),
-          ])
+          )
         })
         return []
       },

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -647,11 +647,12 @@ export function handleKeyDown(
         if (selectedElement == null) {
           return []
         }
-        if ((window as any).EyeDropper == null) {
+        const EyeDropper = window.EyeDropper
+        if (EyeDropper == null) {
           return []
         }
 
-        ;(new (window as any).EyeDropper() as any).open().then((result: any) => {
+        void new EyeDropper().open().then((result: any) => {
           dispatch([
             EditorActions.setProperty(
               selectedElement,

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -86,6 +86,7 @@ import {
   TOGGLE_FOCUSED_OMNIBOX_TAB,
   FOCUS_CLASS_NAME_INPUT,
   INSERT_DIV_SHORTCUT,
+  OPEN_EYEDROPPPER,
 } from './shortcut-definitions'
 import { DerivedState, EditorState, getOpenFile, RightMenuTab } from './store/editor-state'
 import { CanvasMousePositionRaw, WindowMousePositionRaw } from '../../utils/global-positions'
@@ -95,6 +96,7 @@ import {
   boundingArea,
   createHoverInteractionViaMouse,
 } from '../canvas/canvas-strategies/interaction-state'
+import { emptyComments, jsxAttributeValue } from '../../core/shared/element-template'
 
 function updateKeysPressed(
   keysPressed: KeysPressed,
@@ -639,6 +641,22 @@ export function handleKeyDown(
         } else {
           return []
         }
+      },
+      [OPEN_EYEDROPPPER]: () => {
+        const selectedElement = editor.selectedViews.at(0)
+        if (selectedElement == null) {
+          return []
+        }
+        ;(new (window as any).EyeDropper() as any).open().then((result: any) => {
+          dispatch([
+            EditorActions.setProperty(
+              selectedElement,
+              PP.create(['style', 'backgroundColor']),
+              jsxAttributeValue(result.sRGBHex as string, emptyComments),
+            ),
+          ])
+        })
+        return []
       },
     })
   }

--- a/editor/src/components/editor/shortcut-definitions.ts
+++ b/editor/src/components/editor/shortcut-definitions.ts
@@ -73,6 +73,8 @@ export const TOGGLE_CODE_EDITOR_SHORTCUT = 'toggle-code-editor'
 export const TOGGLE_INSPECTOR_AND_LEFT_MENU_SHORTCUT = 'toggle-inspector-and-left-menu'
 export const CONVERT_ELEMENT_SHORTCUT = 'convert-element'
 
+export const OPEN_EYEDROPPPER = 'open-eyedropper'
+
 export type ShortcutDetails = { [key: string]: Shortcut }
 
 const shortcutDetailsWithDefaults: ShortcutDetails = {
@@ -210,6 +212,7 @@ const shortcutDetailsWithDefaults: ShortcutDetails = {
   ),
   [CONVERT_ELEMENT_SHORTCUT]: shortcut('Convert selected element to...', key('c', [])),
   [ADD_ELEMENT_SHORTCUT]: shortcut('Add element...', key('a', [])),
+  [OPEN_EYEDROPPPER]: shortcut('Open the eyedropper', key('c', 'ctrl')),
 }
 
 export type ShortcutConfiguration = { [key: string]: Array<Key> }

--- a/editor/src/components/editor/shortcuts.spec.browser2.tsx
+++ b/editor/src/components/editor/shortcuts.spec.browser2.tsx
@@ -1,0 +1,86 @@
+import { ctrlModifier } from '../../utils/modifiers'
+import { wait } from '../../utils/utils.test-utils'
+import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
+import { keyDown, mouseClickAtPoint } from '../canvas/event-helpers.test-utils'
+import { renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
+
+const TestIdOne = 'one'
+const TestIdTwo = 'two'
+const backgroundColor = '#384C5CAB'
+
+// for some reason, ctrl + c does not trigger the eyedropper in tests
+// maybe for security since the event is programmatically triggered?
+xdescribe('shortcuts', () => {
+  describe('eyedropper', () => {
+    it('use eyedropper to set background color', async () => {
+      const editor = await renderTestEditorWithCode(project, 'await-first-dom-report')
+
+      const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
+      const div = editor.renderedDOM.getByTestId(TestIdOne)
+      const divBounds = div.getBoundingClientRect()
+      const divCorner = {
+        x: divBounds.x + 50,
+        y: divBounds.y + 40,
+      }
+
+      mouseClickAtPoint(canvasControlsLayer, divCorner)
+
+      expect(editor.getEditorState().editor.selectedViews.length).toEqual(1)
+
+      await wait(5000)
+
+      keyDown('c', { modifiers: ctrlModifier })
+
+      await wait(5000)
+
+      const div2 = editor.renderedDOM.getByTestId(TestIdTwo)
+      const div2Bounds = div2.getBoundingClientRect()
+      const div2Corner = {
+        x: div2Bounds.x + 50,
+        y: div2Bounds.y + 40,
+      }
+
+      mouseClickAtPoint(canvasControlsLayer, div2Corner)
+
+      await editor.getDispatchFollowUpActionsFinished()
+
+      await wait(10000)
+
+      //   expect(div.style.backgroundColor).toEqual(backgroundColor)
+      expect(div2.style.backgroundColor).toEqual(backgroundColor)
+    })
+  })
+})
+
+const project = `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+    export var storyboard = (
+  <Storyboard data-uid='0cd'>
+    <div
+      data-testid='${TestIdOne}'
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 67,
+        top: 128,
+        width: 161,
+        height: 171,
+      }}
+      data-uid='e6b'
+    />
+    <div
+      data-testid='${TestIdTwo}'
+      style={{
+        backgroundColor: '${backgroundColor}',
+        position: 'absolute',
+        left: 183,
+        top: 350,
+        width: 173,
+        height: 222,
+      }}
+      data-uid='ecf'
+    />
+  </Storyboard>
+)
+`

--- a/editor/src/missing-types/eyedropper.d.ts
+++ b/editor/src/missing-types/eyedropper.d.ts
@@ -1,0 +1,19 @@
+interface EyeDropperConstructor {
+  new (): EyeDropper
+}
+
+interface ColorSelectionOptions {
+  signal: AbortSignal
+}
+
+interface ColorSelectionResult {
+  sRGBHex: string
+}
+
+interface EyeDropper extends EyeDropperConstructor {
+  open: (options?: ColorSelectionOptions = {}) => Promise<ColorSelectionResult>
+}
+
+interface Window {
+  EyeDropper: EyeDropper | undefined
+}

--- a/editor/src/utils/modifiers.ts
+++ b/editor/src/utils/modifiers.ts
@@ -14,6 +14,13 @@ export const emptyModifiers: Modifiers = optionalDeepFreeze({
   shift: false,
 })
 
+export const ctrlModifier: Modifiers = {
+  alt: false,
+  cmd: false,
+  ctrl: true,
+  shift: false,
+}
+
 export const shiftModifier: Modifiers = {
   alt: false,
   cmd: false,


### PR DESCRIPTION
## Problem
Background colors can only be picked via the color picker

## Fix
Use the [Eyedropper API](https://developer.mozilla.org/en-US/docs/Web/API/EyeDropper_API) to make picking a background color easier.

If there are one or more elements selected, the color picker can be opened by pressing `ctrl + C` (same as in Sketch). Once a color has been picked, it is set as the `backgroundColor` prop of all selected elements. The interaction can be aborted with `Esc`.

[Demo](https://screenshot.click/hack.mp4)