### PR TITLE
Highlight overridden branch in navigator

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -485,7 +485,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
     return getConditionalFlag(element)
   }, [element])
 
-  const branchConditionalOverride = React.useMemo(() => {
+  const isActiveBranchOfOverriddenConditional = React.useMemo(() => {
     const parentOverride = getConditionalFlag(parent)
     if (
       parentOverride == null ||
@@ -493,7 +493,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
       isLeft(parent.element) ||
       !isJSXConditionalExpression(parent.element.value)
     ) {
-      return null
+      return false
     }
 
     const thenPath = getConditionalClausePath(parentPath, parent.element.value.whenTrue, 'then')
@@ -505,11 +505,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
     } else if (EP.pathsEqual(props.elementPath, elsePath)) {
       branch = false
     }
-
-    if (branch !== parentOverride) {
-      return null
-    }
-    return branch
+    return branch === parentOverride
   }, [props.elementPath, parent, parentPath])
 
   return (
@@ -532,7 +528,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
         inputVisible={EP.pathsEqual(props.renamingTarget, props.elementPath)}
         style={{
           color:
-            !props.selected && branchConditionalOverride != null
+            !props.selected && isActiveBranchOfOverriddenConditional
               ? colorTheme.brandNeonPink.value
               : 'inherit',
         }}

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -499,13 +499,13 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
     const thenPath = getConditionalClausePath(parentPath, parent.element.value.whenTrue, 'then')
     const elsePath = getConditionalClausePath(parentPath, parent.element.value.whenFalse, 'else')
 
-    let branch: boolean | null = null
     if (EP.pathsEqual(props.elementPath, thenPath)) {
-      branch = true
+      return parentOverride
     } else if (EP.pathsEqual(props.elementPath, elsePath)) {
-      branch = false
+      return !parentOverride
+    } else {
+      return false
     }
-    return branch === parentOverride
   }, [props.elementPath, parent, parentPath])
 
   return (

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -23,11 +23,12 @@ import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { when } from '../../../utils/react-conditionals'
 import { isLeft } from '../../../core/shared/either'
 import {
+  ChildOrAttribute,
   ElementInstanceMetadata,
   isJSXConditionalExpression,
 } from '../../../core/shared/element-template'
 import { findUtopiaCommentFlag } from '../../../core/shared/comment-flags'
-import { getConditionalClausePath } from '../../../core/model/conditionals'
+import { getConditionalClausePath, ThenOrElse } from '../../../core/model/conditionals'
 
 export const NavigatorItemTestId = (pathString: string): string =>
   `NavigatorItemTestId-${pathString}`
@@ -496,16 +497,21 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
       return false
     }
 
-    const thenPath = getConditionalClausePath(parentPath, parent.element.value.whenTrue, 'then')
-    const elsePath = getConditionalClausePath(parentPath, parent.element.value.whenFalse, 'else')
-
-    if (EP.pathsEqual(props.elementPath, thenPath)) {
-      return parentOverride
-    } else if (EP.pathsEqual(props.elementPath, elsePath)) {
-      return !parentOverride
-    } else {
-      return false
+    function matchesOverriddenBranch(
+      clause: ChildOrAttribute,
+      thenOrElse: ThenOrElse,
+      wantOverride: boolean,
+    ): boolean {
+      return (
+        wantOverride === parentOverride &&
+        EP.pathsEqual(props.elementPath, getConditionalClausePath(parentPath, clause, thenOrElse))
+      )
     }
+
+    return (
+      matchesOverriddenBranch(parent.element.value.whenTrue, 'then', true) ||
+      matchesOverriddenBranch(parent.element.value.whenFalse, 'else', false)
+    )
   }, [props.elementPath, parent, parentPath])
 
   return (


### PR DESCRIPTION
Fixes #3357 

**Problem:**
Now that we show both conditional branches in the navigator, when there are overrides the current branch should also be highlighted in the navigator.

**Fix:**

The PR sets the color of the (unselected) branches to match the one of the override accents used for the conditional condition badge and inspector section.

![Kapture 2023-02-27 at 17 39 38](https://user-images.githubusercontent.com/1081051/221625042-ab1fd244-db43-4f50-9d6e-71211071200a.gif)
