### PR TITLE
Pop `reparentedToPaths` on undo - long version

### DIFF
--- a/editor/src/components/canvas/commands/add-to-reparented-to-paths-command.ts
+++ b/editor/src/components/canvas/commands/add-to-reparented-to-paths-command.ts
@@ -25,10 +25,8 @@ export const runAddToReparentedToPaths: CommandFunction<AddToReparentedToPaths> 
 ): CommandFunctionResult => {
   const editorStatePatch: Spec<EditorState> = {
     canvas: {
-      controls: {
-        reparentedToPaths: {
-          $push: command.reparentedToPaths,
-        },
+      reparentedToPaths: {
+        $push: command.reparentedToPaths,
       },
     },
   }

--- a/editor/src/components/canvas/controls/select-mode/cursor-component.tsx
+++ b/editor/src/components/canvas/controls/select-mode/cursor-component.tsx
@@ -7,7 +7,7 @@ import { useDelayedEditorState } from '../../canvas-strategies/canvas-strategies
 
 export function getCursorFromEditor(editorState: EditorState): CSSCursor | null {
   const forMissingReparentedItems = cursorForMissingReparentedItems(
-    editorState.canvas.controls.reparentedToPaths,
+    editorState.canvas.reparentedToPaths,
     editorState.spyMetadata,
   )
   return (

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -936,6 +936,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
       resizeOptions: currentEditor.canvas.resizeOptions,
       domWalkerAdditionalElementsToUpdate: currentEditor.canvas.domWalkerAdditionalElementsToUpdate,
       controls: currentEditor.canvas.controls,
+      reparentedToPaths: poppedEditor.canvas.reparentedToPaths,
     },
     floatingInsertMenu: currentEditor.floatingInsertMenu,
     inspector: {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -841,7 +841,6 @@ export interface EditorStateCanvasControls {
   strategyIntendedBounds: Array<CanvasFrameAndTarget>
   flexReparentTargetLines: Array<CanvasRectangle>
   parentHighlightPaths: Array<ElementPath> | null
-  reparentedToPaths: Array<ElementPath>
   dragToMoveIndicatorFlags: DragToMoveIndicatorFlags
   parentOutlineHighlight: ElementPath | null
 }
@@ -852,7 +851,6 @@ export function editorStateCanvasControls(
   strategyIntendedBounds: Array<CanvasFrameAndTarget>,
   flexReparentTargetLines: Array<CanvasRectangle>,
   parentHighlightPaths: Array<ElementPath> | null,
-  reparentedToPaths: Array<ElementPath>,
   dragToMoveIndicatorFlagsValue: DragToMoveIndicatorFlags,
   parentOutlineHighlight: ElementPath | null,
 ): EditorStateCanvasControls {
@@ -862,7 +860,6 @@ export function editorStateCanvasControls(
     strategyIntendedBounds: strategyIntendedBounds,
     flexReparentTargetLines: flexReparentTargetLines,
     parentHighlightPaths: parentHighlightPaths,
-    reparentedToPaths: reparentedToPaths,
     dragToMoveIndicatorFlags: dragToMoveIndicatorFlagsValue,
     parentOutlineHighlight: parentOutlineHighlight,
   }
@@ -893,6 +890,7 @@ export interface EditorStateCanvas {
   resizeOptions: ResizeOptions
   domWalkerAdditionalElementsToUpdate: Array<ElementPath>
   controls: EditorStateCanvasControls
+  reparentedToPaths: Array<ElementPath>
 }
 
 export function editorStateCanvas(
@@ -918,6 +916,7 @@ export function editorStateCanvas(
   resizeOpts: ResizeOptions,
   domWalkerAdditionalElementsToUpdate: Array<ElementPath>,
   controls: EditorStateCanvasControls,
+  reparentedToPaths: Array<ElementPath>,
 ): EditorStateCanvas {
   return {
     elementsToRerender: elementsToRerender,
@@ -942,6 +941,7 @@ export function editorStateCanvas(
     resizeOptions: resizeOpts,
     domWalkerAdditionalElementsToUpdate: domWalkerAdditionalElementsToUpdate,
     controls: controls,
+    reparentedToPaths: reparentedToPaths,
   }
 }
 
@@ -2229,10 +2229,10 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
         strategyIntendedBounds: [],
         flexReparentTargetLines: [],
         parentHighlightPaths: null,
-        reparentedToPaths: [],
         dragToMoveIndicatorFlags: emptyDragToMoveIndicatorFlags,
         parentOutlineHighlight: null,
       },
+      reparentedToPaths: [],
     },
     floatingInsertMenu: {
       insertMenuMode: 'closed',
@@ -2553,10 +2553,10 @@ export function editorModelFromPersistentModel(
         strategyIntendedBounds: [],
         flexReparentTargetLines: [],
         parentHighlightPaths: null,
-        reparentedToPaths: [],
         dragToMoveIndicatorFlags: emptyDragToMoveIndicatorFlags,
         parentOutlineHighlight: null,
       },
+      reparentedToPaths: [],
     },
     floatingInsertMenu: {
       insertMenuMode: 'closed',

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1672,7 +1672,7 @@ export const DragToMoveIndicatorFlagsKeepDeepEquality: KeepDeepEqualityCall<Drag
   )
 
 export const EditorStateCanvasControlsKeepDeepEquality: KeepDeepEqualityCall<EditorStateCanvasControls> =
-  combine8EqualityCalls(
+  combine7EqualityCalls(
     (controls) => controls.snappingGuidelines,
     arrayDeepEquality(GuidelineWithSnappingVectorAndPointsOfRelevanceKeepDeepEquality),
     (controls) => controls.outlineHighlights,
@@ -1683,8 +1683,6 @@ export const EditorStateCanvasControlsKeepDeepEquality: KeepDeepEqualityCall<Edi
     arrayDeepEquality(CanvasRectangleKeepDeepEquality),
     (controls) => controls.parentHighlightPaths,
     nullableDeepEquality(arrayDeepEquality(ElementPathKeepDeepEquality)),
-    (controls) => controls.reparentedToPaths,
-    ElementPathArrayKeepDeepEquality,
     (controls) => controls.dragToMoveIndicatorFlags,
     DragToMoveIndicatorFlagsKeepDeepEquality,
     (controls) => controls.parentOutlineHighlight,
@@ -2081,6 +2079,10 @@ export const EditorStateCanvasKeepDeepEquality: KeepDeepEqualityCall<EditorState
     oldValue.controls,
     newValue.controls,
   )
+  const reparentedPathsResult = ElementPathArrayKeepDeepEquality(
+    oldValue.reparentedToPaths,
+    newValue.reparentedToPaths,
+  )
 
   const areEqual =
     elementsToRerenderResult.areEqual &&
@@ -2104,7 +2106,8 @@ export const EditorStateCanvasKeepDeepEquality: KeepDeepEqualityCall<EditorState
     transientPropertiesResult.areEqual &&
     resizeOptionsResult.areEqual &&
     domWalkerAdditionalElementsToUpdateResult.areEqual &&
-    controlsResult.areEqual
+    controlsResult.areEqual &&
+    reparentedPathsResult.areEqual
   if (areEqual) {
     return keepDeepEqualityResult(oldValue, true)
   } else {
@@ -2131,6 +2134,7 @@ export const EditorStateCanvasKeepDeepEquality: KeepDeepEqualityCall<EditorState
       resizeOptionsResult.value,
       domWalkerAdditionalElementsToUpdateResult.value,
       controlsResult.value,
+      reparentedPathsResult.value,
     )
     return keepDeepEqualityResult(newDeepValue, false)
   }

--- a/editor/src/components/editor/store/store-hook-substore-helpers.ts
+++ b/editor/src/components/editor/store/store-hook-substore-helpers.ts
@@ -89,10 +89,10 @@ export const EmptyEditorStateForKeysOnly: EditorState = {
       strategyIntendedBounds: [],
       flexReparentTargetLines: [],
       parentHighlightPaths: null,
-      reparentedToPaths: [],
       dragToMoveIndicatorFlags: null as any,
       parentOutlineHighlight: null,
     },
+    reparentedToPaths: [],
   },
   floatingInsertMenu: {
     insertMenuMode: 'closed',

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -500,10 +500,10 @@ export function runLocalCanvasAction(
             [],
             [],
             null,
-            [],
             emptyDragToMoveIndicatorFlags,
             null,
           ),
+          reparentedToPaths: [],
         },
       }
     case 'UPDATE_INTERACTION_SESSION':


### PR DESCRIPTION
## Description
This PR factors out `reparentedPaths` from `EditorStateCanvasControls` and places it on `EditorStateCanvas`. This state is restored from `poppedEditor` when undo occurs.

## Background
During paste, the pasted element is added to `reparentedPaths` (since reparenting functionality is reused via the `getReparentOutcome` function). This state however isn't reset on undo, which led to a bug where a seemingly "random" cursor was shown on the canvas after undoing a paste (this was a side effect of a fix implemented in https://github.com/concrete-utopia/utopia/pull/2462). To maintain the state of `reparentedPaths` across undos, it was removed from `EditorStateCanvasControls` (which is not restored on undo), and moved onto `EditorStateCanvas` so it can be popped on its own.