### PR TITLE
Fix indentation calculation in navigator

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -41,12 +41,15 @@ export function getElementPadding(
     return EP.navigatorDepth(elementPath) * BasePaddingUnit
   }
 
-  const ancestors = EP.getAncestorsForLastPart(elementPath)
+  const ancestors = EP.getAncestors(elementPath)
   const ancestorsNotInNavigator = ancestors.filter(
     (path) => !visibleNavigatorTargets.some((navigatorPath) => EP.pathsEqual(path, navigatorPath)),
   )
+  // an empty path and the storyboard is always part of the ancestorsNotInNavigator list and that doesn't matter,
+  // so we can add 2 to the offset. NOTE: this 2 is also a constant in EP.navigatorDepth for the same reason
+  const paddingOffset = 2 - ancestorsNotInNavigator.length
 
-  return (EP.navigatorDepth(elementPath) - ancestorsNotInNavigator.length) * BasePaddingUnit
+  return (EP.navigatorDepth(elementPath) + paddingOffset) * BasePaddingUnit
 }
 
 export interface NavigatorItemInnerProps {

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -631,6 +631,18 @@ export function getAncestorsForLastPart(path: ElementPath): ElementPath[] {
   return allPathsForLastPart(path).slice(0, -1)
 }
 
+export function getAncestors(path: ElementPath): ElementPath[] {
+  let workingPath = parentPath(path)
+  let ancestors = [workingPath]
+
+  while (!isEmptyPath(workingPath)) {
+    workingPath = parentPath(workingPath)
+    ancestors.push(workingPath)
+  }
+
+  return ancestors
+}
+
 function dropFromElementPaths(elementPathParts: ElementPathPart[], n: number): ElementPathPart[] {
   const prefix = dropLast(elementPathParts)
   const lastPart = last(elementPathParts)


### PR DESCRIPTION
**Description:**
When the fragment feature switch is off, we need to omit fragments from the navigator.
However, when we calculate the padding of the navigator items, we just normally rely on the element path depth. But if we omit fragments, the descendants of the fragments should not have an extra level of padding because of the omitted fragment ancestor.

To solve this there is a check that (when the fragments FS is off) only those ancestors should count in the padding calculation which are in the `visibleNavigatorTargets` list. But this check was buggy, because it used the `getAncestorsForLastPart` function to get the ancestors, but that only returns the ancestors in the last part (hence its name....)

I wrote a new EP helper called `getAncestors` to return all the ancestors, and use that to calculate the navigator item padding.
