### PR TITLE
Derive reorder direction from child metadata

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-helpers.ts
@@ -48,7 +48,7 @@ export function areAllSiblingsInOneDimensionFlexOrFlow(
   target: ElementPath,
   metadata: ElementInstanceMetadataMap,
 ): boolean {
-  const siblings = MetadataUtils.getSiblingsUnordered(metadata, target) // including target
+  const siblings = MetadataUtils.getSiblingsOrdered(metadata, target) // including target
   if (siblings.length === 1) {
     return false
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-helpers.ts
@@ -53,10 +53,6 @@ export function areAllSiblingsInOneDimensionFlexOrFlow(
     return false
   }
 
-  // return (
-  //   singleAxisAutoLayoutContainerDirections(EP.parentPath(target), metadata) !==
-  //   'non-single-axis-autolayout'
-  // )
   return singleAxisAutoLayoutChildrenDirections(siblings, metadata) !== 'non-single-axis-autolayout'
 }
 

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -4015,6 +4015,11 @@ const flexWrapParser: Parser<FlexWrap> = isOneOfTheseParser([
 export type Direction = 'horizontal' | 'vertical'
 export type ForwardOrReverse = 'forward' | 'reverse'
 
+export interface SimpleFlexDirection {
+  direction: Direction
+  forwardOrReverse: ForwardOrReverse
+}
+
 export type FlexDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse'
 export const AllFlexDirections: Array<FlexDirection> = [
   'row',

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -109,6 +109,7 @@ import {
   Direction,
   FlexDirection,
   ForwardOrReverse,
+  SimpleFlexDirection,
 } from '../../components/inspector/common/css-utils'
 import { isFeatureEnabled } from '../../utils/feature-switches'
 
@@ -417,10 +418,7 @@ export const MetadataUtils = {
   getFlexDirection: function (instance: ElementInstanceMetadata | null): FlexDirection {
     return instance?.specialSizeMeasurements?.flexDirection ?? 'row'
   },
-  getSimpleFlexDirection: function (instance: ElementInstanceMetadata | null): {
-    direction: Direction
-    forwardOrReverse: ForwardOrReverse
-  } {
+  getSimpleFlexDirection: function (instance: ElementInstanceMetadata | null): SimpleFlexDirection {
     return MetadataUtils.flexDirectionToSimpleFlexDirection(
       MetadataUtils.getFlexDirection(instance),
     )


### PR DESCRIPTION
## Problem
The reorder strategies assume that the parent of the elements being reordered
- is an actual element in the DOM and
- has its `specialSizeMeasurements` filled out by the DOM walker.

After fragments have been introduced, both of these assumptions have been invalidated, so reordering doesn't work among children of a fragment.

## Fix
Instead of patching fragment metadata to make it look like a DOM element (as implemented by https://github.com/concrete-utopia/utopia/pull/3311), this PR refactors the reorder strategies to only take into account the metadata of reordered elements (instead of checking the parent's metadata).

