### PR TITLE
Auto-delete empty fragments on deletion

### DIFF
--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -1,0 +1,275 @@
+/* eslint-disable jest/expect-expect */
+import * as EP from '../../../core/shared/element-path'
+import { BakedInStoryboardUID } from '../../../core/model/scene-utils'
+import {
+  getPrintedUiJsCode,
+  makeTestProjectCodeWithSnippet,
+  renderTestEditorWithCode,
+  TestAppUID,
+  TestSceneUID,
+} from '../../../components/canvas/ui-jsx.test-utils'
+import { deleteSelected, selectComponents } from './action-creators'
+import { ElementPath } from '../../../core/shared/project-file-types'
+
+async function deleteFromScene(
+  inputSnippet: string,
+  targets: ElementPath[],
+): Promise<{ code: string; selection: ElementPath[] }> {
+  const renderResult = await renderTestEditorWithCode(
+    makeTestProjectCodeWithSnippet(inputSnippet),
+    'await-first-dom-report',
+  )
+  await renderResult.dispatch([selectComponents(targets, true)], true)
+  await renderResult.dispatch([deleteSelected()], true)
+
+  return {
+    code: getPrintedUiJsCode(renderResult.getEditorState()),
+    selection: renderResult.getEditorState().editor.selectedViews,
+  }
+}
+
+function makeTargetPath(suffix: string): ElementPath {
+  return EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:${suffix}`)
+}
+
+describe('actions', () => {
+  describe('DELETE_SELECTED', () => {
+    const tests: {
+      name: string
+      input: string
+      targets: ElementPath[]
+      wantCode: string
+      wantSelection: ElementPath[]
+    }[] = [
+      {
+        name: 'delete selected element',
+        input: `
+		<View data-uid='aaa'>
+			<View
+				style={{ background: '#09f', width: 50, height: 50 }}
+				data-uid='bbb'
+				data-testid='bbb'
+			/>
+			<View
+				style={{ background: '#f90', width: 50, height: 50 }}
+				data-uid='ccc'
+				data-testid='ccc'
+			/>
+		</View>
+		`,
+        targets: [makeTargetPath('aaa/bbb')],
+        wantCode: `
+		<View data-uid='aaa'>
+			<View
+				style={{ background: '#f90', width: 50, height: 50 }}
+				data-uid='ccc'
+				data-testid='ccc'
+			/>
+		</View>
+		`,
+        wantSelection: [makeTargetPath('aaa')],
+      },
+      {
+        name: 'delete multiple elements',
+        input: `
+		<View data-uid='aaa'>
+			<View
+				style={{ background: '#09f', width: 50, height: 50 }}
+				data-uid='bbb'
+				data-testid='bbb'
+			/>
+			<View
+				style={{ background: '#f90', width: 50, height: 50 }}
+				data-uid='ccc'
+				data-testid='ccc'
+			/>
+			<View
+				style={{ background: '#f09', width: 50, height: 50 }}
+				data-uid='ddd'
+				data-testid='ddd'
+			/>
+		</View>
+		`,
+        targets: [makeTargetPath('aaa/bbb'), makeTargetPath('aaa/ddd')],
+        wantCode: `
+		<View data-uid='aaa'>
+			<View
+				style={{ background: '#f90', width: 50, height: 50 }}
+				data-uid='ccc'
+				data-testid='ccc'
+			/>
+		</View>
+		`,
+        wantSelection: [makeTargetPath('aaa')],
+      },
+      {
+        name: 'delete empty fragments (single fragment)',
+        input: `
+		<View data-uid='aaa'>
+			<View
+				style={{ background: '#09f', width: 50, height: 50 }}
+				data-uid='bbb'
+				data-testid='bbb'
+			/>
+			<React.Fragment data-uid='000'>
+				<View
+					style={{ background: '#f90', width: 50, height: 50 }}
+					data-uid='ccc'
+					data-testid='ccc'
+				/>
+			</React.Fragment>
+			<View
+				style={{ background: '#f09', width: 50, height: 50 }}
+				data-uid='ddd'
+				data-testid='ddd'
+			/>
+		</View>
+		`,
+        targets: [makeTargetPath('aaa/000/ccc')],
+        wantCode: `
+		<View data-uid='aaa'>
+			<View
+				style={{ background: '#09f', width: 50, height: 50 }}
+				data-uid='bbb'
+				data-testid='bbb'
+			/>
+
+			<View
+				style={{ background: '#f09', width: 50, height: 50 }}
+				data-uid='ddd'
+				data-testid='ddd'
+			/>
+		</View>
+		`,
+        wantSelection: [makeTargetPath('aaa')],
+      },
+      {
+        name: "don't delete fragments if not empty",
+        input: `
+		<View data-uid='aaa'>
+			<View
+				style={{ background: '#09f', width: 50, height: 50 }}
+				data-uid='bbb'
+				data-testid='bbb'
+			/>
+			<React.Fragment data-uid='000'>
+				<View
+					style={{ background: '#f90', width: 50, height: 50 }}
+					data-uid='ccc'
+					data-testid='ccc'
+				/>
+				<View
+					style={{ background: '#90f', width: 50, height: 50 }}
+					data-uid='eee'
+					data-testid='eee'
+				/>
+			</React.Fragment>
+			<View
+				style={{ background: '#f09', width: 50, height: 50 }}
+				data-uid='ddd'
+				data-testid='ddd'
+			/>
+		</View>
+		`,
+        targets: [makeTargetPath('aaa/000/eee')],
+        wantCode: `
+		<View data-uid='aaa'>
+			<View
+				style={{ background: '#09f', width: 50, height: 50 }}
+				data-uid='bbb'
+				data-testid='bbb'
+			/>
+			<React.Fragment>
+				<View
+					style={{ background: '#f90', width: 50, height: 50 }}
+					data-uid='ccc'
+					data-testid='ccc'
+				/>
+			</React.Fragment>
+			<View
+				style={{ background: '#f09', width: 50, height: 50 }}
+				data-uid='ddd'
+				data-testid='ddd'
+			/>
+		</View>
+		`,
+        wantSelection: [makeTargetPath('aaa/000')],
+      },
+      {
+        name: 'delete empty fragments (multiple targets)',
+        input: `
+		<View data-uid='aaa'>
+			<View
+				style={{ background: '#09f', width: 50, height: 50 }}
+				data-uid='bbb'
+				data-testid='bbb'
+			/>
+			<React.Fragment data-uid='000'>
+				<View
+					style={{ background: '#f90', width: 50, height: 50 }}
+					data-uid='ccc'
+					data-testid='ccc'
+				/>
+				<View
+					style={{ background: '#90f', width: 50, height: 50 }}
+					data-uid='eee'
+					data-testid='eee'
+				/>
+			</React.Fragment>
+			<View
+				style={{ background: '#f09', width: 50, height: 50 }}
+				data-uid='ddd'
+				data-testid='ddd'
+			/>
+			<React.Fragment data-uid='001'>
+				<View
+					style={{ background: '#0f9', width: 50, height: 50 }}
+					data-uid='fff'
+					data-testid='fff'
+				/>
+				<View
+					style={{ background: '#9f0', width: 50, height: 50 }}
+					data-uid='ggg'
+					data-testid='ggg'
+				/>
+			</React.Fragment>
+		</View>
+		`,
+        targets: [
+          makeTargetPath('aaa/000/eee'),
+          makeTargetPath('aaa/001/fff'),
+          makeTargetPath('aaa/001/ggg'),
+        ],
+        wantCode: `
+		<View data-uid='aaa'>
+			<View
+				style={{ background: '#09f', width: 50, height: 50 }}
+				data-uid='bbb'
+				data-testid='bbb'
+			/>
+			<React.Fragment>
+				<View
+					style={{ background: '#f90', width: 50, height: 50 }}
+					data-uid='ccc'
+					data-testid='ccc'
+				/>
+			</React.Fragment>
+			<View
+				style={{ background: '#f09', width: 50, height: 50 }}
+				data-uid='ddd'
+				data-testid='ddd'
+			/>
+		</View>
+		`,
+        wantSelection: [makeTargetPath('aaa/000'), makeTargetPath('aaa')],
+      },
+    ]
+    tests.forEach((tt, idx) => {
+      it(`(${idx + 1}) ${tt.name}`, async () => {
+        const got = await deleteFromScene(tt.input, tt.targets)
+        expect(got.code).toEqual(makeTestProjectCodeWithSnippet(tt.wantCode))
+        expect(got.selection).toEqual(tt.wantSelection)
+      })
+    })
+  })
+})

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1808,13 +1808,20 @@ export const UPDATE_FNS = {
             )
             return !MetadataUtils.isElementGenerated(selectedView)
           })
-          .map((path) => {
+          .map((path, _, all) => {
+            const siblings = MetadataUtils.getSiblings(editor.jsxMetadata, path)
+            const selectedSiblings = all.filter((v) =>
+              siblings.includes(editor.jsxMetadata[EP.toString(v)]),
+            )
+
             const parentPath = EP.parentPath(path)
             const parentIsFragment = MetadataUtils.isFragmentFromMetadata(
               editor.jsxMetadata[EP.toString(parentPath)],
             )
-            const siblings = MetadataUtils.getChildren(editor.jsxMetadata, parentPath)
-            if (parentIsFragment && siblings.length === 1) {
+            const parentWillBeEmpty =
+              MetadataUtils.getChildren(editor.jsxMetadata, parentPath).length ===
+              selectedSiblings.length
+            if (parentIsFragment && parentWillBeEmpty) {
               return parentPath
             }
             return path

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1808,10 +1808,10 @@ export const UPDATE_FNS = {
             )
             return !MetadataUtils.isElementGenerated(selectedView)
           })
-          .map((path, _, all) => {
+          .map((path, _, allSelectedPaths) => {
             const siblings = MetadataUtils.getSiblings(editor.jsxMetadata, path)
-            const selectedSiblings = all.filter((v) =>
-              siblings.includes(editor.jsxMetadata[EP.toString(v)]),
+            const selectedSiblings = allSelectedPaths.filter((p) =>
+              siblings.includes(editor.jsxMetadata[EP.toString(p)]),
             )
 
             const parentPath = EP.parentPath(path)
@@ -1824,6 +1824,7 @@ export const UPDATE_FNS = {
             if (parentIsFragment && parentWillBeEmpty) {
               return parentPath
             }
+
             return path
           })
 


### PR DESCRIPTION
Fixes #3287 

This PR updates the `DELETE_SELECTED` action so that Fragments that become empty as an effect of a user-driven deletion are deleted as well.

![Kapture 2023-02-15 at 12 46 17](https://user-images.githubusercontent.com/1081051/219051569-d947ac97-b837-418b-9a65-c293eda590a3.gif)
