### PR TITLE
Experiment/canvas absolute outlines aabb

### DIFF
--- a/editor/src/components/canvas/controls/absolute-children-outline.tsx
+++ b/editor/src/components/canvas/controls/absolute-children-outline.tsx
@@ -5,26 +5,29 @@ import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
 import { OutlineControl } from './select-mode/simple-outline-control'
 
 export const AbsoluteChildrenOutline = React.memo(() => {
-  const absoluteChildren = useEditorState(
+  const elementWithAbsoluteChildren = useEditorState(
     Substores.metadata,
     (store) => {
       return store.editor.selectedViews.flatMap((view) => {
-        return MetadataUtils.getChildrenPaths(store.editor.jsxMetadata, view).filter((child) => {
-          const metadata = MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, child)
-          return MetadataUtils.isPositionAbsolute(metadata)
-        })
+        const children = MetadataUtils.getChildrenPaths(store.editor.jsxMetadata, view).filter(
+          (child) => {
+            const metadata = MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, child)
+            return MetadataUtils.isPositionAbsolute(metadata)
+          },
+        )
+        return [...children, view]
       })
     },
-    'AbsoluteChildrenOutline absoluteChildrenBoundingBox',
+    'AbsoluteChildrenOutline elementWithAbsoluteChildren',
   )
 
-  if (absoluteChildren.length === 0) {
+  if (elementWithAbsoluteChildren.length === 0) {
     return null
   }
   return (
     <CanvasOffsetWrapper>
       <OutlineControl
-        targets={absoluteChildren}
+        targets={elementWithAbsoluteChildren}
         outlineStyle={'dotted'}
         color='multiselect-bounds'
       />

--- a/editor/src/components/canvas/controls/absolute-children-outline.tsx
+++ b/editor/src/components/canvas/controls/absolute-children-outline.tsx
@@ -21,13 +21,31 @@ export const AbsoluteChildrenOutline = React.memo(() => {
     'AbsoluteChildrenOutline elementWithAbsoluteChildren',
   )
 
-  if (elementWithAbsoluteChildren.length === 0) {
+  const absoluteChildren = useEditorState(
+    Substores.metadata,
+    (store) => {
+      return store.editor.selectedViews.flatMap((view) => {
+        return MetadataUtils.getChildrenPaths(store.editor.jsxMetadata, view).filter((child) => {
+          const metadata = MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, child)
+          return MetadataUtils.isPositionAbsolute(metadata)
+        })
+      })
+    },
+    'AbsoluteChildrenOutline absoluteChildren',
+  )
+
+  if (elementWithAbsoluteChildren.length <= 1 && absoluteChildren.length === 0) {
     return null
   }
   return (
     <CanvasOffsetWrapper>
       <OutlineControl
         targets={elementWithAbsoluteChildren}
+        outlineStyle={'dotted'}
+        color='multiselect-bounds'
+      />
+      <OutlineControl
+        targets={absoluteChildren}
         outlineStyle={'dotted'}
         color='multiselect-bounds'
       />

--- a/editor/src/components/canvas/controls/absolute-children-outline.tsx
+++ b/editor/src/components/canvas/controls/absolute-children-outline.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { Substores, useEditorState } from '../../editor/store/store-hook'
+import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
+import { OutlineControl } from './select-mode/simple-outline-control'
+
+export const AbsoluteChildrenOutline = React.memo(() => {
+  const absoluteChildren = useEditorState(
+    Substores.metadata,
+    (store) => {
+      return store.editor.selectedViews.flatMap((view) => {
+        return MetadataUtils.getChildrenPaths(store.editor.jsxMetadata, view).filter((child) => {
+          const metadata = MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, child)
+          return MetadataUtils.isPositionAbsolute(metadata)
+        })
+      })
+    },
+    'AbsoluteChildrenOutline absoluteChildrenBoundingBox',
+  )
+
+  if (absoluteChildren.length === 0) {
+    return null
+  }
+  return (
+    <CanvasOffsetWrapper>
+      <OutlineControl
+        targets={absoluteChildren}
+        outlineStyle={'dotted'}
+        color='multiselect-bounds'
+      />
+    </CanvasOffsetWrapper>
+  )
+})

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -56,6 +56,7 @@ import { DRAW_TO_INSERT_TEXT_STRATEGY_ID } from '../canvas-strategies/strategies
 import { TextEditableControl } from './text-editable-control'
 import { TextEditCanvasOverlay } from './text-edit-mode/text-edit-canvas-overlay'
 import { useDispatch } from '../../editor/store/dispatch-context'
+import { AbsoluteChildrenOutline } from './absolute-children-outline'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
@@ -405,6 +406,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
           {renderHighlightControls()}
           {renderTextEditableControls()}
           {unless(dragging, <LayoutParentControl />)}
+          {when(isSelectMode(editorMode), <AbsoluteChildrenOutline />)}
           <MultiSelectOutlineControl localSelectedElements={localSelectedViews} />
           <GuidelineControls />
           <ZeroSizedElementControls.control showAllPossibleElements={false} />

--- a/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
@@ -30,9 +30,15 @@ export const MultiSelectOutlineControl = React.memo<MultiSelectOutlineControlPro
           key='multiselect-outline'
           targets={localSelectedElements}
           color='multiselect-bounds'
+          outlineStyle='solid'
         />,
         ...localSelectedElements.map((path) => (
-          <OutlineControl key={EP.toString(path)} targets={[path]} color='primary' />
+          <OutlineControl
+            key={EP.toString(path)}
+            targets={[path]}
+            color='primary'
+            outlineStyle='solid'
+          />
         )),
       ]}
     </CanvasOffsetWrapper>
@@ -42,9 +48,10 @@ export const MultiSelectOutlineControl = React.memo<MultiSelectOutlineControlPro
 interface OutlineControlProps {
   targets: Array<ElementPath>
   color: 'primary' | 'multiselect-bounds'
+  outlineStyle: 'solid' | 'dotted'
 }
 
-const OutlineControl = React.memo<OutlineControlProps>((props) => {
+export const OutlineControl = React.memo<OutlineControlProps>((props) => {
   const colorTheme = useColorTheme()
   const targets = props.targets
   const scale = useEditorState(
@@ -92,7 +99,7 @@ const OutlineControl = React.memo<OutlineControlProps>((props) => {
           position: 'absolute',
           borderColor: color,
           borderWidth: `${1 / scale}px`,
-          borderStyle: 'solid',
+          borderStyle: props.outlineStyle,
           pointerEvents: 'none',
         }}
       />

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`404`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`406`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`393`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`395`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`664`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`665`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`736`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`737`)
   })
 })


### PR DESCRIPTION
**Problem:**
Absolute child elements are often out of their parent element bounds.

**Fix:**
Extend the parent outline, shows dotted outline around the bounding box of absolute child elements.

**Commit Details:**
- added new control
- extend outline to be able to use the dotted version but keep the same selection color
