### PR TITLE
Better Performance Marks

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -437,7 +437,9 @@ export function runDomWalker({
   }
 
   const LogDomWalkerPerformance =
-    isFeatureEnabled('Debug mode – Performance Marks') && PERFORMANCE_MARKS_ALLOWED
+    (isFeatureEnabled('Debug – Performance Marks (Fast)') ||
+      isFeatureEnabled('Debug – Performance Marks (Slow)')) &&
+    PERFORMANCE_MARKS_ALLOWED
 
   const canvasRootContainer = document.getElementById(CanvasContainerID)
 

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -613,7 +613,9 @@ export function handleStrategies(
   oldDerivedState: DerivedState,
 ): HandleStrategiesResult & { patchedDerivedState: DerivedState } {
   const MeasureDispatchTime =
-    isFeatureEnabled('Debug mode – Performance Marks') && PERFORMANCE_MARKS_ALLOWED
+    (isFeatureEnabled('Debug – Performance Marks (Fast)') ||
+      isFeatureEnabled('Debug – Performance Marks (Slow)')) &&
+    PERFORMANCE_MARKS_ALLOWED
 
   if (MeasureDispatchTime) {
     window.performance.mark('strategies_begin')

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -643,7 +643,9 @@ function editorDispatchInner(
   // console.log('DISPATCH', simpleStringifyActions(dispatchedActions))
 
   const MeasureDispatchTime =
-    isFeatureEnabled('Debug mode – Performance Marks') && PERFORMANCE_MARKS_ALLOWED
+    (isFeatureEnabled('Debug – Performance Marks (Fast)') ||
+      isFeatureEnabled('Debug – Performance Marks (Slow)')) &&
+    PERFORMANCE_MARKS_ALLOWED
 
   if (MeasureDispatchTime) {
     window.performance.mark('dispatch_begin')

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -50,9 +50,9 @@ function useWrapSelectorInPerformanceMeasureBlock<U>(
     // let's create a new wrapped selector
     const wrappedSelector = (state: EditorStorePatched) => {
       const LogSelectorPerformance =
-        isFeatureEnabled('Debug mode – Performance Marks') && PERFORMANCE_MARKS_ALLOWED
+        isFeatureEnabled('Debug – Performance Marks (Slow)') && PERFORMANCE_MARKS_ALLOWED
 
-      const MeasureSelectors = isFeatureEnabled('Debug mode – Measure Selectors')
+      const MeasureSelectors = isFeatureEnabled('Debug – Measure Selectors')
 
       if (LogSelectorPerformance) {
         window.performance.mark('selector_begin')

--- a/editor/src/core/shared/redux-devtools.ts
+++ b/editor/src/core/shared/redux-devtools.ts
@@ -125,11 +125,7 @@ export function reduxDevtoolsSendActions(
   newStore: EditorStoreFull,
   isTransient: boolean,
 ): void {
-  if (
-    maybeDevTools != null &&
-    sendActionUpdates &&
-    isFeatureEnabled('Debug mode – Redux Devtools')
-  ) {
+  if (maybeDevTools != null && sendActionUpdates && isFeatureEnabled('Debug – Redux Devtools')) {
     // filter out the actions we are not interested in
     const filteredActions = mapDropNulls((action) => {
       switch (action.action) {
@@ -179,31 +175,19 @@ export function reduxDevtoolsSendInitialState(newStore: EditorStoreFull): void {
 }
 
 export function reduxDevtoolsLogMessage(message: string, optionalPayload?: any): void {
-  if (
-    maybeDevTools != null &&
-    sendActionUpdates &&
-    isFeatureEnabled('Debug mode – Redux Devtools')
-  ) {
+  if (maybeDevTools != null && sendActionUpdates && isFeatureEnabled('Debug – Redux Devtools')) {
     maybeDevTools.send({ type: `🟢 ${message}`, payload: optionalPayload }, lastDispatchedStore)
   }
 }
 
 export function reduxDevtoolsLogError(message: string, optionalPayload?: any): void {
-  if (
-    maybeDevTools != null &&
-    sendActionUpdates &&
-    isFeatureEnabled('Debug mode – Redux Devtools')
-  ) {
+  if (maybeDevTools != null && sendActionUpdates && isFeatureEnabled('Debug – Redux Devtools')) {
     maybeDevTools.send({ type: `🔴 ${message}`, payload: optionalPayload }, lastDispatchedStore)
   }
 }
 
 export function reduxDevtoolsUpdateState(message: string, newStore: EditorStoreFull): void {
-  if (
-    maybeDevTools != null &&
-    sendActionUpdates &&
-    isFeatureEnabled('Debug mode – Redux Devtools')
-  ) {
+  if (maybeDevTools != null && sendActionUpdates && isFeatureEnabled('Debug – Redux Devtools')) {
     const sanitizedStore = sanitizeLoggedState(newStore)
     maybeDevTools.send(`🟣 ${message}`, sanitizedStore)
     lastDispatchedStore = sanitizedStore

--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -124,7 +124,7 @@ const mangleFunctionType = Utils.memoize(
     const mangledFunction = {
       [mangledFunctionName]: (p: any, context?: any) => {
         const MeasureRenderTimes =
-          isFeatureEnabled('Debug mode – Performance Marks') && PERFORMANCE_MARKS_ALLOWED
+          isFeatureEnabled('Debug – Performance Marks (Slow)') && PERFORMANCE_MARKS_ALLOWED
         const uuid = MeasureRenderTimes ? v4() : ''
         if (MeasureRenderTimes) {
           performance.mark(`render_start_${uuid}`)
@@ -165,7 +165,7 @@ const mangleClassType = Utils.memoize(
     // mutation
     type.prototype.render = function monkeyRender() {
       const MeasureRenderTimes =
-        isFeatureEnabled('Debug mode – Performance Marks') && PERFORMANCE_MARKS_ALLOWED
+        isFeatureEnabled('Debug – Performance Marks (Slow)') && PERFORMANCE_MARKS_ALLOWED
       const uuid = MeasureRenderTimes ? v4() : ''
       if (MeasureRenderTimes) {
         performance.mark(`render_start_${uuid}`)

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -3,9 +3,10 @@ import { IS_TEST_ENVIRONMENT, PRODUCTION_CONFIG } from '../common/env-vars'
 import { fastForEach, isBrowserEnvironment } from '../core/shared/utils'
 
 export type FeatureName =
-  | 'Debug mode – Redux Devtools'
-  | 'Debug mode – Performance Marks'
-  | 'Debug mode – Measure Selectors'
+  | 'Debug – Redux Devtools'
+  | 'Debug – Performance Marks (Slow)'
+  | 'Debug – Performance Marks (Fast)'
+  | 'Debug – Measure Selectors'
   | 'Dragging Reparents By Default'
   | 'Re-parse Project Button'
   | 'Performance Test Triggers'
@@ -17,9 +18,10 @@ export type FeatureName =
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
   // 'Dragging Shows Overlay', // Removing this option so that we can experiment on this later
-  'Debug mode – Redux Devtools',
-  'Debug mode – Performance Marks',
-  'Debug mode – Measure Selectors',
+  'Debug – Redux Devtools',
+  'Debug – Performance Marks (Slow)',
+  'Debug – Performance Marks (Fast)',
+  'Debug – Measure Selectors',
   'Re-parse Project Button',
   'Performance Test Triggers',
   'Canvas Strategies Debug Panel',
@@ -29,9 +31,10 @@ export const AllFeatureNames: FeatureName[] = [
 ]
 
 let FeatureSwitches: { [feature in FeatureName]: boolean } = {
-  'Debug mode – Redux Devtools': false,
-  'Debug mode – Performance Marks': false,
-  'Debug mode – Measure Selectors': false,
+  'Debug – Redux Devtools': false,
+  'Debug – Performance Marks (Slow)': false,
+  'Debug – Performance Marks (Fast)': false,
+  'Debug – Measure Selectors': false,
   'Dragging Reparents By Default': false,
   'Re-parse Project Button': !(PRODUCTION_CONFIG as boolean),
   'Performance Test Triggers': !(PRODUCTION_CONFIG as boolean),


### PR DESCRIPTION
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/2226774/208498365-a9c02bd9-8cb6-4bd7-894a-cdf9b4903f8f.png">

The performance marks are incredibly slow. They are also not too helpful when it comes to debugging the performance of our Stores. So I split into two feature switches:
<img width="255" alt="image" src="https://user-images.githubusercontent.com/2226774/208498890-f7315764-7071-41a1-bef6-6f7953d3265f.png">

The Slow switch is the "legacy" switch, it turns on _all_ marks, including the very fine grained performance marks around individual selectors and component renders. They incur a ton of overhead, be careful!

The Fast switch is for the store marks only, which means it doesn't incur so much overhead. 
