### PR TITLE
Dedicated canvas strategy ID type

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -142,12 +142,60 @@ export function getInsertionSubjectsFromInteractionTarget(
   return []
 }
 
-export type CanvasStrategyId = string
+export type TestStrategyId =
+  | 'WORST_STRATEGY'
+  | 'UNFIT_STRATEGY'
+  | 'TEST_STRATEGY'
+  | 'EMPTY_TEST_STRATEGY'
+  | 'AVERAGE_STRATEGY'
+  | 'BEST_STRATEGY'
+
+export type MoveOrReorderStrategyId =
+  | 'ABSOLUTE_DUPLICATE'
+  | 'KEYBOARD_ABSOLUTE_MOVE'
+  | 'KEYBOARD_REORDER'
+  | 'CONVERT_TO_ABSOLUTE_AND_MOVE_STRATEGY'
+  | 'REORDER_SLIDER'
+
+export type ReparentStrategy = 'REPARENT_AS_ABSOLUTE' | 'REPARENT_AS_STATIC'
+
+export type LeafStrategyId =
+  | 'FLEX_RESIZE'
+  | 'ABSOLUTE_RESIZE_BOUNDING_BOX'
+  | 'KEYBOARD_ABSOLUTE_RESIZE'
+  | 'FLEX_RESIZE_BASIC'
+  | 'FLEX_RESIZE'
+  | 'BASIC_RESIZE'
+  | 'DO_NOTHING'
+  | 'SET_PADDING_STRATEGY'
+  | 'SET_FLEX_GAP_STRATEGY'
+  | 'SET_BORDER_RADIUS_STRATEGY'
+  | 'ABSOLUTE_MOVE'
+  | 'RELATIVE_MOVE'
+  | 'SET_FONT_WEIGHT'
+  | 'SET_FONT_SIZE'
+  | 'SET_OPACITY'
+  | 'FLOW_REORDER'
+  | 'FLEX_REORDER'
+  | 'FLEX_REPARENT_TO_ABSOLUTE'
+  | 'ABSOLUTE_REPARENT'
+  | 'REPARENT_TO_FLEX'
+  | 'REPARENT_TO_FLOW'
+  | 'DRAW_TO_INSERT_TEXT'
+  | 'DRAG_TO_INSERT_ABSOLUTE'
+  | 'DRAG_TO_INSERT_FLOW'
+  | 'DRAG_TO_INSERT_FLEX'
+
+export type SimpleStrategyId = MoveOrReorderStrategyId | LeafStrategyId | TestStrategyId
+
+export type AncestorMetaStrategyID = `${SimpleStrategyId}_ANCESTOR_${number}`
+
+export type CanvasStrategyId = SimpleStrategyId // | AncestorMetaStrategyID
 
 export type InteractionLifecycle = 'mid-interaction' | 'end-interaction'
 
