### PR TITLE
NavigatorItemWrapper properly memoized selectors

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -86,20 +86,22 @@ const staticNameSelector = createSelector(targetJsxElementSelector, (targetEleme
   )
 })
 
-const navigatorItemWrapperSelector = createSelector(
-  (store: EditorStorePatched) => store.editor.jsxMetadata,
-  (store: EditorStorePatched) => store.derived.elementWarnings,
+const labelSelector = createSelector(
+  targetElementMetadataSelector,
   (store: EditorStorePatched) => store.editor.allElementProps,
-  (sto_re: EditorStorePatched, elementPath: ElementPath) => elementPath,
-  (jsxMetadata, elementWarnings, allElementProps, elementPath) => {
-    const labelInner = MetadataUtils.getElementLabel(allElementProps, elementPath, jsxMetadata)
-
-    const elementWarningsInner = getValueFromComplexMap(EP.toString, elementWarnings, elementPath)
-
-    return {
-      label: labelInner,
-      elementWarnings: elementWarningsInner ?? defaultElementWarnings,
+  (elementMetadata, allElementProps) => {
+    if (elementMetadata == null) {
+      return 'Element 👻'
     }
+    return MetadataUtils.getElementLabelFromMetadata(allElementProps, elementMetadata)
+  },
+)
+
+const elementWarningsSelector = createSelector(
+  (store: EditorStorePatched) => store.derived.elementWarnings,
+  (_: EditorStorePatched, elementPath: ElementPath) => elementPath,
+  (elementWarnings, elementPath) => {
+    return getValueFromComplexMap(EP.toString, elementWarnings, elementPath)
   },
 )
 
@@ -146,9 +148,14 @@ export const NavigatorItemWrapper: React.FunctionComponent<
     'NavigatorItemWrapper targetSupportsChildrenSelector',
   )
 
-  const { label, elementWarnings } = useEditorState(
-    (store) => navigatorItemWrapperSelector(store, props.elementPath),
-    'NavigatorItemWrapper',
+  const label = useEditorState(
+    (store) => labelSelector(store, props.elementPath),
+    'NavigatorItemWrapper labelSelector',
+  )
+
+  const elementWarnings = useEditorState(
+    (store) => elementWarningsSelector(store, props.elementPath),
+    'NavigatorItemWrapper elementWarningsSelector',
   )
 
   const { isElementVisible, renamingTarget, appropriateDropTargetHint, dispatch, isCollapsed } =

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -101,7 +101,9 @@ const elementWarningsSelector = createSelector(
   (store: EditorStorePatched) => store.derived.elementWarnings,
   (_: EditorStorePatched, elementPath: ElementPath) => elementPath,
   (elementWarnings, elementPath) => {
-    return getValueFromComplexMap(EP.toString, elementWarnings, elementPath)
+    return (
+      getValueFromComplexMap(EP.toString, elementWarnings, elementPath) ?? defaultElementWarnings
+    )
   },
 )
 

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -2,39 +2,33 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/react'
 import React from 'react'
-import {
-  isParseSuccess,
-  isTextFile,
-  ParseSuccess,
-  ElementPath,
-} from '../../../core/shared/project-file-types'
-import { useEditorState } from '../../editor/store/store-hook'
+import { createSelector } from 'reselect'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { Either, foldEither } from '../../../core/shared/either'
 import * as EP from '../../../core/shared/element-path'
+import {
+  ElementInstanceMetadata,
+  isJSXElement,
+  JSXElementChild,
+  jsxElementName,
+} from '../../../core/shared/element-template'
+import { forceNotNull } from '../../../core/shared/optional-utils'
+import { ElementPath } from '../../../core/shared/project-file-types'
+import { nullableDeepEquality } from '../../../utils/deep-equality'
+import { JSXElementNameKeepDeepEqualityCall } from '../../../utils/deep-equality-instances'
+import { getValueFromComplexMap } from '../../../utils/map'
+import { useKeepDeepEqualityCall } from '../../../utils/react-performance'
+import {
+  defaultElementWarnings,
+  DropTargetHint,
+  EditorStorePatched,
+} from '../../editor/store/editor-state'
+import { useEditorState } from '../../editor/store/store-hook'
 import {
   DragSelection,
   NavigatorItemContainer,
   NavigatorItemDragAndDropWrapperProps,
 } from './navigator-item-dnd-container'
-import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import {
-  defaultElementWarnings,
-  DropTargetHint,
-  EditorStorePatched,
-  TransientFileState,
-} from '../../editor/store/editor-state'
-import { UtopiaJSXComponent, isUtopiaJSXComponent } from '../../../core/shared/element-template'
-import { getValueFromComplexMap } from '../../../utils/map'
-import { createSelector } from 'reselect'
-import { nullableDeepEquality } from '../../../utils/deep-equality'
-import { JSXElementNameKeepDeepEqualityCall } from '../../../utils/deep-equality-instances'
-import { useKeepDeepEqualityCall } from '../../../utils/react-performance'
-import {
-  normalisePathSuccessOrThrowError,
-  normalisePathToUnderlyingTarget,
-} from '../../custom-code/code-file'
-import { forceNotNull, optionalMap } from '../../../core/shared/optional-utils'
-import { getContentsTreeFileFromString } from '../../assets'
-import { emptyImports } from '../../../core/workers/common/project-file-utils'
 
 interface NavigatorItemWrapperProps {
   index: number
@@ -46,89 +40,80 @@ interface NavigatorItemWrapperProps {
   windowStyle: React.CSSProperties
 }
 
+const targetElementMetadataSelector = createSelector(
+  (store: EditorStorePatched) => store.editor.jsxMetadata,
+  (store: EditorStorePatched, targetPath: ElementPath) => targetPath,
+  (metadata, targetPath): ElementInstanceMetadata | null => {
+    return MetadataUtils.findElementByElementPath(metadata, targetPath)
+  },
+)
+
+const targetJsxElementSelector = createSelector(
+  targetElementMetadataSelector,
+  (metadata): Either<string, JSXElementChild> | undefined => {
+    return metadata?.element
+  },
+)
+
+const targetInNavigatorItemsSelector = createSelector(
+  (store: EditorStorePatched) => store.derived.navigatorTargets,
+  (store: EditorStorePatched, targetPath: ElementPath) => targetPath,
+  (navigatorTargets, targetPath) => {
+    return EP.containsPath(targetPath, navigatorTargets)
+  },
+)
+
+const targetSupportsChildrenSelector = createSelector(
+  (store: EditorStorePatched) => store.editor.projectContents,
+  targetElementMetadataSelector,
+  targetInNavigatorItemsSelector,
+  (projectContents, elementMetadata, elementInNavigatorTargets) => {
+    if (!elementInNavigatorTargets || elementMetadata == null) {
+      return false
+    }
+    return MetadataUtils.targetElementSupportsChildren(projectContents, elementMetadata)
+  },
+)
+
+const staticNameSelector = createSelector(targetJsxElementSelector, (targetElement) => {
+  if (targetElement == null) {
+    return null
+  }
+  return foldEither(
+    (intrinsic) => jsxElementName(intrinsic, []),
+    (element) => (isJSXElement(element) ? element.name : null),
+    targetElement,
+  )
+})
+
 const navigatorItemWrapperSelector = createSelector(
   (store: EditorStorePatched) => store.editor.jsxMetadata,
-  (store: EditorStorePatched) => store.editor.selectedViews,
-  (store: EditorStorePatched) => store.editor.highlightedViews,
-  (store: EditorStorePatched) => store.derived.transientState,
-  (store: EditorStorePatched) => store.derived.navigatorTargets,
   (store: EditorStorePatched) => store.derived.elementWarnings,
-  (store: EditorStorePatched) => store.editor.projectContents,
-  (store: EditorStorePatched) => store.editor.nodeModules.files,
-  (store: EditorStorePatched) => store.editor.canvas.openFile?.filename ?? null,
   (store: EditorStorePatched) => store.editor.allElementProps,
-  (_: EditorStorePatched, elementPath: ElementPath) => elementPath,
-  (
-    jsxMetadata,
-    selectedViews,
-    highlightedViews,
-    transientState,
-    navigatorTargets,
-    elementWarnings,
-    projectContents,
-    nodeModules,
-    currentFilePath,
-    allElementProps,
-    elementPath,
-  ) => {
-    const underlying = normalisePathToUnderlyingTarget(
-      projectContents,
-      nodeModules,
-      forceNotNull('Should be a file path.', currentFilePath),
-      elementPath,
-    )
-    const elementFilePath =
-      underlying.type === 'NORMALISE_PATH_SUCCESS' ? underlying.filePath : currentFilePath
-    const elementProjectFile =
-      elementFilePath == null
-        ? null
-        : getContentsTreeFileFromString(projectContents, elementFilePath)
-    const elementTextFile = isTextFile(elementProjectFile) ? elementProjectFile : null
-    let parsedElementFile: ParseSuccess | null = null
-    if (elementTextFile != null && isParseSuccess(elementTextFile.fileContents.parsed)) {
-      parsedElementFile = elementTextFile.fileContents.parsed
-    }
-    const fileState =
-      elementFilePath == null ? null : transientState.filesState?.[elementFilePath] ?? null
-    const topLevelElements =
-      fileState?.topLevelElementsIncludingScenes ?? parsedElementFile?.topLevelElements ?? []
-    const componentsIncludingScenes = topLevelElements.filter(isUtopiaJSXComponent)
-
-    const staticName = MetadataUtils.getStaticElementName(elementPath, componentsIncludingScenes)
-    const labelInner = MetadataUtils.getElementLabel(
-      allElementProps,
-      elementPath,
-      jsxMetadata,
-      staticName,
-    )
-    // FIXME: This is a mitigation for a situation where somehow this component re-renders
-    // when the navigatorTargets indicate it shouldn't exist...
-    const isInNavigatorTargets = EP.containsPath(elementPath, navigatorTargets)
-    let noOfChildrenInner: number = 0
-    let supportsChildren: boolean = false
-    if (isInNavigatorTargets) {
-      noOfChildrenInner = MetadataUtils.getImmediateChildren(jsxMetadata, elementPath).length
-      supportsChildren = MetadataUtils.targetSupportsChildren(
-        projectContents,
-        jsxMetadata,
-        elementPath,
-      )
-    }
+  (sto_re: EditorStorePatched, elementPath: ElementPath) => elementPath,
+  (jsxMetadata, elementWarnings, allElementProps, elementPath) => {
+    const labelInner = MetadataUtils.getElementLabel(allElementProps, elementPath, jsxMetadata)
 
     const elementWarningsInner = getValueFromComplexMap(EP.toString, elementWarnings, elementPath)
 
     return {
-      staticElementName: staticName,
       label: labelInner,
-      isSelected: EP.containsPath(elementPath, transientState.selectedViews ?? selectedViews),
-      isHighlighted: EP.containsPath(
-        elementPath,
-        transientState.highlightedViews ?? highlightedViews,
-      ),
-      noOfChildren: noOfChildrenInner,
-      supportsChildren: supportsChildren,
       elementWarnings: elementWarningsInner ?? defaultElementWarnings,
     }
+  },
+)
+
+const noOfChildrenSelector = createSelector(
+  (store: EditorStorePatched) => store.derived.navigatorTargets,
+  (_: EditorStorePatched, targetPath: ElementPath) => targetPath,
+  (navigatorTargets, targetPath) => {
+    let result = 0
+    for (const nt of navigatorTargets) {
+      if (EP.isChildOf(nt, targetPath)) {
+        result += 1
+      }
+    }
+    return result
   },
 )
 
@@ -139,15 +124,29 @@ const nullableJSXElementNameKeepDeepEquality = nullableDeepEquality(
 export const NavigatorItemWrapper: React.FunctionComponent<
   React.PropsWithChildren<NavigatorItemWrapperProps>
 > = React.memo((props) => {
-  const {
-    isSelected,
-    isHighlighted,
-    noOfChildren,
-    supportsChildren,
-    staticElementName,
-    label,
-    elementWarnings,
-  } = useEditorState(
+  const { isSelected, isHighlighted } = useEditorState(
+    (store) => ({
+      isSelected: EP.containsPath(props.elementPath, store.editor.selectedViews),
+      isHighlighted: EP.containsPath(props.elementPath, store.editor.highlightedViews),
+    }),
+    'NavigatorItemWrapper isSelected',
+  )
+
+  const noOfChildren = useEditorState((store) => {
+    return noOfChildrenSelector(store, props.elementPath)
+  }, 'NavigatorItemWrapper noOfChildren')
+
+  const staticElementName = useEditorState(
+    (store) => staticNameSelector(store, props.elementPath),
+    'NavigatorItemWrapper staticName',
+  )
+
+  const supportsChildren = useEditorState(
+    (store) => targetSupportsChildrenSelector(store, props.elementPath),
+    'NavigatorItemWrapper targetSupportsChildrenSelector',
+  )
+
+  const { label, elementWarnings } = useEditorState(
     (store) => navigatorItemWrapperSelector(store, props.elementPath),
     'NavigatorItemWrapper',
   )


### PR DESCRIPTION
**Problem:**
The NavigatorItemWrapper's selectors was not fast, and for a large enough project, we would call it a bunch of times.
<img width="945" alt="image" src="https://user-images.githubusercontent.com/2226774/207649828-340c5694-6b29-404f-9434-2aee8141db48.png">
it would use up about 1ms each frame, cumulatively.

**Fix:**
Split the one big mega-selector into small selectors, reorganize them so that memoization can prevent us from doing expensive calculations
<img width="907" alt="image" src="https://user-images.githubusercontent.com/2226774/207649981-84b20921-4554-4b97-8d9a-1174b63c3486.png">


