### PR TITLE
Nine-block control: design polish

### DIFF
--- a/editor/src/components/inspector/nine-block-controls.tsx
+++ b/editor/src/components/inspector/nine-block-controls.tsx
@@ -133,7 +133,6 @@ export const NineBlockControl = React.memo<NineBlockControlProps>(({ flexDirecti
   return (
     <div
       style={{
-        gap: 3,
         margin: 2,
         height: 100,
         display: 'grid',
@@ -155,6 +154,7 @@ export const NineBlockControl = React.memo<NineBlockControlProps>(({ flexDirecti
             key={`${alignItems}-${justifyContent}`}
             style={{
               display: 'flex',
+              padding: 1,
               alignItems: 'center',
               position: 'relative',
               boxSizing: 'border-box',
@@ -172,6 +172,7 @@ export const NineBlockControl = React.memo<NineBlockControlProps>(({ flexDirecti
                 width: '100%',
                 height: '100%',
                 backgroundColor: colorTheme.bg0.value,
+                opacity: isSelected ? 1 : 0.5,
               }}
             >
               <Slabs


### PR DESCRIPTION
# Before
![nine_before](https://user-images.githubusercontent.com/16385508/207023953-7d212f1b-12d8-4b9e-984d-66241b06fc79.gif)

# After
![nine_after](https://user-images.githubusercontent.com/16385508/207023997-85f1ba45-7724-46d4-8138-5fd96aae433c.gif)

# Description

## Problems
- There's a "dead zone" between the segments of the nine-block control, where the pointer as between segments and none of them are highlighted (except of course the currently selected one)
- the opacity on a hovered segment should be `0.5`, this has regressed (except of course the currently selected one)

## Fix:
Tweak CSS to fix the above problems
