### PR TITLE
Rename "New Layout System" to "Layout System"

### DIFF
--- a/editor/src/components/inspector/add-remove-layout-system-control.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.tsx
@@ -20,8 +20,12 @@ import {
 import { detectAreElementsFlexContainers } from './inspector-common'
 import { executeFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
 import { useDispatch } from '../editor/store/dispatch-context'
+import { isFeatureEnabled } from '../../utils/feature-switches'
 
 export const AddRemoveLayouSystemControlTestId = (): string => 'AddRemoveLayouSystemControlTestId'
+
+const LayoutSystemSectionTitle = () =>
+  isFeatureEnabled('Nine block control') ? 'Layout System' : 'New Layout System'
 
 interface AddRemoveLayoutSystemControlProps {}
 
@@ -82,7 +86,7 @@ export const AddRemoveLayouSystemControl = React.memo<AddRemoveLayoutSystemContr
         }}
       >
         <InspectorSectionIcons.LayoutSystem />
-        <span>New Layout System</span>
+        <span>{LayoutSystemSectionTitle()}</span>
       </FlexRow>
       {isFlexLayoutedContainer ? (
         <SquareButton

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-subsection.tsx
@@ -22,7 +22,7 @@ import { usePropControlledStateV2 } from '../../../common/inspector-utils'
 import { isFeatureEnabled } from '../../../../../utils/feature-switches'
 
 const LayoutSystemSectionTitle = () =>
-  isFeatureEnabled('Nine block control') ? 'Old Layout System' : 'Layout System'
+  isFeatureEnabled('Nine block control') ? 'Layout System Props' : 'Layout System'
 
 interface LayoutSystemSubsectionProps {
   specialSizeMeasurements: SpecialSizeMeasurements

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-subsection.tsx
@@ -1,7 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 import React from 'react'
-import { jsx, css } from '@emotion/react'
+import { jsx } from '@emotion/react'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import {
   LayoutSystemControl,
@@ -9,11 +9,7 @@ import {
   useLayoutSystemData,
 } from './layout-system-controls'
 import { FlexContainerControls } from '../flex-container-subsection/flex-container-subsection'
-import { PropertyLabel } from '../../../widgets/property-label'
-import {
-  DetectedLayoutSystem,
-  SpecialSizeMeasurements,
-} from '../../../../../core/shared/element-template'
+import { SpecialSizeMeasurements } from '../../../../../core/shared/element-template'
 import {
   FlexRow,
   Icons,
@@ -22,9 +18,11 @@ import {
   SquareButton,
   useColorTheme,
 } from '../../../../../uuiui'
-import { useInspectorInfoLonghandShorthand } from '../../../common/longhand-shorthand-hooks'
-import { isNotUnsetOrDefault } from '../../../common/control-status'
 import { usePropControlledStateV2 } from '../../../common/inspector-utils'
+import { isFeatureEnabled } from '../../../../../utils/feature-switches'
+
+const LayoutSystemSectionTitle = () =>
+  isFeatureEnabled('Nine block control') ? 'Old Layout System' : 'Layout System'
 
 interface LayoutSystemSubsectionProps {
   specialSizeMeasurements: SpecialSizeMeasurements
@@ -70,7 +68,7 @@ export const LayoutSystemSubsection = React.memo<LayoutSystemSubsectionProps>((p
           }}
         >
           <InspectorSectionIcons.LayoutSystem />
-          <span>Layout System</span>
+          <span>{LayoutSystemSectionTitle()}</span>
         </FlexRow>
         {layoutSectionOpen && <DeleteAllLayoutSystemConfigButton />}
         {!layoutSectionOpen && (


### PR DESCRIPTION
## Description
Rename the "New Layout System" section to "Layout System" behind the `Nine block control feature switch` (when the feature switch is off, the "new" section isn't visible).

In an analogue way, rename the "old" layout system "Layout System Props", to reflect that it allows users to adjust the individual props of the layout system.