### PR TITLE
Reordering fragment children

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2802,9 +2802,13 @@ export function reorderComponent(
 
   const jsxElement = findElementAtPath(target, workingComponents)
   const parentPath = EP.parentPath(target)
-  const parentElement = findJSXElementAtPath(parentPath, workingComponents)
+  const parentElement = findElementAtPath(parentPath, workingComponents)
 
-  if (jsxElement != null && parentElement != null) {
+  if (
+    jsxElement != null &&
+    parentElement != null &&
+    (isJSXElement(parentElement) || isJSXFragment(parentElement))
+  ) {
     const indexOfRemovedElement = parentElement.children.indexOf(jsxElement)
     if (indexOfRemovedElement < 0) {
       throw new Error(`Unable to determine old element index.`)

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1876,6 +1876,9 @@ function fillSpyOnlyMetadata(
       ...sameThingFromWorkingElems,
       specialSizeMeasurements: {
         ...spyElem.specialSizeMeasurements,
+        layoutSystemForChildren: allElemsEqual(parentLayoutSystemFromChildren)
+          ? parentLayoutSystemFromChildren[0]
+          : spyElem.specialSizeMeasurements.parentLayoutSystem,
         parentLayoutSystem: allElemsEqual(parentLayoutSystemFromChildren)
           ? parentLayoutSystemFromChildren[0]
           : spyElem.specialSizeMeasurements.parentLayoutSystem,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1871,20 +1871,23 @@ function fillSpyOnlyMetadata(
       (c) => c.specialSizeMeasurements.immediateParentBounds,
     )
 
+    const parentLayoutSystem = allElemsEqual(parentLayoutSystemFromChildren)
+      ? parentLayoutSystemFromChildren[0]
+      : spyElem.specialSizeMeasurements.parentLayoutSystem
+
+    const parentFlexDirection = allElemsEqual(parentFlexDirectionFromChildren)
+      ? parentFlexDirectionFromChildren[0]
+      : spyElem.specialSizeMeasurements.parentFlexDirection
+
     workingElements[pathStr] = {
       ...spyElem,
       ...sameThingFromWorkingElems,
       specialSizeMeasurements: {
         ...spyElem.specialSizeMeasurements,
-        layoutSystemForChildren: allElemsEqual(parentLayoutSystemFromChildren)
-          ? parentLayoutSystemFromChildren[0]
-          : spyElem.specialSizeMeasurements.parentLayoutSystem,
-        parentLayoutSystem: allElemsEqual(parentLayoutSystemFromChildren)
-          ? parentLayoutSystemFromChildren[0]
-          : spyElem.specialSizeMeasurements.parentLayoutSystem,
-        parentFlexDirection: allElemsEqual(parentFlexDirectionFromChildren)
-          ? parentFlexDirectionFromChildren[0]
-          : spyElem.specialSizeMeasurements.parentFlexDirection,
+        layoutSystemForChildren: parentLayoutSystem,
+        parentLayoutSystem: parentLayoutSystem,
+        parentFlexDirection: parentFlexDirection,
+        flexDirection: parentFlexDirection,
         immediateParentBounds: allElemsEqual(immediateParentBoundsFromChildren)
           ? immediateParentBoundsFromChildren[0]
           : spyElem.specialSizeMeasurements.immediateParentBounds,


### PR DESCRIPTION
## Description

This PR makes the existing reorder strategies work with children of fragments. The way to accomplish this was to "fake" `flexDirection` and `parentFlexDirection` for fragments in `specialSizeMeasurements`, as the reorder strategies rely on these props when reordering children.

`flexDirection` and `parentFlexDirection` are both set to the `parentFlexDirection` of a fragement's children, since the fragment doesn't influence these in any way.