### PR TITLE
Use a different color for the padding controls

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
@@ -36,6 +36,7 @@ import {
 } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
 import { areAllSiblingsInOneDimensionFlexOrFlow } from './flow-reorder-helpers'
+import { colorTheme } from '../../../../uuiui'
 
 export const SetFlexGapStrategyId = 'SET_FLEX_GAP_STRATEGY'
 
@@ -110,7 +111,7 @@ export const setFlexGapStrategy: CanvasStrategyFactory = (
       resizeControl,
       controlWithProps({
         control: FloatingIndicator,
-        props: props,
+        props: { ...props, color: colorTheme.brandNeonGreen.value },
         key: 'padding-value-indicator-control',
         show: 'visible-except-when-other-strategy-is-active',
       }),

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
@@ -111,7 +111,7 @@ export const setFlexGapStrategy: CanvasStrategyFactory = (
       resizeControl,
       controlWithProps({
         control: FloatingIndicator,
-        props: { ...props, color: colorTheme.brandNeonGreen.value },
+        props: { ...props, color: colorTheme.gapControls.value },
         key: 'padding-value-indicator-control',
         show: 'visible-except-when-other-strategy-is-active',
       }),

--- a/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
@@ -42,7 +42,7 @@ export const FlexGapControlHandleTestId = 'FlexGapControlHandleTestId'
 export const FlexGapControl = controlForStrategyMemoized<FlexGapControlProps>((props) => {
   const { selectedElement, flexDirection, updatedGapValue } = props
   const colorTheme = useColorTheme()
-  const indicatorColor = colorTheme.brandNeonPink.value
+  const indicatorColor = colorTheme.brandNeonGreen.value
 
   const hoveredViews = useEditorState(
     Substores.highlightedHoveredViews,
@@ -246,7 +246,7 @@ const GapControlSegment = React.memo<GapControlSegmentProps>((props) => {
             <CanvasLabel
               value={printCSSNumber(gapValue, null)}
               scale={scale}
-              color={colorTheme.brandNeonPink.value}
+              color={colorTheme.brandNeonGreen.value}
               textColor={colorTheme.white.value}
             />,
           )}
@@ -254,7 +254,7 @@ const GapControlSegment = React.memo<GapControlSegmentProps>((props) => {
         <PillHandle
           width={width}
           height={height}
-          pillColor={colorTheme.brandNeonPink.value}
+          pillColor={colorTheme.brandNeonGreen.value}
           borderWidth={borderWidth}
         />
       </div>

--- a/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
@@ -42,7 +42,7 @@ export const FlexGapControlHandleTestId = 'FlexGapControlHandleTestId'
 export const FlexGapControl = controlForStrategyMemoized<FlexGapControlProps>((props) => {
   const { selectedElement, flexDirection, updatedGapValue } = props
   const colorTheme = useColorTheme()
-  const indicatorColor = colorTheme.brandNeonGreen.value
+  const indicatorColor = colorTheme.gapControls.value
 
   const hoveredViews = useEditorState(
     Substores.highlightedHoveredViews,
@@ -246,7 +246,7 @@ const GapControlSegment = React.memo<GapControlSegmentProps>((props) => {
             <CanvasLabel
               value={printCSSNumber(gapValue, null)}
               scale={scale}
-              color={colorTheme.brandNeonGreen.value}
+              color={colorTheme.gapControls.value}
               textColor={colorTheme.white.value}
             />,
           )}
@@ -254,7 +254,7 @@ const GapControlSegment = React.memo<GapControlSegmentProps>((props) => {
         <PillHandle
           width={width}
           height={height}
-          pillColor={colorTheme.brandNeonGreen.value}
+          pillColor={colorTheme.gapControls.value}
           borderWidth={borderWidth}
         />
       </div>

--- a/editor/src/components/canvas/controls/select-mode/floating-number-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/floating-number-indicator.tsx
@@ -11,11 +11,14 @@ export const FloatingCSSNumberIndicatorTestId = 'PaddingValueIndicatorTestId'
 export interface FloatingIndicatorProps {
   value: string | number
   position: CanvasPoint
+  color?: string
 }
 
 export const FloatingIndicator = controlForStrategyMemoized<FloatingIndicatorProps>((props) => {
   const { value, position } = props
   const colorTheme = useColorTheme()
+
+  const color = props.color ?? colorTheme.brandNeonPink.value
 
   const scale = useEditorState(
     Substores.canvas,
@@ -33,12 +36,7 @@ export const FloatingIndicator = controlForStrategyMemoized<FloatingIndicatorPro
           top: position.y,
         }}
       >
-        <CanvasLabel
-          value={value}
-          scale={scale}
-          color={colorTheme.brandNeonPink.value}
-          textColor={colorTheme.white.value}
-        />
+        <CanvasLabel value={value} scale={scale} color={color} textColor={colorTheme.white.value} />
       </div>
     </CanvasOffsetWrapper>
   )

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -15,7 +15,6 @@ const darkBase = {
   brandPurple: base.purple,
   brandNeonYellow: base.neonyellow,
   brandNeonPink: base.neonpink,
-  brandNeonGreen: base.neongreen,
   jsYellow: base.jsYellow,
   secondaryBlue: createUtopiColor('#679AD1'),
   secondaryOrange: createUtopiColor('#E89A74'),
@@ -225,4 +224,7 @@ export const dark: typeof light = {
   codeEditorBreadcrumbs: darkBase.fg5,
   codeEditorTabRowFg: darkBase.fg5,
   codeEditorGrid: createUtopiColor('#6d705b'),
+
+  // Gap controls
+  gapControls: createUtopiColor('#FFA500'),
 }

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -15,6 +15,7 @@ const darkBase = {
   brandPurple: base.purple,
   brandNeonYellow: base.neonyellow,
   brandNeonPink: base.neonpink,
+  brandNeonCyan: base.neongreen,
   jsYellow: base.jsYellow,
   secondaryBlue: createUtopiColor('#679AD1'),
   secondaryOrange: createUtopiColor('#E89A74'),

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -15,7 +15,7 @@ const darkBase = {
   brandPurple: base.purple,
   brandNeonYellow: base.neonyellow,
   brandNeonPink: base.neonpink,
-  brandNeonCyan: base.neongreen,
+  brandNeonGreen: base.neongreen,
   jsYellow: base.jsYellow,
   secondaryBlue: createUtopiColor('#679AD1'),
   secondaryOrange: createUtopiColor('#E89A74'),

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -15,7 +15,6 @@ const lightBase = {
   brandPurple: base.purple,
   brandNeonYellow: base.neonyellow,
   brandNeonPink: base.neonpink,
-  brandNeonGreen: base.neongreen,
   jsYellow: base.jsYellow,
   secondaryBlue: createUtopiColor('#49B6FF'),
   secondaryOrange: createUtopiColor('#EEA544'),
@@ -225,4 +224,7 @@ export const light = {
   codeEditorBreadcrumbs: lightBase.fg5,
   codeEditorTabRowFg: createUtopiColor('rgba(97, 97, 97, 0.8)'),
   codeEditorGrid: createUtopiColor('#6d705b'),
+
+  // Gap controls
+  gapControls: createUtopiColor('#FFA500'),
 }

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -15,6 +15,7 @@ const lightBase = {
   brandPurple: base.purple,
   brandNeonYellow: base.neonyellow,
   brandNeonPink: base.neonpink,
+  brandNeonGreen: base.neongreen,
   jsYellow: base.jsYellow,
   secondaryBlue: createUtopiColor('#49B6FF'),
   secondaryOrange: createUtopiColor('#EEA544'),


### PR DESCRIPTION
Fixes #3142 

**Problem:**

The gap and padding controls have the same color and for the same direction it can look confusing.

**Fix:**

Use a different color for the gap controls.

~~Note: I temporarily picked the `neonGreen` color, it's not necessarily the right one (e.g. I think using a cyan-ish color would look better).~~ 

![Kapture 2023-01-20 at 10 31 14](https://user-images.githubusercontent.com/1081051/213668403-b8bfff99-e9cd-4ab1-95b6-0ef40c7a8dc2.gif)
