### PR TITLE
Change no-constant-condition linter rule to warning level

### DIFF
--- a/editor/src/core/workers/linter/eslint-config.ts
+++ b/editor/src/core/workers/linter/eslint-config.ts
@@ -18,7 +18,7 @@ const EsLintRecommended: Linter.RulesRecord = {
   'no-compare-neg-zero': 'error',
   'no-cond-assign': 'error',
   'no-const-assign': 'error',
-  'no-constant-condition': 'error',
+  'no-constant-condition': 'warn',
   'no-control-regex': 'error',
   'no-debugger': 'error',
   'no-delete-var': 'error',


### PR DESCRIPTION
**Problem:**
The `no-constant-condition` rule makes it hard to play with conditionals, it is just too strict to not show the canvas at all just because you used a constant condition in a ternary.
This also make it hard to insert a default ternary, because in a default ternary we want a constant condition what the user can replace to a real one later.

**Fix:**
Set the `no-constant-condition` rule to warning level.