### PR TITLE
Cmd + click to cycle the padding control backwards

### DIFF
--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   wrappedEmptyOrUnknownOnSubmitValue,
 } from '../../../../../uuiui'
-import { Substores, useEditorState } from '../../../../editor/store/store-hook'
+import { Substores, useEditorState, useRefEditorState } from '../../../../editor/store/store-hook'
 import { ControlStatus, PropertyStatus } from '../../../common/control-status'
 import { CSSNumber, isCSSNumber, UnknownOrEmptyInput } from '../../../common/css-utils'
 import { InspectorInfo } from '../../../common/property-path-hooks'
@@ -185,11 +185,7 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
     [left, right],
   )
 
-  const isCmdPressed = useEditorState(
-    Substores.restOfEditor,
-    (store) => store.editor.keysPressed.cmd === true,
-    'SplitChainedNumberInput isCmdPressed',
-  )
+  const isCmdPressedRef = useRefEditorState((store) => store.editor.keysPressed.cmd === true)
 
   const isCurrentModeApplicable = React.useCallback(() => {
     if (mode === 'one-value' && oneValue == null) {
@@ -251,10 +247,10 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
     if (mode == null) {
       return
     }
-    const delta = isCmdPressed ? -1 : 1
+    const delta = isCmdPressedRef.current ? -1 : 1
     const index = controlModeOrder.indexOf(mode) + delta
     setMode(controlModeOrder[wrapValue(index, 0, controlModeOrder.length - 1)])
-  }, [isCmdPressed, mode])
+  }, [isCmdPressedRef, mode])
 
   const updateShorthandIfUsed = React.useMemo(() => {
     return props.shorthand.controlStatus === 'simple' ? props.updateShorthand : null

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
@@ -10,6 +10,8 @@ import {
   Tooltip,
   wrappedEmptyOrUnknownOnSubmitValue,
 } from '../../../../../uuiui'
+import { edgePosition } from '../../../../canvas/canvas-types'
+import { Substores, useEditorState } from '../../../../editor/store/store-hook'
 import { ControlStatus, PropertyStatus } from '../../../common/control-status'
 import { CSSNumber, isCSSNumber, UnknownOrEmptyInput } from '../../../common/css-utils'
 import { InspectorInfo } from '../../../common/property-path-hooks'
@@ -184,6 +186,12 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
     [left, right],
   )
 
+  const isCmdPressed = useEditorState(
+    Substores.restOfEditor,
+    (store) => store.editor.keysPressed.cmd === true,
+    'SplitChainedNumberInput isCmdPressed',
+  )
+
   const isCurrentModeApplicable = React.useCallback(() => {
     if (mode === 'one-value' && oneValue == null) {
       return false
@@ -244,9 +252,10 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
     if (mode == null) {
       return
     }
-    const index = controlModeOrder.indexOf(mode) + 1
+    const delta = isCmdPressed ? -1 : 1
+    const index = controlModeOrder.indexOf(mode) + delta
     setMode(controlModeOrder[wrapValue(index, 0, controlModeOrder.length - 1)])
-  }, [mode])
+  }, [isCmdPressed, mode])
 
   const updateShorthandIfUsed = React.useMemo(() => {
     return props.shorthand.controlStatus === 'simple' ? props.updateShorthand : null

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
@@ -10,7 +10,6 @@ import {
   Tooltip,
   wrappedEmptyOrUnknownOnSubmitValue,
 } from '../../../../../uuiui'
-import { edgePosition } from '../../../../canvas/canvas-types'
 import { Substores, useEditorState } from '../../../../editor/store/store-hook'
 import { ControlStatus, PropertyStatus } from '../../../common/control-status'
 import { CSSNumber, isCSSNumber, UnknownOrEmptyInput } from '../../../common/css-utils'


### PR DESCRIPTION
## Description
The padding control can be cycled between the 4 / 2 / 1 segment setting by clicking the `[ - ]` icon next to the segments. This PR adds an improvement related to this, namely that when the icon is clicked while `cmd` is held, the segments are cycled in the reverse direction (so instead of going `1 -> 2 -> 4`, it goes `1 -> 4 -> 2`.