### PR TITLE
Fix: Draw to insert doesn't become Flow insertion for parent of conditional expression

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -2763,7 +2763,13 @@ describe('Conditionals support', () => {
         expect(renderResult.getEditorState().editor.highlightedViews.map(EP.toUid)).toEqual(['bbb'])
 
         // Drag from inside bbb to inside ccc
-        await mouseDragFromPointToPoint(canvasControlsLayer, startPoint, endPoint)
+        await mouseDragFromPointToPoint(canvasControlsLayer, startPoint, endPoint, {
+          midDragCallback: async () => {
+            expect(renderResult.getEditorState().strategyState.currentStrategy).toEqual(
+              'Draw to Insert (Abs)',
+            )
+          },
+        })
 
         await renderResult.getDispatchFollowUpActionsFinished()
 
@@ -2845,8 +2851,13 @@ describe('Conditionals support', () => {
         // Highlight should show the candidate parent
         expect(renderResult.getEditorState().editor.highlightedViews.map(EP.toUid)).toEqual(['aaa'])
 
-        // Drag from inside bbb to inside ccc
-        await mouseDragFromPointToPoint(canvasControlsLayer, startPoint, endPoint)
+        await mouseDragFromPointToPoint(canvasControlsLayer, startPoint, endPoint, {
+          midDragCallback: async () => {
+            expect(renderResult.getEditorState().strategyState.currentStrategy).toEqual(
+              'Draw to Insert (Abs)',
+            )
+          },
+        })
 
         await renderResult.getDispatchFollowUpActionsFinished()
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -10,6 +10,7 @@ import {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
   isJSXFragment,
+  isNonDomElement,
 } from '../../../../../core/shared/element-template'
 import {
   CanvasPoint,
@@ -466,20 +467,22 @@ export function flowParentAbsoluteOrStatic(
   parent: ElementPath,
 ): ReparentStrategy {
   const parentMetadata = MetadataUtils.findElementByElementPath(metadata, parent)
-  const flattenFragmentChildren = (c: ElementInstanceMetadata): ElementInstanceMetadata[] => {
+  const flattenFragmentAndConditionalChildren = (
+    c: ElementInstanceMetadata,
+  ): ElementInstanceMetadata[] => {
     if (isLeft(c.element)) {
       return [c]
     }
-    if (!isJSXFragment(c.element.value)) {
+    if (!isNonDomElement(c.element.value)) {
       return [c]
     }
     return MetadataUtils.getChildrenUnordered(metadata, c.elementPath).flatMap(
-      flattenFragmentChildren,
+      flattenFragmentAndConditionalChildren,
     )
   }
   const children = MetadataUtils.getChildrenUnordered(metadata, parent)
     // filter out fragment blocks and merge their children with the parent children
-    .flatMap(flattenFragmentChildren)
+    .flatMap(flattenFragmentAndConditionalChildren)
 
   const storyboardRoot = EP.isStoryboardPath(parent)
   if (storyboardRoot) {

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -420,26 +420,29 @@ export function findJSXElementChildAtPath(
         }
       }
     } else if (isJSXConditionalExpression(element)) {
-      const tailPath = workingPath.slice(1)
-      if (tailPath.length === 0) {
-        // this is the element we want
-        return element
-      } else {
-        function elementOrNullFromClause(
-          clause: ChildOrAttribute,
-          branch: ThenOrElse,
-        ): JSXElementChild | null {
-          // if it's an attribute, match its path with the right branch
-          if (!childOrBlockIsChild(clause)) {
-            return tailPath[0] === thenOrElsePathPart(branch) ? element : null
+      const uid = getUtopiaID(element)
+      if (uid === firstUIDOrIndex) {
+        const tailPath = workingPath.slice(1)
+        if (tailPath.length === 0) {
+          // this is the element we want
+          return element
+        } else {
+          function elementOrNullFromClause(
+            clause: ChildOrAttribute,
+            branch: ThenOrElse,
+          ): JSXElementChild | null {
+            // if it's an attribute, match its path with the right branch
+            if (!childOrBlockIsChild(clause)) {
+              return tailPath[0] === thenOrElsePathPart(branch) ? element : null
+            }
+            // if it's a child, get its inner element
+            return findAtPathInner(clause, tailPath)
           }
-          // if it's a child, get its inner element
-          return findAtPathInner(clause, tailPath)
+          return (
+            elementOrNullFromClause(element.whenTrue, 'then') ??
+            elementOrNullFromClause(element.whenFalse, 'else')
+          )
         }
-        return (
-          elementOrNullFromClause(element.whenTrue, 'then') ??
-          elementOrNullFromClause(element.whenFalse, 'else')
-        )
       }
     }
     return null

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1114,6 +1114,12 @@ export function isJSXElementLike(element: JSXElementChild): element is JSXElemen
   return isJSXElement(element) || isJSXFragment(element)
 }
 
+export type JSXNonDomElement = JSXFragment | JSXConditionalExpression
+
+export function isNonDomElement(element: JSXElementChild): element is JSXNonDomElement {
+  return isJSXFragment(element) || isJSXConditionalExpression(element)
+}
+
 export type JSXElementChildren = Array<JSXElementChild>
 
 export function clearJSXElementUniqueIDs<T extends JSXElementChild>(element: T): T {


### PR DESCRIPTION
## Problem
When drawing to insert into a parent that has a conditional expression as a child, the inserted element becomes zero-sized (actually it stays zero-sized all through the drawing process).

## Fix
The root cause was a missing check in `findJSXElementChildAtPath`, which mistakenly returned the conditional expression as the newly added child element.