### PR TITLE
Feature/text edit mode insert button

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.spec.browser2.tsx
@@ -65,9 +65,8 @@ describe('draw-to-insert text', () => {
                   }}
                   data-uid='39e'
                 >Hello</div>
-                <div
+                <span
                   style={{
-                    backgroundColor: '#aaaaaa33',
                     position: 'absolute',
                     left: 389,
                     top: 101,
@@ -75,7 +74,7 @@ describe('draw-to-insert text', () => {
                     height: 250,
                   }}
                   data-uid='${newElementUID}'
-                >Utopia</div>
+                >Utopia</span>
               </Storyboard>
             )`),
       )
@@ -128,9 +127,8 @@ describe('draw-to-insert text', () => {
                   }}
                   data-uid='39e'
                 >Hello</div>
-                <div
+                <span
                   style={{
-                    backgroundColor: '#aaaaaa33',
                     position: 'absolute',
                     left: 339,
                     top: 51,
@@ -138,7 +136,7 @@ describe('draw-to-insert text', () => {
                     height: 100,
                   }}
                   data-uid='${newElementUID}'
-                >Utopia</div>
+                >Utopia</span>
               </Storyboard>
             )`),
       )
@@ -230,9 +228,8 @@ describe('draw-to-insert text', () => {
 
             export var storyboard = (
               <Storyboard data-uid='sb'>
-                <div
+                <span
                   style={{
-                    backgroundColor: '#aaaaaa33',
                     position: 'absolute',
                     left: 112,
                     top: 391,
@@ -240,7 +237,7 @@ describe('draw-to-insert text', () => {
                     height: 50,
                   }}
                   data-uid='${newElementUID}'
-                >Hey root</div>
+                >Hey root</span>
               </Storyboard>
             )`),
       )

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -31,7 +31,7 @@ import {
   useEnterDrawToInsertForButton,
   useEnterDrawToInsertForDiv,
   useEnterDrawToInsertForImage,
-  useEnterDrawToInsertForSpan,
+  useEnterTextEditMode,
 } from './insert-callbacks'
 import { FloatingInsertMenuState, NavigatorWidthAtom, RightMenuTab } from './store/editor-state'
 import { useEditorState, useRefEditorState } from './store/store-hook'
@@ -47,7 +47,7 @@ export const CanvasToolbar = React.memo(() => {
   const imgInsertion = useCheckInsertModeForElementType('img')
   const insertImgCallback = useEnterDrawToInsertForImage()
   const spanInsertion = useCheckInsertModeForElementType('span')
-  const insertSpanCallback = useEnterDrawToInsertForSpan()
+  const insertSpanCallback = useEnterTextEditMode()
   const buttonInsertion = useCheckInsertModeForElementType('button')
   const insertButtonCallback = useEnterDrawToInsertForButton()
 

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -150,7 +150,7 @@ export function defaultDivElement(uid: string): JSXElement {
   )
 }
 
-export function defaultSpanElement(uid: string): JSXElement {
+export function defaultSpanElementWithPlaceholder(uid: string): JSXElement {
   return jsxElement(
     jsxElementName('span', []),
     uid,
@@ -158,6 +158,23 @@ export function defaultSpanElement(uid: string): JSXElement {
       'data-uid': jsxAttributeValue(uid, emptyComments),
     }),
     [jsxTextBlock('utopia')],
+  )
+}
+
+export function defaultSpanElement(uid: string): JSXElement {
+  return jsxElement(
+    jsxElementName('span', []),
+    uid,
+    jsxAttributesFromMap({
+      style: jsxAttributeValue(
+        {
+          position: 'absolute',
+        },
+        emptyComments,
+      ),
+      'data-uid': jsxAttributeValue(uid, emptyComments),
+    }),
+    [],
   )
 }
 

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -30,6 +30,7 @@ import {
   defaultDivElement,
   defaultEllipseElement,
   defaultRectangleElement,
+  defaultSpanElement,
   defaultViewElement,
 } from './defaults'
 import { EditorModes, isInsertMode, isLiveMode, isSelectMode, isTextEditMode } from './editor-modes'
@@ -693,7 +694,7 @@ export function handleKeyDown(
         if (firstTextEditableView == null) {
           actions.push(
             EditorActions.enableInsertModeForJSXElement(
-              defaultDivElement(newUID),
+              defaultSpanElement(newUID),
               newUID,
               {},
               null,

--- a/editor/src/components/editor/insert-callbacks.ts
+++ b/editor/src/components/editor/insert-callbacks.ts
@@ -16,6 +16,7 @@ import {
   defaultDivElement,
   defaultImgElement,
   defaultSpanElement,
+  defaultSpanElementWithPlaceholder,
 } from './defaults'
 import { EditorModes } from './editor-modes'
 import { useEditorState, useRefEditorState } from './store/store-hook'
@@ -42,7 +43,10 @@ export function useEnterTextEditMode(): (event: React.MouseEvent<Element>) => vo
   const dispatch = useEditorState((store) => store.dispatch, 'useEnterTextEditMode dispatch')
   const selectedViewsRef = useRefEditorState((store) => store.editor.selectedViews)
   const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
-  const textInsertCallback = useEnterDrawToInsertForElement(defaultSpanElement)
+  const textInsertCallbackWithoutTextEditing = useEnterDrawToInsertForElement(
+    defaultSpanElementWithPlaceholder,
+  )
+  const textInsertCallbackWithTextEditing = useEnterDrawToInsertForElement(defaultSpanElement)
 
   return React.useCallback(
     (event: React.MouseEvent<Element>): void => {
@@ -50,14 +54,20 @@ export function useEnterTextEditMode(): (event: React.MouseEvent<Element>) => vo
         MetadataUtils.targetTextEditable(metadataRef.current, v),
       )
       if (!isFeatureEnabled('Text editing')) {
-        textInsertCallback(event, { textEdit: false })
+        textInsertCallbackWithoutTextEditing(event, { textEdit: false })
       } else if (firstTextEditableView == null) {
-        textInsertCallback(event, { textEdit: true })
+        textInsertCallbackWithTextEditing(event, { textEdit: true })
       } else {
         dispatch([switchEditorMode(EditorModes.textEditMode(firstTextEditableView))])
       }
     },
-    [dispatch, selectedViewsRef, metadataRef, textInsertCallback],
+    [
+      dispatch,
+      selectedViewsRef,
+      metadataRef,
+      textInsertCallbackWithoutTextEditing,
+      textInsertCallbackWithTextEditing,
+    ],
   )
 }
 


### PR DESCRIPTION
**Feature:**
Enter text edit mode from the UI, using the text tool from the canvas toolbar triggers text editing or text insertion if there are no text targets.

**Commit Details:**
- extend insertion callback
- when the text editing feature is disabled it works as before
- updated default span element to be absolute and removed the placeholder 'utopia' text, it fits better with current insertion
- changed global shortcut insertion to use a span element, when inserting now it will highlight the [T] icon in the toolbar instead of the div icon
