### PR TITLE
Nine-block control & inspector strategies POC

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -72,6 +72,7 @@ import { LayoutTargetableProp } from '../../core/layout/layout-helpers-new'
 import { BuildType } from '../../core/workers/common/worker-types'
 import { ProjectContentTreeRoot } from '../assets'
 import { GithubOperationType } from './actions/action-creators'
+import { CanvasCommand } from '../canvas/commands/commands'
 export { isLoggedIn, loggedInUser, notLoggedIn } from '../../common/user'
 export type { LoginState, UserDetails } from '../../common/user'
 
@@ -1068,6 +1069,10 @@ export interface SetImageDragSessionState {
   action: 'SET_IMAGE_DRAG_SESSION_STATE'
   imageDragSessionState: ImageDragSessionState
 }
+export interface ApplyCommandsAction {
+  action: 'APPLY_COMMANDS'
+  commands: CanvasCommand[]
+}
 
 export type EditorAction =
   | ClearSelection
@@ -1242,6 +1247,7 @@ export type EditorAction =
   | UpdateBranchContents
   | SetRefreshingDependencies
   | SetAssetChecksum
+  | ApplyCommandsAction
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -1695,6 +1695,6 @@ export function setImageDragSessionState(
 export function applyCommandsAction(commands: CanvasCommand[]): ApplyCommandsAction {
   return {
     action: 'APPLY_COMMANDS',
-    commands,
+    commands: commands,
   }
 }

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -38,6 +38,7 @@ import type { CSSCursor } from '../../../uuiui-deps'
 import { ProjectContentTreeRoot } from '../../assets'
 import CanvasActions from '../../canvas/canvas-actions'
 import type { PinOrFlexFrameChange, SelectionLocked } from '../../canvas/canvas-types'
+import { CanvasCommand } from '../../canvas/commands/commands'
 import type { EditorPane, EditorPanel } from '../../common/actions'
 import { Notice } from '../../common/notice'
 import type { CodeResultCache, PropertyControlsInfo } from '../../custom-code/code-file'
@@ -221,6 +222,7 @@ import type {
   SetHoveredView,
   ClearHoveredViews,
   SetAssetChecksum,
+  ApplyCommandsAction,
 } from '../action-types'
 import { EditorModes, insertionSubject, Mode } from '../editor-modes'
 import type {
@@ -1687,5 +1689,12 @@ export function setImageDragSessionState(
   return {
     action: 'SET_IMAGE_DRAG_SESSION_STATE',
     imageDragSessionState: imageDragSessionState,
+  }
+}
+
+export function applyCommandsAction(commands: CanvasCommand[]): ApplyCommandsAction {
+  return {
+    action: 'APPLY_COMMANDS',
+    commands,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -188,6 +188,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'RUN_ESCAPE_HATCH':
     case 'SET_IMAGE_DRAG_SESSION_STATE':
     case 'UPDATE_AGAINST_GITHUB':
+    case 'APPLY_COMMANDS':
       return false
     case 'SAVE_ASSET':
       return (

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -5163,8 +5163,9 @@ export const UPDATE_FNS = {
       imageDragSessionState: action.imageDragSessionState,
     }
   },
-  APPLY_COMMANDS: (action: ApplyCommandsAction, editor: EditorModel): EditorModel =>
-    foldAndApplyCommandsSimple(editor, action.commands),
+  APPLY_COMMANDS: (action: ApplyCommandsAction, editor: EditorModel): EditorModel => {
+    return foldAndApplyCommandsSimple(editor, action.commands)
+  },
 }
 
 /** DO NOT USE outside of actions.ts, only exported for testing purposes */

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -314,6 +314,7 @@ import {
   SetHoveredView,
   ClearHoveredViews,
   SetAssetChecksum,
+  ApplyCommandsAction,
 } from '../action-types'
 import { defaultSceneElement, defaultTransparentViewElement } from '../defaults'
 import { EditorModes, isLiveMode, isSelectMode, Mode } from '../editor-modes'
@@ -5162,6 +5163,8 @@ export const UPDATE_FNS = {
       imageDragSessionState: action.imageDragSessionState,
     }
   },
+  APPLY_COMMANDS: (action: ApplyCommandsAction, editor: EditorModel): EditorModel =>
+    foldAndApplyCommandsSimple(editor, action.commands),
 }
 
 /** DO NOT USE outside of actions.ts, only exported for testing purposes */

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -372,6 +372,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.UPDATE_AGAINST_GITHUB(action, state)
     case 'SET_IMAGE_DRAG_SESSION_STATE':
       return UPDATE_FNS.SET_FILE_BROWSER_DRAG_STATE(action, state)
+    case 'APPLY_COMMANDS':
+      return UPDATE_FNS.APPLY_COMMANDS(action, state)
     default:
       return state
   }

