### PR TITLE
Support pasting content during text editing

### DIFF
--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -1,8 +1,5 @@
-import { createEvent } from '@testing-library/react'
-import { ClipboardEvent } from 'react'
 import { setFeatureEnabled } from '../../utils/feature-switches'
 import { cmdModifier, Modifiers, shiftCmdModifier } from '../../utils/modifiers'
-import { wait } from '../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
 import { mouseClickAtPoint, pressKey } from '../canvas/event-helpers.test-utils'
 import {
@@ -239,86 +236,7 @@ describe('Use the text editor', () => {
       )
     })
   })
-
-  it('supports pasting content', async () => {
-    // test plan:
-    // 1. type 'Hello Utopia'
-    // 2. move the caret to the 5th position
-    // 3. type ', ' => the text is now 'Hello, Utopia'
-    // 4. paste 'dear' => the text is now 'Hello, dear Utopia'
-    // 5. type 'friendly ' => the text is finally 'Hello, dear friendly Utopia'
-
-    const editor = await renderTestEditorWithCode(projectWithoutText, 'await-first-dom-report')
-    await prepareTestModifierEditor(editor)
-
-    const textEditorElement = document.getElementById(TextEditorSpanId)
-    expect(textEditorElement).not.toBe(null)
-    if (textEditorElement != null) {
-      const sel = document.createRange()
-      sel.collapse()
-      sel.selectNodeContents(textEditorElement)
-      const range = document.createRange()
-      range.selectNodeContents(textEditorElement)
-      range.collapse(true)
-
-      if (textEditorElement.firstChild != null) {
-        range.setStart(textEditorElement.firstChild, 5)
-        range.setEnd(textEditorElement.firstChild, 5)
-
-        const selection = window.getSelection()
-        if (selection != null) {
-          selection.removeAllRanges()
-          selection.addRange(range)
-        }
-      }
-    }
-
-    typeText(', ')
-
-    const pasteData = new DataTransfer()
-    pasteData.getData = () => 'dear'
-    const event = createEvent.paste(textEditorElement ?? document.body, {
-      clipboardData: pasteData,
-    } as ClipboardEvent)
-    if (textEditorElement != null) {
-      textEditorElement.dispatchEvent(event)
-    }
-    await editor.getDispatchFollowUpActionsFinished()
-
-    // ensure that the caret position is preserved
-    typeText(' friendly')
-
-    await closeTextEditor()
-    await editor.getDispatchFollowUpActionsFinished()
-    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-      projectWithCustomText('Hello, dear friendly Utopia'),
-    )
-  })
 })
