### PR TITLE
Fixed up the distance guideline styling

### DIFF
--- a/editor/src/components/canvas/controls/distance-guideline.tsx
+++ b/editor/src/components/canvas/controls/distance-guideline.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import Utils from '../../../utils/utils'
 import { CanvasPoint, CanvasRectangle, CanvasVector } from '../../../core/shared/math-utils'
-import { ElementPath } from '../../../core/shared/project-file-types'
 import { Guideline, Guidelines, XAxisGuideline, YAxisGuideline } from '../guideline'
 //TODO: switch to functional component and make use of 'useColorTheme':
 import { colorTheme } from '../../../uuiui'
+import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
 
-const StrokeColor = colorTheme.canvasLayoutStroke.value
+const StrokeColor = colorTheme.brandNeonPink.value
 const LineEndSegmentSize = 3.5
 
 type GuidelineWithDistance = {
@@ -93,7 +93,6 @@ interface DistanceGuidelineProps {
   boundingBox: CanvasRectangle
   guidelines: Array<Guideline>
 }
-
 export class DistanceGuideline extends React.Component<DistanceGuidelineProps> {
   getNewControlForDistance(
     distance: number,
@@ -121,45 +120,36 @@ export class DistanceGuideline extends React.Component<DistanceGuidelineProps> {
     isHorizontal: boolean,
     id: string,
   ): JSX.Element {
-    const fontSize = 11 / this.props.scale
-    let position: CanvasPoint
-    let width: undefined | number
-    if (isHorizontal) {
-      position = {
-        x: Math.min(from.x, to.x),
-        y: Math.min(from.y, to.y),
-      } as CanvasPoint
-      width = Math.abs(from.x - to.x)
-    } else {
-      const offset = {
-        x: 2 / this.props.scale,
-        y: -fontSize / 2,
-      } as CanvasPoint
-      const middle = {
-        x: (from.x + to.x) / 2,
-        y: (from.y + to.y) / 2,
-      } as CanvasPoint
-      position = Utils.offsetPoint(middle, offset)
-    }
-
     return (
-      <div
-        key={id}
-        style={{
-          position: 'absolute',
-          left: this.props.canvasOffset.x + position.x,
-          top: this.props.canvasOffset.y + position.y,
-          width: width,
-          textAlign: 'center',
-          fontFamily:
-            '-apple-system, BlinkMacSystemFont, Helvetica, "Segoe UI", Roboto,  Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
-          fontSize: fontSize,
-          color: StrokeColor,
-          pointerEvents: 'none',
-        }}
-      >
-        {`${distance.toFixed(0)}`}
-      </div>
+      <CanvasOffsetWrapper>
+        <div
+          key={id}
+          style={{
+            position: 'absolute',
+            top: Math.min(from.y, to.y),
+            left: Math.min(from.x, to.x),
+            width: isHorizontal ? Math.abs(from.x - to.x) : undefined,
+            height: isHorizontal ? undefined : Math.abs(from.y - to.y),
+            pointerEvents: 'none',
+            display: 'flex',
+            flexDirection: isHorizontal ? 'row' : 'column',
+            justifyContent: 'center',
+          }}
+        >
+          <div
+            style={{
+              margin: 4 / this.props.scale,
+              padding: 4 / this.props.scale,
+              borderRadius: 4 / this.props.scale,
+              color: colorTheme.white.value,
+              backgroundColor: StrokeColor,
+              fontSize: 12 / this.props.scale,
+            }}
+          >
+            {`${distance.toFixed(0)}`}
+          </div>
+        </div>
+      </CanvasOffsetWrapper>
     )
   }
 

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -346,7 +346,6 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
         resizeStatus !== 'disabled',
         <>
           {when(isSelectMode(props.editor.mode) && !anyStrategyActive, <PinLines />)}
-          {when(isSelectMode(props.editor.mode), <DistanceGuidelineControl />)}
           {when(isSelectMode(props.editor.mode), <InsertionControls />)}
           {renderHighlightControls()}
           {unless(dragging, <LayoutParentControl />)}
@@ -365,6 +364,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
               ))}
             </>,
           )}
+          {when(isSelectMode(props.editor.mode), <DistanceGuidelineControl />)}
         </>,
       )}
       <CursorComponent />


### PR DESCRIPTION
Fixes #3000 

**Problem:**
The distance guidelines were often very hard to read or even see

**Fix:**
Use the same colours and styling as the floating number controls used for padding and gap controls. I've also moved these controls after the others so that they always appear on top.

**Before:**
<img width="227" alt="image" src="https://user-images.githubusercontent.com/1044774/207640493-7a1e66d9-d5b9-4576-a38a-9015d2560e98.png">

<img width="190" alt="image" src="https://user-images.githubusercontent.com/1044774/207640065-61dd4ee4-a50f-4a89-879c-fe42e1eac388.png">

<img width="193" alt="image" src="https://user-images.githubusercontent.com/1044774/207640727-a9b1bc0a-3d99-47d4-aa48-5a1433f36133.png">


**After:**
<img width="208" alt="image" src="https://user-images.githubusercontent.com/1044774/207640375-c96e802d-90ae-4d88-8a0e-5d705c0890c2.png">

<img width="189" alt="image" src="https://user-images.githubusercontent.com/1044774/207640209-aeafb5da-2072-4161-a0c0-63dec1831741.png">

<img width="200" alt="image" src="https://user-images.githubusercontent.com/1044774/207640870-a6656b97-b77f-4955-94e9-833f81a9bbbd.png">
