### PR TITLE
fix: show the `New layout section +` control when the selected element is not a flex container

### DIFF
--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -23,15 +23,15 @@ export const FlexSection = React.memo(() => {
   )
 
   return (
-    <>
+    <div>
+      <AddRemoveLayouSystemControl />
       {when(
         allElementsInFlexLayout,
-        <div>
-          <AddRemoveLayouSystemControl />
+        <>
           <FlexDirectionToggle flexDirection={flexDirection} />
           <NineBlockControl flexDirection={flexDirection} />
-        </div>,
+        </>,
       )}
-    </>
+    </div>
   )
 })


### PR DESCRIPTION
## Problem:
The `New layout section +` control was not shown when the selected element is not a flex container

## Fix:
Show it at all times