### PR TITLE
Move conditionals toggle flag comments to the leading comments

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4355,6 +4355,7 @@ export const UPDATE_FNS = {
               makeUtopiaFlagComment({ type: 'conditional', value: action.condition }),
             ],
             trailingComments: element.comments.trailingComments.filter(isNotConditionalFlag),
+            questionTokenComments: element.comments.questionTokenComments,
           },
         }
       },

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -53,6 +53,7 @@ import {
 } from '../../../core/shared/either'
 import * as EP from '../../../core/shared/element-path'
 import {
+  Comment,
   deleteJSXAttribute,
   DetectedLayoutSystem,
   ElementInstanceMetadataMap,
@@ -4345,16 +4346,15 @@ export const UPDATE_FNS = {
         if (!isJSXConditionalExpression(element)) {
           return element
         }
+        const isNotConditionalFlag = (c: Comment) => !isUtopiaCommentFlag(c, 'conditional')
         return {
           ...element,
           comments: {
-            leadingComments: element.comments.leadingComments,
-            trailingComments: [
+            leadingComments: [
+              ...element.comments.leadingComments.filter(isNotConditionalFlag),
               makeUtopiaFlagComment({ type: 'conditional', value: action.condition }),
-              ...element.comments.trailingComments.filter(
-                (c) => !isUtopiaCommentFlag(c, 'conditional'),
-              ),
             ],
+            trailingComments: element.comments.trailingComments.filter(isNotConditionalFlag),
           },
         }
       },

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -2262,7 +2262,7 @@ describe('inspector tests with real metadata', () => {
         <div data-uid='aaa'>
         {
           // hello
-          [].length === 0 ? (
+          [].length === 0 /*inside*/ ? (
           <div data-uid='bbb' data-testid='bbb'>foo</div>
         ) : (
           <div data-uid='ccc' data-testid='ccc'>bar</div>
@@ -2294,7 +2294,7 @@ describe('inspector tests with real metadata', () => {
               {
                 // hello
                 // @utopia/conditional=false
-                [].length === 0 ? (
+                [].length === 0 /*inside*/ ? (
                   <div data-uid='bbb' data-testid='bbb'>foo</div>
                 ) : (
                   <div data-uid='ccc' data-testid='ccc'>bar</div>

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -38,7 +38,11 @@ import { DefaultPackageJson, StoryboardFilePath } from '../../editor/store/edito
 import { createCodeFile } from '../../custom-code/code-file.test-utils'
 import { matchInlineSnapshotBrowser } from '../../../../test/karma-snapshots'
 import { EditorAction } from '../../editor/action-types'
-import { selectComponentsForTest, setFeatureForBrowserTests } from '../../../utils/utils.test-utils'
+import {
+  expectSingleUndoStep,
+  selectComponentsForTest,
+  setFeatureForBrowserTests,
+} from '../../../utils/utils.test-utils'
 import { SubduedBorderRadiusControlTestId } from '../../canvas/controls/select-mode/subdued-border-radius-control'
 import { FOR_TESTS_setNextGeneratedUids } from '../../../core/model/element-template-utils.test-utils'
 import { setFeatureEnabled } from '../../../utils/feature-switches'
@@ -96,9 +100,11 @@ async function toggleConditional(
   buttonTestId: string,
   targetPath: ElementPath,
 ): Promise<void> {
-  await act(async () => {
-    fireEvent.click(screen.getByTestId(buttonTestId))
-    await renderResult.getDispatchFollowUpActionsFinished()
+  await expectSingleUndoStep(renderResult, async () => {
+    await act(async () => {
+      fireEvent.click(screen.getByTestId(buttonTestId))
+      await renderResult.getDispatchFollowUpActionsFinished()
+    })
   })
 
   await act(async () => {

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -32,6 +32,7 @@ import type { FlexAlignment, FlexJustifyContent } from '../../components/inspect
 export interface ParsedComments {
   leadingComments: Array<Comment>
   trailingComments: Array<Comment>
+  questionTokenComments?: ParsedComments
 }
 
 export const emptyComments: ParsedComments = {

--- a/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
@@ -92,7 +92,7 @@ describe('Parsing and printing code with comments', () => {
           >
           {
             ${comments.commentAtStartOfJSXExpression}
-            true ${comments.commentInsideJSXExpression}
+            [].length === 0 ${comments.commentInsideJSXExpression}
             ? <div/>
             : <div/>
             ${comments.commentAtEndOfJSXExpression}
@@ -172,7 +172,7 @@ describe('Parsing and printing code with comments', () => {
           >
             {
               /* Comment at start of JSX expression */
-              true /* Comment inside JSX expression */ ? (
+              [].length === 0 /* Comment inside JSX expression */ ? (
                 <div data-uid='4cf' />
               ) : (
                 <div data-uid='1a9' />

--- a/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
@@ -172,7 +172,8 @@ describe('Parsing and printing code with comments', () => {
           >
             {
               /* Comment at start of JSX expression */
-              [].length === 0 /* Comment inside JSX expression */ ? (
+              [].length ===
+              0 /* Comment inside JSX expression */ ? (
                 <div data-uid='4cf' />
               ) : (
                 <div data-uid='1a9' />

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -1849,7 +1849,10 @@ export function parseOutJSXElements(
               left('Expression fallback.')
             // Handle ternaries.
             if (elem.expression != null && TS.isConditionalExpression(elem.expression)) {
-              const leadingComments = getLeadingComments(sourceText, elem.expression)
+              const leadingComments = [
+                ...getLeadingComments(sourceText, elem.expression),
+                ...getTrailingComments(sourceText, elem.expression.condition),
+              ]
 
               const childrenOfExpression = elem.getChildren(sourceFile)
               const lastChild = childrenOfExpression[childrenOfExpression.length - 1]

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -505,10 +505,15 @@ function jsxElementToExpression(
       const whenFalse = childOrBlockIsChild(element.whenFalse)
         ? jsxElementToExpression(element.whenFalse, imports, stripUIDs)
         : jsxAttributeToExpression(element.whenFalse)
-      // Trailing comments of the entire expression appear to be attached to the
-      // closing brace of the expression.
-      addCommentsToNode(whenFalse, element.comments)
-      return TS.createConditional(condition, whenTrue as TS.Expression, whenFalse as TS.Expression)
+
+      const node = TS.createConditional(
+        condition,
+        whenTrue as TS.Expression,
+        whenFalse as TS.Expression,
+      )
+      addCommentsToNode(node, element.comments)
+
+      return node
     }
     default:
       const _exhaustiveCheck: never = element

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -512,6 +512,7 @@ function jsxElementToExpression(
         whenFalse as TS.Expression,
       )
       addCommentsToNode(node, element.comments)
+      addCommentsToNode(node.questionToken, element.comments.questionTokenComments ?? emptyComments)
 
       return node
     }


### PR DESCRIPTION
Fixes #3332 

**Problem:**

The `@utopia` flag comments in https://github.com/concrete-utopia/utopia/pull/3316 were temporarily put in the trailing comments for the expression, because the expression parsing was not taking the leading comments into account. However this is suboptimal since those annotations should intuitively be at the top of the expression block.

**Fix:**

This PR adjusts the comments parsing and printing so that the flag comments are inserted at the top of the expression when using the inspector controls:
![Kapture 2023-02-24 at 11 29 04](https://user-images.githubusercontent.com/1081051/221157185-981215f7-aa70-4d24-a4a8-755fc80614d6.gif)

Additionally, the changes make sure that when there are other comments mixed in with the flag comment(s), they are arranged correctly so that leading and trailing comments stay where they were.

![Kapture 2023-02-24 at 11 29 44](https://user-images.githubusercontent.com/1081051/221157362-28002f18-dd40-44de-94d8-6489d3a7991b.gif)

Finally, the changes make it so that the comment flag can be put in either leading or trailing comments when done via the code, and the canvas renders the right conditional consequently.

To recap, the final form of the comments will follow this structure:

```
{
  [leading comments]
  [toggle flag]
  [condition] ? [true branch] : [false branch]
  [trailing comments]
}
```