### PR TITLE
Fix the way text editor inherited properties were being applied.

### DIFF
--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -14,6 +14,7 @@ import {
   renderTestEditorWithCode,
 } from '../canvas/ui-jsx.test-utils'
 import { TextEditorSpanId } from './text-editor'
+import { TextRelatedProperties } from 'src/core/properties/css-properties'
 
 describe('Use the text editor', () => {
   it('Click to edit text', async () => {
@@ -146,6 +147,54 @@ describe('Use the text editor', () => {
           </Storyboard>
         )`),
     )
+  })
+  it(`ensure that a bunch of the text editor properties are set to 'inherit'`, async () => {
+    const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
+
+    await enterTextEditMode(editor)
+    const textEditorElement = document.getElementById(TextEditorSpanId)
+    if (textEditorElement == null) {
+      throw new Error('A text editor should exist at this point.')
+    }
+    expect(textEditorElement.style.font).toEqual('inherit')
+    expect(textEditorElement.style.fontFamily).toEqual('inherit')
+    expect(textEditorElement.style.fontFeatureSettings).toEqual('inherit')
+    expect(textEditorElement.style.fontKerning).toEqual('inherit')
+    expect(textEditorElement.style.fontOpticalSizing).toEqual('inherit')
+    expect(textEditorElement.style.fontSize).toEqual('inherit')
+    expect(textEditorElement.style.fontSizeAdjust).toEqual('inherit')
+    expect(textEditorElement.style.fontStretch).toEqual('inherit')
+    expect(textEditorElement.style.fontStyle).toEqual('inherit')
+    expect(textEditorElement.style.fontSynthesis).toEqual('inherit')
+    expect(textEditorElement.style.fontVariant).toEqual('inherit')
+    expect(textEditorElement.style.fontVariantCaps).toEqual('inherit')
+    expect(textEditorElement.style.fontVariantEastAsian).toEqual('inherit')
+    expect(textEditorElement.style.fontVariantLigatures).toEqual('inherit')
+    expect(textEditorElement.style.fontVariantNumeric).toEqual('inherit')
+    expect(textEditorElement.style.fontVariantPosition).toEqual('inherit')
+    expect(textEditorElement.style.fontVariationSettings).toEqual('inherit')
+    expect(textEditorElement.style.fontWeight).toEqual('inherit')
+    expect(textEditorElement.style.textAlign).toEqual('inherit')
+    expect(textEditorElement.style.textAlignLast).toEqual('inherit')
+    expect(textEditorElement.style.textCombineUpright).toEqual('inherit')
+    expect(textEditorElement.style.textDecorationColor).toEqual('inherit')
+    expect(textEditorElement.style.textDecorationLine).toEqual('inherit')
+    expect(textEditorElement.style.textDecorationSkipInk).toEqual('inherit')
+    expect(textEditorElement.style.textDecorationStyle).toEqual('inherit')
+    expect(textEditorElement.style.textDecorationThickness).toEqual('inherit')
+    expect(textEditorElement.style.textEmphasisColor).toEqual('inherit')
+    expect(textEditorElement.style.textEmphasisPosition).toEqual('inherit')
+    expect(textEditorElement.style.textEmphasisStyle).toEqual('inherit')
+    expect(textEditorElement.style.textIndent).toEqual('inherit')
+    expect(textEditorElement.style.textOrientation).toEqual('inherit')
+    expect(textEditorElement.style.textOverflow).toEqual('inherit')
+    expect(textEditorElement.style.textRendering).toEqual('inherit')
+    expect(textEditorElement.style.textShadow).toEqual('inherit')
+    expect(textEditorElement.style.textTransform).toEqual('inherit')
+    expect(textEditorElement.style.textUnderlineOffset).toEqual('inherit')
+    expect(textEditorElement.style.textUnderlinePosition).toEqual('inherit')
+    expect(textEditorElement.style.letterSpacing).toEqual('inherit')
+    expect(textEditorElement.style.lineHeight).toEqual('inherit')
   })
   describe('formatting shortcuts', () => {
     it('supports bold', async () => {

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -1,5 +1,5 @@
 import { unescape } from 'he'
-import React from 'react'
+import React, { CSSProperties } from 'react'
 import { ElementInstanceMetadataMap } from '../../core/shared/element-template'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { ElementPath } from '../../core/shared/project-file-types'
@@ -36,7 +36,7 @@ import {
   toggleTextUnderline,
 } from './text-editor-shortcut-helpers'
 import { useColorTheme } from '../../uuiui'
-import { arrayToObject } from '../../core/shared/array-utils'
+import { mapArrayToDictionary } from '../../core/shared/array-utils'
 import { TextRelatedProperties } from '../../core/properties/css-properties'
 
 export const TextEditorSpanId = 'text-editor'
@@ -347,6 +347,13 @@ const TextEditor = React.memo((props: TextEditorProps) => {
     ref: myElement,
     id: TextEditorSpanId,
     style: {
+      // Ensure that font and text settings are inherited from
+      // the containing element:
+      ...mapArrayToDictionary<keyof CSSProperties, 'inherit', keyof CSSProperties>(
+        TextRelatedProperties,
+        (key) => key,
+        () => 'inherit',
+      ),
       // These properties need to be set to get the positioning that
       // is required of the text editor element itself:
       display: 'inline-block',
@@ -354,9 +361,6 @@ const TextEditor = React.memo((props: TextEditorProps) => {
       height: '100%',
       // text editor outline
       boxShadow: `0px 0px 0px ${outlineWidth}px ${outlineColor}`,
-      // Ensure that font and text settings are inherited from
-      // the containing element:
-      ...arrayToObject(TextRelatedProperties, () => 'inherit'),
       // Prevent double applying these properties:
       opacity: 1,
     },


### PR DESCRIPTION
**Problem:**
This commit: https://github.com/concrete-utopia/utopia/commit/df184f0ab441b399d9fcbf909cb5978bbcc3a7a5 caused the object that was spread into the style properties to be incorrectly constructed thereby undoing the original work.

**Fix:**
Changed how the object was constructed to make it apply the values of the array to the keys of the object not the other way around.

**Commit Details:**
- Used `mapArrayToDictionary` instead of `arrayToObject` so that the values in the object that is spread into the `style` properties have `'inherit'` for the values and using the array values as the keys.
