### PR TITLE
Improve module resolution performance.

### DIFF
--- a/editor/src/core/webpack-loaders/loaders.ts
+++ b/editor/src/core/webpack-loaders/loaders.ts
@@ -23,10 +23,6 @@ function loaderForFile(filename: string): ModuleLoader | undefined {
   return moduleLoaders.find((loader) => loader.match(filename))
 }
 
-export function loaderExistsForFile(filename: string): boolean {
-  return loaderForFile(filename) != null
-}
-
 export function applyLoaders(filename: string, contents: string): LoadModuleResult {
   const matchedLoader = loaderForFile(filename)
   if (matchedLoader != null) {

--- a/editor/src/core/workers/ts/ts-worker.ts
+++ b/editor/src/core/workers/ts/ts-worker.ts
@@ -37,11 +37,7 @@ import { fastForEach } from '../../shared/utils'
 import infiniteLoopPrevention from '../parser-printer/transform-prevent-infinite-loops'
 import { ProjectContentTreeRoot, walkContentsTree } from '../../../components/assets'
 import { isDirectory } from '../../model/project-file-utils'
-import {
-  applyLoaders,
-  filenameWithoutJSSuffix,
-  loaderExistsForFile,
-} from '../../webpack-loaders/loaders'
+import { applyLoaders, filenameWithoutJSSuffix } from '../../webpack-loaders/loaders'
 import { isCssFile, isJsOrTsFile, isTsFile, isJsFile } from '../../shared/file-utils'
 import {
   ExportsInfo,
@@ -449,13 +445,12 @@ function isNodeExported(node: TS.Node): boolean {
 
 function existingFilenameToRead(filename: string): string | undefined {
   // Checks that a filename exists that we can load, and returns the filename
-  if (loaderExistsForFile(filename) && (fs.existsSync(filename) as boolean)) {
+  if (fs.existsSync(filename) as boolean) {
     return filename
   } else {
     const alternativeFilenameToTest = filenameWithoutJSSuffix(filename)
     if (
       alternativeFilenameToTest != null &&
-      loaderExistsForFile(alternativeFilenameToTest) &&
       (fs.existsSync(alternativeFilenameToTest) as boolean)
     ) {
       return alternativeFilenameToTest


### PR DESCRIPTION
**Problem:**
Module resolution is used by both the inspector and the canvas, so any time wasted there impinges on our two most time sensitive parts of the editor.

**Fix:**
Three main tweaks were done:
- Remove a bunch of intermediary arrays created in `getImportedUtopiaJSXComponents`, which is used by the inspector.
- Changed a few of the functions in the module resolution code to eliminate a lot of anonymous functions, where some would produce one that was then invoked by the calling function.
- Delete `loaderExistsForFile` as it relied on `loaderForFile`, which in turn relies on `moduleLoaders`. `moduleLoaders` includes `FileLoader`, which returns `true` when checking if it supports a file. So a loader would always be returned to `loaderExistsForFile` and as a result would then return `true`.

**Results:**
Looking at `createExecutionScope`, that tended to take 4-6ms before and now takes 2-4ms.

**Commit Details:**
- Tweak `getImportedUtopiaJSXComponents` to cut the number of intermediary arrays created.
- Removed `failoverResolveResults`, inlining the logic it includes into the functions where it was previously used.
- Make `fallbackLookup` a function to invoke rather than one that produces an anonymous function.
- Change `nodeModulesFileLookup` and `projectContentsFileLookup` to functions rather than those that produce an anonymous function.
- Delete `loaderExistsForFile` as it was just returning `true` every time.