### PR TITLE
Trigger canvas controls via the inspector padding controls

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -142,7 +142,7 @@
     "immutability-helper": "3.1.1",
     "istextorbinary": "5.11.0",
     "jest-fetch-mock": "3.0.1",
-    "jotai": "^1.4.2",
+    "jotai": "2.0.0",
     "json5": "0.5.1",
     "jszip": "3.5.0",
     "keycode": "2.2.1",

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -157,7 +157,7 @@ specifiers:
   jest-fetch-mock: 3.0.1
   jest-matcher-deep-close-to: 2.0.1
   jest-transform-stub: 2.0.0
-  jotai: ^1.4.2
+  jotai: 2.0.0
   jsdom: 17.0.0
   json5: 0.5.1
   jszip: 3.5.0
@@ -323,7 +323,7 @@ dependencies:
   immutability-helper: 3.1.1
   istextorbinary: 5.11.0
   jest-fetch-mock: 3.0.1
-  jotai: 1.4.2_c8568ef6511711a4cdb79f0a6d5315db
+  jotai: 2.0.0_react@18.1.0
   json5: 0.5.1
   jszip: 3.5.0
   keycode: 2.2.1
@@ -5989,7 +5989,7 @@ packages:
     dev: true
 
   /component-indexof/0.0.3:
-    resolution: {integrity: sha1-EdCRMSI5648yyPJa6csAL/6NPCQ=}
+    resolution: {integrity: sha512-puDQKvx/64HZXb4hBwIcvQLaLgux8o1CbWl39s41hrIIZDl1lJiD5jc22gj3RBeGK0ovxALDYpIbyjqDUUl0rw==}
     dev: false
 
   /compressible/2.0.18:
@@ -10418,44 +10418,16 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jotai/1.4.2_c8568ef6511711a4cdb79f0a6d5315db:
-    resolution: {integrity: sha512-/NcK8DGvfGcVCqoOvjWIo8/KaUYtadXEl+6uxLiQJUxbyiqCtXkhAdrugk5jmpAFXXD2y6fNDw2Ln7h0EuY+ng==}
-    engines: {node: '>=12.7.0'}
+  /jotai/2.0.0_react@18.1.0:
+    resolution: {integrity: sha512-04G0CRZQgp3xrFAezd6X14psZ2TRGekHeYMBcbDJ/BR8ZJQPS+j0YkMTxUxyG58HJnN2+adfj5sWQWoqgtp1XQ==}
+    engines: {node: '>=12.20.0'}
     peerDependencies:
-      '@babel/core': '*'
-      '@babel/template': '*'
-      '@urql/core': '*'
-      immer: '*'
-      optics-ts: '*'
-      react: '>=16.8'
-      react-query: '*'
-      valtio: '*'
-      wonka: '*'
-      xstate: '*'
+      react: '>=17.0.0'
     peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@babel/template':
-        optional: true
-      '@urql/core':
-        optional: true
-      immer:
-        optional: true
-      optics-ts:
-        optional: true
-      react-query:
-        optional: true
-      valtio:
-        optional: true
-      wonka:
-        optional: true
-      xstate:
+      react:
         optional: true
     dependencies:
-      '@babel/core': 7.15.5
-      immer: 3.2.0
       react: 18.1.0
-      xstate: 4.23.1
     dev: false
 
   /js-base64/2.6.4:

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -57,6 +57,11 @@ import { TextEditableControl } from './text-editable-control'
 import { TextEditCanvasOverlay } from './text-edit-mode/text-edit-canvas-overlay'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { AbsoluteChildrenOutline } from './absolute-children-outline'
+import { useAtom } from 'jotai'
+import {
+  InspectorFocusedCanvasControls,
+  InspectorHoveredCanvasControls,
+} from '../../inspector/common/inspector-atoms'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
@@ -222,6 +227,8 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
   const dispatch = useDispatch()
   const colorTheme = useColorTheme()
   const strategyControls = useGetApplicableStrategyControls()
