### PR TITLE
Check keys pressed in `keyboard-reorder-strategy`

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -143,13 +143,13 @@ const keyboardShortcutStrategies: MetaCanvasStrategy = (
 }
 
 export const RegisteredCanvasStrategies: Array<MetaCanvasStrategy> = [
+  keyboardShortcutStrategies,
   ...AncestorCompatibleStrategies,
   preventOnRootElements(resizeStrategies),
   propertyControlStrategies,
   drawToInsertMetaStrategy,
   dragToInsertMetaStrategy,
   ancestorMetaStrategy(AncestorCompatibleStrategies, 1),
-  keyboardShortcutStrategies,
   drawToInsertTextStrategy,
 ]
 

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -143,13 +143,13 @@ const keyboardShortcutStrategies: MetaCanvasStrategy = (
 }
 
 export const RegisteredCanvasStrategies: Array<MetaCanvasStrategy> = [
-  keyboardShortcutStrategies,
   ...AncestorCompatibleStrategies,
   preventOnRootElements(resizeStrategies),
   propertyControlStrategies,
   drawToInsertMetaStrategy,
   dragToInsertMetaStrategy,
   ancestorMetaStrategy(AncestorCompatibleStrategies, 1),
+  keyboardShortcutStrategies,
   drawToInsertTextStrategy,
 ]
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-reorder-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-reorder-strategy.ts
@@ -55,7 +55,7 @@ export function keyboardReorderStrategy(
     id: 'KEYBOARD_REORDER',
     name: 'Reorder',
     controlsToRender: [],
-    fitness: 1,
+    fitness: fitness(interactionSession),
     apply: () => {
       if (interactionSession != null && interactionSession.interactionData.type === 'KEYBOARD') {
         const accumulatedPresses = accumulatePresses(interactionSession.interactionData.keyStates)
@@ -106,6 +106,21 @@ export function keyboardReorderStrategy(
       }
     },
   }
+}
+
+function fitness(interactionSession: InteractionSession | null): number {
+  if (interactionSession == null || interactionSession.interactionData.type !== 'KEYBOARD') {
+    return 0
+  }
+
+  const accumulatedPresses = accumulatePresses(interactionSession.interactionData.keyStates)
+  const matches = accumulatedPresses.some((accumulatedPress) =>
+    Array.from(accumulatedPress.keysPressed).some(
+      (key) => key === 'left' || key === 'right' || key === 'up' || key === 'down',
+    ),
+  )
+
+  return matches ? 1 : 0
 }
 
 // This function creates the map which describes which keyboard cursor button should move the index which way.


### PR DESCRIPTION
## Problem
Both the `keyboard-set-font-size` strategy and `keyboard-reorder-strategy` had `fitness: 1`, however
- `keyboard-reorder-strategy` didn't actually check which keys were pressed, only that a keyboard interaction session is in flight
- `keyboard-reorder-strategy` was listed before  in `RegisteredCanvasStrategies`,
which led to it trumping `keyboard-set-font-size` in the strategy picker when the shortcut for `keyboard-set-font-size` was pressed.

## Solution
Actually check which keys are pressed in `keyboard-reorder-strategy`