### PR TITLE
Handle asset renames when undoing or redoing.

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1634,7 +1634,7 @@ export const UPDATE_FNS = {
   },
   UNDO: (editor: EditorModel, stateHistory: StateHistory): EditorModel => {
     if (History.canUndo(stateHistory)) {
-      const history = History.undo(stateHistory)
+      const history = History.undo(editor.id, stateHistory, 'run-side-effects')
       return restoreEditorState(editor, history)
     } else {
       return editor
@@ -1642,7 +1642,7 @@ export const UPDATE_FNS = {
   },
   REDO: (editor: EditorModel, stateHistory: StateHistory): EditorModel => {
     if (History.canRedo(stateHistory)) {
-      const history = History.redo(stateHistory)
+      const history = History.redo(editor.id, stateHistory, 'run-side-effects')
       return restoreEditorState(editor, history)
     } else {
       return editor
@@ -4641,7 +4641,12 @@ export const UPDATE_FNS = {
       return {
         ...editorStore,
         unpatchedEditor: withCollapsedElements,
-        history: History.add(editorStore.history, withUpdatedText, editorStore.unpatchedDerived),
+        history: History.add(
+          editorStore.history,
+          withUpdatedText,
+          editorStore.unpatchedDerived,
+          [],
+        ),
       }
     }
   },

--- a/editor/src/components/editor/history.spec.ts
+++ b/editor/src/components/editor/history.spec.ts
@@ -1,0 +1,93 @@
+import { add, baseAssetPromise, init, redo, undo } from './history'
+import { createEditorState, deriveState } from './store/editor-state'
+import { updateAssetFileName } from './server'
+
+jest.mock('./server')
+
+describe('history', () => {
+  describe('asset renames', () => {
+    beforeEach(() => {
+      return jest.clearAllMocks()
+    })
+
+    it('should be added to the history', async () => {
+      const editorState = {
+        ...createEditorState(() => {}),
+        id: 'testproject',
+      }
+      const derivedState = deriveState(editorState, null)
+      const stateHistory = init(editorState, derivedState)
+      const updatedStateHistory = add(stateHistory, editorState, derivedState, [
+        { filenameChangedFrom: 'thing.jpg', filenameChangedTo: 'otherthing.jpg' },
+      ])
+      await baseAssetPromise
+      expect(updatedStateHistory.current.assetRenames).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "filenameChangedFrom": "thing.jpg",
+            "filenameChangedTo": "otherthing.jpg",
+          },
+        ]
+      `)
+    })
+    it('should be undone with 1 undo if they were the last change', async () => {
+      const editorState = {
+        ...createEditorState(() => {}),
+        id: 'testproject',
+      }
+      const derivedState = deriveState(editorState, null)
+      const stateHistory = init(editorState, derivedState)
+      const updatedStateHistory = add(stateHistory, editorState, derivedState, [
+        { filenameChangedFrom: 'thing.jpg', filenameChangedTo: 'otherthing.jpg' },
+      ])
+      const undoneStateHistory = undo('testproject', updatedStateHistory, 'run-side-effects')
+      await baseAssetPromise
+      expect(undoneStateHistory.current.assetRenames).toMatchInlineSnapshot(`Array []`)
+      expect((updateAssetFileName as any).mock.calls).toHaveLength(1)
+      expect((updateAssetFileName as any).mock.calls[0]).toMatchInlineSnapshot(`
+        Array [
+          "testproject",
+          "otherthing.jpg",
+          "thing.jpg",
+        ]
+      `)
+    })
+    it('should be redone with 1 redo if they are the next change', async () => {
+      const editorState = {
+        ...createEditorState(() => {}),
+        id: 'testproject',
+      }
+      const derivedState = deriveState(editorState, null)
+      const stateHistory = init(editorState, derivedState)
+      const updatedStateHistory = add(stateHistory, editorState, derivedState, [
+        { filenameChangedFrom: 'thing.jpg', filenameChangedTo: 'otherthing.jpg' },
+      ])
+      const undoneStateHistory = undo('testproject', updatedStateHistory, 'run-side-effects')
+      const redoneStateHistory = redo('testproject', undoneStateHistory, 'run-side-effects')
+      await baseAssetPromise
+      expect(redoneStateHistory.current.assetRenames).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "filenameChangedFrom": "thing.jpg",
+            "filenameChangedTo": "otherthing.jpg",
+          },
+        ]
+      `)
+      expect((updateAssetFileName as any).mock.calls).toHaveLength(2)
+      expect((updateAssetFileName as any).mock.calls[0]).toMatchInlineSnapshot(`
+        Array [
+          "testproject",
+          "otherthing.jpg",
+          "thing.jpg",
+        ]
+      `)
+      expect((updateAssetFileName as any).mock.calls[1]).toMatchInlineSnapshot(`
+        Array [
+          "testproject",
+          "thing.jpg",
+          "otherthing.jpg",
+        ]
+      `)
+    })
+  })
+})

--- a/editor/src/components/editor/history.ts
+++ b/editor/src/components/editor/history.ts
@@ -28,7 +28,7 @@ export type AssetFilenameUpdate = (
 ) => Promise<void>
 
 // Chain promises off of this so that there's not 50 running at once.
