### PR TITLE
Fix flicker when exiting text editor

### DIFF
--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -430,6 +430,8 @@ describe('Use the text editor', () => {
 
         await wait(50) // give it time to adjust the caret position
 
+        typeText('l')
+
         await closeTextEditor()
         await editor.getDispatchFollowUpActionsFinished()
 
@@ -446,7 +448,7 @@ describe('Use the text editor', () => {
               data-testid='first-div'
               data-uid='first-div'
             >
-              Hello this
+              Helllo this
             </div>
             <div
               style={{ backgroundColor: 'red' }}

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -22,7 +22,7 @@ describe('Use the text editor', () => {
 
     await enterTextEditMode(editor)
     typeText(' Utopia')
-    await closeTextEditor()
+    await expectSingleUndoStep(editor, async () => closeTextEditor())
     await editor.getDispatchFollowUpActionsFinished()
 
     expect(editor.getEditorState().editor.mode.type).toEqual('select')
@@ -55,7 +55,7 @@ describe('Use the text editor', () => {
 
     await enterTextEditMode(editor)
     typeText('Utopia')
-    await closeTextEditor()
+    await expectSingleUndoStep(editor, async () => closeTextEditor())
     await editor.getDispatchFollowUpActionsFinished()
 
     expect(editor.getEditorState().editor.mode.type).toEqual('select')
@@ -120,7 +120,7 @@ describe('Use the text editor', () => {
 
     await enterTextEditMode(editor)
     typeText('this is a <test> with bells & whistles')
-    await closeTextEditor()
+    await expectSingleUndoStep(editor, async () => closeTextEditor())
     await editor.getDispatchFollowUpActionsFinished()
 
     expect(editor.getEditorState().editor.mode.type).toEqual('select')

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -279,9 +279,7 @@ const TextEditor = React.memo((props: TextEditorProps) => {
         } else {
           if (elementState != null && savedContentRef.current !== content) {
             savedContentRef.current = content
-            requestAnimationFrame(() =>
-              dispatch([updateChildText(elementPath, escapeHTML(content))]),
-            )
+            requestAnimationFrame(() => dispatch([getSaveAction(elementPath, content)]))
           }
         }
       }
@@ -346,10 +344,7 @@ const TextEditor = React.memo((props: TextEditorProps) => {
     const content = myElement.current?.textContent
     if (content != null && elementState != null && savedContentRef.current !== content) {
       savedContentRef.current = content
-      dispatch([
-        updateChildText(elementPath, escapeHTML(content)),
-        updateEditorMode(EditorModes.selectMode()),
-      ])
+      dispatch([getSaveAction(elementPath, content), updateEditorMode(EditorModes.selectMode())])
     } else {
       dispatch([updateEditorMode(EditorModes.selectMode())])
     }
@@ -487,4 +482,8 @@ function filterEventHandlerProps(props: Record<string, any>) {
     ...filteredProps
   } = props
   return filteredProps
+}
+
+function getSaveAction(elementPath: ElementPath, content: string): EditorAction {
+  return updateChildText(elementPath, escapeHTML(content))
 }

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -238,6 +238,8 @@ const TextEditor = React.memo((props: TextEditorProps) => {
 
   const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
 
+  const savedContentRef = React.useRef<string | null>(null)
+
   const scale = useEditorState(
     Substores.canvasOffset,
     (store) => store.editor.canvas.scale,
@@ -259,6 +261,7 @@ const TextEditor = React.memo((props: TextEditorProps) => {
     }
 
     currentElement.focus()
+    savedContentRef.current = currentElement.textContent
 
     const elementCanvasFrame = MetadataUtils.getFrameOrZeroRectInCanvasCoords(
       elementPath,
@@ -272,10 +275,13 @@ const TextEditor = React.memo((props: TextEditorProps) => {
       const content = currentElement.textContent
       if (content != null) {
         if (elementState === 'new' && content.replace(/\n/g, '') === '') {
-          setTimeout(() => dispatch([deleteView(elementPath)]))
+          requestAnimationFrame(() => dispatch([deleteView(elementPath)]))
         } else {
-          if (elementState != null) {
-            setTimeout(() => dispatch([updateChildText(elementPath, escapeHTML(content))]))
+          if (elementState != null && savedContentRef.current !== content) {
+            savedContentRef.current = content
+            requestAnimationFrame(() =>
+              dispatch([updateChildText(elementPath, escapeHTML(content))]),
+            )
           }
         }
       }
@@ -337,8 +343,17 @@ const TextEditor = React.memo((props: TextEditorProps) => {
   )
 
   const onBlur = React.useCallback(() => {
-    dispatch([updateEditorMode(EditorModes.selectMode())])
-  }, [dispatch])
+    const content = myElement.current?.textContent
+    if (content != null && elementState != null && savedContentRef.current !== content) {
+      savedContentRef.current = content
+      dispatch([
+        updateChildText(elementPath, escapeHTML(content)),
+        updateEditorMode(EditorModes.selectMode()),
+      ])
+    } else {
+      dispatch([updateEditorMode(EditorModes.selectMode())])
+    }
+  }, [dispatch, elementPath, elementState])
 
   const editorProps: React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLSpanElement>,


### PR DESCRIPTION
**Problem:**
Text flickers back to original state for a frame when exiting the text editor.

**Fix:**
The reason is twofold:
1) We save the text when the text editor unmounts
2) We do the save in a setTimeout (since this: https://github.com/concrete-utopia/utopia/pull/3166 )

I brought the save dispatch to an earlier phase with two methods:
1) I save text in the `onBlur` handler - that happens earlier than the unmount, because we go to select mode in the blur handler, and then the text editor unmounts, because in select mode it is not rendered
2) I use `requestAnimationFrame` instead of `setTimeout` in unmount

I thought about completely removing the save on unmount, but that sounds a bit unsafe. If the editor goes to select mode from a different source, it could happen that the blur handler is never called (the blur handler is not called when a focused element is unmounted without losing focus).

This solution could result in a double save, which we should avoid (we don't want to have 2 undo steps). So I added an extra check before save whether there is real change in the text content. This is advantageous anyway, because it avoids adding an unnecessary undo step when you leave the text editor with unmodified content. Because of this change I needed to update one test to contain an editing operation.