### PR TITLE
ux(distance markers) - show if > 0, reduce dimensions

### DIFF
--- a/editor/src/components/canvas/controls/distance-guideline.tsx
+++ b/editor/src/components/canvas/controls/distance-guideline.tsx
@@ -125,6 +125,7 @@ export class DistanceGuideline extends React.Component<DistanceGuidelineProps> {
         <div
           key={id}
           style={{
+            visibility: distance > 0 ? 'visible' : 'hidden',
             position: 'absolute',
             top: Math.min(from.y, to.y),
             left: Math.min(from.x, to.x),
@@ -139,11 +140,12 @@ export class DistanceGuideline extends React.Component<DistanceGuidelineProps> {
           <div
             style={{
               margin: 4 / this.props.scale,
-              padding: 4 / this.props.scale,
+              paddingLeft: 4 / this.props.scale,
+              paddingRight: 4 / this.props.scale,
               borderRadius: 4 / this.props.scale,
               color: colorTheme.white.value,
               backgroundColor: StrokeColor,
-              fontSize: 12 / this.props.scale,
+              fontSize: 11 / this.props.scale,
             }}
           >
             {`${distance.toFixed(0)}`}


### PR DESCRIPTION
**Problem:**
Distance can be distracting:
- markers currently show even if distance is zero
- markers are bigly
<img width="389" alt="image" src="https://user-images.githubusercontent.com/2945037/216335290-eacf68cc-2e9d-456c-9779-c17854f75c97.png">


**Fix:**
- Hide markers if distance < 0
- Less bigly
<img width="218" alt="image" src="https://user-images.githubusercontent.com/2945037/216335698-f7373ed3-c988-46f2-ba8f-68c3efc86c20.png">

