### PR TITLE
Ensure border width is nonzero when enabled in the inspector

### DIFF
--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -5229,8 +5229,13 @@ export function toggleBorderEnabled(_: null, oldValue: CSSBorder): CSSBorder {
     delete workingNewValue.style
     return workingNewValue
   } else {
+    const widthValue =
+      oldValue.width != null && oldValue.width.value.value > 0
+        ? oldValue.width
+        : cssLineWidth(cssNumber(1, 'px'))
     return {
       ...oldValue,
+      width: widthValue,
       style: cssLineStyle(cssKeyword('solid')),
     }
   }


### PR DESCRIPTION
## Problem
When enabling `border` in the inspector, it is possible that a border of `borderWidth: 0` is applied. While technically this is still a valid border, this goes against the principle of least surprise (since nothing happens on screen).

## Fix
Check if the border width to be applied is not null and nonzero, and if it isn't, apply a `borderWidth` of `1px`