### PR TITLE
Ancestor metastrategy behavior with children affecting elements

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.spec.browser2.tsx
@@ -530,7 +530,7 @@ describe('finds an applicable strategy for the nearest ancestor', () => {
 
 describe('Fragments are transparent for ancestor metastrategy', () => {
   setFeatureForBrowserTests('Fragment support', true)
-  it('dragging a fragment with absolute children trigger absolute move', () =>
+  it('dragging a fragment with multiple absolute children trigger absolute move', () =>
     runTest(
       TestProjectFragmentWithAbsoluteChildren,
       EP.fromString('storyboard/scene/container/outer/fragment'),

--- a/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.spec.browser2.tsx
@@ -545,7 +545,7 @@ describe('Fragments are transparent for ancestor metastrategy', () => {
         expect(strategies[0].strategy.id).toEqual('ABSOLUTE_MOVE')
       },
     ))
-  it('dragging a fragment with no siblings and children no siblings triggers ancestor metastrategy', () =>
+  it('dragging a fragment with no siblings and single child triggers ancestor metastrategy', () =>
     runTest(
       TestProjectFragmentWithNoSiblings,
       EP.fromString('storyboard/scene/container/outer/fragment'),

--- a/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.spec.browser2.tsx
@@ -2,6 +2,7 @@ import * as EP from '../../../../core/shared/element-path'
 import { WindowPoint, windowPoint } from '../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import { shiftModifier } from '../../../../utils/modifiers'
+import { setFeatureForBrowserTests, wait } from '../../../../utils/utils.test-utils'
 import { selectComponents } from '../../../editor/actions/meta-actions'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import {
@@ -321,6 +322,133 @@ const TestProjectAbsoluteAndFlow = `
 </div>
 `
 
+const TestProjectFragmentWithAbsoluteChildren = `
+import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+import { App } from '/src/app.js'
+import { View, Rectangle } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='storyboard'>
+    <Scene
+      style={{
+        width: 700,
+        height: 759,
+        position: 'absolute',
+        left: 207,
+        top: 126,
+      }}
+      data-label='Playground'
+      data-uid='scene'
+    >
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          contain: 'layout',
+        }}
+        data-uid='container'
+      >
+        <div
+          style={{
+            position: 'absolute',
+            left: 359,
+            top: 57,
+            width: 196,
+            height: 82,
+          }}
+          data-uid='outer'
+        >
+          <React.Fragment data-uid='fragment'>
+            <div
+              data-testid='${DraggedDivId}'
+              style={{
+                backgroundColor: 'red',
+                position: 'absolute',
+                flexBasis: 80,
+                height: 28,
+                width: 40,
+                left: 27,
+                top: 37,
+              }}
+              data-uid='child1'
+            />
+            <div
+              style={{
+                backgroundColor: 'red',
+                position: 'absolute',
+                flexBasis: 80,
+                height: 28,
+                width: 40,
+                left: 27,
+                top: 37,
+              }}
+              data-uid='child2'
+            />
+          </React.Fragment>
+        </div>
+      </div>
+    </Scene>
+  </Storyboard>
+)
+`
+
+const TestProjectFragmentWithNoSiblings = `
+import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+import { App } from '/src/app.js'
+import { View, Rectangle } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='storyboard'>
+    <Scene
+      style={{
+        width: 700,
+        height: 759,
+        position: 'absolute',
+        left: 207,
+        top: 126,
+      }}
+      data-label='Playground'
+      data-uid='scene'
+    >
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          contain: 'layout',
+        }}
+        data-uid='container'
+      >
+        <div
+          style={{
+            top: 73,
+            left: 63,
+            width: 200,
+            height: 200,
+            position: 'absolute',
+          }}
+          data-uid='outer'
+        >
+          <React.Fragment data-uid='fragment'>
+            <div
+              data-testid='${DraggedDivId}'
+              style={{
+                backgroundColor: 'red',
+                flexBasis: 80,
+                height: 28,
+                width: 40,
+              }}
+              data-uid='child'
+            />
+          </React.Fragment>
+        </div>
+      </div>
+    </Scene>
+  </Storyboard>
+)
+`
+
 async function dragElement(
   canvasControlsLayer: HTMLElement,
   startPoint: WindowPoint,
@@ -398,6 +526,40 @@ describe('finds an applicable strategy for the nearest ancestor', () => {
       }
       expect(strategies[0].strategy.id).toEqual('FLOW_REORDER')
     }))
+})
+
+describe('Fragments are transparent for ancestor metastrategy', () => {
+  setFeatureForBrowserTests('Fragment support', true)
+  it('dragging a fragment with absolute children trigger absolute move', () =>
+    runTest(
+      TestProjectFragmentWithAbsoluteChildren,
+      EP.fromString('storyboard/scene/container/outer/fragment'),
+      (editor) => {
+        const strategies = editor.getEditorState().strategyState.sortedApplicableStrategies
+
+        expect(strategies?.length).toBeGreaterThan(0)
+        if (strategies == null) {
+          // here for type assertion
+          throw new Error('`strategies` should not be null')
+        }
+        expect(strategies[0].strategy.id).toEqual('ABSOLUTE_MOVE')
+      },
+    ))
+  it('dragging a fragment with no siblings and children no siblings triggers ancestor metastrategy', () =>
+    runTest(
+      TestProjectFragmentWithNoSiblings,
+      EP.fromString('storyboard/scene/container/outer/fragment'),
+      (editor) => {
+        const strategies = editor.getEditorState().strategyState.sortedApplicableStrategies
+
+        expect(strategies?.length).toBeGreaterThan(0)
+        if (strategies == null) {
+          // here for type assertion
+          throw new Error('`strategies` should not be null')
+        }
+        expect(strategies[0].strategy.id.endsWith('_ANCESTOR_1')).toBeTruthy()
+      },
+    ))
 })
 
 describe('finds keyboard strategy for absolute ancestor', () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.tsx
@@ -37,6 +37,12 @@ export function ancestorMetaStrategy(
 
     const target = targets[0]
 
+    // Avoid children of the storyboard
+    if (EP.isEmptyPath(target) || EP.isStoryboardPath(target) || EP.isStoryboardChild(target)) {
+      // TODO Maybe avoid root elements?
+      return []
+    }
+
     const groupLikeChildren = retargetStrategyToChildrenOfContentAffectingElements(canvasState)
 
     if (groupLikeChildren.length !== 1) {
@@ -44,12 +50,6 @@ export function ancestorMetaStrategy(
     }
 
     const groupLikeChild = groupLikeChildren[0]
-
-    // Avoid children of the storyboard
-    if (EP.isEmptyPath(target) || EP.isStoryboardPath(target) || EP.isStoryboardChild(target)) {
-      // TODO Maybe avoid root elements?
-      return []
-    }
 
     // Is the selected element an only child?
     const siblings = MetadataUtils.getSiblingsUnordered(

--- a/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.tsx
@@ -43,19 +43,16 @@ export function ancestorMetaStrategy(
       return []
     }
 
-    const groupLikeChildren = retargetStrategyToChildrenOfContentAffectingElements(canvasState)
+    const unrolledChildren = retargetStrategyToChildrenOfContentAffectingElements(canvasState)
 
-    if (groupLikeChildren.length !== 1) {
+    if (unrolledChildren.length !== 1) {
       return []
     }
 
-    const groupLikeChild = groupLikeChildren[0]
+    const unrolledChild = unrolledChildren[0]
 
     // Is the selected element an only child?
-    const siblings = MetadataUtils.getSiblingsUnordered(
-      canvasState.startingMetadata,
-      groupLikeChild,
-    )
+    const siblings = MetadataUtils.getSiblingsUnordered(canvasState.startingMetadata, unrolledChild)
     if (siblings.length > 1) {
       return []
     }
@@ -63,7 +60,7 @@ export function ancestorMetaStrategy(
     // Is the selected element a flow layout element?
     const targetMetadata = MetadataUtils.findElementByElementPath(
       canvasState.startingMetadata,
-      groupLikeChild,
+      unrolledChild,
     )
     const isStaticLayout = !(
       MetadataUtils.isPositionAbsolute(targetMetadata) ||

--- a/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.tsx
@@ -14,6 +14,10 @@ import {
   InteractionLifecycle,
   targetPaths,
 } from '../canvas-strategy-types'
+import {
+  retargetStrategyToChildrenOfContentAffectingElements,
+  treatElementAsContentAffecting,
+} from './group-like-helpers'
 
 export function ancestorMetaStrategy(
   allOtherStrategies: Array<MetaCanvasStrategy>,
@@ -33,6 +37,14 @@ export function ancestorMetaStrategy(
 
     const target = targets[0]
 
+    const groupLikeChildren = retargetStrategyToChildrenOfContentAffectingElements(canvasState)
+
+    if (groupLikeChildren.length !== 1) {
+      return []
+    }
+
+    const groupLikeChild = groupLikeChildren[0]
+
     // Avoid children of the storyboard
     if (EP.isEmptyPath(target) || EP.isStoryboardPath(target) || EP.isStoryboardChild(target)) {
       // TODO Maybe avoid root elements?
@@ -40,7 +52,10 @@ export function ancestorMetaStrategy(
     }
 
     // Is the selected element an only child?
-    const siblings = MetadataUtils.getSiblingsUnordered(canvasState.startingMetadata, target)
+    const siblings = MetadataUtils.getSiblingsUnordered(
+      canvasState.startingMetadata,
+      groupLikeChild,
+    )
     if (siblings.length > 1) {
       return []
     }
@@ -48,7 +63,7 @@ export function ancestorMetaStrategy(
     // Is the selected element a flow layout element?
     const targetMetadata = MetadataUtils.findElementByElementPath(
       canvasState.startingMetadata,
-      target,
+      groupLikeChild,
     )
     const isStaticLayout = !(
       MetadataUtils.isPositionAbsolute(targetMetadata) ||


### PR DESCRIPTION
**Problem:**
Ancestor metastrategy doesn't work well with children-affecting targets, because it checks for the properties of the children-affecting target, and not its children (even though e.g. with absolute move, the children will be moved and not the original target).

**Fix:**
Make the children affecting target transparent for the ancestor metastrategy: when we are not checking a property which is in relation to the parent (e.g. is this a root element), then use the children of a children affecting element.

**Disclaimer:**
The ancestor metastrategy does not work for multiselection. Because we modify the target to all children, when there are multiple children, the ancestor metastrategy will never be active. I did not improve this in the PR, because ancestor metastrategy behavior for multiselection was out of scope. On the other hand this really limits the usecases for the PR - because e.g. why would you use fragments at all when there is only a single child. So let's improve this later.

