### PR TITLE
Fix Fragments when they are hiddenInstances or displayNoneInstances

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -617,14 +617,18 @@ function renderJSXElement(
 }
 
 function isHidden(hiddenInstances: ElementPath[], elementPath: ElementPath | null): boolean {
-  return elementPath != null && hiddenInstances.some((path) => EP.pathsEqual(path, elementPath))
+  return (
+    elementPath != null &&
+    hiddenInstances.some((path) => EP.isDescendantOfOrEqualTo(elementPath, path))
+  )
 }
 function elementIsDisplayNone(
   displayNoneInstances: ElementPath[],
   elementPath: ElementPath | null,
 ): boolean {
   return (
-    elementPath != null && displayNoneInstances.some((path) => EP.pathsEqual(path, elementPath))
+    elementPath != null &&
+    displayNoneInstances.some((path) => EP.isDescendantOfOrEqualTo(elementPath, path))
   )
 }
 


### PR DESCRIPTION
**Context:**
During reparent and some other interactions, we often create a duplicate of the original dragged element, and mark it as a hiddenInstance. this places it on the canvas, but immediately makes it invisible. This makes these hidden clones perfect placeholder of the original element, as otherwise they have the exact same properties and sizing behaviors affecting them. We use this technique to prevent elements jumping around on the canvas during a reparent. (the jumping-around only happens when you release the mouse)

**Problem:**
If a Fragment is a hiddenInstance or a displayNoneInstance, what do we do? Currenty, the code applies a style prop on them, which will do nothing and it's sad.

**Fix:**
The fix is dead simple. If an element is marked as displayNone or hiddenInstance, make _all_ descendants also display: none or hidden. 

**Commit Details:**
- Hide all descendants of hidden elements
- Test!!!