### PR TITLE
Clearer handling when no default strategy available

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-move-metastrategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-move-metastrategy.spec.browser2.tsx
@@ -126,6 +126,40 @@ describe('Drag To Move Metastrategy', () => {
 })
 
 describe('Drag To Move Strategy Indicator', () => {
+  it('when the DO_NOTHING strategy is active, nothing is active in the Strategy Indicator', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(TestProject1),
+      'await-first-dom-report',
+    )
+
+    const targetElement = renderResult.renderedDOM.getByTestId('child-1')
+    const targetElementBounds = targetElement.getBoundingClientRect()
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    const startPoint = windowPoint({ x: targetElementBounds.x + 5, y: targetElementBounds.y + 5 })
+    const dragDelta = windowPoint({ x: 10, y: 10 })
+
+    const midDragCallback = async () => {
+      expect(renderResult.getEditorState().strategyState.currentStrategy).toEqual('DO_NOTHING')
+
+      const { showIndicator, dragType, reparent, ancestor } =
+        renderResult.getEditorState().editor.canvas.controls.dragToMoveIndicatorFlags
+
+      expect(showIndicator).toEqual(true)
+      expect(dragType).toEqual('none')
+      expect(reparent).toEqual('none')
+      expect(ancestor).toEqual(false)
+
+      const indicator = renderResult.renderedDOM.getByTestId('drag-strategy-indicator')
+      expect(indicator).toBeDefined()
+    }
+
+    await mouseClickAtPoint(canvasControlsLayer, startPoint, { modifiers: cmdModifier })
+    await mouseDragFromPointWithDelta(canvasControlsLayer, startPoint, dragDelta, {
+      modifiers: emptyModifiers,
+      midDragCallback: midDragCallback,
+    })
+  })
   it('when reparenting an element the Strategy Indicator is visible', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(TestProject1),

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-move-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-move-metastrategy.tsx
@@ -123,7 +123,7 @@ export function doNothingStrategy(
   const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
   return {
     id: 'DO_NOTHING',
-    name: '(Move)',
+    name: 'No Default Available',
     controlsToRender: [
       controlWithProps({
         control: DragOutlineControl,
@@ -153,7 +153,7 @@ export function doNothingStrategy(
               dragToMoveIndicatorFlags: {
                 $set: {
                   showIndicator: true,
-                  dragType: 'static',
+                  dragType: 'none',
                   reparent: 'none',
                   ancestor: false,
                 },

--- a/editor/src/components/canvas/controls/select-mode/strategy-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/strategy-indicator.tsx
@@ -54,7 +54,7 @@ export const StrategyIndicator = React.memo(() => {
 })
 
 interface MoveIndicatorItemProps {
-  dragType: 'absolute' | 'static'
+  dragType: 'absolute' | 'static' | 'none'
 }
 
 const MoveIndicatorItem = React.memo<MoveIndicatorItemProps>((props) => {
@@ -73,8 +73,11 @@ const MoveIndicatorItem = React.memo<MoveIndicatorItemProps>((props) => {
           <VisibilityWrapper visible={props.dragType === 'absolute'}>
             <ModalityIcons.MoveAbsolute color={'on-highlight-main'} />
           </VisibilityWrapper>
-          <VisibilityWrapper visible={props.dragType !== 'absolute'}>
+          <VisibilityWrapper visible={props.dragType === 'static'}>
             <ModalityIcons.MoveAbsolute color={'main'} />
+          </VisibilityWrapper>
+          <VisibilityWrapper visible={props.dragType === 'none'}>
+            <ModalityIcons.MoveAbsolute color={'subdued'} />
           </VisibilityWrapper>
         </div>
         <div
@@ -88,12 +91,21 @@ const MoveIndicatorItem = React.memo<MoveIndicatorItemProps>((props) => {
           <VisibilityWrapper visible={props.dragType === 'static'}>
             <ModalityIcons.Reorder color={'on-highlight-main'} />
           </VisibilityWrapper>
-          <VisibilityWrapper visible={props.dragType !== 'static'}>
+          <VisibilityWrapper visible={props.dragType === 'absolute'}>
             <ModalityIcons.Reorder color={'main'} />
+          </VisibilityWrapper>
+          <VisibilityWrapper visible={props.dragType === 'none'}>
+            <ModalityIcons.Reorder color={'subdued'} />
           </VisibilityWrapper>
         </div>
       </FlexRow>
-      <div style={{}}>{props.dragType === 'absolute' ? 'Move' : 'Reorder'}</div>
+      <div
+        style={{
+          color: props.dragType === 'none' ? colorTheme.fg8.value : colorTheme.fg2.value,
+        }}
+      >
+        {props.dragType === 'static' ? 'Reorder' : 'Move'}
+      </div>
     </FlexColumn>
   )
 })

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -821,7 +821,7 @@ export function editorStateCanvasTransientProperty(
 
 export function dragToMoveIndicatorFlags(
   showIndicator: boolean,
-  dragType: 'absolute' | 'static',
+  dragType: 'absolute' | 'static' | 'none',
   reparent: 'same-component' | 'different-component' | 'none',
   ancestor: boolean,
 ): DragToMoveIndicatorFlags {
@@ -841,7 +841,7 @@ export const emptyDragToMoveIndicatorFlags = dragToMoveIndicatorFlags(
 )
 export interface DragToMoveIndicatorFlags {
   showIndicator: boolean
-  dragType: 'absolute' | 'static'
+  dragType: 'absolute' | 'static' | 'none'
   reparent: 'same-component' | 'different-component' | 'none'
   ancestor: boolean
 }

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1669,7 +1669,7 @@ export const DragToMoveIndicatorFlagsKeepDeepEquality: KeepDeepEqualityCall<Drag
     (indicatorFlag) => indicatorFlag.showIndicator,
     BooleanKeepDeepEquality,
     (indicatorFlag) => indicatorFlag.dragType,
-    createCallWithTripleEquals<'absolute' | 'static'>(),
+    createCallWithTripleEquals<'absolute' | 'static' | 'none'>(),
     (indicatorFlag) => indicatorFlag.reparent,
     createCallWithTripleEquals<'same-component' | 'different-component' | 'none'>(),
     (indicatorFlag) => indicatorFlag.ancestor,


### PR DESCRIPTION
**Problem:**
The "DO_NOTHING" strategy serves as a placeholder for when there are strategies missing, or we actually want to do nothing by default, but it is very unclear that nothing is happening **deliberately**.

**Fix:**
1. Change styling of the top bar to reflect that nothing is applicable
2. Change the "Do nothing" strategy's label from "(Move)" to "No Default Available"

![do-nothing-strategy](https://user-images.githubusercontent.com/1044774/221930963-5c057568-5da0-43a3-ba34-0ac76556864e.gif)
