### PR TITLE
`keyboardSetFontWeightStrategy`

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -48,6 +48,7 @@ import { setBorderRadiusStrategy } from './strategies/set-border-radius-strategy
 import { getDragTargets } from './strategies/shared-move-strategies-helpers'
 import * as EP from '../../../core/shared/element-path'
 import { keyboardSetFontSizeStrategy } from './strategies/keyboard-set-font-size-strategy'
+import { keyboardSetFontWeightStrategy } from './strategies/keyboard-set-font-weight-strategy'
 
 export type CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
@@ -128,18 +129,16 @@ const AncestorCompatibleStrategies: Array<MetaCanvasStrategy> = preventAllOnRoot
   dragToMoveMetaStrategy,
 ])
 
-const metaStrategy =
-  (strategy: CanvasStrategyFactory): MetaCanvasStrategy =>
-  (
-    canvasState: InteractionCanvasState,
-    interactionSession: InteractionSession | null,
-    customStrategyState: CustomStrategyState,
-  ): Array<CanvasStrategy> => {
-    return mapDropNulls(
-      (factory) => factory(canvasState, interactionSession, customStrategyState),
-      [strategy],
-    )
-  }
+const keyboardTweakStrategy: MetaCanvasStrategy = (
+  canvasState: InteractionCanvasState,
+  interactionSession: InteractionSession | null,
+  customStrategyState: CustomStrategyState,
+): Array<CanvasStrategy> => {
+  return mapDropNulls(
+    (factory) => factory(canvasState, interactionSession),
+    [keyboardSetFontSizeStrategy, keyboardSetFontWeightStrategy],
+  )
+}
 
 export const RegisteredCanvasStrategies: Array<MetaCanvasStrategy> = [
   ...AncestorCompatibleStrategies,
@@ -148,7 +147,7 @@ export const RegisteredCanvasStrategies: Array<MetaCanvasStrategy> = [
   drawToInsertMetaStrategy,
   dragToInsertMetaStrategy,
   ancestorMetaStrategy(AncestorCompatibleStrategies, 1),
-  metaStrategy(keyboardSetFontSizeStrategy),
+  keyboardTweakStrategy,
 ]
 
 export function pickCanvasStateFromEditorState(

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -129,7 +129,7 @@ const AncestorCompatibleStrategies: Array<MetaCanvasStrategy> = preventAllOnRoot
   dragToMoveMetaStrategy,
 ])
 