-let baseAssetPromise: Promise<void> = Promise.resolve()
+export let baseAssetPromise: Promise<void> = Promise.resolve()
 
 export function triggerAssetRenames(
   projectId: string | null,

--- a/editor/src/components/editor/history.ts
+++ b/editor/src/components/editor/history.ts
@@ -1,10 +1,18 @@
+import { assertNever } from '../../core/shared/utils'
+import { updateAssetFileName } from './server'
 import { DerivedState, EditorState } from './store/editor-state'
 
 const MAX_HISTORY = 50
 
+export interface AssetRename {
+  filenameChangedFrom: string
+  filenameChangedTo: string
+}
+
 export type HistoryItem = {
   editor: EditorState
   derived: DerivedState
+  assetRenames: Array<AssetRename>
 }
 
 export interface StateHistory {
@@ -13,7 +21,63 @@ export interface StateHistory {
   next: HistoryItem[]
 }
 
-export function undo(stateHistory: StateHistory): StateHistory {
+export type AssetFilenameUpdate = (
+  projectId: string,
+  oldFileName: string,
+  newFileName: string,
+) => Promise<void>
+
+// Chain promises off of this so that there's not 50 running at once.
+let baseAssetPromise: Promise<void> = Promise.resolve()
+
+export function triggerAssetRenames(
+  projectId: string | null,
+  assetRenames: Array<AssetRename>,
+  undoOrRedo: 'undo' | 'redo',
+): void {
+  if (projectId != null) {
+    switch (undoOrRedo) {
+      case 'undo':
+        baseAssetPromise = assetRenames.reduceRight(async (working, rename) => {
+          return working.then(() => {
+            return updateAssetFileName(
+              projectId,
+              rename.filenameChangedTo,
+              rename.filenameChangedFrom,
+            )
+          })
+        }, baseAssetPromise)
+        break
+      case 'redo':
+        baseAssetPromise = assetRenames.reduce(async (working, rename) => {
+          return working.then(() => {
+            return updateAssetFileName(
+              projectId,
+              rename.filenameChangedFrom,
+              rename.filenameChangedTo,
+            )
+          })
+        }, baseAssetPromise)
+        break
+      default:
+        assertNever(undoOrRedo)
+    }
+  }
+}
+
+type RunEffects = 'run-side-effects' | 'no-side-effects'
+
+export function undo(
+  projectId: string | null,
+  stateHistory: StateHistory,
+  runSideEffects: RunEffects,
+): StateHistory {
+  if (runSideEffects === 'run-side-effects') {
+    // Unwind any asset renames.
+    triggerAssetRenames(projectId, stateHistory.current.assetRenames, 'undo')
+  }
+
+  // Create the new state history.
   const newCurrent = stateHistory.previous[0]
   return {
     previous: stateHistory.previous.slice(1),
@@ -22,10 +86,21 @@ export function undo(stateHistory: StateHistory): StateHistory {
   }
 }
 
-export function redo(stateHistory: StateHistory): StateHistory {
+export function redo(
+  projectId: string | null,
+  stateHistory: StateHistory,
+  runSideEffects: RunEffects,
+): StateHistory {
+  const newCurrent = stateHistory.next[0]
+  if (runSideEffects === 'run-side-effects') {
+    // Playback any asset renames.
+    triggerAssetRenames(projectId, newCurrent.assetRenames, 'redo')
+  }
+
+  // Create the new state history.
   return {
     previous: [stateHistory.current, ...stateHistory.previous],
-    current: stateHistory.next[0],
+    current: newCurrent,
     next: stateHistory.next.slice(1),
   }
 }
@@ -50,17 +125,19 @@ export function add(
   stateHistory: StateHistory,
   editor: EditorState,
   derived: DerivedState,
+  assetRenames: Array<AssetRename>,
 ): StateHistory {
   let previous =
     stateHistory.previous.length > MAX_HISTORY
       ? stateHistory.previous.slice(0, MAX_HISTORY)
       : stateHistory.previous
 
-  const newHistory = {
+  const newHistory: StateHistory = {
     previous: [stateHistory.current, ...previous],
     current: {
       editor: editor,
       derived: derived,
+      assetRenames: assetRenames,
     },
     next: [],
   }
@@ -71,12 +148,14 @@ export function replaceLast(
   stateHistory: StateHistory,
   editor: EditorState,
   derived: DerivedState,
+  assetRenames: Array<AssetRename>,
 ): StateHistory {
-  const newHistory = {
+  const newHistory: StateHistory = {
     previous: stateHistory.previous,
     current: {
       editor: editor,
       derived: derived,
+      assetRenames: stateHistory.current.assetRenames.concat(assetRenames),
     },
     next: [],
   }
@@ -89,6 +168,7 @@ export function init(editor: EditorState, derived: DerivedState): StateHistory {
     current: {
       editor: editor,
       derived: derived,
+      assetRenames: [],
     },
     next: [],
   }


### PR DESCRIPTION
**Problem:**
If an asset like an image is renamed, but then undo is triggered over the step which renamed the file, then the model is updated but the file in S3 is not renamed back to the original path.

This had the side problem of also causing the Github integration to fail when trying to push the project to Github, as it would attempt to retrieve assets that did not exist.

**Fix:**
Now when traversing backwards or forwards through the state history, asset renames are collected and either reversed or replayed as appropriate for the action triggered.

**Commit Details:**
- Added `AssetRename` interface for the history, to represent a rename.
- Implemented `triggerAssetRenames` for applying the asset renames in a consistent ordering.
- `undo` and `redo` now fire `triggerAssetRenames` but only if `run-side-effects` is passed as they are both called from two different places in the editor code.
- `editorDispatch` collects `UPDATE_FILE_PATH` actions and adds the entries for them to the history.