### PR TITLE
Flex -> Absolute reparenting: new tests + fix for fragments

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.spec.browser2.tsx
@@ -15,12 +15,16 @@ import {
   BakedInStoryboardUID,
 } from '../../../../core/model/scene-utils'
 import { mouseClickAtPoint, mouseDragFromPointWithDelta } from '../../event-helpers.test-utils'
+import { setFeatureForBrowserTests, wait } from '../../../../utils/utils.test-utils'
+import { selectComponents } from '../../../editor/actions/meta-actions'
+import * as EP from '../../../../core/shared/element-path'
 
 async function dragElement(
   renderResult: EditorRenderResult,
   targetTestId: string,
   dragDelta: WindowPoint,
   modifiers: Modifiers,
+  click: boolean,
 ): Promise<void> {
   const targetElement = renderResult.renderedDOM.getByTestId(targetTestId)
   const targetElementBounds = targetElement.getBoundingClientRect()
@@ -31,7 +35,10 @@ async function dragElement(
     y: targetElementBounds.y + targetElementBounds.height / 2,
   }
 
-  await mouseClickAtPoint(canvasControlsLayer, startPoint, { modifiers: cmdModifier })
+  if (click) {
+    await mouseClickAtPoint(canvasControlsLayer, startPoint, { modifiers: cmdModifier })
+  }
+
   await mouseDragFromPointWithDelta(canvasControlsLayer, startPoint, dragDelta, {
     modifiers: modifiers,
   })
@@ -169,7 +176,7 @@ describe('Flex Reparent To Absolute Strategy', () => {
       x: targetAbsoluteParentCenter.x - firstFlexChildCenter.x,
       y: targetAbsoluteParentCenter.y - firstFlexChildCenter.y,
     })
-    await dragElement(renderResult, 'flexchild1', dragDelta, cmdModifier)
+    await dragElement(renderResult, 'flexchild1', dragDelta, cmdModifier, true)
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
@@ -250,3 +257,186 @@ describe('Flex Reparent To Absolute Strategy', () => {
     )
   })
 })
