### PR TITLE
Clear min/max fields when giving a flex element a fixed size dimension.

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { CanvasSubstate } from 'src/components/editor/store/store-hook-substore-types'
+import { CanvasSubstate } from '../../../../components/editor/store/store-hook-substore-types'
 import { CanvasVector, size, Size, windowPoint } from '../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import { assertNever } from '../../../../core/shared/utils'

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -507,7 +507,15 @@ const ViewportPercentageLengthUnits: Array<ViewportPercentageLengthUnit> = [
   'vmin',
   'vmax',
 ]
-const AbsoluteLengthUnits: Array<AbsoluteLengthUnit> = ['px', 'cm', 'mm', 'Q', 'in', 'pc', 'pt']
+export const AbsoluteLengthUnits: Array<AbsoluteLengthUnit> = [
+  'px',
+  'cm',
+  'mm',
+  'Q',
+  'in',
+  'pc',
+  'pt',
+]
 export const LengthUnits: Array<LengthUnit> = [
   ...FontRelativeLengthUnits,
   ...ViewportPercentageLengthUnits,
@@ -516,7 +524,7 @@ export const LengthUnits: Array<LengthUnit> = [
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/length-percentage
 export type LengthPercentUnit = LengthUnit | PercentUnit
-const LengthPercentUnits: Array<LengthPercentUnit> = [...LengthUnits, '%']
+export const LengthPercentUnits: Array<LengthPercentUnit> = [...LengthUnits, '%']
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/angle
 export type AngleUnit = 'deg' | 'grad' | 'rad' | 'turn'
@@ -571,6 +579,25 @@ export function setCSSNumberValue(current: CSSNumber | null, newValue: number): 
 
 export function getCSSNumberUnit(current: CSSNumber | null): CSSNumberUnit | null {
   return current == null ? null : current.unit
+}
+
+export function isFixedSize(value: CSSNumber): boolean {
+  if (value.unit == null) {
+    return true
+  } else {
+    switch (value.unit) {
+      case 'px':
+      case 'cm':
+      case 'mm':
+      case 'Q':
+      case 'in':
+      case 'pc':
+      case 'pt':
+        return true
+      default:
+        return false
+    }
+  }
 }
 
 function parseCSSNumberUnit(
@@ -3976,13 +4003,14 @@ export type Direction = 'horizontal' | 'vertical'
 export type ForwardOrReverse = 'forward' | 'reverse'
 
 export type FlexDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse'
-
-export const parseFlexDirection: Parser<FlexDirection> = isOneOfTheseParser([
+export const AllFlexDirections: Array<FlexDirection> = [
   'row',
   'row-reverse',
   'column',
   'column-reverse',
-])
+]
+
+export const parseFlexDirection: Parser<FlexDirection> = isOneOfTheseParser(AllFlexDirections)
 
 const flexAlignmentsParser: Parser<FlexAlignment> = isOneOfTheseParser([
   FlexAlignment.Auto,

--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -254,7 +254,7 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
           dispatch,
           metadataRef.current,
           selectedViewsRef.current,
-          setPropFixedStrategies('vertical', value),
+          setPropFixedStrategies('always', 'vertical', cssNumber(value, null)),
         )
       }
     },
@@ -268,7 +268,7 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
           dispatch,
           metadataRef.current,
           selectedViewsRef.current,
-          setPropFixedStrategies('horizontal', value),
+          setPropFixedStrategies('always', 'horizontal', cssNumber(value, null)),
         )
       }
     },
