### PR TITLE
colors(canvas) - experimental neon pink outline

### DIFF
--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -145,7 +145,7 @@ export const light = {
   canvasSelectionAlternateOutlineYogaParent: base.neonpink,
   canvasSelectionAlternateOutlineYogaChild: createUtopiColor('rgba(255,51,255,1)'),
   canvasSelectionSecondaryOutline: createUtopiColor('hsla(0,0%,10%,0.5)'),
-  canvasSelectionNotFocusable: base.darkgray,
+  canvasSelectionNotFocusable: base.neonpink,
   canvasDraggingPlaceholderYoga: createUtopiColor('rgba(255,0,255,0.3)'),
   canvasDragOutlineBlock: lightBase.primary,
   canvasDragOutlineInline: base.red,


### PR DESCRIPTION
**Problem:**
Our canvas controls sometimes are too low contrast w/ the contents. Trying to see if neon pink can help us (it's the brightest colour until `display-p3` support lands in Chrome

**Fix:**
Outline colour becomes `brand.neonpink`