### PR TITLE
try to fail the Puppeteer tests instead of a silent error

### DIFF
--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -744,11 +744,6 @@ async function createSummaryPng(
 
 testPerformance().catch((e) => {
   console.error(e)
-  const errorMessage = `"There was an error with Puppeteer: ${e.name} – ${e.message}"`
-  console.info(`::set-output name=perf-result::${errorMessage}`)
-
-  // Output the individual parts for building a discord message
-  console.info(`::set-output name=perf-discord-message:: ${errorMessage}`)
-  console.info(`::set-output name=perf-chart:: ""`)
-  return
+  console.error(`"There was an error with Puppeteer: ${e.name} – ${e.message}"`)
+  process.exit(1)
 })

--- a/puppeteer-tests/src/screenshot-test.ts
+++ b/puppeteer-tests/src/screenshot-test.ts
@@ -22,9 +22,10 @@ async function takeScreenshot() {
 
     console.info(`Screenshot captured`)
     console.info(`::set-output name=screenshot:: ${uploadResult}`)
-  } catch (e) {
-    const errorMessage = `"There was an error with Puppeteer: ${e.name} – ${e.message}"`
-    console.info(`::set-output name=screenshot::${errorMessage}`)
+  } catch (e: any) {
+    await browser.close()
+    console.error(`"There was an error with Puppeteer: ${e.name} – ${e.message}"`)
+    process.exit(1)
   } finally {
     await browser.close()
   }


### PR DESCRIPTION
Instead of printing an error message in the comments, 
<img width="534" alt="image" src="https://user-images.githubusercontent.com/2226774/213237441-3fc989bc-08a1-4b4b-85f9-832f86740460.png">
we should instead properly fail the PR in case the performance tests have a problem:
<img width="923" alt="image" src="https://user-images.githubusercontent.com/2226774/213237620-d9540097-d1b9-49b8-bef2-a8b85cceb219.png">

**Details:**
- In the catch block instead of logging the error, exit the node process with an error code