### PR TITLE
Measure Selectors!

### DIFF
--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -63,10 +63,12 @@ function useWrapSelectorInPerformanceMeasureBlock<U>(
       let calledNumberOfTimes = 1
 
       // Uncomment this to stress-test selectors
-      for (let index = 0; index < 99; index++) {
-        calledNumberOfTimes++
-        selector(state)
-      }
+      // if (MeasureSelectors) {
+      //   for (let index = 0; index < 99; index++) {
+      //     calledNumberOfTimes++
+      //     selector(state)
+      //   }
+      // }
 
       const result = selector(state)
       if (LogSelectorPerformance) {

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -5,6 +5,7 @@ import { fastForEach, isBrowserEnvironment } from '../core/shared/utils'
 export type FeatureName =
   | 'Debug mode – Redux Devtools'
   | 'Debug mode – Performance Marks'
+  | 'Debug mode – Measure Selectors'
   | 'Dragging Reparents By Default'
   | 'Re-parse Project Button'
   | 'Performance Test Triggers'
@@ -18,6 +19,7 @@ export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Shows Overlay', // Removing this option so that we can experiment on this later
   'Debug mode – Redux Devtools',
   'Debug mode – Performance Marks',
+  'Debug mode – Measure Selectors',
   'Re-parse Project Button',
   'Performance Test Triggers',
   'Canvas Strategies Debug Panel',
@@ -29,6 +31,7 @@ export const AllFeatureNames: FeatureName[] = [
 let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Debug mode – Redux Devtools': false,
   'Debug mode – Performance Marks': false,
+  'Debug mode – Measure Selectors': false,
   'Dragging Reparents By Default': false,
   'Re-parse Project Button': !(PRODUCTION_CONFIG as boolean),
   'Performance Test Triggers': !(PRODUCTION_CONFIG as boolean),


### PR DESCRIPTION
<img width="809" alt="image" src="https://user-images.githubusercontent.com/2226774/207899355-a419686e-c39c-4583-8c7b-428aed367400.png">

it's a new toy that can help us get some insight into selectors.

Unfortunately the precision of performance.now() is not enough to capture the fast selectors :( 
But for the selectors that are slow, it's neat!