### PR TITLE
Text editing tests

### DIFF
--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -1,0 +1,182 @@
+import { setFeatureEnabled } from '../../utils/feature-switches'
+import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
+import { mouseClickAtPoint, pressKey } from '../canvas/event-helpers.test-utils'
+import {
+  EditorRenderResult,
+  formatTestProjectCode,
+  getPrintedUiJsCode,
+  renderTestEditorWithCode,
+} from '../canvas/ui-jsx.test-utils'
+
+describe('Use the text editor', () => {
+  before(() => {
+    setFeatureEnabled('Text editing', true)
+  })
+  it('Edit existing text', async () => {
+    const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
+
+    await enterTextEditMode(editor)
+    typeText(' Utopia')
+    closeTextEditor()
+    await editor.getDispatchFollowUpActionsFinished()
+
+    expect(editor.getEditorState().editor.mode.type).toEqual('select')
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      formatTestProjectCode(`
+        import * as React from 'react'
+        import { Storyboard } from 'utopia-api'
+
+
+        export var storyboard = (
+          <Storyboard data-uid='sb'>
+            <div
+              data-testid='div'
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                left: 0,
+                top: 0,
+                width: 288,
+                height: 362,
+              }}
+              data-uid='39e'
+            >Hello Utopia</div>
+          </Storyboard>
+        )`),
+    )
+  })
+  it('Add new text', async () => {
+    const editor = await renderTestEditorWithCode(projectWithoutText, 'await-first-dom-report')
+
+    await enterTextEditMode(editor)
+    typeText('Utopia')
+    closeTextEditor()
+    await editor.getDispatchFollowUpActionsFinished()
+
+    expect(editor.getEditorState().editor.mode.type).toEqual('select')
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      formatTestProjectCode(`
+        import * as React from 'react'
+        import { Storyboard } from 'utopia-api'
+
+
+        export var storyboard = (
+          <Storyboard data-uid='sb'>
+            <div
+              data-testid='div'
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                left: 0,
+                top: 0,
+                width: 288,
+                height: 362,
+              }}
+              data-uid='39e'
+            >Utopia</div>
+          </Storyboard>
+        )`),
+    )
+  })
+  it('Do not save content before exiting the text editor', async () => {
+    const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
+
+    await enterTextEditMode(editor)
+    typeText(' Utopia')
+    await editor.getDispatchFollowUpActionsFinished()
+
+    expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      formatTestProjectCode(`
+        import * as React from 'react'
+        import { Storyboard } from 'utopia-api'
+
+
+        export var storyboard = (
+          <Storyboard data-uid='sb'>
+            <div
+              data-testid='div'
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                left: 0,
+                top: 0,
+                width: 288,
+                height: 362,
+              }}
+              data-uid='39e'
+            >Hello</div>
+          </Storyboard>
+        )`),
+    )
+  })
+})
+
+async function enterTextEditMode(editor: EditorRenderResult) {
+  const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
+  const div = editor.renderedDOM.getByTestId('div')
+  const divBounds = div.getBoundingClientRect()
+  const divCorner = {
+    x: divBounds.x + 50,
+    y: divBounds.y + 40,
+  }
+
+  mouseClickAtPoint(canvasControlsLayer, divCorner)
+  await editor.getDispatchFollowUpActionsFinished()
+  pressKey('t')
+  await editor.getDispatchFollowUpActionsFinished()
+}
+
+function typeText(text: string) {
+  document.execCommand('insertText', false, text)
+}
+
+function closeTextEditor() {
+  pressKey('Escape')
+}
+
+const projectWithText = formatTestProjectCode(`import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      data-testid='div'
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 288,
+        height: 362,
+      }}
+      data-uid='39e'
+    >
+      Hello
+    </div>
+  </Storyboard>
+)
+`)
+
+const projectWithoutText = formatTestProjectCode(`import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      data-testid='div'
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 288,
+        height: 362,
+      }}
+      data-uid='39e'
+    />
+  </Storyboard>
+)
+`)


### PR DESCRIPTION
**Problem:**
The initial text editing PR https://github.com/concrete-utopia/utopia/pull/2992 did not include tests

**Fix:**
Let's add some tests!

Note: you can not dispatch keyboard evenst from javascript to edit a contenteditable, the workaround is to use `document.execCommand`. This is deprecated, but at least it works..., we can revisit this later if necessary.
