### PR TITLE
Feature/canvas text edit mode

### DIFF
--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
@@ -53,6 +53,17 @@ describe('Text edit mode', () => {
         EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
       ).toEqual('sb/39e')
     })
+    it('Entering text edit mode with pressing enter on a text editable selected element', async () => {
+      const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
+      await selectElement(editor, EP.fromString('sb/39e'))
+      pressKey('enter')
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
+      expect(
+        EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
+      ).toEqual('sb/39e')
+    })
   })
 
   describe('Click to choose target text for editing', () => {

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -372,14 +372,26 @@ export function handleKeyDown(
       },
       [FIRST_CHILD_OR_EDIT_TEXT_SHORTCUT]: () => {
         if (isSelectMode(editor.mode)) {
-          const textTarget = getTextEditorTarget(editor, derived)
-          if (textTarget != null && isSelectMode(editor.mode)) {
-            return [EditorActions.focusFormulaBar()]
-          } else {
-            const childToSelect = Canvas.getFirstChild(editor.selectedViews, editor.jsxMetadata)
-            if (childToSelect != null) {
-              return MetaActions.selectComponents([childToSelect], false)
+          if (isFeatureEnabled('Text editing')) {
+            const firstTextEditableView = editor.selectedViews.find((v) =>
+              MetadataUtils.targetTextEditable(editor.jsxMetadata, v),
+            )
+            if (firstTextEditableView != null) {
+              return [
+                EditorActions.switchEditorMode(
+                  EditorModes.textEditMode(firstTextEditableView, null, 'existing'),
+                ),
+              ]
             }
+          } else {
+            const textTarget = getTextEditorTarget(editor, derived)
+            if (textTarget != null && isSelectMode(editor.mode)) {
+              return [EditorActions.focusFormulaBar()]
+            }
+          }
+          const childToSelect = Canvas.getFirstChild(editor.selectedViews, editor.jsxMetadata)
+          if (childToSelect != null) {
+            return MetaActions.selectComponents([childToSelect], false)
           }
         }
         return []


### PR DESCRIPTION
**Fix:**
Pressing the enter key should start text edit mode if possible.

**Commit Details:**
- added a test
- updated `FIRST_CHILD_OR_EDIT_TEXT_SHORTCUT`