-const keyboardTweakStrategy: MetaCanvasStrategy = (
+const keyboardShortcutStrategies: MetaCanvasStrategy = (
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
   customStrategyState: CustomStrategyState,
@@ -147,7 +147,7 @@ export const RegisteredCanvasStrategies: Array<MetaCanvasStrategy> = [
   drawToInsertMetaStrategy,
   dragToInsertMetaStrategy,
   ancestorMetaStrategy(AncestorCompatibleStrategies, 1),
-  keyboardTweakStrategy,
+  keyboardShortcutStrategies,
 ]
 
 export function pickCanvasStateFromEditorState(

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size-strategy.tsx
@@ -100,7 +100,7 @@ function fitness(interactionSession: InteractionSession | null): number {
     interactionSession.interactionData.keyStates,
     Keyboard.keyTriggersFontSizeStrategy,
   )
-  if (lastKeyState == null) {
+  if (lastKeyState == null || !lastKeyState.modifiers.cmd || !lastKeyState.modifiers.shift) {
     return 0
   }
   return 1

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight-strategy.tsx
@@ -1,0 +1,169 @@
+import {
+  getSimpleAttributeAtPath,
+  MetadataUtils,
+} from '../../../../core/model/element-metadata-utils'
+import { elementOnlyHasTextChildren } from '../../../../core/model/element-template-utils'
+import { mapDropNulls } from '../../../../core/shared/array-utils'
+import { defaultEither, isLeft, right } from '../../../../core/shared/either'
+import { ElementInstanceMetadataMap, isJSXElement } from '../../../../core/shared/element-template'
+import { ElementPath } from '../../../../core/shared/project-file-types'
+import * as PP from '../../../../core/shared/property-path'
+import Keyboard from '../../../../utils/keyboard'
+import {
+  cssNumber,
+  CSSNumber,
+  parseCSSLengthPercent,
+  printCSSNumber,
+} from '../../../inspector/common/css-utils'
+import { setProperty } from '../../commands/set-property-command'
+import {
+  InteractionCanvasState,
+  CanvasStrategy,
+  getTargetPathsFromInteractionTarget,
+  emptyStrategyApplicationResult,
+  strategyApplicationResult,
+} from '../canvas-strategy-types'
+import { InteractionSession } from '../interaction-state'
+import { accumulatePresses, getLastKeyPressState } from './shared-keyboard-strategy-helpers'
+
+export function keyboardSetFontWeightStrategy(
+  canvasState: InteractionCanvasState,
+  interactionSession: InteractionSession | null,
+): CanvasStrategy | null {
+  const validTargets = getTargetPathsFromInteractionTarget(canvasState.interactionTarget).filter(
+    (path) => isValidTarget(canvasState.startingMetadata, path),
+  )
+
+  if (validTargets.length === 0) {
+    return null
+  }
+
+  return {
+    id: 'set-font-size',
+    name: 'Set font size',
+    controlsToRender: [],
+    fitness: fitness(interactionSession),
+    apply: () => {
+      if (interactionSession == null || interactionSession.interactionData.type !== 'KEYBOARD') {
+        return emptyStrategyApplicationResult
+      }
+
+      let fontSizeDelta: number = 0
+
+      const accumulatedPresses = accumulatePresses(interactionSession.interactionData.keyStates)
+      accumulatedPresses.forEach((accumulatedPress) => {
+        accumulatedPress.keysPressed.forEach((key) => {
+          if (accumulatedPress.modifiers.cmd && accumulatedPress.modifiers.shift) {
+            if (key === 'period') {
+              fontSizeDelta += accumulatedPress.count
+            }
+            if (key === 'comma') {
+              fontSizeDelta -= accumulatedPress.count
+            }
+          }
+        })
+      })
+
+      const commands = mapDropNulls(
+        (path) => getFontSize(canvasState.startingMetadata, path),
+        validTargets,
+      ).map(([fontSize, path]) =>
+        setProperty(
+          'always',
+          path,
+          PP.create(['style', 'fontSize']),
+          printCSSNumber(adjust(fontSize, fontSizeDelta), null),
+        ),
+      )
+
+      return strategyApplicationResult(commands)
+    },
+  }
+}
+
+function isValidTarget(metadata: ElementInstanceMetadataMap, elementPath: ElementPath): boolean {
+  const element = MetadataUtils.findElementByElementPath(metadata, elementPath)
+  if (element == null || isLeft(element.element) || !isJSXElement(element.element.value)) {
+    return false
+  }
+  return (
+    elementOnlyHasTextChildren(element.element.value) ||
+    getFontWeightFromProp(metadata, elementPath) != null
+  )
+}
+
+function fitness(interactionSession: InteractionSession | null): number {
+  if (interactionSession == null || interactionSession.interactionData.type !== 'KEYBOARD') {
+    return 0
+  }
+  const lastKeyState = getLastKeyPressState(
+    interactionSession.interactionData.keyStates,
+    Keyboard.keyTriggersFontSizeStrategy,
+  )
+  if (lastKeyState == null) {
+    return 0
+  }
+  return 1
+}
+
+const FontWeightProp = 'fontSize'
+
+function parseMaybeFontWeight(maybeFontSize: unknown): CSSNumber | null {
+  return defaultEither(null, parseCSSLengthPercent(maybeFontSize))
+}
+
+function getFontWeightFromProp(
+  metadata: ElementInstanceMetadataMap,
+  elementPath: ElementPath,
+): CSSNumber | null {
+  const element = MetadataUtils.findElementByElementPath(metadata, elementPath)
+  if (element == null || isLeft(element.element) || !isJSXElement(element.element.value)) {
+    return null
+  }
+
+  const attribute: string | null = defaultEither(
+    null,
+    getSimpleAttributeAtPath(
+      right(element.element.value.props),
+      PP.create(['style', FontWeightProp]),
+    ),
+  )
+
+  return parseMaybeFontWeight(attribute)
+}
+
+function getFontWeightFromComputedStyle(
+  metadata: ElementInstanceMetadataMap,
+  elementPath: ElementPath,
+): CSSNumber | null {
+  const element = MetadataUtils.findElementByElementPath(metadata, elementPath)
+  if (element == null) {
+    return null
+  }
+
+  return parseMaybeFontWeight(element.computedStyle?.[FontWeightProp])
+}
+
+function adjust(value: CSSNumber, delta: number): CSSNumber {
+  const scaleFactor = value.unit === 'em' ? 0.1 : 1
+  if (value.unit === 'em' && value.value < 1) {
+    return value
+  }
+  if (value.unit === 'px' && value.value < 5) {
+    return value
+  }
+  return cssNumber(value.value + delta * scaleFactor, value.unit)
+}
+
+function getFontSize(
+  metadata: ElementInstanceMetadataMap,
+  elementPath: ElementPath,
+): [CSSNumber, ElementPath] | null {
+  const size =
+    getFontWeightFromProp(metadata, elementPath) ??
+    getFontWeightFromComputedStyle(metadata, elementPath)
+  if (size != null) {
+    return [size, elementPath]
+  }
+  return null
+}

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight.spec.browser2.tsx
@@ -1,0 +1,226 @@
+import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
+import { mouseClickAtPoint, pressKey } from '../../event-helpers.test-utils'
+import { EditorRenderResult, renderTestEditorWithCode } from '../../ui-jsx.test-utils'
+
+describe('adjust font weight with the keyboard', () => {
+  describe('no font weight specified', () => {
+    it('increase font weight', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithNoFontWeight,
+        'await-first-dom-report',
+      )
+
+      const div = editor.renderedDOM.getByTestId('div')
+      await doSelect(editor)
+      await doTestWithDelta(editor, { increaseBy: 1, decreaseBy: 0 })
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(div.style.fontWeight).toEqual('500')
+    })
+
+    it('increase font weight multiple times', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithNoFontWeight,
+        'await-first-dom-report',
+      )
+
+      const div = editor.renderedDOM.getByTestId('div')
+      await doSelect(editor)
+      await doTestWithDelta(editor, { increaseBy: 2, decreaseBy: 0 })
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(div.style.fontWeight).toEqual('600')
+    })
+
+    it('try to increase font weight above the limit', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithNoFontWeight,
+        'await-first-dom-report',
+      )
+
+      const div = editor.renderedDOM.getByTestId('div')
+      await doSelect(editor)
+      await doTestWithDelta(editor, { increaseBy: 6, decreaseBy: 0 })
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(div.style.fontWeight).toEqual('900')
+    })
+
+    it('decrease font weight', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithNoFontWeight,
+        'await-first-dom-report',
+      )
+
+      const div = editor.renderedDOM.getByTestId('div')
+      await doSelect(editor)
+      await doTestWithDelta(editor, { increaseBy: 0, decreaseBy: 1 })
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(div.style.fontWeight).toEqual('300')
+    })
+
+    it('decrease font weight multiple times', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithNoFontWeight,
+        'await-first-dom-report',
+      )
+
+      const div = editor.renderedDOM.getByTestId('div')
+      await doSelect(editor)
+      await doTestWithDelta(editor, { increaseBy: 0, decreaseBy: 3 })
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(div.style.fontWeight).toEqual('100')
+    })
+
+    it('try to increase font weight below the limit', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithNoFontWeight,
+        'await-first-dom-report',
+      )
+
+      const div = editor.renderedDOM.getByTestId('div')
+      await doSelect(editor)
+      await doTestWithDelta(editor, { increaseBy: 0, decreaseBy: 9 })
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(div.style.fontWeight).toEqual('100')
+    })
+  })
+
+  describe('font weight already set', () => {
+    it('increase font weight', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithFontWeight('500'),
+        'await-first-dom-report',
+      )
+
+      const div = editor.renderedDOM.getByTestId('div')
+      await doSelect(editor)
+      await doTestWithDelta(editor, { increaseBy: 1, decreaseBy: 0 })
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(div.style.fontWeight).toEqual('600')
+    })
+
+    it('increase font weight multiple times', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithFontWeight('500'),
+        'await-first-dom-report',
+      )
+
+      const div = editor.renderedDOM.getByTestId('div')
+      await doSelect(editor)
+      await doTestWithDelta(editor, { increaseBy: 3, decreaseBy: 0 })
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(div.style.fontWeight).toEqual('800')
+    })
+
+    it('decrease font weight', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithFontWeight('400'),
+        'await-first-dom-report',
+      )
+
+      const div = editor.renderedDOM.getByTestId('div')
+      await doSelect(editor)
+      await doTestWithDelta(editor, { increaseBy: 0, decreaseBy: 1 })
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(div.style.fontWeight).toEqual('300')
+    })
+
+    it('decrease font weight multiple times', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithFontWeight('500'),
+        'await-first-dom-report',
+      )
+
+      const div = editor.renderedDOM.getByTestId('div')
+      await doSelect(editor)
+      await doTestWithDelta(editor, { increaseBy: 0, decreaseBy: 3 })
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(div.style.fontWeight).toEqual('200')
+    })
+  })
+})
+
+async function doSelect(editor: EditorRenderResult) {
+  const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
+  const div = editor.renderedDOM.getByTestId('div')
+  const divBounds = div.getBoundingClientRect()
+  const divCorner = {
+    x: divBounds.x + 50,
+    y: divBounds.y + 40,
+  }
+
+  mouseClickAtPoint(canvasControlsLayer, divCorner)
+  await editor.getDispatchFollowUpActionsFinished()
+}
+
+async function doTestWithDelta(
+  editor: EditorRenderResult,
+  delta: { decreaseBy: number; increaseBy: number },
+) {
+  for (let i = 0; i < delta.increaseBy; i++) {
+    pressKey('.', { modifiers: { shift: false, cmd: true, alt: true, ctrl: false } })
+  }
+
+  for (let i = 0; i < delta.decreaseBy; i++) {
+    pressKey(',', { modifiers: { shift: false, cmd: true, alt: true, ctrl: false } })
+  }
+
+  await editor.getDispatchFollowUpActionsFinished()
+}
+
+const projectWithNoFontWeight = `import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      data-testid='div'
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 377,
+        top: 271,
+        width: 288,
+        height: 362,
+      }}
+      data-uid='39e'
+    >
+      hello
+    </div>
+  </Storyboard>
+)
+`
+
+const projectWithFontWeight = (fontWeight: string) => `import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      data-testid='div'
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 377,
+        top: 271,
+        width: 288,
+        height: 362,
+        fontWeight: '${fontWeight}'
+      }}
+      data-uid='39e'
+    >
+      hello
+    </div>
+  </Storyboard>
+)
+`

