### PR TITLE
Test utility to assert that a single UI action only generates a single undo step

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -35,7 +35,11 @@ import {
   BakedInStoryboardVariableName,
   BakedInStoryboardUID,
 } from '../../../../core/model/scene-utils'
-import { mouseClickAtPoint, mouseDragFromPointWithDelta } from '../../event-helpers.test-utils'
+import {
+  expectSingleUndoStep,
+  mouseClickAtPoint,
+  mouseDragFromPointWithDelta,
+} from '../../event-helpers.test-utils'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import { setFeatureEnabled } from '../../../../utils/feature-switches'
 import { CSSProperties } from 'react'
@@ -288,7 +292,9 @@ async function doDblClickTest(editor: EditorRenderResult, testId: string): Promi
 
   const nineBlockControlSegment = editor.renderedDOM.getByTestId(testId)
 
-  mouseClickAtPoint(nineBlockControlSegment, { x: 2, y: 30 }, { eventOptions: { detail: 2 } })
+  await expectSingleUndoStep(editor, async () =>
+    mouseClickAtPoint(nineBlockControlSegment, { x: 2, y: 30 }, { eventOptions: { detail: 2 } }),
+  )
 
   return div
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -35,11 +35,7 @@ import {
   BakedInStoryboardVariableName,
   BakedInStoryboardUID,
 } from '../../../../core/model/scene-utils'
-import {
-  expectSingleUndoStep,
-  mouseClickAtPoint,
-  mouseDragFromPointWithDelta,
-} from '../../event-helpers.test-utils'
+import { mouseClickAtPoint, mouseDragFromPointWithDelta } from '../../event-helpers.test-utils'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import { setFeatureEnabled } from '../../../../utils/feature-switches'
 import { CSSProperties } from 'react'
@@ -292,9 +288,7 @@ async function doDblClickTest(editor: EditorRenderResult, testId: string): Promi
 
   const nineBlockControlSegment = editor.renderedDOM.getByTestId(testId)
 
-  await expectSingleUndoStep(editor, async () =>
-    mouseClickAtPoint(nineBlockControlSegment, { x: 2, y: 30 }, { eventOptions: { detail: 2 } }),
-  )
+  mouseClickAtPoint(nineBlockControlSegment, { x: 2, y: 30 }, { eventOptions: { detail: 2 } })
 
   return div
 }

--- a/editor/src/components/canvas/event-helpers.test-utils.tsx
+++ b/editor/src/components/canvas/event-helpers.test-utils.tsx
@@ -2,8 +2,7 @@ import { act, createEvent, fireEvent } from '@testing-library/react'
 import { emptyModifiers, Modifiers } from '../../utils/modifiers'
 import { resetMouseStatus } from '../mouse-move'
 import keycode from 'keycode'
-import { assertNever, NO_OP } from '../../core/shared/utils'
-import { EditorRenderResult } from './ui-jsx.test-utils'
+import { NO_OP } from '../../core/shared/utils'
 
 // TODO Should the mouse move and mouse up events actually be fired at the parent of the event source?
 // Or document.body?

--- a/editor/src/components/canvas/event-helpers.test-utils.tsx
+++ b/editor/src/components/canvas/event-helpers.test-utils.tsx
@@ -695,13 +695,3 @@ export function switchDragAndDropElementTargets(
     fireEvent(targetElement, makeDragEvent('dragover', targetElement, endPoint, fileList))
   })
 }
-
-export async function expectSingleUndoStep<T>(
-  editor: EditorRenderResult,
-  action: () => Promise<T>,
-): Promise<T> {
-  const undoCount = editor.getUndoCount()
-  const result = await action()
-  expect(editor.getUndoCount()).toEqual(undoCount + 1)
-  return result
-}

--- a/editor/src/components/canvas/event-helpers.test-utils.tsx
+++ b/editor/src/components/canvas/event-helpers.test-utils.tsx
@@ -3,6 +3,7 @@ import { emptyModifiers, Modifiers } from '../../utils/modifiers'
 import { resetMouseStatus } from '../mouse-move'
 import keycode from 'keycode'
 import { assertNever, NO_OP } from '../../core/shared/utils'
