### PR TITLE
Pop `EditorStateCanvaControls.reparentedToPaths` on undo

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -935,7 +935,16 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
       transientProperties: null,
       resizeOptions: currentEditor.canvas.resizeOptions,
       domWalkerAdditionalElementsToUpdate: currentEditor.canvas.domWalkerAdditionalElementsToUpdate,
-      controls: currentEditor.canvas.controls,
+      controls: {
+        snappingGuidelines: currentEditor.canvas.controls.snappingGuidelines,
+        outlineHighlights: currentEditor.canvas.controls.outlineHighlights,
+        strategyIntendedBounds: currentEditor.canvas.controls.strategyIntendedBounds,
+        flexReparentTargetLines: currentEditor.canvas.controls.flexReparentTargetLines,
+        parentHighlightPaths: currentEditor.canvas.controls.parentHighlightPaths,
+        reparentedToPaths: poppedEditor.canvas.controls.reparentedToPaths,
+        dragToMoveIndicatorFlags: currentEditor.canvas.controls.dragToMoveIndicatorFlags,
+        parentOutlineHighlight: currentEditor.canvas.controls.parentOutlineHighlight,
+      },
     },
     floatingInsertMenu: currentEditor.floatingInsertMenu,
     inspector: {


### PR DESCRIPTION
## Description
This PR changes `restoreEditorState` so that it restores `EditorStateCanvaControls.reparentedToPaths` on undo

## Background
During paste, the pasted element is added to `reparentedToPaths` (as a result of reusing reparenting functionality via the `getReparentOutcome` function).  `reparentedToPaths` is used in `cursorForMissingReparentedItems` to detemine if that element is actually rendered on screen (this a fix implemented in #2462). If the element is not rendered, an "operation not permitted" cursor is shown.

`reparentedToPaths` however isn't reset on undo, which led to a bug where the "operation not permitted" cursor was shown on the canvas after undoing a paste, since the path of the pasted element was added to `reparentedToPaths`, but it wasn't removed on undo.

This is fixed by popping `reparentedToPaths` on undo.