### PR TITLE
Chore/use span for text editing

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -322,7 +322,6 @@ export function renderCoreElement(
     }
     case 'JSX_TEXT_BLOCK': {
       const parentPath = Utils.optionalMap(EP.parentPath, elementPath)
-      const lines = element.text.split('<br />').map((line) => unescapeHTML(line))
 
       // when the text is just edited its parent renders it in a text editor, so no need to render anything here
       if (parentPath != null && EP.pathsEqual(parentPath, editedText)) {
@@ -331,6 +330,7 @@ export function renderCoreElement(
         )
       }
 
+      const lines = element.text.split('<br />').map((line) => unescapeHTML(line))
       return (
         <>
           {lines.map((l, index) => (

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -52,7 +52,7 @@ import { optionalMap } from '../../../core/shared/optional-utils'
 import { canvasMissingJSXElementError } from './canvas-render-errors'
 import { importedFromWhere } from '../../editor/import-utils'
 import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../../core/shared/dom-utils'
-import { TextEditorWrapperWrapper, unescapeHTML } from '../../text-editor/text-editor'
+import { TextEditorWrapper, unescapeHTML } from '../../text-editor/text-editor'
 
 export function createLookupRender(
   elementPath: ElementPath | null,
@@ -326,9 +326,7 @@ export function renderCoreElement(
 
       // when the text is just edited its parent renders it in a text editor, so no need to render anything here
       if (parentPath != null && EP.pathsEqual(parentPath, editedText)) {
-        return (
-          <TextEditorWrapperWrapper elementPath={parentPath} text={unescapeHTML(element.text)} />
-        )
+        return <TextEditorWrapper elementPath={parentPath} text={unescapeHTML(element.text)} />
       }
 
       const textToRender = (

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -322,13 +322,16 @@ export function renderCoreElement(
     }
     case 'JSX_TEXT_BLOCK': {
       const parentPath = Utils.optionalMap(EP.parentPath, elementPath)
+      const lines = element.text.split('<br />').map((line) => unescapeHTML(line))
+
       // when the text is just edited its parent renders it in a text editor, so no need to render anything here
       if (parentPath != null && EP.pathsEqual(parentPath, editedText)) {
-        return <></>
+        return (
+          <TextEditorWrapperWrapper elementPath={parentPath} text={unescapeHTML(element.text)} />
+        )
       }
 
-      const lines = element.text.split('<br />').map((line) => unescapeHTML(line))
-      return (
+      const textToRender = (
         <>
           {lines.map((l, index) => (
             <React.Fragment key={index}>
@@ -338,6 +341,8 @@ export function renderCoreElement(
           ))}
         </>
       )
+
+      return textToRender
     }
     default:
       const _exhaustiveCheck: never = element
@@ -461,34 +466,6 @@ function renderJSXElement(
   }
 
   if (elementPath != null && validPaths.has(EP.makeLastPartOfPathStatic(elementPath))) {
-    if (elementIsTextEdited) {
-      const text = childrenWithNewTextBlock
-        .filter(filterJSXElementChildIsTextOrNewline)
-        .map((c) => (c.text != null ? c.text.trim() : '\n'))
-        .join('')
-      const textContent = unescapeHTML(text ?? '')
-      const textEditorProps = {
-        elementPath: elementPath,
-        text: textContent.trim(),
-        component: FinalElement,
-        passthroughProps: finalPropsIcludingElementPath,
-      }
-
-      return buildSpyWrappedElement(
-        jsx,
-        textEditorProps,
-        elementPath,
-        metadataContext,
-        updateInvalidatedPaths,
-        childrenElements,
-        TextEditorWrapperWrapper,
-        inScope,
-        jsxFactoryFunctionName,
-        shouldIncludeCanvasRootInTheSpy,
-        imports,
-        filePath,
-      )
-    }
     return buildSpyWrappedElement(
       jsx,
       finalPropsIcludingElementPath,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -326,10 +326,12 @@ export function renderCoreElement(
 
       // when the text is just edited its parent renders it in a text editor, so no need to render anything here
       if (parentPath != null && EP.pathsEqual(parentPath, editedText)) {
-        return <TextEditorWrapper elementPath={parentPath} text={unescapeHTML(element.text)} />
+        return (
+          <TextEditorWrapper elementPath={parentPath} text={unescapeHTML(element.text.trim())} />
+        )
       }
 
-      const textToRender = (
+      return (
         <>
           {lines.map((l, index) => (
             <React.Fragment key={index}>
@@ -339,8 +341,6 @@ export function renderCoreElement(
           ))}
         </>
       )
-
-      return textToRender
     }
     default:
       const _exhaustiveCheck: never = element

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -128,15 +128,15 @@ const handleSetFontWeightShortcut = (
   ]
 }
 
-export const TextEditorWrapperWrapper = React.memo((props: TextEditorProps) => {
+export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
   return (
     <MainEditorStoreProvider>
-      <TextEditorWrapper {...props} />
+      <TextEditor {...props} />
     </MainEditorStoreProvider>
   )
 })
 
-const TextEditorWrapper = React.memo((props: TextEditorProps) => {
+const TextEditor = React.memo((props: TextEditorProps) => {
   const { elementPath, text } = props
   const dispatch = useDispatch()
   const allElementProps = useEditorState(

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -289,6 +289,15 @@ const TextEditorWrapper = React.memo((props: TextEditorProps) => {
       onKeyUp={stopPropagation}
       onKeyPress={stopPropagation}
       onBlur={onBlur}
+      onClick={stopPropagation}
+      onContextMenu={stopPropagation}
+      onMouseDown={stopPropagation}
+      onMouseEnter={stopPropagation}
+      onMouseLeave={stopPropagation}
+      onMouseMove={stopPropagation}
+      onMouseOut={stopPropagation}
+      onMouseOver={stopPropagation}
+      onMouseUp={stopPropagation}
       contentEditable={'plaintext-only' as any} // note: not supported on firefox
       suppressContentEditableWarning={true}
     />
@@ -357,23 +366,6 @@ async function setSelectionToOffset(
   }
 }
 
-function stopPropagation(e: React.KeyboardEvent | React.ClipboardEvent) {
+function stopPropagation(e: React.KeyboardEvent | React.ClipboardEvent | React.MouseEvent) {
   e.stopPropagation()
-}
-
-function filterMouseHandlerProps(props: Record<string, any>) {
-  const {
-    onClick,
-    onContextMenu,
-    onDblClick,
-    onMouseDown,
-    onMouseEnter,
-    onMouseLeave,
-    onMouseMove,
-    onMouseOut,
-    onMouseOver,
-    onMouseUp,
-    ...filteredProps
-  } = props
-  return filteredProps
 }


### PR DESCRIPTION
**Problem:**
We agreed to always render a separate span for the text editor, because that is a simpler and less risky solution than the hack to inject content editability into the parent component.
E.g. that makes it impossible to type a space into a button, because that just presses the button itself.

**Fix:**
I remove all the wrapping functionality which patches the parent component, and just render the text editor as a span. I made sure the keyboard and mouse events are stopped, so the parent component don't react to them.

Disclaimer: button components will still animate on space, because that is not handled by a javascript event handler.