### PR TITLE
Fix brittle solution for forced reparsing

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -22,7 +22,6 @@ import {
   applyToAllUIJSFiles,
   applyUtopiaJSXComponentsChanges,
   assetFile,
-  canUpdateFile,
   directory,
   fileTypeFromFileName,
   getHighlightBoundsFromParseResult,
@@ -37,6 +36,7 @@ import {
   switchToFileType,
   uniqueProjectContentID,
   updateFileContents,
+  updateFileIfPossible,
   updateParsedTextFileHighlightBounds,
 } from '../../../core/model/project-file-utils'
 import { getStoryboardElementPath, PathForSceneDataLabel } from '../../../core/model/scene-utils'
@@ -3714,32 +3714,31 @@ export const UPDATE_FNS = {
 
     const { file } = action
 
-    if (isTextFile(file)) {
-      const existing = getContentsTreeFileFromString(editor.projectContents, action.filePath)
-      const canUpdate = canUpdateFile(file, existing)
-      if (!canUpdate) {
-        return editor
-      }
+    const existing = getContentsTreeFileFromString(editor.projectContents, action.filePath)
+    const updatedFile = updateFileIfPossible(file, existing)
+
+    if (updatedFile == null) {
+      return editor
     }
 
     const updatedProjectContents = addFileToProjectContents(
       editor.projectContents,
       action.filePath,
-      file,
+      updatedFile,
     )
 
     let updatedNodeModulesFiles = editor.nodeModules.files
     let packageLoadingStatus: PackageStatusMap = {}
 
     // Ensure dependencies are updated if the `package.json` file has been changed.
-    if (action.filePath === '/package.json' && isTextFile(file)) {
+    if (action.filePath === '/package.json' && isTextFile(updatedFile)) {
       const packageJson = packageJsonFileFromProjectContents(editor.projectContents)
       const currentDeps = isTextFile(packageJson)
         ? dependenciesFromPackageJsonContents(packageJson.fileContents.code)
         : null
       void refreshDependencies(
         dispatch,
-        file.fileContents.code,
+        updatedFile.fileContents.code,
         currentDeps,
         builtInDependencies,
         editor.nodeModules.files,
@@ -3752,9 +3751,9 @@ export const UPDATE_FNS = {
       canvas: {
         ...editor.canvas,
         canvasContentInvalidateCount:
-          editor.canvas.canvasContentInvalidateCount + (isTextFile(file) ? 0 : 1),
+          editor.canvas.canvasContentInvalidateCount + (isTextFile(updatedFile) ? 0 : 1),
         domWalkerInvalidateCount:
-          editor.canvas.domWalkerInvalidateCount + (isTextFile(file) ? 0 : 1),
+          editor.canvas.domWalkerInvalidateCount + (isTextFile(updatedFile) ? 0 : 1),
       },
       nodeModules: {
         ...editor.nodeModules,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3717,7 +3717,7 @@ export const UPDATE_FNS = {
     const existing = getContentsTreeFileFromString(editor.projectContents, action.filePath)
     const updatedFile = updateFileIfPossible(file, existing)
 
-    if (updatedFile == null) {
+    if (updatedFile === 'cant-update') {
       return editor
     }
 

--- a/editor/src/components/editor/store/editor-state.spec.ts
+++ b/editor/src/components/editor/store/editor-state.spec.ts
@@ -23,6 +23,7 @@ import {
   isParseSuccess,
   parseSuccess,
   ParseSuccess,
+  RevisionsState,
 } from '../../../core/shared/project-file-types'
 import { addImport, emptyImports } from '../../../core/workers/common/project-file-utils'
 import { omit } from '../../../core/shared/object-utils'
@@ -243,7 +244,7 @@ describe('Revision state management', () => {
     const resultingFile = getTextFileByPath(actualResult.projectContents, '/src/app.js')
     expect(resultingFile.fileContents.revisionsState).toEqual('PARSED_AHEAD')
   })
-  it('updating PARSED_AHEAD_NEEDS_REPARSING revision state to PARSED_AHEAD keeps PARSED_AHEAD_NEEDS_REPARSING', () => {
+  it('updating RevisionsState.ParsedAheadNeedsReparsing to ParsedAhead keeps ParsedAheadNeedsReparsing', () => {
     const pathToElement = EP.fromString('app-outer-div/card-instance')
 
     // This is just initialization, make /src/app.js PARSED_AHEAD
@@ -260,12 +261,12 @@ describe('Revision state management', () => {
         return jsxElement(element.name, element.uid, updatedAttributes, element.children)
       },
       defaultModifyParseSuccess,
-      'PARSED_AHEAD_NEEDS_REPARSING',
+      RevisionsState.ParsedAheadNeedsReparsing,
     )
     const resultingFile = getTextFileByPath(actualResult.projectContents, '/src/app.js')
 
-    // This is the tested feature, PARSED_AHEAD_NEEDS_REPARSING should be kept even if
-    // it is tried to be updated to PARSED_AHEAD
+    // This is the tested feature, RevisionsState.ParsedAheadNeedsReparsing should be kept even if
+    // it is tried to be updated to RevisionsState.ParsedAhead
     const actualResult2 = modifyUnderlyingTarget(
       pathToElement,
       '/src/app.js',
@@ -282,6 +283,8 @@ describe('Revision state management', () => {
       'PARSED_AHEAD',
     )
     const resultingFile2 = getTextFileByPath(actualResult2.projectContents, '/src/app.js')
-    expect(resultingFile2.fileContents.revisionsState).toEqual('PARSED_AHEAD_NEEDS_REPARSING')
+    expect(resultingFile2.fileContents.revisionsState).toEqual(
+      RevisionsState.ParsedAheadNeedsReparsing,
+    )
   })
 })

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -56,6 +56,7 @@ import {
   HighlightBoundsWithFileForUids,
   parseSuccess,
   ParsedAheadRevisionsState,
+  RevisionsStateType,
 } from '../../../core/shared/project-file-types'
 import { diagnosticToErrorMessage } from '../../../core/workers/ts/ts-utils'
 import {
@@ -3015,9 +3016,17 @@ export function modifyParseSuccessAtPath(
       if (updatedParseSuccess === parsedFileContents) {
         return editor
       } else {
+        const updatedRevisionState = getNextRevisionsState(
+          projectFile.fileContents.revisionsState,
+          revisionsState,
+        )
         const updatedFile = saveTextFileContents(
           projectFile,
-          textFileContents(projectFile.fileContents.code, updatedParseSuccess, revisionsState),
+          textFileContents(
+            projectFile.fileContents.code,
+            updatedParseSuccess,
+            updatedRevisionState,
+          ),
           false,
         )
         return {
@@ -3110,6 +3119,19 @@ export function modifyUnderlyingTarget(
     innerModifyParseSuccess,
     revisionsState,
   )
+}
+
+function getNextRevisionsState(
+  prevRevisionState: RevisionsStateType,
+  nextRevisionState: ParsedAheadRevisionsState,
+): ParsedAheadRevisionsState {
+  if (
+    prevRevisionState === 'PARSED_AHEAD_NEEDS_REPARSING' &&
+    nextRevisionState === 'PARSED_AHEAD'
+  ) {
+    return 'PARSED_AHEAD_NEEDS_REPARSING'
+  }
+  return nextRevisionState
 }
 
 export function modifyUnderlyingForOpenFile(

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -3126,10 +3126,10 @@ function getNextRevisionsState(
   nextRevisionState: ParsedAheadRevisionsState,
 ): ParsedAheadRevisionsState {
   if (
-    prevRevisionState === 'PARSED_AHEAD_NEEDS_REPARSING' &&
-    nextRevisionState === 'PARSED_AHEAD'
+    prevRevisionState === RevisionsState.ParsedAheadNeedsReparsing &&
+    nextRevisionState === RevisionsState.ParsedAhead
   ) {
-    return 'PARSED_AHEAD_NEEDS_REPARSING'
+    return RevisionsState.ParsedAheadNeedsReparsing
   }
   return nextRevisionState
 }

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -471,7 +471,7 @@ export function isOlderThan(maybeNew: ProjectFile, existing: ProjectFile | null)
 export function updateFileIfPossible(
   updated: ProjectFile,
   existing: ProjectFile | null,
-): ProjectFile | null {
+): ProjectFile | 'cant-update' {
   if (existing == null || !isTextFile(existing)) {
     return updated
   }
@@ -501,7 +501,7 @@ export function updateFileIfPossible(
     return updated
   }
 
-  return null
+  return 'cant-update'
 }
 
 export function updateUiJsCode(file: TextFile, code: string, codeIsNowAhead: boolean): TextFile {

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -484,17 +484,17 @@ export function updateFileIfPossible(
       existing.fileContents.revisionsState,
     )
   ) {
-    // we should not overwrite PARSED_AHEAD_NEEDS_REPARSING with PARSED_AHEAD, because we don't want to lose that
+    // we should not overwrite RevisionsState.ParsedAheadNeedsReparsing with RevisionsState.ParsedAhead, because we don't want to lose that
     // the file needs reparsing
     if (
-      existing.fileContents.revisionsState === 'PARSED_AHEAD_NEEDS_REPARSING' &&
-      updated.fileContents.revisionsState === 'PARSED_AHEAD'
+      existing.fileContents.revisionsState === RevisionsState.ParsedAheadNeedsReparsing &&
+      updated.fileContents.revisionsState === RevisionsState.ParsedAhead
     ) {
       return {
         ...updated,
         fileContents: {
           ...updated.fileContents,
-          revisionsState: 'PARSED_AHEAD_NEEDS_REPARSING',
+          revisionsState: RevisionsState.ParsedAheadNeedsReparsing,
         },
       }
     }


### PR DESCRIPTION
**Problem:**
The introduction of `RevisionsState.ParsedAheadNeedsReparsing` [#3082](https://github.com/concrete-utopia/utopia/pull/3082)) has been proven to be far too brittle (see [#3106](https://github.com/concrete-utopia/utopia/pull/3106) where the revisions state was previously being accidentally overwritten),

**Fix:**
I updated `modifyParseSuccessAtPath` and the `UPDATE_FILE` action:
- when the existing file has the revision state `RevisionsState.ParsedAheadNeedsReparsing`, and we try to set it to `RevisionsState.ParsedAhead`, we should keep it as ``RevisionsState.ParsedAheadNeedsReparsing`, because we don't want to lose the information that this file needs to be reparsed.