### PR TITLE
Pressing or releasing cmd during keyboard interaction ends the current interaction

### DIFF
--- a/editor/src/components/canvas/event-helpers.test-utils.tsx
+++ b/editor/src/components/canvas/event-helpers.test-utils.tsx
@@ -538,6 +538,37 @@ export function keyDown(
   })
 }
 
+export function keyUp(
+  key: string,
+  options: {
+    modifiers?: Modifiers
+    eventOptions?: KeyboardEventInit
+  } = {},
+) {
+  const modifiers = options.modifiers ?? emptyModifiers
+  const passedEventOptions = options.eventOptions ?? {}
+  const eventOptions = {
+    ctrlKey: modifiers.ctrl,
+    metaKey: modifiers.cmd,
+    altKey: modifiers.alt,
+    shiftKey: modifiers.shift,
+    ...passedEventOptions,
+  }
+
+  act(() => {
+    fireEvent(
+      document.body,
+      new KeyboardEvent('keyup', {
+        bubbles: true,
+        cancelable: true,
+        key: key,
+        keyCode: keycode(key),
+        ...eventOptions,
+      }),
+    )
+  })
+}
+
 export async function pressKey(
   key: string,
   options: {


### PR DESCRIPTION
**Problem:**
By design, macOS will not fire keyup events if the `cmd` key is held down, which was mostly fixed via #2377, however this didn't take into account when toggling the `cmd` modifier, which switches strategies, leading to strategy results overwriting each other and breaking.

**Fix:**
Whenever the `cmd` key is either pressed down or released we end the current interaction session (applying any changes), and create a new one (if the key was pressed down). This means that a new undo step will be added in each case, but since toggling the `cmd` modifier changes the strategy anyway, that would be expected anyway.

I've also updated the existing absolute move and resize tests to reflect both the macOS issue, and to test that the desired behaviour occurs when toggling cmd during an interaction.