### PR TITLE
Better handling of Github errors

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -264,7 +264,7 @@ export interface UserState extends UserConfiguration {
 }
 
 export interface GithubCommitAndPush {
-  name: 'commit-and-push'
+  name: 'commitAndPush'
 }
 
 export interface GithubListBranches {
@@ -291,6 +291,11 @@ export interface GithubListPullRequestsForBranch {
   branchName: string
 }
 
+export interface GithubSaveAsset {
+  name: 'saveAsset'
+  path: string
+}
+
 export type GithubOperation =
   | GithubCommitAndPush
   | GithubListBranches
@@ -298,11 +303,12 @@ export type GithubOperation =
   | GithubLoadRepositories
   | GithubUpdateAgainstBranch
   | GithubListPullRequestsForBranch
+  | GithubSaveAsset
 
 export function githubOperationPrettyName(op: GithubOperation): string {
   switch (op.name) {
-    case 'commit-and-push':
-      return 'Saving'
+    case 'commitAndPush':
+      return 'Saving to Github'
     case 'listBranches':
       return 'Listing branches'
     case 'loadBranch':
@@ -313,6 +319,8 @@ export function githubOperationPrettyName(op: GithubOperation): string {
       return 'Updating'
     case 'listPullRequestsForBranch':
       return 'Listing pull requests'
+    case 'saveAsset':
+      return 'Saving asset to Github'
     default:
       const _exhaustiveCheck: never = op
       return 'Unknown operation' // this should never happen
@@ -345,7 +353,7 @@ export function isGithubLoadingBranch(
 }
 
 export function isGithubCommitting(operations: Array<GithubOperation>): boolean {
-  return operations.some((o) => o.name === 'commit-and-push')
+  return operations.some((o) => o.name === 'commitAndPush')
 }
 
 export function isGithubLoadingRepositories(operations: Array<GithubOperation>): boolean {

--- a/editor/src/core/shared/github/operations/list-branches.ts
+++ b/editor/src/core/shared/github/operations/list-branches.ts
@@ -1,11 +1,16 @@
 import urljoin from 'url-join'
 import { UTOPIA_BACKEND } from '../../../../common/env-vars'
 import { HEADERS, MODE } from '../../../../common/server'
-import { notice } from '../../../../components/common/notice'
 import { EditorAction, EditorDispatch } from '../../../../components/editor/action-types'
-import { showToast, updateGithubData } from '../../../../components/editor/actions/action-creators'
-import { GithubRepo } from '../../../../components/editor/store/editor-state'
-import { GithubBranch, GithubFailure, runGithubOperation } from '../helpers'
+import { updateGithubData } from '../../../../components/editor/actions/action-creators'
+import { GithubOperation, GithubRepo } from '../../../../components/editor/store/editor-state'
+import {
+  githubAPIError,
+  githubAPIErrorFromResponse,
+  GithubBranch,
+  GithubFailure,
+  runGithubOperation,
+} from '../helpers'
 
 export type GetBranchesResult = Array<GithubBranch>
 
@@ -20,44 +25,40 @@ export async function getBranchesForGithubRepository(
   dispatch: EditorDispatch,
   githubRepo: GithubRepo,
 ): Promise<Array<EditorAction>> {
-  return runGithubOperation({ name: 'listBranches' }, dispatch, async () => {
-    const url = urljoin(
-      UTOPIA_BACKEND,
-      'github',
-      'branches',
-      githubRepo.owner,
-      githubRepo.repository,
-    )
+  return runGithubOperation(
+    { name: 'listBranches' },
+    dispatch,
+    async (operation: GithubOperation) => {
+      const url = urljoin(
+        UTOPIA_BACKEND,
+        'github',
+        'branches',
+        githubRepo.owner,
+        githubRepo.repository,
+      )
 
-    const response = await fetch(url, {
-      method: 'GET',
-      credentials: 'include',
-      headers: HEADERS,
-      mode: MODE,
-    })
+      const response = await fetch(url, {
+        method: 'GET',
+        credentials: 'include',
+        headers: HEADERS,
+        mode: MODE,
+      })
 
-    if (response.ok) {
+      if (!response.ok) {
+        throw await githubAPIErrorFromResponse(operation, response)
+      }
+
       const responseBody: GetBranchesResponse = await response.json()
 
       switch (responseBody.type) {
         case 'FAILURE':
-          return [
-            showToast(
-              notice(`Error when listing branches: ${responseBody.failureReason}`, 'ERROR'),
-            ),
-          ]
+          throw githubAPIError(operation, responseBody.failureReason)
         case 'SUCCESS':
           return [updateGithubData({ branches: responseBody.branches })]
         default:
           const _exhaustiveCheck: never = responseBody
-          throw new Error(`Unhandled response body ${JSON.stringify(responseBody)}`)
+          throw githubAPIError(operation, `Unhandled response body ${JSON.stringify(responseBody)}`)
       }
-    } else {
-      return [
-        showToast(
-          notice(`Github: Unexpected status returned from endpoint: ${response.status}`, 'ERROR'),
-        ),
-      ]
-    }
-  })
+    },
+  )
 }

--- a/editor/src/core/shared/github/operations/load-branch.ts
+++ b/editor/src/core/shared/github/operations/load-branch.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../../components/editor/actions/action-creators'
 import {
   GithubData,
+  GithubOperation,
   GithubRepo,
   packageJsonFileFromProjectContents,
 } from '../../../../components/editor/store/editor-state'
@@ -20,6 +21,8 @@ import {
   connectRepo,
   getBranchContentFromServer,
   GetBranchContentResponse,
+  githubAPIError,
+  githubAPIErrorFromResponse,
   runGithubOperation,
 } from '../helpers'
 
@@ -38,83 +41,66 @@ export async function updateProjectWithBranchContent(
       githubRepo: githubRepo,
     },
     dispatch,
-    async () => {
+    async (operation: GithubOperation) => {
       const response = await getBranchContentFromServer(githubRepo, branchName, null, null)
-      if (response.ok) {
-        const responseBody: GetBranchContentResponse = await response.json()
-        switch (responseBody.type) {
-          case 'FAILURE':
-            dispatch(
-              [showToast(notice(`Error saving to Github: ${responseBody.failureReason}`, 'ERROR'))],
-              'everyone',
+      if (!response.ok) {
+        throw await githubAPIErrorFromResponse(operation, response)
+      }
+
+      const responseBody: GetBranchContentResponse = await response.json()
+      switch (responseBody.type) {
+        case 'FAILURE':
+          throw githubAPIError(operation, responseBody.failureReason)
+        case 'SUCCESS':
+          if (responseBody.branch == null) {
+            throw githubAPIError(operation, `Could not find branch ${branchName}`)
+          }
+          const newGithubData: Partial<GithubData> = {
+            upstreamChanges: null,
+          }
+          if (resetBranches) {
+            newGithubData.branches = null
+          }
+
+          const packageJson = packageJsonFileFromProjectContents(responseBody.branch.content)
+          if (packageJson != null && isTextFile(packageJson)) {
+            await refreshDependencies(
+              dispatch,
+              packageJson.fileContents.code,
+              currentDeps,
+              builtInDependencies,
+              {},
             )
-            break
-          case 'SUCCESS':
-            if (responseBody.branch == null) {
-              dispatch(
-                [showToast(notice(`Github: Could not find branch ${branchName}.`, 'ERROR'))],
-                'everyone',
-              )
-            } else {
-              const newGithubData: Partial<GithubData> = {
-                upstreamChanges: null,
-              }
-              if (resetBranches) {
-                newGithubData.branches = null
-              }
+          }
 
-              const packageJson = packageJsonFileFromProjectContents(responseBody.branch.content)
-              if (packageJson != null && isTextFile(packageJson)) {
-                await refreshDependencies(
-                  dispatch,
-                  packageJson.fileContents.code,
-                  currentDeps,
-                  builtInDependencies,
-                  {},
-                )
-              }
-
-              dispatch(
-                [
-                  ...connectRepo(
-                    resetBranches,
-                    githubRepo,
-                    responseBody.branch.originCommit,
-                    branchName,
-                    true,
-                  ),
-                  updateGithubChecksums(
-                    getProjectContentsChecksums(responseBody.branch.content, {}),
-                  ),
-                  updateProjectContents(responseBody.branch.content),
-                  updateBranchContents(responseBody.branch.content),
-                  showToast(
-                    notice(
-                      `Github: Updated the project with the content from ${branchName}`,
-                      'SUCCESS',
-                    ),
-                  ),
-                ],
-                'everyone',
-              )
-            }
-            break
-          default:
-            const _exhaustiveCheck: never = responseBody
-            throw new Error(`Github: Unhandled response body ${JSON.stringify(responseBody)}`)
-        }
-      } else {
-        dispatch(
-          [
-            showToast(
-              notice(
-                `Github: Unexpected status returned from endpoint: ${response.status}`,
-                'ERROR',
+          dispatch(
+            [
+              ...connectRepo(
+                resetBranches,
+                githubRepo,
+                responseBody.branch.originCommit,
+                branchName,
+                true,
               ),
-            ),
-          ],
-          'everyone',
-        )
+              updateGithubChecksums(getProjectContentsChecksums(responseBody.branch.content, {})),
+              updateProjectContents(responseBody.branch.content),
+              updateBranchContents(responseBody.branch.content),
+              showToast(
+                notice(
+                  `Github: Updated the project with the content from ${branchName}`,
+                  'SUCCESS',
+                ),
+              ),
+            ],
+            'everyone',
+          )
+          break
+        default:
+          const _exhaustiveCheck: never = responseBody
+          throw githubAPIError(
+            operation,
+            `Github: Unhandled response body ${JSON.stringify(responseBody)}`,
+          )
       }
       return []
     },

--- a/editor/src/core/shared/github/operations/load-repositories.ts
+++ b/editor/src/core/shared/github/operations/load-repositories.ts
@@ -1,16 +1,23 @@
 import urljoin from 'url-join'
 import { UTOPIA_BACKEND } from '../../../../common/env-vars'
 import { HEADERS, MODE } from '../../../../common/server'
-import { notice } from '../../../../components/common/notice'
 import { EditorAction, EditorDispatch } from '../../../../components/editor/action-types'
 import {
   setGithubState,
-  showToast,
   updateGithubData,
   updateGithubSettings,
 } from '../../../../components/editor/actions/action-creators'
-import { emptyGithubSettings } from '../../../../components/editor/store/editor-state'
-import { GithubFailure, RepositoryEntry, runGithubOperation } from '../helpers'
+import {
+  emptyGithubSettings,
+  GithubOperation,
+} from '../../../../components/editor/store/editor-state'
+import {
+  githubAPIError,
+  githubAPIErrorFromResponse,
+  GithubFailure,
+  RepositoryEntry,
+  runGithubOperation,
+} from '../helpers'
 
 export interface GetUsersPublicRepositoriesSuccess {
   type: 'SUCCESS'
@@ -22,34 +29,35 @@ export type GetUsersPublicRepositoriesResponse = GetUsersPublicRepositoriesSucce
 export async function getUsersPublicGithubRepositories(
   dispatch: EditorDispatch,
 ): Promise<Array<EditorAction>> {
-  return runGithubOperation({ name: 'loadRepositories' }, dispatch, async () => {
-    const url = urljoin(UTOPIA_BACKEND, 'github', 'user', 'repositories')
+  return runGithubOperation(
+    { name: 'loadRepositories' },
+    dispatch,
+    async (operation: GithubOperation) => {
+      const url = urljoin(UTOPIA_BACKEND, 'github', 'user', 'repositories')
 
-    const response = await fetch(url, {
-      method: 'GET',
-      credentials: 'include',
-      headers: HEADERS,
-      mode: MODE,
-    })
-    if (response.ok) {
+      const response = await fetch(url, {
+        method: 'GET',
+        credentials: 'include',
+        headers: HEADERS,
+        mode: MODE,
+      })
+      if (!response.ok) {
+        throw await githubAPIErrorFromResponse(operation, response)
+      }
+
       const responseBody: GetUsersPublicRepositoriesResponse = await response.json()
       switch (responseBody.type) {
         case 'FAILURE':
-          const actions: EditorAction[] = [
-            showToast(
-              notice(
-                `Github: Error getting a user's repositories: ${responseBody.failureReason}`,
-                'ERROR',
-              ),
-            ),
-          ]
           if (responseBody.failureReason.includes('Authentication')) {
-            actions.push(
-              updateGithubSettings(emptyGithubSettings()),
-              setGithubState({ authenticated: false }),
+            dispatch(
+              [
+                updateGithubSettings(emptyGithubSettings()),
+                setGithubState({ authenticated: false }),
+              ],
+              'everyone',
             )
           }
-          return actions
+          throw githubAPIError(operation, responseBody.failureReason)
         case 'SUCCESS':
           return [
             updateGithubData({
@@ -58,14 +66,8 @@ export async function getUsersPublicGithubRepositories(
           ]
         default:
           const _exhaustiveCheck: never = responseBody
-          throw new Error(`Github: Unhandled response body ${JSON.stringify(responseBody)}`)
+          throw githubAPIError(operation, `Unhandled response body ${JSON.stringify(responseBody)}`)
       }
-    } else {
-      return [
-        showToast(
-          notice(`Github: Unexpected status returned from endpoint: ${response.status}`, 'ERROR'),
-        ),
-      ]
-    }
-  })
+    },
+  )
 }


### PR DESCRIPTION
Fixes #3221

**Problem:**

When Github API calls return errors, it's hard to understand what went wrong and why.

**Fix:**

This PR does two things:
1. consolidate the way Github operation errors are handled
2. handle the errors happening during the `runGithubOperation` calls, so that the errors are logged in a more structured way to the console
3. make the error toast a bit more informative and consistent about which operation failed, as well as pointing to the console for more info

<img width="816" alt="Screenshot 2023-02-01 at 5 12 39 PM" src="https://user-images.githubusercontent.com/1081051/216100264-c5b92e4b-b902-41c0-b5c0-de9b8ed2de35.png">

The error format is as follows:
- for the toasts: `<name of the operation> failed. See the console for more information`
- for the console: `[GitHub] operation "<name>" failed: <JSON object>`

The `JSON object` is:
```typescript
{
  operation: GithubOperation // the operation which failed
  status: string // a short description of the error (e.g. status text + status code)
  data?: string // a string containing more failure data (e.g. the body of the error response)
}
```

As a followup to this PR we should also touch the server logic which performs the GH API calls so that the actual error messages coming from GH are not shadowed and are returned (at least in their meaningful parts) to the client.