### PR TITLE
Bump reselect, remove factory

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -186,7 +186,7 @@
     "react-vtree": "2.0.0",
     "react-window": "1.8.7",
     "react-windowed-select": "3.1.2",
-    "reselect": "4.0.0",
+    "reselect": "4.1.7",
     "resize-observer-polyfill": "1.5.0",
     "scheduler": "0.17.0",
     "semver": "7.3.2",

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -219,7 +219,7 @@ specifiers:
   react-vtree: 2.0.0
   react-window: 1.8.7
   react-windowed-select: 3.1.2
-  reselect: 4.0.0
+  reselect: 4.1.7
   resize-observer-polyfill: 1.5.0
   scheduler: 0.17.0
   script-ext-html-webpack-plugin: 2.1.4
@@ -363,7 +363,7 @@ dependencies:
   react-vtree: 2.0.0_fc75b599a283ce88adf32a755f569cd4
   react-window: 1.8.7_react-dom@18.1.0+react@18.1.0
   react-windowed-select: 3.1.2_3b9cfa1ca2be6d0dc04583129899fdc5
-  reselect: 4.0.0
+  reselect: 4.1.7
   resize-observer-polyfill: 1.5.0
   scheduler: 0.17.0
   semver: 7.3.2
@@ -13881,8 +13881,8 @@ packages:
     resolution: {integrity: sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=}
     dev: true
 
-  /reselect/4.0.0:
-    resolution: {integrity: sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==}
+  /reselect/4.1.7:
+    resolution: {integrity: sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A==}
     dev: false
 
   /resize-observer-polyfill/1.5.0:

