### PR TITLE
Make `x` play nice with spans

### DIFF
--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -158,6 +158,7 @@ export function defaultSpanElement(uid: string): JSXElement {
       style: jsxAttributeValue(
         {
           position: 'absolute',
+          display: 'inline-block',
           wordBreak: 'break-word',
         },
         emptyComments,

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -158,7 +158,6 @@ export function defaultSpanElement(uid: string): JSXElement {
       style: jsxAttributeValue(
         {
           position: 'absolute',
-          display: 'inline-block',
           wordBreak: 'break-word',
         },
         emptyComments,

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -110,8 +110,6 @@ import {
   jsxAttributesFromMap,
   jsxAttributeValue,
   jsxElement,
-  jsxElementName,
-  jsxElementNameEquals,
 } from '../../core/shared/element-template'
 import {
   toggleTextBold,
@@ -131,13 +129,9 @@ import {
   sizeToVisualDimensions,
   toggleResizeToFitSetToFixed,
   isIntrinsicallyInlineElement,
-  sizeElementAsDisplayBlock,
-  isElementDisplayInline,
 } from '../inspector/inspector-common'
 import { CSSProperties } from 'react'
-import { defaultEither } from '../../core/shared/either'
-import { inlineHtmlElements } from '../../utils/html-elements'
-import { size } from '../../core/shared/math-utils'
+import { setProperty } from '../canvas/commands/set-property-command'
 
 function updateKeysPressed(
   keysPressed: KeysPressed,
@@ -874,22 +868,21 @@ export function handleKeyDown(
               if (MetadataUtils.isPositionAbsolute(element)) {
                 return [
                   ...nukeAllAbsolutePositioningPropsCommands(elementPath),
-                  /**
-                   * the `isElementDisplayInline` check is not performed here because elements with
-                   * `position: absolute` are treated as `display: block`
-                   */
                   ...(isIntrinsicallyInlineElement(element)
-                    ? sizeElementAsDisplayBlock(elementPath, size(100, 50))
+                    ? [
+                        ...sizeToVisualDimensions(editor.jsxMetadata, elementPath),
+                        setProperty(
+                          'always',
+                          elementPath,
+                          PP.create('style', 'display'),
+                          'inline-block',
+                        ),
+                      ]
                     : []),
                 ]
               } else {
-                const isInlineElement =
-                  isIntrinsicallyInlineElement(element) &&
-                  isElementDisplayInline(editor.jsxMetadata, elementPath)
                 return [
-                  ...(isInlineElement
-                    ? sizeElementAsDisplayBlock(elementPath, size(100, 50))
-                    : sizeToVisualDimensions(editor.jsxMetadata, elementPath)),
+                  ...sizeToVisualDimensions(editor.jsxMetadata, elementPath),
                   ...addPositionAbsoluteTopLeft(editor.jsxMetadata, elementPath),
                 ]
               }

--- a/editor/src/components/editor/shortcuts.spec.browser2.tsx
+++ b/editor/src/components/editor/shortcuts.spec.browser2.tsx
@@ -109,6 +109,35 @@ describe('shortcuts', () => {
       expect(div.style.height).toEqual('363px')
       expect(div.style.contain).toEqual('layout')
     })
+
+    it('does not convert spans to zero-sized elements', async () => {
+      const editor = await renderTestEditorWithCode(projectWithSpan, 'await-first-dom-report')
+
+      const div = editor.renderedDOM.getByTestId(TestIdOne)
+
+      await selectComponentsForTest(editor, [EP.fromString('sb/span')])
+
+      await expectSingleUndoStep(editor, async () => {
+        await pressKey('x')
+      })
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(div.style.position).toEqual('')
+      expect(div.style.display).toEqual('inline-block')
+      expect(div.style.width).toEqual('182px')
+      expect(div.style.height).toEqual('130px')
+
+      await expectSingleUndoStep(editor, async () => {
+        await pressKey('x')
+      })
+      await editor.getDispatchFollowUpActionsFinished()
+      expect(div.style.position).toEqual('absolute')
+      expect(div.style.display).toEqual('inline-block')
+      expect(div.style.width).toEqual('182px')
+      expect(div.style.height).toEqual('130px')
+      expect(div.style.top).toEqual('0px')
+      expect(div.style.left).toEqual('0px')
+    })
   })
 })
 
@@ -174,6 +203,29 @@ export var storyboard = (
         data-uid='${TestIdOne}'
       />
     </div>
+  </Storyboard>
+)
+`
+
+const projectWithSpan = `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <span
+      style={{
+        position: 'absolute',
+        wordBreak: 'break-word',
+        left: 172,
+        top: 189,
+        width: 182,
+        height: 130,
+      }}
+      data-testid='${TestIdOne}'
+      data-uid='span'
+    >
+      hello there
+    </span>
   </Storyboard>
 )
 `


### PR DESCRIPTION
## Problem(s)
The `x` shortcut either removes absolute positioning from and element, or sizes it to its visual dimension (its `clientWidth` / `clientHeight`), and adds `position: absolute` with a `top` and `left` offset.

This however break down in the case of `<span />`s for the following reasons:
- when converting from `position: absolute` to participating in the layout, spans collapse to their smallest possible size, since inline elements disregard their width/height set from CSS
- when converting to `position: absolute`, we cannot detemine the `clientWidth` / `clientHeight`of inline elements, because they are considered to be 0 by the browser [1]

### Repro
- create a text element by pressing `t`, drawing a text box and typing in some text
- select the new text element
- press `x`, observe the text box collapsing to hug the text inside
- press `x` again, observe the text box collapsing to a zero-sized element

## Fix
#### `defaultSpanElement`
Our `defaultSpanElement` has `display: 'inline-block'` set. This way, all out helpers that expect elements to behave as block elements will work as expected.

#### Special casing
When converting from `x` special cases inline elements in the following way:
- when converting from `position: absolute` to participating in the layout, inline elements are sized to an arbitrary size and have `display: 'inline-block'` set, so they can be dragged around the canvas.
- when converting to `position: absolute`, if an inline element isn't set to block display, the same conversion as above is performed. If an inline element already has block sizing set (for example, as a result of converting it via `x`), it is simply sized to its visual dimensions.

[1] https://developer.mozilla.org/en-US/docs/Web/API/Element/clientWidth