### PR TITLE
Fix/canvas select mode hook text blur

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -594,6 +594,7 @@ function useSelectOrLiveModeSelectAndHover(
   const getSelectableViewsForSelectMode = useGetSelectableViewsForSelectMode()
   const windowToCanvasCoordinates = useWindowToCanvasCoordinates()
   const interactionSessionHappened = React.useRef(false)
+  const didWeHandleMouseDown = React.useRef(false) //  this is here to avoid selecting when closing text editing
 
   const { onMouseMove: innerOnMouseMove } = useHighlightCallbacks(
     active,
@@ -641,12 +642,18 @@ function useSelectOrLiveModeSelectAndHover(
 
       const activeControl = editorStoreRef.current.editor.canvas.interactionSession?.activeControl
       const mouseUpSelectionAllowed =
+        didWeHandleMouseDown.current &&
         !hadInteractionSessionThatWasCancelled &&
         (activeControl == null || activeControl.type === 'BOUNDING_AREA')
 
+      if (event.type === 'mousedown') {
+        didWeHandleMouseDown.current = true
+      }
       if (event.type === 'mouseup') {
         // Clear the interaction session tracking flag
         interactionSessionHappened.current = false
+        // didWeHandleMouseDown is used to avoid selecting when closing text editing
+        didWeHandleMouseDown.current = false
 
         if (!mouseUpSelectionAllowed) {
           // We should skip this mouseup

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -563,13 +563,12 @@ export function useHighlightCallbacks(
 function getPreferredSelectionForEvent(
   eventType: 'mousedown' | 'mouseup' | string,
   isDoubleClick: boolean,
-  mouseUpSelectionAllowed: boolean,
 ): 'prefer-selected' | 'dont-prefer-selected' {
   // mousedown keeps selection on a single click to allow dragging overlapping elements and selection happens on mouseup
   // with continuous clicking mousedown should select
   switch (eventType) {
     case 'mousedown':
-      return isDoubleClick || !mouseUpSelectionAllowed ? 'dont-prefer-selected' : 'prefer-selected'
+      return isDoubleClick ? 'dont-prefer-selected' : 'prefer-selected'
     case 'mouseup':
       return isDoubleClick ? 'prefer-selected' : 'dont-prefer-selected'
     default:
@@ -641,9 +640,7 @@ function useSelectOrLiveModeSelectAndHover(
         interactionSessionHappened.current && !hasInteractionSession
 
       const activeControl = editorStoreRef.current.editor.canvas.interactionSession?.activeControl
-      const isCurrentSelectionMultiselect = selectedViewsRef.current.length > 1
       const mouseUpSelectionAllowed =
-        isCurrentSelectionMultiselect &&
         !hadInteractionSessionThatWasCancelled &&
         (activeControl == null || activeControl.type === 'BOUNDING_AREA')
 
@@ -664,11 +661,7 @@ function useSelectOrLiveModeSelectAndHover(
 
       const doubleClick = event.type === 'mousedown' && event.detail > 0 && event.detail % 2 === 0
       const selectableViews = getSelectableViewsForSelectMode(event.metaKey, doubleClick)
-      const preferAlreadySelected = getPreferredSelectionForEvent(
-        event.type,
-        doubleClick,
-        mouseUpSelectionAllowed,
-      )
+      const preferAlreadySelected = getPreferredSelectionForEvent(event.type, doubleClick)
       const foundTarget = findValidTarget(
         selectableViews,
         windowPoint(point(event.clientX, event.clientY)),

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -134,7 +134,7 @@ export const TextEditor = React.memo(({ elementPath, text }: TextEditorProps) =>
   )
 
   const onBlur = React.useCallback(() => {
-    dispatch([updateEditorMode(EditorModes.selectMode()), clearSelection()])
+    dispatch([updateEditorMode(EditorModes.selectMode())])
   }, [dispatch])
 
   return (


### PR DESCRIPTION
Fixes https://github.com/concrete-utopia/utopia/issues/3033

**Problem:**
When exiting text editing by clicking on the canvas it can select an element under the mouse on mouseup.

**Fix:**
~~Only allow mouseup selection when there is a multiselection.~~
It turns out my solution was breaking dragging overflow hidden elements. I found a short fix for closing text editing and not selecting anything on mouseup, it relies on the fact there is no canvas controls layer during text editing, so there are no mousedown events.

**Commit Details:**
- ~~add multiselect to `mouseUpSelectionAllowed` flag~~
- ~~there is a selection preference for mousedown/mouseup, it is extended to include `mouseUpSelectionAllowed` and prefers selecting the element when there is only mousedown~~
- add `didWeHandleMouseDown` to select mode hook 
- remove `clearSelection` when the text-editor calls `onBlur`, clicking somewhere else to close text editing keeps text selection
