### PR TITLE
Unset style props if possible when toggling them

### DIFF
--- a/editor/src/components/text-editor/text-editor-shortcut-helpers.ts
+++ b/editor/src/components/text-editor/text-editor-shortcut-helpers.ts
@@ -206,11 +206,13 @@ const toggleStylePropWithUnset = (
     const computedValue = getComputedValue()
     if (computedValue !== newValue) {
       dispatch([
-        EditorActions.setProperty(
-          elementPath,
-          PP.create('style', prop),
-          jsxAttributeValue(newValue, emptyComments),
-        ),
+        EditorActions.transientActions([
+          EditorActions.setProperty(
+            elementPath,
+            PP.create('style', prop),
+            jsxAttributeValue(newValue, emptyComments),
+          ),
+        ]),
       ])
     }
   } else {

--- a/editor/src/components/text-editor/text-editor-shortcut-helpers.ts
+++ b/editor/src/components/text-editor/text-editor-shortcut-helpers.ts
@@ -18,6 +18,38 @@ export function toggleTextBold(target: ElementPath, fontWeight: string | null): 
   return toggleStyleProp(target, 'fontWeight', currentValue, toggledFontWeight, defaultFontWeight)
 }
 
+export function toggleTextBoldWithUnset(
+  target: ElementPath,
+  fontWeight: string | null,
+  dispatch: EditorDispatch,
+  metadataRef: {
+    readonly current: ElementInstanceMetadataMap
+  },
+): void {
+  const toggledFontWeight = 'bold'
+  const defaultFontWeight = 'normal'
+  const currentValue = fontWeight === '400' ? defaultFontWeight : toggledFontWeight
+
+  toggleStylePropWithUnset(
+    target,
+    'fontWeight',
+    currentValue,
+    toggledFontWeight,
+    defaultFontWeight,
+    dispatch,
+    () => {
+      const specialSizeMeasurements = MetadataUtils.findElementByElementPath(
+        metadataRef.current,
+        target,
+      )?.specialSizeMeasurements
+      if (specialSizeMeasurements?.fontWeight === '400') {
+        return 'normal'
+      }
+      return specialSizeMeasurements?.fontWeight ?? null
+    },
+  )
+}
+
 export function toggleTextItalic(
   target: ElementPath,
   currentFontStyle: string | null,
@@ -39,33 +71,21 @@ export function toggleTextItalicWithUnset(
   const toggledFontStyle = 'italic'
   const defaultFontStyle = 'normal'
 
-  const newValue = currentFontStyle === toggledFontStyle ? defaultFontStyle : toggledFontStyle
-
-  if (newValue === defaultFontStyle) {
-    dispatch([EditorActions.unsetProperty(target, PP.create('style', 'fontStyle'))])
-    const specialSizeMeasurements = MetadataUtils.findElementByElementPath(
-      metadataRef.current,
-      target,
-    )?.specialSizeMeasurements
-    const newFontStyle = specialSizeMeasurements?.fontStyle
-    if (newFontStyle !== newValue) {
-      dispatch([
-        EditorActions.setProperty(
-          target,
-          PP.create('style', 'fontStyle'),
-          jsxAttributeValue(newValue, emptyComments),
-        ),
-      ])
-    }
-  } else {
-    dispatch([
-      EditorActions.setProperty(
+  toggleStylePropWithUnset(
+    target,
+    'fontStyle',
+    currentFontStyle,
+    toggledFontStyle,
+    defaultFontStyle,
+    dispatch,
+    () => {
+      const specialSizeMeasurements = MetadataUtils.findElementByElementPath(
+        metadataRef.current,
         target,
-        PP.create('style', 'fontStyle'),
-        jsxAttributeValue(newValue, emptyComments),
-      ),
-    ])
-  }
+      )?.specialSizeMeasurements
+      return specialSizeMeasurements?.fontStyle ?? null
+    },
+  )
 }
 
 export function toggleTextUnderline(
@@ -81,6 +101,34 @@ export function toggleTextUnderline(
     currentTextDecorationLine,
     toggledDecoration,
     defaultDecoration,
+  )
+}
+
+export function toggleTextUnderlineWithUnset(
+  target: ElementPath,
+  currentTextDecorationLine: string | null,
+  dispatch: EditorDispatch,
+  metadataRef: {
+    readonly current: ElementInstanceMetadataMap
+  },
+): void {
+  const toggledDecoration = 'underline'
+  const defaultDecoration = 'none'
+
+  toggleStylePropWithUnset(
+    target,
+    'textDecoration',
+    currentTextDecorationLine,
+    toggledDecoration,
+    defaultDecoration,
+    dispatch,
+    () => {
+      const specialSizeMeasurements = MetadataUtils.findElementByElementPath(
+        metadataRef.current,
+        target,
+      )?.specialSizeMeasurements
+      return specialSizeMeasurements?.textDecorationLine ?? null
+    },
   )
 }
 
@@ -100,6 +148,34 @@ export function toggleTextStrikeThrough(
   )
 }
 
