### PR TITLE
Reopen the code editor setting it at least 100px wide

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -470,6 +470,8 @@ import { getReparentPropertyChanges } from '../../canvas/canvas-strategies/strat
 import { styleStringInArray } from '../../../utils/common-constants'
 import { collapseTextElements } from '../../../components/text-editor/text-handling'
 
+const MIN_CODE_PANE_REOPEN_WIDTH = 100
+
 export function updateSelectedLeftMenuTab(editorState: EditorState, tab: LeftMenuTab): EditorState {
   return {
     ...editorState,
@@ -2708,6 +2710,10 @@ export const UPDATE_FNS = {
           interfaceDesigner: {
             ...editor.interfaceDesigner,
             codePaneVisible: action.visible,
+            codePaneWidth:
+              action.visible && editor.interfaceDesigner.codePaneWidth < MIN_CODE_PANE_REOPEN_WIDTH
+                ? MIN_CODE_PANE_REOPEN_WIDTH
+                : editor.interfaceDesigner.codePaneWidth,
           },
         }
       case 'misccodeeditor':


### PR DESCRIPTION
Fixes #3155 

**Problem:**

When the code editor is closed, reopening it is almost impossible due to its width being just a couple pixels.

**Fix:**

When reopening the code editor, if the width is less than 100px, max it to 100px.

`.pizza` vs fix:
![Kapture 2023-01-23 at 11 42 54](https://user-images.githubusercontent.com/1081051/214021029-797c6195-bdc0-41fc-a448-fe2b07c94e7f.gif)
