### PR TITLE
fix(canvas) select mode hook filters for event button

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -627,6 +627,7 @@ function useSelectOrLiveModeSelectAndHover(
   )
   const mouseHandler = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
+      const isLeftClick = event.button === 0
       const isDragIntention =
         editorStoreRef.current.editor.keysPressed['space'] || event.button === 1
       const hasInteractionSessionWithMouseMoved =
@@ -658,7 +659,7 @@ function useSelectOrLiveModeSelectAndHover(
         }
       }
 
-      if (isDragIntention || hasInteractionSessionWithMouseMoved || !active) {
+      if (isDragIntention || hasInteractionSessionWithMouseMoved || !active || !isLeftClick) {
         // Skip all of this handling if 'space' is pressed or a mousemove happened in an interaction, or the hook is not active
         return
       }


### PR DESCRIPTION
**Problem:**
When you have an element with editable text and you click to select it then follow it quickly with a right click it enters text edit mode. It should open the contextmenu instead.

**Fix:**
Early return in select-mode-hook when the event button is not a left-click

**Commit Details:**
- update `useSelectOrLiveModeSelectAndHover`
