### PR TITLE
Always render a span for the text editor

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -52,7 +52,7 @@ import { optionalMap } from '../../../core/shared/optional-utils'
 import { canvasMissingJSXElementError } from './canvas-render-errors'
 import { importedFromWhere } from '../../editor/import-utils'
 import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../../core/shared/dom-utils'
-import { TextEditorWrapperWrapper, unescapeHTML } from '../../text-editor/text-editor'
+import { TextEditorWrapper, unescapeHTML } from '../../text-editor/text-editor'
 
 export function createLookupRender(
   elementPath: ElementPath | null,
@@ -481,7 +481,7 @@ function renderJSXElement(
         metadataContext,
         updateInvalidatedPaths,
         childrenElements,
-        TextEditorWrapperWrapper,
+        TextEditorWrapper,
         inScope,
         jsxFactoryFunctionName,
         shouldIncludeCanvasRootInTheSpy,

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -364,7 +364,7 @@ async function setSelectionToOffset(
   }
 }
 
-function stopPropagation(e: React.KeyboardEvent | React.ClipboardEvent | React.MouseEvent) {
+function stopPropagation(e: React.UIEvent | React.ClipboardEvent) {
   e.stopPropagation()
 }
 

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -127,15 +127,15 @@ const handleSetFontWeightShortcut = (
   ]
 }
 
-export const TextEditorWrapperWrapper = React.memo((props: TextEditorProps) => {
+export const TextEditorWrapper = React.memo((props: TextEditorProps) => {
   return (
     <MainEditorStoreProvider>
-      <TextEditorWrapper {...props} />
+      <TextEditor {...props} />
     </MainEditorStoreProvider>
   )
 })
 
-const TextEditorWrapper = React.memo((props: TextEditorProps) => {
+const TextEditor = React.memo((props: TextEditorProps) => {
   const { elementPath, text, component, passthroughProps } = props
   const dispatch = useDispatch()
   const cursorPosition = useEditorState(
@@ -284,19 +284,21 @@ const TextEditorWrapper = React.memo((props: TextEditorProps) => {
     onKeyUp: stopPropagation,
     onKeyPress: stopPropagation,
     onBlur: onBlur,
+    onClick: stopPropagation,
+    onContextMenu: stopPropagation,
+    onMouseDown: stopPropagation,
+    onMouseEnter: stopPropagation,
+    onMouseLeave: stopPropagation,
+    onMouseMove: stopPropagation,
+    onMouseOut: stopPropagation,
+    onMouseOver: stopPropagation,
+    onMouseUp: stopPropagation,
     contentEditable: 'plaintext-only' as any, // note: not supported on firefox,
     suppressContentEditableWarning: true,
   }
 
-  const filteredPassthroughProps = filterMouseHandlerProps(passthroughProps)
+  const filteredPassthroughProps = filterEventHandlerProps(passthroughProps)
 
-  // When the component to render is a simple html element we should make that contenteditable
-  if (typeof component === 'string') {
-    return React.createElement(component, {
-      ...filteredPassthroughProps,
-      ...editorProps,
-    })
-  }
   return React.createElement(component, filteredPassthroughProps, <span {...editorProps} />)
 })
 
@@ -362,11 +364,11 @@ async function setSelectionToOffset(
   }
 }
 
-function stopPropagation(e: React.KeyboardEvent | React.ClipboardEvent) {
+function stopPropagation(e: React.KeyboardEvent | React.ClipboardEvent | React.MouseEvent) {
   e.stopPropagation()
 }
 
-function filterMouseHandlerProps(props: Record<string, any>) {
+function filterEventHandlerProps(props: Record<string, any>) {
   const {
     onClick,
     onContextMenu,
@@ -378,6 +380,10 @@ function filterMouseHandlerProps(props: Record<string, any>) {
     onMouseOut,
     onMouseOver,
     onMouseUp,
+    onPaste,
+    onKeyDown,
+    onKeyUp,
+    onKeyPress,
     ...filteredProps
   } = props
   return filteredProps

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -283,7 +283,6 @@ const TextEditor = React.memo((props: TextEditorProps) => {
     onKeyDown: onKeyDown,
     onKeyUp: stopPropagation,
     onKeyPress: stopPropagation,
-    onBlur: onBlur,
     onClick: stopPropagation,
     onContextMenu: stopPropagation,
     onMouseDown: stopPropagation,
@@ -293,6 +292,7 @@ const TextEditor = React.memo((props: TextEditorProps) => {
     onMouseOut: stopPropagation,
     onMouseOver: stopPropagation,
     onMouseUp: stopPropagation,
+    onBlur: onBlur,
     contentEditable: 'plaintext-only' as any, // note: not supported on firefox,
     suppressContentEditableWarning: true,
   }


### PR DESCRIPTION
**Problem:**
Another try for https://github.com/concrete-utopia/utopia/pull/3093/
It seems you can not prevent an onClick with stopping the propagation of events, you have to preventDefault, but that disables text editing.
So I did not find any better solution then to remove the keyboard and mouse handler props from the parent element. There can be still components which react to these events, but that is a rarer occurence.
The real solution will be to extract the text editor to a control layer, but until then this PR makes the situation better.
