### PR TITLE
Support retaining UIDs when changing multiple elements

### DIFF
--- a/editor/src/core/workers/parser-printer/uid-fix.spec.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.spec.ts
@@ -162,6 +162,47 @@ describe('fixParseSuccessUIDs', () => {
     `)
   })
 
+  it('multiple uid changes but the number of elements stays the same', () => {
+    const threeViews = lintAndParse('test.js', fileWithTwoDuplicatedViews, null, emptySet())
+    const updatedThreeViews = lintAndParse(
+      'test.js',
+      fileWithTwoDuplicatedViewsWithChanges,
+      asParseSuccessOrNull(threeViews),
+      emptySet(),
+    )
+    expect(getUidTree(updatedThreeViews)).toEqual(getUidTree(threeViews))
+  })
+
+  it('re-ordered elements should re-order the uid tree', () => {
+    const beforeReOrder = lintAndParse('test.js', fileWithOneInsertedView, null, emptySet())
+    const afterReOrder = lintAndParse(
+      'test.js',
+      fileWithOneInsertedViewReOrdered,
+      asParseSuccessOrNull(beforeReOrder),
+      emptySet(),
+    )
+    expect(getUidTree(beforeReOrder)).toMatchInlineSnapshot(`
+      "4ed
+        random-uuid
+      001
+        a2e
+        f6d
+      storyboard
+        scene
+          component"
+    `)
+    expect(getUidTree(afterReOrder)).toMatchInlineSnapshot(`
+      "4ed
+        random-uuid
+      001
+        f6d
+        a2e
+      storyboard
+        scene
+          component"
+    `)
+  })
+
   it('uids should match including root element when root element changes', () => {
     const firstResult = lintAndParse('test.js', baseFileContents, null, emptySet())
     const secondResult = lintAndParse(
@@ -335,6 +376,27 @@ export var SameFileApp = (props) => {
 }
 `)
 
+const fileWithOneInsertedViewReOrdered = createFileText(`
+export var SameFileApp = (props) => {
+  return (
+    <div
+      style={{ position: 'relative', width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
+    >
+      <View
+        style={{
+          width: 191,
+        }}
+      />
+      <View
+        style={{
+          width: 100,
+        }}
+      />
+    </div>
+  )
+}
+`)
+
 const fileWithTwoDuplicatedViews = createFileText(`
 export var SameFileApp = (props) => {
   return (
@@ -385,6 +447,35 @@ export var SameFileApp = (props) => {
       <View
         style={{
           width: 191,
+        }}
+      />
+    </div>
+  )
+}
+`)
+
+const fileWithTwoDuplicatedViewsWithChanges = createFileText(`
+export var SameFileApp = (props) => {
+  return (
+    <div
+      style={{ position: 'relative', width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
+    >
+      <View
+        style={{
+          width: 191,
+          height: 100,
+        }}
+      />
+      <View
+        style={{
+          width: 191,
+          height: 200,
+        }}
+      />
+      <View
+        style={{
+          width: 191,
+          height: 300,
         }}
       />
     </div>

--- a/editor/src/core/workers/parser-printer/uid-fix.spec.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.spec.ts
@@ -173,6 +173,28 @@ describe('fixParseSuccessUIDs', () => {
     expect(getUidTree(updatedThreeViews)).toEqual(getUidTree(threeViews))
   })
 
+  it('can handle text children fine', () => {
+    const start = lintAndParse('test.js', fileWithTwoTextElements, null, emptySet())
+    const end = lintAndParse(
+      'test.js',
+      fileWithTwoTextElementsWithChanges,
+      asParseSuccessOrNull(start),
+      emptySet(),
+    )
+    expect(getUidTree(end)).toEqual(getUidTree(start))
+  })
+
+  it('can handle changes to a parent and child', () => {
+    const start = lintAndParse('test.js', baseFileContents, null, emptySet())
+    const end = lintAndParse(
+      'test.js',
+      fileWithChildAndParentUpdated,
+      asParseSuccessOrNull(start),
+      emptySet(),
+    )
+    expect(getUidTree(end)).toEqual(getUidTree(start))
+  })
+
   it('re-ordered elements should re-order the uid tree', () => {
     const beforeReOrder = lintAndParse('test.js', fileWithOneInsertedView, null, emptySet())
     const afterReOrder = lintAndParse(
@@ -348,6 +370,22 @@ export var SameFileApp = (props) => {
       <View
         style={{
           width: 101, // <- this is updated
+        }}
+      />
+    </div>
+  )
+}
+`)
+
+const fileWithChildAndParentUpdated = createFileText(`
+export var SameFileApp = (props) => {
+  return (
+    <div
+      style={{ position: 'relative', width: '150', height: '100%', backgroundColor: '#FFFFFF' }}
+    >
+      <View
+        style={{
+          width: 150,
         }}
       />
     </div>
@@ -574,6 +612,56 @@ export var SameFileApp = (props) => {
       style={{ position: 'relative', width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
     >
       <div><div>Hello</div></div>
+    </div>
+  )
+}
+`)
+
+const fileWithTwoTextElements = createFileText(`
+export var SameFileApp = (props) => {
+  return (
+    <div
+      style={{ position: 'relative', width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
+    >
+      <div
+        style={{
+          width: 100,
+        }}
+      >
+      Hello
+      </div>
+      <div
+        style={{
+          width: 200,
+        }}
+      >
+      There
+      </div>
+    </div>
+  )
+}
+`)
+
+const fileWithTwoTextElementsWithChanges = createFileText(`
+export var SameFileApp = (props) => {
+  return (
+    <div
+      style={{ position: 'relative', width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
+    >
+      <div
+        style={{
+          width: 150,
+        }}
+      >
+      Hello,
+      </div>
+      <div
+        style={{
+          width: 250,
+        }}
+      >
+      There!
+      </div>
     </div>
   )
 }

--- a/editor/src/core/workers/parser-printer/uid-fix.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.ts
@@ -47,7 +47,7 @@ export function fixParseSuccessUIDs(
     }
   } = {}
 
-  zipTopLevelElements(
+  const numberOfElementsMatch = zipTopLevelElements(
     oldParsed.topLevelElements,
     newParsed.topLevelElements,
     (
@@ -70,8 +70,10 @@ export function fixParseSuccessUIDs(
 
   const newToOldUidMappingArray = Object.values(newToOldUidMapping)
 
-  if (newToOldUidMappingArray.length === 1) {
-    // we found a single UID mismatch, which means there's a very good chance that it was an update element, let's fix that up
+  if (newToOldUidMappingArray.length === 1 || numberOfElementsMatch) {
+    // we found a single UID mismatch, or the total number of elements has stayed the same,
+    // which means there's a very good chance that it was an update to existing elements,
+    // or a single new element was inserted
     let workingComponents = getComponentsFromTopLevelElements(newParsed.topLevelElements)
 
     newToOldUidMappingArray.forEach((mapping) => {
@@ -144,22 +146,28 @@ function zipTopLevelElements(
   firstTopLevelElements: Array<TopLevelElement>,
   secondTopLevelElements: Array<TopLevelElement>,
   onElement: OnElement,
-): void {
+): boolean {
   const firstComponents = getComponentsFromTopLevelElements(firstTopLevelElements)
   const secondComponents = getComponentsFromTopLevelElements(secondTopLevelElements)
+
+  const lengthsMatchAtThisLevel = firstComponents.length === secondComponents.length
+  let numberOfElementsMatch = lengthsMatchAtThisLevel
 
   firstComponents.forEach((firstComponent, index) => {
     if (secondComponents.length > index) {
       const secondComponent = secondComponents[index]
 
-      walkElementChildren(
+      const lengthsOfChildrenMatch = walkElementChildren(
         EP.emptyElementPathPart,
         [firstComponent.rootElement],
         [secondComponent.rootElement],
         onElement,
       )
+      numberOfElementsMatch = numberOfElementsMatch && lengthsOfChildrenMatch
     }
   })
+
+  return numberOfElementsMatch
 }
 
 function walkElementsWithin(
@@ -167,17 +175,29 @@ function walkElementsWithin(
   oldElements: ElementsWithin,
   newElements: ElementsWithin,
   onElement: OnElement,
-): void {
+): boolean {
   const oldElementKeys = Object.keys(oldElements)
   const newElementKeys = Object.keys(newElements)
+
+  const lengthsMatchAtThisLevel = newElementKeys.length === oldElementKeys.length
+  let numberOfElementsMatch = lengthsMatchAtThisLevel
+
   newElementKeys.forEach((elementKey, index) => {
     const newElement = newElements[elementKey]
     const oldElementKey: string | null = oldElementKeys[index] ?? null
     const oldElement: JSXElementChild | null =
       oldElementKey == null ? null : oldElements[oldElementKey] ?? null
 
-    compareAndWalkElements(oldElement, newElement, pathSoFar, onElement)
+    const lengthsOfChildrenMatch = compareAndWalkElements(
+      oldElement,
+      newElement,
+      pathSoFar,
+      onElement,
+    )
+    numberOfElementsMatch = numberOfElementsMatch && lengthsOfChildrenMatch
   })
+
+  return numberOfElementsMatch
 }
 
 function walkElementChildren(
@@ -185,12 +205,23 @@ function walkElementChildren(
   oldElements: Array<JSXElementChild>,
   newElements: Array<JSXElementChild>,
   onElement: OnElement,
-): void {
+): boolean {
+  const lengthsMatchAtThisLevel = newElements.length === oldElements.length
+  let numberOfElementsMatch = lengthsMatchAtThisLevel
+
   newElements.forEach((newElement, index) => {
     const oldElement: JSXElementChild | null = oldElements[index] ?? null
 
-    compareAndWalkElements(oldElement, newElement, pathSoFar, onElement)
+    const lengthsOfChildrenMatch = compareAndWalkElements(
+      oldElement,
+      newElement,
+      pathSoFar,
+      onElement,
+    )
+    numberOfElementsMatch = numberOfElementsMatch && lengthsOfChildrenMatch
   })
+
+  return numberOfElementsMatch
 }
 
 function compareAndWalkElements(
@@ -198,7 +229,7 @@ function compareAndWalkElements(
   newElement: JSXElementChild,
   pathSoFar: StaticElementPathPart,
   onElement: OnElement,
-) {
+): boolean {
   /**
    * this first version works by trying to match up indexes. this is really primitive.
    * here's some ideas how could we improve it
@@ -213,11 +244,18 @@ function compareAndWalkElements(
       const path = EP.appendToElementPath(pathSoFar, newUid)
       const oldPathToRestore = EP.appendToElementPath(pathSoFar, oldUID)
       onElement(oldUID, newUid, oldPathToRestore, path)
-      walkElementChildren(path, oldElement.children, newElement.children, onElement)
+      return walkElementChildren(path, oldElement.children, newElement.children, onElement)
     } else if (isJSXFragment(oldElement) && isJSXFragment(newElement)) {
-      walkElementChildren(pathSoFar, oldElement.children, newElement.children, onElement)
+      return walkElementChildren(pathSoFar, oldElement.children, newElement.children, onElement)
     } else if (isJSXArbitraryBlock(oldElement) && isJSXArbitraryBlock(newElement)) {
-      walkElementsWithin(pathSoFar, oldElement.elementsWithin, newElement.elementsWithin, onElement)
+      return walkElementsWithin(
+        pathSoFar,
+        oldElement.elementsWithin,
+        newElement.elementsWithin,
+        onElement,
+      )
     }
   }
+
+  return false
 }

--- a/editor/src/core/workers/parser-printer/uid-fix.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.ts
@@ -3,6 +3,7 @@ import {
   isJSXArbitraryBlock,
   isJSXElement,
   isJSXFragment,
+  isJSXTextBlock,
   isUtopiaJSXComponent,
   JSXElementChild,
   TopLevelElement,
@@ -75,6 +76,10 @@ export function fixParseSuccessUIDs(
     // which means there's a very good chance that it was an update to existing elements,
     // or a single new element was inserted
     let workingComponents = getComponentsFromTopLevelElements(newParsed.topLevelElements)
+
+    // We need to sort the array first, as the pathToModify will be based on the new UIDs up to the leaf,
+    // so we must update the deepest elements first
+    newToOldUidMappingArray.sort((l, r) => r.pathToModify.length - l.pathToModify.length)
 
     newToOldUidMappingArray.forEach((mapping) => {
       const oldPathAlreadyExistingElement = findJSXElementChildAtPath(
@@ -254,6 +259,8 @@ function compareAndWalkElements(
         newElement.elementsWithin,
         onElement,
       )
+    } else if (isJSXTextBlock(oldElement) && isJSXTextBlock(newElement)) {
+      return true
     }
   }
 


### PR DESCRIPTION
Fixes #3108

**Problem:**
The uid-fix behaviour is a bit too strict, and fails if there are changes to multiple elements at the same time.

**Fix:**
If we discover more than one UID in the file has changed, we then check that the number of elements has stayed the same, in which case we assume that we're still fine to retain the old UIDs. This also requires us to sort the results in descending order of the length of `pathsToModify`, since those are based on the new UIDs and not the old ones (meaning that correcting a parent's UID would then prevent us from being able to also correct a child's UID).

I've also added a test to check that element re-ordering is still compatible with this change.