### PR TITLE
Fix whitespace around {} code in text editor

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -396,14 +396,14 @@ function trimWhitespaces(
     text[text.length - 1] === ' ' && elementAfter?.type === 'JSX_ARBITRARY_BLOCK'
 
   if (keepSpaceBefore && keepSpaceAfter) {
-    return text[0] + trimmedText + text[text.length - 1]
+    return ' ' + trimmedText + ' '
   }
 
   if (keepSpaceAfter) {
-    return trimmedText + text[text.length - 1]
+    return trimmedText + ' '
   }
   if (keepSpaceBefore) {
-    return text[0] + trimmedText
+    return ' ' + trimmedText
   }
 
   return trimmedText

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -522,7 +522,6 @@ function renderJSXElement(
 
   if (elementPath != null && validPaths.has(EP.makeLastPartOfPathStatic(elementPath))) {
     if (elementIsTextEdited) {
-      // const text = mapDropNulls(trimmedTextOrNullFromJSXElement, childrenWithNewTextBlock).join('')
       const text = trimAndJoinTextFromJSXElements(childrenWithNewTextBlock)
       const textContent = unescapeHTML(text ?? '')
       const textEditorProps = {

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -53,7 +53,6 @@ import { canvasMissingJSXElementError } from './canvas-render-errors'
 import { importedFromWhere } from '../../editor/import-utils'
 import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../../core/shared/dom-utils'
 import { TextEditorWrapper, unescapeHTML } from '../../text-editor/text-editor'
-import { mapDropNulls } from '../../../core/shared/array-utils'
 
 export function createLookupRender(
   elementPath: ElementPath | null,
@@ -346,37 +345,68 @@ export function renderCoreElement(
   }
 }
 
-function trimmedTextOrNullFromJSXElement(c: JSXElementChild): string | null {
-  switch (c.type) {
-    case 'JSX_TEXT_BLOCK':
-      if (c.text.trim().length === 0) {
-        return c.text
-      }
-      return trimWhitespaces(c.text)
-    case 'JSX_ELEMENT':
-      return c.name.baseVariable === 'br' ? '\n' : null
-    case 'JSX_ARBITRARY_BLOCK':
-      if (c.transpiledJavascript === `return ${c.javascript}`) {
-        return `{${c.originalJavascript}}`
-      }
-      return null
-    case 'JSX_FRAGMENT':
-      return null
-    default:
-      assertNever(c)
+function trimAndJoinTextFromJSXElements(elements: Array<JSXElementChild>): string | null {
+  let combinedText = ''
+  for (let i = 0; i < elements.length; i++) {
+    const c = elements[i]
+    switch (c.type) {
+      case 'JSX_TEXT_BLOCK':
+        combinedText += trimWhitespaces(c.text, elements[i - 1] ?? null, elements[i + 1] ?? null)
+        break
+      case 'JSX_ELEMENT':
+        if (c.name.baseVariable === 'br') {
+          combinedText += '\n'
+        }
+        break
+      case 'JSX_ARBITRARY_BLOCK':
+        if (c.transpiledJavascript === `return ${c.javascript}`) {
+          combinedText += `{${c.originalJavascript}}`
+        }
+        break
+      case 'JSX_FRAGMENT':
+        break
+      default:
+        assertNever(c)
+    }
   }
+  return combinedText
 }
 
-function trimWhitespaces(text: string): string {
-  return (
-    text
-      // split around all whitespaces, we don't want to keep newlines or repeated spaces
-      .split(/\s/)
-      // empty strings will appear between repeated whitespaces, we can ignore them
-      .filter((s) => s.length > 0)
-      // join back everything with a single space
-      .join(' ')
-  )
+function trimWhitespaces(
+  text: string,
+  elementBefore: JSXElementChild | null,
+  elementAfter: JSXElementChild | null,
+): string {
+  if (text.length === 0) {
+    return ''
+  }
+
+  const trimmedText = text
+    // split around all whitespaces, we don't want to keep newlines or repeated spaces
+    .split(/\s/)
+    // empty strings will appear between repeated whitespaces, we can ignore them
+    .filter((s) => s.length > 0)
+    // join back everything with a single space
+    .join(' ')
+
+  // when the text has a leading whitespace and there is an arbitrary block before that, we need to keep the whitespace
+  const keepSpaceBefore = text[0] === ' ' && elementBefore?.type === 'JSX_ARBITRARY_BLOCK'
+  // when the text has an trailing whitespace and there is an arbitrary block after that, we need to keep the whitespace
+  const keepSpaceAfter =
+    text[text.length - 1] === ' ' && elementAfter?.type === 'JSX_ARBITRARY_BLOCK'
+
+  if (keepSpaceBefore && keepSpaceAfter) {
+    return text[0] + trimmedText + text[text.length - 1]
+  }
+
+  if (keepSpaceAfter) {
+    return trimmedText + text[text.length - 1]
+  }
+  if (keepSpaceBefore) {
+    return text[0] + trimmedText
+  }
+
+  return trimmedText
 }
 
 function renderJSXElement(
@@ -492,7 +522,8 @@ function renderJSXElement(
 
   if (elementPath != null && validPaths.has(EP.makeLastPartOfPathStatic(elementPath))) {
     if (elementIsTextEdited) {
-      const text = mapDropNulls(trimmedTextOrNullFromJSXElement, childrenWithNewTextBlock).join('')
+      // const text = mapDropNulls(trimmedTextOrNullFromJSXElement, childrenWithNewTextBlock).join('')
+      const text = trimAndJoinTextFromJSXElements(childrenWithNewTextBlock)
       const textContent = unescapeHTML(text ?? '')
       const textEditorProps = {
         elementPath: elementPath,

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -665,6 +665,65 @@ describe('Use the text editor', () => {
         )`),
       )
     })
+    it('doesnt trim whitespace around code', async () => {
+      const editor = await renderTestEditorWithCode(
+        formatTestProjectCode(`import * as React from 'react'
+      import { Storyboard } from 'utopia-api'
+      
+      const ipsum = 'ipsum in a variable'
+      export var storyboard = (
+        <Storyboard data-uid='sb'>
+          <div
+            data-testid='div'
+            style={{
+              backgroundColor: '#0091FFAA',
+              position: 'absolute',
+              left: 0,
+              top: 0,
+              width: 288,
+              height: 362,
+            }}
+            data-uid='39e'
+          >
+            Lorem {ipsum} dolor   sit   amet
+          </div>
+        </Storyboard>
+      )
+      `),
+        'await-first-dom-report',
+      )
+
+      await enterTextEditMode(editor)
+      await closeTextEditor()
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
+      expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+        formatTestProjectCode(`
+        import * as React from 'react'
+        import { Storyboard } from 'utopia-api'
+
+        const ipsum = 'ipsum in a variable'
+        export var storyboard = (
+          <Storyboard data-uid='sb'>
+            <div
+              data-testid='div'
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                left: 0,
+                top: 0,
+                width: 288,
+                height: 362,
+              }}
+              data-uid='39e'
+            >
+              Lorem {ipsum} dolor sit amet
+            </div>
+          </Storyboard>
+        )`),
+      )
+    })
   })
   describe('inline expressions', () => {
     it('handles expressions', async () => {

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -72,6 +72,10 @@ export function escapeHTML(s: string): string {
 
 // editor → canvas
 export function unescapeHTML(s: string): string {
+  if (s.length === 0) {
+    return ''
+  }
+
   const unescaped = unescape(s)
 
   // We need to add a trailing newline so that the contenteditable can render and reach the last newline


### PR DESCRIPTION
**Problem:**
If there is a {} expression inside text content, the whitespace around it is lost when entering the text editor.
So e.g. `Hello {props.title} Utopia` becomes `Hello{props.title}Utopia`

**Fix:**
The problem is that we trim text content by element and `Hello {props.title} Utopia` is built up from 3 elements:
1. `Hello ` text block
2. `props.title` arbitrary js block
3. ` Utopia` text block

Normally we can trim leading and trailing whitespace from text blocks, but this is not true when they are next to an arbitrary block, when we have to take care the keep the connecting whitespace (if it exists)

**Wontfix**
We can not keep whitespaces between the {} expressions because that information is lost in our parser.
