### PR TITLE
Remove old jsx regex when escaping html

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -491,7 +491,7 @@ function renderJSXElement(
       const text = mapDropNulls(textOrNullFromJSXElement, childrenWithNewTextBlock)
         .map(trimTextBeforeNewline)
         .join('')
-      const textContent = unescapeHTML(text ?? '', { renderCurlyBraces: true })
+      const textContent = unescapeHTML(text ?? '')
       const textEditorProps = {
         elementPath: elementPath,
         filePath: filePath,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -491,7 +491,7 @@ function renderJSXElement(
       const text = mapDropNulls(textOrNullFromJSXElement, childrenWithNewTextBlock)
         .map(trimTextBeforeNewline)
         .join('')
-      const textContent = unescapeHTML(text ?? '')
+      const textContent = unescapeHTML(text ?? '', { renderCurlyBraces: true })
       const textEditorProps = {
         elementPath: elementPath,
         filePath: filePath,

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -635,50 +635,6 @@ describe('Use the text editor', () => {
       )
       expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('the answer is 42')
     })
-    it('supports escaping curly braces', async () => {
-      const editor = await renderTestEditorWithCode(projectWithoutText, 'await-first-dom-report')
-
-      await enterTextEditMode(editor)
-      typeText('the answer is \\{41 + 1\\}')
-      closeTextEditor()
-
-      await editor.getDispatchFollowUpActionsFinished()
-      await wait(50)
-
-      expect(editor.getEditorState().editor.mode.type).toEqual('select')
-      expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-        formatTestProjectCode(`
-              import * as React from 'react'
-              import { Storyboard } from 'utopia-api'
-
-
-              export var storyboard = (
-                <Storyboard data-uid='sb'>
-                  <div
-                    data-testid='div'
-                    style={{
-                      backgroundColor: '#0091FFAA',
-                      position: 'absolute',
-                      left: 0,
-                      top: 0,
-                      width: 288,
-                      height: 362,
-                    }}
-                    data-uid='39e'
-                  >the answer is &#123;41 + 1&#125;</div>
-                </Storyboard>
-              )`),
-      )
-      expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('the answer is {41 + 1}')
-
-      await enterTextEditMode(editor) // reopening the editor dislpays the slashes
-      await editor.getDispatchFollowUpActionsFinished()
-      await wait(50)
-      expect(editor.renderedDOM.getByTestId('div').innerText).toEqual(
-        'the answer is \\{41 + 1\\}\n',
-      )
-      closeTextEditor()
-    })
   })
 })
 

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -607,7 +607,7 @@ describe('Use the text editor', () => {
       closeTextEditor()
 
       await editor.getDispatchFollowUpActionsFinished()
-      await wait(500)
+      await wait(50)
 
       expect(editor.getEditorState().editor.mode.type).toEqual('select')
       expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
@@ -634,6 +634,50 @@ describe('Use the text editor', () => {
               )`),
       )
       expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('the answer is 42')
+    })
+    it('supports escaping curly braces', async () => {
+      const editor = await renderTestEditorWithCode(projectWithoutText, 'await-first-dom-report')
+
+      await enterTextEditMode(editor)
+      typeText('the answer is \\{41 + 1\\}')
+      closeTextEditor()
+
+      await editor.getDispatchFollowUpActionsFinished()
+      await wait(50)
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
+      expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+        formatTestProjectCode(`
+              import * as React from 'react'
+              import { Storyboard } from 'utopia-api'
+
+
+              export var storyboard = (
+                <Storyboard data-uid='sb'>
+                  <div
+                    data-testid='div'
+                    style={{
+                      backgroundColor: '#0091FFAA',
+                      position: 'absolute',
+                      left: 0,
+                      top: 0,
+                      width: 288,
+                      height: 362,
+                    }}
+                    data-uid='39e'
+                  >the answer is &#123;41 + 1&#125;</div>
+                </Storyboard>
+              )`),
+      )
+      expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('the answer is {41 + 1}')
+
+      await enterTextEditMode(editor) // reopening the editor dislpays the slashes
+      await editor.getDispatchFollowUpActionsFinished()
+      await wait(50)
+      expect(editor.renderedDOM.getByTestId('div').innerText).toEqual(
+        'the answer is \\{41 + 1\\}\n',
+      )
+      closeTextEditor()
     })
   })
 })

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -64,21 +64,12 @@ export function escapeHTML(s: string): string {
       .replace('>', entities.greaterThan)
       // restore br tags
       .replace(/\n/g, '\n<br />')
-      // escape curly braces
-      .replace(/\\\{/g, entities.curlyBraceLeft)
-      .replace(/\\\}/g, entities.curlyBraceRight)
   )
 }
 
 // editor → canvas
-export function unescapeHTML(s: string, options?: { renderCurlyBraces?: boolean }): string {
-  let replaced = s
-  if (options?.renderCurlyBraces === true) {
-    replaced = replaced
-      .replace(new RegExp(entities.curlyBraceLeft, 'g'), '\\{')
-      .replace(new RegExp(entities.curlyBraceRight, 'g'), '\\}')
-  }
-  const unescaped = unescape(replaced).replace(/ +$/, '') // prettier fix
+export function unescapeHTML(s: string): string {
+  const unescaped = unescape(s).replace(/ +$/, '') // prettier fix
 
   // We need to add a trailing newline so that the contenteditable can render and reach the last newline
   // if the string _ends_ with a newline.

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -53,11 +53,6 @@ const entities = {
   curlyBraceRight: '&#125;',
 }
 
-const reValidInlineJSXExpression = new RegExp(
-  `(^|[^${'\\\\'}])${entities.curlyBraceLeft}([^}]?[^}\\\\]+)${entities.curlyBraceRight}`,
-  'g',
-)
-
 // canvas → editor
 export function escapeHTML(s: string): string {
   return (
@@ -69,12 +64,21 @@ export function escapeHTML(s: string): string {
       .replace('>', entities.greaterThan)
       // restore br tags
       .replace(/\n/g, '\n<br />')
+      // escape curly braces
+      .replace(/\\\{/g, entities.curlyBraceLeft)
+      .replace(/\\\}/g, entities.curlyBraceRight)
   )
 }
 
 // editor → canvas
-export function unescapeHTML(s: string): string {
-  const unescaped = unescape(s).replace(/ +$/, '') // prettier fix
+export function unescapeHTML(s: string, options?: { renderCurlyBraces?: boolean }): string {
+  let replaced = s
+  if (options?.renderCurlyBraces === true) {
+    replaced = replaced
+      .replace(new RegExp(entities.curlyBraceLeft, 'g'), '\\{')
+      .replace(new RegExp(entities.curlyBraceRight, 'g'), '\\}')
+  }
+  const unescaped = unescape(replaced).replace(/ +$/, '') // prettier fix
 
   // We need to add a trailing newline so that the contenteditable can render and reach the last newline
   // if the string _ends_ with a newline.


### PR DESCRIPTION
Fixes #3126 

This is a followup to https://github.com/concrete-utopia/utopia/pull/3123 which removes the unused `reValidInlineJSXExpression` regex.