### PR TITLE
Feat/wrap conditionals

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -468,13 +468,10 @@ export function updateFramesOfScenesAndComponents(
       (success, underlyingElement) => underlyingElement,
     )
 
-    const targetElementMetadata = MetadataUtils.findElementByElementPath(
-      editorState.jsxMetadata,
-      target,
-    )
-    const targetElementProps = editorState.allElementProps[EP.toString(target)] ?? {}
+    const elementMetadata = MetadataUtils.findElementByElementPath(editorState.jsxMetadata, target)
+    const elementProps = editorState.allElementProps[EP.toString(target)] ?? {}
 
-    const elementProps = isJSXConditionalExpression(element) ? [] : element.props
+    const elementAttributes = isJSXConditionalExpression(element) ? [] : element.props
 
     const isFlexContainer =
       frameAndTarget.type !== 'PIN_FRAME_CHANGE' &&
@@ -527,12 +524,12 @@ export function updateFramesOfScenesAndComponents(
               'style',
             ])
             const valueFromDOM = getObservableValueForLayoutProp(
-              targetElementMetadata,
+              elementMetadata,
               frameAndTarget.targetProperty,
-              targetElementProps,
+              elementProps,
             )
             const valueFromAttributes = eitherToMaybe(
-              getSimpleAttributeAtPath(right(elementProps), targetPropertyPath),
+              getSimpleAttributeAtPath(right(elementAttributes), targetPropertyPath),
             )
             // Defer through these in order: observable value >>> value from attribute >>> 0.
             const currentAttributeToChange = valueFromDOM ?? valueFromAttributes ?? 0
@@ -611,7 +608,6 @@ export function updateFramesOfScenesAndComponents(
             )
             const currentFullFrame = optionalMap(Frame.getFullFrame, currentLocalFrame)
             const fullFrame = Frame.getFullFrame(newLocalFrame)
