### PR TITLE
SplitChainedNumberInput performance fixes

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/subdued-padding-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/subdued-padding-control.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import { useColorTheme } from '../../../../uuiui'
-import { useRefEditorState } from '../../../editor/store/store-hook'
+import { Substores, useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
 import { EdgePiece } from '../../canvas-types'
 import {
   combinePaddings,
@@ -15,11 +15,16 @@ import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 interface SubduedPaddingControlProps {
   side: EdgePiece
   hoveredOrFocused: 'hovered' | 'focused'
-  targets: Array<ElementPath>
 }
 
 export const SubduedPaddingControl = React.memo<SubduedPaddingControlProps>((props) => {
-  const { side, hoveredOrFocused, targets } = props
+  const { side, hoveredOrFocused } = props
+  const targets = useEditorState(
+    Substores.selectedViews,
+    (store) => store.editor.selectedViews,
+    'SubduedPaddingControl selectedViews',
+  )
+
   const elementMetadata = useRefEditorState((store) => store.editor.jsxMetadata)
 
   const isHorizontalPadding = side === 'left' || side === 'right'

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -226,11 +226,6 @@ export const PaddingControl = React.memo(() => {
   )
 
   const { selectedViewsRef } = useInspectorContext()
-  const selectedViews = useEditorState(
-    Substores.selectedViews,
-    (store) => store.editor.selectedViews,
-    'PaddingControl selectedViews',
-  )
 
   const canvasControlsForSides = React.useMemo(() => {
     return mapArrayToDictionary(
@@ -242,7 +237,6 @@ export const PaddingControl = React.memo(() => {
           props: {
             side: side,
             hoveredOrFocused: 'hovered',
-            targets: selectedViews,
           },
           key: `subdued-padding-control-hovered-${side}`,
         },
@@ -251,13 +245,12 @@ export const PaddingControl = React.memo(() => {
           props: {
             side: side,
             hoveredOrFocused: 'focused',
-            targets: selectedViews,
           },
           key: `subdued-padding-control-focused-${side}`,
         },
       }),
     )
-  }, [selectedViews])
+  }, [])
 
   return (
     <SplitChainedNumberInput

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
@@ -25,6 +25,7 @@ import {
   UnknownOrEmptyInput,
 } from '../../../common/css-utils'
 import { InspectorInfo } from '../../../common/property-path-hooks'
+import { useUpdateAtom } from 'jotai/utils'
 
 export type ControlMode =
   | 'one-value' // a single value that applies to all sides
@@ -314,8 +315,8 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
     [updateShorthandIfUsed, sidesVertical, excludeVertical],
   )
 
-  const [, setHoveredCanvasControls] = useAtom(InspectorHoveredCanvasControls)
-  const [, setFocusedCanvasControls] = useAtom(InspectorFocusedCanvasControls)
+  const setHoveredCanvasControls = useUpdateAtom(InspectorHoveredCanvasControls)
+  const setFocusedCanvasControls = useUpdateAtom(InspectorFocusedCanvasControls)
 
   const chainedPropsToRender: Array<Omit<NumberInputProps, 'chained' | 'id'>> =
     React.useMemo(() => {

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
@@ -1,4 +1,4 @@
-import { useUpdateAtom } from 'jotai/utils'
+import { useSetAtom } from 'jotai'
 import React from 'react'
 import { wrapValue } from '../../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../../core/shared/project-file-types'
@@ -314,8 +314,8 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
     [updateShorthandIfUsed, sidesVertical, excludeVertical],
   )
 
-  const setHoveredCanvasControls = useUpdateAtom(InspectorHoveredCanvasControls)
-  const setFocusedCanvasControls = useUpdateAtom(InspectorFocusedCanvasControls)
+  const setHoveredCanvasControls = useSetAtom(InspectorHoveredCanvasControls)
+  const setFocusedCanvasControls = useSetAtom(InspectorFocusedCanvasControls)
 
   const chainedPropsToRender: Array<Omit<NumberInputProps, 'chained' | 'id'>> =
     React.useMemo(() => {

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
@@ -1,5 +1,5 @@
-import { useAtom } from 'jotai'
-import React, { EventHandler, FocusEventHandler, MouseEventHandler, SyntheticEvent } from 'react'
+import { useUpdateAtom } from 'jotai/utils'
+import React from 'react'
 import { wrapValue } from '../../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../../core/shared/project-file-types'
 import { assertNever } from '../../../../../core/shared/utils'
@@ -14,18 +14,17 @@ import {
 import { useRefEditorState } from '../../../../editor/store/store-hook'
 import { ControlStatus, PropertyStatus } from '../../../common/control-status'
 import {
-  CanvasControlWithProps,
-  InspectorFocusedCanvasControls,
-  InspectorHoveredCanvasControls,
-} from '../../../common/inspector-atoms'
-import {
   CSSNumber,
   CSSNumberType,
   isCSSNumber,
   UnknownOrEmptyInput,
 } from '../../../common/css-utils'
+import {
+  CanvasControlWithProps,
+  InspectorFocusedCanvasControls,
+  InspectorHoveredCanvasControls,
+} from '../../../common/inspector-atoms'
 import { InspectorInfo } from '../../../common/property-path-hooks'
-import { useUpdateAtom } from 'jotai/utils'
 
 export type ControlMode =
   | 'one-value' // a single value that applies to all sides

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`768`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`659`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`840`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`731`)
   })
 })


### PR DESCRIPTION
This PR addresses two issues:

**Problem 1:**
Changing the selected view forced a re-render on the padding row. 
**Fix**
The problem was a useEditorState that I managed to move to the `SubduedPaddingControl` which means we don't need to wire it through multiple components anymore.

**Problem 2:**
Whenever a mouse enter / mouse leave updated either the `InspectorHoveredCanvasControls` or the `InspectorFocusedCanvasControls` atoms, the `SplitChainedNumberInput` would re-render. 
**Fix**
This is because the `useAtom` hook returns the atom value and the updater function, this means whenever the atom's value changes it has no other option but to re-render the caller component. 
There is actually a pattern where one component only ever _sets_ atom values, and another component only consumes it. The setter-only component should not be punished with re-renders. The way to avoid these unnecessary re-renders is to use an alternative hook that returns only the atom's setter, and doesn't bother with the atom's current value.
In jotai, this hook is the badly named `useSetAtom` from `jotai/utils`.