### PR TITLE
Strategy for changing flex direction in the presence of children set to Fill Container

### DIFF
--- a/editor/src/components/inspector/flex-direction-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/flex-direction-control.spec.browser2.tsx
@@ -64,7 +64,7 @@ describe('set flex direction', () => {
     expect(div.style.flexDirection).toEqual('row')
   })
 
-  it('when updating flex direction, child sizes are hardcoded', async () => {
+  it('when updating flex direction, and children are set to fill container, cross axis sizings are swapped', async () => {
     const editor = await renderTestEditorWithCode(
       projectWithFillContainerChildren(),
       'await-first-dom-report',
@@ -76,18 +76,21 @@ describe('set flex direction', () => {
 
     const blue = editor.renderedDOM.getByTestId('blue')
     expect(blue.style.flex).toEqual('')
-    expect(blue.style.width).toEqual('333px')
-    expect(blue.style.height).toEqual('170px')
+    expect(blue.style.height).toEqual('')
+    expect(blue.style.width).toEqual('170px')
+    expect(blue.style.flexGrow).toEqual('1')
 
     const red = editor.renderedDOM.getByTestId('red')
     expect(red.style.flex).toEqual('')
-    expect(red.style.width).toEqual('333px')
-    expect(red.style.height).toEqual('211px')
+    expect(red.style.height).toEqual('')
+    expect(red.style.width).toEqual('211px')
+    expect(red.style.flexGrow).toEqual('1')
 
     const green = editor.renderedDOM.getByTestId('green')
     expect(green.style.flex).toEqual('')
-    expect(green.style.width).toEqual('333px')
-    expect(green.style.height).toEqual('188px')
+    expect(green.style.height).toEqual('')
+    expect(green.style.width).toEqual('188px')
+    expect(green.style.flexGrow).toEqual('1')
   })
 })
 

--- a/editor/src/components/inspector/inspector-strategies/change-flex-direction-swap-axes.ts
+++ b/editor/src/components/inspector/inspector-strategies/change-flex-direction-swap-axes.ts
@@ -1,0 +1,91 @@
+import * as PP from '../../../core/shared/property-path'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { elementPath } from '../../../core/shared/element-path'
+import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
+import { ElementPath } from '../../../core/shared/project-file-types'
+import { CanvasCommand } from '../../canvas/commands/commands'
+import { setProperty } from '../../canvas/commands/set-property-command'
+import { FlexDirection } from '../common/css-utils'
+import {
+  detectFillHugFixedState,
+  detectFlexDirection,
+  detectFlexDirectionOne,
+  nullOrNonEmpty,
+} from '../inspector-common'
+import { fillContainerStrategyBasic } from './fill-container-basic-strategy'
+import { fixedSizeBasicStrategy } from './fixed-size-basic-strategy'
+import { InspectorStrategy } from './inspector-strategy'
+
+function setFlexDirectionSwapAxesSingleElement(
+  direction: FlexDirection,
+  metadata: ElementInstanceMetadataMap,
+  selectedElement: ElementPath,
+): Array<CanvasCommand> {
+  if (
+    !MetadataUtils.isFlexLayoutedContainer(
+      MetadataUtils.findElementByElementPath(metadata, selectedElement),
+    )
+  ) {
+    return []
+  }
+
+  const currentFlexDirection = detectFlexDirectionOne(metadata, selectedElement)
+
+  const commands = MetadataUtils.getChildrenPaths(metadata, selectedElement).flatMap((child) => {
+    const horizontalSizing = detectFillHugFixedState('horizontal', metadata, child)
+    const verticalSizing = detectFillHugFixedState('vertical', metadata, child)
+    if (
+      direction.startsWith('col') &&
+      currentFlexDirection?.startsWith('row') &&
+      horizontalSizing?.type === 'fill' &&
+      verticalSizing?.type === 'fixed'
+    ) {
+      return [
+        ...(fillContainerStrategyBasic('vertical', 'default', false).strategy(metadata, [child]) ??
+          []),
+        ...(fixedSizeBasicStrategy('always', 'horizontal', verticalSizing.value).strategy(
+          metadata,
+          [child],
+        ) ?? []),
+      ]
+    }
+
+    if (
+      direction.startsWith('row') &&
+      currentFlexDirection?.startsWith('col') &&
+      verticalSizing?.type === 'fill' &&
+      horizontalSizing?.type === 'fixed'
+    ) {
+      return [
+        ...(fillContainerStrategyBasic('horizontal', 'default', false).strategy(metadata, [
+          child,
+        ]) ?? []),
+        ...(fixedSizeBasicStrategy('always', 'vertical', horizontalSizing.value).strategy(
+          metadata,
+          [child],
+        ) ?? []),
+      ]
+    }
+
+    return []
+  })
+
+  if (commands.length === 0) {
+    return []
+  }
+
+  return [
+    ...commands,
+    setProperty('always', selectedElement, PP.create('style', 'flexDirection'), direction),
+  ]
+}
+
+export const setFlexDirectionSwapAxes = (direction: FlexDirection): InspectorStrategy => ({
+  name: 'Swap fill axes',
+  strategy: (metadata, selectedElementPaths) =>
+    nullOrNonEmpty(
+      selectedElementPaths.flatMap((path) =>
+        setFlexDirectionSwapAxesSingleElement(direction, metadata, path),
+      ),
+    ),
+})

--- a/editor/src/components/inspector/inspector-strategies/change-flex-direction-swap-axes.ts
+++ b/editor/src/components/inspector/inspector-strategies/change-flex-direction-swap-axes.ts
@@ -1,6 +1,5 @@
 import * as PP from '../../../core/shared/property-path'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { elementPath } from '../../../core/shared/element-path'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { CanvasCommand } from '../../canvas/commands/commands'
@@ -8,11 +7,10 @@ import { setProperty } from '../../canvas/commands/set-property-command'
 import { FlexDirection } from '../common/css-utils'
 import {
   detectFillHugFixedState,
-  detectFlexDirection,
   detectFlexDirectionOne,
   nullOrNonEmpty,
 } from '../inspector-common'
-import { fillContainerStrategyBasic } from './fill-container-basic-strategy'
+import { fillContainerStrategyFlexParent } from './fill-container-basic-strategy'
 import { fixedSizeBasicStrategy } from './fixed-size-basic-strategy'
 import { InspectorStrategy } from './inspector-strategy'
 
@@ -41,12 +39,13 @@ function setFlexDirectionSwapAxesSingleElement(
       verticalSizing?.type === 'fixed'
     ) {
       return [
-        ...(fillContainerStrategyBasic('vertical', 'default', false).strategy(metadata, [child]) ??
-          []),
         ...(fixedSizeBasicStrategy('always', 'horizontal', verticalSizing.value).strategy(
           metadata,
           [child],
         ) ?? []),
+        ...(fillContainerStrategyFlexParent('vertical', 'default', {
+          forceFlexDirectionForParent: direction,
+        }).strategy(metadata, [child]) ?? []),
       ]
     }
 
@@ -57,13 +56,13 @@ function setFlexDirectionSwapAxesSingleElement(
       horizontalSizing?.type === 'fixed'
     ) {
       return [
-        ...(fillContainerStrategyBasic('horizontal', 'default', false).strategy(metadata, [
-          child,
-        ]) ?? []),
         ...(fixedSizeBasicStrategy('always', 'vertical', horizontalSizing.value).strategy(
           metadata,
           [child],
         ) ?? []),
+        ...(fillContainerStrategyFlexParent('horizontal', 'default', {
+          forceFlexDirectionForParent: direction,
+        }).strategy(metadata, [child]) ?? []),
       ]
     }
 

--- a/editor/src/components/inspector/inspector-strategies/fixed-size-basic-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/fixed-size-basic-strategy.ts
@@ -1,0 +1,37 @@
+import * as PP from '../../../core/shared/property-path'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { WhenToRun } from '../../canvas/commands/commands'
+import {
+  setCssLengthProperty,
+  setExplicitCssValue,
+} from '../../canvas/commands/set-css-length-command'
+import { CSSNumber } from '../common/css-utils'
+import { Axis, widthHeightFromAxis } from '../inspector-common'
+import { InspectorStrategy } from './inspector-strategy'
+
+export const fixedSizeBasicStrategy = (
+  whenToRun: WhenToRun,
+  axis: Axis,
+  value: CSSNumber,
+): InspectorStrategy => ({
+  name: 'Set to Fixed',
+  strategy: (metadata, elementPaths) => {
+    if (elementPaths.length === 0) {
+      return null
+    }
+
+    return elementPaths.map((path) => {
+      const parentFlexDirection =
+        MetadataUtils.findElementByElementPath(metadata, path)?.specialSizeMeasurements
+          .parentFlexDirection ?? null
+
+      return setCssLengthProperty(
+        whenToRun,
+        path,
+        PP.create('style', widthHeightFromAxis(axis)),
+        setExplicitCssValue(value),
+        parentFlexDirection,
+      )
+    })
+  },
+})

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.ts
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.ts
@@ -8,7 +8,6 @@ import {
   FlexJustifyContent,
   pruneFlexPropsCommands,
   sizeToVisualDimensions,
-  widthHeightFromAxis,
 } from '../inspector-common'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { deleteProperties } from '../../canvas/commands/delete-properties-command'
@@ -17,7 +16,10 @@ import { removeFlexConvertToAbsolute } from './remove-flex-convert-to-absolute-s
 import { InspectorStrategy } from './inspector-strategy'
 import { WhenToRun } from '../../../components/canvas/commands/commands'
 import { hugContentsBasicStrategy } from './hug-contents-basic-strategy'
-import { fillContainerStrategyBasic } from './fill-container-basic-strategy'
+import {
+  fillContainerStrategyFlexParent,
+  fillContainerStrategyFlow,
+} from './fill-container-basic-strategy'
 import { setSpacingModePacked, setSpacingModeSpaceBetween } from './spacing-mode-strategies'
 import { convertLayoutToFlexCommands } from '../../common/shared-strategies/convert-to-flex-strategy'
 import { fixedSizeBasicStrategy } from './fixed-size-basic-strategy'
@@ -152,7 +154,10 @@ export const setPropFillStrategies = (
   axis: Axis,
   value: 'default' | number,
   otherAxisSetToFill: boolean,
-): Array<InspectorStrategy> => [fillContainerStrategyBasic(axis, value, otherAxisSetToFill)]
+): Array<InspectorStrategy> => [
+  fillContainerStrategyFlexParent(axis, value),
+  fillContainerStrategyFlow(axis, value, otherAxisSetToFill),
+]
 
 export const setPropFixedStrategies = (
   whenToRun: WhenToRun,

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.ts
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.ts
@@ -17,13 +17,11 @@ import { removeFlexConvertToAbsolute } from './remove-flex-convert-to-absolute-s
 import { InspectorStrategy } from './inspector-strategy'
 import { WhenToRun } from '../../../components/canvas/commands/commands'
 import { hugContentsBasicStrategy } from './hug-contents-basic-strategy'
-import {
-  setCssLengthProperty,
-  setExplicitCssValue,
-} from '../../canvas/commands/set-css-length-command'
 import { fillContainerStrategyBasic } from './fill-container-basic-strategy'
 import { setSpacingModePacked, setSpacingModeSpaceBetween } from './spacing-mode-strategies'
 import { convertLayoutToFlexCommands } from '../../common/shared-strategies/convert-to-flex-strategy'
+import { fixedSizeBasicStrategy } from './fixed-size-basic-strategy'
+import { setFlexDirectionSwapAxes } from './change-flex-direction-swap-axes'
 
 export const setFlexAlignStrategies = (flexAlignment: FlexAlignment): Array<InspectorStrategy> => [
   {
@@ -102,6 +100,7 @@ export const removeFlexDirectionStrategies = (): Array<InspectorStrategy> => [
 export const updateFlexDirectionStrategies = (
   flexDirection: FlexDirection,
 ): Array<InspectorStrategy> => [
+  setFlexDirectionSwapAxes(flexDirection),
   {
     name: 'Set flex direction',
     strategy: (metadata, elementPaths) => {
@@ -159,30 +158,7 @@ export const setPropFixedStrategies = (
   whenToRun: WhenToRun,
   axis: Axis,
   value: CSSNumber,
-): Array<InspectorStrategy> => [
-  {
-    name: 'Set to Fixed',
-    strategy: (metadata, elementPaths) => {
-      if (elementPaths.length === 0) {
-        return null
-      }
-
-      return elementPaths.map((path) => {
-        const parentFlexDirection =
-          MetadataUtils.findElementByElementPath(metadata, path)?.specialSizeMeasurements
-            .parentFlexDirection ?? null
-
-        return setCssLengthProperty(
-          whenToRun,
-          path,
-          PP.create('style', widthHeightFromAxis(axis)),
-          setExplicitCssValue(value),
-          parentFlexDirection,
-        )
-      })
-    },
-  },
-]
+): Array<InspectorStrategy> => [fixedSizeBasicStrategy(whenToRun, axis, value)]
 
 export const setPropHugStrategies = (axis: Axis): Array<InspectorStrategy> => [
   hugContentsBasicStrategy(axis),


### PR DESCRIPTION
## Description
This PR adds an inspector strategy for changing flex direction on a flex container. This strategy kicks in when the selected container has at least one child element set to "Fill container" on one axis and "Fixed size" on the other. These settings are swapped along the cross-axes so that they are the other way around (e.g., if the child was Fixed Size horizontally and Fill Container vertically, after the strategy as run, the child will be set to Fixed Size vertically and Fill Container horizontally).

### Details
- The new strategy is added
- The FIll Container strategy is taken apart into two separate strategies: one that applies to flex containers (and uses `flexGrow: 1` to implement Fill Container), and a catchall one (which uses `width/height: 100%` to implement Fill Container). This makes it easier to reuse the either of the specific variants of the Fill Container strategies.