### PR TITLE
Fix Tab and Escape key handling in the text editor

### DIFF
--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -224,12 +224,16 @@ export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
         dispatch(shortcuts)
       }
 
+      if (event.key === 'Tab') {
+        event.preventDefault()
+      }
+
       if (event.key === 'Escape') {
         // eslint-disable-next-line no-unused-expressions
         myElement.current?.blur()
-      } else {
-        event.stopPropagation()
       }
+
+      event.stopPropagation()
     },
     [dispatch, elementPath, metadataRef, passthroughProps],
   )


### PR DESCRIPTION
**Problem:**
When the text editor is active, pressing the Tab key will blur it, and pressing the Escape key will blur it and select the immediate parent element.

**Fix:**
Call `preventDefault()` when Tab is pressed, and `stopPropagation()` on all keys (previously we weren't doing this for the Escape key).

Annoyingly, due to the limitation mentioned in #3001 I have been unable to write a test that actually proves this behaviour is working correctly, as the manually fired keyboard events are handled in a different way.