+  const [inspectorHoveredControls] = useAtom(InspectorHoveredCanvasControls)
+  const [inspectorFocusedControls] = useAtom(InspectorFocusedCanvasControls)
 
   const anyStrategyActive = useEditorState(
     Substores.restOfStore,
@@ -401,6 +408,12 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       {when(
         resizeStatus !== 'disabled',
         <>
+          {inspectorFocusedControls.map((c) => (
+            <RenderControlMemoized key={c.key} control={c.control} propsForControl={c.props} />
+          ))}
+          {inspectorHoveredControls.map((c) => (
+            <RenderControlMemoized key={c.key} control={c.control} propsForControl={c.props} />
+          ))}
           {when(isSelectMode(editorMode) && !anyStrategyActive, <PinLines />)}
           {when(isSelectMode(editorMode), <InsertionControls />)}
           {renderHighlightControls()}

--- a/editor/src/components/canvas/controls/select-mode/subdued-padding-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/subdued-padding-control.tsx
@@ -20,7 +20,6 @@ interface SubduedPaddingControlProps {
 
 export const SubduedPaddingControl = React.memo<SubduedPaddingControlProps>((props) => {
   const { side, hoveredOrFocused, targets } = props
-  // TODO can we get away with ref editor state here?
   const elementMetadata = useRefEditorState((store) => store.editor.jsxMetadata)
 
   const isHorizontalPadding = side === 'left' || side === 'right'
@@ -59,9 +58,17 @@ export const SubduedPaddingControl = React.memo<SubduedPaddingControlProps>((pro
           position: 'absolute',
           border: `1px ${solidOrDashed} ${color}`,
         }}
+        data-testid={getSubduedPaddingControlTestID(side, hoveredOrFocused)}
       />
     </CanvasOffsetWrapper>
   )
 })
+
+export function getSubduedPaddingControlTestID(
+  side: EdgePiece,
+  hoveredOrFocused: 'hovered' | 'focused',
+): string {
+  return `SubduedPaddingControl-${side}-${hoveredOrFocused}`
+}
 
 const numberToPxValue = (n: number) => n + 'px'

--- a/editor/src/components/canvas/controls/select-mode/subdued-padding-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/subdued-padding-control.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { ElementPath } from '../../../../core/shared/project-file-types'
+import { useColorTheme } from '../../../../uuiui'
+import { useRefEditorState } from '../../../editor/store/store-hook'
+import { EdgePiece } from '../../canvas-types'
+import {
+  combinePaddings,
+  paddingFromSpecialSizeMeasurements,
+  paddingPropForEdge,
+  simplePaddingFromMetadata,
+} from '../../padding-utils'
+import { useBoundingBox } from '../bounding-box-hooks'
+import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
+
+interface SubduedPaddingControlProps {
+  side: EdgePiece
+  hoveredOrFocused: 'hovered' | 'focused'
+  targets: Array<ElementPath>
+}
+
+export const SubduedPaddingControl = React.memo<SubduedPaddingControlProps>((props) => {
+  const { side, hoveredOrFocused, targets } = props
+  // TODO can we get away with ref editor state here?
+  const elementMetadata = useRefEditorState((store) => store.editor.jsxMetadata)
+
+  const isHorizontalPadding = side === 'left' || side === 'right'
+  const isVerticalPadding = !isHorizontalPadding
+  const paddingKey = paddingPropForEdge(side)
+
+  // TODO Multiselect
+  const sideRef = useBoundingBox(targets, (ref, boundingBox) => {
+    const padding = simplePaddingFromMetadata(elementMetadata.current, targets[0])
+    const paddingValue = padding[paddingKey]?.renderedValuePx ?? 0
+
+    const { x, y, width, height } = boundingBox
+    const left = side === 'right' ? x + width - paddingValue : x
+    const top = side === 'bottom' ? y + height - paddingValue : y
+
+    ref.current.style.display = 'block'
+    ref.current.style.left = `${left}px`
+    ref.current.style.top = `${top}px`
+    ref.current.style.height = isVerticalPadding
+      ? numberToPxValue(paddingValue)
+      : numberToPxValue(boundingBox.height)
+    ref.current.style.width = isHorizontalPadding
+      ? numberToPxValue(paddingValue)
+      : numberToPxValue(boundingBox.width)
+  })
+
+  const color = useColorTheme().brandNeonPink.value
+
+  const solidOrDashed = hoveredOrFocused === 'focused' ? 'solid' : 'dashed'
+
+  return (
+    <CanvasOffsetWrapper>
+      <div
+        ref={sideRef}
+        style={{
+          position: 'absolute',
+          border: `1px ${solidOrDashed} ${color}`,
+        }}
+      />
+    </CanvasOffsetWrapper>
+  )
+})
+
+const numberToPxValue = (n: number) => n + 'px'

--- a/editor/src/components/inspector/common/inspector-atoms.ts
+++ b/editor/src/components/inspector/common/inspector-atoms.ts
@@ -1,3 +1,12 @@
 import { atom } from 'jotai'
 
 export const InspectorWidthAtom = atom<'regular' | 'wide'>('regular')
+
+export interface CanvasControlWithProps<P> {
+  control: React.NamedExoticComponent<P>
+  props: P
+  key: string
+}
+
+export const InspectorHoveredCanvasControls = atom<Array<CanvasControlWithProps<any>>>([])
+export const InspectorFocusedCanvasControls = atom<Array<CanvasControlWithProps<any>>>([])

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -39,6 +39,7 @@ import { createCodeFile } from '../../custom-code/code-file.test-utils'
 import { matchInlineSnapshotBrowser } from '../../../../test/karma-snapshots'
 import { EditorAction } from '../../editor/action-types'
 import { expectSingleUndoStep } from '../../../utils/utils.test-utils'
+import { getSubduedPaddingControlTestID } from '../../canvas/controls/select-mode/subdued-padding-control'
 
 async function getControl(
   controlTestId: string,
@@ -2193,6 +2194,133 @@ describe('inspector tests with real metadata', () => {
         expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
           makeTestProjectCodeWithSnippet(tt.endSnippet),
         )
+      })
+    })
+  })
+
+  describe('canvas padding controls from the inspector', () => {
+    function makeCodeSnippetWithKeyValue(props: { [key: string]: any }): string {
+      const propsStr = Object.keys(props)
+        .map((k) => `${k}: ${JSON.stringify(props[k])},`)
+        .join('\n')
+      return `
+        <div
+          data-uid='aaa'
+        >
+          <div
+            style={{ ${propsStr} }}
+            data-uid='bbb'
+          >test</div>
+        </div>
+    `
+    }
+
+    const tests = [
+      {
+        name: 'single value shows controls on all sides',
+        startSnippet: makeCodeSnippetWithKeyValue({ padding: '50px' }),
+        controlTestID: 'padding-one',
+        hoveredCanvasControls: [
+          getSubduedPaddingControlTestID('top', 'hovered'),
+          getSubduedPaddingControlTestID('right', 'hovered'),
+          getSubduedPaddingControlTestID('bottom', 'hovered'),
+          getSubduedPaddingControlTestID('left', 'hovered'),
+        ],
+        focusedCanvasControls: [
+          getSubduedPaddingControlTestID('top', 'focused'),
+          getSubduedPaddingControlTestID('right', 'focused'),
+          getSubduedPaddingControlTestID('bottom', 'focused'),
+          getSubduedPaddingControlTestID('left', 'focused'),
+        ],
+      },
+      {
+        name: 'per-direction H value shows controls on horizontal sides',
+        startSnippet: makeCodeSnippetWithKeyValue({ padding: '50px 60px' }),
+        controlTestID: 'padding-H',
+        hoveredCanvasControls: [
+          getSubduedPaddingControlTestID('right', 'hovered'),
+          getSubduedPaddingControlTestID('left', 'hovered'),
+        ],
+        focusedCanvasControls: [
+          getSubduedPaddingControlTestID('right', 'focused'),
+          getSubduedPaddingControlTestID('left', 'focused'),
+        ],
+      },
+      {
+        name: 'per-direction V value shows controls on vertical sides',
+        startSnippet: makeCodeSnippetWithKeyValue({ padding: '50px 60px' }),
+        controlTestID: 'padding-V',
+        hoveredCanvasControls: [
+          getSubduedPaddingControlTestID('top', 'hovered'),
+          getSubduedPaddingControlTestID('bottom', 'hovered'),
+        ],
+        focusedCanvasControls: [
+          getSubduedPaddingControlTestID('top', 'focused'),
+          getSubduedPaddingControlTestID('bottom', 'focused'),
+        ],
+      },
+      {
+        name: 'per-side T value shows controls on top side',
+        startSnippet: makeCodeSnippetWithKeyValue({ padding: '50px 60px 70px 80px' }),
+        controlTestID: 'padding-T',
+        hoveredCanvasControls: [getSubduedPaddingControlTestID('top', 'hovered')],
+        focusedCanvasControls: [getSubduedPaddingControlTestID('top', 'focused')],
+      },
+      {
+        name: 'per-side R value shows controls on right side',
+        startSnippet: makeCodeSnippetWithKeyValue({ padding: '50px 60px 70px 80px' }),
+        controlTestID: 'padding-R',
+        hoveredCanvasControls: [getSubduedPaddingControlTestID('right', 'hovered')],
+        focusedCanvasControls: [getSubduedPaddingControlTestID('right', 'focused')],
+      },
+      {
+        name: 'per-side B value shows controls on bottom side',
+        startSnippet: makeCodeSnippetWithKeyValue({ padding: '50px 60px 70px 80px' }),
+        controlTestID: 'padding-B',
+        hoveredCanvasControls: [getSubduedPaddingControlTestID('bottom', 'hovered')],
+        focusedCanvasControls: [getSubduedPaddingControlTestID('bottom', 'focused')],
+      },
+      {
+        name: 'per-side L value shows controls on left side',
+        startSnippet: makeCodeSnippetWithKeyValue({ padding: '50px 60px 70px 80px' }),
+        controlTestID: 'padding-L',
+        hoveredCanvasControls: [getSubduedPaddingControlTestID('left', 'hovered')],
+        focusedCanvasControls: [getSubduedPaddingControlTestID('left', 'focused')],
+      },
+    ]
+
+    tests.forEach((t) => {
+      it(`${t.name} when hovering and focusing`, async () => {
+        const renderResult = await renderTestEditorWithCode(
+          makeTestProjectCodeWithSnippet(t.startSnippet),
+          'await-first-dom-report',
+        )
+
+        const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
+
+        await act(async () => {
+          await renderResult.dispatch([selectComponents([targetPath], false)], false)
+        })
+
+        const control = await getControl(t.controlTestID, renderResult.renderedDOM)
+
+        // Check the controls show when hovering
+        fireEvent.mouseEnter(control)
+        await renderResult.getDispatchFollowUpActionsFinished()
+
+        const hoveredControls = t.hoveredCanvasControls.flatMap((expectedControl) =>
+          renderResult.renderedDOM.queryAllByTestId(expectedControl),
+        )
+        expect(hoveredControls.length).toEqual(t.hoveredCanvasControls.length)
+
+        // Check the controls show when focusing
+        fireEvent.focus(control)
+        await renderResult.getDispatchFollowUpActionsFinished()
+
+        const focusedControls = t.focusedCanvasControls.flatMap((expectedControl) =>
+          renderResult.renderedDOM.queryAllByTestId(expectedControl),
+        )
+        expect(focusedControls.length).toEqual(t.focusedCanvasControls.length)
       })
     })
   })

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -1,13 +1,16 @@
+import { useAtom } from 'jotai'
 import React from 'react'
 
 import { useContextSelector } from 'use-context-selector'
 import { LayoutSystem } from 'utopia-api/core'
