### PR TITLE
detect flex direction/justify-content/align-items based on all selected elements

### DIFF
--- a/editor/src/components/inspector/add-remove-layout-system-control.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.tsx
@@ -18,13 +18,14 @@ import {
   removeFlexLayoutStrategies,
   runStrategies,
 } from './inspector-strategies'
-import { detectAreElementsInFlexLayout } from './inspector-common'
+import { detectAreElementsFlexContainers } from './inspector-common'
 
 interface AddRemoveLayoutSystemControlProps {}
 
 export const AddRemoveLayouSystemControl = React.memo<AddRemoveLayoutSystemControlProps>(() => {
   const isFlexLayoutedContainer = useEditorState(
-    (store) => detectAreElementsInFlexLayout(metadataSelector(store), selectedViewsSelector(store)),
+    (store) =>
+      detectAreElementsFlexContainers(metadataSelector(store), selectedViewsSelector(store)),
     'AddRemoveLayouSystemControl, isFlexLayoutedContainer',
   )
 

--- a/editor/src/components/inspector/add-remove-layout-system-control.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.tsx
@@ -2,7 +2,6 @@
 /** @jsx jsx */
 import React from 'react'
 import { jsx } from '@emotion/react'
-import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import {
   InspectorSectionIcons,
   Icons,
@@ -19,19 +18,15 @@ import {
   removeFlexLayoutStrategies,
   runStrategies,
 } from './inspector-strategies'
+import { detectAreElementsInFlexLayout } from './inspector-common'
 
 interface AddRemoveLayoutSystemControlProps {}
 
 export const AddRemoveLayouSystemControl = React.memo<AddRemoveLayoutSystemControlProps>(() => {
-  const isFlexLayoutedContainer = useEditorState((store) => {
-    const selectedElements = selectedViewsSelector(store)
-    if (selectedElements.length === 0) {
-      return false
-    }
-    return MetadataUtils.isFlexLayoutedContainer(
-      MetadataUtils.findElementByElementPath(metadataSelector(store), selectedElements[0]),
-    )
-  }, 'AddRemoveLayouSystemControl, isFlexLayoutedContainer')
+  const isFlexLayoutedContainer = useEditorState(
+    (store) => detectAreElementsInFlexLayout(metadataSelector(store), selectedViewsSelector(store)),
+    'AddRemoveLayouSystemControl, isFlexLayoutedContainer',
+  )
 
   const dispatch = useEditorState((store) => store.dispatch, 'AddRemoveLayouSystemControl dispatch')
   const elementMetadataRef = useRefEditorState(metadataSelector)

--- a/editor/src/components/inspector/flex-direction-control.tsx
+++ b/editor/src/components/inspector/flex-direction-control.tsx
@@ -14,7 +14,7 @@ import {
 } from './inspector-strategies'
 
 interface FlexDirectionToggleProps {
-  flexDirection: FlexDirection
+  flexDirection: FlexDirection | null
 }
 
 export const FlexDirectionToggle = React.memo<FlexDirectionToggleProps>(({ flexDirection }) => {

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
+import { when } from '../../utils/react-conditionals'
 import { useEditorState } from '../editor/store/store-hook'
 import { AddRemoveLayouSystemControl } from './add-remove-layout-system-control'
 import { FlexDirectionToggle } from './flex-direction-control'
 import { selectedViewsSelector, metadataSelector } from './inpector-selectors'
-import { detectFlexDirection } from './inspector-common'
+import { detectAreElementsInFlexLayout, detectFlexDirection } from './inspector-common'
 import { NineBlockControl } from './nine-block-controls'
 
 export const FlexSection = React.memo(() => {
@@ -15,11 +16,21 @@ export const FlexSection = React.memo(() => {
     'FlexSection flexDirection',
   )
 
+  const allElementsInFlexLayout = useEditorState(
+    (store) => detectAreElementsInFlexLayout(metadataSelector(store), selectedViewsSelector(store)),
+    'FlexSection areAllElementsInFlexLayout',
+  )
+
   return (
-    <div>
-      <AddRemoveLayouSystemControl />
-      <FlexDirectionToggle flexDirection={flexDirection} />
-      <NineBlockControl flexDirection={flexDirection} />
-    </div>
+    <>
+      {when(
+        allElementsInFlexLayout,
+        <div>
+          <AddRemoveLayouSystemControl />
+          <FlexDirectionToggle flexDirection={flexDirection} />
+          <NineBlockControl flexDirection={flexDirection} />
+        </div>,
+      )}
+    </>
   )
 })

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -4,7 +4,7 @@ import { useEditorState } from '../editor/store/store-hook'
 import { AddRemoveLayouSystemControl } from './add-remove-layout-system-control'
 import { FlexDirectionToggle } from './flex-direction-control'
 import { selectedViewsSelector, metadataSelector } from './inpector-selectors'
-import { detectAreElementsInFlexLayout, detectFlexDirection } from './inspector-common'
+import { detectAreElementsFlexContainers, detectFlexDirection } from './inspector-common'
 import { NineBlockControl } from './nine-block-controls'
 
 export const FlexSection = React.memo(() => {
@@ -17,7 +17,8 @@ export const FlexSection = React.memo(() => {
   )
 
   const allElementsInFlexLayout = useEditorState(
-    (store) => detectAreElementsInFlexLayout(metadataSelector(store), selectedViewsSelector(store)),
+    (store) =>
+      detectAreElementsFlexContainers(metadataSelector(store), selectedViewsSelector(store)),
     'FlexSection areAllElementsInFlexLayout',
   )
 

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -10,7 +10,7 @@ export const FlexSection = React.memo(() => {
     (store) =>
       selectedViewsSelector(store).length === 0
         ? 'row'
-        : detectFlexDirection(metadataSelector(store), selectedViewsSelector(store)[0]),
+        : detectFlexDirection(metadataSelector(store), selectedViewsSelector(store)),
     'FlexSection flexDirection',
   )
 

--- a/editor/src/components/inspector/inspector-common.tsx
+++ b/editor/src/components/inspector/inspector-common.tsx
@@ -1,7 +1,6 @@
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { ElementInstanceMetadataMap } from '../../core/shared/element-template'
 import { ElementPath } from '../../core/shared/project-file-types'
-import { EditorState, EditorStorePatched } from '../editor/store/editor-state'
 import { FlexDirection } from './common/css-utils'
 
 export type StartCenterEnd = 'flex-start' | 'center' | 'flex-end'
@@ -130,6 +129,15 @@ export function detectFlexDirection(
   return allElemsEqual(allDetectedMeasurement, (l, r) => l === r)
     ? allDetectedMeasurement[0]
     : DefaultFlexDirection
+}
+
+export function detectAreElementsInFlexLayout(
+  metadata: ElementInstanceMetadataMap,
+  elementPaths: Array<ElementPath>,
+): boolean {
+  return elementPaths.every((path) =>
+    MetadataUtils.isFlexLayoutedContainer(MetadataUtils.findElementByElementPath(metadata, path)),
+  )
 }
 
 export const isFlexColumn = (flexDirection: FlexDirection): boolean =>

--- a/editor/src/components/inspector/inspector-common.tsx
+++ b/editor/src/components/inspector/inspector-common.tsx
@@ -150,7 +150,7 @@ export function filterKeepFlexContainers(
   )
 }
 
-export function detectAreElementsInFlexLayout(
+export function detectAreElementsFlexContainers(
   metadata: ElementInstanceMetadataMap,
   elementPaths: Array<ElementPath>,
 ): boolean {

--- a/editor/src/components/inspector/inspector-common.tsx
+++ b/editor/src/components/inspector/inspector-common.tsx
@@ -61,6 +61,11 @@ function stringToFlexDirection(str: string | null): FlexDirection | null {
   }
 }
 
+export interface JustifyContentFlexAlignemt {
+  justifyContent: FlexJustifyContent
+  alignItems: FlexAlignment
+}
+
 type Detect<T> = (
   metadata: ElementInstanceMetadataMap,
   elementPaths: Array<ElementPath>,
@@ -95,7 +100,7 @@ export const detectFlexDirection: Detect<FlexDirection> = (
 function detectFlexAlignJustifyContentOne(
   metadata: ElementInstanceMetadataMap,
   elementPath: ElementPath,
-): [FlexJustifyContent, FlexAlignment] | null {
+): JustifyContentFlexAlignemt | null {
   const element = MetadataUtils.findElementByElementPath(metadata, elementPath)
   if (element == null || !MetadataUtils.isFlexLayoutedContainer(element)) {
     return null
@@ -104,18 +109,18 @@ function detectFlexAlignJustifyContentOne(
   const justifyContent: FlexJustifyContent | null = getFlexJustifyContent(
     element.computedStyle?.['justifyContent'] ?? null,
   )
-  const flexAlignment: FlexAlignment | null = getFlexAlignment(
+  const alignItems: FlexAlignment | null = getFlexAlignment(
     element.computedStyle?.['alignItems'] ?? null,
   )
 
-  if (justifyContent == null || flexAlignment == null) {
+  if (justifyContent == null || alignItems == null) {
     return null
   }
 
-  return [justifyContent, flexAlignment]
+  return { justifyContent, alignItems }
 }
 
-export const detectFlexAlignJustifyContent: Detect<[FlexJustifyContent, FlexAlignment]> = (
+export const detectFlexAlignJustifyContent: Detect<JustifyContentFlexAlignemt> = (
   metadata: ElementInstanceMetadataMap,
   elementPaths: Array<ElementPath>,
 ) => {
@@ -128,7 +133,10 @@ export const detectFlexAlignJustifyContent: Detect<[FlexJustifyContent, FlexAlig
     return null
   }
 
-  return allElemsEqual(allDetectedMeasurements, (l, r) => l[0] === r[0] && l[1] === r[1])
+  return allElemsEqual(
+    allDetectedMeasurements,
+    (l, r) => l.alignItems === r.alignItems && l.justifyContent === r.justifyContent,
+  )
     ? allDetectedMeasurements[0]
     : null
 }
@@ -156,13 +164,13 @@ export const isFlexColumn = (flexDirection: FlexDirection): boolean =>
 
 export function justifyContentAlignItemsEquals(
   flexDirection: FlexDirection,
-  left: [FlexJustifyContent, FlexAlignment],
-  right: [FlexJustifyContent, FlexAlignment],
+  left: JustifyContentFlexAlignemt,
+  right: JustifyContentFlexAlignemt,
 ): boolean {
-  const [justifyContent, alignItems] = left
+  const { justifyContent, alignItems } = left
   return isFlexColumn(flexDirection)
-    ? alignItems === right[0] && justifyContent === right[1]
-    : alignItems === right[1] && justifyContent === right[0]
+    ? alignItems === right.justifyContent && justifyContent === right.alignItems
+    : alignItems === right.alignItems && justifyContent === right.justifyContent
 }
 
 function allElemsEqual<T>(objects: T[], areEqual: (a: T, b: T) => boolean): boolean {

--- a/editor/src/components/inspector/nine-block-controls.tsx
+++ b/editor/src/components/inspector/nine-block-controls.tsx
@@ -152,7 +152,7 @@ export const NineBlockControl = React.memo<NineBlockControlProps>(({ flexDirecti
           detectedJustifyContentFlexAlignment != null &&
           justifyContentAlignItemsEquals(
             flexDirectionWithDefault,
-            [alignItems, justifyContent],
+            { alignItems, justifyContent },
             detectedJustifyContentFlexAlignment,
           )
         return (

--- a/editor/src/components/inspector/nine-block-controls.tsx
+++ b/editor/src/components/inspector/nine-block-controls.tsx
@@ -10,9 +10,11 @@ import { useEditorState, useRefEditorState } from '../editor/store/store-hook'
 import { FlexDirection } from './common/css-utils'
 import { metadataSelector, selectedViewsSelector } from './inpector-selectors'
 import {
+  DefaultFlexDirection,
   detectFlexAlignJustifyContent,
   filterKeepFlexContainers,
   isFlexColumn,
+  justifyContentAlignItemsEquals,
   StartCenterEnd,
 } from './inspector-common'
 import { runStrategies, setFlexAlignJustifyContentStrategies } from './inspector-strategies'
@@ -94,14 +96,14 @@ const Slabs = React.memo<SlabsProps>(({ flexDirection, alignItems, justifyConten
 const DotSize = 2
 
 interface NineBlockControlProps {
-  flexDirection: FlexDirection
+  flexDirection: FlexDirection | null
 }
 
 export const NineBlockControl = React.memo<NineBlockControlProps>(({ flexDirection }) => {
   const colorTheme = useColorTheme()
 
   const dispatch = useEditorState((store) => store.dispatch, 'NineBlockControl dispatch')
-  const [flexJustifyContent, flexAlignment] = useEditorState(
+  const detectedJustifyContentFlexAlignment = useEditorState(
     (store) => detectFlexAlignJustifyContent(metadataSelector(store), selectedViewsSelector(store)),
     'NineBlockControl [flexJustifyContent, flexAlignment]',
   )
@@ -115,14 +117,16 @@ export const NineBlockControl = React.memo<NineBlockControlProps>(({ flexDirecti
   const metadataRef = useRefEditorState(metadataSelector)
   const selectedViewsRef = useRefEditorState(selectedViewsSelector)
 
+  const flexDirectionWithDefault: FlexDirection = flexDirection ?? DefaultFlexDirection
+
   const setAlignItemsJustifyContent = React.useCallback(
     (intendedFlexAlignment: StartCenterEnd, intendedJustifyContent: StartCenterEnd) => {
-      const strategies = isFlexColumn(flexDirection)
+      const strategies = isFlexColumn(flexDirectionWithDefault)
         ? setFlexAlignJustifyContentStrategies(intendedJustifyContent, intendedFlexAlignment)
         : setFlexAlignJustifyContentStrategies(intendedFlexAlignment, intendedJustifyContent)
       runStrategies(dispatch, metadataRef.current, selectedViewsRef.current, strategies)
     },
-    [dispatch, flexDirection, metadataRef, selectedViewsRef],
+    [dispatch, flexDirectionWithDefault, metadataRef, selectedViewsRef],
   )
 
   if (nFlexContainers === 0) {
@@ -144,9 +148,13 @@ export const NineBlockControl = React.memo<NineBlockControlProps>(({ flexDirecti
       }}
     >
       {NineBlockSectors.map(([alignItems, justifyContent], index) => {
-        const isSelected = isFlexColumn(flexDirection)
-          ? alignItems === flexJustifyContent && justifyContent === flexAlignment
-          : alignItems === flexAlignment && justifyContent === flexJustifyContent
+        const isSelected =
+          detectedJustifyContentFlexAlignment != null &&
+          justifyContentAlignItemsEquals(
+            flexDirectionWithDefault,
+            [alignItems, justifyContent],
+            detectedJustifyContentFlexAlignment,
+          )
         return (
           <div
             onClick={() => setAlignItemsJustifyContent(alignItems, justifyContent)}
@@ -175,8 +183,8 @@ export const NineBlockControl = React.memo<NineBlockControlProps>(({ flexDirecti
               }}
             >
               <Slabs
-                {...slabAlignment(justifyContent, alignItems, flexDirection)}
-                flexDirection={flexDirection}
+                {...slabAlignment(justifyContent, alignItems, flexDirectionWithDefault)}
+                flexDirection={flexDirectionWithDefault}
                 bgColor={colorTheme.fg5.value}
               />
             </div>

--- a/editor/src/components/inspector/nine-block-controls.tsx
+++ b/editor/src/components/inspector/nine-block-controls.tsx
@@ -102,8 +102,7 @@ export const NineBlockControl = React.memo<NineBlockControlProps>(({ flexDirecti
 
   const dispatch = useEditorState((store) => store.dispatch, 'NineBlockControl dispatch')
   const [flexJustifyContent, flexAlignment] = useEditorState(
-    (store) =>
-      detectFlexAlignJustifyContent(metadataSelector(store), selectedViewsSelector(store)[0]),
+    (store) => detectFlexAlignJustifyContent(metadataSelector(store), selectedViewsSelector(store)),
     'NineBlockControl [flexJustifyContent, flexAlignment]',
   )
 


### PR DESCRIPTION
## Problem
In the inspector-strategies backed inspector controls, `flex-direction`, `justify-content`, `align-items` and `display(: flex)` were determined only by inspecting the first selected element, disregarding the rest. This lead to misleading UI states.

## Fix
Check all selected elements for the props in question, and
- if they are set to the same value, display that value on the UI
- otherwise, display a default value on the UI

## After
![null_state](https://user-images.githubusercontent.com/16385508/207076093-6b0b5083-a46b-43f1-a2dd-681ff59f79b3.gif)


## Before
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/16385508/207059216-3a4e20c8-247a-41a2-84af-b11c6796d2b0.png">