--- a/editor/src/components/inspector/inspector-common.tsx
+++ b/editor/src/components/inspector/inspector-common.tsx
@@ -1,0 +1,66 @@
+import { MetadataUtils } from '../../core/model/element-metadata-utils'
+import { ElementInstanceMetadataMap } from '../../core/shared/element-template'
+import { ElementPath } from '../../core/shared/project-file-types'
+
+export type FlexJustifyContent =
+  | 'flex-start'
+  | 'center'
+  | 'flex-end'
+  | 'space-around'
+  | 'space-between'
+  | 'space-evenly'
+
+function getFlexJustifyContent(value: string | null): FlexJustifyContent | null {
+  switch (value) {
+    case 'flex-start':
+      return 'flex-start'
+    case 'center':
+      return 'center'
+    case 'flex-end':
+      return 'flex-end'
+    case 'space-around':
+      return 'space-around'
+    case 'space-between':
+      return 'space-between'
+    case 'space-evenly':
+      return 'space-evenly'
+    default:
+      return null
+  }
+}
+
+export type FlexAlignment = 'auto' | 'flex-start' | 'center' | 'flex-end' | 'stretch'
+
+function getFlexAlignment(value: string | null): FlexAlignment | null {
+  switch (value) {
+    case 'auto':
+      return 'auto'
+    case 'flex-start':
+      return 'flex-start'
+    case 'center':
+      return 'center'
+    case 'flex-end':
+      return 'flex-end'
+    case 'stretch':
+      return 'stretch'
+    default:
+      return null
+  }
+}
+
+export function detectFlexAlignJustifyContent(
+  metadata: ElementInstanceMetadataMap,
+  elementPath: ElementPath,
+): [FlexJustifyContent, FlexAlignment] {
+  const element = MetadataUtils.findElementByElementPath(metadata, elementPath)
+  if (element == null) {
+    return ['flex-start', 'flex-start']
+  }
+
+  const justifyContent: FlexJustifyContent =
+    getFlexJustifyContent(element.computedStyle?.['alignItems'] ?? null) ?? 'flex-start'
+  const flexAlignment: FlexAlignment =
+    getFlexAlignment(element.computedStyle?.['justifyContent'] ?? null) ?? 'flex-start'
+
+  return [justifyContent, flexAlignment]
+}

--- a/editor/src/components/inspector/inspector-common.tsx
+++ b/editor/src/components/inspector/inspector-common.tsx
@@ -64,3 +64,12 @@ export function detectFlexAlignJustifyContent(
 
   return [justifyContent, flexAlignment]
 }
+
+export function filterKeepFlexContainers(
+  metadata: ElementInstanceMetadataMap,
+  elementPaths: ElementPath[],
+): ElementPath[] {
+  return elementPaths.filter((e: ElementPath | null) =>
+    MetadataUtils.isFlexLayoutedContainer(MetadataUtils.findElementByElementPath(metadata, e)),
+  )
+}

--- a/editor/src/components/inspector/inspector-common.tsx
+++ b/editor/src/components/inspector/inspector-common.tsx
@@ -58,9 +58,9 @@ export function detectFlexAlignJustifyContent(
   }
 
   const justifyContent: FlexJustifyContent =
-    getFlexJustifyContent(element.computedStyle?.['alignItems'] ?? null) ?? 'flex-start'
+    getFlexJustifyContent(element.computedStyle?.['justifyContent'] ?? null) ?? 'flex-start'
   const flexAlignment: FlexAlignment =
-    getFlexAlignment(element.computedStyle?.['justifyContent'] ?? null) ?? 'flex-start'
+    getFlexAlignment(element.computedStyle?.['alignItems'] ?? null) ?? 'flex-start'
 
   return [justifyContent, flexAlignment]
 }

