### PR TITLE
Copy/cut/paste conditionals via the navigator

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
@@ -67,13 +67,17 @@ describe('a project with conditionals', () => {
   it('fills the content of the navigator', async () => {
     FOR_TESTS_setNextGeneratedUids([
       'mock1',
-      'conditional2',
       'mock2',
+      'mock3',
+      'mock4',
       'conditional1',
+      'conditional2',
       'mock1',
-      'conditional2',
       'mock2',
+      'mock3',
+      'mock4',
       'conditional1',
+      'conditional2',
     ])
     const renderedProject = await createAndRenderProject()
     const navigatorTargets = renderedProject.getEditorState().derived.visibleNavigatorTargets

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3044,8 +3044,13 @@ export const UPDATE_FNS = {
             currentValue.originalElementPath,
           )
           const pastedElementIsAbsolute = MetadataUtils.isPositionAbsolute(pastedElementMetadata)
+          const pastedElementIsConditional =
+            MetadataUtils.isConditionalFromMetadata(pastedElementMetadata)
 
-          if (!(pastedElementIsAbsolute || pastedElementIsFlex)) {
+          const continueWithPaste =
+            pastedElementIsAbsolute || pastedElementIsFlex || pastedElementIsConditional
+
+          if (!continueWithPaste) {
             return workingEditorState
           } else {
             const propertyChangeCommands = getReparentPropertyChanges(

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -23,6 +23,8 @@ describe('conditionals', () => {
         'skip4',
         'skip5',
         'skip6',
+        'skip7',
+        'skip8',
         'conditional',
       ])
       const startSnippet = `
@@ -63,7 +65,7 @@ describe('conditionals', () => {
       )
     })
     it('replaces a text string branch with null', async () => {
-      FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'conditional'])
+      FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'skip3', 'skip4', 'conditional'])
       const startSnippet = `
         <div data-uid='aaa'>
         {

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -2196,6 +2196,8 @@ describe('inspector tests with real metadata', () => {
         'skip4',
         'skip5',
         'skip6',
+        'skip7',
+        'skip8',
         'conditional',
       ])
       const startSnippet = `
@@ -2323,6 +2325,8 @@ describe('inspector tests with real metadata', () => {
         'skip4',
         'skip5',
         'skip6',
+        'skip7',
+        'skip8',
         'conditional',
       ])
       const startSnippet = `
@@ -2385,9 +2389,13 @@ describe('inspector tests with real metadata', () => {
         'skip7',
         'skip8',
         'skip9',
-        'conditional1',
         'skip10',
         'skip11',
+        'skip12',
+        'skip13',
+        'skip14',
+        'skip15',
+        'conditional1',
         'conditional2',
       ])
       const startSnippet = `

--- a/editor/src/core/model/element-metadata.spec.browser2.tsx
+++ b/editor/src/core/model/element-metadata.spec.browser2.tsx
@@ -72,7 +72,7 @@ describe('Frame calculation for fragments', () => {
     )
   })
   it('Conditionals have metadata and their frame is the frame of the active branch', async () => {
-    FOR_TESTS_setNextGeneratedUids(['foo1', 'foo2', 'foo3', 'foo4', 'cond']) // ugly, but the conditional is the 5th uid which is generated
+    FOR_TESTS_setNextGeneratedUids(['foo1', 'foo2', 'foo3', 'foo4', 'foo5', 'foo6', 'cond']) // ugly, but the conditional is the 5th uid which is generated
 
     const condComponentPath = 'story/scene/app:root/cond'
     const trueBranchComponentPath = 'story/scene/app:root/cond/truebranch'

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -90,6 +90,14 @@ function getAllUniqueUidsInner(
     } else if (isJSXFragment(element)) {
       fastForEach(element.children, extractUid)
       uniqueIDs.add(element.uid)
+    } else if (isJSXConditionalExpression(element)) {
+      uniqueIDs.add(element.uid)
+      if (childOrBlockIsChild(element.whenTrue)) {
+        extractUid(element.whenTrue)
+      }
+      if (childOrBlockIsChild(element.whenFalse)) {
+        extractUid(element.whenFalse)
+      }
     }
   }
 

--- a/editor/src/core/workers/parser-printer/parser-printer-conditionals.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-conditionals.spec.ts
@@ -15,9 +15,11 @@ describe('JSX parser', () => {
     FOR_TESTS_setNextGeneratedUids([
       'mock1',
       'mock2',
+      'mock3',
       'conditional',
-      'mock1',
-      'mock2',
+      'mock4',
+      'mock5',
+      'mock6',
       'conditional',
     ])
     const code = applyPrettier(SimpleConditionalsExample, false).formatted
@@ -58,13 +60,17 @@ describe('JSX parser', () => {
   it('handles nested ternaries', () => {
     FOR_TESTS_setNextGeneratedUids([
       'mock1',
-      'conditional2',
       'mock2',
+      'mock3',
+      'mock4',
       'conditional1',
+      'conditional2',
       'mock1',
-      'conditional2',
       'mock2',
+      'mock3',
+      'mock4',
       'conditional1',
+      'conditional2',
     ])
     const code = applyPrettier(NestedTernariesExample, false).formatted
     const firstParseResult = testParseCode(code)
@@ -103,7 +109,14 @@ describe('JSX parser', () => {
 
 describe('JSX printer', () => {
   it('handles nested ternaries', () => {
-    FOR_TESTS_setNextGeneratedUids(['mock1', 'conditional2', 'mock2', 'conditional1'])
+    FOR_TESTS_setNextGeneratedUids([
+      'mock1',
+      'mock2',
+      'mock3',
+      'mock4',
+      'conditional1',
+      'conditional2',
+    ])
     const code = applyPrettier(NestedTernariesExample, false).formatted
     const parseResult = testParseCode(code)
     if (isParseSuccess(parseResult)) {


### PR DESCRIPTION
Fixes #3397

**Problem:**

Currently pasting cut/copied conditionals via the navigator does not work.

**Fix:**

Allow pasting conditional elements. Additionally, to avoid uid clashes, update the unique ids detection for conditionals and their branches.