### PR TITLE
`Fill container` improvements

### DIFF
--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -15,6 +15,7 @@ import { CSSNumber, cssNumber, EmptyInputValue, parseCSSLengthPercent } from './
 import { metadataSelector, selectedViewsSelector } from './inpector-selectors'
 import { fillContainerApplicable, hugContentsApplicable } from './inspector-common'
 import {
+  Axis,
   InspectorStrategy,
   runStrategies,
   setPropFillStrategies,
@@ -184,7 +185,7 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
   const onSubmitHeight = React.useCallback(
     ({ value: anyValue }: SelectOption) => {
       const value = anyValue as FixedHugFillMode
-      const strategy = strategyForMode(heightComputedValueRef.current, 'height', value)
+      const strategy = strategyForMode(heightComputedValueRef.current, 'vertical', value)
       runStrategies(dispatch, metadataRef.current, selectedViewsRef.current, strategy)
     },
     [dispatch, heightComputedValueRef, metadataRef, selectedViewsRef],
@@ -198,7 +199,7 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
           metadataRef.current,
           selectedViewsRef.current,
           setPropFixedStrategies(
-            'height',
+            'vertical',
             cssNumber(value, heightComputedValueRef.current?.unit ?? null),
           ),
         )
@@ -215,7 +216,7 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
           metadataRef.current,
           selectedViewsRef.current,
           setPropFixedStrategies(
-            'width',
+            'horizontal',
             cssNumber(value, widthComputedValueRef.current?.unit ?? null),
           ),
         )
