### PR TITLE
Save assets to server when loading branch from Github.

### DIFF
--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -4,6 +4,7 @@
 import { jsx } from '@emotion/react'
 import React, { useEffect } from 'react'
 import TimeAgo from 'react-timeago'
+import { forceNotNull } from '../../../../core/shared/optional-utils'
 import { projectDependenciesSelector } from '../../../../core/shared/dependencies'
 import {
   dispatchPromiseActions,
@@ -833,6 +834,8 @@ const BranchNotLoadedBlock = () => {
     'Built-in dependencies',
   )
 
+  const projectID = useEditorState(Substores.restOfEditor, (store) => store.editor.id, 'Project ID')
+
   const currentDependencies = useEditorState(
     Substores.fullStore,
     projectDependenciesSelector,
@@ -843,6 +846,7 @@ const BranchNotLoadedBlock = () => {
     if (githubRepo != null && branchName != null) {
       void updateProjectWithBranchContent(
         dispatch,
+        forceNotNull('Should have a project ID by now.', projectID),
         githubRepo,
         branchName,
         false,
@@ -850,7 +854,7 @@ const BranchNotLoadedBlock = () => {
         builtInDependencies,
       )
     }
-  }, [dispatch, githubRepo, branchName, currentDependencies, builtInDependencies])
+  }, [dispatch, githubRepo, branchName, currentDependencies, builtInDependencies, projectID])
 
   const isANewBranch = React.useMemo(() => {
     if (branches == null) {


### PR DESCRIPTION
**Problem:**
This PR: https://github.com/concrete-utopia/utopia/pull/2766 removed the saving of assets as part of loading the branch, because we needed to load branch content so as to be able to compare the contents. But the functionality was not subsequently re-added.

**Fix:**
When loading a project from Github, the assets are saved to the server from the project contents returned.

**Commit Details:**
- Added `saveAssetsToProject` utility function that works through the newly downloaded project contents saving the assets to the server.
- Integrated `saveAssetsToProject` into `updateProjectWithBranchContent`.
- Tweaked call to `updateProjectWithBranchContent` so that it supplies the project ID.
