### PR TITLE
fix(canvas) context menu copy properties

### DIFF
--- a/editor/src/components/canvas/canvas-context-menu.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-context-menu.spec.browser2.tsx
@@ -1,7 +1,7 @@
 import { fireEvent } from '@testing-library/react'
 import { BakedInStoryboardUID } from '../../core/model/scene-utils'
 import * as EP from '../../core/shared/element-path'
-import { cmdModifier } from '../../utils/modifiers'
+import { altCmdModifier, cmdModifier } from '../../utils/modifiers'
 import { selectComponents } from '../editor/actions/meta-actions'
 import { CanvasControlsContainerID } from './controls/new-canvas-controls'
 import { mouseClickAtPoint, pressKey } from './event-helpers.test-utils'
@@ -53,7 +53,7 @@ describe('canvas context menu', () => {
     await renderResult.dispatch(selectComponents([copyPropertiesFrom], false), true)
 
     // copy properties first
-    pressKey('c', { modifiers: cmdModifier })
+    pressKey('c', { modifiers: altCmdModifier })
     await renderResult.getDispatchFollowUpActionsFinished()
 
     const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/ccc`)
@@ -101,7 +101,7 @@ describe('canvas context menu', () => {
     await renderResult.dispatch(selectComponents([copyPropertiesFrom], false), true)
 
     // copy properties first
-    pressKey('c', { modifiers: cmdModifier })
+    pressKey('c', { modifiers: altCmdModifier })
     await renderResult.getDispatchFollowUpActionsFinished()
 
     const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/ccc`)

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -101,6 +101,15 @@ export const pasteElements: ContextMenuItem<CanvasData> = {
   },
 }
 
