### PR TITLE
Better whitespace trimming

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -346,13 +346,13 @@ export function renderCoreElement(
   }
 }
 
-export function textOrNullFromJSXElement(c: JSXElementChild): string | null {
+function trimmedTextOrNullFromJSXElement(c: JSXElementChild): string | null {
   switch (c.type) {
     case 'JSX_TEXT_BLOCK':
       if (c.text.trim().length === 0) {
         return c.text
       }
-      return c.text.replace(/\n +/, '').replace('\n', '') // trimming to remove code formatting (prettier)
+      return trimWhitespaces(c.text)
     case 'JSX_ELEMENT':
       return c.name.baseVariable === 'br' ? '\n' : null
     case 'JSX_ARBITRARY_BLOCK':
@@ -367,12 +367,16 @@ export function textOrNullFromJSXElement(c: JSXElementChild): string | null {
   }
 }
 
-// if the element's text is not a newline and the next one is, trim the current element.
-function trimTextBeforeNewline(e: string, index: number, arr: string[]) {
-  if (e !== '\n' && index < arr.length - 1 && arr[index + 1] === '\n') {
-    return e.trim()
-  }
-  return e
+function trimWhitespaces(text: string): string {
+  return (
+    text
+      // split around all whitespaces, we don't want to keep newlines or repeated spaces
+      .split(/\s/)
+      // empty strings will appear between repeated whitespaces, we can ignore them
+      .filter((s) => s.length > 0)
+      // join back everything with a single space
+      .join(' ')
+  )
 }
 
 function renderJSXElement(
@@ -488,9 +492,7 @@ function renderJSXElement(
 
   if (elementPath != null && validPaths.has(EP.makeLastPartOfPathStatic(elementPath))) {
     if (elementIsTextEdited) {
-      const text = mapDropNulls(textOrNullFromJSXElement, childrenWithNewTextBlock)
-        .map(trimTextBeforeNewline)
-        .join('')
+      const text = mapDropNulls(trimmedTextOrNullFromJSXElement, childrenWithNewTextBlock).join('')
       const textContent = unescapeHTML(text ?? '')
       const textEditorProps = {
         elementPath: elementPath,

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -597,6 +597,74 @@ describe('Use the text editor', () => {
         )`),
       )
     })
+    it('trims all whitespaces', async () => {
+      const editor = await renderTestEditorWithCode(
+        formatTestProjectCode(`import * as React from 'react'
+      import { Storyboard } from 'utopia-api'
+      
+      
+      export var storyboard = (
+        <Storyboard data-uid='sb'>
+          <div
+            data-testid='div'
+            style={{
+              backgroundColor: '#0091FFAA',
+              position: 'absolute',
+              left: 0,
+              top: 0,
+              width: 288,
+              height: 362,
+            }}
+            data-uid='39e'
+          >
+            
+           Lorem   ipsum dolor sit amet, consectetur
+           adipiscing elit, sed    do eiusmod
+           
+           tempor
+
+
+          </div>
+        </Storyboard>
+      )
+      `),
+        'await-first-dom-report',
+      )
+
+      await enterTextEditMode(editor)
+      typeText('\n\n')
+      closeTextEditor()
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
+      expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+        formatTestProjectCode(`
+        import * as React from 'react'
+        import { Storyboard } from 'utopia-api'
+
+
+        export var storyboard = (
+          <Storyboard data-uid='sb'>
+            <div
+              data-testid='div'
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                left: 0,
+                top: 0,
+                width: 288,
+                height: 362,
+              }}
+              data-uid='39e'
+            >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+              <br />
+              <br />
+            </div>
+          </Storyboard>
+        )`),
+      )
+    })
   })
   describe('inline expressions', () => {
     it('handles expressions', async () => {

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -70,7 +70,7 @@ export function escapeHTML(s: string): string {
 
 // editor → canvas
 export function unescapeHTML(s: string): string {
-  const unescaped = unescape(s).replace(/ +$/, '') // prettier fix
+  const unescaped = unescape(s)
 
   // We need to add a trailing newline so that the contenteditable can render and reach the last newline
   // if the string _ends_ with a newline.


### PR DESCRIPTION
**Problem:**
When you have a long line in the text editor, it is split into multiple lines in the code editor (by prettier).
These lines caused a problem next time you opened the text editor: the newline and the extra lines are removed so the words before and after the newline were merged.

**Fix:**
The whitespace sanitization logic become too complex and scattered, and moved it into a single place and simplified it.