### PR TITLE
Fix/zero sized text elements

### DIFF
--- a/editor/src/components/canvas/controls/zero-sized-element-controls.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.spec.browser2.tsx
@@ -1,0 +1,81 @@
+import {
+  EditorRenderResult,
+  getPrintedUiJsCode,
+  makeTestProjectCodeWithSnippet,
+  renderTestEditorWithCode,
+  TestAppUID,
+  TestSceneUID,
+} from '../ui-jsx.test-utils'
+import { mouseDoubleClickAtPoint } from '../event-helpers.test-utils'
+import * as EP from '../../../core/shared/element-path'
+import { BakedInStoryboardUID } from '../../../core/model/scene-utils'
+import { selectComponents } from '../../editor/actions/meta-actions'
+import { ZeroSizedControlTestID } from './zero-sized-element-controls'
+import { ElementPath } from '../../../core/shared/project-file-types'
+
+async function selectTargetAndDoubleClickOnZeroSizeControl(
+  renderResult: EditorRenderResult,
+  target: ElementPath,
+  testID: string,
+) {
+  await renderResult.dispatch(selectComponents([target], false), true)
+
+  const zeroSizeControl = renderResult.renderedDOM.getByTestId(ZeroSizedControlTestID)
+  const element = renderResult.renderedDOM.getByTestId(testID)
+  const elementBounds = element.getBoundingClientRect()
+
+  const topLeftCorner = {
+    x: elementBounds.x,
+    y: elementBounds.y,
+  }
+  mouseDoubleClickAtPoint(zeroSizeControl, topLeftCorner)
+
+  await renderResult.getDispatchFollowUpActionsFinished()
+}
+
+describe('Zero sized element controls', () => {
+  it('double click on a span element opens text editor', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(
+        `<div style={{ ...props.style }} data-uid='aaa'>
+          <span style={{ position: 'absolute', top: 20, left: 20 }} data-uid='bbb' data-testid='bbb' />
+        </div>`,
+      ),
+      'await-first-dom-report',
+    )
+
+    const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/bbb`)
+    await selectTargetAndDoubleClickOnZeroSizeControl(renderResult, target, 'bbb')
+
+    expect(renderResult.getEditorState().editor.mode.type).toEqual('textEdit')
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<div style={{ ...props.style }} data-uid='aaa'>
+          <span style={{ position: 'absolute', top: 20, left: 20 }} data-uid='bbb' data-testid='bbb' />
+        </div>`,
+      ),
+    )
+  })
+
+  it('double click on a div element adds size', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(
+        `<div style={{ ...props.style }} data-uid='aaa'>
+          <div style={{ position: 'absolute', top: 20, left: 20 }} data-uid='bbb' data-testid='bbb' />
+        </div>`,
+      ),
+      'await-first-dom-report',
+    )
+
+    const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/bbb`)
+    await selectTargetAndDoubleClickOnZeroSizeControl(renderResult, target, 'bbb')
+
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<div style={{ ...props.style }} data-uid='aaa'>
+          <div style={{ position: 'absolute', top: 20, left: 20, width: 100, height: 100 }} data-uid='bbb' data-testid='bbb' />
+        </div>`,
+      ),
+    )
+  })
+})

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -31,6 +31,7 @@ import { styleStringInArray } from '../../../utils/common-constants'
 import { EditorModes } from '../../editor/editor-modes'
 import * as EditorActions from '../../editor/actions/action-creators'
 
+export const ZeroSizedControlTestID = 'zero-sized-control'
 interface ZeroSizedElementControlProps {
   showAllPossibleElements: boolean
 }
@@ -366,6 +367,7 @@ export const ZeroSizeResizeControl = React.memo((props: ZeroSizeResizeControlPro
         onMouseUp={onControlStopPropagation}
         onDoubleClick={onControlDoubleClick}
         className='role-resize-no-size'
+        data-testid={ZeroSizedControlTestID}
         style={{
           position: 'absolute',
           left: props.frame.x - ZeroControlSize / 2,

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -298,7 +298,7 @@ export const ZeroSizeResizeControl = React.memo((props: ZeroSizeResizeControlPro
       dispatch(
         [
           EditorActions.switchEditorMode(
-            EditorModes.textEditMode(element?.elementPath, null, 'existing', 'no-text-selection'),
+            EditorModes.textEditMode(element.elementPath, null, 'existing', 'no-text-selection'),
           ),
         ],
         'everyone',

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -28,6 +28,8 @@ import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
 import { controlForStrategyMemoized } from '../canvas-strategies/canvas-strategy-types'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { styleStringInArray } from '../../../utils/common-constants'
+import { EditorModes } from '../../editor/editor-modes'
+import * as EditorActions from '../../editor/actions/action-creators'
 
 interface ZeroSizedElementControlProps {
   showAllPossibleElements: boolean
@@ -270,7 +272,7 @@ interface ZeroSizeResizeControlProps {
   frame: CanvasRectangle
   scale: number
   color: string | null | undefined
-  element: ElementInstanceMetadata | null
+  element: ElementInstanceMetadata
   dispatch: EditorDispatch
   maybeClearHighlightsOnHoverEnd: () => void
 }
@@ -291,8 +293,19 @@ export const ZeroSizeResizeControl = React.memo((props: ZeroSizeResizeControlPro
   )
 
   const onControlDoubleClick = React.useCallback(() => {
-    let propsToSet: Array<{ path: PropertyPath; value: any }> = []
-    if (element != null) {
+    const isTextElement = MetadataUtils.isSpan(element)
+    if (isTextElement) {
+      dispatch(
+        [
+          EditorActions.switchEditorMode(
+            EditorModes.textEditMode(element?.elementPath, null, 'existing', 'no-text-selection'),
+          ),
+        ],
+        'everyone',
+      )
+    } else {
+      let propsToSet: Array<{ path: PropertyPath; value: any }> = []
+
       const isFlexParent = element.specialSizeMeasurements.parentLayoutSystem === 'flex'
       if (props.frame.width === 0 || element.specialSizeMeasurements.display === 'inline') {
         if (

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -1,5 +1,6 @@
 import { escape, unescape } from 'he'
 import React from 'react'
+import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { ElementInstanceMetadataMap } from '../../core/shared/element-template'
 import { ElementPath } from '../../core/shared/project-file-types'
 import * as PP from '../../core/shared/property-path'
@@ -157,6 +158,11 @@ export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
 
     currentElement.focus()
 
+    const element = MetadataUtils.findElementByElementPath(metadataRef.current, elementPath)
+    if (element?.globalFrame?.width === 0) {
+      currentElement.style.minWidth = '0.5px'
+    }
+
     return () => {
       const content = currentElement.textContent
       if (content != null) {
@@ -167,7 +173,7 @@ export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
         }
       }
     }
-  }, [dispatch, elementPath, elementState])
+  }, [dispatch, elementPath, elementState, metadataRef])
 
   React.useEffect(() => {
     if (myElement.current == null) {


### PR DESCRIPTION
**Fix:**
Double clicking on zero sized elements: span element enters text edit mode while div and component elements keep adding size props.
When this happens the text editor modifies the text editor min-width to show the blinking cursor, otherwise it's not visible because it has no size.

**Commit Details:**
- extend control double click callback
- tests
