### PR TITLE
Fix/reparent flow flex empty

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
@@ -2254,6 +2254,9 @@ describe('Reparent indicators', () => {
 
     // Check the indicator presence and position.
     await checkReparentIndicator(renderResult, 388, 610, 2, 123)
+    expect(renderResult.getEditorState().editor.displayNoneInstances).toEqual([
+      EP.fromString('storyboard/scene/parentsibling/seconddiv'),
+    ])
   })
 
   it(`shows the reparent indicator before all the elements in a 'row-reverse' container`, async () => {
@@ -2536,6 +2539,11 @@ describe('Reparent indicators', () => {
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
+    expect(renderResult.getEditorState().editor.displayNoneInstances).toEqual([
+      EP.fromString(
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/flexcontainer/absolutechild',
+      ),
+    ])
     // Check that the indicator is not there.
     await expect(async () =>
       renderResult.renderedDOM.findByTestId('flex-reparent-indicator-0'),
@@ -2611,6 +2619,11 @@ describe('Reparent indicators', () => {
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
+    expect(renderResult.getEditorState().editor.displayNoneInstances).toEqual([
+      EP.fromString(
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/flowcontainer/absolutechild',
+      ),
+    ])
     // Check that the indicator is not there.
     await expect(async () =>
       renderResult.renderedDOM.findByTestId('flex-reparent-indicator-0'),
@@ -2702,6 +2715,11 @@ describe('Reparent indicators', () => {
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
+    expect(renderResult.getEditorState().editor.displayNoneInstances).toEqual([
+      EP.fromString(
+        'utopia-storyboard-uid/scene-aaa/app-entity:container/flowcontainer/absolutechild',
+      ),
+    ])
     expect(renderResult.getEditorState().editor.canvas.controls.parentOutlineHighlight).toBeNull()
     await checkReparentIndicator(renderResult, 389, 227, 75, 2)
   })

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
@@ -2541,4 +2541,168 @@ describe('Reparent indicators', () => {
       renderResult.renderedDOM.findByTestId('flex-reparent-indicator-0'),
     ).rejects.toThrow()
   })
+  it(`in a flow layout doesn't show reparent indicators when there are no siblings`, async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+      <div
+        style={{
+          position: 'absolute',
+          width: 600,
+          height: 600,
+        }}
+        data-uid='container'
+        data-testid='container'
+      >
+        <div
+          style={{
+            position: 'absolute',
+            width: 50,
+            height: 50,
+            top: -50,
+          }}
+          data-uid='absolutechild'
+          data-testid='absolutechild'
+        />
+        <div
+          style={{
+            width: 400,
+            height: 400,
+          }}
+          data-uid='flowcontainer'
+          data-testid='flowcontainer'
+        />
+      </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    // Select the target first.
+    const targetPath = EP.fromString(
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/absolutechild',
+    )
+    await act(() => renderResult.dispatch([selectComponents([targetPath], false)], false))
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Start dragging the target.
+    const targetElement = renderResult.renderedDOM.getByTestId('absolutechild')
+    const targetElementBounds = targetElement.getBoundingClientRect()
+
+    const flexContainer = renderResult.renderedDOM.getByTestId('flowcontainer')
+    const flexContainerBounds = flexContainer.getBoundingClientRect()
+
+    const startPoint = { x: targetElementBounds.x + 20, y: targetElementBounds.y + 20 }
+    const endPoint = {
+      x: flexContainerBounds.x + flexContainerBounds.width - 20,
+      y: flexContainerBounds.y + flexContainerBounds.height / 2,
+    }
+    const dragDelta = windowPoint({
+      x: endPoint.x - startPoint.x,
+      y: endPoint.y - startPoint.y,
+    })
+
+    dragElement(
+      renderResult,
+      'absolutechild',
+      defaultMouseDownOffset,
+      dragDelta,
+      emptyModifiers,
+      false,
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Check that the indicator is not there.
+    await expect(async () =>
+      renderResult.renderedDOM.findByTestId('flex-reparent-indicator-0'),
+    ).rejects.toThrow()
+
+    expect(
+      renderResult.getEditorState().editor.canvas.controls.parentOutlineHighlight,
+    ).toBeDefined()
+  })
+  it(`in a flow layout shows reparent indicator when there are siblings`, async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+      <div
+        style={{
+          position: 'absolute',
+          width: 600,
+          height: 600,
+        }}
+        data-uid='container'
+        data-testid='container'
+      >
+        <div
+          style={{
+            position: 'absolute',
+            width: 50,
+            height: 50,
+            top: -50,
+          }}
+          data-uid='absolutechild'
+          data-testid='absolutechild'
+        />
+        <div
+          style={{ width: 400, height: 400 }}
+          data-uid='flowcontainer'
+          data-testid='flowcontainer'
+        >
+          <div
+            style={{
+              width: 75,
+              height: 58,
+            }}
+            data-uid='child1'
+          />
+          <div
+            style={{
+              width: 75,
+              height: 60,
+            }}
+            data-uid='child2'
+          />
+        </div>
+      </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    // Select the target first.
+    const targetPath = EP.fromString(
+      'utopia-storyboard-uid/scene-aaa/app-entity:container/absolutechild',
+    )
+    await act(() => renderResult.dispatch([selectComponents([targetPath], false)], false))
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Start dragging the target.
+    const targetElement = renderResult.renderedDOM.getByTestId('absolutechild')
+    const targetElementBounds = targetElement.getBoundingClientRect()
+
+    const flexContainer = renderResult.renderedDOM.getByTestId('flowcontainer')
+    const flexContainerBounds = flexContainer.getBoundingClientRect()
+
+    const startPoint = { x: targetElementBounds.x + 20, y: targetElementBounds.y + 20 }
+    const endPoint = {
+      x: flexContainerBounds.x + flexContainerBounds.width - 20,
+      y: flexContainerBounds.y + flexContainerBounds.height / 2,
+    }
+    const dragDelta = windowPoint({
+      x: endPoint.x - startPoint.x,
+      y: endPoint.y - startPoint.y,
+    })
+
+    dragElement(
+      renderResult,
+      'absolutechild',
+      defaultMouseDownOffset,
+      dragDelta,
+      emptyModifiers,
+      false,
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(renderResult.getEditorState().editor.canvas.controls.parentOutlineHighlight).toBeNull()
+    await checkReparentIndicator(renderResult, 389, 227, 75, 2)
+  })
 })

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -210,6 +210,9 @@ function applyStaticReparent(
                 wildcardPatch('mid-interaction', {
                   canvas: { controls: { parentHighlightPaths: { $set: [newParent] } } },
                 }),
+                wildcardPatch('mid-interaction', {
+                  displayNoneInstances: { $push: [newPath] },
+                }),
                 ...placeholderResult.commands,
               ]
               duplicatedElementNewUids = placeholderResult.duplicatedElementNewUids
@@ -217,6 +220,7 @@ function applyStaticReparent(
               if (shouldShowPositionIndicator) {
                 return [...commonPatches, showReorderIndicator(newParent, newIndex)]
               } else {
+                // TODO add nice parent highlight here
                 return commonPatches
               }
             }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -19,7 +19,7 @@ import {
   dragTargetsElementPaths,
 } from '../../controls/select-mode/drag-outline-control'
 import { FlexReparentTargetIndicator } from '../../controls/select-mode/flex-reparent-target-indicator'
-import { FlexReparentParentOutlineIndicator } from '../../controls/select-mode/reparent-parent-outline-indicator'
+import { StaticReparentTargetOutlineIndicator } from '../../controls/select-mode/static-reparent-target-outline'
 import { ZeroSizedElementControls } from '../../controls/zero-sized-element-controls'
 import { CanvasStrategyFactory } from '../canvas-strategies'
 import {
@@ -92,7 +92,7 @@ export function baseReparentAsStaticStrategy(
           show: 'visible-only-while-active',
         }),
         controlWithProps({
-          control: FlexReparentParentOutlineIndicator,
+          control: StaticReparentTargetOutlineIndicator,
           props: {},
           key: 'parent-outline-highlight',
           show: 'visible-only-while-active',

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -19,6 +19,7 @@ import {
   dragTargetsElementPaths,
 } from '../../controls/select-mode/drag-outline-control'
 import { FlexReparentTargetIndicator } from '../../controls/select-mode/flex-reparent-target-indicator'
+import { FlexReparentParentOutlineIndicator } from '../../controls/select-mode/reparent-parent-outline-indicator'
 import { ZeroSizedElementControls } from '../../controls/zero-sized-element-controls'
 import { CanvasStrategyFactory } from '../canvas-strategies'
 import {
@@ -88,6 +89,12 @@ export function baseReparentAsStaticStrategy(
           control: ZeroSizedElementControls,
           props: { showAllPossibleElements: true },
           key: 'zero-size-control',
+          show: 'visible-only-while-active',
+        }),
+        controlWithProps({
+          control: FlexReparentParentOutlineIndicator,
+          props: {},
+          key: 'parent-outline-highlight',
           show: 'visible-only-while-active',
         }),
       ],
@@ -220,8 +227,12 @@ function applyStaticReparent(
               if (shouldShowPositionIndicator) {
                 return [...commonPatches, showReorderIndicator(newParent, newIndex)]
               } else {
-                // TODO add nice parent highlight here
-                return commonPatches
+                return [
+                  ...commonPatches,
+                  wildcardPatch('mid-interaction', {
+                    canvas: { controls: { parentOutlineHighlight: { $set: newParent } } },
+                  }),
+                ]
               }
             }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -195,7 +195,9 @@ function applyStaticReparent(
               setCursorCommand(CSSCursor.Move),
             ]
 
-            function midInteractionCommandsForTarget(shouldReorder: boolean): Array<CanvasCommand> {
+            function midInteractionCommandsForTarget(
+              shouldShowPositionIndicator: boolean,
+            ): Array<CanvasCommand> {
               // we want to keep a placeholder element where the original dragged element was to avoid the new parent shifting around on the screen
               const placeholderResult = placeholderCloneCommands(
                 canvasState,
@@ -212,14 +214,8 @@ function applyStaticReparent(
               ]
               duplicatedElementNewUids = placeholderResult.duplicatedElementNewUids
 
-              if (shouldReorder) {
-                return [
-                  ...commonPatches,
-                  showReorderIndicator(newParent, newIndex),
-                  wildcardPatch('mid-interaction', {
-                    displayNoneInstances: { $push: [newPath] },
-                  }),
-                ]
+              if (shouldShowPositionIndicator) {
+                return [...commonPatches, showReorderIndicator(newParent, newIndex)]
               } else {
                 return commonPatches
               }
@@ -228,8 +224,10 @@ function applyStaticReparent(
             let interactionFinishCommands: Array<CanvasCommand>
             let midInteractionCommands: Array<CanvasCommand>
 
-            if (reparentResult.shouldReorder && siblingsOfTarget.length > 0) {
-              midInteractionCommands = midInteractionCommandsForTarget(reparentResult.shouldReorder)
+            if (reparentResult.shouldShowPositionIndicator && siblingsOfTarget.length > 0) {
+              midInteractionCommands = midInteractionCommandsForTarget(
+                reparentResult.shouldShowPositionIndicator,
+              )
 
               interactionFinishCommands = [
                 ...commandsBeforeReorder,
@@ -239,7 +237,7 @@ function applyStaticReparent(
             } else {
               if (parentRect != null) {
                 midInteractionCommands = midInteractionCommandsForTarget(
-                  reparentResult.shouldReorder,
+                  reparentResult.shouldShowPositionIndicator,
                 )
               } else {
                 // this should be an error because parentRect should never be null

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
@@ -92,7 +92,7 @@ export function findReparentStrategies(
 export interface ReparentTarget {
   shouldReparent: boolean
   newParent: ElementPath
-  shouldReorder: boolean
+  shouldShowPositionIndicator: boolean
   newIndex: number
   shouldConvertToInline: Direction | 'do-not-convert'
   defaultReparentType: ReparentStrategy
@@ -101,7 +101,7 @@ export interface ReparentTarget {
 export function reparentTarget(
   shouldReparent: boolean,
   newParent: ElementPath,
-  shouldReorder: boolean,
+  shouldShowPositionIndicator: boolean,
   newIndex: number,
   shouldConvertToInline: Direction | 'do-not-convert',
   defaultReparentType: ReparentStrategy,
@@ -109,7 +109,7 @@ export function reparentTarget(
   return {
     shouldReparent: shouldReparent,
     newParent: newParent,
-    shouldReorder: shouldReorder,
+    shouldShowPositionIndicator: shouldShowPositionIndicator,
     newIndex: newIndex,
     shouldConvertToInline: shouldConvertToInline,
     defaultReparentType: defaultReparentType,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -497,5 +497,5 @@ function isSingleAxisAutoLayoutCompatibleWithReorder(
     (child) => child.specialSizeMeasurements.position !== 'absolute',
   )
 
-  return flowChildren.length > 1
+  return flowChildren.length === 0 || flowChildren.length > 1
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -267,7 +267,7 @@ function findParentByPaddedInsertionZone(
     if (shouldReparentAsFlowOrStatic === 'REPARENT_AS_ABSOLUTE') {
       return null
     }
-    const compatibleWith1DReorder = isSingleAxisAutoLayoutComaptibleWithReorder(metadata, element)
+    const compatibleWith1DReorder = isSingleAxisAutoLayoutCompatibleWithReorder(metadata, element)
     if (!compatibleWith1DReorder) {
       return null
     }
@@ -325,7 +325,7 @@ function findParentUnderPointByArea(
 ) {
   const autolayoutDirection = singleAxisAutoLayoutContainerDirections(targetParentPath, metadata)
   const shouldReparentAsFlowOrStatic = autoLayoutParentAbsoluteOrStatic(metadata, targetParentPath)
-  const compatibleWith1DReorder = isSingleAxisAutoLayoutComaptibleWithReorder(
+  const compatibleWith1DReorder = isSingleAxisAutoLayoutCompatibleWithReorder(
     metadata,
     targetParentPath,
   )
@@ -483,7 +483,7 @@ export function flowParentAbsoluteOrStatic(
   // should there be a DO_NOT_REPARENT return type here?
 }
 
-function isSingleAxisAutoLayoutComaptibleWithReorder(
+function isSingleAxisAutoLayoutCompatibleWithReorder(
   metadata: ElementInstanceMetadataMap,
   parent: ElementPath,
 ): boolean {

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -354,10 +354,13 @@ function findParentUnderPointByArea(
           pointOnCanvas,
         )
 
+      const hasStaticChildren =
+        MetadataUtils.getChildrenParticipatingInAutoLayout(metadata, targetParentPath).length > 0
+
       return {
         shouldReparent: true,
         newParent: targetParentPath,
-        shouldShowPositionIndicator: targetUnderMouseIndex !== -1,
+        shouldShowPositionIndicator: targetUnderMouseIndex !== -1 && hasStaticChildren,
         newIndex: targetUnderMouseIndex,
         shouldConvertToInline: shouldConvertToInline,
         defaultReparentType: 'REPARENT_AS_STATIC',

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -497,5 +497,5 @@ function isSingleAxisAutoLayoutCompatibleWithReorder(
     (child) => child.specialSizeMeasurements.position !== 'absolute',
   )
 
-  return flowChildren.length === 0 || flowChildren.length > 1
+  return flowChildren.length > 1
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -305,7 +305,7 @@ function findParentByPaddedInsertionZone(
       // we found a first good target parent, early return
       return {
         shouldReparent: true,
-        shouldReorder: true,
+        shouldShowPositionIndicator: true,
         newParent: singleAxisAutoLayoutContainer.path,
         newIndex: targetUnderMouseIndex,
         shouldConvertToInline:
@@ -336,7 +336,7 @@ function findParentUnderPointByArea(
       return {
         shouldReparent: true,
         newParent: targetParentPath,
-        shouldReorder: false,
+        shouldShowPositionIndicator: false,
         newIndex: -1,
         shouldConvertToInline: 'do-not-convert',
         defaultReparentType: 'REPARENT_AS_ABSOLUTE',
@@ -354,7 +354,7 @@ function findParentUnderPointByArea(
       return {
         shouldReparent: true,
         newParent: targetParentPath,
-        shouldReorder: targetUnderMouseIndex !== -1,
+        shouldShowPositionIndicator: targetUnderMouseIndex !== -1,
         newIndex: targetUnderMouseIndex,
         shouldConvertToInline: shouldConvertToInline,
         defaultReparentType: 'REPARENT_AS_STATIC',
@@ -364,7 +364,7 @@ function findParentUnderPointByArea(
       return {
         shouldReparent: true,
         newParent: targetParentPath,
-        shouldReorder: false,
+        shouldShowPositionIndicator: false,
         newIndex: -1,
         shouldConvertToInline: 'do-not-convert',
         defaultReparentType: 'REPARENT_AS_STATIC',

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -263,8 +263,8 @@ function findParentByPaddedInsertionZone(
     if (autolayoutDirection === 'non-single-axis-autolayout') {
       return null
     }
-    const shouldReparentAsFlowOrStatic = autoLayoutParentAbsoluteOrStatic(metadata, element)
-    if (shouldReparentAsFlowOrStatic === 'REPARENT_AS_ABSOLUTE') {
+    const shouldReparentAsAbsoluteOrStatic = autoLayoutParentAbsoluteOrStatic(metadata, element)
+    if (shouldReparentAsAbsoluteOrStatic === 'REPARENT_AS_ABSOLUTE') {
       return null
     }
     const compatibleWith1DReorder = isSingleAxisAutoLayoutCompatibleWithReorder(metadata, element)
@@ -324,14 +324,17 @@ function findParentUnderPointByArea(
   pointOnCanvas: CanvasPoint,
 ) {
   const autolayoutDirection = singleAxisAutoLayoutContainerDirections(targetParentPath, metadata)
-  const shouldReparentAsFlowOrStatic = autoLayoutParentAbsoluteOrStatic(metadata, targetParentPath)
+  const shouldReparentAsAbsoluteOrStatic = autoLayoutParentAbsoluteOrStatic(
+    metadata,
+    targetParentPath,
+  )
   const compatibleWith1DReorder = isSingleAxisAutoLayoutCompatibleWithReorder(
     metadata,
     targetParentPath,
   )
 
   const targetParentUnderPoint: ReparentTarget = (() => {
-    if (shouldReparentAsFlowOrStatic === 'REPARENT_AS_ABSOLUTE') {
+    if (shouldReparentAsAbsoluteOrStatic === 'REPARENT_AS_ABSOLUTE') {
       // TODO we now assume this is "absolute", but this is too vauge
       return {
         shouldReparent: true,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -487,17 +487,8 @@ function isSingleAxisAutoLayoutCompatibleWithReorder(
   metadata: ElementInstanceMetadataMap,
   parent: ElementPath,
 ): boolean {
-  const newParentMetadata = MetadataUtils.findElementByElementPath(metadata, parent)
-  const parentIsFlexLayout = MetadataUtils.isFlexLayoutedContainer(newParentMetadata)
   const flowChildren = MetadataUtils.getChildren(metadata, parent).filter(
-    (child) => child.specialSizeMeasurements.position !== 'absolute',
+    MetadataUtils.elementParticipatesInAutoLayout,
   )
-  if (flowChildren.length === 0) {
-    return false
-  }
-  if (parentIsFlexLayout || flowChildren.length > 1) {
-    return true
-  }
-
-  return false
+  return flowChildren.length > 0
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -489,13 +489,15 @@ function isSingleAxisAutoLayoutCompatibleWithReorder(
 ): boolean {
   const newParentMetadata = MetadataUtils.findElementByElementPath(metadata, parent)
   const parentIsFlexLayout = MetadataUtils.isFlexLayoutedContainer(newParentMetadata)
-  if (parentIsFlexLayout) {
-    return true
-  }
-
   const flowChildren = MetadataUtils.getChildren(metadata, parent).filter(
     (child) => child.specialSizeMeasurements.position !== 'absolute',
   )
+  if (flowChildren.length === 0) {
+    return false
+  }
+  if (parentIsFlexLayout || flowChildren.length > 1) {
+    return true
+  }
 
-  return flowChildren.length > 1
+  return false
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -487,8 +487,13 @@ function isSingleAxisAutoLayoutCompatibleWithReorder(
   metadata: ElementInstanceMetadataMap,
   parent: ElementPath,
 ): boolean {
+  const newParentMetadata = MetadataUtils.findElementByElementPath(metadata, parent)
+  const parentIsFlexLayout = MetadataUtils.isFlexLayoutedContainer(newParentMetadata)
+  if (parentIsFlexLayout) {
+    return true
+  }
   const flowChildren = MetadataUtils.getChildren(metadata, parent).filter(
     MetadataUtils.elementParticipatesInAutoLayout,
   )
-  return flowChildren.length > 0
+  return flowChildren.length > 1
 }

--- a/editor/src/components/canvas/controls/parent-bounds.tsx
+++ b/editor/src/components/canvas/controls/parent-bounds.tsx
@@ -49,6 +49,9 @@ export const ParentBounds = controlForStrategyMemoized(({ targetParent }: Parent
   const scale = useEditorState((store) => store.editor.canvas.scale, 'ParentBounds canvas scale')
 
   const parentFrame = useEditorState((store) => {
+    if (store.editor.canvas.controls.parentOutlineHighlight != null) {
+      return null
+    }
     if (!EP.isStoryboardPath(targetParent)) {
       return MetadataUtils.getFrameInCanvasCoords(targetParent, store.editor.jsxMetadata)
     } else {

--- a/editor/src/components/canvas/controls/select-mode/reparent-parent-outline-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/reparent-parent-outline-indicator.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import { useColorTheme } from '../../../../uuiui'
+import { useEditorState } from '../../../editor/store/store-hook'
+import { controlForStrategyMemoized } from '../../canvas-strategies/canvas-strategy-types'
+import { HighlightControl } from '../highlight-control'
+
+export const FlexReparentParentOutlineIndicator = controlForStrategyMemoized(() => {
+  const colorTheme = useColorTheme()
+  const scale = useEditorState(
+    (store) => store.editor.canvas.scale,
+    'FlexReparentTargetIndicator scale',
+  )
+  const canvasOffset = useEditorState(
+    (store) => store.editor.canvas.realCanvasOffset,
+    'FlexReparentTargetIndicator scale',
+  )
+  const parentFrame = useEditorState((store) => {
+    const parentPath = store.editor.canvas.controls.parentOutlineHighlight
+    if (parentPath != null) {
+      return MetadataUtils.getFrameInCanvasCoords(parentPath, store.editor.jsxMetadata)
+    } else {
+      return null
+    }
+  }, 'FlexReparentParentOutlineIndicator')
+
+  if (parentFrame != null) {
+    return (
+      <HighlightControl
+        canvasOffset={canvasOffset}
+        scale={scale}
+        color={colorTheme.canvasSelectionPrimaryOutline.value}
+        frame={parentFrame}
+      />
+    )
+  } else {
+    return null
+  }
+})

--- a/editor/src/components/canvas/controls/select-mode/static-reparent-target-outline.tsx
+++ b/editor/src/components/canvas/controls/select-mode/static-reparent-target-outline.tsx
@@ -5,7 +5,7 @@ import { useEditorState } from '../../../editor/store/store-hook'
 import { controlForStrategyMemoized } from '../../canvas-strategies/canvas-strategy-types'
 import { HighlightControl } from '../highlight-control'
 
-export const FlexReparentParentOutlineIndicator = controlForStrategyMemoized(() => {
+export const StaticReparentTargetOutlineIndicator = controlForStrategyMemoized(() => {
   const colorTheme = useColorTheme()
   const scale = useEditorState(
     (store) => store.editor.canvas.scale,
@@ -22,7 +22,7 @@ export const FlexReparentParentOutlineIndicator = controlForStrategyMemoized(() 
     } else {
       return null
     }
-  }, 'FlexReparentParentOutlineIndicator')
+  }, 'StaticReparentTargetOutlineIndicator')
 
   if (parentFrame != null) {
     return (

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -836,6 +836,7 @@ export interface EditorStateCanvasControls {
   parentHighlightPaths: Array<ElementPath> | null
   reparentedToPaths: Array<ElementPath>
   dragToMoveIndicatorFlags: DragToMoveIndicatorFlags
+  parentOutlineHighlight: ElementPath | null
 }
 
 export function editorStateCanvasControls(
@@ -846,6 +847,7 @@ export function editorStateCanvasControls(
   parentHighlightPaths: Array<ElementPath> | null,
   reparentedToPaths: Array<ElementPath>,
   dragToMoveIndicatorFlagsValue: DragToMoveIndicatorFlags,
+  parentOutlineHighlight: ElementPath | null,
 ): EditorStateCanvasControls {
   return {
     snappingGuidelines: snappingGuidelines,
@@ -855,6 +857,7 @@ export function editorStateCanvasControls(
     parentHighlightPaths: parentHighlightPaths,
     reparentedToPaths: reparentedToPaths,
     dragToMoveIndicatorFlags: dragToMoveIndicatorFlagsValue,
+    parentOutlineHighlight: parentOutlineHighlight,
   }
 }
 
@@ -2192,6 +2195,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
         parentHighlightPaths: null,
         reparentedToPaths: [],
         dragToMoveIndicatorFlags: emptyDragToMoveIndicatorFlags,
+        parentOutlineHighlight: null,
       },
     },
     floatingInsertMenu: {
@@ -2511,6 +2515,7 @@ export function editorModelFromPersistentModel(
         parentHighlightPaths: null,
         reparentedToPaths: [],
         dragToMoveIndicatorFlags: emptyDragToMoveIndicatorFlags,
+        parentOutlineHighlight: null,
       },
     },
     floatingInsertMenu: {

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1633,7 +1633,7 @@ export const DragToMoveIndicatorFlagsKeepDeepEquality: KeepDeepEqualityCall<Drag
   )
 
 export const EditorStateCanvasControlsKeepDeepEquality: KeepDeepEqualityCall<EditorStateCanvasControls> =
-  combine7EqualityCalls(
+  combine8EqualityCalls(
     (controls) => controls.snappingGuidelines,
     arrayDeepEquality(GuidelineWithSnappingVectorAndPointsOfRelevanceKeepDeepEquality),
     (controls) => controls.outlineHighlights,
@@ -1648,6 +1648,8 @@ export const EditorStateCanvasControlsKeepDeepEquality: KeepDeepEqualityCall<Edi
     ElementPathArrayKeepDeepEquality,
     (controls) => controls.dragToMoveIndicatorFlags,
     DragToMoveIndicatorFlagsKeepDeepEquality,
+    (controls) => controls.parentOutlineHighlight,
+    nullableDeepEquality(ElementPathKeepDeepEquality),
     editorStateCanvasControls,
   )
 

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -500,6 +500,7 @@ export function runLocalCanvasAction(
             null,
             [],
             emptyDragToMoveIndicatorFlags,
+            null,
           ),
         },
       }


### PR DESCRIPTION
**Problem:**
Flex and flow behaves differently when reparenting to empty parent targets.

**Fix:**
For flex and flow reparent the dragged elements is always set to display: none. For empty targets instead of the indicator parent highlight is used. 

**Commit Details:**
- tests for flow reparent indicators, parent highlight and if the element is included in the `displayNoneInstances`
- fix typo in function `isSingleAxisAutoLayoutCompatibleWithReorder`
- rename `shouldReorder` to `shouldShowPositionIndicator` as it is used to show the indicator
- `shouldShowPositionIndicator` is false if there are no static siblings available
- when `shouldShowPositionIndicator` is false the parent highlight is added
- added a highlight control for the target parent
