### PR TITLE
position caret with double click

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
@@ -2,6 +2,7 @@ import { EditorModes } from '../../../../components/editor/editor-modes'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
 import { wildcardPatch } from '../../commands/wildcard-patch-command'
+import { canvasPointToWindowPoint } from '../../dom-lookup'
 import { MetaCanvasStrategy } from '../canvas-strategies'
 import {
   CanvasStrategy,
@@ -78,7 +79,16 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
         if (!isRoot && textEditable) {
           return strategyApplicationResult([
             wildcardPatch('on-complete', {
-              mode: { $set: EditorModes.textEditMode(targetParent) },
+              mode: {
+                $set: EditorModes.textEditMode(
+                  targetParent,
+                  canvasPointToWindowPoint(
+                    pointOnCanvas,
+                    canvasState.scale,
+                    canvasState.canvasOffset,
+                  ),
+                ),
+              },
             }),
           ])
         }

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -23,7 +23,6 @@ import {
   selectComponents,
   setHoveredView,
   clearHoveredViews,
-  switchEditorMode,
 } from '../../../editor/actions/action-creators'
 import { cancelInsertModeActions } from '../../../editor/actions/meta-actions'
 import { EditorState, EditorStorePatched, LockedElements } from '../../../editor/store/editor-state'
@@ -725,7 +724,11 @@ function useSelectOrLiveModeSelectAndHover(
           if (isEditableText && isFeatureEnabled('Text editing')) {
             editorActions.push(CanvasActions.clearInteractionSession(false))
             // We need to dispatch switching to text edit mode in the next frame, otherwise the mouse up blurs the text editor immediately
-            scheduleTextEditForNextFrame(foundTarget.elementPath, dispatch)
+            scheduleTextEditForNextFrame(
+              foundTarget.elementPath,
+              { x: event.clientX, y: event.clientY },
+              dispatch,
+            )
           }
         }
 

--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode-hooks.tsx
@@ -6,7 +6,7 @@ import { NO_OP } from '../../../../core/shared/utils'
 import { useKeepShallowReferenceEquality } from '../../../../utils/react-performance'
 import { EditorDispatch } from '../../../editor/action-types'
 import { switchEditorMode } from '../../../editor/actions/action-creators'
-import { EditorModes, isTextEditMode } from '../../../editor/editor-modes'
+import { Coordinates, EditorModes, isTextEditMode } from '../../../editor/editor-modes'
 import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
 import {
   MouseCallbacks,
@@ -72,7 +72,10 @@ export function useTextEditModeSelectAndHover(active: boolean): MouseCallbacks {
 
 export function scheduleTextEditForNextFrame(
   elementPath: ElementPath,
+  cursorPosition: Coordinates | null,
   dispatch: EditorDispatch,
 ): void {
-  setTimeout(() => dispatch([switchEditorMode(EditorModes.textEditMode(elementPath))]))
+  setTimeout(() =>
+    dispatch([switchEditorMode(EditorModes.textEditMode(elementPath, cursorPosition))]),
+  )
 }

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -408,3 +408,27 @@ export function windowToCanvasCoordinates(
     throw new Error('calling screenToElementCoordinates() before being mounted')
   }
 }
+
+export function canvasPointToWindowPoint(
+  point: CanvasPoint,
+  canvasScale: number,
+  canvasOffset: CanvasVector,
+): WindowPoint {
+  const canvasWrapper = document.getElementById('canvas-root')
+
+  if (canvasWrapper != null) {
+    const canvasWrapperRect = canvasWrapper.getBoundingClientRect()
+    const withoutOffset = {
+      x: point.x + canvasOffset.x,
+      y: point.y + canvasOffset.y,
+    } as WindowPoint
+    const scaledBack = scaleVector(withoutOffset, canvasScale)
+    const offsetByWrapper = {
+      x: scaledBack.x + canvasWrapperRect.left,
+      y: scaledBack.y + canvasWrapperRect.top,
+    }
+    return windowPoint(offsetByWrapper)
+  } else {
+    throw new Error('calling screenToElementCoordinates() before being mounted')
+  }
+}

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -92,6 +92,12 @@ export interface SelectMode {
 export interface TextEditMode {
   type: 'textEdit'
   editedText: ElementPath | null
+  cursorPosition: Coordinates | null
+}
+
+export interface Coordinates {
+  x: number
+  y: number
 }
 
 export interface LiveCanvasMode {
@@ -121,10 +127,14 @@ export const EditorModes = {
       controlId: controlId,
     }
   },
-  textEditMode: function (editedText: ElementPath | null): TextEditMode {
+  textEditMode: function (
+    editedText: ElementPath | null,
+    cursorPosition: Coordinates | null = null,
+  ): TextEditMode {
     return {
       type: 'textEdit',
       editedText: editedText,
+      cursorPosition: cursorPosition,
     }
   },
 }

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -414,6 +414,7 @@ import {
   TargetedInsertionParent,
   imageInsertionSubject,
   TextEditMode,
+  Coordinates,
 } from '../editor-modes'
 import { EditorPanel } from '../../common/actions'
 import { notice, Notice, NoticeLevel } from '../../common/notice'
@@ -2687,10 +2688,20 @@ export const LiveCanvasModeKeepDeepEquality: KeepDeepEqualityCall<LiveCanvasMode
     EditorModes.liveMode,
   )
 
+export const CoordinateKeepDeepEquality: KeepDeepEqualityCall<Coordinates> = combine2EqualityCalls(
+  (c) => c.x,
+  NumberKeepDeepEquality,
+  (c) => c.y,
+  NumberKeepDeepEquality,
+  (x: number, y: number) => ({ x, y }),
+)
+
 export const TextEditModeKeepDeepEquality: KeepDeepEqualityCall<TextEditMode> =
-  combine1EqualityCall(
+  combine2EqualityCalls(
     (mode) => mode.editedText,
     nullableDeepEquality(ElementPathKeepDeepEquality),
+    (mode) => mode.cursorPosition,
+    nullableDeepEquality(CoordinateKeepDeepEquality),
     EditorModes.textEditMode,
   )
 

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -215,9 +215,6 @@ describe('Use the text editor', () => {
       const textEditorElement = document.getElementById(TextEditorSpanId)
       expect(textEditorElement).not.toBe(null)
       if (textEditorElement != null) {
-        const sel = document.createRange()
-        sel.collapse()
-        sel.selectNodeContents(textEditorElement)
         const range = document.createRange()
         range.selectNodeContents(textEditorElement)
         range.collapse(true)

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -174,8 +174,8 @@ async function setSelectionToOffset(
   scale: number,
   cursorPosition: Coordinates | null,
 ) {
-  const sel = window.getSelection()
-  if (sel == null) {
+  const selection = window.getSelection()
+  if (selection == null) {
     return
   }
   if (element.childNodes.length != 1) {
@@ -187,14 +187,14 @@ async function setSelectionToOffset(
   }
 
   const setRange = (start: number | null) => {
-    sel.removeAllRanges()
+    selection.removeAllRanges()
     const range = document.createRange()
     range.selectNodeContents(textNode)
     range.collapse(start != null)
     if (start != null) {
       range.setStart(textNode, start)
     }
-    sel.addRange(range)
+    selection.addRange(range)
     return range
   }
 

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -211,17 +211,13 @@ async function setSelectionToOffset(
     // linear search is a tad slow, but it should be fine
     // and it's a lot easier when dealing with the scaling of the editor
     const targetX = cursorPosition.x / scale
+    const targetY = cursorPosition.y / scale
     for (let i = 0; i <= maxLength; i++) {
       const range = setRange(i)
       const rect = range.getBoundingClientRect()
       if (i > 0 && rect.x > targetX) {
         validX.push(i > 0 ? i - 1 : 0)
       }
-    }
-    const targetY = cursorPosition.y / scale
-    for (let i = 0; i <= maxLength; i++) {
-      const range = setRange(i)
-      const rect = range.getBoundingClientRect()
       if (rect.y <= targetY && targetY <= rect.y + rect.height) {
         validY.push(i)
       }

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -10,7 +10,7 @@ import {
   updateChildText,
   updateEditorMode,
 } from '../editor/actions/action-creators'
-import { EditorModes } from '../editor/editor-modes'
+import { Coordinates, EditorModes } from '../editor/editor-modes'
 import { useEditorState } from '../editor/store/store-hook'
 
 export const TextEditorSpanId = 'text-editor'
@@ -50,6 +50,11 @@ const handleShortcut = (
 export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
   const { elementPath, text, component, passthroughProps } = props
   const dispatch = useEditorState((store) => store.dispatch, 'TextEditor dispatch')
+  const cursorPosition = useEditorState(
+    (store) => (store.editor.mode.type === 'textEdit' ? store.editor.mode.cursorPosition : null),
+    'TextEditor cursor position',
+  )
+  const scale = useEditorState((store) => store.editor.canvas.scale, 'TextEditor scale')
   const [firstTextProp] = React.useState(text)
 
   const myElement = React.useRef<HTMLSpanElement>(null)
@@ -75,8 +80,14 @@ export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
       return
     }
     myElement.current.textContent = firstTextProp
-    setSelectionToEnd(myElement.current)
   }, [firstTextProp])
+
+  React.useEffect(() => {
+    if (myElement.current == null) {
+      return
+    }
+    void setSelectionToOffset(myElement.current, scale, cursorPosition)
+  }, [scale, cursorPosition])
 
   const onKeyDown = React.useCallback(
     (event: React.KeyboardEvent) => {
@@ -144,7 +155,7 @@ export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
     onKeyUp: stopPropagation,
     onKeyPress: stopPropagation,
     onBlur: onBlur,
-    contentEditable: 'plaintext-only' as any, // note: not supported on firefo,
+    contentEditable: 'plaintext-only' as any, // note: not supported on firefox,
     suppressContentEditableWarning: true,
   }
 
@@ -158,15 +169,69 @@ export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
   return React.createElement(component, passthroughProps, <span {...editorProps} />)
 })
 
-function setSelectionToEnd(element: HTMLSpanElement) {
-  const range = document.createRange()
-  range.selectNodeContents(element)
-  range.collapse(false)
+async function setSelectionToOffset(
+  element: HTMLSpanElement,
+  scale: number,
+  cursorPosition: Coordinates | null,
+) {
+  const sel = window.getSelection()
+  if (sel == null) {
+    return
+  }
+  if (element.childNodes.length != 1) {
+    return
+  }
+  const textNode = element.childNodes[0]
+  if (textNode.nodeType !== element.TEXT_NODE) {
+    return
+  }
 
-  const selection = window.getSelection()
-  if (selection != null) {
-    selection.removeAllRanges()
-    selection.addRange(range)
+  const setRange = (start: number | null) => {
+    sel.removeAllRanges()
+    const range = document.createRange()
+    range.selectNodeContents(textNode)
+    range.collapse(start != null)
+    if (start != null) {
+      range.setStart(textNode, start)
+    }
+    sel.addRange(range)
+    return range
+  }
+
+  const maxLength = setRange(null).endOffset
+
+  if (cursorPosition != null) {
+    // to find the right target offset:
+    // 1. find the valid X points
+    // 2. find the valid Y points
+    // 3. either use the intersection of the two arrays, or the minimum possible
+    //    location if the intersection is empty
+    let validX: number[] = []
+    let validY: number[] = []
+    // linear search is a tad slow, but it should be fine
+    // and it's a lot easier when dealing with the scaling of the editor
+    const targetX = cursorPosition.x / scale
+    for (let i = 0; i <= maxLength; i++) {
+      const range = setRange(i)
+      const rect = range.getBoundingClientRect()
+      if (i > 0 && rect.x > targetX) {
+        validX.push(i > 0 ? i - 1 : 0)
+      }
+    }
+    const targetY = cursorPosition.y / scale
+    for (let i = 0; i <= maxLength; i++) {
+      const range = setRange(i)
+      const rect = range.getBoundingClientRect()
+      if (rect.y <= targetY && targetY <= rect.y + rect.height) {
+        validY.push(i)
+      }
+    }
+    const intersection = validX.filter((xx) => validY.includes(xx))
+    if (intersection.length > 0) {
+      setRange(intersection[0])
+    } else {
+      setRange(validY.length > 0 ? validY[validY.length - 1] : maxLength)
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #3060 

**Problem:**

Currently double-clicking or click-to-insert-click a text-editable element positions the caret at the very end of the text contents. It would be nice to be able to position the caret under the mouse immediately.

**Fix:**

1. When double clicking, position the caret under the mouse (**Including multi-line**)
2. When click-to-insert, position the caret under the mouse (**including multi-line**)

![click caret](https://user-images.githubusercontent.com/1081051/211031705-11a8d3e9-9ab2-4e75-b048-77486cde06c5.gif)

The positioning is done with a best-effort logic, so it may happen that the cursor is placed before or after the exact character "kinda-under" the mouse depending on the window positioning (the boundaries are calculated relative to _the caret itself_).

The position is found with a linear search instead of a BS in order to keep the code readable and not overcomplicate things too much since we're going to be dealing with really small arrays anyways.