### PR TITLE
fix(reparent) reorder inside the parent should not trigger reparent

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -55,11 +55,28 @@ export function getReparentTargetUnified(
     allowSmallerParent,
   )
 
+  // with current parent under cursor filter ancestors from reparent targets
+  const currentParentUnderCursor =
+    reparentSubjects.type === 'EXISTING_ELEMENTS'
+      ? validTargetparentsUnderPoint.find((targetParent) =>
+          EP.isParentOf(targetParent, reparentSubjects.elements[0]),
+        ) ?? null
+      : null
+  const validTargetparentsUnderPointFiltered = validTargetparentsUnderPoint.filter(
+    (targetParent) => {
+      if (currentParentUnderCursor != null) {
+        return !EP.isDescendantOf(currentParentUnderCursor, targetParent)
+      } else {
+        return true
+      }
+    },
+  )
+
   // For Flex parents, we want to be able to insert between two children that don't have a gap between them.
   const targetParentWithPaddedInsertionZone: ReparentTarget | null =
     findParentByPaddedInsertionZone(
       metadata,
-      validTargetparentsUnderPoint,
+      validTargetparentsUnderPointFiltered,
       canvasScale,
       pointOnCanvas,
     )


### PR DESCRIPTION
**Problem:**
It's very easy to reparent to be the sibling of the direct parent in a flex in flex layout while only reordering between current siblings, because the cursor position already matches the parent padded area.

**Fix:**
Filter out ancestors while dragging inside the parent area. Added 2 tests for this.

**Commit Details:**
- fix `getReparentTargetUnified`
- tests
