### PR TITLE
Selective dom-walking also walks children

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -348,30 +348,35 @@ function runSelectiveDomWalker(
        * The assumption is that querySelector will return the "topmost" DOM-element with the matching prefix,
        * which is the same as the "rootest" element we are looking for
        */
-      const element = document.querySelector(
+      const foundElement = document.querySelector(
         `[${UTOPIA_PATH_KEY}^="${EP.toString(path)}"]`,
       ) as HTMLElement | null
 
-      if (element != null) {
-        const pathsWithStrings = getPathWithStringsOnDomElement(element)
-        const foundValidPaths = pathsWithStrings.filter((pathWithString) => {
-          const staticPath = EP.toString(EP.makeLastPartOfPathStatic(pathWithString.path))
-          return validPaths.has(staticPath)
+      if (foundElement != null) {
+        const elementsToWalk = [foundElement, ...foundElement.childNodes]
+        elementsToWalk.forEach((element) => {
+          if (element instanceof HTMLElement) {
+            const pathsWithStrings = getPathWithStringsOnDomElement(element)
+            const foundValidPaths = pathsWithStrings.filter((pathWithString) => {
+              const staticPath = EP.toString(EP.makeLastPartOfPathStatic(pathWithString.path))
+              return validPaths.has(staticPath)
+            })
+
+            const { collectedMetadata } = collectAndCreateMetadataForElement(
+              element,
+              parentPoint,
+              path,
+              scale,
+              containerRectLazy,
+              foundValidPaths.map((p) => p.path),
+              domWalkerMutableState.invalidatedPathsForStylesheetCache,
+              selectedViews,
+              domWalkerMutableState.invalidatedPaths,
+            )
+
+            mergeMetadataMaps_MUTATE(workingMetadata, collectedMetadata)
+          }
         })
-
-        const { collectedMetadata } = collectAndCreateMetadataForElement(
-          element,
-          parentPoint,
-          path, // TODO is this good enough?
-          scale,
-          containerRectLazy,
-          foundValidPaths.map((p) => p.path),
-          domWalkerMutableState.invalidatedPathsForStylesheetCache,
-          selectedViews,
-          domWalkerMutableState.invalidatedPaths,
-        )
-
-        mergeMetadataMaps_MUTATE(workingMetadata, collectedMetadata)
       }
     })
     const otherElementPaths = Object.keys(rootMetadataInStateRef.current).filter(


### PR DESCRIPTION
**Problem:**
We use the selective DOM walker during canvas interactions for performance reasons, but now that we have controls specifically for children of the selected element we need to ensure those controls are using up to date metadata.

**Fix:**
When running the selective DOM walker, we also walk down the child nodes of the target elements until we find the closest children with path attributes, and collect the metadata for those.