### PR TITLE
removing resize performance test, as it uses dragstate

### DIFF
--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -227,12 +227,12 @@ export const testPerformanceInner = async function (url: string): Promise<Perfor
     selection: EmptyResult,
     deselection: EmptyResult,
   })
-  const resizeResult = await retryPageCalls(
-    url,
-    testResizePerformance,
-    frameResultSuccess,
-    EmptyResult,
-  )
+  // const resizeResult = await retryPageCalls(
+  //   url,
+  //   testResizePerformance,
+  //   frameResultSuccess,
+  //   EmptyResult,
+  // )
   const scrollResult = await retryPageCalls(
     url,
     testScrollingPerformance,
@@ -260,7 +260,7 @@ export const testPerformanceInner = async function (url: string): Promise<Perfor
       deselectionResult: selectionResult.deselection,
       selectionChangeResult: selectionChangeResult,
       scrollResult: scrollResult,
-      resizeResult: resizeResult,
+      // resizeResult: resizeResult,
       // absoluteMoveLargeMoveResult: absoluteMoveLargeResult.move,
       // absoluteMoveSmallMoveResult: absoluteMoveSmallResult.move,
     },
@@ -304,32 +304,32 @@ export const testScrollingPerformance = async function (
   return getFrameData(traceJson, 'scroll', 'Scroll Canvas', succeeded)
 }
 
-export const testResizePerformance = async function (page: puppeteer.Page): Promise<FrameResult> {
-  console.log('Test Resize Performance')
-  await page.waitForXPath(ResizeButtonXPath)
+// export const testResizePerformance = async function (page: puppeteer.Page): Promise<FrameResult> {
+//   console.log('Test Resize Performance')
+//   await page.waitForXPath(ResizeButtonXPath)
 
-  // select element using the navigator
-  const navigatorElement = await page.waitForXPath(
-    '//div[contains(@class, "item-label-container")]',
-  )
-  await navigatorElement!.click()
+//   // select element using the navigator
+//   const navigatorElement = await page.waitForXPath(
+//     '//div[contains(@class, "item-label-container")]',
+//   )
+//   await navigatorElement!.click()
 
-  // we run it twice without measurements to warm up the environment
-  await clickOnce(page, ResizeButtonXPath, 'RESIZE_TEST_FINISHED', 'RESIZE_TEST_ERROR')
-  await clickOnce(page, ResizeButtonXPath, 'RESIZE_TEST_FINISHED', 'RESIZE_TEST_ERROR')
+//   // we run it twice without measurements to warm up the environment
+//   await clickOnce(page, ResizeButtonXPath, 'RESIZE_TEST_FINISHED', 'RESIZE_TEST_ERROR')
+//   await clickOnce(page, ResizeButtonXPath, 'RESIZE_TEST_FINISHED', 'RESIZE_TEST_ERROR')
 
-  // and then we run the test for a third time, this time running tracing
-  await page.tracing.start({ categories: ['blink.user_timing'], path: 'trace.json' })
-  const succeeded = await clickOnce(
-    page,
-    ResizeButtonXPath,
-    'RESIZE_TEST_FINISHED',
-    'RESIZE_TEST_ERROR',
-  )
-  await page.tracing.stop()
-  const traceJson = await loadTraceEventsJSON()
-  return getFrameData(traceJson, 'resize', 'Resize', succeeded)
-}
+//   // and then we run the test for a third time, this time running tracing
+//   await page.tracing.start({ categories: ['blink.user_timing'], path: 'trace.json' })
+//   const succeeded = await clickOnce(
+//     page,
+//     ResizeButtonXPath,
+//     'RESIZE_TEST_FINISHED',
+//     'RESIZE_TEST_ERROR',
+//   )
+//   await page.tracing.stop()
+//   const traceJson = await loadTraceEventsJSON()
+//   return getFrameData(traceJson, 'resize', 'Resize', succeeded)
+// }
 
 export const testHighlightRegularPerformance = async function (
   page: puppeteer.Page,


### PR DESCRIPTION
**Problem:**
I broke the performance tests in https://github.com/concrete-utopia/utopia/pull/3075 with an addition of this line https://github.com/concrete-utopia/utopia/blob/2e5f2fee521d5a20f5327d077818ebe14b4495ea/editor/src/components/editor/store/dispatch.tsx#L706

I didn't know if there's any active code paths left over that still use the dragState, and it turns out that pretty much the last code path standing was the `P R` resize performance test.

**Fix:**
To make things simple, I'm simply removing this test from the list of active tests. I'm not touching the actual code just yet. I looked at the test code and I think it was already regressed as it was, not in effect resizing anything, just dispatching actions. 

The real TODO now is to actually remove all dragState code from the codebase, that'll be fun!

**Commit Details:**
- Comment out `testResizePerformance` from `performance-test.ts`
