### PR TITLE
Replace non-JSXElementChild conditional branches with `null` upon deletion

### DIFF
--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -14,20 +14,21 @@ import { deleteSelected, selectComponents } from '../editor/actions/action-creat
 describe('conditionals', () => {
   before(() => setFeatureEnabled('Conditional support', true))
   after(() => setFeatureEnabled('Conditional support', false))
-  it('deleting a conditional branch replaces it with null', async () => {
-    FOR_TESTS_setNextGeneratedUids([
-      'skip1',
-      'skip2',
-      'skip3',
-      'skip4',
-      'skip5',
-      'skip6',
-      'conditional',
-    ])
-    const startSnippet = `
+  describe('deletion', () => {
+    it('replaces a branch with null', async () => {
+      FOR_TESTS_setNextGeneratedUids([
+        'skip1',
+        'skip2',
+        'skip3',
+        'skip4',
+        'skip5',
+        'skip6',
+        'conditional',
+      ])
+      const startSnippet = `
         <div data-uid='aaa'>
         {
-          [].length === 0 ? (
+          true ? (
             <div data-uid='bbb' data-testid='bbb'>foo</div>
           ) : (
             <div data-uid='ccc' data-testid='ccc'>bar</div>
@@ -35,30 +36,64 @@ describe('conditionals', () => {
         }
         </div>
       `
-    const renderResult = await renderTestEditorWithCode(
-      makeTestProjectCodeWithSnippet(startSnippet),
-      'await-first-dom-report',
-    )
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(startSnippet),
+        'await-first-dom-report',
+      )
 
-    const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional', 'bbb'])
-    await act(async () => {
-      await renderResult.dispatch([selectComponents([targetPath], false)], false)
-    })
+      const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional', 'bbb'])
+      await act(async () => {
+        await renderResult.dispatch([selectComponents([targetPath], false)], false)
+      })
 
-    await act(async () => {
-      await renderResult.dispatch([deleteSelected()], true)
-    })
+      await act(async () => {
+        await renderResult.dispatch([deleteSelected()], true)
+      })
 
-    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
-      makeTestProjectCodeWithSnippet(`
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        makeTestProjectCodeWithSnippet(`
             <div data-uid='aaa'>
               {
-                [].length === 0 ? null : (
+                true ? null : (
                   <div data-uid='ccc' data-testid='ccc'>bar</div>
                 )
               }
             </div>
          `),
-    )
+      )
+    })
+    it('replaces a text string branch with null', async () => {
+      FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'conditional'])
+      const startSnippet = `
+        <div data-uid='aaa'>
+        {
+          true ? 'hello' : 'there'
+        }
+        </div>
+      `
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(startSnippet),
+        'await-first-dom-report',
+      )
+
+      const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional', 'then-case'])
+      await act(async () => {
+        await renderResult.dispatch([selectComponents([targetPath], false)], false)
+      })
+
+      await act(async () => {
+        await renderResult.dispatch([deleteSelected()], true)
+      })
+
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        makeTestProjectCodeWithSnippet(`
+            <div data-uid='aaa'>
+              {
+                true ? null : 'there'
+              }
+            </div>
+         `),
+      )
+    })
   })
 })

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -7,11 +7,23 @@ import {
 } from '../shared/element-template'
 import { ElementPathTree } from '../shared/element-path-tree'
 import { getUtopiaID } from './element-template-utils'
+import { assertNever } from '../shared/utils'
 
 export type ThenOrElse = 'then' | 'else'
 
