### PR TITLE
Converting Parent to Flex Will Remove Absolute Props of Children

### DIFF
--- a/editor/src/components/inspector/add-remove-layout-system-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.spec.browser2.tsx
@@ -123,6 +123,61 @@ describe('add layout system', () => {
     expect(child.style.left).toEqual('')
     expect(child.style.bottom).toEqual('')
     expect(child.style.right).toEqual('')
+    expect(child.style.contain).toEqual('layout')
+    expect(child.style.width).toEqual('100px')
+    expect(child.style.height).toEqual('120px')
+  })
+
+  it('adding flex layout does not add contain layout to static positioned child', async () => {
+    const editor = await renderTestEditorWithCode(
+      `
+      import * as React from 'react'
+      import { Storyboard } from 'utopia-api'
+
+      export var storyboard = (
+        <Storyboard data-uid='0cd'>
+          <div
+            data-testid='mydiv'
+            style={{
+              backgroundColor: '#aaaaaa33',
+              position: 'absolute',
+              left: 0,
+              top: 0,
+              width: 120,
+              height: 140,
+            }}
+            data-uid='5f9'
+          >
+            <div
+              data-testid='child'
+              style={{
+                backgroundColor: '#aaaaaa33',
+                width: 100,
+                height: 120,
+              }}
+              data-uid='9e4'
+            />
+          </div>
+        </Storyboard>
+      )`,
+      'await-first-dom-report',
+    )
+    const div = await selectDiv(editor)
+    await clickOn(editor)
+
+    expect(div.style.display).toEqual('flex')
+
+    const child = editor.renderedDOM.getByTestId('child')
+
+    // Ensure contain layout was not added
+    expect(child.style.contain).toEqual('')
+
+    // Might as well check the other props are correct whilst we're here
+    expect(child.style.position).toEqual('')
+    expect(child.style.top).toEqual('')
+    expect(child.style.left).toEqual('')
+    expect(child.style.bottom).toEqual('')
+    expect(child.style.right).toEqual('')
     expect(child.style.width).toEqual('100px')
     expect(child.style.height).toEqual('120px')
   })

--- a/editor/src/components/inspector/add-remove-layout-system-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.spec.browser2.tsx
@@ -74,6 +74,58 @@ describe('add layout system', () => {
     expect(child.style.height).toEqual('')
     expect(child.style.flexGrow).toEqual('1')
   })
+
+  it('adding flex layout removes absolute props and sets explicit width and height', async () => {
+    const editor = await renderTestEditorWithCode(
+      `
+      import * as React from 'react'
+      import { Storyboard } from 'utopia-api'
+
+      export var storyboard = (
+        <Storyboard data-uid='0cd'>
+          <div
+            data-testid='mydiv'
+            style={{
+              backgroundColor: '#aaaaaa33',
+              position: 'absolute',
+              left: 0,
+              top: 0,
+              width: 120,
+              height: 140,
+            }}
+            data-uid='5f9'
+          >
+            <div
+              data-testid='child'
+              style={{
+                backgroundColor: '#aaaaaa33',
+                position: 'absolute',
+                top: 10,
+                left: 10,
+                bottom: 10,
+                right: 10,
+              }}
+              data-uid='9e4'
+            />
+          </div>
+        </Storyboard>
+      )`,
+      'await-first-dom-report',
+    )
+    const div = await selectDiv(editor)
+    await clickOn(editor)
+
+    expect(div.style.display).toEqual('flex')
+
+    const child = editor.renderedDOM.getByTestId('child')
+    expect(child.style.position).toEqual('')
+    expect(child.style.top).toEqual('')
+    expect(child.style.left).toEqual('')
+    expect(child.style.bottom).toEqual('')
+    expect(child.style.right).toEqual('')
+    expect(child.style.width).toEqual('100px')
+    expect(child.style.height).toEqual('120px')
+  })
 })
 
 async function selectDiv(editor: EditorRenderResult): Promise<HTMLElement> {

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
@@ -96,9 +96,10 @@ export const addFlexLayoutStrategies: Array<InspectorStrategy> = [
     strategy: (metadata, elementPaths) => {
       return elementPaths.flatMap((path) => [
         setProperty('always', path, PP.create(['style', 'display']), 'flex'),
-        ...MetadataUtils.getChildrenPaths(metadata, path).flatMap((child) =>
-          convertWidthToFlexGrow(metadata, child),
-        ),
+        ...MetadataUtils.getChildrenPaths(metadata, path).flatMap((child) => [
+          nukeAllAbsolutePositioningPropsCommand(child),
+          ...convertWidthToFlexGrow(metadata, child),
+        ]),
       ])
     },
   },

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
@@ -97,7 +97,7 @@ export const addFlexLayoutStrategies: Array<InspectorStrategy> = [
       return elementPaths.flatMap((path) => [
         setProperty('always', path, PP.create(['style', 'display']), 'flex'),
         ...MetadataUtils.getChildrenPaths(metadata, path).flatMap((child) => [
-          nukeAllAbsolutePositioningPropsCommand(child),
+          ...nukeAllAbsolutePositioningPropsCommands(child),
           ...sizeToVisualDimensions(metadata, child),
           ...convertWidthToFlexGrow(metadata, child),
         ]),

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
@@ -98,6 +98,7 @@ export const addFlexLayoutStrategies: Array<InspectorStrategy> = [
         setProperty('always', path, PP.create(['style', 'display']), 'flex'),
         ...MetadataUtils.getChildrenPaths(metadata, path).flatMap((child) => [
           nukeAllAbsolutePositioningPropsCommand(child),
+          ...sizeToVisualDimensions(metadata, child),
           ...convertWidthToFlexGrow(metadata, child),
         ]),
       ])


### PR DESCRIPTION
**Problem:**
When converting an element to a flex container, children would still retain certain absolute positioning props.

**Fix:**
Aggressively remove those props, ensuring we still have a width and height set if one wasn't before. I've also added a test for this, and ensured that it doesn't interfere with the logic to add `flexGrow` when the relevant axis has `width: 100%` (for which there is already an existing test)