### PR TITLE
Fix/canvas zero size double click

### DIFF
--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -390,7 +390,6 @@ export const ZeroSizeResizeControl = React.memo((props: ZeroSizeResizeControlPro
         )
       })
       dispatch([...setPropActions, CanvasActions.clearInteractionSession(false)], 'everyone')
-      // dispatch(setPropActions, 'everyone')
     }
   }, [dispatch, element, props.frame])
 

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -308,10 +308,6 @@ interface ZeroSizeResizeControlProps {
 export const ZeroSizeResizeControl = React.memo((props: ZeroSizeResizeControlProps) => {
   const { dispatch, element, maybeClearHighlightsOnHoverEnd } = props
 
-  const onControlStopPropagation = React.useCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    event.stopPropagation()
-  }, [])
-
   const onControlMouseDown = useZeroSizeStartDrag(element.elementPath)
 
   const onControlMouseMove = React.useCallback(
@@ -320,6 +316,14 @@ export const ZeroSizeResizeControl = React.memo((props: ZeroSizeResizeControlPro
       maybeClearHighlightsOnHoverEnd()
     },
     [maybeClearHighlightsOnHoverEnd],
+  )
+
+  const onControlMouseUp = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      event.stopPropagation()
+      dispatch([CanvasActions.clearInteractionSession(true)], 'everyone')
+    },
+    [dispatch],
   )
 
   const onControlDoubleClick = React.useCallback(() => {
@@ -386,6 +390,7 @@ export const ZeroSizeResizeControl = React.memo((props: ZeroSizeResizeControlPro
         )
       })
       dispatch([...setPropActions, CanvasActions.clearInteractionSession(false)], 'everyone')
+      // dispatch(setPropActions, 'everyone')
     }
   }, [dispatch, element, props.frame])
 
@@ -394,7 +399,7 @@ export const ZeroSizeResizeControl = React.memo((props: ZeroSizeResizeControlPro
       <div
         onMouseMove={onControlMouseMove}
         onMouseDown={onControlMouseDown}
-        onMouseUp={onControlStopPropagation}
+        onMouseUp={onControlMouseUp}
         onDoubleClick={onControlDoubleClick}
         className='role-resize-no-size'
         data-testid={ZeroSizedControlTestID}

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -330,6 +330,7 @@ export const ZeroSizeResizeControl = React.memo((props: ZeroSizeResizeControlPro
           EditorActions.switchEditorMode(
             EditorModes.textEditMode(element.elementPath, null, 'existing', 'no-text-selection'),
           ),
+          CanvasActions.clearInteractionSession(false),
         ],
         'everyone',
       )
@@ -384,7 +385,7 @@ export const ZeroSizeResizeControl = React.memo((props: ZeroSizeResizeControlPro
           jsxAttributeValue(prop.value, emptyComments),
         )
       })
-      dispatch(setPropActions, 'everyone')
+      dispatch([...setPropActions, CanvasActions.clearInteractionSession(false)], 'everyone')
     }
   }, [dispatch, element, props.frame])
 


### PR DESCRIPTION
**Problem:**
When interacting with zero size elements mouseup and doubleclick keeps an active interaction session.

**Fix:**
Clear interaction session in the event handlers. 

**Commit Details:**
- update zero size control
