### PR TITLE
Fix drag to resize of absolute element with missing position props

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -509,6 +509,39 @@ describe('Absolute Resize Strategy', () => {
       `),
     )
   })
+  it('resizes absolute positioned element with missing position values', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ left: 100, top: 100, width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+            style={{ backgroundColor: '#aaaaaa33', position: 'absolute', width: 200, height: 120 }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    const target = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
+    const dragDelta = windowPoint({ x: 40, y: 50 })
+
+    await renderResult.dispatch([selectComponents([target], false)], true)
+    resizeElement(renderResult, dragDelta, EdgePositionTopLeft, emptyModifiers)
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ left: 100, top: 100, width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+            style={{ backgroundColor: '#aaaaaa33', position: 'absolute', width: 160, height: 70, left: 40, top: 50 }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+    )
+  })
   it('resizes absolute element with snapping, `bbb` should snap to `ccc`', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -8,8 +8,10 @@ import { isRight, right } from '../../../../core/shared/either'
 import { ElementInstanceMetadataMap, JSXElement } from '../../../../core/shared/element-template'
 import {
   CanvasRectangle,
+  canvasRectangleToLocalRectangle,
   rectangleDifference,
   roundTo,
+  SimpleRectangle,
   transformFrameUsingBoundingBox,
 } from '../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
@@ -236,7 +238,12 @@ function createResizeCommandsFromFrame(
           true,
         )
       } else {
-        const valueToSet = allPinsFromFrame(newFrame)[pin]
+        // If this element has a parent, we need to take that parent's bounds into account
+        const frameToUse =
+          elementParentBounds == null
+            ? newFrame
+            : canvasRectangleToLocalRectangle(newFrame, elementParentBounds)
+        const valueToSet = allPinsFromFrame(frameToUse)[pin]
         return setCssLengthProperty(
           'always',
           selectedElement,
@@ -251,7 +258,7 @@ function createResizeCommandsFromFrame(
   }, pins)
 }
 
-function allPinsFromFrame(frame: CanvasRectangle): { [key: string]: number } {
+function allPinsFromFrame(frame: SimpleRectangle): { [key: string]: number } {
   return {
     left: frame.x,
     top: frame.y,


### PR DESCRIPTION
Fixes #3164

**Problem:**
Dragging to resize absolute positioned elements without position props will set those values using the canvas rectangle rather than the local one.

**Fix:**
Convert the updated frame to a `LocalRectangle` before grabbing the value needed to set the prop
