### PR TITLE
Fixed ref equality blowing in retargetStrategyToChildrenOfContentAffectingElements

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
@@ -59,6 +59,8 @@ import {
 import { InteractionSession } from '../interaction-state'
 import { AbsolutePin } from './resize-helpers'
 import { FlexDirection } from '../../../inspector/common/css-utils'
+import { memoize } from '../../../../core/shared/memoize'
+import { is } from '../../../../core/shared/equality-utils'
 
 export interface MoveCommandsOptions {
   ignoreLocalFrame?: boolean
@@ -292,12 +294,19 @@ export function getFileOfElement(
   )
 }
 
+export const getDragTargets = memoize(getDragTargetsInner, {
+  maxSize: 1,
+  equals: is,
+})
+
 // No need to include descendants in multiselection when dragging
 // Note: this maybe slow when there are lot of selected views
-export function getDragTargets(selectedViews: Array<ElementPath>): Array<ElementPath> {
-  return selectedViews.filter((view) =>
+function getDragTargetsInner(selectedViews: Array<ElementPath>): Array<ElementPath> {
+  const filteredTargets = selectedViews.filter((view) =>
     selectedViews.every((otherView) => !EP.isDescendantOf(view, otherView)),
   )
+
+  return filteredTargets.length === selectedViews.length ? selectedViews : filteredTargets
 }
 
 export function snapDrag(

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`455`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`451`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`466`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`462`)
   })
 
   it('Changing the selected view with a simple project', async () => {


### PR DESCRIPTION
**Problem:**
The use of `retargetStrategyToChildrenOfContentAffectingElements` would blow reference equality of the target element paths, meaning controls dependent on those would be re-rendered constantly.

**Fix:**
Add some ref equality memoisation of both `replaceContentAffectingPathsWithTheirChildrenRecursive` and `getDragTargets`, along with checks inside both functions that return the original arrays if no paths were changed.