### PR TITLE
hide the unit of the padding value when dragging

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -48,6 +48,7 @@ import { getDragTargets, getMultiselectBounds } from './shared-move-strategies-h
 import {
   canvasPoint,
   CanvasPoint,
+  canvasVector,
   CanvasVector,
   isInfinityRectangle,
 } from '../../../../core/shared/math-utils'
@@ -65,6 +66,7 @@ import { foldEither } from '../../../../core/shared/either'
 import { styleStringInArray } from '../../../../utils/common-constants'
 import { elementHasOnlyTextChildren } from '../../canvas-utils'
 import { Modifiers } from '../../../../utils/modifiers'
+import { printCSSNumber } from '../../../inspector/common/css-utils'
 
 const StylePaddingProp = stylePropPathMappingFn('padding', styleStringInArray)
 const IndividualPaddingProps: Array<CSSPaddingKey> = [
@@ -353,13 +355,13 @@ function paddingValueIndicatorProps(
     interactionSession == null ||
     interactionSession.interactionData.type !== 'DRAG' ||
     interactionSession.activeControl.type !== 'PADDING_RESIZE_HANDLE' ||
-    interactionSession.interactionData.drag == null ||
     filteredSelectedElements.length !== 1
   ) {
     return null
   }
 
-  const { drag, dragStart } = interactionSession.interactionData
+  const drag = interactionSession.interactionData.drag ?? canvasVector({ x: 0, y: 0 })
+  const dragStart = interactionSession.interactionData.dragStart
 
   const edgePiece = interactionSession.activeControl.edgePiece
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -66,7 +66,6 @@ import { foldEither } from '../../../../core/shared/either'
 import { styleStringInArray } from '../../../../utils/common-constants'
 import { elementHasOnlyTextChildren } from '../../canvas-utils'
 import { Modifiers } from '../../../../utils/modifiers'
-import { printCSSNumber } from '../../../inspector/common/css-utils'
 
 const StylePaddingProp = stylePropPathMappingFn('padding', styleStringInArray)
 const IndividualPaddingProps: Array<CSSPaddingKey> = [

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -171,7 +171,7 @@ export function indicatorMessage(
   value: CSSNumberWithRenderedValue,
 ): string | number {
   if (isOverThreshold) {
-    return printCSSNumber(value.value, null)
+    return printCSSNumber(value.value, value.value.unit)
   }
 
   return Emdash // emdash


### PR DESCRIPTION
> A last set of padding control improvements: hover shows padding value without px suffix (correct, since it’s the default). MouseDown on the control should keep showing that (it doesn’t today), and drag should still show it without the px suffix.