### PR TITLE
rename `runStrategies` to `executeFirstApplicableStrategy`

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -15,7 +15,7 @@ import { getMetadata } from '../../../editor/store/editor-state'
 import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
 import { invert } from '../../../inspector/inspector-common'
 import { setPropHugStrategies } from '../../../inspector/inspector-strategies/inspector-strategies'
-import { runFirstApplicableStrategy } from '../../../inspector/inspector-strategies/inspector-strategy'
+import { executeFirstApplicableStrategy } from '../../../inspector/inspector-strategies/inspector-strategy'
 import CanvasActions from '../../canvas-actions'
 import { controlForStrategyMemoized } from '../../canvas-strategies/canvas-strategy-types'
 import { createInteractionViaMouse } from '../../canvas-strategies/interaction-state'
@@ -246,7 +246,7 @@ const ResizeEdge = React.memo(
           return
         }
 
-        runFirstApplicableStrategy(
+        executeFirstApplicableStrategy(
           dispatch,
           metadataRef.current,
           selectedElementsRef.current,

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -15,7 +15,7 @@ import { getMetadata } from '../../../editor/store/editor-state'
 import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
 import { invert } from '../../../inspector/inspector-common'
 import { setPropHugStrategies } from '../../../inspector/inspector-strategies/inspector-strategies'
-import { runStrategies } from '../../../inspector/inspector-strategies/inspector-strategy'
+import { runFirstApplicableStrategy } from '../../../inspector/inspector-strategies/inspector-strategy'
 import CanvasActions from '../../canvas-actions'
 import { controlForStrategyMemoized } from '../../canvas-strategies/canvas-strategy-types'
 import { createInteractionViaMouse } from '../../canvas-strategies/interaction-state'
@@ -246,7 +246,7 @@ const ResizeEdge = React.memo(
           return
         }
 
-        runStrategies(
+        runFirstApplicableStrategy(
           dispatch,
           metadataRef.current,
           selectedElementsRef.current,

--- a/editor/src/components/inspector/add-remove-layout-system-control.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.tsx
@@ -18,7 +18,7 @@ import {
   removeFlexLayoutStrategies,
 } from './inspector-strategies/inspector-strategies'
 import { detectAreElementsFlexContainers } from './inspector-common'
-import { runFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
+import { executeFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
 import { useDispatch } from '../editor/store/dispatch-context'
 
 export const AddRemoveLayouSystemControlTestId = (): string => 'AddRemoveLayouSystemControlTestId'
@@ -38,7 +38,7 @@ export const AddRemoveLayouSystemControl = React.memo<AddRemoveLayoutSystemContr
 
   const addLayoutSystem = React.useCallback(
     () =>
-      runFirstApplicableStrategy(
+      executeFirstApplicableStrategy(
         dispatch,
         elementMetadataRef.current,
         selectedViewsRef.current,
@@ -49,7 +49,7 @@ export const AddRemoveLayouSystemControl = React.memo<AddRemoveLayoutSystemContr
 
   const removeLayoutSystem = React.useCallback(
     () =>
-      runFirstApplicableStrategy(
+      executeFirstApplicableStrategy(
         dispatch,
         elementMetadataRef.current,
         selectedViewsRef.current,

--- a/editor/src/components/inspector/add-remove-layout-system-control.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.tsx
@@ -18,7 +18,7 @@ import {
   removeFlexLayoutStrategies,
 } from './inspector-strategies/inspector-strategies'
 import { detectAreElementsFlexContainers } from './inspector-common'
-import { runStrategies } from './inspector-strategies/inspector-strategy'
+import { runFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
 import { useDispatch } from '../editor/store/dispatch-context'
 
 export const AddRemoveLayouSystemControlTestId = (): string => 'AddRemoveLayouSystemControlTestId'
@@ -38,7 +38,7 @@ export const AddRemoveLayouSystemControl = React.memo<AddRemoveLayoutSystemContr
 
   const addLayoutSystem = React.useCallback(
     () =>
-      runStrategies(
+      runFirstApplicableStrategy(
         dispatch,
         elementMetadataRef.current,
         selectedViewsRef.current,
@@ -49,7 +49,7 @@ export const AddRemoveLayouSystemControl = React.memo<AddRemoveLayoutSystemContr
 
   const removeLayoutSystem = React.useCallback(
     () =>
-      runStrategies(
+      runFirstApplicableStrategy(
         dispatch,
         elementMetadataRef.current,
         selectedViewsRef.current,

--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -33,7 +33,10 @@ import {
   setPropFixedStrategies,
   setPropHugStrategies,
 } from './inspector-strategies/inspector-strategies'
-import { runStrategies, InspectorStrategy } from './inspector-strategies/inspector-strategy'
+import {
+  runFirstApplicableStrategy,
+  InspectorStrategy,
+} from './inspector-strategies/inspector-strategy'
 
 export const controlId = (segment: 'width' | 'height'): string => `hug-fixed-fill-${segment}`
 
@@ -228,7 +231,7 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
     ({ value: anyValue }: SelectOption) => {
       const value = anyValue as FixedHugFillMode
       const strategy = strategyForMode(heightComputedValueRef.current, 'vertical', value)
-      runStrategies(dispatch, metadataRef.current, selectedViewsRef.current, strategy)
+      runFirstApplicableStrategy(dispatch, metadataRef.current, selectedViewsRef.current, strategy)
     },
     [dispatch, heightComputedValueRef, metadataRef, selectedViewsRef],
   )
@@ -236,7 +239,7 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
   const onAdjustHeight = React.useCallback(
     (value: number | EmptyInputValue) => {
       if (typeof value === 'number') {
-        runStrategies(
+        runFirstApplicableStrategy(
           dispatch,
           metadataRef.current,
           selectedViewsRef.current,
@@ -253,7 +256,7 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
   const onAdjustWidth = React.useCallback(
     (value: number | EmptyInputValue) => {
       if (typeof value === 'number') {
-        runStrategies(
+        runFirstApplicableStrategy(
           dispatch,
           metadataRef.current,
           selectedViewsRef.current,
@@ -271,7 +274,7 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
     ({ value: anyValue }: SelectOption) => {
       const value = anyValue as FixedHugFillMode
       const strategy = strategyForMode(widthComputedValueRef.current, 'horizontal', value)
-      runStrategies(dispatch, metadataRef.current, selectedViewsRef.current, strategy)
+      runFirstApplicableStrategy(dispatch, metadataRef.current, selectedViewsRef.current, strategy)
     },
     [dispatch, metadataRef, selectedViewsRef, widthComputedValueRef],
   )

--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -34,7 +34,7 @@ import {
   setPropHugStrategies,
 } from './inspector-strategies/inspector-strategies'
 import {
-  runFirstApplicableStrategy,
+  executeFirstApplicableStrategy,
   InspectorStrategy,
 } from './inspector-strategies/inspector-strategy'
 
@@ -231,7 +231,12 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
     ({ value: anyValue }: SelectOption) => {
       const value = anyValue as FixedHugFillMode
       const strategy = strategyForMode(heightComputedValueRef.current, 'vertical', value)
-      runFirstApplicableStrategy(dispatch, metadataRef.current, selectedViewsRef.current, strategy)
+      executeFirstApplicableStrategy(
+        dispatch,
+        metadataRef.current,
+        selectedViewsRef.current,
+        strategy,
+      )
     },
     [dispatch, heightComputedValueRef, metadataRef, selectedViewsRef],
   )
@@ -239,7 +244,7 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
   const onAdjustHeight = React.useCallback(
     (value: number | EmptyInputValue) => {
       if (typeof value === 'number') {
-        runFirstApplicableStrategy(
+        executeFirstApplicableStrategy(
           dispatch,
           metadataRef.current,
           selectedViewsRef.current,
@@ -256,7 +261,7 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
   const onAdjustWidth = React.useCallback(
     (value: number | EmptyInputValue) => {
       if (typeof value === 'number') {
-        runFirstApplicableStrategy(
+        executeFirstApplicableStrategy(
           dispatch,
           metadataRef.current,
           selectedViewsRef.current,
@@ -274,7 +279,12 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
     ({ value: anyValue }: SelectOption) => {
       const value = anyValue as FixedHugFillMode
       const strategy = strategyForMode(widthComputedValueRef.current, 'horizontal', value)
-      runFirstApplicableStrategy(dispatch, metadataRef.current, selectedViewsRef.current, strategy)
+      executeFirstApplicableStrategy(
+        dispatch,
+        metadataRef.current,
+        selectedViewsRef.current,
+        strategy,
+      )
     },
     [dispatch, metadataRef, selectedViewsRef, widthComputedValueRef],
   )

--- a/editor/src/components/inspector/flex-direction-control.tsx
+++ b/editor/src/components/inspector/flex-direction-control.tsx
@@ -17,7 +17,7 @@ import {
   removeFlexDirectionStrategies,
   updateFlexDirectionStrategies,
 } from './inspector-strategies/inspector-strategies'
-import { runFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
+import { executeFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
 
 const nFlexContainersSelector = createSelector(
   metadataSelector,
@@ -122,5 +122,5 @@ function maybeSetFlexDirection(
     desiredFlexDirection == null
       ? removeFlexDirectionStrategies()
       : updateFlexDirectionStrategies(desiredFlexDirection)
-  runFirstApplicableStrategy(dispatch, metadata, selectedViews, strategies)
+  executeFirstApplicableStrategy(dispatch, metadata, selectedViews, strategies)
 }

--- a/editor/src/components/inspector/flex-direction-control.tsx
+++ b/editor/src/components/inspector/flex-direction-control.tsx
@@ -17,7 +17,7 @@ import {
   removeFlexDirectionStrategies,
   updateFlexDirectionStrategies,
 } from './inspector-strategies/inspector-strategies'
-import { runStrategies } from './inspector-strategies/inspector-strategy'
+import { runFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
 
 const nFlexContainersSelector = createSelector(
   metadataSelector,
@@ -122,5 +122,5 @@ function maybeSetFlexDirection(
     desiredFlexDirection == null
       ? removeFlexDirectionStrategies()
       : updateFlexDirectionStrategies(desiredFlexDirection)
-  runStrategies(dispatch, metadata, selectedViews, strategies)
+  runFirstApplicableStrategy(dispatch, metadata, selectedViews, strategies)
 }

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategy.tsx
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategy.tsx
@@ -9,7 +9,7 @@ export type InspectorStrategy = (
   selectedElementPaths: Array<ElementPath>,
 ) => Array<CanvasCommand> | null
 
-export function runStrategies(
+export function runFirstApplicableStrategy(
   dispatch: EditorDispatch,
   metadata: ElementInstanceMetadataMap,
   selectedViews: ElementPath[],

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategy.tsx
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategy.tsx
@@ -9,7 +9,7 @@ export type InspectorStrategy = (
   selectedElementPaths: Array<ElementPath>,
 ) => Array<CanvasCommand> | null
 
-export function runFirstApplicableStrategy(
+export function executeFirstApplicableStrategy(
   dispatch: EditorDispatch,
   metadata: ElementInstanceMetadataMap,
   selectedViews: ElementPath[],

--- a/editor/src/components/inspector/nine-block-controls.tsx
+++ b/editor/src/components/inspector/nine-block-controls.tsx
@@ -22,7 +22,7 @@ import {
   StartCenterEnd,
 } from './inspector-common'
 import { setFlexAlignJustifyContentStrategies } from './inspector-strategies/inspector-strategies'
-import { runFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
+import { executeFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
 
 export const NineBlockTestId = (
   alignItems: FlexAlignment,
@@ -259,7 +259,7 @@ export const NineBlockControl = React.memo(() => {
       const strategies = isFlexColumn(flexDirectionRef.current ?? DefaultFlexDirection)
         ? setFlexAlignJustifyContentStrategies(intendedJustifyContent, intendedFlexAlignment)
         : setFlexAlignJustifyContentStrategies(intendedFlexAlignment, intendedJustifyContent)
-      runFirstApplicableStrategy(
+      executeFirstApplicableStrategy(
         dispatch,
         metadataRef.current,
         selectedViewsRef.current,

--- a/editor/src/components/inspector/nine-block-controls.tsx
+++ b/editor/src/components/inspector/nine-block-controls.tsx
@@ -22,7 +22,7 @@ import {
   StartCenterEnd,
 } from './inspector-common'
 import { setFlexAlignJustifyContentStrategies } from './inspector-strategies/inspector-strategies'
-import { runStrategies } from './inspector-strategies/inspector-strategy'
+import { runFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
 
 export const NineBlockTestId = (
   alignItems: FlexAlignment,
@@ -259,7 +259,12 @@ export const NineBlockControl = React.memo(() => {
       const strategies = isFlexColumn(flexDirectionRef.current ?? DefaultFlexDirection)
         ? setFlexAlignJustifyContentStrategies(intendedJustifyContent, intendedFlexAlignment)
         : setFlexAlignJustifyContentStrategies(intendedFlexAlignment, intendedJustifyContent)
-      runStrategies(dispatch, metadataRef.current, selectedViewsRef.current, strategies)
+      runFirstApplicableStrategy(
+        dispatch,
+        metadataRef.current,
+        selectedViewsRef.current,
+        strategies,
+      )
     },
     [dispatch, flexDirectionRef, metadataRef, selectedViewsRef],
   )


### PR DESCRIPTION
## Description
rename `runStrategies` to `executeFirstApplicableStrategy`, as it describes the inner workings of the function better (since it doesn't run all the strategies passed to it, just the first matching one)