### PR TITLE
Outline view for conditional expressions.

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
@@ -3,6 +3,7 @@ import { StoryboardFilePath } from '../../editor/store/editor-state'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
 import * as EP from '../../../core/shared/element-path'
 import { FOR_TESTS_setNextGeneratedUids } from '../../../core/model/element-template-utils.test-utils'
+import { setFeatureForBrowserTests } from '../../../utils/utils.test-utils'
 
 const appFilePath = '/src/app.js'
 const appFileContent = `
@@ -62,6 +63,7 @@ async function createAndRenderProject() {
 }
 
 describe('a project with conditionals', () => {
+  setFeatureForBrowserTests('Conditional support', true)
   it('fills the content of the navigator', async () => {
     FOR_TESTS_setNextGeneratedUids([
       'mock1',
@@ -74,7 +76,7 @@ describe('a project with conditionals', () => {
       'conditional1',
     ])
     const renderedProject = await createAndRenderProject()
-    const navigatorTargets = renderedProject.getEditorState().derived.navigatorTargets
+    const navigatorTargets = renderedProject.getEditorState().derived.visibleNavigatorTargets
     const pathStrings = navigatorTargets.map(EP.toString)
     expect(pathStrings).toEqual([
       'storyboard/scene',
@@ -83,6 +85,8 @@ describe('a project with conditionals', () => {
       'storyboard/scene/app:app-root/conditional1',
       'storyboard/scene/app:app-root/conditional1/conditional2',
       'storyboard/scene/app:app-root/conditional1/conditional2/div-inside-conditionals',
+      'storyboard/scene/app:app-root/conditional1/conditional2/else-case',
+      'storyboard/scene/app:app-root/conditional1/else-case',
     ])
   })
 })

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -344,8 +344,11 @@ export function renderCoreElement(
     case 'JSX_CONDITIONAL_EXPRESSION': {
       const commentFlag = findUtopiaCommentFlag(element.comments, 'conditional')
       const override = isUtopiaCommentFlagConditional(commentFlag) ? commentFlag.value : null
-      const conditionValue =
+      const conditionValueAsAny =
         override ?? jsxAttributeToValue(filePath, inScope, requireResult, element.condition)
+      // Coerce `conditionValueAsAny` to a value that is definitely a boolean, not something that is truthy.
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      const conditionValue: boolean = !!conditionValueAsAny
       const actualElement = conditionValue ? element.whenTrue : element.whenFalse
 
       if (elementPath != null) {

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -1,0 +1,58 @@
+import { ElementPath } from '../shared/project-file-types'
+import * as EP from '../shared/element-path'
+import {
+  ChildOrAttribute,
+  childOrBlockIsChild,
+  JSXConditionalExpression,
+} from '../shared/element-template'
+import { ElementPathTree } from '../shared/element-path-tree'
+import { getUtopiaID } from './element-template-utils'
+
+export type ThenOrElse = 'then' | 'else'
+
+export function getThenOrElsePath(elementPath: ElementPath, thenOrElse: ThenOrElse): ElementPath {
+  return EP.appendToPath(elementPath, `${thenOrElse}-case`)
+}
+
+// Get the path for the clause (then or else) of a conditional.
+export function getConditionalClausePath(
+  conditionalPath: ElementPath,
+  conditionalClause: ChildOrAttribute,
+  thenOrElse: ThenOrElse,
+): ElementPath {
+  if (childOrBlockIsChild(conditionalClause)) {
+    return EP.appendToPath(conditionalPath, getUtopiaID(conditionalClause))
+  } else {
+    return getThenOrElsePath(conditionalPath, thenOrElse)
+  }
+}
+
+// Ensure that the children of a conditional are the whenTrue clause followed
+// by the whenFalse clause.
+export function reorderConditionalChildPathTrees(
+  conditional: JSXConditionalExpression,
+  conditionalPath: ElementPath,
+  childPaths: Array<ElementPathTree>,
+): Array<ElementPathTree> {
+  if (childPaths.length > 2) {
+    throw new Error(`Too many child paths.`)
+  } else {
+    let result: Array<ElementPathTree> = []
+
+    // The whenTrue clause should be first.
+    const thenPath = getConditionalClausePath(conditionalPath, conditional.whenTrue, 'then')
+    const thenPathTree = childPaths.find((childPath) => EP.pathsEqual(childPath.path, thenPath))
+    if (thenPathTree != null) {
+      result.push(thenPathTree)
+    }
+
+    // The whenFalse clause should be second.
+    const elsePath = getConditionalClausePath(conditionalPath, conditional.whenFalse, 'else')
+    const elsePathTree = childPaths.find((childPath) => EP.pathsEqual(childPath.path, elsePath))
+    if (elsePathTree != null) {
+      result.push(elsePathTree)
+    }
+
+    return result
+  }
+}

--- a/editor/src/core/shared/optics/optic-utilities.spec.ts
+++ b/editor/src/core/shared/optics/optic-utilities.spec.ts
@@ -7,6 +7,7 @@ import {
   anyBy,
   exists,
   foldLOf,
+  forEachOf,
   inverseGet,
   modify,
   set,
@@ -456,6 +457,53 @@ describe('exists', () => {
   it('returns the expected value with a TRAVERSAL', () => {
     const property = FastCheck.property(FastCheck.array(FastCheck.integer()), (integerArray) => {
       return fastDeepEquals(exists(traverseArray(), integerArray), integerArray.length > 0)
+    })
+    FastCheck.assert(property, { verbose: true })
+  })
+})
+
+describe('forEachOf', () => {
+  it('returns the expected value with an ISO', () => {
+    const property = FastCheck.property(FastCheck.boolean(), (bool) => {
+      let result: Array<boolean> = []
+      forEachOf(not, bool, (b) => {
+        result.push(b)
+      })
+      return fastDeepEquals(result, [!bool])
+    })
+    FastCheck.assert(property, { verbose: true })
+  })
+  it('returns the expected value with a LENS', () => {
+    const property = FastCheck.property(fromFieldTestArbitrary, (fromFieldTest) => {
+      let result: Array<string> = []
+      forEachOf(fromField<FromFieldTest, 'testField'>('testField'), fromFieldTest, (s) => {
+        result.push(s)
+      })
+      return fastDeepEquals(result, [fromFieldTest.testField])
+    })
+    FastCheck.assert(property, { verbose: true })
+  })
+  it('returns the expected value with a PRISM', () => {
+    const property = FastCheck.property(FastCheck.integer(), (number) => {
+      let result: Array<number> = []
+      forEachOf(
+        filtered((toCheck: number) => toCheck > 1000),
+        number,
+        (n) => {
+          result.push(n)
+        },
+      )
+      return fastDeepEquals(result, number > 1000 ? [number] : [])
+    })
+    FastCheck.assert(property, { verbose: true })
+  })
+  it('returns the expected value with a TRAVERSAL', () => {
+    const property = FastCheck.property(FastCheck.array(FastCheck.integer()), (integerArray) => {
+      let result: Array<number> = []
+      forEachOf(traverseArray<number>(), integerArray, (n) => {
+        result.push(n)
+      })
+      return fastDeepEquals(result, integerArray)
     })
     FastCheck.assert(property, { verbose: true })
   })

--- a/editor/src/core/shared/optics/optic-utilities.ts
+++ b/editor/src/core/shared/optics/optic-utilities.ts
@@ -1,5 +1,5 @@
 import { prism, lens, traversal, iso, Optic } from './optics'
-import { right, left, foldEither, Either } from '../either'
+import { right, left, foldEither, Either, forEachRight } from '../either'
 import { assertNever } from '../utils'
 
 export function toArrayOf<S, A>(withOptic: Optic<S, A>, s: S): Array<A> {
@@ -176,4 +176,23 @@ export function unsafeGet<S, A>(withOptic: Optic<S, A>, s: S): A {
     },
     toFirst(withOptic, s),
   )
+}
+
+export function forEachOf<S, A>(withOptic: Optic<S, A>, s: S, withEach: (a: A) => void): void {
+  switch (withOptic.type) {
+    case 'ISO':
+      withEach(withOptic.from(s))
+      break
+    case 'LENS':
+      withEach(withOptic.from(s))
+      break
+    case 'PRISM':
+      forEachRight(withOptic.from(s), withEach)
+      break
+    case 'TRAVERSAL':
+      withOptic.from(s).forEach(withEach)
+      break
+    default:
+      assertNever(withOptic)
+  }
 }


### PR DESCRIPTION
**Problem:**
Currently conditionals only show the currently enabled branch, which means that it's impossible to modify the structure without flipping the conditional back and forth.

**Fix:**
Now when rendering the canvas, upon reaching a conditional expression the alternative case of the conditional is partly explored to provide an entry so that it can be shown in the navigator. As opposed to all the other elements which rely on insertion order to provide the ordering in the navigator for a conditional we fix the ordering to have the `whenTrue` case before the `whenFalse` case.

A fix was also included for `fillSpyOnlyMetadata` which was only including recursive children, not the immediate children in a listing of children.

**Screenshot:**
![image](https://user-images.githubusercontent.com/217400/221570044-0dea0005-4454-447f-bfb1-1721786f7019.png)

**Limitations:**
Currently this is a view only rendering, so reparenting into the alternative case will not work.

**Commit Details:**
- Added `addConditionalAlternative` which builds spy entries for conditional clauses which don't ordinarily generate them.
- Created `addFakeSpyEntry` to create a fake spy entry.
- Added `getThenOrElsePath` and `getConditionalClausePath` utility functions.
- Implemented `reorderConditionalChildPathTrees` to create a consistent ordering of `ElementPathTree` children if an element is a conditional expression.
- Fixed an issue in `fillSpyOnlyMetadata` where `childrenAndUnfurledComponentsNotInDom` was not included in `childrenAndUnfurledComponents`.
- Added `forEachOf` optic utility function.