### PR TITLE
Text insert mode on `t` even when there is selection

### DIFF
--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
@@ -30,16 +30,16 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.mode.type).toEqual('insert')
       expect((editor.getEditorState().editor.mode as InsertMode).subjects.length).toBeGreaterThan(0)
     })
-    it('Entering text edit mode with text editable selected element', async () => {
+    it('Entering insert even if editable element is selected', async () => {
       const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
       await selectElement(editor, EP.fromString('sb/39e'))
       pressKey('t')
       await editor.getDispatchFollowUpActionsFinished()
 
-      expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
-      expect(
-        EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
-      ).toEqual('sb/39e')
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('insert')
+      expect((editor.getEditorState().editor.mode as InsertMode).subjects.length).toBeGreaterThan(0)
     })
     it('Entering text edit mode with double click on selected text editable element', async () => {
       const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -91,7 +91,7 @@ export interface SelectMode {
 
 export interface TextEditMode {
   type: 'textEdit'
-  editedText: ElementPath | null
+  editedText: ElementPath
   cursorPosition: Coordinates | null
   elementState: TextEditableElementState
 }
@@ -131,7 +131,7 @@ export const EditorModes = {
     }
   },
   textEditMode: function (
-    editedText: ElementPath | null,
+    editedText: ElementPath,
     cursorPosition: Coordinates | null,
     elementState: TextEditableElementState,
   ): TextEditMode {

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -693,39 +693,27 @@ export function handleKeyDown(
           return []
         }
 
-        const firstTextEditableView = editor.selectedViews.find((v) =>
-          MetadataUtils.targetTextEditable(editor.jsxMetadata, v),
-        )
-
         const newUID = generateUidWithExistingComponents(editor.projectContents)
 
-        const actions: Array<EditorAction> = [
-          EditorActions.switchEditorMode(
-            EditorModes.textEditMode(firstTextEditableView ?? null, null, 'existing'),
+        actions.push(
+          EditorActions.enableInsertModeForJSXElement(
+            defaultSpanElement(newUID),
+            newUID,
+            {},
+            null,
+            {
+              textEdit: true,
+            },
           ),
-        ]
-
-        if (firstTextEditableView == null) {
-          actions.push(
-            EditorActions.enableInsertModeForJSXElement(
-              defaultSpanElement(newUID),
-              newUID,
-              {},
-              null,
-              {
-                textEdit: true,
-              },
+          CanvasActions.createInteractionSession(
+            createHoverInteractionViaMouse(
+              CanvasMousePositionRaw!,
+              modifiers,
+              boundingArea(),
+              'zero-drag-permitted',
             ),
-            CanvasActions.createInteractionSession(
-              createHoverInteractionViaMouse(
-                CanvasMousePositionRaw!,
-                modifiers,
-                boundingArea(),
-                'zero-drag-permitted',
-              ),
-            ),
-          )
-        }
+          ),
+        )
         return actions
       },
     })

--- a/editor/src/components/editor/insert-callbacks.ts
+++ b/editor/src/components/editor/insert-callbacks.ts
@@ -41,9 +41,6 @@ export function useEnterDrawToInsertForDiv(): (event: React.MouseEvent<Element>)
 }
 
 export function useEnterTextEditMode(): (event: React.MouseEvent<Element>) => void {
-  const dispatch = useDispatch()
-  const selectedViewsRef = useRefEditorState((store) => store.editor.selectedViews)
-  const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
   const textInsertCallbackWithoutTextEditing = useEnterDrawToInsertForElement(
     defaultSpanElementWithPlaceholder,
   )
@@ -51,26 +48,13 @@ export function useEnterTextEditMode(): (event: React.MouseEvent<Element>) => vo
 
   return React.useCallback(
     (event: React.MouseEvent<Element>): void => {
-      const firstTextEditableView = selectedViewsRef.current.find((v) =>
-        MetadataUtils.targetTextEditable(metadataRef.current, v),
-      )
       if (!isFeatureEnabled('Text editing')) {
         textInsertCallbackWithoutTextEditing(event, { textEdit: false })
-      } else if (firstTextEditableView == null) {
-        textInsertCallbackWithTextEditing(event, { textEdit: true })
       } else {
-        dispatch([
-          switchEditorMode(EditorModes.textEditMode(firstTextEditableView, null, 'existing')),
-        ])
+        textInsertCallbackWithTextEditing(event, { textEdit: true })
       }
     },
-    [
-      dispatch,
-      selectedViewsRef,
-      metadataRef,
-      textInsertCallbackWithoutTextEditing,
-      textInsertCallbackWithTextEditing,
-    ],
+    [textInsertCallbackWithoutTextEditing, textInsertCallbackWithTextEditing],
   )
 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -2709,7 +2709,7 @@ export const TextEditableElementStateKeepDeepEquality: KeepDeepEqualityCall<
 export const TextEditModeKeepDeepEquality: KeepDeepEqualityCall<TextEditMode> =
   combine3EqualityCalls(
     (mode) => mode.editedText,
-    nullableDeepEquality(ElementPathKeepDeepEquality),
+    ElementPathKeepDeepEquality,
     (mode) => mode.cursorPosition,
     nullableDeepEquality(CoordinateKeepDeepEquality),
     (mode) => mode.elementState,

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -20,43 +20,10 @@ describe('Use the text editor', () => {
   before(() => {
     setFeatureEnabled('Text editing', true)
   })
-  it('Edit existing selected text', async () => {
-    const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
-
-    await enterTextEditMode(editor, 'select-then-text-edit-mode')
-    typeText(' Utopia')
-    closeTextEditor()
-    await editor.getDispatchFollowUpActionsFinished()
-
-    expect(editor.getEditorState().editor.mode.type).toEqual('select')
-    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-      formatTestProjectCode(`
-        import * as React from 'react'
-        import { Storyboard } from 'utopia-api'
-
-
-        export var storyboard = (
-          <Storyboard data-uid='sb'>
-            <div
-              data-testid='div'
-              style={{
-                backgroundColor: '#0091FFAA',
-                position: 'absolute',
-                left: 0,
-                top: 0,
-                width: 288,
-                height: 362,
-              }}
-              data-uid='39e'
-            >Hello Utopia</div>
-          </Storyboard>
-        )`),
-    )
-  })
   it('Click to edit text', async () => {
     const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
 
-    await enterTextEditMode(editor, 'text-edit-mode-then-select')
+    await enterTextEditMode(editor)
     typeText(' Utopia')
     closeTextEditor()
     await editor.getDispatchFollowUpActionsFinished()
@@ -89,7 +56,7 @@ describe('Use the text editor', () => {
   it('Add new text', async () => {
     const editor = await renderTestEditorWithCode(projectWithoutText, 'await-first-dom-report')
 
-    await enterTextEditMode(editor, 'select-then-text-edit-mode')
+    await enterTextEditMode(editor)
     typeText('Utopia')
     closeTextEditor()
     await editor.getDispatchFollowUpActionsFinished()
@@ -122,7 +89,7 @@ describe('Use the text editor', () => {
   it('Do not save content before exiting the text editor', async () => {
     const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
 
-    await enterTextEditMode(editor, 'select-then-text-edit-mode')
+    await enterTextEditMode(editor)
     typeText(' Utopia')
     await editor.getDispatchFollowUpActionsFinished()
 
@@ -154,7 +121,7 @@ describe('Use the text editor', () => {
   it('Escapes HTML entities', async () => {
     const editor = await renderTestEditorWithCode(projectWithoutText, 'await-first-dom-report')
 
-    await enterTextEditMode(editor, 'select-then-text-edit-mode')
+    await enterTextEditMode(editor)
     typeText('this is a <test> with bells & whistles')
     closeTextEditor()
     await editor.getDispatchFollowUpActionsFinished()
@@ -313,7 +280,7 @@ describe('Use the text editor', () => {
       it('keeps existing elements', async () => {
         const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
 
-        await enterTextEditMode(editor, 'select-then-text-edit-mode')
+        await enterTextEditMode(editor)
 
         deleteTypedText()
 
@@ -439,7 +406,7 @@ function deleteTypedText() {
 }
 
 async function prepareTestModifierEditor(editor: EditorRenderResult) {
-  await enterTextEditMode(editor, 'select-then-text-edit-mode')
+  await enterTextEditMode(editor)
   typeText('Hello Utopia')
 }
 
@@ -459,17 +426,14 @@ async function testModifier(mod: Modifiers, key: string) {
   await pressShortcut(editor, mod, key)
   const before = getPrintedUiJsCode(editor.getEditorState())
 
-  await enterTextEditMode(editor, 'select-then-text-edit-mode')
+  await enterTextEditMode(editor)
   await pressShortcut(editor, mod, key)
   const after = getPrintedUiJsCode(editor.getEditorState())
 
   return { before, after }
 }
 
-async function enterTextEditMode(
-  editor: EditorRenderResult,
-  order: 'text-edit-mode-then-select' | 'select-then-text-edit-mode',
-) {
+async function enterTextEditMode(editor: EditorRenderResult) {
   const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
   const div = editor.renderedDOM.getByTestId('div')
   const divBounds = div.getBoundingClientRect()
@@ -478,17 +442,10 @@ async function enterTextEditMode(
     y: divBounds.y + 40,
   }
 
-  if (order === 'select-then-text-edit-mode') {
-    mouseClickAtPoint(canvasControlsLayer, divCorner)
-    await editor.getDispatchFollowUpActionsFinished()
-    pressKey('t')
-    await editor.getDispatchFollowUpActionsFinished()
-  } else {
-    pressKey('t')
-    await editor.getDispatchFollowUpActionsFinished()
-    mouseClickAtPoint(canvasControlsLayer, divCorner)
-    await editor.getDispatchFollowUpActionsFinished()
-  }
+  pressKey('t')
+  await editor.getDispatchFollowUpActionsFinished()
+  mouseClickAtPoint(canvasControlsLayer, divCorner)
+  await editor.getDispatchFollowUpActionsFinished()
 }
 
 function typeText(text: string) {


### PR DESCRIPTION
**Problem:**
Currently when you press `t` and there is an existing text editable selection, we start to edit that text immediately.
Instead of that we should just activate text insert mode (the same way as we do without selection.

**Fix:**
Just removed all the code which checks the selection to decide what to do and fixed the tests.
I also made `TextEditMode.editedText` non-nullable, because there is no such thing anymore as text edit mode without edited text.