### PR TITLE
Don't show padding controls if no padding set and no children

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.spec.browser2.tsx
@@ -654,21 +654,19 @@ describe('Padding resize strategy', () => {
       })
     })
 
-    it("controls are shown if padding is NOT specified on the component instance and instance doesn't have computed padding", async () => {
+    it("controls are not shown if padding is not specified on the component instance and instance doesn't have computed padding", async () => {
       const editor = await renderTestEditorWithCode(
         projectWithComponentThatDefinesPaddingInternally({}),
         'await-first-dom-report',
       )
 
       await clickOnMyDiv(editor)
-      EdgePieces.forEach((edge) => {
-        const paddingControlOuter = editor.renderedDOM.getByTestId(paddingControlTestId(edge))
-        expect(paddingControlOuter).toBeTruthy()
-        const paddingControlHandle = editor.renderedDOM.getByTestId(
-          paddingControlHandleTestId(edge),
-        )
-        expect(paddingControlHandle).toBeTruthy()
-      })
+      const paddingControls = EdgePieces.flatMap((edge) => [
+        ...editor.renderedDOM.queryAllByTestId(paddingControlTestId(edge)),
+        ...editor.renderedDOM.queryAllByTestId(paddingControlHandleTestId(edge)),
+      ])
+
+      expect(paddingControls).toEqual([])
     })
 
     it('controls are NOT shown if padding is NOT specified on the component instance and instance has computed padding', async () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -336,16 +336,8 @@ function supportsPaddingControls(metadata: ElementInstanceMetadataMap, path: Ele
     return false
   }
 
-  const elementIsIntrinsicElement = foldEither(
-    () => false,
-    (e) =>
-      isJSXElement(e) &&
-      (isIntrinsicElement(e.name) || jsxElementNameEquals(e.name, jsxElementName('Scene', []))),
-    element.element,
-  )
-
   if (
-    !elementIsIntrinsicElement &&
+    elementHasNonzeroPaddingFromProps &&
     shouldShowControls(elementHasNonzeroPaddingFromProps, elementHasNonzeroPaddingFromMeasurements)
   ) {
     return true


### PR DESCRIPTION
**Problem:**
For components we will show padding controls even if there are no children and no padding has been set, making it very easy to accidentally set padding (rather than update the width) on a newly inserted component instance (but not on an intrinsic element).

**Fix:**
We were special casing the handling of components here, so I've removed that to bring the logic inline with intrinsic elements (i.e. only show padding if the element has children that can be affected by padding, or if there is padding explicitly set via the `style` prop)
