### PR TITLE
Render text editor without adding an extra span to the dom

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -21,6 +21,7 @@ import {
   getJSXAttribute,
   emptyComments,
   jsxTextBlock,
+  JSXTextBlock,
 } from '../../../core/shared/element-template'
 import {
   getAccumulatedElementsWithin,
@@ -50,7 +51,7 @@ import { optionalMap } from '../../../core/shared/optional-utils'
 import { canvasMissingJSXElementError } from './canvas-render-errors'
 import { importedFromWhere } from '../../editor/import-utils'
 import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../../core/shared/dom-utils'
-import { TextEditor, unescapeHTML } from '../../text-editor/text-editor'
+import { TextEditorWrapper, unescapeHTML } from '../../text-editor/text-editor'
 
 export function createLookupRender(
   elementPath: ElementPath | null,
@@ -319,12 +320,14 @@ export function renderCoreElement(
       return <>{renderedChildren}</>
     }
     case 'JSX_TEXT_BLOCK': {
-      const unescaped = unescapeHTML(element.text)
       const parentPath = Utils.optionalMap(EP.parentPath, elementPath)
-      if (parentPath == null || !EP.pathsEqual(parentPath, editedText)) {
-        return unescaped
+      // when the text is just edited its parent renders it in a text editor, so no need to render anything here
+      if (parentPath != null && EP.pathsEqual(parentPath, editedText)) {
+        return <></>
       }
-      return <TextEditor elementPath={parentPath} text={unescaped.trim()} />
+
+      const unescaped = unescapeHTML(element.text)
+      return unescaped
     }
     default:
       const _exhaustiveCheck: never = element
@@ -444,6 +447,33 @@ function renderJSXElement(
   }
 
   if (elementPath != null && validPaths.has(EP.makeLastPartOfPathStatic(elementPath))) {
+    if (elementIsTextEdited) {
+      const textBlock = childrenWithNewTextBlock.find(
+        (c): c is JSXTextBlock => c.type === 'JSX_TEXT_BLOCK',
+      )
+      const textContent = textBlock?.text ?? ''
+      const textEditorProps = {
+        elementPath: elementPath,
+        text: textContent,
+        component: FinalElement,
+        passthroughProps: finalPropsIcludingElementPath,
+      }
+
+      return buildSpyWrappedElement(
+        jsx,
+        textEditorProps,
+        elementPath,
+        metadataContext,
+        updateInvalidatedPaths,
+        childrenElements,
+        TextEditorWrapper,
+        inScope,
+        jsxFactoryFunctionName,
+        shouldIncludeCanvasRootInTheSpy,
+        imports,
+        filePath,
+      )
+    }
     return buildSpyWrappedElement(
       jsx,
       finalPropsIcludingElementPath,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -326,8 +326,7 @@ export function renderCoreElement(
         return <></>
       }
 
-      const unescaped = unescapeHTML(element.text)
-      return unescaped
+      return unescapeHTML(element.text)
     }
     default:
       const _exhaustiveCheck: never = element
@@ -451,10 +450,10 @@ function renderJSXElement(
       const textBlock = childrenWithNewTextBlock.find(
         (c): c is JSXTextBlock => c.type === 'JSX_TEXT_BLOCK',
       )
-      const textContent = textBlock?.text ?? ''
+      const textContent = unescapeHTML(textBlock?.text ?? '')
       const textEditorProps = {
         elementPath: elementPath,
-        text: textContent,
+        text: textContent.trim(),
         component: FinalElement,
         passthroughProps: finalPropsIcludingElementPath,
       }

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -51,109 +51,108 @@ const handleShortcut = (
   ]
 }
 
-export const TextEditorWrapper = React.memo(
-  ({ elementPath, text, component, passthroughProps }: TextEditorProps) => {
-    const dispatch = useEditorState((store) => store.dispatch, 'TextEditor dispatch')
-    const allElementProps = useEditorState((store) => store.editor.allElementProps, 'Editor')
-    const [firstTextProp] = React.useState(text)
+export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
+  const { elementPath, text, component, passthroughProps } = props
+  const dispatch = useEditorState((store) => store.dispatch, 'TextEditor dispatch')
+  const allElementProps = useEditorState((store) => store.editor.allElementProps, 'Editor')
+  const [firstTextProp] = React.useState(text)
 
-    const myElement = React.useRef<HTMLSpanElement>(null)
+  const myElement = React.useRef<HTMLSpanElement>(null)
 
-    React.useEffect(() => {
-      const currentElement = myElement.current
-      if (currentElement == null) {
-        return
+  React.useEffect(() => {
+    const currentElement = myElement.current
+    if (currentElement == null) {
+      return
+    }
+
+    currentElement.focus()
+
+    return () => {
+      const content = currentElement.textContent
+      if (content != null) {
+        dispatch([updateChildText(elementPath, escapeHTML(content))])
+      }
+    }
+  }, [dispatch, elementPath])
+
+  React.useEffect(() => {
+    if (myElement.current == null) {
+      return
+    }
+    myElement.current.textContent = firstTextProp
+    setSelectionToEnd(myElement.current)
+  }, [firstTextProp])
+
+  const onKeyDown = React.useCallback(
+    (event: React.KeyboardEvent) => {
+      const modifiers = Modifier.modifiersForEvent(event)
+      const meta = modifiers.cmd || modifiers.ctrl
+      const shortcuts = [
+        ...handleShortcut(
+          meta && event.key === 'b', // Meta+b = bold
+          allElementProps,
+          elementPath,
+          'fontWeight',
+          'bold',
+          'normal',
+        ),
+        ...handleShortcut(
+          meta && event.key === 'i', // Meta+i = italic
+          allElementProps,
+          elementPath,
+          'fontStyle',
+          'italic',
+          'normal',
+        ),
+        ...handleShortcut(
+          meta && event.key === 'u', // Meta+u = underline
+          allElementProps,
+          elementPath,
+          'textDecoration',
+          'underline',
+          'none',
+        ),
+        ...handleShortcut(
+          meta && modifiers.shift && event.key === 'x', // Meta+shift+x = strikethrough
+          allElementProps,
+          elementPath,
+          'textDecoration',
+          'line-through',
+          'none',
+        ),
+      ]
+      if (shortcuts.length > 0) {
+        event.stopPropagation()
+        dispatch(shortcuts)
       }
 
-      currentElement.focus()
-
-      return () => {
-        const content = currentElement.textContent
-        if (content != null) {
-          dispatch([updateChildText(elementPath, escapeHTML(content))])
-        }
+      if (event.key === 'Escape') {
+        // eslint-disable-next-line no-unused-expressions
+        myElement.current?.blur()
+      } else {
+        event.stopPropagation()
       }
-    }, [dispatch, elementPath])
+    },
+    [dispatch, elementPath, allElementProps],
+  )
 
-    React.useEffect(() => {
-      if (myElement.current == null) {
-        return
-      }
-      myElement.current.textContent = firstTextProp
-      setSelectionToEnd(myElement.current)
-    }, [firstTextProp])
+  const onBlur = React.useCallback(() => {
+    dispatch([updateEditorMode(EditorModes.selectMode())])
+  }, [dispatch])
 
-    const onKeyDown = React.useCallback(
-      (event: React.KeyboardEvent) => {
-        const modifiers = Modifier.modifiersForEvent(event)
-        const meta = modifiers.cmd || modifiers.ctrl
-        const shortcuts = [
-          ...handleShortcut(
-            meta && event.key === 'b', // Meta+b = bold
-            allElementProps,
-            elementPath,
-            'fontWeight',
-            'bold',
-            'normal',
-          ),
-          ...handleShortcut(
-            meta && event.key === 'i', // Meta+i = italic
-            allElementProps,
-            elementPath,
-            'fontStyle',
-            'italic',
-            'normal',
-          ),
-          ...handleShortcut(
-            meta && event.key === 'u', // Meta+u = underline
-            allElementProps,
-            elementPath,
-            'textDecoration',
-            'underline',
-            'none',
-          ),
-          ...handleShortcut(
-            meta && modifiers.shift && event.key === 'x', // Meta+shift+x = strikethrough
-            allElementProps,
-            elementPath,
-            'textDecoration',
-            'line-through',
-            'none',
-          ),
-        ]
-        if (shortcuts.length > 0) {
-          event.stopPropagation()
-          dispatch(shortcuts)
-        }
-
-        if (event.key === 'Escape') {
-          // eslint-disable-next-line no-unused-expressions
-          myElement.current?.blur()
-        } else {
-          event.stopPropagation()
-        }
-      },
-      [dispatch, elementPath, allElementProps],
-    )
-
-    const onBlur = React.useCallback(() => {
-      dispatch([updateEditorMode(EditorModes.selectMode())])
-    }, [dispatch])
-
-    return React.createElement(component, {
-      ...passthroughProps,
-      ref: myElement,
-      id: TextEditorSpanId,
-      onPaste: stopPropagation,
-      onKeyDown: onKeyDown,
-      onKeyUp: stopPropagation,
-      onKeyPress: stopPropagation,
-      onBlur: onBlur,
-      contentEditable: 'plaintext-only' as any, // note: not supported on firefo,
-      suppressContentEditableWarning: true,
-    })
-  },
-)
+  return React.createElement(component, {
+    ...passthroughProps,
+    ref: myElement,
+    id: TextEditorSpanId,
+    onPaste: stopPropagation,
+    onKeyDown: onKeyDown,
+    onKeyUp: stopPropagation,
+    onKeyPress: stopPropagation,
+    onBlur: onBlur,
+    contentEditable: 'plaintext-only' as any, // note: not supported on firefo,
+    suppressContentEditableWarning: true,
+  })
+})
 
 function setSelectionToEnd(element: HTMLSpanElement) {
   const range = document.createRange()

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -152,6 +152,7 @@ export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
     suppressContentEditableWarning: true,
   }
 
+  // When the component to render is a simple html element we should make that contenteditable
   if (typeof component === 'string') {
     return React.createElement(component, {
       ...passthroughProps,

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -140,8 +140,7 @@ export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
     dispatch([updateEditorMode(EditorModes.selectMode())])
   }, [dispatch])
 
-  return React.createElement(component, {
-    ...passthroughProps,
+  const editorProps = {
     ref: myElement,
     id: TextEditorSpanId,
     onPaste: stopPropagation,
@@ -151,7 +150,15 @@ export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
     onBlur: onBlur,
     contentEditable: 'plaintext-only' as any, // note: not supported on firefo,
     suppressContentEditableWarning: true,
-  })
+  }
+
+  if (typeof component === 'string') {
+    return React.createElement(component, {
+      ...passthroughProps,
+      ...editorProps,
+    })
+  }
+  return React.createElement(component, passthroughProps, <span {...editorProps} />)
 })
 
 function setSelectionToEnd(element: HTMLSpanElement) {

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -21,7 +21,7 @@ export const TextEditorSpanId = 'text-editor'
 interface TextEditorProps {
   elementPath: ElementPath
   text: string
-  component: any
+  component: React.ComponentType<React.PropsWithChildren<any>>
   passthroughProps: Record<string, unknown>
 }
 


### PR DESCRIPTION
**Problem:**
Text editing implementation inserts an extra contenteditable span around the text content to make it editable. This solution has some risks, e.g. what if there is a css rule for spans, which modifies the styling of the text.

**Fix:**
Modify the TextEditor component in a way that it wraps the existing parent component and makes it contenteditable.
This also fixes the "clicking in the edited element, but outside of the text content blurs the editor" bug

**UPDATE:**
I realized this solution doesn't work when we try to text edit a user defined component which doesn't forward refs (because we need the ref to the underlying rendered html element)
I needed to modify the code to only use this new wrapped method in case of simple html elements and not components.

