### PR TITLE
Double click on resize edge to set container to `hug contents`

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -84,24 +84,28 @@ export const AbsoluteResizeControl = controlForStrategyMemoized(
           }}
         >
           <ResizeEdge
+            // onClick={() => alert('right')}
             ref={rightRef}
             position={{ x: 1, y: 0.5 }}
             cursor={CSSCursor.ResizeEW}
             direction='vertical'
           />
           <ResizeEdge
+            // onClick={() => alert('bottom')}
             ref={bottomRef}
             position={{ x: 0.5, y: 1 }}
             cursor={CSSCursor.ResizeNS}
             direction='horizontal'
           />
           <ResizeEdge
+            // onClick={() => alert('left')}
             ref={leftRef}
             position={{ x: 0, y: 0.5 }}
             cursor={CSSCursor.ResizeEW}
             direction='vertical'
           />
           <ResizeEdge
+            // onClick={() => alert('top')}
             ref={topRef}
             position={{ x: 0.5, y: 0 }}
             cursor={CSSCursor.ResizeNS}

--- a/editor/src/components/inspector/inspector-common.tsx
+++ b/editor/src/components/inspector/inspector-common.tsx
@@ -200,6 +200,17 @@ function allElemsEqual<T>(objects: T[], areEqual: (a: T, b: T) => boolean): bool
 
 export type Axis = 'horizontal' | 'vertical'
 
+export function invert(axis: Axis): Axis {
+  switch (axis) {
+    case 'horizontal':
+      return 'vertical'
+    case 'vertical':
+      return 'horizontal'
+    default:
+      assertNever(axis)
+  }
+}
+
 export function widthHeightFromAxis(axis: Axis): 'width' | 'height' {
   switch (axis) {
     case 'horizontal':


### PR DESCRIPTION
![dbl_click_hug](https://user-images.githubusercontent.com/16385508/211004015-e9a6b9e3-5c6b-4b70-9704-f5a9bb3f7a1c.gif)

## Description
When double clicking on the resize edge of a container, it will be size to `Hug contents`, if applicable.