### PR TITLE
invert padding drag delta when container is set to hug

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -1,6 +1,6 @@
 import { assertNever } from '../../../../core/shared/utils'
 import { cmdModifier, Modifiers, shiftModifier } from '../../../../utils/modifiers'
-import { wait } from '../../../../utils/utils.test-utils'
+import { expectSingleUndoStep, wait } from '../../../../utils/utils.test-utils'
 import { cssNumber } from '../../../inspector/common/css-utils'
 import { EdgePiece } from '../../canvas-types'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
@@ -817,7 +817,9 @@ async function testPaddingResizeForEdge(
     alt: mode === 'cross-axis' || mode === 'all',
     shift: mode === 'all',
   }
-  mouseDragFromPointToPoint(paddingControl, paddingControlCenter, endPoint, { modifiers })
+  await expectSingleUndoStep(editor, async () =>
+    mouseDragFromPointToPoint(paddingControl, paddingControlCenter, endPoint, { modifiers }),
+  )
   await editor.getDispatchFollowUpActionsFinished()
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -671,11 +671,11 @@ describe('Padding resize strategy', () => {
     // eslint-disable-next-line jest/expect-expect
     it('top', async () => testAdjustIndividualPaddingValue('top', 'precise'))
     // eslint-disable-next-line jest/expect-expect
-    it('bottom', async () => testAdjustIndividualPaddingValue('top', 'precise'))
+    it('bottom', async () => testAdjustIndividualPaddingValue('bottom', 'precise'))
     // eslint-disable-next-line jest/expect-expect
-    it('left', async () => testAdjustIndividualPaddingValue('top', 'precise'))
+    it('left', async () => testAdjustIndividualPaddingValue('left', 'precise'))
     // eslint-disable-next-line jest/expect-expect
-    it('right', async () => testAdjustIndividualPaddingValue('top', 'precise'))
+    it('right', async () => testAdjustIndividualPaddingValue('right', 'precise'))
   })
 
   describe('Adjusting individual padding values, coarse', () => {
@@ -683,11 +683,31 @@ describe('Padding resize strategy', () => {
     // eslint-disable-next-line jest/expect-expect
     it('top', async () => testAdjustIndividualPaddingValue('top', 'coarse'))
     // eslint-disable-next-line jest/expect-expect
-    it('bottom', async () => testAdjustIndividualPaddingValue('top', 'coarse'))
+    it('bottom', async () => testAdjustIndividualPaddingValue('bottom', 'coarse'))
     // eslint-disable-next-line jest/expect-expect
-    it('left', async () => testAdjustIndividualPaddingValue('top', 'coarse'))
+    it('left', async () => testAdjustIndividualPaddingValue('left', 'coarse'))
     // eslint-disable-next-line jest/expect-expect
-    it('right', async () => testAdjustIndividualPaddingValue('top', 'coarse'))
+    it('right', async () => testAdjustIndividualPaddingValue('right', 'coarse'))
+  })
+
+  describe('Adjusting individual padding values, with container set to hug', () => {
+    // the expect is in `testAdjustIndividualPaddingValue`
+    // eslint-disable-next-line jest/expect-expect
+    it('top', async () => {
+      await testAdjustIndividualPaddingValueWithHuggingContainer('top', 'coarse', 12, 12)
+    })
+    // eslint-disable-next-line jest/expect-expect
+    it('bottom', async () => {
+      await testAdjustIndividualPaddingValueWithHuggingContainer('bottom', 'coarse', 12, -12)
+    })
+    // eslint-disable-next-line jest/expect-expect
+    it('left', async () => {
+      await testAdjustIndividualPaddingValueWithHuggingContainer('left', 'coarse', 12, 12)
+    })
+    // eslint-disable-next-line jest/expect-expect
+    it('right', async () => {
+      await testAdjustIndividualPaddingValueWithHuggingContainer('right', 'coarse', 12, -12)
+    })
   })
 })
 
