### PR TITLE
Delete new text editable elements when left empty

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
@@ -87,7 +87,7 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
                     canvasState.scale,
                     canvasState.canvasOffset,
                   ),
-                  false,
+                  'existing',
                 ),
               },
             }),
@@ -114,7 +114,7 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
         result.commands.push(
           wildcardPatch('on-complete', {
             mode: {
-              $set: EditorModes.textEditMode(targetElement, null, true),
+              $set: EditorModes.textEditMode(targetElement, null, 'new'),
             },
           }),
         )

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
@@ -87,6 +87,7 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
                     canvasState.scale,
                     canvasState.canvasOffset,
                   ),
+                  false,
                 ),
               },
             }),
@@ -112,7 +113,9 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
         const result = strategy.apply(s)
         result.commands.push(
           wildcardPatch('on-complete', {
-            mode: { $set: EditorModes.textEditMode(targetElement) },
+            mode: {
+              $set: EditorModes.textEditMode(targetElement, null, true),
+            },
           }),
         )
 

--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode-hooks.tsx
@@ -58,7 +58,9 @@ export function useTextEditModeSelectAndHover(active: boolean): MouseCallbacks {
       if (foundTarget == null) {
         return
       }
-      dispatch([switchEditorMode(EditorModes.textEditMode(foundTarget.elementPath, null, false))])
+      dispatch([
+        switchEditorMode(EditorModes.textEditMode(foundTarget.elementPath, null, 'existing')),
+      ])
     },
     [findValidTarget, getTextEditableViews, dispatch],
   )
@@ -76,6 +78,6 @@ export function scheduleTextEditForNextFrame(
   dispatch: EditorDispatch,
 ): void {
   setTimeout(() =>
-    dispatch([switchEditorMode(EditorModes.textEditMode(elementPath, cursorPosition, false))]),
+    dispatch([switchEditorMode(EditorModes.textEditMode(elementPath, cursorPosition, 'existing'))]),
   )
 }

--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode-hooks.tsx
@@ -58,7 +58,7 @@ export function useTextEditModeSelectAndHover(active: boolean): MouseCallbacks {
       if (foundTarget == null) {
         return
       }
-      dispatch([switchEditorMode(EditorModes.textEditMode(foundTarget.elementPath))])
+      dispatch([switchEditorMode(EditorModes.textEditMode(foundTarget.elementPath, null, false))])
     },
     [findValidTarget, getTextEditableViews, dispatch],
   )
@@ -76,6 +76,6 @@ export function scheduleTextEditForNextFrame(
   dispatch: EditorDispatch,
 ): void {
   setTimeout(() =>
-    dispatch([switchEditorMode(EditorModes.textEditMode(elementPath, cursorPosition))]),
+    dispatch([switchEditorMode(EditorModes.textEditMode(elementPath, cursorPosition, false))]),
   )
 }

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -93,6 +93,7 @@ export interface TextEditMode {
   type: 'textEdit'
   editedText: ElementPath | null
   cursorPosition: Coordinates | null
+  isNewElement: boolean
 }
 
 export interface Coordinates {
@@ -129,12 +130,14 @@ export const EditorModes = {
   },
   textEditMode: function (
     editedText: ElementPath | null,
-    cursorPosition: Coordinates | null = null,
+    cursorPosition: Coordinates | null,
+    isNewElement: boolean,
   ): TextEditMode {
     return {
       type: 'textEdit',
       editedText: editedText,
       cursorPosition: cursorPosition,
+      isNewElement: isNewElement,
     }
   },
 }

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -93,8 +93,10 @@ export interface TextEditMode {
   type: 'textEdit'
   editedText: ElementPath | null
   cursorPosition: Coordinates | null
-  isNewElement: boolean
+  elementState: TextEditableElementState
 }
