### PR TITLE
Chore/fixed size deletes flex props

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -418,6 +418,7 @@ function createUpdatePinsCommands(
     path,
   )?.specialSizeMeasurements
   const parentFrame = specialSizeMeasurements?.immediateParentBounds ?? null
+  const parentFlexDirection = specialSizeMeasurements?.parentFlexDirection ?? null
   const frameWithoutMargin = getFrameWithoutMargin(frame, specialSizeMeasurements)
   const updatedFrame = offsetRect(frameWithoutMargin, asLocal(dragDelta ?? zeroCanvasRect))
   const fullFrame = getFullFrame(updatedFrame)
@@ -437,6 +438,7 @@ function createUpdatePinsCommands(
             ? parentFrame?.width
             : parentFrame?.height,
         ),
+        parentFlexDirection,
       ),
     )
   })

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
@@ -44,6 +44,7 @@ import {
   pickCursorFromEdgePosition,
   resizeBoundingBox,
 } from './resize-helpers'
+import { FlexDirection } from '../../../inspector/common/css-utils'
 
 export function flexResizeBasicStrategy(
   canvasState: InteractionCanvasState,
@@ -67,6 +68,7 @@ export function flexResizeBasicStrategy(
   )
   const elementDimensions = metadata != null ? getElementDimensions(metadata) : null
   const elementParentBounds = metadata?.specialSizeMeasurements.immediateParentBounds ?? null
+  const elementParentFlexDirection = metadata?.specialSizeMeasurements.parentFlexDirection ?? null
 
   const hasDimensions =
     elementDimensions != null &&
@@ -159,6 +161,7 @@ export function flexResizeBasicStrategy(
             original: number,
             resized: number,
             parent: number | undefined,
+            parentFlexDirection: FlexDirection | null,
           ): AdjustCssLengthProperty[] => {
             if (elementDimension == null && (original === resized || hasSizedParent)) {
               return []
@@ -170,7 +173,8 @@ export function flexResizeBasicStrategy(
                 stylePropPathMappingFn(name, styleStringInArray),
                 elementDimension != null ? resized - original : resized,
                 parent,
-                true,
+                parentFlexDirection,
+                'create-if-not-existing',
               ),
             ]
           }
@@ -182,6 +186,7 @@ export function flexResizeBasicStrategy(
               originalBounds.width,
               resizedBounds.width,
               elementParentBounds?.width,
+              elementParentFlexDirection,
             ),
             ...makeResizeCommand(
               'height',
@@ -189,6 +194,7 @@ export function flexResizeBasicStrategy(
               originalBounds.height,
               resizedBounds.height,
               elementParentBounds?.height,
+              elementParentFlexDirection,
             ),
           ]
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
@@ -149,16 +149,16 @@ export function keyboardAbsoluteResizeStrategy(
                 null,
                 (_, e) => e,
               )
-              const elementParentBounds =
-                MetadataUtils.findElementByElementPath(
-                  canvasState.startingMetadata,
-                  selectedElement,
-                )?.specialSizeMeasurements.immediateParentBounds ?? null
 
-              const elementGlobalFrame = MetadataUtils.getFrameInCanvasCoords(
-                selectedElement,
+              const elementMetadata = MetadataUtils.findElementByElementPath(
                 canvasState.startingMetadata,
+                selectedElement,
               )
+              const elementParentBounds =
+                elementMetadata?.specialSizeMeasurements.immediateParentBounds ?? null
+              const elementParentFlexDirection =
+                elementMetadata?.specialSizeMeasurements.parentFlexDirection ?? null
+              const elementGlobalFrame = elementMetadata?.globalFrame ?? null
 
               if (element != null) {
                 const elementResult = createResizeCommands(
@@ -168,6 +168,7 @@ export function keyboardAbsoluteResizeStrategy(
                   movementWithEdge.movement,
                   elementGlobalFrame,
                   elementParentBounds,
+                  elementParentFlexDirection,
                 )
                 commands.push(...elementResult.commands)
                 if (elementResult.intendedBounds != null) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes.ts
@@ -19,7 +19,7 @@ import { ElementPath, PropertyPath } from '../../../../../core/shared/project-fi
 import * as PP from '../../../../../core/shared/property-path'
 import { ProjectContentTreeRoot } from '../../../../assets'
 import { getElementFromProjectContents } from '../../../../editor/store/editor-state'
-import { CSSPosition, Direction } from '../../../../inspector/common/css-utils'
+import { CSSPosition, Direction, FlexDirection } from '../../../../inspector/common/css-utils'
 import { stylePropPathMappingFn } from '../../../../inspector/common/property-path-hooks'
 import {
   AdjustCssLengthProperty,
@@ -92,6 +92,7 @@ export function getAbsoluteReparentPropertyChanges(
     pin: LayoutPinnedProp,
     newValue: number,
     parentDimension: number | undefined,
+    elementParentFlexDirection: FlexDirection | null,
   ): AdjustCssLengthProperty | null => {
     const value = getLayoutProperty(pin, right(element.props), styleStringInArray)
     if (isRight(value) && value.value != null) {
@@ -102,7 +103,8 @@ export function getAbsoluteReparentPropertyChanges(
         stylePropPathMappingFn(pin, styleStringInArray),
         newValue,
         parentDimension,
-        true,
+        elementParentFlexDirection,
+        'create-if-not-existing',
       )
     } else {
       return null
@@ -126,6 +128,9 @@ export function getAbsoluteReparentPropertyChanges(
   }
 
   const newParentFrame = MetadataUtils.getFrameInCanvasCoords(newParent, newParentStartingMetadata)
+  const newParentFlexDirection =
+    MetadataUtils.findElementByElementPath(newParentStartingMetadata, newParent)
+      ?.specialSizeMeasurements.flexDirection ?? null
 
   return [
     ...mapDropNulls(
@@ -135,6 +140,7 @@ export function getAbsoluteReparentPropertyChanges(
           pin,
           horizontal ? offsetTL.x : offsetTL.y,
           horizontal ? newParentFrame?.width : newParentFrame?.height,
+          newParentFlexDirection,
         )
       },
       ['top', 'left'] as const,
@@ -146,6 +152,7 @@ export function getAbsoluteReparentPropertyChanges(
           pin,
           horizontal ? offsetBR.x : offsetBR.y,
           horizontal ? newParentFrame?.width : newParentFrame?.height,
+          newParentFlexDirection,
         )
       },
       ['bottom', 'right'] as const,

--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-absolute-resize-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-absolute-resize-strategy-helpers.ts
@@ -24,6 +24,7 @@ import {
 import { pointGuidelineToBoundsEdge } from '../../controls/guideline-helpers'
 import { GuidelineWithSnappingVectorAndPointsOfRelevance } from '../../guideline'
 import { AbsolutePin, IsCenterBased, resizeBoundingBox } from './resize-helpers'
+import { FlexDirection } from '../../../inspector/common/css-utils'
 
 export function createResizeCommands(
   element: JSXElement,
@@ -32,6 +33,7 @@ export function createResizeCommands(
   drag: CanvasVector,
   elementGlobalFrame: CanvasRectangle | null,
   elementParentBounds: CanvasRectangle | null,
+  elementParentFlexDirection: FlexDirection | null,
 ): { commands: AdjustCssLengthProperty[]; intendedBounds: CanvasFrameAndTarget | null } {
   const pins = pinsForEdgePosition(edgePosition)
   const commands = mapDropNulls((pin) => {
@@ -53,7 +55,8 @@ export function createResizeCommands(
         stylePropPathMappingFn(pin, styleStringInArray),
         (horizontal ? drag.x : drag.y) * (negative ? -1 : 1),
         horizontal ? elementParentBounds?.width : elementParentBounds?.height,
-        true,
+        elementParentFlexDirection,
+        'create-if-not-existing',
       )
     } else {
       return null

--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
@@ -57,6 +57,7 @@ import {
 } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
 import { AbsolutePin } from './resize-helpers'
+import { FlexDirection } from '../../../inspector/common/css-utils'
 
 export interface MoveCommandsOptions {
   ignoreLocalFrame?: boolean
@@ -205,6 +206,7 @@ export function getMoveCommandsForSelectedElement(
     localFrame,
     globalFrame,
     elementParentBounds,
+    elementMetadata?.specialSizeMeasurements.parentFlexDirection ?? null,
   )
 }
 
@@ -216,6 +218,7 @@ function createMoveCommandsForElement(
   localFrame: LocalRectangle | null,
   globalFrame: CanvasRectangle | null,
   elementParentBounds: CanvasRectangle | null,
+  elementParentFlexDirection: FlexDirection | null,
 ): {
   commands: Array<AdjustCssLengthProperty>
   intendedBounds: Array<CanvasFrameAndTarget>
@@ -246,7 +249,8 @@ function createMoveCommandsForElement(
       stylePropPathMappingFn(pin, styleStringInArray),
       updatedPropValue,
       parentDimension,
-      true,
+      elementParentFlexDirection,
+      'create-if-not-existing',
     )
   }, extendedPins)
 

--- a/editor/src/components/canvas/commands/adjust-css-length-command.ts
+++ b/editor/src/components/canvas/commands/adjust-css-length-command.ts
@@ -1,3 +1,4 @@
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { isLeft, isRight, left } from '../../../core/shared/either'
 import * as EP from '../../../core/shared/element-path'
 import { emptyComments, jsxAttributeValue } from '../../../core/shared/element-template'
@@ -284,6 +285,13 @@ function updatePercentageValueByPixel(
   }
 }
 
+const FlexSizeProperties: Array<PropertyPath> = [
+  PP.create(['style', 'flex']),
+  PP.create(['style', 'flexGrow']),
+  PP.create(['style', 'flexShrink']),
+  PP.create(['style', 'flexBasis']),
+]
+
 export function deleteConflictingPropsForWidthHeight(
   editorState: EditorState,
   target: ElementPath,
@@ -291,12 +299,24 @@ export function deleteConflictingPropsForWidthHeight(
   parentFlexDirection: FlexDirection | null,
 ): EditorState {
   let propertiesToDelete: Array<PropertyPath> = []
+
+  const parentFlexDimension =
+    parentFlexDirection == null
+      ? null
+      : MetadataUtils.flexDirectionToSimpleFlexDirection(parentFlexDirection).direction
+
   switch (PP.lastPart(propertyPath)) {
     case 'width':
       propertiesToDelete = [PP.create(['style', 'minWidth']), PP.create(['style', 'maxWidth'])]
+      if (parentFlexDimension === 'horizontal') {
+        propertiesToDelete.push(...FlexSizeProperties)
+      }
       break
     case 'height':
       propertiesToDelete = [PP.create(['style', 'minHeight']), PP.create(['style', 'maxHeight'])]
+      if (parentFlexDimension === 'vertical') {
+        propertiesToDelete.push(...FlexSizeProperties)
+      }
       break
   }
 

--- a/editor/src/components/canvas/commands/set-css-length-command.spec.tsx
+++ b/editor/src/components/canvas/commands/set-css-length-command.spec.tsx
@@ -1,15 +1,20 @@
-import { styleStringInArray } from '../../../utils/common-constants'
+import { CSSObject } from '@emotion/styled'
 import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import * as EP from '../../../core/shared/element-path'
 import { getNumberPropertyFromProps } from '../../../core/shared/jsx-attributes'
+import { ElementPath } from '../../../core/shared/project-file-types'
 import { complexDefaultProjectPreParsed } from '../../../sample-projects/sample-project-utils.test-utils'
-import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
+import { styleStringInArray } from '../../../utils/common-constants'
+import { EditorState, withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
+import { cssPixelLength, ParsedCSSProperties } from '../../inspector/common/css-utils'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
-import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
+import { renderTestEditorWithCode, renderTestEditorWithModel } from '../ui-jsx.test-utils'
 import { updateEditorStateWithPatches } from './commands'
 import {
   runSetCssLengthProperty,
+  SetCssLengthProperty,
   setCssLengthProperty,
+  setExplicitCssValue,
   setValueKeepingOriginalUnit,
 } from './set-css-length-command'
 
@@ -59,19 +64,173 @@ describe('setCssLengthProperty', () => {
     expect(updatedHeightProp).toEqual(valueToSet)
   })
 
-  it('Setting width removes min-width and max-width props', () => {
-    throw new Error('implement me Balazs')
+  it('Setting width removes min-width and max-width props', async () => {
+    const editor = await renderTestEditorWithCode(
+      projectWithChildStyle('row', { minWidth: 50, maxWidth: 150, width: 50, height: 60 }),
+      'await-first-dom-report',
+    )
+
+    const targetPath = EP.fromString('sb/parent/child')
+
+    const command = setCssLengthProperty(
+      'always',
+      targetPath,
+      stylePropPathMappingFn('width', styleStringInArray),
+      setExplicitCssValue(cssPixelLength(400)),
+      'row',
+    )
+
+    const result = runCommandUpdateEditor(editor.getEditorState().editor, command)
+    expect(getStylePropForElement(result, targetPath, 'width')).toBe(400)
+    expect(getStylePropForElement(result, targetPath, 'minWidth')).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'maxWidth')).toBeNull()
   })
 
-  it('Setting width removes flex props if the parent is a horizontal flex', () => {
-    throw new Error('implement me Balazs')
+  it('Setting height does not remove min-width and max-width props', async () => {
+    const editor = await renderTestEditorWithCode(
+      projectWithChildStyle('row', { minWidth: 50, maxWidth: 150, width: 50, height: 60 }),
+      'await-first-dom-report',
+    )
+
+    const targetPath = EP.fromString('sb/parent/child')
+
+    const command = setCssLengthProperty(
+      'always',
+      targetPath,
+      stylePropPathMappingFn('height', styleStringInArray),
+      setExplicitCssValue(cssPixelLength(400)),
+      'row',
+    )
+
+    const result = runCommandUpdateEditor(editor.getEditorState().editor, command)
+    expect(getStylePropForElement(result, targetPath, 'height')).toBe(400)
+    expect(getStylePropForElement(result, targetPath, 'minWidth')).toBe(50)
+    expect(getStylePropForElement(result, targetPath, 'maxWidth')).toBe(150)
   })
 
-  it('Setting width keeps flex props if the parent is a vertical flex', () => {
-    throw new Error('implement me Balazs')
+  it('Setting width removes flex props if the parent is a horizontal flex', async () => {
+    const editor = await renderTestEditorWithCode(
+      projectWithChildStyle('row', {
+        minWidth: 50,
+        maxWidth: 150,
+        width: 50,
+        height: 60,
+        flexGrow: 1,
+        flexShrink: 1,
+        flexBasis: 200,
+        flex: 1,
+      }),
+      'await-first-dom-report',
+    )
+
+    const targetPath = EP.fromString('sb/parent/child')
+
+    const command = setCssLengthProperty(
+      'always',
+      targetPath,
+      stylePropPathMappingFn('width', styleStringInArray),
+      setExplicitCssValue(cssPixelLength(400)),
+      'row',
+    )
+
+    const result = runCommandUpdateEditor(editor.getEditorState().editor, command)
+    expect(getStylePropForElement(result, targetPath, 'width')).toBe(400)
+    expect(getStylePropForElement(result, targetPath, 'minWidth')).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'maxWidth')).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'flex')).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'flexGrow')).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'flexShrink')).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'flexBasis')).toBeNull()
   })
 
-  it('Setting width keeps flex props if the parent is not flex', () => {
-    throw new Error('implement me Balazs')
+  it('Setting width keeps flex props if the parent is a vertical flex', async () => {
+    const editor = await renderTestEditorWithCode(
+      projectWithChildStyle('column', {
+        minWidth: 50,
+        maxWidth: 150,
+        width: 50,
+        height: 60,
+        flexGrow: 1,
+        flexShrink: 1,
+        flexBasis: 200,
+        flex: 1,
+      }),
+      'await-first-dom-report',
+    )
+
+    const targetPath = EP.fromString('sb/parent/child')
+
+    const command = setCssLengthProperty(
+      'always',
+      targetPath,
+      stylePropPathMappingFn('width', styleStringInArray),
+      setExplicitCssValue(cssPixelLength(400)),
+      'column',
+    )
+
+    const result = runCommandUpdateEditor(editor.getEditorState().editor, command)
+    expect(getStylePropForElement(result, targetPath, 'width')).toBe(400)
+    expect(getStylePropForElement(result, targetPath, 'minWidth')).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'maxWidth')).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'flex')).not.toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'flexGrow')).not.toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'flexShrink')).not.toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'flexBasis')).not.toBeNull()
   })
 })