+
+describe('Flex Reparent to Absolute – children affecting elements', () => {
+  setFeatureForBrowserTests('Fragment support', true)
+  ;(['fragment', 'div'] as const).forEach((divOrFragment) => {
+    describe(`– ${divOrFragment} parents`, () => {
+      it('reparents regular child from a children-affecting flex parent to absolute', async () => {
+        const renderResult = await renderTestEditorWithCode(
+          makeTestProjectCodeWithSnippet(fragmentTestCode(divOrFragment)),
+          'await-first-dom-report',
+        )
+
+        const targetAbsoluteParent = await renderResult.renderedDOM.findByTestId('absolutechild')
+        const targetAbsoluteParentRect = targetAbsoluteParent.getBoundingClientRect()
+        const targetAbsoluteParentCenter = {
+          x: targetAbsoluteParentRect.x + targetAbsoluteParentRect.width / 2,
+          y: targetAbsoluteParentRect.y + targetAbsoluteParentRect.height / 2,
+        }
+        const firstFlexChild = await renderResult.renderedDOM.findByTestId('flexchild1')
+        const firstFlexChildRect = firstFlexChild.getBoundingClientRect()
+        const firstFlexChildCenter = {
+          x: firstFlexChildRect.x + firstFlexChildRect.width / 2,
+          y: firstFlexChildRect.y + firstFlexChildRect.height / 2,
+        }
+
+        await renderResult.getDispatchFollowUpActionsFinished()
+        const dragDelta = windowPoint({
+          x: targetAbsoluteParentCenter.x - firstFlexChildCenter.x,
+          y: targetAbsoluteParentCenter.y - firstFlexChildCenter.y,
+        })
+        await dragElement(renderResult, 'flexchild1', dragDelta, cmdModifier, true)
+
+        await renderResult.getDispatchFollowUpActionsFinished()
+
+        expect(Object.keys(renderResult.getEditorState().editor.spyMetadata)).toEqual([
+          'utopia-storyboard-uid',
+          'utopia-storyboard-uid/scene-aaa',
+          'utopia-storyboard-uid/scene-aaa/app-entity',
+          'utopia-storyboard-uid/scene-aaa/app-entity:container',
+          'utopia-storyboard-uid/scene-aaa/app-entity:container/absoluteparent',
+          'utopia-storyboard-uid/scene-aaa/app-entity:container/absoluteparent/absolutechild',
+          'utopia-storyboard-uid/scene-aaa/app-entity:container/absoluteparent/absolutechild/flexchild1', // <- flexChild1 is successfully reparented
+          'utopia-storyboard-uid/scene-aaa/app-entity:container/flexparent',
+          'utopia-storyboard-uid/scene-aaa/app-entity:container/flexparent/children-affecting',
+          'utopia-storyboard-uid/scene-aaa/app-entity:container/flexparent/children-affecting/flexchild2',
+        ])
+      })
+
+      it('reparents children-affecting element from flex to absolute', async () => {
+        const renderResult = await renderTestEditorWithCode(
+          makeTestProjectCodeWithSnippet(fragmentTestCode(divOrFragment)),
+          'await-first-dom-report',
+        )
+
+        const targetAbsoluteParent = await renderResult.renderedDOM.findByTestId('absolutechild')
+        const targetAbsoluteParentRect = targetAbsoluteParent.getBoundingClientRect()
+        const targetAbsoluteParentCenter = {
+          x: targetAbsoluteParentRect.x + targetAbsoluteParentRect.width / 2,
+          y: targetAbsoluteParentRect.y + targetAbsoluteParentRect.height / 2,
+        }
+        const firstFlexChild = await renderResult.renderedDOM.findByTestId('flexchild1')
+        const firstFlexChildRect = firstFlexChild.getBoundingClientRect()
+        const firstFlexChildCenter = {
+          x: firstFlexChildRect.x + firstFlexChildRect.width / 2,
+          y: firstFlexChildRect.y + firstFlexChildRect.height / 2,
+        }
+
+        await renderResult.getDispatchFollowUpActionsFinished()
+        const dragDelta = windowPoint({
+          x: targetAbsoluteParentCenter.x - firstFlexChildCenter.x,
+          y: targetAbsoluteParentCenter.y - firstFlexChildCenter.y,
+        })
+
+        // selecting the fragment-like parent manually, so that dragElement drags _it_ instead of child-2!
+        await renderResult.dispatch(
+          selectComponents(
+            [
+              EP.fromString(
+                'utopia-storyboard-uid/scene-aaa/app-entity:container/flexparent/children-affecting',
+              ),
+            ],
+            false,
+          ),
+          true,
+        )
+        await dragElement(renderResult, 'flexchild1', dragDelta, cmdModifier, false)
+
+        await renderResult.getDispatchFollowUpActionsFinished()
+
+        expect(Object.keys(renderResult.getEditorState().editor.spyMetadata)).toEqual([
+          'utopia-storyboard-uid',
+          'utopia-storyboard-uid/scene-aaa',
+          'utopia-storyboard-uid/scene-aaa/app-entity',
+          'utopia-storyboard-uid/scene-aaa/app-entity:container',
+          'utopia-storyboard-uid/scene-aaa/app-entity:container/absoluteparent',
+          'utopia-storyboard-uid/scene-aaa/app-entity:container/absoluteparent/absolutechild',
+          'utopia-storyboard-uid/scene-aaa/app-entity:container/absoluteparent/absolutechild/children-affecting',
+          'utopia-storyboard-uid/scene-aaa/app-entity:container/absoluteparent/absolutechild/children-affecting/flexchild1',
+          'utopia-storyboard-uid/scene-aaa/app-entity:container/absoluteparent/absolutechild/children-affecting/flexchild2',
+          'utopia-storyboard-uid/scene-aaa/app-entity:container/flexparent',
+        ])
+      })
+    })
+  })
+})
+
+function fragmentTestCode(divOrFragment: 'div' | 'fragment') {
+  return `
+  <div
+    style={{
+      position: 'absolute',
+      width: 700,
+      height: 600,
+    }}
+    data-uid='container'
+    data-testid='container'
+  >
+    <div
+      style={{
+        position: 'absolute',
+        width: 250,
+        height: 500,
+        left: 0,
+        top: 0,
+        backgroundColor: 'lightblue',
+      }}
+      data-uid='absoluteparent'
+      data-testid='absoluteparent'
+    >
+      <div
+        style={{
+          position: 'absolute',
+          left: 93.5,
+          top: 58,
+          width: 100,
+          height: 100,
+          backgroundColor: 'yellow',
+        }}
+        data-uid='absolutechild'
+        data-testid='absolutechild'
+      />
+    </div>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        position: 'absolute',
+        width: 250,
+        height: 500,
+        left: 350,
+        top: 0,
+        backgroundColor: 'lightgreen',
+      }}
+      data-uid='flexparent'
+      data-testid='flexparent'
+    >
+      ${
+        divOrFragment === 'div'
+          ? `<div data-uid='children-affecting' data-testid='children-affecting'>`
+          : `<React.Fragment data-uid='children-affecting' data-testid='children-affecting'>`
+      }
+        <div
+          style={{
+            width: 100,
+            height: 100,
+            backgroundColor: 'teal',
+          }}
+          data-uid='flexchild1'
+          data-testid='flexchild1'
+        />
+        <div
+          style={{
+            width: 100,
+            height: 100,
+            backgroundColor: 'red',
+          }}
+          data-uid='flexchild2'
+          data-testid='flexchild2'
+        />
+      ${divOrFragment === 'div' ? `</div>` : `</React.Fragment>`}
+    </div>
+  </div>
+`
+}

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
@@ -95,13 +95,7 @@ export function baseFlexReparentToAbsoluteStrategy(
             )
 
             const escapeHatchCommands = getEscapeHatchCommands(
-              filteredSelectedElements.filter((path) => {
-                return !treatElementAsContentAffecting(
-                  canvasState.startingMetadata,
-                  canvasState.startingAllElementProps,
-                  path,
-                )
-              }),
+              filteredSelectedElements,
               canvasState.startingMetadata,
               canvasState,
               canvasPoint({ x: 0, y: 0 }),


### PR DESCRIPTION
**Problem:**
The flex -> absolute reparent did not work for fragments.

**Fix:**
With the escape hatch being fixed on master, the fix was very simple: I reverted to the old code from a week ago :D 

**Commit Details:**
- New test cases for flex -> absolute reparent with fragments and children-affecting divs.
- Fixing the behavior for fragments.
