### PR TITLE
Move the inspector-strategy backed controls next to each other in the inspector

### DIFF
--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -343,12 +343,26 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
             onStyleSelectorInsert={props.onStyleSelectorInsert}
           />
           {when(isFeatureEnabled('Nine block control'), <FlexSection />)}
-          <LayoutSection
-            hasNonDefaultPositionAttributes={hasNonDefaultPositionAttributes}
-            aspectRatioLocked={aspectRatioLocked}
-            toggleAspectRatioLock={toggleAspectRatioLock}
-          />
-          <StyleSection />
+          {isFeatureEnabled('Nine block control') ? (
+            <>
+              <StyleSection />
+              <LayoutSection
+                hasNonDefaultPositionAttributes={hasNonDefaultPositionAttributes}
+                aspectRatioLocked={aspectRatioLocked}
+                toggleAspectRatioLock={toggleAspectRatioLock}
+              />
+            </>
+          ) : (
+            <>
+              <LayoutSection
+                hasNonDefaultPositionAttributes={hasNonDefaultPositionAttributes}
+                aspectRatioLocked={aspectRatioLocked}
+                toggleAspectRatioLock={toggleAspectRatioLock}
+              />
+              <StyleSection />
+            </>
+          )}
+
           <WarningSubsection />
           <ImgSection />
           <EventHandlersSection />

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`662`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`663`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`734`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`735`)
   })
 })


### PR DESCRIPTION
## After
<img width="270" alt="image" src="https://user-images.githubusercontent.com/16385508/208072752-ffe11cb7-8197-439c-acae-82c6c89d0add.png">

## Before
<img width="260" alt="image" src="https://user-images.githubusercontent.com/16385508/208072796-94696ff9-2c0e-4303-9749-4b7d5209118a.png">

## Problem:
The inspector-strategy backed controls are far from each other, which makes playing/experimenting with them hard

## Fix:
Move the section next to each other