+
+function projectWithChildStyle(
+  parentFlexDirection: 'row' | 'column',
+  childStyleProps: CSSObject,
+): string {
+  return `import * as React from 'react'
+      import { Storyboard } from 'utopia-api'
+      
+      export var storyboard = (
+        <Storyboard data-uid='sb'>
+          <div
+            style={{
+              backgroundColor: '#aaaaaa33',
+              position: 'absolute',
+              left: 133,
+              top: 228,
+              width: 342,
+              height: 368,
+              display: 'flex',
+              flexDirection: ${JSON.stringify(parentFlexDirection)}
+            }}
+            data-uid='parent'
+          >
+            <div
+              style={${JSON.stringify(childStyleProps)}}
+              data-uid='child'
+            />
+          </div>
+        </Storyboard>
+      )
+      `
+}
+
+function runCommandUpdateEditor(editor: EditorState, command: SetCssLengthProperty): EditorState {
+  const result = runSetCssLengthProperty(editor, command)
+
+  return updateEditorStateWithPatches(editor, result.editorStatePatches)
+}
+
+function getStylePropForElement(
+  editor: EditorState,
+  elementPath: ElementPath,
+  styleProp: keyof ParsedCSSProperties,
+) {
+  return withUnderlyingTargetFromEditorState(
+    elementPath,
+    editor,
+    null,
+    (success, element, underlyingTarget, underlyingFilePath) => {
+      return getNumberPropertyFromProps(
+        element.props,
+        stylePropPathMappingFn(styleProp, styleStringInArray),
+      )
+    },
+  )
+}