+export function toggleTextStrikeThroughWithUnset(
+  target: ElementPath,
+  currentTextDecorationLine: string | null,
+  dispatch: EditorDispatch,
+  metadataRef: {
+    readonly current: ElementInstanceMetadataMap
+  },
+): void {
+  const toggledDecoration = 'line-through'
+  const defaultDecoration = 'none'
+
+  toggleStylePropWithUnset(
+    target,
+    'textDecoration',
+    currentTextDecorationLine,
+    toggledDecoration,
+    defaultDecoration,
+    dispatch,
+    () => {
+      const specialSizeMeasurements = MetadataUtils.findElementByElementPath(
+        metadataRef.current,
+        target,
+      )?.specialSizeMeasurements
+      return specialSizeMeasurements?.textDecorationLine ?? null
+    },
+  )
+}
+
 const toggleStyleProp = (
   elementPath: ElementPath,
   prop: string,
@@ -113,4 +189,37 @@ const toggleStyleProp = (
     PP.create('style', prop),
     jsxAttributeValue(newValue, emptyComments),
   )
+}
+
+const toggleStylePropWithUnset = (
+  elementPath: ElementPath,
+  prop: string,
+  currentValue: string | null,
+  toggledValue: string,
+  defaultValue: string,
+  dispatch: EditorDispatch,
+  getComputedValue: () => string | null,
+): void => {
+  const newValue = currentValue === toggledValue ? defaultValue : toggledValue
+  if (newValue === defaultValue) {
+    dispatch([EditorActions.unsetProperty(elementPath, PP.create('style', prop))])
+    const computedValue = getComputedValue()
+    if (computedValue !== newValue) {
+      dispatch([
+        EditorActions.setProperty(
+          elementPath,
+          PP.create('style', prop),
+          jsxAttributeValue(newValue, emptyComments),
+        ),
+      ])
+    }
+  } else {
+    dispatch([
+      EditorActions.setProperty(
+        elementPath,
+        PP.create('style', prop),
+        jsxAttributeValue(newValue, emptyComments),
+      ),
+    ])
+  }
 }

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -150,32 +150,56 @@ describe('Use the text editor', () => {
   describe('formatting shortcuts', () => {
     it('supports bold', async () => {
       const { before, after } = await testModifier(cmdModifier, 'b')
-      expect(before).toEqual(projectWithStyle('fontWeight', 'bold'))
-      expect(after).toEqual(projectWithStyle('fontWeight', 'normal'))
+      expect(before).toEqual(projectWithStyle({ fontWeight: 'bold' }))
+      expect(after).toEqual(projectWithStyle({}))
     })
-
+    it('doesnt unset bold when regular is not default', async () => {
+      const { before, after } = await testModifier(
+        cmdModifier,
+        'b',
+        projectWithoutTextWithStyleProp('font', 'bold 1.2em "Fira Sans"'),
+      )
+      expect(before).toEqual(
+        projectWithStyle({ font: 'bold 1.2em "Fira Sans"', fontWeight: 'normal' }),
+      )
+      expect(after).toEqual(
+        projectWithStyle({ font: 'bold 1.2em "Fira Sans"', fontWeight: 'bold' }),
+      )
+    })
     it('supports italic', async () => {
       const { before, after } = await testModifier(cmdModifier, 'i')
-      expect(before).toEqual(projectWithStyle('fontStyle', 'italic'))
-      expect(after).toEqual(projectWithStyle('fontStyle', 'normal'))
+      expect(before).toEqual(projectWithStyle({ fontStyle: 'italic' }))
+      expect(after).toEqual(projectWithStyle({}))
     })
-
+    it('doesnt unset italic when normal is not default', async () => {
+      const { before, after } = await testModifier(
+        cmdModifier,
+        'i',
+        projectWithoutTextWithStyleProp('font', 'italic 1.2em "Fira Sans"'),
+      )
+      expect(before).toEqual(
+        projectWithStyle({ font: 'italic 1.2em "Fira Sans"', fontStyle: 'normal' }),
+      )
+      expect(after).toEqual(
+        projectWithStyle({ font: 'italic 1.2em "Fira Sans"', fontStyle: 'italic' }),
+      )
+    })
     it('supports underline', async () => {
       const { before, after } = await testModifier(cmdModifier, 'u')
-      expect(before).toEqual(projectWithStyle('textDecoration', 'underline'))
-      expect(after).toEqual(projectWithStyle('textDecoration', 'none'))
+      expect(before).toEqual(projectWithStyle({ textDecoration: 'underline' }))
+      expect(after).toEqual(projectWithStyle({}))
     })
 
     it('supports strikethrough', async () => {
       const { before, after } = await testModifier(shiftCmdModifier, 'x')
-      expect(before).toEqual(projectWithStyle('textDecoration', 'line-through'))
-      expect(after).toEqual(projectWithStyle('textDecoration', 'none'))
+      expect(before).toEqual(projectWithStyle({ textDecoration: 'line-through' }))
+      expect(after).toEqual(projectWithStyle({}))
     })
 
     xit('supports increasing font size', async () => {
       const { before, after } = await testModifier(shiftCmdModifier, '.')
-      expect(before).toEqual(projectWithStyle('fontSize', '17px'))
-      expect(after).toEqual(projectWithStyle('fontSize', '18px'))
+      expect(before).toEqual(projectWithStyle({ fontSize: '17px' }))
+      expect(after).toEqual(projectWithStyle({ fontSize: '18px' }))
     })
 
     xit('supports increasing font weight', async () => {
@@ -185,8 +209,8 @@ describe('Use the text editor', () => {
     })
     xit('supports decreasing font size', async () => {
       const { before, after } = await testModifier(shiftCmdModifier, ',')
-      expect(before).toEqual(projectWithStyle('fontSize', '15px'))
-      expect(after).toEqual(projectWithStyle('fontSize', '14px'))
+      expect(before).toEqual(projectWithStyle({ fontSize: '15px' }))
+      expect(after).toEqual(projectWithStyle({ fontSize: '14px' }))
     })
 
     xit('supports decreasing font weight', async () => {
@@ -221,7 +245,7 @@ describe('Use the text editor', () => {
       await pressShortcut(editor, cmdModifier, 'b')
 
       expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-        projectWithStyle('fontWeight', 'bold'),
+        projectWithStyle({ fontWeight: 'bold' }),
       )
     })
   })
@@ -706,7 +730,16 @@ describe('Use the text editor', () => {
   })
 })
 
-function projectWithStyle(prop: string, value: string) {
+function projectWithStyle(props: { [prop: string]: string }) {
+  const styleProps = {
+    backgroundColor: '#0091FFAA',
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    width: 288,
+    height: 362,
+    ...props,
+  }
   return formatTestProjectCode(`
         import * as React from 'react'
         import { Storyboard } from 'utopia-api'
@@ -716,15 +749,7 @@ function projectWithStyle(prop: string, value: string) {
           <Storyboard data-uid='sb'>
             <div
               data-testid='div'
-              style={{
-                backgroundColor: '#0091FFAA',
-                position: 'absolute',
-                left: 0,
-                top: 0,
-                width: 288,
-                height: 362,
-                ${prop}: '${value}'
-              }}
+              style={${JSON.stringify(styleProps)}}
               data-uid='39e'
             >Hello Utopia</div>
           </Storyboard>
@@ -781,8 +806,12 @@ async function pressShortcut(editor: EditorRenderResult, mod: Modifiers, key: st
   await editor.getDispatchFollowUpActionsFinished()
 }
 
-async function testModifier(mod: Modifiers, key: string) {
-  const editor = await renderTestEditorWithCode(projectWithoutText, 'await-first-dom-report')
+async function testModifier(
+  mod: Modifiers,
+  key: string,
+  startingProject: string = projectWithoutText,
+) {
+  const editor = await renderTestEditorWithCode(startingProject, 'await-first-dom-report')
 
   await prepareTestModifierEditor(editor)
   await pressShortcut(editor, mod, key)
@@ -864,6 +893,31 @@ export var storyboard = (
   </Storyboard>
 )
 `)
+
+function projectWithoutTextWithStyleProp(prop: string, value: string) {
+  return formatTestProjectCode(`import * as React from 'react'
+    import { Storyboard } from 'utopia-api'
+
+
+    export var storyboard = (
+      <Storyboard data-uid='sb'>
+        <div
+          data-testid='div'
+          style={{
+            backgroundColor: '#0091FFAA',
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            width: 288,
+            height: 362,
+            ${prop}: '${value}'
+          }}
+          data-uid='39e'
+        />
+      </Storyboard>
+    )
+  `)
+}
 
 const emptyProject = formatTestProjectCode(`import * as React from 'react'
 import { Storyboard } from 'utopia-api'

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -31,10 +31,13 @@ import { Substores, useEditorState, useRefEditorState } from '../editor/store/st
 import { printCSSNumber } from '../inspector/common/css-utils'
 import {
   toggleTextBold,
+  toggleTextBoldWithUnset,
   toggleTextItalic,
   toggleTextItalicWithUnset,
   toggleTextStrikeThrough,
+  toggleTextStrikeThroughWithUnset,
   toggleTextUnderline,
+  toggleTextUnderlineWithUnset,
 } from './text-editor-shortcut-helpers'
 import { useColorTheme } from '../../uuiui'
 import { arrayToObject } from '../../core/shared/array-utils'
@@ -97,7 +100,13 @@ const handleToggleShortcuts = (
 
   // Meta+b = bold
   if (meta && event.key === 'b') {
-    return [toggleTextBold(target, specialSizeMeasurements?.fontWeight ?? null)]
+    toggleTextBoldWithUnset(
+      target,
+      specialSizeMeasurements?.fontWeight ?? null,
+      dispatch,
+      metadataRef,
+    )
+    return []
   }
   // Meta+i = italic
   if (meta && event.key === 'i') {
@@ -111,11 +120,23 @@ const handleToggleShortcuts = (
   }
   // Meta+u = underline
   if (meta && event.key === 'u') {
-    return [toggleTextUnderline(target, specialSizeMeasurements?.textDecorationLine ?? null)]
+    toggleTextUnderlineWithUnset(
+      target,
+      specialSizeMeasurements?.textDecorationLine ?? null,
+      dispatch,
+      metadataRef,
+    )
+    return []
   }
   // Meta+shift+x = strikethrough
   if (meta && modifiers.shift && event.key === 'x') {
-    return [toggleTextStrikeThrough(target, specialSizeMeasurements?.textDecorationLine ?? null)]
+    toggleTextStrikeThroughWithUnset(
+      target,
+      specialSizeMeasurements?.textDecorationLine ?? null,
+      dispatch,
+      metadataRef,
+    )
+    return []
   }
   return []
 }


### PR DESCRIPTION
**Problem:**
Toggling bold/italic/etc.... pollutes the code with `fontStyle`/`fontWeight` `normal` lines, which are in most cases unnecessary.

**Fix:**
The difficulty in this is that sometimes the explicit normal rule is necessary to override an inherited property.
But it is hard to know beforehand if that is necessary or not. The solution is to unset the property, check the updated style prop value in specialSizeMeasurements, and when it is incorrect dispatch another action to set it to te default value.

Missing:
- make it work outside of the text editor in select mode
- prevent double undo