### PR TITLE
When determining fixed/fill/hug state, fall back to fixed size based on global frame

### DIFF
--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -11,6 +11,7 @@ import {
 } from '../../core/shared/element-template'
 import { ElementPath, PropertyPath } from '../../core/shared/project-file-types'
 import {
+  cssNumber,
   CSSNumber,
   cssPixelLength,
   FlexDirection,
@@ -32,7 +33,7 @@ import {
 } from '../canvas/commands/set-css-length-command'
 import { setPropHugStrategies } from './inspector-strategies/inspector-strategies'
 import { commandsForFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
-import { isInfinityRectangle } from '../../core/shared/math-utils'
+import { isFiniteRectangle, isInfinityRectangle } from '../../core/shared/math-utils'
 import { inlineHtmlElements } from '../../utils/html-elements'
 import { showToastCommand } from '../canvas/commands/show-toast-command'
 
@@ -559,6 +560,12 @@ export function detectFillHugFixedState(
 
   if (parsed != null) {
     return { type: 'fixed', value: parsed }
+  }
+
+  const frame = element.globalFrame
+  if (frame != null && isFiniteRectangle(frame)) {
+    const dimension = widthHeightFromAxis(axis)
+    return { type: 'fixed', value: cssNumber(frame[dimension], 'px') }
   }
 
   return null


### PR DESCRIPTION
## Problem
When detecting which of the fill/fixed/hug settings are set on an element, if no `width`/`height`/flex sizing prop is defined on `style`, we return `null`, meaning that no applicable setting can be found. This is sometimes misleading since images can have an intrinsic size even without explicit sizing properties.

## Fix
If no applicable setting can be found, we fall back to returning fixed size, with a measurement taken from the element's `globalFrame`. NB: this can still be null or an infinite rectangle, so `detectFillHugFixedState` still returns a nullable value.
