### PR TITLE
Don't preventDefault on cmd + left or right in Inspector fields

### DIFF
--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -168,13 +168,17 @@ function getTextEditorTarget(editor: EditorState, derived: DerivedState): Elemen
   }
 }
 
-function shouldTabBeHandledByBrowser(editor: EditorState): boolean {
-  return (
-    editor.focusedPanel === 'inspector' ||
-    editor.focusedPanel === 'dependencylist' ||
-    editor.floatingInsertMenu.insertMenuMode !== 'closed'
-  )
+function activeElementIsAnInput(): boolean {
+  const activeElement = document.activeElement
+  if (activeElement != null) {
+    const activeElementTag = activeElement.tagName.toLowerCase()
+    return activeElementTag === 'input' || activeElementTag === 'textarea'
+  }
+
+  return false
 }
+
+const activeElementIsNotAnInput = () => !activeElementIsAnInput()
 
 export function preventBrowserShortcuts(editor: EditorState, event: KeyboardEvent): void {
   const key = Keyboard.keyCharacterForCode(event.keyCode)
@@ -185,7 +189,7 @@ export function preventBrowserShortcuts(editor: EditorState, event: KeyboardEven
 
   switch (key) {
     case 'tab':
-      if (!shouldTabBeHandledByBrowser(editor)) {
+      if (activeElementIsNotAnInput()) {
         event.preventDefault()
       }
       break
@@ -208,7 +212,9 @@ export function preventBrowserShortcuts(editor: EditorState, event: KeyboardEven
     case 'left':
     case 'right':
       if (cmd) {
-        event.preventDefault()
+        if (activeElementIsNotAnInput()) {
+          event.preventDefault()
+        }
       }
       break
     case 'b':
@@ -340,7 +346,7 @@ export function handleKeyDown(
   }
 
   function getUIFileActions(): Array<EditorAction> {
-    if (key === 'tab' && shouldTabBeHandledByBrowser(editor)) {
+    if (key === 'tab' && activeElementIsAnInput()) {
       return []
     }
     return handleShortcuts<Array<EditorAction>>(namesByKey, event, [], {


### PR DESCRIPTION
Fixes #2989 

**Problem:**
Pressing `cmd` + the left or right arrow keys whilst editing the text in an Inspector input field does not behave as expected.

**Fix:**
This was caused by some of our global shortcut logic which calls `event.preventDefault()` for a lot of keyboard events to prevent the default browser behaviour. However, the default browser behaviour is exactly what we want to trigger in these cases, so I have added a function that checks if the `document.activeElement` is either a `input` or `textarea` element, and used that check when deciding whether or not to call `preventDefault` on specific key combinations.
