### PR TITLE
Fix calculation of which conditional branch is hidden

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -284,24 +284,32 @@ const isHiddenConditionalBranchSelector = createCachedSelector(
     elementPath: ElementPath,
     parentPath: ElementPath,
   ): boolean => {
+    if (parent == null) {
+      return false
+    }
+    const originalConditionValue = parent.conditionalValue
+    if (originalConditionValue === 'not-a-conditional') {
+      return false
+    }
+
     const conditional = asConditional(parent)
     if (conditional == null) {
       return false
     }
+
     const flag = getConditionalFlag(conditional)
-    return flag === false
-      ? matchesOverriddenBranch(elementPath, parentPath, {
-          clause: conditional.whenTrue,
-          branch: 'then',
-          wantOverride: true,
-          parentOverride: true,
-        })
-      : matchesOverriddenBranch(elementPath, parentPath, {
-          clause: conditional.whenFalse,
-          branch: 'else',
-          wantOverride: false,
-          parentOverride: false,
-        })
+
+    // the final condition value, either from the original or from the override
+    const overriddenConditionValue = flag ?? originalConditionValue
+
+    // when the condition is true, then the 'then' branch is not hidden
+    if (overriddenConditionValue) {
+      const trueClausePath = getConditionalClausePath(parentPath, conditional.whenTrue, 'then')
+      return !EP.pathsEqual(elementPath, trueClausePath)
+    }
+    // when the condition is false, then the 'else' branch is not hidden
+    const falseClausePath = getConditionalClausePath(parentPath, conditional.whenFalse, 'else')
+    return !EP.pathsEqual(elementPath, falseClausePath)
   },
 )((_, elementPath, parentPath) => `${EP.toString(elementPath)}_${EP.toString(parentPath)}`)
 

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -300,7 +300,7 @@ const isHiddenConditionalBranchSelector = createCachedSelector(
     const flag = getConditionalFlag(conditional)
 
     // the final condition value, either from the original or from the override
-    const overriddenConditionValue = flag ?? originalConditionValue
+    const overriddenConditionValue: boolean = flag ?? originalConditionValue
 
     // when the condition is true, then the 'then' branch is not hidden
     if (overriddenConditionValue) {


### PR DESCRIPTION
**Problem:**
When we count which branch should be hidden, we only take the condition override into account and not the current real  condition value.

See e.g. this simple project where the true branch should be hidden:
<img width="779" alt="image" src="https://user-images.githubusercontent.com/127662/224298027-fa316f11-4670-4004-994b-b3037603699b.png">


**Fix:**
In `isHiddenConditionalBranchSelector` the current condition value is not used at all, only the override from the comment flag.
