### PR TITLE
Text editing formatting shortcuts

### DIFF
--- a/editor/src/components/canvas/event-helpers.test-utils.tsx
+++ b/editor/src/components/canvas/event-helpers.test-utils.tsx
@@ -541,6 +541,7 @@ export function pressKey(
   options: {
     modifiers?: Modifiers
     eventOptions?: KeyboardEventInit
+    targetElement?: HTMLElement
   } = {},
 ) {
   const modifiers = options.modifiers ?? emptyModifiers
@@ -553,9 +554,11 @@ export function pressKey(
     ...passedEventOptions,
   }
 
+  const target = options?.targetElement ?? document.body
+
   act(() => {
     fireEvent(
-      document.body,
+      target,
       new KeyboardEvent('keydown', {
         bubbles: true,
         cancelable: true,
@@ -566,7 +569,7 @@ export function pressKey(
     )
 
     fireEvent(
-      document.body,
+      target,
       new KeyboardEvent('keyup', {
         bubbles: true,
         cancelable: true,

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -1,4 +1,5 @@
 import { setFeatureEnabled } from '../../utils/feature-switches'
+import { cmdModifier, Modifiers, shiftCmdModifier } from '../../utils/modifiers'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
 import { mouseClickAtPoint, pressKey } from '../canvas/event-helpers.test-utils'
 import {
@@ -7,6 +8,7 @@ import {
   getPrintedUiJsCode,
   renderTestEditorWithCode,
 } from '../canvas/ui-jsx.test-utils'
+import { TextEditorSpanId } from './text-editor'
 
 describe('Use the text editor', () => {
   before(() => {
@@ -143,7 +145,118 @@ describe('Use the text editor', () => {
         )`),
     )
   })
+  describe('formatting shortcuts', () => {
+    it('supports bold', async () => {
+      const { before, after } = await testModifier(cmdModifier, 'b')
+      expect(before).toEqual(projectWithStyle('fontWeight', 'bold'))
+      expect(after).toEqual(projectWithStyle('fontWeight', 'normal'))
+    })
+
+    it('supports italic', async () => {
+      const { before, after } = await testModifier(cmdModifier, 'i')
+      expect(before).toEqual(projectWithStyle('fontStyle', 'italic'))
+      expect(after).toEqual(projectWithStyle('fontStyle', 'normal'))
+    })
+
+    it('supports underline', async () => {
+      const { before, after } = await testModifier(cmdModifier, 'u')
+      expect(before).toEqual(projectWithStyle('textDecoration', 'underline'))
+      expect(after).toEqual(projectWithStyle('textDecoration', 'none'))
+    })
+
+    it('supports strikethrough', async () => {
+      const { before, after } = await testModifier(shiftCmdModifier, 'x')
+      expect(before).toEqual(projectWithStyle('textDecoration', 'line-through'))
+      expect(after).toEqual(projectWithStyle('textDecoration', 'none'))
+    })
+
+    it("doesn't care about selection", async () => {
+      const editor = await renderTestEditorWithCode(projectWithoutText, 'await-first-dom-report')
+      await prepareTestModifierEditor(editor)
+
+      const textEditorElement = document.getElementById(TextEditorSpanId)
+      expect(textEditorElement).not.toBe(null)
+      if (textEditorElement != null) {
+        const sel = document.createRange()
+        sel.collapse()
+        sel.selectNodeContents(textEditorElement)
+        const range = document.createRange()
+        range.selectNodeContents(textEditorElement)
+        range.collapse(true)
+
+        if (textEditorElement.firstChild != null) {
+          range.setStart(textEditorElement.firstChild, 3)
+          range.setEnd(textEditorElement.firstChild, 5)
+
+          const selection = window.getSelection()
+          if (selection != null) {
+            selection.removeAllRanges()
+            selection.addRange(range)
+          }
+        }
+      }
+
+      await pressShortcut(editor, cmdModifier, 'b')
+
+      expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+        projectWithStyle('fontWeight', 'bold'),
+      )
+    })
+  })
 })
+
+function projectWithStyle(prop: string, value: string) {
+  return formatTestProjectCode(`
+        import * as React from 'react'
+        import { Storyboard } from 'utopia-api'
+
+
+        export var storyboard = (
+          <Storyboard data-uid='sb'>
+            <div
+              data-testid='div'
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                left: 0,
+                top: 0,
+                width: 288,
+                height: 362,
+                ${prop}: '${value}'
+              }}
+              data-uid='39e'
+            >Hello Utopia</div>
+          </Storyboard>
+        )`)
+}
+
+async function prepareTestModifierEditor(editor: EditorRenderResult) {
+  await enterTextEditMode(editor)
+  typeText('Hello Utopia')
+}
+
+async function pressShortcut(editor: EditorRenderResult, mod: Modifiers, key: string) {
+  pressKey(key, {
+    modifiers: mod,
+    targetElement: document.getElementById(TextEditorSpanId) ?? undefined,
+  })
+  closeTextEditor()
+  await editor.getDispatchFollowUpActionsFinished()
+}
+
+async function testModifier(mod: Modifiers, key: string) {
+  const editor = await renderTestEditorWithCode(projectWithoutText, 'await-first-dom-report')
+
+  await prepareTestModifierEditor(editor)
+  await pressShortcut(editor, mod, key)
+  const before = getPrintedUiJsCode(editor.getEditorState())
+
+  await enterTextEditMode(editor)
+  await pressShortcut(editor, mod, key)
+  const after = getPrintedUiJsCode(editor.getEditorState())
+
+  return { before, after }
+}
 
 async function enterTextEditMode(editor: EditorRenderResult) {
   const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -2,12 +2,19 @@ import React from 'react'
 import { ElementPath } from '../../core/shared/project-file-types'
 import { useEditorState } from '../editor/store/store-hook'
 import {
+  applyCommandsAction,
   clearSelection,
   updateChildText,
   updateEditorMode,
 } from '../editor/actions/action-creators'
 import { EditorModes } from '../editor/editor-modes'
 import { escape, unescape } from 'he'
+import { AllElementProps } from '../editor/store/editor-state'
+import { Modifier } from '../../utils/modifiers'
+import { setProperty } from '../canvas/commands/set-property-command'
+import * as EP from '../../core/shared/element-path'
+import * as PP from '../../core/shared/property-path'
+import { ApplyCommandsAction } from '../editor/action-types'
 
 interface TextEditorProps {
   elementPath: ElementPath
@@ -22,8 +29,27 @@ export function unescapeHTML(s: string): string {
   return unescape(s)
 }
 
+const handleShortcut = (
+  cond: boolean,
+  allElementProps: AllElementProps,
+  elementPath: ElementPath,
+  prop: string,
+  value: string,
+  defaultValue: string,
+): Array<ApplyCommandsAction> => {
+  if (!cond) {
+    return []
+  }
+  const { style } = allElementProps[EP.toString(elementPath)]
+  const newValue = style != null && style[prop] === value ? defaultValue : value
+  return [
+    applyCommandsAction([setProperty('always', elementPath, PP.create(['style', prop]), newValue)]),
+  ]
+}
+
 export const TextEditor: React.FC<TextEditorProps> = ({ elementPath, text }: TextEditorProps) => {
   const dispatch = useEditorState((store) => store.dispatch, 'TextEditor dispatch')
+  const allElementProps = useEditorState((store) => store.editor.allElementProps, 'Editor')
   const [firstTextProp] = React.useState(text)
 
   const myElement = React.useRef<HTMLSpanElement>(null)
@@ -46,14 +72,58 @@ export const TextEditor: React.FC<TextEditorProps> = ({ elementPath, text }: Tex
     }
   }, [dispatch, elementPath])
 
-  const onKeyDown = React.useCallback((event: React.KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      // eslint-disable-next-line no-unused-expressions
-      myElement.current?.blur()
-    } else {
-      event.stopPropagation()
-    }
-  }, [])
+  const onKeyDown = React.useCallback(
+    (event: React.KeyboardEvent) => {
+      const modifiers = Modifier.modifiersForEvent(event)
+      const meta = modifiers.cmd || modifiers.ctrl
+      const shortcuts = [
+        ...handleShortcut(
+          meta && event.key === 'b', // Meta+b = bold
+          allElementProps,
+          elementPath,
+          'fontWeight',
+          'bold',
+          'normal',
+        ),
+        ...handleShortcut(
+          meta && event.key === 'i', // Meta+i = italic
+          allElementProps,
+          elementPath,
+          'fontStyle',
+          'italic',
+          'normal',
+        ),
+        ...handleShortcut(
+          meta && event.key === 'u', // Meta+u = underline
+          allElementProps,
+          elementPath,
+          'textDecoration',
+          'underline',
+          'none',
+        ),
+        ...handleShortcut(
+          meta && modifiers.shift && event.key === 'x', // Meta+shift+x = strikethrough
+          allElementProps,
+          elementPath,
+          'textDecoration',
+          'line-through',
+          'none',
+        ),
+      ]
+      if (shortcuts.length > 0) {
+        event.stopPropagation()
+        dispatch(shortcuts)
+      }
+
+      if (event.key === 'Escape') {
+        // eslint-disable-next-line no-unused-expressions
+        myElement.current?.blur()
+      } else {
+        event.stopPropagation()
+      }
+    },
+    [dispatch, elementPath, allElementProps],
+  )
 
   const onBlur = React.useCallback(() => {
     dispatch([updateEditorMode(EditorModes.selectMode()), clearSelection()])

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -16,6 +16,8 @@ import * as EP from '../../core/shared/element-path'
 import * as PP from '../../core/shared/property-path'
 import { ApplyCommandsAction } from '../editor/action-types'
 
+export const TextEditorSpanId = 'text-editor'
+
 interface TextEditorProps {
   elementPath: ElementPath
   text: string
@@ -132,6 +134,7 @@ export const TextEditor: React.FC<TextEditorProps> = ({ elementPath, text }: Tex
   return (
     <span
       ref={myElement}
+      id={TextEditorSpanId}
       onKeyDown={onKeyDown}
       onKeyUp={stopPropagation}
       onKeyPress={stopPropagation}


### PR DESCRIPTION
Fixes #3007 

**Problem:**
Currently text editing does not support formatting shortcuts at all.

**Fix:**

This PR adds basic support for formatting shortcuts in text editing mode. They are only applied as a style prop in the containing element tho, not to individual pieces of the text.

Shortcuts:
| Shortcut | Effect |
|----------|----------|
| `⌘ + B` | Bold |
| `⌘ + I` | Italic |
| `⌘ + U` | Underline |
| `⌘ + Shift + X` | Strikethrough |

To support Windows users, the `⌘` is interchangeable with the `Ctrl` key.