### PR TITLE
Fix authenticated flag for Github.

### DIFF
--- a/editor/src/components/editor/store/store-hook-substore-types.ts
+++ b/editor/src/components/editor/store/store-hook-substore-types.ts
@@ -169,4 +169,13 @@ export type NavigatorSubstate = {
 }
 
 export const restOfStoreKeys: ReadonlyArray<keyof Omit<EditorStorePatched, 'editor' | 'derived'>> =
-  ['storeName', 'strategyState', 'history', 'workers', 'persistence', 'alreadySaved']
+  [
+    'storeName',
+    'strategyState',
+    'history',
+    'userState',
+    'workers',
+    'persistence',
+    'builtInDependencies',
+    'alreadySaved',
+  ]


### PR DESCRIPTION
**Problem:**
When a user becomes authenticated (from not) with Github, the Github pane doesn't update to reflect this.

**Fix:**
The value of `restOfStoreKeys` meant that updates to `userState` weren't propagating through the selector.

**Commit Details:**
- `restOfStoreKeys` was missing `userState` and `builtInDependencies`.