### PR TITLE
`foldAndApplyCommandsSimple` shouldn't apply `mid-interaction` commands

### DIFF
--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -189,10 +189,12 @@ export function foldAndApplyCommandsSimple(
   editorState: EditorState,
   commands: Array<CanvasCommand>,
 ): EditorState {
-  const updatedEditorState = commands.reduce((workingEditorState, command) => {
-    const patches = runCanvasCommand(workingEditorState, command, 'end-interaction')
-    return updateEditorStateWithPatches(workingEditorState, patches.editorStatePatches)
-  }, editorState)
+  const updatedEditorState = commands
+    .filter((c) => c.whenToRun === 'always' || c.whenToRun === 'on-complete')
+    .reduce((workingEditorState, command) => {
+      const patches = runCanvasCommand(workingEditorState, command, 'end-interaction')
+      return updateEditorStateWithPatches(workingEditorState, patches.editorStatePatches)
+    }, editorState)
 
   return updatedEditorState
 }


### PR DESCRIPTION
## Description

This PR changes `foldAndApplyCommandsSimple` so that it doesn't apply any commands that are set to execute `mid-interaction`. The reason for this is that if executed, these commands will make their way into the new editor state, and can break undo (which is not designed to deal with maintaining ephemeral state).

The concrete bug that let us discover this was the following: when an element was pasted into the hierarchy, and the paste was undone, the editor got stuck displaying the "operation not permitted cursor". The reason for this was the pasting reused a reparent strategy helper function, `getReparentOutcome`, which put the element path of the pasted element into a piece of canvas control state called `reparentedToPaths`. A fix introduced in https://github.com/concrete-utopia/utopia/pull/2462 had a function that checked the paths in `reparentedToPath`, and if one of these paths weren't in `spyMetadata`, the "operation not permitted cursor" was displayed (see the original PR https://github.com/concrete-utopia/utopia/pull/2462 for details). `reparentedToPaths` wasn't reset on undo, the element path of the pasted element stayed there until a reload, triggering the mistaken cursor (since the element was deleted on undo, so it's only natural that its element path wasn't in `spyMetadata`).

The reason why the element path of the pasted element got added to `reparentedToPaths` in the first place was the command which added it, `AddToReparentedToPaths` was ran with `mid-interaction`. `foldAndApplyCommandsSimple` didn't filter it, and ran it as it were a command that was supposed to alter the editor state in a non-transient way.