### PR TITLE
convert `width: 100%` to `flex-grow: 1` when adding `display: flex` to container

### DIFF
--- a/editor/src/components/inspector/add-remove-layout-system-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.spec.browser2.tsx
@@ -14,7 +14,10 @@ describe('add layout system', () => {
   })
 
   it('add and then remove flex layout', async () => {
-    const editor = await renderTestEditorWithCode(project(), 'await-first-dom-report')
+    const editor = await renderTestEditorWithCode(
+      project({ width: '100px', height: '100px' }),
+      'await-first-dom-report',
+    )
     const div = await selectDiv(editor)
     await clickOn(editor)
 
@@ -26,7 +29,10 @@ describe('add layout system', () => {
   })
 
   it('adding flex layout converts child `width` to `flexGrow`', async () => {
-    const editor = await renderTestEditorWithCode(project(), 'await-first-dom-report')
+    const editor = await renderTestEditorWithCode(
+      project({ width: '100%', height: '100px' }),
+      'await-first-dom-report',
+    )
     const div = await selectDiv(editor)
     await clickOn(editor)
 
@@ -34,6 +40,21 @@ describe('add layout system', () => {
 
     const child = editor.renderedDOM.getByTestId('child')
     expect(child.style.width).toEqual('')
+    expect(child.style.flexGrow).toEqual('1')
+  })
+
+  it('adding flex layout converts child `height` to `flexGrow` if flexDirection is set', async () => {
+    const editor = await renderTestEditorWithCode(
+      projectWithFlexDirectionColumn({ width: '111px', height: '100%' }),
+      'await-first-dom-report',
+    )
+    const div = await selectDiv(editor)
+    await clickOn(editor)
+
+    expect(div.style.display).toEqual('flex')
+
+    const child = editor.renderedDOM.getByTestId('child')
+    expect(child.style.height).toEqual('')
     expect(child.style.flexGrow).toEqual('1')
   })
 })
@@ -58,7 +79,7 @@ async function clickOn(editor: EditorRenderResult) {
   mouseClickAtPoint(flexDirectionToggle, { x: 2, y: 2 })
 }
 
-function project(): string {
+function project({ width, height }: { width: string; height: string }): string {
   return `import * as React from 'react'
       import { Storyboard } from 'utopia-api'
       
@@ -80,8 +101,48 @@ function project(): string {
               data-testid='child'
               style={{
                 backgroundColor: '#aaaaaa33',
-                width: '100%',
-                height: 190,
+                width: '${width}',
+                height: '${height}'
+              }}
+              data-uid='9e4'
+            />
+          </div>
+        </Storyboard>
+      )
+      `
+}
+
+function projectWithFlexDirectionColumn({
+  width,
+  height,
+}: {
+  width: string
+  height: string
+}): string {
+  return `import * as React from 'react'
+      import { Storyboard } from 'utopia-api'
+      
+      export var storyboard = (
+        <Storyboard data-uid='0cd'>
+          <div
+            data-testid='mydiv'
+            style={{
+              backgroundColor: '#aaaaaa33',
+              position: 'absolute',
+              left: 133,
+              top: 228,
+              width: 342,
+              height: 368,
+              flexDirection: 'column'
+            }}
+            data-uid='5f9'
+          >
+            <div
+              data-testid='child'
+              style={{
+                backgroundColor: '#aaaaaa33',
+                width: '${width}',
+                height: '${height}'
               }}
               data-uid='9e4'
             />

--- a/editor/src/components/inspector/add-remove-layout-system-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.spec.browser2.tsx
@@ -24,6 +24,18 @@ describe('add layout system', () => {
 
     expect(div.style.display).toEqual('')
   })
+
+  it('adding flex layout converts child `width` to `flexGrow`', async () => {
+    const editor = await renderTestEditorWithCode(project(), 'await-first-dom-report')
+    const div = await selectDiv(editor)
+    await clickOn(editor)
+
+    expect(div.style.display).toEqual('flex')
+
+    const child = editor.renderedDOM.getByTestId('child')
+    expect(child.style.width).toEqual('')
+    expect(child.style.flexGrow).toEqual('1')
+  })
 })
 
 async function selectDiv(editor: EditorRenderResult): Promise<HTMLElement> {
@@ -65,9 +77,10 @@ function project(): string {
             data-uid='5f9'
           >
             <div
+              data-testid='child'
               style={{
                 backgroundColor: '#aaaaaa33',
-                width: 195,
+                width: '100%',
                 height: 190,
               }}
               data-uid='9e4'

--- a/editor/src/components/inspector/inspector-common.tsx
+++ b/editor/src/components/inspector/inspector-common.tsx
@@ -254,22 +254,30 @@ export function widthHeightFromAxis(axis: Axis): 'width' | 'height' {
 export function convertWidthToFlexGrow(
   metadata: ElementInstanceMetadataMap,
   elementPath: ElementPath,
+  parentPath: ElementPath,
 ): Array<CanvasCommand> {
   const element = MetadataUtils.getJSXElementFromMetadata(metadata, elementPath)
   if (element == null) {
     return []
   }
+
+  const parentFlexDirection =
+    MetadataUtils.findElementByElementPath(metadata, parentPath)?.computedStyle?.[
+      'flexDirection'
+    ] ?? 'row'
+  const prop = parentFlexDirection.startsWith('row') ? 'width' : 'height'
+
   const matches =
     defaultEither(
       null,
-      getSimpleAttributeAtPath(right(element.props), PP.create(['style', 'width'])),
+      getSimpleAttributeAtPath(right(element.props), PP.create(['style', prop])),
     ) === '100%'
 
   if (!matches) {
     return []
   }
   return [
-    deleteProperties('always', elementPath, [PP.create(['style', 'width'])]),
+    deleteProperties('always', elementPath, [PP.create(['style', prop])]),
     setProperty('always', elementPath, PP.create(['style', 'flexGrow']), 1),
   ]
 }

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
@@ -79,7 +79,7 @@ export const addFlexLayoutStrategies: Array<InspectorStrategy> = [
     return elementPaths.flatMap((path) => [
       setProperty('always', path, PP.create(['style', 'display']), 'flex'),
       ...MetadataUtils.getChildrenPaths(metadata, path).flatMap((child) =>
-        convertWidthToFlexGrow(metadata, child),
+        convertWidthToFlexGrow(metadata, child, path),
       ),
     ])
   },

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
@@ -2,6 +2,7 @@ import * as PP from '../../../core/shared/property-path'
 import { setProperty } from '../../canvas/commands/set-property-command'
 import {
   Axis,
+  convertWidthToFlexGrow,
   fillContainerApplicable,
   filterKeepFlexContainers,
   FlexAlignment,
@@ -74,9 +75,12 @@ export const updateFlexDirectionStrategies = (
 
 export const addFlexLayoutStrategies: Array<InspectorStrategy> = [
   (metadata, elementPaths) => {
-    return elementPaths.map((path) =>
+    return elementPaths.flatMap((path) => [
       setProperty('always', path, PP.create(['style', 'display']), 'flex'),
-    )
+      ...MetadataUtils.getChildrenPaths(metadata, path).flatMap((child) =>
+        convertWidthToFlexGrow(metadata, child),
+      ),
+    ])
   },
 ]
 


### PR DESCRIPTION
## Description
`flex-grow: 1` is the preferred way to make a child element expand to fill available space in a flex container, so when converting a container to flex, we convert `width: 100%` to `flex-grow: 1` on all children