### PR TITLE
fixing react warning caused by localClearRuntimeErrors 

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -90,8 +90,11 @@ const CanvasComponentEntryInner = React.memo((props: CanvasComponentEntryProps) 
   )
 
   const localClearRuntimeErrors = React.useCallback(() => {
-    setLastRenderReactHookError(false)
-    clearRuntimeErrors()
+    // this is wrapped in a timeout 0 to avoid the React bad setState() warning "Cannot update a component (`Unknown`) while rendering a different component (`Unknown`)."
+    setTimeout(() => {
+      setLastRenderReactHookError(false)
+      clearRuntimeErrors()
+    }, 0)
   }, [clearRuntimeErrors])
 
   const containerRef = useApplyCanvasOffsetToStyle(true)


### PR DESCRIPTION
**Problem:**
localClearRuntimeErrors calls a react setState during the canvas render phase. this is illegal!

**Fix:**
wrap callbacks in a timeout 0