--- a/editor/src/components/canvas/commands/set-css-length-command.spec.tsx
+++ b/editor/src/components/canvas/commands/set-css-length-command.spec.tsx
@@ -32,6 +32,7 @@ describe('setCssLengthProperty', () => {
       cardInstancePath,
       stylePropPathMappingFn('height', styleStringInArray),
       setValueKeepingOriginalUnit(valueToSet, 400),
+      null,
     )
 
     const result = runSetCssLengthProperty(
@@ -56,5 +57,21 @@ describe('setCssLengthProperty', () => {
     )
 
     expect(updatedHeightProp).toEqual(valueToSet)
+  })
+
+  it('Setting width removes min-width and max-width props', () => {
+    throw new Error('implement me Balazs')
+  })
+
+  it('Setting width removes flex props if the parent is a horizontal flex', () => {
+    throw new Error('implement me Balazs')
+  })
+
+  it('Setting width keeps flex props if the parent is a vertical flex', () => {
+    throw new Error('implement me Balazs')
+  })
+
+  it('Setting width keeps flex props if the parent is not flex', () => {
+    throw new Error('implement me Balazs')
   })
 })

--- a/editor/src/components/canvas/commands/set-css-length-command.ts
+++ b/editor/src/components/canvas/commands/set-css-length-command.ts
@@ -13,6 +13,7 @@ import { EditorState, withUnderlyingTargetFromEditorState } from '../../editor/s
 import {
   CSSNumber,
   cssPixelLength,
+  FlexDirection,
   parseCSSPercent,
   printCSSNumber,
 } from '../../inspector/common/css-utils'
