### PR TITLE
Calculate with overflown text bounds too

### DIFF
--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-canvas-overlay.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-canvas-overlay.tsx
@@ -12,14 +12,20 @@ export const TextEditCanvasOverlay = React.memo(() => {
 
   const checkMousePosition = React.useCallback((event: MouseEvent) => {
     const textEditor = document.getElementById(TextEditorSpanId)
-    const textEditorBounds = textEditor?.getBoundingClientRect()
-    if (textEditorBounds == null) {
+    if (textEditor == null) {
       setEnabled(false)
-    } else if (
-      event.clientX >= textEditorBounds.left &&
-      event.clientX <= textEditorBounds.right &&
-      event.clientY >= textEditorBounds.top &&
-      event.clientY <= textEditorBounds.bottom
+      return
+    }
+    const range = document.createRange()
+    range.selectNode(textEditor)
+    const rangeBounding = range.getBoundingClientRect()
+    const textEditorBounding = textEditor.getBoundingClientRect()
+
+    if (
+      event.clientX >= Math.min(rangeBounding.left, textEditorBounding.left) &&
+      event.clientX <= Math.max(rangeBounding.right, textEditorBounding.right) &&
+      event.clientY >= Math.min(rangeBounding.top, textEditorBounding.top) &&
+      event.clientY <= Math.max(rangeBounding.bottom, textEditorBounding.bottom)
     ) {
       setEnabled(false)
     } else {


### PR DESCRIPTION
Followup PR to https://github.com/concrete-utopia/utopia/pull/3064

**Problem:**
In the original PR I did not take into account that a text can be larger then its containing element (if it is overflown)

**Fix:**
Use the union of the bounds of the element and the bounds of the full text range inside.