-
-function projectWithCustomText(text: string) {
-  return formatTestProjectCode(`
-        import * as React from 'react'
-        import { Storyboard } from 'utopia-api'
-
-
-        export var storyboard = (
-          <Storyboard data-uid='sb'>
-            <div
-              data-testid='div'
-              style={{
-                backgroundColor: '#0091FFAA',
-                position: 'absolute',
-                left: 0,
-                top: 0,
-                width: 288,
-                height: 362,
-              }}
-              data-uid='39e'
-            >${text}</div>
-          </Storyboard>
-        )`)
-}
 
 function projectWithStyle(prop: string, value: string) {
   return formatTestProjectCode(`

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -218,8 +218,6 @@ describe('Use the text editor', () => {
     const editor = await renderTestEditorWithCode(projectWithoutText, 'await-first-dom-report')
     await prepareTestModifierEditor(editor)
 
-    await wait(500) // ensure that the caret is correctly placed at the first load
-
     const textEditorElement = document.getElementById(TextEditorSpanId)
     expect(textEditorElement).not.toBe(null)
     if (textEditorElement != null) {

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -1,5 +1,8 @@
+import { createEvent } from '@testing-library/react'
+import { ClipboardEvent } from 'react'
 import { setFeatureEnabled } from '../../utils/feature-switches'
 import { cmdModifier, Modifiers, shiftCmdModifier } from '../../utils/modifiers'
+import { wait } from '../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
 import { mouseClickAtPoint, pressKey } from '../canvas/event-helpers.test-utils'
 import {
@@ -203,7 +206,88 @@ describe('Use the text editor', () => {
       )
     })
   })
+
+  it('supports pasting content', async () => {
+    // test plan:
+    // 1. type 'Hello Utopia'
+    // 2. move the caret to the 5th position
+    // 3. type ', ' => the text is now 'Hello, Utopia'
+    // 4. paste 'dear' => the text is now 'Hello, dear Utopia'
+    // 5. type 'friendly ' => the text is finally 'Hello, dear friendly Utopia'
+
+    const editor = await renderTestEditorWithCode(projectWithoutText, 'await-first-dom-report')
+    await prepareTestModifierEditor(editor)
+
+    await wait(500) // ensure that the caret is correctly placed at the first load
+
+    const textEditorElement = document.getElementById(TextEditorSpanId)
+    expect(textEditorElement).not.toBe(null)
+    if (textEditorElement != null) {
+      const sel = document.createRange()
+      sel.collapse()
+      sel.selectNodeContents(textEditorElement)
+      const range = document.createRange()
+      range.selectNodeContents(textEditorElement)
+      range.collapse(true)
+
+      if (textEditorElement.firstChild != null) {
+        range.setStart(textEditorElement.firstChild, 5)
+        range.setEnd(textEditorElement.firstChild, 5)
+
+        const selection = window.getSelection()
+        if (selection != null) {
+          selection.removeAllRanges()
+          selection.addRange(range)
+        }
+      }
+    }
+
+    typeText(', ')
+
+    const pasteData = new DataTransfer()
+    pasteData.getData = () => 'dear'
+    const event = createEvent.paste(textEditorElement ?? document.body, {
+      clipboardData: pasteData,
+    } as ClipboardEvent)
+    if (textEditorElement != null) {
+      textEditorElement.dispatchEvent(event)
+    }
+    await editor.getDispatchFollowUpActionsFinished()
+
+    // ensure that the caret position is preserved
+    typeText(' friendly')
+
+    await closeTextEditor()
+    await editor.getDispatchFollowUpActionsFinished()
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      projectWithCustomText('Hello, dear friendly Utopia'),
+    )
+  })
 })
+
+function projectWithCustomText(text: string) {
+  return formatTestProjectCode(`
+        import * as React from 'react'
+        import { Storyboard } from 'utopia-api'
+
+
+        export var storyboard = (
+          <Storyboard data-uid='sb'>
+            <div
+              data-testid='div'
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                left: 0,
+                top: 0,
+                width: 288,
+                height: 362,
+              }}
+              data-uid='39e'
+            >${text}</div>
+          </Storyboard>
+        )`)
+}
 
 function projectWithStyle(prop: string, value: string) {
   return formatTestProjectCode(`

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -62,8 +62,6 @@ export const TextEditor = React.memo(({ elementPath, text }: TextEditorProps) =>
       return
     }
 
-    setSelectionToEnd(currentElement)
-
     currentElement.focus()
 
     return () => {
@@ -79,6 +77,7 @@ export const TextEditor = React.memo(({ elementPath, text }: TextEditorProps) =>
       return
     }
     myElement.current.textContent = firstTextProp
+    setSelectionToEnd(myElement.current)
   }, [firstTextProp])
 
   const onKeyDown = React.useCallback(

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -63,6 +63,7 @@ export const TextEditor = React.memo(({ elementPath, text }: TextEditorProps) =>
     }
 
     setSelectionToEnd(currentElement)
+
     currentElement.focus()
 
     return () => {

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -53,7 +53,6 @@ export const TextEditor = React.memo(({ elementPath, text }: TextEditorProps) =>
   const dispatch = useEditorState((store) => store.dispatch, 'TextEditor dispatch')
   const allElementProps = useEditorState((store) => store.editor.allElementProps, 'Editor')
   const [firstTextProp] = React.useState(text)
-  const [loaded, setLoaded] = React.useState(false)
 
   const myElement = React.useRef<HTMLSpanElement>(null)
 
@@ -73,13 +72,6 @@ export const TextEditor = React.memo(({ elementPath, text }: TextEditorProps) =>
       }
     }
   }, [dispatch, elementPath])
-
-  React.useEffect(() => {
-    if (loaded || myElement.current?.firstChild == null) {
-      return
-    }
-    setLoaded(true)
-  }, [loaded, myElement.current?.firstChild])
 
   React.useEffect(() => {
     if (myElement.current == null) {


### PR DESCRIPTION
Fixes #3016 

**Problem:**
Currently pasting content is not possible in text edit mode.

**Fix:**
Handle clipboard events and insert the content in the right place inside the text.

Notes:
- it only works with keyboard-based paste, as right clicking with the mouse will exit the editing mode
- the caret gymnastics are required to make sure that the caret stays effectively where it should be (after the pasted content) instead of jumping around
- undo is a bit borked, but this should probably be fixed in a different PR

![Kapture 2022-12-15 at 15 46 45](https://user-images.githubusercontent.com/1081051/207890798-f5e30b4a-e013-44b1-9174-97c91a7d2438.gif)
