### PR TITLE
Improve `foldAndApplyCommands`.

### DIFF
--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -247,11 +247,28 @@ export function foldAndApplyCommands(
     commandLifecycle,
   )
 
+  const priorPatchedStateWithCurrentSpyValues: EditorState = {
+    ...priorPatchedState,
+
+    // List of parts of the editor state that we already know changed from the last frame, and are not usually affected by Commands
+    _currentAllElementProps_KILLME: editorState._currentAllElementProps_KILLME,
+    jsxMetadata: editorState.jsxMetadata,
+    domMetadata: editorState.domMetadata,
+    spyMetadata: editorState.spyMetadata,
+    canvas: {
+      ...priorPatchedState.canvas,
+      interactionSession: editorState.canvas.interactionSession,
+    },
+  }
+
   let workingEditorState = updatedEditorState
   if (statePatches.length === 0) {
     workingEditorState = editorState
   } else {
-    workingEditorState = EditorStateKeepDeepEquality(priorPatchedState, workingEditorState).value
+    workingEditorState = EditorStateKeepDeepEquality(
+      priorPatchedStateWithCurrentSpyValues,
+      workingEditorState,
+    ).value
   }
 
   return {

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -359,6 +359,7 @@ import {
 } from '../../canvas/canvas-strategies/interaction-state'
 import { Modifiers } from '../../../utils/modifiers'
 import {
+  CanvasFrameAndTarget,
   CSSCursor,
   DragState,
   edgePosition,
@@ -1116,27 +1117,28 @@ function RectangleKeepDeepEquality<C extends CoordinateMarker>(
   }
 }
 
-export const CanvasRectangleKeepDeepEquality: (
-  oldValue: CanvasRectangle,
-  newValue: CanvasRectangle,
-) => KeepDeepEqualityResult<CanvasRectangle> = RectangleKeepDeepEquality
+export const CanvasRectangleKeepDeepEquality: KeepDeepEqualityCall<CanvasRectangle> =
+  RectangleKeepDeepEquality
 
-export function FrameAndTargetKeepDeepEquality<C extends CoordinateMarker>(
-  oldFrameAndTarget: FrameAndTarget<C>,
-  newFrameAndTarget: FrameAndTarget<C>,
-): KeepDeepEqualityResult<FrameAndTarget<C>> {
-  if (
-    nullableDeepEquality(RectangleKeepDeepEquality)(
-      oldFrameAndTarget.frame,
-      newFrameAndTarget.frame,
-    ).areEqual &&
-    ElementPathKeepDeepEquality(oldFrameAndTarget.target, newFrameAndTarget.target).areEqual
-  ) {
-    return keepDeepEqualityResult(oldFrameAndTarget, true)
-  } else {
-    return keepDeepEqualityResult(newFrameAndTarget, false)
-  }
+export function FrameAndTargetKeepDeepEqualityCall<
+  C extends CoordinateMarker,
+>(): KeepDeepEqualityCall<FrameAndTarget<C>> {
+  return combine2EqualityCalls(
+    (frameAndTarget) => frameAndTarget.frame,
+    RectangleKeepDeepEquality,
+    (frameAndTarget) => frameAndTarget.target,
+    ElementPathKeepDeepEquality,
+    (frame, target) => {
+      return {
+        frame: frame,
+        target: target,
+      }
+    },
+  )
 }
+
+export const CanvasFrameAndTargetKeepDeepEquality: KeepDeepEqualityCall<CanvasFrameAndTarget> =
+  FrameAndTargetKeepDeepEqualityCall<CanvasRectangle>()
 
 export function LocalRectangleKeepDeepEquality(
   oldRect: LocalRectangle,
@@ -1614,7 +1616,7 @@ export const EditorStateCanvasControlsKeepDeepEquality: KeepDeepEqualityCall<Edi
     (controls) => controls.outlineHighlights,
     arrayDeepEquality(CanvasRectangleKeepDeepEquality),
     (controls) => controls.strategyIntendedBounds,
-    arrayDeepEquality(FrameAndTargetKeepDeepEquality),
+    arrayDeepEquality(CanvasFrameAndTargetKeepDeepEquality),
     (controls) => controls.flexReparentTargetLines,
     arrayDeepEquality(CanvasRectangleKeepDeepEquality),
     (controls) => controls.parentHighlightPaths,
@@ -2455,21 +2457,8 @@ export function ProjectContentTreeRootKeepDeepEquality(): KeepDeepEqualityCall<P
   return objectDeepEquality(ProjectContentsTreeKeepDeepEquality())
 }
 
-const FileChecksumsKeepDeepEquality: KeepDeepEqualityCall<FileChecksums | null> = (
-  oldAttribute,
-  newAttribute,
-) => {
-  if (oldAttribute == null && newAttribute == null) {
-    return keepDeepEqualityResult(oldAttribute, true)
-  }
-  if (oldAttribute == null) {
-    return keepDeepEqualityResult(newAttribute, false)
-  }
-  if (newAttribute == null) {
-    return keepDeepEqualityResult(oldAttribute, false)
-  }
-  return objectDeepEquality(StringKeepDeepEquality)(oldAttribute, newAttribute)
-}
+export const FileChecksumsKeepDeepEquality: KeepDeepEqualityCall<FileChecksums | null> =
+  nullableDeepEquality(objectDeepEquality(StringKeepDeepEquality))
 
 export const DetailedTypeInfoMemberInfoKeepDeepEquality: KeepDeepEqualityCall<DetailedTypeInfoMemberInfo> =
   combine2EqualityCalls(
@@ -3313,6 +3302,9 @@ export const GithubDataKeepDeepEquality: KeepDeepEqualityCall<GithubData> = comb
   emptyGithubData,
 )
 
+export const AllElementPropsKeepDeepEquality: KeepDeepEqualityCall<AllElementProps> =
+  objectDeepEquality(objectDeepEquality(createCallFromIntrospectiveKeepDeep()))
+
 export const GithubOperationKeepDeepEquality: KeepDeepEqualityCall<GithubOperation> = (
   oldValue,
   newValue,
@@ -3543,15 +3535,14 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     oldValue.forceParseFiles,
     newValue.forceParseFiles,
   )
-  const allElementPropsResults = createCallFromIntrospectiveKeepDeep<AllElementProps>()(
+  const allElementPropsResults = AllElementPropsKeepDeepEquality(
     oldValue.allElementProps,
     newValue.allElementProps,
   )
-  const _currentAllElementProps_KILLME_Results =
-    createCallFromIntrospectiveKeepDeep<AllElementProps>()(
-      oldValue._currentAllElementProps_KILLME,
-      newValue._currentAllElementProps_KILLME,
-    )
+  const _currentAllElementProps_KILLME_Results = AllElementPropsKeepDeepEquality(
+    oldValue._currentAllElementProps_KILLME,
+    newValue._currentAllElementProps_KILLME,
+  )
   const githubSettingsResults = ProjectGithubSettingsKeepDeepEquality(
     oldValue.githubSettings,
     newValue.githubSettings,

--- a/editor/src/utils/react-performance.ts
+++ b/editor/src/utils/react-performance.ts
@@ -217,7 +217,7 @@ function keepDeepReferenceEqualityInner(
   possibleNewValue: any,
   stackSizeInner: number,
   valueStackSoFar: Set<any>,
-) {
+): any {
   if (oldValue === possibleNewValue) return oldValue
 
   if (stackSizeInner > 100) {


### PR DESCRIPTION
**Problem:**
Each time we call `foldAndApplyCommands` there's a high cost of maintaining the deep equality, which mostly relates to the big collections of element props. The cost is linear to the complexity of the project, so larger projects suffer even more than smaller ones.

**Fix:**
Primarily this change sidesteps the costs of maintaining equality of several fields by using the new values so that the deep equality check passes over those values. Since they are always going to be updated each frame, the result should be almost the same, but saves around 5ms.

There are also some minor tweaks that should make the deep equality slightly better when it does get run for those fields but also for types like `FrameAndTarget`.

**Commit Details:**
- In `foldAndApplyCommands`, since we know that a subset of fields will always change, there's no benefit in attempting to maintain the deep reference equality for those fields. Especially when the cost of doing so is potentially quite high, like when comparing several hundred values in an object.
- Fixed `FrameAndTargetKeepDeepEquality` to maintain referential equality for other fields if any of the rest have changed. Previously any change to any field would cause it to return the entire new value.
- Simplified `FileChecksumsKeepDeepEquality` to use our existing combinators.
- Added `AllElementPropsKeepDeepEquality` and used it in the fields where appropriate.
