### PR TITLE
Fix/text edit shortcut select

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
@@ -88,6 +88,7 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
                     canvasState.canvasOffset,
                   ),
                   'existing',
+                  'no-text-selection',
                 ),
               },
             }),
@@ -114,7 +115,7 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
         result.commands.push(
           wildcardPatch('on-complete', {
             mode: {
-              $set: EditorModes.textEditMode(targetElement, null, 'new'),
+              $set: EditorModes.textEditMode(targetElement, null, 'new', 'no-text-selection'),
             },
           }),
         )

--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode-hooks.tsx
@@ -57,7 +57,9 @@ export function useTextEditModeSelectAndHover(active: boolean): MouseCallbacks {
         return
       }
       dispatch([
-        switchEditorMode(EditorModes.textEditMode(foundTarget.elementPath, null, 'existing')),
+        switchEditorMode(
+          EditorModes.textEditMode(foundTarget.elementPath, null, 'existing', 'no-text-selection'),
+        ),
       ])
     },
     [findValidTarget, getTextEditableViews, dispatch],
@@ -76,6 +78,10 @@ export function scheduleTextEditForNextFrame(
   dispatch: EditorDispatch,
 ): void {
   setTimeout(() =>
-    dispatch([switchEditorMode(EditorModes.textEditMode(elementPath, cursorPosition, 'existing'))]),
+    dispatch([
+      switchEditorMode(
+        EditorModes.textEditMode(elementPath, cursorPosition, 'existing', 'no-text-selection'),
+      ),
+    ]),
   )
 }

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -94,6 +94,7 @@ export interface TextEditMode {
   editedText: ElementPath | null
   cursorPosition: Coordinates | null
   elementState: TextEditableElementState
+  selectOnFocus: 'select-all-on-focus' | 'no-text-selection'
 }
 
 export type TextEditableElementState = 'existing' | 'new'
@@ -134,12 +135,14 @@ export const EditorModes = {
     editedText: ElementPath | null,
     cursorPosition: Coordinates | null,
     elementState: TextEditableElementState,
+    selectOnFocus: 'select-all-on-focus' | 'no-text-selection',
   ): TextEditMode {
     return {
       type: 'textEdit',
       editedText: editedText,
       cursorPosition: cursorPosition,
       elementState: elementState,
+      selectOnFocus: selectOnFocus,
     }
   },
 }

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -379,7 +379,12 @@ export function handleKeyDown(
             if (firstTextEditableView != null) {
               return [
                 EditorActions.switchEditorMode(
-                  EditorModes.textEditMode(firstTextEditableView, null, 'existing'),
+                  EditorModes.textEditMode(
+                    firstTextEditableView,
+                    null,
+                    'existing',
+                    'select-all-on-focus',
+                  ),
                 ),
               ]
             }
@@ -701,7 +706,12 @@ export function handleKeyDown(
 
         const actions: Array<EditorAction> = [
           EditorActions.switchEditorMode(
-            EditorModes.textEditMode(firstTextEditableView ?? null, null, 'existing'),
+            EditorModes.textEditMode(
+              firstTextEditableView ?? null,
+              null,
+              'existing',
+              'no-text-selection',
+            ),
           ),
         ]
 

--- a/editor/src/components/editor/insert-callbacks.ts
+++ b/editor/src/components/editor/insert-callbacks.ts
@@ -60,7 +60,9 @@ export function useEnterTextEditMode(): (event: React.MouseEvent<Element>) => vo
         textInsertCallbackWithTextEditing(event, { textEdit: true })
       } else {
         dispatch([
-          switchEditorMode(EditorModes.textEditMode(firstTextEditableView, null, 'existing')),
+          switchEditorMode(
+            EditorModes.textEditMode(firstTextEditableView, null, 'existing', 'no-text-selection'),
+          ),
         ])
       }
     },

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -2707,13 +2707,15 @@ export const TextEditableElementStateKeepDeepEquality: KeepDeepEqualityCall<
 }
 
 export const TextEditModeKeepDeepEquality: KeepDeepEqualityCall<TextEditMode> =
-  combine3EqualityCalls(
+  combine4EqualityCalls(
     (mode) => mode.editedText,
     nullableDeepEquality(ElementPathKeepDeepEquality),
     (mode) => mode.cursorPosition,
     nullableDeepEquality(CoordinateKeepDeepEquality),
     (mode) => mode.elementState,
     TextEditableElementStateKeepDeepEquality,
+    (mode) => mode.selectOnFocus,
+    createCallWithTripleEquals<'select-all-on-focus' | 'no-text-selection'>(),
     EditorModes.textEditMode,
   )
 

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -60,6 +60,11 @@ export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
     (store) => (store.editor.mode.type === 'textEdit' ? store.editor.mode.elementState : null),
     'TextEditor element state',
   )
+  const shouldSelectOnFocus = useEditorState(
+    (store) =>
+      store.editor.mode.type === 'textEdit' ? store.editor.mode.selectOnFocus : 'no-text-selection',
+    'TextEditor shouldSelectOnFocus',
+  )
 
   const scale = useEditorState((store) => store.editor.canvas.scale, 'TextEditor scale')
   const [firstTextProp] = React.useState(text)
@@ -99,6 +104,20 @@ export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
     }
     void setSelectionToOffset(myElement.current, scale, cursorPosition)
   }, [scale, cursorPosition])
+
+  React.useEffect(() => {
+    if (myElement.current == null || shouldSelectOnFocus === 'no-text-selection') {
+      return
+    }
+
+    const range = document.createRange()
+    range.selectNodeContents(myElement.current)
+    const selection = window.getSelection()
+    if (selection != null) {
+      selection.removeAllRanges()
+      selection.addRange(range)
+    }
+  }, [shouldSelectOnFocus])
 
   const onKeyDown = React.useCallback(
     (event: React.KeyboardEvent) => {


### PR DESCRIPTION
**Problem:**
When pressing enter to start text editing text should be selected.

**Fix:**
Select all text only when using the enter key. 

**Commit Details:**
- updated text editor mode
- added useEffect to text editor to select text