+import { mapArrayToDictionary } from '../../../../../core/shared/array-utils'
 import {
   DetectedLayoutSystem,
   SettableLayoutSystem,
 } from '../../../../../core/shared/element-template'
 import { PropertyPath } from '../../../../../core/shared/project-file-types'
 import { FunctionIcons, SquareButton } from '../../../../../uuiui'
+import { SubduedPaddingControl } from '../../../../canvas/controls/select-mode/subdued-padding-control'
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { switchLayoutSystem } from '../../../../editor/actions/action-creators'
 import { useDispatch } from '../../../../editor/store/dispatch-context'
@@ -18,6 +21,10 @@ import {
   getControlStatusFromPropertyStatus,
   getControlStyles,
 } from '../../../common/control-status'
+import {
+  InspectorFocusedCanvasControls,
+  InspectorHoveredCanvasControls,
+} from '../../../common/inspector-atoms'
 import { useInspectorInfoLonghandShorthand } from '../../../common/longhand-shorthand-hooks'
 import {
   InspectorCallbackContext,
@@ -224,6 +231,33 @@ export const PaddingControl = React.memo(() => {
 
   const { selectedViewsRef } = useInspectorContext()
 
+  const canvasControlsForSides = React.useMemo(() => {
+    return mapArrayToDictionary(
+      ['top', 'right', 'bottom', 'left'],
+      (k) => k,
+      (side) => ({
+        onHover: {
+          control: SubduedPaddingControl,
+          props: {
+            side: side,
+            hoveredOrFocused: 'hovered',
+            targets: selectedViewsRef.current,
+          },
+          key: `subdued-padding-control-hovered-${side}`,
+        },
+        onFocus: {
+          control: SubduedPaddingControl,
+          props: {
+            side: side,
+            hoveredOrFocused: 'focused',
+            targets: selectedViewsRef.current,
+          },
+          key: `subdued-padding-control-focused-${side}`,
+        },
+      }),
+    )
+  }, [selectedViewsRef])
+
   return (
     <SplitChainedNumberInput
       controlModeOrder={['one-value', 'per-direction', 'per-side']}
@@ -241,6 +275,7 @@ export const PaddingControl = React.memo(() => {
       right={paddingRight}
       shorthand={shorthand}
       updateShorthand={updateShorthand}
+      canvasControls={canvasControlsForSides}
     />
   )
 })

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -1,4 +1,3 @@
-import { useAtom } from 'jotai'
 import React from 'react'
 
 import { useContextSelector } from 'use-context-selector'
@@ -14,6 +13,7 @@ import { SubduedPaddingControl } from '../../../../canvas/controls/select-mode/s
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { switchLayoutSystem } from '../../../../editor/actions/action-creators'
 import { useDispatch } from '../../../../editor/store/dispatch-context'
+import { useEditorState, Substores } from '../../../../editor/store/store-hook'
 import { optionalAddOnUnsetValues } from '../../../common/context-menu-items'
 import {
   ControlStatus,
@@ -21,10 +21,6 @@ import {
   getControlStatusFromPropertyStatus,
   getControlStyles,
 } from '../../../common/control-status'
-import {
-  InspectorFocusedCanvasControls,
-  InspectorHoveredCanvasControls,
-} from '../../../common/inspector-atoms'
 import { useInspectorInfoLonghandShorthand } from '../../../common/longhand-shorthand-hooks'
 import {
   InspectorCallbackContext,
@@ -230,6 +226,11 @@ export const PaddingControl = React.memo(() => {
   )
 
   const { selectedViewsRef } = useInspectorContext()
+  const selectedViews = useEditorState(
+    Substores.selectedViews,
+    (store) => store.editor.selectedViews,
+    'PaddingControl selectedViews',
+  )
 
   const canvasControlsForSides = React.useMemo(() => {
     return mapArrayToDictionary(
@@ -241,7 +242,7 @@ export const PaddingControl = React.memo(() => {
           props: {
             side: side,
             hoveredOrFocused: 'hovered',
-            targets: selectedViewsRef.current,
+            targets: selectedViews,
           },
           key: `subdued-padding-control-hovered-${side}`,
         },
@@ -250,13 +251,13 @@ export const PaddingControl = React.memo(() => {
           props: {
             side: side,
             hoveredOrFocused: 'focused',
-            targets: selectedViewsRef.current,
+            targets: selectedViews,
           },
           key: `subdued-padding-control-focused-${side}`,
         },
       }),
     )
-  }, [selectedViewsRef])
+  }, [selectedViews])
 
   return (
     <SplitChainedNumberInput

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`659`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`768`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`731`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`840`)
   })
 })

