### PR TITLE
Double click on resize corner to resize to fit

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -35,7 +35,11 @@ import {
   BakedInStoryboardVariableName,
   BakedInStoryboardUID,
 } from '../../../../core/model/scene-utils'
-import { mouseClickAtPoint, mouseDragFromPointWithDelta } from '../../event-helpers.test-utils'
+import {
+  mouseClickAtPoint,
+  mouseDoubleClickAtPoint,
+  mouseDragFromPointWithDelta,
+} from '../../event-helpers.test-utils'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import { setFeatureEnabled } from '../../../../utils/feature-switches'
 import { CSSProperties } from 'react'
@@ -293,11 +297,7 @@ async function doDblClickTest(
 
   const nineBlockControlSegment = editor.renderedDOM.getByTestId(testId)
 
-  await mouseClickAtPoint(
-    nineBlockControlSegment,
-    { x: 2, y: verticalOffset },
-    { eventOptions: { detail: 2 } },
-  )
+  await mouseDoubleClickAtPoint(nineBlockControlSegment, { x: 2, y: verticalOffset })
 
   return div
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -279,7 +279,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
 async function doDblClickTest(
   editor: EditorRenderResult,
   testId: string,
-  offset = 30,
+  verticalOffset: number = 30,
 ): Promise<HTMLElement> {
   const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
   const div = editor.renderedDOM.getByTestId('mydiv')
@@ -295,7 +295,7 @@ async function doDblClickTest(
 
   await mouseClickAtPoint(
     nineBlockControlSegment,
-    { x: 2, y: offset },
+    { x: 2, y: verticalOffset },
     { eventOptions: { detail: 2 } },
   )
 
@@ -1324,8 +1324,6 @@ describe('double click on resize corner', () => {
       projectForEdgeDblClickWithText,
       'await-first-dom-report',
     )
-
-    // await wait(10000)
 
     const view = await doDblClickTest(editor, ResizePointTestId(EdgePositionTopLeft), 1)
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -40,6 +40,7 @@ import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import { setFeatureEnabled } from '../../../../utils/feature-switches'
 import { CSSProperties } from 'react'
 import { MaxContent } from '../../../inspector/inspector-common'
+import { ResizePointTestId } from '../../controls/select-mode/absolute-resize-control'
 
 async function resizeElement(
   renderResult: EditorRenderResult,
@@ -275,7 +276,11 @@ export var ${BakedInStoryboardVariableName} = (props) => {
 `
 }
 
-async function doDblClickTest(editor: EditorRenderResult, testId: string): Promise<HTMLElement> {
+async function doDblClickTest(
+  editor: EditorRenderResult,
+  testId: string,
+  offset = 30,
+): Promise<HTMLElement> {
   const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
   const div = editor.renderedDOM.getByTestId('mydiv')
   const divBounds = div.getBoundingClientRect()
@@ -288,7 +293,11 @@ async function doDblClickTest(editor: EditorRenderResult, testId: string): Promi
 
   const nineBlockControlSegment = editor.renderedDOM.getByTestId(testId)
 
-  await mouseClickAtPoint(nineBlockControlSegment, { x: 2, y: 30 }, { eventOptions: { detail: 2 } })
+  await mouseClickAtPoint(
+    nineBlockControlSegment,
+    { x: 2, y: offset },
+    { eventOptions: { detail: 2 } },
+  )
 
   return div
 }
@@ -1303,5 +1312,32 @@ describe('Double click on resize edge', () => {
     const div = await doDblClickTest(editor, edgeResizeControlTestId(EdgePositionRight))
     expect(div.style.width).toEqual(MaxContent)
     expect(div.style.height).toEqual('445px')
+  })
+})
+
+describe('double click on resize corner', () => {
+  before(() => setFeatureEnabled('Nine block control', true))
+  after(() => setFeatureEnabled('Nine block control', false))
+
+  it('resizes to fit when resize corner is double clicked', async () => {
+    const editor = await renderTestEditorWithCode(
+      projectForEdgeDblClickWithText,
+      'await-first-dom-report',
+    )
+
+    // await wait(10000)
+
+    const view = await doDblClickTest(editor, ResizePointTestId(EdgePositionTopLeft), 1)
+
+    expect(view.style.width).toEqual(MaxContent)
+    expect(view.style.minWidth).toEqual('')
+    expect(view.style.maxWidth).toEqual('')
+    expect(view.style.height).toEqual(MaxContent)
+    expect(view.style.minHeight).toEqual('')
+    expect(view.style.maxHeight).toEqual('')
+    expect(view.style.flex).toEqual('')
+    expect(view.style.flexShrink).toEqual('')
+    expect(view.style.flexGrow).toEqual('')
+    expect(view.style.flexBasis).toEqual('')
   })
 })

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -183,19 +183,11 @@ const ResizePoint = React.memo(
     const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
     const selectedElementsRef = useRefEditorState((store) => store.editor.selectedViews)
 
-    const onEdgeDblClick = React.useCallback(
-      (event: React.MouseEvent<HTMLDivElement>) => {
-        if (event.detail !== 2) {
-          return
-        }
-        dispatch([
-          applyCommandsAction(
-            resizeToFitCommands(metadataRef.current, selectedElementsRef.current),
-          ),
-        ])
-      },
-      [dispatch, metadataRef, selectedElementsRef],
-    )
+    const onEdgeDblClick = React.useCallback(() => {
+      dispatch([
+        applyCommandsAction(resizeToFitCommands(metadataRef.current, selectedElementsRef.current)),
+      ])
+    }, [dispatch, metadataRef, selectedElementsRef])
 
     return (
       <div
@@ -225,7 +217,7 @@ const ResizePoint = React.memo(
           }}
         />
         <div
-          onClick={onEdgeDblClick}
+          onDoubleClick={onEdgeDblClick}
           style={{
             position: 'relative',
             width: ResizePointMouseAreaSize / scale,
@@ -280,21 +272,14 @@ const ResizeEdge = React.memo(
       [maybeClearHighlightsOnHoverEnd],
     )
 
-    const onEdgeDblClick = React.useCallback(
-      (event: React.MouseEvent<HTMLDivElement>) => {
-        if (event.detail !== 2) {
-          return
-        }
-
-        executeFirstApplicableStrategy(
-          dispatch,
-          metadataRef.current,
-          selectedElementsRef.current,
-          setPropHugStrategies(invert(props.direction)),
-        )
-      },
-      [dispatch, metadataRef, props.direction, selectedElementsRef],
-    )
+    const onEdgeDblClick = React.useCallback(() => {
+      executeFirstApplicableStrategy(
+        dispatch,
+        metadataRef.current,
+        selectedElementsRef.current,
+        setPropHugStrategies(invert(props.direction)),
+      )
+    }, [dispatch, metadataRef, props.direction, selectedElementsRef])
 
     const lineSize = ResizeMouseAreaSize / scale
     const width = props.direction === 'horizontal' ? undefined : lineSize
@@ -303,7 +288,7 @@ const ResizeEdge = React.memo(
     const offsetTop = props.direction === 'vertical' ? `0px` : `${-lineSize / 2}px`
     return (
       <div
-        onClick={onEdgeDblClick}
+        onDoubleClick={onEdgeDblClick}
         ref={ref}
         style={{
           position: 'absolute',


### PR DESCRIPTION
## Description
This PR upgrades the resize corner controls so that when they are double clicked on, the component they are rendered on resizes to fit its contents (if this behaviour is applicable).