### PR TITLE
Basic flow resize strategy

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -51,6 +51,7 @@ import { keyboardSetFontSizeStrategy } from './strategies/keyboard-set-font-size
 import { keyboardSetFontWeightStrategy } from './strategies/keyboard-set-font-weight-strategy'
 import { keyboardSetOpacityStrategy } from './strategies/keyboard-set-opacity-strategy'
 import { drawToInsertTextStrategy } from './strategies/draw-to-insert-text-strategy'
+import { flowResizeBasicStrategy } from './strategies/flow-resize-basic-strategy'
 
 export type CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
@@ -88,7 +89,12 @@ const resizeStrategies: MetaCanvasStrategy = (
 ): Array<CanvasStrategy> => {
   return mapDropNulls(
     (factory) => factory(canvasState, interactionSession),
-    [keyboardAbsoluteResizeStrategy, absoluteResizeBoundingBoxStrategy, flexResizeBasicStrategy],
+    [
+      keyboardAbsoluteResizeStrategy,
+      absoluteResizeBoundingBoxStrategy,
+      flexResizeBasicStrategy,
+      flowResizeBasicStrategy,
+    ],
   )
 }
 
@@ -466,6 +472,7 @@ export function isResizableStrategy(canvasStrategy: CanvasStrategy): boolean {
     case 'ABSOLUTE_RESIZE_BOUNDING_BOX':
     case 'KEYBOARD_ABSOLUTE_RESIZE':
     case 'FLEX_RESIZE_BASIC':
+    case 'FLOW_RESIZE_BASIC':
       return true
     default:
       return false

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -51,7 +51,7 @@ import { keyboardSetFontSizeStrategy } from './strategies/keyboard-set-font-size
 import { keyboardSetFontWeightStrategy } from './strategies/keyboard-set-font-weight-strategy'
 import { keyboardSetOpacityStrategy } from './strategies/keyboard-set-opacity-strategy'
 import { drawToInsertTextStrategy } from './strategies/draw-to-insert-text-strategy'
-import { flowResizeBasicStrategy } from './strategies/flow-resize-basic-strategy'
+import { basicResizeStrategy } from './strategies/basic-resize-strategy'
 
 export type CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
@@ -93,7 +93,7 @@ const resizeStrategies: MetaCanvasStrategy = (
       keyboardAbsoluteResizeStrategy,
       absoluteResizeBoundingBoxStrategy,
       flexResizeBasicStrategy,
-      flowResizeBasicStrategy,
+      basicResizeStrategy,
     ],
   )
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.spec.browser2.tsx
@@ -8,6 +8,7 @@ import { slightlyOffsetPointBecauseVeryWeirdIssue } from '../../../../utils/util
 import { selectComponents } from '../../../editor/actions/action-creators'
 import {
   EditorRenderResult,
+  formatTestProjectCode,
   getPrintedUiJsCode,
   makeTestProjectCodeWithSnippet,
   renderTestEditorWithCode,
@@ -547,10 +548,7 @@ async function resizeWithModifiers(
   const inputCode = makeTestProjectCodeWithSnippet(`
       <div
         data-uid='aaa'
-        style={{
-          width: '100%',
-          height: '100%',
-        }}
+        style={{ width: '100%', height: '100%' }}
       >
         <div
           data-uid='ccc'
@@ -572,10 +570,7 @@ async function resizeWithModifiers(
     makeTestProjectCodeWithSnippet(`
       <div
         data-uid='aaa'
-        style={{
-          width: '100%',
-          height: '100%',
-        }}
+        style={{ width: '100%', height: '100%' }}
       >
         <div
           data-uid='ccc'

--- a/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.spec.browser2.tsx
@@ -25,6 +25,7 @@ async function dragResizeControl(
   pos: EdgePosition,
   dragDelta: CanvasVector,
   modifiers?: Modifiers,
+  shouldStrategyBeActive: boolean = true,
 ) {
   await renderResult.dispatch([selectComponents([target], false)], true)
   const resizeControl = renderResult.renderedDOM.getByTestId(`resize-control-${pos.x}-${pos.y}`)
@@ -44,9 +45,11 @@ async function dragResizeControl(
   await mouseDownAtPoint(resizeControl, startPoint)
   await mouseMoveToPoint(canvasControlsLayer, endPoint, { eventOptions: { buttons: 1 }, modifiers })
 
-  expect(renderResult.getEditorState().strategyState.currentStrategy).toEqual(
-    BASIC_RESIZE_STRATEGY_ID,
-  )
+  if (shouldStrategyBeActive === true) {
+    expect(renderResult.getEditorState().strategyState.currentStrategy).toEqual(
+      BASIC_RESIZE_STRATEGY_ID,
+    )
+  }
 
   await mouseUpAtPoint(canvasControlsLayer, endPoint)
 
@@ -158,19 +161,37 @@ describe('when the element has missing dimensions', () => {
   describe('both missing', () => {
     describe('horizontal movement', () => {
       it('does nothing', async () => {
-        await resizeWithoutDimensions(edgePosition(1, 0), canvasPoint({ x: 15, y: 0 }), {}, {})
+        await resizeWithoutDimensions(
+          edgePosition(1, 0),
+          canvasPoint({ x: 15, y: 0 }),
+          {},
+          {},
+          false,
+        )
       })
     })
 
     describe('vertical movement', () => {
       it('does nothing', async () => {
-        await resizeWithoutDimensions(edgePosition(0, 0), canvasPoint({ x: 0, y: 15 }), {}, {})
+        await resizeWithoutDimensions(
+          edgePosition(0, 0),
+          canvasPoint({ x: 0, y: 15 }),
+          {},
+          {},
+          false,
+        )
       })
     })
 
     describe('diagonal movement', () => {
       it('does nothing', async () => {
-        await resizeWithoutDimensions(edgePosition(0, 0), canvasPoint({ x: 10, y: 15 }), {}, {})
+        await resizeWithoutDimensions(
+          edgePosition(0, 0),
+          canvasPoint({ x: 10, y: 15 }),
+          {},
+          {},
+          false,
+        )
       })
     })
   })
@@ -178,7 +199,13 @@ describe('when the element has missing dimensions', () => {
   describe('width missing', () => {
     describe('horizontal movement', () => {
       it('does nothing', async () => {
-        await resizeWithoutDimensions(edgePosition(1, 0), canvasPoint({ x: 15, y: 0 }), {}, {})
+        await resizeWithoutDimensions(
+          edgePosition(1, 0),
+          canvasPoint({ x: 15, y: 0 }),
+          {},
+          {},
+          false,
+        )
       })
     })
 
@@ -224,6 +251,7 @@ describe('when the element has missing dimensions', () => {
           canvasPoint({ x: 0, y: 15 }),
           { width: 15 },
           { width: 15 },
+          false,
         )
       })
     })
@@ -327,6 +355,7 @@ async function resizeTest(
   dragVector: CanvasVector,
   expectedWidth: number,
   expextedHeight: number,
+  shouldStrategyBeActive: boolean = true,
 ) {
   const inputCode = makeTestProjectCodeWithSnippet(`
       <div
@@ -371,7 +400,7 @@ async function resizeTest(
   const renderResult = await renderTestEditorWithCode(inputCode, 'await-first-dom-report')
   const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/ccc`)
 
-  await dragResizeControl(renderResult, target, pos, dragVector)
+  await dragResizeControl(renderResult, target, pos, dragVector, undefined, shouldStrategyBeActive)
 
   expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
     makeTestProjectCodeWithSnippet(`
@@ -421,6 +450,7 @@ const resizeWithoutDimensions = async (
   dragVector: CanvasVector,
   initialDimensions: { width?: number; height?: number },
   expectDimensions: { width?: number; height?: number },
+  shouldStrategyBeActive: boolean = true,
 ) => {
   const inputCode = makeTestProjectCodeWithSnippet(`
       <div
@@ -463,7 +493,7 @@ const resizeWithoutDimensions = async (
   const renderResult = await renderTestEditorWithCode(inputCode, 'await-first-dom-report')
   const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/ccc`)
 
-  await dragResizeControl(renderResult, target, pos, dragVector)
+  await dragResizeControl(renderResult, target, pos, dragVector, undefined, shouldStrategyBeActive)
 
   expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
     makeTestProjectCodeWithSnippet(`
@@ -512,6 +542,7 @@ async function resizeWithModifiers(
   initial: { width: number; height: number },
   expected: { width: number; height: number },
   modifiers: Modifiers,
+  shouldStrategyBeActive: boolean = true,
 ) {
   const inputCode = makeTestProjectCodeWithSnippet(`
       <div
@@ -535,7 +566,7 @@ async function resizeWithModifiers(
   const renderResult = await renderTestEditorWithCode(inputCode, 'await-first-dom-report')
   const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/ccc`)
 
-  await dragResizeControl(renderResult, target, pos, dragVector, modifiers)
+  await dragResizeControl(renderResult, target, pos, dragVector, modifiers, shouldStrategyBeActive)
 
   expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
     makeTestProjectCodeWithSnippet(`

--- a/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.spec.browser2.tsx
@@ -1,0 +1,560 @@
+/* eslint-disable jest/expect-expect */
+import { BakedInStoryboardUID } from '../../../../core/model/scene-utils'
+import * as EP from '../../../../core/shared/element-path'
+import { canvasPoint, CanvasVector, offsetPoint } from '../../../../core/shared/math-utils'
+import { ElementPath } from '../../../../core/shared/project-file-types'
+import { Modifiers, shiftModifier } from '../../../../utils/modifiers'
+import { slightlyOffsetPointBecauseVeryWeirdIssue } from '../../../../utils/utils.test-utils'
+import { selectComponents } from '../../../editor/actions/action-creators'
+import {
+  EditorRenderResult,
+  getPrintedUiJsCode,
+  makeTestProjectCodeWithSnippet,
+  renderTestEditorWithCode,
+  TestAppUID,
+  TestSceneUID,
+} from '../../ui-jsx.test-utils'
+import { EdgePosition, edgePosition } from '../../canvas-types'
+import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
+import { mouseDownAtPoint, mouseMoveToPoint, mouseUpAtPoint } from '../../event-helpers.test-utils'
+import { BASIC_RESIZE_STRATEGY_ID } from './basic-resize-strategy'
+
+async function dragResizeControl(
+  renderResult: EditorRenderResult,
+  target: ElementPath,
+  pos: EdgePosition,
+  dragDelta: CanvasVector,
+  modifiers?: Modifiers,
+) {
+  await renderResult.dispatch([selectComponents([target], false)], true)
+  const resizeControl = renderResult.renderedDOM.getByTestId(`resize-control-${pos.x}-${pos.y}`)
+  const resizeControlBounds = resizeControl.getBoundingClientRect()
+  const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+  const startPoint = canvasPoint(
+    slightlyOffsetPointBecauseVeryWeirdIssue({
+      x: resizeControlBounds.x + resizeControlBounds.width / 2,
+      y: resizeControlBounds.y + resizeControlBounds.height / 2,
+    }),
+  )
+
+  const endPoint = offsetPoint(startPoint, dragDelta)
+
+  await mouseMoveToPoint(resizeControl, startPoint)
+  await mouseDownAtPoint(resizeControl, startPoint)
+  await mouseMoveToPoint(canvasControlsLayer, endPoint, { eventOptions: { buttons: 1 }, modifiers })
+
+  expect(renderResult.getEditorState().strategyState.currentStrategy).toEqual(
+    BASIC_RESIZE_STRATEGY_ID,
+  )
+
+  await mouseUpAtPoint(canvasControlsLayer, endPoint)
+
+  await renderResult.getDispatchFollowUpActionsFinished()
+}
+
+describe('Basic Resize', () => {
+  // Corner tests
+  it('resizes a flex element from edgePosition 0, 0 with drag vector (15, 25)', async () => {
+    await resizeTest(edgePosition(0, 0), canvasPoint({ x: 15, y: 25 }), 65, 165)
+  })
+  it('resizes a flex element from edgePosition 0, 0 with drag vector (15, -25)', async () => {
+    await resizeTest(edgePosition(0, 0), canvasPoint({ x: 15, y: -25 }), 65, 215)
+  })
+  it('resizes a flex element from edgePosition 0, 0 with drag vector (-15, 25)', async () => {
+    await resizeTest(edgePosition(0, 0), canvasPoint({ x: -15, y: 25 }), 95, 165)
+  })
+  it('resizes a flex element from edgePosition 0, 0 with drag vector (-15, -25)', async () => {
+    await resizeTest(edgePosition(0, 0), canvasPoint({ x: -15, y: -25 }), 95, 215)
+  })
+  it('resizes a flex element from edgePosition 0, 1 with drag vector (15, 25)', async () => {
+    await resizeTest(edgePosition(0, 1), canvasPoint({ x: 15, y: 25 }), 65, 215)
+  })
+  it('resizes a flex element from edgePosition 0, 1 with drag vector (15, -25)', async () => {
+    await resizeTest(edgePosition(0, 1), canvasPoint({ x: 15, y: -25 }), 65, 165)
+  })
+  it('resizes a flex element from edgePosition 0, 1 with drag vector (-15, 25)', async () => {
+    await resizeTest(edgePosition(0, 1), canvasPoint({ x: -15, y: 25 }), 95, 215)
+  })
+  it('resizes a flex element from edgePosition 0, 1 with drag vector (-15, -25)', async () => {
+    await resizeTest(edgePosition(0, 1), canvasPoint({ x: -15, y: -25 }), 95, 165)
+  })
+  it('resizes a flex element from edgePosition 1, 0 with drag vector (15, 25)', async () => {
+    await resizeTest(edgePosition(1, 0), canvasPoint({ x: 15, y: 25 }), 95, 165)
+  })
+  it('resizes a flex element from edgePosition 1, 0 with drag vector (15, -25)', async () => {
+    await resizeTest(edgePosition(1, 0), canvasPoint({ x: 15, y: -25 }), 95, 215)
+  })
+  it('resizes a flex element from edgePosition 1, 0 with drag vector (-15, 25)', async () => {
+    await resizeTest(edgePosition(1, 0), canvasPoint({ x: -15, y: 25 }), 65, 165)
+  })
+  it('resizes a flex element from edgePosition 1, 0 with drag vector (-15, -25)', async () => {
+    await resizeTest(edgePosition(1, 0), canvasPoint({ x: -15, y: -25 }), 65, 215)
+  })
+  it('resizes a flex element from edgePosition 1, 1 with drag vector (15, 25)', async () => {
+    await resizeTest(edgePosition(1, 1), canvasPoint({ x: 15, y: 25 }), 95, 215)
+  })
+  it('resizes a flex element from edgePosition 1, 1 with drag vector (15, -25)', async () => {
+    await resizeTest(edgePosition(1, 1), canvasPoint({ x: 15, y: -25 }), 95, 165)
+  })
+  it('resizes a flex element from edgePosition 1, 1 with drag vector (-15, 25)', async () => {
+    await resizeTest(edgePosition(1, 1), canvasPoint({ x: -15, y: 25 }), 65, 215)
+  })
+  it('resizes a flex element from edgePosition 1, 1 with drag vector (-15, -25)', async () => {
+    await resizeTest(edgePosition(1, 1), canvasPoint({ x: -15, y: -25 }), 65, 165)
+  })
+  // Edge tests
+  it('resizes a flex element from edgePosition 0, 0.5 with drag vector (15, 25)', async () => {
+    await resizeTest(edgePosition(0, 0.5), canvasPoint({ x: 15, y: 25 }), 65, 190)
+  })
+  it('resizes a flex element from edgePosition 0, 0.5 with drag vector (15, -25)', async () => {
+    await resizeTest(edgePosition(0, 0.5), canvasPoint({ x: 15, y: -25 }), 65, 190)
+  })
+  it('resizes a flex element from edgePosition 0, 0.5 with drag vector (-15, 25)', async () => {
+    await resizeTest(edgePosition(0, 0.5), canvasPoint({ x: -15, y: 25 }), 95, 190)
+  })
+  it('resizes a flex element from edgePosition 0, 0.5 with drag vector (-15, -25)', async () => {
+    await resizeTest(edgePosition(0, 0.5), canvasPoint({ x: -15, y: -25 }), 95, 190)
+  })
+  it('resizes a flex element from edgePosition 0.5, 0 with drag vector (15, 25)', async () => {
+    await resizeTest(edgePosition(0.5, 0), canvasPoint({ x: 15, y: 25 }), 80, 165)
+  })
+  it('resizes a flex element from edgePosition 0.5, 0 with drag vector (15, -25)', async () => {
+    await resizeTest(edgePosition(0.5, 0), canvasPoint({ x: 15, y: -25 }), 80, 215)
+  })
+  it('resizes a flex element from edgePosition 0.5, 0 with drag vector (-15, 25)', async () => {
+    await resizeTest(edgePosition(0.5, 0), canvasPoint({ x: -15, y: 25 }), 80, 165)
+  })
+  it('resizes a flex element from edgePosition 0.5, 0 with drag vector (-15, -25)', async () => {
+    await resizeTest(edgePosition(0.5, 0), canvasPoint({ x: -15, y: -25 }), 80, 215)
+  })
+  it('resizes a flex element from edgePosition 1, 0.5 with drag vector (15, 25)', async () => {
+    await resizeTest(edgePosition(1, 0.5), canvasPoint({ x: 15, y: 25 }), 95, 190)
+  })
+  it('resizes a flex element from edgePosition 1, 0.5 with drag vector (15, -25)', async () => {
+    await resizeTest(edgePosition(1, 0.5), canvasPoint({ x: 15, y: -25 }), 95, 190)
+  })
+  it('resizes a flex element from edgePosition 1, 0.5 with drag vector (-15, 25)', async () => {
+    await resizeTest(edgePosition(1, 0.5), canvasPoint({ x: -15, y: 25 }), 65, 190)
+  })
+  it('resizes a flex element from edgePosition 1, 0.5 with drag vector (-15, -25)', async () => {
+    await resizeTest(edgePosition(1, 0.5), canvasPoint({ x: -15, y: -25 }), 65, 190)
+  })
+  it('resizes a flex element from edgePosition 0.5, 1 with drag vector (15, 25)', async () => {
+    await resizeTest(edgePosition(0.5, 1), canvasPoint({ x: 15, y: 25 }), 80, 215)
+  })
+  it('resizes a flex element from edgePosition 0.5, 1 with drag vector (15, -25)', async () => {
+    await resizeTest(edgePosition(0.5, 1), canvasPoint({ x: 15, y: -25 }), 80, 165)
+  })
+  it('resizes a flex element from edgePosition 0.5, 1 with drag vector (-15, 25)', async () => {
+    await resizeTest(edgePosition(0.5, 1), canvasPoint({ x: -15, y: 25 }), 80, 215)
+  })
+  it('resizes a flex element from edgePosition 0.5, 1 with drag vector (-15, -25)', async () => {
+    await resizeTest(edgePosition(0.5, 1), canvasPoint({ x: -15, y: -25 }), 80, 165)
+  })
+})
+
+describe('when the element has missing dimensions', () => {
+  describe('both missing', () => {
+    describe('horizontal movement', () => {
+      it('does nothing', async () => {
+        await resizeWithoutDimensions(edgePosition(1, 0), canvasPoint({ x: 15, y: 0 }), {}, {})
+      })
+    })
+
+    describe('vertical movement', () => {
+      it('does nothing', async () => {
+        await resizeWithoutDimensions(edgePosition(0, 0), canvasPoint({ x: 0, y: 15 }), {}, {})
+      })
+    })
+
+    describe('diagonal movement', () => {
+      it('does nothing', async () => {
+        await resizeWithoutDimensions(edgePosition(0, 0), canvasPoint({ x: 10, y: 15 }), {}, {})
+      })
+    })
+  })
+
+  describe('width missing', () => {
+    describe('horizontal movement', () => {
+      it('does nothing', async () => {
+        await resizeWithoutDimensions(edgePosition(1, 0), canvasPoint({ x: 15, y: 0 }), {}, {})
+      })
+    })
+
+    describe('vertical movement', () => {
+      it('adds the height, does not add the width', async () => {
+        await resizeWithoutDimensions(
+          edgePosition(0, 0),
+          canvasPoint({ x: 0, y: 15 }),
+          { height: 20 },
+          { height: 5 },
+        )
+      })
+    })
+
+    describe('diagonal movement', () => {
+      it('updates the height, does not add the width', async () => {
+        await resizeWithoutDimensions(
+          edgePosition(0, 0),
+          canvasPoint({ x: 10, y: 15 }),
+          { height: 20 },
+          { height: 5 },
+        )
+      })
+    })
+  })
+
+  describe('height missing', () => {
+    describe('horizontal movement', () => {
+      it('updates only the width', async () => {
+        await resizeWithoutDimensions(
+          edgePosition(1, 0),
+          canvasPoint({ x: 15, y: 0 }),
+          { width: 15 },
+          { width: 30 },
+        )
+      })
+    })
+
+    describe('vertical movement', () => {
+      it('does nothing', async () => {
+        await resizeWithoutDimensions(
+          edgePosition(0, 0),
+          canvasPoint({ x: 0, y: 15 }),
+          { width: 15 },
+          { width: 15 },
+        )
+      })
+    })
+
+    describe('diagonal movement', () => {
+      it('does not add the height and updates width', async () => {
+        await resizeWithoutDimensions(
+          edgePosition(0, 0),
+          canvasPoint({ x: 10, y: 15 }),
+          { width: 15 },
+          { width: 5 },
+        )
+      })
+    })
+  })
+})
+
+describe('when aspect ratio is locked', () => {
+  describe('horizontal', () => {
+    it('respects ratio (right)', async () => {
+      await resizeWithModifiers(
+        edgePosition(1, 0.5),
+        canvasPoint({ x: 15, y: 20 }),
+        { width: 100, height: 200 },
+        { width: 115, height: 230 },
+        shiftModifier,
+      )
+    })
+    it('respects ratio (left)', async () => {
+      await resizeWithModifiers(
+        edgePosition(0, 0.5),
+        canvasPoint({ x: 15, y: 20 }),
+        { width: 100, height: 200 },
+        { width: 85, height: 170 },
+        shiftModifier,
+      )
+    })
+  })
+  describe('vertical', () => {
+    it('respects ratio (bottom)', async () => {
+      await resizeWithModifiers(
+        edgePosition(0.5, 1),
+        canvasPoint({ x: 20, y: 15 }),
+        { width: 100, height: 200 },
+        { width: 107.5, height: 215 },
+        shiftModifier,
+      )
+    })
+    it('respects ratio (top)', async () => {
+      await resizeWithModifiers(
+        edgePosition(0.5, 0),
+        canvasPoint({ x: 20, y: 15 }),
+        { width: 100, height: 200 },
+        { width: 92.5, height: 185 },
+        shiftModifier,
+      )
+    })
+  })
+  describe('diagonal', () => {
+    it('respects ratio (br)', async () => {
+      await resizeWithModifiers(
+        edgePosition(1, 1),
+        canvasPoint({ x: 15, y: 20 }),
+        { width: 100, height: 200 },
+        { width: 115, height: 230 },
+        shiftModifier,
+      )
+    })
+    it('respects ratio (tr)', async () => {
+      await resizeWithModifiers(
+        edgePosition(1, 0),
+        canvasPoint({ x: 15, y: 20 }),
+        { width: 100, height: 200 },
+        { width: 115, height: 230 },
+        shiftModifier,
+      )
+    })
+    it('respects ratio (tl)', async () => {
+      await resizeWithModifiers(
+        edgePosition(0, 0),
+        canvasPoint({ x: 15, y: 20 }),
+        { width: 100, height: 200 },
+        { width: 90, height: 180 },
+        shiftModifier,
+      )
+    })
+    it('respects ratio (bl)', async () => {
+      await resizeWithModifiers(
+        edgePosition(0, 1),
+        canvasPoint({ x: 15, y: 20 }),
+        { width: 100, height: 200 },
+        { width: 110, height: 220 },
+        shiftModifier,
+      )
+    })
+  })
+})
+
+async function resizeTest(
+  pos: EdgePosition,
+  dragVector: CanvasVector,
+  expectedWidth: number,
+  expextedHeight: number,
+) {
+  const inputCode = makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+          position: 'relative',
+          gap: 10,
+        }}
+      >
+        <div
+          data-uid='bbb'
+          data-testid='bbb'
+          style={{
+            position: 'relative',
+            width: 180,
+            height: 180,
+            backgroundColor: '#d3d3d3',
+          }}
+        />
+        <div
+          data-uid='ccc'
+          style={{
+            width: 80,
+            height: 190,
+            backgroundColor: '#FF0000',
+          }}
+        />
+        <div
+          data-uid='ddd'
+          style={{
+            width: 50,
+            height: 110,
+            backgroundColor: '#FF0000',
+          }}
+        />
+      </div>
+    `)
+
+  const renderResult = await renderTestEditorWithCode(inputCode, 'await-first-dom-report')
+  const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/ccc`)
+
+  await dragResizeControl(renderResult, target, pos, dragVector)
+
+  expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+    makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+          position: 'relative',
+          gap: 10,
+        }}
+      >
+        <div
+          data-uid='bbb'
+          data-testid='bbb'
+          style={{
+            position: 'relative',
+            width: 180,
+            height: 180,
+            backgroundColor: '#d3d3d3',
+          }}
+        />
+        <div
+          data-uid='ccc'
+          style={{
+            width: ${expectedWidth},
+            height: ${expextedHeight},
+            backgroundColor: '#FF0000',
+          }}
+        />
+        <div
+          data-uid='ddd'
+          style={{
+            width: 50,
+            height: 110,
+            backgroundColor: '#FF0000',
+          }}
+        />
+      </div>
+      `),
+  )
+}
+
+const resizeWithoutDimensions = async (
+  pos: EdgePosition,
+  dragVector: CanvasVector,
+  initialDimensions: { width?: number; height?: number },
+  expectDimensions: { width?: number; height?: number },
+) => {
+  const inputCode = makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+          position: 'relative',
+          gap: 10,
+        }}
+      >
+        <div
+          data-uid='bbb'
+          data-testid='bbb'
+          style={{
+            position: 'relative',
+            width: 180,
+            height: 180,
+            backgroundColor: '#d3d3d3',
+          }}
+        />
+        <div
+          data-uid='ccc'
+          style={
+            ${JSON.stringify({ backgroundColor: '#f0f', ...initialDimensions })}
+          }
+        />
+        <div
+          data-uid='ddd'
+          style={{
+            width: 50,
+            height: 110,
+            backgroundColor: '#FF0000',
+          }}
+        />
+      </div>
+    `)
+
+  const renderResult = await renderTestEditorWithCode(inputCode, 'await-first-dom-report')
+  const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/ccc`)
+
+  await dragResizeControl(renderResult, target, pos, dragVector)
+
+  expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+    makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+          position: 'relative',
+          gap: 10,
+        }}
+      >
+        <div
+          data-uid='bbb'
+          data-testid='bbb'
+          style={{
+            position: 'relative',
+            width: 180,
+            height: 180,
+            backgroundColor: '#d3d3d3',
+          }}
+        />
+        <div
+          data-uid='ccc'
+          style={
+            ${JSON.stringify({ backgroundColor: '#f0f', ...expectDimensions })}
+          }
+        />
+        <div
+          data-uid='ddd'
+          style={{
+            width: 50,
+            height: 110,
+            backgroundColor: '#FF0000',
+          }}
+        />
+      </div>
+      `),
+  )
+}
+
+async function resizeWithModifiers(
+  pos: EdgePosition,
+  dragVector: CanvasVector,
+  initial: { width: number; height: number },
+  expected: { width: number; height: number },
+  modifiers: Modifiers,
+) {
+  const inputCode = makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          width: '100%',
+          height: '100%',
+        }}
+      >
+        <div
+          data-uid='ccc'
+          style={{
+            width: ${initial.width},
+            height: ${initial.height},
+            backgroundColor: '#09f',
+          }}
+        />
+      </div>
+    `)
+
+  const renderResult = await renderTestEditorWithCode(inputCode, 'await-first-dom-report')
+  const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/ccc`)
+
+  await dragResizeControl(renderResult, target, pos, dragVector, modifiers)
+
+  expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+    makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          width: '100%',
+          height: '100%',
+        }}
+      >
+        <div
+          data-uid='ccc'
+          style={{
+            width: ${expected.width},
+            height: ${expected.height},
+            backgroundColor: '#09f',
+          }}
+        />
+      </div>
+      `),
+  )
+}

--- a/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
@@ -46,19 +46,15 @@ import {
   resizeBoundingBox,
 } from './resize-helpers'
 
-export function flowResizeBasicStrategy(
+export const BASIC_RESIZE_STRATEGY_ID = 'BASIC_RESIZE'
+
+export function basicResizeStrategy(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
 ): CanvasStrategy | null {
   const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
 
-  if (
-    selectedElements.length !== 1 ||
-    !MetadataUtils.isPositionedByFlow(
-      MetadataUtils.findElementByElementPath(canvasState.startingMetadata, selectedElements[0]),
-    ) ||
-    !honoursPropsSize(canvasState, selectedElements[0])
-  ) {
+  if (selectedElements.length !== 1 || !honoursPropsSize(canvasState, selectedElements[0])) {
     return null
   }
   const metadata = MetadataUtils.findElementByElementPath(
@@ -84,8 +80,8 @@ export function flowResizeBasicStrategy(
     (elementParentBounds.width !== 0 || elementParentBounds.height !== 0)
 
   return {
-    id: 'FLOW_RESIZE_BASIC',
-    name: 'Flow Resize (Basic)',
+    id: BASIC_RESIZE_STRATEGY_ID,
+    name: 'Resize (Basic)',
     controlsToRender: [
       controlWithProps({
         control: AbsoluteResizeControl,

--- a/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
@@ -227,7 +227,7 @@ export function resizeWidthHeight(
       y: 1 - edgePosition.y,
     } as EdgePosition
 
-    let oppositeCorner = pickPointOnRect(boundingBox, startingCornerPosition)
+    let oppositeCorner = pickPointOnRect(boundingBox, oppositeCornerPosition)
     const draggedCorner = pickPointOnRect(boundingBox, edgePosition)
     const newCorner = offsetPoint(draggedCorner, drag)
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
@@ -222,7 +222,7 @@ export function resizeWidthHeight(
   edgePosition: EdgePosition,
 ): CanvasRectangle {
   if (isEdgePositionACorner(edgePosition)) {
-    const startingCornerPosition = {
+    const oppositeCornerPosition = {
       x: 1 - edgePosition.x,
       y: 1 - edgePosition.y,
     } as EdgePosition

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.spec.browser2.tsx
@@ -17,6 +17,7 @@ import {
 import { EdgePosition, edgePosition, EdgePositionTopRight } from '../../canvas-types'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import { mouseDownAtPoint, mouseMoveToPoint, mouseUpAtPoint } from '../../event-helpers.test-utils'
+import { FLEX_RESIZE_STRATEGY_ID } from './flex-resize-basic-strategy'
 
 async function dragResizeControl(
   renderResult: EditorRenderResult,
@@ -24,6 +25,7 @@ async function dragResizeControl(
   pos: EdgePosition,
   dragDelta: CanvasVector,
   modifiers?: Modifiers,
+  shouldStrategyBeActive: boolean = true,
 ) {
   await renderResult.dispatch([selectComponents([target], false)], true)
   const resizeControl = renderResult.renderedDOM.getByTestId(`resize-control-${pos.x}-${pos.y}`)
@@ -42,6 +44,13 @@ async function dragResizeControl(
   await mouseMoveToPoint(resizeControl, startPoint)
   await mouseDownAtPoint(resizeControl, startPoint)
   await mouseMoveToPoint(canvasControlsLayer, endPoint, { eventOptions: { buttons: 1 }, modifiers })
+
+  if (shouldStrategyBeActive === true) {
+    expect(renderResult.getEditorState().strategyState.currentStrategy).toEqual(
+      FLEX_RESIZE_STRATEGY_ID,
+    )
+  }
+
   await mouseUpAtPoint(canvasControlsLayer, endPoint)
 
   await renderResult.getDispatchFollowUpActionsFinished()
@@ -254,19 +263,37 @@ describe('Flex Resize', () => {
     describe('both missing', () => {
       describe('horizontal movement', () => {
         it('does nothing', async () => {
-          await resizeWithoutDimensions(edgePosition(1, 0), canvasPoint({ x: 15, y: 0 }), {}, {})
+          await resizeWithoutDimensions(
+            edgePosition(1, 0),
+            canvasPoint({ x: 15, y: 0 }),
+            {},
+            {},
+            false,
+          )
         })
       })
 
       describe('vertical movement', () => {
         it('does nothing', async () => {
-          await resizeWithoutDimensions(edgePosition(0, 0), canvasPoint({ x: 0, y: 15 }), {}, {})
+          await resizeWithoutDimensions(
+            edgePosition(0, 0),
+            canvasPoint({ x: 0, y: 15 }),
+            {},
+            {},
+            false,
+          )
         })
       })
 
       describe('diagonal movement', () => {
         it('does nothing', async () => {
-          await resizeWithoutDimensions(edgePosition(0, 0), canvasPoint({ x: 10, y: 15 }), {}, {})
+          await resizeWithoutDimensions(
+            edgePosition(0, 0),
+            canvasPoint({ x: 10, y: 15 }),
+            {},
+            {},
+            false,
+          )
         })
       })
     })
@@ -274,7 +301,13 @@ describe('Flex Resize', () => {
     describe('width missing', () => {
       describe('horizontal movement', () => {
         it('does nothing', async () => {
-          await resizeWithoutDimensions(edgePosition(1, 0), canvasPoint({ x: 15, y: 0 }), {}, {})
+          await resizeWithoutDimensions(
+            edgePosition(1, 0),
+            canvasPoint({ x: 15, y: 0 }),
+            {},
+            {},
+            false,
+          )
         })
       })
 
@@ -729,6 +762,7 @@ const resizeWithoutDimensions = async (
   dragVector: CanvasVector,
   initialDimensions: { width?: number; height?: number },
   expectDimensions: { width?: number; height?: number },
+  shouldStrategyBeActive: boolean = true,
 ) => {
   const inputCode = makeTestProjectCodeWithSnippet(`
       <div
@@ -772,7 +806,7 @@ const resizeWithoutDimensions = async (
   const renderResult = await renderTestEditorWithCode(inputCode, 'await-first-dom-report')
   const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/ccc`)
 
-  await dragResizeControl(renderResult, target, pos, dragVector)
+  await dragResizeControl(renderResult, target, pos, dragVector, undefined, shouldStrategyBeActive)
 
   expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
     makeTestProjectCodeWithSnippet(`

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
@@ -47,6 +47,8 @@ import {
 } from './resize-helpers'
 import { FlexDirection } from '../../../inspector/common/css-utils'
 
+export const FLEX_RESIZE_STRATEGY_ID = 'FLEX_RESIZE_BASIC'
+
 export function flexResizeBasicStrategy(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
@@ -98,7 +100,7 @@ export function flexResizeBasicStrategy(
     (elementParentBounds.width !== 0 || elementParentBounds.height !== 0)
 
   return {
-    id: 'FLEX_RESIZE_BASIC',
+    id: FLEX_RESIZE_STRATEGY_ID,
     name: 'Flex Resize (Basic)',
     controlsToRender: [
       controlWithProps({

--- a/editor/src/components/canvas/canvas-strategies/strategies/flow-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flow-resize-basic-strategy.tsx
@@ -1,0 +1,306 @@
+import { styleStringInArray } from '../../../../utils/common-constants'
+import { getLayoutProperty } from '../../../../core/layout/getLayoutProperty'
+import { MetadataUtils, PropsOrJSXAttributes } from '../../../../core/model/element-metadata-utils'
+import { foldEither, isLeft, right } from '../../../../core/shared/either'
+import { ElementInstanceMetadata, isJSXElement } from '../../../../core/shared/element-template'
+import {
+  CanvasPoint,
+  canvasRectangle,
+  CanvasRectangle,
+  isInfinityRectangle,
+  offsetPoint,
+} from '../../../../core/shared/math-utils'
+import { stylePropPathMappingFn } from '../../../inspector/common/property-path-hooks'
+import { EdgePosition, oppositeEdgePosition } from '../../canvas-types'
+import {
+  isEdgePositionACorner,
+  isEdgePositionAHorizontalEdge,
+  pickPointOnRect,
+} from '../../canvas-utils'
+import {
+  AdjustCssLengthProperty,
+  adjustCssLengthProperty,
+} from '../../commands/adjust-css-length-command'
+import { setCursorCommand } from '../../commands/set-cursor-command'
+import { setElementsToRerenderCommand } from '../../commands/set-elements-to-rerender-command'
+import { updateHighlightedViews } from '../../commands/update-highlighted-views-command'
+import { ImmediateParentBounds } from '../../controls/parent-bounds'
+import { ImmediateParentOutlines } from '../../controls/parent-outlines'
+import { AbsoluteResizeControl } from '../../controls/select-mode/absolute-resize-control'
+import { ZeroSizeResizeControlWrapper } from '../../controls/zero-sized-element-controls'
+import {
+  CanvasStrategy,
+  controlWithProps,
+  emptyStrategyApplicationResult,
+  getTargetPathsFromInteractionTarget,
+  InteractionCanvasState,
+  InteractionLifecycle,
+  strategyApplicationResult,
+} from '../canvas-strategy-types'
+import { InteractionSession } from '../interaction-state'
+import { honoursPropsSize } from './absolute-utils'
+import {
+  getLockedAspectRatio,
+  isAnySelectedElementAspectRatioLocked,
+  pickCursorFromEdgePosition,
+  resizeBoundingBox,
+} from './resize-helpers'
+
+export function flowResizeBasicStrategy(
+  canvasState: InteractionCanvasState,
+  interactionSession: InteractionSession | null,
+): CanvasStrategy | null {
+  const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
+
+  if (
+    selectedElements.length !== 1 ||
+    !MetadataUtils.isPositionedByFlow(
+      MetadataUtils.findElementByElementPath(canvasState.startingMetadata, selectedElements[0]),
+    ) ||
+    !honoursPropsSize(canvasState, selectedElements[0])
+  ) {
+    return null
+  }
+  const metadata = MetadataUtils.findElementByElementPath(
+    canvasState.startingMetadata,
+    selectedElements[0],
+  )
+  const elementDimensionsProps = metadata != null ? getElementDimensions(metadata) : null
+  const elementParentBounds = metadata?.specialSizeMeasurements.immediateParentBounds ?? null
+
+  const elementDimensions =
+    elementDimensionsProps == null
+      ? null
+      : {
+          width: elementDimensionsProps.width,
+          height: elementDimensionsProps.height,
+        }
+
+  const hasDimensions =
+    elementDimensions != null &&
+    (elementDimensions.width != null || elementDimensions.height != null)
+  const hasSizedParent =
+    elementParentBounds != null &&
+    (elementParentBounds.width !== 0 || elementParentBounds.height !== 0)
+
+  return {
+    id: 'FLOW_RESIZE_BASIC',
+    name: 'Flow Resize (Basic)',
+    controlsToRender: [
+      controlWithProps({
+        control: AbsoluteResizeControl,
+        props: { targets: selectedElements },
+        key: 'absolute-resize-control',
+        show: 'always-visible',
+      }),
+      controlWithProps({
+        control: ZeroSizeResizeControlWrapper,
+        props: { targets: selectedElements },
+        key: 'zero-size-resize-control',
+        show: 'always-visible',
+      }),
+      controlWithProps({
+        control: ImmediateParentOutlines,
+        props: { targets: selectedElements },
+        key: 'parent-outlines-control',
+        show: 'visible-only-while-active',
+      }),
+      controlWithProps({
+        control: ImmediateParentBounds,
+        props: { targets: selectedElements },
+        key: 'parent-bounds-control',
+        show: 'visible-only-while-active',
+      }),
+    ],
+    fitness:
+      interactionSession != null &&
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.activeControl.type === 'RESIZE_HANDLE' &&
+      (hasDimensions || !hasSizedParent)
+        ? 1
+        : 0,
+    apply: (_strategyLifecycle: InteractionLifecycle) => {
+      if (
+        interactionSession != null &&
+        interactionSession.interactionData.type === 'DRAG' &&
+        interactionSession.activeControl.type === 'RESIZE_HANDLE'
+      ) {
+        // no multiselection support yet
+        const selectedElement = selectedElements[0]
+        const edgePosition = interactionSession.activeControl.edgePosition
+        if (interactionSession.interactionData.drag != null) {
+          const drag = interactionSession.interactionData.drag
+          const originalBounds = MetadataUtils.getFrameInCanvasCoords(
+            selectedElement,
+            canvasState.startingMetadata,
+          )
+
+          if (originalBounds == null || isInfinityRectangle(originalBounds)) {
+            return emptyStrategyApplicationResult
+          }
+
+          if (metadata == null) {
+            return emptyStrategyApplicationResult
+          }
+
+          const anySelectedElementAspectRatioLocked = isAnySelectedElementAspectRatioLocked(
+            canvasState.startingMetadata,
+            [selectedElement],
+          )
+
+          const resizedBounds = resizeBoundingBox(
+            originalBounds,
+            drag,
+            edgePosition,
+            getLockedAspectRatio(
+              interactionSession,
+              interactionSession.interactionData.modifiers,
+              originalBounds,
+              anySelectedElementAspectRatioLocked,
+            ),
+            'non-center-based',
+          )
+
+          const makeResizeCommand = (
+            name: 'width' | 'height',
+            elementDimension: number | null | undefined,
+            original: number,
+            resized: number,
+            parent: number | undefined,
+          ): AdjustCssLengthProperty[] => {
+            if (elementDimension == null && (original === resized || hasSizedParent)) {
+              return []
+            }
+            return [
+              adjustCssLengthProperty(
+                'always',
+                selectedElement,
+                stylePropPathMappingFn(name, styleStringInArray),
+                elementDimension != null ? resized - original : resized,
+                parent,
+                null,
+                'create-if-not-existing',
+              ),
+            ]
+          }
+
+          const resizeCommands: Array<AdjustCssLengthProperty> = [
+            ...makeResizeCommand(
+              'width',
+              elementDimensionsProps?.width,
+              originalBounds.width,
+              resizedBounds.width,
+              elementParentBounds?.width,
+            ),
+            ...makeResizeCommand(
+              'height',
+              elementDimensionsProps?.height,
+              originalBounds.height,
+              resizedBounds.height,
+              elementParentBounds?.height,
+            ),
+          ]
+
+          return strategyApplicationResult([
+            ...resizeCommands,
+            updateHighlightedViews('mid-interaction', []),
+            setCursorCommand(pickCursorFromEdgePosition(edgePosition)),
+            setElementsToRerenderCommand(selectedElements),
+          ])
+        } else {
+          return strategyApplicationResult([
+            updateHighlightedViews('mid-interaction', []),
+            setCursorCommand(pickCursorFromEdgePosition(edgePosition)),
+          ])
+        }
+      }
+      // Fallback for when the checks above are not satisfied.
+      return emptyStrategyApplicationResult
+    },
+  }
+}
+
+export function resizeWidthHeight(
+  boundingBox: CanvasRectangle,
+  drag: CanvasPoint,
+  edgePosition: EdgePosition,
+): CanvasRectangle {
+  if (isEdgePositionACorner(edgePosition)) {
+    const startingCornerPosition = {
+      x: 1 - edgePosition.x,
+      y: 1 - edgePosition.y,
+    } as EdgePosition
+
+    let oppositeCorner = pickPointOnRect(boundingBox, startingCornerPosition)
+    const draggedCorner = pickPointOnRect(boundingBox, edgePosition)
+    const newCorner = offsetPoint(draggedCorner, drag)
+
+    const newWidth = Math.abs(oppositeCorner.x - newCorner.x)
+    const newHeight = Math.abs(oppositeCorner.y - newCorner.y)
+
+    return canvasRectangle({
+      x: boundingBox.x,
+      y: boundingBox.y,
+      width: newWidth,
+      height: newHeight,
+    })
+  } else {
+    const isEdgeHorizontalSide = isEdgePositionAHorizontalEdge(edgePosition)
+
+    const oppositeSideCenterPosition = oppositeEdgePosition(edgePosition)
+
+    const oppositeSideCenter = pickPointOnRect(boundingBox, oppositeSideCenterPosition)
+    const draggedSideCenter = pickPointOnRect(boundingBox, edgePosition)
+
+    if (isEdgeHorizontalSide) {
+      const newHeight = Math.abs(oppositeSideCenter.y - (draggedSideCenter.y + drag.y))
+      return canvasRectangle({
+        x: boundingBox.x,
+        y: boundingBox.y,
+        width: boundingBox.width,
+        height: newHeight,
+      })
+    } else {
+      const newWidth = Math.abs(oppositeSideCenter.x - (draggedSideCenter.x + drag.x))
+      return canvasRectangle({
+        x: boundingBox.x,
+        y: boundingBox.y,
+        width: newWidth,
+        height: boundingBox.height,
+      })
+    }
+  }
+}
+
+const getOffsetPropValue = (
+  name: 'width' | 'height',
+  attrs: PropsOrJSXAttributes,
+): number | null => {
+  return foldEither(
+    (_) => null,
+    (v) => v?.value ?? null,
+    getLayoutProperty(name, attrs, styleStringInArray),
+  )
+}
+
+type ElementDimensions = {
+  width: number | null
+  height: number | null
+} | null
+
+const getElementDimensions = (metadata: ElementInstanceMetadata): ElementDimensions => {
+  if (isLeft(metadata.element)) {
+    return null
+  }
+  const { value } = metadata.element
+  if (!isJSXElement(value)) {
+    return null
+  }
+
+  const attrs = right(value.props)
+
+  return {
+    width: getOffsetPropValue('width', attrs),
+    height: getOffsetPropValue('height', attrs),
+  }
+}


### PR DESCRIPTION
## Description
This PR adds a basic resize strategy, which is applicable to all elements honoring size props (regardless of whether they are in a flex context or not).

### Details
- Added the new strategy
- Added tests
- Added extra assertions to check if the intended strategy is running in the tests for flex resizing and basic resizing

![17-23-ycoog-lpcp0](https://user-images.githubusercontent.com/16385508/219619294-0bf380fe-82d2-4f5d-bba7-90838c373b37.gif)
