### PR TITLE
Make text format global shortcuts work well with property unset

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -88,6 +88,7 @@ function useDelayedValueHook(inputValue: boolean, delayMs: number): boolean {
 export const EditorComponentInner = React.memo((props: EditorProps) => {
   const dispatch = useDispatch()
   const editorStoreRef = useRefEditorState((store) => store)
+  const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
   const colorTheme = useColorTheme()
   const onWindowMouseUp = React.useCallback((event: MouseEvent) => {
     return [EditorActions.updateMouseButtonsPressed(null, event.button)]
@@ -179,17 +180,11 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
       }
 
       actions.push(
-        ...handleKeyDown(
-          event,
-          editorStoreRef.current.editor,
-          editorStoreRef.current.derived,
-          namesByKey,
-          dispatch,
-        ),
+        ...handleKeyDown(event, editorStoreRef.current.editor, metadataRef, namesByKey, dispatch),
       )
       return actions
     },
-    [dispatch, editorStoreRef, namesByKey, setClearKeyboardInteraction],
+    [dispatch, editorStoreRef, metadataRef, namesByKey, setClearKeyboardInteraction],
   )
 
   const onWindowKeyUp = React.useCallback(

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -104,7 +104,11 @@ import {
   boundingArea,
   createHoverInteractionViaMouse,
 } from '../canvas/canvas-strategies/interaction-state'
-import { emptyComments, jsxAttributeValue } from '../../core/shared/element-template'
+import {
+  ElementInstanceMetadataMap,
+  emptyComments,
+  jsxAttributeValue,
+} from '../../core/shared/element-template'
 import {
   toggleTextBold,
   toggleTextItalic,
@@ -340,7 +344,7 @@ export function preventBrowserShortcuts(editor: EditorState, event: KeyboardEven
 export function handleKeyDown(
   event: KeyboardEvent,
   editor: EditorState,
-  derived: DerivedState,
+  metadataRef: { current: ElementInstanceMetadataMap },
   namesByKey: ShortcutNamesByKey,
   dispatch: EditorDispatch,
 ): Array<EditorAction> {
@@ -733,42 +737,72 @@ export function handleKeyDown(
         return actions
       },
       [TOGGLE_TEXT_BOLD]: () => {
-        return isSelectMode(editor.mode)
-          ? editor.selectedViews.map((target) => {
-              const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, target)
-              return toggleTextBold(target, element?.specialSizeMeasurements.fontWeight ?? null)
-            })
-          : []
+        if (isSelectMode(editor.mode)) {
+          let first = true
+          editor.selectedViews.forEach((target) => {
+            const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, target)
+            toggleTextBold(
+              target,
+              element?.specialSizeMeasurements.fontWeight ?? null,
+              dispatch,
+              metadataRef,
+              first ? 'separate-undo-step' : 'merge-with-previous',
+            )
+            first = false
+          })
+        }
+        return []
       },
       [TOGGLE_TEXT_ITALIC]: () => {
-        return isSelectMode(editor.mode)
-          ? editor.selectedViews.map((target) => {
-              const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, target)
-              return toggleTextItalic(target, element?.specialSizeMeasurements.fontStyle ?? null)
-            })
-          : []
+        if (isSelectMode(editor.mode)) {
+          let first = true
+          editor.selectedViews.forEach((target) => {
+            const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, target)
+            toggleTextItalic(
+              target,
+              element?.specialSizeMeasurements.fontStyle ?? null,
+              dispatch,
+              metadataRef,
+              first ? 'separate-undo-step' : 'merge-with-previous',
+            )
+            first = false
+          })
+        }
+        return []
       },
       [TOGGLE_TEXT_UNDERLINE]: () => {
-        return isSelectMode(editor.mode)
-          ? editor.selectedViews.map((target) => {
-              const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, target)
-              return toggleTextUnderline(
-                target,
-                element?.specialSizeMeasurements.textDecorationLine ?? null,
-              )
-            })
-          : []
+        if (isSelectMode(editor.mode)) {
+          let first = true
+          editor.selectedViews.forEach((target) => {
+            const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, target)
+            toggleTextUnderline(
+              target,
+              element?.specialSizeMeasurements.textDecorationLine ?? null,
+              dispatch,
+              metadataRef,
+              first ? 'separate-undo-step' : 'merge-with-previous',
+            )
+            first = false
+          })
+        }
+        return []
       },
       [TOGGLE_TEXT_STRIKE_THROUGH]: () => {
-        return isSelectMode(editor.mode)
-          ? editor.selectedViews.map((target) => {
-              const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, target)
-              return toggleTextStrikeThrough(
-                target,
-                element?.specialSizeMeasurements.textDecorationLine ?? null,
-              )
-            })
-          : []
+        if (isSelectMode(editor.mode)) {
+          let first = true
+          editor.selectedViews.forEach((target) => {
+            const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, target)
+            toggleTextStrikeThrough(
+              target,
+              element?.specialSizeMeasurements.textDecorationLine ?? null,
+              dispatch,
+              metadataRef,
+              first ? 'separate-undo-step' : 'merge-with-previous',
+            )
+            first = false
+          })
+        }
+        return []
       },
       [PASTE_STYLE_PROPERTIES]: () => {
         return isSelectMode(editor.mode)

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -738,68 +738,60 @@ export function handleKeyDown(
       },
       [TOGGLE_TEXT_BOLD]: () => {
         if (isSelectMode(editor.mode)) {
-          let first = true
-          editor.selectedViews.forEach((target) => {
+          editor.selectedViews.forEach((target, i) => {
             const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, target)
             toggleTextBold(
               target,
               element?.specialSizeMeasurements.fontWeight ?? null,
               dispatch,
               metadataRef,
-              first ? 'separate-undo-step' : 'merge-with-previous',
+              i === 0 ? 'separate-undo-step' : 'merge-with-previous',
             )
-            first = false
           })
         }
         return []
       },
       [TOGGLE_TEXT_ITALIC]: () => {
         if (isSelectMode(editor.mode)) {
-          let first = true
-          editor.selectedViews.forEach((target) => {
+          editor.selectedViews.forEach((target, i) => {
             const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, target)
             toggleTextItalic(
               target,
               element?.specialSizeMeasurements.fontStyle ?? null,
               dispatch,
               metadataRef,
-              first ? 'separate-undo-step' : 'merge-with-previous',
+              i === 0 ? 'separate-undo-step' : 'merge-with-previous',
             )
-            first = false
           })
         }
         return []
       },
       [TOGGLE_TEXT_UNDERLINE]: () => {
         if (isSelectMode(editor.mode)) {
-          let first = true
-          editor.selectedViews.forEach((target) => {
+          editor.selectedViews.forEach((target, i) => {
             const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, target)
             toggleTextUnderline(
               target,
               element?.specialSizeMeasurements.textDecorationLine ?? null,
               dispatch,
               metadataRef,
-              first ? 'separate-undo-step' : 'merge-with-previous',
+              i === 0 ? 'separate-undo-step' : 'merge-with-previous',
             )
-            first = false
           })
         }
         return []
       },
       [TOGGLE_TEXT_STRIKE_THROUGH]: () => {
         if (isSelectMode(editor.mode)) {
-          let first = true
-          editor.selectedViews.forEach((target) => {
+          editor.selectedViews.forEach((target, i) => {
             const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, target)
             toggleTextStrikeThrough(
               target,
               element?.specialSizeMeasurements.textDecorationLine ?? null,
               dispatch,
               metadataRef,
-              first ? 'separate-undo-step' : 'merge-with-previous',
+              i === 0 ? 'separate-undo-step' : 'merge-with-previous',
             )
-            first = false
           })
         }
         return []

--- a/editor/src/components/editor/shortcuts.spec.browser2.tsx
+++ b/editor/src/components/editor/shortcuts.spec.browser2.tsx
@@ -188,7 +188,7 @@ describe('global shortcuts to set properties', () => {
     const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/bbb`)
     await renderResult.dispatch(selectComponents([target], false), true)
 
-    pressKey('b', { modifiers: cmdModifier })
+    await expectSingleUndoStep(renderResult, async () => pressKey('b', { modifiers: cmdModifier }))
     await renderResult.getDispatchFollowUpActionsFinished()
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
@@ -201,7 +201,7 @@ describe('global shortcuts to set properties', () => {
       ),
     )
   })
-  it('cmd + b toggles text to normal if it was bold', async () => {
+  it('cmd + b unsets font weight if it was bold', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
         `<div style={{ ...props.style }} data-uid='aaa'>
@@ -217,14 +217,12 @@ describe('global shortcuts to set properties', () => {
     const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/bbb`)
     await renderResult.dispatch(selectComponents([target], false), true)
 
-    pressKey('b', { modifiers: cmdModifier })
+    await expectSingleUndoStep(renderResult, async () => pressKey('b', { modifiers: cmdModifier }))
     await renderResult.getDispatchFollowUpActionsFinished()
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
         `<div style={{ ...props.style }} data-uid='aaa'>
-          <div
-            style={{ fontWeight: 'normal' }}
-            data-uid='bbb'
+          <div style={{}} data-uid='bbb'
           >hello text</div>
         </div>`,
       ),
@@ -246,7 +244,7 @@ describe('global shortcuts to set properties', () => {
     const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/bbb`)
     await renderResult.dispatch(selectComponents([target], false), true)
 
-    pressKey('i', { modifiers: cmdModifier })
+    await expectSingleUndoStep(renderResult, async () => pressKey('i', { modifiers: cmdModifier }))
     await renderResult.getDispatchFollowUpActionsFinished()
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
@@ -259,7 +257,7 @@ describe('global shortcuts to set properties', () => {
       ),
     )
   })
-  it('cmd + i toggles text to normal if it was italic', async () => {
+  it('cmd + i unsets font style if it was italic', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
         `<div style={{ ...props.style }} data-uid='aaa'>
@@ -275,13 +273,13 @@ describe('global shortcuts to set properties', () => {
     const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/bbb`)
     await renderResult.dispatch(selectComponents([target], false), true)
 
-    pressKey('i', { modifiers: cmdModifier })
+    await expectSingleUndoStep(renderResult, async () => pressKey('i', { modifiers: cmdModifier }))
     await renderResult.getDispatchFollowUpActionsFinished()
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
         `<div style={{ ...props.style }} data-uid='aaa'>
           <div
-            style={{ fontStyle: 'normal' }}
+            style={{}}
             data-uid='bbb'
           >hello text</div>
         </div>`,
@@ -304,7 +302,7 @@ describe('global shortcuts to set properties', () => {
     const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/bbb`)
     await renderResult.dispatch(selectComponents([target], false), true)
 
-    pressKey('u', { modifiers: cmdModifier })
+    await expectSingleUndoStep(renderResult, async () => pressKey('u', { modifiers: cmdModifier }))
     await renderResult.getDispatchFollowUpActionsFinished()
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
@@ -317,7 +315,7 @@ describe('global shortcuts to set properties', () => {
       ),
     )
   })
-  it('cmd + u toggles text to none if it was underlined', async () => {
+  it('cmd + u unsets text decoration if it was underlined', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
         `<div style={{ ...props.style }} data-uid='aaa'>
@@ -333,13 +331,13 @@ describe('global shortcuts to set properties', () => {
     const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/bbb`)
     await renderResult.dispatch(selectComponents([target], false), true)
 
-    pressKey('u', { modifiers: cmdModifier })
+    await expectSingleUndoStep(renderResult, async () => pressKey('u', { modifiers: cmdModifier }))
     await renderResult.getDispatchFollowUpActionsFinished()
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
         `<div style={{ ...props.style }} data-uid='aaa'>
           <div
-            style={{ textDecoration: 'none' }}
+            style={{}}
             data-uid='bbb'
           >hello text</div>
         </div>`,

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -31,13 +31,9 @@ import { Substores, useEditorState, useRefEditorState } from '../editor/store/st
 import { printCSSNumber } from '../inspector/common/css-utils'
 import {
   toggleTextBold,
-  toggleTextBoldWithUnset,
   toggleTextItalic,
-  toggleTextItalicWithUnset,
   toggleTextStrikeThrough,
-  toggleTextStrikeThroughWithUnset,
   toggleTextUnderline,
-  toggleTextUnderlineWithUnset,
 } from './text-editor-shortcut-helpers'
 import { useColorTheme } from '../../uuiui'
 import { arrayToObject } from '../../core/shared/array-utils'
@@ -104,41 +100,45 @@ const handleToggleShortcuts = (
 
   // Meta+b = bold
   if (meta && event.key === 'b') {
-    toggleTextBoldWithUnset(
+    toggleTextBold(
       target,
       specialSizeMeasurements?.fontWeight ?? null,
       dispatch,
       metadataRef,
+      'separate-undo-step',
     )
     return []
   }
   // Meta+i = italic
   if (meta && event.key === 'i') {
-    toggleTextItalicWithUnset(
+    toggleTextItalic(
       target,
       specialSizeMeasurements?.fontStyle ?? null,
       dispatch,
       metadataRef,
+      'separate-undo-step',
     )
     return []
   }
   // Meta+u = underline
   if (meta && event.key === 'u') {
-    toggleTextUnderlineWithUnset(
+    toggleTextUnderline(
       target,
       specialSizeMeasurements?.textDecorationLine ?? null,
       dispatch,
       metadataRef,
+      'separate-undo-step',
     )
     return []
   }
   // Meta+shift+x = strikethrough
   if (meta && modifiers.shift && event.key === 'x') {
-    toggleTextStrikeThroughWithUnset(
+    toggleTextStrikeThrough(
       target,
       specialSizeMeasurements?.textDecorationLine ?? null,
       dispatch,
       metadataRef,
+      'separate-undo-step',
     )
     return []
   }


### PR DESCRIPTION
**Problem:**
This is a followup to https://github.com/concrete-utopia/utopia/pull/3202 : the same feature is implemented for select mode too.

**Fix:**
The obstacle to do this was that the toggle helpers (e.f. `toggleTextBoldWithUnset`) only accept a single target element path, and they dispatch their own actions themselves. In select mode we have to support multiselection too, and I wanted to avoid creating separate undo steps for each selected element.

So my first plan was to refactor the toggle helpers to support multiple elements. Which means we need some bookkeeping, because we also have to check whether we can unset the prop or not one by one for each element, and collect all the actions to be dispatched for that too.

However, I realized there is a much simpler solution: I just use the new undo api from https://github.com/concrete-utopia/utopia/pull/3223 , call the toggle helpers separately for each element, and take care of not generating extra undo step by wrapping all actions into `MergeWithPrevUndo` actions, except the first one.

The downside of this solution that it does not fix the "juggling multiselect toggling" bug, but that was not the goal now, and we can always come back and improve this solution.