### PR TITLE
delete element values

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -38,7 +38,7 @@ import { DefaultPackageJson, StoryboardFilePath } from '../../editor/store/edito
 import { createCodeFile } from '../../custom-code/code-file.test-utils'
 import { matchInlineSnapshotBrowser } from '../../../../test/karma-snapshots'
 import { EditorAction } from '../../editor/action-types'
-import { expectSingleUndoStep, wait } from '../../../utils/utils.test-utils'
+import { expectSingleUndoStep } from '../../../utils/utils.test-utils'
 import { getSubduedPaddingControlTestID } from '../../canvas/controls/select-mode/subdued-padding-control'
 import { SubduedBorderRadiusControlTestId } from '../../canvas/controls/select-mode/subdued-border-radius-control'
 
@@ -2200,6 +2200,108 @@ describe('inspector tests with real metadata', () => {
           })
         },
         endSnippet: makeCodeSnippetWithKeyValue({ padding: '10px 20px 10px 10px' }),
+      },
+      {
+        name: 'delete value (shorthand, one value)',
+        startSnippet: makeCodeSnippetWithKeyValue({ padding: 10 }),
+        control: async (renderResult: EditorRenderResult) => {
+          await expectSingleUndoStep(renderResult, async () => {
+            await setControlValue('padding-one', '', renderResult.renderedDOM)
+          })
+        },
+        endSnippet: makeCodeSnippetWithKeyValue({}),
+      },
+      {
+        name: 'delete value (longhand, one value)',
+        startSnippet: makeCodeSnippetWithKeyValue({
+          paddingLeft: 10,
+          paddingRight: 10,
+          paddingTop: 10,
+          paddingBottom: 10,
+        }),
+        control: async (renderResult: EditorRenderResult) => {
+          await expectSingleUndoStep(renderResult, async () => {
+            await setControlValue('padding-one', '', renderResult.renderedDOM)
+          })
+        },
+        endSnippet: makeCodeSnippetWithKeyValue({}),
+      },
+      {
+        name: 'delete value (shorthand, two value)',
+        startSnippet: makeCodeSnippetWithKeyValue({ padding: '10px 20px' }),
+        control: async (renderResult: EditorRenderResult) => {
+          await expectSingleUndoStep(renderResult, async () => {
+            await setControlValue('padding-H', '', renderResult.renderedDOM)
+          })
+        },
+        endSnippet: makeCodeSnippetWithKeyValue({ padding: '10px 0px' }),
+      },
+      {
+        name: 'delete value (longhand, two value)',
+        startSnippet: makeCodeSnippetWithKeyValue({
+          paddingLeft: 10,
+          paddingRight: 10,
+          paddingTop: 20,
+          paddingBottom: 20,
+        }),
+        control: async (renderResult: EditorRenderResult) => {
+          await expectSingleUndoStep(renderResult, async () => {
+            await setControlValue('padding-H', '', renderResult.renderedDOM)
+          })
+        },
+        endSnippet: makeCodeSnippetWithKeyValue({
+          paddingTop: 20,
+          paddingBottom: 20,
+        }),
+      },
+      {
+        name: 'delete value (shorthand, two value, all empty)',
+        startSnippet: makeCodeSnippetWithKeyValue({ padding: '0px 10px' }),
+        control: async (renderResult: EditorRenderResult) => {
+          await expectSingleUndoStep(renderResult, async () => {
+            await setControlValue('padding-H', '', renderResult.renderedDOM)
+          })
+        },
+        endSnippet: makeCodeSnippetWithKeyValue({}),
+      },
+      {
+        name: 'delete value (shorthand, four value)',
+        startSnippet: makeCodeSnippetWithKeyValue({ padding: '10px 20px 30px 40px' }),
+        control: async (renderResult: EditorRenderResult) => {
+          await expectSingleUndoStep(renderResult, async () => {
+            await setControlValue('padding-R', '', renderResult.renderedDOM)
+          })
+        },
+        endSnippet: makeCodeSnippetWithKeyValue({ padding: '10px 0px 30px 40px' }),
+      },
+      {
+        name: 'delete value (shorthand, four value, all empty)',
+        startSnippet: makeCodeSnippetWithKeyValue({ padding: '0px 20px 0px 0px' }),
+        control: async (renderResult: EditorRenderResult) => {
+          await expectSingleUndoStep(renderResult, async () => {
+            await setControlValue('padding-R', '', renderResult.renderedDOM)
+          })
+        },
+        endSnippet: makeCodeSnippetWithKeyValue({}),
+      },
+      {
+        name: 'delete value (longhand, four value)',
+        startSnippet: makeCodeSnippetWithKeyValue({
+          paddingLeft: 10,
+          paddingTop: 20,
+        }),
+        before: async (renderResult: EditorRenderResult) => {
+          await act(async () => {
+            fireEvent.click(screen.getByTestId('padding-cycle-mode'))
+            await renderResult.getDispatchFollowUpActionsFinished()
+          })
+        },
+        control: async (renderResult: EditorRenderResult) => {
+          await expectSingleUndoStep(renderResult, async () => {
+            await setControlValue('padding-T', '', renderResult.renderedDOM)
+          })
+        },
+        endSnippet: makeCodeSnippetWithKeyValue({ paddingLeft: 10 }),
       },
     ]
 


### PR DESCRIPTION
Fixes #3278 

**Problem:**

Deleting values from the 4/2/1 split controls does not remove the related props from controlled element.

**Fix:**

This PR updates the event handler so that when a value is deleted the element is updated consequently.
Tests are added for all possible combinations - in a nutshell:
- if a shorthand is used, if the shorthand is not entirely made of `0`s, a `0` is set for the deleted value; otherwise, the entire shorthand is deleted
- if a longhand is used, it's removed on delete