### PR TITLE
Select edited text when going to text edit mode

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
@@ -1,6 +1,8 @@
 import { EditorModes } from '../../../../components/editor/editor-modes'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
+import { updateSelectedRightMenuTab } from '../../../editor/actions/actions'
+import { updateSelectedViews } from '../../commands/update-selected-views-command'
 import { wildcardPatch } from '../../commands/wildcard-patch-command'
 import { canvasPointToWindowPoint } from '../../dom-lookup'
 import { MetaCanvasStrategy } from '../canvas-strategies'
@@ -78,6 +80,7 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
         const isRoot = targetParentPathParts === 1
         if (!isRoot && textEditable) {
           return strategyApplicationResult([
+            updateSelectedViews('on-complete', [targetParent]),
             wildcardPatch('on-complete', {
               mode: {
                 $set: EditorModes.textEditMode(
@@ -113,6 +116,7 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
 
         const result = strategy.apply(s)
         result.commands.push(
+          updateSelectedViews('on-complete', [targetElement]),
           wildcardPatch('on-complete', {
             mode: {
               $set: EditorModes.textEditMode(targetElement, null, 'new', 'no-text-selection'),

--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode-hooks.tsx
@@ -56,7 +56,7 @@ export function useTextEditModeSelectAndHover(active: boolean): MouseCallbacks {
       if (foundTarget == null) {
         return
       }
-      activateTextEditing(foundTarget.elementPath, dispatch)
+      activateTextEditing(foundTarget.elementPath, null, dispatch)
     },
     [findValidTarget, getTextEditableViews, dispatch],
   )
@@ -73,12 +73,18 @@ export function scheduleTextEditForNextFrame(
   cursorPosition: Coordinates | null,
   dispatch: EditorDispatch,
 ): void {
-  setTimeout(() => activateTextEditing(elementPath, dispatch))
+  setTimeout(() => activateTextEditing(elementPath, cursorPosition, dispatch))
 }
 
-function activateTextEditing(elementPath: ElementPath, dispatch: EditorDispatch): void {
+function activateTextEditing(
+  elementPath: ElementPath,
+  cursorPosition: Coordinates | null,
+  dispatch: EditorDispatch,
+): void {
   dispatch([
     selectComponents([elementPath], false),
-    switchEditorMode(EditorModes.textEditMode(elementPath, null, 'existing', 'no-text-selection')),
+    switchEditorMode(
+      EditorModes.textEditMode(elementPath, cursorPosition, 'existing', 'no-text-selection'),
+    ),
   ])
 }

--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode-hooks.tsx
@@ -5,7 +5,7 @@ import { ElementPath } from '../../../../core/shared/project-file-types'
 import { NO_OP } from '../../../../core/shared/utils'
 import { useKeepShallowReferenceEquality } from '../../../../utils/react-performance'
 import { EditorDispatch } from '../../../editor/action-types'
-import { switchEditorMode } from '../../../editor/actions/action-creators'
+import { selectComponents, switchEditorMode } from '../../../editor/actions/action-creators'
 import { Coordinates, EditorModes, isTextEditMode } from '../../../editor/editor-modes'
 import { useDispatch } from '../../../editor/store/dispatch-context'
 import { useRefEditorState } from '../../../editor/store/store-hook'
@@ -56,11 +56,7 @@ export function useTextEditModeSelectAndHover(active: boolean): MouseCallbacks {
       if (foundTarget == null) {
         return
       }
-      dispatch([
-        switchEditorMode(
-          EditorModes.textEditMode(foundTarget.elementPath, null, 'existing', 'no-text-selection'),
-        ),
-      ])
+      activateTextEditing(foundTarget.elementPath, dispatch)
     },
     [findValidTarget, getTextEditableViews, dispatch],
   )
@@ -77,11 +73,12 @@ export function scheduleTextEditForNextFrame(
   cursorPosition: Coordinates | null,
   dispatch: EditorDispatch,
 ): void {
-  setTimeout(() =>
-    dispatch([
-      switchEditorMode(
-        EditorModes.textEditMode(elementPath, cursorPosition, 'existing', 'no-text-selection'),
-      ),
-    ]),
-  )
+  setTimeout(() => activateTextEditing(elementPath, dispatch))
+}
+
+function activateTextEditing(elementPath: ElementPath, dispatch: EditorDispatch): void {
+  dispatch([
+    selectComponents([elementPath], false),
+    switchEditorMode(EditorModes.textEditMode(elementPath, null, 'existing', 'no-text-selection')),
+  ])
 }

--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
@@ -52,6 +52,8 @@ describe('Text edit mode', () => {
       expect(
         EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
       ).toEqual('sb/39e')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
     })
     it('Entering text edit mode with pressing enter on a text editable selected element', async () => {
       const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
@@ -63,6 +65,8 @@ describe('Text edit mode', () => {
       expect(
         EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
       ).toEqual('sb/39e')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
     })
   })
 
@@ -77,6 +81,8 @@ describe('Text edit mode', () => {
       expect(
         EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
       ).toEqual('sb/39e')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
     })
   })
 })


### PR DESCRIPTION
**Problem:**
Editing text does not select the element, so e.g. they will not shown on the navigator, inspector, etc.

**Fix:**
Select the element when going to text edit mode.