### PR TITLE
Prevent the testing library from printing the dom on getElementError

### DIFF
--- a/editor/karma-setup.js
+++ b/editor/karma-setup.js
@@ -1,6 +1,7 @@
 // // The matchers API
 import expect from 'expect'
 import * as BrowserFS from 'browserfs'
+import * as ReactTestingLibrary from '@testing-library/react'
 
 // eslint react plugin uses this
 BrowserFS.configure({ fs: 'InMemory', options: {} }, (e) => {
@@ -9,6 +10,13 @@ BrowserFS.configure({ fs: 'InMemory', options: {} }, (e) => {
   }
 })
 window.BrowserFS = BrowserFS
+
+ReactTestingLibrary.configure({
+  getElementError: (message, _container) => {
+    // Prevent the testing library from serialising the whole dom
+    return new Error(message)
+  },
+})
 
 window.expect = expect
 window.jest = null


### PR DESCRIPTION
**Problem:**
When react-testing-library cannot find an element, it  makes a ginormous error message with most of the dom printed, making the test output unreadable and bad.

**Fix:**
@Rheeseyb fixed this problem in f7ffb5064a3d76e6c894cab3c4d1cd5229b1eb38

**Details:**
- This is just Rheese's fix, in a PR for merging.