### PR TITLE
Fix/react fragment warning

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -587,15 +587,17 @@ function renderJSXElement(
       ? { ...elementPropsWithScenePath, [UTOPIA_SCENE_ID_KEY]: EP.toString(elementPath) }
       : elementPropsWithScenePath
 
-  const finalProps =
-    elementIsIntrinsic && !elementIsBaseHTML
-      ? filterDataProps(elementPropsWithSceneID)
-      : elementPropsWithSceneID
-
-  const finalPropsIcludingElementPath = {
-    ...finalProps,
+  const propsIncludingElementPath = {
+    ...elementPropsWithSceneID,
     [UTOPIA_PATH_KEY]: optionalMap(EP.toString, elementPath),
   }
+
+  const looksLikeReactIntrinsicButNotHTML = elementIsIntrinsic && !elementIsBaseHTML
+
+  const finalProps =
+    looksLikeReactIntrinsicButNotHTML || elementIsFragment
+      ? filterDataProps(propsIncludingElementPath)
+      : propsIncludingElementPath
 
   if (!elementIsFragment && FinalElement == null) {
     throw canvasMissingJSXElementError(jsxFactoryFunctionName, code, jsx, filePath, highlightBounds)
@@ -610,7 +612,7 @@ function renderJSXElement(
         filePath: filePath,
         text: textContent,
         component: FinalElement,
-        passthroughProps: finalPropsIcludingElementPath,
+        passthroughProps: finalProps,
       }
 
       return buildSpyWrappedElement(
@@ -630,7 +632,7 @@ function renderJSXElement(
     }
     return buildSpyWrappedElement(
       jsx,
-      finalPropsIcludingElementPath,
+      finalProps,
       elementPath,
       metadataContext,
       updateInvalidatedPaths,
@@ -647,7 +649,7 @@ function renderJSXElement(
       inScope,
       jsxFactoryFunctionName,
       FinalElementOrFragment,
-      finalPropsIcludingElementPath,
+      finalProps,
       ...childrenElements,
     )
   }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-warnings-errors.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-warnings-errors.spec.browser2.tsx
@@ -1,0 +1,32 @@
+import { getConsoleLogsForTests } from '../../../core/shared/runtime-report-logs'
+import { setFeatureForBrowserTests } from '../../../utils/utils.test-utils'
+import { makeTestProjectCodeWithSnippet, renderTestEditorWithCode } from '../ui-jsx.test-utils'
+
+describe('Canvas Renderer Warnings', () => {
+  setFeatureForBrowserTests('Fragment support', true)
+
+  it('renders a Fragment without a react props error', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div data-uid='wrapper-div'>
+          <React.Fragment data-uid='cica'>
+            <View
+              style={{
+                backgroundColor: '#aaaaaa33',
+                position: 'absolute',
+                left: 190,
+                top: 174,
+                width: 132,
+                height: 146,
+              }}
+              data-uid='99f'
+            />
+          </React.Fragment>
+        </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    expect(getConsoleLogsForTests()).toEqual([])
+  })
+})

--- a/editor/src/core/shared/runtime-report-logs.tsx
+++ b/editor/src/core/shared/runtime-report-logs.tsx
@@ -116,3 +116,7 @@ export function useWriteOnlyConsoleLogs(): {
     clearConsoleLogs: clearConsoleLogs,
   }
 }
+
+export function getConsoleLogsForTests(): Array<ConsoleLog> {
+  return consoleLogsAtom.currentValue
+}


### PR DESCRIPTION
**Problem:**
When rendering fragments we accidentally put data-path and other stuff on them that are NOT coming from the user's code.

**Fix:**
Omit utopia's automatic props from Fragments.

**Commit Details:**
- Test!!!!
- A tweak to renderCoreElement, omitting Utopia props from framgents