### PR TITLE
Hug contents with children not participating in the layout

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -387,6 +387,31 @@ export var storyboard = (
 )
 `
 
+const projectForEdgeDblClickNoChildren = `import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard>
+    <div
+      data-testid='mydiv'
+      style={{
+        backgroundColor: '#3EA881FC',
+        position: 'absolute',
+        left: -231,
+        top: 221,
+        width: 637,
+        display: 'flex',
+        gap: 31,
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: 445,
+      }}
+    >
+    </div>
+  </Storyboard>
+)
+`
+
 describe('Absolute Resize Strategy', () => {
   it('resizes component instances that honour the size properties', async () => {
     const renderResult = await renderTestEditorWithCode(
@@ -1173,7 +1198,7 @@ describe('Double click on resize edge', () => {
 
   it('not applicable when children are positioned absolute', async () => {
     const editor = await renderTestEditorWithCode(
-      projectForEdgeDblClickWithPosition('absolute', 'absolute'),
+      projectForEdgeDblClickNoChildren,
       'await-first-dom-report',
     )
     const div = await doDblClickTest(editor, edgeResizeControlTestId(EdgePositionBottom))

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -38,6 +38,7 @@ import {
 import { mouseClickAtPoint, mouseDragFromPointWithDelta } from '../../event-helpers.test-utils'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import { setFeatureEnabled } from '../../../../utils/feature-switches'
+import { CSSProperties } from 'react'
 
 function resizeElement(
   renderResult: EditorRenderResult,
@@ -329,6 +330,56 @@ export var storyboard = (
           width: 73,
           height: 358,
           contain: 'layout',
+        }}
+      />
+    </div>
+  </Storyboard>
+)
+`
+
+const projectForEdgeDblClickWithPosition = (
+  leftPos: CSSProperties['position'],
+  rightPos: CSSProperties['position'],
+) => `import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard>
+    <div
+      data-testid='mydiv'
+      style={{
+        backgroundColor: '#3EA881FC',
+        position: 'absolute',
+        left: -231,
+        top: 221,
+        width: 637,
+        display: 'flex',
+        gap: 31,
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: 445,
+      }}
+    >
+      <div
+        style={{
+          backgroundColor: '#E91C1CC4',
+          width: 200,
+          height: 192,
+          contain: 'layout',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          flexDirection: 'column',
+          position: '${leftPos}'
+        }}
+      ></div>
+      <div
+        style={{
+          backgroundColor: '#2C49C9B3',
+          width: 73,
+          height: 358,
+          contain: 'layout',
+          position: '${rightPos}'
         }}
       />
     </div>
@@ -1108,5 +1159,45 @@ describe('Double click on resize edge', () => {
     const div = await doDblClickTest(editor, edgeResizeControlTestId(EdgePositionBottom))
     expect(div.style.width).toEqual('637px')
     expect(div.style.height).toEqual(minContent)
+  })
+
+  it("not applicable when children don't participate in the layout", async () => {
+    const editor = await renderTestEditorWithCode(
+      projectForEdgeDblClickWithPosition('absolute', 'absolute'),
+      'await-first-dom-report',
+    )
+    const div = await doDblClickTest(editor, edgeResizeControlTestId(EdgePositionBottom))
+    expect(div.style.width).toEqual('637px')
+    expect(div.style.height).toEqual('445px')
+  })
+
+  it('not applicable when children are positioned absolute', async () => {
+    const editor = await renderTestEditorWithCode(
+      projectForEdgeDblClickWithPosition('absolute', 'absolute'),
+      'await-first-dom-report',
+    )
+    const div = await doDblClickTest(editor, edgeResizeControlTestId(EdgePositionBottom))
+    expect(div.style.width).toEqual('637px')
+    expect(div.style.height).toEqual('445px')
+  })
+
+  it('not applicable when children are positioned sticky', async () => {
+    const editor = await renderTestEditorWithCode(
+      projectForEdgeDblClickWithPosition('sticky', 'sticky'),
+      'await-first-dom-report',
+    )
+    const div = await doDblClickTest(editor, edgeResizeControlTestId(EdgePositionBottom))
+    expect(div.style.width).toEqual('637px')
+    expect(div.style.height).toEqual('445px')
+  })
+
+  it('not applicable when children are positioned fixed', async () => {
+    const editor = await renderTestEditorWithCode(
+      projectForEdgeDblClickWithPosition('fixed', 'fixed'),
+      'await-first-dom-report',
+    )
+    const div = await doDblClickTest(editor, edgeResizeControlTestId(EdgePositionBottom))
+    expect(div.style.width).toEqual('637px')
+    expect(div.style.height).toEqual('445px')
   })
 })

--- a/editor/src/components/inspector/inspector-common.tsx
+++ b/editor/src/components/inspector/inspector-common.tsx
@@ -174,7 +174,21 @@ export const isFlexColumn = (flexDirection: FlexDirection): boolean =>
 export const hugContentsApplicable = (
   metadata: ElementInstanceMetadataMap,
   elementPath: ElementPath,
-): boolean => MetadataUtils.getChildrenPaths(metadata, elementPath).length > 0
+): boolean => {
+  return (
+    mapDropNulls(
+      (path) => MetadataUtils.findElementByElementPath(metadata, path),
+      MetadataUtils.getChildrenPaths(metadata, elementPath),
+    ).filter(
+      (element) =>
+        !(
+          MetadataUtils.isPositionFixed(element) ||
+          MetadataUtils.isPositionSticky(element) ||
+          MetadataUtils.isPositionAbsolute(element)
+        ),
+    ).length > 0
+  )
+}
 
 export const fillContainerApplicable = (elementPath: ElementPath): boolean =>
   !isStoryboardChild(elementPath)

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -236,6 +236,15 @@ export const MetadataUtils = {
   isPositionAbsolute(instance: ElementInstanceMetadata | null): boolean {
     return instance?.specialSizeMeasurements.position === 'absolute'
   },
+  isPositionFixed(instance: ElementInstanceMetadata | null): boolean {
+    return instance?.specialSizeMeasurements.position === 'fixed'
+  },
+  isPositionSticky(instance: ElementInstanceMetadata | null): boolean {
+    return (
+      instance?.specialSizeMeasurements.position === 'sticky' ||
+      instance?.specialSizeMeasurements.position === '-webkit-sticky'
+    )
+  },
   isPositionRelative(instance: ElementInstanceMetadata | null): boolean {
     return instance?.specialSizeMeasurements.position === 'relative'
   },


### PR DESCRIPTION
## Description

This PR fixes an omission in the `Hug contents` inspector strategy, by checking if the element the strategy is being applied to acutally has any children that participate in the layout (otherwise the element can be collapsed to become 0-sized).