### PR TITLE
ux(github) - only show github settings to logged-in users

### DIFF
--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -14,6 +14,7 @@ import {
   updateProjectWithBranchContent,
   useGithubFileChanges,
 } from '../../../../core/shared/github'
+import { User } from '../../../../uuiui-deps'
 import { startGithubAuthentication } from '../../../../utils/github-auth'
 import { unless, when } from '../../../../utils/react-conditionals'
 import {
@@ -27,6 +28,7 @@ import {
   SectionTitleRow,
   StringInput,
   Title,
+  UtopiaTheme,
 } from '../../../../uuiui'
 import * as EditorActions from '../../../editor/actions/action-creators'
 import {
@@ -949,10 +951,12 @@ const PullRequestBlock = () => {
 }
 
 export const GithubPane = React.memo(() => {
-  const githubUser = useEditorState(
-    (store) => store.editor.githubData.githubUserDetails,
-    'Github user details',
-  )
+  const { isLoggedIn, githubUser } = useEditorState((store) => {
+    return {
+      isLoggedIn: User.isLoggedIn(store.userState.loginState),
+      githubUser: store.editor.githubData.githubUserDetails,
+    }
+  }, 'Github user details')
   const openGithubProfile = React.useCallback(() => {
     if (githubUser != null) {
       window.open(githubUser.htmlURL, '_blank')
@@ -981,17 +985,31 @@ export const GithubPane = React.memo(() => {
             </Button>,
           )}
         </SectionTitleRow>
+        {unless(
+          isLoggedIn,
+          <FlexRow
+            style={{
+              paddingLeft: UtopiaTheme.layout.rowHorizontalPadding,
+              paddingRight: UtopiaTheme.layout.rowHorizontalPadding,
+            }}
+          >
+            <p>You need to be signed into Utopia to use the Github integration</p>
+          </FlexRow>,
+        )}
       </Section>
-      <Section style={{ padding: '10px' }}>
-        <AccountBlock />
-        <RepositoryBlock />
-        <BranchBlock />
-        <BranchNotLoadedBlock />
-        <RemoteChangesBlock />
-        <LocalChangesBlock />
-        <PullRequestBlock />
-        <PullRequestButton />
-      </Section>
+      {when(
+        isLoggedIn,
+        <Section style={{ padding: '10px' }}>
+          <AccountBlock />
+          <RepositoryBlock />
+          <BranchBlock />
+          <BranchNotLoadedBlock />
+          <RemoteChangesBlock />
+          <LocalChangesBlock />
+          <PullRequestBlock />
+          <PullRequestButton />
+        </Section>,
+      )}
     </>
   )
 })

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -951,12 +951,14 @@ const PullRequestBlock = () => {
 }
 
 export const GithubPane = React.memo(() => {
-  const { isLoggedIn, githubUser } = useEditorState((store) => {
-    return {
-      isLoggedIn: User.isLoggedIn(store.userState.loginState),
-      githubUser: store.editor.githubData.githubUserDetails,
-    }
-  }, 'Github user details')
+  const githubUser = useEditorState(
+    (store) => store.editor.githubData.githubUserDetails,
+    'GithubPane githubUser',
+  )
+  const isLoggedIn = useEditorState((store) => {
+    return User.isLoggedIn(store.userState.loginState)
+  }, 'GithubPane isLoggedIn')
+
   const openGithubProfile = React.useCallback(() => {
     if (githubUser != null) {
       window.open(githubUser.htmlURL, '_blank')

--- a/editor/src/components/navigator/left-pane/logged-out-pane.tsx
+++ b/editor/src/components/navigator/left-pane/logged-out-pane.tsx
@@ -18,7 +18,7 @@ import { UIGridRow } from '../../inspector/widgets/ui-grid-row'
 export const LoggedOutPane = React.memo(() => {
   return (
     <Section data-name='Storyboards' tabIndex={-1}>
-      <SectionTitleRow minimised={false}>
+      <SectionTitleRow minimised={false} hideButton>
         <FlexRow flexGrow={1} style={{ position: 'relative' }}>
           <Title>Sign in to</Title>
         </FlexRow>
@@ -46,6 +46,7 @@ export const LoggedOutPane = React.memo(() => {
             <li>Design and code from anywhere</li>
             <li>Save and preview your projects</li>
             <li>Use custom assets, fonts, and more</li>
+            <li>Load and save projects on Github</li>
           </ul>
         </UIGridRow>
         <UIGridRow style={{ gap: 8 }} padded variant='<--1fr--><--1fr-->'>


### PR DESCRIPTION
**Problem:**
- We show non-authenticated users the github pane with the "sign up" CTA - but if you're not signed up, you can't then authorise github to load/save projects. And we don't inform you of that limitation.

**Fix:**
- Only show the contents of the github pane if you're authenticated with Utopia already

**Notes:**
This is a quick fix, not a systemic one integrating the authentication systems.