### PR TITLE
fix(canvas) text editing can scroll the canvas

### DIFF
--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -758,6 +758,21 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
     event.preventDefault()
   }
 
+  updateCanvasOffsetViaScroll = (event: React.UIEvent<HTMLElement, UIEvent>): void => {
+    if (this.canvasWrapperRef != null) {
+      const scrollDelta = {
+        x: this.canvasWrapperRef.scrollLeft / this.props.model.scale,
+        y: this.canvasWrapperRef.scrollTop / this.props.model.scale,
+      } as CanvasVector
+
+      // Reset wrapper scroll first
+      this.canvasWrapperRef.scrollTo({ left: 0, top: 0 })
+
+      // Update canvasOffset
+      this.props.dispatch([CanvasActions.scrollCanvas(scrollDelta)], 'canvas')
+    }
+  }
+
   componentDidMount() {
     if (this.canvasWrapperRef != null) {
       // Due to the introduction of this https://www.chromestatus.com/features/6662647093133312 combined with
@@ -1064,6 +1079,9 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
               'canvas',
             )
           }
+        },
+        onScroll: (event) => {
+          this.updateCanvasOffsetViaScroll(event)
         },
       },
       nodeConnectorsDiv,


### PR DESCRIPTION
**Problem:**
When writing in text edit mode without fixed width/height set on the span near the edge of the screen the text content can scroll the canvas away automatically. After finishing text editing canvas interactions are incorrectly positioned as our canvas offset is not following this change.

**Fix:**
I found that the 'canvas-root' div receives the scroll event triggered by text editing. When this happens I dispatch the action to update the canvas offset and also reset the scroll offset of the canvas-root div.

**Commit Details:**
- `EditorCanvas ` receives `onScroll` event handler
