### PR TITLE
fix(reparent) fix arrayEquals when rerendering the canvas

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -70,7 +70,7 @@ import { ProjectContentTreeRoot, getContentsTreeFileFromString } from '../assets
 import { createExecutionScope } from './ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope'
 import { applyUIDMonkeyPatch } from '../../utils/canvas-react-utils'
 import { getParseSuccessOrTransientForFilePath, getValidElementPaths } from './canvas-utils'
-import { fastForEach, NO_OP } from '../../core/shared/utils'
+import { arrayEquals, fastForEach, NO_OP } from '../../core/shared/utils'
 import { useTwind } from '../../core/tailwind/tailwind'
 import {
   AlwaysFalse,
@@ -342,7 +342,7 @@ export const UiJsxCanvas = React.memo<UiJsxCanvasPropsWithErrorCallback>((props)
   shouldRerenderRef.current =
     ElementsToRerenderGLOBAL.current === 'rerender-all-elements' ||
     elementsToRerenderRef.current === 'rerender-all-elements' || // TODO this means the first drag frame will still be slow, figure out a nicer way to immediately switch to true. probably this should live in a dedicated a function
-    !pathArraysEqual(ElementsToRerenderGLOBAL.current, elementsToRerenderRef.current) // once we get here, we know that both `ElementsToRerenderGLOBAL.current` and `elementsToRerenderRef.current` are arrays
+    !arrayEquals(ElementsToRerenderGLOBAL.current, elementsToRerenderRef.current, EP.pathsEqual) // once we get here, we know that both `ElementsToRerenderGLOBAL.current` and `elementsToRerenderRef.current` are arrays
   elementsToRerenderRef.current = ElementsToRerenderGLOBAL.current
 
   const maybeOldProjectContents = React.useRef(projectContents)
@@ -805,16 +805,3 @@ const CanvasContainer = React.forwardRef<
   )
 })
 CanvasContainer.displayName = 'CanvasContainer'
-
-function pathArraysEqual(one: Array<ElementPath>, other: Array<ElementPath>) {
-  if (one.length != other.length) {
-    return false
-  }
-
-  for (const path of one) {
-    if (other.find((p) => EP.pathsEqual(p, path)) == null) {
-      return false
-    }
-  }
-  return true
-}


### PR DESCRIPTION
**Problem:**
Reparenting elements the cursor shows 'not allowed' when it shouldn't, releasing the drag moves the element correctly. The 'not allowed' cursor is shown when first dragging an element over a new target parent, then dragged to a different target parent then dragged to the first parent target again.

**Fix:**
The problem originated from the canvas not rerendering when a reparent happened in case the 'elements to rerender' array matched with the previous one but the array contained the element paths in different order.  This rerender is needed to create spy metadata which then helps to decide which cursor to show, the 'not allowed' reparent is for cases when a component doesn't support children props. 

**Commit Details:**
- change `pathArraysEqual` to `arrayEquals`
