### PR TITLE
Fix DOM walker path invalidation for non-scenes in mutation observers

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -66,6 +66,7 @@ import { CanvasContainerID } from './canvas-types'
 import { emptySet } from '../../core/shared/set-utils'
 import {
   getDeepestPathOnDomElement,
+  getPathStringsOnDomElement,
   getPathWithStringsOnDomElement,
 } from '../../core/shared/uid-utils'
 import { pluck, uniqBy } from '../../core/shared/array-utils'
@@ -162,10 +163,19 @@ function isScene(node: Node): node is HTMLElement {
 }
 
 function findParentScene(target: HTMLElement): string | null {
+  // First check if the node is a Scene element, which could be nested at any level
   const sceneID = getDOMAttribute(target, UTOPIA_SCENE_ID_KEY)
   if (sceneID != null) {
     return sceneID
   } else {
+    // Failing that, check if it is a child of the storyboard
+    const allPaths = getPathStringsOnDomElement(target)
+    allPaths.sort((a, b) => a.length - b.length)
+    const shallowestPath = allPaths[0]
+    if (shallowestPath != null) {
+      return shallowestPath
+    }
+
     if (target.parentElement != null) {
       return findParentScene(target.parentElement)
     } else {

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -168,20 +168,26 @@ function findParentScene(target: HTMLElement): string | null {
   if (sceneID != null) {
     return sceneID
   } else {
-    // Failing that, check if it is a child of the storyboard
-    const allPaths = getPathStringsOnDomElement(target)
-    allPaths.sort((a, b) => a.length - b.length)
-    const shallowestPath = allPaths[0]
-    if (shallowestPath != null) {
-      return shallowestPath
-    }
+    const parent = target.parentElement
 
-    if (target.parentElement != null) {
-      return findParentScene(target.parentElement)
-    } else {
-      return null
+    if (parent != null) {
+      const parentPath = getDeepestPathOnDomElement(parent)
+      const parentIsStoryboard = parentPath != null && EP.isStoryboardPath(parentPath)
+      if (parentIsStoryboard) {
+        // If the parent element is the storyboard, then we've reached the top and have to stop
+        const allPaths = getPathStringsOnDomElement(target)
+        allPaths.sort((a, b) => a.length - b.length)
+        const shallowestPath = allPaths[0]
+        if (shallowestPath != null) {
+          return shallowestPath
+        }
+      } else {
+        return findParentScene(parent)
+      }
     }
   }
+
+  return null
 }
 
 function lazyValue<T>(getter: () => T) {

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -172,7 +172,7 @@ function findParentScene(target: HTMLElement): string | null {
 
     if (parent != null) {
       const parentPath = getDeepestPathOnDomElement(parent)
-      const parentIsStoryboard = parentPath != null && EP.isStoryboardPath(parentPath)
+      const parentIsStoryboard = parentPath == null || EP.isStoryboardPath(parentPath)
       if (parentIsStoryboard) {
         // If the parent element is the storyboard, then we've reached the top and have to stop
         const allPaths = getPathStringsOnDomElement(target)

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -253,6 +253,11 @@ export function getPathsOnDomElement(element: Element): Array<ElementPath> {
   return getPathsFromString(pathsAttribute)
 }
 
+export function getPathStringsOnDomElement(element: Element): Array<string> {
+  const pathsAttribute = getDOMAttribute(element, UTOPIA_PATH_KEY)
+  return getSplitPathsStrings(pathsAttribute)
+}
+
 export function getDeepestPathOnDomElement(element: Element): ElementPath | null {
   const pathAttribute = getDOMAttribute(element, UTOPIA_PATH_KEY)
   return pathAttribute == null ? null : EP.fromString(pathAttribute)


### PR DESCRIPTION
**Problem:**
We still had a remaining path invalidation issue after #3277 for elements that weren't children of scenes, which would be caused when the path should have been invalidated by one of the mutation observers.

**Fix:**
The actual problem here was that the mutation observers would walk up the DOM to find the nearest Scene element, so if one doesn't exist then no paths would be invalidated. To fix this, that logic will now settle for the top level element in that hierarchy if no Scene element was found along the way.