### PR TITLE
Reading parent flex direction for flex child

### DIFF
--- a/editor/src/components/inspector/inspector-common.tsx
+++ b/editor/src/components/inspector/inspector-common.tsx
@@ -83,6 +83,18 @@ type Detect<T> = (
 
 export const DefaultFlexDirection: FlexDirection = 'row'
 
+export function detectParentFlexDirection(
+  metadata: ElementInstanceMetadataMap,
+  elementPath: ElementPath,
+): FlexDirection | null {
+  const element = MetadataUtils.findElementByElementPath(metadata, elementPath)
+  if (element == null) {
+    return null
+  }
+
+  return element.specialSizeMeasurements.parentFlexDirection
+}
+
 export function detectFlexDirectionOne(
   metadata: ElementInstanceMetadataMap,
   elementPath: ElementPath,

--- a/editor/src/components/inspector/inspector-common.tsx
+++ b/editor/src/components/inspector/inspector-common.tsx
@@ -336,3 +336,22 @@ export function sizeToVisualDimensions(
     setProperty('always', elementPath, styleP('height'), height),
   ]
 }
+
+export const nukeSizingPropsForAxisCommand = (axis: Axis, path: ElementPath): CanvasCommand => {
+  switch (axis) {
+    case 'horizontal':
+      return deleteProperties('always', path, [
+        PP.create(['style', 'width']),
+        PP.create(['style', 'minWidth']),
+        PP.create(['style', 'maxWidth']),
+      ])
+    case 'vertical':
+      return deleteProperties('always', path, [
+        PP.create(['style', 'height']),
+        PP.create(['style', 'minHeight']),
+        PP.create(['style', 'maxHeight']),
+      ])
+    default:
+      assertNever(axis)
+  }
+}

--- a/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
@@ -107,7 +107,7 @@ describe('Fixed / Fill / Hug control', () => {
       const button = (await editor.renderedDOM.findAllByText(HugContentsLabel))[0]
       mouseClickAtPoint(button, { x: 5, y: 5 })
 
-      expect(div.style.width).toEqual('212px') // TODO: this should be `min-content` because that's what the action is setting
+      expect(div.style.width).toEqual('min-content')
       expect(div.style.minWidth).toEqual('')
       expect(div.style.maxWidth).toEqual('')
     })
@@ -126,7 +126,7 @@ describe('Fixed / Fill / Hug control', () => {
       const button = (await editor.renderedDOM.findAllByText(HugContentsLabel))[0]
       mouseClickAtPoint(button, { x: 5, y: 5 })
 
-      expect(div.style.height).toEqual('144px') // TODO: this should be `min-content` because that's what the action is setting
+      expect(div.style.height).toEqual('min-content')
       expect(div.style.minHeight).toEqual('')
       expect(div.style.maxHeight).toEqual('')
     })
@@ -138,7 +138,7 @@ async function select(
   testId: 'child' | 'parent',
 ): Promise<HTMLElement> {
   const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
-  const div = editor.renderedDOM.getByTestId('child')
+  const div = editor.renderedDOM.getByTestId(testId)
   const divBounds = div.getBoundingClientRect()
   const divCorner = {
     x: divBounds.x + 50,
@@ -161,36 +161,35 @@ import { Scene, Storyboard } from 'utopia-api'
 import { App } from '/src/app.js'
 
 export var storyboard = (
-  <Storyboard data-uid='0cd'>
-    <div
+  <Storyboard>
+    <Scene
       data-testid='parent'
       style={{
-        backgroundColor: '#aaaaaa33',
+        width: 700,
+        height: 759,
         position: 'absolute',
-        left: 333,
-        top: 314,
-        minWidth: 100,
-        maxWidth: 1000,
-        width: 415,
-        height: 449,
+        left: 212,
+        top: 128,
         display: 'flex',
         flexDirection: '${flexDirection}'
       }}
-      data-uid='c47'
+      data-label='Playground'
     >
       <div
         data-testid='child'
         style={{
           backgroundColor: '#aaaaaa33',
-          width: 212,
-          height: 144,
+          minWidth: 100,
+          maxWidth: 1000,
+          width: 229,
+          height: 149,
           contain: 'layout',
         }}
-        data-uid='945'
       />
-    </div>
+    </Scene>
   </Storyboard>
 )
+
 `
 
 const projectWithHeight = (flexDirection: FlexDirection) => `import * as React from 'react'
@@ -199,33 +198,31 @@ import { App } from '/src/app.js'
 
 export var storyboard = (
   <Storyboard data-uid='0cd'>
-    <div
+    <Scene
       data-testid='parent'
       style={{
-        backgroundColor: '#aaaaaa33',
+        width: 700,
+        height: 759,
         position: 'absolute',
-        left: 333,
-        top: 314,
-        minHeight: 100,
-        maxHeight: 1000,
-        width: 415,
-        height: 449,
+        left: 212,
+        top: 128,
         display: 'flex',
         flexDirection: '${flexDirection}'
       }}
-      data-uid='c47'
+      data-label='Playground'
     >
       <div
         data-testid='child'
         style={{
           backgroundColor: '#aaaaaa33',
-          width: 212,
-          height: 144,
+          minHeight: 100,
+          maxHeight: 1000,
+          width: 229,
+          height: 149,
           contain: 'layout',
         }}
-        data-uid='945'
       />
-    </div>
+    </Scene>
   </Storyboard>
 )
 `

--- a/editor/src/components/inspector/inspector-strategies/hug-contents-text.tsx
+++ b/editor/src/components/inspector/inspector-strategies/hug-contents-text.tsx
@@ -8,6 +8,7 @@ import {
   Axis,
   nullOrNonEmpty,
   hugContentsApplicableForText,
+  nukeSizingPropsForAxisCommand,
 } from '../inspector-common'
 import { InspectorStrategy } from './inspector-strategy'
 
@@ -20,6 +21,7 @@ const hugContentsTextStrategyI = (
     return []
   }
   return [
+    nukeSizingPropsForAxisCommand(axis, elementPath),
     setProperty(
       'always',
       elementPath,

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
@@ -4,6 +4,7 @@ import {
   Axis,
   convertWidthToFlexGrow,
   detectFlexDirectionOne,
+  detectParentFlexDirection,
   fillContainerApplicable,
   filterKeepFlexContainers,
   FlexAlignment,
@@ -155,7 +156,7 @@ export const setPropFillStrategies = (axis: Axis): Array<InspectorStrategy> => [
           ]
         }
 
-        const flexDirection = detectFlexDirectionOne(metadata, EP.parentPath(path)) ?? 'row'
+        const flexDirection = detectParentFlexDirection(metadata, path) ?? 'row'
 
         if (
           (flexDirection.startsWith('row') && axis === 'vertical') ||

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
@@ -3,7 +3,6 @@ import { setProperty } from '../../canvas/commands/set-property-command'
 import {
   Axis,
   convertWidthToFlexGrow,
-  detectFlexDirectionOne,
   detectParentFlexDirection,
   fillContainerApplicable,
   filterKeepFlexContainers,
@@ -11,14 +10,13 @@ import {
   flexChildProps,
   FlexJustifyContent,
   hugContentsApplicableForContainer,
+  nukeSizingPropsForAxisCommand,
   pruneFlexPropsCommands,
   sizeToVisualDimensions,
   widthHeightFromAxis,
 } from '../inspector-common'
 import * as EP from '../../../core/shared/element-path'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { ElementPath } from '../../../core/shared/project-file-types'
-import { assertNever } from '../../../core/shared/utils'
 import { deleteProperties } from '../../canvas/commands/delete-properties-command'
 import { CSSNumber, FlexDirection, printCSSNumber } from '../common/css-utils'
 import { removeFlexConvertToAbsolute } from './remove-flex-convert-to-absolute-strategy'
@@ -128,30 +126,11 @@ export const setPropFillStrategies = (axis: Axis): Array<InspectorStrategy> => [
         return null
       }
 
-      const nukePropsCommand = (path: ElementPath) => {
-        switch (axis) {
-          case 'horizontal':
-            return deleteProperties('always', path, [
-              PP.create(['style', 'width']),
-              PP.create(['style', 'minWidth']),
-              PP.create(['style', 'maxWidth']),
-            ])
-          case 'vertical':
-            return deleteProperties('always', path, [
-              PP.create(['style', 'height']),
-              PP.create(['style', 'minHeight']),
-              PP.create(['style', 'maxHeight']),
-            ])
-          default:
-            assertNever(axis)
-        }
-      }
-
       return elements.flatMap((path) => {
         const parentInstance = MetadataUtils.findElementByElementPath(metadata, EP.parentPath(path))
         if (!MetadataUtils.isFlexLayoutedContainer(parentInstance)) {
           return [
-            nukePropsCommand(path),
+            nukeSizingPropsForAxisCommand(axis, path),
             setProperty('always', path, PP.create(['style', widthHeightFromAxis(axis)]), '100%'),
           ]
         }
@@ -163,13 +142,13 @@ export const setPropFillStrategies = (axis: Axis): Array<InspectorStrategy> => [
           (flexDirection.startsWith('column') && axis === 'horizontal')
         ) {
           return [
-            nukePropsCommand(path),
+            nukeSizingPropsForAxisCommand(axis, path),
             setProperty('always', path, PP.create(['style', widthHeightFromAxis(axis)]), '100%'),
           ]
         }
 
         return [
-          nukePropsCommand(path),
+          nukeSizingPropsForAxisCommand(axis, path),
           setProperty('always', path, PP.create(['style', 'flexGrow']), '1'),
         ]
       })
@@ -210,9 +189,10 @@ export const setPropHugStrategies = (axis: Axis): Array<InspectorStrategy> => [
         return null
       }
 
-      return elements.map((path) =>
+      return elements.flatMap((path) => [
+        nukeSizingPropsForAxisCommand(axis, path),
         setProperty('always', path, PP.create(['style', widthHeightFromAxis(axis)]), 'min-content'),
-      )
+      ])
     },
   },
 ]


### PR DESCRIPTION
## Problem
When setting `Fill container` on a flex child, `computedStyle` of its parent was used as the source for determining `flex-direction`. This proved to be an unreliable method, as `computedStyle` was `null` in some cases for the parent.

## Fix
Use `SpecialSizeMeasurements.parentFlexDirection` as the source for determining the `flex-direction` of the parent.

Also, fix browser tests for this feature