### PR TITLE
Use a slightly darker color for the swatch border

### DIFF
--- a/editor/src/components/inspector/controls/color-picker-swatches.tsx
+++ b/editor/src/components/inspector/controls/color-picker-swatches.tsx
@@ -130,7 +130,7 @@ export const ColorPickerSwatches = React.memo((props: ColorPickerSwatchesProps) 
                   backgroundImage: `linear-gradient(to bottom right, transparent 65%, ${rgbString} 65%), linear-gradient(${rgbaString}, ${rgbaString}), ${checkerboardBackground.backgroundImage}`,
                   backgroundSize: `100% 100%, ${checkerboardBackground.backgroundSize}`,
                   backgroundPosition: `0 0, ${checkerboardBackground.backgroundPosition}`,
-                  border: `1px solid ${colorTheme.bg0.value}`,
+                  border: `1px solid ${colorTheme.bg3.value}`,
                   boxShadow: currentColor === c.hex ? `${c.hex} 0px 0px 3px` : 'none',
                   borderRadius: 2,
                 }}


### PR DESCRIPTION
**Problem:**

The border color for the color swatches makes it impossible to see very light colors (e.g. plain white).

**Fix:**

Use a slightly darker color for the border so it adds a light outline to color swatches.
