### PR TITLE
Feature/text editing insert autosize text

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
@@ -16,6 +16,7 @@ import {
   CanvasRectangle,
   canvasRectangle,
   offsetPoint,
+  size,
   zeroCanvasPoint,
 } from '../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
@@ -147,15 +148,18 @@ function dragToInsertStrategyFactory(
     const pointOnCanvas = Utils.roundPointToNearestHalf(
       interactionSession.interactionData.dragStart,
     )
-    return insertionSubjects.map((s) => ({
-      subject: s,
-      frame: canvasRectangle({
-        x: pointOnCanvas.x - s.defaultSize.width / 2,
-        y: pointOnCanvas.y - s.defaultSize.height / 2,
-        width: s.defaultSize.width,
-        height: s.defaultSize.height,
-      }),
-    }))
+    return insertionSubjects.map((s) => {
+      const defaultSize = s.defaultSize === 'skip-size-props' ? size(0, 0) : s.defaultSize
+      return {
+        subject: s,
+        frame: canvasRectangle({
+          x: pointOnCanvas.x - defaultSize.width / 2,
+          y: pointOnCanvas.y - defaultSize.height / 2,
+          width: defaultSize.width,
+          height: defaultSize.height,
+        }),
+      }
+    })
   })()
 
   // we don't want outline for images for now

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -433,12 +433,12 @@ function getStyleAttributesForPointInAbsolutePosition(
 ) {
   const propsToSet: Array<ValueAtPath> = [
     {
-      path: stylePropPathMappingFn('top', ['style']),
-      value: jsxAttributeValue(point.y, emptyComments),
-    },
-    {
       path: stylePropPathMappingFn('left', ['style']),
       value: jsxAttributeValue(point.x, emptyComments),
+    },
+    {
+      path: stylePropPathMappingFn('top', ['style']),
+      value: jsxAttributeValue(point.y, emptyComments),
     },
   ]
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.spec.browser2.tsx
@@ -132,7 +132,13 @@ describe('draw-to-insert text', () => {
                   data-uid='39e'
                 >Hello</div>
                 <span
-                  style={{ position: 'absolute', left: 389, top: 101 }}
+                  style={{
+                    position: 'absolute',
+                    left: 329,
+                    top: 81,
+                    width: 120,
+                    height: 40,
+                  }}
                   data-uid='${newElementUID}'
                 >Utopia</span>
               </Storyboard>
@@ -245,7 +251,7 @@ describe('draw-to-insert text', () => {
                 >
                   <div data-uid='111' />
                   <span
-                    style={{ width: 50, height: 50, contain: 'layout' }}
+                    style={{ contain: 'layout', width: 50, height: 50 }}
                     data-uid='ddd'
                   >Hello Utopia</span>
                 </div>

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.spec.browser2.tsx
@@ -128,13 +128,7 @@ describe('draw-to-insert text', () => {
                   data-uid='39e'
                 >Hello</div>
                 <span
-                  style={{
-                    position: 'absolute',
-                    left: 339,
-                    top: 51,
-                    width: 100,
-                    height: 100,
-                  }}
+                  style={{ position: 'absolute', left: 389, top: 101 }}
                   data-uid='${newElementUID}'
                 >Utopia</span>
               </Storyboard>

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
@@ -1,4 +1,4 @@
-import { EditorModes } from '../../../../components/editor/editor-modes'
+import { EditorModes, InsertionSubject } from '../../../../components/editor/editor-modes'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
 import { wildcardPatch } from '../../commands/wildcard-patch-command'
@@ -83,8 +83,12 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
           ])
         }
 
+        const updatedCanvasState = EP.isStoryboardPath(targetParent)
+          ? setDefaultSizeForStoryboard(canvasState, insertionSubjects)
+          : canvasState
+
         const strategy = drawToInsertStrategyFactory(
-          canvasState,
+          updatedCanvasState,
           interactionSession,
           customStrategyState,
           factory.factory,
@@ -110,4 +114,24 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
       },
     },
   ]
+}
+
+function setDefaultSizeForStoryboard(
+  canvasState: InteractionCanvasState,
+  insertionSubjects: Array<InsertionSubject>,
+): InteractionCanvasState {
+  if (canvasState.interactionTarget.type === 'INSERTION_SUBJECTS') {
+    return {
+      ...canvasState,
+      interactionTarget: {
+        ...canvasState.interactionTarget,
+        subjects: insertionSubjects.map((subject) => ({
+          ...subject,
+          defaultSize: { width: 120, height: 40 },
+        })),
+      },
+    }
+  } else {
+    return canvasState
+  }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
@@ -3,7 +3,7 @@ import {
   MetadataUtils,
 } from '../../../../../core/model/element-metadata-utils'
 import { ElementInstanceMetadataMap } from '../../../../../core/shared/element-template'
-import { CanvasPoint, Size } from '../../../../../core/shared/math-utils'
+import { CanvasPoint, size, Size } from '../../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../../core/shared/project-file-types'
 import {
   getTargetPathsFromInteractionTarget,
@@ -153,7 +153,11 @@ export function reparentSubjectsForInteractionTarget(
 ): ReparentSubjects {
   switch (interactionTarget.type) {
     case 'INSERTION_SUBJECTS':
-      return newReparentSubjects(interactionTarget.subjects[0].defaultSize)
+      const defaultSize =
+        interactionTarget.subjects[0].defaultSize === 'skip-size-props'
+          ? size(0, 0)
+          : interactionTarget.subjects[0].defaultSize
+      return newReparentSubjects(defaultSize)
     case 'TARGET_PATHS':
       return existingReparentSubjects(
         getDragTargets(getTargetPathsFromInteractionTarget(interactionTarget)),

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -482,7 +482,7 @@ export function enableInsertModeForJSXElement(
   element: JSXElement,
   uid: string,
   importsToAdd: Imports,
-  size: Size | null,
+  size: Size | null | 'skip-size-props',
   options?: {
     textEdit?: boolean
   },

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -12,7 +12,7 @@ export const DefaultInsertSize: Size = { width: 100, height: 100 }
 export interface InsertionSubject {
   uid: string
   element: JSXElement
-  defaultSize: Size
+  defaultSize: Size | 'skip-size-props'
   importsToAdd: Imports
   parent: InsertionParent
   textEdit: boolean
@@ -21,7 +21,7 @@ export interface InsertionSubject {
 export function insertionSubject(
   uid: string,
   element: JSXElement,
-  size: Size | null,
+  size: Size | null | 'skip-size-props',
   importsToAdd: Imports,
   parent: InsertionParent,
   textEdit: boolean,

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -697,7 +697,7 @@ export function handleKeyDown(
               defaultSpanElement(newUID),
               newUID,
               {},
-              null,
+              'skip-size-props',
               {
                 textEdit: true,
               },

--- a/editor/src/components/editor/insert-callbacks.ts
+++ b/editor/src/components/editor/insert-callbacks.ts
@@ -56,7 +56,7 @@ export function useEnterTextEditMode(): (event: React.MouseEvent<Element>) => vo
       if (!isFeatureEnabled('Text editing')) {
         textInsertCallbackWithoutTextEditing(event, { textEdit: false })
       } else if (firstTextEditableView == null) {
-        textInsertCallbackWithTextEditing(event, { textEdit: true })
+        textInsertCallbackWithTextEditing(event, { textEdit: true }, 'skip-size-props')
       } else {
         dispatch([switchEditorMode(EditorModes.textEditMode(firstTextEditableView))])
       }
@@ -84,6 +84,7 @@ function useEnterDrawToInsertForElement(elementFactory: (newUID: string) => JSXE
   insertOptions?: {
     textEdit?: boolean
   },
+  skipSize?: 'skip-size-props' | null,
 ) => void {
   const dispatch = useEditorState((store) => store.dispatch, 'enterDrawToInsertForDiv dispatch')
   const projectContentsRef = useRefEditorState((store) => store.editor.projectContents)
@@ -94,12 +95,13 @@ function useEnterDrawToInsertForElement(elementFactory: (newUID: string) => JSXE
       insertOptions: {
         textEdit?: boolean
       } = {},
+      skipSize: 'skip-size-props' | null = null,
     ): void => {
       const modifiers = Modifier.modifiersForEvent(event)
       const newUID = generateUidWithExistingComponents(projectContentsRef.current)
 
       dispatch([
-        enableInsertModeForJSXElement(elementFactory(newUID), newUID, {}, null, insertOptions),
+        enableInsertModeForJSXElement(elementFactory(newUID), newUID, {}, skipSize, insertOptions),
         CanvasActions.createInteractionSession(
           createHoverInteractionViaMouse(
             CanvasMousePositionRaw!,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -210,6 +210,7 @@ import {
   NumberKeepDeepEquality,
   NullableNumberKeepDeepEquality,
   combine9EqualityCalls,
+  unionDeepEquality,
 } from '../../../utils/deep-equality'
 import {
   ElementPathArrayKeepDeepEquality,
@@ -2649,7 +2650,14 @@ export const InsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<InsertionSub
     (subject) => subject.element,
     JSXElementKeepDeepEquality,
     (subject) => subject.defaultSize,
-    nullableDeepEquality(SizeKeepDeepEquality),
+    nullableDeepEquality(
+      unionDeepEquality(
+        createCallWithTripleEquals<'skip-size-props'>(),
+        SizeKeepDeepEquality,
+        (p): p is 'skip-size-props' => p === 'skip-size-props',
+        (p): p is Size => p !== 'skip-size-props',
+      ),
+    ),
     (subject) => subject.importsToAdd,
     objectDeepEquality(ImportDetailsKeepDeepEquality),
     (subject) => subject.parent,

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -67,6 +67,13 @@ export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
 
     currentElement.focus()
 
+    // always show at least 1px wide area for the cursor
+    const frame = currentElement.getBoundingClientRect()
+    if (frame.width === 0) {
+      currentElement.style.minWidth = `1px`
+      currentElement.style.maxWidth = `none`
+    }
+
     return () => {
       const content = currentElement.textContent
       if (content != null) {


### PR DESCRIPTION
**Problem:**
Inserting a new span with clicking adds a fix width and height of 100px. It should start from an unset size to allow it automatically grow when typing.

**Fix:**
Extended insertion subject to not always use a default or given size, but it's possible to skip all size props and only set top and left. Draw to insert still adds width and height.
When inserting a span without size the cursor is not visible, so in this case a 1px minwidth is set on the text editor wrapper.

**Commit Details:**
- updated insertion strategies
- both `t` shortcut and canvas toolbar button inserts a span without a size
- TextEditorWrapper adds minwidth/unsets maxwidth if size is 0, to always show a cursor