+import { EditorRenderResult } from './ui-jsx.test-utils'
 
 // TODO Should the mouse move and mouse up events actually be fired at the parent of the event source?
 // Or document.body?
@@ -693,4 +694,14 @@ export function switchDragAndDropElementTargets(
   act(() => {
     fireEvent(targetElement, makeDragEvent('dragover', targetElement, endPoint, fileList))
   })
+}
+
+export async function expectSingleUndoStep<T>(
+  editor: EditorRenderResult,
+  action: () => Promise<T>,
+): Promise<T> {
+  const undoCount = editor.getUndoCount()
+  const result = await action()
+  expect(editor.getUndoCount()).toEqual(undoCount + 1)
+  return result
 }

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -161,7 +161,6 @@ export interface EditorRenderResult {
   renderedDOM: RenderResult
   getNumberOfCommits: () => number
   getNumberOfRenders: () => number
-  getUndoCount: () => number
   clearRecordedActions: () => void
   getRecordedActions: () => ReadonlyArray<EditorAction>
 }
@@ -230,8 +229,6 @@ export async function renderTestEditorWithModel(
     innerStrategiesToUse: Array<MetaCanvasStrategy> = strategiesToUse,
   ) => {
     recordedActions.push(...actions)
-    const allTransientActions = actions.every((a) => isTransientAction(a))
-    undoCount += allTransientActions ? 0 : 1
     const result = editorDispatch(
       asyncTestDispatch,
       actions,
@@ -421,7 +418,6 @@ export async function renderTestEditorWithModel(
     renderedDOM: result,
     getNumberOfCommits: () => numberOfCommits,
     getNumberOfRenders: () => renderCount - renderCountBaseline,
-    getUndoCount: () => undoCount,
     clearRecordedActions: () => {
       recordedActions = []
     },

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -116,6 +116,7 @@ import {
   RegisteredCanvasStrategies,
 } from './canvas-strategies/canvas-strategies'
 import { createStoresAndState, UtopiaStoreAPI } from '../editor/store/store-hook'
+import { isTransientAction } from '../editor/actions/action-utils'
 
 // eslint-disable-next-line no-unused-expressions
 typeof process !== 'undefined' &&
@@ -160,6 +161,7 @@ export interface EditorRenderResult {
   renderedDOM: RenderResult
   getNumberOfCommits: () => number
   getNumberOfRenders: () => number
+  getUndoCount: () => number
   clearRecordedActions: () => void
   getRecordedActions: () => ReadonlyArray<EditorAction>
 }
@@ -199,6 +201,7 @@ export async function renderTestEditorWithModel(
   loginState: LoginState = notLoggedIn,
 ): Promise<EditorRenderResult> {
   const renderCountBaseline = renderCount
+  let undoCount = 0
   let recordedActions: Array<EditorAction> = []
 
   let emptyEditorState = createEditorState(NO_OP)
@@ -227,6 +230,8 @@ export async function renderTestEditorWithModel(
     innerStrategiesToUse: Array<MetaCanvasStrategy> = strategiesToUse,
   ) => {
     recordedActions.push(...actions)
+    const allTransientActions = actions.every((a) => isTransientAction(a))
+    undoCount += allTransientActions ? 0 : 1
     const result = editorDispatch(
       asyncTestDispatch,
       actions,
@@ -416,6 +421,7 @@ export async function renderTestEditorWithModel(
     renderedDOM: result,
     getNumberOfCommits: () => numberOfCommits,
     getNumberOfRenders: () => renderCount - renderCountBaseline,
+    getUndoCount: () => undoCount,
     clearRecordedActions: () => {
       recordedActions = []
     },

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -200,7 +200,6 @@ export async function renderTestEditorWithModel(
   loginState: LoginState = notLoggedIn,
 ): Promise<EditorRenderResult> {
   const renderCountBaseline = renderCount
-  let undoCount = 0
   let recordedActions: Array<EditorAction> = []
 
   let emptyEditorState = createEditorState(NO_OP)

--- a/editor/src/components/inspector/add-remove-layout-system-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.spec.browser2.tsx
@@ -1,11 +1,8 @@
 import { setFeatureEnabled } from '../../utils/feature-switches'
 import { shiftModifier } from '../../utils/modifiers'
+import { expectSingleUndoStep } from '../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
-import {
-  expectSingleUndoStep,
-  mouseClickAtPoint,
-  pressKey,
-} from '../canvas/event-helpers.test-utils'
+import { mouseClickAtPoint, pressKey } from '../canvas/event-helpers.test-utils'
 import { renderTestEditorWithCode, EditorRenderResult } from '../canvas/ui-jsx.test-utils'
 import { AddRemoveLayouSystemControlTestId } from './add-remove-layout-system-control'
 

--- a/editor/src/components/inspector/add-remove-layout-system-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.spec.browser2.tsx
@@ -1,7 +1,11 @@
 import { setFeatureEnabled } from '../../utils/feature-switches'
 import { shiftModifier } from '../../utils/modifiers'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
-import { mouseClickAtPoint, pressKey } from '../canvas/event-helpers.test-utils'
+import {
+  expectSingleUndoStep,
+  mouseClickAtPoint,
+  pressKey,
+} from '../canvas/event-helpers.test-utils'
 import { renderTestEditorWithCode, EditorRenderResult } from '../canvas/ui-jsx.test-utils'
 import { AddRemoveLayouSystemControlTestId } from './add-remove-layout-system-control'
 
@@ -23,10 +27,11 @@ describe('add layout system', () => {
 
     expect(div.style.display).toEqual('')
 
-    pressKey('a', { modifiers: shiftModifier })
+    await expectSingleUndoStep(editor, async () => pressKey('a', { modifiers: shiftModifier }))
+
     expect(div.style.display).toEqual('flex')
 
-    pressKey('a', { modifiers: shiftModifier })
+    await expectSingleUndoStep(editor, async () => pressKey('a', { modifiers: shiftModifier }))
     expect(div.style.display).toEqual('')
   })
 
@@ -36,11 +41,11 @@ describe('add layout system', () => {
       'await-first-dom-report',
     )
     const div = await selectDiv(editor)
-    await clickOn(editor)
+    await expectSingleUndoStep(editor, () => clickOn(editor))
 
     expect(div.style.display).toEqual('flex')
 
-    await clickOn(editor)
+    await expectSingleUndoStep(editor, () => clickOn(editor))
 
     expect(div.style.display).toEqual('')
   })
@@ -51,7 +56,7 @@ describe('add layout system', () => {
       'await-first-dom-report',
     )
     const div = await selectDiv(editor)
-    await clickOn(editor)
+    await expectSingleUndoStep(editor, () => clickOn(editor))
 
     expect(div.style.display).toEqual('flex')
 
@@ -66,7 +71,7 @@ describe('add layout system', () => {
       'await-first-dom-report',
     )
     const div = await selectDiv(editor)
-    await clickOn(editor)
+    await expectSingleUndoStep(editor, () => clickOn(editor))
 
     expect(div.style.display).toEqual('flex')
 

--- a/editor/src/components/inspector/flex-direction-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/flex-direction-control.spec.browser2.tsx
@@ -46,7 +46,7 @@ describe('set flex direction', () => {
 
     expect(div.style.flexDirection).toEqual('column')
 
-    await expectSingleUndoStep(editor, () => clickOn(editor, 'column'))
+    await expectSingleUndoStep(editor, () => rightClickOn(editor, 'column'))
 
     expect(div.style.flexDirection).toEqual('')
   })

--- a/editor/src/components/inspector/flex-direction-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/flex-direction-control.spec.browser2.tsx
@@ -1,6 +1,7 @@
 import { setFeatureEnabled } from '../../utils/feature-switches'
+import { expectSingleUndoStep } from '../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
-import { expectSingleUndoStep, mouseClickAtPoint } from '../canvas/event-helpers.test-utils'
+import { mouseClickAtPoint } from '../canvas/event-helpers.test-utils'
 import { EditorRenderResult, renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
 import { FlexDirection } from './common/css-utils'
 import { FlexDirectionToggleTestId } from './flex-direction-control'

--- a/editor/src/components/inspector/flex-direction-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/flex-direction-control.spec.browser2.tsx
@@ -1,6 +1,6 @@
 import { setFeatureEnabled } from '../../utils/feature-switches'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
-import { mouseClickAtPoint } from '../canvas/event-helpers.test-utils'
+import { expectSingleUndoStep, mouseClickAtPoint } from '../canvas/event-helpers.test-utils'
 import { EditorRenderResult, renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
 import { FlexDirection } from './common/css-utils'
 import { FlexDirectionToggleTestId } from './flex-direction-control'
@@ -17,7 +17,8 @@ describe('set flex direction', () => {
   it('set flex direction to row from not set', async () => {
     const editor = await renderTestEditorWithCode(project(), 'await-first-dom-report')
     const div = await selectDiv(editor)
-    await clickOn(editor, 'row')
+
+    await expectSingleUndoStep(editor, () => clickOn(editor, 'row'))
 
     expect(div.style.flexDirection).toEqual('row')
 
@@ -33,7 +34,7 @@ describe('set flex direction', () => {
 
     expect(div.style.flexDirection).toEqual('row')
 
-    await clickOn(editor, 'column')
+    await expectSingleUndoStep(editor, () => clickOn(editor, 'column'))
 
     expect(div.style.flexDirection).toEqual('column')
   })
@@ -45,7 +46,7 @@ describe('set flex direction', () => {
 
     expect(div.style.flexDirection).toEqual('column')
 
-    await rightClickOn(editor, 'column')
+    await expectSingleUndoStep(editor, () => clickOn(editor, 'column'))
 
     expect(div.style.flexDirection).toEqual('')
   })

--- a/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
@@ -1,7 +1,11 @@
 import { assertNever } from '../../../core/shared/utils'
 import { setFeatureEnabled } from '../../../utils/feature-switches'
 import { CanvasControlsContainerID } from '../../canvas/controls/new-canvas-controls'
-import { mouseClickAtPoint, mouseDoubleClickAtPoint } from '../../canvas/event-helpers.test-utils'
+import {
+  expectSingleUndoStep,
+  mouseClickAtPoint,
+  mouseDoubleClickAtPoint,
+} from '../../canvas/event-helpers.test-utils'
 import {
   EditorRenderResult,
   formatTestProjectCode,
@@ -29,7 +33,9 @@ describe('Fixed / Fill / Hug control', () => {
       mouseClickAtPoint(control, { x: 5, y: 5 })
 
       const button = (await editor.renderedDOM.findAllByText(FillContainerLabel))[0]
-      mouseClickAtPoint(button, { x: 5, y: 5 })
+      await expectSingleUndoStep(editor, async () => {
+        mouseClickAtPoint(button, { x: 5, y: 5 })
+      })
 
       expect(div.style.width).toEqual('')
       expect(div.style.minWidth).toEqual('')
@@ -49,7 +55,9 @@ describe('Fixed / Fill / Hug control', () => {
       mouseClickAtPoint(control, { x: 5, y: 5 })
 
       const button = (await editor.renderedDOM.findAllByText(FillContainerLabel))[0]
-      mouseClickAtPoint(button, { x: 5, y: 5 })
+      await expectSingleUndoStep(editor, async () => {
+        mouseClickAtPoint(button, { x: 5, y: 5 })
+      })
 
       expect(div.style.minWidth).toEqual('')
       expect(div.style.maxWidth).toEqual('')
@@ -69,7 +77,9 @@ describe('Fixed / Fill / Hug control', () => {
       mouseClickAtPoint(control, { x: 5, y: 5 })
 
       const button = (await editor.renderedDOM.findAllByText(FillContainerLabel))[0]
-      mouseClickAtPoint(button, { x: 5, y: 5 })
+      await expectSingleUndoStep(editor, async () => {
+        mouseClickAtPoint(button, { x: 5, y: 5 })
+      })
 
       expect(div.style.minHeight).toEqual('')
       expect(div.style.maxHeight).toEqual('')
@@ -89,7 +99,9 @@ describe('Fixed / Fill / Hug control', () => {
       mouseClickAtPoint(control, { x: 5, y: 5 })
 
       const button = (await editor.renderedDOM.findAllByText(FillContainerLabel))[0]
-      mouseClickAtPoint(button, { x: 5, y: 5 })
+      await expectSingleUndoStep(editor, async () => {
+        mouseClickAtPoint(button, { x: 5, y: 5 })
+      })
 
       expect(div.style.minHeight).toEqual('')
       expect(div.style.maxHeight).toEqual('')
@@ -115,7 +127,9 @@ describe('Fixed / Fill / Hug control', () => {
       mouseClickAtPoint(control, { x: 5, y: 5 })
 
       const button = (await editor.renderedDOM.findAllByText(FillContainerLabel))[0]
-      mouseClickAtPoint(button, { x: 5, y: 5 })
+      await expectSingleUndoStep(editor, async () => {
+        mouseClickAtPoint(button, { x: 5, y: 5 })
+      })
 
       expect(getPrintedUiJsCodeWithoutUIDs(editor.getEditorState())).toEqual(
         absoluteProjectWithInjectedStyle(`
@@ -144,7 +158,9 @@ describe('Fixed / Fill / Hug control', () => {
       mouseClickAtPoint(control, { x: 5, y: 5 })
 
       const button = (await editor.renderedDOM.findAllByText(FillContainerLabel))[0]
-      mouseClickAtPoint(button, { x: 5, y: 5 })
+      await expectSingleUndoStep(editor, async () => {
+        mouseClickAtPoint(button, { x: 5, y: 5 })
+      })
 
       expect(getPrintedUiJsCodeWithoutUIDs(editor.getEditorState())).toEqual(
         absoluteProjectWithInjectedStyle(`
@@ -173,7 +189,9 @@ describe('Fixed / Fill / Hug control', () => {
       mouseClickAtPoint(control, { x: 5, y: 5 })
 
       const button = (await editor.renderedDOM.findAllByText(FillContainerLabel))[0]
-      mouseClickAtPoint(button, { x: 5, y: 5 })
+      await expectSingleUndoStep(editor, async () => {
+        mouseClickAtPoint(button, { x: 5, y: 5 })
+      })
 
       expect(getPrintedUiJsCodeWithoutUIDs(editor.getEditorState())).toEqual(
         absoluteProjectWithInjectedStyle(`
@@ -202,7 +220,9 @@ describe('Fixed / Fill / Hug control', () => {
       mouseClickAtPoint(control, { x: 5, y: 5 })
 
       const button = (await editor.renderedDOM.findAllByText(FillContainerLabel))[1]
-      mouseClickAtPoint(button, { x: 5, y: 5 })
+      await expectSingleUndoStep(editor, async () => {
+        mouseClickAtPoint(button, { x: 5, y: 5 })
+      })
 
       expect(getPrintedUiJsCodeWithoutUIDs(editor.getEditorState())).toEqual(
         absoluteProjectWithInjectedStyle(`
@@ -229,7 +249,9 @@ describe('Fixed / Fill / Hug control', () => {
       mouseClickAtPoint(control, { x: 5, y: 5 })
 
       const button = (await editor.renderedDOM.findAllByText(FillContainerLabel))[1]
-      mouseClickAtPoint(button, { x: 5, y: 5 })
+      await expectSingleUndoStep(editor, async () => {
+        mouseClickAtPoint(button, { x: 5, y: 5 })
+      })
 
       // Should not add contain: layout
       expect(getPrintedUiJsCodeWithoutUIDs(editor.getEditorState())).toEqual(
@@ -251,7 +273,9 @@ describe('Fixed / Fill / Hug control', () => {
       mouseClickAtPoint(control, { x: 5, y: 5 })
 
       const button = (await editor.renderedDOM.findAllByText(HugContentsLabel))[0]
-      mouseClickAtPoint(button, { x: 5, y: 5 })
+      await expectSingleUndoStep(editor, async () => {
+        mouseClickAtPoint(button, { x: 5, y: 5 })
+      })
 
       expect(div.style.width).toEqual(MaxContent)
       expect(div.style.minWidth).toEqual('')
@@ -270,7 +294,9 @@ describe('Fixed / Fill / Hug control', () => {
       mouseClickAtPoint(control, { x: 5, y: 5 })
 
       const button = (await editor.renderedDOM.findAllByText(HugContentsLabel))[0]
-      mouseClickAtPoint(button, { x: 5, y: 5 })
+      await expectSingleUndoStep(editor, async () => {
+        mouseClickAtPoint(button, { x: 5, y: 5 })
+      })
 
       expect(div.style.height).toEqual(MaxContent)
       expect(div.style.minHeight).toEqual('')
@@ -295,7 +321,9 @@ describe('Fixed / Fill / Hug control', () => {
         mouseClickAtPoint(control, { x: 5, y: 5 })
 
         const button = (await editor.renderedDOM.findAllByText(HugContentsLabel))[0]
-        mouseClickAtPoint(button, { x: 5, y: 5 })
+        await expectSingleUndoStep(editor, async () => {
+          mouseClickAtPoint(button, { x: 5, y: 5 })
+        })
 
         expect(parent.style.height).toEqual('759px')
         expect(child.style.height).toEqual('149px')
@@ -319,7 +347,9 @@ describe('Fixed / Fill / Hug control', () => {
         mouseClickAtPoint(control, { x: 5, y: 5 })
 
         const button = (await editor.renderedDOM.findAllByText(HugContentsLabel))[0]
-        mouseClickAtPoint(button, { x: 5, y: 5 })
+        await expectSingleUndoStep(editor, async () => {
+          mouseClickAtPoint(button, { x: 5, y: 5 })
+        })
 
         expect(parent.style.width).toEqual('700px')
         expect(child.style.width).toEqual('149px')
@@ -343,7 +373,9 @@ describe('Fixed / Fill / Hug control', () => {
         mouseClickAtPoint(control, { x: 5, y: 5 })
 
         const button = (await editor.renderedDOM.findAllByText(HugContentsLabel))[0]
-        mouseClickAtPoint(button, { x: 5, y: 5 })
+        await expectSingleUndoStep(editor, async () => {
+          mouseClickAtPoint(button, { x: 5, y: 5 })
+        })
 
         expect(parent.style.width).toEqual(MaxContent)
         expect(child.style.width).toEqual('302px')
@@ -367,7 +399,9 @@ describe('Fixed / Fill / Hug control', () => {
         mouseClickAtPoint(control, { x: 5, y: 5 })
 
         const button = (await editor.renderedDOM.findAllByText(HugContentsLabel))[0]
-        mouseClickAtPoint(button, { x: 5, y: 5 })
+        await expectSingleUndoStep(editor, async () => {
+          mouseClickAtPoint(button, { x: 5, y: 5 })
+        })
 
         expect(parent.style.width).toEqual('700px')
         expect(child.style.width).toEqual('302px')
@@ -391,7 +425,9 @@ describe('Fixed / Fill / Hug control', () => {
         mouseClickAtPoint(control, { x: 5, y: 5 })
 
         const button = (await editor.renderedDOM.findAllByText(HugContentsLabel))[0]
-        mouseClickAtPoint(button, { x: 5, y: 5 })
+        await expectSingleUndoStep(editor, async () => {
+          mouseClickAtPoint(button, { x: 5, y: 5 })
+        })
 
         expect(parent.style.width).toEqual(MaxContent)
         expect(child.style.width).toEqual(MaxContent)
@@ -415,7 +451,9 @@ describe('Fixed / Fill / Hug control', () => {
         mouseClickAtPoint(control, { x: 5, y: 5 })
 
         const button = (await editor.renderedDOM.findAllByText(HugContentsLabel))[0]
-        mouseClickAtPoint(button, { x: 5, y: 5 })
+        await expectSingleUndoStep(editor, async () => {
+          mouseClickAtPoint(button, { x: 5, y: 5 })
+        })
 
         expect(parent.style.width).toEqual('508px')
         expect(child.style.width).toEqual(MaxContent)

--- a/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
@@ -1,11 +1,8 @@
 import { assertNever } from '../../../core/shared/utils'
 import { setFeatureEnabled } from '../../../utils/feature-switches'
+import { expectSingleUndoStep } from '../../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../../canvas/controls/new-canvas-controls'
-import {
-  expectSingleUndoStep,
-  mouseClickAtPoint,
-  mouseDoubleClickAtPoint,
-} from '../../canvas/event-helpers.test-utils'
+import { mouseClickAtPoint, mouseDoubleClickAtPoint } from '../../canvas/event-helpers.test-utils'
 import {
   EditorRenderResult,
   formatTestProjectCode,

--- a/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.spec.browser2.tsx
@@ -1,6 +1,6 @@
 import { setFeatureEnabled } from '../../../utils/feature-switches'
 import { CanvasControlsContainerID } from '../../canvas/controls/new-canvas-controls'
-import { mouseClickAtPoint } from '../../canvas/event-helpers.test-utils'
+import { expectSingleUndoStep, mouseClickAtPoint } from '../../canvas/event-helpers.test-utils'
 import { renderTestEditorWithCode, EditorRenderResult } from '../../canvas/ui-jsx.test-utils'
 import { AddRemoveLayouSystemControlTestId } from '../add-remove-layout-system-control'
 
@@ -17,7 +17,7 @@ describe('remove-flex-convert-to-absolute strategy', () => {
     const editor = await renderTestEditorWithCode(project(), 'await-first-dom-report')
     const root = await selectDiv(editor)
 
-    await clickOn(editor)
+    await expectSingleUndoStep(editor, () => clickOn(editor))
 
     expect(root.style.display).toEqual('')
     expect(root.style.alignItems).toEqual('')

--- a/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.spec.browser2.tsx
@@ -1,6 +1,7 @@
 import { setFeatureEnabled } from '../../../utils/feature-switches'
+import { expectSingleUndoStep } from '../../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../../canvas/controls/new-canvas-controls'
-import { expectSingleUndoStep, mouseClickAtPoint } from '../../canvas/event-helpers.test-utils'
+import { mouseClickAtPoint } from '../../canvas/event-helpers.test-utils'
 import { renderTestEditorWithCode, EditorRenderResult } from '../../canvas/ui-jsx.test-utils'
 import { AddRemoveLayouSystemControlTestId } from '../add-remove-layout-system-control'
 

--- a/editor/src/components/inspector/nine-block-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/nine-block-control.spec.browser2.tsx
@@ -1,6 +1,7 @@
 import { setFeatureEnabled } from '../../utils/feature-switches'
+import { expectSingleUndoStep } from '../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
-import { expectSingleUndoStep, mouseClickAtPoint } from '../canvas/event-helpers.test-utils'
+import { mouseClickAtPoint } from '../canvas/event-helpers.test-utils'
 import { EditorRenderResult, renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
 import { StartCenterEnd } from './inspector-common'
 import { NineBlockSectors, NineBlockTestId } from './nine-block-controls'

--- a/editor/src/components/inspector/nine-block-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/nine-block-control.spec.browser2.tsx
@@ -1,6 +1,6 @@
 import { setFeatureEnabled } from '../../utils/feature-switches'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
-import { mouseClickAtPoint } from '../canvas/event-helpers.test-utils'
+import { expectSingleUndoStep, mouseClickAtPoint } from '../canvas/event-helpers.test-utils'
 import { EditorRenderResult, renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
 import { StartCenterEnd } from './inspector-common'
 import { NineBlockSectors, NineBlockTestId } from './nine-block-controls'
@@ -56,7 +56,9 @@ async function doTest(
     NineBlockTestId(justifyContent, alignItems),
   )
 
-  mouseClickAtPoint(nineBlockControlSegment, { x: 2, y: 2 })
+  await expectSingleUndoStep(editor, async () =>
+    mouseClickAtPoint(nineBlockControlSegment, { x: 2, y: 2 }),
+  )
 
   return div
 }

--- a/editor/src/components/inspector/resize-to-fit-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/resize-to-fit-control.spec.browser2.tsx
@@ -1,7 +1,11 @@
 import { setFeatureEnabled } from '../../utils/feature-switches'
 import { wait } from '../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
-import { mouseClickAtPoint, mouseDoubleClickAtPoint } from '../canvas/event-helpers.test-utils'
+import {
+  expectSingleUndoStep,
+  mouseClickAtPoint,
+  mouseDoubleClickAtPoint,
+} from '../canvas/event-helpers.test-utils'
 import { EditorRenderResult, renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
 import { MaxContent } from './inspector-common'
 import { ResizeToFitControlTestId } from './resize-to-fit-control'
@@ -13,7 +17,7 @@ describe('Resize to fit control', () => {
   it('resizes to fit', async () => {
     const editor = await renderTestEditorWithCode(project, 'await-first-dom-report')
     const view = await selectView(editor)
-    await clickResizeToFit(editor)
+    await expectSingleUndoStep(editor, () => clickResizeToFit(editor))
 
     expect(view.style.width).toEqual(MaxContent)
     expect(view.style.minWidth).toEqual('')

--- a/editor/src/components/inspector/resize-to-fit-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/resize-to-fit-control.spec.browser2.tsx
@@ -1,11 +1,7 @@
 import { setFeatureEnabled } from '../../utils/feature-switches'
-import { wait } from '../../utils/utils.test-utils'
+import { expectSingleUndoStep } from '../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
-import {
-  expectSingleUndoStep,
-  mouseClickAtPoint,
-  mouseDoubleClickAtPoint,
-} from '../canvas/event-helpers.test-utils'
+import { mouseClickAtPoint, mouseDoubleClickAtPoint } from '../canvas/event-helpers.test-utils'
 import { EditorRenderResult, renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
 import { MaxContent } from './inspector-common'
 import { ResizeToFitControlTestId } from './resize-to-fit-control'

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -70,6 +70,7 @@ import {
   createEmptyStrategyState,
   StrategyState,
 } from '../components/canvas/canvas-strategies/interaction-state'
+import { EditorRenderResult } from '../components/canvas/ui-jsx.test-utils'
 
 export function delay(time: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, time))
@@ -417,4 +418,14 @@ export function slightlyOffsetPointBecauseVeryWeirdIssue(point: { x: number; y: 
   // FIXME when running in headless chrome, the result of getBoundingClientRect will be slightly
   // offset for some unknown reason, meaning the inserted element will be 1 pixel of in each dimension
   return { x: point.x - 0.001, y: point.y - 0.001 }
+}
+
+export async function expectSingleUndoStep(
+  editor: EditorRenderResult,
+  action: () => Promise<void>,
+): Promise<void> {
+  const historySizeBefore = editor.getEditorState().history.previous.length
+  await action()
+  const historySizeAfter = editor.getEditorState().history.previous.length
+  expect(historySizeAfter - historySizeBefore).toEqual(1)
 }


### PR DESCRIPTION
## Description
This PR adds a test utility which enables us to assert that a given UI action only generates a single undo.

This implemented by adding a helper, `expectSingleUndoStep`, which checks the size of `EditorStorePatched.history.previous` before and after a given UI action, and expects the size difference to be 1 (meaning that 1 new undo frame was added).