### PR TITLE
Increase weight of space triggered escape hatch

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -104,7 +104,7 @@ export function convertToAbsoluteAndMoveStrategy(
       interactionSession.interactionData.type === 'DRAG' &&
       interactionSession.activeControl.type === 'BOUNDING_AREA'
         ? interactionSession.interactionData.spacePressed
-          ? 5
+          ? 100 // If space is pressed, this should happening!
           : 0.5
         : 0,
     apply: () => {


### PR DESCRIPTION
**Problem:**
If it is possible to trigger the ancestor metastrategy by dragging a component, that would prevent using the space key to trigger the escape hatch (converting the element to absolute positioning)

**Fix:**
Significantly increased the weight of the `CONVERT_TO_ABSOLUTE_AND_MOVE_STRATEGY` when the space key is depressed, and added a test to check that this will beat the ancestor metastrategy.