+export function thenOrElsePathPart(thenOrElse: ThenOrElse): string {
+  switch (thenOrElse) {
+    case 'then':
+      return 'then-case'
+    case 'else':
+      return 'else-case'
+    default:
+      assertNever(thenOrElse)
+  }
+}
+
 export function getThenOrElsePath(elementPath: ElementPath, thenOrElse: ThenOrElse): ElementPath {
-  return EP.appendToPath(elementPath, `${thenOrElse}-case`)
+  return EP.appendToPath(elementPath, thenOrElsePathPart(thenOrElse))
 }
 
 // Get the path for the clause (then or else) of a conditional.

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -428,9 +428,12 @@ export function findJSXElementChildAtPath(
           clause: ChildOrAttribute,
           branch: ThenOrElse,
         ): JSXElementChild | null {
+          // if it's an attribute, match its path with the right branch
           if (!childOrBlockIsChild(clause)) {
             return tailPath[0] === thenOrElsePathPart(branch) ? element : null
           }
+
+          // if it's a child, get its inner element
           if (tailPath[0] !== getUtopiaID(clause)) {
             return null
           }

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -438,13 +438,13 @@ export function findJSXElementChildAtPath(
           return null
         }
 
-        const whenTrue = elementOrNullFromClause(element.whenTrue, 'then')
-        if (whenTrue != null) {
-          return whenTrue
+        const elementWhenTrue = elementOrNullFromClause(element.whenTrue, 'then')
+        if (elementWhenTrue != null) {
+          return elementWhenTrue
         }
-        const whenFalse = elementOrNullFromClause(element.whenFalse, 'else')
-        if (whenFalse != null) {
-          return whenFalse
+        const elementWhenFalse = elementOrNullFromClause(element.whenFalse, 'else')
+        if (elementWhenFalse != null) {
+          return elementWhenFalse
         }
 
         return null

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -428,22 +428,26 @@ export function findJSXElementChildAtPath(
           clause: ChildOrAttribute,
           branch: ThenOrElse,
         ): JSXElementChild | null {
-          // if it's an attribute, match its path with the right branch
-          if (!childOrBlockIsChild(clause)) {
-            return tailPath[0] === thenOrElsePathPart(branch) ? element : null
+          const isBlock = childOrBlockIsChild(clause)
+          if (isBlock && tailPath[0] === getUtopiaID(clause)) {
+            return findAtPathInner(clause, tailPath)
           }
-
-          // if it's a child, get its inner element
-          if (tailPath[0] !== getUtopiaID(clause)) {
-            return null
+          if (!isBlock && tailPath[0] === thenOrElsePathPart(branch)) {
+            return element
           }
-          return findAtPathInner(clause, tailPath)
+          return null
         }
 
-        return (
-          elementOrNullFromClause(element.whenTrue, 'then') ??
-          elementOrNullFromClause(element.whenFalse, 'else')
-        )
+        const whenTrue = elementOrNullFromClause(element.whenTrue, 'then')
+        if (whenTrue != null) {
+          return whenTrue
+        }
+        const whenFalse = elementOrNullFromClause(element.whenFalse, 'else')
+        if (whenFalse != null) {
+          return whenFalse
+        }
+
+        return null
       }
     }
     return null

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -428,25 +428,18 @@ export function findJSXElementChildAtPath(
           clause: ChildOrAttribute,
           branch: ThenOrElse,
         ): JSXElementChild | null {
-          if (childOrBlockIsChild(clause)) {
-            if (tailPath[0] === getUtopiaID(clause)) {
-              const elementWithin = clause
-              const withinResult = findAtPathInner(elementWithin, tailPath)
-              if (withinResult != null) {
-                return withinResult
-              }
-            }
-          } else {
-            if (tailPath[0] === thenOrElsePathPart(branch)) {
-              return element
-            }
+          if (!childOrBlockIsChild(clause)) {
+            return tailPath[0] === thenOrElsePathPart(branch) ? element : null
           }
-          return null
+          if (tailPath[0] !== getUtopiaID(clause)) {
+            return null
+          }
+          return findAtPathInner(clause, tailPath)
         }
+
         return (
           elementOrNullFromClause(element.whenTrue, 'then') ??
-          elementOrNullFromClause(element.whenFalse, 'else') ??
-          null
+          elementOrNullFromClause(element.whenFalse, 'else')
         )
       }
     }

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -40,6 +40,7 @@ import {
   isJSXConditionalExpression,
   childOrBlockIsChild,
   emptyComments,
+  ChildOrAttribute,
 } from '../shared/element-template'
 import {
   Imports,
@@ -67,7 +68,7 @@ import { getStoryboardElementPath } from './scene-utils'
 import { getJSXAttributeAtPath, GetJSXAttributeResult } from '../shared/jsx-attributes'
 import { styleStringInArray } from '../../utils/common-constants'
 import { forceNotNull } from '../shared/optional-utils'
-import { getConditionalClausePath } from './conditionals'
+import { getConditionalClausePath, ThenOrElse, thenOrElsePathPart } from './conditionals'
 
 function getAllUniqueUidsInner(
   projectContents: ProjectContentTreeRoot,
@@ -423,26 +424,30 @@ export function findJSXElementChildAtPath(
         // this is the element we want
         return element
       } else {
-        if (
-          childOrBlockIsChild(element.whenTrue) &&
-          tailPath[0] === getUtopiaID(element.whenTrue)
-        ) {
-          const elementWithin = element.whenTrue
-          const withinResult = findAtPathInner(elementWithin, tailPath)
-          if (withinResult != null) {
-            return withinResult
+        function elementOrNullFromClause(
+          clause: ChildOrAttribute,
+          branch: ThenOrElse,
+        ): JSXElementChild | null {
+          if (childOrBlockIsChild(clause)) {
+            if (tailPath[0] === getUtopiaID(clause)) {
+              const elementWithin = clause
+              const withinResult = findAtPathInner(elementWithin, tailPath)
+              if (withinResult != null) {
+                return withinResult
+              }
+            }
+          } else {
+            if (tailPath[0] === thenOrElsePathPart(branch)) {
+              return element
+            }
           }
+          return null
         }
-        if (
-          childOrBlockIsChild(element.whenFalse) &&
-          tailPath[0] === getUtopiaID(element.whenFalse)
-        ) {
-          const elementWithin = element.whenFalse
-          const withinResult = findAtPathInner(elementWithin, tailPath)
-          if (withinResult != null) {
-            return withinResult
-          }
-        }
+        return (
+          elementOrNullFromClause(element.whenTrue, 'then') ??
+          elementOrNullFromClause(element.whenFalse, 'else') ??
+          null
+        )
       }
     }
     return null

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -428,26 +428,17 @@ export function findJSXElementChildAtPath(
           clause: ChildOrAttribute,
           branch: ThenOrElse,
         ): JSXElementChild | null {
-          const isBlock = childOrBlockIsChild(clause)
-          if (isBlock && tailPath[0] === getUtopiaID(clause)) {
-            return findAtPathInner(clause, tailPath)
+          // if it's an attribute, match its path with the right branch
+          if (!childOrBlockIsChild(clause)) {
+            return tailPath[0] === thenOrElsePathPart(branch) ? element : null
           }
-          if (!isBlock && tailPath[0] === thenOrElsePathPart(branch)) {
-            return element
-          }
-          return null
+          // if it's a child, get its inner element
+          return findAtPathInner(clause, tailPath)
         }
-
-        const elementWhenTrue = elementOrNullFromClause(element.whenTrue, 'then')
-        if (elementWhenTrue != null) {
-          return elementWhenTrue
-        }
-        const elementWhenFalse = elementOrNullFromClause(element.whenFalse, 'else')
-        if (elementWhenFalse != null) {
-          return elementWhenFalse
-        }
-
-        return null
+        return (
+          elementOrNullFromClause(element.whenTrue, 'then') ??
+          elementOrNullFromClause(element.whenFalse, 'else')
+        )
       }
     }
     return null


### PR DESCRIPTION
Fixes #3383 

**Problem:**

Deleting conditional branches works only if the branch itself is a `JSXElementChild`. This is not necessarily the case, for example for conditional branches being text strings (`{ true ? 'foo' : 'bar' }`).

**Fix:**

This PR adjusts the `findJSXElementChildAtPath` function so that it handles correctly the cases where the branches are `JSXAttribute`.

![Kapture 2023-03-03 at 12 14 55](https://user-images.githubusercontent.com/1081051/222706663-bd284a7f-3ff4-40d7-807d-6a23c703f731.gif)
