### PR TITLE
Canvas Resize nukes min max too

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -241,8 +241,13 @@ function createResizeCommandsFromFrame(
           'always',
           selectedElement,
           stylePropPathMappingFn(pin, styleStringInArray),
-          roundTo(valueToSet, 0),
-          horizontal ? elementParentBounds?.width : elementParentBounds?.height,
+          {
+            type: 'KEEP_ORIGINAL_UNIT',
+            valuePx: roundTo(valueToSet, 0),
+            parentDimensionPx: horizontal
+              ? elementParentBounds?.width
+              : elementParentBounds?.height,
+          },
         )
       }
     } else {

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -21,7 +21,11 @@ import {
   adjustCssLengthProperty,
 } from '../../commands/adjust-css-length-command'
 import { pushIntendedBounds } from '../../commands/push-intended-bounds-command'
-import { SetCssLengthProperty, setCssLengthProperty } from '../../commands/set-css-length-command'
+import {
+  SetCssLengthProperty,
+  setCssLengthProperty,
+  setValueKeepingOriginalUnit,
+} from '../../commands/set-css-length-command'
 import { setCursorCommand } from '../../commands/set-cursor-command'
 import { setElementsToRerenderCommand } from '../../commands/set-elements-to-rerender-command'
 import { setSnappingGuidelines } from '../../commands/set-snapping-guidelines-command'
@@ -241,13 +245,10 @@ function createResizeCommandsFromFrame(
           'always',
           selectedElement,
           stylePropPathMappingFn(pin, styleStringInArray),
-          {
-            type: 'KEEP_ORIGINAL_UNIT',
-            valuePx: roundTo(valueToSet, 0),
-            parentDimensionPx: horizontal
-              ? elementParentBounds?.width
-              : elementParentBounds?.height,
-          },
+          setValueKeepingOriginalUnit(
+            roundTo(valueToSet, 0),
+            horizontal ? elementParentBounds?.width : elementParentBounds?.height,
+          ),
         )
       }
     } else {

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -423,15 +423,13 @@ function createUpdatePinsCommands(
   fastForEach(pinsToSet, (framePin) => {
     const pinValue = pinValueToSet(framePin, fullFrame, parentFrame)
     commands.push(
-      setCssLengthProperty(
-        'always',
-        path,
-        stylePropPathMappingFn(framePin, styleStringInArray),
-        pinValue,
-        isHorizontalPoint(framePointForPinnedProp(framePin))
+      setCssLengthProperty('always', path, stylePropPathMappingFn(framePin, styleStringInArray), {
+        type: 'KEEP_ORIGINAL_UNIT',
+        valuePx: pinValue,
+        parentDimensionPx: isHorizontalPoint(framePointForPinnedProp(framePin))
           ? parentFrame?.width
           : parentFrame?.height,
-      ),
+      }),
     )
   })
   return commands

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -32,7 +32,11 @@ import { stylePropPathMappingFn } from '../../../inspector/common/property-path-
 import { CanvasFrameAndTarget } from '../../canvas-types'
 import { CanvasCommand } from '../../commands/commands'
 import { convertToAbsolute } from '../../commands/convert-to-absolute-command'
-import { SetCssLengthProperty, setCssLengthProperty } from '../../commands/set-css-length-command'
+import {
+  SetCssLengthProperty,
+  setCssLengthProperty,
+  setValueKeepingOriginalUnit,
+} from '../../commands/set-css-length-command'
 import { updateSelectedViews } from '../../commands/update-selected-views-command'
 import { ImmediateParentBounds } from '../../controls/parent-bounds'
 import { ImmediateParentOutlines } from '../../controls/parent-outlines'
@@ -423,13 +427,17 @@ function createUpdatePinsCommands(
   fastForEach(pinsToSet, (framePin) => {
     const pinValue = pinValueToSet(framePin, fullFrame, parentFrame)
     commands.push(
-      setCssLengthProperty('always', path, stylePropPathMappingFn(framePin, styleStringInArray), {
-        type: 'KEEP_ORIGINAL_UNIT',
-        valuePx: pinValue,
-        parentDimensionPx: isHorizontalPoint(framePointForPinnedProp(framePin))
-          ? parentFrame?.width
-          : parentFrame?.height,
-      }),
+      setCssLengthProperty(
+        'always',
+        path,
+        stylePropPathMappingFn(framePin, styleStringInArray),
+        setValueKeepingOriginalUnit(
+          pinValue,
+          isHorizontalPoint(framePointForPinnedProp(framePin))
+            ? parentFrame?.width
+            : parentFrame?.height,
+        ),
+      ),
     )
   })
   return commands

--- a/editor/src/components/canvas/commands/set-css-length-command.spec.tsx
+++ b/editor/src/components/canvas/commands/set-css-length-command.spec.tsx
@@ -7,7 +7,11 @@ import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-s
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
 import { updateEditorStateWithPatches } from './commands'
-import { runSetCssLengthProperty, setCssLengthProperty } from './set-css-length-command'
+import {
+  runSetCssLengthProperty,
+  setCssLengthProperty,
+  setValueKeepingOriginalUnit,
+} from './set-css-length-command'
 
 describe('setCssLengthProperty', () => {
   it('works for height style prop', async () => {
@@ -27,7 +31,7 @@ describe('setCssLengthProperty', () => {
       'always',
       cardInstancePath,
       stylePropPathMappingFn('height', styleStringInArray),
-      { type: 'KEEP_ORIGINAL_UNIT', valuePx: valueToSet, parentDimensionPx: 400 },
+      setValueKeepingOriginalUnit(valueToSet, 400),
     )
 
     const result = runSetCssLengthProperty(

--- a/editor/src/components/canvas/commands/set-css-length-command.spec.tsx
+++ b/editor/src/components/canvas/commands/set-css-length-command.spec.tsx
@@ -27,8 +27,7 @@ describe('setCssLengthProperty', () => {
       'always',
       cardInstancePath,
       stylePropPathMappingFn('height', styleStringInArray),
-      valueToSet,
-      400,
+      { type: 'KEEP_ORIGINAL_UNIT', valuePx: valueToSet, parentDimensionPx: 400 },
     )
 
     const result = runSetCssLengthProperty(

--- a/editor/src/components/canvas/commands/set-css-length-command.ts
+++ b/editor/src/components/canvas/commands/set-css-length-command.ts
@@ -24,6 +24,17 @@ type CssNumberOrKeepOriginalUnit =
   | { type: 'EXPLICIT_CSS_NUMBER'; value: CSSNumber }
   | { type: 'KEEP_ORIGINAL_UNIT'; valuePx: number; parentDimensionPx: number | undefined }
 
+export function setExplicitCssValue(value: CSSNumber): CssNumberOrKeepOriginalUnit {
+  return { type: 'EXPLICIT_CSS_NUMBER', value: value }
+}
+
+export function setValueKeepingOriginalUnit(
+  valuePx: number,
+  parentDimensionPx: number | undefined,
+): CssNumberOrKeepOriginalUnit {
+  return { type: 'KEEP_ORIGINAL_UNIT', valuePx: valuePx, parentDimensionPx: parentDimensionPx }
+}
+
 export interface SetCssLengthProperty extends BaseCommand {
   type: 'SET_CSS_LENGTH_PROPERTY'
   target: ElementPath

--- a/editor/src/components/canvas/commands/set-css-length-command.ts
+++ b/editor/src/components/canvas/commands/set-css-length-command.ts
@@ -113,7 +113,7 @@ export const runSetCssLengthProperty: CommandFunction<SetCssLengthProperty> = (
         ? command.value.value
         : cssPixelLength(command.value.valuePx)
 
-    const printedValue = printCSSNumber(newCssValue, null)
+    const printedValue = printCSSNumber(newCssValue, 'px')
 
     propsToUpdate.push({
       path: command.property,

--- a/editor/src/components/canvas/commands/set-css-length-command.ts
+++ b/editor/src/components/canvas/commands/set-css-length-command.ts
@@ -19,7 +19,7 @@ import {
 import { applyValuesAtPath } from './adjust-number-command'
 import { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
-type LengthValue =
+type CssNumberOrKeepOriginalUnit =
   | { type: 'EXPLICIT_CSS_NUMBER'; value: CSSNumber }
   | { type: 'KEEP_ORIGINAL_UNIT'; valuePx: number; parentDimensionPx: number | undefined }
 
@@ -27,14 +27,14 @@ export interface SetCssLengthProperty extends BaseCommand {
   type: 'SET_CSS_LENGTH_PROPERTY'
   target: ElementPath
   property: PropertyPath
-  value: LengthValue
+  value: CssNumberOrKeepOriginalUnit
 }
 
 export function setCssLengthProperty(
   whenToRun: WhenToRun,
   target: ElementPath,
   property: PropertyPath,
-  value: LengthValue,
+  value: CssNumberOrKeepOriginalUnit,
 ): SetCssLengthProperty {
   return {
     type: 'SET_CSS_LENGTH_PROPERTY',

--- a/editor/src/components/canvas/commands/set-css-length-command.ts
+++ b/editor/src/components/canvas/commands/set-css-length-command.ts
@@ -18,6 +18,7 @@ import {
 } from '../../inspector/common/css-utils'
 import { applyValuesAtPath } from './adjust-number-command'
 import { BaseCommand, CommandFunction, WhenToRun } from './commands'
+import { deleteValuesAtPath } from './delete-properties-command'
 
 type CssNumberOrKeepOriginalUnit =
   | { type: 'EXPLICIT_CSS_NUMBER'; value: CSSNumber }
@@ -113,9 +114,25 @@ export const runSetCssLengthProperty: CommandFunction<SetCssLengthProperty> = (
     })
   }
 
+  let propertiesToDelete: Array<PropertyPath> = []
+  switch (PP.lastPart(command.property)) {
+    case 'width':
+      propertiesToDelete = [PP.create(['style', 'minWidth']), PP.create(['style', 'maxWidth'])]
+      break
+    case 'height':
+      propertiesToDelete = [PP.create(['style', 'minHeight']), PP.create(['style', 'maxHeight'])]
+      break
+  }
+
+  const { editorStateWithChanges: editorStateWithPropsDeleted } = deleteValuesAtPath(
+    editorState,
+    command.target,
+    propertiesToDelete,
+  )
+
   // Apply the update to the properties.
   const { editorStatePatch: propertyUpdatePatch } = applyValuesAtPath(
-    editorState,
+    editorStateWithPropsDeleted,
     command.target,
     propsToUpdate,
   )

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -487,7 +487,12 @@ export type CSSNumberType =
 export type FontRelativeLengthUnit = 'cap' | 'ch' | 'em' | 'ex' | 'ic' | 'lh' | 'rem' | 'rlh'
 export type ViewportPercentageLengthUnit = 'vh' | 'vw' | 'vi' | 'vb' | 'vmin' | 'vmax'
 export type AbsoluteLengthUnit = 'px' | 'cm' | 'mm' | 'Q' | 'in' | 'pc' | 'pt'
-export type LengthUnit = FontRelativeLengthUnit | ViewportPercentageLengthUnit | AbsoluteLengthUnit
+export type FlexibleLengthUnit = 'fr' // https://www.w3.org/TR/css3-grid-layout/#fr-unit
+export type LengthUnit =
+  | FontRelativeLengthUnit
+  | ViewportPercentageLengthUnit
+  | AbsoluteLengthUnit
+  | FlexibleLengthUnit
 
 const FontRelativeLengthUnits: Array<FontRelativeLengthUnit> = [
   'cap',
@@ -516,10 +521,12 @@ export const AbsoluteLengthUnits: Array<AbsoluteLengthUnit> = [
   'pc',
   'pt',
 ]
+export const FlexibleLengthUnits: Array<FlexibleLengthUnit> = ['fr']
 export const LengthUnits: Array<LengthUnit> = [
   ...FontRelativeLengthUnits,
   ...ViewportPercentageLengthUnits,
   ...AbsoluteLengthUnits,
+  ...FlexibleLengthUnits,
 ]
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/length-percentage

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
@@ -172,53 +172,12 @@ export const setPropFixedStrategies = (
         return null
       }
 
-      return elementPaths.flatMap((path) => {
-        // Only delete these properties when this is a flex child.
-        let propertiesToDelete: Array<PropertyPath> = []
-        const elementMetadata = MetadataUtils.findElementByElementPath(metadata, path)
-        if (
-          elementMetadata != null &&
-          elementMetadata.specialSizeMeasurements.parentLayoutSystem === 'flex'
-        ) {
-          switch (axis) {
-            case 'horizontal':
-              propertiesToDelete = [
-                PP.create(['style', 'minWidth']),
-                PP.create(['style', 'maxWidth']),
-              ]
-              break
-            case 'vertical':
-              propertiesToDelete = [
-                PP.create(['style', 'minHeight']),
-                PP.create(['style', 'maxHeight']),
-              ]
-              break
-            default:
-              assertNever(axis)
-          }
-        }
-
-        switch (axis) {
-          case 'horizontal':
-            return [
-              deleteProperties(whenToRun, path, propertiesToDelete),
-              setCssLengthProperty(whenToRun, path, PP.create(['style', 'width']), {
-                type: 'EXPLICIT_CSS_NUMBER',
-                value: value,
-              }),
-            ]
-          case 'vertical':
-            return [
-              deleteProperties(whenToRun, path, propertiesToDelete),
-              setCssLengthProperty(whenToRun, path, PP.create(['style', 'height']), {
-                type: 'EXPLICIT_CSS_NUMBER',
-                value: value,
-              }),
-            ]
-          default:
-            assertNever(axis)
-        }
-      })
+      return elementPaths.map((path) =>
+        setCssLengthProperty(whenToRun, path, PP.create(['style', widthHeightFromAxis(axis)]), {
+          type: 'EXPLICIT_CSS_NUMBER',
+          value: value,
+        }),
+      )
     },
   },
 ]

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
@@ -25,6 +25,7 @@ import { InspectorStrategy } from './inspector-strategy'
 import { WhenToRun } from '../../../components/canvas/commands/commands'
 import { assertNever } from '../../../core/shared/utils'
 import { PropertyPath } from 'src/core/shared/project-file-types'
+import { setCssLengthProperty } from '../../canvas/commands/set-css-length-command'
 
 export const setFlexAlignJustifyContentStrategies = (
   flexAlignment: FlexAlignment,
@@ -201,22 +202,18 @@ export const setPropFixedStrategies = (
           case 'horizontal':
             return [
               deleteProperties(whenToRun, path, propertiesToDelete),
-              setProperty(
-                whenToRun,
-                path,
-                PP.create(['style', 'width']),
-                printCSSNumber(value, null),
-              ),
+              setCssLengthProperty(whenToRun, path, PP.create(['style', 'width']), {
+                type: 'EXPLICIT_CSS_NUMBER',
+                value: value,
+              }),
             ]
           case 'vertical':
             return [
               deleteProperties(whenToRun, path, propertiesToDelete),
-              setProperty(
-                whenToRun,
-                path,
-                PP.create(['style', 'height']),
-                printCSSNumber(value, null),
-              ),
+              setCssLengthProperty(whenToRun, path, PP.create(['style', 'height']), {
+                type: 'EXPLICIT_CSS_NUMBER',
+                value: value,
+              }),
             ]
           default:
             assertNever(axis)

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
@@ -25,7 +25,10 @@ import { InspectorStrategy } from './inspector-strategy'
 import { WhenToRun } from '../../../components/canvas/commands/commands'
 import { assertNever } from '../../../core/shared/utils'
 import { PropertyPath } from 'src/core/shared/project-file-types'
-import { setCssLengthProperty } from '../../canvas/commands/set-css-length-command'
+import {
+  setCssLengthProperty,
+  setExplicitCssValue,
+} from '../../canvas/commands/set-css-length-command'
 
 export const setFlexAlignJustifyContentStrategies = (
   flexAlignment: FlexAlignment,
@@ -173,10 +176,12 @@ export const setPropFixedStrategies = (
       }
 
       return elementPaths.map((path) =>
-        setCssLengthProperty(whenToRun, path, PP.create(['style', widthHeightFromAxis(axis)]), {
-          type: 'EXPLICIT_CSS_NUMBER',
-          value: value,
-        }),
+        setCssLengthProperty(
+          whenToRun,
+          path,
+          PP.create(['style', widthHeightFromAxis(axis)]),
+          setExplicitCssValue(value),
+        ),
       )
     },
   },

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.spec.browser2.tsx
@@ -164,7 +164,7 @@ function getCrossDimensionTestId(flexDirection: FlexDirection): string {
 async function changeDimensionValue(
   editor: EditorRenderResult,
   flexDirection: FlexDirection,
-  newValue: string,
+  newValue: string | number,
 ): Promise<void> {
   // Select the flex child.
   const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
@@ -203,10 +203,10 @@ async function changeDimensionValue(
 
 describe('flex dimension controls', () => {
   // For every unit added on the end and for when no unit is explicitly supplied...
-  for (const lengthUnit of [...LengthPercentUnits, null]) {
+  for (const lengthUnit of ['fr', '%', null] as const) {
     // Common values relating to the length unit.
     const unitText = lengthUnit == null ? 'with no unit' : `with a unit of ${lengthUnit}`
-    const newValue = lengthUnit == null ? '90px' : `90${lengthUnit}`
+    const newValue = lengthUnit == null ? 90 : `90${lengthUnit}`
     const isFixedUnit =
       lengthUnit == null
         ? true


### PR DESCRIPTION
**Problem:**
With #3152 we gained a functionality to automatically remove conflicting width/height properties (min-width, max-width, min-height, max-height) when setting width or height from the inspector.
But this did not cover the canvas strategies.

**Fix:**
Move the automatic prop removal to AdjustCssLengthProperty and SetCssLengthProperty commands. This ensures that all places using these commands will share the same behavior.

**Commit Details:**
- Extended SetCssLengthProperty so it can take an explicit CssNumber value
- Make `setPropFixedStrategies` use `SetCssLengthProperty`
- Removed prop removal code from `setPropFixedStrategies`
- Add prop removal code to SetCssLengthProperty
- Also use prop removal code in AdjustCssLengthProperty
