### PR TITLE
design(layout system) - also show padding controls, tidy up spacing

### DIFF
--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -7,6 +7,8 @@ import { FlexDirectionToggle } from './flex-direction-control'
 import { selectedViewsSelector, metadataSelector } from './inpector-selectors'
 import { detectAreElementsFlexContainers } from './inspector-common'
 import { NineBlockControl } from './nine-block-controls'
+import { UIGridRow } from './widgets/ui-grid-row'
+import { PaddingRow } from '../../components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls'
 
 const areElementsFlexContainersSelector = createSelector(
   metadataSelector,
@@ -27,8 +29,13 @@ export const FlexSection = React.memo(() => {
       {when(
         allElementsInFlexLayout,
         <>
-          <FlexDirectionToggle />
-          <NineBlockControl />
+          <UIGridRow padded variant='<-------------1fr------------->'>
+            <FlexDirectionToggle />
+          </UIGridRow>
+          <UIGridRow padded variant='<-------------1fr------------->'>
+            <NineBlockControl />
+          </UIGridRow>
+          <PaddingRow />
         </>,
       )}
     </div>


### PR DESCRIPTION
**Problem:**
- The padding controls aren't in the new layout system section w/ the 9-block
- That section isn't padded and looks incongruous w/ the rest of the inspector

**Fix:**
- Also show the padding controls in the section
- Tidy up the section w/ padded `UIGridRow`

Like so:
<img width="258" alt="image" src="https://user-images.githubusercontent.com/2945037/215094049-a370937f-fa05-4aae-9639-21bab7717c0e.png">

