### PR TITLE
Use imported react fragment directly in renderer

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -401,10 +401,6 @@ function trimWhitespaces(
   return trimmedText
 }
 
-export var Fragment: React.FunctionComponent<React.PropsWithChildren<any>> = ({ children }) => {
-  return <>{children}</>
-}
-
 function renderJSXElement(
   key: string,
   jsx: JSXElementLike,
@@ -496,7 +492,7 @@ function renderJSXElement(
   const elementOrScene = elementIsScene ? SceneComponent : elementFromScopeOrImport
 
   const FinalElement = elementIsIntrinsic ? jsx.name.baseVariable : elementOrScene
-  const FinalElementOrFragment = elementIsFragment ? Fragment : FinalElement
+  const FinalElementOrFragment = elementIsFragment ? React.Fragment : FinalElement
   const elementPropsWithScenePath = isComponentRendererComponent(FinalElement)
     ? { ...elementProps, [UTOPIA_INSTANCE_PATH]: elementPath }
     : elementProps


### PR DESCRIPTION
**Problem:**
It was overcomplicated that the canvas rendered  fragments using our own `Fragment` component which just rendered its children into a fragment.

**Fix:**
We can just directly use `React.Fragment` to render a fragment and its children.

