### PR TITLE
Fix checking existing text content for existing element

### DIFF
--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -882,8 +882,13 @@ export const MetadataUtils = {
       return false
     }
 
-    const textContent = MetadataUtils.getTextContentOfElement(element)
-    return textContent != null && textContent.length > 0
+    if (isRight(element.element) && isJSXElement(element.element.value)) {
+      const elementValue = element.element.value
+      return (
+        elementValue.children.length >= 1 && elementValue.children.some((c) => isJSXTextBlock(c))
+      )
+    }
+    return false
   },
   getTextContentOfElement(element: ElementInstanceMetadata): string | null {
     if (isRight(element.element) && isJSXElement(element.element.value)) {


### PR DESCRIPTION
**Problem:**
My recent PR https://github.com/concrete-utopia/utopia/pull/3099 is buggy: `getTextContentOfElement` only returns the content when there are no multiple children, so it doesn't support multiline texts

**Fix:**
I changed the implementation to support multiline text when all the children are text editable.

