### PR TITLE
Escape Hatch to Handle Fragments

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
@@ -257,27 +257,18 @@ const escapeHatchTestCases: Array<EscapeHatchTestCases> = [
     globalFrameUnchangedForElements: [
       {
         path: AbsoluteDivInFlex,
-        pathAfter: EP.appendToPath(
-          EP.appendToPath(AppRoot, EP.toUid(FlexRow)),
-          EP.toUid(AbsoluteDivInFlex),
-        ),
       },
       {
         path: RelativeContainer,
-        pathAfter: EP.appendToPath(
-          EP.appendToPath(AppRoot, EP.toUid(FlexRow)),
-          EP.toUid(RelativeContainer),
-        ),
       },
       {
         path: AbsoluteDivInRelative,
-        pathAfter: EP.appendToPath(
-          EP.appendToPath(AppRoot, EP.toUid(FlexRow)),
-          EP.toUid(AbsoluteDivInRelative),
-        ),
+      },
+      {
+        path: FlexRow,
       },
     ],
-    expectedAbsoluteElements: [FlexContainer, EP.appendToPath(AppRoot, EP.toUid(FlexRow))],
+    expectedAbsoluteElements: [FlexContainer],
   },
   {
     targetsToConvert: [CardInner],

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
@@ -174,7 +174,7 @@ const complexProject = () => {
               }}
               data-uid='plum-static-div-2'
             />
