### PR TITLE
Extended undo API: merge with previous undo step

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -261,6 +261,15 @@ export type TransientActions = {
   elementsToRerender: Array<ElementPath> | null
 }
 
+// This is a wrapper action which changes the undo behavior for the included actions.
+// When you wrap actions in this, dispatching them will not create a new undo step.
+// Instead of that the effects of the actions will be merged into the previous undo step.
+// (Practically the previous undo snapshot will be replaced with the result of these actions.)
+export type MergeWithPrevUndo = {
+  action: 'MERGE_WITH_PREV_UNDO'
+  actions: Array<EditorAction>
+}
+
 export type Atomic = {
   action: 'ATOMIC'
   actions: Array<EditorAction>
@@ -1111,6 +1120,7 @@ export type EditorAction =
   | MoveSelectedForward
   | SetZIndex
   | TransientActions
+  | MergeWithPrevUndo
   | Atomic
   | NewProject
   | Load

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -226,6 +226,7 @@ import type {
   UpdateColorSwatches,
   PasteProperties,
   CopyProperties,
+  MergeWithPrevUndo,
 } from '../action-types'
 import { EditorModes, insertionSubject, Mode } from '../editor-modes'
 import type {
@@ -323,6 +324,13 @@ export function transientActions(
     action: 'TRANSIENT_ACTIONS',
     transientActions: actions,
     elementsToRerender: elementsToRerender,
+  }
+}
+
+export function mergeWithPrevUndo(actions: Array<EditorAction>): MergeWithPrevUndo {
+  return {
+    action: 'MERGE_WITH_PREV_UNDO',
+    actions: actions,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -130,6 +130,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'NEW':
     case 'LOAD':
     case 'ATOMIC':
+    case 'MERGE_WITH_PREV_UNDO':
     case 'DELETE_SELECTED':
     case 'DELETE_VIEW':
     case 'UNSET_PROPERTY':
@@ -208,6 +209,7 @@ export function isUndoOrRedo(action: EditorAction): boolean {
     case 'TRANSIENT_ACTIONS':
       return action.transientActions.some(isUndoOrRedo)
     case 'ATOMIC':
+    case 'MERGE_WITH_PREV_UNDO':
       return action.actions.some(isUndoOrRedo)
     case 'UNDO':
     case 'REDO':
@@ -222,6 +224,7 @@ export function isParsedModelUpdate(action: EditorAction): boolean {
     case 'TRANSIENT_ACTIONS':
       return action.transientActions.some(isParsedModelUpdate)
     case 'ATOMIC':
+    case 'MERGE_WITH_PREV_UNDO':
       return action.actions.some(isParsedModelUpdate)
     case 'UPDATE_FROM_WORKER':
       return action.updates.some((update) => update.type === 'WORKER_PARSED_UPDATE')
@@ -235,6 +238,7 @@ export function isFromVSCode(action: EditorAction): boolean {
     case 'TRANSIENT_ACTIONS':
       return action.transientActions.some(isFromVSCode)
     case 'ATOMIC':
+    case 'MERGE_WITH_PREV_UNDO':
       return action.actions.some(isFromVSCode)
     case 'UPDATE_FROM_CODE_EDITOR':
     case 'SEND_LINTER_REQUEST_MESSAGE':
@@ -249,6 +253,7 @@ export function isClearInteractionSession(action: EditorAction): boolean {
     case 'TRANSIENT_ACTIONS':
       return action.transientActions.some(isClearInteractionSession)
     case 'ATOMIC':
+    case 'MERGE_WITH_PREV_UNDO':
       return action.actions.some(isClearInteractionSession)
     case 'CLEAR_INTERACTION_SESSION':
       return true
@@ -262,6 +267,7 @@ export function isCreateOrUpdateInteractionSession(action: EditorAction): boolea
     case 'TRANSIENT_ACTIONS':
       return action.transientActions.some(isCreateOrUpdateInteractionSession)
     case 'ATOMIC':
+    case 'MERGE_WITH_PREV_UNDO':
       return action.actions.some(isCreateOrUpdateInteractionSession)
     case 'CREATE_INTERACTION_SESSION':
     case 'UPDATE_INTERACTION_SESSION':
@@ -276,6 +282,7 @@ export function shouldApplyClearInteractionSessionResult(action: EditorAction): 
     case 'TRANSIENT_ACTIONS':
       return action.transientActions.some(shouldApplyClearInteractionSessionResult)
     case 'ATOMIC':
+    case 'MERGE_WITH_PREV_UNDO':
       return action.actions.some(shouldApplyClearInteractionSessionResult)
     case 'CLEAR_INTERACTION_SESSION':
       return action.applyChanges

--- a/editor/src/components/editor/history.ts
+++ b/editor/src/components/editor/history.ts
@@ -67,6 +67,22 @@ export function add(
   return newHistory
 }
 
+export function replaceLast(
+  stateHistory: StateHistory,
+  editor: EditorState,
+  derived: DerivedState,
+): StateHistory {
+  const newHistory = {
+    previous: stateHistory.previous,
+    current: {
+      editor: editor,
+      derived: derived,
+    },
+    next: [],
+  }
+  return newHistory
+}
+
 export function init(editor: EditorState, derived: DerivedState): StateHistory {
   return {
     previous: [],

--- a/editor/src/components/text-editor/text-editor-shortcut-helpers.ts
+++ b/editor/src/components/text-editor/text-editor-shortcut-helpers.ts
@@ -206,7 +206,7 @@ const toggleStylePropWithUnset = (
     const computedValue = getComputedValue()
     if (computedValue !== newValue) {
       dispatch([
-        EditorActions.transientActions([
+        EditorActions.mergeWithPrevUndo([
           EditorActions.setProperty(
             elementPath,
             PP.create('style', prop),

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -1,4 +1,4 @@
-import { wait } from '../../utils/utils.test-utils'
+import { expectSingleUndoStep, wait } from '../../utils/utils.test-utils'
 import { altCmdModifier, cmdModifier, Modifiers, shiftCmdModifier } from '../../utils/modifiers'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
 import {
@@ -857,10 +857,12 @@ async function prepareTestModifierEditor(editor: EditorRenderResult) {
 }
 
 async function pressShortcut(editor: EditorRenderResult, mod: Modifiers, key: string) {
-  pressKey(key, {
-    modifiers: mod,
-    targetElement: document.getElementById(TextEditorSpanId) ?? undefined,
-  })
+  await expectSingleUndoStep(editor, async () =>
+    pressKey(key, {
+      modifiers: mod,
+      targetElement: document.getElementById(TextEditorSpanId) ?? undefined,
+    }),
+  )
   await closeTextEditor()
   await editor.getDispatchFollowUpActionsFinished()
 }


### PR DESCRIPTION
**Problem:**
It is not possible to dispatch an action without making a new undo step. But sometimes it is not possible, or really uncomfortable to collect all the actions and dispatch them together.

One example is text format toggling: when you toggle back a bold text to normal, we don't want to include `fontWeight: normal` in the style props if it is not necessary. But we can only decide whether it is necessary or not if we actually try to unset and check the format of the text. If it is not normal, we have to put `fontWeight: normal` back to style props, but we should avoid creating two undo steps.

**Fix:**
Created a new a wrapper action called `MergeWithPrevUndo`. When the actions are dispatched in this wrapper, the last undo snapshot will be replaced with the result of these actions.

Added mergeWithPrevUndo into the text format toggling logic, and extended the tests to check for the single undo action.
