### PR TITLE
Fix clicking in text edited div outside of text content bounds

### DIFF
--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -298,9 +298,17 @@ const TextEditor = React.memo((props: TextEditorProps) => {
     dispatch([updateEditorMode(EditorModes.selectMode())])
   }, [dispatch])
 
-  const editorProps = {
+  const editorProps: React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLSpanElement>,
+    HTMLSpanElement
+  > = {
     ref: myElement,
     id: TextEditorSpanId,
+    style: {
+      display: 'inline-block',
+      width: '100%',
+      height: '100%',
+    },
     onPaste: stopPropagation,
     onKeyDown: onKeyDown,
     onKeyUp: stopPropagation,


### PR DESCRIPTION
**Problem:**
If you edit text in an element, and you click outside of the text contents, but inside the element, you will accidentally close the text editor.

**Fix:**
The reason is that the text editor span is not stretched to fill its parent.

