### PR TITLE
Insert element on drag over text editable element in text mode

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.spec.browser2.tsx
@@ -141,7 +141,7 @@ describe('draw-to-insert text', () => {
     })
   })
   describe('when the target is editable', () => {
-    it('just goes into text edit mode immediately', async () => {
+    it('inserts new text when dragging to insert', async () => {
       const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
 
       const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
@@ -166,6 +166,10 @@ describe('draw-to-insert text', () => {
       closeTextEditor()
       await editor.getDispatchFollowUpActionsFinished()
 
+      const newElementUID = Object.keys(editor.getEditorState().editor.domMetadata)
+        .find((k) => k.startsWith('sb/') && k !== 'sb/39e')
+        ?.replace('sb/39e/', '')
+
       expect(editor.getEditorState().editor.mode.type).toEqual('select')
       expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
         formatTestProjectCode(`
@@ -185,7 +189,22 @@ describe('draw-to-insert text', () => {
                     height: 362,
                   }}
                   data-uid='39e'
-                >Hello Utopia</div>
+                >Hello
+                  <span
+                    style={{
+                      position: 'absolute',
+                      wordBreak: 'break-word',
+                      left: 145,
+                      top: 182,
+                      width: 50,
+                      height: 50,
+                    }}
+                    data-uid='${newElementUID}'
+                  >
+                    {' '}
+                    Utopia
+                  </span>
+                </div>
               </Storyboard>
             )`),
       )

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
@@ -11,6 +11,7 @@ import { MetaCanvasStrategy } from '../canvas-strategies'
 import {
   CanvasStrategy,
   CustomStrategyState,
+  emptyStrategyApplicationResult,
   getInsertionSubjectsFromInteractionTarget,
   InteractionCanvasState,
   strategyApplicationResult,
@@ -56,6 +57,9 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
       controlsToRender: [],
       fitness: insertionSubject.textEdit && drawToInsertFitness(interactionSession) ? 1 : 0,
       apply: (s) => {
+        if (interactionSession.interactionData.type !== 'DRAG') {
+          return emptyStrategyApplicationResult
+        }
         const applicableReparentFactories = getApplicableReparentFactories(
           canvasState,
           pointOnCanvas,
@@ -80,7 +84,8 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
         const targetParentPathParts =
           targetParent.parts.length > 0 ? targetParent.parts[0].length : 0
         const isRoot = targetParentPathParts === 1
-        if (!isRoot && textEditable) {
+        const isClick = s === 'end-interaction' && interactionSession.interactionData.drag == null
+        if (!isRoot && textEditable && isClick) {
           return strategyApplicationResult([
             updateSelectedViews('on-complete', [targetParent]),
             setCursorCommand(CSSCursor.Select),


### PR DESCRIPTION
**Problem:**
Probably it was not a best idea that text drag-to-insert over an existing (text editable) element edits the element itself, instead of that we should insert a new text in this case.
Note: click should still keep edit the existing text editable element.

