### PR TITLE
Show the flex gap control even if gap is not set

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.spec.browser2.tsx
@@ -59,7 +59,7 @@ export var storyboard = (
 
     expect(gapControls).toEqual([])
   })
-  it('gap controls are not present when flex gap is not set on element', async () => {
+  it('gap controls are present when flex gap is not set on element and element has more than 1 child', async () => {
     const editor = await renderTestEditorWithCode(
       `import * as React from 'react'
 import { Scene, Storyboard } from 'utopia-api'
@@ -117,9 +117,9 @@ export var storyboard = (
       ...editor.renderedDOM.queryAllByTestId(FlexGapControlHandleTestId),
     ]
 
-    expect(gapControls).toEqual([])
+    expect(gapControls.length).toEqual(2)
   })
-  it('gap controls are present when flex gap is set on element and element has children', async () => {
+  it('gap controls are not present when flex gap is not set on element and element only has 1 child', async () => {
     const editor = await renderTestEditorWithCode(
       `import * as React from 'react'
 import { Scene, Storyboard } from 'utopia-api'
@@ -149,15 +149,6 @@ export var storyboard = (
         }}
         data-uid='fed'
       />
-      <div
-        style={{
-          backgroundColor: '#aaaaaa33',
-          width: 187,
-          height: 150,
-          contain: 'layout',
-        }}
-        data-uid='a39'
-      />
     </div>
   </Storyboard>
 )
@@ -173,11 +164,9 @@ export var storyboard = (
       y: divBounds.y + 5,
     })
 
-    const gapControlContainer = editor.renderedDOM.getByTestId(FlexGapControlTestId)
     const gapControlHandles = editor.renderedDOM.queryAllByTestId(FlexGapControlHandleTestId)
 
-    expect(gapControlContainer).toBeTruthy()
-    expect(gapControlHandles.length).toEqual(1)
+    expect(gapControlHandles).toEqual([])
   })
 
   it('gap controls are not present when elements are wrapped', async () => {

--- a/editor/src/components/canvas/gap-utils.ts
+++ b/editor/src/components/canvas/gap-utils.ts
@@ -9,7 +9,7 @@ import { ElementPath } from '../../core/shared/project-file-types'
 import { assertNever } from '../../core/shared/utils'
 import { CSSCursor } from './canvas-types'
 import { CSSNumberWithRenderedValue } from './controls/select-mode/controls-common'
-import { CSSNumber, FlexDirection } from '../inspector/common/css-utils'
+import { cssNumber, CSSNumber, FlexDirection } from '../inspector/common/css-utils'
 import { Sides, sides } from 'utopia-api/core'
 import { styleStringInArray } from '../../utils/common-constants'
 
@@ -167,11 +167,10 @@ export function maybeFlexGapFromElement(
     getLayoutProperty('gap', right(element.element.value.props), styleStringInArray),
   )
 
-  if (gapFromProps == null) {
-    return null
-  }
-
   const flexDirection = children[0].specialSizeMeasurements.parentFlexDirection ?? 'row'
 
-  return { value: { renderedValuePx: flexGap, value: gapFromProps }, direction: flexDirection }
+  return {
+    value: { renderedValuePx: flexGap, value: gapFromProps ?? cssNumber(0) },
+    direction: flexDirection,
+  }
 }


### PR DESCRIPTION
## Problem
The gap control is only shown if the `gap` property is set on an element, which renders it useless for adding gap to newly created elements (without scrolling down in the inspector, or adding some code in the code editor).

## Fix
Show the gap control with a default value if no set value is detected.