### PR TITLE
Fix runtime error overlay

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -90,11 +90,8 @@ const CanvasComponentEntryInner = React.memo((props: CanvasComponentEntryProps) 
   )
 
   const localClearRuntimeErrors = React.useCallback(() => {
-    // this is wrapped in a timeout 0 to avoid the React bad setState() warning "Cannot update a component (`Unknown`) while rendering a different component (`Unknown`)."
-    setTimeout(() => {
-      setLastRenderReactHookError(false)
-      clearRuntimeErrors()
-    }, 0)
+    setLastRenderReactHookError(false)
+    clearRuntimeErrors()
   }, [clearRuntimeErrors])
 
   const containerRef = useApplyCanvasOffsetToStyle(true)

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -321,10 +321,12 @@ export const UiJsxCanvas = React.memo<UiJsxCanvasPropsWithErrorCallback>((props)
   clearConsoleLogs()
   proxyConsole(console, addToConsoleLogs)
 
-  if (clearErrors != null) {
-    // a new canvas render, a new chance at having no errors
-    clearErrors()
-  }
+  React.useEffect(() => {
+    if (clearErrors != null) {
+      // a new canvas render, a new chance at having no errors
+      clearErrors()
+    }
+  }, [clearErrors])
 
   let metadataContext: UiJsxCanvasContextData = forceNotNull(
     `Missing UiJsxCanvasCtxAtom provider`,


### PR DESCRIPTION
**Problem:**
#3353 introduced a regression, as it was causing runtime errors to be cleared immediately _after_ they had been caught, causing the error overlay to hide after a single frame.

**Fix:**
Use a `useEffect` to clear the runtime errors, so that the clearing will still happen on a canvas render (before the errors are caught), but won't illegally call `setState` during the render.