### PR TITLE
display the border radius controls for intrinsic elements even if it's not defined

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.spec.browser2.tsx
@@ -1,4 +1,4 @@
-import { appendNewElementPath, elementPath, fromString } from '../../../../core/shared/element-path'
+import { fromString } from '../../../../core/shared/element-path'
 import {
   canvasVector,
   CanvasVector,
@@ -9,7 +9,6 @@ import {
 } from '../../../../core/shared/math-utils'
 import { assertNever } from '../../../../core/shared/utils'
 import { cmdModifier, emptyModifiers, Modifiers } from '../../../../utils/modifiers'
-import { wait } from '../../../../utils/utils.test-utils'
 import { selectComponents } from '../../../editor/actions/action-creators'
 import { BorderRadiusCorner, BorderRadiusCorners } from '../../border-radius-control-utils'
 import { EdgePosition, EdgePositionBottomRight } from '../../canvas-types'
@@ -53,7 +52,7 @@ describe('set border radius strategy', () => {
     expect(borderRadiusControls.length).toEqual(4)
   })
 
-  it("border radius controls don't show up for elements that have don't border radius set", async () => {
+  it("border radius controls do show up for elements that have don't border radius set", async () => {
     const editor = await renderTestEditorWithCode(codeForDragTest(``), 'await-first-dom-report')
 
     const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
@@ -66,11 +65,11 @@ describe('set border radius strategy', () => {
 
     mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
 
-    const paddingControls = BorderRadiusCorners.flatMap((corner) =>
+    const borderRadiusControls = BorderRadiusCorners.flatMap((corner) =>
       editor.renderedDOM.queryAllByTestId(CircularHandleTestId(corner)),
     )
 
-    expect(paddingControls).toEqual([])
+    expect(borderRadiusControls.length).toEqual(4)
   })
 
   it("border radius controls don't show up for elements that are smaller than 40px", async () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -230,10 +230,14 @@ function borderRadiusFromElement(
           fromProps,
         )
 
+        const defaultBorderRadiusSides = borderRadiusSidesFromValue(
+          unitlessCSSNumberWithRenderedValue(0),
+        )
+
         if (borderRadius == null && isElementIntrinsic) {
           return {
             mode: 'all',
-            borderRadius: borderRadiusSidesFromValue(unitlessCSSNumberWithRenderedValue(0)),
+            borderRadius: defaultBorderRadiusSides,
           }
         }
 
@@ -249,7 +253,7 @@ function borderRadiusFromElement(
           mode: fromProps?.type === 'sides' ? 'individual' : 'all',
           borderRadius: mapBorderRadiusSides(
             (n) => adjustBorderRadius(borderRadiusMinMax, n),
-            borderRadius,
+            borderRadius ?? defaultBorderRadiusSides,
           ),
         }
       } else {

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -2,13 +2,12 @@ import { styleStringInArray } from '../../../../utils/common-constants'
 import { Sides } from 'utopia-api/core'
 import { getLayoutProperty } from '../../../../core/layout/getLayoutProperty'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
-import { defaultEither, foldEither, isLeft, isRight, right } from '../../../../core/shared/either'
+import { defaultEither, foldEither, right } from '../../../../core/shared/either'
 import {
   ElementInstanceMetadata,
   isIntrinsicElement,
   isJSXElement,
   JSXAttributes,
-  JSXElement,
   jsxElementName,
   jsxElementNameEquals,
 } from '../../../../core/shared/element-template'
@@ -212,9 +211,10 @@ function borderRadiusFromElement(
           }
         })
 
+        const isElementIntrinsic = isIntrinsicElement(jsxElement.name)
+
         const elementIsIntrinsicElementOrScene =
-          isIntrinsicElement(jsxElement.name) ||
-          jsxElementNameEquals(jsxElement.name, jsxElementName('Scene', []))
+          isElementIntrinsic || jsxElementNameEquals(jsxElement.name, jsxElementName('Scene', []))
 
         if (
           !(
@@ -230,14 +230,10 @@ function borderRadiusFromElement(
           fromProps,
         )
 
-        if (borderRadius == null) {
-          if (elementIsIntrinsicElementOrScene) {
-            return null
-          } else {
-            return {
-              mode: 'all',
-              borderRadius: borderRadiusSidesFromValue(unitlessCSSNumberWithRenderedValue(0)),
-            }
+        if (borderRadius == null && isElementIntrinsic) {
+          return {
+            mode: 'all',
+            borderRadius: borderRadiusSidesFromValue(unitlessCSSNumberWithRenderedValue(0)),
           }
         }
 

--- a/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import * as EP from '../../../../core/shared/element-path'
 import { CanvasVector, Size, windowPoint } from '../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
-import { isFeatureEnabled } from '../../../../utils/feature-switches'
 import { Modifier } from '../../../../utils/modifiers'
 import { when } from '../../../../utils/react-conditionals'
 import { useColorTheme } from '../../../../uuiui'
@@ -70,7 +69,7 @@ export const BorderRadiusControl = controlForStrategyMemoized<BorderRadiusContro
 
   const hoveredViews = useEditorState(
     Substores.highlightedHoveredViews,
-    (store) => store.editor.highlightedViews,
+    (store) => store.editor.hoveredViews,
     'BorderRadiusControl hoveredViews',
   )
 


### PR DESCRIPTION
## Problem
During usability testing, it turned out that when using divs to build a UI, if one wants to set `border-radius`, first it has to be set via the inspector, and only then can the actual on-canvas controls be used.

## Solution
Update the border radius visibility rules in `borderRadiusFromElement` to use a default border radius value if the selected element is an intrinsic element and it doesn't have a border radius value set.

## Details
- update border radius control visibility ruleset
- check `hoveredViews` instead of `highlightedViews` to determine whether the border radius control should be set to `visible` (this was a regression)