### PR TITLE
Don't show the size label for fragments and conditionals

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -29,7 +29,11 @@ import {
   EdgePositionBottom,
   EdgePositionTop,
 } from '../../canvas-types'
-import { setFeatureForBrowserTests, wait } from '../../../../utils/utils.test-utils'
+import {
+  selectComponentsForTest,
+  setFeatureForBrowserTests,
+  wait,
+} from '../../../../utils/utils.test-utils'
 import { ControlDelay } from '../canvas-strategy-types'
 import {
   BakedInStoryboardVariableName,
@@ -43,7 +47,10 @@ import {
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import { CSSProperties } from 'react'
 import { MaxContent } from '../../../inspector/inspector-common'
-import { ResizePointTestId } from '../../controls/select-mode/absolute-resize-control'
+import {
+  AbsoluteResizeControlTestId,
+  ResizePointTestId,
+} from '../../controls/select-mode/absolute-resize-control'
 
 async function resizeElement(
   renderResult: EditorRenderResult,
@@ -181,6 +188,19 @@ export var storyboard = (
     </Scene>
   </Storyboard>
 )`
+
+const projectWithFragment = `import * as React from 'react'
+
+const foo = true
+
+export var storyboard = (
+  <div data-uid='root'>
+    <React.Fragment data-uid='fragment'>
+      Fragment
+    </React.Fragment>
+  </div>
+)
+`
 
 const projectDoesNotHonourSizeProperties = `
 import * as React from 'react'
@@ -448,6 +468,12 @@ export var storyboard = (
 `
 
 describe('Absolute Resize Strategy', () => {
+  it('control is not shown when a fragment is selected', async () => {
+    const editor = await renderTestEditorWithCode(projectWithFragment, 'await-first-dom-report')
+    await selectComponentsForTest(editor, [EP.fromString('root/fragment')])
+    const absoluteResizeControl = editor.renderedDOM.queryAllByTestId(AbsoluteResizeControlTestId)
+    expect(absoluteResizeControl).toEqual([])
+  })
   it('resizes component instances that honour the size properties', async () => {
     const renderResult = await renderTestEditorWithCode(
       projectDoesHonourSizeProperties(300, 300),

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -48,7 +48,7 @@ import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import { CSSProperties } from 'react'
 import { MaxContent } from '../../../inspector/inspector-common'
 import {
-  AbsoluteResizeControlTestId,
+  SizeLabelTestId,
   ResizePointTestId,
 } from '../../controls/select-mode/absolute-resize-control'
 
@@ -196,7 +196,7 @@ const foo = true
 export var storyboard = (
   <div data-uid='root'>
     <React.Fragment data-uid='fragment'>
-      Fragment
+
     </React.Fragment>
   </div>
 )
@@ -468,10 +468,10 @@ export var storyboard = (
 `
 
 describe('Absolute Resize Strategy', () => {
-  it('control is not shown when a fragment is selected', async () => {
+  it('the size label is not shown when an empty fragment is selected', async () => {
     const editor = await renderTestEditorWithCode(projectWithFragment, 'await-first-dom-report')
     await selectComponentsForTest(editor, [EP.fromString('root/fragment')])
-    const absoluteResizeControl = editor.renderedDOM.queryAllByTestId(AbsoluteResizeControlTestId)
+    const absoluteResizeControl = editor.renderedDOM.queryAllByTestId(SizeLabelTestId)
     expect(absoluteResizeControl).toEqual([])
   })
   it('resizes component instances that honour the size properties', async () => {

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -319,7 +319,7 @@ const sizeLabel = (state: FixedHugFill['type'], actualSize: number): string => {
 function sizeLabelContents(
   metadata: ElementInstanceMetadataMap,
   selectedElements: Array<ElementPath>,
-): [string, string] | null {
+): { h: string; v: string } | null {
   if (selectedElements.length === 0) {
     return null
   }
@@ -337,14 +337,17 @@ function sizeLabelContents(
       detectFillHugFixedState('horizontal', metadata, selectedElements[0])?.type ?? 'fixed'
     const vertical =
       detectFillHugFixedState('vertical', metadata, selectedElements[0])?.type ?? 'fixed'
-    return [sizeLabel(horizontal, globalFrame.width), sizeLabel(vertical, globalFrame.height)]
+    return {
+      h: sizeLabel(horizontal, globalFrame.width),
+      v: sizeLabel(vertical, globalFrame.height),
+    }
   }
 
   const boundingBox = boundingRectangleArray(
     selectedElements.map((t) => nullIfInfinity(MetadataUtils.getFrameInCanvasCoords(t, metadata))),
   )
   if (boundingBox != null) {
-    return [`${boundingBox.width}`, `${boundingBox.height}`]
+    return { h: `${boundingBox.width}`, v: `${boundingBox.height}` }
   }
 
   return null
@@ -377,6 +380,8 @@ const SizeLabel = React.memo(
 
     const label = sizeLabelContents(metadata, targets)
 
+    const labelText = label == null ? null : `${label.h} x ${label.v}`
+
     return (
       <div
         ref={ref}
@@ -389,7 +394,7 @@ const SizeLabel = React.memo(
         data-testid='parent-resize-label'
       >
         {when(
-          label != null,
+          labelText != null,
           <div
             style={{
               display: 'flex',
@@ -403,7 +408,7 @@ const SizeLabel = React.memo(
               height: ExplicitHeightHacked / scale,
             }}
           >
-            {`${label![0]} x ${label![1]}`}
+            {labelText}
           </div>,
         )}
       </div>

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -40,6 +40,8 @@ interface AbsoluteResizeControlProps {
   targets: Array<ElementPath>
 }
 
+export const AbsoluteResizeControlTestId = 'AbsoluteResizeControlTestId'
+
 export const AbsoluteResizeControl = controlForStrategyMemoized(
   ({ targets }: AbsoluteResizeControlProps) => {
     const controlRef = useBoundingBox(targets, (ref, boundingBox) => {
@@ -91,6 +93,7 @@ export const AbsoluteResizeControl = controlForStrategyMemoized(
     return (
       <CanvasOffsetWrapper>
         <div
+          data-testid={AbsoluteResizeControlTestId}
           ref={controlRef}
           style={{
             position: 'absolute',

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -40,7 +40,7 @@ interface AbsoluteResizeControlProps {
   targets: Array<ElementPath>
 }
 
-export const AbsoluteResizeControlTestId = 'AbsoluteResizeControlTestId'
+export const SizeLabelTestId = 'SizeLabelTestId'
 
 export const AbsoluteResizeControl = controlForStrategyMemoized(
   ({ targets }: AbsoluteResizeControlProps) => {
@@ -93,7 +93,6 @@ export const AbsoluteResizeControl = controlForStrategyMemoized(
     return (
       <CanvasOffsetWrapper>
         <div
-          data-testid={AbsoluteResizeControlTestId}
           ref={controlRef}
           style={{
             position: 'absolute',
@@ -399,6 +398,7 @@ const SizeLabel = React.memo(
         {when(
           labelText != null,
           <div
+            data-testid={SizeLabelTestId}
             style={{
               display: 'flex',
               alignItems: 'center',

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -877,6 +877,16 @@ export const MetadataUtils = {
   ): boolean {
     if (metadata == null) {
       return false
+    }
+
+    const isElementFragmentOrConditional = foldEither(
+      () => false,
+      (e) => isJSXFragment(e) || isJSXConditionalExpression(e),
+      metadata.element,
+    )
+
+    if (isElementFragmentOrConditional) {
+      return false
     } else {
       const underlyingComponent = findUnderlyingTargetComponentImplementationFromImportInfo(
         projectContents,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -877,16 +877,6 @@ export const MetadataUtils = {
   ): boolean {
     if (metadata == null) {
       return false
-    }
-
-    const isElementFragmentOrConditional = foldEither(
-      () => false,
-      (e) => isJSXFragment(e) || isJSXConditionalExpression(e),
-      metadata.element,
-    )
-
-    if (isElementFragmentOrConditional) {
-      return false
     } else {
       const underlyingComponent = findUnderlyingTargetComponentImplementationFromImportInfo(
         projectContents,


### PR DESCRIPTION
## Repro
Select the fragment in the navigator in the project:
```
import * as React from 'react'

const foo = true

export var storyboard = (
  <div>
    <>
      
    </>
  </div>
)
```

## Description
We show the absolute resize control for fragments, which leads to the editor crashing.

## Fix
The `!`s in the size label on the absolute resize control crash the editor. The direct fix for this is to do the null check before generating the label text and render the label with the generated text.

The root cause of this problem was that `MetadataUtils.targetHonoursPropsSize` assumed that any element that doesn't have a corresponding underlying component, as determined by `findUnderlyingTargetComponentImplementationFromImportInfo`, so the absolute resize control was shown. This PR adds a check for JSX fragments and conditionals and classifies them as elements that don't honor size props.