### PR TITLE
Improve target finding performance.

### DIFF
--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -300,7 +300,11 @@ export function depth(path: ElementPath): number {
 }
 
 export function navigatorDepth(path: ElementPath): number {
-  return path.parts.reduce((working, next) => working + next.length, -2)
+  let result: number = -2
+  for (const pathPart of path.parts) {
+    result += pathPart.length
+  }
+  return result
 }
 
 export function isInsideFocusedComponent(path: ElementPath): boolean {
@@ -592,20 +596,27 @@ export function isDescendantOf(target: ElementPath, maybeAncestor: ElementPath):
   const targetElementPath = target.parts
   const maybeAncestorElementPath = maybeAncestor.parts
   if (targetElementPath.length >= maybeAncestorElementPath.length) {
-    const partsToCheck = targetElementPath.slice(0, maybeAncestorElementPath.length)
-    return partsToCheck.every((elementPathPart, i) => {
+    for (let pathPartIndex = 0; pathPartIndex < maybeAncestorElementPath.length; pathPartIndex++) {
+      const elementPathPart = targetElementPath[pathPartIndex]
       // all parts up to the last must match, and the last must be a descendant
-      if (i < maybeAncestorElementPath.length - 1) {
-        return elementPathPartsEqual(elementPathPart, maybeAncestorElementPath[i])
+      const maybeAncestorElementPathPart = maybeAncestorElementPath[pathPartIndex]
+      if (pathPartIndex < maybeAncestorElementPath.length - 1) {
+        if (!elementPathPartsEqual(elementPathPart, maybeAncestorElementPathPart)) {
+          return false
+        }
       } else {
-        const finalPartComparison =
-          targetElementPath.length === maybeAncestorElementPath.length
-            ? elementIsDescendant
-            : elementIsDescendantOrEqualTo
-
-        return finalPartComparison(elementPathPart, maybeAncestorElementPath[i])
+        if (targetElementPath.length === maybeAncestorElementPath.length) {
+          if (!elementIsDescendant(elementPathPart, maybeAncestorElementPathPart)) {
+            return false
+          }
+        } else {
+          if (!elementIsDescendantOrEqualTo(elementPathPart, maybeAncestorElementPathPart)) {
+            return false
+          }
+        }
       }
-    })
+    }
+    return true
   } else {
     return false
   }


### PR DESCRIPTION
**Problem:**
`getSelectionOrValidTargetAtPoint` is called quite a lot and can also be quite costly to invoke, sometimes taking over 10ms to run.

**Fix:**
A few tweaks to mainly `findFirstParentWithValidElementPathInner` and some functions it calls have been made in the usual approach to performance improvements like not creating intermediary arrays. Along with memoizing `findParentSceneValidPaths` purely within the scope of `findFirstParentWithValidElementPathInner` so that any repeated calls back up to the parent elements take virtually no time at all, which makes a huge difference to early calls taking them often from over 10ms to a maximum of 2ms.

**Commit Details:**
- Memoize `findParentSceneValidPaths`, as lots of lookups for the same values are being done in other functions.
- In `findFirstParentWithValidElementPathInner` avoid creating intermediary arrays where possible.
- `navigatorDepth` simplified to a dumb loop.
- `isDescendantOf` avoids creating an intermediary and is now just a simple loop internally.