### PR TITLE
Selection hot path improvements.

### DIFF
--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -4836,10 +4836,12 @@ function parseValueFactory<T, K extends keyof T>(parserMap: {
   }
 }
 
-const parseMetadataValue = parseValueFactory(elementPropertiesParsers)
-const parseCSSValue = parseValueFactory(cssParsers)
-const parseOldLayoutValue = parseValueFactory(layoutParsers)
-const parseNewLayoutValue = parseValueFactory(layoutParsersNew)
+const parseMetadataValue = Utils.memoize(parseValueFactory(elementPropertiesParsers), {
+  maxSize: 1000,
+})
+const parseCSSValue = Utils.memoize(parseValueFactory(cssParsers), { maxSize: 1000 })
+const parseOldLayoutValue = Utils.memoize(parseValueFactory(layoutParsers), { maxSize: 1000 })
+const parseNewLayoutValue = Utils.memoize(parseValueFactory(layoutParsersNew), { maxSize: 1000 })
 
 function isMetadataProp(prop: unknown): prop is keyof ParsedElementProperties {
   return typeof prop === 'string' && prop in elementPropertiesEmptyValues

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -250,9 +250,7 @@ export class NavigatorItemDndWrapper extends PureComponent<
         key='navigatorItem'
         id={`navigator-item-${safeComponentId}`}
         data-testid={`navigator-item-${safeComponentId}`}
-        style={{
-          ...props.windowStyle,
-        }}
+        style={props.windowStyle}
       >
         <NavigatorItem
           elementPath={this.props.elementPath}

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../uuiui'
 import { last } from '../../core/shared/array-utils'
 import { UtopiaTheme } from '../../uuiui/styles/theme/utopia-theme'
+import { useKeepReferenceEqualityIfPossible } from '../../utils/react-performance'
 
 interface ItemProps extends ListChildComponentProps {}
 
@@ -94,6 +95,7 @@ const Item = React.memo(({ index, style }: ItemProps) => {
 
   const targetPath = visibleNavigatorTargets[index]
   const componentKey = EP.toComponentId(targetPath)
+  const deepKeptStyle = useKeepReferenceEqualityIfPossible(style)
   return (
     <NavigatorItemWrapper
       key={componentKey}
@@ -103,7 +105,7 @@ const Item = React.memo(({ index, style }: ItemProps) => {
       getMaximumDistance={getDistanceFromAncestorWhereImTheLastLeaf}
       getDragSelections={getDragSelections}
       getSelectedViewsInRange={getSelectedViewsInRange}
-      windowStyle={style}
+      windowStyle={deepKeptStyle}
     />
   )
 })

--- a/editor/src/utils/hashed-assets.ts
+++ b/editor/src/utils/hashed-assets.ts
@@ -2,7 +2,7 @@ import { HEADERS, MODE } from '../common/server'
 import { BASE_URL, STATIC_BASE_URL } from '../common/env-vars'
 import { isBrowserEnvironment } from '../core/shared/utils'
 import { cachedPromise } from '../core/shared/promise-utils'
-import urljoin from 'url-join'
+import { appendToPath } from './path-utils'
 
 const HASHED_ASSETS_ENDPOINT = BASE_URL + 'hashed-assets.json'
 
@@ -35,7 +35,7 @@ function getPossiblyHashedURLInner(url: string): string {
 
 export function getPossiblyHashedURL(url: string): string {
   const relativeURL = getPossiblyHashedURLInner(url)
-  return urljoin(STATIC_BASE_URL, relativeURL)
+  return appendToPath(STATIC_BASE_URL, relativeURL)
 }
 
 const prioritisedAssets = [


### PR DESCRIPTION
**Problem:**
Selection is still quite expensive because of the numerous things that happen during selection.

**Fix:**
This is a collection of small fixes which improve the performance of changing selection.

**Results:**
The average time of 4 selection related mouse down events was dropped from 100.22ms to 91.12ms as measured by the Chrome profiler.

**Commit Details:**
- Memoized some of the lower level CSS parsing functions which are called from the inspector.
- `NavigatorItemDndWrapper` now doesn't unnecessarily spread `props.windowStyle`.
- Used `useKeepReferenceEqualityIfPossible` for the `windowStyle` property of `Item`, as it was changing unnecessarily.
- Use `traverseEither` instead of mapping an array and then invoking `sequenceEither`.
- Replaced `urljoin` with `appendToPath` as the former utilises a bunch of regexes and as a result is very slow.