--- a/editor/src/components/editor/store/reselect-examples.spec.tsx
+++ b/editor/src/components/editor/store/reselect-examples.spec.tsx
@@ -92,7 +92,7 @@ describe('Reselect Investigation', () => {
     selectorFn()(store)
     expect(numberOfTimesCalled).toBe(4)
 
-    // uh oh!!! be very careful when craeting a selector with a curry function
+    // uh oh!!! be very careful when creating a selector with a curry function
   })
 
   it('selectors that take an argument are memoized', () => {

--- a/editor/src/components/editor/store/reselect-examples.spec.tsx
+++ b/editor/src/components/editor/store/reselect-examples.spec.tsx
@@ -1,0 +1,196 @@
+import { createSelector } from 'reselect'
+
+interface ExampleStore {
+  exNumber: number
+  exString: string
+}
+
+describe('Reselect Investigation', () => {
+  it('selectors are memoized', () => {
+    let numberOfTimesCalled = 0
+    const selector = createSelector(
+      (store: ExampleStore) => store.exNumber,
+      (store: ExampleStore) => store.exString,
+      (n, s) => {
+        numberOfTimesCalled += 1
+      },
+    )
+
+    const store: ExampleStore = {
+      exNumber: 5,
+      exString: 'hello',
+    }
+
+    selector(store)
+    expect(numberOfTimesCalled).toBe(1)
+
+    // calling it two more times will not increase numberOfTimesCalled!
+    selector(store)
+    selector(store)
+
+    expect(numberOfTimesCalled).toBe(1)
+  })
+
+  it('two instances of the same selector are memoized separately', () => {
+    let numberOfTimesCalled = { s1: 0, s2: 0 }
+    const selectorFn = (selectorKey: 's1' | 's2') =>
+      createSelector(
+        (store: ExampleStore) => store.exNumber,
+        (store: ExampleStore) => store.exString,
+        (n, s) => {
+          numberOfTimesCalled[selectorKey] += 1
+        },
+      )
+
+    const selector1 = selectorFn('s1')
+    const selector2 = selectorFn('s2')
+
+    const store: ExampleStore = {
+      exNumber: 5,
+      exString: 'hello',
+    }
+
+    selector1(store)
+    expect(numberOfTimesCalled.s1).toBe(1)
+    expect(numberOfTimesCalled.s2).toBe(0)
+    selector2(store)
+    expect(numberOfTimesCalled.s1).toBe(1)
+    expect(numberOfTimesCalled.s2).toBe(1)
+
+    // calling it two more times will not increase numberOfTimesCalled!
+    selector1(store)
+    selector1(store)
+    selector2(store)
+    selector2(store)
+
+    expect(numberOfTimesCalled.s1).toBe(1)
+    expect(numberOfTimesCalled.s2).toBe(1)
+  })
+
+  it('!!! WARNING: accidentally creating a new will not be memoized properly!!!!!', () => {
+    let numberOfTimesCalled = 0
+    const selectorFn = () =>
+      createSelector(
+        (store: ExampleStore) => store.exNumber,
+        (store: ExampleStore) => store.exString,
+        (n, s) => {
+          numberOfTimesCalled += 1
+        },
+      )
+
+    const store: ExampleStore = {
+      exNumber: 5,
+      exString: 'hello',
+    }
+
+    selectorFn()(store)
+    expect(numberOfTimesCalled).toBe(1)
+    selectorFn()(store)
+    expect(numberOfTimesCalled).toBe(2)
+    selectorFn()(store)
+    expect(numberOfTimesCalled).toBe(3)
+    selectorFn()(store)
+    expect(numberOfTimesCalled).toBe(4)
+
+    // uh oh!!! be very careful when craeting a selector with a curry function
+  })
+
+  it('selectors that take an argument are memoized', () => {
+    let numberOfTimesCalled = 0
+    const selector = createSelector(
+      (store: ExampleStore) => store.exNumber,
+      (store: ExampleStore) => store.exString,
+      (store: ExampleStore, argument: { greeting: string }) => argument.greeting,
+      (n, s, argument) => {
+        numberOfTimesCalled += 1
+      },
+    )
+
+    const store: ExampleStore = {
+      exNumber: 5,
+      exString: 'hello',
+    }
+
+    const argumentReferentiallyStable = { greeting: 'hi there!' }
+
+    selector(store, argumentReferentiallyStable)
+    expect(numberOfTimesCalled).toBe(1)
+
+    // calling it two more times will not increase numberOfTimesCalled!
+    selector(store, argumentReferentiallyStable)
+    selector(store, argumentReferentiallyStable)
+
+    expect(numberOfTimesCalled).toBe(1)
+  })
+
+  it("the argument doesn't need to be referentially stable, it's enough that the selector picking the argument returns a stable value", () => {
+    let numberOfTimesCalled = 0
+    const selector = createSelector(
+      (store: ExampleStore) => store.exNumber,
+      (store: ExampleStore) => store.exString,
+      (store: ExampleStore, argument: { greeting: string }) => argument.greeting,
+      (n, s, argument) => {
+        numberOfTimesCalled += 1
+      },
+    )
+
+    const store: ExampleStore = {
+      exNumber: 5,
+      exString: 'hello',
+    }
+
+    selector(store, { greeting: 'hi there!' })
+    expect(numberOfTimesCalled).toBe(1)
+
+    // calling it two more times will not increase numberOfTimesCalled!
+    selector(store, { greeting: 'hi there!' })
+    selector(store, { greeting: 'hi there!' })
+
+    expect(numberOfTimesCalled).toBe(1)
+  })
+
+  it('nested selectors are memoized as expected', () => {
+    let numberOfTimesInnerCalled = 0
+    let numberOfTimesOuterCalled = 0
+
+    interface ComplexStore {
+      outerProp: {
+        innerProp: {
+          value: string
+        }
+      }
+    }
+    const innerSelector = createSelector(
+      (store: ComplexStore) => store.outerProp.innerProp,
+      (store: ComplexStore, parameter: 'value') => parameter,
+      (innerProp, parameter) => {
+        numberOfTimesInnerCalled += 1
+        // imagine that this is a cheap selector that goes for a narrow state slice
+        return innerProp[parameter]
+      },
+    )
+
+    const outerSelector = createSelector(innerSelector, (selected) => {
+      numberOfTimesOuterCalled += 1
+      // imagine that this is an expensive selector here!
+      return selected
+    })
+
+    const referentiallyStableValue = 'hello'
+
+    outerSelector({ outerProp: { innerProp: { value: referentiallyStableValue } } }, 'value')
+
+    expect(numberOfTimesInnerCalled).toBe(1)
+    expect(numberOfTimesOuterCalled).toBe(1)
+
+    outerSelector({ outerProp: { innerProp: { value: referentiallyStableValue } } }, 'value')
+    expect(numberOfTimesInnerCalled).toBe(2)
+    expect(numberOfTimesOuterCalled).toBe(1)
+
+    outerSelector({ outerProp: { innerProp: { value: referentiallyStableValue } } }, 'value')
+    expect(numberOfTimesInnerCalled).toBe(3)
+    expect(numberOfTimesOuterCalled).toBe(1)
+
+    // the inner selector's memoization prevents the outer selector from re-running
+  })
+})

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -46,96 +46,97 @@ interface NavigatorItemWrapperProps {
   windowStyle: React.CSSProperties
 }
 
-const navigatorItemWrapperSelectorFactory = (elementPath: ElementPath) =>
-  createSelector(
-    (store: EditorStorePatched) => store.editor.jsxMetadata,
-    (store: EditorStorePatched) => store.editor.selectedViews,
-    (store: EditorStorePatched) => store.editor.highlightedViews,
-    (store: EditorStorePatched) => store.derived.transientState,
-    (store: EditorStorePatched) => store.derived.navigatorTargets,
-    (store: EditorStorePatched) => store.derived.elementWarnings,
-    (store: EditorStorePatched) => store.editor.projectContents,
-    (store: EditorStorePatched) => store.editor.nodeModules.files,
-    (store: EditorStorePatched) => store.editor.canvas.openFile?.filename ?? null,
-    (store: EditorStorePatched) => store.editor.allElementProps,
-    (
-      jsxMetadata,
-      selectedViews,
-      highlightedViews,
-      transientState,
-      navigatorTargets,
-      elementWarnings,
+const navigatorItemWrapperSelectorFactory = createSelector(
+  (store: EditorStorePatched) => store.editor.jsxMetadata,
+  (store: EditorStorePatched) => store.editor.selectedViews,
+  (store: EditorStorePatched) => store.editor.highlightedViews,
+  (store: EditorStorePatched) => store.derived.transientState,
+  (store: EditorStorePatched) => store.derived.navigatorTargets,
+  (store: EditorStorePatched) => store.derived.elementWarnings,
+  (store: EditorStorePatched) => store.editor.projectContents,
+  (store: EditorStorePatched) => store.editor.nodeModules.files,
+  (store: EditorStorePatched) => store.editor.canvas.openFile?.filename ?? null,
+  (store: EditorStorePatched) => store.editor.allElementProps,
+  (_: EditorStorePatched, elementPath: ElementPath) => elementPath,
+  (
+    jsxMetadata,
+    selectedViews,
+    highlightedViews,
+    transientState,
+    navigatorTargets,
+    elementWarnings,
+    projectContents,
+    nodeModules,
+    currentFilePath,
+    allElementProps,
+    elementPath,
+  ) => {
+    const underlying = normalisePathToUnderlyingTarget(
       projectContents,
       nodeModules,
-      currentFilePath,
+      forceNotNull('Should be a file path.', currentFilePath),
+      elementPath,
+    )
+    const elementFilePath =
+      underlying.type === 'NORMALISE_PATH_SUCCESS' ? underlying.filePath : currentFilePath
+    const elementProjectFile =
+      elementFilePath == null
+        ? null
+        : getContentsTreeFileFromString(projectContents, elementFilePath)
+    const elementTextFile = isTextFile(elementProjectFile) ? elementProjectFile : null
+    let parsedElementFile: ParseSuccess | null = null
+    if (elementTextFile != null && isParseSuccess(elementTextFile.fileContents.parsed)) {
+      parsedElementFile = elementTextFile.fileContents.parsed
+    }
+    const fileState =
+      elementFilePath == null ? null : transientState.filesState?.[elementFilePath] ?? null
+    const topLevelElements =
+      fileState?.topLevelElementsIncludingScenes ?? parsedElementFile?.topLevelElements ?? []
+    const componentsIncludingScenes = topLevelElements.filter(isUtopiaJSXComponent)
+
+    const elementOriginType = MetadataUtils.getElementOriginType(
+      componentsIncludingScenes,
+      elementPath,
+    )
+    const staticName = MetadataUtils.getStaticElementName(elementPath, componentsIncludingScenes)
+    const labelInner = MetadataUtils.getElementLabel(
       allElementProps,
-    ) => {
-      const underlying = normalisePathToUnderlyingTarget(
+      elementPath,
+      jsxMetadata,
+      staticName,
+    )
+    // FIXME: This is a mitigation for a situation where somehow this component re-renders
+    // when the navigatorTargets indicate it shouldn't exist...
+    const isInNavigatorTargets = EP.containsPath(elementPath, navigatorTargets)
+    let noOfChildrenInner: number = 0
+    let supportsChildren: boolean = false
+    if (isInNavigatorTargets) {
+      noOfChildrenInner = MetadataUtils.getImmediateChildren(jsxMetadata, elementPath).length
+      supportsChildren = MetadataUtils.targetSupportsChildren(
         projectContents,
-        nodeModules,
-        forceNotNull('Should be a file path.', currentFilePath),
-        elementPath,
-      )
-      const elementFilePath =
-        underlying.type === 'NORMALISE_PATH_SUCCESS' ? underlying.filePath : currentFilePath
-      const elementProjectFile =
-        elementFilePath == null
-          ? null
-          : getContentsTreeFileFromString(projectContents, elementFilePath)
-      const elementTextFile = isTextFile(elementProjectFile) ? elementProjectFile : null
-      let parsedElementFile: ParseSuccess | null = null
-      if (elementTextFile != null && isParseSuccess(elementTextFile.fileContents.parsed)) {
-        parsedElementFile = elementTextFile.fileContents.parsed
-      }
-      const fileState =
-        elementFilePath == null ? null : transientState.filesState?.[elementFilePath] ?? null
-      const topLevelElements =
-        fileState?.topLevelElementsIncludingScenes ?? parsedElementFile?.topLevelElements ?? []
-      const componentsIncludingScenes = topLevelElements.filter(isUtopiaJSXComponent)
-
-      const elementOriginType = MetadataUtils.getElementOriginType(
-        componentsIncludingScenes,
-        elementPath,
-      )
-      const staticName = MetadataUtils.getStaticElementName(elementPath, componentsIncludingScenes)
-      const labelInner = MetadataUtils.getElementLabel(
-        allElementProps,
-        elementPath,
+        currentFilePath,
         jsxMetadata,
-        staticName,
+        elementPath,
       )
-      // FIXME: This is a mitigation for a situation where somehow this component re-renders
-      // when the navigatorTargets indicate it shouldn't exist...
-      const isInNavigatorTargets = EP.containsPath(elementPath, navigatorTargets)
-      let noOfChildrenInner: number = 0
-      let supportsChildren: boolean = false
-      if (isInNavigatorTargets) {
-        noOfChildrenInner = MetadataUtils.getImmediateChildren(jsxMetadata, elementPath).length
-        supportsChildren = MetadataUtils.targetSupportsChildren(
-          projectContents,
-          currentFilePath,
-          jsxMetadata,
-          elementPath,
-        )
-      }
+    }
 
-      const elementWarningsInner = getValueFromComplexMap(EP.toString, elementWarnings, elementPath)
+    const elementWarningsInner = getValueFromComplexMap(EP.toString, elementWarnings, elementPath)
 
-      return {
-        staticElementName: staticName,
-        label: labelInner,
-        isSelected: EP.containsPath(elementPath, transientState.selectedViews ?? selectedViews),
-        isHighlighted: EP.containsPath(
-          elementPath,
-          transientState.highlightedViews ?? highlightedViews,
-        ),
-        noOfChildren: noOfChildrenInner,
-        supportsChildren: supportsChildren,
-        elementOriginType: elementOriginType,
-        elementWarnings: elementWarningsInner ?? defaultElementWarnings,
-      }
-    },
-  )
+    return {
+      staticElementName: staticName,
+      label: labelInner,
+      isSelected: EP.containsPath(elementPath, transientState.selectedViews ?? selectedViews),
+      isHighlighted: EP.containsPath(
+        elementPath,
+        transientState.highlightedViews ?? highlightedViews,
+      ),
+      noOfChildren: noOfChildrenInner,
+      supportsChildren: supportsChildren,
+      elementOriginType: elementOriginType,
+      elementWarnings: elementWarningsInner ?? defaultElementWarnings,
+    }
+  },
+)
 
 const nullableJSXElementNameKeepDeepEquality = nullableDeepEquality(
   JSXElementNameKeepDeepEqualityCall,
@@ -144,10 +145,6 @@ const nullableJSXElementNameKeepDeepEquality = nullableDeepEquality(
 export const NavigatorItemWrapper: React.FunctionComponent<
   React.PropsWithChildren<NavigatorItemWrapperProps>
 > = React.memo((props) => {
-  const selector = React.useMemo(
-    () => navigatorItemWrapperSelectorFactory(props.elementPath),
-    [props.elementPath],
-  )
   const {
     isSelected,
     isHighlighted,
@@ -157,7 +154,10 @@ export const NavigatorItemWrapper: React.FunctionComponent<
     staticElementName,
     label,
     elementWarnings,
-  } = useEditorState(selector, 'NavigatorItemWrapper')
+  } = useEditorState(
+    (store) => navigatorItemWrapperSelectorFactory(store, props.elementPath),
+    'NavigatorItemWrapper',
+  )
 
   const { isElementVisible, renamingTarget, appropriateDropTargetHint, dispatch, isCollapsed } =
     useEditorState((store) => {

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -46,7 +46,7 @@ interface NavigatorItemWrapperProps {
   windowStyle: React.CSSProperties
 }
 
-const navigatorItemWrapperSelectorFactory = createSelector(
+const navigatorItemWrapperSelector = createSelector(
   (store: EditorStorePatched) => store.editor.jsxMetadata,
   (store: EditorStorePatched) => store.editor.selectedViews,
   (store: EditorStorePatched) => store.editor.highlightedViews,
@@ -155,7 +155,7 @@ export const NavigatorItemWrapper: React.FunctionComponent<
     label,
     elementWarnings,
   } = useEditorState(
-    (store) => navigatorItemWrapperSelectorFactory(store, props.elementPath),
+    (store) => navigatorItemWrapperSelector(store, props.elementPath),
     'NavigatorItemWrapper',
   )
 

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -798,10 +798,10 @@ export async function getUsersPublicGithubRepositories(
 
 const githubFileChangesSelector = createSelector(
   (store: EditorStorePatched) => store.editor.projectContents,
-  (store) => store.userState.githubState.authenticated,
-  (store) => store.editor.githubChecksums,
-  (store) => store.editor.githubData.treeConflicts,
-  (store) => store.editor.assetChecksums,
+  (store: EditorStorePatched) => store.userState.githubState.authenticated,
+  (store: EditorStorePatched) => store.editor.githubChecksums,
+  (store: EditorStorePatched) => store.editor.githubData.treeConflicts,
+  (store: EditorStorePatched) => store.editor.assetChecksums,
   (
     projectContents,
     githubAuthenticated,


### PR DESCRIPTION
**Problem:**
If you wanted to pass a parameter to reselect, you had to make ugly hacks, such as the `navigatorItemWrapperSelectorFactory`, which was a function that returned a selector. Since selectors are memoized _by instance_ (not globally), you had to be very careful to then wrap this factory in a useMemo. All in all, too finicky and hard to make robust.

**Fix:**
A new version of reselect supports parametrized selectors! Yay!

**Commit Details:**
- Made a .spec.ts tets file that demonstrates how reselect memoization works
- bumped reselect
- killed navigatorItemWrapperSelectorFactory