### PR TITLE
only store parentFlexDirection if the parent is display flex

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -859,9 +859,11 @@ function getSpecialMeasurements(
 
   const parentLayoutSystem = elementLayoutSystem(parentElementStyle)
   const parentProvidesLayout = element.parentElement === element.offsetParent
-  const parentFlexDirection = eitherToMaybe(
-    parseFlexDirection(parentElementStyle?.flexDirection, null),
-  )
+  const parentFlexDirection =
+    parentLayoutSystem !== 'flex'
+      ? null
+      : eitherToMaybe(parseFlexDirection(parentElementStyle?.flexDirection, null))
+
   const flexDirection = eitherToMaybe(parseFlexDirection(elementStyle.flexDirection, null))
   const parentTextDirection = eitherToMaybe(parseDirection(parentElementStyle?.direction, null))
 


### PR DESCRIPTION
**Problem:**
If an element is display: block or otherwise not Flex, computedStyle.flexDirection will still default to `row`. 
In the specialSizeMeasurements we already store parentFlexDirection as FlexDirection | null. 

I'm working on a new feature that conditionally removes properties based on the parent being flex or not.

To simplify the logic, it'd be better if parentFlexDirection would be `null` for non-flex parents.

**Fix:**
Store parentFlexDirection as null if the parent is not flex
