### PR TITLE
split the editor tests into 3 parallel jobs

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -30,7 +30,7 @@ jobs:
         uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
-      - name: Run the tests
+      - name: Run tsc, eslint, depdendency-cruiser and the website tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-code-ci
   test-editor-jest:
@@ -61,7 +61,7 @@ jobs:
         uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
-      - name: Run the tests
+      - name: Run the Jest tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-jest-ci
   test-editor-karma:
@@ -92,7 +92,7 @@ jobs:
         uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
-      - name: Run the tests
+      - name: Run the Karma tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-karma-ci
 

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -2,8 +2,8 @@ name: Pull Request
 on: [pull_request]
 
 jobs:
-  test-editor:
-    name: Test Editor PR
+  test-editor-code:
+    name: Test Editor PR – TypeScript, ESLint, dependency-cruiser
     runs-on: ubuntu-latest
     env:
       UTOPIA_SHA: ${{ github.sha }}
@@ -32,7 +32,69 @@ jobs:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
       - name: Run the tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
-        run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-all-ci
+        run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-code-ci
+  test-editor-jest:
+    name: Test Editor PR – Jest tests
+    runs-on: ubuntu-latest
+    env:
+      UTOPIA_SHA: ${{ github.sha }}
+    steps:
+      - name: Cancel existing runs on this branch
+        uses: fauguste/auto-cancellation-running-action@0.1.4
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Cache editor test result
+        id: cache-editor-tests
+        uses: actions/cache@v2
+        with:
+          # For the tests it doesn't really matter what we cache
+          path: editor/lib
+          key: ${{ runner.os }}-editor-tests-PR-${{ hashFiles('editor/src/**') }}-${{ hashFiles('utopia-api/src/**') }}-${{ hashFiles('editor/package.json') }}-${{ hashFiles('utopia-api/package.json') }}
+      - name: Cache .pnpm-store
+        uses: actions/cache@v2
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+      - name: Install nix
+        uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
+      - name: Run the tests
+        if: steps.cache-editor-tests.outputs.cache-hit != 'true'
+        run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-jest-ci
+  test-editor-karma:
+    name: Test Editor PR – Karma tests
+    runs-on: ubuntu-latest
+    env:
+      UTOPIA_SHA: ${{ github.sha }}
+    steps:
+      - name: Cancel existing runs on this branch
+        uses: fauguste/auto-cancellation-running-action@0.1.4
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Cache editor test result
+        id: cache-editor-tests
+        uses: actions/cache@v2
+        with:
+          # For the tests it doesn't really matter what we cache
+          path: editor/lib
+          key: ${{ runner.os }}-editor-tests-PR-${{ hashFiles('editor/src/**') }}-${{ hashFiles('utopia-api/src/**') }}-${{ hashFiles('editor/package.json') }}-${{ hashFiles('utopia-api/package.json') }}
+      - name: Cache .pnpm-store
+        uses: actions/cache@v2
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+      - name: Install nix
+        uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
+      - name: Run the tests
+        if: steps.cache-editor-tests.outputs.cache-hit != 'true'
+        run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-karma-ci
 
   deploy-staging:
     name: Deploy Staging Editor

--- a/editor/package.json
+++ b/editor/package.json
@@ -14,6 +14,7 @@
     "clean": "rm -rf lib/",
     "check": "tsc --noEmit && pnpm run lint && pnpm run check-dependency-cruiser && pnpm run prettier-check && pnpm run test && pnpm run test-browser",
     "check-ci": "tsc --noEmit && pnpm run lint && pnpm run check-dependency-cruiser && pnpm run prettier-check && pnpm run test-ci && pnpm run test-browser",
+    "check-code": "tsc --noEmit && pnpm run lint && pnpm run check-dependency-cruiser && pnpm run prettier-check",
     "lint": "pnpx eslint \"src/**/*.{js,ts,tsx}\" --quiet",
     "lint-loud": "pnpx eslint \"src/**/*.{js,ts,tsx}\"",
     "lint-lite": "pnpm run lint -- --config ./.eslintrc-lite.js --no-eslintrc",

