### PR TITLE
Smart Flex Conversion: guess align items 

### DIFF
--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
@@ -469,6 +469,116 @@ describe('Smart Convert to Flex Reordering Children if Needed', () => {
   })
 })
 
+describe('Smart Convert to Flex alignItems', () => {
+  let originalFSValue: boolean = false
+  before(() => {
+    originalFSValue = isFeatureEnabled('Nine block control')
+    setFeatureEnabled('Nine block control', true)
+  })
+
+  after(() => {
+    setFeatureEnabled('Nine block control', originalFSValue)
+  })
+
+  it('all elements aligned at the start become alignItems flex-start, but we omit that for simplicity', async () => {
+    const editor = await renderProjectWith({
+      parent: [50, 50, 500, 150],
+      children: [
+        [0, 0, 50, 60],
+        [65, 0, 50, 30],
+        [130, 0, 50, 60],
+      ],
+    })
+
+    await convertParentToFlex(editor)
+
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      makeReferenceProjectWith({
+        parent: {
+          left: 50,
+          top: 50,
+          width: MaxContent,
+          height: MaxContent,
+          display: 'flex',
+          flexDirection: 'row',
+          gap: 15,
+        },
+        children: [
+          [50, 60],
+          [50, 30],
+          [50, 60],
+        ],
+      }),
+    )
+  })
+
+  it('elements aligned at their center become alignItems center', async () => {
+    const editor = await renderProjectWith({
+      parent: [50, 50, 500, 150],
+      children: [
+        [0, 0, 50, 60],
+        [65, 15, 50, 30],
+        [130, 0, 50, 60],
+      ],
+    })
+
+    await convertParentToFlex(editor)
+
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      makeReferenceProjectWith({
+        parent: {
+          left: 50,
+          top: 50,
+          width: MaxContent,
+          height: MaxContent,
+          display: 'flex',
+          flexDirection: 'row',
+          gap: 15,
+          alignItems: 'center',
+        },
+        children: [
+          [50, 60],
+          [50, 30],
+          [50, 60],
+        ],
+      }),
+    )
+  })
+
+  it('elements aligned at their bottom become alignItems flex-end', async () => {
+    const editor = await renderProjectWith({
+      parent: [50, 50, 500, 150],
+      children: [
+        [0, 0, 50, 60],
+        [65, 30, 50, 30],
+        [130, 0, 50, 60],
+      ],
+    })
+
+    await convertParentToFlex(editor)
+
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      makeReferenceProjectWith({
+        parent: {
+          left: 50,
+          top: 50,
+          width: MaxContent,
+          height: MaxContent,
+          display: 'flex',
+          flexDirection: 'row',
+          gap: 15,
+          alignItems: 'flex-end',
+        },
+        children: [
+          [50, 60],
+          [50, 30],
+          [50, 60],
+        ],
+      }),
+    )
+  })
+})
+
 function renderProjectWith(input: { parent: LTWH; children: Array<LTWH> }) {
   const [parentL, parentT, parentW, parentH] = input.parent
   return renderTestEditorWithCode(

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
@@ -19,6 +19,7 @@ import {
 import { setHugContentForAxis } from '../../inspector/inspector-strategies/hug-contents-basic-strategy'
 
 type FlexDirection = 'row' | 'column' // a limited subset as we won't never guess row-reverse or column-reverse
+type FlexAlignItems = 'center' | 'flex-end'
 
 export function convertLayoutToFlexCommands(
   metadata: ElementInstanceMetadataMap,
@@ -36,7 +37,7 @@ export function convertLayoutToFlexCommands(
       return [setProperty('always', path, PP.create('style', 'display'), 'flex')]
     }
 
-    const { direction, sortedChildren, averageGap, padding } = guessMatchingFlexSetup(
+    const { direction, sortedChildren, averageGap, padding, alignItems } = guessMatchingFlexSetup(
       metadata,
       path,
       childrenPaths,
@@ -73,6 +74,7 @@ export function convertLayoutToFlexCommands(
       setHugContentForAxis('horizontal', path, parentFlexDirection),
       setHugContentForAxis('vertical', path, parentFlexDirection),
       ...setPropertyOmitNullProp('always', path, PP.create('style', 'padding'), padding),
+      ...setPropertyOmitNullProp('always', path, PP.create('style', 'alignItems'), alignItems),
       ...childrenPaths.flatMap((child) => [
         ...nukeAllAbsolutePositioningPropsCommands(child),
         ...sizeToVisualDimensions(metadata, child),
@@ -91,11 +93,12 @@ function guessMatchingFlexSetup(
   sortedChildren: Array<CanvasFrameAndTarget>
   averageGap: number | null
   padding: string | null
+  alignItems: FlexAlignItems | null
 } {
   const result = guessLayoutDirection(metadata, target, children)
 
   if (result.sortedChildren.length === 0) {
-    return { ...result, padding: null }
+    return { ...result, padding: null, alignItems: null }
   }
 
   const padding: string | null = guessPadding(
@@ -104,7 +107,9 @@ function guessMatchingFlexSetup(
     result.sortedChildren,
   )
 
-  return { ...result, padding: padding }
+  const alignItems: FlexAlignItems | null = guessAlignItems(result.direction, result.sortedChildren)
+
+  return { ...result, padding: padding, alignItems: alignItems }
 }
 
 function guessLayoutDirection(
@@ -228,4 +233,58 @@ function detectConfigurationInDirection(
     averageGap: averageGap === 0 ? null : averageGap,
     parentRect: parentRect,
   }
+}
+
+function guessAlignItems(
+  direction: FlexDirection,
+  children: Array<CanvasFrameAndTarget>,
+): FlexAlignItems | null {
+  if (children.length < 2) {
+    return null
+  }
+  const leftOrTop: 'x' | 'y' = direction === 'column' ? 'x' : 'y'
+  const widthOrHeight: 'width' | 'height' = direction === 'column' ? 'width' : 'height'
+
+  let allAlignedAtStart: boolean = true
+  let allAlignedAtCenter: boolean = true
+  let allAlignedAtEnd: boolean = true
+
+  for (let index = 1; index < children.length; index++) {
+    const previousElement = children[index - 1].frame
+    const currentElement = children[index].frame
+
+    // check for flex-start
+    if (previousElement[leftOrTop] !== currentElement[leftOrTop]) {
+      allAlignedAtStart = false
+    }
+
+    // check for center
+    if (
+      previousElement[leftOrTop] + previousElement[widthOrHeight] / 2 !==
+      currentElement[leftOrTop] + currentElement[widthOrHeight] / 2
+    ) {
+      allAlignedAtCenter = false
+    }
+
+    // check for flex-end
+    if (
+      previousElement[leftOrTop] + previousElement[widthOrHeight] !==
+      currentElement[leftOrTop] + currentElement[widthOrHeight]
+    ) {
+      allAlignedAtEnd = false
+    }
+  }
+
+  if (allAlignedAtStart) {
+    return null // we omit flex-start as that is the default anyways. Improvement: check if it _is_ the default computed style!
+  }
+  if (allAlignedAtCenter) {
+    return 'center'
+  }
+  if (allAlignedAtEnd) {
+    return 'flex-end'
+  }
+
+  // fallback: null, which implicitly means a default of flex-start
+  return null
 }


### PR DESCRIPTION
This PR adds alignItems to the guessed properties.

**Behavior:**
- check if all the elements are aligned at their top, it infers flex-start, BUT DOES NOT ADD alignItems: flex-start to the code, to avoid noise,because it's the default value
- if not, then check if all the elements are aligned at their center line, it returns alignItems: center
- if not, then check if all elements are bottom aligned, return alignItems: flex-end
- fallback: null (which defaults to alignItems: flex-start)

**Commit Details:**
- guessAlignItems function with the above described behavior
- Tests!
