### PR TITLE
Don't show ⚠️ icon for group children

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -2554,23 +2554,16 @@ function getElementWarningsInner(
     )
 
     const isParentConfiguredForPins =
-      MetadataUtils.isPositionAbsolute(
-        MetadataUtils.findElementByElementPath(rootMetadata, elementMetadata.elementPath),
-      ) && !elementMetadata.specialSizeMeasurements.immediateParentProvidesLayout
+      MetadataUtils.isPositionAbsolute(elementMetadata) &&
+      !elementMetadata.specialSizeMeasurements.immediateParentProvidesLayout
     const absoluteWithUnpositionedParent = isParentConfiguredForPins && isParentGroupLike === false
 
-    // Build the warnings object and add it to the map.
-    if (
-      widthOrHeightZero !== defaultElementWarnings.widthOrHeightZero ||
-      absoluteWithUnpositionedParent !== defaultElementWarnings.absoluteWithUnpositionedParent
-    ) {
-      const warnings: ElementWarnings = {
-        widthOrHeightZero: widthOrHeightZero,
-        absoluteWithUnpositionedParent: absoluteWithUnpositionedParent,
-        dynamicSceneChildWidthHeightPercentage: false,
-      }
-      result = addToComplexMap(toString, result, elementMetadata.elementPath, warnings)
+    const warnings: ElementWarnings = {
+      widthOrHeightZero: widthOrHeightZero,
+      absoluteWithUnpositionedParent: absoluteWithUnpositionedParent,
+      dynamicSceneChildWidthHeightPercentage: false,
     }
+    result = addToComplexMap(toString, result, elementMetadata.elementPath, warnings)
   })
   return result
 }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -2553,10 +2553,10 @@ function getElementWarningsInner(
       EP.parentPath(elementMetadata.elementPath),
     )
 
-    const isParentConfiguredForPins =
+    const isParentNotConfiguredForPins =
       MetadataUtils.isPositionAbsolute(elementMetadata) &&
       !elementMetadata.specialSizeMeasurements.immediateParentProvidesLayout
-    const absoluteWithUnpositionedParent = isParentConfiguredForPins && isParentGroupLike === false
+    const absoluteWithUnpositionedParent = isParentNotConfiguredForPins && !isParentGroupLike
 
     const warnings: ElementWarnings = {
       widthOrHeightZero: widthOrHeightZero,

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -73,7 +73,6 @@ export interface NavigatorItemDragAndDropWrapperProps {
   label: string
   isElementVisible: boolean
   renamingTarget: ElementPath | null
-  elementWarnings: ElementWarnings
   windowStyle: React.CSSProperties
   visibleNavigatorTargets: Array<NavigatorEntry>
 }
@@ -562,7 +561,6 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
           renamingTarget={props.renamingTarget}
           collapsed={props.collapsed}
           selected={props.selected}
-          elementWarnings={props.elementWarnings}
           shouldShowParentOutline={shouldShowParentOutline}
           visibleNavigatorTargets={props.visibleNavigatorTargets}
         />

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -86,21 +86,6 @@ const labelSelector = createCachedSelector(
   },
 )((_, navigatorEntry) => navigatorEntryToKey(navigatorEntry))
 
-const elementWarningsSelector = createCachedSelector(
-  (store: DerivedSubstate) => store.derived.elementWarnings,
-  (_: DerivedSubstate, navigatorEntry: NavigatorEntry) => navigatorEntry,
-  (elementWarnings, navigatorEntry) => {
-    if (isRegularNavigatorEntry(navigatorEntry)) {
-      return (
-        getValueFromComplexMap(EP.toString, elementWarnings, navigatorEntry.elementPath) ??
-        defaultElementWarnings
-      )
-    } else {
-      return defaultElementWarnings
-    }
-  },
-)((_, navigatorEntry) => navigatorEntryToKey(navigatorEntry))
-
 const noOfChildrenSelector = createCachedSelector(
   (store: DerivedSubstate) => store.derived.navigatorTargets,
   (_: DerivedSubstate, navigatorEntry: NavigatorEntry) => navigatorEntry,
@@ -220,12 +205,6 @@ export const NavigatorItemWrapper: React.FunctionComponent<
     'NavigatorItemWrapper entryDepth',
   )
 
