### PR TITLE
Clicking to insert text always inserts a new span

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
@@ -76,7 +76,7 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
 
         const { targetParent } = factory
 
-        const textEditable = MetadataUtils.targetTextEditable(
+        const textEditableAndHasText = MetadataUtils.targetTextEditableAndHasText(
           canvasState.startingMetadata,
           targetParent,
         )
@@ -85,7 +85,7 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
           targetParent.parts.length > 0 ? targetParent.parts[0].length : 0
         const isRoot = targetParentPathParts === 1
         const isClick = s === 'end-interaction' && interactionSession.interactionData.drag == null
-        if (!isRoot && textEditable && isClick) {
+        if (!isRoot && textEditableAndHasText && isClick) {
           return strategyApplicationResult([
             updateSelectedViews('on-complete', [targetParent]),
             setCursorCommand(CSSCursor.Select),

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -357,7 +357,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
           return false
         }
         return (
-          MetadataUtils.targetTextEditable(componentMetadata, EP.fromString(p)) &&
+          MetadataUtils.targetTextEditableAndHasText(componentMetadata, EP.fromString(p)) &&
           ['hasOnlyTextChildren', 'supportsChildren'].includes(
             MetadataUtils.targetElementSupportsChildrenAlsoText(projectContents, metadata),
           )

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -14,6 +14,7 @@ import {
   renderTestEditorWithCode,
 } from '../canvas/ui-jsx.test-utils'
 import { TextEditorSpanId } from './text-editor'
+import { FOR_TESTS_setNextGeneratedUid } from '../../core/model/element-template-utils.test-utils'
 
 describe('Use the text editor', () => {
   it('Click to edit text', async () => {
@@ -77,7 +78,7 @@ describe('Use the text editor', () => {
                 height: 362,
               }}
               data-uid='39e'
-            >Utopia</div>
+            >${textSpan('Utopia')}</div>
           </Storyboard>
         )`),
     )
@@ -142,7 +143,7 @@ describe('Use the text editor', () => {
                 height: 362,
               }}
               data-uid='39e'
-            >this is a &lt;test&gt; with bells & whistles</div>
+            >${textSpan('this is a &lt;test&gt; with bells & whistles')}</div>
           </Storyboard>
         )`),
     )
@@ -205,13 +206,13 @@ describe('Use the text editor', () => {
       const { before, after } = await testModifier(
         cmdModifier,
         'b',
-        projectWithoutTextWithStyleProp('font', 'bold 1.2em "Fira Sans"'),
+        projectWithoutTextWithExtraStyle({ font: 'bold 1.2em "Fira Sans"' }),
       )
       expect(before).toEqual(
-        projectWithStyle({ font: 'bold 1.2em "Fira Sans"', fontWeight: 'normal' }),
+        projectWithStyle({ fontWeight: 'normal' }, { font: 'bold 1.2em "Fira Sans"' }),
       )
       expect(after).toEqual(
-        projectWithStyle({ font: 'bold 1.2em "Fira Sans"', fontWeight: 'bold' }),
+        projectWithStyle({ fontWeight: 'bold' }, { font: 'bold 1.2em "Fira Sans"' }),
       )
     })
     it('supports italic', async () => {
@@ -223,13 +224,13 @@ describe('Use the text editor', () => {
       const { before, after } = await testModifier(
         cmdModifier,
         'i',
-        projectWithoutTextWithStyleProp('font', 'italic 1.2em "Fira Sans"'),
+        projectWithoutTextWithExtraStyle({ font: 'italic 1.2em "Fira Sans"' }),
       )
       expect(before).toEqual(
-        projectWithStyle({ font: 'italic 1.2em "Fira Sans"', fontStyle: 'normal' }),
+        projectWithStyle({ fontStyle: 'normal' }, { font: 'italic 1.2em "Fira Sans"' }),
       )
       expect(after).toEqual(
-        projectWithStyle({ font: 'italic 1.2em "Fira Sans"', fontStyle: 'italic' }),
+        projectWithStyle({ fontStyle: 'italic' }, { font: 'italic 1.2em "Fira Sans"' }),
       )
     })
     it('supports underline', async () => {
@@ -830,7 +831,9 @@ describe('Use the text editor', () => {
                       height: 362,
                     }}
                     data-uid='39e'
-                  >the answer is {41 + 1}</div>
+                  >
+                    ${textSpan('the answer is {41 + 1}')}
+                  </div>
                 </Storyboard>
               )`),
       )
@@ -839,30 +842,55 @@ describe('Use the text editor', () => {
   })
 })
 
-function projectWithStyle(props: { [prop: string]: string }) {
+function textSpan(text: string, extraStyleProps?: { [prop: string]: string }): string {
   const styleProps = {
+    position: 'absolute',
+    wordBreak: 'break-word',
+    left: 51,
+    top: 41,
+    width: 200,
+    ...extraStyleProps,
+  }
+  return `
+    <span
+      style={${JSON.stringify(styleProps)}}
+      data-uid='text-span'
+    >
+      ${text}
+    </span>
+  `
+}
+
+function projectWithStyle(
+  props: { [prop: string]: string },
+  divExtraStyleProps?: { [prop: string]: string },
+) {
+  const divStyleProps = {
     backgroundColor: '#0091FFAA',
     position: 'absolute',
     left: 0,
     top: 0,
     width: 288,
     height: 362,
-    ...props,
+    ...divExtraStyleProps,
   }
+
   return formatTestProjectCode(`
-        import * as React from 'react'
-        import { Storyboard } from 'utopia-api'
+    import * as React from 'react'
+    import { Storyboard } from 'utopia-api'
 
 
-        export var storyboard = (
-          <Storyboard data-uid='sb'>
-            <div
-              data-testid='div'
-              style={${JSON.stringify(styleProps)}}
-              data-uid='39e'
-            >Hello Utopia</div>
-          </Storyboard>
-        )`)
+    export var storyboard = (
+      <Storyboard data-uid='sb'>
+        <div
+          data-testid='div'
+          style={${JSON.stringify(divStyleProps)}}
+          data-uid='39e'
+        >
+          ${textSpan('Hello Utopia', props)}
+        </div>
+      </Storyboard>
+    )`)
 }
 
 function projectWithStyleNoQuotes(prop: string, value: string) {
@@ -928,7 +956,6 @@ async function testModifier(
   await pressShortcut(editor, mod, key)
   const before = getPrintedUiJsCode(editor.getEditorState())
 
-  await enterTextEditMode(editor)
   await pressShortcut(editor, mod, key)
   const after = getPrintedUiJsCode(editor.getEditorState())
 
@@ -943,6 +970,8 @@ async function enterTextEditMode(editor: EditorRenderResult): Promise<void> {
     x: divBounds.x + 50,
     y: divBounds.y + 40,
   }
+
+  FOR_TESTS_setNextGeneratedUid('text-span')
 
   await pressKey('t')
   await editor.getDispatchFollowUpActionsFinished()
@@ -1005,7 +1034,17 @@ export var storyboard = (
 )
 `)
 
-function projectWithoutTextWithStyleProp(prop: string, value: string) {
+function projectWithoutTextWithExtraStyle(extraStyleProps: { [prop: string]: string }) {
+  const styleProps = {
+    backgroundColor: '#0091FFAA',
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    width: 288,
+    height: 362,
+    ...extraStyleProps,
+  }
+
   return formatTestProjectCode(`import * as React from 'react'
     import { Storyboard } from 'utopia-api'
 
@@ -1014,15 +1053,7 @@ function projectWithoutTextWithStyleProp(prop: string, value: string) {
       <Storyboard data-uid='sb'>
         <div
           data-testid='div'
-          style={{
-            backgroundColor: '#0091FFAA',
-            position: 'absolute',
-            left: 0,
-            top: 0,
-            width: 288,
-            height: 362,
-            ${prop}: '${value}'
-          }}
+          style={${JSON.stringify(styleProps)}}
           data-uid='39e'
         />
       </Storyboard>


### PR DESCRIPTION
**Problem:**
Clicking on an empty `div` to insert text would add text to the `div` itself, meaning the text wouldn't be inserted at the point of the click.

**Fix:**
Wrap the text in a new `span` when clicking to insert. If there is existing text in the `div` then we will still choose to edit that rather than inserting a new `span`