@@ -719,6 +739,46 @@ async function testAdjustIndividualPaddingValue(edge: EdgePiece, precision: Adju
         combinePaddings(
           defaultPadding,
           offsetPaddingByEdge(paddingPropForEdge(edge), dragDelta, padding, precision),
+        ),
+      ),
+    ),
+  )
+}
+
+async function testAdjustIndividualPaddingValueWithHuggingContainer(
+  edge: EdgePiece,
+  precision: AdjustPrecision,
+  intendedDragDelta: number,
+  actualDragDelta: number,
+) {
+  const padding: CSSPaddingMeasurements = {
+    paddingTop: unitlessCSSNumberWithRenderedValue(22),
+    paddingBottom: unitlessCSSNumberWithRenderedValue(33),
+    paddingLeft: unitlessCSSNumberWithRenderedValue(44),
+    paddingRight: unitlessCSSNumberWithRenderedValue(55),
+  }
+
+  const editor = await renderTestEditorWithCode(
+    makeTestProjectCodeWithHugContentsContainerStringPaddingValues(paddingToPaddingString(padding)),
+    'await-first-dom-report',
+  )
+
+  const defaultPadding: CSSPaddingMappedValues<number> = {
+    paddingTop: 0,
+    paddingRight: 0,
+    paddingBottom: 0,
+    paddingLeft: 0,
+  }
+
+  await testPaddingResizeForEdge(editor, intendedDragDelta, edge, precision)
+  await editor.getDispatchFollowUpActionsFinished()
+
+  expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+    makeTestProjectCodeWithHugContentsContainerStringPaddingValues(
+      paddingToPaddingString(
+        combinePaddings(
+          defaultPadding,
+          offsetPaddingByEdge(paddingPropForEdge(edge), actualDragDelta, padding, precision),
         ),
       ),
     ),
@@ -803,6 +863,34 @@ function makeTestProjectCodeWithStringPaddingValues(padding: string): string {
             backgroundColor: '#aaaaaa33',
             width: '100%',
             height: '100%',
+          }}
+          data-uid='002'
+        />
+      </div>
+    </div>`)
+}
+
+function makeTestProjectCodeWithHugContentsContainerStringPaddingValues(padding: string): string {
+  return makeTestProjectCodeWithSnippet(`
+    <div data-uid='root'>
+      <div
+        data-uid='mydiv'
+        data-testid='mydiv'
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 28,
+          top: 28,
+          width: 'max-content',
+          height: 'max-content',
+          padding: '${padding}',
+        }}
+      >
+        <div
+          style={{
+            backgroundColor: '#aaaaaa33',
+            width: 342,
+            height: 274,
           }}
           data-uid='002'
         />

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -114,7 +114,7 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
   const maybePaddingValueProps = paddingValueIndicatorProps(
     canvasState,
     interactionSession,
-    selectedElements,
+    selectedElements[0],
   )
 
   const resizeControl = controlWithProps({
@@ -151,17 +151,6 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
         return emptyStrategyApplicationResult
       }
 
-      const drag = interactionSession.interactionData.drag
-      if (drag == null) {
-        return emptyStrategyApplicationResult
-      }
-
-      const edgePiece = interactionSession.activeControl.edgePiece
-
-      if (interactionSession.interactionData.drag == null) {
-        return emptyStrategyApplicationResult
-      }
-
       const filteredSelectedElements = getDragTargets(selectedElements)
       const originalBoundingBox = getMultiselectBounds(
         canvasState.startingMetadata,
@@ -174,40 +163,29 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
 
       const selectedElement = filteredSelectedElements[0]
 
-      const paddingPropInteractedWith = paddingPropForEdge(edgePiece)
-      const precision = precisionFromModifiers(interactionSession.interactionData.modifiers)
-
+      const edgePiece = interactionSession.activeControl.edgePiece
+      const drag = interactionSession.interactionData.drag ?? canvasVector({ x: 0, y: 0 })
       const padding = simplePaddingFromMetadata(canvasState.startingMetadata, selectedElement)
+      const paddingPropInteractedWith = paddingPropForEdge(edgePiece)
       const currentPadding = padding[paddingPropForEdge(edgePiece)]?.renderedValuePx ?? 0
       const rawDelta = deltaFromEdge(drag, edgePiece)
       const maxedDelta = Math.max(-currentPadding, rawDelta)
+      const precision = precisionFromModifiers(interactionSession.interactionData.modifiers)
       const newPaddingEdge = offsetMeasurementByDelta(
         padding[paddingPropInteractedWith] ?? unitlessCSSNumberWithRenderedValue(maxedDelta),
         rawDelta,
         precision,
       )
 
-      const delta = newPaddingEdge.renderedValuePx < PaddingTearThreshold ? rawDelta : maxedDelta
-
-      const axis: Axis =
-        paddingPropInteractedWith === 'paddingBottom' || paddingPropInteractedWith === 'paddingTop'
-          ? 'vertical'
-          : 'horizontal'
-
-      const isHug =
-        detectFillHugFixedState(axis, canvasState.startingMetadata, selectedElement)?.type === 'hug'
-
-      const deltaAdjusted =
-        isHug &&
-        (paddingPropInteractedWith === 'paddingRight' ||
-          paddingPropInteractedWith === 'paddingBottom')
-          ? -delta
-          : delta
+      const delta = calculateAdjustDelta(canvasState, interactionSession, selectedElement)
+      if (delta == null) {
+        return emptyStrategyApplicationResult
+      }
 
       const newPaddingMaxed = adjustPaddingsWithAdjustMode(
         paddingAdjustMode(interactionSession.interactionData.modifiers),
         paddingPropInteractedWith,
-        deltaAdjusted,
+        delta,
         padding,
         precision,
       )
@@ -362,15 +340,14 @@ function supportsPaddingControls(metadata: ElementInstanceMetadataMap, path: Ele
 function paddingValueIndicatorProps(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
-  selectedElements: ElementPath[],
+  selectedElement: ElementPath,
 ): FloatingIndicatorProps | null {
-  const filteredSelectedElements = getDragTargets(selectedElements)
+  const filteredSelectedElements = getDragTargets([selectedElement])
 
   if (
     interactionSession == null ||
     interactionSession.interactionData.type !== 'DRAG' ||
-    interactionSession.activeControl.type !== 'PADDING_RESIZE_HANDLE' ||
-    filteredSelectedElements.length !== 1
+    interactionSession.activeControl.type !== 'PADDING_RESIZE_HANDLE'
   ) {
     return null
   }
@@ -387,7 +364,10 @@ function paddingValueIndicatorProps(
   const currentPadding =
     padding[paddingPropForEdge(edgePiece)] ?? unitlessCSSNumberWithRenderedValue(0)
 
-  const delta = deltaFromEdge(drag, edgePiece)
+  const delta = calculateAdjustDelta(canvasState, interactionSession, selectedElement)
+  if (delta == null) {
+    return null
+  }
 
   const updatedPaddingMeasurement = offsetMeasurementByDelta(
     currentPadding,
@@ -472,4 +452,62 @@ function adjustPaddingsWithAdjustMode(
     default:
       assertNever(adjustMode)
   }
+}
+
+function isElementSetToHugAlongAffectedAxis(
+  paddingPropInteractedWith: CSSPaddingKey,
+  metadata: ElementInstanceMetadataMap,
+  selectedElement: ElementPath,
+): boolean {
+  const axis: Axis =
+    paddingPropInteractedWith === 'paddingBottom' || paddingPropInteractedWith === 'paddingTop'
+      ? 'vertical'
+      : 'horizontal'
+
+  const isHug = detectFillHugFixedState(axis, metadata, selectedElement)?.type === 'hug'
+  return isHug
+}
+
+function calculateAdjustDelta(
+  canvasState: InteractionCanvasState,
+  interactionSession: InteractionSession | null,
+  selectedElement: ElementPath,
+): number | null {
+  if (
+    interactionSession == null ||
+    interactionSession.interactionData.type !== 'DRAG' ||
+    interactionSession.activeControl.type !== 'PADDING_RESIZE_HANDLE'
+  ) {
+    return null
+  }
+
+  const edgePiece = interactionSession.activeControl.edgePiece
+  const drag = interactionSession.interactionData.drag ?? canvasVector({ x: 0, y: 0 })
+  const padding = simplePaddingFromMetadata(canvasState.startingMetadata, selectedElement)
+  const paddingPropInteractedWith = paddingPropForEdge(edgePiece)
+  const currentPadding = padding[paddingPropForEdge(edgePiece)]?.renderedValuePx ?? 0
+  const rawDelta = deltaFromEdge(drag, edgePiece)
+  const maxedDelta = Math.max(-currentPadding, rawDelta)
+  const precision = precisionFromModifiers(interactionSession.interactionData.modifiers)
+  const newPaddingEdge = offsetMeasurementByDelta(
+    padding[paddingPropInteractedWith] ?? unitlessCSSNumberWithRenderedValue(maxedDelta),
+    rawDelta,
+    precision,
+  )
+
+  const delta = newPaddingEdge.renderedValuePx < PaddingTearThreshold ? rawDelta : maxedDelta
+
+  const isHug = isElementSetToHugAlongAffectedAxis(
+    paddingPropInteractedWith,
+    canvasState.startingMetadata,
+    selectedElement,
+  )
+
+  const deltaAdjusted =
+    isHug &&
+    (paddingPropInteractedWith === 'paddingRight' || paddingPropInteractedWith === 'paddingBottom')
+      ? -delta
+      : delta
+
+  return deltaAdjusted
 }


### PR DESCRIPTION
# Try it [here](https://utopia.pizza/p/0c05345e-scalloped-tarsal/?branch_name=feature/adjust-padding-when-hugging-contents)

![adjust](https://user-images.githubusercontent.com/16385508/216609290-672bc648-f124-463e-bebb-aa52b0e093bc.gif)


## Description
This PR makes adjusting padding a bit more intuitive, by inverting the drag delta, when the element being interacted with is set to Hug contents (inspired by Figma).
