### PR TITLE
Fixed set-utils tests

### DIFF
--- a/editor/src/core/shared/set-utils.spec.ts
+++ b/editor/src/core/shared/set-utils.spec.ts
@@ -4,12 +4,12 @@ import { intersection } from './set-utils'
 describe('intersection', () => {
   it('intersection of overlapping sets', () => {
     const result = intersection([new Set([1, 2, 3, 4]), new Set([3, 4, 5, 6])])
-    expect([...result]).toEqual([3, 4])
+    expect(result).toEqual(new Set([3, 4]))
   })
 
   it('intersection of disjunct sets', () => {
     const result = intersection([new Set([1, 2, 3]), new Set([4, 5, 6])])
-    expect([...result]).toEqual([])
+    expect(result).toEqual(new Set([]))
   })
 
   it('intersection is commutative', () => {
@@ -17,7 +17,7 @@ describe('intersection', () => {
       fc.property(fc.set(fc.nat()), fc.set(fc.nat()), (left, right) => {
         const resultA = intersection([new Set(left), new Set(right)])
         const resultB = intersection([new Set(right), new Set(left)])
-        expect([...resultA]).toEqual([...resultB])
+        expect(resultA).toEqual(resultB)
       }),
     )
   })
@@ -26,7 +26,7 @@ describe('intersection', () => {
     fc.assert(
       fc.property(fc.set(fc.nat()), (xs) => {
         const resultA = intersection([new Set(xs), new Set(xs)])
-        expect([...resultA]).toEqual([...xs])
+        expect(resultA).toEqual(new Set(xs))
       }),
     )
   })


### PR DESCRIPTION
**Problem:**
The tests would occasionally fail because we were converting sets to arrays before comparing the results, meaning the ordering of the values would sometimes differ.

**Fix:**
Just compare sets!