### PR TITLE
Only show flex section in the Inspector if there are selected elements

### DIFF
--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -1,7 +1,7 @@
 import * as PP from '../../core/shared/property-path'
 import * as EP from '../../core/shared/element-path'
 import { getSimpleAttributeAtPath, MetadataUtils } from '../../core/model/element-metadata-utils'
-import { allElemsEqual, mapDropNulls, stripNulls } from '../../core/shared/array-utils'
+import { allElemsEqual, mapDropNulls, strictEvery, stripNulls } from '../../core/shared/array-utils'
 import {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
@@ -212,7 +212,7 @@ export function detectAreElementsFlexContainers(
   metadata: ElementInstanceMetadataMap,
   elementPaths: Array<ElementPath>,
 ): boolean {
-  return elementPaths.every((path) =>
+  return strictEvery(elementPaths, (path) =>
     MetadataUtils.isFlexLayoutedContainer(MetadataUtils.findElementByElementPath(metadata, path)),
   )
 }

--- a/editor/src/core/shared/array-utils.spec.ts
+++ b/editor/src/core/shared/array-utils.spec.ts
@@ -1,4 +1,4 @@
-import { aperture, intersection, mapAndFilter } from './array-utils'
+import { aperture, intersection, mapAndFilter, strictEvery } from './array-utils'
 
 describe('intersection', () => {
   it('two empty arrays should return an empty array', () => {
@@ -63,5 +63,23 @@ describe('mapAndFilter', () => {
   it('should correctly map and filter an array', () => {
     const actualResult = mapAndFilter(mapFn, filter, input)
     expect(actualResult).toEqual([12, 14])
+  })
+})
+
+describe('strictEvery', () => {
+  it('returns false for empty arrays', () => {
+    // Because `[].every()` always returns true, and that has caused so much pain
+    expect([].every(() => false)).toBeTruthy()
+    expect(strictEvery([], () => false)).toBeFalsy()
+  })
+
+  it('returns true for non-empty arrays where the predicate is satisfied', () => {
+    expect([1].every(() => true)).toBeTruthy()
+    expect(strictEvery([1], () => true)).toBeTruthy()
+  })
+
+  it('returns false for non-empty arrays where the predicate is not satisfied', () => {
+    expect([1].every(() => false)).toBeFalsy()
+    expect(strictEvery([1], () => false)).toBeFalsy()
   })
 })

--- a/editor/src/core/shared/array-utils.ts
+++ b/editor/src/core/shared/array-utils.ts
@@ -426,3 +426,10 @@ export function allElemsEqual<T>(
 
   return ts.slice(1).every((obj) => areEqual(ts[0], obj))
 }
+
+export function strictEvery<T>(
+  ts: T[],
+  predicate: (t: T, index: number, array: T[]) => boolean,
+): boolean {
+  return ts.length > 0 && ts.every(predicate)
+}


### PR DESCRIPTION
**Problem:**
De-selection performance had regressed in #3367 and we weren't sure exactly why.

**Fix:**
The issue is that when determining whether or not to render the flex controls in the Inspector, we use an `Array.prototype.every()` call. Since that function will return `true` for an empty array, it meant that upon de-selection we would be paying the cost of rendering that section, even though it wouldn't be visible.

The fix here is clearly to check whether the array of selected views is empty, but, since this is something that has caught us out before, I have also introduced a new `strictEvery` function for us to use rather than `.every`