### PR TITLE
Toggle conditionals

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -3070,7 +3070,10 @@ function createCanvasTransientStateFromProperties(
           currentProp.elementPath,
           Utils.forceNotNull('No open file found', getOpenUIJSFileKey(editor)),
           working,
-          (element: JSXElement) => {
+          (element) => {
+            if (isJSXConditionalExpression(element)) {
+              return element
+            }
             const valuesAtPath = Object.keys(currentProp.attributesToUpdate).map((key) => {
               return {
                 path: PP.fromString(key),

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -334,12 +334,9 @@ export function renderCoreElement(
       )
     }
     case 'JSX_CONDITIONAL_EXPRESSION': {
-      const conditionValue: boolean = jsxAttributeToValue(
-        filePath,
-        inScope,
-        requireResult,
-        element.condition,
-      )
+      const conditionValue: boolean =
+        element.overriddenCondition ??
+        jsxAttributeToValue(filePath, inScope, requireResult, element.condition)
       const actualElement = conditionValue ? element.whenTrue : element.whenFalse
 
       if (childOrBlockIsChild(actualElement)) {

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -54,6 +54,10 @@ import { canvasMissingJSXElementError } from './canvas-render-errors'
 import { importedFromWhere } from '../../editor/import-utils'
 import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../../core/shared/dom-utils'
 import { TextEditorWrapper, unescapeHTML } from '../../text-editor/text-editor'
+import {
+  findUtopiaCommentFlag,
+  isUtopiaCommentFlagConditional,
+} from '../../../core/shared/comment-flags'
 
 export function createLookupRender(
   elementPath: ElementPath | null,
@@ -334,9 +338,10 @@ export function renderCoreElement(
       )
     }
     case 'JSX_CONDITIONAL_EXPRESSION': {
+      const commentFlag = findUtopiaCommentFlag(element.comments, 'conditional')
+      const override = isUtopiaCommentFlagConditional(commentFlag) ? commentFlag.value : null
       const conditionValue: boolean =
-        element.overriddenCondition ??
-        jsxAttributeToValue(filePath, inScope, requireResult, element.condition)
+        override ?? jsxAttributeToValue(filePath, inScope, requireResult, element.condition)
       const actualElement = conditionValue ? element.whenTrue : element.whenFalse
 
       if (childOrBlockIsChild(actualElement)) {

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -807,6 +807,12 @@ export interface UpdateJSXElementName {
   importsToAdd: Imports
 }
 
+export interface SetConditionalOverriddenCondition {
+  action: 'SET_CONDITIONAL_OVERRIDDEN_CONDITION'
+  target: ElementPath
+  condition: boolean
+}
+
 export interface AddImports {
   action: 'ADD_IMPORTS'
   target: ElementPath
@@ -1278,6 +1284,7 @@ export type EditorAction =
   | SetAssetChecksum
   | ApplyCommandsAction
   | UpdateColorSwatches
+  | SetConditionalOverriddenCondition
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -227,6 +227,7 @@ import type {
   PasteProperties,
   CopyProperties,
   MergeWithPrevUndo,
+  SetConditionalOverriddenCondition,
 } from '../action-types'
 import { EditorModes, insertionSubject, Mode } from '../editor-modes'
 import type {
@@ -1059,6 +1060,7 @@ export function updateGithubSettings(
     settings: settings,
   }
 }
+
 export function updateGithubData(data: Partial<GithubData>): UpdateGithubData {
   return {
     action: 'UPDATE_GITHUB_DATA',
@@ -1741,5 +1743,16 @@ export function updateColorSwatches(colorSwatches: Array<ColorSwatch>): UpdateCo
   return {
     action: 'UPDATE_COLOR_SWATCHES',
     colorSwatches: colorSwatches,
+  }
+}
+
+export function setConditionalOverriddenCondition(
+  target: ElementPath,
+  condition: boolean,
+): SetConditionalOverriddenCondition {
+  return {
+    action: 'SET_CONDITIONAL_OVERRIDDEN_CONDITION',
+    target: target,
+    condition: condition,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -192,6 +192,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_AGAINST_GITHUB':
     case 'APPLY_COMMANDS':
     case 'UPDATE_COLOR_SWATCHES':
+    case 'SET_CONDITIONAL_OVERRIDDEN_CONDITION':
       return false
     case 'SAVE_ASSET':
       return (

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -76,6 +76,7 @@ import {
   jsxElementName,
   jsxTextBlock,
   SettableLayoutSystem,
+  singleLineComment,
   UtopiaJSXComponent,
   walkElements,
 } from '../../../core/shared/element-template'
@@ -475,6 +476,7 @@ import { styleStringInArray } from '../../../utils/common-constants'
 import { collapseTextElements } from '../../../components/text-editor/text-handling'
 import { LayoutPropsWithoutTLBR, StyleProperties } from '../../inspector/common/css-utils'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
+import { isUtopiaCommentFlag, utopiaCommentFlag } from '../../../core/shared/comment-flags'
 
 export const MIN_CODE_PANE_REOPEN_WIDTH = 100
 
@@ -4343,9 +4345,18 @@ export const UPDATE_FNS = {
         if (!isJSXConditionalExpression(element)) {
           return element
         }
+        const comment = utopiaCommentFlag({ type: 'conditional', value: action.condition })
         return {
           ...element,
-          overriddenCondition: action.condition,
+          comments: {
+            leadingComments: element.comments.leadingComments,
+            trailingComments: [
+              singleLineComment(comment, comment, true, 0),
+              ...element.comments.trailingComments.filter(
+                (c) => !isUtopiaCommentFlag(c, 'conditional'),
+              ),
+            ],
+          },
         }
       },
       editor,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -476,7 +476,7 @@ import { styleStringInArray } from '../../../utils/common-constants'
 import { collapseTextElements } from '../../../components/text-editor/text-handling'
 import { LayoutPropsWithoutTLBR, StyleProperties } from '../../inspector/common/css-utils'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
-import { isUtopiaCommentFlag, utopiaCommentFlag } from '../../../core/shared/comment-flags'
+import { isUtopiaCommentFlag, makeUtopiaFlagComment } from '../../../core/shared/comment-flags'
 
 export const MIN_CODE_PANE_REOPEN_WIDTH = 100
 
@@ -4345,13 +4345,12 @@ export const UPDATE_FNS = {
         if (!isJSXConditionalExpression(element)) {
           return element
         }
-        const comment = utopiaCommentFlag({ type: 'conditional', value: action.condition })
         return {
           ...element,
           comments: {
             leadingComments: element.comments.leadingComments,
             trailingComments: [
-              singleLineComment(comment, comment, true, 0),
+              makeUtopiaFlagComment({ type: 'conditional', value: action.condition }),
               ...element.comments.trailingComments.filter(
                 (c) => !isUtopiaCommentFlag(c, 'conditional'),
               ),

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -61,6 +61,7 @@ import {
   getJSXAttribute,
   isImportStatement,
   isJSXAttributeValue,
+  isJSXConditionalExpression,
   isJSXElement,
   isJSXFragment,
   isPartOfJSXAttributeValue,
@@ -323,6 +324,7 @@ import {
   UpdateColorSwatches,
   PasteProperties,
   CopyProperties,
+  SetConditionalOverriddenCondition,
 } from '../action-types'
 import { defaultSceneElement, defaultTransparentViewElement } from '../defaults'
 import { EditorModes, isLiveMode, isSelectMode, Mode } from '../editor-modes'
@@ -391,6 +393,7 @@ import {
   vsCodeBridgeIdProjectId,
   withUnderlyingTarget,
   EditorStoreUnpatched,
+  modifyOpenJsxElementOrConditionalAtPath,
 } from '../store/editor-state'
 import { loadStoredState } from '../stored-state'
 import { applyMigrations } from './migrations/migrations'
@@ -4328,6 +4331,24 @@ export const UPDATE_FNS = {
         }
       },
       updatedEditor,
+    )
+  },
+  SET_CONDITIONAL_OVERRIDDEN_CONDITION: (
+    action: SetConditionalOverriddenCondition,
+    editor: EditorModel,
+  ): EditorModel => {
+    return modifyOpenJsxElementOrConditionalAtPath(
+      action.target,
+      (element) => {
+        if (!isJSXConditionalExpression(element)) {
+          return element
+        }
+        return {
+          ...element,
+          overriddenCondition: action.condition,
+        }
+      },
+      editor,
     )
   },
   ADD_IMPORTS: (action: AddImports, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/store/editor-state.spec.ts
+++ b/editor/src/components/editor/store/editor-state.spec.ts
@@ -11,6 +11,7 @@ import {
 } from '../../custom-code/code-file.test-utils'
 import {
   emptyComments,
+  isJSXConditionalExpression,
   jsxAttributeValue,
   jsxElement,
   JSXElement,
@@ -57,7 +58,10 @@ describe('modifyUnderlyingTarget', () => {
       pathToElement,
       '/src/app.js',
       startingEditorModel,
-      (element: JSXElement) => {
+      (element) => {
+        if (isJSXConditionalExpression(element)) {
+          return element
+        }
         const updatedAttributes = setJSXAttributesAttribute(
           element.props,
           'data-thing',
@@ -102,7 +106,7 @@ describe('modifyUnderlyingTarget', () => {
       pathToElement,
       '/src/card.js',
       startingEditorModel,
-      (element: JSXElement) => element,
+      (element) => element,
       (success: ParseSuccess) => {
         return parseSuccess(
           omit<string, Imports>(['utopia-api'], success.imports),
@@ -139,7 +143,10 @@ describe('modifyUnderlyingTarget', () => {
       pathToElement,
       StoryboardFilePath,
       startingEditorModel,
-      (element: JSXElement) => {
+      (element) => {
+        if (isJSXConditionalExpression(element)) {
+          return element
+        }
         const updatedAttributes = setJSXAttributesAttribute(
           element.props,
           'data-thing',
@@ -190,7 +197,10 @@ describe('modifyUnderlyingTarget', () => {
         pathToElement,
         '/src/app.js',
         startingEditorModel,
-        (element: JSXElement) => {
+        (element) => {
+          if (isJSXConditionalExpression(element)) {
+            return element
+          }
           const updatedAttributes = setJSXAttributesAttribute(
             element.props,
             'data-thing',
@@ -208,7 +218,10 @@ describe('modifyUnderlyingTarget', () => {
         pathToElement,
         '/src/kitchen.js',
         startingEditorModel,
-        (element: JSXElement) => {
+        (element) => {
+          if (isJSXConditionalExpression(element)) {
+            return element
+          }
           const updatedAttributes = setJSXAttributesAttribute(
             element.props,
             'data-thing',
@@ -232,7 +245,10 @@ describe('Revision state management', () => {
       pathToElement,
       '/src/app.js',
       startingEditorModel,
-      (element: JSXElement) => {
+      (element) => {
+        if (isJSXConditionalExpression(element)) {
+          return element
+        }
         const updatedAttributes = setJSXAttributesAttribute(
           element.props,
           'data-thing',
@@ -252,7 +268,10 @@ describe('Revision state management', () => {
       pathToElement,
       '/src/app.js',
       startingEditorModel,
-      (element: JSXElement) => {
+      (element) => {
+        if (isJSXConditionalExpression(element)) {
+          return element
+        }
         const updatedAttributes = setJSXAttributesAttribute(
           element.props,
           'data-thing',
@@ -271,7 +290,10 @@ describe('Revision state management', () => {
       pathToElement,
       '/src/app.js',
       actualResult,
-      (element: JSXElement) => {
+      (element) => {
+        if (isJSXConditionalExpression(element)) {
+          return element
+        }
         const updatedAttributes = setJSXAttributesAttribute(
           element.props,
           'data-thing',

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -376,6 +376,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.APPLY_COMMANDS(action, state)
     case 'UPDATE_COLOR_SWATCHES':
       return UPDATE_FNS.UPDATE_COLOR_SWATCHES(action, state)
+    case 'SET_CONDITIONAL_OVERRIDDEN_CONDITION':
+      return UPDATE_FNS.SET_CONDITIONAL_OVERRIDDEN_CONDITION(action, state)
     default:
       return state
   }

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -55,18 +55,6 @@ async function getControlValue(controlTestId: string, renderedDOM: RenderResult)
   return control.value
 }
 
-function elementDoesNotExist(renderResult: EditorRenderResult, testId: string) {
-  try {
-    const trueBranch = renderResult.renderedDOM.getByTestId(testId)
-    if (trueBranch != null) {
-      return false
-    }
-  } catch {
-    // nothing to do
-  }
-  return true
-}
-
 async function setControlValue(
   controlTestId: string,
   newValue: string,
@@ -2205,7 +2193,7 @@ describe('inspector tests with real metadata', () => {
         await renderResult.getDispatchFollowUpActionsFinished()
 
         expect(renderResult.renderedDOM.getByTestId('ccc')).not.toBeNull()
-        expect(elementDoesNotExist(renderResult, 'bbb')).toBe(true)
+        expect(renderResult.renderedDOM.queryByTestId('bbb')).toBeNull()
 
         expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
           makeTestProjectCodeWithSnippet(`
@@ -2237,7 +2225,7 @@ describe('inspector tests with real metadata', () => {
 
         await renderResult.getDispatchFollowUpActionsFinished()
 
-        expect(elementDoesNotExist(renderResult, 'ccc')).toBe(true)
+        expect(renderResult.renderedDOM.queryByTestId('ccc')).toBeNull()
         expect(renderResult.renderedDOM.getByTestId('bbb')).not.toBeNull()
 
         expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -2189,21 +2189,71 @@ describe('inspector tests with real metadata', () => {
         await renderResult.dispatch([selectComponents([targetPath], false)], false)
       })
 
-      await act(async () => {
-        fireEvent.click(screen.getByTestId('conditionals-control-false'))
+      // toggle to false
+      {
+        await act(async () => {
+          fireEvent.click(screen.getByTestId('conditionals-control-false'))
+          await renderResult.getDispatchFollowUpActionsFinished()
+        })
+
+        await act(async () => {
+          const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+          await renderResult.dispatch([selectComponents([targetPath], false)], true)
+          await dispatchDone
+        })
+
         await renderResult.getDispatchFollowUpActionsFinished()
-      })
 
-      await act(async () => {
-        const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
-        await renderResult.dispatch([selectComponents([targetPath], false)], true)
-        await dispatchDone
-      })
+        expect(renderResult.renderedDOM.getByTestId('ccc')).not.toBeNull()
+        expect(elementDoesNotExist(renderResult, 'bbb')).toBe(true)
 
-      await renderResult.getDispatchFollowUpActionsFinished()
+        expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+          makeTestProjectCodeWithSnippet(`
+          <div data-uid='aaa'>
+            {
+              true ? (
+                <div data-uid='bbb' data-testid='bbb'>foo</div>
+              ) : (
+                <div data-uid='ccc' data-testid='ccc'>bar</div>
+              ) // @utopia/conditional=false
+            }
+          </div>
+        `),
+        )
+      }
 
-      expect(renderResult.renderedDOM.getByTestId('ccc')).not.toBeNull()
-      expect(elementDoesNotExist(renderResult, 'bbb')).toBe(true)
+      // toggle to true
+      {
+        await act(async () => {
+          fireEvent.click(screen.getByTestId('conditionals-control-true'))
+          await renderResult.getDispatchFollowUpActionsFinished()
+        })
+
+        await act(async () => {
+          const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+          await renderResult.dispatch([selectComponents([targetPath], false)], true)
+          await dispatchDone
+        })
+
+        await renderResult.getDispatchFollowUpActionsFinished()
+
+        expect(elementDoesNotExist(renderResult, 'ccc')).toBe(true)
+        expect(renderResult.renderedDOM.getByTestId('bbb')).not.toBeNull()
+
+        expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+          makeTestProjectCodeWithSnippet(`
+          <div data-uid='aaa'>
+            {
+              true ? (
+                <div data-uid='bbb' data-testid='bbb'>foo</div>
+              ) : (
+                <div data-uid='ccc' data-testid='ccc'>bar</div>
+              ) // @utopia/conditional=true
+            }
+          </div>
+        `),
+        )
+      }
     })
   })
 })

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -40,7 +40,8 @@ import { matchInlineSnapshotBrowser } from '../../../../test/karma-snapshots'
 import { EditorAction } from '../../editor/action-types'
 import { selectComponentsForTest, setFeatureForBrowserTests } from '../../../utils/utils.test-utils'
 import { SubduedBorderRadiusControlTestId } from '../../canvas/controls/select-mode/subdued-border-radius-control'
-
+import { FOR_TESTS_setNextGeneratedUids } from '../../../core/model/element-template-utils.test-utils'
+import { setFeatureEnabled } from '../../../utils/feature-switches'
 async function getControl(
   controlTestId: string,
   renderedDOM: RenderResult,
@@ -2155,8 +2156,18 @@ describe('inspector tests with real metadata', () => {
   })
 
   describe('conditionals', () => {
-    setFeatureForBrowserTests('Conditional support', true)
+    before(() => setFeatureEnabled('Conditional support', true))
+    after(() => setFeatureEnabled('Conditional support', false))
     it('toggles conditional branch', async () => {
+      FOR_TESTS_setNextGeneratedUids([
+        'skip1',
+        'skip2',
+        'skip3',
+        'skip4',
+        'skip5',
+        'skip6',
+        'conditional',
+      ])
       const startSnippet = `
         <div data-uid='aaa'>
         {true ? (
@@ -2173,7 +2184,7 @@ describe('inspector tests with real metadata', () => {
 
       expect(renderResult.renderedDOM.getByTestId('bbb')).not.toBeNull()
 
-      const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'ca0'])
+      const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional'])
       await act(async () => {
         await renderResult.dispatch([selectComponents([targetPath], false)], false)
       })

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -81,6 +81,7 @@ import { FlexSection } from './flex-section'
 import { useDispatch } from '../editor/store/dispatch-context'
 import { styleStringInArray } from '../../utils/common-constants'
 import { SizingSection } from './sizing-section'
+import { ConditionalSection } from './sections/layout-section/conditional-section'
 
 export interface ElementPathElement {
   name?: string
@@ -358,6 +359,10 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
             aspectRatioLocked={aspectRatioLocked}
             toggleAspectRatioLock={toggleAspectRatioLock}
           />
+          {when(
+            isFeatureEnabled('Conditional support'),
+            <ConditionalSection paths={selectedViews} />,
+          )}
           <StyleSection />
           <WarningSubsection />
           <ImgSection />

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -1,0 +1,107 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */ import { jsx } from '@emotion/react'
+import React from 'react'
+import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import { isRight } from '../../../../core/shared/either'
+import { isJSXConditionalExpression } from '../../../../core/shared/element-template'
+import { ElementPath } from '../../../../core/shared/project-file-types'
+import {
+  Button,
+  FlexRow,
+  InspectorSectionIcons,
+  InspectorSubsectionHeader,
+} from '../../../../uuiui'
+import { setConditionalOverriddenCondition } from '../../../editor/actions/action-creators'
+import { useDispatch } from '../../../editor/store/dispatch-context'
+import { Substores, useEditorState } from '../../../editor/store/store-hook'
+import { UIGridRow } from '../../widgets/ui-grid-row'
+
+export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] }) => {
+  const dispatch = useDispatch()
+
+  const jsxMetadata = useEditorState(
+    Substores.metadata,
+    (store) => store.editor.jsxMetadata,
+    'Metadata',
+  )
+
+  const path = React.useMemo(() => {
+    if (paths.length !== 1) {
+      return null
+    }
+    return paths[0]
+  }, [paths])
+
+  const element = React.useMemo(() => {
+    if (path == null) {
+      return
+    }
+    const elementMetadata = MetadataUtils.findElementByElementPath(jsxMetadata, path)
+    if (
+      elementMetadata == null ||
+      !isRight(elementMetadata.element) ||
+      !isJSXConditionalExpression(elementMetadata.element.value)
+    ) {
+      return null
+    }
+    return elementMetadata.element.value
+  }, [jsxMetadata, path])
+
+  const condition = React.useMemo(() => {
+    if (element == null) {
+      return true
+    }
+    return element.overriddenCondition ?? true
+  }, [element])
+
+  const setCondition = React.useCallback(
+    (value: boolean) => () => {
+      if (path == null || element == null) {
+        return
+      }
+      dispatch([setConditionalOverriddenCondition(path, value)])
+    },
+    [dispatch, path, element],
+  )
+
+  if (element == null) {
+    return null
+  }
+
+  return (
+    <React.Fragment>
+      <InspectorSubsectionHeader>
+        <FlexRow
+          style={{
+            flexGrow: 1,
+            gap: 8,
+          }}
+        >
+          <InspectorSectionIcons.Conditionals style={{ width: 16, height: 16 }} />
+          <span>Conditional</span>
+        </FlexRow>
+      </InspectorSubsectionHeader>
+      <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
+        Branch
+        <FlexRow style={{ flexGrow: 1, gap: 4 }}>
+          <Button
+            style={{ flex: 1 }}
+            spotlight={condition}
+            highlight
+            onMouseDown={setCondition(true)}
+          >
+            True
+          </Button>
+          <Button
+            style={{ flex: 1 }}
+            spotlight={!condition}
+            highlight
+            onMouseDown={setCondition(false)}
+          >
+            False
+          </Button>
+        </FlexRow>
+      </UIGridRow>
+    </React.Fragment>
+  )
+})

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -2,6 +2,7 @@
 /** @jsx jsx */ import { jsx } from '@emotion/react'
 import React from 'react'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import { findUtopiaCommentFlag } from '../../../../core/shared/comment-flags'
 import { isRight } from '../../../../core/shared/either'
 import { isJSXConditionalExpression } from '../../../../core/shared/element-template'
 import { ElementPath } from '../../../../core/shared/project-file-types'
@@ -10,6 +11,7 @@ import {
   FlexRow,
   InspectorSectionIcons,
   InspectorSubsectionHeader,
+  useColorTheme,
 } from '../../../../uuiui'
 import { setConditionalOverriddenCondition } from '../../../editor/actions/action-creators'
 import { useDispatch } from '../../../editor/store/dispatch-context'
@@ -18,6 +20,7 @@ import { UIGridRow } from '../../widgets/ui-grid-row'
 
 export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] }) => {
   const dispatch = useDispatch()
+  const colorTheme = useColorTheme()
 
   const jsxMetadata = useEditorState(
     Substores.metadata,
@@ -49,9 +52,9 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
 
   const condition = React.useMemo(() => {
     if (element == null) {
-      return true
+      return null
     }
-    return element.overriddenCondition ?? true
+    return findUtopiaCommentFlag(element.comments, 'conditional')?.value ?? null
   }, [element])
 
   const setCondition = React.useCallback(
@@ -81,12 +84,16 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
           <span>Conditional</span>
         </FlexRow>
       </InspectorSubsectionHeader>
-      <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
+      <UIGridRow
+        padded={true}
+        variant='<---1fr--->|------172px-------|'
+        style={{ color: condition != null ? colorTheme.primary.value : 'inherit' }}
+      >
         Branch
         <FlexRow style={{ flexGrow: 1, gap: 4 }}>
           <Button
             style={{ flex: 1 }}
-            spotlight={condition}
+            spotlight={condition !== false}
             highlight
             onClick={setCondition(true)}
             data-testid='conditionals-control-true'
@@ -95,7 +102,7 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
           </Button>
           <Button
             style={{ flex: 1 }}
-            spotlight={!condition}
+            spotlight={condition === false}
             highlight
             onClick={setCondition(false)}
             data-testid='conditionals-control-false'

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -88,7 +88,8 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
             style={{ flex: 1 }}
             spotlight={condition}
             highlight
-            onMouseDown={setCondition(true)}
+            onClick={setCondition(true)}
+            data-testid='conditionals-control-true'
           >
             True
           </Button>
@@ -96,7 +97,8 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
             style={{ flex: 1 }}
             spotlight={!condition}
             highlight
-            onMouseDown={setCondition(false)}
+            onClick={setCondition(false)}
+            data-testid='conditionals-control-false'
           >
             False
           </Button>

--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -137,6 +137,16 @@ function createLayoutIconProps(
 export function createElementIconPropsFromMetadata(
   element: ElementInstanceMetadata | null,
 ): IcnPropsBase {
+  const isConditional = MetadataUtils.isConditionalFromMetadata(element)
+  if (isConditional) {
+    return {
+      category: 'element',
+      type: 'arc',
+      width: 18,
+      height: 18,
+    }
+  }
+
   const isFragment = MetadataUtils.isFragmentFromMetadata(element)
   if (isFragment) {
     return {

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -5,7 +5,10 @@ import React from 'react'
 import { createSelector } from 'reselect'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import * as EP from '../../../core/shared/element-path'
-import { ElementInstanceMetadata } from '../../../core/shared/element-template'
+import {
+  ElementInstanceMetadata,
+  isJSXConditionalExpression,
+} from '../../../core/shared/element-template'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { getValueFromComplexMap } from '../../../utils/map'

--- a/editor/src/components/text-editor/text-handling.ts
+++ b/editor/src/components/text-editor/text-handling.ts
@@ -15,6 +15,7 @@ import {
   JSXElementChild,
   jsxTextBlock,
   isJSXAttributesEntry,
+  isJSXConditionalExpression,
 } from '../../core/shared/element-template'
 import { jsxSimpleAttributeToValue } from '../../core/shared/jsx-attributes'
 import { getUtopiaID } from '../../core/model/element-template-utils'
@@ -215,7 +216,10 @@ export function collapseTextElements(target: ElementPath, editor: EditorState): 
           targetParent,
           openFile,
           editor,
-          (element: JSXElement) => {
+          (element) => {
+            if (isJSXConditionalExpression(element)) {
+              return element
+            }
             // Create the new collection of children by skipping those found in the target run.
             let updatedChildren: Array<JSXElementChild> = []
             for (const child of element.children) {

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -329,6 +329,7 @@ function transformAtPathOptionally(
             whenFalse: updatedWhenFalse,
           }
         }
+        return transform(element) // if no branch matches, transform the conditional itself
       }
       if (
         childOrBlockIsChild(element.whenTrue) &&

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`661`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`662`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`733`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`734`)
   })
 })

--- a/editor/src/core/shared/comment-flags.ts
+++ b/editor/src/core/shared/comment-flags.ts
@@ -1,5 +1,5 @@
 import { mapDropNulls } from './array-utils'
-import { Comment, ParsedComments } from './element-template'
+import { Comment, ParsedComments, singleLineComment } from './element-template'
 
 const UtopiaCommentFlagPrefix = '@utopia/'
 
@@ -20,16 +20,17 @@ export function isUtopiaCommentFlagConditional(
   return flag?.type === 'conditional'
 }
 
-function utopiaFlagKey(type: UtopiaCommentFlagType): string {
+function utopiaCommentFlagKey(type: UtopiaCommentFlagType): string {
   return `${UtopiaCommentFlagPrefix}${type}`
 }
 
-export function utopiaCommentFlag(flag: UtopiaCommentFlag): string {
-  return `${utopiaFlagKey(flag.type)}=${flag.value}`
+export function makeUtopiaFlagComment(flag: UtopiaCommentFlag): Comment {
+  const comment = ` ${utopiaCommentFlagKey(flag.type)}=${flag.value}`
+  return singleLineComment(comment, comment, true, 0)
 }
 
 export function isUtopiaCommentFlag(c: Comment, type: UtopiaCommentFlagType): boolean {
-  return commentString(c).startsWith(utopiaFlagKey(type) + '=')
+  return commentString(c).startsWith(utopiaCommentFlagKey(type) + '=')
 }
 
 function commentString(c: Comment): string {
@@ -48,13 +49,10 @@ function getUtopiaCommentFlag(c: Comment, type: UtopiaCommentFlagType): UtopiaCo
   }
 
   const comment = commentString(c)
-  const prefix = utopiaFlagKey(type) + '='
+  const prefix = utopiaCommentFlagKey(type) + '='
 
   if (comment.startsWith(prefix)) {
-    const value = comment
-      .replace(new RegExp(`^${prefix}`), '')
-      .trim()
-      .toLowerCase()
+    const value = comment.slice(prefix.length)
     switch (type) {
       case 'conditional':
         return {

--- a/editor/src/core/shared/comment-flags.ts
+++ b/editor/src/core/shared/comment-flags.ts
@@ -1,0 +1,78 @@
+import { mapDropNulls } from './array-utils'
+import { Comment, ParsedComments } from './element-template'
+
+const UtopiaCommentFlagPrefix = '@utopia/'
+
+export type UtopiaCommentFlagTypeConditional = 'conditional'
+
+export type UtopiaCommentFlagConditional = {
+  type: UtopiaCommentFlagTypeConditional
+  value: boolean | null
+}
+
+export type UtopiaCommentFlagType = UtopiaCommentFlagTypeConditional
+
+export type UtopiaCommentFlag = UtopiaCommentFlagConditional
+
+export function isUtopiaCommentFlagConditional(
+  flag: UtopiaCommentFlag | null,
+): flag is UtopiaCommentFlagConditional {
+  return flag?.type === 'conditional'
+}
+
+function utopiaFlagKey(type: UtopiaCommentFlagType): string {
+  return `${UtopiaCommentFlagPrefix}${type}`
+}
+
+export function utopiaCommentFlag(flag: UtopiaCommentFlag): string {
+  return `${utopiaFlagKey(flag.type)}=${flag.value}`
+}
+
+export function isUtopiaCommentFlag(c: Comment, type: UtopiaCommentFlagType): boolean {
+  return commentString(c).startsWith(utopiaFlagKey(type) + '=')
+}
+
+function commentString(c: Comment): string {
+  return c.comment.trim().toLowerCase()
+}
+
+function getUtopiaCommentFlag(c: Comment, type: UtopiaCommentFlagType): UtopiaCommentFlag | null {
+  function parseBooleanOrNull(value: string): boolean | null {
+    if (value === 'true') {
+      return true
+    }
+    if (value === 'false') {
+      return false
+    }
+    return null
+  }
+
+  const comment = commentString(c)
+  const prefix = utopiaFlagKey(type) + '='
+
+  if (comment.startsWith(prefix)) {
+    const value = comment
+      .replace(new RegExp(`^${prefix}`), '')
+      .trim()
+      .toLowerCase()
+    switch (type) {
+      case 'conditional':
+        return {
+          type: 'conditional',
+          value: parseBooleanOrNull(value),
+        }
+    }
+  }
+  return null
+}
+
+export function findUtopiaCommentFlag(
+  comments: ParsedComments,
+  key: UtopiaCommentFlagType,
+): UtopiaCommentFlag | null {
+  const commentConds = mapDropNulls(
+    (c) => getUtopiaCommentFlag(c, key),
+    [...comments.leadingComments, ...comments.trailingComments],
+  )
+  return commentConds.length > 0 ? commentConds[0] : null
+}

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1059,6 +1059,7 @@ export interface JSXConditionalExpression extends WithComments {
   type: 'JSX_CONDITIONAL_EXPRESSION'
   uniqueID: string
   condition: JSXAttribute
+  overriddenCondition: boolean | null
   whenTrue: ChildOrAttribute
   whenFalse: ChildOrAttribute
 }
@@ -1074,6 +1075,7 @@ export function jsxConditionalExpression(
     type: 'JSX_CONDITIONAL_EXPRESSION',
     uniqueID: uid,
     condition: condition,
+    overriddenCondition: null,
     whenTrue: whenTrue,
     whenFalse: whenFalse,
     comments: comments,

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1059,7 +1059,6 @@ export interface JSXConditionalExpression extends WithComments {
   type: 'JSX_CONDITIONAL_EXPRESSION'
   uniqueID: string
   condition: JSXAttribute
-  overriddenCondition: boolean | null
   whenTrue: ChildOrAttribute
   whenFalse: ChildOrAttribute
 }
@@ -1075,7 +1074,6 @@ export function jsxConditionalExpression(
     type: 'JSX_CONDITIONAL_EXPRESSION',
     uniqueID: uid,
     condition: condition,
-    overriddenCondition: null,
     whenTrue: whenTrue,
     whenFalse: whenFalse,
     comments: comments,

--- a/editor/src/uuiui/icons.tsx
+++ b/editor/src/uuiui/icons.tsx
@@ -88,6 +88,13 @@ export const InspectorSectionIcons = {
     width: 16,
     height: 16,
   }),
+  Conditionals: makeIcon({
+    category: 'element',
+    type: 'arc',
+    color: 'main',
+    width: 18,
+    height: 18,
+  }),
   Layer: makeIcon({
     category: 'inspector',
     type: 'layer',


### PR DESCRIPTION
Fixes #3321 

This PR adds an inspector section to override the rendered branch of a conditional.

![Kapture 2023-02-22 at 17 17 45](https://user-images.githubusercontent.com/1081051/220688184-8b4dfad9-aaf4-4dde-8636-45625ba49e60.gif)

Notes:
- only single conditionals are supported, on purpose (I don't think it'd make much sense to toggle multiple conditionals at the same time).
- the icons used for the conditional elements (`arc`) are pure placeholders, I just picked something that was not being used elsewhere
- the section only appears if the FS is enabled
- the conditional overrides are controlled via "flag comments" in the form `@utopia/[flag]=[value]`. For now they're placed in the trailing portion of the comments, because the leading portion is not being parsed for conditionals (yet).