### PR TITLE
Handle nested ternaries.

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
@@ -25,8 +25,7 @@ const DefaultComments = [
 
 const Comment = () => <div data-uid='comment-root'>hat</div>
 
-export var App = () =>
-  true ? DefaultComments.map((comment) => <Comment comment={comment} />) : null
+export var App = () => DefaultComments.map((comment) => <Comment comment={comment} />)
 
 export var storyboard = (
   <Storyboard data-uid='sb'>

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
@@ -1,0 +1,88 @@
+import { createModifiedProject } from '../../../sample-projects/sample-project-utils.test-utils'
+import { StoryboardFilePath } from '../../editor/store/editor-state'
+import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
+import * as EP from '../../../core/shared/element-path'
+import { FOR_TESTS_setNextGeneratedUids } from '../../../core/model/element-template-utils.test-utils'
+
+const appFilePath = '/src/app.js'
+const appFileContent = `
+import * as React from 'react'
+export var App = (props) => {
+  return (
+    <div
+      data-testid='app-root-div'
+      data-uid='app-root'
+      style={{
+        position: 'relative',
+        left: 0,
+        top: 0,
+        width: '100%',
+        height: '100%'
+      }}
+    >
+      {[0, 1].length > 1 ? (
+        [0, 1].length === 2 ? (
+          <div data-uid='div-inside-conditionals' />
+        ) : null
+      ) : (
+        5
+      )}
+    </div>
+  )
+}
+`
+
+const storyboardFileContent = `
+import * as React from 'react';
+import Utopia, {
+  Scene,
+  Storyboard,
+  registerModule,
+} from 'utopia-api';
+import { App } from '${appFilePath}';
+
+export var storyboard = (
+  <Storyboard data-uid='storyboard'>
+    <Scene
+      data-uid='scene'
+      style={{ position: 'absolute', left: 400, top: 0, width: 375, height: 812 }}
+    >
+      <App data-uid='app' />
+    </Scene>
+  </Storyboard>
+);
+`
+
+async function createAndRenderProject() {
+  const project = createModifiedProject({
+    [StoryboardFilePath]: storyboardFileContent,
+    [appFilePath]: appFileContent,
+  })
+  return renderTestEditorWithModel(project, 'await-first-dom-report')
+}
+
+describe('a project with conditionals', () => {
+  it('fills the content of the navigator', async () => {
+    FOR_TESTS_setNextGeneratedUids([
+      'mock1',
+      'conditional2',
+      'mock2',
+      'conditional1',
+      'mock1',
+      'conditional2',
+      'mock2',
+      'conditional1',
+    ])
+    const renderedProject = await createAndRenderProject()
+    const navigatorTargets = renderedProject.getEditorState().derived.navigatorTargets
+    const pathStrings = navigatorTargets.map(EP.toString)
+    expect(pathStrings).toEqual([
+      'storyboard/scene',
+      'storyboard/scene/app',
+      'storyboard/scene/app:app-root',
+      'storyboard/scene/app:app-root/conditional1',
+      'storyboard/scene/app:app-root/conditional1/conditional2',
+      'storyboard/scene/app:app-root/conditional1/conditional2/div-inside-conditionals',
+    ])
+  })
+})

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1783,12 +1783,16 @@ function fillSpyOnlyMetadata(
       return existing
     }
 
-    const spyElem = fromSpy[pathStr] ?? conditionalsWithDefaultMetadata[pathStr]
+    const fromSpyAndConditionals = {
+      ...conditionalsWithDefaultMetadata,
+      ...fromSpy,
+    }
+    const spyElem = fromSpyAndConditionals[pathStr]
 
     const { children: childrenFromSpy, unfurledComponents: unfurledComponentsFromSpy } =
       MetadataUtils.getAllChildrenElementsIncludingUnfurledFocusedComponentsUnordered(
         spyElem.elementPath,
-        fromSpy,
+        fromSpyAndConditionals,
       )
     const childrenAndUnfurledComponentsFromSpy = [...childrenFromSpy, ...unfurledComponentsFromSpy]
 

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1138,6 +1138,21 @@ export function clearJSXElementUniqueIDs<T extends JSXElementChild>(element: T):
       uniqueID: '',
       children: updatedChildren,
     }
+  } else if (isJSXConditionalExpression(element)) {
+    const updatedCondition = clearAttributeUniqueIDs(element.condition)
+    const updatedWhenTrue = childOrBlockIsChild(element.whenTrue)
+      ? clearJSXElementUniqueIDs(element.whenTrue)
+      : clearAttributeUniqueIDs(element.whenTrue)
+    const updatedWhenFalse = childOrBlockIsChild(element.whenFalse)
+      ? clearJSXElementUniqueIDs(element.whenFalse)
+      : clearAttributeUniqueIDs(element.whenFalse)
+    return {
+      ...element,
+      uniqueID: '',
+      condition: updatedCondition,
+      whenTrue: updatedWhenTrue,
+      whenFalse: updatedWhenFalse,
+    }
   } else {
     return {
       ...element,

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -580,56 +580,7 @@ export var whatever = (props) => {
 
 exports[`JSX parser parses fine with a circular dependency. 1`] = `
 Object {
-  "combinedTopLevelArbitraryBlock": Object {
-    "definedElsewhere": Array [
-      "utopiaCanvasJSXLookup",
-    ],
-    "definedWithin": Array [
-      "a",
-      "b",
-    ],
-    "elementsWithin": Object {},
-    "javascript": "const a = (n) => n > 0 ? n : b(10)
-const b = (n) => n > 0 ? n : a(10)",
-    "sourceMap": Object {
-      "file": "code.tsx",
-      "mappings": "AAICA,IAAMC,CAACC,GAAGC,SAAJF,CAAIE,CAACC,CAADD;AAAAA,SAAOC,CAACF,GAAGG,CAAJD,GAAQA,CAARA,GAAYE,CAACH,CAACI,EAADJ,CAApBA;AAAAA,CAAVH;;AAEAA,IAAMM,CAACJ,GAAGC,SAAJG,CAAIH,CAACC,CAADD;AAAAA,SAAOC,CAACF,GAAGG,CAAJD,GAAQA,CAARA,GAAYH,CAACE,CAACI,EAADJ,CAApBA;AAAAA,CAAVH",
-      "names": Array [
-        "const",
-        "a",
-        " ",
-        "(",
-        "n",
-        "0",
-        "b",
-        "10",
-      ],
-      "sources": Array [
-        "code.tsx",
-      ],
-      "sourcesContent": Array [
-        "import * as React from \\"react\\";
-import {
-  View
-} from \\"utopia-api\\";
-const a = (n) => n > 0 ? n : b(10)
-export var whatever = (props) => <View data-uid='aaa' />
-const b = (n) => n > 0 ? n : a(10)
-",
-      ],
-      "version": 3,
-    },
-    "transpiledJavascript": "var a = function a(n) {
-  return n > 0 ? n : b(10);
-};
-
-var b = function b(n) {
-  return n > 0 ? n : a(10);
-};
-return { a: a, b: b };",
-    "type": "ARBITRARY_JS_BLOCK",
-    "uniqueID": "",
-  },
+  "combinedTopLevelArbitraryBlock": null,
   "exportsDetail": Array [
     Object {
       "functionName": "whatever",
@@ -637,6 +588,20 @@ return { a: a, b: b };",
     },
   ],
   "highlightBounds": Object {
+    "7dd": Object {
+      "endCol": 34,
+      "endLine": 4,
+      "startCol": 17,
+      "startLine": 4,
+      "uid": "7dd",
+    },
+    "aa0": Object {
+      "endCol": 34,
+      "endLine": 6,
+      "startCol": 17,
+      "startLine": 6,
+      "uid": "aa0",
+    },
     "aaa": Object {
       "endCol": 56,
       "endLine": 5,
@@ -695,33 +660,50 @@ return { a: a, b: b };",
       "type": "UNPARSED_CODE",
     },
     Object {
-      "definedElsewhere": Array [
-        "b",
-        "utopiaCanvasJSXLookup",
-      ],
-      "definedWithin": Array [
-        "a",
-      ],
-      "elementsWithin": Object {},
-      "javascript": "const a = (n) => n > 0 ? n : b(10)",
-      "sourceMap": Object {
-        "file": "code.tsx",
-        "mappings": "AAICA,IAAMC,CAACC,GAAGC,SAAJF,CAAIE,CAACC,CAADD;AAAAA,SAAOC,CAACF,GAAGG,CAAJD,GAAQA,CAARA,GAAYE,CAACH,CAACI,EAADJ,CAApBA;AAAAA,CAAVH",
-        "names": Array [
-          "const",
-          "a",
-          " ",
-          "(",
-          "n",
-          "0",
-          "b",
-          "10",
-        ],
-        "sources": Array [
-          "code.tsx",
-        ],
-        "sourcesContent": Array [
-          "import * as React from \\"react\\";
+      "arbitraryJSBlock": null,
+      "blockOrExpression": "expression",
+      "declarationSyntax": "const",
+      "isFunction": true,
+      "name": "a",
+      "param": Object {
+        "boundParam": Object {
+          "defaultExpression": null,
+          "paramName": "n",
+          "type": "REGULAR_PARAM",
+        },
+        "dotDotDotToken": false,
+        "type": "PARAM",
+      },
+      "propsUsed": Array [],
+      "returnStatementComments": Object {
+        "leadingComments": Array [],
+        "trailingComments": Array [],
+      },
+      "rootElement": Object {
+        "comments": Object {
+          "leadingComments": Array [],
+          "trailingComments": Array [],
+        },
+        "condition": Object {
+          "definedElsewhere": Array [
+            "n",
+          ],
+          "elementsWithin": Object {},
+          "javascript": "n > 0",
+          "sourceMap": Object {
+            "file": "code.tsx",
+            "mappings": "OAImBA,CAACC,GAAEC,CAAJC",
+            "names": Array [
+              " ",
+              ">",
+              "0",
+              "n",
+            ],
+            "sources": Array [
+              "code.tsx",
+            ],
+            "sourcesContent": Array [
+              "import * as React from \\"react\\";
 import {
   View
 } from \\"utopia-api\\";
@@ -729,15 +711,82 @@ const a = (n) => n > 0 ? n : b(10)
 export var whatever = (props) => <View data-uid='aaa' />
 const b = (n) => n > 0 ? n : a(10)
 ",
-        ],
-        "version": 3,
+            ],
+            "version": 3,
+          },
+          "transpiledJavascript": "return n > 0;",
+          "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
+          "uniqueID": "",
+        },
+        "type": "JSX_CONDITIONAL_EXPRESSION",
+        "uniqueID": "",
+        "whenFalse": Object {
+          "definedElsewhere": Array [
+            "b",
+          ],
+          "elementsWithin": Object {},
+          "javascript": "b(10)",
+          "sourceMap": Object {
+            "file": "code.tsx",
+            "mappings": "OAI+BA,CAACC,IAAFC",
+            "names": Array [
+              "(",
+              "10",
+              "b",
+            ],
+            "sources": Array [
+              "code.tsx",
+            ],
+            "sourcesContent": Array [
+              "import * as React from \\"react\\";
+import {
+  View
+} from \\"utopia-api\\";
+const a = (n) => n > 0 ? n : b(10)
+export var whatever = (props) => <View data-uid='aaa' />
+const b = (n) => n > 0 ? n : a(10)
+",
+            ],
+            "version": 3,
+          },
+          "transpiledJavascript": "return b(10);",
+          "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
+          "uniqueID": "",
+        },
+        "whenTrue": Object {
+          "definedElsewhere": Array [
+            "n",
+          ],
+          "elementsWithin": Object {},
+          "javascript": "n",
+          "sourceMap": Object {
+            "file": "code.tsx",
+            "mappings": "OAI0BA",
+            "names": Array [
+              "n",
+            ],
+            "sources": Array [
+              "code.tsx",
+            ],
+            "sourcesContent": Array [
+              "import * as React from \\"react\\";
+import {
+  View
+} from \\"utopia-api\\";
+const a = (n) => n > 0 ? n : b(10)
+export var whatever = (props) => <View data-uid='aaa' />
+const b = (n) => n > 0 ? n : a(10)
+",
+            ],
+            "version": 3,
+          },
+          "transpiledJavascript": "return n;",
+          "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
+          "uniqueID": "",
+        },
       },
-      "transpiledJavascript": "var a = function a(n) {
-  return n > 0 ? n : b(10);
-};
-return { a: a };",
-      "type": "ARBITRARY_JS_BLOCK",
-      "uniqueID": "",
+      "type": "UTOPIA_JSX_COMPONENT",
+      "usedInReactDOMRender": false,
     },
     Object {
       "rawCode": "
@@ -802,33 +851,50 @@ return { a: a };",
       "type": "UNPARSED_CODE",
     },
     Object {
-      "definedElsewhere": Array [
-        "a",
-        "utopiaCanvasJSXLookup",
-      ],
-      "definedWithin": Array [
-        "b",
-      ],
-      "elementsWithin": Object {},
-      "javascript": "const b = (n) => n > 0 ? n : a(10)",
-      "sourceMap": Object {
-        "file": "code.tsx",
-        "mappings": "AAMCA,IAAMC,CAACC,GAAGC,SAAJF,CAAIE,CAACC,CAADD;AAAAA,SAAOC,CAACF,GAAGG,CAAJD,GAAQA,CAARA,GAAYE,CAACH,CAACI,EAADJ,CAApBA;AAAAA,CAAVH",
-        "names": Array [
-          "const",
-          "b",
-          " ",
-          "(",
-          "n",
-          "0",
-          "a",
-          "10",
-        ],
-        "sources": Array [
-          "code.tsx",
-        ],
-        "sourcesContent": Array [
-          "import * as React from \\"react\\";
+      "arbitraryJSBlock": null,
+      "blockOrExpression": "expression",
+      "declarationSyntax": "const",
+      "isFunction": true,
+      "name": "b",
+      "param": Object {
+        "boundParam": Object {
+          "defaultExpression": null,
+          "paramName": "n",
+          "type": "REGULAR_PARAM",
+        },
+        "dotDotDotToken": false,
+        "type": "PARAM",
+      },
+      "propsUsed": Array [],
+      "returnStatementComments": Object {
+        "leadingComments": Array [],
+        "trailingComments": Array [],
+      },
+      "rootElement": Object {
+        "comments": Object {
+          "leadingComments": Array [],
+          "trailingComments": Array [],
+        },
+        "condition": Object {
+          "definedElsewhere": Array [
+            "n",
+          ],
+          "elementsWithin": Object {},
+          "javascript": "n > 0",
+          "sourceMap": Object {
+            "file": "code.tsx",
+            "mappings": "OAMmBA,CAACC,GAAEC,CAAJC",
+            "names": Array [
+              " ",
+              ">",
+              "0",
+              "n",
+            ],
+            "sources": Array [
+              "code.tsx",
+            ],
+            "sourcesContent": Array [
+              "import * as React from \\"react\\";
 import {
   View
 } from \\"utopia-api\\";
@@ -836,15 +902,82 @@ const a = (n) => n > 0 ? n : b(10)
 export var whatever = (props) => <View data-uid='aaa' />
 const b = (n) => n > 0 ? n : a(10)
 ",
-        ],
-        "version": 3,
+            ],
+            "version": 3,
+          },
+          "transpiledJavascript": "return n > 0;",
+          "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
+          "uniqueID": "",
+        },
+        "type": "JSX_CONDITIONAL_EXPRESSION",
+        "uniqueID": "",
+        "whenFalse": Object {
+          "definedElsewhere": Array [
+            "a",
+          ],
+          "elementsWithin": Object {},
+          "javascript": "a(10)",
+          "sourceMap": Object {
+            "file": "code.tsx",
+            "mappings": "OAM+BA,CAACC,IAAFC",
+            "names": Array [
+              "(",
+              "10",
+              "a",
+            ],
+            "sources": Array [
+              "code.tsx",
+            ],
+            "sourcesContent": Array [
+              "import * as React from \\"react\\";
+import {
+  View
+} from \\"utopia-api\\";
+const a = (n) => n > 0 ? n : b(10)
+export var whatever = (props) => <View data-uid='aaa' />
+const b = (n) => n > 0 ? n : a(10)
+",
+            ],
+            "version": 3,
+          },
+          "transpiledJavascript": "return a(10);",
+          "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
+          "uniqueID": "",
+        },
+        "whenTrue": Object {
+          "definedElsewhere": Array [
+            "n",
+          ],
+          "elementsWithin": Object {},
+          "javascript": "n",
+          "sourceMap": Object {
+            "file": "code.tsx",
+            "mappings": "OAM0BA",
+            "names": Array [
+              "n",
+            ],
+            "sources": Array [
+              "code.tsx",
+            ],
+            "sourcesContent": Array [
+              "import * as React from \\"react\\";
+import {
+  View
+} from \\"utopia-api\\";
+const a = (n) => n > 0 ? n : b(10)
+export var whatever = (props) => <View data-uid='aaa' />
+const b = (n) => n > 0 ? n : a(10)
+",
+            ],
+            "version": 3,
+          },
+          "transpiledJavascript": "return n;",
+          "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
+          "uniqueID": "",
+        },
       },
-      "transpiledJavascript": "var b = function b(n) {
-  return n > 0 ? n : a(10);
-};
-return { b: b };",
-      "type": "ARBITRARY_JS_BLOCK",
-      "uniqueID": "",
+      "type": "UTOPIA_JSX_COMPONENT",
+      "usedInReactDOMRender": false,
     },
     Object {
       "rawCode": "

--- a/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
@@ -82,8 +82,8 @@ import { GithubPicker } from "react-color";
 function Picker() {
   const [color, setColor] = useThemeContext();
   const [visible, setVisible] = usePickerVisibilityContext();
-  return visible ? (
-    <GithubPicker
+  if (visible) {
+    return <GithubPicker
       style={{ position: "absolute" }}
       triangle="hide"
       color={color}
@@ -92,7 +92,9 @@ function Picker() {
         setVisible(false);
       }}
     />
-  ) : null;
+  } else {
+    return null
+  }
 }
 `,
       false,

--- a/editor/src/core/workers/parser-printer/parser-printer-conditionals.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-conditionals.spec.ts
@@ -1,9 +1,13 @@
 import { applyPrettier } from 'utopia-vscode-common'
 import { testParseCode, elementsStructure } from './parser-printer.test-utils'
 import { isParseSuccess } from '../../shared/project-file-types'
-import { SimpleConditionalsExample } from './parser-printer-conditionals.test-utils'
+import {
+  NestedTernariesExample,
+  SimpleConditionalsExample,
+} from './parser-printer-conditionals.test-utils'
 import { setFeatureForUnitTests } from '../../../utils/utils.test-utils'
 import { FOR_TESTS_setNextGeneratedUids } from '../../../core/model/element-template-utils.test-utils'
+import { printCode, printCodeOptions } from './parser-printer'
 
 describe('JSX parser', () => {
   setFeatureForUnitTests('Conditional support', true)
@@ -45,10 +49,133 @@ describe('JSX parser', () => {
           elementsStructure(firstParseResult.topLevelElements),
         )
       } else {
-        throw new Error(JSON.stringify(secondParseResult))
+        throw new Error(JSON.stringify(secondParseResult, null, 2))
       }
     } else {
-      throw new Error(JSON.stringify(firstParseResult))
+      throw new Error(JSON.stringify(firstParseResult, null, 2))
+    }
+  })
+  it('handles nested ternaries', () => {
+    FOR_TESTS_setNextGeneratedUids([
+      'mock1',
+      'conditional2',
+      'mock2',
+      'conditional1',
+      'mock1',
+      'conditional2',
+      'mock2',
+      'conditional1',
+    ])
+    const code = applyPrettier(NestedTernariesExample, false).formatted
+    const firstParseResult = testParseCode(code)
+    if (isParseSuccess(firstParseResult)) {
+      expect(elementsStructure(firstParseResult.topLevelElements)).toMatchInlineSnapshot(`
+        "IMPORT_STATEMENT
+        UNPARSED_CODE
+        IMPORT_STATEMENT
+        UNPARSED_CODE
+        UTOPIA_JSX_COMPONENT - App
+          JSX_ELEMENT - div - div
+            JSX_CONDITIONAL_EXPRESSION - conditional1
+              JSX_CONDITIONAL_EXPRESSION - conditional2
+                JSX_ELEMENT - div - middle
+        UNPARSED_CODE
+        UTOPIA_JSX_COMPONENT - storyboard
+          JSX_ELEMENT - Storyboard - eee
+            JSX_ELEMENT - Scene - fff
+              JSX_ELEMENT - App - app
+        UNPARSED_CODE"
+      `)
+
+      const secondParseResult = testParseCode(code)
+      if (isParseSuccess(secondParseResult)) {
+        expect(elementsStructure(secondParseResult.topLevelElements)).toEqual(
+          elementsStructure(firstParseResult.topLevelElements),
+        )
+      } else {
+        throw new Error(JSON.stringify(secondParseResult, null, 2))
+      }
+    } else {
+      throw new Error(JSON.stringify(firstParseResult, null, 2))
+    }
+  })
+})
+
+describe('JSX printer', () => {
+  it('handles nested ternaries', () => {
+    FOR_TESTS_setNextGeneratedUids(['mock1', 'conditional2', 'mock2', 'conditional1'])
+    const code = applyPrettier(NestedTernariesExample, false).formatted
+    const parseResult = testParseCode(code)
+    if (isParseSuccess(parseResult)) {
+      expect(elementsStructure(parseResult.topLevelElements)).toMatchInlineSnapshot(`
+        "IMPORT_STATEMENT
+        UNPARSED_CODE
+        IMPORT_STATEMENT
+        UNPARSED_CODE
+        UTOPIA_JSX_COMPONENT - App
+          JSX_ELEMENT - div - div
+            JSX_CONDITIONAL_EXPRESSION - conditional1
+              JSX_CONDITIONAL_EXPRESSION - conditional2
+                JSX_ELEMENT - div - middle
+        UNPARSED_CODE
+        UTOPIA_JSX_COMPONENT - storyboard
+          JSX_ELEMENT - Storyboard - eee
+            JSX_ELEMENT - Scene - fff
+              JSX_ELEMENT - App - app
+        UNPARSED_CODE"
+      `)
+
+      const printedCode = printCode(
+        'code.tsx',
+        printCodeOptions(false, true, true, false),
+        parseResult.imports,
+        parseResult.topLevelElements,
+        parseResult.jsxFactoryFunction,
+        parseResult.exportsDetail,
+      )
+      expect(printedCode).toMatchInlineSnapshot(`
+        "import * as React from 'react'
+        import { Scene, Storyboard, View } from 'utopia-api'
+        export var App = (props) => {
+          return (
+            <div data-uid='div'>
+              {[0, 1].length > 1 ? (
+                [0, 1].length === 0 ? (
+                  <div data-uid='middle' />
+                ) : null
+              ) : null}
+            </div>
+          )
+        }
+        export var storyboard = (
+          <Storyboard data-uid='eee'>
+            <Scene
+              style={{
+                position: 'absolute',
+                height: 812,
+                left: 0,
+                width: 375,
+                top: 0,
+              }}
+              data-uid='fff'
+            >
+              <App
+                data-uid='app'
+                style={{
+                  position: 'absolute',
+                  bottom: 0,
+                  left: 0,
+                  right: 0,
+                  top: 0,
+                }}
+              />
+            </Scene>
+          </Storyboard>
+        )
+        "
+      `)
+    } else {
+      throw new Error(JSON.stringify(parseResult, null, 2))
     }
   })
 })

