### PR TITLE
Support multiline editing

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -22,6 +22,7 @@ import {
   emptyComments,
   jsxTextBlock,
   JSXTextBlock,
+  JSXElementChildren,
 } from '../../../core/shared/element-template'
 import {
   getAccumulatedElementsWithin,
@@ -344,6 +345,10 @@ export function renderCoreElement(
   }
 }
 
+export function filterJSXElementChildIsTextOrNewline(c: JSXElementChild): c is JSXTextBlock {
+  return c.type === 'JSX_TEXT_BLOCK' || (c.type === 'JSX_ELEMENT' && c.name.baseVariable === 'br')
+}
+
 function renderJSXElement(
   key: string,
   jsx: JSXElement,
@@ -458,11 +463,7 @@ function renderJSXElement(
   if (elementPath != null && validPaths.has(EP.makeLastPartOfPathStatic(elementPath))) {
     if (elementIsTextEdited) {
       const text = childrenWithNewTextBlock
-        .filter(
-          (c): c is JSXTextBlock =>
-            c.type === 'JSX_TEXT_BLOCK' ||
-            (c.type === 'JSX_ELEMENT' && c.name.baseVariable === 'br'),
-        )
+        .filter(filterJSXElementChildIsTextOrNewline)
         .map((c) => (c.text != null ? c.text.trim() : '\n'))
         .join('')
       const textContent = unescapeHTML(text ?? '')

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -326,7 +326,17 @@ export function renderCoreElement(
         return <></>
       }
 
-      return unescapeHTML(element.text)
+      const lines = element.text.split('<br />').map((line) => unescapeHTML(line))
+      return (
+        <>
+          {lines.map((l, index) => (
+            <React.Fragment key={index}>
+              {l}
+              {index < lines.length - 1 ? <br /> : null}
+            </React.Fragment>
+          ))}
+        </>
+      )
     }
     default:
       const _exhaustiveCheck: never = element
@@ -447,10 +457,15 @@ function renderJSXElement(
 
   if (elementPath != null && validPaths.has(EP.makeLastPartOfPathStatic(elementPath))) {
     if (elementIsTextEdited) {
-      const textBlock = childrenWithNewTextBlock.find(
-        (c): c is JSXTextBlock => c.type === 'JSX_TEXT_BLOCK',
-      )
-      const textContent = unescapeHTML(textBlock?.text ?? '')
+      const text = childrenWithNewTextBlock
+        .filter(
+          (c): c is JSXTextBlock =>
+            c.type === 'JSX_TEXT_BLOCK' ||
+            (c.type === 'JSX_ELEMENT' && c.name.baseVariable === 'br'),
+        )
+        .map((c) => (c.text != null ? c.text.trim() : '\n'))
+        .join('')
+      const textContent = unescapeHTML(text ?? '')
       const textEditorProps = {
         elementPath: elementPath,
         text: textContent.trim(),

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -26,11 +26,11 @@ interface TextEditorProps {
 }
 
 export function escapeHTML(s: string): string {
-  return escape(s)
+  return escape(s).replace(/\n/g, '<br />')
 }
 
 export function unescapeHTML(s: string): string {
-  return unescape(s)
+  return unescape(s).replace(/<br \/>/g, '\n')
 }
 
 const handleShortcut = (
@@ -70,7 +70,7 @@ export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
     return () => {
       const content = currentElement.textContent
       if (content != null) {
-        dispatch([updateChildText(elementPath, escapeHTML(content))])
+        dispatch([updateChildText(elementPath, escapeHTML(content).replace(/\n/g, '<br />'))])
       }
     }
   }, [dispatch, elementPath])

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -846,7 +846,16 @@ export const MetadataUtils = {
       return false
     }
     const children = MetadataUtils.getChildren(metadata, target)
-    return children.length === 0
+    const hasNonEditableChildren = children
+      .map((c) =>
+        foldEither(
+          () => null,
+          (v) => (isJSXElement(v) ? v.name.baseVariable : null),
+          c.element,
+        ),
+      )
+      .some((e) => e !== 'br')
+    return children.length === 0 || !hasNonEditableChildren
   },
   getTextContentOfElement(element: ElementInstanceMetadata): string | null {
     if (isRight(element.element) && isJSXElement(element.element.value)) {


### PR DESCRIPTION
Fixes #3047 

**Problem:**

Editing text with multiple lines doesn't really work as newlines get chomped when exiting text edit mode.

**Fix:**

1. Convert the newlines to `<br />` tags
2. Render the `<br />` tags as newlines
3. Join the multiple fragments correctly per the two above

![multiline](https://user-images.githubusercontent.com/1081051/210600890-8fd6f92c-8b6a-4ee6-bf18-399361708154.gif)