--- a/editor/src/utils/keyboard.ts
+++ b/editor/src/utils/keyboard.ts
@@ -274,9 +274,22 @@ export const Keyboard = {
         return false
     }
   },
+  keyTriggersFontWeightStrategy: function (keyChar: KeyCharacter): boolean {
+    switch (keyChar) {
+      case 'period':
+      case 'comma':
+        return true
+      default:
+        return false
+    }
+  },
   // This needs to be extended when we introduce new keys in canvas strategies
   keyIsInteraction: function (keyChar: KeyCharacter): boolean {
-    return this.keyIsArrow(keyChar) || this.keyTriggersFontSizeStrategy(keyChar)
+    return (
+      this.keyIsArrow(keyChar) ||
+      this.keyTriggersFontSizeStrategy(keyChar) ||
+      this.keyTriggersFontWeightStrategy(keyChar)
+    )
   },
   keyTriggersScroll: function (keyChar: KeyCharacter, keysPressed: KeysPressed): boolean {
     return (


### PR DESCRIPTION
## Set `font-weight` on a selected element with the keyboard
This PR adds a new strategy that makes it possible to set `font-weight` by pressing `alt-cmd-,` to decrease font weight, and `alt-cmd-.` to increase it. `font-weight` cannot be set to a value lower than 100 and higher than 900.