### PR TITLE
Store conditional value in spy metadata

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -760,6 +760,7 @@ function collectAndCreateMetadataForElement(
       attributeMetadata,
       null,
       null,
+      null,
     )
   })
 
@@ -1085,6 +1086,7 @@ function walkCanvasRootFragment(
       emptyAttributeMetadatada,
       null,
       null, // this comes from the Spy Wrapper
+      null,
     )
 
     rootMetadata[EP.toString(canvasRootPath)] = metadata

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -352,7 +352,7 @@ export function renderCoreElement(
       const actualElement = conditionValue ? element.whenTrue : element.whenFalse
 
       if (elementPath != null) {
-        addFakeSpyEntry(metadataContext, elementPath, element, filePath, imports)
+        addFakeSpyEntry(metadataContext, elementPath, element, filePath, imports, conditionValue)
       }
 
       let result: any

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
@@ -33,7 +33,7 @@ export function addFakeSpyEntry(
   elementOrAttribute: ChildOrAttribute,
   filePath: string,
   imports: Imports,
-  conditionValue: boolean | null,
+  conditionalValue: boolean | null,
 ): void {
   let element: Either<string, JSXElementChild>
   if (childOrBlockIsChild(elementOrAttribute)) {
@@ -80,7 +80,7 @@ export function addFakeSpyEntry(
       },
       element,
     ),
-    conditionValue: conditionValue,
+    conditionalValue: conditionalValue,
   }
   const elementPathString = EP.toComponentId(elementPath)
   metadataContext.current.spyValues.metadata[elementPathString] = instanceMetadata
@@ -159,7 +159,7 @@ export function buildSpyWrappedElement(
       importInfo: isJSXElement(jsx)
         ? importInfoFromImportDetails(jsx.name, imports, filePath)
         : null,
-      conditionValue: null,
+      conditionalValue: null,
     }
     if (!EP.isStoryboardPath(elementPath) || shouldIncludeCanvasRootInTheSpy) {
       const elementPathString = EP.toComponentId(elementPath)

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
@@ -33,6 +33,7 @@ export function addFakeSpyEntry(
   elementOrAttribute: ChildOrAttribute,
   filePath: string,
   imports: Imports,
+  conditionValue: boolean | null,
 ): void {
   let element: Either<string, JSXElementChild>
   if (childOrBlockIsChild(elementOrAttribute)) {
@@ -79,6 +80,7 @@ export function addFakeSpyEntry(
       },
       element,
     ),
+    conditionValue: conditionValue,
   }
   const elementPathString = EP.toComponentId(elementPath)
   metadataContext.current.spyValues.metadata[elementPathString] = instanceMetadata
@@ -96,7 +98,7 @@ export function addConditionalAlternative(
   thenOrElseCase: 'then' | 'else',
 ): void {
   const elementPath = getConditionalClausePath(parentPath, alternativeCase, thenOrElseCase)
-  addFakeSpyEntry(metadataContext, elementPath, alternativeCase, filePath, imports)
+  addFakeSpyEntry(metadataContext, elementPath, alternativeCase, filePath, imports, null)
 
   forEachOf(childOrAttributeToConditionalOptic, alternativeCase, (elementAsConditional) => {
     addConditionalAlternative(
@@ -157,6 +159,7 @@ export function buildSpyWrappedElement(
       importInfo: isJSXElement(jsx)
         ? importInfoFromImportDetails(jsx.name, imports, filePath)
         : null,
+      conditionValue: null,
     }
     if (!EP.isStoryboardPath(elementPath) || shouldIncludeCanvasRootInTheSpy) {
       const elementPathString = EP.toComponentId(elementPath)

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -869,6 +869,7 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
     attributeMetadatada: emptyAttributeMetadatada,
     label: null,
     importInfo: null,
+    conditionValue: null,
   }
 
   const childElementProps: ElementProps = {
@@ -892,6 +893,7 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
     attributeMetadatada: emptyAttributeMetadatada,
     label: null,
     importInfo: null,
+    conditionValue: null,
   }
 
   const elementMetadataMap: ElementInstanceMetadataMap = {
@@ -1549,6 +1551,7 @@ describe('SET_FOCUSED_ELEMENT', () => {
       emptyAttributeMetadatada,
       null,
       null,
+      null,
     )
     const fakeMetadata: ElementInstanceMetadataMap = {
       [EP.toString(pathToFocus)]: divElementMetadata,
@@ -1581,6 +1584,7 @@ describe('SET_FOCUSED_ELEMENT', () => {
       emptySpecialSizeMeasurements,
       emptyComputedStyle,
       emptyAttributeMetadatada,
+      null,
       null,
       null,
     )

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -869,7 +869,7 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
     attributeMetadatada: emptyAttributeMetadatada,
     label: null,
     importInfo: null,
-    conditionValue: null,
+    conditionalValue: null,
   }
 
   const childElementProps: ElementProps = {
@@ -893,7 +893,7 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
     attributeMetadatada: emptyAttributeMetadatada,
     label: null,
     importInfo: null,
-    conditionValue: null,
+    conditionalValue: null,
   }
 
   const elementMetadataMap: ElementInstanceMetadataMap = {

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1434,7 +1434,7 @@ export const ElementInstanceMetadataKeepDeepEquality: KeepDeepEqualityCall<Eleme
     nullableDeepEquality(createCallWithTripleEquals()),
     (metadata) => metadata.importInfo,
     nullableDeepEquality(ImportInfoKeepDeepEquality),
-    (metadata) => metadata.conditionValue,
+    (metadata) => metadata.conditionalValue,
     nullableDeepEquality(BooleanKeepDeepEquality),
     elementInstanceMetadata,
   )

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1411,7 +1411,7 @@ export const ElementInstanceMetadataPropsKeepDeepEquality: KeepDeepEqualityCall<
   createCallWithShallowEquals()
 
 export const ElementInstanceMetadataKeepDeepEquality: KeepDeepEqualityCall<ElementInstanceMetadata> =
-  combine11EqualityCalls(
+  combine12EqualityCalls(
     (metadata) => metadata.elementPath,
     ElementPathKeepDeepEquality,
     (metadata) => metadata.element,
@@ -1434,6 +1434,8 @@ export const ElementInstanceMetadataKeepDeepEquality: KeepDeepEqualityCall<Eleme
     nullableDeepEquality(createCallWithTripleEquals()),
     (metadata) => metadata.importInfo,
     nullableDeepEquality(ImportInfoKeepDeepEquality),
+    (metadata) => metadata.conditionValue,
+    nullableDeepEquality(BooleanKeepDeepEquality),
     elementInstanceMetadata,
   )
 

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -117,6 +117,7 @@ function callPropertyControlsHook(
       null,
       null,
       importInfos[0],
+      null,
     ),
   }
   let allElementProps: AllElementProps = {
@@ -136,6 +137,7 @@ function callPropertyControlsHook(
       null,
       null,
       importInfos[1],
+      null,
     )
     allElementProps[EP.toString(selectedViews[1])] = {
       propWithControlButNoValue: 'but there is a value!',
@@ -154,6 +156,7 @@ function callPropertyControlsHook(
       null,
       null,
       importInfos[2],
+      null,
     )
 
     allElementProps[EP.toString(selectedViews[2])] = { propWithOtherKey: 10 }

--- a/editor/src/core/model/element-metadata-utils.spec.tsx
+++ b/editor/src/core/model/element-metadata-utils.spec.tsx
@@ -71,6 +71,7 @@ const testComponentMetadataChild1: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
+  conditionValue: null,
 }
 const testComponentMetadataChild2: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
@@ -87,6 +88,7 @@ const testComponentMetadataChild2: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
+  conditionValue: null,
 }
 
 const testComponentMetadataGrandchild: ElementInstanceMetadata = {
@@ -104,6 +106,7 @@ const testComponentMetadataGrandchild: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
+  conditionValue: null,
 }
 
 const testComponentPropsGrandchild: ElementProps = {
@@ -125,6 +128,7 @@ const testComponentMetadataChild3: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
+  conditionValue: null,
 }
 
 const testComponentRoot1: ElementInstanceMetadata = {
@@ -139,6 +143,7 @@ const testComponentRoot1: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
+  conditionValue: null,
 }
 
 const testComponentSceneChildElementRootChild: ElementInstanceMetadata = {
@@ -156,6 +161,7 @@ const testComponentSceneChildElementRootChild: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
+  conditionValue: null,
 }
 
 const testComponentSceneChildElementRoot: ElementInstanceMetadata = {
@@ -173,6 +179,7 @@ const testComponentSceneChildElementRoot: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
+  conditionValue: null,
 }
 
 const testComponentSceneChildElement: ElementInstanceMetadata = {
@@ -187,6 +194,7 @@ const testComponentSceneChildElement: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
+  conditionValue: null,
 }
 
 const testComponentSceneElement: ElementInstanceMetadata = {
@@ -201,6 +209,7 @@ const testComponentSceneElement: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
+  conditionValue: null,
 }
 
 const testComponentSceneElementProps: ElementProps = {
@@ -222,6 +231,7 @@ const testStoryboardGrandChildElement: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
+  conditionValue: null,
 }
 
 const testStoryboardChildElement: ElementInstanceMetadata = {
@@ -236,6 +246,7 @@ const testStoryboardChildElement: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
+  conditionValue: null,
 }
 
 const testStoryboardElement: ElementInstanceMetadata = {
@@ -250,6 +261,7 @@ const testStoryboardElement: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
+  conditionValue: null,
 }
 
 const testElementMetadataMap: ElementInstanceMetadataMap = {
@@ -338,6 +350,7 @@ function dummyInstanceDataForElementType(
     attributeMetadatada: emptyAttributeMetadatada,
     label: null,
     importInfo: importInfo,
+    conditionValue: null,
   }
 }
 
@@ -777,6 +790,7 @@ describe('getElementLabel', () => {
     emptyAttributeMetadatada,
     null,
     null,
+    null,
   )
   const spanElementProps: ElementProps = {
     'data-uid': 'span-1',
@@ -797,6 +811,7 @@ describe('getElementLabel', () => {
     emptySpecialSizeMeasurements,
     emptyComputedStyle,
     emptyAttributeMetadatada,
+    null,
     null,
     null,
   )

--- a/editor/src/core/model/element-metadata-utils.spec.tsx
+++ b/editor/src/core/model/element-metadata-utils.spec.tsx
@@ -71,7 +71,7 @@ const testComponentMetadataChild1: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
-  conditionValue: null,
+  conditionalValue: null,
 }
 const testComponentMetadataChild2: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
@@ -88,7 +88,7 @@ const testComponentMetadataChild2: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
-  conditionValue: null,
+  conditionalValue: null,
 }
 
 const testComponentMetadataGrandchild: ElementInstanceMetadata = {
@@ -106,7 +106,7 @@ const testComponentMetadataGrandchild: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
-  conditionValue: null,
+  conditionalValue: null,
 }
 
 const testComponentPropsGrandchild: ElementProps = {
@@ -128,7 +128,7 @@ const testComponentMetadataChild3: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
-  conditionValue: null,
+  conditionalValue: null,
 }
 
 const testComponentRoot1: ElementInstanceMetadata = {
@@ -143,7 +143,7 @@ const testComponentRoot1: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
-  conditionValue: null,
+  conditionalValue: null,
 }
 
 const testComponentSceneChildElementRootChild: ElementInstanceMetadata = {
@@ -161,7 +161,7 @@ const testComponentSceneChildElementRootChild: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
-  conditionValue: null,
+  conditionalValue: null,
 }
 
 const testComponentSceneChildElementRoot: ElementInstanceMetadata = {
@@ -179,7 +179,7 @@ const testComponentSceneChildElementRoot: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
-  conditionValue: null,
+  conditionalValue: null,
 }
 
 const testComponentSceneChildElement: ElementInstanceMetadata = {
@@ -194,7 +194,7 @@ const testComponentSceneChildElement: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
-  conditionValue: null,
+  conditionalValue: null,
 }
 
 const testComponentSceneElement: ElementInstanceMetadata = {
@@ -209,7 +209,7 @@ const testComponentSceneElement: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
-  conditionValue: null,
+  conditionalValue: null,
 }
 
 const testComponentSceneElementProps: ElementProps = {
@@ -231,7 +231,7 @@ const testStoryboardGrandChildElement: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
-  conditionValue: null,
+  conditionalValue: null,
 }
 
 const testStoryboardChildElement: ElementInstanceMetadata = {
@@ -246,7 +246,7 @@ const testStoryboardChildElement: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
-  conditionValue: null,
+  conditionalValue: null,
 }
 
 const testStoryboardElement: ElementInstanceMetadata = {
@@ -261,7 +261,7 @@ const testStoryboardElement: ElementInstanceMetadata = {
   attributeMetadatada: emptyAttributeMetadatada,
   label: null,
   importInfo: null,
-  conditionValue: null,
+  conditionalValue: null,
 }
 
 const testElementMetadataMap: ElementInstanceMetadataMap = {
@@ -350,7 +350,7 @@ function dummyInstanceDataForElementType(
     attributeMetadatada: emptyAttributeMetadatada,
     label: null,
     importInfo: importInfo,
-    conditionValue: null,
+    conditionalValue: null,
   }
 }
 

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1795,6 +1795,12 @@ export const MetadataUtils = {
       isJSXConditionalExpression(element.element.value)
     )
   },
+  getConditionValueFromMetadata(element: ElementInstanceMetadata | null): boolean | null {
+    if (!this.isConditionalFromMetadata(element)) {
+      return null
+    }
+    return element?.conditionValue ?? null
+  },
   findLayoutSystemForChildren(
     metadata: ElementInstanceMetadataMap,
     parentPath: ElementPath,
@@ -2068,6 +2074,7 @@ function findConditionalsAndCreateMetadata(
             emptyAttributeMetadatada,
             'Conditional',
             null,
+            null,
           )
         }
       },
@@ -2187,6 +2194,7 @@ export function createFakeMetadataForElement(
     false,
     false,
     specialSizeMeasurements,
+    null,
     null,
     null,
     null,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1795,11 +1795,11 @@ export const MetadataUtils = {
       isJSXConditionalExpression(element.element.value)
     )
   },
-  getConditionValueFromMetadata(element: ElementInstanceMetadata | null): boolean | null {
+  getConditionalValueFromMetadata(element: ElementInstanceMetadata | null): boolean | null {
     if (!this.isConditionalFromMetadata(element)) {
       return null
     }
-    return element?.conditionValue ?? null
+    return element?.conditionalValue ?? null
   },
   findLayoutSystemForChildren(
     metadata: ElementInstanceMetadataMap,

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1641,7 +1641,7 @@ export interface ElementInstanceMetadata {
   attributeMetadatada: StyleAttributeMetadata | null
   label: string | null
   importInfo: ImportInfo | null
-  conditionValue: boolean | null
+  conditionalValue: boolean | null
 }
 
 export function elementInstanceMetadata(
@@ -1656,7 +1656,7 @@ export function elementInstanceMetadata(
   attributeMetadatada: StyleAttributeMetadata | null,
   label: string | null,
   importInfo: ImportInfo | null,
-  conditionValue: boolean | null,
+  conditionalValue: boolean | null,
 ): ElementInstanceMetadata {
   return {
     elementPath: elementPath,
@@ -1670,7 +1670,7 @@ export function elementInstanceMetadata(
     attributeMetadatada: attributeMetadatada,
     label: label,
     importInfo: importInfo,
-    conditionValue: conditionValue,
+    conditionalValue: conditionalValue,
   }
 }
 

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1641,6 +1641,7 @@ export interface ElementInstanceMetadata {
   attributeMetadatada: StyleAttributeMetadata | null
   label: string | null
   importInfo: ImportInfo | null
+  conditionValue: boolean | null
 }
 
 export function elementInstanceMetadata(
@@ -1655,6 +1656,7 @@ export function elementInstanceMetadata(
   attributeMetadatada: StyleAttributeMetadata | null,
   label: string | null,
   importInfo: ImportInfo | null,
+  conditionValue: boolean | null,
 ): ElementInstanceMetadata {
   return {
     elementPath: elementPath,
@@ -1668,6 +1670,7 @@ export function elementInstanceMetadata(
     attributeMetadatada: attributeMetadatada,
     label: label,
     importInfo: importInfo,
+    conditionValue: conditionValue,
   }
 }
 


### PR DESCRIPTION
Fixes #3387 

This PR adds the `conditionValue` field to `ElementInstanceMetadata`, and sets it to `true | false | null` in the spy metadata map when parsing a conditional. It also adds a helper method in `MetadataUtils` to retrieve that value.

This can be later reused e.g. in the navigator with something like

```ts
const elementSpy = useEditorState(
  Substores.metadata,
  (store) => MetadataUtils.findElementByElementPath(store.editor.spyMetadata, elementPath),
  '...',
)

// ...

const conditionValue = MetadataUtils.getConditionalValueFromMetadata(elementSpy))
```