@@ -227,7 +228,7 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
   const onSubmitWidth = React.useCallback(
     ({ value: anyValue }: SelectOption) => {
       const value = anyValue as FixedHugFillMode
-      const strategy = strategyForMode(widthComputedValueRef.current, 'width', value)
+      const strategy = strategyForMode(widthComputedValueRef.current, 'horizontal', value)
       runStrategies(dispatch, metadataRef.current, selectedViewsRef.current, strategy)
     },
     [dispatch, metadataRef, selectedViewsRef, widthComputedValueRef],
@@ -304,16 +305,16 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
 
 function strategyForMode(
   fixedValue: CSSNumber,
-  prop: 'width' | 'height',
+  axis: Axis,
   mode: FixedHugFillMode,
 ): Array<InspectorStrategy> {
   switch (mode) {
     case 'fill':
-      return setPropFillStrategies(prop)
+      return setPropFillStrategies(axis)
     case 'hug':
-      return setPropHugStrategies(prop)
+      return setPropHugStrategies(axis)
     case 'fixed':
-      return setPropFixedStrategies(prop, fixedValue)
+      return setPropFixedStrategies(axis, fixedValue)
     default:
       assertNever(mode)
   }

--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { getLayoutProperty } from '../../core/layout/getLayoutProperty'
 import { getSimpleAttributeAtPath, MetadataUtils } from '../../core/model/element-metadata-utils'
 import { stripNulls } from '../../core/shared/array-utils'
-import { defaultEither, isLeft, right } from '../../core/shared/either'
+import { defaultEither, foldEither, isLeft, right } from '../../core/shared/either'
+import { parentPath } from '../../core/shared/element-path'
 import { ElementInstanceMetadataMap, isJSXElement } from '../../core/shared/element-template'
 import { optionalMap } from '../../core/shared/optional-utils'
 import { ElementPath } from '../../core/shared/project-file-types'
@@ -11,11 +11,22 @@ import { assertNever, NO_OP } from '../../core/shared/utils'
 import { PopupList, SimpleNumberInput } from '../../uuiui'
 import { getControlStyles, SelectOption } from '../../uuiui-deps'
 import { useEditorState, useRefEditorState } from '../editor/store/store-hook'
-import { CSSNumber, cssNumber, EmptyInputValue, parseCSSLengthPercent } from './common/css-utils'
+import {
+  CSSNumber,
+  cssNumber,
+  EmptyInputValue,
+  parseCSSLengthPercent,
+  parseCSSNumber,
+} from './common/css-utils'
 import { metadataSelector, selectedViewsSelector } from './inpector-selectors'
-import { fillContainerApplicable, hugContentsApplicable } from './inspector-common'
 import {
   Axis,
+  detectFlexDirectionOne,
+  fillContainerApplicable,
+  hugContentsApplicable,
+  widthHeightFromAxis,
+} from './inspector-common'
+import {
   InspectorStrategy,
   runStrategies,
   setPropFillStrategies,
@@ -25,7 +36,10 @@ import {
 
 const controlId = (segment: 'width' | 'height') => `hug-fixed-fill-${segment}`
 
-type FixedHugFill = { type: 'fixed'; amount: CSSNumber } | { type: 'hug' } | { type: 'fill' }
+type FixedHugFill =
+  | { type: 'fixed'; amount: CSSNumber }
+  | { type: 'hug' }
+  | { type: 'fill'; value: CSSNumber }
 type FixedHugFillMode = FixedHugFill['type']
 
 function isFixedHugFillEqual(a: FixedHugFill | undefined, b: FixedHugFill | undefined): boolean {
@@ -80,7 +94,7 @@ const FillHugFixedControlOptions = ({
   ])
 
 function detectFillHugFixedState(
-  property: 'width' | 'height',
+  axis: Axis,
   metadata: ElementInstanceMetadataMap,
   elementPath: ElementPath | null,
 ): FixedHugFill | null {
@@ -88,6 +102,31 @@ function detectFillHugFixedState(
   if (element == null || isLeft(element.element) || !isJSXElement(element.element.value)) {
     return null
   }
+
+  const flexGrow = foldEither(
+    () => null,
+    (value) => defaultEither(null, parseCSSNumber(value, 'Unitless')),
+    getSimpleAttributeAtPath(right(element.element.value.props), PP.create(['style', 'flexGrow'])),
+  )
+
+  if (flexGrow != null) {
+    const flexDirection = optionalMap(
+      (e) => detectFlexDirectionOne(metadata, parentPath(e)),
+      elementPath,
+    )
+
+    const isFlexDirectionHorizontal = flexDirection === 'row' || flexDirection === 'row-reverse'
+    if (axis === 'horizontal' && isFlexDirectionHorizontal) {
+      return { type: 'fill', value: flexGrow }
+    }
+
+    const isFlexDirectionVertical = flexDirection === 'column' || flexDirection === 'column-reverse'
+    if (axis === 'vertical' && isFlexDirectionVertical) {
+      return { type: 'fill', value: flexGrow }
+    }
+  }
+
+  const property = widthHeightFromAxis(axis)
 
   const prop = defaultEither(
     null,
@@ -99,7 +138,7 @@ function detectFillHugFixedState(
   }
 
   if (prop === '100%') {
-    return { type: 'fill' }
+    return { type: 'fill', value: cssNumber(100, '%') }
   }
 
   const parsed = defaultEither(null, parseCSSLengthPercent(prop))
@@ -145,7 +184,7 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
   const widthCurrentValue = useEditorState(
     (store) =>
       detectFillHugFixedState(
-        'width',
+        'horizontal',
         metadataSelector(store),
         selectedViewsSelector(store).at(0) ?? null,
       ) ?? undefined,
@@ -165,7 +204,7 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
   const heightCurrentValue = useEditorState(
     (store) =>
       detectFillHugFixedState(
-        'height',
+        'vertical',
         metadataSelector(store),
         selectedViewsSelector(store).at(0) ?? null,
       ) ?? undefined,
@@ -323,6 +362,9 @@ function strategyForMode(
 function pickFixedValue(value: FixedHugFill): CSSNumber | undefined {
   if (value.type === 'fixed') {
     return value.amount
+  }
+  if (value.type === 'fill') {
+    return value.value
   }
   return undefined
 }

--- a/editor/src/components/inspector/inspector-common.tsx
+++ b/editor/src/components/inspector/inspector-common.tsx
@@ -75,7 +75,7 @@ type Detect<T> = (
 
 export const DefaultFlexDirection: FlexDirection = 'row'
 
-function detectFlexDirectionOne(
+export function detectFlexDirectionOne(
   metadata: ElementInstanceMetadataMap,
   elementPath: ElementPath,
 ): FlexDirection | null {

--- a/editor/src/components/inspector/inspector-common.tsx
+++ b/editor/src/components/inspector/inspector-common.tsx
@@ -4,6 +4,7 @@ import { mapDropNulls } from '../../core/shared/array-utils'
 import { ElementInstanceMetadataMap } from '../../core/shared/element-template'
 import { ElementPath } from '../../core/shared/project-file-types'
 import { FlexDirection } from './common/css-utils'
+import { assertNever } from '../../core/shared/utils'
 
 export type StartCenterEnd = 'flex-start' | 'center' | 'flex-end'
 
@@ -188,4 +189,17 @@ function allElemsEqual<T>(objects: T[], areEqual: (a: T, b: T) => boolean): bool
   }
 
   return objects.slice(1).every((obj) => areEqual(objects[0], obj))
+}
+
+export type Axis = 'horizontal' | 'vertical'
+
+export function widthHeightFromAxis(axis: Axis): 'width' | 'height' {
+  switch (axis) {
+    case 'horizontal':
+      return 'width'
+    case 'vertical':
+      return 'height'
+    default:
+      assertNever(axis)
+  }
 }

--- a/editor/src/components/inspector/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies.tsx
@@ -67,9 +67,9 @@ export const updateFlexDirectionStrategies = (
       return null
     }
 
-    return elements.flatMap((path) => [
+    return elements.map((path) =>
       setProperty('always', path, PP.create(['style', 'flexDirection']), flexDirection),
-    ])
+    )
   },
 ]
 

--- a/editor/src/components/inspector/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies.tsx
@@ -5,11 +5,13 @@ import { CanvasCommand } from '../canvas/commands/commands'
 import { setProperty } from '../canvas/commands/set-property-command'
 import { EditorDispatch } from '../editor/action-types'
 import {
+  Axis,
   fillContainerApplicable,
   filterKeepFlexContainers,
   FlexAlignment,
   FlexJustifyContent,
   hugContentsApplicable,
+  widthHeightFromAxis,
 } from './inspector-common'
 import { applyCommandsAction } from '../editor/actions/action-creators'
 import { deleteProperties } from '../canvas/commands/delete-properties-command'
@@ -92,19 +94,6 @@ export const removeFlexLayoutStrategies: Array<InspectorStrategy> = [
     )
   },
 ]
-
-export type Axis = 'horizontal' | 'vertical'
-
-function widthHeightFromAxis(axis: Axis): 'width' | 'height' {
-  switch (axis) {
-    case 'horizontal':
-      return 'width'
-    case 'vertical':
-      return 'height'
-    default:
-      assertNever(axis)
-  }
-}
 
 export const setPropFillStrategies = (axis: Axis): Array<InspectorStrategy> => [
   (metadata, elementPaths) => {

--- a/editor/src/components/inspector/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies.tsx
@@ -14,6 +14,7 @@ import {
 import { applyCommandsAction } from '../editor/actions/action-creators'
 import { deleteProperties } from '../canvas/commands/delete-properties-command'
 import { CSSNumber, FlexDirection, printCSSNumber } from './common/css-utils'
+import { MetadataUtils } from '../../core/model/element-metadata-utils'
 
 export type InspectorStrategy = (
   metadata: ElementInstanceMetadataMap,
@@ -90,7 +91,18 @@ export const removeFlexLayoutStrategies: Array<InspectorStrategy> = [
   },
 ]
 
-export const setPropFillStrategies = (prop: 'width' | 'height'): Array<InspectorStrategy> => [
+export type Axis = 'horizontal' | 'vertical'
+
+function widthHeightFromAxis(axis: Axis): 'width' | 'height' {
+  switch (axis) {
+    case 'horizontal':
+      return 'width'
+    case 'vertical':
+      return 'height'
+  }
+}
+
+export const setPropFillStrategies = (axis: Axis): Array<InspectorStrategy> => [
   (metadata, elementPaths) => {
     const elements = elementPaths.filter(fillContainerApplicable)
 
@@ -98,26 +110,30 @@ export const setPropFillStrategies = (prop: 'width' | 'height'): Array<Inspector
       return null
     }
 
-    return elements.map((path) => setProperty('always', path, PP.create(['style', prop]), '100%'))
+    return elements.map((path) =>
+      setProperty('always', path, PP.create(['style', widthHeightFromAxis(axis)]), '100%'),
+    )
   },
 ]
 
-export const setPropFixedStrategies = (
-  prop: 'width' | 'height',
-  value: CSSNumber,
-): Array<InspectorStrategy> => [
+export const setPropFixedStrategies = (axis: Axis, value: CSSNumber): Array<InspectorStrategy> => [
   (metadata, elementPaths) => {
     if (elementPaths.length === 0) {
       return null
     }
 
     return elementPaths.map((path) =>
-      setProperty('always', path, PP.create(['style', prop]), printCSSNumber(value, null)),
+      setProperty(
+        'always',
+        path,
+        PP.create(['style', widthHeightFromAxis(axis)]),
+        printCSSNumber(value, null),
+      ),
     )
   },
 ]
 
-export const setPropHugStrategies = (prop: 'width' | 'height'): Array<InspectorStrategy> => [
+export const setPropHugStrategies = (axis: Axis): Array<InspectorStrategy> => [
   (metadata, elementPaths) => {
     const elements = elementPaths.filter((path) => hugContentsApplicable(metadata, path))
 
@@ -126,7 +142,7 @@ export const setPropHugStrategies = (prop: 'width' | 'height'): Array<InspectorS
     }
 
     return elements.map((path) =>
-      setProperty('always', path, PP.create(['style', prop]), 'min-content'),
+      setProperty('always', path, PP.create(['style', widthHeightFromAxis(axis)]), 'min-content'),
     )
   },
 ]

--- a/editor/src/components/inspector/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies.tsx
@@ -110,9 +110,12 @@ export const setPropFillStrategies = (axis: Axis): Array<InspectorStrategy> => [
       return null
     }
 
-    return elements.map((path) =>
-      setProperty('always', path, PP.create(['style', widthHeightFromAxis(axis)]), '100%'),
-    )
+    return elements.map((path) => {
+      const instance = MetadataUtils.findElementByElementPath(metadata, path)
+      return MetadataUtils.isFlexLayoutedContainer(instance)
+        ? setProperty('always', path, PP.create(['style', 'flexGrow']), '1')
+        : setProperty('always', path, PP.create(['style', widthHeightFromAxis(axis)]), '100%')
+    })
   },
 ]
 

--- a/editor/src/components/inspector/inspector-strategy-utils.tsx
+++ b/editor/src/components/inspector/inspector-strategy-utils.tsx
@@ -1,0 +1,15 @@
+import { getSimpleAttributeAtPath } from '../../core/model/element-metadata-utils'
+import { isLeft, isRight, right } from '../../core/shared/either'
+import { ElementInstanceMetadata, isJSXElement } from '../../core/shared/element-template'
+import { PropertyPath } from '../../core/shared/project-file-types'
+
+export function propertyExists(
+  property: PropertyPath,
+  element: ElementInstanceMetadata | null,
+): boolean {
+  if (element == null || isLeft(element.element) || !isJSXElement(element.element.value)) {
+    return false
+  }
+
+  return isRight(getSimpleAttributeAtPath(right(element.element.value.props), property))
+}


### PR DESCRIPTION
This PR improves the fill/fixed/hug control by setting `flex-grow: 1` instead of `width: 100%`, when a flex child is set to `Fill container`. In the same vein, when determining the state of the fixed/fill/hug control, `flex-grow` is classified as `Fill container`, and the value of `flex-grow` is displayed in the number input (not editable yet).