### PR TITLE
Visualise defaults in the nine-block control

### DIFF
--- a/editor/src/components/inspector/nine-block-controls.tsx
+++ b/editor/src/components/inspector/nine-block-controls.tsx
@@ -108,20 +108,20 @@ const flexDirectionSelector = createSelector(
   detectFlexDirection,
 )
 
+const DefaultJustifyContentFlexAlignment: JustifyContentFlexAlignemt = {
+  justifyContent: 'flex-start',
+  alignItems: 'flex-start',
+}
+
 const isSelectedSelector = createSelector(
   justifyAlignSelector,
   flexDirectionSelector,
   (_: MetadataSubstate, x: JustifyContentFlexAlignemt) => x,
   (detectedJustifyContentFlexAlignment, flexDirection, fixedJustifyContentFlexAlignment) => {
-    const defaultJustifyContentFlexAlignment: JustifyContentFlexAlignemt = {
-      justifyContent: 'flex-start',
-      alignItems: 'flex-start',
-    }
-
     return justifyContentAlignItemsEquals(
       flexDirection,
       fixedJustifyContentFlexAlignment,
-      detectedJustifyContentFlexAlignment ?? defaultJustifyContentFlexAlignment,
+      detectedJustifyContentFlexAlignment ?? DefaultJustifyContentFlexAlignment,
     )
   },
 )

--- a/editor/src/components/inspector/nine-block-controls.tsx
+++ b/editor/src/components/inspector/nine-block-controls.tsx
@@ -113,13 +113,18 @@ const isSelectedSelector = createSelector(
   justifyAlignSelector,
   flexDirectionSelector,
   (_: MetadataSubstate, x: JustifyContentFlexAlignemt) => x,
-  (detectedJustifyContentFlexAlignment, flexDirection, fixedJustifyContentFlexAlignment) =>
-    detectedJustifyContentFlexAlignment != null &&
-    justifyContentAlignItemsEquals(
+  (detectedJustifyContentFlexAlignment, flexDirection, fixedJustifyContentFlexAlignment) => {
+    const defaultJustifyContentFlexAlignment: JustifyContentFlexAlignemt = {
+      justifyContent: 'flex-start',
+      alignItems: 'flex-start',
+    }
+
+    return justifyContentAlignItemsEquals(
       flexDirection,
       fixedJustifyContentFlexAlignment,
-      detectedJustifyContentFlexAlignment,
-    ),
+      detectedJustifyContentFlexAlignment ?? defaultJustifyContentFlexAlignment,
+    )
+  },
 )
 
 const opacity = (isSelected: boolean, flexDirectionMatches: boolean): number => {


### PR DESCRIPTION
## Description
This PR updates the nine-block control so that when no `justify-contents` and `align-items` is detected (as per `detectFlexAlignJustifyContent`), the nine block control displays a state as if `justify-contents: flex-start` and `align-items: flex-start` were active.