### PR TITLE
Modify draw and click to insert so you can insert into elements

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -282,7 +282,7 @@ function getHighlightAndReorderIndicatorCommands(
   if (targetParent != null) {
     const highlightParentCommand = updateHighlightedViews('mid-interaction', [targetParent])
 
-    if (targetIndex != null) {
+    if (targetIndex != null && targetIndex > -1) {
       return [highlightParentCommand, showReorderIndicator(targetParent, targetIndex)]
     } else {
       return [highlightParentCommand]

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.spec.browser2.tsx
@@ -1,3 +1,7 @@
+import {
+  FOR_TESTS_setNextGeneratedUid,
+  FOR_TESTS_setNextGeneratedUids,
+} from '../../../../core/model/element-template-utils.test-utils'
 import { setFeatureEnabled } from '../../../../utils/feature-switches'
 import { CanvasControlsContainerID } from '../../../canvas/controls/new-canvas-controls'
 import {
@@ -193,6 +197,69 @@ describe('draw-to-insert text', () => {
       )
     })
   })
+  describe('when the target is not editable', () => {
+    it('just goes into text edit mode immediately', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithNonTextEditableDiv,
+        'await-first-dom-report',
+      )
+
+      const newUID = 'ddd'
+      FOR_TESTS_setNextGeneratedUid(newUID)
+
+      const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
+      const div = editor.renderedDOM.getByTestId('div')
+      const divBounds = div.getBoundingClientRect()
+
+      pressKey('t')
+      await editor.getDispatchFollowUpActionsFinished()
+
+      const insideDiv = {
+        x: divBounds.x + divBounds.width / 2,
+        y: divBounds.y + divBounds.height / 2,
+      }
+
+      mouseDragFromPointToPoint(canvasControlsLayer, insideDiv, {
+        x: insideDiv.x + 50,
+        y: insideDiv.y + 50,
+      })
+      await editor.getDispatchFollowUpActionsFinished()
+
+      typeText('Hello Utopia')
+      closeTextEditor()
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
+      expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+        formatTestProjectCode(`
+            import * as React from 'react'
+            import { Storyboard } from 'utopia-api'
+
+            export var storyboard = (
+              <Storyboard data-uid='sb'>
+                <div
+                  data-testid='div'
+                  style={{
+                    backgroundColor: '#0091FFAA',
+                    position: 'absolute',
+                    left: 0,
+                    top: 0,
+                    width: 288,
+                    height: 362,
+                  }}
+                  data-uid='39e'
+                >
+                  <div data-uid='111' />
+                  <span
+                    style={{ width: 50, height: 50, contain: 'layout' }}
+                    data-uid='ddd'
+                  >Hello Utopia</span>
+                </div>
+              </Storyboard>
+            )`),
+      )
+    })
+  })
   describe('when the target is root', () => {
     it('creates a new element', async () => {
       const editor = await renderTestEditorWithCode(emptyProject, 'await-first-dom-report')
@@ -272,6 +339,30 @@ export var storyboard = (
       data-uid='39e'
     >
       Hello
+    </div>
+  </Storyboard>
+)
+`)
+
+const projectWithNonTextEditableDiv = formatTestProjectCode(`import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      data-testid='div'
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 288,
+        height: 362,
+      }}
+      data-uid='39e'
+    >
+      <div data-uid='111'/>
     </div>
   </Storyboard>
 )

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.spec.browser2.tsx
@@ -198,7 +198,7 @@ describe('draw-to-insert text', () => {
     })
   })
   describe('when the target is not editable', () => {
-    it('just goes into text edit mode immediately', async () => {
+    it('inserts new text', async () => {
       const editor = await renderTestEditorWithCode(
         projectWithNonTextEditableDiv,
         'await-first-dom-report',

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
@@ -75,9 +75,6 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
         const targetParentPathParts =
           targetParent.parts.length > 0 ? targetParent.parts[0].length : 0
         const isRoot = targetParentPathParts === 1
-        if (!isRoot && !textEditable) {
-          return strategyApplicationResult([])
-        }
         if (!isRoot && textEditable) {
           return strategyApplicationResult([
             wildcardPatch('on-complete', {

--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
@@ -53,16 +53,6 @@ describe('Text edit mode', () => {
         EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
       ).toEqual('sb/39e')
     })
-    it.skip('Does not enter text edit mode with non-text editable selected element', async () => {
-      const editor = await renderTestEditorWithCode(projectWithNestedDiv, 'await-first-dom-report')
-
-      await selectElement(editor, EP.fromString('sb/39e'))
-      pressKey('t')
-      await editor.getDispatchFollowUpActionsFinished()
-
-      expect(editor.getEditorState().editor.mode.type).toEqual('select') // FIXME this is incorrect, it should be `insert`
-      expect((editor.getEditorState().editor.mode as InsertMode).subjects.length).toBeGreaterThan(0)
-    })
   })
 
   describe('Click to choose target text for editing', () => {
@@ -76,14 +66,6 @@ describe('Text edit mode', () => {
       expect(
         EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
       ).toEqual('sb/39e')
-    })
-    it('Click to select on non-text editable target doesnt work', async () => {
-      const editor = await renderTestEditorWithCode(projectWithNestedDiv, 'await-first-dom-report')
-
-      pressKey('t')
-      await clickOnElement(editor, 'div')
-
-      expect(editor.getEditorState().editor.mode.type).toEqual('select')
     })
   })
 })


### PR DESCRIPTION
**Problem:**
Click/draw-to-insert only allows inserting into root, but we would like to be able to insert into any non-text-editable elements.

**Fix:**
This was deliberately not allowed by the strategy, so it was easy to fix it. I added a test for this case.

