### PR TITLE
Perf: Bail out from unapplicable strategies as early as possible

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
@@ -74,6 +74,9 @@ export const dragToInsertMetaStrategy: MetaCanvasStrategy = (
   const { interactionData } = interactionSession
 
   const insertionSubjects = getInsertionSubjectsFromInteractionTarget(canvasState.interactionTarget)
+  if (insertionSubjects.length === 0) {
+    return []
+  }
 
   const pointOnCanvas =
     interactionData.type === 'DRAG'

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -72,6 +72,12 @@ export const drawToInsertMetaStrategy: MetaCanvasStrategy = (
   ) {
     return []
   }
+
+  const insertionSubjects = getInsertionSubjectsFromInteractionTarget(canvasState.interactionTarget)
+  if (insertionSubjects.length != 1) {
+    return []
+  }
+
   const pointOnCanvas =
     interactionSession.interactionData.type === 'DRAG'
       ? interactionSession.interactionData.originalDragStart

--- a/editor/src/components/canvas/canvas-strategies/strategies/reorder-slider-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reorder-slider-strategy.tsx
@@ -22,6 +22,7 @@ import {
 } from './flow-reorder-helpers'
 import { InteractionSession } from '../interaction-state'
 import { isReorderAllowed } from './reorder-utils'
+import { onlyFitWhenDraggingThisControl } from '../canvas-strategies'
 
 export function reorderSliderStategy(
   canvasState: InteractionCanvasState,
@@ -59,12 +60,8 @@ export function reorderSliderStategy(
         show: 'always-visible',
       }),
     ],
-    fitness:
-      interactionSession != null &&
-      interactionSession.interactionData.type === 'DRAG' &&
-      interactionSession.activeControl.type === 'REORDER_SLIDER'
-        ? 100
-        : 0,
+    fitness: onlyFitWhenDraggingThisControl(interactionSession, 'REORDER_SLIDER', 100),
+
     apply: () => {
       if (
         interactionSession != null &&


### PR DESCRIPTION
## Problem:
Canvas performance has room to improve

## Fix:
In the drag-to-insert and draw-to-insert strategies, add a check for the number of insertion subjects, and if there are none, bail out.

**Commit Details:**
- Renamed `thing` to `otherThing`
- Removed `cake` from `fridge-contents.ts`
- Did [other things]
