### PR TITLE
fix(canvas) move context menu line separator

### DIFF
--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -57,8 +57,8 @@ interface ElementContextMenuProps {
 const ElementContextMenuItems: Array<ContextMenuItem<CanvasData>> = [
   setAsFocusedElement,
   removeAsFocusedElement,
-  lineSeparator,
   scrollToElement,
+  lineSeparator,
   cutElements,
   copyElements,
   copyPropertiesMenuItem,


### PR DESCRIPTION
**Fix:**
Very minor change in the context menu to have all copy/paste related items in the same category.

**Commit Details:**
- moved separator line between 'scroll to' and 'cut' context menu items 
