### PR TITLE
Fix/code pane toggle min width

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2698,10 +2698,10 @@ export const UPDATE_FNS = {
           interfaceDesigner: {
             ...editor.interfaceDesigner,
             codePaneVisible: action.visible,
-            codePaneWidth:
-              action.visible && editor.interfaceDesigner.codePaneWidth < MIN_CODE_PANE_REOPEN_WIDTH
-                ? MIN_CODE_PANE_REOPEN_WIDTH
-                : editor.interfaceDesigner.codePaneWidth,
+            codePaneWidth: Math.max(
+              MIN_CODE_PANE_REOPEN_WIDTH,
+              editor.interfaceDesigner.codePaneWidth,
+            ),
           },
         }
       case 'misccodeeditor':
@@ -2824,6 +2824,10 @@ export const UPDATE_FNS = {
           interfaceDesigner: {
             ...editor.interfaceDesigner,
             codePaneVisible: !editor.interfaceDesigner.codePaneVisible,
+            codePaneWidth: Math.max(
+              MIN_CODE_PANE_REOPEN_WIDTH,
+              editor.interfaceDesigner.codePaneWidth,
+            ),
           },
         }
       case 'misccodeeditor':


### PR DESCRIPTION
This PR adds the `MIN_CODE_PANE_REOPEN_WIDTH` safeguard check to the `TOGGLE_PANEL` action as well, like we did for https://github.com/concrete-utopia/utopia/pull/3156