### PR TITLE
Feature/canvas text insertion defaultsize

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -1,15 +1,20 @@
 import { BuiltInDependencies } from '../../../../core/es-modules/package-manager/built-in-dependencies-list'
-import { LayoutHelpers } from '../../../../core/layout/layout-helpers'
+import { LayoutHelpers, TopLeftWidthHeight } from '../../../../core/layout/layout-helpers'
 import {
   createFakeMetadataForElement,
   MetadataUtils,
 } from '../../../../core/model/element-metadata-utils'
 import { isImg } from '../../../../core/model/project-file-utils'
 import { mapDropNulls } from '../../../../core/shared/array-utils'
-import { foldEither } from '../../../../core/shared/either'
+import { Either, foldEither } from '../../../../core/shared/either'
 import * as EP from '../../../../core/shared/element-path'
 import { elementPath } from '../../../../core/shared/element-path'
-import { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
+import {
+  ElementInstanceMetadataMap,
+  emptyComments,
+  JSXAttributes,
+  jsxAttributeValue,
+} from '../../../../core/shared/element-template'
 import {
   canvasPoint,
   canvasRectangle,
@@ -57,6 +62,12 @@ import {
 import { boundingArea, InteractionSession } from '../interaction-state'
 import { getApplicableReparentFactories } from './reparent-metastrategy'
 import { ReparentStrategy } from './reparent-helpers/reparent-strategy-helpers'
+import { setJSXValuesAtPaths, ValueAtPath } from '../../../../core/shared/jsx-attributes'
+import { omit } from '../../../../core/shared/object-utils'
+import { stylePropPathMappingFn } from '../../../inspector/common/property-path-hooks'
+import { LayoutPinnedProp, LayoutPinnedProps } from '../../../../core/layout/layout-helpers-new'
+import { MapLike } from 'typescript'
+import { FullFrame } from '../../../frame'
 
 export const drawToInsertMetaStrategy: MetaCanvasStrategy = (
   canvasState: InteractionCanvasState,
@@ -230,11 +241,12 @@ export function drawToInsertStrategyFactory(
               ])
             }
           } else if (strategyLifecycle === 'end-interaction') {
+            const defaultSizeType = insertionSubject.textEdit ? 'only-width' : 'default-size'
             const insertionCommand = getInsertionCommands(
               insertionSubject,
               interactionSession,
               insertionSubject.defaultSize,
-              'default-size',
+              defaultSizeType,
             )
 
             if (insertionCommand != null) {
@@ -296,7 +308,7 @@ function getInsertionCommands(
   subject: InsertionSubject,
   interactionSession: InteractionSession,
   insertionSubjectSize: Size,
-  sizing: 'zero-size' | 'default-size',
+  sizing: 'zero-size' | 'default-size' | 'only-width',
 ): { command: InsertElementInsertionSubject; frame: CanvasRectangle } | null {
   if (
     interactionSession.interactionData.type === 'DRAG' &&
@@ -324,14 +336,33 @@ function getInsertionCommands(
       frame,
     )
 
-    const updatedInsertionSubject: InsertionSubject = {
-      ...subject,
-      parent: subject.parent,
-      element: {
-        ...subject.element,
-        props: updatedAttributesWithPosition,
-      },
+    const updatedInsertionSubject = updateInsertionSubjectWithAttributes(
+      subject,
+      updatedAttributesWithPosition,
+    )
+
+    return {
+      command: insertElementInsertionSubject('always', updatedInsertionSubject),
+      frame: frame,
     }
+  } else if (interactionSession.interactionData.type === 'DRAG' && sizing === 'only-width') {
+    const pointOnCanvas = interactionSession.interactionData.dragStart
+    const frame = canvasRectangle({
+      x: pointOnCanvas.x,
+      y: pointOnCanvas.y,
+      width: 200,
+      height: 0,
+    })
+
+    const updatedAttributesWithPosition = getStyleAttributesForPartialFrame(
+      subject,
+      omit(['height'], frame),
+    )
+
+    const updatedInsertionSubject = updateInsertionSubjectWithAttributes(
+      subject,
+      updatedAttributesWithPosition,
+    )
 
     return {
       command: insertElementInsertionSubject('always', updatedInsertionSubject),
@@ -352,14 +383,10 @@ function getInsertionCommands(
       frame,
     )
 
-    const updatedInsertionSubject: InsertionSubject = {
-      ...subject,
-      parent: subject.parent,
-      element: {
-        ...subject.element,
-        props: updatedAttributesWithPosition,
-      },
-    }
+    const updatedInsertionSubject = updateInsertionSubjectWithAttributes(
+      subject,
+      updatedAttributesWithPosition,
+    )
 
     return {
       command: insertElementInsertionSubject('always', updatedInsertionSubject),
@@ -391,6 +418,53 @@ function getStyleAttributesForFrameInAbsolutePosition(
       ['style'],
     ),
   )
+}
+
+function getStyleAttributesForPartialFrame(
+  subject: InsertionSubject,
+  frame: Partial<CanvasRectangle>,
+): JSXAttributes {
+  const frameToPinnedProp = {
+    left: frame.x,
+    top: frame.y,
+    width: frame.width,
+    height: frame.height,
+  }
+  const propsToSet: Array<ValueAtPath> = mapDropNulls((pinnedProp) => {
+    const value = frameToPinnedProp[pinnedProp]
+    if (value != null) {
+      return {
+        path: stylePropPathMappingFn(pinnedProp, ['style']),
+        value: jsxAttributeValue(value, emptyComments),
+      }
+    } else {
+      return null
+    }
+  }, Object.keys(frameToPinnedProp) as Array<keyof TopLeftWidthHeight>)
+
+  const layoutProps = setJSXValuesAtPaths(subject.element.props, propsToSet)
+  // Assign the new properties
+  return foldEither(
+    (_) => {
+      throw new Error(`Problem setting frame on an element we just created.`)
+    },
+    (attr) => attr,
+    layoutProps,
+  )
+}
+
+function updateInsertionSubjectWithAttributes(
+  subject: InsertionSubject,
+  updatedAttributes: JSXAttributes,
+): InsertionSubject {
+  return {
+    ...subject,
+    parent: subject.parent,
+    element: {
+      ...subject.element,
+      props: updatedAttributes,
+    },
+  }
 }
 
 function runTargetStrategiesForFreshlyInsertedElementToReparent(

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -68,6 +68,7 @@ import { stylePropPathMappingFn } from '../../../inspector/common/property-path-
 import { LayoutPinnedProp, LayoutPinnedProps } from '../../../../core/layout/layout-helpers-new'
 import { MapLike } from 'typescript'
 import { FullFrame } from '../../../frame'
+import { DefaultTextWidth } from '../../../editor/defaults'
 
 export const drawToInsertMetaStrategy: MetaCanvasStrategy = (
   canvasState: InteractionCanvasState,
@@ -350,7 +351,7 @@ function getInsertionCommands(
     const frame = canvasRectangle({
       x: pointOnCanvas.x,
       y: pointOnCanvas.y,
-      width: 200,
+      width: DefaultTextWidth,
       height: 0,
     })
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -242,7 +242,9 @@ export function drawToInsertStrategyFactory(
               ])
             }
           } else if (strategyLifecycle === 'end-interaction') {
-            const defaultSizeType = insertionSubject.textEdit ? 'only-width' : 'default-size'
+            const defaultSizeType = insertionSubject.textEdit
+              ? 'text-edit-only-width'
+              : 'default-size'
             const insertionCommand = getInsertionCommands(
               insertionSubject,
               interactionSession,
@@ -309,7 +311,7 @@ function getInsertionCommands(
   subject: InsertionSubject,
   interactionSession: InteractionSession,
   insertionSubjectSize: Size,
-  sizing: 'zero-size' | 'default-size' | 'only-width',
+  sizing: 'zero-size' | 'default-size' | 'text-edit-only-width',
 ): { command: InsertElementInsertionSubject; frame: CanvasRectangle } | null {
   if (
     interactionSession.interactionData.type === 'DRAG' &&
@@ -346,7 +348,10 @@ function getInsertionCommands(
       command: insertElementInsertionSubject('always', updatedInsertionSubject),
       frame: frame,
     }
-  } else if (interactionSession.interactionData.type === 'DRAG' && sizing === 'only-width') {
+  } else if (
+    interactionSession.interactionData.type === 'DRAG' &&
+    sizing === 'text-edit-only-width'
+  ) {
     const pointOnCanvas = interactionSession.interactionData.dragStart
     const frame = canvasRectangle({
       x: pointOnCanvas.x,

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.spec.browser2.tsx
@@ -72,6 +72,7 @@ describe('draw-to-insert text', () => {
                 <span
                   style={{
                     position: 'absolute',
+                    wordBreak: 'break-word',
                     left: 389,
                     top: 101,
                     width: 100,
@@ -134,10 +135,10 @@ describe('draw-to-insert text', () => {
                 <span
                   style={{
                     position: 'absolute',
-                    left: 339,
-                    top: 51,
-                    width: 100,
-                    height: 100,
+                    wordBreak: 'break-word',
+                    left: 389,
+                    top: 101,
+                    width: 200,
                   }}
                   data-uid='${newElementUID}'
                 >Utopia</span>
@@ -251,7 +252,12 @@ describe('draw-to-insert text', () => {
                 >
                   <div data-uid='111' />
                   <span
-                    style={{ width: 50, height: 50, contain: 'layout' }}
+                    style={{
+                      wordBreak: 'break-word',
+                      width: 50,
+                      height: 50,
+                      contain: 'layout',
+                    }}
                     data-uid='ddd'
                   >Hello Utopia</span>
                 </div>
@@ -298,6 +304,7 @@ describe('draw-to-insert text', () => {
                 <span
                   style={{
                     position: 'absolute',
+                    wordBreak: 'break-word',
                     left: 112,
                     top: 391,
                     width: 50,

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -178,6 +178,7 @@ export function defaultSpanElement(uid: string): JSXElement {
     [],
   )
 }
+export const DefaultTextWidth = 200
 
 export function defaultImgElement(uid: string): JSXElement {
   return jsxElement(

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -169,6 +169,7 @@ export function defaultSpanElement(uid: string): JSXElement {
       style: jsxAttributeValue(
         {
           position: 'absolute',
+          wordBreak: 'break-word',
         },
         emptyComments,
       ),


### PR DESCRIPTION
Problem:
Inserting a new span with clicking adds a fix width and height of 100px. It should be something more realistic, as unset width caused weird wrapping problems, this solutiuon adds a fixed width without height set.
Also the click to insert is center positioned by default but for text left aligned insertion would look nicer.

Fix:
Extended draw-to-insert strategy for text editing to add only a fixed default width prop but only on CLICK! Drawing to insert still adds width and height.

Commit Details:
- updated draw to insert strategy and tests
- added default width to defaults
- both t shortcut and canvas toolbar button inserts a span without a size
- an extra wordbreak prop is added to default style