### PR TITLE
smaller handle, smaller control, no px

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -84,8 +84,10 @@ export function measurementBasedOnOtherMeasurement(
   }
 }
 
-const FontSize = 12
-const Padding = 4
+const FontSize = 11
+const PaddingV = 0
+const PaddingH = 2
+
 const BorderRadius = 2
 
 interface CanvasLabelProps {
@@ -98,13 +100,17 @@ interface CanvasLabelProps {
 export const CanvasLabel = React.memo((props: CanvasLabelProps): JSX.Element => {
   const { scale, color, value, textColor } = props
   const fontSize = FontSize / scale
-  const padding = Padding / scale
+  const paddingV = PaddingV / scale
+  const paddingH = PaddingH / scale
   const borderRadius = BorderRadius / scale
   return (
     <div
       style={{
         fontSize: fontSize,
-        padding: padding,
+        paddingLeft: paddingH,
+        paddingRight: paddingH,
+        paddingTop: paddingV,
+        paddingBottom: paddingV,
         backgroundColor: color,
         color: textColor,
         borderRadius: borderRadius,
@@ -130,6 +136,7 @@ export const PillHandle = React.memo((props: PillHandleProps): JSX.Element => {
         width: width,
         height: height,
         backgroundColor: pillColor,
+        borderRadius: 1,
         border: `${borderWidth}px solid ${colorTheme.white.value}`,
       }}
     />

--- a/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
@@ -264,7 +264,7 @@ const GapControlSegment = React.memo<GapControlSegmentProps>((props) => {
 
 function handleDimensions(flexDirection: FlexDirection, scale: number): Size {
   if (flexDirection === 'row' || flexDirection === 'row-reverse') {
-    return size(4 / scale, 12 / scale)
+    return size(3 / scale, 12 / scale)
   }
   if (flexDirection === 'column' || flexDirection === 'column-reverse') {
     return size(12 / scale, 4 / scale)

--- a/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
@@ -63,7 +63,7 @@ function sizeFromOrientation(orientation: Orientation, desiredSize: Size): Size 
 
 export const PaddingResizeControlHoverTimeout: number = 0
 
-const PaddingResizeControlWidth = 4
+const PaddingResizeControlWidth = 3
 const PaddingResizeControlHeight = 12
 const PaddingResizeControlBorder = 1
 const PaddingResizeDragBorder = 1
@@ -185,7 +185,7 @@ const PaddingResizeControlI = React.memo(
               }}
             >
               <CanvasLabel
-                value={printCSSNumber(props.paddingValue.value, null)}
+                value={printCSSNumber(props.paddingValue.value, 'px')}
                 scale={scale}
                 color={color}
                 textColor={colorTheme.white.value}


### PR DESCRIPTION
**Problem:**
The inline controls for padding etc seemed a bit heavy, and obscured content sometimes

**Fix:**
- Reduced the width of the handle
- Reduced padding on the label
- Eliminated the `px` for pixel values

<img width="118" alt="image" src="https://user-images.githubusercontent.com/2945037/215162463-d13ec51d-b256-4db0-a599-30d3331d17c6.png">