+export const copyPropertiesMenuItem: ContextMenuItem<CanvasData> = {
+  name: 'Copy Properties',
+  enabled: true,
+  shortcut: '⌥⌘C',
+  action: (data, dispatch?: EditorDispatch) => {
+    requireDispatch(dispatch)([EditorActions.copyProperties()], 'noone')
+  },
+}
+
 export const pasteStyle: ContextMenuItem<CanvasData> = {
   name: 'Paste Style',
   enabled: true,

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -347,6 +347,10 @@ export interface PasteJSXElements {
 export interface CopySelectionToClipboard {
   action: 'COPY_SELECTION_TO_CLIPBOARD'
 }
+
+export interface CopyProperties {
+  action: 'COPY_PROPERTIES'
+}
 export interface PasteProperties {
   action: 'PASTE_PROPERTIES'
   type: 'style' | 'layout'
@@ -1132,6 +1136,7 @@ export type EditorAction =
   | OpenPopup
   | PasteJSXElements
   | CopySelectionToClipboard
+  | CopyProperties
   | PasteProperties
   | SetProjectID
   | SetForkedFromProjectID

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -226,6 +226,7 @@ import type {
   WorkerCodeAndParsedUpdate,
   UpdateColorSwatches,
   PasteProperties,
+  CopyProperties,
 } from '../action-types'
 import { EditorModes, insertionSubject, Mode } from '../editor-modes'
 import type {
@@ -455,6 +456,12 @@ export function pasteJSXElements(
 export function copySelectionToClipboard(): CopySelectionToClipboard {
   return {
     action: 'COPY_SELECTION_TO_CLIPBOARD',
+  }
+}
+
+export function copyProperties(): CopyProperties {
+  return {
+    action: 'COPY_PROPERTIES',
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -32,6 +32,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'TOGGLE_FOCUSED_OMNIBOX_TAB':
     case 'TOGGLE_PANE':
     case 'COPY_SELECTION_TO_CLIPBOARD':
+    case 'COPY_PROPERTIES':
     case 'OPEN_TEXT_EDITOR':
     case 'CLOSE_TEXT_EDITOR':
     case 'SET_LEFT_MENU_TAB':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -320,6 +320,7 @@ import {
   ApplyCommandsAction,
   UpdateColorSwatches,
   PasteProperties,
+  CopyProperties,
 } from '../action-types'
 import { defaultSceneElement, defaultTransparentViewElement } from '../defaults'
 import { EditorModes, isLiveMode, isSelectMode, Mode } from '../editor-modes'
@@ -2994,21 +2995,6 @@ export const UPDATE_FNS = {
     dispatch: EditorDispatch,
     builtInDependencies: BuiltInDependencies,
   ): EditorModel => {
-    const styleClipboardData = (): Array<ValueAtPath> => {
-      if (editorForAction.selectedViews.length === 0) {
-        return []
-      } else {
-        const target = editorForAction.selectedViews[0]
-        const styleProps =
-          editorForAction._currentAllElementProps_KILLME[EP.toString(target)]?.style ?? {}
-        return Object.keys(styleProps).map((name) =>
-          valueAtPath(
-            PP.create(['style', name]),
-            jsxAttributeValue(styleProps[name], emptyComments),
-          ),
-        )
-      }
-    }
     return toastOnUncopyableElementsSelected(
       'Cannot copy these elements.',
       editorForAction,
@@ -3019,11 +3005,26 @@ export const UPDATE_FNS = {
         return {
           ...editor,
           pasteTargetsToIgnore: editor.selectedViews,
-          styleClipboard: styleClipboardData(),
+          styleClipboard: [],
         }
       },
       dispatch,
     )
+  },
+  COPY_PROPERTIES: (action: CopyProperties, editor: EditorModel): EditorModel => {
+    if (editor.selectedViews.length === 0) {
+      return editor
+    } else {
+      const target = editor.selectedViews[0]
+      const styleProps = editor._currentAllElementProps_KILLME[EP.toString(target)]?.style ?? {}
+      const styleClipboardData = Object.keys(styleProps).map((name) =>
+        valueAtPath(PP.create(['style', name]), jsxAttributeValue(styleProps[name], emptyComments)),
+      )
+      return {
+        ...editor,
+        styleClipboard: styleClipboardData,
+      }
+    }
   },
   OPEN_TEXT_EDITOR: (action: OpenTextEditor, editor: EditorModel): EditorModel => {
     return {

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -94,6 +94,7 @@ import {
   TOGGLE_TEXT_UNDERLINE,
   TOGGLE_TEXT_STRIKE_THROUGH,
   PASTE_STYLE_PROPERTIES,
+  COPY_STYLE_PROPERTIES,
   CONVERT_TO_FLEX_CONTAINER,
 } from './shortcut-definitions'
 import { DerivedState, EditorState, getOpenFile, RightMenuTab } from './store/editor-state'
@@ -770,6 +771,13 @@ export function handleKeyDown(
         return isSelectMode(editor.mode)
           ? editor.selectedViews.map((target) => {
               return EditorActions.pasteProperties('style')
+            })
+          : []
+      },
+      [COPY_STYLE_PROPERTIES]: () => {
+        return isSelectMode(editor.mode)
+          ? editor.selectedViews.map((target) => {
+              return EditorActions.copyProperties()
             })
           : []
       },

--- a/editor/src/components/editor/shortcut-definitions.ts
+++ b/editor/src/components/editor/shortcut-definitions.ts
@@ -78,6 +78,7 @@ export const TOGGLE_TEXT_ITALIC = 'toggle-text-italic'
 export const TOGGLE_TEXT_UNDERLINE = 'toggle-text-underline'
 export const TOGGLE_TEXT_STRIKE_THROUGH = 'toggle-text-strike-through'
 export const PASTE_STYLE_PROPERTIES = 'paste-style-properties'
+export const COPY_STYLE_PROPERTIES = 'copy-style-properties'
 
 export const OPEN_EYEDROPPPER = 'open-eyedropper'
 export const CONVERT_TO_FLEX_CONTAINER = 'convert-to-flex-container'
@@ -231,11 +232,12 @@ const shortcutDetailsWithDefaults: ShortcutDetails = {
     'Toggle text-decoration to line-through of the currently selected text element.',
     key('x', ['cmd', 'shift']),
   ),
-  [PASTE_STYLE_PROPERTIES]: shortcut('Paste style properties', key('v', ['alt', 'cmd'])),
   [CONVERT_TO_FLEX_CONTAINER]: shortcut(
     'Convert selected elements to flex containers',
     key('a', ['shift']),
   ),
+  [COPY_STYLE_PROPERTIES]: shortcut('Copy style properties', key('c', ['alt', 'cmd'])),
+  [PASTE_STYLE_PROPERTIES]: shortcut('Paste style properties', key('v', ['alt', 'cmd'])),
 }
 
 export type ShortcutConfiguration = { [key: string]: Array<Key> }

--- a/editor/src/components/editor/shortcuts.spec.browser2.tsx
+++ b/editor/src/components/editor/shortcuts.spec.browser2.tsx
@@ -292,7 +292,7 @@ describe('global shortcuts to set properties', () => {
     await renderResult.dispatch(selectComponents([copyPropertiesFrom], false), true)
 
     // copy style properties first
-    pressKey('c', { modifiers: cmdModifier })
+    pressKey('c', { modifiers: altCmdModifier })
     await renderResult.getDispatchFollowUpActionsFinished()
 
     const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/ccc`)

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -123,6 +123,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.PASTE_PROPERTIES(action, state)
     case 'COPY_SELECTION_TO_CLIPBOARD':
       return UPDATE_FNS.COPY_SELECTION_TO_CLIPBOARD(action, state, dispatch, builtInDependencies)
+    case 'COPY_PROPERTIES':
+      return UPDATE_FNS.COPY_PROPERTIES(action, state)
     case 'OPEN_TEXT_EDITOR':
       return UPDATE_FNS.OPEN_TEXT_EDITOR(action, state)
     case 'CLOSE_TEXT_EDITOR':

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -28,6 +28,7 @@ import {
   escapeHatch,
   pasteStyle,
   pasteLayout,
+  copyPropertiesMenuItem,
 } from './context-menu-items'
 import { MomentumContextMenu } from './context-menu-wrapper'
 import { useRefEditorState, useEditorState, Substores } from './editor/store/store-hook'
@@ -60,6 +61,7 @@ const ElementContextMenuItems: Array<ContextMenuItem<CanvasData>> = [
   scrollToElement,
   cutElements,
   copyElements,
+  copyPropertiesMenuItem,
   pasteStyle,
   pasteLayout,
   duplicateElement,


### PR DESCRIPTION
**Fix:**
New item in the contextmenu and a new shortcut to copy only style properties.

**Commit Details:**
- a new shortcut
- added an action to copy properties only
- updated tests to use copy properties shortcut