-            const elementAttributes = elementProps
 
             // Pinning layout.
             const frameProps = LayoutPinnedProps.filter((p) => {
@@ -688,7 +684,7 @@ export function updateFramesOfScenesAndComponents(
           let frameProps: { [k: string]: string | number | undefined } = {}
           Utils.fastForEach(LayoutPinnedProps, (p) => {
             if (p !== 'width' && p !== 'height') {
-              const value = getLayoutProperty(p, right(elementProps), styleStringInArray)
+              const value = getLayoutProperty(p, right(elementAttributes), styleStringInArray)
               if (isLeft(value) || value.value != null) {
                 frameProps[p] = cssNumberAsNumberIfPossible(value.value)
                 propsToSkip.push(stylePropPathMappingFn(p, styleStringInArray))
@@ -725,7 +721,7 @@ export function updateFramesOfScenesAndComponents(
           let frameProps: { [k: string]: string | number | undefined } = {}
           Utils.fastForEach(LayoutPinnedProps, (p) => {
             const framePoint = framePointForPinnedProp(p)
-            const value = getLayoutProperty(p, right(elementProps), styleStringInArray)
+            const value = getLayoutProperty(p, right(elementAttributes), styleStringInArray)
             if (isLeft(value) || value.value != null) {
               frameProps[framePoint] = cssNumberAsNumberIfPossible(value.value)
               propsToSkip.push(stylePropPathMappingFn(p, styleStringInArray))

--- a/editor/src/components/canvas/controls/render-as.tsx
+++ b/editor/src/components/canvas/controls/render-as.tsx
@@ -48,6 +48,9 @@ export const RenderAsRow = React.memo(() => {
   const onSelect = React.useCallback(
     (selectOption: SelectOption) => {
       const value: InsertableComponent = selectOption.value
+      if (value.element === 'conditional') {
+        return
+      }
       onElementTypeChange(value.element.name, value.importsToAdd)
     },
     [onElementTypeChange],

--- a/editor/src/components/canvas/controls/render-as.tsx
+++ b/editor/src/components/canvas/controls/render-as.tsx
@@ -98,7 +98,7 @@ export const RenderAsRow = React.memo(() => {
       for (const selectOptionGroup of insertableComponents) {
         for (const selectOption of selectOptionGroup.options ?? []) {
           const insertableComponent: InsertableComponent = selectOption.value
-          if (insertableComponent != null) {
+          if (insertableComponent != null && insertableComponent.element !== 'conditional') {
             if (jsxElementNameEquals(insertableComponent.element.name, nameToSearchFor)) {
               return selectOption
             }

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -588,12 +588,12 @@ export var FloatingMenu = React.memo(() => {
     },
     [
       floatingMenuState,
-      selectedViewsref,
-      addContentForInsertion,
-      fixedSizeForInsertion,
-      preserveVisualPositionForWrap,
       projectContentsRef,
+      selectedViewsref,
+      fixedSizeForInsertion,
+      addContentForInsertion,
       wrapContentForInsertion,
+      preserveVisualPositionForWrap,
     ],
   )
 

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -489,42 +489,50 @@ export var FloatingMenu = React.memo(() => {
         switch (floatingMenuState.insertMenuMode) {
           case 'wrap': {
             const newUID = generateUidWithExistingComponents(projectContentsRef.current)
-            const newElement = jsxElement(
-              pickedInsertableComponent.element.name,
-              newUID,
-              setJSXAttributesAttribute(
-                pickedInsertableComponent.element.props,
-                'data-uid',
-                jsxAttributeValue(newUID, emptyComments),
-              ),
-              pickedInsertableComponent.element.children,
-            )
 
-            const isFlexLayoutSystemMaybe_KILLME = getIsFlexBasedOnName_KILLME_EXPERIMENTAL(
-              newElement.name,
-            )
-            const flexDirection_KILLME =
-              getIsFlexDirectionBasedOnName_KILLME_SERIOUSLY_EXPERIMENTAL(newElement.name)
+            if (pickedInsertableComponent.element === 'conditional') {
+              actionsToDispatch = [wrapInView(selectedViews, 'conditional')]
+            } else {
+              const newElement = jsxElement(
+                pickedInsertableComponent.element.name,
+                newUID,
+                setJSXAttributesAttribute(
+                  pickedInsertableComponent.element.props,
+                  'data-uid',
+                  jsxAttributeValue(newUID, emptyComments),
+                ),
+                pickedInsertableComponent.element.children,
+              )
 
-            actionsToDispatch = [
-              preserveVisualPositionForWrap
-                ? wrapInView(
-                    selectedViews,
-                    {
+              const isFlexLayoutSystemMaybe_KILLME = getIsFlexBasedOnName_KILLME_EXPERIMENTAL(
+                newElement.name,
+              )
+              const flexDirection_KILLME =
+                getIsFlexDirectionBasedOnName_KILLME_SERIOUSLY_EXPERIMENTAL(newElement.name)
+
+              actionsToDispatch = [
+                preserveVisualPositionForWrap
+                  ? wrapInView(
+                      selectedViews,
+                      {
+                        element: newElement,
+                        importsToAdd: pickedInsertableComponent.importsToAdd,
+                      },
+                      isFlexLayoutSystemMaybe_KILLME ? 'flex' : LayoutSystem.PinSystem,
+                      flexDirection_KILLME,
+                    )
+                  : wrapInElement(selectedViews, {
                       element: newElement,
                       importsToAdd: pickedInsertableComponent.importsToAdd,
-                    },
-                    isFlexLayoutSystemMaybe_KILLME ? 'flex' : LayoutSystem.PinSystem,
-                    flexDirection_KILLME,
-                  )
-                : wrapInElement(selectedViews, {
-                    element: newElement,
-                    importsToAdd: pickedInsertableComponent.importsToAdd,
-                  }),
-            ]
+                    }),
+              ]
+            }
             break
           }
           case 'insert': {
+            if (pickedInsertableComponent.element === 'conditional') {
+              break
+            }
             let elementToInsert = pickedInsertableComponent
             if (addContentForInsertion && pickedInsertableComponent.element.children.length === 0) {
               elementToInsert = {
@@ -553,14 +561,14 @@ export var FloatingMenu = React.memo(() => {
             break
           }
           case 'convert': {
+            if (pickedInsertableComponent.element === 'conditional') {
+              break
+            }
+            const { element, importsToAdd } = pickedInsertableComponent
             // this is taken from render-as.tsx
             const targetsForUpdates = getElementsToTarget(selectedViews)
             actionsToDispatch = targetsForUpdates.flatMap((path) => {
-              return updateJSXElementName(
-                path,
-                pickedInsertableComponent.element.name,
-                pickedInsertableComponent.importsToAdd,
-              )
+              return updateJSXElementName(path, element.name, importsToAdd)
             })
             break
           }

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -34,7 +34,6 @@ import {
   isIntrinsicElement,
   isJSXAttributeOtherJavaScript,
   isUtopiaJSXComponent,
-  JSXConditionalWithoutUID,
   JSXElement,
   JSXElementWithoutUID,
   UtopiaJSXComponent,
@@ -95,15 +94,17 @@ export type UtopiaRequireFn = (
 
 export type CurriedUtopiaRequireFn = (projectContents: ProjectContentTreeRoot) => UtopiaRequireFn
 
+export type ComponentElementToInsert = JSXElementWithoutUID | 'conditional'
+
 export interface ComponentInfo {
   insertMenuLabel: string
-  elementToInsert: JSXElementWithoutUID | JSXConditionalWithoutUID
+  elementToInsert: ComponentElementToInsert
   importsToAdd: Imports
 }
 
 export function componentInfo(
   insertMenuLabel: string,
-  elementToInsert: JSXElementWithoutUID,
+  elementToInsert: ComponentElementToInsert,
   importsToAdd: Imports,
 ): ComponentInfo {
   return {

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -34,6 +34,7 @@ import {
   isIntrinsicElement,
   isJSXAttributeOtherJavaScript,
   isUtopiaJSXComponent,
+  JSXConditionalWithoutUID,
   JSXElement,
   JSXElementWithoutUID,
   UtopiaJSXComponent,
@@ -96,7 +97,7 @@ export type CurriedUtopiaRequireFn = (projectContents: ProjectContentTreeRoot) =
 
 export interface ComponentInfo {
   insertMenuLabel: string
-  elementToInsert: JSXElementWithoutUID
+  elementToInsert: JSXElementWithoutUID | JSXConditionalWithoutUID
   importsToAdd: Imports
 }
 

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -500,7 +500,10 @@ export interface WrapInView {
   targets: ElementPath[]
   layoutSystem: SettableLayoutSystem
   newParentMainAxis: 'horizontal' | 'vertical' | null
-  whatToWrapWith: { element: JSXElement; importsToAdd: Imports } | 'default-empty-div'
+  whatToWrapWith:
+    | { element: JSXElement; importsToAdd: Imports }
+    | 'default-empty-div'
+    | 'conditional'
 }
 
 export interface WrapInElement {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -755,7 +755,10 @@ export function openFloatingInsertMenu(mode: FloatingInsertMenuState): OpenFloat
 
 export function wrapInView(
   targets: Array<ElementPath>,
-  whatToWrapWith: { element: JSXElement; importsToAdd: Imports } | 'default-empty-div',
+  whatToWrapWith:
+    | { element: JSXElement; importsToAdd: Imports }
+    | 'default-empty-div'
+    | 'conditional',
   layoutSystem: SettableLayoutSystem = LayoutSystem.PinSystem,
   newParentMainAxis: 'horizontal' | 'vertical' | null = null,
 ): WrapInView {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2418,22 +2418,28 @@ export const UPDATE_FNS = {
 
           const targetSuccess = normalisePathSuccessOrThrowError(underlyingTarget)
 
+          function getElementToInsert(): JSXElement | JSXConditionalExpression {
+            switch (action.whatToWrapWith) {
+              case 'default-empty-div':
+                return defaultTransparentViewElement(newUID)
+              case 'conditional':
+                return jsxConditionalExpression(
+                  newUID,
+                  jsxAttributeValue(true, emptyComments),
+                  jsxAttributeValue(null, emptyComments),
+                  jsxAttributeValue(null, emptyComments),
+                  emptyComments,
+                )
+              default:
+                return action.whatToWrapWith.element
+            }
+          }
+
           const withWrapperViewAddedNoFrame = modifyParseSuccessAtPath(
             targetSuccess.filePath,
             editor,
             (parseSuccess) => {
-              const elementToInsert: JSXElement | JSXConditionalExpression =
-                action.whatToWrapWith === 'default-empty-div'
-                  ? defaultTransparentViewElement(newUID)
-                  : action.whatToWrapWith === 'conditional'
-                  ? jsxConditionalExpression(
-                      newUID,
-                      { type: 'ATTRIBUTE_VALUE', value: true, comments: emptyComments },
-                      { type: 'ATTRIBUTE_VALUE', value: null, comments: emptyComments },
-                      { type: 'ATTRIBUTE_VALUE', value: null, comments: emptyComments },
-                      emptyComments,
-                    )
-                  : action.whatToWrapWith.element
+              const elementToInsert = getElementToInsert()
 
               const utopiaJSXComponents = getUtopiaJSXComponentsFromSuccess(parseSuccess)
               let withTargetAdded: Array<UtopiaJSXComponent>

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2454,8 +2454,15 @@ export const UPDATE_FNS = {
                     if (metadata == null || isLeft(metadata.element)) {
                       return null
                     }
-                    return metadata.element.value
+                    const value = { ...metadata.element.value }
+                    if (isElementWithUid(value)) {
+                      value.uid = generateUidWithExistingComponents(editor.projectContents)
+                    }
+                    return value
                   }
+
+                  // if the selection is a single element, put it directly into the true branch.
+                  // otherwise, wrap the selected elements into a fragment, and then put that fragment into the true branch.
                   const targetElements: JSXElementChild | JSXFragment | null =
                     action.targets.length === 1
                       ? getSingleElement(action.targets[0])
@@ -2464,12 +2471,9 @@ export const UPDATE_FNS = {
                           mapDropNulls(getSingleElement, action.targets),
                           false,
                         )
+
                   if (targetElements != null) {
-                    const branch = { ...targetElements }
-                    if (isElementWithUid(branch)) {
-                      branch.uid = generateUidWithExistingComponents(editor.projectContents)
-                    }
-                    elementToInsert.whenTrue = branch
+                    elementToInsert.whenTrue = targetElements
                     withTargetAdded = insertElementAtPath(
                       editor.projectContents,
                       editor.canvas.openFile?.filename ?? null,

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -240,7 +240,14 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
             dependencyStatus={getInsertableGroupPackageStatus(insertableGroup.source)}
           >
             {insertableGroup.insertableComponents.map((component, componentIndex) => {
+              if (component.element === 'conditional') {
+                return null
+              }
               const insertItemOnMouseDown = (event: React.MouseEvent) => {
+                if (component.element === 'conditional') {
+                  return
+                }
+
                 const newUID = this.getNewUID()
 
                 const updatedPropsWithPosition = addPositionAbsoluteToProps(component.element.props)

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -408,6 +408,7 @@ import {
   componentDescriptor,
   ComponentDescriptor,
   ComponentDescriptorsForFile,
+  ComponentElementToInsert,
   componentInfo,
   ComponentInfo,
   CurriedResolveFn,
@@ -2779,12 +2780,20 @@ export const CodeResultCacheKeepDeepEquality: KeepDeepEqualityCall<CodeResultCac
     codeResultCache,
   )
 
+export const ComponentElementToInsertKeepDeepEquality: KeepDeepEqualityCall<ComponentElementToInsert> =
+  unionDeepEquality(
+    createCallWithTripleEquals<ComponentElementToInsert>(),
+    JSXElementWithoutUIDKeepDeepEquality(),
+    (p): p is 'conditional' => p === 'conditional',
+    (p): p is JSXElementWithoutUID => (p as JSXElementWithoutUID).name != null,
+  )
+
 export const ComponentInfoKeepDeepEquality: KeepDeepEqualityCall<ComponentInfo> =
   combine3EqualityCalls(
     (info) => info.insertMenuLabel,
     StringKeepDeepEquality,
     (info) => info.elementToInsert,
-    JSXElementWithoutUIDKeepDeepEquality(),
+    ComponentElementToInsertKeepDeepEquality,
     (info) => info.importsToAdd,
     objectDeepEquality(ImportDetailsKeepDeepEquality),
     componentInfo,

--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -417,6 +417,22 @@ Array [
     },
   },
   Object {
+    "insertableComponents": Array [
+      Object {
+        "defaultSize": null,
+        "element": "conditional",
+        "importsToAdd": Object {},
+        "name": "Conditional",
+        "stylePropOptions": Array [
+          "do-not-add",
+        ],
+      },
+    ],
+    "source": Object {
+      "type": "CONDITIONALS_GROUP",
+    },
+  },
+  Object {
     "insertableComponents": Array [],
     "source": Object {
       "dependencyName": "@heroicons/react",
@@ -841,6 +857,22 @@ Array [
     ],
     "source": Object {
       "type": "HTML_GROUP",
+    },
+  },
+  Object {
+    "insertableComponents": Array [
+      Object {
+        "defaultSize": null,
+        "element": "conditional",
+        "importsToAdd": Object {},
+        "name": "Conditional",
+        "stylePropOptions": Array [
+          "do-not-add",
+        ],
+      },
+    ],
+    "source": Object {
+      "type": "CONDITIONALS_GROUP",
     },
   },
   Object {

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -316,6 +316,19 @@ const basicHTMLElementsDescriptors = {
   ),
 }
 
+const conditionalElementsDescriptors: ComponentDescriptorsForFile = {
+  conditional: {
+    properties: {},
+    variants: [
+      {
+        insertMenuLabel: 'Conditional',
+        elementToInsert: 'conditional',
+        importsToAdd: {},
+      },
+    ],
+  },
+}
+
 export function stylePropOptionsForPropertyControls(
   propertyControls: PropertyControls,
 ): Array<StylePropOption> {
@@ -491,18 +504,11 @@ export function getComponentGroups(
   addDependencyDescriptor(null, insertableComponentGroupHTML(), basicHTMLElementsDescriptors)
 
   // Add conditionals group.
-  addDependencyDescriptor(null, insertableComponentGroupConditionals(), {
-    conditional: {
-      properties: {},
-      variants: [
-        {
-          insertMenuLabel: 'Conditional',
-          elementToInsert: 'conditional',
-          importsToAdd: {},
-        },
-      ],
-    },
-  })
+  addDependencyDescriptor(
+    null,
+    insertableComponentGroupConditionals(),
+    conditionalElementsDescriptors,
+  )
 
   // Add entries for dependencies of the project.
   for (const dependency of dependencies) {

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -60,7 +60,7 @@ export type WrapContentOption = 'wrap-content' | 'do-now-wrap-content'
 
 export interface InsertableComponent {
   importsToAdd: Imports
-  element: JSXElementWithoutUID
+  element: JSXElementWithoutUID | 'conditional'
   name: string
   stylePropOptions: Array<StylePropOption>
   defaultSize: Size | null
@@ -68,7 +68,7 @@ export interface InsertableComponent {
 
 export function insertableComponent(
   importsToAdd: Imports,
-  element: JSXElementWithoutUID,
+  element: JSXElementWithoutUID | 'conditional',
   name: string,
   stylePropOptions: Array<StylePropOption>,
   defaultSize: Size | null,
@@ -89,6 +89,16 @@ export interface InsertableComponentGroupHTML {
 export function insertableComponentGroupHTML(): InsertableComponentGroupHTML {
   return {
     type: 'HTML_GROUP',
+  }
+}
+
+export interface InsertableComponentGroupConditionals {
+  type: 'CONDITIONALS_GROUP'
+}
+
+export function insertableComponentGroupConditionals(): InsertableComponentGroupConditionals {
+  return {
+    type: 'CONDITIONALS_GROUP',
   }
 }
 
@@ -127,6 +137,7 @@ export type InsertableComponentGroupType =
   | InsertableComponentGroupHTML
   | InsertableComponentGroupProjectComponent
   | InsertableComponentGroupProjectDependency
+  | InsertableComponentGroupConditionals
 
 export interface InsertableComponentGroup {
   source: InsertableComponentGroupType
@@ -151,6 +162,8 @@ export function getInsertableGroupLabel(insertableType: InsertableComponentGroup
       return insertableType.dependencyName
     case 'PROJECT_COMPONENT_GROUP':
       return insertableType.path
+    case 'CONDITIONALS_GROUP':
+      return 'Conditionals'
     default:
       const _exhaustiveCheck: never = insertableType
       throw new Error(`Unhandled insertable type ${JSON.stringify(insertableType)}`)
@@ -166,6 +179,8 @@ export function getInsertableGroupPackageStatus(
     case 'PROJECT_DEPENDENCY_GROUP':
       return insertableType.dependencyStatus
     case 'PROJECT_COMPONENT_GROUP':
+      return 'loaded'
+    case 'CONDITIONALS_GROUP':
       return 'loaded'
     default:
       const _exhaustiveCheck: never = insertableType
@@ -474,6 +489,20 @@ export function getComponentGroups(
 
   // Add HTML entries.
   addDependencyDescriptor(null, insertableComponentGroupHTML(), basicHTMLElementsDescriptors)
+
+  // Add conditionals group.
+  addDependencyDescriptor(null, insertableComponentGroupConditionals(), {
+    conditional: {
+      properties: {},
+      variants: [
+        {
+          insertMenuLabel: 'Conditional',
+          elementToInsert: 'conditional',
+          importsToAdd: {},
+        },
+      ],
+    },
+  })
 
   // Add entries for dependencies of the project.
   for (const dependency of dependencies) {

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -22,7 +22,6 @@ import {
   jsxAttributeValue,
   jsxElementName,
   jsxElementWithoutUID,
-  JSXElementWithoutUID,
   parsedComments,
   simpleAttribute,
 } from '../../core/shared/element-template'
@@ -51,6 +50,7 @@ import {
   PropertyControlsInfo,
   ComponentDescriptor,
   ComponentDescriptorsForFile,
+  ComponentElementToInsert,
 } from '../custom-code/code-file'
 import { defaultViewElementStyle } from '../editor/defaults'
 import { getExportedComponentImports } from '../editor/export-utils'
@@ -60,7 +60,7 @@ export type WrapContentOption = 'wrap-content' | 'do-now-wrap-content'
 
 export interface InsertableComponent {
   importsToAdd: Imports
-  element: JSXElementWithoutUID | 'conditional'
+  element: ComponentElementToInsert
   name: string
   stylePropOptions: Array<StylePropOption>
   defaultSize: Size | null
@@ -68,7 +68,7 @@ export interface InsertableComponent {
 
 export function insertableComponent(
   importsToAdd: Imports,
-  element: JSXElementWithoutUID | 'conditional',
+  element: ComponentElementToInsert,
   name: string,
   stylePropOptions: Array<StylePropOption>,
   defaultSize: Size | null,

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -37,6 +37,7 @@ import {
   childOrBlockIsChild,
   emptyComments,
   ChildOrAttribute,
+  jsxAttributeValue,
 } from '../shared/element-template'
 import {
   isParseSuccess,
@@ -540,11 +541,7 @@ export function removeJSXElementChild(
       const thenPath = getConditionalClausePath(parentPath, parentElement.whenTrue, 'then')
       const elsePath = getConditionalClausePath(parentPath, parentElement.whenFalse, 'else')
 
-      const nullAttribute: JSXAttribute = {
-        type: 'ATTRIBUTE_VALUE',
-        value: null,
-        comments: emptyComments,
-      }
+      const nullAttribute = jsxAttributeValue(null, emptyComments)
 
       return {
         ...parentElement,

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1114,6 +1114,14 @@ export function isJSXElementLike(element: JSXElementChild): element is JSXElemen
   return isJSXElement(element) || isJSXFragment(element)
 }
 
+interface ElementWithUid {
+  uid: string
+}
+
+export function isElementWithUid(element: unknown): element is ElementWithUid {
+  return (element as ElementWithUid).uid != null
+}
+
 export type JSXElementChildren = Array<JSXElementChild>
 
 export function clearJSXElementUniqueIDs<T extends JSXElementChild>(element: T): T {


### PR DESCRIPTION
Fixes #3409 

This PR allows using the `Wrap in...` menu action to wrap elements in a conditional.

- If the selection is made of only one element, it is wrapped directly and put into the `true` branch of the new conditional.
- If the selection is made of `2+` elements, they are wrapped into a fragment and that fragment is put into the `true` branch. Note that if the elements to be wrapped do _not_ share the same parent, [nothing will happen instead](https://github.com/concrete-utopia/utopia/pull/3411/files#diff-08394b03ad7395f52a3b75948b233402e5d2b4ca5b7f7b1b329fdc03dd3ca15bR2464-R2476).