-            <React.Fragment data-path="fragment-1">
+            <React.Fragment data-uid="fragment-1">
               <div
                 style={{
                   backgroundColor: 'plum',

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
@@ -138,6 +138,70 @@ const complexProject = () => {
             />
           </div>
         </div>
+        <div
+          style={{
+            display: 'flex',
+            padding: 8,
+            flexDirection: 'column',
+          }}
+          data-uid='flex-column-2'
+        >
+          <div
+            style={{
+              backgroundColor: 'rebeccapurple',
+              width: '100%',
+              height: 80,
+              marginBottom: 20,
+              display: 'flex',
+              flexDirection: 'row',
+              gap: 15,
+              paddingLeft: 15,
+            }}
+            data-uid='purple-flex-row'
+          >
+            <div
+              style={{
+                backgroundColor: 'plum',
+                width: 50,
+                marginBottom: 20,
+              }}
+              data-uid='plum-static-div-1'
+            />
+            <div
+              style={{
+                backgroundColor: 'plum',
+                width: 50,
+              }}
+              data-uid='plum-static-div-2'
+            />
+            <React.Fragment data-path="fragment-1">
+              <div
+                style={{
+                  backgroundColor: 'plum',
+                  width: 75,
+                  height: 40,
+                  alignSelf: 'flex-end',
+                }}
+                data-uid='plum-static-div-fragment-child-1'
+              />
+              <div
+                style={{
+                  backgroundColor: 'plum',
+                  width: 50,
+                }}
+                data-uid='plum-static-div-fragment-child-2'
+              />
+            </React.Fragment>
+            <div
+              style={{
+                backgroundColor: 'plum',
+                width: 50,
+                marginTop: 20,
+              }}
+              data-uid='plum-static-div-5'
+            />
+          </div>
+        </div>
       </div>
     )
   }
@@ -206,6 +270,36 @@ const AbsoluteDivInRelative = EP.appendNewElementPath(TestScenePath, [
   'absolute-div-in-relative',
 ])
 
+const FlexChild1 = EP.appendNewElementPath(TestScenePath, [
+  'app-inner',
+  'flex-column-2',
+  'purple-flex-row',
+  'plum-static-div-1',
+])
+
+const FragmentInFlex = EP.appendNewElementPath(TestScenePath, [
+  'app-inner',
+  'flex-column-2',
+  'purple-flex-row',
+  'fragment-1',
+])
+
+const FragmentChild1 = EP.appendNewElementPath(TestScenePath, [
+  'app-inner',
+  'flex-column-2',
+  'purple-flex-row',
+  'fragment-1',
+  'plum-static-div-fragment-child-1',
+])
+
+const FragmentChild2 = EP.appendNewElementPath(TestScenePath, [
+  'app-inner',
+  'flex-column-2',
+  'purple-flex-row',
+  'fragment-1',
+  'plum-static-div-fragment-child-2',
+])
+
 interface EscapeHatchTestCases {
   targetsToConvert: Array<ElementPath>
   focusedElement: ElementPath | null
@@ -251,6 +345,7 @@ const escapeHatchTestCases: Array<EscapeHatchTestCases> = [
     ],
     expectedAbsoluteElements: [RelativeContainer, CardInstance],
   },
+  // selecting an element and its child results in only the parent being absolute converted (drag-to-move rules)
   {
     targetsToConvert: [FlexContainer, FlexRow],
     focusedElement: null,
@@ -279,6 +374,88 @@ const escapeHatchTestCases: Array<EscapeHatchTestCases> = [
       { path: CardTitle },
     ],
     expectedAbsoluteElements: [CardInner],
+  },
+  // Multiselection across parents will reparent the elements to a common ancestor!!!!
+  {
+    targetsToConvert: [RelativeContainer, FlexChild1],
+    focusedElement: null,
+    globalFrameUnchangedForElements: [
+      {
+        path: RelativeContainer,
+        pathAfter: EP.appendNewElementPath(TestScenePath, [
+          'app-inner',
+          'relative-container-green',
+        ]),
+      },
+      {
+        path: FlexChild1,
+        pathAfter: EP.appendNewElementPath(TestScenePath, ['app-inner', 'plum-static-div-1']),
+      },
+    ],
+    expectedAbsoluteElements: [
+      EP.appendNewElementPath(TestScenePath, ['app-inner', 'relative-container-green']),
+      EP.appendNewElementPath(TestScenePath, ['app-inner', 'plum-static-div-1']),
+    ],
+  },
+  {
+    targetsToConvert: [FragmentInFlex],
+    focusedElement: null,
+    globalFrameUnchangedForElements: [{ path: FragmentChild1 }, { path: FragmentChild2 }],
+    expectedAbsoluteElements: [FragmentChild1, FragmentChild2],
+  },
+  // for a sibling of the fragment, there's no reparent involved
+  {
+    targetsToConvert: [FlexChild1, FragmentInFlex],
+    focusedElement: null,
+    globalFrameUnchangedForElements: [
+      { path: FlexChild1 },
+      { path: FragmentChild1 },
+      { path: FragmentChild2 },
+    ],
+    expectedAbsoluteElements: [FlexChild1, FragmentChild1, FragmentChild2],
+  },
+  // For fragment in a multiselect, we reparent the fragment, but absolutize the children of the fragment.
+  {
+    targetsToConvert: [RelativeContainer, FragmentInFlex],
+    focusedElement: null,
+    globalFrameUnchangedForElements: [
+      {
+        path: RelativeContainer,
+        pathAfter: EP.appendNewElementPath(TestScenePath, [
+          'app-inner',
+          'relative-container-green',
+        ]),
+      },
+      {
+        path: FragmentChild1,
+        pathAfter: EP.appendNewElementPath(TestScenePath, [
+          'app-inner',
+          'fragment-1',
+          'plum-static-div-fragment-child-1',
+        ]),
+      },
+      {
+        path: FragmentChild2,
+        pathAfter: EP.appendNewElementPath(TestScenePath, [
+          'app-inner',
+          'fragment-1',
+          'plum-static-div-fragment-child-2',
+        ]),
+      },
+    ],
+    expectedAbsoluteElements: [
+      EP.appendNewElementPath(TestScenePath, ['app-inner', 'relative-container-green']),
+      EP.appendNewElementPath(TestScenePath, [
+        'app-inner',
+        'fragment-1',
+        'plum-static-div-fragment-child-1',
+      ]),
+      EP.appendNewElementPath(TestScenePath, [
+        'app-inner',
+        'fragment-1',
+        'plum-static-div-fragment-child-2',
+      ]),
+    ],
   },
 ]
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -55,6 +55,10 @@ import { getReparentOutcome, pathToReparent } from './reparent-utils'
 import { applyMoveCommon, getDragTargets } from './shared-move-strategies-helpers'
 import { wildcardPatch } from '../../commands/wildcard-patch-command'
 import { styleStringInArray } from '../../../../utils/common-constants'
