### PR TITLE
fix(canvas) br tags are not shown in the navigator

### DIFF
--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -67,7 +67,10 @@ export const ZeroSizedElementControls = controlForStrategyMemoized(
             if (child.globalFrame == null) {
               return false
             } else {
-              return isZeroSizedElement(child.globalFrame)
+              return (
+                isZeroSizedElement(child.globalFrame) &&
+                MetadataUtils.targetElementSupportsChildren(store.editor.projectContents, child)
+              )
             }
           })
         })

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -955,7 +955,11 @@ export const MetadataUtils = {
           const path = subTree.path
           const isHiddenInNavigator = EP.containsPath(path, hiddenInNavigator)
           navigatorTargets.push(path)
-          if (!collapsedAncestor && !isHiddenInNavigator) {
+          if (
+            !collapsedAncestor &&
+            !isHiddenInNavigator &&
+            !MetadataUtils.isElementTypeHiddenInNavigator(path, metadata)
+          ) {
             visibleNavigatorTargets.push(path)
           }
 
@@ -993,6 +997,19 @@ export const MetadataUtils = {
       maxSize: 1,
     },
   ),
+  isElementTypeHiddenInNavigator(path: ElementPath, metadata: ElementInstanceMetadataMap): boolean {
+    const VoidElementsToFilter = ['br', 'wbr']
+    const element = MetadataUtils.findElementByElementPath(metadata, path)
+    if (element == null) {
+      return false
+    } else {
+      return foldEither(
+        (l) => VoidElementsToFilter.includes(l),
+        (r) => (isJSXElement(r) ? VoidElementsToFilter.includes(r.name.baseVariable) : false),
+        element.element,
+      )
+    }
+  },
   transformAtPathOptionally(
     elementMap: ElementInstanceMetadataMap,
     path: ElementPath,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -12,7 +12,10 @@ import {
   uniqBy,
   mapAndFilter,
 } from '../shared/array-utils'
-import { intrinsicHTMLElementNamesThatSupportChildren } from '../shared/dom-utils'
+import {
+  intrinsicHTMLElementNamesThatSupportChildren,
+  VoidElementsToFilter,
+} from '../shared/dom-utils'
 import {
   alternativeEither,
   Either,
@@ -998,7 +1001,6 @@ export const MetadataUtils = {
     },
   ),
   isElementTypeHiddenInNavigator(path: ElementPath, metadata: ElementInstanceMetadataMap): boolean {
-    const VoidElementsToFilter = ['br', 'wbr']
     const element = MetadataUtils.findElementByElementPath(metadata, path)
     if (element == null) {
       return false

--- a/editor/src/core/shared/dom-utils.ts
+++ b/editor/src/core/shared/dom-utils.ts
@@ -204,6 +204,8 @@ export const intrinsicHTMLElementNamesThatSupportChildren: Array<string> = [
   'span',
 ]
 
+export const VoidElementsToFilter = ['br', 'wbr']
+
 export function getDOMAttribute(element: Element, attributeName: string): string | null {
   const attr = element.attributes.getNamedItemNS(null, attributeName)
   if (attr == null) {


### PR DESCRIPTION
**Problem:**
Inside text elements there can be `<br>` tags, some of these are added automatically for new lines. The problem is that they show canvas controls when the text is selected and they should be excluded from the navigator too.

**Fix:**
I was looking at the list of [Void Elements](https://developer.mozilla.org/en-US/docs/Glossary/Void_element) to filter other text related tags from the navigator, only `br` and `wbr` looked like a good match for us.

**Commit Details:**
- don't show zero size control on canvas when the child element is not a reparent target
- filter special tags from visible navigator elements
