### PR TITLE
Updating padding on the canvas can resize the element

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -247,6 +247,15 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
 
       const sizeDelta = combinedContentSizeInDimension - targetFrame[dimensionKey]
       if (sizeDelta > 0) {
+        const elementMetadata = MetadataUtils.findElementByElementPath(
+          canvasState.startingMetadata,
+          selectedElement,
+        )
+        const elementParentBounds = elementMetadata?.specialSizeMeasurements.immediateParentBounds
+        const parentDimensionPx = elementParentBounds?.[dimensionKey]
+        const elementParentFlexDirection =
+          elementMetadata?.specialSizeMeasurements.parentFlexDirection
+
         // FIXME Find the correct strategy to use for resizing
         basicCommands.push(
           adjustCssLengthProperty(
@@ -254,8 +263,8 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
             selectedElement,
             stylePropPathMappingFn(dimensionKey, styleStringInArray),
             roundTo(sizeDelta, 0),
-            undefined, // TODO Parent Bounds
-            null, // TODO Parent Flex Direction
+            parentDimensionPx,
+            elementParentFlexDirection ?? null,
             'create-if-not-existing',
           ),
         )

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -256,7 +256,9 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
         const elementParentFlexDirection =
           elementMetadata?.specialSizeMeasurements.parentFlexDirection
 
-        // FIXME Find the correct strategy to use for resizing
+        // TODO We need a way to call the correct resizing strategy here, but they are all assuming
+        // the drag originates from a given edge, whereas we want to pass in the desired delta to a
+        // dimension and receive the required commands to resize the element
         basicCommands.push(
           adjustCssLengthProperty(
             'always',
@@ -265,7 +267,7 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
             roundTo(sizeDelta, 0),
             parentDimensionPx,
             elementParentFlexDirection ?? null,
-            'create-if-not-existing',
+            'do-not-create-if-doesnt-exist',
           ),
         )
       }

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -222,10 +222,15 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
         selectedElement,
       )
 
+      const isHorizontalEdge = isHorizontalEdgePiece(edgePiece)
+
       const fixedSizeChildrenPaths = allChildPaths.filter(
         (childPath) =>
-          detectFillHugFixedState('horizontal', canvasState.startingMetadata, childPath)?.type ===
-          'fixed',
+          detectFillHugFixedState(
+            isHorizontalEdge ? 'horizontal' : 'vertical',
+            canvasState.startingMetadata,
+            childPath,
+          )?.type === 'fixed',
       )
       const fixedSizeNonAbsoluteChildrenPaths = fixedSizeChildrenPaths.filter((childPath) =>
         MetadataUtils.targetParticipatesInAutoLayout(canvasState.startingMetadata, childPath),
@@ -241,7 +246,7 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
       const combinedPaddingInDimension =
         paddingForEdgeSimplePadding(edgePiece, padding) +
         paddingForEdgeSimplePadding(oppositeEdgePiece(edgePiece), padding)
-      const dimensionKey = isHorizontalEdgePiece(edgePiece) ? 'width' : 'height'
+      const dimensionKey = isHorizontalEdge ? 'width' : 'height'
       const combinedContentSizeInDimension =
         combinedPaddingInDimension + childrenBoundingFrame[dimensionKey] + delta
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -241,7 +241,6 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
       )
       const childrenBoundingFrame = zeroRectIfNullOrInfinity(childrenBoundingFrameMaybeInfinite)
 
-      // FIXME include child offset
       // Check if child content size + padding exceeds parent size in that dimension
       const combinedPaddingInDimension =
         paddingForEdgeSimplePadding(edgePiece, padding) +

--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -16,7 +16,7 @@ import { EditorPanel } from '../common/actions/index'
 import { Mode } from '../editor/editor-modes'
 import { EditorState, OriginalCanvasAndLocalFrame } from '../editor/store/editor-state'
 import { isFeatureEnabled } from '../../utils/feature-switches'
-import { xor } from '../../core/shared/utils'
+import { assertNever, xor } from '../../core/shared/utils'
 import { LayoutTargetableProp } from '../../core/layout/layout-helpers-new'
 import {
   DragInteractionData,
@@ -754,12 +754,31 @@ export function oppositeEdgePositionPart(part: EdgePositionPart): EdgePositionPa
   }
 }
 
-export type EdgePiece = 'top' | 'bottom' | 'left' | 'right'
-
 export function oppositeEdgePosition(edgePos: EdgePosition): EdgePosition {
   return {
     x: oppositeEdgePositionPart(edgePos.x),
     y: oppositeEdgePositionPart(edgePos.y),
+  }
+}
+
+export type EdgePiece = 'top' | 'bottom' | 'left' | 'right'
+
+export function isHorizontalEdgePiece(edgePiece: EdgePiece): boolean {
+  return edgePiece === 'left' || edgePiece === 'right'
+}
+
+export function oppositeEdgePiece(edgePiece: EdgePiece): EdgePiece {
+  switch (edgePiece) {
+    case 'left':
+      return 'right'
+    case 'right':
+      return 'left'
+    case 'top':
+      return 'bottom'
+    case 'bottom':
+      return 'top'
+    default:
+      assertNever(edgePiece)
   }
 }
 

--- a/editor/src/components/canvas/padding-utils.tsx
+++ b/editor/src/components/canvas/padding-utils.tsx
@@ -158,6 +158,13 @@ export function paddingForEdge(edgePiece: EdgePiece, padding: CSSPaddingMeasurem
   return padding[paddingPropForEdge(edgePiece)].renderedValuePx
 }
 
+export function paddingForEdgeSimplePadding(
+  edgePiece: EdgePiece,
+  padding: CSSPaddingMappedValues<CSSNumberWithRenderedValue | undefined>,
+): number {
+  return padding[paddingPropForEdge(edgePiece)]?.renderedValuePx ?? 0
+}
+
 export function offsetPaddingByEdge(
   prop: CSSPaddingKey,
   delta: number,


### PR DESCRIPTION
**Test it [here](https://utopia.pizza/p/0aba9ce5-therapeutic-argument/?branch_name=spike-padding-resizes-element)**

**Problem:**
When dragging the padding controls on the canvas, if the element and its content are fixed sized (for non-absolute positioned content), and if the combined size of the content plus the padding in that dimension exceeds the size of the element, we should update the size of the element along with the padding.

**Fix:**
I have updated the `setPaddingStrategy` canvas strategy so that the size of all of these things can be checked and compared, and either the `width` or `height` (or both) will be adjusted if required (taking into account any modifiers being applied).

Note that this only works if the element has a `width` or `height` set. When we have the required resizing strategies we should delegate to those for the actual resizing here, though that will require modifying parts of the `InteractionSession` used when calling those strategies in order to fake the drag and the dragged control, or will require the core of those to be extracted in a way that also allows querying the fitness of them.