### PR TITLE
Show padding controls when an element has only text children

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -123,6 +123,46 @@ describe('Padding resize strategy', () => {
     })
   })
 
+  it('Padding resize handle is present for elements that are dimensioned and have only text children', async () => {
+    const editor = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+      <div data-uid='root'>
+        <div
+          data-uid='mydiv'
+          data-testid='mydiv'
+          style={{
+            backgroundColor: '#aaaaaa33',
+            position: 'absolute',
+            left: 28,
+            top: 28,
+            width: 612,
+            height: 461,
+          }}
+        >
+          Hello <br /> there!
+        </div>
+      </div>`),
+      'await-first-dom-report',
+    )
+
+    const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
+    const div = editor.renderedDOM.getByTestId('mydiv')
+    const divBounds = div.getBoundingClientRect()
+    const divCorner = {
+      x: divBounds.x + 25,
+      y: divBounds.y + 24,
+    }
+
+    mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
+
+    EdgePieces.forEach((edge) => {
+      const paddingControlOuter = editor.renderedDOM.getByTestId(paddingControlTestId(edge))
+      expect(paddingControlOuter).toBeTruthy()
+      const paddingControlHandle = editor.renderedDOM.getByTestId(paddingControlHandleTestId(edge))
+      expect(paddingControlHandle).toBeTruthy()
+    })
+  })
+
   it("padding controls don't show up for elements that are smaller than 40px", async () => {
     const editor = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`<div

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -54,6 +54,7 @@ import {
 import { CanvasCommand } from '../../commands/commands'
 import { foldEither } from '../../../../core/shared/either'
 import { styleStringInArray } from '../../../../utils/common-constants'
+import { elementHasOnlyTextChildren } from '../../canvas-utils'
 
 const StylePaddingProp = stylePropPathMappingFn('padding', styleStringInArray)
 const IndividualPaddingProps: Array<CSSPaddingKey> = [
@@ -302,9 +303,8 @@ function supportsPaddingControls(metadata: ElementInstanceMetadataMap, path: Ele
     return true
   }
 
-  const children = MetadataUtils.getChildren(metadata, path)
-  if (children.length === 0) {
-    return false
+  if (elementHasOnlyTextChildren(element)) {
+    return true
   }
 
   const childrenNotPositionedAbsoluteOrSticky = MetadataUtils.getChildren(metadata, path).filter(

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -6,6 +6,7 @@ import { Modifiers } from '../../../../utils/modifiers'
 import { ProjectContentTreeRoot } from '../../../assets'
 import { colorTheme } from '../../../../uuiui'
 import { CSSNumber, CSSNumberUnit, printCSSNumber } from '../../../inspector/common/css-utils'
+import { elementHasOnlyTextChildren } from '../../canvas-utils'
 
 export const Emdash: string = '\u2014'
 
@@ -175,6 +176,9 @@ export function cssNumberEqual(left: CSSNumber, right: CSSNumber): boolean {
 
 type CanvasPropControl = 'padding' | 'borderRadius' | 'gap'
 
+const CONTROL_CROWDING_UPPER_THRESHOLD = 80
+const CONTROL_CROWDING_LOWER_THRESHOLD = 40
+
 export function canShowCanvasPropControl(
   projectContents: ProjectContentTreeRoot,
   element: ElementInstanceMetadata,
@@ -185,12 +189,16 @@ export function canShowCanvasPropControl(
     (element.globalFrame?.height ?? 0) * scale,
   )
 
-  if (width > 80 && height > 80) {
+  if (width > CONTROL_CROWDING_UPPER_THRESHOLD && height > CONTROL_CROWDING_UPPER_THRESHOLD) {
     return new Set<CanvasPropControl>(['borderRadius', 'padding', 'gap'])
   }
 
-  if (Math.min(width, height) < 40) {
+  if (Math.min(width, height) < CONTROL_CROWDING_LOWER_THRESHOLD) {
     return new Set<CanvasPropControl>([])
+  }
+
+  if (elementHasOnlyTextChildren(element)) {
+    return new Set<CanvasPropControl>(['padding'])
   }
 
   if (!MetadataUtils.targetElementSupportsChildren(projectContents, element)) {


### PR DESCRIPTION
## Problem
Padding controls weren't shown when an element only had text children.

## Fix
- Check if an element's JSX children are all JSX text elements. If so, show the padding controls.
- If some controls are hidden to reduce "control clutter" on an element, prefer to show padding controls for elements with only JSX text children (instead of border radius controls, which are less relevant for text).