--- a/editor/src/core/workers/parser-printer/parser-printer-conditionals.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-conditionals.test-utils.ts
@@ -19,3 +19,27 @@ export var ${BakedInStoryboardVariableName} = (
   </Storyboard>
 )
 `
+
+export const NestedTernariesExample = `
+import * as React from 'react'
+import { Scene, Storyboard, View } from 'utopia-api'
+export var App = (props) => {
+  return <div data-uid={'div'}>
+    {[0, 1].length > 1 ? (
+      [0, 1].length === 0 ? (
+        <div data-uid='middle'/>
+      ) : null
+    ) : null}
+  </div>
+}
+export var ${BakedInStoryboardVariableName} = (
+  <Storyboard data-uid={'eee'}>
+    <Scene
+      style={{ position: 'absolute', height: 812, left: 0, width: 375, top: 0 }}
+      data-uid={'fff'}
+    >
+      <App data-uid={'app'} style={{ position: 'absolute', bottom: 0, left: 0, right: 0, top: 0 }} />
+    </Scene>
+  </Storyboard>
+)
+`

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -377,7 +377,13 @@ function jsxElementToExpression(
   element: JSXElementChild,
   imports: Imports,
   stripUIDs: boolean,
-): TS.JsxElement | TS.JsxSelfClosingElement | TS.JsxText | TS.JsxExpression | TS.JsxFragment {
+):
+  | TS.JsxElement
+  | TS.JsxSelfClosingElement
+  | TS.JsxText
+  | TS.JsxExpression
+  | TS.JsxFragment
+  | TS.ConditionalExpression {
   switch (element.type) {
     case 'JSX_ELEMENT': {
       let attribsArray: Array<TS.JsxAttributeLike> = []
@@ -434,7 +440,7 @@ function jsxElementToExpression(
         const closing = TS.createJsxClosingElement(tagName)
         return TS.createJsxElement(
           opening,
-          element.children.map((child) => jsxElementToExpression(child, imports, stripUIDs)),
+          element.children.map((child) => jsxElementToJSXExpression(child, imports, stripUIDs)),
           closing,
         )
       }
@@ -469,7 +475,7 @@ function jsxElementToExpression(
     }
     case 'JSX_FRAGMENT': {
       const children = element.children.map((child) => {
-        return jsxElementToExpression(child, imports, stripUIDs)
+        return jsxElementToJSXExpression(child, imports, stripUIDs)
       })
       if (element.longForm) {
         const tagName = jsxElementNameToExpression(getFragmentElementNameFromImports(imports))
@@ -502,14 +508,24 @@ function jsxElementToExpression(
       // Trailing comments of the entire expression appear to be attached to the
       // closing brace of the expression.
       addCommentsToNode(whenFalse, element.comments)
-      return TS.createJsxExpression(
-        undefined,
-        TS.createConditional(condition, whenTrue as TS.Expression, whenFalse as TS.Expression),
-      )
+      return TS.createConditional(condition, whenTrue as TS.Expression, whenFalse as TS.Expression)
     }
     default:
       const _exhaustiveCheck: never = element
       throw new Error(`Unhandled element type ${JSON.stringify(element)}`)
+  }
+}
+
+function jsxElementToJSXExpression(
+  element: JSXElementChild,
+  imports: Imports,
+  stripUIDs: boolean,
+): TS.JsxElement | TS.JsxSelfClosingElement | TS.JsxText | TS.JsxExpression | TS.JsxFragment {
+  const expression = jsxElementToExpression(element, imports, stripUIDs)
+  if (TS.isConditionalExpression(expression)) {
+    return TS.createJsxExpression(undefined, expression)
+  } else {
+    return expression
   }
 }
 
@@ -599,7 +615,12 @@ function printUtopiaJSXComponent(
   detailOfExports: ExportsDetail,
 ): TS.Node {
   const asJSX = jsxElementToExpression(element.rootElement, imports, printOptions.stripUIDs)
-  if (TS.isJsxElement(asJSX) || TS.isJsxSelfClosingElement(asJSX) || TS.isJsxFragment(asJSX)) {
+  if (
+    TS.isJsxElement(asJSX) ||
+    TS.isJsxSelfClosingElement(asJSX) ||
+    TS.isJsxFragment(asJSX) ||
+    TS.isConditionalExpression(asJSX)
+  ) {
     let elementNode: TS.Node
     const jsxElementExpression = asJSX
     const modifiers = getModifersForComponent(element, detailOfExports)


### PR DESCRIPTION
**Problem:**
Currently if ternaries are nested, the parsing fails and defaults back down to treating the code as an arbitrary block.

**Fix:**
The primary change here is to slightly tweak the parser to handle conditionals which are not wrapped with a JSX expression. When one is a child of a JSX element, that will be the case, but when it is a child of another conditional or is the root element of a component there will not be a wrapping JSX expression around it.

Otherwise there was a fix to how spy metadata is backfilled for conditionals, as it did not handle the case that a child of a conditional could be another conditional and assumed that there would be an element which it could find in the metadata.

**Commit Details:**
- `fillSpyOnlyMetadata` now looks up the children for a spy element from the combined metadata of the spy and missing filled in metadata.
- `clearJSXElementUniqueIDs` now supports conditional expressions.
- The JSX parser supports parsing a conditional expression both within a JSX expression and without one surrounding it, which is necessary to capture child conditionals of another.
- Added `jsxElementToJSXExpression` as a wrapper around `jsxElementToExpression` so that conditionals get wrapped in a JSX expression which is necessary for the case where a conditional is a child of another JSX element.
- Fixed some tests as these changes made more code parseable than was previously possible.