+
+export type TextEditableElementState = 'existing' | 'new'
 
 export interface Coordinates {
   x: number
@@ -131,13 +133,13 @@ export const EditorModes = {
   textEditMode: function (
     editedText: ElementPath | null,
     cursorPosition: Coordinates | null,
-    isNewElement: boolean,
+    elementState: TextEditableElementState,
   ): TextEditMode {
     return {
       type: 'textEdit',
       editedText: editedText,
       cursorPosition: cursorPosition,
-      isNewElement: isNewElement,
+      elementState: elementState,
     }
   },
 }

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -688,7 +688,9 @@ export function handleKeyDown(
         const newUID = generateUidWithExistingComponents(editor.projectContents)
 
         const actions: Array<EditorAction> = [
-          EditorActions.switchEditorMode(EditorModes.textEditMode(firstTextEditableView ?? null)),
+          EditorActions.switchEditorMode(
+            EditorModes.textEditMode(firstTextEditableView ?? null, null, false),
+          ),
         ]
 
         if (firstTextEditableView == null) {

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -689,7 +689,7 @@ export function handleKeyDown(
 
         const actions: Array<EditorAction> = [
           EditorActions.switchEditorMode(
-            EditorModes.textEditMode(firstTextEditableView ?? null, null, false),
+            EditorModes.textEditMode(firstTextEditableView ?? null, null, 'existing'),
           ),
         ]
 

--- a/editor/src/components/editor/insert-callbacks.ts
+++ b/editor/src/components/editor/insert-callbacks.ts
@@ -58,7 +58,9 @@ export function useEnterTextEditMode(): (event: React.MouseEvent<Element>) => vo
       } else if (firstTextEditableView == null) {
         textInsertCallbackWithTextEditing(event, { textEdit: true })
       } else {
-        dispatch([switchEditorMode(EditorModes.textEditMode(firstTextEditableView, null, false))])
+        dispatch([
+          switchEditorMode(EditorModes.textEditMode(firstTextEditableView, null, 'existing')),
+        ])
       }
     },
     [

--- a/editor/src/components/editor/insert-callbacks.ts
+++ b/editor/src/components/editor/insert-callbacks.ts
@@ -58,7 +58,7 @@ export function useEnterTextEditMode(): (event: React.MouseEvent<Element>) => vo
       } else if (firstTextEditableView == null) {
         textInsertCallbackWithTextEditing(event, { textEdit: true })
       } else {
-        dispatch([switchEditorMode(EditorModes.textEditMode(firstTextEditableView))])
+        dispatch([switchEditorMode(EditorModes.textEditMode(firstTextEditableView, null, false))])
       }
     },
     [

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -415,6 +415,7 @@ import {
   imageInsertionSubject,
   TextEditMode,
   Coordinates,
+  TextEditableElementState,
 } from '../editor-modes'
 import { EditorPanel } from '../../common/actions'
 import { notice, Notice, NoticeLevel } from '../../common/notice'
@@ -2696,14 +2697,23 @@ export const CoordinateKeepDeepEquality: KeepDeepEqualityCall<Coordinates> = com
   (x: number, y: number) => ({ x, y }),
 )
 
+export const TextEditableElementStateKeepDeepEquality: KeepDeepEqualityCall<
+  TextEditableElementState
+> = (oldValue, newValue) => {
+  if (oldValue === newValue) {
+    return keepDeepEqualityResult(newValue, true)
+  }
+  return keepDeepEqualityResult(oldValue, false)
+}
+
 export const TextEditModeKeepDeepEquality: KeepDeepEqualityCall<TextEditMode> =
   combine3EqualityCalls(
     (mode) => mode.editedText,
     nullableDeepEquality(ElementPathKeepDeepEquality),
     (mode) => mode.cursorPosition,
     nullableDeepEquality(CoordinateKeepDeepEquality),
-    (mode) => mode.isNewElement,
-    BooleanKeepDeepEquality,
+    (mode) => mode.elementState,
+    TextEditableElementStateKeepDeepEquality,
     EditorModes.textEditMode,
   )
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -2697,11 +2697,13 @@ export const CoordinateKeepDeepEquality: KeepDeepEqualityCall<Coordinates> = com
 )
 
 export const TextEditModeKeepDeepEquality: KeepDeepEqualityCall<TextEditMode> =
-  combine2EqualityCalls(
+  combine3EqualityCalls(
     (mode) => mode.editedText,
     nullableDeepEquality(ElementPathKeepDeepEquality),
     (mode) => mode.cursorPosition,
     nullableDeepEquality(CoordinateKeepDeepEquality),
+    (mode) => mode.isNewElement,
+    BooleanKeepDeepEquality,
     EditorModes.textEditMode,
   )
 

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -51,15 +51,16 @@ const handleShortcut = (
 export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
   const { elementPath, text, component, passthroughProps } = props
 
-  const { dispatch, cursorPosition, isNewElement } = useEditorState(
-    (store) => ({
-      dispatch: store.dispatch,
-      cursorPosition:
-        store.editor.mode.type === 'textEdit' ? store.editor.mode.cursorPosition : null,
-      isNewElement: store.editor.mode.type === 'textEdit' && store.editor.mode.isNewElement,
-    }),
-    'TextEditor dispatch',
+  const dispatch = useEditorState((store) => store.dispatch, 'TextEditor dispatch')
+  const cursorPosition = useEditorState(
+    (store) => (store.editor.mode.type === 'textEdit' ? store.editor.mode.cursorPosition : null),
+    'TextEditor cursor position',
   )
+  const elementState = useEditorState(
+    (store) => (store.editor.mode.type === 'textEdit' ? store.editor.mode.elementState : null),
+    'TextEditor element state',
+  )
+
   const scale = useEditorState((store) => store.editor.canvas.scale, 'TextEditor scale')
   const [firstTextProp] = React.useState(text)
 
@@ -76,14 +77,14 @@ export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
     return () => {
       const content = currentElement.textContent
       if (content != null) {
-        if (isNewElement && content === '') {
+        if (elementState === 'new' && content === '') {
           dispatch([deleteView(elementPath)])
         } else {
           dispatch([updateChildText(elementPath, escapeHTML(content).replace(/\n/g, '<br />'))])
         }
       }
     }
-  }, [dispatch, elementPath, isNewElement])
+  }, [dispatch, elementPath, elementState])
 
   React.useEffect(() => {
     if (myElement.current == null) {


### PR DESCRIPTION
Fixes #3067 

**Problem:**

When a new text element is created but its contents are left empty, the new element should be removed from the project.

**Fix:**

When a _new_ element is left empty after exiting text edit mode (`Escape`, click away, etc.), it is removed from the tree.
Non-new elements that are edited and left empty, instead, are not removed.

![Kapture 2023-01-09 at 13 36 57](https://user-images.githubusercontent.com/1081051/211309753-2b3d7b8b-5642-4feb-a128-f5e95ab5fbcf.gif)