+import {
+  replaceContentAffectingPathsWithTheirChildrenRecursive,
+  retargetStrategyToChildrenOfContentAffectingElements,
+} from './group-like-helpers'
 
 export function convertToAbsoluteAndMoveStrategy(
   canvasState: InteractionCanvasState,
@@ -178,18 +182,24 @@ export function getEscapeHatchCommands(
   const commonAncestor = EP.getCommonParent(selectedElements, false)
   const sortedElements = EP.getOrderedPathsByDepth(selectedElements)
 
+  const elementsToConvertToAbsolute = replaceContentAffectingPathsWithTheirChildrenRecursive(
+    metadata,
+    canvasState.startingAllElementProps,
+    sortedElements,
+  )
+
   /**
    * It's possible to have descendants where the layout is defined by an ancestor
    * these are offset here as the new layout parents will be the selected elements
    */
   const descendantsInNewContainingBlock = moveDescendantsToNewContainingBlock(
     metadata,
-    selectedElements,
+    elementsToConvertToAbsolute,
     canvasState,
   )
   commands.push(...descendantsInNewContainingBlock)
 
-  sortedElements.forEach((path) => {
+  elementsToConvertToAbsolute.forEach((path) => {
     const elementResult = collectSetLayoutPropCommands(
       path,
       metadata,
@@ -197,8 +207,13 @@ export function getEscapeHatchCommands(
       dragDelta,
       commonAncestor,
     )
+
     intendedBounds.push(...elementResult.intendedBounds)
     commands.push(...elementResult.commands)
+  })
+  sortedElements.forEach((path) => {
+    const reparentResult = collectReparentCommands(path, canvasState, commonAncestor)
+    commands.push(...reparentResult)
   })
   commands.push(
     updateSelectedViews(
@@ -221,12 +236,10 @@ function collectSetLayoutPropCommands(
   commands: Array<CanvasCommand>
   intendedBounds: Array<CanvasFrameAndTarget>
 } {
-  const currentParentPath = EP.parentPath(path)
-  const shouldReparent = targetParent != null && !EP.pathsEqual(targetParent, currentParentPath)
   const globalFrame = MetadataUtils.getFrameInCanvasCoords(path, metadata)
   if (globalFrame != null && isFiniteRectangle(globalFrame)) {
     const newLocalFrame = MetadataUtils.getFrameRelativeToTargetContainingBlock(
-      shouldReparent ? targetParent : currentParentPath,
+      targetParent ?? EP.parentPath(path),
       metadata,
       globalFrame,
     )
@@ -248,24 +261,37 @@ function collectSetLayoutPropCommands(
       newLocalFrame,
     )
     commands.push(...updatePinsCommands)
-    if (shouldReparent) {
-      const outcomeResult = getReparentOutcome(
-        canvasState.builtInDependencies,
-        canvasState.projectContents,
-        canvasState.nodeModules,
-        canvasState.openFile,
-        pathToReparent(path),
-        targetParent,
-        'always',
-      )
-      if (outcomeResult != null) {
-        commands.push(...outcomeResult.commands)
-      }
-    }
+
     return { commands: commands, intendedBounds: intendedBounds }
   } else {
     return { commands: [], intendedBounds: [] }
   }
+}
+
+function collectReparentCommands(
+  path: ElementPath,
+  canvasState: InteractionCanvasState,
+  targetParent: ElementPath | null,
+): Array<CanvasCommand> {
+  const currentParentPath = EP.parentPath(path)
+  const shouldReparent = targetParent != null && !EP.pathsEqual(targetParent, currentParentPath)
+
+  if (!shouldReparent) {
+    return []
+  }
+  const outcomeResult = getReparentOutcome(
+    canvasState.builtInDependencies,
+    canvasState.projectContents,
+    canvasState.nodeModules,
+    canvasState.openFile,
+    pathToReparent(path),
+    targetParent,
+    'always',
+  )
+  if (outcomeResult == null) {
+    return []
+  }
+  return outcomeResult.commands
 }
 
 function filterPinsToSet(

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -156,7 +156,7 @@ export function convertToAbsoluteAndMoveStrategy(
 }
 
 export function getEscapeHatchCommands(
-  selectedElements: Array<ElementPath>,
+  _selectedElements: Array<ElementPath>,
   metadata: ElementInstanceMetadataMap,
   canvasState: InteractionCanvasState,
   dragDelta: CanvasVector | null,
@@ -164,6 +164,7 @@ export function getEscapeHatchCommands(
   commands: Array<CanvasCommand>
   intendedBounds: Array<CanvasFrameAndTarget>
 } {
+  const selectedElements = getDragTargets(_selectedElements)
   if (selectedElements.length === 0) {
     return { commands: [], intendedBounds: [] }
   }


### PR DESCRIPTION
**Problem:**
Children-affecting elements did not play nicely with the "convert to absolute and move" strategy and action, aka the Escape Hatch.

To my surprise, the escape hatch does reparenting too, and the reparenting was intermixed with the absolute conversion.

**Fix:**
The escape hatch now splits the duties into two parts: Elements to actually reparent (including fragments) and elements where the absolute conversion happens (children of fragments).

**Commit Details:**
- Added new test cases to the test file. I found that @enidemi 's original test format was very nice to extend!
- new `collectReparentCommands` split out from `collectSetLayoutPropCommands` which is now _really_ only setting layout props
- Fragmens!