--- a/editor/src/components/inspector/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies.tsx
@@ -1,8 +1,44 @@
-import { ElementInstanceMetadataMap } from '../../core/shared/element-template'
+import { MetadataUtils } from '../../core/model/element-metadata-utils'
+import {
+  ElementInstanceMetadataMap,
+  emptyComments,
+  jsxAttributeValue,
+} from '../../core/shared/element-template'
 import { ElementPath } from '../../core/shared/project-file-types'
+import * as PP from '../../core/shared/property-path'
 import { EditorAction } from '../editor/action-types'
+import { setProperty } from '../editor/actions/action-creators'
+import { FlexAlignment, FlexJustifyContent } from './inspector-common'
 
 export type InspectorStrategy = (
   metadata: ElementInstanceMetadataMap,
   selectedElementPaths: Array<ElementPath>,
-) => Array<EditorAction>
+) => Array<EditorAction> | null
+
+export const setFlexAlignJustifyContentStrategies = (
+  flexAlignment: FlexAlignment,
+  justifyContent: FlexJustifyContent,
+): Array<InspectorStrategy> => [
+  (metadata, elementPaths) => {
+    const elements = elementPaths.filter((e) =>
+      MetadataUtils.isFlexLayoutedContainer(MetadataUtils.findElementByElementPath(metadata, e)),
+    )
+
+    if (elements.length === 0) {
+      return null
+    }
+
+    return elements.flatMap((path) => [
+      setProperty(
+        path,
+        PP.create(['style', 'alignItems']),
+        jsxAttributeValue(flexAlignment, emptyComments),
+      ),
+      setProperty(
+        path,
+        PP.create(['style', 'justifyContent']),
+        jsxAttributeValue(justifyContent, emptyComments),
+      ),
+    ])
+  },
+]

--- a/editor/src/components/inspector/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies.tsx
@@ -1,0 +1,8 @@
+import { ElementInstanceMetadataMap } from '../../core/shared/element-template'
+import { ElementPath } from '../../core/shared/project-file-types'
+import { EditorAction } from '../editor/action-types'
+
+export type InspectorStrategy = (
+  metadata: ElementInstanceMetadataMap,
+  selectedElementPaths: Array<ElementPath>,
+) => Array<EditorAction>

--- a/editor/src/components/inspector/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies.tsx
@@ -6,7 +6,7 @@ import {
 } from '../../core/shared/element-template'
 import { ElementPath } from '../../core/shared/project-file-types'
 import * as PP from '../../core/shared/property-path'
-import { EditorAction } from '../editor/action-types'
+import { EditorAction, EditorDispatch } from '../editor/action-types'
 import { setProperty } from '../editor/actions/action-creators'
 import { FlexAlignment, FlexJustifyContent } from './inspector-common'
 
@@ -42,3 +42,18 @@ export const setFlexAlignJustifyContentStrategies = (
     ])
   },
 ]
+
+export function runStrategies(
+  dispatch: EditorDispatch,
+  metadata: ElementInstanceMetadataMap,
+  selectedViews: ElementPath[],
+  strategies: InspectorStrategy[],
+): void {
+  for (const strategy of strategies) {
+    const actions = strategy(metadata, selectedViews)
+    if (actions != null) {
+      dispatch(actions)
+    }
+    return
+  }
+}

--- a/editor/src/components/inspector/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies.tsx
@@ -1,11 +1,10 @@
-import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { ElementInstanceMetadataMap } from '../../core/shared/element-template'
 import { ElementPath } from '../../core/shared/project-file-types'
 import * as PP from '../../core/shared/property-path'
 import { CanvasCommand } from '../canvas/commands/commands'
 import { setProperty } from '../canvas/commands/set-property-command'
 import { EditorDispatch } from '../editor/action-types'