-export interface CanvasStrategy {
-  id: CanvasStrategyId // We'd need to do something to guarantee uniqueness here if using this for the commands' reason
+export interface CanvasStrategy<Id extends CanvasStrategyId> {
+  id: Id // We'd need to do something to guarantee uniqueness here if using this for the commands' reason
   name: string
 
   // The controls to render when this strategy is applicable, regardless of if it is currently active

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
@@ -43,6 +43,7 @@ import {
 } from '../canvas-strategies'
 import {
   CanvasStrategy,
+  CanvasStrategyId,
   controlWithProps,
   CustomStrategyState,
   emptyStrategyApplicationResult,
@@ -93,7 +94,10 @@ export const dragToInsertMetaStrategy: MetaCanvasStrategy = (
   )
 
   return mapDropNulls((result): CanvasStrategy | null => {
-    const name = getDragToInsertStrategyName(result.strategyType, result.targetParentDisplayType)
+    const { name, id } = getDragToInsertStrategyName(
+      result.strategyType,
+      result.targetParentDisplayType,
+    )
 
     return dragToInsertStrategyFactory(
       canvasState,
@@ -102,6 +106,7 @@ export const dragToInsertMetaStrategy: MetaCanvasStrategy = (
       insertionSubjects,
       result.factory,
       name,
+      id,
       result.fitness,
       result.targetParent,
     )
@@ -111,15 +116,15 @@ export const dragToInsertMetaStrategy: MetaCanvasStrategy = (
 function getDragToInsertStrategyName(
   strategyType: ReparentStrategy,
   parentDisplayType: 'flex' | 'flow',
-): string {
+): { name: string; id: CanvasStrategyId } {
   switch (strategyType) {
     case 'REPARENT_AS_ABSOLUTE':
-      return 'Drag to Insert (Abs)'
+      return { name: 'Drag to Insert (Abs)', id: 'DRAG_TO_INSERT_ABSOLUTE' }
     case 'REPARENT_AS_STATIC':
       if (parentDisplayType === 'flex') {
-        return 'Drag to Insert (Flex)'
+        return { name: 'Drag to Insert (Flex)', id: 'DRAG_TO_INSERT_FLEX' }
       } else {
-        return 'Drag to Insert (Flow)'
+        return { name: 'Drag to Insert (Flow)', id: 'DRAG_TO_INSERT_FLOW' }
       }
   }
 }
@@ -131,6 +136,7 @@ function dragToInsertStrategyFactory(
   insertionSubjects: Array<InsertionSubject>,
   reparentStrategyToUse: CanvasStrategyFactory,
   name: string,
+  startegyId: CanvasStrategyId,
   fitness: number,
   targetParent: ElementPath,
 ): CanvasStrategy | null {
@@ -165,7 +171,7 @@ function dragToInsertStrategyFactory(
   )
 
   return {
-    id: name,
+    id: startegyId,
     name: name,
     controlsToRender: [
       controlWithProps({

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
@@ -20,7 +20,7 @@ import { InteractionSession } from '../interaction-state'
 import { drawToInsertFitness, drawToInsertStrategyFactory } from './draw-to-insert-metastrategy'
 import { getApplicableReparentFactories } from './reparent-metastrategy'
 
-export const DRAW_TO_INSERT_TEXT_STRATEGY_ID = 'draw-to-insert-text'
+export const DRAW_TO_INSERT_TEXT_STRATEGY_ID = 'DRAW_TO_INSERT_TEXT'
 
 export const drawToInsertTextStrategy: MetaCanvasStrategy = (
   canvasState: InteractionCanvasState,

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size-strategy.tsx
@@ -30,7 +30,7 @@ import { accumulatePresses, getLastKeyPressState } from './shared-keyboard-strat
 export function keyboardSetFontSizeStrategy(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
-): CanvasStrategy | null {
+): CanvasStrategy<'SET_FONT_SIZE'> | null {
   const validTargets = getTargetPathsFromInteractionTarget(canvasState.interactionTarget).filter(
     (path) => isValidTarget(canvasState.startingMetadata, path),
   )
@@ -40,7 +40,7 @@ export function keyboardSetFontSizeStrategy(
   }
 
   return {
-    id: 'set-font-size',
+    id: 'SET_FONT_SIZE',
     name: 'Set font size',
     controlsToRender: [],
     fitness: fitness(interactionSession),

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight-strategy.tsx
@@ -35,7 +35,7 @@ export function keyboardSetFontWeightStrategy(
   }
 
   return {
-    id: 'set-font-weight',
+    id: 'SET_FONT_WEIGHT',
     name: 'Set font weight',
     controlsToRender: [],
     fitness: fitness(interactionSession),

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
@@ -24,7 +24,7 @@ export function keyboardSetOpacityStrategy(
   }
 
   return {
-    id: 'set-opacity',
+    id: 'SET_OPACITY',
     name: 'Set opacity',
     controlsToRender: [],
     fitness: fitness(interactionSession),

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -24,6 +24,7 @@ import { ZeroSizedElementControls } from '../../controls/zero-sized-element-cont
 import { CanvasStrategyFactory } from '../canvas-strategies'
 import {
   CanvasStrategy,
+  CanvasStrategyId,
   controlWithProps,
   CustomStrategyState,
   emptyStrategyApplicationResult,
@@ -112,7 +113,7 @@ export function baseReparentAsStaticStrategy(
 }
 
 function getIdAndNameOfReparentToStaticStrategy(targetLayout: 'flex' | 'flow'): {
-  id: string
+  id: CanvasStrategyId
   name: string
 } {
   switch (targetLayout) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
@@ -9,6 +9,7 @@ import {
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
   InteractionTarget,
+  ReparentStrategy,
 } from '../../canvas-strategy-types'
 import { AllowSmallerParent } from '../../interaction-state'
 import {
@@ -17,8 +18,6 @@ import {
 } from './reparent-strategy-parent-lookup'
 import { getDragTargets } from '../shared-move-strategies-helpers'
 import { Direction } from '../../../../inspector/common/css-utils'
-
-export type ReparentStrategy = 'REPARENT_AS_ABSOLUTE' | 'REPARENT_AS_STATIC'
 
 export type FindReparentStrategyResult = {
   strategy: ReparentStrategy

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -16,6 +16,7 @@ import {
   InteractionCanvasState,
   isInsertionSubjects,
   isTargetPaths,
+  ReparentStrategy,
 } from '../canvas-strategy-types'
 import { AllowSmallerParent, InteractionSession } from '../interaction-state'
 import { baseAbsoluteReparentStrategy } from './absolute-reparent-strategy'
@@ -25,7 +26,6 @@ import { replaceContentAffectingPathsWithTheirChildrenRecursive } from './group-
 import { baseReparentAsStaticStrategy } from './reparent-as-static-strategy'
 import {
   findReparentStrategies,
-  ReparentStrategy,
   reparentSubjectsForInteractionTarget,
   ReparentTarget,
 } from './reparent-helpers/reparent-strategy-helpers'


### PR DESCRIPTION
I gave up at AncestorMetaStrategyID being instantiated recursively.

Although we know that `AncestorMetaStrategy` isn't passed itself recursively, this should be reflected on the type-level (probably through a generic param in `CanvasStrategy` that parameterizes `CanvasStrategyID`).