### PR TITLE
Fix recursive group sizing

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
@@ -107,7 +107,10 @@ export const App2 = (props) => {
 
 export var App = (props) => {
   return (
-    <div data-uid='app-root'>
+    <div
+      data-uid='app-root'
+      style={{ width: '100%', height: '100%' }}
+    >
       <App2
         data-uid='app2'
         style={{

--- a/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
@@ -692,7 +692,7 @@ describe('Fixed / Fill / Hug control', () => {
         expect((heightControl as HTMLInputElement).value).toEqual('407px')
       }
 
-      const groupGlobalFrame = await getGlobalFrame(editor, EP.fromString('sb/group'))
+      const groupGlobalFrame = await getGlobalFrame(editor, EP.fromString('sb/supergroup/group'))
       expect(groupGlobalFrame.width).toBe(326)
       expect(groupGlobalFrame.height).toBe(407)
 
@@ -1310,7 +1310,7 @@ async function getGlobalFrame(editor: EditorRenderResult, path: ElementPath) {
   await selectComponentsForTest(editor, [path])
   const instance = MetadataUtils.findElementByElementPath(
     editor.getEditorState().editor.jsxMetadata,
-    EP.fromString('sb/supergroup'),
+    path,
   )
   if (instance?.globalFrame == null) {
     throw new Error('`instance?.globalFrame` is null')

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1972,6 +1972,9 @@ function fillSpyOnlyMetadata(
   elementsWithoutDomMetadata.sort()
   elementsWithoutDomMetadata.reverse()
 
+  elementsWithoutIntrinsicSize.sort()
+  elementsWithoutIntrinsicSize.reverse()
+
   const workingElements: ElementInstanceMetadataMap = {}
 
   fastForEach([...elementsWithoutDomMetadata, ...elementsWithoutIntrinsicSize], (pathStr) => {

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1978,13 +1978,12 @@ function fillSpyOnlyMetadata(
   // Sort and then reverse these, so that lower level elements (with longer paths) are handled ahead of their parents
   // and ancestors. This means that if there are a grandparent and parent which both lack global frames
   // then the parent is fixed ahead of the grandparent, which will be based on the parent.
+  elementsWithoutIntrinsicSize.sort()
+  elementsWithoutIntrinsicSize.reverse()
   elementsWithoutDomMetadata.sort()
   elementsWithoutDomMetadata.reverse()
   elementsWithoutParentData.sort()
   elementsWithoutParentData.reverse()
-
-  elementsWithoutIntrinsicSize.sort()
-  elementsWithoutIntrinsicSize.reverse()
 
   const workingElements: ElementInstanceMetadataMap = {}
 


### PR DESCRIPTION
**Problem:**
Groups of groups had all sorts of weird globalFrame issues on the canvas

**Fix:**
The fix is dead simple, just do the same two-liner trick for `elementsWithoutIntrinsicSize` that we already had in there for `elementsWithoutDomMetadata` 

**Bonus**
Wonderful test from @bkrmendy 