### PR TITLE
Allow controlling multiple conditionals via the inspector

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -19,11 +19,7 @@ import {
   unparsed,
 } from '../../../core/shared/project-file-types'
 import { setFeatureEnabled } from '../../../utils/feature-switches'
-import {
-  expectSingleUndoStep,
-  selectComponentsForTest,
-  wait,
-} from '../../../utils/utils.test-utils'
+import { expectSingleUndoStep, selectComponentsForTest } from '../../../utils/utils.test-utils'
 import { contentsToTree } from '../../assets'
 import { SubduedBorderRadiusControlTestId } from '../../canvas/controls/select-mode/subdued-border-radius-control'
 import {
@@ -103,7 +99,7 @@ function actionsForUpdatedCode(updatedCodeSnippet: string) {
 async function clickButtonAndSelectTarget(
   renderResult: EditorRenderResult,
   buttonTestId: string,
-  targetPath: ElementPath,
+  targetPath: ElementPath[],
 ): Promise<void> {
   await expectSingleUndoStep(renderResult, async () => {
     await act(async () => {
@@ -114,7 +110,7 @@ async function clickButtonAndSelectTarget(
 
   await act(async () => {
     const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
-    await renderResult.dispatch([selectComponents([targetPath], false)], true)
+    await renderResult.dispatch([selectComponents(targetPath, false)], true)
     await dispatchDone
   })
 
@@ -2227,11 +2223,9 @@ describe('inspector tests with real metadata', () => {
 
       // open the section in the inspector
       {
-        await clickButtonAndSelectTarget(
-          renderResult,
-          ConditionalsControlSectionOpenTestId,
+        await clickButtonAndSelectTarget(renderResult, ConditionalsControlSectionOpenTestId, [
           targetPath,
-        )
+        ])
         expect(renderResult.renderedDOM.getByTestId('bbb')).not.toBeNull()
         expect(renderResult.renderedDOM.queryByTestId('ccc')).toBeNull()
 
@@ -2253,11 +2247,9 @@ describe('inspector tests with real metadata', () => {
 
       // toggle to false
       {
-        await clickButtonAndSelectTarget(
-          renderResult,
-          ConditionalsControlToggleFalseTestId,
+        await clickButtonAndSelectTarget(renderResult, ConditionalsControlToggleFalseTestId, [
           targetPath,
-        )
+        ])
 
         expect(renderResult.renderedDOM.getByTestId('ccc')).not.toBeNull()
         expect(renderResult.renderedDOM.queryByTestId('bbb')).toBeNull()
@@ -2280,11 +2272,9 @@ describe('inspector tests with real metadata', () => {
 
       // toggle to true
       {
-        await clickButtonAndSelectTarget(
-          renderResult,
-          ConditionalsControlToggleTrueTestId,
+        await clickButtonAndSelectTarget(renderResult, ConditionalsControlToggleTrueTestId, [
           targetPath,
-        )
+        ])
 
         expect(renderResult.renderedDOM.queryByTestId('ccc')).toBeNull()
         expect(renderResult.renderedDOM.getByTestId('bbb')).not.toBeNull()
@@ -2307,11 +2297,9 @@ describe('inspector tests with real metadata', () => {
 
       // close the inspector section
       {
-        await clickButtonAndSelectTarget(
-          renderResult,
-          ConditionalsControlSectionCloseTestId,
+        await clickButtonAndSelectTarget(renderResult, ConditionalsControlSectionCloseTestId, [
           targetPath,
-        )
+        ])
         expect(renderResult.renderedDOM.getByTestId('bbb')).not.toBeNull()
         expect(renderResult.renderedDOM.queryByTestId('ccc')).toBeNull()
         expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
@@ -2364,11 +2352,9 @@ describe('inspector tests with real metadata', () => {
         await renderResult.dispatch([selectComponents([targetPath], false)], false)
       })
 
-      await clickButtonAndSelectTarget(
-        renderResult,
-        ConditionalsControlToggleFalseTestId,
+      await clickButtonAndSelectTarget(renderResult, ConditionalsControlToggleFalseTestId, [
         targetPath,
-      )
+      ])
 
       expect(renderResult.renderedDOM.getByTestId('ccc')).not.toBeNull()
       expect(renderResult.renderedDOM.queryByTestId('bbb')).toBeNull()
@@ -2389,6 +2375,189 @@ describe('inspector tests with real metadata', () => {
             </div>
          `),
       )
+    })
+    it('toggles multiple conditional branches', async () => {
+      FOR_TESTS_setNextGeneratedUids([
+        'skip1',
+        'skip2',
+        'skip3',
+        'skip4',
+        'skip5',
+        'skip6',
+        'skip7',
+        'skip8',
+        'skip9',
+        'conditional1',
+        'skip10',
+        'skip11',
+        'conditional2',
+      ])
+      const startSnippet = `
+        <div data-uid='aaa'>
+          {true ? (
+            <div data-uid='bbb' data-testid='bbb'>foo</div>
+          ) : (
+            <div data-uid='ccc' data-testid='ccc'>bar</div>
+          )}
+          {true ? (
+            <div data-uid='ddd' data-testid='ddd'>baz</div>
+          ) : (
+            <div data-uid='eee' data-testid='eee'>qux</div>
+          )}
+        </div>
+      `
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(startSnippet),
+        'await-first-dom-report',
+      )
+
+      expect(renderResult.renderedDOM.getByTestId('bbb')).not.toBeNull()
+
+      const firstConditional = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional1'])
+      const secondConditional = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional2'])
+
+      await act(async () => {
+        await renderResult.dispatch([selectComponents([firstConditional], false)], false)
+      })
+
+      // open the section in the inspector
+      {
+        await clickButtonAndSelectTarget(renderResult, ConditionalsControlSectionOpenTestId, [
+          firstConditional,
+        ])
+        expect(renderResult.renderedDOM.queryByTestId('bbb')).not.toBeNull()
+        expect(renderResult.renderedDOM.queryByTestId('ccc')).toBeNull()
+        expect(renderResult.renderedDOM.queryByTestId('ddd')).not.toBeNull()
+        expect(renderResult.renderedDOM.queryByTestId('eee')).toBeNull()
+
+        expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+          makeTestProjectCodeWithSnippet(`
+            <div data-uid='aaa'>
+              {
+                // @utopia/conditional=true
+                true ? (
+                  <div data-uid='bbb' data-testid='bbb'>foo</div>
+                ) : (
+                  <div data-uid='ccc' data-testid='ccc'>bar</div>
+                )
+              }
+              {true ? (
+                <div data-uid='ddd' data-testid='ddd'>baz</div>
+              ) : (
+                <div data-uid='eee' data-testid='eee'>qux</div>
+              )}
+            </div>
+          `),
+        )
+      }
+
+      const bothConditionals = [firstConditional, secondConditional]
+
+      await act(async () => {
+        await renderResult.dispatch([selectComponents(bothConditionals, false)], false)
+      })
+
+      // toggle both to false
+      {
+        await clickButtonAndSelectTarget(
+          renderResult,
+          ConditionalsControlToggleFalseTestId,
+          bothConditionals,
+        )
+
+        expect(renderResult.renderedDOM.queryByTestId('bbb')).toBeNull()
+        expect(renderResult.renderedDOM.queryByTestId('ccc')).not.toBeNull()
+        expect(renderResult.renderedDOM.queryByTestId('ddd')).toBeNull()
+        expect(renderResult.renderedDOM.queryByTestId('eee')).not.toBeNull()
+
+        expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+          makeTestProjectCodeWithSnippet(`
+            <div data-uid='aaa'>
+            {
+              // @utopia/conditional=false
+              true ? (
+                  <div data-uid='bbb' data-testid='bbb'>foo</div>
+                ) : (
+                  <div data-uid='ccc' data-testid='ccc'>bar</div>
+                )
+              }
+              {
+                // @utopia/conditional=false
+                true ? (
+                  <div data-uid='ddd' data-testid='ddd'>baz</div>
+                  ) : (
+                    <div data-uid='eee' data-testid='eee'>qux</div>
+                    )}
+                    </div>
+                    `),
+        )
+      }
+
+      // toggle to true
+      {
+        await clickButtonAndSelectTarget(
+          renderResult,
+          ConditionalsControlToggleTrueTestId,
+          bothConditionals,
+        )
+
+        expect(renderResult.renderedDOM.queryByTestId('bbb')).not.toBeNull()
+        expect(renderResult.renderedDOM.queryByTestId('ccc')).toBeNull()
+        expect(renderResult.renderedDOM.queryByTestId('ddd')).not.toBeNull()
+        expect(renderResult.renderedDOM.queryByTestId('eee')).toBeNull()
+
+        expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+          makeTestProjectCodeWithSnippet(`
+            <div data-uid='aaa'>
+              {
+                // @utopia/conditional=true
+                true ? (
+                  <div data-uid='bbb' data-testid='bbb'>foo</div>
+                ) : (
+                  <div data-uid='ccc' data-testid='ccc'>bar</div>
+                )
+              }
+              {
+                // @utopia/conditional=true
+                true ? (
+                <div data-uid='ddd' data-testid='ddd'>baz</div>
+              ) : (
+                <div data-uid='eee' data-testid='eee'>qux</div>
+              )}
+            </div>
+          `),
+        )
+      }
+
+      // close the inspector section
+      {
+        await clickButtonAndSelectTarget(
+          renderResult,
+          ConditionalsControlSectionCloseTestId,
+          bothConditionals,
+        )
+        expect(renderResult.renderedDOM.queryByTestId('bbb')).not.toBeNull()
+        expect(renderResult.renderedDOM.queryByTestId('ccc')).toBeNull()
+        expect(renderResult.renderedDOM.queryByTestId('ddd')).not.toBeNull()
+        expect(renderResult.renderedDOM.queryByTestId('eee')).toBeNull()
+
+        expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+          makeTestProjectCodeWithSnippet(`
+            <div data-uid='aaa'>
+              {true ? (
+                <div data-uid='bbb' data-testid='bbb'>foo</div>
+              ) : (
+                <div data-uid='ccc' data-testid='ccc'>bar</div>
+              )}
+              {true ? (
+                <div data-uid='ddd' data-testid='ddd'>baz</div>
+              ) : (
+                <div data-uid='eee' data-testid='eee'>qux</div>
+              )}
+            </div>
+          `),
+        )
+      }
     })
   })
 })

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -41,19 +41,7 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
     'Metadata',
   )
 
-  const areAllConditionals = React.useMemo(() => {
-    return paths.every((path) => {
-      return MetadataUtils.isConditionalFromMetadata(
-        MetadataUtils.findElementByElementPath(jsxMetadata, path),
-      )
-    })
-  }, [paths, jsxMetadata])
-
   const elements = React.useMemo(() => {
-    if (!areAllConditionals) {
-      return []
-    }
-
     return mapDropNulls((path) => {
       const elementMetadata = MetadataUtils.findElementByElementPath(jsxMetadata, path)
       if (
@@ -66,7 +54,7 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
 
       return elementMetadata.element.value
     }, paths)
-  }, [jsxMetadata, paths, areAllConditionals])
+  }, [jsxMetadata, paths])
 
   const condition: Condition = React.useMemo(() => {
     if (elements.length === 0) {
@@ -103,7 +91,7 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
     [dispatch, paths, elements],
   )
 
-  if (!areAllConditionals) {
+  if (elements.length === 0) {
     return null
   }
 


### PR DESCRIPTION
Fixes #3373 

**Problem:**

The conditionals inspector section only allows to control _one_ selected conditional.

**Fix:**

Allow setting the conditional values for multiple selected conditionals.

The contents of the conditionals overrides section will be shown according to the following logic:

| selection                       | show                                 |
| ------------------------------- | ------------------------------------ |
| no overrides set                | collapsed section                    |
| some overrides set              | expanded section, no selected branch |
| all overrides set, mixed values | expanded section, no selected branch |
| all overrides set, equal values | expanded section, selected branch    |

![Kapture 2023-03-01 at 16 22 41](https://user-images.githubusercontent.com/1081051/222191666-93eaed1f-c09d-445a-bd0c-5e673ae50f9f.gif)

Note: this will work even if the selection contains non-conditional items, as they will simply be skipped:

![Kapture 2023-03-01 at 16 55 55](https://user-images.githubusercontent.com/1081051/222192742-2dd33011-0412-40e8-b50b-a952ee8336ab.gif)
