### PR TITLE
Default color swatches to empty array, fix migration number

### DIFF
--- a/editor/src/components/editor/actions/migrations/migrations.ts
+++ b/editor/src/components/editor/actions/migrations/migrations.ts
@@ -423,7 +423,7 @@ function migrateFromVersion11(
 function migrateFromVersion12(
   persistentModel: PersistentModel,
 ): PersistentModel & { projectVersion: 13 } {
-  if (persistentModel.projectVersion != null && persistentModel.projectVersion !== 11) {
+  if (persistentModel.projectVersion != null && persistentModel.projectVersion !== 12) {
     return persistentModel as any
   } else {
     return {

--- a/editor/src/components/inspector/controls/color-picker-swatches.tsx
+++ b/editor/src/components/inspector/controls/color-picker-swatches.tsx
@@ -30,7 +30,7 @@ export const ColorPickerSwatches = React.memo((props: ColorPickerSwatchesProps) 
 
   const storeColorSwatches = useEditorState(
     Substores.restOfEditor,
-    (store) => store.editor.colorSwatches,
+    (store) => store.editor.colorSwatches ?? [],
     'ColorPickerSwatches color swatches',
   )
 


### PR DESCRIPTION
**Problem:**

The color swatches may not be defined for an old project. Also, fix the migration number check for `13`.

**Fix:**

Use an empty array.
