### PR TITLE
Change selection eagerly

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import ReactDOM from 'react-dom'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { uniqBy } from '../../../../core/shared/array-utils'
 import { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
@@ -709,14 +710,17 @@ function useSelectOrLiveModeSelectAndHover(
         }
 
         if (!foundTargetIsSelected) {
+          // first we only set the selected views for the canvas controls
+          ReactDOM.flushSync(() => {
+            setSelectedViewsForCanvasControlsOnly(updatedSelection)
+          })
+
           requestAnimationFrame(() => {
             if (innerAnimationFrameRef.current != null) {
               window.cancelAnimationFrame(innerAnimationFrameRef.current)
             }
             innerAnimationFrameRef.current = requestAnimationFrame(() => {
               let editorActions: Array<EditorAction> = []
-              // first we only set the selected views for the canvas controls
-              setSelectedViewsForCanvasControlsOnly(updatedSelection)
 
               // In either case cancel insert mode.
               if (isInsertMode(editorStoreRef.current.editor.mode)) {


### PR DESCRIPTION
**Problem:**
Ideally we can change the selection outline more eagerly than we update the rest of the editor.

**Fix:**
This brings back a more eager selection outline update which happens ahead of actual selection change.

**Limitations:**
This currently does not include the functionality to integrate it into the new strategy controls.

**Commit Details:**
- `setSelectedViewsForCanvasControlsOnly` works with React 18 by using `flushSync`.
- Delayed editor actions functionality resurrected.
