### PR TITLE
Only show re-order slider on hover

### DIFF
--- a/editor/src/components/canvas/controls/reorder-slider-control.tsx
+++ b/editor/src/components/canvas/controls/reorder-slider-control.tsx
@@ -46,10 +46,10 @@ export const ReorderSliderControl = controlForStrategyMemoized(
         store.editor.canvas.interactionSession.activeControl.type === 'REORDER_SLIDER',
       'ReorderSliderControl isDragging',
     )
-    const isSelectedElementHovered = useEditorState((store) => {
-      const { hoveredViews, selectedViews } = store.editor
-      return hoveredViews.includes(selectedViews[0])
-    }, 'ReorderSliderControl isSelectedElementHovered')
+    const isTargetElementHovered = useEditorState((store) => {
+      const { hoveredViews } = store.editor
+      return target != null && hoveredViews.includes(target)
+    }, 'ReorderSliderControl isTargetElementHovered')
 
     const { siblings, latestIndex, startingIndex, startingFrame } = useEditorState(
       (store) => {
@@ -114,7 +114,7 @@ export const ReorderSliderControl = controlForStrategyMemoized(
       } as CanvasPoint
     }, [startingFrame, controlAreaTopLeft, latestIndex, scale])
 
-    if (siblings.length > 1 && (isDragging || isSelectedElementHovered)) {
+    if (siblings.length > 1 && (isDragging || isTargetElementHovered)) {
       return (
         <CanvasOffsetWrapper>
           {when(

--- a/editor/src/components/canvas/controls/reorder-slider-control.tsx
+++ b/editor/src/components/canvas/controls/reorder-slider-control.tsx
@@ -46,6 +46,10 @@ export const ReorderSliderControl = controlForStrategyMemoized(
         store.editor.canvas.interactionSession.activeControl.type === 'REORDER_SLIDER',
       'ReorderSliderControl isDragging',
     )
+    const isSelectedElementHovered = useEditorState((store) => {
+      const { hoveredViews, selectedViews } = store.editor
+      return hoveredViews.includes(selectedViews[0])
+    }, 'ReorderSliderControl isSelectedElementHovered')
 
     const { siblings, latestIndex, startingIndex, startingFrame } = useEditorState(
       (store) => {
@@ -110,7 +114,7 @@ export const ReorderSliderControl = controlForStrategyMemoized(
       } as CanvasPoint
     }, [startingFrame, controlAreaTopLeft, latestIndex, scale])
 
-    if (siblings.length > 1) {
+    if (siblings.length > 1 && (isDragging || isSelectedElementHovered)) {
       return (
         <CanvasOffsetWrapper>
           {when(


### PR DESCRIPTION
Fixes #3012 

**Problem:**
We want to hide the re-order slider unless the element is hovered or the control is already being dragged

**Fix:**
Add a check to see if the element is either hovered, or the control is being dragged, plus some tests to capture that.