### PR TITLE
Fix flushsync warning

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.spec.browser2.tsx
@@ -1,4 +1,5 @@
 import { FOR_TESTS_setNextGeneratedUid } from '../../../../core/model/element-template-utils.test-utils'
+import { wait } from '../../../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../../../canvas/controls/new-canvas-controls'
 import {
   mouseClickAtPoint,
@@ -35,7 +36,7 @@ describe('draw-to-insert text', () => {
       await editor.getDispatchFollowUpActionsFinished()
 
       typeText('Utopia')
-      closeTextEditor()
+      await closeTextEditor()
       await editor.getDispatchFollowUpActionsFinished()
 
       const newElementUID = Object.keys(editor.getEditorState().editor.domMetadata)
@@ -98,7 +99,7 @@ describe('draw-to-insert text', () => {
       await editor.getDispatchFollowUpActionsFinished()
 
       typeText('Utopia')
-      closeTextEditor()
+      await closeTextEditor()
       await editor.getDispatchFollowUpActionsFinished()
 
       const newElementUID = Object.keys(editor.getEditorState().editor.domMetadata)
@@ -163,7 +164,7 @@ describe('draw-to-insert text', () => {
       await editor.getDispatchFollowUpActionsFinished()
 
       typeText(' Utopia')
-      closeTextEditor()
+      await closeTextEditor()
       await editor.getDispatchFollowUpActionsFinished()
 
       const newElementUID = Object.keys(editor.getEditorState().editor.domMetadata)
@@ -239,7 +240,7 @@ describe('draw-to-insert text', () => {
       await editor.getDispatchFollowUpActionsFinished()
 
       typeText('Hello Utopia')
-      closeTextEditor()
+      await closeTextEditor()
       await editor.getDispatchFollowUpActionsFinished()
 
       expect(editor.getEditorState().editor.mode.type).toEqual('select')
@@ -298,7 +299,7 @@ describe('draw-to-insert text', () => {
       await editor.getDispatchFollowUpActionsFinished()
 
       typeText('Hey root')
-      closeTextEditor()
+      await closeTextEditor()
       await editor.getDispatchFollowUpActionsFinished()
 
       const newElementUID = Object.keys(editor.getEditorState().editor.domMetadata)
@@ -335,8 +336,9 @@ function typeText(text: string) {
   document.execCommand('insertText', false, text)
 }
 
-function closeTextEditor() {
+async function closeTextEditor() {
   pressKey('Escape')
+  await wait(0) // this is needed so we wait until the dispatch call is launched in a settimeout when the text editor unmounts
 }
 
 const projectWithText = formatTestProjectCode(`import * as React from 'react'

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -816,7 +816,7 @@ function typeText(text: string) {
 
 async function closeTextEditor() {
   pressKey('Escape')
-  await wait(0)
+  await wait(0) // this is needed so we wait until the dispatch call is launched in a settimeout when the text editor unmounts
 }
 
 const projectWithText = formatTestProjectCode(`import * as React from 'react'

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -21,7 +21,7 @@ describe('Use the text editor', () => {
 
     await enterTextEditMode(editor)
     typeText(' Utopia')
-    closeTextEditor()
+    await closeTextEditor()
     await editor.getDispatchFollowUpActionsFinished()
 
     expect(editor.getEditorState().editor.mode.type).toEqual('select')
@@ -54,7 +54,7 @@ describe('Use the text editor', () => {
 
     await enterTextEditMode(editor)
     typeText('Utopia')
-    closeTextEditor()
+    await closeTextEditor()
     await editor.getDispatchFollowUpActionsFinished()
 
     expect(editor.getEditorState().editor.mode.type).toEqual('select')
@@ -119,7 +119,7 @@ describe('Use the text editor', () => {
 
     await enterTextEditMode(editor)
     typeText('this is a <test> with bells & whistles')
-    closeTextEditor()
+    await closeTextEditor()
     await editor.getDispatchFollowUpActionsFinished()
 
     expect(editor.getEditorState().editor.mode.type).toEqual('select')
@@ -243,7 +243,7 @@ describe('Use the text editor', () => {
 
     typeText('--HEY--')
 
-    closeTextEditor()
+    await closeTextEditor()
     await editor.getDispatchFollowUpActionsFinished()
 
     expect(editor.getEditorState().editor.mode.type).toEqual('select')
@@ -280,7 +280,7 @@ describe('Use the text editor', () => {
 
         deleteTypedText()
 
-        closeTextEditor()
+        await closeTextEditor()
         await editor.getDispatchFollowUpActionsFinished()
 
         expect(editor.getEditorState().editor.mode.type).toEqual('select')
@@ -321,7 +321,7 @@ describe('Use the text editor', () => {
 
         deleteTypedText()
 
-        closeTextEditor()
+        await closeTextEditor()
         await editor.getDispatchFollowUpActionsFinished()
 
         expect(editor.getEditorState().editor.mode.type).toEqual('select')
@@ -357,7 +357,7 @@ describe('Use the text editor', () => {
 
         await wait(50) // give it time to adjust the caret position
 
-        closeTextEditor()
+        await closeTextEditor()
         await editor.getDispatchFollowUpActionsFinished()
 
         expect(editor.getEditorState().editor.mode.type).toEqual('select')
@@ -413,7 +413,7 @@ describe('Use the text editor', () => {
 
         typeText(' there')
 
-        closeTextEditor()
+        await closeTextEditor()
         await editor.getDispatchFollowUpActionsFinished()
 
         expect(editor.getEditorState().editor.mode.type).toEqual('select')
@@ -456,7 +456,7 @@ describe('Use the text editor', () => {
 
       await enterTextEditMode(editor)
       typeText('\nHow are you?')
-      closeTextEditor()
+      await closeTextEditor()
       await editor.getDispatchFollowUpActionsFinished()
 
       expect(editor.getEditorState().editor.mode.type).toEqual('select')
@@ -490,7 +490,7 @@ describe('Use the text editor', () => {
 
       await enterTextEditMode(editor)
       typeText('\n\nblablabla')
-      closeTextEditor()
+      await closeTextEditor()
       await editor.getDispatchFollowUpActionsFinished()
 
       expect(editor.getEditorState().editor.mode.type).toEqual('select')
@@ -530,7 +530,7 @@ describe('Use the text editor', () => {
 
       await enterTextEditMode(editor)
       typeText('\n\n')
-      closeTextEditor()
+      await closeTextEditor()
       await editor.getDispatchFollowUpActionsFinished()
 
       expect(editor.getEditorState().editor.mode.type).toEqual('select')
@@ -564,7 +564,7 @@ describe('Use the text editor', () => {
 
       await enterTextEditMode(editor)
       typeText('test')
-      closeTextEditor()
+      await closeTextEditor()
       await editor.getDispatchFollowUpActionsFinished()
 
       expect(editor.getEditorState().editor.mode.type).toEqual('select')
@@ -633,7 +633,7 @@ describe('Use the text editor', () => {
 
       await enterTextEditMode(editor)
       typeText('\n\n')
-      closeTextEditor()
+      await closeTextEditor()
       await editor.getDispatchFollowUpActionsFinished()
 
       expect(editor.getEditorState().editor.mode.type).toEqual('select')
@@ -672,7 +672,7 @@ describe('Use the text editor', () => {
 
       await enterTextEditMode(editor)
       typeText('the answer is {41 + 1}')
-      closeTextEditor()
+      await closeTextEditor()
 
       await editor.getDispatchFollowUpActionsFinished()
       await wait(50)
@@ -777,7 +777,7 @@ async function pressShortcut(editor: EditorRenderResult, mod: Modifiers, key: st
     modifiers: mod,
     targetElement: document.getElementById(TextEditorSpanId) ?? undefined,
   })
-  closeTextEditor()
+  await closeTextEditor()
   await editor.getDispatchFollowUpActionsFinished()
 }
 
@@ -814,8 +814,9 @@ function typeText(text: string) {
   document.execCommand('insertText', false, text)
 }
 
-function closeTextEditor() {
+async function closeTextEditor() {
   pressKey('Escape')
+  await wait(0)
 }
 
 const projectWithText = formatTestProjectCode(`import * as React from 'react'

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -232,10 +232,10 @@ const TextEditor = React.memo((props: TextEditorProps) => {
       const content = currentElement.textContent
       if (content != null) {
         if (elementState === 'new' && content.replace(/\n/g, '') === '') {
-          dispatch([deleteView(elementPath)])
+          setTimeout(() => dispatch([deleteView(elementPath)]))
         } else {
           if (elementState != null) {
-            dispatch([updateChildText(elementPath, escapeHTML(content))])
+            setTimeout(() => dispatch([updateChildText(elementPath, escapeHTML(content))]))
           }
         }
       }


### PR DESCRIPTION
**Problem:**
In the text editor we dispatched actions in a lifecycle method which resulted in a react warning.

**Fix:**
Wrap the dispatch call in a setTimeout

