### PR TITLE
Fix keyboard move distance guidelines

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
@@ -91,7 +91,6 @@ export function keyboardAbsoluteMoveStrategy(
 
         const guidelines = getKeyboardStrategyGuidelines(canvasState, interactionSession, newFrame)
 
-        commands.push(updateHighlightedViews('mid-interaction', []))
         commands.push(setSnappingGuidelines('mid-interaction', guidelines))
         commands.push(pushIntendedBounds(intendedBounds))
         commands.push(setElementsToRerenderCommand(selectedElements))

--- a/editor/src/components/canvas/controls/distance-guideline.tsx
+++ b/editor/src/components/canvas/controls/distance-guideline.tsx
@@ -147,6 +147,7 @@ export class DistanceGuideline extends React.Component<DistanceGuidelineProps> {
               backgroundColor: StrokeColor,
               fontSize: 11 / this.props.scale,
             }}
+            data-testid={id}
           >
             {`${distance.toFixed(0)}`}
           </div>
@@ -279,7 +280,7 @@ export class DistanceGuideline extends React.Component<DistanceGuidelineProps> {
           Math.abs(frame.y + frame.height - bottomGuidelineY),
           bottomStart,
           bottomEnd,
-          'distance',
+          'distance-bottom',
         ),
       ]
     } else {


### PR DESCRIPTION
**Problem:**
Distance guidelines (shown by holding alt) are supposed to be measured against the element under the mouse, but when moving the selected element via the keyboard the distances would switch to using the parent element.

**Fix:**
The problem is that we are clearing the `highlightedViews` during the keyboard move interaction, so I've removed that line. This does mean that we'll still be showing the highlight control on the canvas, which feels wrong, but it feels even more wrong to hide the highlight control but still show the distance guidelines. I think the optimal setup here would be to introduce a new type of border for the sake of the distance guidelines, but I suggest that doesn't happen as part of this bug fix.