### PR TITLE
Fix keyboard shortcut click to insert

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -355,80 +355,92 @@ describe('Inserting into absolute', () => {
     )
   })
 
-  it('Click to insert with default size', async () => {
-    const renderResult = await setupInsertTest(inputCode)
-    await enterInsertModeFromInsertMenu(renderResult)
+  describe('Click to insert with default size', () => {
+    async function runClickToInsertTest(renderResult: EditorRenderResult) {
+      const targetElement = renderResult.renderedDOM.getByTestId('bbb')
+      const targetElementBounds = targetElement.getBoundingClientRect()
+      const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
 
-    const targetElement = renderResult.renderedDOM.getByTestId('bbb')
-    const targetElementBounds = targetElement.getBoundingClientRect()
-    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+      const point = slightlyOffsetWindowPointBecauseVeryWeirdIssue({
+        x: targetElementBounds.x + 65,
+        y: targetElementBounds.y + 55,
+      })
 
-    const point = slightlyOffsetWindowPointBecauseVeryWeirdIssue({
-      x: targetElementBounds.x + 65,
-      y: targetElementBounds.y + 55,
-    })
+      // Move before clicking
+      await mouseMoveToPoint(canvasControlsLayer, point)
 
-    // Move before clicking
-    await mouseMoveToPoint(canvasControlsLayer, point)
+      // Highlight should show the candidate parent
+      expect(renderResult.getEditorState().editor.highlightedViews.map(EP.toUid)).toEqual(['bbb'])
 
-    // Highlight should show the candidate parent
-    expect(renderResult.getEditorState().editor.highlightedViews.map(EP.toUid)).toEqual(['bbb'])
+      // Click in bbb
+      await mouseClickAtPoint(canvasControlsLayer, point)
 
-    // Click in bbb
-    await mouseClickAtPoint(canvasControlsLayer, point)
+      await renderResult.getDispatchFollowUpActionsFinished()
 
-    await renderResult.getDispatchFollowUpActionsFinished()
-
-    // Check that the inserted element is a child of bbb
-    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
-      makeTestProjectCodeWithSnippet(`
-        <div
-          data-uid='aaa'
-          style={{
-            width: '100%',
-            height: '100%',
-            backgroundColor: '#FFFFFF',
-            position: 'relative',
-          }}
-        >
+      // Check that the inserted element is a child of bbb
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        makeTestProjectCodeWithSnippet(`
           <div
-            data-uid='bbb'
-            data-testid='bbb'
+            data-uid='aaa'
             style={{
-              position: 'absolute',
-              left: 10,
-              top: 10,
-              width: 380,
-              height: 180,
-              backgroundColor: '#d3d3d3',
+              width: '100%',
+              height: '100%',
+              backgroundColor: '#FFFFFF',
+              position: 'relative',
             }}
           >
             <div
+              data-uid='bbb'
+              data-testid='bbb'
               style={{
-                backgroundColor: '#aaaaaa33',
                 position: 'absolute',
-                left: 15,
-                top: 5,
-                width: 100,
-                height: 100,
+                left: 10,
+                top: 10,
+                width: 380,
+                height: 180,
+                backgroundColor: '#d3d3d3',
               }}
-              data-uid='ddd'
+            >
+              <div
+                style={{
+                  backgroundColor: '#aaaaaa33',
+                  position: 'absolute',
+                  left: 15,
+                  top: 5,
+                  width: 100,
+                  height: 100,
+                }}
+                data-uid='ddd'
+              />
+            </div>
+            <div
+              data-uid='ccc'
+              style={{
+                position: 'absolute',
+                left: 10,
+                top: 200,
+                width: 380,
+                height: 190,
+                backgroundColor: '#FF0000',
+              }}
             />
           </div>
-          <div
-            data-uid='ccc'
-            style={{
-              position: 'absolute',
-              left: 10,
-              top: 200,
-              width: 380,
-              height: 190,
-              backgroundColor: '#FF0000',
-            }}
-          />
-        </div>
-      `),
-    )
+        `),
+      )
+    }
+
+    it('works from the insert menu', async () => {
+      const renderResult = await setupInsertTest(inputCode)
+      await enterInsertModeFromInsertMenu(renderResult)
+      await runClickToInsertTest(renderResult)
+    })
+
+    it('works with the keyboard shortcut', async () => {
+      const renderResult = await setupInsertTest(inputCode)
+      await pressKey('d')
+      ensureInInsertMode(renderResult)
+      await runClickToInsertTest(renderResult)
+    })
   })
 
   it('Click to insert into an element smaller than the default size', async () => {

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -146,7 +146,7 @@ import {
   setCssLengthProperty,
   setExplicitCssValue,
 } from '../canvas/commands/set-css-length-command'
-import { isInfinityRectangle } from '../../core/shared/math-utils'
+import { isInfinityRectangle, zeroCanvasPoint } from '../../core/shared/math-utils'
 
 function updateKeysPressed(
   keysPressed: KeysPressed,
@@ -1057,19 +1057,13 @@ function addCreateHoverInteractionActionToSwitchModeAction(
   switchModeAction: SwitchEditorMode,
   modifiers: Modifiers,
 ) {
-  return CanvasMousePositionRaw != null
-    ? [
-        switchModeAction,
-        CanvasActions.createInteractionSession(
-          createHoverInteractionViaMouse(
-            CanvasMousePositionRaw,
-            modifiers,
-            boundingArea(),
-            'zero-drag-permitted',
-          ),
-        ),
-      ]
-    : [switchModeAction]
+  const mousePoint = CanvasMousePositionRaw ?? zeroCanvasPoint
+  return [
+    switchModeAction,
+    CanvasActions.createInteractionSession(
+      createHoverInteractionViaMouse(mousePoint, modifiers, boundingArea(), 'zero-drag-permitted'),
+    ),
+  ]
 }
 
 function detectBestWrapperElement(

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -1065,7 +1065,7 @@ function addCreateHoverInteractionActionToSwitchModeAction(
             CanvasMousePositionRaw,
             modifiers,
             boundingArea(),
-            'zero-drag-not-permitted',
+            'zero-drag-permitted',
           ),
         ),
       ]

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -201,19 +201,13 @@ function handleCanvasEvent(
       optionalDragStateAction = cancelInsertModeActions(shouldApplyChanges)
     } else if (event.event === 'MOUSE_DOWN') {
       if (model.editorState.canvas.interactionSession == null) {
-        optionalDragStateAction = [
-          CanvasActions.createInteractionSession(
-            createInteractionViaMouse(
-              event.canvasPositionRounded,
-              event.modifiers,
-              {
-                type: 'RESIZE_HANDLE',
-                edgePosition: { x: 1, y: 1 },
-              },
-              'zero-drag-not-permitted',
-            ),
-          ),
-        ]
+        // This code path should absolutely not be live, because there should always be an
+        // existing interaction session whilst in insert mode. However, since the path is
+        // technically possible, we throw an error here so that we can quickly discover
+        // if we've accidentally re-enabled it
+        throw new Error(
+          `It shouldn't be possible to be in insert mode without an active interactionSession`,
+        )
       } else if (
         model.editorState.canvas.interactionSession.interactionData.type === 'DRAG' ||
         model.editorState.canvas.interactionSession.interactionData.type === 'HOVER'


### PR DESCRIPTION
**Problem:**
Entering insert mode via a keyboard shortcut would prevent click to insert behaviour

**Fix:**
The problem was that in this case we were using `zero-drag-not-permitted` when creating the `InteractionSession`, whereas we should have been using `zero-drag-permitted`. I've fixed that, and added a test to cover it.

Whilst fixing that, I discovered another place that was incorrectly using `zero-drag-not-permitted`, but realised the code path there is dead. Since it is possible that we could accidentally revive that dead code path, and we don't want to be accidentally running stale code a year or so from now, I have added an error to that path with an explanation.

Finally, running the test in isolation immediately triggered that error, because there had been no mouse interaction yet, meaning `CanvasMousePositionRaw` was `null`, which happened to be the one case where we wouldn't initialise an `InteractionSession` when switching to insert mode! So since that is a situation that could only happen in a purely synthetic environment, and since it was IMO the wrong thing to do anyway, I've removed that null check and now use `zeroCanvasPoint` if it is `null`.