### PR TITLE
Highlight padding when hovering over the new layout system controls

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -28,6 +28,7 @@ import {
   combinePaddings,
   paddingPropForEdge,
   PaddingAdjustMode,
+  EdgePieces,
 } from '../../padding-utils'
 import {
   EditorRenderResult,
@@ -36,8 +37,6 @@ import {
   renderTestEditorWithCode,
 } from '../../ui-jsx.test-utils'
 import { PaddingTearThreshold, SetPaddingStrategyName } from './set-padding-strategy'
-
-const EdgePieces: Array<EdgePiece> = ['top', 'bottom', 'left', 'right']
 
 describe('Padding resize strategy', () => {
   it('Padding resize handle is not present for elements that have no padding set', async () => {

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -869,7 +869,7 @@ export function useClearKeyboardInteraction(editorStoreRef: {
   }, [dispatch, editorStoreRef])
 }
 
-export function useHighlighPaddingHandlers(): {
+export function useHighlightPaddingHandlers(): {
   onMouseEnter: () => void
   onMouseLeave: () => void
 } {

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -55,8 +55,13 @@ import {
 } from '../text-edit-mode/text-edit-mode-hooks'
 import { useDispatch } from '../../../editor/store/dispatch-context'
 import { useSetAtom } from 'jotai'
-import { InspectorHoveredCanvasControls } from '../../../inspector/common/inspector-atoms'
-import { SubduedPaddingControl } from './subdued-padding-control'
+import {
+  CanvasControlWithProps,
+  InspectorHoveredCanvasControls,
+} from '../../../inspector/common/inspector-atoms'
+import { SubduedPaddingControl, SubduedPaddingControlProps } from './subdued-padding-control'
+import { ControlWithProps } from '../../canvas-strategies/canvas-strategy-types'
+import { EdgePieces } from '../../padding-utils'
 
 const DRAG_START_THRESHOLD = 2
 
@@ -869,35 +874,18 @@ export function useClearKeyboardInteraction(editorStoreRef: {
   }, [dispatch, editorStoreRef])
 }
 
-export function useHighlightPaddingHandlers(): {
-  onMouseEnter: () => void
+export function useSetHoveredControlsHandlers<T>(): {
+  onMouseEnter: (controls: Array<CanvasControlWithProps<T>>) => void
   onMouseLeave: () => void
 } {
-  const paddingControlsForHover = React.useMemo(() => {
-    return mapArrayToDictionary(
-      ['top', 'right', 'bottom', 'left'],
-      (k) => k,
-      (side) => ({
-        control: SubduedPaddingControl,
-        props: {
-          side: side,
-          hoveredOrFocused: 'hovered',
-        },
-        key: `subdued-padding-control-hovered-${side}`,
-      }),
-    )
-  }, [])
-
   const setHoveredCanvasControls = useSetAtom(InspectorHoveredCanvasControls)
 
-  const onMouseEnter = React.useCallback(() => {
-    setHoveredCanvasControls([
-      paddingControlsForHover['top'],
-      paddingControlsForHover['right'],
-      paddingControlsForHover['bottom'],
-      paddingControlsForHover['left'],
-    ])
-  }, [paddingControlsForHover, setHoveredCanvasControls])
+  const onMouseEnter = React.useCallback(
+    (controls: Array<CanvasControlWithProps<T>>) => {
+      setHoveredCanvasControls(controls)
+    },
+    [setHoveredCanvasControls],
+  )
 
   const onMouseLeave = React.useCallback(
     () => setHoveredCanvasControls([]),

--- a/editor/src/components/canvas/controls/select-mode/subdued-padding-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/subdued-padding-control.tsx
@@ -1,18 +1,12 @@
 import React from 'react'
-import { ElementPath } from '../../../../core/shared/project-file-types'
 import { useColorTheme } from '../../../../uuiui'
 import { Substores, useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
 import { EdgePiece } from '../../canvas-types'
-import {
-  combinePaddings,
-  paddingFromSpecialSizeMeasurements,
-  paddingPropForEdge,
-  simplePaddingFromMetadata,
-} from '../../padding-utils'
+import { paddingPropForEdge, simplePaddingFromMetadata } from '../../padding-utils'
 import { useBoundingBox } from '../bounding-box-hooks'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 
-interface SubduedPaddingControlProps {
+export interface SubduedPaddingControlProps {
   side: EdgePiece
   hoveredOrFocused: 'hovered' | 'focused'
 }

--- a/editor/src/components/canvas/padding-utils.tsx
+++ b/editor/src/components/canvas/padding-utils.tsx
@@ -1,7 +1,7 @@
 import { styleStringInArray } from '../../utils/common-constants'
 import { getLayoutProperty } from '../../core/layout/getLayoutProperty'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
-import { defaultEither, Either, isLeft, right } from '../../core/shared/either'
+import { defaultEither, isLeft, right } from '../../core/shared/either'
 import { ElementInstanceMetadataMap, isJSXElement } from '../../core/shared/element-template'
 import { CanvasVector } from '../../core/shared/math-utils'
 import { optionalMap } from '../../core/shared/optional-utils'
@@ -17,6 +17,8 @@ import {
   unitlessCSSNumberWithRenderedValue,
 } from './controls/select-mode/controls-common'
 import { Modifiers } from '../../utils/modifiers'
+
+export const EdgePieces: Array<EdgePiece> = ['top', 'bottom', 'left', 'right']
 
 export type CSSPaddingKey = keyof CSSPadding
 export type CSSPaddingMappedValues<T> = { [key in CSSPaddingKey]: T }

--- a/editor/src/components/inspector/flex-direction-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/flex-direction-control.spec.browser2.tsx
@@ -1,10 +1,16 @@
+import * as EP from '../../core/shared/element-path'
 import { setFeatureEnabled } from '../../utils/feature-switches'
-import { expectSingleUndoStep } from '../../utils/utils.test-utils'
+import {
+  expectSingleUndoStep,
+  hoverControlWithCheck,
+  selectComponentsForTest,
+} from '../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
+import { getSubduedPaddingControlTestID } from '../canvas/controls/select-mode/subdued-padding-control'
 import { mouseClickAtPoint } from '../canvas/event-helpers.test-utils'
 import { EditorRenderResult, renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
 import { FlexDirection } from './common/css-utils'
-import { FlexDirectionToggleTestId } from './flex-direction-control'
+import { FlexDirectionControlTestId, FlexDirectionToggleTestId } from './flex-direction-control'
 
 describe('set flex direction', () => {
   before(() => {
@@ -97,6 +103,21 @@ describe('set flex direction', () => {
     expect(green.style.height).toEqual('')
     expect(green.style.width).toEqual('188px')
     expect(green.style.flexGrow).toEqual('1')
+  })
+
+  it('when spaced/packed control is hovered, padding hihglights are shown', async () => {
+    const editor = await renderTestEditorWithCode(projectWithPadding, 'await-first-dom-report')
+    await selectComponentsForTest(editor, [EP.fromString('sb/div')])
+    await hoverControlWithCheck(editor, FlexDirectionControlTestId, async () => {
+      const controls = [
+        getSubduedPaddingControlTestID('top', 'hovered'),
+        getSubduedPaddingControlTestID('bottom', 'hovered'),
+        getSubduedPaddingControlTestID('left', 'hovered'),
+        getSubduedPaddingControlTestID('right', 'hovered'),
+      ].flatMap((id) => editor.renderedDOM.queryAllByTestId(id))
+
+      expect(controls.length).toEqual(4)
+    })
   })
 })
 
@@ -211,3 +232,26 @@ function projectWithFillContainerChildren(): string {
   )
   `
 }
+
+const projectWithPadding = `import * as React from 'react'
+import { Scene, Storyboard, FlexCol } from 'utopia-api'
+import { App } from '/src/app.js'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        left: -189,
+        top: 34,
+        width: 326,
+        height: 168,
+        display: 'flex',
+        padding: 20,
+      }}
+      data-uid='div'
+    />
+  </Storyboard>
+)
+`

--- a/editor/src/components/inspector/flex-direction-control.tsx
+++ b/editor/src/components/inspector/flex-direction-control.tsx
@@ -3,11 +3,17 @@ import { createSelector } from 'reselect'
 import { ElementInstanceMetadataMap } from '../../core/shared/element-template'
 import { ElementPath } from '../../core/shared/project-file-types'
 import { Icons, useColorTheme } from '../../uuiui'
-import { useHighlighPaddingHandlers } from '../canvas/controls/select-mode/select-mode-hooks'
+import { useSetHoveredControlsHandlers } from '../canvas/controls/select-mode/select-mode-hooks'
+import {
+  SubduedPaddingControlProps,
+  SubduedPaddingControl,
+} from '../canvas/controls/select-mode/subdued-padding-control'
+import { EdgePieces } from '../canvas/padding-utils'
 import { EditorDispatch } from '../editor/action-types'
 import { useDispatch } from '../editor/store/dispatch-context'
 import { Substores, useEditorState, useRefEditorState } from '../editor/store/store-hook'
 import { FlexDirection } from './common/css-utils'
+import { CanvasControlWithProps } from './common/inspector-atoms'
 import {
   flexDirectionSelector,
   metadataSelector,
@@ -73,7 +79,25 @@ export const FlexDirectionToggle = React.memo(() => {
     [dispatch, metadataRef, selectedViewsRef],
   )
 
-  const { onMouseEnter, onMouseLeave } = useHighlighPaddingHandlers()
+  const paddingControlsForHover: Array<CanvasControlWithProps<SubduedPaddingControlProps>> =
+    React.useMemo(
+      () =>
+        EdgePieces.map((side) => ({
+          control: SubduedPaddingControl,
+          props: {
+            side: side,
+            hoveredOrFocused: 'hovered',
+          },
+          key: `subdued-padding-control-hovered-${side}`,
+        })),
+      [],
+    )
+
+  const { onMouseEnter, onMouseLeave } = useSetHoveredControlsHandlers<SubduedPaddingControlProps>()
+  const onMouseEnterWithPaddingControls = React.useCallback(
+    () => onMouseEnter(paddingControlsForHover),
+    [onMouseEnter, paddingControlsForHover],
+  )
 
   if (nFlexContainers === 0) {
     return null
@@ -82,7 +106,7 @@ export const FlexDirectionToggle = React.memo(() => {
   return (
     <div
       data-testid={FlexDirectionControlTestId}
-      onMouseEnter={onMouseEnter}
+      onMouseEnter={onMouseEnterWithPaddingControls}
       onMouseLeave={onMouseLeave}
       style={{
         display: 'grid',

--- a/editor/src/components/inspector/flex-direction-control.tsx
+++ b/editor/src/components/inspector/flex-direction-control.tsx
@@ -25,6 +25,9 @@ const nFlexContainersSelector = createSelector(
   selectedViewsSelector,
   numberOfFlexContainers,
 )
+
+export const FlexDirectionControlTestId = 'FlexDirectionControlTestId'
+
 export const FlexDirectionToggleTestId = (direction: FlexDirection): string =>
   `FlexDirectionToggle-${direction}`
 
@@ -78,6 +81,7 @@ export const FlexDirectionToggle = React.memo(() => {
 
   return (
     <div
+      data-testid={FlexDirectionControlTestId}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       style={{

--- a/editor/src/components/inspector/flex-direction-control.tsx
+++ b/editor/src/components/inspector/flex-direction-control.tsx
@@ -3,6 +3,7 @@ import { createSelector } from 'reselect'
 import { ElementInstanceMetadataMap } from '../../core/shared/element-template'
 import { ElementPath } from '../../core/shared/project-file-types'
 import { Icons, useColorTheme } from '../../uuiui'
+import { useHighlighPaddingHandlers } from '../canvas/controls/select-mode/select-mode-hooks'
 import { EditorDispatch } from '../editor/action-types'
 import { useDispatch } from '../editor/store/dispatch-context'
 import { Substores, useEditorState, useRefEditorState } from '../editor/store/store-hook'
@@ -69,12 +70,16 @@ export const FlexDirectionToggle = React.memo(() => {
     [dispatch, metadataRef, selectedViewsRef],
   )
 
+  const { onMouseEnter, onMouseLeave } = useHighlighPaddingHandlers()
+
   if (nFlexContainers === 0) {
     return null
   }
 
   return (
     <div
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
       style={{
         display: 'grid',
         gridTemplateRows: '1fr',

--- a/editor/src/components/inspector/nine-block-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/nine-block-control.spec.browser2.tsx
@@ -1,10 +1,16 @@
+import * as EP from '../../core/shared/element-path'
 import { setFeatureEnabled } from '../../utils/feature-switches'
-import { expectSingleUndoStep } from '../../utils/utils.test-utils'
+import {
+  expectSingleUndoStep,
+  hoverControlWithCheck,
+  selectComponentsForTest,
+} from '../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
+import { getSubduedPaddingControlTestID } from '../canvas/controls/select-mode/subdued-padding-control'
 import { mouseClickAtPoint } from '../canvas/event-helpers.test-utils'
 import { EditorRenderResult, renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
 import { StartCenterEnd } from './inspector-common'
-import { NineBlockSectors, NineBlockTestId } from './nine-block-controls'
+import { NineBlockControlTestId, NineBlockSectors, NineBlockTestId } from './nine-block-controls'
 
 describe('Nine-block control', () => {
   before(() => {
@@ -35,6 +41,21 @@ describe('Nine-block control', () => {
         expect(div.style.alignItems).toEqual(alignItems)
       })
     }
+  })
+
+  it('when nine-block control is hovered, padding hihglights are shown', async () => {
+    const editor = await renderTestEditorWithCode(projectWithPadding, 'await-first-dom-report')
+    await selectComponentsForTest(editor, [EP.fromString('sb/div')])
+    await hoverControlWithCheck(editor, NineBlockControlTestId, async () => {
+      const controls = [
+        getSubduedPaddingControlTestID('top', 'hovered'),
+        getSubduedPaddingControlTestID('bottom', 'hovered'),
+        getSubduedPaddingControlTestID('left', 'hovered'),
+        getSubduedPaddingControlTestID('right', 'hovered'),
+      ].flatMap((id) => editor.renderedDOM.queryAllByTestId(id))
+
+      expect(controls.length).toEqual(4)
+    })
   })
 })
 
@@ -130,3 +151,26 @@ function projectFlexColumn(): string {
   )
   `
 }
+
+const projectWithPadding = `import * as React from 'react'
+import { Scene, Storyboard, FlexCol } from 'utopia-api'
+import { App } from '/src/app.js'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        left: -189,
+        top: 34,
+        width: 326,
+        height: 168,
+        display: 'flex',
+        padding: 20,
+      }}
+      data-uid='div'
+    />
+  </Storyboard>
+)
+`

--- a/editor/src/components/inspector/nine-block-controls.tsx
+++ b/editor/src/components/inspector/nine-block-controls.tsx
@@ -28,6 +28,7 @@ import { executeFirstApplicableStrategy } from './inspector-strategies/inspector
 import { MetadataSubstate } from '../editor/store/store-hook-substore-types'
 import { Dot } from './inspector-common-components'
 import { styled } from '@stitches/react'
+import { useHighlighPaddingHandlers } from '../canvas/controls/select-mode/select-mode-hooks'
 
 export const NineBlockTestId = (
   alignItems: FlexAlignment,
@@ -275,6 +276,8 @@ export const NineBlockControl = React.memo(() => {
     [dispatch, flexDirectionRef, metadataRef, selectedViewsRef],
   )
 
+  const { onMouseEnter, onMouseLeave } = useHighlighPaddingHandlers()
+
   const callbacks: {
     [key in NineKey]: () => void
   } = React.useMemo(
@@ -296,6 +299,8 @@ export const NineBlockControl = React.memo(() => {
 
   return (
     <div
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
       style={{
         margin: 2,
         height: 100,

--- a/editor/src/components/inspector/nine-block-controls.tsx
+++ b/editor/src/components/inspector/nine-block-controls.tsx
@@ -30,6 +30,8 @@ import { Dot } from './inspector-common-components'
 import { styled } from '@stitches/react'
 import { useHighlighPaddingHandlers } from '../canvas/controls/select-mode/select-mode-hooks'
 
+export const NineBlockControlTestId = 'NineBlockControlTestId'
+
 export const NineBlockTestId = (
   alignItems: FlexAlignment,
   justifyContent: FlexJustifyContent,
@@ -299,6 +301,7 @@ export const NineBlockControl = React.memo(() => {
 
   return (
     <div
+      data-testid={NineBlockControlTestId}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       style={{

--- a/editor/src/components/inspector/nine-block-controls.tsx
+++ b/editor/src/components/inspector/nine-block-controls.tsx
@@ -28,7 +28,13 @@ import { executeFirstApplicableStrategy } from './inspector-strategies/inspector
 import { MetadataSubstate } from '../editor/store/store-hook-substore-types'
 import { Dot } from './inspector-common-components'
 import { styled } from '@stitches/react'
-import { useHighlighPaddingHandlers } from '../canvas/controls/select-mode/select-mode-hooks'
+import { useSetHoveredControlsHandlers } from '../canvas/controls/select-mode/select-mode-hooks'
+import {
+  SubduedPaddingControlProps,
+  SubduedPaddingControl,
+} from '../canvas/controls/select-mode/subdued-padding-control'
+import { EdgePieces } from '../canvas/padding-utils'
+import { CanvasControlWithProps } from './common/inspector-atoms'
 
 export const NineBlockControlTestId = 'NineBlockControlTestId'
 
@@ -278,7 +284,25 @@ export const NineBlockControl = React.memo(() => {
     [dispatch, flexDirectionRef, metadataRef, selectedViewsRef],
   )
 
-  const { onMouseEnter, onMouseLeave } = useHighlighPaddingHandlers()
+  const paddingControlsForHover: Array<CanvasControlWithProps<SubduedPaddingControlProps>> =
+    React.useMemo(
+      () =>
+        EdgePieces.map((side) => ({
+          control: SubduedPaddingControl,
+          props: {
+            side: side,
+            hoveredOrFocused: 'hovered',
+          },
+          key: `subdued-padding-control-hovered-${side}`,
+        })),
+      [],
+    )
+
+  const { onMouseEnter, onMouseLeave } = useSetHoveredControlsHandlers<SubduedPaddingControlProps>()
+  const onMouseEnterWithPaddingControls = React.useCallback(
+    () => onMouseEnter(paddingControlsForHover),
+    [onMouseEnter, paddingControlsForHover],
+  )
 
   const callbacks: {
     [key in NineKey]: () => void
@@ -302,7 +326,7 @@ export const NineBlockControl = React.memo(() => {
   return (
     <div
       data-testid={NineBlockControlTestId}
-      onMouseEnter={onMouseEnter}
+      onMouseEnter={onMouseEnterWithPaddingControls}
       onMouseLeave={onMouseLeave}
       style={{
         margin: 2,

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -9,8 +9,12 @@ import {
 } from '../../../../../core/shared/element-template'
 import { PropertyPath } from '../../../../../core/shared/project-file-types'
 import { FunctionIcons, SquareButton } from '../../../../../uuiui'
-import { useHighlighPaddingHandlers } from '../../../../canvas/controls/select-mode/select-mode-hooks'
-import { SubduedPaddingControl } from '../../../../canvas/controls/select-mode/subdued-padding-control'
+import { useSetHoveredControlsHandlers } from '../../../../canvas/controls/select-mode/select-mode-hooks'
+import {
+  SubduedPaddingControl,
+  SubduedPaddingControlProps,
+} from '../../../../canvas/controls/select-mode/subdued-padding-control'
+import { EdgePieces } from '../../../../canvas/padding-utils'
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { switchLayoutSystem } from '../../../../editor/actions/action-creators'
 import { useDispatch } from '../../../../editor/store/dispatch-context'
@@ -21,6 +25,7 @@ import {
   getControlStatusFromPropertyStatus,
   getControlStyles,
 } from '../../../common/control-status'
+import { CanvasControlWithProps } from '../../../common/inspector-atoms'
 import { useInspectorInfoLonghandShorthand } from '../../../common/longhand-shorthand-hooks'
 import {
   InspectorCallbackContext,
@@ -180,7 +185,25 @@ export const PaddingRow = React.memo(() => {
     [contextMenuLabel, metadata.propertyStatus.set, metadata.onUnsetValues],
   )
 
-  const { onMouseEnter, onMouseLeave } = useHighlighPaddingHandlers()
+  const paddingControlsForHover: Array<CanvasControlWithProps<SubduedPaddingControlProps>> =
+    React.useMemo(
+      () =>
+        EdgePieces.map((side) => ({
+          control: SubduedPaddingControl,
+          props: {
+            side: side,
+            hoveredOrFocused: 'hovered',
+          },
+          key: `subdued-padding-control-hovered-${side}`,
+        })),
+      [],
+    )
+
+  const { onMouseEnter, onMouseLeave } = useSetHoveredControlsHandlers<SubduedPaddingControlProps>()
+  const onMouseEnterWithPaddingControls = React.useCallback(
+    () => onMouseEnter(paddingControlsForHover),
+    [onMouseEnter, paddingControlsForHover],
+  )
 
   return (
     <InspectorContextMenuWrapper
@@ -189,13 +212,13 @@ export const PaddingRow = React.memo(() => {
       data={null}
     >
       <UIGridRow
-        onMouseEnter={onMouseEnter}
+        onMouseEnter={onMouseEnterWithPaddingControls}
         onMouseLeave={onMouseLeave}
         tall
         padded={true}
         variant='<---1fr--->|------172px-------|'
       >
-        <div onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+        <div onMouseEnter={onMouseEnterWithPaddingControls} onMouseLeave={onMouseLeave}>
           <PropertyLabel
             target={paddingPropsToUnset}
             propNamesToUnset={contextMenuLabel}

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -9,11 +9,11 @@ import {
 } from '../../../../../core/shared/element-template'
 import { PropertyPath } from '../../../../../core/shared/project-file-types'
 import { FunctionIcons, SquareButton } from '../../../../../uuiui'
+import { useHighlighPaddingHandlers } from '../../../../canvas/controls/select-mode/select-mode-hooks'
 import { SubduedPaddingControl } from '../../../../canvas/controls/select-mode/subdued-padding-control'
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { switchLayoutSystem } from '../../../../editor/actions/action-creators'
 import { useDispatch } from '../../../../editor/store/dispatch-context'
-import { Substores, useEditorState } from '../../../../editor/store/store-hook'
 import { optionalAddOnUnsetValues } from '../../../common/context-menu-items'
 import {
   ControlStatus,
@@ -180,22 +180,32 @@ export const PaddingRow = React.memo(() => {
     [contextMenuLabel, metadata.propertyStatus.set, metadata.onUnsetValues],
   )
 
+  const { onMouseEnter, onMouseLeave } = useHighlighPaddingHandlers()
+
   return (
     <InspectorContextMenuWrapper
       id='padding-subsection-context-menu'
       items={contextMenuItems}
       data={null}
     >
-      <UIGridRow tall padded={true} variant='<---1fr--->|------172px-------|'>
-        <PropertyLabel
-          target={paddingPropsToUnset}
-          propNamesToUnset={contextMenuLabel}
-          style={{
-            paddingBottom: 20,
-          }}
-        >
-          Padding
-        </PropertyLabel>
+      <UIGridRow
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        tall
+        padded={true}
+        variant='<---1fr--->|------172px-------|'
+      >
+        <div onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+          <PropertyLabel
+            target={paddingPropsToUnset}
+            propNamesToUnset={contextMenuLabel}
+            style={{
+              paddingBottom: 20,
+            }}
+          >
+            Padding
+          </PropertyLabel>
+        </div>
         <PaddingControl />
       </UIGridRow>
     </InspectorContextMenuWrapper>

--- a/editor/src/components/inspector/spaced-packed-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/spaced-packed-control.spec.browser2.tsx
@@ -1,9 +1,18 @@
 import * as EP from '../../core/shared/element-path'
 import { setFeatureEnabled } from '../../utils/feature-switches'
-import { expectSingleUndoStep, selectComponentsForTest } from '../../utils/utils.test-utils'
+import {
+  expectSingleUndoStep,
+  hoverControlWithCheck,
+  selectComponentsForTest,
+} from '../../utils/utils.test-utils'
+import { getSubduedPaddingControlTestID } from '../canvas/controls/select-mode/subdued-padding-control'
 import { mouseClickAtPoint } from '../canvas/event-helpers.test-utils'
 import { EditorRenderResult, renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
-import { PackedLabelCopy, SpacedLabelCopy } from './spaced-packed-control'
+import {
+  PackedLabelCopy,
+  SpacedLabelCopy,
+  SpacedPackedControlTestId,
+} from './spaced-packed-control'
 
 type SpacedPackedButtonLabel = typeof PackedLabelCopy | typeof SpacedLabelCopy
 
@@ -36,6 +45,21 @@ describe('spaced - packed control', () => {
     await expectSingleUndoStep(editor, () => clickButton(editor, SpacedLabelCopy))
     await expectSingleUndoStep(editor, () => clickButton(editor, PackedLabelCopy))
     expect(div.style.justifyContent).toEqual('flex-start')
+  })
+
+  it('when spaced/packed control is hovered, padding hihglights are shown', async () => {
+    const editor = await renderTestEditorWithCode(projectWithPadding, 'await-first-dom-report')
+    await selectComponentsForTest(editor, [EP.fromString('sb/div')])
+    await hoverControlWithCheck(editor, SpacedPackedControlTestId, async () => {
+      const controls = [
+        getSubduedPaddingControlTestID('top', 'hovered'),
+        getSubduedPaddingControlTestID('bottom', 'hovered'),
+        getSubduedPaddingControlTestID('left', 'hovered'),
+        getSubduedPaddingControlTestID('right', 'hovered'),
+      ].flatMap((id) => editor.renderedDOM.queryAllByTestId(id))
+
+      expect(controls.length).toEqual(4)
+    })
   })
 })
 
@@ -111,6 +135,29 @@ export var storyboard = (
         />
       </div>
     </Scene>
+  </Storyboard>
+)
+`
+
+const projectWithPadding = `import * as React from 'react'
+import { Scene, Storyboard, FlexCol } from 'utopia-api'
+import { App } from '/src/app.js'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        left: -189,
+        top: 34,
+        width: 326,
+        height: 168,
+        display: 'flex',
+        padding: 20,
+      }}
+      data-uid='div'
+    />
   </Storyboard>
 )
 `

--- a/editor/src/components/inspector/spaced-packed-control.tsx
+++ b/editor/src/components/inspector/spaced-packed-control.tsx
@@ -2,9 +2,15 @@ import React from 'react'
 import { createSelector } from 'reselect'
 import { assertNever } from '../../core/shared/utils'
 import { ControlStatus, getControlStyles } from '../../uuiui-deps'
-import { useHighlighPaddingHandlers } from '../canvas/controls/select-mode/select-mode-hooks'
+import { useSetHoveredControlsHandlers } from '../canvas/controls/select-mode/select-mode-hooks'
+import {
+  SubduedPaddingControlProps,
+  SubduedPaddingControl,
+} from '../canvas/controls/select-mode/subdued-padding-control'
+import { EdgePieces } from '../canvas/padding-utils'
 import { useDispatch } from '../editor/store/dispatch-context'
 import { Substores, useEditorState, useRefEditorState } from '../editor/store/store-hook'
+import { CanvasControlWithProps } from './common/inspector-atoms'
 import { OptionChainControl, OptionChainOption } from './controls/option-chain-control'
 import { metadataSelector, selectedViewsSelector } from './inpector-selectors'
 import { detectPackedSpacedSetting, PackedSpaced } from './inspector-common'
@@ -70,13 +76,31 @@ export const SpacedPackedControl = React.memo(() => {
     [dispatch, metadataRef, selectedViewsRef],
   )
 
-  const { onMouseEnter, onMouseLeave } = useHighlighPaddingHandlers()
+  const paddingControlsForHover: Array<CanvasControlWithProps<SubduedPaddingControlProps>> =
+    React.useMemo(
+      () =>
+        EdgePieces.map((side) => ({
+          control: SubduedPaddingControl,
+          props: {
+            side: side,
+            hoveredOrFocused: 'hovered',
+          },
+          key: `subdued-padding-control-hovered-${side}`,
+        })),
+      [],
+    )
+
+  const { onMouseEnter, onMouseLeave } = useSetHoveredControlsHandlers<SubduedPaddingControlProps>()
+  const onMouseEnterWithPaddingControls = React.useCallback(
+    () => onMouseEnter(paddingControlsForHover),
+    [onMouseEnter, paddingControlsForHover],
+  )
 
   const controlStatus: ControlStatus = 'simple'
   return (
     <UIGridRow
       data-testid={SpacedPackedControlTestId}
-      onMouseEnter={onMouseEnter}
+      onMouseEnter={onMouseEnterWithPaddingControls}
       onMouseLeave={onMouseLeave}
       padded={true}
       variant='<---1fr--->|------172px-------|'

--- a/editor/src/components/inspector/spaced-packed-control.tsx
+++ b/editor/src/components/inspector/spaced-packed-control.tsx
@@ -15,6 +15,8 @@ import {
 import { executeFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
 import { UIGridRow } from './widgets/ui-grid-row'
 
+export const SpacedPackedControlTestId = 'SpacedPackedControlTestId'
+
 export const PackedLabelCopy = 'Packed' as const
 export const SpacedLabelCopy = 'Spaced' as const
 
@@ -73,6 +75,7 @@ export const SpacedPackedControl = React.memo(() => {
   const controlStatus: ControlStatus = 'simple'
   return (
     <UIGridRow
+      data-testid={SpacedPackedControlTestId}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       padded={true}

--- a/editor/src/components/inspector/spaced-packed-control.tsx
+++ b/editor/src/components/inspector/spaced-packed-control.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { createSelector } from 'reselect'
 import { assertNever } from '../../core/shared/utils'
 import { ControlStatus, getControlStyles } from '../../uuiui-deps'
+import { useHighlighPaddingHandlers } from '../canvas/controls/select-mode/select-mode-hooks'
 import { useDispatch } from '../editor/store/dispatch-context'
 import { Substores, useEditorState, useRefEditorState } from '../editor/store/store-hook'
 import { OptionChainControl, OptionChainOption } from './controls/option-chain-control'
@@ -67,9 +68,16 @@ export const SpacedPackedControl = React.memo(() => {
     [dispatch, metadataRef, selectedViewsRef],
   )
 
+  const { onMouseEnter, onMouseLeave } = useHighlighPaddingHandlers()
+
   const controlStatus: ControlStatus = 'simple'
   return (
-    <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
+    <UIGridRow
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      padded={true}
+      variant='<---1fr--->|------172px-------|'
+    >
       Spacing
       <OptionChainControl
         id={'spaced-packed-control'}

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`423`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`424`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`412`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`413`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`659`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`660`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`731`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`732`)
   })
 })

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -72,6 +72,7 @@ import {
 } from '../components/canvas/canvas-strategies/interaction-state'
 import { EditorRenderResult } from '../components/canvas/ui-jsx.test-utils'
 import { selectComponents } from '../components/editor/actions/action-creators'
+import { fireEvent } from '@testing-library/react'
 
 export function delay(time: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, time))
@@ -437,4 +438,15 @@ export async function selectComponentsForTest(
 ): Promise<void> {
   await editor.dispatch([selectComponents(paths, false)], true)
   await editor.getDispatchFollowUpActionsFinished()
+}
+
+export async function hoverControlWithCheck(
+  editor: EditorRenderResult,
+  controlTestId: string,
+  check: () => Promise<void>,
+): Promise<void> {
+  const control = (await editor.renderedDOM.findByTestId(controlTestId)) as HTMLInputElement
+  fireEvent.mouseEnter(control)
+  await editor.getDispatchFollowUpActionsFinished()
+  await check()
 }


### PR DESCRIPTION
## Try it [here](https://utopia.pizza/p/240f12fa-uneven-poinsettia/?branch_name=experiment-highlight-padding-more)
![hover_everywhere](https://user-images.githubusercontent.com/16385508/217770792-113602be-530a-4457-93db-f6f752297391.gif)

## Description
Padding is highlighted whenever any of the AutoLayout: Flex controls are hovered, not just the inputs in the padding control.
