### PR TITLE
Only end keyboard interactions on cmd keyup

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../../../core/model/scene-utils'
 import { SceneLabelTestID } from '../../controls/select-mode/scene-label'
 import {
+  keyUp,
   mouseDownAtPoint,
   mouseDragFromPointWithDelta,
   mouseMoveToPoint,
@@ -172,6 +173,33 @@ describe('Absolute Move Strategy', () => {
     const endPoint = windowPoint({ x: targetElementBounds.x + 45, y: targetElementBounds.y - 20 })
 
     await mouseDownAtPoint(canvasControlsLayer, startPoint, { modifiers: cmdModifier })
+    await mouseMoveToPoint(canvasControlsLayer, endPoint, { eventOptions: { buttons: 1 } })
+    await mouseUpAtPoint(canvasControlsLayer, endPoint)
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      projectDoesHonourPositionProperties(60, -5),
+    )
+  })
+  it('releasing cmd mid drag does not break the interaction', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      projectDoesHonourPositionProperties(20, 20),
+      'await-first-dom-report',
+    )
+    const targetElement = renderResult.renderedDOM.getByTestId('aaa')
+    const targetElementBounds = targetElement.getBoundingClientRect()
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    const startPoint = windowPoint({ x: targetElementBounds.x + 5, y: targetElementBounds.y + 5 })
+    const midPoint = windowPoint({ x: targetElementBounds.x + 25, y: targetElementBounds.y - 10 })
+    const endPoint = windowPoint({ x: targetElementBounds.x + 45, y: targetElementBounds.y - 20 })
+
+    await mouseDownAtPoint(canvasControlsLayer, startPoint, { modifiers: cmdModifier })
+    await mouseMoveToPoint(canvasControlsLayer, midPoint, {
+      modifiers: cmdModifier,
+      eventOptions: { buttons: 1 },
+    })
+    await keyUp('Meta')
     await mouseMoveToPoint(canvasControlsLayer, endPoint, { eventOptions: { buttons: 1 } })
     await mouseUpAtPoint(canvasControlsLayer, endPoint)
 

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -206,7 +206,10 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
       let actions: Array<EditorAction> = []
       const existingInteractionSession = editorStoreRef.current.editor.canvas.interactionSession
       if (existingInteractionSession != null) {
-        if (event.key === 'Meta') {
+        if (
+          existingInteractionSession.interactionData.type === 'KEYBOARD' &&
+          event.key === 'Meta'
+        ) {
           actions.push(CanvasActions.clearInteractionSession(true))
         } else {
           const action = CanvasActions.createInteractionSession(


### PR DESCRIPTION
**Problem:**
Someone (could have been anyone, we don't really know, and it's irrelevant anyway) made a silly mistake in a previous PR #3319) that causes all interactions to end on a cmd keyup event.

**Fix:**
Only end the interaction on cmd keyup if it is a keyboard interaction. Also a test to confirm this.
