### PR TITLE
Fix/canvas reparent more tests, fix bug with flex in flex layouts 

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../../../core/model/scene-utils'
 import { mouseClickAtPoint, mouseDragFromPointWithDelta } from '../../event-helpers.test-utils'
 import * as EP from '../../../../core/shared/element-path'
+import { ExtraPadding } from './reparent-helpers/reparent-strategy-sibling-position-helpers'
 
 async function dragElement(
   renderResult: EditorRenderResult,
@@ -526,7 +527,7 @@ const complexProject = (flexDirection: 'row' | 'column' = 'row') => `
 </div>
 `
 
-const PaddingThreshold = 10 // ExtraPadding in drawTargetRectanglesForChildrenOfElement
+const PaddingThreshold = ExtraPadding(1)
 describe('Absolute Reparent To Flex Strategy with more complex flex layouts', () => {
   it('moving the element into a flex layout after the last child reparents to the end as a sibling', async () => {
     const renderResult = await renderTestEditorWithCode(

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
@@ -651,7 +651,7 @@ describe('Absolute Reparent To Flex Strategy with more complex flex layouts', ()
       'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/targetdiv',
     ])
   })
-  it('moving the element into a flex layout over a flex child with children will reparent to flex child near edge', async () => {
+  it('moving the element to the edge of a flex in flex layout will reparent to the outer flex container', async () => {
     // TODO THIS IS WRONG, IT SHOULD CHOSE THE OUTER FLEX DIV
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(complexProject('row')),
@@ -663,19 +663,18 @@ describe('Absolute Reparent To Flex Strategy with more complex flex layouts', ()
       x: absoluteChildRect.x + absoluteChildRect.width / 2,
       y: absoluteChildRect.y + absoluteChildRect.height / 2,
     }
-    const flexSibling = await renderResult.renderedDOM.findByTestId('innerchild1')
-    const flexSiblingRect = flexSibling.getBoundingClientRect()
-    const flexSiblingEnd = {
-      x: flexSiblingRect.x + flexSiblingRect.width - PaddingThreshold / 2,
-      y: flexSiblingRect.y + flexSiblingRect.height / 2,
+    const flexInnerChild = await renderResult.renderedDOM.findByTestId('innerchild1')
+    const flexInnerChildRect = flexInnerChild.getBoundingClientRect()
+    const flexInnerChildLeft = {
+      x: flexInnerChildRect.x + PaddingThreshold / 2,
+      y: flexInnerChildRect.y + flexInnerChildRect.height / 2,
     }
 
     const dragDelta = windowPoint({
-      x: flexSiblingEnd.x - absoluteChildCenter.x,
-      y: flexSiblingEnd.y - absoluteChildCenter.y,
+      x: flexInnerChildLeft.x - absoluteChildCenter.x,
+      y: flexInnerChildLeft.y - absoluteChildCenter.y,
     })
     await dragElement(renderResult, 'targetdiv', dragDelta, cmdModifier)
-
     await renderResult.getDispatchFollowUpActionsFinished()
 
     expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
@@ -687,13 +686,13 @@ describe('Absolute Reparent To Flex Strategy with more complex flex layouts', ()
       'utopia-storyboard-uid/scene-aaa/app-entity:container',
       'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer',
       'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex',
-      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild1',
       'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/targetdiv',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild1',
       'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild2',
       'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child2',
     ])
   })
-  it('moving the element to a flex layout to the middle of the flex child with children will reparent to flex grandchild', async () => {
+  it('moving the element to the center of a flex in flex layout will reparent to flex grandchild', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(complexProject('row')),
       'await-first-dom-report',
@@ -704,16 +703,16 @@ describe('Absolute Reparent To Flex Strategy with more complex flex layouts', ()
       x: absoluteChildRect.x + absoluteChildRect.width / 2,
       y: absoluteChildRect.y + absoluteChildRect.height / 2,
     }
-    const flexSibling = await renderResult.renderedDOM.findByTestId('innerchild1')
-    const flexSiblingRect = flexSibling.getBoundingClientRect()
-    const flexSiblingCenter = {
-      x: flexSiblingRect.x + flexSiblingRect.width / 2,
-      y: flexSiblingRect.y + flexSiblingRect.height / 2,
+    const flexInnerChild = await renderResult.renderedDOM.findByTestId('innerchild1')
+    const flexInnerChildRect = flexInnerChild.getBoundingClientRect()
+    const flexInnerChildCenter = {
+      x: flexInnerChildRect.x + flexInnerChildRect.width / 2,
+      y: flexInnerChildRect.y + flexInnerChildRect.height / 2,
     }
 
     const dragDelta = windowPoint({
-      x: flexSiblingCenter.x - absoluteChildCenter.x,
-      y: flexSiblingCenter.y - absoluteChildCenter.y,
+      x: flexInnerChildCenter.x - absoluteChildCenter.x,
+      y: flexInnerChildCenter.y - absoluteChildCenter.y,
     })
     await dragElement(renderResult, 'targetdiv', dragDelta, cmdModifier)
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
@@ -703,7 +703,7 @@ describe('Absolute Reparent To Flex Strategy with more complex flex layouts', ()
       x: absoluteChildRect.x + absoluteChildRect.width / 2,
       y: absoluteChildRect.y + absoluteChildRect.height / 2,
     }
-    const flexInnerChild = await renderResult.renderedDOM.findByTestId('innerchild1')
+    const flexInnerChild = await renderResult.renderedDOM.findByTestId('innerchild2')
     const flexInnerChildRect = flexInnerChild.getBoundingClientRect()
     const flexInnerChildCenter = {
       x: flexInnerChildRect.x + flexInnerChildRect.width / 2,
@@ -719,7 +719,7 @@ describe('Absolute Reparent To Flex Strategy with more complex flex layouts', ()
     await renderResult.getDispatchFollowUpActionsFinished()
 
     expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
-      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/targetdiv',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild2/targetdiv',
     ])
     expect(renderResult.getEditorState().derived.navigatorTargets.map(EP.toString)).toEqual([
       'utopia-storyboard-uid/scene-aaa',
@@ -728,8 +728,8 @@ describe('Absolute Reparent To Flex Strategy with more complex flex layouts', ()
       'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer',
       'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex',
       'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild1',
-      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/targetdiv',
       'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild2',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild2/targetdiv',
       'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child2',
     ])
   })

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
@@ -653,7 +653,6 @@ describe('Absolute Reparent To Flex Strategy with more complex flex layouts', ()
     ])
   })
   it('moving the element to the edge of a flex in flex layout will reparent to the outer flex container', async () => {
-    // TODO THIS IS WRONG, IT SHOULD CHOSE THE OUTER FLEX DIV
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(complexProject('row')),
       'await-first-dom-report',
@@ -679,15 +678,15 @@ describe('Absolute Reparent To Flex Strategy with more complex flex layouts', ()
     await renderResult.getDispatchFollowUpActionsFinished()
 
     expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
-      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/targetdiv',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/targetdiv',
     ])
     expect(renderResult.getEditorState().derived.navigatorTargets.map(EP.toString)).toEqual([
       'utopia-storyboard-uid/scene-aaa',
       'utopia-storyboard-uid/scene-aaa/app-entity',
       'utopia-storyboard-uid/scene-aaa/app-entity:container',
       'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/targetdiv',
       'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex',
-      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/targetdiv',
       'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild1',
       'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild2',
       'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child2',

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
@@ -14,6 +14,7 @@ import {
   BakedInStoryboardUID,
 } from '../../../../core/model/scene-utils'
 import { mouseClickAtPoint, mouseDragFromPointWithDelta } from '../../event-helpers.test-utils'
+import * as EP from '../../../../core/shared/element-path'
 
 async function dragElement(
   renderResult: EditorRenderResult,
@@ -453,5 +454,284 @@ describe('Absolute Reparent To Flex Strategy', () => {
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(defaultTestCode),
     )
+  })
+})
+
+const complexProject = (flexDirection: 'row' | 'column' = 'row') => `
+<div
+  style={{
+    width: '100%',
+    height: '100%',
+    position: 'relative',
+  }}
+  data-uid='container'
+>
+  <div
+    style={{
+      position: 'absolute',
+      display: 'flex',
+      flexDirection: '${flexDirection}',
+    }}
+    data-uid='flexcontainer'
+    data-testid='flexcontainer'
+  >
+    <div
+      style={{
+        backgroundColor: '#04FF00AB',
+        display: 'flex',
+        flexDirection: '${flexDirection}',
+      }}
+      data-uid='child1flex'
+      data-testid='child1flex'
+    >
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          width: 50,
+          height: 50,
+        }}
+        data-uid='innerchild1'
+        data-testid='innerchild1'
+      />
+      <div
+        style={{
+          backgroundColor: '#AA00FFAB',
+          width: 50,
+          height: 50,
+        }}
+        data-uid='innerchild2'
+        data-testid='innerchild2'
+      />
+    </div>
+    <div
+      style={{
+        backgroundColor: '#0D00FFAB',
+        width: 100,
+        height: 100,
+      }}
+      data-uid='child2'
+      data-testid='child2'
+    />
+  </div>
+  <div
+    style={{
+      backgroundColor: '#FF0033AB',
+      position: 'absolute',
+      width: 40,
+      height: 40,
+    }}
+    data-uid='targetdiv'
+    data-testid='targetdiv'
+  />
+</div>
+`
+
+const PaddingThreshold = 10 // ExtraPadding in drawTargetRectanglesForChildrenOfElement
+describe('Absolute Reparent To Flex Strategy with more complex flex layouts', () => {
+  it('moving the element into a flex layout after the last child reparents to the end as a sibling', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(complexProject('row')),
+      'await-first-dom-report',
+    )
+    const absoluteChild = await renderResult.renderedDOM.findByTestId('targetdiv')
+    const absoluteChildRect = absoluteChild.getBoundingClientRect()
+    const absoluteChildCenter = {
+      x: absoluteChildRect.x + absoluteChildRect.width / 2,
+      y: absoluteChildRect.y + absoluteChildRect.height / 2,
+    }
+    const flexParent = await renderResult.renderedDOM.findByTestId('flexcontainer')
+    const flexParentRect = flexParent.getBoundingClientRect()
+    const flexParentEnd = {
+      x: flexParentRect.x + flexParentRect.width - PaddingThreshold / 2,
+      y: flexParentRect.y + flexParentRect.height / 2,
+    }
+
+    const dragDelta = windowPoint({
+      x: flexParentEnd.x - absoluteChildCenter.x,
+      y: flexParentEnd.y - absoluteChildCenter.y,
+    })
+    await dragElement(renderResult, 'targetdiv', dragDelta, cmdModifier)
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/targetdiv',
+    ])
+    expect(renderResult.getEditorState().derived.navigatorTargets.map(EP.toString)).toEqual([
+      'utopia-storyboard-uid/scene-aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild1',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild2',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child2',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/targetdiv',
+    ])
+  })
+  it('moving the element into a flex layout to the middle of the last child reparents to the child', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(complexProject('row')),
+      'await-first-dom-report',
+    )
+    const absoluteChild = await renderResult.renderedDOM.findByTestId('targetdiv')
+    const absoluteChildRect = absoluteChild.getBoundingClientRect()
+    const absoluteChildCenter = {
+      x: absoluteChildRect.x + absoluteChildRect.width / 2,
+      y: absoluteChildRect.y + absoluteChildRect.height / 2,
+    }
+    const flexSibling = await renderResult.renderedDOM.findByTestId('child2')
+    const flexSiblingRect = flexSibling.getBoundingClientRect()
+    const flexSiblingCenter = {
+      x: flexSiblingRect.x + flexSiblingRect.width / 2,
+      y: flexSiblingRect.y + flexSiblingRect.height / 2,
+    }
+
+    const dragDelta = windowPoint({
+      x: flexSiblingCenter.x - absoluteChildCenter.x,
+      y: flexSiblingCenter.y - absoluteChildCenter.y,
+    })
+    await dragElement(renderResult, 'targetdiv', dragDelta, cmdModifier)
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child2/targetdiv',
+    ])
+    expect(renderResult.getEditorState().derived.navigatorTargets.map(EP.toString)).toEqual([
+      'utopia-storyboard-uid/scene-aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild1',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild2',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child2',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child2/targetdiv',
+    ])
+  })
+  it('moving the element into a flex layout to the edge of the last child reparents to the end as a sibling', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(complexProject('row')),
+      'await-first-dom-report',
+    )
+    const absoluteChild = await renderResult.renderedDOM.findByTestId('targetdiv')
+    const absoluteChildRect = absoluteChild.getBoundingClientRect()
+    const absoluteChildCenter = {
+      x: absoluteChildRect.x + absoluteChildRect.width / 2,
+      y: absoluteChildRect.y + absoluteChildRect.height / 2,
+    }
+    const flexSibling = await renderResult.renderedDOM.findByTestId('child2')
+    const flexSiblingRect = flexSibling.getBoundingClientRect()
+    const flexSiblingEnd = {
+      x: flexSiblingRect.x + flexSiblingRect.width - PaddingThreshold / 2,
+      y: flexSiblingRect.y + flexSiblingRect.height / 2,
+    }
+
+    const dragDelta = windowPoint({
+      x: flexSiblingEnd.x - absoluteChildCenter.x,
+      y: flexSiblingEnd.y - absoluteChildCenter.y,
+    })
+    await dragElement(renderResult, 'targetdiv', dragDelta, cmdModifier)
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/targetdiv',
+    ])
+    expect(renderResult.getEditorState().derived.navigatorTargets.map(EP.toString)).toEqual([
+      'utopia-storyboard-uid/scene-aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild1',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild2',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child2',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/targetdiv',
+    ])
+  })
+  it('moving the element into a flex layout over a flex child with children will reparent to flex child near edge', async () => {
+    // TODO THIS IS WRONG, IT SHOULD CHOSE THE OUTER FLEX DIV
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(complexProject('row')),
+      'await-first-dom-report',
+    )
+    const absoluteChild = await renderResult.renderedDOM.findByTestId('targetdiv')
+    const absoluteChildRect = absoluteChild.getBoundingClientRect()
+    const absoluteChildCenter = {
+      x: absoluteChildRect.x + absoluteChildRect.width / 2,
+      y: absoluteChildRect.y + absoluteChildRect.height / 2,
+    }
+    const flexSibling = await renderResult.renderedDOM.findByTestId('innerchild1')
+    const flexSiblingRect = flexSibling.getBoundingClientRect()
+    const flexSiblingEnd = {
+      x: flexSiblingRect.x + flexSiblingRect.width - PaddingThreshold / 2,
+      y: flexSiblingRect.y + flexSiblingRect.height / 2,
+    }
+
+    const dragDelta = windowPoint({
+      x: flexSiblingEnd.x - absoluteChildCenter.x,
+      y: flexSiblingEnd.y - absoluteChildCenter.y,
+    })
+    await dragElement(renderResult, 'targetdiv', dragDelta, cmdModifier)
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/targetdiv',
+    ])
+    expect(renderResult.getEditorState().derived.navigatorTargets.map(EP.toString)).toEqual([
+      'utopia-storyboard-uid/scene-aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild1',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/targetdiv',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild2',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child2',
+    ])
+  })
+  it('moving the element to a flex layout to the middle of the flex child with children will reparent to flex grandchild', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(complexProject('row')),
+      'await-first-dom-report',
+    )
+    const absoluteChild = await renderResult.renderedDOM.findByTestId('targetdiv')
+    const absoluteChildRect = absoluteChild.getBoundingClientRect()
+    const absoluteChildCenter = {
+      x: absoluteChildRect.x + absoluteChildRect.width / 2,
+      y: absoluteChildRect.y + absoluteChildRect.height / 2,
+    }
+    const flexSibling = await renderResult.renderedDOM.findByTestId('innerchild1')
+    const flexSiblingRect = flexSibling.getBoundingClientRect()
+    const flexSiblingCenter = {
+      x: flexSiblingRect.x + flexSiblingRect.width / 2,
+      y: flexSiblingRect.y + flexSiblingRect.height / 2,
+    }
+
+    const dragDelta = windowPoint({
+      x: flexSiblingCenter.x - absoluteChildCenter.x,
+      y: flexSiblingCenter.y - absoluteChildCenter.y,
+    })
+    await dragElement(renderResult, 'targetdiv', dragDelta, cmdModifier)
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/targetdiv',
+    ])
+    expect(renderResult.getEditorState().derived.navigatorTargets.map(EP.toString)).toEqual([
+      'utopia-storyboard-uid/scene-aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild1',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/targetdiv',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child1flex/innerchild2',
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/child2',
+    ])
   })
 })

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -241,7 +241,7 @@ function findParentByPaddedInsertionZone(
   validTargetparentsUnderPoint: ElementPath[],
   canvasScale: number,
   pointOnCanvas: CanvasPoint,
-) {
+): ReparentTarget | null {
   const singleAxisAutoLayoutContainersUnderPoint = mapDropNulls((element) => {
     const autolayoutDirection = singleAxisAutoLayoutContainerDirections(element, metadata)
     if (autolayoutDirection === 'non-single-axis-autolayout') {

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -242,7 +242,6 @@ function findParentByPaddedInsertionZone(
   canvasScale: number,
   pointOnCanvas: CanvasPoint,
 ) {
-  let targetParentWithPaddedInsertionZone: ReparentTarget | null = null
   const singleAxisAutoLayoutContainersUnderPoint = mapDropNulls((element) => {
     const autolayoutDirection = singleAxisAutoLayoutContainerDirections(element, metadata)
     if (autolayoutDirection === 'non-single-axis-autolayout') {
@@ -287,8 +286,8 @@ function findParentByPaddedInsertionZone(
     const targetUnderMouseIndex = foundTarget?.insertionIndex
 
     if (targetUnderMouseIndex != null) {
-      // we found a target!
-      targetParentWithPaddedInsertionZone = {
+      // we found a first good target parent, early return
+      return {
         shouldReparent: true,
         shouldReorder: true,
         newParent: singleAxisAutoLayoutContainer.path,
@@ -299,7 +298,7 @@ function findParentByPaddedInsertionZone(
       }
     }
   }
-  return targetParentWithPaddedInsertionZone
+  return null
 }
 
 function findParentUnderPointByArea(

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-sibling-position-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-sibling-position-helpers.ts
@@ -11,6 +11,7 @@ import {
 import { ElementPath } from '../../../../../core/shared/project-file-types'
 import { Direction, ForwardOrReverse } from '../../../../inspector/common/css-utils'
 
+export const ExtraPadding = (canvasScale: number): number => 10 / canvasScale
 export function drawTargetRectanglesForChildrenOfElement(
   metadata: ElementInstanceMetadataMap,
   singleAxisAutolayoutContainerPath: ElementPath,
@@ -19,8 +20,7 @@ export function drawTargetRectanglesForChildrenOfElement(
   simpleFlexDirection: Direction | null,
   forwardsOrBackwards: ForwardOrReverse | null,
 ): Array<{ rect: CanvasRectangle; insertionIndex: number }> {
-  const ExtraPadding = 10 / canvasScale
-
+  const extraPadding = ExtraPadding(canvasScale)
   const parentBounds = MetadataUtils.getFrameInCanvasCoords(
     singleAxisAutolayoutContainerPath,
     metadata,
@@ -95,12 +95,12 @@ export function drawTargetRectanglesForChildrenOfElement(
           insertionIndex: forwardsOrBackwards === 'forward' ? bounds.index : bounds.index + 1,
           rect: rectFromTwoPoints(
             {
-              [leftOrTop]: normalizedStart - ExtraPadding,
+              [leftOrTop]: normalizedStart - extraPadding,
               [leftOrTopComplement]: parentBounds[leftOrTopComplement],
             } as any as CanvasPoint, // TODO improve my type
             {
               [leftOrTop]: Math.min(
-                normalizedStart + ExtraPadding,
+                normalizedStart + extraPadding,
                 normalizedStart + bounds.size / 2,
               ),
               [leftOrTopComplement]:
@@ -112,11 +112,11 @@ export function drawTargetRectanglesForChildrenOfElement(
           insertionIndex: forwardsOrBackwards === 'forward' ? bounds.index + 1 : bounds.index,
           rect: rectFromTwoPoints(
             {
-              [leftOrTop]: Math.max(normalizedEnd - ExtraPadding, normalizedEnd - bounds.size / 2),
+              [leftOrTop]: Math.max(normalizedEnd - extraPadding, normalizedEnd - bounds.size / 2),
               [leftOrTopComplement]: parentBounds[leftOrTopComplement],
             } as any as CanvasPoint, // TODO improve my type
             {
-              [leftOrTop]: normalizedEnd + ExtraPadding,
+              [leftOrTop]: normalizedEnd + extraPadding,
               [leftOrTopComplement]:
                 parentBounds[leftOrTopComplement] + parentBounds[widthOrHeightComplement],
             } as any as CanvasPoint, // TODO improve my type


### PR DESCRIPTION
Tests for reparenting into flex in flex layout.

There is a bug with multiple flex reparent targets, the issue is that instead of the inner flex container the outer flex div should be the valid target. Fixing the issue in `findParentByPaddedInsertionZone`.

**Commit Details:**
- added tests to absolute to flex testcases
- fix parent target
