### PR TITLE
Resize to fit control & "Size" section

### DIFF
--- a/editor/src/components/inspector/resize-to-fit-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/resize-to-fit-control.spec.browser2.tsx
@@ -1,0 +1,100 @@
+import { setFeatureEnabled } from '../../utils/feature-switches'
+import { wait } from '../../utils/utils.test-utils'
+import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
+import { mouseClickAtPoint, mouseDoubleClickAtPoint } from '../canvas/event-helpers.test-utils'
+import { EditorRenderResult, renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
+import { ResizeToFitControlTestId } from './resize-to-fit-control'
+
+describe('Resize to fit control', () => {
+  before(() => setFeatureEnabled('Nine block control', true))
+  after(() => setFeatureEnabled('Nine block control', false))
+
+  it('resizes to fit', async () => {
+    const editor = await renderTestEditorWithCode(project, 'await-first-dom-report')
+    const view = await selectView(editor)
+    await clickResizeToFit(editor)
+
+    expect(view.style.width).toEqual('min-content')
+    expect(view.style.minWidth).toEqual('')
+    expect(view.style.maxWidth).toEqual('')
+    expect(view.style.height).toEqual('min-content')
+    expect(view.style.minHeight).toEqual('')
+    expect(view.style.maxHeight).toEqual('')
+  })
+})
+
+const ViewTestId = 'view'
+
+async function selectView(editor: EditorRenderResult): Promise<HTMLElement> {
+  const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
+  const view = editor.renderedDOM.getByTestId(ViewTestId)
+  const viewBounds = view.getBoundingClientRect()
+  const viewCorner = {
+    x: viewBounds.x + 50,
+    y: viewBounds.y + 40,
+  }
+
+  mouseDoubleClickAtPoint(canvasControlsLayer, viewCorner)
+
+  return view
+}
+
+async function clickResizeToFit(editor: EditorRenderResult) {
+  const resizeToFitControl = editor.renderedDOM.getByTestId(ResizeToFitControlTestId)
+
+  mouseClickAtPoint(resizeToFitControl, { x: 2, y: 2 })
+}
+
+const project = `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+import { View } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='0cd'>
+    <Scene
+      style={{
+        width: 700,
+        height: 759,
+        position: 'absolute',
+        left: 212,
+        top: 128,
+      }}
+      data-label='Playground'
+      data-uid='3fc'
+    >
+      <View
+        data-testid='${ViewTestId}'
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 181,
+          top: 118,
+          width: 325,
+          height: 294,
+          display: 'flex',
+        }}
+        data-uid='b51'
+      >
+        <div
+          style={{
+            backgroundColor: '#aaaaaa33',
+            width: 159,
+            height: 154,
+            contain: 'layout',
+          }}
+          data-uid='aae'
+        />
+        <div
+          style={{
+            backgroundColor: '#aaaaaa33',
+            width: 62,
+            height: 101,
+            contain: 'layout',
+          }}
+          data-uid='733'
+        />
+      </View>
+    </Scene>
+  </Storyboard>
+)
+`

--- a/editor/src/components/inspector/resize-to-fit-control.tsx
+++ b/editor/src/components/inspector/resize-to-fit-control.tsx
@@ -48,8 +48,12 @@ export const ResizeToFitControl = React.memo<ResizeToFitControlProps>(() => {
 
   return (
     <Tooltip title={'Resize to Fit'}>
-      <FlexRow data-testid={ResizeToFitControlTestId} onMouseDown={onMouseDown}>
-        <Icn type='warningtriangle' color='warning' width={16} height={16} />
+      <FlexRow
+        data-testid={ResizeToFitControlTestId}
+        onMouseDown={onMouseDown}
+        style={{ cursor: 'pointer' }}
+      >
+        <Icn type='fitToChildren' color='main' category='layout/commands' width={18} height={18} />
       </FlexRow>
     </Tooltip>
   )

--- a/editor/src/components/inspector/resize-to-fit-control.tsx
+++ b/editor/src/components/inspector/resize-to-fit-control.tsx
@@ -1,10 +1,14 @@
 import React from 'react'
 import { FlexRow, Icn, Tooltip } from '../../uuiui'
 import { EditorAction, EditorDispatch } from '../editor/action-types'
+import { applyCommandsAction } from '../editor/actions/action-creators'
 import { useDispatch } from '../editor/store/dispatch-context'
-import { Substores, useEditorState } from '../editor/store/store-hook'
+import { Substores, useEditorState, useRefEditorState } from '../editor/store/store-hook'
 import { setPropHugStrategies } from './inspector-strategies/inspector-strategies'
-import { executeFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
+import {
+  commandsForFirstApplicableStrategy,
+  executeFirstApplicableStrategy,
+} from './inspector-strategies/inspector-strategy'
 
 export const ResizeToFitControlTestId = 'ResizeToFitControlTestId'
 
@@ -12,39 +16,27 @@ interface ResizeToFitControlProps {}
 
 export const ResizeToFitControl = React.memo<ResizeToFitControlProps>(() => {
   const dispatch = useDispatch()
-  const selectedViews = useEditorState(
-    Substores.selectedViews,
-    (store) => store.editor.selectedViews,
-    'ResizeToFitControl selectedViews',
-  )
+  const selectedViewsRef = useRefEditorState((store) => store.editor.selectedViews)
 
-  const metadata = useEditorState(
-    Substores.metadata,
-    (store) => store.editor.jsxMetadata,
-    'ResizeToFitControl metadata',
-  )
+  const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
 
   const onMouseDown = React.useCallback(() => {
-    let batchedActions: Array<EditorAction> = []
-    const batchedDispatch: EditorDispatch = (actions) => {
-      batchedActions.push(...actions)
+    const commands = [
+      ...(commandsForFirstApplicableStrategy(
+        metadataRef.current,
+        selectedViewsRef.current,
+        setPropHugStrategies('horizontal'),
+      ) ?? []),
+      ...(commandsForFirstApplicableStrategy(
+        metadataRef.current,
+        selectedViewsRef.current,
+        setPropHugStrategies('vertical'),
+      ) ?? []),
+    ]
+    if (commands.length > 0) {
+      dispatch([applyCommandsAction(commands)])
     }
-    executeFirstApplicableStrategy(
-      batchedDispatch,
-      metadata,
-      selectedViews,
-      setPropHugStrategies('horizontal'),
-    )
-    executeFirstApplicableStrategy(
-      batchedDispatch,
-      metadata,
-      selectedViews,
-      setPropHugStrategies('vertical'),
-    )
-    if (batchedActions.length > 0) {
-      dispatch(batchedActions)
-    }
-  }, [dispatch, metadata, selectedViews])
+  }, [dispatch, metadataRef, selectedViewsRef])
 
   return (
     <Tooltip title={'Resize to Fit'}>

--- a/editor/src/components/inspector/resize-to-fit-control.tsx
+++ b/editor/src/components/inspector/resize-to-fit-control.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { FlexRow, Icn, Tooltip } from '../../uuiui'
+import { EditorAction, EditorDispatch } from '../editor/action-types'
+import { useDispatch } from '../editor/store/dispatch-context'
+import { Substores, useEditorState } from '../editor/store/store-hook'
+import { setPropHugStrategies } from './inspector-strategies/inspector-strategies'
+import { executeFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
+
+interface ResizeToFitControlProps {}
+
+export const ResizeToFitControl = React.memo<ResizeToFitControlProps>(() => {
+  const dispatch = useDispatch()
+  const selectedViews = useEditorState(
+    Substores.selectedViews,
+    (store) => store.editor.selectedViews,
+    'ResizeToFitControl selectedViews',
+  )
+
+  const metadata = useEditorState(
+    Substores.metadata,
+    (store) => store.editor.jsxMetadata,
+    'ResizeToFitControl metadata',
+  )
+
+  const onMouseDown = React.useCallback(() => {
+    let batchedActions: Array<EditorAction> = []
+    const batchedDispatch: EditorDispatch = (actions) => {
+      batchedActions.push(...actions)
+    }
+    executeFirstApplicableStrategy(
+      batchedDispatch,
+      metadata,
+      selectedViews,
+      setPropHugStrategies('horizontal'),
+    )
+    executeFirstApplicableStrategy(
+      batchedDispatch,
+      metadata,
+      selectedViews,
+      setPropHugStrategies('vertical'),
+    )
+    if (batchedActions.length > 0) {
+      dispatch(batchedActions)
+    }
+  }, [dispatch, metadata, selectedViews])
+
+  return (
+    <Tooltip title={'Resize to Fit'}>
+      <FlexRow onMouseDown={onMouseDown}>
+        <Icn type='warningtriangle' color='warning' width={16} height={16} />
+      </FlexRow>
+    </Tooltip>
+  )
+})

--- a/editor/src/components/inspector/resize-to-fit-control.tsx
+++ b/editor/src/components/inspector/resize-to-fit-control.tsx
@@ -6,6 +6,8 @@ import { Substores, useEditorState } from '../editor/store/store-hook'
 import { setPropHugStrategies } from './inspector-strategies/inspector-strategies'
 import { executeFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
 
+export const ResizeToFitControlTestId = 'ResizeToFitControlTestId'
+
 interface ResizeToFitControlProps {}
 
 export const ResizeToFitControl = React.memo<ResizeToFitControlProps>(() => {
@@ -46,7 +48,7 @@ export const ResizeToFitControl = React.memo<ResizeToFitControlProps>(() => {
 
   return (
     <Tooltip title={'Resize to Fit'}>
-      <FlexRow onMouseDown={onMouseDown}>
+      <FlexRow data-testid={ResizeToFitControlTestId} onMouseDown={onMouseDown}>
         <Icn type='warningtriangle' color='warning' width={16} height={16} />
       </FlexRow>
     </Tooltip>

--- a/editor/src/components/inspector/sections/style-section/container-subsection/container-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/container-subsection.tsx
@@ -1,13 +1,10 @@
 import React from 'react'
-import { isFeatureEnabled } from '../../../../../utils/feature-switches'
-import { when } from '../../../../../utils/react-conditionals'
 import {
   FlexRow,
   Icons,
   InspectorSectionIcons,
   InspectorSubsectionHeader,
 } from '../../../../../uuiui'
-import { FillHugFixedControl } from '../../../fill-hug-fixed-control'
 import { SeeMoreHOC, useToggle } from '../../../widgets/see-more'
 import { PaddingRow } from '../../layout-section/layout-system-subsection/layout-system-controls'
 import { BlendModeRow } from './blendmode-row'
@@ -35,7 +32,6 @@ export const ContainerSubsection = React.memo(() => {
           onClick={toggleSeeMoreVisible}
         />
       </InspectorSubsectionHeader>
-      {when(isFeatureEnabled('Nine block control'), <FillHugFixedControl />)}
       <OpacityRow />
       <OverflowRow />
       <RadiusRow />

--- a/editor/src/components/inspector/sections/style-section/style-section.tsx
+++ b/editor/src/components/inspector/sections/style-section/style-section.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
+import { isFeatureEnabled } from '../../../../utils/feature-switches'
+import { when } from '../../../../utils/react-conditionals'
 import { InspectorPartProps } from '../../inspector'
+import { SizingSection } from '../../sizing-section'
 import { BackgroundSubsection } from './background-subsection/background-subsection'
 import { BorderSubsection } from './border-subsection/border-subsection'
 import { ContainerSubsection } from './container-subsection/container-subsection'
@@ -25,6 +28,7 @@ export interface StyleSectionProps extends InspectorPartProps<React.CSSPropertie
 export const StyleSection = React.memo(() => {
   return (
     <React.Fragment>
+      {when(isFeatureEnabled('Nine block control'), <SizingSection />)}
       <ContainerSubsection />
       <TextSubsection />
       <TransformSubsection />

--- a/editor/src/components/inspector/sizing-section.tsx
+++ b/editor/src/components/inspector/sizing-section.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { FlexRow, InspectorSectionIcons, InspectorSubsectionHeader } from '../../uuiui'
+import { FillHugFixedControl } from './fill-hug-fixed-control'
+import { ResizeToFitControl } from './resize-to-fit-control'
+
+interface SizingSectionProps {}
+
+export const SizingSection = React.memo<SizingSectionProps>(() => {
+  return (
+    <>
+      <InspectorSubsectionHeader>
+        <FlexRow
+          style={{
+            flexGrow: 1,
+            gap: 8,
+          }}
+        >
+          <InspectorSectionIcons.Layer />
+          <span>Size</span>
+        </FlexRow>
+      </InspectorSubsectionHeader>
+      <FlexRow style={{ padding: 4, justifyContent: 'flex-end' }}>
+        <ResizeToFitControl />
+      </FlexRow>
+      <FillHugFixedControl />
+    </>
+  )
+})


### PR DESCRIPTION
## Description
This PR adds a "Size to fit" button, which makes the selected element resize to fit its contents (if applicable). The control reuses the `setPropHugStrategies` strategy set (on both axes).

Since there are two new sizing controls with this PR (Resize to Fit and Fixed/Fill/Hug), a new Size section is created for these two controls.