-  const elementWarnings = useEditorState(
-    Substores.derived,
-    (store) => elementWarningsSelector(store, props.navigatorEntry),
-    'NavigatorItemWrapper elementWarningsSelector',
-  )
-
   const visibleNavigatorTargets = useEditorState(
     Substores.derived,
     (store) => store.derived.visibleNavigatorTargets,
@@ -282,7 +261,6 @@ export const NavigatorItemWrapper: React.FunctionComponent<
     label: label,
     isElementVisible: isElementVisible,
     renamingTarget: renamingTarget,
-    elementWarnings: elementWarnings,
     windowStyle: props.windowStyle,
     visibleNavigatorTargets: visibleNavigatorTargets,
   }

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -312,6 +312,84 @@ export var storyboard = (
 )
 `
 
+const projectWithGroupsAndNotGroups = `import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div data-uid='group'>
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 1136,
+          top: 325,
+          width: 141,
+          height: 190,
+        }}
+        data-uid='groupchild'
+      />
+    </div>
+    <React.Fragment data-uid='fragment'>
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 257.5,
+          top: 229,
+          width: 250,
+          height: 238,
+        }}
+        data-uid='fragmentchild'
+      />
+    </React.Fragment>
+    <div
+      data-uid='offsetparent'
+      style={{
+        position: 'absolute',
+        width: 310,
+        height: 575,
+        left: 566,
+        top: -2,
+      }}
+    >
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 165,
+          top: 360,
+          width: 119,
+          height: 193,
+        }}
+        data-uid='offsetchild'
+      />
+    </div>
+    <div
+      data-uid='nonoffsetparent'
+      style={{
+        width: 310,
+        height: 575,
+        left: 248,
+        top: 515,
+      }}
+    >
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 83,
+          top: 274,
+          width: 119,
+          height: 193,
+        }}
+        data-uid='nonoffsetchild'
+      />
+    </div>
+  </Storyboard>
+)
+`
+
 describe('Navigator', () => {
   describe('selecting elements', () => {
     it('by clicking the center of the item', async () => {
@@ -1019,6 +1097,32 @@ describe('Navigator', () => {
         'regular-sb/parent2/aab',
         'regular-sb/text',
       ])
+    })
+  })
+
+  describe('derived data', () => {
+    it('element warnings', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithGroupsAndNotGroups,
+        'await-first-dom-report',
+      )
+
+      await selectComponentsForTest(editor, [EP.fromString('sb/group/groupchild')])
+
+      const { elementWarnings } = editor.getEditorState().derived
+
+      expect(elementWarnings['sb/group/groupchild'].value.absoluteWithUnpositionedParent).toEqual(
+        false,
+      )
+      expect(
+        elementWarnings['sb/fragment/fragmentchild'].value.absoluteWithUnpositionedParent,
+      ).toEqual(false)
+      expect(
+        elementWarnings['sb/offsetparent/offsetchild'].value.absoluteWithUnpositionedParent,
+      ).toEqual(false)
+      expect(
+        elementWarnings['sb/nonoffsetparent/nonoffsetchild'].value.absoluteWithUnpositionedParent,
+      ).toEqual(true)
     })
   })
 })


### PR DESCRIPTION
## Problem
Absolute children of sizeless divs, which we consider group-like elements, displayed a ⚠️ indicating that they aren't positioned by their parent.

## Fix
Since we consider sizeless divs group-like elements, they aren't supposed to position their children anyway. To prevent misleading messaging on the UI, to reduce clutter, and to make the behaviour consistent with fragments, sizeless divs are now special-cased not to trigger the ⚠️ warning.