### PR TITLE
Chore: smarter property path

### DIFF
--- a/editor/src/components/aspect-ratio.ts
+++ b/editor/src/components/aspect-ratio.ts
@@ -24,10 +24,7 @@ export function isAspectRatioLockedNew(
   const element = component.element
   if (isRight(element) && isJSXElement(element.value)) {
     const props = element.value.props
-    const aspectRatioProp = getModifiableJSXAttributeAtPath(
-      props,
-      PP.create([AspectRatioLockedProp]),
-    )
+    const aspectRatioProp = getModifiableJSXAttributeAtPath(props, PP.create(AspectRatioLockedProp))
     if (isLeft(aspectRatioProp)) {
       return false
     } else {

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size-strategy.tsx
@@ -72,7 +72,7 @@ export function keyboardSetFontSizeStrategy(
         setProperty(
           'always',
           path,
-          PP.create(['style', 'fontSize']),
+          PP.create('style', 'fontSize'),
           printCSSNumber(adjustFontSize(fontSize, fontSizeDelta), null),
         ),
       )
@@ -131,10 +131,7 @@ function getFontSizeFromProp(
 
   const attribute: string | null = defaultEither(
     null,
-    getSimpleAttributeAtPath(
-      right(element.element.value.props),
-      PP.create(['style', FontSizeProp]),
-    ),
+    getSimpleAttributeAtPath(right(element.element.value.props), PP.create('style', FontSizeProp)),
   )
 
   return parseMaybeFontSize(attribute)

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight-strategy.tsx
@@ -71,7 +71,7 @@ export function keyboardSetFontWeightStrategy(
         setProperty(
           'always',
           path,
-          PP.create(['style', FontWeightProp]),
+          PP.create('style', FontWeightProp),
           adjustFontWeight(fontWeight, fontSizeDelta),
         ),
       )

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
@@ -41,7 +41,7 @@ export function keyboardSetOpacityStrategy(
       }
 
       const commands = selectedElements.map((path) =>
-        setProperty('always', path, PP.create(['style', 'opacity']), inputValue),
+        setProperty('always', path, PP.create('style', 'opacity'), inputValue),
       )
 
       return strategyApplicationResult(commands)

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes.ts
@@ -39,10 +39,10 @@ import {
 import { ReparentStrategy } from './reparent-strategy-helpers'
 
 const propertiesToRemove: Array<PropertyPath> = [
-  PP.create(['style', 'left']),
-  PP.create(['style', 'top']),
-  PP.create(['style', 'right']),
-  PP.create(['style', 'bottom']),
+  PP.create('style', 'left'),
+  PP.create('style', 'top'),
+  PP.create('style', 'right'),
+  PP.create('style', 'bottom'),
 ]
 
 export function getAbsoluteReparentPropertyChanges(
@@ -182,8 +182,8 @@ export function getStaticReparentPropertyChanges(
 
   return [
     ...optionalInlineConversionCommand,
-    deleteProperties('always', newPath, [...propertiesToRemove, PP.create(['style', 'position'])]),
-    setProperty('always', newPath, PP.create(['style', 'contain']), 'layout'),
+    deleteProperties('always', newPath, [...propertiesToRemove, PP.create('style', 'position')]),
+    setProperty('always', newPath, PP.create('style', 'contain'), 'layout'),
   ]
 }
 

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2359,7 +2359,7 @@ function preventAnimationsOnTargets(editorState: EditorState, targets: ElementPa
         (underlyingElement) => {
           const styleUpdated = setJSXValuesAtPaths(underlyingElement.props, [
             {
-              path: PP.create(['style', 'transition']),
+              path: PP.create('style', 'transition'),
               value: jsxAttributeValue('none', emptyComments),
             },
           ])

--- a/editor/src/components/canvas/commands/add-contain-layout-if-needed-command.ts
+++ b/editor/src/components/canvas/commands/add-contain-layout-if-needed-command.ts
@@ -41,7 +41,7 @@ export const runAddContainLayoutIfNeeded: CommandFunction<AddContainLayoutIfNeed
   } else {
     // Apply the update to the properties.
     const { editorStatePatch } = applyValuesAtPath(editorState, command.element, [
-      { path: PP.create(['style', 'contain']), value: jsxAttributeValue('layout', emptyComments) },
+      { path: PP.create('style', 'contain'), value: jsxAttributeValue('layout', emptyComments) },
     ])
 
     return {

--- a/editor/src/components/canvas/commands/adjust-css-length-command.ts
+++ b/editor/src/components/canvas/commands/adjust-css-length-command.ts
@@ -286,10 +286,10 @@ function updatePercentageValueByPixel(
 }
 
 const FlexSizeProperties: Array<PropertyPath> = [
-  PP.create(['style', 'flex']),
-  PP.create(['style', 'flexGrow']),
-  PP.create(['style', 'flexShrink']),
-  PP.create(['style', 'flexBasis']),
+  PP.create('style', 'flex'),
+  PP.create('style', 'flexGrow'),
+  PP.create('style', 'flexShrink'),
+  PP.create('style', 'flexBasis'),
 ]
 
 export function deleteConflictingPropsForWidthHeight(
@@ -307,13 +307,13 @@ export function deleteConflictingPropsForWidthHeight(
 
   switch (PP.lastPart(propertyPath)) {
     case 'width':
-      propertiesToDelete = [PP.create(['style', 'minWidth']), PP.create(['style', 'maxWidth'])]
+      propertiesToDelete = [PP.create('style', 'minWidth'), PP.create('style', 'maxWidth')]
       if (parentFlexDimension === 'horizontal') {
         propertiesToDelete.push(...FlexSizeProperties)
       }
       break
     case 'height':
-      propertiesToDelete = [PP.create(['style', 'minHeight']), PP.create(['style', 'maxHeight'])]
+      propertiesToDelete = [PP.create('style', 'minHeight'), PP.create('style', 'maxHeight')]
       if (parentFlexDimension === 'vertical') {
         propertiesToDelete.push(...FlexSizeProperties)
       }

--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -211,7 +211,7 @@ export const ClassNameSelect = React.memo(
                   [
                     EditorActions.setPropTransient(
                       targets[0],
-                      PP.create(['className']),
+                      PP.create('className'),
                       jsxAttributeValue(newClassNameString, emptyComments),
                     ),
                   ],
@@ -241,7 +241,7 @@ export const ClassNameSelect = React.memo(
             [
               EditorActions.setProp_UNSAFE(
                 elementPath,
-                PP.create(['className']),
+                PP.create('className'),
                 jsxAttributeValue(newValue.map((value) => value.value).join(' '), emptyComments),
               ),
               EditorActions.clearTransientProps(),

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -83,7 +83,7 @@ export function createLookupRender(
     const generatedUID = createIndexedUid(innerUID, index)
     const withGeneratedUID = setJSXValueAtPath(
       element.props,
-      PP.create(['data-uid']),
+      PP.create('data-uid'),
       jsxAttributeValue(generatedUID, emptyComments),
     )
 

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -148,7 +148,7 @@ export const toggleBorderItem: ContextMenuItem<CanvasData> = {
     const actions = data.selectedViews.map((target) =>
       EditorActions.toggleProperty(
         target,
-        toggleStylePropPath(PP.create(['style', 'border']), toggleBorder),
+        toggleStylePropPath(PP.create('style', 'border'), toggleBorder),
       ),
     )
     requireDispatch(dispatch)(actions, 'everyone')
@@ -163,7 +163,7 @@ export const toggleShadowItem: ContextMenuItem<CanvasData> = {
     const actions = data.selectedViews.map((target) =>
       EditorActions.toggleProperty(
         target,
-        toggleStylePropPath(PP.create(['style', 'boxShadow']), toggleShadow),
+        toggleStylePropPath(PP.create('style', 'boxShadow'), toggleShadow),
       ),
     )
     requireDispatch(dispatch)(actions, 'everyone')

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -256,7 +256,7 @@ describe('SET_PROP', () => {
   it('updates a simple value property', () => {
     const action = setProp_UNSAFE(
       EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa', 'bbb']),
-      PP.create(['test', 'prop']),
+      PP.create('test', 'prop'),
       jsxAttributeValue(100, emptyComments),
     )
     const newEditor = UPDATE_FNS.SET_PROP(action, testEditor)
@@ -277,7 +277,7 @@ describe('SET_PROP', () => {
     )
     const updatedTestProp = getModifiableJSXAttributeAtPath(
       updatedViewProps,
-      PP.create(['test', 'prop']),
+      PP.create('test', 'prop'),
     )
     chaiExpect(updatedTestProp).to.deep.equal(right(partOfJsxAttributeValue(100)))
   })

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2286,7 +2286,7 @@ export const UPDATE_FNS = {
               props: forceRight(
                 setJSXValueAtPath(
                   elementToWrapWith.props,
-                  PP.create(['style', 'position']), // todo make it optional
+                  PP.create('style', 'position'), // todo make it optional
                   jsxAttributeValue(position, emptyComments),
                 ),
               ),
@@ -2964,9 +2964,7 @@ export const UPDATE_FNS = {
     return editor.selectedViews.reduce((working, target) => {
       return setPropertyOnTarget(working, target, (attributes) => {
         const filterForNames = action.type === 'layout' ? LayoutPropsWithoutTLBR : StyleProperties
-        const originalPropsToUnset = filterForNames.map((propName) =>
-          PP.create(['style', propName]),
-        )
+        const originalPropsToUnset = filterForNames.map((propName) => PP.create('style', propName))
         const withOriginalPropertiesCleared = unsetJSXValuesAtPaths(
           attributes,
           originalPropsToUnset,
@@ -3018,7 +3016,7 @@ export const UPDATE_FNS = {
       const target = editor.selectedViews[0]
       const styleProps = editor._currentAllElementProps_KILLME[EP.toString(target)]?.style ?? {}
       const styleClipboardData = Object.keys(styleProps).map((name) =>
-        valueAtPath(PP.create(['style', name]), jsxAttributeValue(styleProps[name], emptyComments)),
+        valueAtPath(PP.create('style', name), jsxAttributeValue(styleProps[name], emptyComments)),
       )
       return {
         ...editor,
@@ -3355,7 +3353,7 @@ export const UPDATE_FNS = {
     if (action.imageDetails != null) {
       if (replaceImage) {
         const imageWithoutHashURL = imagePathURL(assetFilename)
-        const propertyPath = PP.create(['src'])
+        const propertyPath = PP.create('src')
         walkContentsTreeForParseSuccess(editor.projectContents, (filePath, success) => {
           walkElements(getUtopiaJSXComponentsFromSuccess(success), (element, elementPath) => {
             if (isJSXElement(element)) {
@@ -4245,8 +4243,8 @@ export const UPDATE_FNS = {
   // If you want other types of JSXAttributes, that needs to be added
   RENAME_PROP_KEY: (action: RenameStyleSelector, editor: EditorModel): EditorModel => {
     return setPropertyOnTarget(editor, action.target, (props) => {
-      const originalPropertyPath = PP.create(action.cssTargetPath.path)
-      const newPropertyPath = PP.create(action.value)
+      const originalPropertyPath = PP.create(...action.cssTargetPath.path)
+      const newPropertyPath = PP.create(...action.value)
       const originalValue = getJSXAttributeAtPath(props, originalPropertyPath).attribute
       const attributesWithUnsetKey = unsetJSXValueAtPath(props, originalPropertyPath)
       if (isJSXAttributeValue(originalValue) || isPartOfJSXAttributeValue(originalValue)) {
@@ -4322,7 +4320,7 @@ export const UPDATE_FNS = {
     return modifyOpenJsxElementAtPath(
       action.target,
       (element) => {
-        const path = PP.create([AspectRatioLockedProp])
+        const path = PP.create(AspectRatioLockedProp)
         const updatedProps = action.locked
           ? eitherToMaybe(
               setJSXValueAtPath(element.props, path, jsxAttributeValue(true, emptyComments)),
@@ -4842,7 +4840,7 @@ export const UPDATE_FNS = {
           const propsWithUid = forceRight(
             setJSXValueAtPath(
               action.toInsert.element.props,
-              PP.create([UTOPIA_UID_KEY]),
+              PP.create(UTOPIA_UID_KEY),
               jsxAttributeValue(newUID, emptyComments),
             ),
             `Could not set data-uid on props of insertable element ${action.toInsert.element.name}`,
@@ -4851,9 +4849,9 @@ export const UPDATE_FNS = {
           let props = propsWithUid
           if (action.styleProps === 'add-size') {
             const sizesToSet: Array<ValueAtPath> = [
-              { path: PP.create(['style', 'width']), value: jsxAttributeValue(100, emptyComments) },
+              { path: PP.create('style', 'width'), value: jsxAttributeValue(100, emptyComments) },
               {
-                path: PP.create(['style', 'height']),
+                path: PP.create('style', 'height'),
                 value: jsxAttributeValue(100, emptyComments),
               },
             ]

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -475,7 +475,7 @@ export function handleKeyDown(
           ? editor.selectedViews.map((target) =>
               EditorActions.toggleProperty(
                 target,
-                toggleStylePropPath(PP.create(['style', 'border']), toggleBorder),
+                toggleStylePropPath(PP.create('style', 'border'), toggleBorder),
               ),
             )
           : []
@@ -590,7 +590,7 @@ export function handleKeyDown(
         return editor.selectedViews.map((target) =>
           EditorActions.toggleProperty(
             target,
-            toggleStylePropPath(PP.create(['style', 'boxShadow']), toggleShadow),
+            toggleStylePropPath(PP.create('style', 'boxShadow'), toggleShadow),
           ),
         )
       },
@@ -696,7 +696,7 @@ export function handleKeyDown(
               selectedViews.map((view) =>
                 EditorActions.setProperty(
                   view,
-                  PP.create(['style', 'backgroundColor']),
+                  PP.create('style', 'backgroundColor'),
                   jsxAttributeValue(sRGBHex, emptyComments),
                 ),
               ),

--- a/editor/src/components/inspector/common/css-utils.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/css-utils.spec.browser2.tsx
@@ -27,7 +27,7 @@ describe('toggle style prop', () => {
       [
         toggleProperty(
           EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb']),
-          toggleStylePropPath(PP.create(['style', 'border']), toggleBorder),
+          toggleStylePropPath(PP.create('style', 'border'), toggleBorder),
         ),
       ],
       true,
@@ -62,7 +62,7 @@ describe('toggle style prop', () => {
       [
         toggleProperty(
           EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb']),
-          toggleStylePropPath(PP.create(['style', 'border']), toggleBorder),
+          toggleStylePropPath(PP.create('style', 'border'), toggleBorder),
         ),
       ],
       true,
@@ -96,7 +96,7 @@ describe('toggle style prop', () => {
       [
         toggleProperty(
           EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb']),
-          toggleStylePropPath(PP.create(['style', 'border']), toggleBorder),
+          toggleStylePropPath(PP.create('style', 'border'), toggleBorder),
         ),
       ],
       true,
@@ -138,7 +138,7 @@ describe('toggle style prop', () => {
       [
         toggleProperty(
           EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb']),
-          toggleStylePropPath(PP.create(['style', 'boxShadow']), toggleShadow),
+          toggleStylePropPath(PP.create('style', 'boxShadow'), toggleShadow),
         ),
       ],
       true,
@@ -172,7 +172,7 @@ describe('toggle style prop', () => {
       [
         toggleProperty(
           EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb']),
-          toggleStylePropPath(PP.create(['style', 'boxShadow']), toggleShadow),
+          toggleStylePropPath(PP.create('style', 'boxShadow'), toggleShadow),
         ),
       ],
       true,

--- a/editor/src/components/inspector/common/css-utils.spec.ts
+++ b/editor/src/components/inspector/common/css-utils.spec.ts
@@ -68,10 +68,7 @@ import {
 } from './css-utils'
 
 describe('toggleStyleProp', () => {
-  const simpleToggleProp = toggleStylePropPath(
-    PP.create(['style', 'backgroundColor']),
-    toggleSimple,
-  )
+  const simpleToggleProp = toggleStylePropPath(PP.create('style', 'backgroundColor'), toggleSimple)
 
   it('disables simple value', () => {
     const element = jsxTestElement(

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -72,7 +72,6 @@ import {
   printMarginAsAttributeValue,
 } from '../../../printer-parsers/css/css-parser-margin'
 import { parseFlex, printFlexAsAttributeValue } from '../../../printer-parsers/css/css-parser-flex'
-import { styleStringInArray } from '../../../utils/common-constants'
 
 var combineRegExp = function (regexpList: Array<RegExp | string>, flags?: string) {
   let source: string = ''
@@ -3747,8 +3746,8 @@ export function toggleSimple(attribute: ModifiableAttribute): ModifiableAttribut
   }
 }
 
-const backgroundColorPathWithoutStyle = PP.create(['backgroundColor'])
-const backgroundImagePathWithoutStyle = PP.create(['backgroundImage'])
+const backgroundColorPathWithoutStyle = PP.create('backgroundColor')
+const backgroundImagePathWithoutStyle = PP.create('backgroundImage')
 
 const updateBackgroundImageLayersWithNewValues = (
   backgroundImageAttribute: ModifiableAttribute,
@@ -3906,14 +3905,10 @@ export function toggleStylePropPaths(
   toggleFn: (attribute: JSXAttribute) => JSXAttribute,
 ): (element: JSXElement) => JSXElement {
   return (element: JSXElement): JSXElement => {
-    const styleProp = getJSXAttributeAtPath(element.props, PP.create(styleStringInArray))
+    const styleProp = getJSXAttributeAtPath(element.props, PP.create('style'))
     const attribute = styleProp.attribute
     if (styleProp.remainingPath == null && isRegularJSXAttribute(attribute)) {
-      const newProps = setJSXValueAtPath(
-        element.props,
-        PP.create(styleStringInArray),
-        toggleFn(attribute),
-      )
+      const newProps = setJSXValueAtPath(element.props, PP.create('style'), toggleFn(attribute))
       if (isRight(newProps)) {
         return { ...element, props: newProps.value }
       }

--- a/editor/src/components/inspector/common/inspector-update-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-update-tests.spec.browser2.tsx
@@ -32,7 +32,7 @@ describe('updating style properties keeps the original order', () => {
 
     const changePinProps = setProp_UNSAFE(
       EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb']),
-      PP.create(['style', 'paddingRight']),
+      PP.create('style', 'paddingRight'),
       jsxAttributeValue(30, emptyComments),
     )
 

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -298,7 +298,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
         [
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingLeft']),
+            PP.create('style', 'paddingLeft'),
             jsxAttributeValue(100, emptyComments),
           ),
         ],
@@ -321,7 +321,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
         [
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'padding']),
+            PP.create('style', 'padding'),
             jsxAttributeValue('8px 8px 8px 50px', emptyComments),
           ),
         ],
@@ -344,7 +344,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
         [
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingRight']),
+            PP.create('style', 'paddingRight'),
             jsxAttributeValue(5, emptyComments),
           ),
         ],
@@ -367,7 +367,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
         [
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingLeft']),
+            PP.create('style', 'paddingLeft'),
             jsxAttributeValue(8, emptyComments),
           ),
         ],
@@ -390,7 +390,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
         [
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingLeft']),
+            PP.create('style', 'paddingLeft'),
             jsxAttributeValue(8, emptyComments),
           ),
         ],
@@ -414,7 +414,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           unsetProperty(TestSelectedComponent, { propertyElements: ['style', 'paddingLeft'] }),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingLeft']),
+            PP.create('style', 'paddingLeft'),
             jsxAttributeValue(16, emptyComments),
           ),
         ],
@@ -438,7 +438,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           unsetProperty(TestSelectedComponent, { propertyElements: ['style', 'paddingLeft'] }),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'padding']),
+            PP.create('style', 'padding'),
             jsxAttributeValue('4px 8px 4px 18px', emptyComments),
           ),
         ],
@@ -460,7 +460,7 @@ describe('useInspectorInfo: onUnsetValues', () => {
     const paddingLeft = hookResult.paddingLeft
     paddingLeft.onUnsetValues()
     expect(mockDispatch.mock.calls).toEqual([
-      [[unsetProperty(TestSelectedComponent, PP.create(['style', 'paddingLeft']))]],
+      [[unsetProperty(TestSelectedComponent, PP.create('style', 'paddingLeft'))]],
     ])
   })
 
@@ -478,21 +478,21 @@ describe('useInspectorInfo: onUnsetValues', () => {
     expect(mockDispatch.mock.calls).toEqual([
       [
         [
-          unsetProperty(TestSelectedComponent, PP.create(['style', 'paddingLeft'])),
-          unsetProperty(TestSelectedComponent, PP.create(['style', 'padding'])),
+          unsetProperty(TestSelectedComponent, PP.create('style', 'paddingLeft')),
+          unsetProperty(TestSelectedComponent, PP.create('style', 'padding')),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingTop']),
+            PP.create('style', 'paddingTop'),
             jsxAttributeValue(10, emptyComments),
           ),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingRight']),
+            PP.create('style', 'paddingRight'),
             jsxAttributeValue(10, emptyComments),
           ),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingBottom']),
+            PP.create('style', 'paddingBottom'),
             jsxAttributeValue(10, emptyComments),
           ),
         ],
@@ -514,10 +514,10 @@ describe('useInspectorInfo: onUnsetValues', () => {
     expect(mockDispatch.mock.calls).toEqual([
       [
         [
-          unsetProperty(TestSelectedComponent, PP.create(['style', 'paddingLeft'])),
+          unsetProperty(TestSelectedComponent, PP.create('style', 'paddingLeft')),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingLeft']),
+            PP.create('style', 'paddingLeft'),
             jsxAttributeValue(undefined, emptyComments),
           ),
         ],
@@ -539,21 +539,21 @@ describe('useInspectorInfo: onUnsetValues', () => {
     expect(mockDispatch.mock.calls).toEqual([
       [
         [
-          unsetProperty(TestSelectedComponent, PP.create(['style', 'paddingLeft'])),
-          unsetProperty(TestSelectedComponent, PP.create(['style', 'padding'])),
+          unsetProperty(TestSelectedComponent, PP.create('style', 'paddingLeft')),
+          unsetProperty(TestSelectedComponent, PP.create('style', 'padding')),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingTop']),
+            PP.create('style', 'paddingTop'),
             jsxAttributeValue(10, emptyComments),
           ),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingRight']),
+            PP.create('style', 'paddingRight'),
             jsxAttributeValue(10, emptyComments),
           ),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingBottom']),
+            PP.create('style', 'paddingBottom'),
             jsxAttributeValue(10, emptyComments),
           ),
         ],
@@ -575,21 +575,21 @@ describe('useInspectorInfo: onUnsetValues', () => {
     expect(mockDispatch.mock.calls).toEqual([
       [
         [
-          unsetProperty(TestSelectedComponent, PP.create(['style', 'paddingLeft'])),
-          unsetProperty(TestSelectedComponent, PP.create(['style', 'padding'])),
+          unsetProperty(TestSelectedComponent, PP.create('style', 'paddingLeft')),
+          unsetProperty(TestSelectedComponent, PP.create('style', 'padding')),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingTop']),
+            PP.create('style', 'paddingTop'),
             jsxAttributeValue(10, emptyComments),
           ),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingRight']),
+            PP.create('style', 'paddingRight'),
             jsxAttributeValue(10, emptyComments),
           ),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingBottom']),
+            PP.create('style', 'paddingBottom'),
             jsxAttributeValue(10, emptyComments),
           ),
         ],
@@ -611,10 +611,10 @@ describe('useInspectorInfo: onUnsetValues', () => {
     expect(mockDispatch.mock.calls).toEqual([
       [
         [
-          unsetProperty(TestSelectedComponent, PP.create(['style', 'paddingLeft'])),
+          unsetProperty(TestSelectedComponent, PP.create('style', 'paddingLeft')),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingLeft']),
+            PP.create('style', 'paddingLeft'),
             jsxAttributeValue(undefined, emptyComments),
           ),
         ],
@@ -636,10 +636,10 @@ describe('useInspectorInfo: onUnsetValues', () => {
     expect(mockDispatch.mock.calls).toEqual([
       [
         [
-          unsetProperty(TestSelectedComponent, PP.create(['style', 'paddingLeft'])),
+          unsetProperty(TestSelectedComponent, PP.create('style', 'paddingLeft')),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingLeft']),
+            PP.create('style', 'paddingLeft'),
             jsxAttributeValue(undefined, emptyComments),
           ),
         ],
@@ -661,21 +661,21 @@ describe('useInspectorInfo: onUnsetValues', () => {
     expect(mockDispatch.mock.calls).toEqual([
       [
         [
-          unsetProperty(TestSelectedComponent, PP.create(['style', 'paddingLeft'])),
-          unsetProperty(TestSelectedComponent, PP.create(['style', 'padding'])),
+          unsetProperty(TestSelectedComponent, PP.create('style', 'paddingLeft')),
+          unsetProperty(TestSelectedComponent, PP.create('style', 'padding')),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingTop']),
+            PP.create('style', 'paddingTop'),
             jsxAttributeValue(10, emptyComments),
           ),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingRight']),
+            PP.create('style', 'paddingRight'),
             jsxAttributeValue(25, emptyComments),
           ),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingBottom']),
+            PP.create('style', 'paddingBottom'),
             jsxAttributeValue(10, emptyComments),
           ),
         ],
@@ -697,21 +697,21 @@ describe('useInspectorInfo: onUnsetValues', () => {
     expect(mockDispatch.mock.calls).toEqual([
       [
         [
-          unsetProperty(TestSelectedComponent, PP.create(['style', 'paddingLeft'])),
-          unsetProperty(TestSelectedComponent, PP.create(['style', 'padding'])),
+          unsetProperty(TestSelectedComponent, PP.create('style', 'paddingLeft')),
+          unsetProperty(TestSelectedComponent, PP.create('style', 'padding')),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingTop']),
+            PP.create('style', 'paddingTop'),
             jsxAttributeValue(10, emptyComments),
           ),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingRight']),
+            PP.create('style', 'paddingRight'),
             jsxAttributeValue(10, emptyComments),
           ),
           setProp_UNSAFE(
             TestSelectedComponent,
-            PP.create(['style', 'paddingBottom']),
+            PP.create('style', 'paddingBottom'),
             jsxAttributeValue(10, emptyComments),
           ),
         ],

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -337,7 +337,7 @@ export function useCallbackFactory<T>(
 /* eslint-enable react-hooks/rules-of-hooks, react-hooks/exhaustive-deps */
 
 function elementPathMappingFn<P extends ParsedElementPropertiesKeys>(p: P) {
-  return PP.create([p])
+  return PP.create(p)
 }
 
 export function useInspectorElementInfo<P extends ParsedElementPropertiesKeys>(prop: P) {
@@ -356,7 +356,7 @@ export function stylePropPathMappingFn<P extends ParsedCSSPropertiesKeys>(
   p: P,
   target: readonly string[],
 ): PropertyPath {
-  return PP.create([...target, p])
+  return PP.create(...target, p)
 }
 
 export function useInspectorStyleInfo<P extends ParsedCSSPropertiesKeys>(

--- a/editor/src/components/inspector/controls/url-background-layer-metadata-controls.tsx
+++ b/editor/src/components/inspector/controls/url-background-layer-metadata-controls.tsx
@@ -32,7 +32,7 @@ interface URLBackgroundLayerMetadataControlsProps extends BackgroundLayerControl
   value: CSSURLFunctionBackgroundLayer
 }
 
-const backgroundImagePropertyPath = [PP.create(['style', 'backgroundImage'])]
+const backgroundImagePropertyPath = [PP.create('style', 'backgroundImage')]
 
 export const URLBackgroundLayerMetadataControls: React.FunctionComponent<
   React.PropsWithChildren<URLBackgroundLayerMetadataControlsProps>

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -288,15 +288,15 @@ export function convertWidthToFlexGrow(
   const matches =
     defaultEither(
       null,
-      getSimpleAttributeAtPath(right(element.props), PP.create(['style', prop])),
+      getSimpleAttributeAtPath(right(element.props), PP.create('style', prop)),
     ) === '100%'
 
   if (!matches) {
     return []
   }
   return [
-    deleteProperties('always', elementPath, [PP.create(['style', prop])]),
-    setProperty('always', elementPath, PP.create(['style', 'flexGrow']), 1),
+    deleteProperties('always', elementPath, [PP.create('style', prop)]),
+    setProperty('always', elementPath, PP.create('style', 'flexGrow'), 1),
   ]
 }
 
@@ -304,7 +304,7 @@ export function nullOrNonEmpty<T>(ts: Array<T>): Array<T> | null {
   return ts.length === 0 ? null : ts
 }
 
-export const styleP = (prop: keyof CSSProperties): PropertyPath => PP.create(['style', prop])
+export const styleP = (prop: keyof CSSProperties): PropertyPath => PP.create('style', prop)
 
 export const flexContainerProps = [
   styleP('flexDirection'),
@@ -346,15 +346,15 @@ export const nukeSizingPropsForAxisCommand = (axis: Axis, path: ElementPath): Ca
   switch (axis) {
     case 'horizontal':
       return deleteProperties('always', path, [
-        PP.create(['style', 'width']),
-        PP.create(['style', 'minWidth']),
-        PP.create(['style', 'maxWidth']),
+        PP.create('style', 'width'),
+        PP.create('style', 'minWidth'),
+        PP.create('style', 'maxWidth'),
       ])
     case 'vertical':
       return deleteProperties('always', path, [
-        PP.create(['style', 'height']),
-        PP.create(['style', 'minHeight']),
-        PP.create(['style', 'maxHeight']),
+        PP.create('style', 'height'),
+        PP.create('style', 'minHeight'),
+        PP.create('style', 'maxHeight'),
       ])
     default:
       assertNever(axis)
@@ -368,13 +368,13 @@ export const nukePositioningPropsForAxisCommand = (
   switch (axis) {
     case 'horizontal':
       return deleteProperties('always', path, [
-        PP.create(['style', 'left']),
-        PP.create(['style', 'right']),
+        PP.create('style', 'left'),
+        PP.create('style', 'right'),
       ])
     case 'vertical':
       return deleteProperties('always', path, [
-        PP.create(['style', 'top']),
-        PP.create(['style', 'bottom']),
+        PP.create('style', 'top'),
+        PP.create('style', 'bottom'),
       ])
     default:
       assertNever(axis)
@@ -387,11 +387,11 @@ export const nukeAllAbsolutePositioningPropsCommands = (
   return [
     addContainLayoutIfNeeded('always', path),
     deleteProperties('always', path, [
-      PP.create(['style', 'position']),
-      PP.create(['style', 'left']),
-      PP.create(['style', 'right']),
-      PP.create(['style', 'top']),
-      PP.create(['style', 'bottom']),
+      PP.create('style', 'position'),
+      PP.create('style', 'left'),
+      PP.create('style', 'right'),
+      PP.create('style', 'top'),
+      PP.create('style', 'bottom'),
     ]),
   ]
 }
@@ -414,7 +414,7 @@ export function detectFillHugFixedState(
   const flexGrow = foldEither(
     () => null,
     (value) => defaultEither(null, parseCSSNumber(value, 'Unitless')),
-    getSimpleAttributeAtPath(right(element.element.value.props), PP.create(['style', 'flexGrow'])),
+    getSimpleAttributeAtPath(right(element.element.value.props), PP.create('style', 'flexGrow')),
   )
 
   if (flexGrow != null) {
@@ -438,7 +438,7 @@ export function detectFillHugFixedState(
 
   const prop = defaultEither(
     null,
-    getSimpleAttributeAtPath(right(element.element.value.props), PP.create(['style', property])),
+    getSimpleAttributeAtPath(right(element.element.value.props), PP.create('style', property)),
   )
 
   if (prop === MaxContent) {

--- a/editor/src/components/inspector/inspector-strategies/hug-contents-basic-strategy.tsx
+++ b/editor/src/components/inspector/inspector-strategies/hug-contents-basic-strategy.tsx
@@ -26,7 +26,7 @@ function hugContentsSingleElement(
 ): Array<CanvasCommand> {
   const basicCommands = [
     nukeSizingPropsForAxisCommand(axis, elementPath),
-    setProperty('always', elementPath, PP.create(['style', widthHeightFromAxis(axis)]), MaxContent),
+    setProperty('always', elementPath, PP.create('style', widthHeightFromAxis(axis)), MaxContent),
   ]
 
   const chilren = MetadataUtils.getChildrenPaths(metadata, elementPath)

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.tsx
@@ -43,8 +43,8 @@ export const setFlexAlignJustifyContentStrategies = (
       }
 
       return elements.flatMap((path) => [
-        setProperty('always', path, PP.create(['style', 'alignItems']), flexAlignment),
-        setProperty('always', path, PP.create(['style', 'justifyContent']), justifyContent),
+        setProperty('always', path, PP.create('style', 'alignItems'), flexAlignment),
+        setProperty('always', path, PP.create('style', 'justifyContent'), justifyContent),
       ])
     },
   },
@@ -61,7 +61,7 @@ export const removeFlexDirectionStrategies = (): Array<InspectorStrategy> => [
       }
 
       return elements.map((path) =>
-        deleteProperties('always', path, [PP.create(['style', 'flexDirection'])]),
+        deleteProperties('always', path, [PP.create('style', 'flexDirection')]),
       )
     },
   },
@@ -80,7 +80,7 @@ export const updateFlexDirectionStrategies = (
       }
 
       return elements.flatMap((path) => [
-        setProperty('always', path, PP.create(['style', 'flexDirection']), flexDirection),
+        setProperty('always', path, PP.create('style', 'flexDirection'), flexDirection),
         ...MetadataUtils.getChildrenPaths(metadata, path).flatMap((child) => [
           ...pruneFlexPropsCommands(flexChildProps, child),
           ...sizeToVisualDimensions(metadata, child),
@@ -95,7 +95,7 @@ export const addFlexLayoutStrategies: Array<InspectorStrategy> = [
     name: 'Add flex layout',
     strategy: (metadata, elementPaths) => {
       return elementPaths.flatMap((path) => [
-        setProperty('always', path, PP.create(['style', 'display']), 'flex'),
+        setProperty('always', path, PP.create('style', 'display'), 'flex'),
         ...MetadataUtils.getChildrenPaths(metadata, path).flatMap((child) => [
           ...nukeAllAbsolutePositioningPropsCommands(child),
           ...sizeToVisualDimensions(metadata, child),
@@ -118,7 +118,7 @@ export const removeFlexLayoutStrategies: Array<InspectorStrategy> = [
       }
 
       return elements.map((path) =>
-        deleteProperties('always', path, [PP.create(['style', 'display'])]),
+        deleteProperties('always', path, [PP.create('style', 'display')]),
       )
     },
   },
@@ -147,7 +147,7 @@ export const setPropFillStrategies = (
           return [
             nukeSizingPropsForAxisCommand(axis, path),
             ...nukePositioningCommands,
-            setProperty('always', path, PP.create(['style', widthHeightFromAxis(axis)]), '100%'),
+            setProperty('always', path, PP.create('style', widthHeightFromAxis(axis)), '100%'),
           ]
         }
 
@@ -160,14 +160,14 @@ export const setPropFillStrategies = (
           return [
             nukeSizingPropsForAxisCommand(axis, path),
             ...nukeAllAbsolutePositioningPropsCommands(path),
-            setProperty('always', path, PP.create(['style', widthHeightFromAxis(axis)]), '100%'),
+            setProperty('always', path, PP.create('style', widthHeightFromAxis(axis)), '100%'),
           ]
         }
 
         return [
           nukeSizingPropsForAxisCommand(axis, path),
           ...nukeAllAbsolutePositioningPropsCommands(path),
-          setProperty('always', path, PP.create(['style', 'flexGrow']), '1'),
+          setProperty('always', path, PP.create('style', 'flexGrow'), '1'),
         ]
       })
     },
@@ -194,7 +194,7 @@ export const setPropFixedStrategies = (
         return setCssLengthProperty(
           whenToRun,
           path,
-          PP.create(['style', widthHeightFromAxis(axis)]),
+          PP.create('style', widthHeightFromAxis(axis)),
           setExplicitCssValue(value),
           parentFlexDirection,
         )

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -446,7 +446,7 @@ function updateTargets(localJSXElement: JSXElement): Array<CSSTarget> {
   defaults.reverse().forEach((defaultTarget) => {
     const styleObject = getSimpleAttributeAtPath(
       right(localJSXElement.props),
-      PP.create(defaultTarget.path),
+      PP.create(...defaultTarget.path),
     )
     if (isRight(styleObject) && styleObject.value instanceof Object) {
       recursivelyDiscoverStyleTargets(styleObject.value, defaultTarget.path)
@@ -548,7 +548,7 @@ export const SingleInspectorEntryPoint: React.FunctionComponent<
 
   const onStyleSelectorDelete = React.useCallback(
     (deleteTarget: CSSTarget) => {
-      const path = PP.create(deleteTarget.path)
+      const path = PP.create(...deleteTarget.path)
       const actions = Utils.flatMapArray(
         (elem) => [EditorActions.unsetProperty(elem, path)],
         refElementsToTargetForUpdates.current,
@@ -561,7 +561,7 @@ export const SingleInspectorEntryPoint: React.FunctionComponent<
   const onStyleSelectorInsert = React.useCallback(
     (parent: CSSTarget | undefined, label: string) => {
       const newPath = [...(parent?.path ?? []), label]
-      const newPropertyPath = PP.create(newPath)
+      const newPropertyPath = PP.create(...newPath)
       const actions: Array<EditorAction> = refElementsToTargetForUpdates.current.map((elem) =>
         EditorActions.setProp_UNSAFE(elem, newPropertyPath, jsxAttributeValue({}, emptyComments)),
       )

--- a/editor/src/components/inspector/sections/component-section/folder-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/folder-section.tsx
@@ -88,7 +88,7 @@ export const FolderSection = React.memo((props: FolderSectionProps) => {
     return (
       <RowOrFolderWrapper
         key={`section-row-${propName}`}
-        propPath={PP.create([propName])}
+        propPath={PP.create(propName)}
         controlDescription={controlDescription}
         isScene={false}
         setGlobalCursor={props.setGlobalCursor}
@@ -131,7 +131,7 @@ export const FolderSection = React.memo((props: FolderSectionProps) => {
             return (
               <RowForControl
                 key={propName}
-                propPath={PP.create([propName])}
+                propPath={PP.create(propName)}
                 controlDescription={controlDescription}
                 isScene={false}
                 setGlobalCursor={props.setGlobalCursor}

--- a/editor/src/components/inspector/sections/event-handlers-section/event-handlers-section.tsx
+++ b/editor/src/components/inspector/sections/event-handlers-section/event-handlers-section.tsx
@@ -13,7 +13,7 @@ import { useGetMultiselectedProps, useInspectorContext } from '../../common/prop
 import { PropertyLabel } from '../../widgets/property-label'
 import { UIGridRow } from '../../widgets/ui-grid-row'
 
-const ppCreate = (p: string) => PP.create([p])
+const ppCreate = (p: string) => PP.create(p)
 
 const regularArrayDOMEventHandlerNames = [...DOMEventHandlerNames]
 
@@ -24,7 +24,7 @@ interface EventHandlerControlProps {
 
 export const EventHandlerControl = React.memo((props: EventHandlerControlProps) => {
   const { handlerName, value } = props
-  const target = useKeepReferenceEqualityIfPossible([PP.create([handlerName])])
+  const target = useKeepReferenceEqualityIfPossible([PP.create(handlerName)])
   return (
     <>
       <PropertyLabel target={target}>{handlerName}</PropertyLabel>

--- a/editor/src/components/inspector/sections/image-section/image-section.tsx
+++ b/editor/src/components/inspector/sections/image-section/image-section.tsx
@@ -19,8 +19,8 @@ import { useColorTheme, InspectorSectionHeader, InspectorSectionIcons } from '..
 import { ImageSourceControl } from './image-source-control'
 import { useDispatch } from '../../../editor/store/dispatch-context'
 
-const imgSrcProp = [PP.create(['src'])]
-const imgAltProp = [PP.create(['alt'])]
+const imgSrcProp = [PP.create('src')]
+const imgAltProp = [PP.create('alt')]
 
 export const ImgSection = React.memo(() => {
   const colorTheme = useColorTheme()

--- a/editor/src/components/inspector/sections/style-section/background-subsection/background-picker.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/background-picker.tsx
@@ -491,7 +491,7 @@ export const BackgroundPicker: React.FunctionComponent<
           selectedViews.map((view) =>
             setProperty(
               view,
-              create(['style', 'backgroundColor']),
+              create('style', 'backgroundColor'),
               jsxAttributeValue(sRGBHex, emptyComments),
             ),
           ),

--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -277,7 +277,7 @@ const ClassNameControl = React.memo(() => {
           [
             EditorActions.setProp_UNSAFE(
               elementPath,
-              PP.create(['className']),
+              PP.create('className'),
               jsxAttributeValue(newValue.map((value) => value.value).join(' '), emptyComments),
             ),
             EditorActions.clearTransientProps(),
@@ -457,7 +457,7 @@ const ClassNameControl = React.memo(() => {
             [
               EditorActions.setPropTransient(
                 targets[0],
-                PP.create(['className']),
+                PP.create('className'),
                 jsxAttributeValue(newClassNameString, emptyComments),
               ),
             ],

--- a/editor/src/components/inspector/sections/style-section/container-subsection/blendmode-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/blendmode-row.tsx
@@ -17,7 +17,7 @@ const blendModeOptions = [
   { value: 'darken', label: 'Darken' },
 ]
 
-const blendModeProp = [PP.create(['style', 'mixBlendMode'])]
+const blendModeProp = [PP.create('style', 'mixBlendMode')]
 
 export const BlendModeRow = React.memo(() => {
   const blendModeMetadata = useInspectorStyleInfo('mixBlendMode')

--- a/editor/src/components/inspector/sections/style-section/container-subsection/opacity-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/opacity-row.tsx
@@ -22,7 +22,7 @@ const sliderControlOptions = {
 }
 
 // TODO: path should match target
-const opacityProp = [PP.create(['style', 'opacity'])]
+const opacityProp = [PP.create('style', 'opacity')]
 
 export const OpacityRow = React.memo(() => {
   const opacityMetadata = useInspectorStyleInfo('opacity')

--- a/editor/src/components/inspector/sections/style-section/container-subsection/overflow-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/overflow-row.tsx
@@ -6,7 +6,7 @@ import { useInspectorStyleInfo } from '../../../common/property-path-hooks'
 import { OptionChainControl, OptionChainOption } from '../../../controls/option-chain-control'
 import { InspectorContextMenuItems, InspectorContextMenuWrapper } from '../../../../../uuiui-deps'
 
-const overflowProp = [PP.create(['style', 'overflow'])]
+const overflowProp = [PP.create('style', 'overflow')]
 
 const OverflowControlOptions: Array<OptionChainOption<boolean>> = [
   {

--- a/editor/src/components/text-editor/text-editor-shortcut-helpers.ts
+++ b/editor/src/components/text-editor/text-editor-shortcut-helpers.ts
@@ -64,7 +64,7 @@ const toggleStyleProp = (
   const newValue = currentValue === toggledValue ? defaultValue : toggledValue
   return EditorActions.setProperty(
     elementPath,
-    PP.create(['style', prop]),
+    PP.create('style', prop),
     jsxAttributeValue(newValue, emptyComments),
   )
 }

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -132,7 +132,7 @@ const handleSetFontSizeShortcut = (
       setProperty(
         'always',
         elementPath,
-        PP.create(['style', 'fontSize']),
+        PP.create('style', 'fontSize'),
         printCSSNumber(adjustFontSize(fontSize[0], delta), null),
       ),
     ]),
@@ -164,7 +164,7 @@ const handleSetFontWeightShortcut = (
       setProperty(
         'always',
         elementPath,
-        PP.create(['style', 'fontWeight']),
+        PP.create('style', 'fontWeight'),
         adjustFontWeight(fontWeight, delta),
       ),
     ]),

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -300,7 +300,7 @@ export const MetadataUtils = {
     if (element != null) {
       forEachRight(element.element, (elem) => {
         if (isJSXElement(elem)) {
-          const attrResult = getSimpleAttributeAtPath(right(elem.props), PP.create(['role']))
+          const attrResult = getSimpleAttributeAtPath(right(elem.props), PP.create('role'))
           forEachRight(attrResult, (value) => {
             if (value === 'button') {
               buttonRoleFound = true

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -600,13 +600,10 @@ export function componentHonoursPropsPosition(component: UtopiaJSXComponent): bo
   } else {
     const rootElement = component.rootElement
     if (isJSXElement(rootElement)) {
-      const leftStyleAttr = getJSXAttributeAtPath(rootElement.props, PP.create(['style', 'left']))
-      const topStyleAttr = getJSXAttributeAtPath(rootElement.props, PP.create(['style', 'top']))
-      const rightStyleAttr = getJSXAttributeAtPath(rootElement.props, PP.create(['style', 'right']))
-      const bottomStyleAttr = getJSXAttributeAtPath(
-        rootElement.props,
-        PP.create(['style', 'bottom']),
-      )
+      const leftStyleAttr = getJSXAttributeAtPath(rootElement.props, PP.create('style', 'left'))
+      const topStyleAttr = getJSXAttributeAtPath(rootElement.props, PP.create('style', 'top'))
+      const rightStyleAttr = getJSXAttributeAtPath(rootElement.props, PP.create('style', 'right'))
+      const bottomStyleAttr = getJSXAttributeAtPath(rootElement.props, PP.create('style', 'bottom'))
       return (
         ((propertyComesFromPropsStyle(component.param, leftStyleAttr, 'left') ||
           propertyComesFromPropsStyle(component.param, rightStyleAttr, 'right')) &&
@@ -626,11 +623,8 @@ export function componentHonoursPropsSize(component: UtopiaJSXComponent): boolea
   } else {
     const rootElement = component.rootElement
     if (isJSXElement(rootElement)) {
-      const widthStyleAttr = getJSXAttributeAtPath(rootElement.props, PP.create(['style', 'width']))
-      const heightStyleAttr = getJSXAttributeAtPath(
-        rootElement.props,
-        PP.create(['style', 'height']),
-      )
+      const widthStyleAttr = getJSXAttributeAtPath(rootElement.props, PP.create('style', 'width'))
+      const heightStyleAttr = getJSXAttributeAtPath(rootElement.props, PP.create('style', 'height'))
       return (
         (propertyComesFromPropsStyle(component.param, widthStyleAttr, 'width') &&
           propertyComesFromPropsStyle(component.param, heightStyleAttr, 'height')) ||
@@ -646,7 +640,7 @@ export function propsStyleIsSpreadInto(propsParam: Param, attributes: JSXAttribu
   const boundParam = propsParam.boundParam
   switch (boundParam.type) {
     case 'REGULAR_PARAM': {
-      const styleProp = getJSXAttributeAtPath(attributes, PP.create(styleStringInArray))
+      const styleProp = getJSXAttributeAtPath(attributes, PP.create('style'))
       const styleAttribute = styleProp.attribute
       switch (styleAttribute.type) {
         case 'ATTRIBUTE_NOT_FOUND':
@@ -689,7 +683,7 @@ export function propsStyleIsSpreadInto(propsParam: Param, attributes: JSXAttribu
             // This is the aliased name or if there's no alias the field name.
             const propertyToLookFor = partBoundParam.paramName
 
-            const styleProp = getJSXAttributeAtPath(attributes, PP.create(styleStringInArray))
+            const styleProp = getJSXAttributeAtPath(attributes, PP.create('style'))
             const styleAttribute = styleProp.attribute
             switch (styleAttribute.type) {
               case 'ATTRIBUTE_NOT_FOUND':

--- a/editor/src/core/model/jsx-attributes.spec.ts
+++ b/editor/src/core/model/jsx-attributes.spec.ts
@@ -170,7 +170,7 @@ describe('setJSXValueAtPath', () => {
     const updatedAttributes = forceRight(
       setJSXValueAtPath(
         sampleJsxAttributes(),
-        PP.create(['top']),
+        PP.create('top'),
         jsxAttributeValue(55, emptyComments),
       ),
     )
@@ -187,7 +187,7 @@ describe('setJSXValueAtPath', () => {
     const updatedAttributes = forceRight(
       setJSXValueAtPath(
         sampleJsxAttributes(),
-        PP.create(['otherJs']),
+        PP.create('otherJs'),
         jsxAttributeValue('shadowy', emptyComments),
       ),
     )
@@ -198,7 +198,7 @@ describe('setJSXValueAtPath', () => {
     const updatedAttributes = forceRight(
       setJSXValueAtPath(
         sampleJsxAttributes(),
-        PP.create(['my', 'property', 'path']),
+        PP.create('my', 'property', 'path'),
         jsxAttributeValue('hello', emptyComments),
       ),
     )
@@ -215,7 +215,7 @@ describe('setJSXValueAtPath', () => {
     const updatedAttributes = forceRight(
       setJSXValueAtPath(
         sampleJsxAttributes(),
-        PP.create(['layout', 'left']),
+        PP.create('layout', 'left'),
         jsxAttributeValue(2000, emptyComments),
       ),
     )
@@ -232,7 +232,7 @@ describe('setJSXValueAtPath', () => {
     const updatedAttributes = forceRight(
       setJSXValueAtPath(
         sampleJsxAttributes(),
-        PP.create(['layout', 'deep', 'path']),
+        PP.create('layout', 'deep', 'path'),
         jsxAttributeValue('easy!', emptyComments),
       ),
     )
@@ -249,7 +249,7 @@ describe('setJSXValueAtPath', () => {
     const updatedAttributes = forceRight(
       setJSXValueAtPath(
         sampleJsxAttributes(),
-        PP.create(['objectWithArray', 'array', 2]),
+        PP.create('objectWithArray', 'array', 2),
         jsxAttributeValue('wee', emptyComments),
       ),
     )
@@ -266,7 +266,7 @@ describe('setJSXValueAtPath', () => {
     const updatedAttributes = forceRight(
       setJSXValueAtPath(
         sampleJsxAttributes(),
-        PP.create(['objectWithNestedArray', 'array', 2]),
+        PP.create('objectWithNestedArray', 'array', 2),
         jsxAttributeValue('wee', emptyComments),
       ),
     )
@@ -283,7 +283,7 @@ describe('setJSXValueAtPath', () => {
     const updatedAttributes = forceRight(
       setJSXValueAtPath(
         sampleJsxAttributes(),
-        PP.create(['objectWithNestedArray', 'array', '2']),
+        PP.create('objectWithNestedArray', 'array', '2'),
         jsxAttributeValue('wee', emptyComments),
       ),
     )
@@ -300,7 +300,7 @@ describe('setJSXValueAtPath', () => {
     const updatedAttributes = forceRight(
       setJSXValueAtPath(
         sampleJsxAttributes(),
-        PP.create(['objectWithNestedArray', 'array', 'wee']),
+        PP.create('objectWithNestedArray', 'array', 'wee'),
         jsxAttributeValue('wee', emptyComments),
       ),
     )
@@ -318,7 +318,7 @@ describe('setJSXValueAtPath', () => {
       const updatedAttributes = forceRight(
         setJSXValueAtPath(
           sampleJsxAttributes(),
-          PP.create(['style', 'backgroundColor', 'red']),
+          PP.create('style', 'backgroundColor', 'red'),
           jsxAttributeValue('wee', emptyComments),
         ),
       )
@@ -335,7 +335,7 @@ describe('setJSXValueAtPath', () => {
     const updatedAttributes = forceRight(
       setJSXValueAtPath(
         sampleJsxAttributes(),
-        PP.create(['style', 'backgroundColor']),
+        PP.create('style', 'backgroundColor'),
         jsxAttributeValue('wee', emptyComments),
       ),
     )
@@ -352,14 +352,14 @@ describe('setJSXValueAtPath', () => {
     const updatedAttributes = forceRight(
       setJSXValueAtPath(
         sampleJsxAttributes(),
-        PP.create(['my', 'property', 'path']),
+        PP.create('my', 'property', 'path'),
         jsxAttributeValue('hello', emptyComments),
       ),
     )
     const updatedAttributes2 = forceRight(
       setJSXValueAtPath(
         updatedAttributes,
-        PP.create(['my', 'property', 'other', 'path']),
+        PP.create('my', 'property', 'other', 'path'),
         jsxAttributeValue('hola', emptyComments),
       ),
     )
@@ -377,7 +377,7 @@ describe('setJSXValueAtPath', () => {
     const updatedAttributes = forceRight(
       setJSXValueAtPath(
         sampleJsxAttributes(),
-        PP.create(['style', 'backgroundColor']),
+        PP.create('style', 'backgroundColor'),
         jsxAttributeValue('blue', emptyComments),
       ),
     )
@@ -393,19 +393,19 @@ describe('setJSXValueAtPath', () => {
   it('should prevent setting a value inside a special prop', () => {
     const result1 = setJSXValueAtPath(
       sampleJsxAttributes(),
-      PP.create(['style', 'shadow', 'left']),
+      PP.create('style', 'shadow', 'left'),
       jsxAttributeValue('shadowy', emptyComments),
     )
 
     const result2 = setJSXValueAtPath(
       sampleJsxAttributes(),
-      PP.create(['style', 'boxShadow', '0']),
+      PP.create('style', 'boxShadow', '0'),
       jsxAttributeValue('shadowy', emptyComments),
     )
 
     const result3 = setJSXValueAtPath(
       sampleJsxAttributes(),
-      PP.create(['otherJs', 'wrongProp']),
+      PP.create('otherJs', 'wrongProp'),
       jsxAttributeValue('shadowy', emptyComments),
     )
 
@@ -433,7 +433,7 @@ describe('setJSXValueAtPath', () => {
 
     const result = setJSXValueAtPath(
       attributes,
-      PP.create(['style', 'paddingLeft']),
+      PP.create('style', 'paddingLeft'),
       jsxAttributeValue(100, emptyComments),
     )
     if (isLeft(result)) {
@@ -488,7 +488,7 @@ describe('setJSXValueAtPath', () => {
 
     const result = setJSXValueAtPath(
       attributes,
-      PP.create(['style', 'paddingLeft']),
+      PP.create('style', 'paddingLeft'),
       jsxAttributeValue(100, emptyComments),
     )
     if (isLeft(result)) {
@@ -510,7 +510,7 @@ describe('setJSXValueAtPath', () => {
 
   it('creates an array if the property path part is a number', () => {
     const updatedAttributes = forceRight(
-      setJSXValueAtPath([], PP.create(['top', 0]), jsxAttributeValue(55, emptyComments)),
+      setJSXValueAtPath([], PP.create('top', 0), jsxAttributeValue(55, emptyComments)),
     )
     const compiledProps = jsxAttributesToProps(
       'test.js',
@@ -605,7 +605,7 @@ describe('getModifiableJSXAttributeAtPath', () => {
   it('gets a simple value', () => {
     const backgroundColor = getModifiableJSXAttributeAtPath(
       sampleJsxAttributes(),
-      PP.create(['style', 'backgroundColor']),
+      PP.create('style', 'backgroundColor'),
     )
     expect(isRight(backgroundColor)).toBeTruthy()
     if (isRight(backgroundColor)) {
@@ -622,7 +622,7 @@ describe('getModifiableJSXAttributeAtPath', () => {
   it('drills correctly into a simple value containing an object', () => {
     const foundAttribute = getModifiableJSXAttributeAtPath(
       sampleJsxAttributes(),
-      PP.create(['objectValue', 'deep', 'object', 'path']),
+      PP.create('objectValue', 'deep', 'object', 'path'),
     )
     expect(isRight(foundAttribute)).toBeTruthy()
     if (isRight(foundAttribute)) {
@@ -632,7 +632,7 @@ describe('getModifiableJSXAttributeAtPath', () => {
 
     const missingAttribute = getModifiableJSXAttributeAtPath(
       sampleJsxAttributes(),
-      PP.create(['objectValue', 'deep', 'object', 'missing', 'path']),
+      PP.create('objectValue', 'deep', 'object', 'missing', 'path'),
     )
     expect(isRight(missingAttribute)).toBeTruthy()
     if (isRight(missingAttribute)) {
@@ -641,7 +641,7 @@ describe('getModifiableJSXAttributeAtPath', () => {
 
     const completelyMissingAttribute = getModifiableJSXAttributeAtPath(
       sampleJsxAttributes(),
-      PP.create(['cats', 'dogs', 'missing', 'path']),
+      PP.create('cats', 'dogs', 'missing', 'path'),
     )
     expect(completelyMissingAttribute).toEqual(right(jsxAttributeNotFound()))
   })
@@ -649,7 +649,7 @@ describe('getModifiableJSXAttributeAtPath', () => {
   it('returns Right on a path that CAN be updated by an action', () => {
     const impossibleAttribute = getModifiableJSXAttributeAtPath(
       sampleJsxAttributes(),
-      PP.create(['bad', 'path']),
+      PP.create('bad', 'path'),
     )
     expect(isRight(impossibleAttribute)).toBeTruthy()
     expect(impossibleAttribute.value as any).toEqual(jsxAttributeNotFound())
@@ -660,7 +660,7 @@ describe('getModifiableJSXAttributeAtPath', () => {
     // does not contain any real value
     const impossibleAttributeInsideAValue = getModifiableJSXAttributeAtPath(
       sampleJsxAttributes(),
-      PP.create(['top', 'what']),
+      PP.create('top', 'what'),
     )
     expect(isRight(impossibleAttributeInsideAValue)).toBeTruthy()
     expect(impossibleAttributeInsideAValue.value).toEqual(jsxAttributeNotFound())
@@ -693,7 +693,7 @@ describe('unsetJSXValueAtPath', () => {
       top: jsxAttributeValue(0, emptyComments),
       'data-uid': jsxAttributeValue('aaa', emptyComments),
     })
-    const actualValue = unsetJSXValueAtPath(startingValue, PP.create(['left']))
+    const actualValue = unsetJSXValueAtPath(startingValue, PP.create('left'))
     const expectedValue = right(
       jsxAttributesFromMap({
         top: jsxAttributeValue(0, emptyComments),
@@ -707,7 +707,7 @@ describe('unsetJSXValueAtPath', () => {
       top: jsxAttributeValue(0, emptyComments),
       'data-uid': jsxAttributeValue('aaa', emptyComments),
     })
-    const actualValue = unsetJSXValueAtPath(startingValue, PP.create(['left']))
+    const actualValue = unsetJSXValueAtPath(startingValue, PP.create('left'))
     const expectedValue = right(
       jsxAttributesFromMap({
         top: jsxAttributeValue(0, emptyComments),
@@ -721,7 +721,7 @@ describe('unsetJSXValueAtPath', () => {
       style: jsxAttributeValue({ left: 0, top: 0 }, emptyComments),
       'data-uid': jsxAttributeValue('aaa', emptyComments),
     })
-    const actualValue = unsetJSXValueAtPath(startingValue, PP.create(['style', 'left']))
+    const actualValue = unsetJSXValueAtPath(startingValue, PP.create('style', 'left'))
     const expectedValue = right(
       jsxAttributesFromMap({
         style: jsxAttributeValue({ top: 0 }, emptyComments),
@@ -735,7 +735,7 @@ describe('unsetJSXValueAtPath', () => {
       style: jsxAttributeValue({ top: 0 }, emptyComments),
       'data-uid': jsxAttributeValue('aaa', emptyComments),
     })
-    const actualValue = unsetJSXValueAtPath(startingValue, PP.create(['style', 'left']))
+    const actualValue = unsetJSXValueAtPath(startingValue, PP.create('style', 'left'))
     const expectedValue = right(
       jsxAttributesFromMap({
         style: jsxAttributeValue({ top: 0 }, emptyComments),
@@ -749,7 +749,7 @@ describe('unsetJSXValueAtPath', () => {
       style: jsxAttributeValue([0, 1], emptyComments),
       'data-uid': jsxAttributeValue('aaa', emptyComments),
     })
-    const actualValue = unsetJSXValueAtPath(startingValue, PP.create(['style', 1]))
+    const actualValue = unsetJSXValueAtPath(startingValue, PP.create('style', 1))
     const expectedValue = right(
       jsxAttributesFromMap({
         style: jsxAttributeValue([0], emptyComments),
@@ -763,7 +763,7 @@ describe('unsetJSXValueAtPath', () => {
       style: jsxAttributeValue([0], emptyComments),
       'data-uid': jsxAttributeValue('aaa', emptyComments),
     })
-    const actualValue = unsetJSXValueAtPath(startingValue, PP.create(['style', 1]))
+    const actualValue = unsetJSXValueAtPath(startingValue, PP.create('style', 1))
     const expectedValue = right(
       jsxAttributesFromMap({
         style: jsxAttributeValue([0], emptyComments),
@@ -777,7 +777,7 @@ describe('unsetJSXValueAtPath', () => {
       style: jsxAttributeOtherJavaScript('undefined', 'undefined', [], null, {}),
       'data-uid': jsxAttributeValue('aaa', emptyComments),
     })
-    const actualValue = unsetJSXValueAtPath(startingValue, PP.create(['style', 1]))
+    const actualValue = unsetJSXValueAtPath(startingValue, PP.create('style', 1))
     expect(isLeft(actualValue)).toBe(true)
   })
 
@@ -792,7 +792,7 @@ describe('unsetJSXValueAtPath', () => {
       ),
       'data-uid': jsxAttributeValue('aaa', emptyComments),
     })
-    const actualValue = unsetJSXValueAtPath(startingValue, PP.create(['style', 'left']))
+    const actualValue = unsetJSXValueAtPath(startingValue, PP.create('style', 'left'))
     const expectedValue = right(
       jsxAttributesFromMap({
         style: jsxAttributeValue({ top: { x: 1, y: 1 } }, emptyComments),
@@ -809,7 +809,7 @@ describe('unsetJSXValueAtPath', () => {
       ),
       'data-uid': jsxAttributeValue('aaa', emptyComments),
     })
-    const actualValue = unsetJSXValueAtPath(startingValue, PP.create(['style', 'left', 'x']))
+    const actualValue = unsetJSXValueAtPath(startingValue, PP.create('style', 'left', 'x'))
     const expectedValue = right(
       jsxAttributesFromMap({
         style: jsxAttributeValue({ top: { x: 1, y: 1 } }, emptyComments),
@@ -826,7 +826,7 @@ describe('unsetJSXValueAtPath', () => {
       ]),
       'data-uid': jsxAttributeValue('aaa', emptyComments),
     })
-    const actualValue = unsetJSXValueAtPath(startingValue, PP.create(['style', 1]))
+    const actualValue = unsetJSXValueAtPath(startingValue, PP.create('style', 1))
     const expectedValue = right(
       jsxAttributesFromMap({
         style: jsxAttributeValue([0], emptyComments),
@@ -840,7 +840,7 @@ describe('unsetJSXValueAtPath', () => {
       style: jsxAttributeNestedArraySimple([jsxAttributeValue(0, emptyComments)]),
       'data-uid': jsxAttributeValue('aaa', emptyComments),
     })
-    const actualValue = unsetJSXValueAtPath(startingValue, PP.create(['style', 1]))
+    const actualValue = unsetJSXValueAtPath(startingValue, PP.create('style', 1))
     const expectedValue = right(
       jsxAttributesFromMap({
         style: jsxAttributeValue([0], emptyComments),
@@ -885,7 +885,7 @@ describe('unsetJSXValueAtPath', () => {
     })
     const actualValue = unsetJSXValueAtPath(
       startingValue,
-      PP.create(['style', 'left', 1, 'stateEnabled', 0, 'lightSide', 'eleven']),
+      PP.create('style', 'left', 1, 'stateEnabled', 0, 'lightSide', 'eleven'),
     )
     const expectedValue = right(
       jsxAttributesFromMap({
@@ -981,7 +981,7 @@ describe('getAllPathsFromAttributes', () => {
     const result = getAllPathsFromAttributes(
       jsxAttributesFromMap({ cica: jsxAttributeValue('hello!', emptyComments) }),
     )
-    expect(result).toEqual([PP.create(['cica'])])
+    expect(result).toEqual([PP.create('cica')])
   })
 
   it('works for a nested object', () => {
@@ -999,9 +999,9 @@ describe('getAllPathsFromAttributes', () => {
       }),
     )
     expect(result).toEqual([
-      PP.create(['cica']),
-      PP.create(['cica', 'deep']),
-      PP.create(['cica', 'deep', 'path']),
+      PP.create('cica'),
+      PP.create('cica', 'deep'),
+      PP.create('cica', 'deep', 'path'),
     ])
   })
 
@@ -1037,9 +1037,9 @@ describe('getAllPathsFromAttributes', () => {
       }),
     )
     expect(result).toEqual([
-      PP.create(['cica']),
-      PP.create(['cica', 'deep']),
-      PP.create(['cica', 'deep', 0]),
+      PP.create('cica'),
+      PP.create('cica', 'deep'),
+      PP.create('cica', 'deep', 0),
     ])
   })
 
@@ -1057,7 +1057,7 @@ describe('getAllPathsFromAttributes', () => {
         ),
       }),
     )
-    expect(result).toEqual([PP.create(['cica']), PP.create(['cica', 'deep'])])
+    expect(result).toEqual([PP.create('cica'), PP.create('cica', 'deep')])
   })
 
   it('drills into paths of object values too', () => {
@@ -1065,9 +1065,9 @@ describe('getAllPathsFromAttributes', () => {
       jsxAttributesFromMap({ cica: jsxAttributeValue({ deep: { path: 5 } }, emptyComments) }),
     )
     expect(result).toEqual([
-      PP.create(['cica']),
-      PP.create(['cica', 'deep']),
-      PP.create(['cica', 'deep', 'path']),
+      PP.create('cica'),
+      PP.create('cica', 'deep'),
+      PP.create('cica', 'deep', 'path'),
     ])
   })
 })

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -56,7 +56,6 @@ import { VSCodeLoadingScreenID } from '../../components/code-editor/vscode-edito
 import { v4 as UUID } from 'uuid'
 import { SmallSingleDivProjectContents } from '../../test-cases/simple-single-div-project'
 import { useDispatch } from '../../components/editor/store/dispatch-context'
-import { styleStringInArray } from '../../utils/common-constants'
 
 let NumberOfIterations = 5
 if (window != null) {
@@ -605,7 +604,7 @@ export function useTriggerAbsoluteMovePerformanceTest(
           selectComponents([childTargetPath!], false),
           setProp_UNSAFE(
             childTargetPath!,
-            PP.create(styleStringInArray),
+            PP.create('style'),
             jsxAttributeValue(childStyleValue, emptyComments),
           ),
         ],
@@ -791,7 +790,7 @@ export function useTriggerSelectionChangePerformanceTest(): () => void {
           selectComponents([childTargetPath!], false),
           setProp_UNSAFE(
             childTargetPath!,
-            PP.create(styleStringInArray),
+            PP.create('style'),
             jsxAttributeValue(childStyleValue, emptyComments),
           ),
         ],

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -48,20 +48,19 @@ import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../../com
 import { getUtopiaJSXComponentsFromSuccess } from './project-file-utils'
 import { generateConsistentUID, generateUID } from '../shared/uid-utils'
 import { emptySet } from '../shared/set-utils'
-import { styleStringInArray } from '../../utils/common-constants'
 
-export const PathForSceneComponent = PP.create(['component'])
-export const PathForSceneDataUid = PP.create(['data-uid'])
-export const PathForSceneDataLabel = PP.create(['data-label'])
-export const PathForSceneFrame = PP.create(styleStringInArray)
+export const PathForSceneComponent = PP.create('component')
+export const PathForSceneDataUid = PP.create('data-uid')
+export const PathForSceneDataLabel = PP.create('data-label')
+export const PathForSceneFrame = PP.create('style')
 
 export const BakedInStoryboardUID = 'utopia-storyboard-uid'
 export const BakedInStoryboardVariableName = 'storyboard'
 
 export const EmptyUtopiaCanvasComponent = convertScenesToUtopiaCanvasComponent([])
 
-export const PathForSceneProps = PP.create(['props'])
-export const PathForSceneStyle = PP.create(styleStringInArray)
+export const PathForSceneProps = PP.create('props')
+export const PathForSceneStyle = PP.create('style')
 
 export function createSceneUidFromIndex(sceneIndex: number): string {
   return `scene-${sceneIndex}`
@@ -100,12 +99,12 @@ export function unmapScene(element: JSXElementChild): SceneMetadata | null {
         }
         return scene
       },
-      getSimpleAttributeAtPathCustom(element.props, PP.create(['component'])),
-      getSimpleAttributeAtPathCustom(element.props, PP.create(['props'])),
-      getSimpleAttributeAtPathCustom(element.props, PP.create(styleStringInArray)),
-      getSimpleAttributeAtPathCustom(element.props, PP.create(['layout'])),
-      getSimpleAttributeAtPathCustom(element.props, PP.create(['data-label'])),
-      getSimpleAttributeAtPathCustom(element.props, PP.create(['data-uid'])),
+      getSimpleAttributeAtPathCustom(element.props, PP.create('component')),
+      getSimpleAttributeAtPathCustom(element.props, PP.create('props')),
+      getSimpleAttributeAtPathCustom(element.props, PP.create('style')),
+      getSimpleAttributeAtPathCustom(element.props, PP.create('layout')),
+      getSimpleAttributeAtPathCustom(element.props, PP.create('data-label')),
+      getSimpleAttributeAtPathCustom(element.props, PP.create('data-uid')),
     ),
   )
 }

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -44,7 +44,7 @@ describe('React Render Count Tests -', () => {
       [
         setProp_UNSAFE(
           EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb']),
-          PP.create(['style', 'opacity']),
+          PP.create('style', 'opacity'),
           jsxAttributeValue(0.3, emptyComments),
         ),
       ],
@@ -100,7 +100,7 @@ describe('React Render Count Tests -', () => {
       [
         setProp_UNSAFE(
           EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb']),
-          PP.create(['style', 'opacity']),
+          PP.create('style', 'opacity'),
           jsxAttributeValue(0.3, emptyComments),
         ),
       ],

--- a/editor/src/core/property-controls/property-control-values.ts
+++ b/editor/src/core/property-controls/property-control-values.ts
@@ -96,7 +96,7 @@ function rawAndRealValueAtIndex(
   index: number,
 ): { rawValue: Either<string, ModifiableAttribute>; realValue: unknown } {
   const rawValueAtIndex = flatMapEither(
-    (v) => getModifiableJSXAttributeAtPathFromAttribute(v, PP.create([index])),
+    (v) => getModifiableJSXAttributeAtPathFromAttribute(v, PP.create(index)),
     rawValue,
   )
   const realValueAtIndex = Array.isArray(realValue) ? realValue[index] : undefined
@@ -176,7 +176,7 @@ function rawAndRealValueAtKey(
   key: PropertyPathPart,
 ): { rawValue: Either<string, ModifiableAttribute>; realValue: unknown } {
   const rawValueAtPath = flatMapEither(
-    (v) => getModifiableJSXAttributeAtPathFromAttribute(v, PP.create([key])),
+    (v) => getModifiableJSXAttributeAtPathFromAttribute(v, PP.create(key)),
     rawValue,
   )
   const realValueAtPath =

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -912,7 +912,7 @@ export function jsxElementName(
 ): JSXElementName {
   return {
     baseVariable: baseVariable,
-    propertyPath: PP.create(propertyPathParts),
+    propertyPath: PP.create(...propertyPathParts),
   }
 }
 

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -904,10 +904,10 @@ function walkAttributes(
   fastForEach(attributes, (attr) => {
     switch (attr.type) {
       case 'JSX_ATTRIBUTES_ENTRY':
-        walkAttribute(attr.value, PP.create([attr.key]), walk)
+        walkAttribute(attr.value, PP.create(attr.key), walk)
         break
       case 'JSX_ATTRIBUTES_SPREAD':
-        walkAttribute(attr.spreadValue, PP.create([]), walk)
+        walkAttribute(attr.spreadValue, PP.create(), walk)
         break
       default:
         const _exhaustiveCheck: never = attr
@@ -924,7 +924,7 @@ export function getAllPathsFromAttributes(attributes: JSXAttributes): Array<Prop
       if (isJSXAttributeValue(attribute) && typeof attribute.value === 'object') {
         paths.push(
           ...getAllObjectPaths(attribute.value).map((p) =>
-            PP.create([...path.propertyElements, ...p]),
+            PP.create(...path.propertyElements, ...p),
           ),
         )
       }

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -27,8 +27,8 @@ export interface ElementPath {
 
 export type PropertyPathPart = string | number
 
-export type PropertyPath = {
-  propertyElements: Array<PropertyPathPart>
+export type PropertyPath<T extends Array<PropertyPathPart> = Array<PropertyPathPart>> = {
+  propertyElements: T
 }
 
 export type PackageType = 'base' | 'svg' | 'app'

--- a/editor/src/core/shared/property-path.spec.ts
+++ b/editor/src/core/shared/property-path.spec.ts
@@ -2,10 +2,10 @@ import { create } from './property-path'
 
 describe('create', () => {
   it('distinguishes between paths containing strings and numbers', () => {
-    const firstEndsWithString = create(['path', '0'])
-    const firstEndsWithNumber = create(['path', 0])
-    const secondEndsWithString = create(['path', '0'])
-    const secondEndsWithNumber = create(['path', 0])
+    const firstEndsWithString = create('path', '0')
+    const firstEndsWithNumber = create('path', 0)
+    const secondEndsWithString = create('path', '0')
+    const secondEndsWithNumber = create('path', 0)
     expect(firstEndsWithString).toStrictEqual({ propertyElements: ['path', '0'] })
     expect(firstEndsWithNumber).toStrictEqual({ propertyElements: ['path', 0] })
     expect(secondEndsWithString).toStrictEqual({ propertyElements: ['path', '0'] })

--- a/editor/src/core/shared/property-path.ts
+++ b/editor/src/core/shared/property-path.ts
@@ -5,7 +5,7 @@ import { arrayEquals, fastForEach, longestCommonArray } from './utils'
 export function fromString(value: string): PropertyPath {
   let fromPathStringCache: PropertyPath | null = globalPathStringToPathCache[value]
   if (fromPathStringCache == null) {
-    const result = create(value.split('.'))
+    const result = create(...value.split('.'))
     globalPathStringToPathCache[value] = result
     return result
   } else {
@@ -52,7 +52,20 @@ function getPathCache(elements: Array<PropertyPathPart>): PropertyPathCache {
   return workingPathCache
 }
 
-export function create(elements: Array<PropertyPathPart>): PropertyPath {
+export function create<T1 extends PropertyPathPart>(element1: T1): PropertyPath<[T1]>
+export function create<T1 extends PropertyPathPart, T2 extends PropertyPathPart>(
+  element1: T1,
+  element2: T2,
+): PropertyPath<[T1, T2]>
+export function create<
+  T1 extends PropertyPathPart,
+  T2 extends PropertyPathPart,
+  T3 extends PropertyPathPart,
+>(element1: T1, element2: T2, element3: T3): PropertyPath<[T1, T2, T3]>
+export function create(...elements: Array<PropertyPathPart>): PropertyPath<Array<PropertyPathPart>>
+export function create(
+  ...elements: Array<PropertyPathPart>
+): PropertyPath<Array<PropertyPathPart>> {
   const pathCache = getPathCache(elements)
   if (pathCache.cached == null) {
     const newPath = { propertyElements: elements }
@@ -62,6 +75,22 @@ export function create(elements: Array<PropertyPathPart>): PropertyPath {
     return pathCache.cached
   }
 }
+
+// export function create<T extends string | number>(elements: [T]): PropertyPath<[T]>
+// export function create<T1 extends PropertyPathPart, T2 extends PropertyPathPart>(
+//   elements: readonly [T1, T2],
+// ): PropertyPath<[T1, T2]>
+// export function create<T extends Array<PropertyPathPart>>(elements: T): PropertyPath<T>
+// export function create<T extends Array<PropertyPathPart>>(elements: T): PropertyPath<T> {
+//   const pathCache = getPathCache(elements)
+//   if (pathCache.cached == null) {
+//     const newPath = { propertyElements: elements }
+//     pathCache.cached = newPath
+//     return newPath
+//   } else {
+//     return pathCache.cached as PropertyPath<T>
+//   }
+// }
 
 export function toString(propertyPath: PropertyPath): string {
   const joinWith = '.'
@@ -97,7 +126,7 @@ export function firstPart(propertyPath: PropertyPath): PropertyPathPart {
 export function tail(propertyPath: PropertyPath): PropertyPath {
   const newElements =
     propertyPath.propertyElements.length > 0 ? propertyPath.propertyElements.slice(1) : []
-  return create(newElements)
+  return create(...newElements)
 }
 
 export function getElements(propertyPath: PropertyPath): Array<PropertyPathPart> {
@@ -108,14 +137,14 @@ export function appendPropertyPathElems(
   path: PropertyPath,
   elems: Array<PropertyPathPart>,
 ): PropertyPath {
-  return create(path.propertyElements.concat(elems))
+  return create(...path.propertyElements.concat(elems))
 }
 
 export function prependPropertyPathElems(
   elems: Array<PropertyPathPart>,
   path: PropertyPath,
 ): PropertyPath {
-  return create(elems.concat(path.propertyElements))
+  return create(...elems.concat(path.propertyElements))
 }
 
 export function append(first: PropertyPath, second: PropertyPath): PropertyPath {
@@ -168,7 +197,7 @@ export function isSameProperty(path: PropertyPath, stringPath: string): boolean 
 }
 
 export function rootPath(path: PropertyPath): PropertyPath {
-  return create([getElements(path)[0]])
+  return create(getElements(path)[0])
 }
 
 export function stepDownPath(
@@ -185,7 +214,7 @@ export function stepDownPath(
   if (pathToStep == null) {
     return rootPath(pathToFollow)
   } else {
-    return create(pathToFollow.propertyElements.slice(0, pathToStep.propertyElements.length + 1))
+    return create(...pathToFollow.propertyElements.slice(0, pathToStep.propertyElements.length + 1))
   }
 }
 
@@ -208,5 +237,5 @@ export function findLongestMatchingPropertyPath(
   path: PropertyPath,
   from: Array<PropertyPathPart>,
 ): PropertyPath {
-  return create(findLongestMatchingSubPath(path.propertyElements, from))
+  return create(...findLongestMatchingSubPath(path.propertyElements, from))
 }

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -28,7 +28,7 @@ import { UTOPIA_PATH_KEY, UTOPIA_UID_KEY } from '../model/utopia-constants'
 import { addAllUniquely, mapDropNulls } from './array-utils'
 import { ElementPath } from './project-file-types'
 
-export const UtopiaIDPropertyPath = PP.create(['data-uid'])
+export const UtopiaIDPropertyPath = PP.create('data-uid')
 
 const atoz = [
   'a',

--- a/editor/src/core/tailwind/tailwind-options.tsx
+++ b/editor/src/core/tailwind/tailwind-options.tsx
@@ -256,7 +256,7 @@ function getClassNameAttribute(element: JSXElementChild | null): {
 } {
   if (element != null && isJSXElement(element)) {
     const jsxAttributes = element.props
-    const foundAttribute = getModifiableJSXAttributeAtPath(jsxAttributes, PP.create(['className']))
+    const foundAttribute = getModifiableJSXAttributeAtPath(jsxAttributes, PP.create('className'))
     const foundAttributeValue = flatMapEither(jsxSimpleAttributeToValue, foundAttribute)
     const isSettable = foldEither(
       () => false,

--- a/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.tsx
@@ -181,7 +181,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
             const elementWithin = firstChild.elementsWithin['bbb']
             const newAttributes = setJSXValueAtPath(
               elementWithin.props,
-              PP.create(styleStringInArray),
+              PP.create('style'),
               jsxAttributeValue({ left: 20, top: 300 }, emptyComments),
             )
             forEachRight(newAttributes, (updated) => {

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -378,7 +378,7 @@ export function parsePropertyPathLikeExpression(
     } else if (TS.isIdentifier(inner)) {
       return right({
         identifier: inner.getText(sourceFile),
-        property: PP.create(pathSoFar),
+        property: PP.create(...pathSoFar),
       })
     } else {
       return left(`Unhandled expression type.`)

--- a/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
@@ -398,7 +398,7 @@ export function propertyPathPartsArbitrary(): Arbitrary<Array<string | number>> 
 
 export function propertyPathArbitrary(): Arbitrary<PropertyPath> {
   return propertyPathPartsArbitrary().map((pathParts) => {
-    return PP.create(pathParts)
+    return PP.create(...pathParts)
   })
 }
 

--- a/editor/src/templates/image-drop.tsx
+++ b/editor/src/templates/image-drop.tsx
@@ -321,7 +321,7 @@ function updateImageSrcsActions(
       ? null
       : EditorActions.setProperty(
           fromString(path),
-          PP.create(['src']),
+          PP.create('src'),
           jsxAttributeValue(maybeImageUpdateData.path, emptyComments),
         )
   }, Object.entries(allElementProps))


### PR DESCRIPTION
**Problem:**
I came across a problem: in our API I want to be able to say "property path where the last element is either width or height" or "property path where the last element is **not** one of these 6 string literals". 

**Fix:**
To be able to do this, the PropertyPath has to become a generic type which contains the _actual_ path elements. This allows  us to still make a _default_ property path type that matches with the current one, but also allows, if I need, to be more precise: every current place can use `function (myParameter: PropertyPath)` just like today, but I can now write `function newFunction(myParameter: PropertyPath<[string, 'width' | 'height']>)` and typescript will help me enforce new API contracts!

The only struggle was that our factory function `PP.create` takes an array of path elements. Which typescript types as an array instead of an enum. Instead of adding `as const` to 144 places, I changed the function signature from `PP.create(['style', 'left'])` to `PP.create('style', 'left')`. Places that need to pass in an array change from `PP.create(myArray)` to `PP.create(...myArray)`. This allows for excellent automatic type inference!

**Details:**
- New backwards-compatible PropertyPath signature
- PP.create loses the array-wrapping
- I regex fixed a few hundred callsites
- Profit!