### PR TITLE
Make 4/2/1 control prefer shorthands where applicable

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -38,7 +38,7 @@ import { DefaultPackageJson, StoryboardFilePath } from '../../editor/store/edito
 import { createCodeFile } from '../../custom-code/code-file.test-utils'
 import { matchInlineSnapshotBrowser } from '../../../../test/karma-snapshots'
 import { EditorAction } from '../../editor/action-types'
-import { expectSingleUndoStep, expectUndoSteps } from '../../../utils/utils.test-utils'
+import { expectSingleUndoStep } from '../../../utils/utils.test-utils'
 
 async function getControl(
   controlTestId: string,
@@ -2095,9 +2095,7 @@ describe('inspector tests with real metadata', () => {
         name: 'with single value (2-values)',
         startSnippet: makeCodeSnippetWithKeyValue({ paddingLeft: 10 }),
         control: async (renderResult: EditorRenderResult) => {
-          await expectUndoSteps(renderResult, 2, async () => {
-            await setControlValue('padding-V', '20', renderResult.renderedDOM)
-          })
+          await setControlValue('padding-V', '20', renderResult.renderedDOM)
         },
         endSnippet: makeCodeSnippetWithKeyValue({
           paddingLeft: 10,
@@ -2117,9 +2115,7 @@ describe('inspector tests with real metadata', () => {
           })
         },
         control: async (renderResult: EditorRenderResult) => {
-          await expectUndoSteps(renderResult, 4, async () => {
-            await setControlValue('padding-one', '20', renderResult.renderedDOM)
-          })
+          await setControlValue('padding-one', '20', renderResult.renderedDOM)
         },
         endSnippet: makeCodeSnippetWithKeyValue({
           paddingLeft: 20,
@@ -2140,9 +2136,7 @@ describe('inspector tests with real metadata', () => {
           })
         },
         control: async (renderResult: EditorRenderResult) => {
-          await expectUndoSteps(renderResult, 4, async () => {
-            await setControlValue('padding-one', '20', renderResult.renderedDOM)
-          })
+          await setControlValue('padding-one', '20', renderResult.renderedDOM)
         },
         endSnippet: makeCodeSnippetWithKeyValue({
           paddingLeft: 20,

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -38,6 +38,7 @@ import { DefaultPackageJson, StoryboardFilePath } from '../../editor/store/edito
 import { createCodeFile } from '../../custom-code/code-file.test-utils'
 import { matchInlineSnapshotBrowser } from '../../../../test/karma-snapshots'
 import { EditorAction } from '../../editor/action-types'
+import { expectSingleUndoStep, expectUndoSteps } from '../../../utils/utils.test-utils'
 
 async function getControl(
   controlTestId: string,
@@ -2073,19 +2074,31 @@ describe('inspector tests with real metadata', () => {
       {
         name: 'without props',
         startSnippet: makeCodeSnippetWithKeyValue({}),
-        control: async (dom: any) => setControlValue('padding-V', '20', dom),
+        control: async (renderResult: EditorRenderResult) => {
+          await expectSingleUndoStep(renderResult, async () => {
+            await setControlValue('padding-V', '20', renderResult.renderedDOM)
+          })
+        },
         endSnippet: makeCodeSnippetWithKeyValue({ padding: '20px 0px' }),
       },
       {
         name: 'with shorthand',
         startSnippet: makeCodeSnippetWithKeyValue({ padding: 10 }),
-        control: async (dom: any) => setControlValue('padding-one', '20', dom),
+        control: async (renderResult: EditorRenderResult) => {
+          await expectSingleUndoStep(renderResult, async () => {
+            await setControlValue('padding-one', '20', renderResult.renderedDOM)
+          })
+        },
         endSnippet: makeCodeSnippetWithKeyValue({ padding: 20 }),
       },
       {
         name: 'with single value (2-values)',
         startSnippet: makeCodeSnippetWithKeyValue({ paddingLeft: 10 }),
-        control: async (dom: any) => setControlValue('padding-V', '20', dom),
+        control: async (renderResult: EditorRenderResult) => {
+          await expectUndoSteps(renderResult, 2, async () => {
+            await setControlValue('padding-V', '20', renderResult.renderedDOM)
+          })
+        },
         endSnippet: makeCodeSnippetWithKeyValue({
           paddingLeft: 10,
           paddingTop: 20,
@@ -2103,7 +2116,11 @@ describe('inspector tests with real metadata', () => {
             await renderResult.getDispatchFollowUpActionsFinished()
           })
         },
-        control: async (dom: any) => setControlValue('padding-one', '20', dom),
+        control: async (renderResult: EditorRenderResult) => {
+          await expectUndoSteps(renderResult, 4, async () => {
+            await setControlValue('padding-one', '20', renderResult.renderedDOM)
+          })
+        },
         endSnippet: makeCodeSnippetWithKeyValue({
           paddingLeft: 20,
           paddingTop: 20,
@@ -2122,7 +2139,11 @@ describe('inspector tests with real metadata', () => {
             await renderResult.getDispatchFollowUpActionsFinished()
           })
         },
-        control: async (dom: any) => setControlValue('padding-one', '20', dom),
+        control: async (renderResult: EditorRenderResult) => {
+          await expectUndoSteps(renderResult, 4, async () => {
+            await setControlValue('padding-one', '20', renderResult.renderedDOM)
+          })
+        },
         endSnippet: makeCodeSnippetWithKeyValue({
           paddingLeft: 20,
           paddingRight: 20,
@@ -2139,7 +2160,11 @@ describe('inspector tests with real metadata', () => {
             await renderResult.getDispatchFollowUpActionsFinished()
           })
         },
-        control: async (dom: any) => setControlValue('padding-H', '20', dom),
+        control: async (renderResult: EditorRenderResult) => {
+          await expectSingleUndoStep(renderResult, async () => {
+            await setControlValue('padding-H', '20', renderResult.renderedDOM)
+          })
+        },
         endSnippet: makeCodeSnippetWithKeyValue({ padding: '10px 20px' }),
       },
     ]
@@ -2161,7 +2186,7 @@ describe('inspector tests with real metadata', () => {
           await tt.before(renderResult)
           await renderResult.getDispatchFollowUpActionsFinished()
         }
-        await tt.control(renderResult.renderedDOM)
+        await tt.control(renderResult)
 
         await act(async () => {
           const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -241,6 +241,7 @@ export const PaddingControl = React.memo(() => {
       right={paddingRight}
       shorthand={shorthand}
       updateShorthand={updateShorthand}
+      numberType={'Px'}
     />
   )
 })

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -241,7 +241,7 @@ export const PaddingControl = React.memo(() => {
       right={paddingRight}
       shorthand={shorthand}
       updateShorthand={updateShorthand}
-      numberType={'Px'}
+      numberType={'Length'}
     />
   )
 })

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -241,7 +241,7 @@ export const PaddingControl = React.memo(() => {
       right={paddingRight}
       shorthand={shorthand}
       updateShorthand={updateShorthand}
-      numberType={'Length'}
+      numberType={'LengthPercent'}
     />
   )
 })

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
@@ -12,7 +12,12 @@ import {
 } from '../../../../../uuiui'
 import { useRefEditorState } from '../../../../editor/store/store-hook'
 import { ControlStatus, PropertyStatus } from '../../../common/control-status'
-import { CSSNumber, isCSSNumber, UnknownOrEmptyInput } from '../../../common/css-utils'
+import {
+  CSSNumber,
+  CSSNumberType,
+  isCSSNumber,
+  UnknownOrEmptyInput,
+} from '../../../common/css-utils'
 import { InspectorInfo } from '../../../common/property-path-hooks'
 
 export type ControlMode =
@@ -99,6 +104,7 @@ export interface SplitChainedNumberInputProps<T> {
     perDirection?: string
     perSide?: string
   }
+  numberType: CSSNumberType
 }
 
 function getInitialMode(
@@ -160,7 +166,7 @@ const onSubmitValueShorthand =
   }
 
 export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInputProps<any>) => {
-  const { name, top, left, bottom, right, controlModeOrder } = props
+  const { name, top, left, bottom, right, controlModeOrder, numberType } = props
 
   const [oneValue, setOneValue] = React.useState<CSSNumber | null>(null)
   const [horizontal, setHorizontal] = React.useState<CSSNumber | null>(null)
@@ -247,8 +253,16 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
   }, [isCmdPressedRef, mode, controlModeOrder])
 
   const updateShorthandIfUsed = React.useMemo(() => {
-    return props.shorthand.controlStatus === 'simple' ? props.updateShorthand : null
-  }, [props.shorthand, props.updateShorthand])
+    const allUnset =
+      top.controlStatus === 'trivial-default' &&
+      bottom.controlStatus === 'trivial-default' &&
+      left.controlStatus === 'trivial-default' &&
+      right.controlStatus === 'trivial-default'
+
+    const useShorthand = props.shorthand.controlStatus === 'simple' || allUnset
+
+    return useShorthand ? props.updateShorthand : null
+  }, [props.shorthand, props.updateShorthand, top, bottom, left, right])
 
   const onSubmitValueOne = React.useCallback(
     (transient: boolean) => () => {
@@ -295,7 +309,7 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
               minimum: 0,
               onSubmitValue: onSubmitValueOne(false)(),
               onTransientSubmitValue: onSubmitValueOne(true)(),
-              numberType: 'LengthPercent',
+              numberType: numberType,
               defaultUnitToHide: 'px',
               controlStatus: allSides[0].controlStatus,
               testId: `${name}-one`,
@@ -309,7 +323,7 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
               minimum: 0,
               onSubmitValue: onSubmitValueHorizontal(false)(),
               onTransientSubmitValue: onSubmitValueHorizontal(true)(),
-              numberType: 'LengthPercent',
+              numberType: numberType,
               controlStatus: sidesHorizontal[0].controlStatus,
               defaultUnitToHide: 'px',
               testId: `${name}-H`,
@@ -320,7 +334,7 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
               minimum: 0,
               onSubmitValue: onSubmitValueVertical(false)(),
               onTransientSubmitValue: onSubmitValueVertical(true)(),
-              numberType: 'LengthPercent',
+              numberType: numberType,
               controlStatus: sidesVertical[0].controlStatus,
               defaultUnitToHide: 'px',
               testId: `${name}-V`,
@@ -335,7 +349,7 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
               onSubmitValue: onSubmitValue(top),
               onTransientSubmitValue: onTransientSubmitValue(top),
               controlStatus: top.controlStatus,
-              numberType: 'LengthPercent',
+              numberType: numberType,
               defaultUnitToHide: 'px',
               testId: `${name}-T`,
             },
@@ -346,7 +360,7 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
               onSubmitValue: onSubmitValue(right),
               onTransientSubmitValue: onTransientSubmitValue(right),
               controlStatus: right.controlStatus,
-              numberType: 'LengthPercent',
+              numberType: numberType,
               defaultUnitToHide: 'px',
               testId: `${name}-R`,
             },
@@ -357,7 +371,7 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
               onSubmitValue: onSubmitValue(bottom),
               onTransientSubmitValue: onTransientSubmitValue(bottom),
               controlStatus: bottom.controlStatus,
-              numberType: 'LengthPercent',
+              numberType: numberType,
               defaultUnitToHide: 'px',
               testId: `${name}-B`,
             },
@@ -368,7 +382,7 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
               onSubmitValue: onSubmitValue(left),
               onTransientSubmitValue: onTransientSubmitValue(left),
               controlStatus: left.controlStatus,
-              numberType: 'LengthPercent',
+              numberType: numberType,
               defaultUnitToHide: 'px',
               testId: `${name}-L`,
             },
@@ -395,6 +409,7 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
       onSubmitValueOne,
       onSubmitValueHorizontal,
       onSubmitValueVertical,
+      numberType,
     ])
 
   const tooltipTitle = React.useMemo(() => {

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
@@ -445,7 +445,9 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
   return (
     <div style={{ display: 'flex', flexDirection: 'row', gap: 4 }}>
       <Tooltip title={tooltipTitle}>
-        <SquareButton onClick={cycleToNextMode}>{modeIcon}</SquareButton>
+        <SquareButton data-testid={`${name}-cycle-mode`} onClick={cycleToNextMode}>
+          {modeIcon}
+        </SquareButton>
       </Tooltip>
       <ChainedNumberInput
         idPrefix={name}

--- a/editor/src/components/inspector/sections/style-section/container-subsection/radius-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/radius-row.tsx
@@ -260,6 +260,7 @@ export const BorderRadiusControl = React.memo(() => {
         perSide: 'Radius per corner',
       }}
       controlModeOrder={['one-value', 'per-side']}
+      numberType={'LengthPercent'}
       selectedViews={selectedViewsRef.current}
       name='radius'
       defaultMode='one-value'

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -425,10 +425,18 @@ export async function expectSingleUndoStep(
   editor: EditorRenderResult,
   action: () => Promise<void>,
 ): Promise<void> {
+  await expectUndoSteps(editor, 1, action)
+}
+
+export async function expectUndoSteps(
+  editor: EditorRenderResult,
+  steps: number,
+  action: () => Promise<void>,
+): Promise<void> {
   const historySizeBefore = editor.getEditorState().history.previous.length
   await action()
   const historySizeAfter = editor.getEditorState().history.previous.length
-  expect(historySizeAfter - historySizeBefore).toEqual(1)
+  expect(historySizeAfter - historySizeBefore).toEqual(steps)
 }
 
 export async function selectComponentsForTest(

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -425,18 +425,10 @@ export async function expectSingleUndoStep(
   editor: EditorRenderResult,
   action: () => Promise<void>,
 ): Promise<void> {
-  await expectUndoSteps(editor, 1, action)
-}
-
-export async function expectUndoSteps(
-  editor: EditorRenderResult,
-  steps: number,
-  action: () => Promise<void>,
-): Promise<void> {
   const historySizeBefore = editor.getEditorState().history.previous.length
   await action()
   const historySizeAfter = editor.getEditorState().history.previous.length
-  expect(historySizeAfter - historySizeBefore).toEqual(steps)
+  expect(historySizeAfter - historySizeBefore).toEqual(1)
 }
 
 export async function selectComponentsForTest(


### PR DESCRIPTION
Fixes #3238 

**Problem:**

The 4/2/1 controls doesn't use the shorthand notation when it would make sense to do so, e.g. when there are no other values set for the same property.

**Fix:**

This PR will make the 4/2/1 controls prefer the shorthand notation whenever it makes sense to use it. If instead other values are set that would make the shorthand notation be redundant/confusing, the individual values will be updated instead.

Examples:

| Case                                             | Example                                                                                                                                     |
| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
| 1-value with empty prop                          | ![1](https://user-images.githubusercontent.com/1081051/216572762-4407c9c4-cb88-4a66-9e5b-1f608ff93aa4.gif)                              |
| 2-values with empty prop                         | ![2](https://user-images.githubusercontent.com/1081051/216572812-860e6e7b-b4d3-4aa5-859a-c70f6767e0d3.gif)                              |
| 4-values with empty prop                         | ![3](https://user-images.githubusercontent.com/1081051/216572865-47fa9586-ba08-41b8-85da-8bde23091100.gif)                              |
| 2-values with shorthand but no individual values | ![4](https://user-images.githubusercontent.com/1081051/216572917-326d9040-8db8-4086-b376-a63c2c33d778.gif)                              |
| 4-values with shorthand but no individual values | ![5](https://user-images.githubusercontent.com/1081051/216573007-c4361374-8c57-45d2-9175-9b0a165b6452.gif)                              |
| 1-value with individual values                   | ![6](https://user-images.githubusercontent.com/1081051/216573551-2c30dead-2d98-4f2a-a122-2ad40a55b31f.gif)                              |
| 2-values with individual values                  | ![Kapture 2023-02-03 at 11 12 57](https://user-images.githubusercontent.com/1081051/216573943-547e6a0d-b330-468e-85e0-657969066dce.gif) |

Additionally, the PR makes the `numberType` customizable, setting it to `LengthPercent` for the border radius control and `Length` for the padding control.