--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -3,7 +3,7 @@
 /** @jsxFrag React.Fragment */
 import { Interpolation, jsx } from '@emotion/react'
 import classNames from 'classnames'
-import React from 'react'
+import React, { MouseEventHandler } from 'react'
 import {
   cssNumber,
   CSSNumber,
@@ -143,6 +143,8 @@ export interface NumberInputProps extends AbstractNumberInputProps<CSSNumber> {
   onTransientSubmitValue?: OnSubmitValueOrUnknownOrEmpty<CSSNumber>
   onForcedSubmitValue?: OnSubmitValueOrUnknownOrEmpty<CSSNumber>
   setGlobalCursor?: (cursor: CSSCursor | null) => void
+  onMouseEnter?: MouseEventHandler
+  onMouseLeave?: MouseEventHandler
 }
 
 const ScrubThreshold = 3
@@ -172,6 +174,8 @@ export const NumberInput = React.memo<NumberInputProps>(
     numberType,
     defaultUnitToHide,
     setGlobalCursor,
+    onMouseEnter,
+    onMouseLeave,
   }) => {
     const nonNullPropsValue: CSSNumber = propsValue ?? cssNumber(0)
     const ref = React.useRef<HTMLInputElement>(null)
@@ -604,7 +608,7 @@ export const NumberInput = React.memo<NumberInputProps>(
         : undefined
 
     return (
-      <div style={style}>
+      <div style={style} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
         <div
           className='number-input-container'
           css={{


### PR DESCRIPTION
**Problem:**
We want to make it extra clear what you are changing on the canvas when hovering or focusing the padding controls in the Inspector

**Fix:**
By using a pair of `jotai` atoms we can specify which canvas controls to render when a given inspector field is either hovered or focused. This is tied to the `mouseenter`, `mouseleave`, `focus` and `blur` events of the inspector control (in this case the `SplitChainedNumberInput`), as we can rely on the ordering of the firing of those events to set the array of controls directly in both cases. The atoms are then read in `new-canvas-controls.tsx` and used to render the controls with the provided props (similarly to how we do with controls tied to canvas strategies).

![padding-inspector-canvas-controls](https://user-images.githubusercontent.com/1044774/216415666-617095ac-4a54-4816-8f31-47447b1d04fa.gif)
