### PR TITLE
Navigator Then Else Feedback Changes.

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -2161,25 +2161,17 @@ export function navigatorEntriesEqual(
   second: NavigatorEntry | null,
 ): boolean {
   if (first == null) {
-    if (second == null) {
-      return true
-    } else {
-      return false
-    }
+    return second == null
+  } else if (second == null) {
+    return false
+  } else if (first.type === 'REGULAR' && second.type === 'REGULAR') {
+    return regularNavigatorEntriesEqual(first, second)
+  } else if (first.type === 'CONDITIONAL_CLAUSE' && second.type === 'CONDITIONAL_CLAUSE') {
+    return conditionalClauseNavigatorEntriesEqual(first, second)
+  } else if (first.type === 'SYNTHETIC' && second.type === 'SYNTHETIC') {
+    return syntheticNavigatorEntriesEqual(first, second)
   } else {
-    if (second == null) {
-      return false
-    } else {
-      if (first.type === 'REGULAR' && second.type === 'REGULAR') {
-        return regularNavigatorEntriesEqual(first, second)
-      } else if (first.type === 'CONDITIONAL_CLAUSE' && second.type === 'CONDITIONAL_CLAUSE') {
-        return conditionalClauseNavigatorEntriesEqual(first, second)
-      } else if (first.type === 'SYNTHETIC' && second.type === 'SYNTHETIC') {
-        return syntheticNavigatorEntriesEqual(first, second)
-      } else {
-        return false
-      }
-    }
+    return false
   }
 }
 

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -140,7 +140,7 @@ function getNavigatorEntryLabel(
           case 'JSX_ELEMENT':
             return getJSXElementNameLastPart(navigatorEntry.childOrAttribute.name)
           case 'JSX_ARBITRARY_BLOCK':
-            return 'Unknown'
+            return '(code)'
           case 'JSX_TEXT_BLOCK':
             return navigatorEntry.childOrAttribute.text
           case 'JSX_FRAGMENT':

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -50,10 +50,7 @@ interface ComputedLook {
 export const BasePaddingUnit = 20
 
 export function getElementPadding(withNavigatorDepth: number): number {
-  // an empty path and the storyboard is always part of the ancestorsNotInNavigator list and that doesn't matter,
-  // so we can add 2 to the offset. NOTE: this 2 is also a constant in EP.navigatorDepth for the same reason
   const paddingOffset = withNavigatorDepth - 1
-
   return paddingOffset * BasePaddingUnit
 }
 

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -91,8 +91,9 @@ export function getNavigatorTargets(
   collapsedViews: Array<ElementPath>,
   hiddenInNavigator: Array<ElementPath>,
 ): GetNavigatorTargetsResults {
-  // Note: This will not necessarily be representative of the structured ordering in
-  // the code that produced these elements.
+  // Note: This value will not necessarily be representative of the structured ordering in
+  // the code that produced these elements, between siblings, as a result of it
+  // relying on `metadata`, which has insertion ordering.
   const projectTree = buildTree(objectValues(metadata).map((m) => m.elementPath)).map((subTree) => {
     return reorderTree(subTree, metadata)
   })


### PR DESCRIPTION
**Problem:**
Some feedback wasn't able to be addressed in the original PR: https://github.com/concrete-utopia/utopia/pull/3377

**Fix:**
Addressed some of the PR feedback by making some small code changes but mostly improving some comments.

**Commit Details:**
- Tweaked `navigatorEntriesEqual` to make it less nested and a bit clearer.
- Small change in `getNavigatorEntryLabel` to make it match the metadata based label.
- Removed a comment from `getElementPadding` as the code is super simple now.
- Improved a comment in `getNavigatorTargets`.