### PR TITLE
Padding/Border radius controls update the selected elements

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -38,7 +38,11 @@ import { DefaultPackageJson, StoryboardFilePath } from '../../editor/store/edito
 import { createCodeFile } from '../../custom-code/code-file.test-utils'
 import { matchInlineSnapshotBrowser } from '../../../../test/karma-snapshots'
 import { EditorAction } from '../../editor/action-types'
-import { expectSingleUndoStep, wait } from '../../../utils/utils.test-utils'
+import {
+  expectSingleUndoStep,
+  selectComponentsForTest,
+  wait,
+} from '../../../utils/utils.test-utils'
 import { getSubduedPaddingControlTestID } from '../../canvas/controls/select-mode/subdued-padding-control'
 import { SubduedBorderRadiusControlTestId } from '../../canvas/controls/select-mode/subdued-border-radius-control'
 
@@ -2235,6 +2239,21 @@ describe('inspector tests with real metadata', () => {
         )
       })
     })
+
+    it('applies padding to the selected element', async () => {
+      const editor = await renderTestEditorWithCode(projectWithTwoDivs, 'await-first-dom-report')
+      const one = editor.renderedDOM.getByTestId('one')
+      const two = editor.renderedDOM.getByTestId('two')
+
+      await selectComponentsForTest(editor, [EP.fromString('sb/one')])
+      await selectComponentsForTest(editor, [EP.fromString('sb/two')])
+
+      await setControlValue('padding-H', '20', editor.renderedDOM)
+
+      expect(one.style.padding).toEqual('')
+
+      expect(two.style.padding).toEqual('0px 20px')
+    })
   })
 
   describe('canvas padding controls from the inspector', () => {
@@ -2361,6 +2380,23 @@ describe('inspector tests with real metadata', () => {
         )
         expect(focusedControls.length).toEqual(t.focusedCanvasControls.length)
       })
+    })
+  })
+
+  describe('border radius controls', () => {
+    it('applied border radius to the selected element', async () => {
+      const editor = await renderTestEditorWithCode(projectWithTwoDivs, 'await-first-dom-report')
+      const one = editor.renderedDOM.getByTestId('one')
+      const two = editor.renderedDOM.getByTestId('two')
+
+      await selectComponentsForTest(editor, [EP.fromString('sb/one')])
+      await selectComponentsForTest(editor, [EP.fromString('sb/two')])
+
+      await setControlValue('radius-one', '20', editor.renderedDOM)
+
+      expect(one.style.borderRadius).toEqual('')
+
+      expect(two.style.borderRadius).toEqual('20px')
     })
   })
 
@@ -2622,3 +2658,54 @@ describe('Undo behavior in inspector', () => {
     )
   })
 })
+
+const projectWithTwoDivs = `import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      data-uid={"one"}
+      data-testid={"one"}
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        left: 149,
+        top: 195,
+        width: 412,
+        height: 447,
+      }}
+    >
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          width: '100%',
+          height: '100%',
+          contain: 'layout',
+        }}
+      />
+    </div>
+    <div
+      data-uid={"two"}
+      data-testid={"two"}
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        left: 717,
+        top: 195,
+        width: 412,
+        height: 447,
+      }}
+    >
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          width: '100%',
+          height: '100%',
+          contain: 'layout',
+        }}
+      />
+    </div>
+  </Storyboard>
+)
+`

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -298,7 +298,7 @@ export const PaddingControl = React.memo(() => {
           B: 'paddingBottom',
           L: 'paddingLeft',
         },
-        selectedViewsRef.current[0],
+        selectedViewsRef,
         dispatch,
       )}
     />

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -18,7 +18,6 @@ import { EdgePieces } from '../../../../canvas/padding-utils'
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { switchLayoutSystem } from '../../../../editor/actions/action-creators'
 import { useDispatch } from '../../../../editor/store/dispatch-context'
