### PR TITLE
disable project thumbnail generation to see if it fixes performance

### DIFF
--- a/editor/src/components/editor/persistence/persistence-backend.ts
+++ b/editor/src/components/editor/persistence/persistence-backend.ts
@@ -33,6 +33,7 @@ import {
   LocalProject,
 } from './generic/persistence-types'
 import { PersistentModel } from '../store/editor-state'
+import { isFeatureEnabled } from '../../../utils/feature-switches'
 
 let _lastThumbnailGenerated: number = 0
 const THUMBNAIL_THROTTLE = 300000
@@ -48,9 +49,11 @@ async function generateThumbnail(force: boolean): Promise<Buffer | null> {
 }
 
 export async function updateRemoteThumbnail(projectId: string, force: boolean): Promise<void> {
-  const buffer = await generateThumbnail(force)
-  if (buffer != null) {
-    await saveThumbnail(buffer, projectId)
+  if (isFeatureEnabled('Project Thumbnail Generation')) {
+    const buffer = await generateThumbnail(force)
+    if (buffer != null) {
+      await saveThumbnail(buffer, projectId)
+    }
   }
 }
 

--- a/editor/src/components/editor/screenshot-utils.ts
+++ b/editor/src/components/editor/screenshot-utils.ts
@@ -4,14 +4,14 @@ const BASE64_PREFIX = 'data:image/png;base64,'
 
 type Dom2ImageOptions = { width?: number; height?: number }
 
-export async function getPNGOfElement(
+async function getPNGOfElement(
   element: HTMLElement,
   options: Dom2ImageOptions = {},
 ): Promise<string | null> {
   return domtoimage.toPng(element, options)
 }
 
-export async function getPNGOfElementWithID(
+async function getPNGOfElementWithID(
   elementID: string,
   options: Dom2ImageOptions = {},
 ): Promise<string | null> {

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -10,6 +10,7 @@ export type FeatureName =
   | 'Performance Test Triggers'
   | 'Canvas Strategies Debug Panel'
   | 'Nine block control'
+  | 'Project Thumbnail Generation'
 
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
@@ -20,6 +21,7 @@ export const AllFeatureNames: FeatureName[] = [
   'Performance Test Triggers',
   'Canvas Strategies Debug Panel',
   'Nine block control',
+  'Project Thumbnail Generation',
 ]
 
 let FeatureSwitches: { [feature in FeatureName]: boolean } = {
@@ -30,6 +32,7 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Performance Test Triggers': !(PRODUCTION_CONFIG as boolean),
   'Canvas Strategies Debug Panel': false,
   'Nine block control': false,
+  'Project Thumbnail Generation': false,
 }
 
 function settingKeyForName(featureName: FeatureName): string {


### PR DESCRIPTION
**Problem:**
We are generating the project thumbnails using dom-to-image on the client side. 

Recently we observed a multi-second long hand that happens at weird times in the editor. it very frequently happens when a chrome tab with utopia editor is reactivated, but sometimes it happens mid-interactions too.

<img width="880" alt="image" src="https://user-images.githubusercontent.com/2226774/207030435-367e9431-60e1-480a-a7ec-806c3af33c67.png">

I happened to catch it during a performance measurement, and it _seems_ to be correlated to dom-to-image.

**Fix:**
Try disabling dom-to-image, see if the big hang goes away

**Commit Details:**
- New feature switch named `'Project Thumbnail Generation'`
- disabled by default
- let's see
