### PR TITLE
Smart Flex Conversion fix: minimum padding is 0

### DIFF
--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
@@ -384,6 +384,45 @@ describe('Smart Convert To Flex', () => {
   `),
     )
   })
+
+  it('single overflowing child does not make negative padding', async () => {
+    const editor = await renderProjectWith({
+      parent: [50, 50, 100, 100],
+      children: [[0, 0, 150, 50]],
+    })
+
+    await convertParentToFlex(editor)
+
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+      <div style={{ ...props.style }} data-uid='a'>
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 50,
+          top: 50,
+          width: 'max-content',
+          height: 'max-content',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+        data-uid='parent'
+      >
+        <div 
+          data-uid='child-0'
+          style={{
+            backgroundColor: '#aaaaaa33', 
+            width: 150, 
+            height: 50, 
+            contain: 'layout',
+          }} 
+        />
+      </div>
+    </div>
+  `),
+    )
+  })
 })
 
 describe('Smart Convert to Flex Reordering Children if Needed', () => {

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
@@ -154,7 +154,7 @@ function guessPadding(
   const paddingLeft = firstChild.frame.x - parentRect.x
   const paddingRight =
     parentRect.x + parentRect.width - (lastChild?.frame.x + lastChild?.frame.width)
-  const horizontalPadding = Math.min(paddingLeft, paddingRight)
+  const horizontalPadding = Math.max(0, Math.min(paddingLeft, paddingRight))
   const paddingTop = firstChild.frame.y - parentRect.y
   const paddingBottom =
     parentRect.y + parentRect.height - (lastChild?.frame.y + lastChild?.frame.height)


### PR DESCRIPTION
**Problem:**
When converting an element to flex and its children overflow, we may end up setting a negative padding value on the parent.

**Fix:**
Make the minimum padding size 0, also a new test
