### PR TITLE
Fix label sizing at low zoom scale

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -345,6 +345,13 @@ interface SizeLabelProps {
   targets: Array<ElementPath>
 }
 
+const FontSize = 11
+const PaddingV = 0
+const PaddingH = 2
+const ExplicitHeightHacked = 20
+const BorderRadius = 2
+const SizeLabelMarginTop = 8
+
 const SizeLabel = React.memo(
   React.forwardRef<HTMLDivElement, SizeLabelProps>(({ targets }, ref) => {
     const scale = useEditorState(
@@ -376,12 +383,15 @@ const SizeLabel = React.memo(
           label != null,
           <div
             style={{
-              marginTop: 8 / scale,
-              padding: `0px ${2 / scale}px`,
-              borderRadius: 2 / scale,
+              display: 'flex',
+              alignItems: 'center',
+              marginTop: SizeLabelMarginTop / scale,
+              padding: `${PaddingV}px ${PaddingH / scale}px`,
+              borderRadius: BorderRadius / scale,
               color: colorTheme.white.value,
               backgroundColor: colorTheme.secondaryBlue.value,
-              fontSize: 11 / scale,
+              fontSize: FontSize / scale,
+              height: ExplicitHeightHacked / scale,
             }}
           >
             {`${label![0]} x ${label![1]}`}

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -87,7 +87,7 @@ export function measurementBasedOnOtherMeasurement(
 const FontSize = 11
 const PaddingV = 0
 const PaddingH = 2
-
+const ExplicitHeightHacked = 20
 const BorderRadius = 2
 
 interface CanvasLabelProps {
@@ -106,6 +106,8 @@ export const CanvasLabel = React.memo((props: CanvasLabelProps): JSX.Element => 
   return (
     <div
       style={{
+        display: 'flex',
+        alignItems: 'center',
         fontSize: fontSize,
         paddingLeft: paddingH,
         paddingRight: paddingH,
@@ -114,6 +116,7 @@ export const CanvasLabel = React.memo((props: CanvasLabelProps): JSX.Element => 
         backgroundColor: color,
         color: textColor,
         borderRadius: borderRadius,
+        height: ExplicitHeightHacked / scale,
       }}
     >
       {value}


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/16385508/216967535-f756c814-4771-4b61-82dc-53dea4d0d226.png)

## After
<img width="285" alt="image" src="https://user-images.githubusercontent.com/16385508/216967505-d5a4108a-199e-41d9-8b9f-7fbb7336acad.png">


## Problem
Size label (and canvas label) rendering regressed so that at low zoom levels, the size of the label container was actually smaller than the label text, which overflowed out of the container.

## Fix
Add an explicit `height` prop to the labels to force the correct height