### PR TITLE
Reparent into grouplike element

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -16,6 +16,7 @@ import {
 import {
   findElementAtPath,
   findJSXElementAtPath,
+  findJSXElementLikeAtPath,
   getSimpleAttributeAtPath,
   MetadataUtils,
 } from '../../core/model/element-metadata-utils'
@@ -2817,7 +2818,7 @@ export function reorderComponent(
 
   const jsxElement = findElementAtPath(target, workingComponents)
   const parentPath = EP.parentPath(target)
-  const parentElement = findJSXElementAtPath(parentPath, workingComponents)
+  const parentElement = findJSXElementLikeAtPath(parentPath, workingComponents)
 
   if (jsxElement != null && parentElement != null) {
     const indexOfRemovedElement = parentElement.children.indexOf(jsxElement)

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -54,6 +54,8 @@ import {
   DetectedLayoutSystem,
   JSXConditionalExpression,
   ConditionalValue,
+  isJSXElementLike,
+  JSXElementLike,
 } from '../shared/element-template'
 import {
   getModifiableJSXAttributeAtPath,
@@ -2133,6 +2135,20 @@ export function findJSXElementAtPath(
   const elem = findElementAtPath(target, components)
   return Utils.optionalMap((e) => {
     if (isJSXElement(e)) {
+      return e
+    } else {
+      return null
+    }
+  }, elem)
+}
+
+export function findJSXElementLikeAtPath(
+  target: ElementPath | null,
+  components: Array<UtopiaJSXComponent>,
+): JSXElementLike | null {
+  const elem = findElementAtPath(target, components)
+  return Utils.optionalMap((e) => {
+    if (isJSXElementLike(e)) {
       return e
     } else {
       return null


### PR DESCRIPTION
## Problem
When reparenting into a fragment via the navigator, the reparented element always ended up as the last sibling, regardless of where it was reparented to.

## Fix
Reparenting to a specific position in the navigator is implemented by reparenting the element to the new parent, and then reordered to the correct index. The root cause of the problem was that the reorder step failed since it was guarded by a check that didn't consider fragments. This PR fixes it by considering fragments as well when performing the check.