### PR TITLE
Fix missing unit on shorthand aggregates for 421 controls

### DIFF
--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
@@ -240,7 +240,15 @@ const actionsForSplitChainedEvent =
         jsxAttributeValue(
           normalizedValues.length === 1 && normalizedValues[0] != null
             ? printCSSNumber(normalizedValues[0], 'px')
-            : mapDropNulls((v) => v, normalizedValues)
+            : mapDropNulls((v) => {
+                if (v == null) {
+                  return null
+                }
+                return {
+                  ...v,
+                  unit: useShorthand && v.unit == null ? 'px' : v.unit,
+                }
+              }, normalizedValues)
                 .map((v) => printCSSNumber(v, null))
                 .join(' '),
           emptyComments,


### PR DESCRIPTION
Fixes #3293 

**Problem:**

When the 4/2/1 controls sets a shorthand value from an empty state, if the value is set via the slider controls (on the label), the unit will be incorrectly missing for aggregate values (e.g. `H`).

**Fix:**

Set the unit to `px` when it's empty while using the shorthand.

Note: despite all my efforts, I was not able to get tests to work with this one as the mouse dragging interaction won't be able to fire the update successfully 😢 