--- a/shell.nix
+++ b/shell.nix
@@ -109,7 +109,7 @@ let
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/editor
       ${pnpm} run check-ci
     '')
-    (pkgs.writeScriptBin "check-editor-ci-code" ''
+    (pkgs.writeScriptBin "check-editor-code" ''
       #!/usr/bin/env bash
       set -e
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/editor
@@ -152,7 +152,7 @@ let
       set -e
       install-editor-ci
       install-website
-      check-editor-ci-code
+      check-editor-code
       test-website
     '')
     (pkgs.writeScriptBin "check-editor-jest-ci" ''
@@ -160,14 +160,14 @@ let
       set -e
       install-editor-ci
       install-website
-      check-editor-ci-jest
+      check-editor-jest
     '')
     (pkgs.writeScriptBin "check-editor-karma-ci" ''
       #!/usr/bin/env bash
       set -e
       install-editor-ci
       install-website
-      check-editor-ci-karma
+      check-editor-karma
     '')
     (pkgs.writeScriptBin "build-editor-staging-ci" ''
       #!/usr/bin/env bash

--- a/shell.nix
+++ b/shell.nix
@@ -109,7 +109,7 @@ let
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/editor
       ${pnpm} run check-ci
     '')
-    (pkgs.writeScriptBin "check-editor-check-editor-ci-code" ''
+    (pkgs.writeScriptBin "check-editor-ci-code" ''
       #!/usr/bin/env bash
       set -e
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/editor

--- a/shell.nix
+++ b/shell.nix
@@ -109,6 +109,24 @@ let
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/editor
       ${pnpm} run check-ci
     '')
+    (pkgs.writeScriptBin "check-editor-check-editor-ci-code" ''
+      #!/usr/bin/env bash
+      set -e
+      cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/editor
+      ${pnpm} run check-code
+    '')
+    (pkgs.writeScriptBin "check-editor-jest" ''
+      #!/usr/bin/env bash
+      set -e
+      cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/editor
+      ${pnpm} run test-ci
+    '')
+    (pkgs.writeScriptBin "check-editor-karma" ''
+      #!/usr/bin/env bash
+      set -e
+      cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/editor
+      ${pnpm} run test-browser
+    '')
     (pkgs.writeScriptBin "test-editor-browser" ''
       #!/usr/bin/env bash
       set -e
@@ -128,6 +146,28 @@ let
       install-website
       check-editor-ci
       test-website
+    '')
+    (pkgs.writeScriptBin "check-editor-code-ci" ''
+      #!/usr/bin/env bash
+      set -e
+      install-editor-ci
+      install-website
+      check-editor-ci-code
+      test-website
+    '')
+    (pkgs.writeScriptBin "check-editor-jest-ci" ''
+      #!/usr/bin/env bash
+      set -e
+      install-editor-ci
+      install-website
+      check-editor-ci-jest
+    '')
+    (pkgs.writeScriptBin "check-editor-karma-ci" ''
+      #!/usr/bin/env bash
+      set -e
+      install-editor-ci
+      install-website
+      check-editor-ci-karma
     '')
     (pkgs.writeScriptBin "build-editor-staging-ci" ''
       #!/usr/bin/env bash


### PR DESCRIPTION
**Problem:**
The "Run the tests" job takes 25 minutes on github actions, runs tsc, jest and karma in succession. If the jest tests fail, we don't even run the karma tests. So if you fix the jest tests, then commit the fix, there is still a chance you'll face a failing karma test.

**Fix:**
Run the tests in 3 separate, _parallelized_ jobs!

**Commit Details:**
- Created new shell.nix commands
- Added one new pnpm run script
- 3 jobs in pull-requests.yml
