### PR TITLE
add/remove layout system - backed by extremely simplistic inspector strategy

### DIFF
--- a/editor/src/components/inspector/add-remove-layout-system-control.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.tsx
@@ -1,0 +1,98 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import React from 'react'
+import { jsx } from '@emotion/react'
+import { MetadataUtils } from '../../core/model/element-metadata-utils'
+import {
+  InspectorSectionIcons,
+  Icons,
+  FlexRow,
+  SquareButton,
+  FunctionIcons,
+  InspectorSectionHeader,
+  useColorTheme,
+} from '../../uuiui'
+import { useEditorState, useRefEditorState } from '../editor/store/store-hook'
+import { metadataSelector, selectedViewsSelector } from './inpector-selectors'
+import {
+  addFlexLayoutStrategies,
+  removeFlexLayoutStrategies,
+  runStrategies,
+} from './inspector-strategies'
+
+interface AddRemoveLayoutSystemControlProps {}
+
+export const AddRemoveLayouSystemControl = React.memo<AddRemoveLayoutSystemControlProps>(() => {
+  const isFlexLayoutedContainer = useEditorState((store) => {
+    const selectedElements = selectedViewsSelector(store)
+    if (selectedElements.length === 0) {
+      return false
+    }
+    return MetadataUtils.isFlexLayoutedContainer(
+      MetadataUtils.findElementByElementPath(metadataSelector(store), selectedElements[0]),
+    )
+  }, 'AddRemoveLayouSystemControl, isFlexLayoutedContainer')
+
+  const dispatch = useEditorState((store) => store.dispatch, 'AddRemoveLayouSystemControl dispatch')
+  const elementMetadataRef = useRefEditorState(metadataSelector)
+  const selectedViewsRef = useRefEditorState(selectedViewsSelector)
+
+  const addLayoutSystem = React.useCallback(
+    () =>
+      runStrategies(
+        dispatch,
+        elementMetadataRef.current,
+        selectedViewsRef.current,
+        addFlexLayoutStrategies,
+      ),
+    [dispatch, elementMetadataRef, selectedViewsRef],
+  )
+
+  const removeLayoutSystem = React.useCallback(
+    () =>
+      runStrategies(
+        dispatch,
+        elementMetadataRef.current,
+        selectedViewsRef.current,
+        removeFlexLayoutStrategies,
+      ),
+    [dispatch, elementMetadataRef, selectedViewsRef],
+  )
+
+  const colorTheme = useColorTheme()
+
+  return (
+    <InspectorSectionHeader
+      css={{
+        marginTop: 8,
+        transition: 'color .1s ease-in-out',
+        color: colorTheme.fg1.value,
+        '--buttonContentOpacity': 0.3,
+        '&:hover': {
+          color: colorTheme.fg1.value,
+          '--buttonContentOpacity': 1,
+        },
+      }}
+    >
+      <FlexRow
+        style={{
+          flexGrow: 1,
+          alignSelf: 'stretch',
+          gap: 8,
+        }}
+      >
+        <InspectorSectionIcons.LayoutSystem />
+        <span>New Layout System</span>
+      </FlexRow>
+      {isFlexLayoutedContainer ? (
+        <SquareButton highlight onClick={removeLayoutSystem}>
+          <FunctionIcons.Remove />
+        </SquareButton>
+      ) : (
+        <SquareButton highlight onClick={addLayoutSystem}>
+          <Icons.Plus style={{ opacity: 'var(--buttonContentOpacity)' }} />
+        </SquareButton>
+      )}
+    </InspectorSectionHeader>
+  )
+})

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useEditorState } from '../editor/store/store-hook'
+import { AddRemoveLayouSystemControl } from './add-remove-layout-system-control'
 import { FlexDirectionToggle } from './flex-direction-control'
 import { selectedViewsSelector, metadataSelector } from './inpector-selectors'
 import { detectFlexDirection } from './inspector-common'
@@ -16,6 +17,7 @@ export const FlexSection = React.memo(() => {
 
   return (
     <div>
+      <AddRemoveLayouSystemControl />
       <FlexDirectionToggle flexDirection={flexDirection} />
       <NineBlockControl flexDirection={flexDirection} />
     </div>

--- a/editor/src/components/inspector/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies.tsx
@@ -62,6 +62,28 @@ export const updateFlexDirectionStrategies = (
   },
 ]
 
+export const addFlexLayoutStrategies: Array<InspectorStrategy> = [
+  (metadata, elementPaths) => {
+    return elementPaths.map((path) =>
+      setProperty('always', path, PP.create(['style', 'display']), 'flex'),
+    )
+  },
+]
+
+export const removeFlexLayoutStrategies: Array<InspectorStrategy> = [
+  (metadata, elementPaths) => {
+    const elements = filterKeepFlexContainers(metadata, elementPaths)
+
+    if (elements.length === 0) {
+      return null
+    }
+
+    return elements.map((path) =>
+      deleteProperties('always', path, [PP.create(['style', 'display'])]),
+    )
+  },
+]
+
 export function runStrategies(
   dispatch: EditorDispatch,
   metadata: ElementInstanceMetadataMap,


### PR DESCRIPTION
![12-18-wf7sq-7hfgr](https://user-images.githubusercontent.com/16385508/207021527-23f24b31-9bbb-42e7-b1f2-3ad3c22738b3.gif)

## Problem:
There's no control using inspector strategies to add/remove 'display: flex` from an element

## Fix:
Add the control (heavily based on the existing one), with a super simplistic, placeholder inspector strategy