@@ -369,7 +369,7 @@ function strategyForMode(
     case 'hug':
       return setPropHugStrategies(axis)
     case 'fixed':
-      return setPropFixedStrategies(axis, fixedValue)
+      return setPropFixedStrategies('always', axis, cssNumber(fixedValue, null))
     default:
       assertNever(mode)
   }

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.spec.browser2.tsx
@@ -18,12 +18,6 @@ import {
 import { act, fireEvent } from '@testing-library/react'
 import { applyPrettier } from 'utopia-vscode-common'
 
-function downClickUp(targetElement: HTMLElement, mouseEventInit: MouseEventInit) {
-  fireEvent(targetElement, new MouseEvent('mousedown', mouseEventInit))
-  fireEvent(targetElement, new MouseEvent('click', mouseEventInit))
-  fireEvent(targetElement, new MouseEvent('mouseup', mouseEventInit))
-}
-
 function getCrossCapitalDimension(flexDirection: FlexDirection): string {
   return flexDirection.startsWith('row') ? 'Height' : 'Width'
 }
@@ -181,7 +175,9 @@ async function changeDimensionValue(
     y: divBounds.y + 40,
   }
 
-  mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
+  act(() => {
+    mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
+  })
 
   // Modify the value.
   const dimensionInput = editor.renderedDOM.getByTestId(
@@ -192,15 +188,9 @@ async function changeDimensionValue(
     x: dimensionInputBounds.x + dimensionInputBounds.width / 2,
     y: dimensionInputBounds.y + dimensionInputBounds.height / 2,
   }
+
   act(() => {
-    downClickUp(dimensionInput, {
-      detail: 1,
-      bubbles: true,
-      cancelable: true,
-      clientX: dimensionInputCenter.x,
-      clientY: dimensionInputCenter.y,
-      buttons: 1,
-    })
+    mouseClickAtPoint(dimensionInput, dimensionInputCenter, {})
   })
 
   act(() => {

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.spec.browser2.tsx
@@ -74,6 +74,50 @@ function createProject(
   ).formatted
 }
 
+function createNonFlexProject(
+  flexDirection: FlexDirection,
+  width: string | number,
+  height: string | number,
+): string {
+  const crossCapitalDimension = getCrossCapitalDimension(flexDirection)
+  return applyPrettier(
+    `import * as React from 'react'
+  import { Storyboard } from 'utopia-api'
+  
+  export var storyboard = (
+    <Storyboard data-uid='storyboard'>
+      <div
+        style={{
+          backgroundColor: 'grey',
+          position: 'absolute',
+          left: 111,
+          top: 121,
+          width: 469,
+          height: 310,
+          paddingTop: 0,
+        }}
+        data-testid='flexparent'
+        data-uid='flexparent'
+      >
+        <div
+          style={{
+            backgroundColor: 'blue',
+            height: ${JSON.stringify(height)},
+            width: ${JSON.stringify(width)},
+            min${crossCapitalDimension}: 40,
+            max${crossCapitalDimension}: 100,
+          }}
+          data-testid='flexchild'
+          data-uid='flexchild'
+        />
+      </div>
+    </Storyboard>
+  )
+  `,
+    false,
+  ).formatted
+}
+
 function createProjectWithoutMinAndMax(
   flexDirection: FlexDirection,
   width: string | number,
@@ -218,4 +262,16 @@ describe('flex dimension controls', () => {
       }
     })
   }
+
+  it('do not delete the properties when the parent is not a flex container', async () => {
+    const editor = await renderTestEditorWithCode(
+      createNonFlexProject('row', 100, 120),
+      'await-first-dom-report',
+    )
+    await changeDimensionValue(editor, 'row', '90')
+
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      createNonFlexProject('row', 100, 90),
+    )
+  })
 })

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.spec.browser2.tsx
@@ -1,0 +1,221 @@
+import { CanvasControlsContainerID } from '../../../../../components/canvas/controls/new-canvas-controls'
+import { mouseClickAtPoint } from '../../../../../components/canvas/event-helpers.test-utils'
+import { cmdModifier } from '../../../../../utils/modifiers'
+import {
+  EditorRenderResult,
+  getPrintedUiJsCode,
+  renderTestEditorWithCode,
+} from '../../../../../components/canvas/ui-jsx.test-utils'
+import {
+  AbsoluteLengthUnits,
+  AllFlexDirections,
+  FlexDirection,
+  LengthPercentUnit,
+  LengthPercentUnits,
+  LengthUnit,
+  LengthUnits,
+} from '../../../../../components/inspector/common/css-utils'
+import { act, fireEvent } from '@testing-library/react'
+import { applyPrettier } from 'utopia-vscode-common'
+
+function downClickUp(targetElement: HTMLElement, mouseEventInit: MouseEventInit) {
+  fireEvent(targetElement, new MouseEvent('mousedown', mouseEventInit))
+  fireEvent(targetElement, new MouseEvent('click', mouseEventInit))
+  fireEvent(targetElement, new MouseEvent('mouseup', mouseEventInit))
+}
+
+function getCrossCapitalDimension(flexDirection: FlexDirection): string {
+  return flexDirection.startsWith('row') ? 'Height' : 'Width'
+}
+
+function createProject(
+  flexDirection: FlexDirection,
+  width: string | number,
+  height: string | number,
+): string {
+  const crossCapitalDimension = getCrossCapitalDimension(flexDirection)
+  return applyPrettier(
+    `import * as React from 'react'
+  import { Storyboard } from 'utopia-api'
+  
+  export var storyboard = (
+    <Storyboard data-uid='storyboard'>
+      <div
+        style={{
+          backgroundColor: 'grey',
+          position: 'absolute',
+          left: 111,
+          top: 121,
+          width: 469,
+          height: 310,
+          display: 'flex',
+          flexDirection: '${flexDirection}',
+          paddingTop: 0,
+        }}
+        data-testid='flexparent'
+        data-uid='flexparent'
+      >
+        <div
+          style={{
+            backgroundColor: 'blue',
+            height: ${JSON.stringify(height)},
+            width: ${JSON.stringify(width)},
+            min${crossCapitalDimension}: 40,
+            max${crossCapitalDimension}: 100,
+          }}
+          data-testid='flexchild'
+          data-uid='flexchild'
+        />
+      </div>
+    </Storyboard>
+  )
+  `,
+    false,
+  ).formatted
+}
+
+function createProjectWithoutMinAndMax(
+  flexDirection: FlexDirection,
+  width: string | number,
+  height: string | number,
+): string {
+  return applyPrettier(
+    `import * as React from 'react'
+  import { Storyboard } from 'utopia-api'
+  
+  export var storyboard = (
+    <Storyboard data-uid='storyboard'>
+      <div
+        style={{
+          backgroundColor: 'grey',
+          position: 'absolute',
+          left: 111,
+          top: 121,
+          width: 469,
+          height: 310,
+          display: 'flex',
+          flexDirection: '${flexDirection}',
+          paddingTop: 0,
+        }}
+        data-testid='flexparent'
+        data-uid='flexparent'
+      >
+        <div
+          style={{
+            backgroundColor: 'blue',
+            height: ${JSON.stringify(height)},
+            width: ${JSON.stringify(width)},
+          }}
+          data-testid='flexchild'
+          data-uid='flexchild'
+        />
+      </div>
+    </Storyboard>
+  )
+  `,
+    false,
+  ).formatted
+}
+
+function getCrossDimensionTestId(flexDirection: FlexDirection): string {
+  return flexDirection.startsWith('row')
+    ? 'position-height-number-input'
+    : 'position-width-number-input'
+}
+
+async function changeDimensionValue(
+  editor: EditorRenderResult,
+  flexDirection: FlexDirection,
+  newValue: string,
+): Promise<void> {
+  // Select the flex child.
+  const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
+  const div = editor.renderedDOM.getByTestId('flexchild')
+  const divBounds = div.getBoundingClientRect()
+  const divCorner = {
+    x: divBounds.x + 50,
+    y: divBounds.y + 40,
+  }
+
+  mouseClickAtPoint(canvasControlsLayer, divCorner, { modifiers: cmdModifier })
+
+  // Modify the value.
+  const dimensionInput = editor.renderedDOM.getByTestId(
+    getCrossDimensionTestId(flexDirection),
+  ) as HTMLInputElement
+  const dimensionInputBounds = dimensionInput.getBoundingClientRect()
+  const dimensionInputCenter = {
+    x: dimensionInputBounds.x + dimensionInputBounds.width / 2,
+    y: dimensionInputBounds.y + dimensionInputBounds.height / 2,
+  }
+  act(() => {
+    downClickUp(dimensionInput, {
+      detail: 1,
+      bubbles: true,
+      cancelable: true,
+      clientX: dimensionInputCenter.x,
+      clientY: dimensionInputCenter.y,
+      buttons: 1,
+    })
+  })
+
+  act(() => {
+    fireEvent.change(dimensionInput, { target: { value: newValue } })
+    fireEvent.blur(dimensionInput)
+  })
+
+  await editor.getDispatchFollowUpActionsFinished()
+}
+
+describe('flex dimension controls', () => {
+  // For every unit added on the end and for when no unit is explicitly supplied...
+  for (const lengthUnit of [...LengthPercentUnits, null]) {
+    // Common values relating to the length unit.
+    const unitText = lengthUnit == null ? 'with no unit' : `with a unit of ${lengthUnit}`
+    const newValue = lengthUnit == null ? '90px' : `90${lengthUnit}`
+    const isFixedUnit =
+      lengthUnit == null
+        ? true
+        : (AbsoluteLengthUnits as Array<LengthPercentUnit>).includes(lengthUnit)
+    // eslint-disable-next-line jest/valid-title
+    describe(unitText, () => {
+      // For every possible flex direction...
+      for (const flexDirection of AllFlexDirections) {
+        // Common properties relating to the flex direction.
+        const isRow = flexDirection.startsWith('row')
+        const crossCapitalDimension = getCrossCapitalDimension(flexDirection)
+        if (isFixedUnit) {
+          // If the unit is a fixed dimension, remove the additional properties.
+          it(`with a direction of ${flexDirection} when the ${crossCapitalDimension.toLowerCase()} is changed min${crossCapitalDimension} and max${crossCapitalDimension} are removed`, async () => {
+            const editor = await renderTestEditorWithCode(
+              createProject(flexDirection, 100, 120),
+              'await-first-dom-report',
+            )
+            await changeDimensionValue(editor, flexDirection, newValue)
+
+            expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+              createProjectWithoutMinAndMax(
+                flexDirection,
+                isRow ? 100 : newValue,
+                isRow ? newValue : 120,
+              ),
+            )
+          })
+        } else {
+          // If it is a proportional dimension, the minX and maxX properties remain.
+          it(`with a direction of ${flexDirection} when the ${crossCapitalDimension.toLowerCase()} is changed min${crossCapitalDimension} and max${crossCapitalDimension} are not removed`, async () => {
+            const editor = await renderTestEditorWithCode(
+              createProject(flexDirection, 100, 120),
+              'await-first-dom-report',
+            )
+            await changeDimensionValue(editor, flexDirection, newValue)
+
+            expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+              createProject(flexDirection, isRow ? 100 : newValue, isRow ? newValue : 120),
+            )
+          })
+        }
+      }
+    })
+  }
+})

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { UIGridRow } from '../../../widgets/ui-grid-row'
-import { PositionControl, MarginControl, AlignSelfControl } from './flex-element-controls'
+import { MarginControl, AlignSelfControl } from './flex-element-controls'
 import { PropertyLabel } from '../../../widgets/property-label'
 import {
   FunctionIcons,
@@ -24,13 +24,16 @@ import {
   InspectorPropsContext,
   stylePropPathMappingFn,
   useGetLayoutControlStatus,
-  useInspectorLayoutInfo,
 } from '../../../common/property-path-hooks'
 import { isNotUnsetDefaultOrDetected } from '../../../common/control-status'
-import { useEditorState } from '../../../../editor/store/store-hook'
+import { useRefEditorState } from '../../../../editor/store/store-hook'
 import { PropertyPath } from '../../../../../core/shared/project-file-types'
 import { usePropControlledStateV2 } from '../../../common/inspector-utils'
 import { useContextSelector } from 'use-context-selector'
+import { useDispatch } from '../../../../../components/editor/store/dispatch-context'
+import { executeFirstApplicableStrategy } from '../../../../../components/inspector/inspector-strategies/inspector-strategy'
+import { CSSNumber } from '../../../../../components/inspector/common/css-utils'
+import { setPropFixedStrategies } from '../../../../../components/inspector/inspector-strategies/inspector-strategies'
 
 function buildMarginProps(propertyTarget: ReadonlyArray<string>): Array<PropertyPath> {
   return [
@@ -304,10 +307,28 @@ const CrossAxisControls = React.memo((props: FlexElementSubsectionProps) => {
 })
 
 const FlexWidthControls = React.memo(() => {
+  const editorStateRef = useRefEditorState((store) => {
+    return {
+      metadata: store.editor.jsxMetadata,
+      selectedViews: store.editor.selectedViews,
+    }
+  })
+  const dispatch = useDispatch()
+  const fixedSizeHandler = React.useCallback(
+    (value: CSSNumber, transient: boolean) => {
+      executeFirstApplicableStrategy(
+        dispatch,
+        editorStateRef.current.metadata,
+        editorStateRef.current.selectedViews,
+        setPropFixedStrategies(transient ? 'mid-interaction' : 'always', 'horizontal', value),
+      )
+    },
+    [dispatch, editorStateRef],
+  )
   return (
     <>
       <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
-        <PinsLayoutNumberControl label='W' prop='width' />
+        <PinsLayoutNumberControl label='W' prop='width' fixedSizeHandler={fixedSizeHandler} />
       </UIGridRow>
       <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
         <FlexStyleNumberControl label='min' styleProp='minWidth' />
@@ -317,10 +338,28 @@ const FlexWidthControls = React.memo(() => {
   )
 })
 const FlexHeightControls = React.memo(() => {
+  const editorStateRef = useRefEditorState((store) => {
+    return {
+      metadata: store.editor.jsxMetadata,
+      selectedViews: store.editor.selectedViews,
+    }
+  })
+  const dispatch = useDispatch()
+  const fixedSizeHandler = React.useCallback(
+    (value: CSSNumber, transient: boolean) => {
+      executeFirstApplicableStrategy(
+        dispatch,
+        editorStateRef.current.metadata,
+        editorStateRef.current.selectedViews,
+        setPropFixedStrategies(transient ? 'mid-interaction' : 'always', 'vertical', value),
+      )
+    },
+    [dispatch, editorStateRef],
+  )
   return (
     <>
       <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
-        <PinsLayoutNumberControl label='H' prop='height' />
+        <PinsLayoutNumberControl label='H' prop='height' fixedSizeHandler={fixedSizeHandler} />
       </UIGridRow>
       <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
         <FlexStyleNumberControl label='min' styleProp='minHeight' />


### PR DESCRIPTION
**Problem:**
When setting the cross axis size of a flex element to a fixed size, the size may not actually appear to apply if there are `minX` and/or `maxX` properties associated with that axis.

**Fix:**
Now if the new value of the property is of a fixed size unit (like `px`), we clear the `minX` and `maxX` properties aassociated with it at the same time.

**Commit Details:**
- Made some values like `AbsoluteLengthUnits` be exported.
- Created `isFixedSize` utility function.
- Changed `setPropFixedStrategies` back to having `CSSNumber` as the type of `value, as well as adding the parameter `whenToRun`.
- `setPropFixedStrategies` now clears the `minX` and `maxX` properties relevant to the axis that is being updated.
- `PinsLayoutNumberControl` now takes an optional `fixedSizeHandler` property, which if exists is called when the property is a fixed size number.