### PR TITLE
highlight text editable items

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
@@ -14,6 +14,8 @@ import { InteractionSession } from '../interaction-state'
 import { drawToInsertFitness, drawToInsertStrategyFactory } from './draw-to-insert-metastrategy'
 import { getApplicableReparentFactories } from './reparent-metastrategy'
 
+export const DRAW_TO_INSERT_TEXT_STRATEGY_ID = 'draw-to-insert-text'
+
 export const drawToInsertTextStrategy: MetaCanvasStrategy = (
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
@@ -44,7 +46,7 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
 
   return [
     {
-      id: 'draw-to-insert-text',
+      id: DRAW_TO_INSERT_TEXT_STRATEGY_ID,
       name: name,
       controlsToRender: [],
       fitness: insertionSubject.textEdit && drawToInsertFitness(interactionSession) ? 1 : 0,

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -331,16 +331,21 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       return []
     }
     return Object.keys(props.editor.allElementProps)
-      .filter(
-        (p) =>
+      .filter((p) => {
+        const metadata = componentMetadata[p]
+        if (metadata == null) {
+          return false
+        }
+        return (
           MetadataUtils.targetTextEditable(componentMetadata, EP.fromString(p)) &&
           ['hasOnlyTextChildren', 'supportsChildren'].includes(
             MetadataUtils.targetElementSupportsChildrenAlsoText(
               props.editor.projectContents,
-              componentMetadata[p],
+              metadata,
             ),
-          ),
-      )
+          )
+        )
+      })
       .map((p) => {
         const elementPath = EP.fromString(p)
         const frame = MetadataUtils.getFrameInCanvasCoords(elementPath, componentMetadata)

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -59,6 +59,8 @@ import { ControlForStrategy, ControlWithProps } from '../canvas-strategies/canva
 import { useKeepShallowReferenceEquality } from '../../../utils/react-performance'
 import { shallowEqual } from '../../../core/shared/equality-utils'
 import { ZeroSizedElementControls } from './zero-sized-element-controls'
+import { DRAW_TO_INSERT_TEXT_STRATEGY_ID } from '../canvas-strategies/strategies/draw-to-insert-text-strategy'
+import { TextEditableControl } from './text-editable-control'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
@@ -240,6 +242,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
     (store) => store.strategyState.currentStrategy != null,
     'currentStrategy',
   )
+  const strategy = useEditorState((store) => store.strategyState, 'strategy')
 
   const { localSelectedViews, localHighlightedViews, setLocalSelectedViews } = props
   const cmdKeyPressed = props.editor.keysPressed['cmd'] ?? false
@@ -323,6 +326,38 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       : []
   }
 
+  const renderTextEditableControls = () => {
+    if (strategy?.currentStrategy !== DRAW_TO_INSERT_TEXT_STRATEGY_ID) {
+      return []
+    }
+    return Object.keys(props.editor.allElementProps)
+      .filter(
+        (p) =>
+          MetadataUtils.targetTextEditable(componentMetadata, EP.fromString(p)) &&
+          ['hasOnlyTextChildren', 'supportsChildren'].includes(
+            MetadataUtils.targetElementSupportsChildrenAlsoText(
+              props.editor.projectContents,
+              componentMetadata[p],
+            ),
+          ),
+      )
+      .map((p) => {
+        const elementPath = EP.fromString(p)
+        const frame = MetadataUtils.getFrameInCanvasCoords(elementPath, componentMetadata)
+        if (frame == null) {
+          return null
+        }
+        return (
+          <TextEditableControl
+            key={`text-editable-control-${EP.toComponentId(elementPath)}`}
+            frame={frame}
+            scale={props.editor.canvas.scale}
+            canvasOffset={props.canvasOffset}
+          />
+        )
+      })
+  }
+
   const resizeStatus = getResizeStatus()
 
   return (
@@ -354,6 +389,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
           {when(isSelectMode(props.editor.mode) && !anyStrategyActive, <PinLines />)}
           {when(isSelectMode(props.editor.mode), <InsertionControls />)}
           {renderHighlightControls()}
+          {renderTextEditableControls()}
           {unless(dragging, <LayoutParentControl />)}
           <MultiSelectOutlineControl localSelectedElements={localSelectedViews} />
           <GuidelineControls />

--- a/editor/src/components/canvas/controls/text-editable-control.tsx
+++ b/editor/src/components/canvas/controls/text-editable-control.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { CanvasPoint, CanvasRectangle } from '../../../core/shared/math-utils'
+import { useColorTheme } from '../../../uuiui'
+import { isZeroSizedElement } from './outline-utils'
+
+interface TextEditableControlProps {
+  frame: CanvasRectangle
+  canvasOffset: CanvasPoint
+  scale: number
+}
+
+export const TextEditableControl = React.memo((props: TextEditableControlProps) => {
+  const colorTheme = useColorTheme()
+  const outlineWidth = 1.5 / props.scale
+  const outlineColor = colorTheme.textEditableOutline.value
+  const backgroundColor = colorTheme.textEditableFill.value
+
+  if (isZeroSizedElement(props.frame)) {
+    return null
+  }
+
+  return (
+    <div
+      className='role-component-highlight-text-editable'
+      style={{
+        position: 'absolute',
+        left: props.canvasOffset.x + props.frame.x,
+        top: props.canvasOffset.y + props.frame.y,
+        width: props.frame.width,
+        height: props.frame.height,
+        boxShadow: `0px 0px 0px ${outlineWidth}px ${outlineColor}`,
+        background: backgroundColor,
+        pointerEvents: 'none',
+      }}
+    />
+  )
+})

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -172,6 +172,9 @@ export const dark: typeof light = {
   canvasComponentButtonFocused: createUtopiColor('rgba(255,239,230,1)'),
   inspectorControlledBackground: createUtopiColor('rgba(242,248,255,1)'),
 
+  textEditableFill: createUtopiColor('rgba(255,128,255,.1)'),
+  textEditableOutline: createUtopiColor('rgba(255,128,255,1)'),
+
   // interface elements: buttons, segment controls, checkboxes etc
 
   inlineButtonColor: darkBase.primary,

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -172,7 +172,7 @@ export const dark: typeof light = {
   canvasComponentButtonFocused: createUtopiColor('rgba(255,239,230,1)'),
   inspectorControlledBackground: createUtopiColor('rgba(242,248,255,1)'),
 
-  textEditableFill: createUtopiColor('rgba(255,128,255,.1)'),
+  textEditableFill: createUtopiColor('rgba(255,128,255,.07)'),
   textEditableOutline: createUtopiColor('rgba(255,128,255,1)'),
 
   // interface elements: buttons, segment controls, checkboxes etc

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -172,7 +172,7 @@ export const light = {
   canvasComponentButtonFocused: createUtopiColor('rgba(255,239,230,1)'),
   inspectorControlledBackground: createUtopiColor('rgba(242,248,255,1)'),
 
-  textEditableFill: createUtopiColor('rgba(255,128,255,.1)'),
+  textEditableFill: createUtopiColor('rgba(255,128,255,.07)'),
   textEditableOutline: createUtopiColor('rgba(255,128,255,1)'),
 
   // interface elements: buttons, segment controls, checkboxes etc

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -172,6 +172,9 @@ export const light = {
   canvasComponentButtonFocused: createUtopiColor('rgba(255,239,230,1)'),
   inspectorControlledBackground: createUtopiColor('rgba(242,248,255,1)'),
 
+  textEditableFill: createUtopiColor('rgba(255,128,255,.1)'),
+  textEditableOutline: createUtopiColor('rgba(255,128,255,1)'),
+
   // interface elements: buttons, segment controls, checkboxes etc
 
   inlineButtonColor: lightBase.primary,


### PR DESCRIPTION
Fixes #3043

**Problem:**

Currently, text edit mode valid targets are impossible to discriminate to the invalid ones during draw-to-insert-text.

**Fix:**

When the draw-to-insert-text mode is active, highlight the editable elements.

<img width="568" alt="Screenshot 2023-01-04 at 11 51 24 AM" src="https://user-images.githubusercontent.com/1081051/210539566-01452c93-a191-4172-96e8-e4701aa81a6b.png">