-import { Substores, useEditorState } from '../../../../editor/store/store-hook'
 import { optionalAddOnUnsetValues } from '../../../common/context-menu-items'
 import {
   ControlStatus,
@@ -33,18 +32,17 @@ import {
   InspectorInfo,
   InspectorPropsContext,
   stylePropPathMappingFn,
+  useInspectorContext,
   useInspectorInfoSimpleUntyped,
   useInspectorLayoutInfo,
   useInspectorStyleInfo,
 } from '../../../common/property-path-hooks'
 import { OptionChainControl } from '../../../controls/option-chain-control'
-import { selectedViewsSelector } from '../../../inpector-selectors'
 import { PropertyLabel } from '../../../widgets/property-label'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import {
   longhandShorthandEventHandler,
   SplitChainedNumberInput,
-  SplitChainedNumberInputEventHandler,
 } from './split-chained-number-input'
 
 function useDefaultedLayoutSystemInfo(): {
@@ -248,6 +246,8 @@ export const PaddingControl = React.memo(() => {
   const shorthand = useInspectorLayoutInfo('padding')
   const dispatch = useDispatch()
 
+  const { selectedViewsRef } = useInspectorContext()
+
   const canvasControlsForSides = React.useMemo(() => {
     return mapArrayToDictionary(
       ['top', 'right', 'bottom', 'left'],
@@ -273,28 +273,6 @@ export const PaddingControl = React.memo(() => {
     )
   }, [])
 
-  const selectedViews = useEditorState(
-    Substores.selectedViews,
-    selectedViewsSelector,
-    'PaddingControl selectedViews',
-  )
-
-  const onSplitChainedEvent: SplitChainedNumberInputEventHandler = React.useMemo(
-    () =>
-      longhandShorthandEventHandler(
-        'padding',
-        {
-          T: 'paddingTop',
-          R: 'paddingRight',
-          B: 'paddingBottom',
-          L: 'paddingLeft',
-        },
-        selectedViews[0],
-        dispatch,
-      ),
-    [dispatch, selectedViews],
-  )
-
   return (
     <SplitChainedNumberInput
       controlModeOrder={['one-value', 'per-direction', 'per-side']}
@@ -312,7 +290,17 @@ export const PaddingControl = React.memo(() => {
       shorthand={shorthand}
       canvasControls={canvasControlsForSides}
       numberType={'LengthPercent'}
-      eventHandler={onSplitChainedEvent}
+      eventHandler={longhandShorthandEventHandler(
+        'padding',
+        {
+          T: 'paddingTop',
+          R: 'paddingRight',
+          B: 'paddingBottom',
+          L: 'paddingLeft',
+        },
+        selectedViewsRef.current[0],
+        dispatch,
+      )}
     />
   )
 })

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -18,6 +18,7 @@ import { EdgePieces } from '../../../../canvas/padding-utils'
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { switchLayoutSystem } from '../../../../editor/actions/action-creators'
 import { useDispatch } from '../../../../editor/store/dispatch-context'
+import { Substores, useEditorState } from '../../../../editor/store/store-hook'
 import { optionalAddOnUnsetValues } from '../../../common/context-menu-items'
 import {
   ControlStatus,
@@ -32,17 +33,18 @@ import {
   InspectorInfo,
   InspectorPropsContext,
   stylePropPathMappingFn,
-  useInspectorContext,
   useInspectorInfoSimpleUntyped,
   useInspectorLayoutInfo,
   useInspectorStyleInfo,
 } from '../../../common/property-path-hooks'
 import { OptionChainControl } from '../../../controls/option-chain-control'
+import { selectedViewsSelector } from '../../../inpector-selectors'
 import { PropertyLabel } from '../../../widgets/property-label'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import {
   longhandShorthandEventHandler,
   SplitChainedNumberInput,
+  SplitChainedNumberInputEventHandler,
 } from './split-chained-number-input'
 
 function useDefaultedLayoutSystemInfo(): {
@@ -246,8 +248,6 @@ export const PaddingControl = React.memo(() => {
   const shorthand = useInspectorLayoutInfo('padding')
   const dispatch = useDispatch()
 
-  const { selectedViewsRef } = useInspectorContext()
-
   const canvasControlsForSides = React.useMemo(() => {
     return mapArrayToDictionary(
       ['top', 'right', 'bottom', 'left'],
@@ -273,6 +273,28 @@ export const PaddingControl = React.memo(() => {
     )
   }, [])
 
+  const selectedViews = useEditorState(
+    Substores.selectedViews,
+    selectedViewsSelector,
+    'PaddingControl selectedViews',
+  )
+
+  const onSplitChainedEvent: SplitChainedNumberInputEventHandler = React.useMemo(
+    () =>
+      longhandShorthandEventHandler(
+        'padding',
+        {
+          T: 'paddingTop',
+          R: 'paddingRight',
+          B: 'paddingBottom',
+          L: 'paddingLeft',
+        },
+        selectedViews[0],
+        dispatch,
+      ),
+    [dispatch, selectedViews],
+  )
+
   return (
     <SplitChainedNumberInput
       controlModeOrder={['one-value', 'per-direction', 'per-side']}
@@ -281,7 +303,6 @@ export const PaddingControl = React.memo(() => {
         perDirection: 'Padding per direction',
         perSide: 'Padding per side',
       }}
-      selectedViews={selectedViewsRef.current}
       name='padding'
       defaultMode='per-direction'
       top={paddingTop}
@@ -291,17 +312,7 @@ export const PaddingControl = React.memo(() => {
       shorthand={shorthand}
       canvasControls={canvasControlsForSides}
       numberType={'LengthPercent'}
-      eventHandler={longhandShorthandEventHandler(
-        'padding',
-        {
-          T: 'paddingTop',
-          R: 'paddingRight',
-          B: 'paddingBottom',
-          L: 'paddingLeft',
-        },
-        selectedViewsRef.current[0],
-        dispatch,
-      )}
+      eventHandler={onSplitChainedEvent}
     />
   )
 })

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
@@ -1,6 +1,5 @@
 import { useSetAtom } from 'jotai'
 import React from 'react'
-import { createSelector } from 'reselect'
 import { mapDropNulls } from '../../../../../core/shared/array-utils'
 import { emptyComments, jsxAttributeValue } from '../../../../../core/shared/element-template'
 import { wrapValue } from '../../../../../core/shared/math-utils'
@@ -296,8 +295,6 @@ const whenCSSNumber = (fn: (v: CSSNumber) => any) => (v: UnknownOrEmptyInput<CSS
   fn(v)
 }
 
-const SelectedViewsSelector = createSelector(selectedViewsSelector, (x) => x)
-
 export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInputProps<any>) => {
   const {
     name,
@@ -325,7 +322,7 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
 
   const selectedViews = useEditorState(
     Substores.selectedViews,
-    SelectedViewsSelector,
+    selectedViewsSelector,
     'PaddingControl selectedViews',
   )
 

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
@@ -281,16 +281,22 @@ export const longhandShorthandEventHandler = (
     B: string
     L: string
   },
-  elementPath: ElementPath,
+  selectedViewsRef: { current: Array<ElementPath> },
   dispatch: EditorDispatch,
 ): SplitChainedNumberInputEventHandler => {
   return (e: SplitChainedEvent, aggregates: SplitControlValues, useShorthand: boolean) => {
-    handleSplitChainedEvent(e, dispatch, elementPath, PP.create('style', shorthand), {
-      T: PP.create('style', longhands.T),
-      R: PP.create('style', longhands.R),
-      B: PP.create('style', longhands.B),
-      L: PP.create('style', longhands.L),
-    })(useShorthand, aggregates)
+    handleSplitChainedEvent(
+      e,
+      dispatch,
+      selectedViewsRef.current[0],
+      PP.create('style', shorthand),
+      {
+        T: PP.create('style', longhands.T),
+        R: PP.create('style', longhands.R),
+        B: PP.create('style', longhands.B),
+        L: PP.create('style', longhands.L),
+      },
+    )(useShorthand, aggregates)
   }
 }
 

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
@@ -1,5 +1,6 @@
 import { useSetAtom } from 'jotai'
 import React from 'react'
+import ReactDOM from 'react-dom'
 import { mapDropNulls } from '../../../../../core/shared/array-utils'
 import { emptyComments, jsxAttributeValue } from '../../../../../core/shared/element-template'
 import { wrapValue } from '../../../../../core/shared/math-utils'
@@ -15,7 +16,12 @@ import {
 } from '../../../../../uuiui'
 import { EditorAction, EditorDispatch } from '../../../../editor/action-types'
 import { setProp_UNSAFE, unsetProperty } from '../../../../editor/actions/action-creators'
-import { Substores, useEditorState, useRefEditorState } from '../../../../editor/store/store-hook'
+import {
+  Substores,
+  useEditorState,
+  useRefEditorState,
+  useSelectorWithCallback,
+} from '../../../../editor/store/store-hook'
 import { ControlStatus, PropertyStatus } from '../../../common/control-status'
 import {
   CSSNumber,
@@ -320,9 +326,12 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
 
   const isCmdPressedRef = useRefEditorState((store) => store.editor.keysPressed.cmd === true)
 
-  const selectedViews = useEditorState(
+  useSelectorWithCallback(
     Substores.selectedViews,
     selectedViewsSelector,
+    () => {
+      updateMode('forced')
+    },
     'PaddingControl selectedViews',
   )
 
@@ -346,35 +355,32 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
     return { oneValue: newOneValue, horizontal: newHorizontal, vertical: newVertical }
   }, [allSides, sidesHorizontal, sidesVertical])
 
-  const updateMode = React.useCallback(() => {
-    if (mode != null) {
-      return
-    }
+  const updateMode = React.useCallback(
+    (force?: 'forced') => {
+      if (mode != null && force !== 'forced') {
+        return
+      }
 
-    const aggregates = updateAggregates()
-    const newMode = getInitialMode(
-      aggregates.oneValue,
-      aggregates.horizontal,
-      aggregates.vertical,
-      areAllSidesSet(allSides),
-      props.defaultMode ?? 'per-side',
-    )
-    setMode(newMode)
-  }, [props.defaultMode, mode, allSides, updateAggregates])
+      const aggregates = updateAggregates()
+      const newMode = getInitialMode(
+        aggregates.oneValue,
+        aggregates.horizontal,
+        aggregates.vertical,
+        areAllSidesSet(allSides),
+        props.defaultMode ?? 'per-side',
+      )
+      setMode(newMode)
+    },
+    [props.defaultMode, mode, allSides, updateAggregates],
+  )
 
   React.useEffect(() => {
     updateMode()
-  }, [selectedViews, updateMode, props.shorthand])
+  }, [updateMode, props.shorthand])
 
   React.useEffect(() => {
     updateAggregates()
   }, [updateAggregates])
-
-  React.useEffect(() => {
-    return function () {
-      setMode(null)
-    }
-  }, [selectedViews])
 
   React.useEffect(() => {
     if (!isCurrentModeApplicable()) {

--- a/editor/src/components/inspector/sections/style-section/container-subsection/radius-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/radius-row.tsx
@@ -162,7 +162,7 @@ export const BorderRadiusControl = React.memo(() => {
           B: 'borderBottomRightRadius',
           L: 'borderBottomLeftRadius',
         },
-        selectedViewsRef.current[0],
+        selectedViewsRef,
         dispatch,
       )}
     />

--- a/editor/src/components/inspector/sections/style-section/container-subsection/radius-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/radius-row.tsx
@@ -8,17 +8,16 @@ import { InspectorContextMenuItems } from '../../../../../uuiui-deps'
 import { SubduedBorderRadiusControl } from '../../../../canvas/controls/select-mode/subdued-border-radius-control'
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { useDispatch } from '../../../../editor/store/dispatch-context'
+import { useEditorState, Substores } from '../../../../editor/store/store-hook'
 import { CSSNumber } from '../../../common/css-utils'
-import {
-  useInspectorContext,
-  useInspectorLayoutInfo,
-  useInspectorStyleInfo,
-} from '../../../common/property-path-hooks'
+import { useInspectorLayoutInfo, useInspectorStyleInfo } from '../../../common/property-path-hooks'
+import { selectedViewsSelector } from '../../../inpector-selectors'
 import { PropertyLabel } from '../../../widgets/property-label'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import {
   longhandShorthandEventHandler,
   SplitChainedNumberInput,
+  SplitChainedNumberInputEventHandler,
 } from '../../layout-section/layout-system-subsection/split-chained-number-input'
 
 export const RadiusRow = React.memo(() => {
@@ -57,8 +56,6 @@ export const BorderRadiusControl = React.memo(() => {
   const shorthand = useInspectorLayoutInfo('borderRadius')
 
   const dispatch = useDispatch()
-
-  const { selectedViewsRef } = useInspectorContext()
 
   const tl: CSSNumber = React.useMemo(
     () =>
@@ -120,6 +117,28 @@ export const BorderRadiusControl = React.memo(() => {
     )
   }, [])
 
+  const selectedViews = useEditorState(
+    Substores.selectedViews,
+    selectedViewsSelector,
+    'PaddingControl selectedViews',
+  )
+
+  const onSplitChainedEvent: SplitChainedNumberInputEventHandler = React.useMemo(
+    () =>
+      longhandShorthandEventHandler(
+        'borderRadius',
+        {
+          T: 'borderTopLeftRadius',
+          R: 'borderTopRightRadius',
+          B: 'borderBottomRightRadius',
+          L: 'borderBottomLeftRadius',
+        },
+        selectedViews[0],
+        dispatch,
+      ),
+    [dispatch, selectedViews],
+  )
+
   return (
     <SplitChainedNumberInput
       labels={{
@@ -134,7 +153,6 @@ export const BorderRadiusControl = React.memo(() => {
       }}
       controlModeOrder={['one-value', 'per-side']}
       numberType={'LengthPercent'}
-      selectedViews={selectedViewsRef.current}
       name='radius'
       defaultMode='one-value'
       top={{
@@ -155,17 +173,7 @@ export const BorderRadiusControl = React.memo(() => {
       }}
       shorthand={shorthand}
       canvasControls={canvasControlsForSides}
-      eventHandler={longhandShorthandEventHandler(
-        'borderRadius',
-        {
-          T: 'borderTopLeftRadius',
-          R: 'borderTopRightRadius',
-          B: 'borderBottomRightRadius',
-          L: 'borderBottomLeftRadius',
-        },
-        selectedViewsRef.current[0],
-        dispatch,
-      )}
+      eventHandler={onSplitChainedEvent}
     />
   )
 })

--- a/editor/src/components/inspector/sections/style-section/container-subsection/radius-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/radius-row.tsx
@@ -8,16 +8,17 @@ import { InspectorContextMenuItems } from '../../../../../uuiui-deps'
 import { SubduedBorderRadiusControl } from '../../../../canvas/controls/select-mode/subdued-border-radius-control'
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { useDispatch } from '../../../../editor/store/dispatch-context'
-import { useEditorState, Substores } from '../../../../editor/store/store-hook'
 import { CSSNumber } from '../../../common/css-utils'
-import { useInspectorLayoutInfo, useInspectorStyleInfo } from '../../../common/property-path-hooks'
-import { selectedViewsSelector } from '../../../inpector-selectors'
+import {
+  useInspectorContext,
+  useInspectorLayoutInfo,
+  useInspectorStyleInfo,
+} from '../../../common/property-path-hooks'
 import { PropertyLabel } from '../../../widgets/property-label'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import {
   longhandShorthandEventHandler,
   SplitChainedNumberInput,
-  SplitChainedNumberInputEventHandler,
 } from '../../layout-section/layout-system-subsection/split-chained-number-input'
 
 export const RadiusRow = React.memo(() => {
@@ -56,6 +57,8 @@ export const BorderRadiusControl = React.memo(() => {
   const shorthand = useInspectorLayoutInfo('borderRadius')
 
   const dispatch = useDispatch()
+
+  const { selectedViewsRef } = useInspectorContext()
 
   const tl: CSSNumber = React.useMemo(
     () =>
@@ -117,28 +120,6 @@ export const BorderRadiusControl = React.memo(() => {
     )
   }, [])
 
-  const selectedViews = useEditorState(
-    Substores.selectedViews,
-    selectedViewsSelector,
-    'PaddingControl selectedViews',
-  )
-
-  const onSplitChainedEvent: SplitChainedNumberInputEventHandler = React.useMemo(
-    () =>
-      longhandShorthandEventHandler(
-        'borderRadius',
-        {
-          T: 'borderTopLeftRadius',
-          R: 'borderTopRightRadius',
-          B: 'borderBottomRightRadius',
-          L: 'borderBottomLeftRadius',
-        },
-        selectedViews[0],
-        dispatch,
-      ),
-    [dispatch, selectedViews],
-  )
-
   return (
     <SplitChainedNumberInput
       labels={{
@@ -173,7 +154,17 @@ export const BorderRadiusControl = React.memo(() => {
       }}
       shorthand={shorthand}
       canvasControls={canvasControlsForSides}
-      eventHandler={onSplitChainedEvent}
+      eventHandler={longhandShorthandEventHandler(
+        'borderRadius',
+        {
+          T: 'borderTopLeftRadius',
+          R: 'borderTopRightRadius',
+          B: 'borderBottomRightRadius',
+          L: 'borderBottomLeftRadius',
+        },
+        selectedViewsRef.current[0],
+        dispatch,
+      )}
     />
   )
 })

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`660`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`792`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`732`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`864`)
   })
 })


### PR DESCRIPTION
## Problem
Due to refs leaking into JSX markup, the padding/border radius controls didn't update the right element after selection has been changed, and the control wasn't re-rendered.

### Repro
- open https://utopia.pizza/p/644e2d16-cute-phosphorus/
- select the div on the left
- select the div on the right
- update padding (or border radius)
- the div on the left is updated instead of the one on the right

## Solution
Factor out the problematic refs and use `React.useMemo` to memoize curried callback functions.
