### PR TITLE
Keyboard opacity strategy: stricter check of pressed keys

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
@@ -1,7 +1,7 @@
 import { shallowEqual } from '../../../../core/shared/equality-utils'
 import * as PP from '../../../../core/shared/property-path'
 import Keyboard, { KeyCharacter } from '../../../../utils/keyboard'
-import { emptyModifiers, Modifiers } from '../../../../utils/modifiers'
+import { emptyModifiers, Modifier, Modifiers } from '../../../../utils/modifiers'
 import { setProperty } from '../../commands/set-property-command'
 import {
   InteractionCanvasState,
@@ -74,13 +74,7 @@ export function parseOpacityFromKeyboard(keys: string): string | null {
 }
 
 function isSetOpacityShortcut(modifiers: Modifiers, key: KeyCharacter): boolean {
-  return (
-    modifiers.alt === false &&
-    modifiers.cmd === false &&
-    modifiers.ctrl === false &&
-    modifiers.shift === false &&
-    Keyboard.keyTriggersOpacityStrategy(key)
-  )
+  return Modifier.equal(modifiers, emptyModifiers) && Keyboard.keyTriggersOpacityStrategy(key)
 }
 
 function fitness(interactionSession: InteractionSession | null): number {

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
@@ -74,7 +74,13 @@ export function parseOpacityFromKeyboard(keys: string): string | null {
 }
 
 function isSetOpacityShortcut(modifiers: Modifiers, key: KeyCharacter): boolean {
-  return shallowEqual(modifiers, emptyModifiers) && Keyboard.keyTriggersOpacityStrategy(key)
+  return (
+    modifiers.alt === false &&
+    modifiers.cmd === false &&
+    modifiers.ctrl === false &&
+    modifiers.shift === false &&
+    Keyboard.keyTriggersOpacityStrategy(key)
+  )
 }
 
 function fitness(interactionSession: InteractionSession | null): number {


### PR DESCRIPTION
## Problem
Pressing option + cmd + 1 (which toggles the navigator) also triggered the keyboard opacity strategy, since it didn't check which keys were pressed strictly enough.

## Solution
Check both modifiers and keys pressed when determining the fithness of `keyboardSetOpacityStrategy` 