### PR TITLE
Allow double click to edit elements with only code inside (and no text)

### DIFF
--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
@@ -50,6 +50,20 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
       expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
     })
+    it('Entering text edit mode with double click on selected text editable element with only code inside', async () => {
+      const editor = await renderTestEditorWithCode(projectWithCodeText, 'await-first-dom-report')
+      await selectElement(editor, EP.fromString('sb/39e'))
+      await clickOnElement(editor, 'div', 'double-click')
+      // wait for the next frame
+      await wait(1)
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
+      expect(
+        EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
+      ).toEqual('sb/39e')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
+    })
     it('Entering text edit mode with double click on selected multiline text editable element', async () => {
       const editor = await renderTestEditorWithCode(
         projectWithMultilineText,
@@ -179,6 +193,30 @@ async function clickOnElement(
   }
   await editor.getDispatchFollowUpActionsFinished()
 }
+
+const projectWithCodeText = formatTestProjectCode(`import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+const title = 'Hello'
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      data-testid='div'
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 288,
+        height: 362,
+      }}
+      data-uid='39e'
+    >
+      {title}
+    </div>
+  </Storyboard>
+)
+`)
 
 const projectWithText = formatTestProjectCode(`import * as React from 'react'
 import { Storyboard } from 'utopia-api'

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -911,7 +911,8 @@ export const MetadataUtils = {
     if (isRight(element.element) && isJSXElement(element.element.value)) {
       const elementValue = element.element.value
       return (
-        elementValue.children.length >= 1 && elementValue.children.some((c) => isJSXTextBlock(c))
+        elementValue.children.length >= 1 &&
+        elementValue.children.some((c) => isJSXTextBlock(c) || isJSXArbitraryBlock(c))
       )
     }
     return false


### PR DESCRIPTION
**Problem:**
When an element has only code inside as text (e.v. `<div>{props.title}</div>`), we don't allow double click to edit

**Fix:**
We only allow double click to edit of text editable components when they have existing text content. However, code is not "text content" in our implementation, so I had to make the condition less strict.