-import { FlexAlignment, FlexJustifyContent } from './inspector-common'
+import { filterKeepFlexContainers, FlexAlignment, FlexJustifyContent } from './inspector-common'
 import { applyCommandsAction } from '../editor/actions/action-creators'
 
 export type InspectorStrategy = (
@@ -18,9 +17,7 @@ export const setFlexAlignJustifyContentStrategies = (
   justifyContent: FlexJustifyContent,
 ): Array<InspectorStrategy> => [
   (metadata, elementPaths) => {
-    const elements = elementPaths.filter((e) =>
-      MetadataUtils.isFlexLayoutedContainer(MetadataUtils.findElementByElementPath(metadata, e)),
-    )
+    const elements = filterKeepFlexContainers(metadata, elementPaths)
 
     if (elements.length === 0) {
       return null

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -87,6 +87,7 @@ import { isStrategyActive } from '../canvas/canvas-strategies/canvas-strategies'
 import type { StrategyState } from '../canvas/canvas-strategies/interaction-state'
 import { LowPriorityStoreProvider } from '../editor/store/low-priority-store'
 import { NineBlockControl } from './nine-block-controls'
+import { isFeatureEnabled } from '../../utils/feature-switches'
 
 export interface ElementPathElement {
   name?: string
@@ -351,7 +352,7 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
             onStyleSelectorDelete={props.onStyleSelectorDelete}
             onStyleSelectorInsert={props.onStyleSelectorInsert}
           />
-          <NineBlockControl />
+          {when(isFeatureEnabled('Nine block control'), <NineBlockControl />)}
           <LayoutSection
             hasNonDefaultPositionAttributes={hasNonDefaultPositionAttributes}
             aspectRatioLocked={aspectRatioLocked}

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -86,6 +86,7 @@ import { isTwindEnabled } from '../../core/tailwind/tailwind'
 import { isStrategyActive } from '../canvas/canvas-strategies/canvas-strategies'
 import type { StrategyState } from '../canvas/canvas-strategies/interaction-state'
 import { LowPriorityStoreProvider } from '../editor/store/low-priority-store'
+import { NineBlockControl } from './nine-block-controls'
 
 export interface ElementPathElement {
   name?: string
@@ -350,6 +351,7 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
             onStyleSelectorDelete={props.onStyleSelectorDelete}
             onStyleSelectorInsert={props.onStyleSelectorInsert}
           />
+          <NineBlockControl />
           <LayoutSection
             hasNonDefaultPositionAttributes={hasNonDefaultPositionAttributes}
             aspectRatioLocked={aspectRatioLocked}

--- a/editor/src/components/inspector/nine-block-controls.tsx
+++ b/editor/src/components/inspector/nine-block-controls.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+interface SlabsProps {
+  flexDirection: 'row' | 'column'
+}
+
+const Slabs = React.memo<SlabsProps>(({ flexDirection }) => {
+  return (
+    <div style={{ display: 'flex', flexDirection }}>
+      <div style={{ width: 10, height: 5, borderRadius: 2 }} />
+      <div style={{ width: 10, height: 7.5, borderRadius: 2 }} />
+      <div style={{ width: 10, height: 2.5, borderRadius: 2 }} />
+    </div>
+  )
+})
+
+interface NineBlockControlProps {}
+
+export const NineBlockControl = React.memo<NineBlockControlProps>(() => (
+  <>Someday, NineBlockControl will live here</>
+))

--- a/editor/src/components/inspector/nine-block-controls.tsx
+++ b/editor/src/components/inspector/nine-block-controls.tsx
@@ -8,6 +8,7 @@ import { useColorTheme } from '../../uuiui'
 import { useEditorState } from '../editor/store/store-hook'
 import {
   detectFlexAlignJustifyContent,
+  filterKeepFlexContainers,
   FlexAlignment,
   FlexJustifyContent,
 } from './inspector-common'
@@ -62,37 +63,40 @@ export const NineBlockControl = React.memo<NineBlockControlProps>(() => {
 
   const [hovered, setHovered] = React.useState<number>(-1)
 
+  // TODO: detect if it's set via css only or code or jsx prop
   const [flexJustifyContent, flexAlignment] = detectFlexAlignJustifyContent(
     metadata,
     selectedViews[0],
   )
 
   const setAlignItemsJustifyContent = React.useCallback(
-    (intededFlexAlignment: FlexAlignment, intededJustifyContent: FlexJustifyContent) => {
+    (intendedFlexAlignment: FlexAlignment, intendedJustifyContent: FlexJustifyContent) => {
       const strategies = setFlexAlignJustifyContentStrategies(
-        intededFlexAlignment,
-        intededJustifyContent,
+        intendedFlexAlignment,
+        intendedJustifyContent,
       )
       runStrategies(dispatch, metadata, selectedViews, strategies)
     },
     [dispatch, metadata, selectedViews],
   )
 
-  if (selectedViews.length === 0) {
+  if (filterKeepFlexContainers(metadata, selectedViews).length === 0) {
     return null
   }
 
   return (
     <div
       style={{
-        display: 'grid',
+        gap: 3,
+        margin: 2,
         height: 100,
+        display: 'grid',
         aspectRatio: '1',
+        boxSizing: 'border-box',
         gridTemplateRows: '1fr 1fr 1fr',
         gridTemplateColumns: '1fr 1fr 1fr',
+        backgroundColor: colorTheme.bg0.value,
         border: `1px solid ${colorTheme.fg5.value}`,
-        boxSizing: 'border-box',
-        margin: 2,
       }}
     >
       {NineBlockSectors.map(([alignItems, justifyContent], index) => {
@@ -104,14 +108,13 @@ export const NineBlockControl = React.memo<NineBlockControlProps>(() => {
             onClick={() => setAlignItemsJustifyContent(alignItems, justifyContent)}
             key={`${alignItems}-${justifyContent}`}
             style={{
-              gridRow: `${Math.floor(index / 3) + 1} / ${Math.floor(index / 3) + 2}`,
-              gridColumn: `${(index % 3) + 1} / ${(index % 3) + 2}`,
-              backgroundColor: colorTheme.bg0.value,
-              boxSizing: 'border-box',
               display: 'flex',
               alignItems: 'center',
-              justifyContent: 'center',
               position: 'relative',
+              boxSizing: 'border-box',
+              justifyContent: 'center',
+              gridColumn: `${(index % 3) + 1} / ${(index % 3) + 2}`,
+              gridRow: `${Math.floor(index / 3) + 1} / ${Math.floor(index / 3) + 2}`,
             }}
           >
             {hovered === index || isSelected ? (

--- a/editor/src/components/inspector/nine-block-controls.tsx
+++ b/editor/src/components/inspector/nine-block-controls.tsx
@@ -1,21 +1,93 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import { jsx } from '@emotion/react'
 import React from 'react'
+import { cartesianProducts } from '../../core/shared/array-utils'
+import { useColorTheme } from '../../uuiui'
+
+type FlexJustifyContent =
+  | 'flex-start'
+  | 'center'
+  | 'flex-end'
+  | 'space-around'
+  | 'space-between'
+  | 'space-evenly'
+
+type FlexAlignment = 'auto' | 'flex-start' | 'center' | 'flex-end' | 'stretch'
+
+const NineBlockSectors = cartesianProducts<FlexAlignment, FlexJustifyContent>(
+  ['flex-start', 'center', 'flex-end'],
+  ['flex-start', 'center', 'flex-end'],
+)
 
 interface SlabsProps {
   flexDirection: 'row' | 'column'
+  justifyContent: FlexJustifyContent
+  alignItems: FlexAlignment
 }
 
-const Slabs = React.memo<SlabsProps>(({ flexDirection }) => {
+const Slabs = React.memo<SlabsProps>(({ flexDirection, alignItems, justifyContent }) => {
   return (
-    <div style={{ display: 'flex', flexDirection }}>
-      <div style={{ width: 10, height: 5, borderRadius: 2 }} />
-      <div style={{ width: 10, height: 7.5, borderRadius: 2 }} />
-      <div style={{ width: 10, height: 2.5, borderRadius: 2 }} />
+    <div
+      css={{
+        display: 'flex',
+        flexDirection,
+        alignItems,
+        justifyContent,
+        gap: 1,
+        padding: 1,
+        width: '100%',
+        height: '100%',
+        opacity: 0,
+        transition: 'opacity 16ms ease-in',
+        '&:hover': {
+          opacity: 0.5,
+        },
+      }}
+    >
+      <div style={{ width: '100%', height: '50%', borderRadius: 2, backgroundColor: 'white' }} />
+      <div style={{ width: '100%', height: '65%', borderRadius: 2, backgroundColor: 'white' }} />
+      <div style={{ width: '100%', height: '35%', borderRadius: 2, backgroundColor: 'white' }} />
     </div>
   )
 })
 
+const DotSize = 3
+
 interface NineBlockControlProps {}
 
-export const NineBlockControl = React.memo<NineBlockControlProps>(() => (
-  <>Someday, NineBlockControl will live here</>
-))
+export const NineBlockControl = React.memo<NineBlockControlProps>(() => {
+  const colorTheme = useColorTheme()
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        height: 100,
+        aspectRatio: '1',
+        gridTemplateRows: '1fr 1fr 1fr',
+        gridTemplateColumns: '1fr 1fr 1fr',
+        boxShadow: '0px 0px 2px 1px rgba(0, 0, 0, 0.5)',
+        boxSizing: 'border-box',
+      }}
+    >
+      {NineBlockSectors.map(([alignItems, justifyContent], index) => (
+        <div
+          key={index}
+          style={{
+            gridRow: `${Math.floor(index / 3) + 1} / ${Math.floor(index / 3) + 2}`,
+            gridColumn: `${(index % 3) + 1} / ${(index % 3) + 2}`,
+            backgroundColor: colorTheme.darkPrimary.value,
+            boxSizing: 'border-box',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Slabs flexDirection='row' alignItems={alignItems} justifyContent={justifyContent} />
+        </div>
+      ))}
+    </div>
+  )
+})

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`661`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`662`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`733`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`734`)
   })
 })

--- a/editor/src/core/shared/array-utils.ts
+++ b/editor/src/core/shared/array-utils.ts
@@ -412,6 +412,6 @@ export function aperture<T>(n: number, array: Array<T>): Array<Array<T>> {
   }
 }
 
-export function cartesianProducts<T, U>(one: T[], other: U[]): [T, U][] {
+export function cartesianProduct<T, U>(one: T[], other: U[]): [T, U][] {
   return one.flatMap((x) => other.map((y): [T, U] => [x, y]))
 }

--- a/editor/src/core/shared/array-utils.ts
+++ b/editor/src/core/shared/array-utils.ts
@@ -411,3 +411,7 @@ export function aperture<T>(n: number, array: Array<T>): Array<Array<T>> {
     return []
   }
 }
+
+export function cartesianProducts<T, U>(one: T[], other: U[]): [T, U][] {
+  return one.flatMap((x) => other.map((y): [T, U] => [x, y]))
+}

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -29,7 +29,7 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Re-parse Project Button': !(PRODUCTION_CONFIG as boolean),
   'Performance Test Triggers': !(PRODUCTION_CONFIG as boolean),
   'Canvas Strategies Debug Panel': false,
-  'Nine block control': true,
+  'Nine block control': false,
 }
 
 function settingKeyForName(featureName: FeatureName): string {

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -9,6 +9,7 @@ export type FeatureName =
   | 'Re-parse Project Button'
   | 'Performance Test Triggers'
   | 'Canvas Strategies Debug Panel'
+  | 'Nine block control'
 
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
@@ -18,6 +19,7 @@ export const AllFeatureNames: FeatureName[] = [
   'Re-parse Project Button',
   'Performance Test Triggers',
   'Canvas Strategies Debug Panel',
+  'Nine block control',
 ]
 
 let FeatureSwitches: { [feature in FeatureName]: boolean } = {
@@ -27,6 +29,7 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Re-parse Project Button': !(PRODUCTION_CONFIG as boolean),
   'Performance Test Triggers': !(PRODUCTION_CONFIG as boolean),
   'Canvas Strategies Debug Panel': false,
+  'Nine block control': true,
 }
 
 function settingKeyForName(featureName: FeatureName): string {


### PR DESCRIPTION
![08-31-7zbki-0nu5e](https://user-images.githubusercontent.com/16385508/206424637-ba23ca3f-fc9c-47f7-a701-e014bc0a870d.gif)

## Problem
The inspector in its current for can only manipulate properties on a one-by-one basis. The drawback of this approach is that there exist some interactions, where multiple props have to be adjusted (such as converting a container to/from flex or changing the flex direction). 

## Solution
To fix this, we're trying a new approach that is geared towards compositionality/customisability. In this new approach, an interaction through a given control is run through a cascade of inspector strategies (inspired by the canvas strategies system that we already have). These inspector strategies detect if they are applicable, and if they are, they return an array of editor actions that are dispatched as the result of that UI interaction.

## This PR
This PR is a PoC/first step in the approach outlined above. It introduces
- a "nine-block" control for setting `align-items` and `justify-content` on a flex container
- the inspector strategies system

