### PR TITLE
Carry over metadata changes when an interaction finishes.

### DIFF
--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -54,7 +54,7 @@ export function interactionFinished(
   storedState: EditorStoreFull,
   result: EditorStoreUnpatched,
 ): HandleStrategiesResult {
-  const newEditorState = result.unpatchedEditor
+  let newEditorState = result.unpatchedEditor
   const withClearedSession = createEmptyStrategyState(
     newEditorState.canvas.interactionSession?.latestMetadata ?? newEditorState.jsxMetadata,
     newEditorState.canvas.interactionSession?.latestAllElementProps ??
@@ -109,6 +109,14 @@ export function interactionFinished(
       newStrategyState: withClearedSession,
     }
   } else {
+    // Try to keep any updated metadata that may have been populated into here
+    // in the meantime.
+    newEditorState = {
+      ...newEditorState,
+      domMetadata: storedState.patchedEditor.domMetadata,
+      spyMetadata: storedState.patchedEditor.spyMetadata,
+      jsxMetadata: storedState.patchedEditor.jsxMetadata,
+    }
     return {
       unpatchedEditorState: newEditorState,
       patchedEditorState: newEditorState,


### PR DESCRIPTION
**Problem:**
When changing selection, values like the `computedStyle` for the newly selected element appear to be lost even though they have been captured.

**Fix:**
An interaction session was being started and cleared in the middle of processing the selection change, which resulted in the update to the metadata getting assigned into the patched editor state and then lost almost immediately by the interaction being finished.

This fix carries over the metadata from the patched editor state to the new editor when the interaction finishes and only specifically when an interaction is not viewed as being "in progress".

**Commit Details:**
- In `interactionFinish`, when closing off the interaction that isn't in progress, carry over the metadata from the patched editor.
