### PR TITLE
Fix/text editor fix default cursor

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
@@ -2,6 +2,8 @@ import { EditorModes } from '../../../../components/editor/editor-modes'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
 import { updateSelectedRightMenuTab } from '../../../editor/actions/actions'
+import { CSSCursor } from '../../canvas-types'
+import { setCursorCommand } from '../../commands/set-cursor-command'
 import { updateSelectedViews } from '../../commands/update-selected-views-command'
 import { wildcardPatch } from '../../commands/wildcard-patch-command'
 import { canvasPointToWindowPoint } from '../../dom-lookup'
@@ -81,6 +83,7 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
         if (!isRoot && textEditable) {
           return strategyApplicationResult([
             updateSelectedViews('on-complete', [targetParent]),
+            setCursorCommand(CSSCursor.Select),
             wildcardPatch('on-complete', {
               mode: {
                 $set: EditorModes.textEditMode(

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -160,7 +160,7 @@ export const NewCanvasControls = React.memo((props: NewCanvasControlsProps) => {
   if (isLiveMode(canvasControlProps.editorMode) && !canvasControlProps.keysPressed.cmd) {
     return null
   } else if (isTextEditMode(canvasControlProps.editorMode)) {
-    return <TextEditCanvasOverlay />
+    return <TextEditCanvasOverlay cursor={props.cursor} />
   } else {
     return (
       <div

--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-canvas-overlay.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-canvas-overlay.tsx
@@ -1,8 +1,13 @@
 import React from 'react'
 import { Substores, useEditorState } from '../../../editor/store/store-hook'
 import { TextEditorSpanId } from '../../../text-editor/text-editor'
+import { CSSCursor } from '../../canvas-types'
 
-export const TextEditCanvasOverlay = React.memo(() => {
+interface TextEditCanvasOverlayProps {
+  cursor: CSSCursor
+}
+
+export const TextEditCanvasOverlay = React.memo((props: TextEditCanvasOverlayProps) => {
   const scale = useEditorState(
     Substores.canvasOffset,
     (store) => store.editor.canvas.scale,
@@ -53,6 +58,7 @@ export const TextEditCanvasOverlay = React.memo(() => {
         height: `${scale < 1 ? 100 / scale : 100}%`,
         transformOrigin: 'top left',
         transform: scale < 1 ? `scale(${scale}) ` : '',
+        cursor: props.cursor,
       }}
     />
   )

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -150,7 +150,7 @@ function getDefaultCursorForMode(mode: Mode): CSSCursor {
     case 'live':
       return CSSCursor.BrowserAuto
     case 'textEdit':
-      return CSSCursor.Insert
+      return CSSCursor.Select
     default:
       const _exhaustiveCheck: never = mode
       throw `Unable to get default cursor for unsupported mode ${(mode as any).type}`


### PR DESCRIPTION
**Problem:**
When in text edit mode the cursor switches back to default.

**Fix:**
Pass cursor prop to text edit overlay and use it. I also noticed that the default text edit mode cursor is 'Insert', but it's actually not in insert mode, so I changed it to 'Select' cursor.

Small fix during insertion: On hover on a text editable field in insert mode shows 'Select' cursor too.

**Commit Details:**
- update`TextEditCanvasOverlay` 
- when mouseover on 'textEditable' field during insert strategy the set cursor command is added
