### PR TITLE
Show merge conflicts lozenge

### DIFF
--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -15,7 +15,12 @@ import {
 } from '../../uuiui'
 import { LoginState } from '../../uuiui-deps'
 import { EditorAction } from '../editor/action-types'
-import { setLeftMenuTab, setPanelVisibility, togglePanel } from '../editor/actions/action-creators'
+import {
+  openCodeEditorFile,
+  setLeftMenuTab,
+  setPanelVisibility,
+  togglePanel,
+} from '../editor/actions/action-creators'
 import { EditorStorePatched, githubRepoFullName, LeftMenuTab } from '../editor/store/editor-state'
 import { useEditorState } from '../editor/store/store-hook'
 import { RoundButton } from './buttons'
@@ -93,6 +98,21 @@ const TitleBar = React.memo(() => {
 
   const loggedIn = React.useMemo(() => loginState.type === 'LOGGED_IN', [loginState])
 
+  const openFile = React.useCallback(
+    (filename: string) => {
+      dispatch([openCodeEditorFile(filename, true)], 'everyone')
+    },
+    [dispatch],
+  )
+  const showMergeConflict = React.useCallback(() => {
+    if (Object.keys(treeConflicts).length < 1) {
+      return
+    }
+    const firstConflictFilename = Object.keys(treeConflicts)[0]
+    openLeftPaneltoGithubTab()
+    openFile(firstConflictFilename)
+  }, [openLeftPaneltoGithubTab, openFile, treeConflicts])
+
   return (
     <SimpleFlexRow
       style={{
@@ -141,7 +161,7 @@ const TitleBar = React.memo(() => {
             )}
             {when(
               hasMergeConflicts,
-              <RoundButton color={colorTheme.errorBgSolid.value} onClick={openLeftPaneltoGithubTab}>
+              <RoundButton color={colorTheme.errorBgSolid.value} onClick={showMergeConflict}>
                 {
                   <Icons.WarningTriangle
                     style={{ width: 19, height: 19 }}

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -1207,30 +1207,18 @@ export function mergeProjectContentsTree(
       return withTreeConflicts(originContents, {})
     } else {
       // There's a code change between the 3 places, perform a merge of the changes.
-      const mergeResult = mergeDiff3(currentCode, originCode, branchCode, {
+      const mergedResult = mergeDiff3(currentCode, originCode, branchCode, {
         label: { a: 'Your Changes', o: 'Original', b: 'Branch Changes' },
         stringSeparator: /\r?\n/,
-      })
-      const { result, conflict } = mergeResult
-
-      const newCode = result.join('\n')
+      }).result.join('\n')
       const updatedTextFile = textFile(
-        textFileContents(newCode, unparsed, RevisionsState.CodeAhead),
+        textFileContents(mergedResult, unparsed, RevisionsState.CodeAhead),
         null,
         null,
         currentTime,
       )
 
-      const conflicts: TreeConflicts = {}
-      if (conflict) {
-        conflicts[fullPath] = differingTypesConflict(
-          currentContents,
-          originContents,
-          branchContents,
-        )
-      }
-
-      return withTreeConflicts(projectContentFile(fullPath, updatedTextFile), conflicts)
+      return withTreeConflicts(projectContentFile(fullPath, updatedTextFile), {})
     }
   } else if (
     isProjectContentDirectory(currentContents) &&


### PR DESCRIPTION
Fixes #3029 

**Problem:**
When merge conflicts are detected, a lozenge should be shown in the top bar.

**Fix:**
Show the lozenge when merge conflicts are detected