### PR TITLE
Fix race conditions around extension starting

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -143,7 +143,7 @@ import {
 } from './store-deep-equality-instances'
 import { forceNotNull } from '../../../core/shared/optional-utils'
 import * as EP from '../../../core/shared/element-path'
-import { defaultConfig, UtopiaVSCodeConfig } from 'utopia-vscode-common'
+import { defaultConfig, UtopiaVSCodeConfig, ProjectIDPlaceholderPrefix } from 'utopia-vscode-common'
 
 import * as OPI from 'object-path-immutable'
 import { MapLike } from 'typescript'
@@ -685,7 +685,7 @@ export type VSCodeBridgeId = VSCodeBridgeIdDefault | VSCodeBridgeIdProjectId
 export function getUnderlyingVSCodeBridgeID(bridgeId: VSCodeBridgeId): string {
   switch (bridgeId.type) {
     case 'VSCODE_BRIDGE_ID_DEFAULT':
-      return bridgeId.defaultID
+      return `${ProjectIDPlaceholderPrefix}_${bridgeId.defaultID}`
     case 'VSCODE_BRIDGE_ID_PROJECT_ID':
       return bridgeId.projectID
     default:

--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -246,7 +246,6 @@ export async function sendGetUtopiaVSCodeConfigMessage(): Promise<void> {
 }
 
 async function sendUtopiaReadyMessage(): Promise<void> {
-  await markFSReady()
   return sendMessage(utopiaReady())
 }
 

--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -56,6 +56,7 @@ import {
   SelectedElementChanged,
   utopiaReady,
   setVSCodeTheme,
+  markFSReady,
 } from 'utopia-vscode-common'
 import { isTextFile, ProjectFile, ElementPath, TextFile } from '../shared/project-file-types'
 import { isBrowserEnvironment } from '../shared/utils'
@@ -245,6 +246,7 @@ export async function sendGetUtopiaVSCodeConfigMessage(): Promise<void> {
 }
 
 async function sendUtopiaReadyMessage(): Promise<void> {
+  await markFSReady()
   return sendMessage(utopiaReady())
 }
 

--- a/utopia-vscode-common/src/index.ts
+++ b/utopia-vscode-common/src/index.ts
@@ -5,3 +5,5 @@ export * from './fs/fs-types'
 export * from './fs/fs-utils'
 export * from './prettier-utils'
 export * from './utopia-vscode-config'
+
+export const ProjectIDPlaceholderPrefix = 'PLACEHOLDER_DURING_LOADING'


### PR DESCRIPTION
**Problem:**
There are some race conditions when starting the VS Code extension that can cause the file system provider to attempt to read files before they have been written, or break the messaging system that transfers instructions between VSCode and Utopia

**Fix:**
- Add some extra safety checking when attempting to read the last consumed message, as the value can be deleted during startup between checking that it exists and reading the value (as we clear the mailbox on startup)
- Wait for the project files to be written to the FS before registering the FS provider part of the extension, as VS Code will patiently wait for a suitable FS provider to be registered if none are available yet