### PR TITLE
ux(title bar) - disappearing sign-in button, projects page navigation

### DIFF
--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -180,11 +180,21 @@ const TitleBar = React.memo(() => {
       <div style={{ flex: '0 0 0px', paddingRight: 8 }}>
         {unless(
           loggedIn,
-          <Button primary style={{ paddingLeft: 8, paddingRight: 8 }} onClick={onClickLoginNewTab}>
+          <Button
+            primary
+            highlight
+            style={{ paddingLeft: 8, paddingRight: 8 }}
+            onClick={onClickLoginNewTab}
+          >
             Sign In To Save
           </Button>,
         )}
-        {when(loggedIn, <Avatar userPicture={userPicture} isLoggedIn={loggedIn} />)}
+        {when(
+          loggedIn,
+          <a href='/projects'>
+            <Avatar userPicture={userPicture} isLoggedIn={loggedIn} />
+          </a>,
+        )}
       </div>
     </SimpleFlexRow>
   )


### PR DESCRIPTION
**Problem:**
The Title Bar has a couple of usability issues:
- The sign-in button in the title bar "disappears" on hover
- You can't navigate back to the `/projects` page

**Fix:**
- Use the right invocation chant to prohibit the sign-in button returning to its ethereal, translucent form
- Make the avatar a link to `/projects` and hope our saved-state detection is good enough. Maybe this should just open in a new tab tho?