@@ -40,6 +41,7 @@ export interface SetCssLengthProperty extends BaseCommand {
   target: ElementPath
   property: PropertyPath
   value: CssNumberOrKeepOriginalUnit
+  parentFlexDirection: FlexDirection | null
 }
 
 export function setCssLengthProperty(
@@ -47,6 +49,7 @@ export function setCssLengthProperty(
   target: ElementPath,
   property: PropertyPath,
   value: CssNumberOrKeepOriginalUnit,
+  parentFlexDirection: FlexDirection | null,
 ): SetCssLengthProperty {
   return {
     type: 'SET_CSS_LENGTH_PROPERTY',
@@ -54,6 +57,7 @@ export function setCssLengthProperty(
     target: target,
     property: property,
     value: value,
+    parentFlexDirection: parentFlexDirection,
   }
 }
 
@@ -66,6 +70,7 @@ export const runSetCssLengthProperty: CommandFunction<SetCssLengthProperty> = (
     editorState,
     command.target,
     command.property,
+    command.parentFlexDirection,
   )
 
   // Identify the current value, whatever that may be.

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
@@ -172,14 +172,19 @@ export const setPropFixedStrategies = (
         return null
       }
 
-      return elementPaths.map((path) =>
-        setCssLengthProperty(
+      return elementPaths.map((path) => {
+        const parentFlexDirection =
+          MetadataUtils.findElementByElementPath(metadata, path)?.specialSizeMeasurements
+            .parentFlexDirection ?? null
+
+        return setCssLengthProperty(
           whenToRun,
           path,
           PP.create(['style', widthHeightFromAxis(axis)]),
           setExplicitCssValue(value),
-        ),
-      )
+          parentFlexDirection,
+        )
+      })
     },
   },
 ]


### PR DESCRIPTION
**Problem:**
As @bkrmendy made it very clear, if you are setting an explicit width or height prop, we also have to delete the flex sizing properties (but only for the relevant dimension), as those are shadowing width or height.

**Fix:**
I extend the `deleteConflictingPropsForWidthHeight` behavior of `setCssLengthProperty` and `adjustCssLengthProperty` commands, so anything using these will now auto-delete flex, flex-grow, flex-shrink and flex-basis. (but only when setting the property in the relevant matching dimension. ie if you change width in a flex-row context)

**Commit Details:**
- Added `parentFlexDirection` to `setCssLengthProperty` and `adjustCssLengthProperty`
- Made `createIfNonExistant` a string literal union
- `deleteConflictingPropsForWidthHeight` now has the capacity to remove these aforementioned flex props
- tests!
