### PR TITLE
Border radius label: always show the current applied value

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -231,7 +231,7 @@ export function borderRadiusFromElement(
         )
 
         const defaultBorderRadiusSides = borderRadiusSidesFromValue(
-          unitlessCSSNumberWithRenderedValue(0),
+          cssNumberWithRenderedValue(cssNumber(0, 'px'), 0),
         )
 
         if (borderRadius == null && isElementIntrinsic) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -106,7 +106,7 @@ export const setBorderRadiusStrategy: CanvasStrategyFactory = (
   const elementSize = sizeFromElement(element)
   const borderRadiusAdjustData = borderRadiusAdjustDataFromInteractionSession(interactionSession)
 
-  const { commands, updatedBorderRadius } = setBorderRadiusStrategyRunResult(
+  const { commands } = setBorderRadiusStrategyRunResult(
     borderRadius,
     borderRadiusAdjustData,
     elementSize,
@@ -129,7 +129,6 @@ export const setBorderRadiusStrategy: CanvasStrategyFactory = (
           mode: mode,
           selectedElement: selectedElement,
           elementSize: elementSize,
-          borderRadius: updatedBorderRadius,
           showIndicatorOnCorner: borderRadiusAdjustData?.corner ?? null,
         },
         key: 'border-radius-handle',
@@ -190,7 +189,7 @@ interface BorderRadiusData<T> {
   borderRadius: BorderRadiusSides<T>
 }
 
-function borderRadiusFromElement(
+export function borderRadiusFromElement(
   element: ElementInstanceMetadata,
 ): BorderRadiusData<CSSNumberWithRenderedValue> | null {
   return foldEither(

--- a/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
@@ -87,13 +87,23 @@ export const BorderRadiusControl = controlForStrategyMemoized<BorderRadiusContro
     }
   })
 
+  const borderRadius = useEditorState(
+    Substores.metadata,
+    (store) => borderRadiusSelector(store, selectedElement),
+    'BorderRadiusControl borderRadius',
+  )
+
+  if (borderRadius == null) {
+    return null
+  }
+
   return (
     <CanvasOffsetWrapper>
       <div ref={controlRef} style={{ position: 'absolute', pointerEvents: 'none' }}>
         {BorderRadiusCorners.map((corner) => (
           <CircularHandle
             key={CircularHandleTestId(corner)}
-            borderRadius={borderRadius[corner]}
+            borderRadius={borderRadius.borderRadius[corner]}
             isDragging={isDragging}
             backgroundShown={backgroundShown}
             scale={scale}

--- a/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import { createSelector } from 'reselect'
+import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
 import { CanvasVector, Size, windowPoint } from '../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
@@ -8,14 +10,14 @@ import { useColorTheme } from '../../../../uuiui'
 import { EditorDispatch } from '../../../editor/action-types'
 import { useDispatch } from '../../../editor/store/dispatch-context'
 import { Substores, useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
+import { CanvasSubstate, MetadataSubstate } from '../../../editor/store/store-hook-substore-types'
 import { printCSSNumber } from '../../../inspector/common/css-utils'
+import { metadataSelector } from '../../../inspector/inpector-selectors'
 import {
   BorderRadiusAdjustMode,
   BorderRadiusControlMinimumForDisplay,
   BorderRadiusCorner,
   BorderRadiusCorners,
-  BorderRadiusHandleBorderWidth,
-  BorderRadiusHandleDotSize,
   BorderRadiusHandleHitArea,
   BorderRadiusHandleSize,
   BorderRadiusSides,
@@ -27,6 +29,7 @@ import {
   borderRadiusResizeHandle,
   createInteractionViaMouse,
 } from '../../canvas-strategies/interaction-state'
+import { borderRadiusFromElement } from '../../canvas-strategies/strategies/set-border-radius-strategy'
 import { CSSCursor } from '../../canvas-types'
 import { windowToCanvasCoordinates } from '../../dom-lookup'
 import { useBoundingBox } from '../bounding-box-hooks'
@@ -37,34 +40,52 @@ import { CanvasLabel, CSSNumberWithRenderedValue } from './controls-common'
 export const CircularHandleTestId = (corner: BorderRadiusCorner): string =>
   `circular-handle-${corner}`
 
+const isDraggingSelector = (store: CanvasSubstate): boolean => {
+  if (store.editor.canvas.interactionSession?.interactionData.type !== 'DRAG') {
+    return false
+  }
+  const borderRadiusHandleIsDragged =
+    store.editor.canvas.interactionSession.activeControl.type === 'BORDER_RADIUS_RESIZE_HANDLE'
+  const { drag } = store.editor.canvas.interactionSession.interactionData
+  const dragIsNotNull = drag != null && (drag?.x !== 0 || drag?.y !== 0)
+
+  return borderRadiusHandleIsDragged && dragIsNotNull
+}
+
+const borderRadiusSelector = createSelector(
+  metadataSelector,
+  (_: MetadataSubstate, x: ElementPath) => x,
+  (metadata, selectedElement) => {
+    const element = MetadataUtils.findElementByElementPath(metadata, selectedElement)
+    if (element == null) {
+      return null
+    }
+    return borderRadiusFromElement(element)
+  },
+)
+
 export interface BorderRadiusControlProps {
   selectedElement: ElementPath
   elementSize: Size
-  borderRadius: BorderRadiusSides<CSSNumberWithRenderedValue>
   showIndicatorOnCorner: BorderRadiusCorner | null
   mode: BorderRadiusAdjustMode
 }
 
 export const BorderRadiusControl = controlForStrategyMemoized<BorderRadiusControlProps>((props) => {
-  const {
-    selectedElement,
-    borderRadius,
-    elementSize,
-    showIndicatorOnCorner: showIndicatorOnEdge,
-    mode,
-  } = props
+  const { selectedElement, elementSize, showIndicatorOnCorner: showIndicatorOnEdge, mode } = props
 
   const canvasOffset = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
   const dispatch = useDispatch()
-  const { scale, isDragging } = useEditorState(
+  const scale = useEditorState(
     Substores.canvas,
-    (store) => ({
-      scale: store.editor.canvas.scale,
-      isDragging:
-        store.editor.canvas.interactionSession?.activeControl.type ===
-        'BORDER_RADIUS_RESIZE_HANDLE',
-    }),
-    'BorderRadiusControl isDragging scale',
+    (store) => store.editor.canvas.scale,
+    'BorderRadiusControl scale',
+  )
+
+  const isDragging = useEditorState(
+    Substores.canvas,
+    isDraggingSelector,
+    'BorderRadiusControl isDragging',
   )
 
   const hoveredViews = useEditorState(
@@ -163,7 +184,7 @@ const CircularHandle = React.memo((props: CircularHandleProp) => {
   const shouldShowIndicator = (!isDragging && hovered) || showIndicatorFromParent
   const shouldShowHandle = isDragging || backgroundShown
 
-  const { padding, size } = BorderRadiusHandleSize(scale)
+  const { padding } = BorderRadiusHandleSize(scale)
   const position = handlePosition(
     isDragging
       ? borderRadius.renderedValuePx


### PR DESCRIPTION
## Problem
When hovering over a border-radius control, we show the border-radius correspoding to the corner of the control. When dragging a border-radius control, we show the border radius value that will be applied when the drag interaction ends. However, in the meantime, afterclicking on a border radius handle, but before passsing the drag threshold, we already show the value that will be applied when the drag ends, but this value is not reflected on the actual element yet, which can be misleading.

## Fix
To simplify data flow, the border radius control calculates the value it should display based on the most up-to-date metadata in the store (instead of the border radius strategy passing it through props).