### PR TITLE
Fix keyboard move snap guidelines

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-resize.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-resize.spec.browser2.tsx
@@ -170,7 +170,7 @@ describe('Keyboard Absolute Resize E2E', () => {
     expectElementWidthOnScreen(2)
     expect(getCanvasGuidelines()).toEqual([
       {
-        guideline: { type: 'XAxisGuideline', x: 40, yBottom: 396, yTop: 300 },
+        guideline: { type: 'XAxisGuideline', x: 40, yBottom: 396, yTop: 100 },
         pointsOfRelevance: [],
         snappingVector: { x: 0, y: 0 },
       },

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
@@ -70,18 +70,16 @@ export function keyboardAbsoluteMoveStrategy(
             keyboardMovement = offsetPoint(keyboardMovement, keyPressMovement)
           })
         })
-        if (keyboardMovement.x !== 0 || keyboardMovement.y !== 0) {
-          selectedElements.forEach((selectedElement) => {
-            const elementResult = getMoveCommandsForSelectedElement(
-              selectedElement,
-              keyboardMovement,
-              canvasState,
-              interactionSession,
-            )
-            commands.push(...elementResult.commands)
-            intendedBounds.push(...elementResult.intendedBounds)
-          })
-        }
+        selectedElements.forEach((selectedElement) => {
+          const elementResult = getMoveCommandsForSelectedElement(
+            selectedElement,
+            keyboardMovement,
+            canvasState,
+            interactionSession,
+          )
+          commands.push(...elementResult.commands)
+          intendedBounds.push(...elementResult.intendedBounds)
+        })
         const multiselectBounds = getMultiselectBounds(
           canvasState.startingMetadata,
           selectedElements,

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
@@ -91,7 +91,6 @@ export function keyboardAbsoluteMoveStrategy(
 
         const guidelines = getKeyboardStrategyGuidelines(canvasState, interactionSession, newFrame)
 
-        commands.push(updateHighlightedViews('mid-interaction', []))
         commands.push(setSnappingGuidelines('mid-interaction', guidelines))
         commands.push(pushIntendedBounds(intendedBounds))
         commands.push(setElementsToRerenderCommand(selectedElements))

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
@@ -134,51 +134,49 @@ export function keyboardAbsoluteResizeStrategy(
         let intendedBounds: Array<CanvasFrameAndTarget> = []
 
         movementsWithEdges.forEach((movementWithEdge) => {
-          if (movementWithEdge.movement.x !== 0 || movementWithEdge.movement.y !== 0) {
-            newFrame = resizeBoundingBox(
-              newFrame,
-              movementWithEdge.movement,
-              movementWithEdge.edge,
+          newFrame = resizeBoundingBox(
+            newFrame,
+            movementWithEdge.movement,
+            movementWithEdge.edge,
+            null,
+            'non-center-based',
+          )
+          selectedElements.forEach((selectedElement) => {
+            const element = withUnderlyingTarget(
+              selectedElement,
+              canvasState.projectContents,
+              {},
+              canvasState.openFile,
               null,
-              'non-center-based',
+              (_, e) => e,
             )
-            selectedElements.forEach((selectedElement) => {
-              const element = withUnderlyingTarget(
-                selectedElement,
-                canvasState.projectContents,
-                {},
-                canvasState.openFile,
-                null,
-                (_, e) => e,
-              )
 
-              const elementMetadata = MetadataUtils.findElementByElementPath(
-                canvasState.startingMetadata,
-                selectedElement,
-              )
-              const elementParentBounds =
-                elementMetadata?.specialSizeMeasurements.immediateParentBounds ?? null
-              const elementParentFlexDirection =
-                elementMetadata?.specialSizeMeasurements.parentFlexDirection ?? null
-              const elementGlobalFrame = nullIfInfinity(elementMetadata?.globalFrame ?? null)
+            const elementMetadata = MetadataUtils.findElementByElementPath(
+              canvasState.startingMetadata,
+              selectedElement,
+            )
+            const elementParentBounds =
+              elementMetadata?.specialSizeMeasurements.immediateParentBounds ?? null
+            const elementParentFlexDirection =
+              elementMetadata?.specialSizeMeasurements.parentFlexDirection ?? null
+            const elementGlobalFrame = nullIfInfinity(elementMetadata?.globalFrame ?? null)
 
-              if (element != null && isJSXElement(element)) {
-                const elementResult = createResizeCommands(
-                  element,
-                  selectedElement,
-                  movementWithEdge.edge,
-                  movementWithEdge.movement,
-                  elementGlobalFrame,
-                  elementParentBounds,
-                  elementParentFlexDirection,
-                )
-                commands.push(...elementResult.commands)
-                if (elementResult.intendedBounds != null) {
-                  intendedBounds.push(elementResult.intendedBounds)
-                }
+            if (element != null && isJSXElement(element)) {
+              const elementResult = createResizeCommands(
+                element,
+                selectedElement,
+                movementWithEdge.edge,
+                movementWithEdge.movement,
+                elementGlobalFrame,
+                elementParentBounds,
+                elementParentFlexDirection,
+              )
+              commands.push(...elementResult.commands)
+              if (elementResult.intendedBounds != null) {
+                intendedBounds.push(elementResult.intendedBounds)
               }
-            })
-          }
+            }
+          })
         })
         const guidelines = getKeyboardStrategyGuidelines(canvasState, interactionSession, newFrame)
         commands.push(setSnappingGuidelines('mid-interaction', guidelines))

--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-keyboard-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-keyboard-strategy-helpers.ts
@@ -3,7 +3,7 @@ import { setsEqual } from '../../../../core/shared/set-utils'
 import { last, mapDropNulls } from '../../../../core/shared/array-utils'
 import { Modifier, Modifiers } from '../../../../utils/modifiers'
 import { CanvasRectangle, CanvasVector } from '../../../../core/shared/math-utils'
-import Keyboard, { KeyCharacter } from '../../../../utils/keyboard'
+import { KeyCharacter } from '../../../../utils/keyboard'
 import {
   collectParentAndSiblingGuidelines,
   oneGuidelinePerDimension,
@@ -114,7 +114,11 @@ export function getKeyboardStrategyGuidelines(
           )
           if (Utils.magnitude(snappingVector) === 0) {
             return {
-              guideline: guideline,
+              guideline: {
+                ...guideline,
+                yTop: Math.min(guideline.yTop, draggedFrame.y),
+                yBottom: Math.max(guideline.yBottom, draggedFrame.y + draggedFrame.height),
+              },
               snappingVector: snappingVector,
               pointsOfRelevance: [],
             } as GuidelineWithSnappingVectorAndPointsOfRelevance
@@ -130,7 +134,11 @@ export function getKeyboardStrategyGuidelines(
           )
           if (Utils.magnitude(snappingVector) === 0) {
             return {
-              guideline: guideline,
+              guideline: {
+                ...guideline,
+                xLeft: Math.min(guideline.xLeft, draggedFrame.x),
+                xRight: Math.max(guideline.xRight, draggedFrame.x + draggedFrame.width),
+              },
               snappingVector: snappingVector,
               pointsOfRelevance: [],
             } as GuidelineWithSnappingVectorAndPointsOfRelevance

--- a/editor/src/components/canvas/controls/distance-guideline.tsx
+++ b/editor/src/components/canvas/controls/distance-guideline.tsx
@@ -147,6 +147,7 @@ export class DistanceGuideline extends React.Component<DistanceGuidelineProps> {
               backgroundColor: StrokeColor,
               fontSize: 11 / this.props.scale,
             }}
+            data-testid={id}
           >
             {`${distance.toFixed(0)}`}
           </div>
@@ -279,7 +280,7 @@ export class DistanceGuideline extends React.Component<DistanceGuidelineProps> {
           Math.abs(frame.y + frame.height - bottomGuidelineY),
           bottomStart,
           bottomEnd,
-          'distance',
+          'distance-bottom',
         ),
       ]
     } else {


### PR DESCRIPTION
**Problem:**
Keyboard snap guidelines are inconsistently shown, and don't connect to the moved element.

**Fix:**
There were two problems here. Firstly, the guidelines don't show when the element returns to its starting point (regardless of if they should show), due to an unnecessary optimisation that meant there would be no `intendedBounds` for the element, so that was removed. Secondly, when generating the final guidelines we weren't taking into account the element's frame for calculating the endpoints of the line to draw, so we now take the max and min points in each direction.