### PR TITLE
Combine common event handlers.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -44,6 +44,10 @@ async function setupInsertTest(inputCode: string): Promise<EditorRenderResult> {
   return renderResult
 }
 
+function ensureInInsertMode(renderResult: EditorRenderResult): void {
+  expect(renderResult.getEditorState().editor.mode.type).toEqual('insert')
+}
+
 async function enterInsertModeFromInsertMenu(
   renderResult: EditorRenderResult,
   elementType: 'div' | 'img' = 'div',
@@ -60,6 +64,8 @@ async function enterInsertModeFromInsertMenu(
   mouseClickAtPoint(insertButton, point)
 
   await renderResult.getDispatchFollowUpActionsFinished()
+
+  ensureInInsertMode(renderResult)
 }
 
 async function enterInsertModeFromInsertMenuStartDrag(renderResult: EditorRenderResult) {
@@ -75,6 +81,8 @@ async function enterInsertModeFromInsertMenuStartDrag(renderResult: EditorRender
   mouseDownAtPoint(insertButton, point)
 
   await renderResult.getDispatchFollowUpActionsFinished()
+
+  ensureInInsertMode(renderResult)
 }
 
 function isIndicatorBeforeSiblingBBB(

--- a/editor/src/components/editor/editor-component-common.tsx
+++ b/editor/src/components/editor/editor-component-common.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { EditorAction } from './action-types'
+import { EditorStorePatched } from './store/editor-state'
+import { useRefEditorState } from './store/store-hook'
+
+type EventHandler<K extends keyof WindowEventMap, R> = (this: Window, event: WindowEventMap[K]) => R
+
+type MouseHandler<R> = EventHandler<'mousedown' | 'mouseup', R>
+
+type MouseHandlerActions = MouseHandler<Array<EditorAction>>
+
+type MouseHandlerUnknown = MouseHandler<unknown>
+
+type KeyboardHandler<R> = EventHandler<'keydown' | 'keyup', R>
+
+type KeyboardHandlerActions = KeyboardHandler<Array<EditorAction>>
+
+type KeyboardHandlerUnknown = KeyboardHandler<unknown>
+
+type EditorStoreRef = { current: EditorStorePatched }
+
+let mouseDownHandlers: Array<MouseHandlerActions> = []
+let currentMouseDownEventHandler: MouseHandlerUnknown | null = null
+
+let mouseUpHandlers: Array<MouseHandlerActions> = []
+let currentMouseUpEventHandler: MouseHandlerUnknown | null = null
+
+let keyDownHandlers: Array<KeyboardHandlerActions> = []
+let currentKeyDownEventHandler: KeyboardHandlerUnknown | null = null
+
+let keyUpHandlers: Array<KeyboardHandlerActions> = []
+let currentKeyUpEventHandler: KeyboardHandlerUnknown | null = null
+
+// Removes an event handler if it exists.
+function removeHandler<K extends keyof WindowEventMap>(
+  eventName: K,
+  handler: EventHandler<K, unknown> | null,
+): void {
+  if (handler != null) {
+    window.removeEventListener(eventName, handler, true)
+  }
+}
+
+// Creates an event handler for a window event from the collection of functions that produce editor actions,
+// which dispatches the actions produced by the functions. Assigns that handler to the window event
+// and then returns it.
+function createHandler<K extends keyof WindowEventMap>(
+  editorStoreRef: EditorStoreRef,
+  eventName: K,
+  handlers: Array<EventHandler<K, Array<EditorAction>>>,
+): EventHandler<K, unknown> {
+  const windowEventHandler = (event: WindowEventMap[K]) => {
+    const collatedActions = handlers.flatMap((handler) => {
+      return handler.bind(window)(event)
+    })
+    editorStoreRef.current.dispatch(collatedActions, 'everyone')
+  }
+
+  const capture = eventName === 'mousedown' || eventName === 'mouseup' ? true : undefined
+  window.addEventListener(eventName, windowEventHandler, capture)
+  return windowEventHandler
+}
+
+// Whenever the global event handler arrays change, this should be invoked to remove
+// and recreate the handlers attached to the window.
+function recreateEventHandlers(editorStoreRef: EditorStoreRef): void {
+  removeHandler('mousedown', currentMouseDownEventHandler)
+  removeHandler('mouseup', currentMouseUpEventHandler)
+  removeHandler('keydown', currentKeyDownEventHandler)
+  removeHandler('keyup', currentKeyUpEventHandler)
+
+  currentMouseDownEventHandler = createHandler(editorStoreRef, 'mousedown', mouseDownHandlers)
+  currentMouseUpEventHandler = createHandler(editorStoreRef, 'mouseup', mouseUpHandlers)
+  currentKeyDownEventHandler = createHandler(editorStoreRef, 'keydown', keyDownHandlers)
+  currentKeyUpEventHandler = createHandler(editorStoreRef, 'keyup', keyUpHandlers)
+}
+
+export interface EditorCommonProps {
+  mouseDown: MouseHandlerActions
+  mouseUp: MouseHandlerActions
+  keyDown: KeyboardHandlerActions
+  keyUp: KeyboardHandlerActions
+}
+
+// Component to be included when functions that produce editor actions from window
+// events need to be "stacked" up and only utilise a single instance of the event listener.
+export function EditorCommon(props: EditorCommonProps): React.ReactElement | null {
+  const editorStoreRef = useRefEditorState((store) => store)
+  React.useEffect(() => {
+    mouseDownHandlers = [...mouseDownHandlers, props.mouseDown]
+    mouseUpHandlers = [...mouseUpHandlers, props.mouseUp]
+    keyDownHandlers = [...keyDownHandlers, props.keyDown]
+    keyUpHandlers = [...keyUpHandlers, props.keyUp]
+    recreateEventHandlers(editorStoreRef)
+
+    return function cleanup() {
+      mouseDownHandlers = mouseDownHandlers.filter((handler) => handler !== props.mouseDown)
+      mouseUpHandlers = mouseUpHandlers.filter((handler) => handler !== props.mouseUp)
+      keyDownHandlers = keyDownHandlers.filter((handler) => handler !== props.keyDown)
+      keyUpHandlers = keyUpHandlers.filter((handler) => handler !== props.keyUp)
+      recreateEventHandlers(editorStoreRef)
+    }
+  })
+
+  return null
+}

--- a/editor/src/components/editor/editor-component-common.tsx
+++ b/editor/src/components/editor/editor-component-common.tsx
@@ -31,25 +31,13 @@ let currentKeyDownEventHandler: KeyboardHandlerUnknown | null = null
 let keyUpHandlers: Array<KeyboardHandlerActions> = []
 let currentKeyUpEventHandler: KeyboardHandlerUnknown | null = null
 
-function eventListenerOptionsForEvent(
-  eventName: keyof WindowEventMap,
-): boolean | EventListenerOptions | undefined {
-  switch (eventName) {
-    case 'mousedown':
-    case 'mouseup':
-      return true
-    default:
-      return undefined
-  }
-}
-
 // Removes an event handler if it exists.
 function removeHandler<K extends keyof WindowEventMap>(
   eventName: K,
   handler: EventHandler<K, unknown> | null,
 ): void {
   if (handler != null) {
-    window.removeEventListener(eventName, handler, eventListenerOptionsForEvent(eventName))
+    window.removeEventListener(eventName, handler)
   }
 }
 
@@ -71,7 +59,7 @@ function createHandler<K extends keyof WindowEventMap>(
       editorStoreRef.current.dispatch(collatedActions, 'everyone')
     }
 
-    window.addEventListener(eventName, windowEventHandler, eventListenerOptionsForEvent(eventName))
+    window.addEventListener(eventName, windowEventHandler)
     return windowEventHandler
   }
 }

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -319,7 +319,7 @@ export function handleKeyDown(
   derived: DerivedState,
   namesByKey: ShortcutNamesByKey,
   dispatch: EditorDispatch,
-): void {
+): Array<EditorAction> {
   // Stop the browser from firing things like save dialogs.
   preventBrowserShortcuts(editor, event)
 
@@ -764,15 +764,14 @@ export function handleKeyDown(
     actions.push(...shortCutActions)
   }
 
-  dispatch(actions, 'everyone')
+  return actions
 }
 
 export function handleKeyUp(
   event: KeyboardEvent,
   editor: EditorState,
   namesByKey: ShortcutNamesByKey,
-  dispatch: EditorDispatch,
-): void {
+): Array<EditorAction> {
   // Stop the browser from firing things like save dialogs.
   preventBrowserShortcuts(editor, event)
 
@@ -813,8 +812,7 @@ export function handleKeyUp(
   if (editorTargeted) {
     actions.push(...getShortcutActions())
   }
-
-  dispatch(actions, 'everyone')
+  return actions
 }
 
 function addCreateHoverInteractionActionToSwitchModeAction(

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`409`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`411`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`398`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`400`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`663`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`664`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`735`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`736`)
   })
 })

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -1010,7 +1010,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
             event,
             () => {
               this.handleMouseMove(event.nativeEvent)
-              this.handleMouseUp(event.nativeEvent)
+              this.props.dispatch(this.handleMouseUp(event.nativeEvent), 'everyone')
             },
             {
               saveAssets: saveAssets,


### PR DESCRIPTION
**Problem:**
There are common event handlers between `editor-component.tsx` and `editor-canvas.tsx` like `mousedown`, the downside of this is that when actions are fired from both they end up running two full "cycles" of our stack, including the costly things that happen after actions are fired.

**Fix:**
A new component has been created, which ensures that a single event handler is created for each relevant event and other components can register their handlers to be run within those event handlers by including it when rendering themselves.

**Results:**
The primary thing targeted by this work was a mouse up handler, which was taking ~46ms:
![Before](https://user-images.githubusercontent.com/217400/210789290-ee524cfc-f87d-48ab-bab5-b6f0b50b9bd8.png)
That now takes ~20ms:
![After](https://user-images.githubusercontent.com/217400/210789430-0490d9f7-6026-4613-8a82-92c6aa73b347.png)

**Commit Details:**
- Created `EditorCommon` component to front the sharing of event handlers, along with several support functions.
- Integrated `EditorCommon` into `EditorComponentInner` and `EditorCanvas`.
- Changed some additional functions like those handling global shortcuts to return actions instead of dispatching them directly.