### PR TITLE
Fix unintended snapping in padding resize controls

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -732,7 +732,7 @@ describe('Padding resize strategy', () => {
       await testAdjustIndividualPaddingValueWithHuggingContainer('right', 'coarse', 12, -12)
     })
 
-    describe('no dead zone when dragging the right or bottom edge', () => {
+    describe('no dead zone when dragging the right or bottom edge with a hugging container', () => {
       // eslint-disable-next-line jest/expect-expect
       it('right', async () => {
         await testAdjustIndividualPaddingValueWithHuggingContainer('right', 'coarse', 57, -57)

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -731,6 +731,17 @@ describe('Padding resize strategy', () => {
     it('right', async () => {
       await testAdjustIndividualPaddingValueWithHuggingContainer('right', 'coarse', 12, -12)
     })
+
+    describe('no dead zone when dragging the right or bottom edge', () => {
+      // eslint-disable-next-line jest/expect-expect
+      it('right', async () => {
+        await testAdjustIndividualPaddingValueWithHuggingContainer('right', 'coarse', 57, -57)
+      })
+      // eslint-disable-next-line jest/expect-expect
+      it('bottom', async () => {
+        await testAdjustIndividualPaddingValueWithHuggingContainer('bottom', 'coarse', 35, -35)
+      })
+    })
   })
 })
 


### PR DESCRIPTION
## Problem
Dragging the bottom or right padding canvas controls of a container set to “hug” causes unexpected snapping at 2x the original value. 

## Fix
The root cause of the problem is that the calculation that checks whether the drag is in the "dead zone" before "tearing off" the padding didn't account for the container being set to hug.