### PR TITLE
Double click should only text edit non empty elements

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -715,7 +715,7 @@ function useSelectOrLiveModeSelectAndHover(
             editorActions.push(setFocusedElement(foundTarget.elementPath))
           }
 
-          const isEditableText = MetadataUtils.targetTextEditable(
+          const isEditableText = MetadataUtils.targetTextEditableAndHasText(
             editorStoreRef.current.editor.jsxMetadata,
             foundTarget.elementPath,
           )

--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
@@ -50,8 +50,32 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
       expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
     })
+    it('Clicking on selected text editable but empty element should not enter text edit mode', async () => {
+      const editor = await renderTestEditorWithCode(projectWithEmptyText, 'await-first-dom-report')
+      await selectElement(editor, EP.fromString('sb/39e'))
+      await clickOnElement(editor, 'div', 'double-click')
+      // wait for the next frame
+      await wait(1)
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
+    })
     it('Entering text edit mode with pressing enter on a text editable selected element', async () => {
       const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
+      await selectElement(editor, EP.fromString('sb/39e'))
+      pressKey('enter')
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
+      expect(
+        EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
+      ).toEqual('sb/39e')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
+    })
+    it('Entering text edit mode with pressing enter on a text editable but empty selected element', async () => {
+      const editor = await renderTestEditorWithCode(projectWithEmptyText, 'await-first-dom-report')
       await selectElement(editor, EP.fromString('sb/39e'))
       pressKey('enter')
       await editor.getDispatchFollowUpActionsFinished()
@@ -127,6 +151,28 @@ export var storyboard = (
     >
       Hello
     </div>
+  </Storyboard>
+)
+`)
+
+const projectWithEmptyText = formatTestProjectCode(`import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      data-testid='div'
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 288,
+        height: 362,
+      }}
+      data-uid='39e'
+    />
   </Storyboard>
 )
 `)

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -869,6 +869,22 @@ export const MetadataUtils = {
       .some((e) => e !== 'br')
     return children.length === 0 || !hasNonEditableChildren
   },
+  targetTextEditableAndHasText(
+    metadata: ElementInstanceMetadataMap,
+    target: ElementPath | null,
+  ): boolean {
+    if (!MetadataUtils.targetTextEditable(metadata, target)) {
+      return false
+    }
+
+    const element = MetadataUtils.findElementByElementPath(metadata, target)
+    if (element == null) {
+      return false
+    }
+
+    const textContent = MetadataUtils.getTextContentOfElement(element)
+    return textContent != null && textContent.length > 0
+  },
   getTextContentOfElement(element: ElementInstanceMetadata): string | null {
     if (isRight(element.element) && isJSXElement(element.element.value)) {
       if (element.element.value.children.length === 1) {


### PR DESCRIPTION
**Problem:**
It is too easy to accidentally text edit something which is not supposed to be a text element.
Furthermore, double click is used for focusing components, but now lot of times we accidentally enter text editing instead of that.

**Fix:**
Only allow double click to enter text editing when the element already has existing text.