### PR TITLE
Text edit mode multiline tests

### DIFF
--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
@@ -50,6 +50,23 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
       expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
     })
+    it('Entering text edit mode with double click on selected multiline text editable element', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithMultilineText,
+        'await-first-dom-report',
+      )
+      await selectElement(editor, EP.fromString('sb/39e'))
+      await clickOnElement(editor, 'div', 'double-click')
+      // wait for the next frame
+      await wait(1)
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
+      expect(
+        EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
+      ).toEqual('sb/39e')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
+    })
     it('Clicking on selected text editable but empty element should not enter text edit mode', async () => {
       const editor = await renderTestEditorWithCode(projectWithEmptyText, 'await-first-dom-report')
       await selectElement(editor, EP.fromString('sb/39e'))
@@ -63,6 +80,22 @@ describe('Text edit mode', () => {
     })
     it('Entering text edit mode with pressing enter on a text editable selected element', async () => {
       const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
+      await selectElement(editor, EP.fromString('sb/39e'))
+      pressKey('enter')
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
+      expect(
+        EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
+      ).toEqual('sb/39e')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
+    })
+    it('Entering text edit mode with pressing enter on a multiline text editable selected element', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithMultilineText,
+        'await-first-dom-report',
+      )
       await selectElement(editor, EP.fromString('sb/39e'))
       pressKey('enter')
       await editor.getDispatchFollowUpActionsFinished()
@@ -92,6 +125,22 @@ describe('Text edit mode', () => {
   describe('Click to choose target text for editing', () => {
     it('Click to select text editable target', async () => {
       const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
+
+      pressKey('t')
+      await clickOnElement(editor, 'div')
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
+      expect(
+        EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
+      ).toEqual('sb/39e')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
+    })
+    it('Click to select multiline text editable target', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithMultilineText,
+        'await-first-dom-report',
+      )
 
       pressKey('t')
       await clickOnElement(editor, 'div')
@@ -150,6 +199,31 @@ export var storyboard = (
       data-uid='39e'
     >
       Hello
+    </div>
+  </Storyboard>
+)
+`)
+
+const projectWithMultilineText = formatTestProjectCode(`import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      data-testid='div'
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 288,
+        height: 362,
+      }}
+      data-uid='39e'
+    >
+      Hello<br />
+      Utopia
     </div>
   </Storyboard>
 )


### PR DESCRIPTION
**Description:**
Followup PR to https://github.com/concrete-utopia/utopia/pull/3104
Double click to text edit was broken on multiline tests, and the tests did not detect it.
I added multiple tests to check entering text mode in the different ways all work with multine text elements too.

