### PR TITLE
Jump to parent by pressing backslash

### DIFF
--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -104,6 +104,7 @@ import {
   CONVERT_TO_FLEX_CONTAINER,
   REMOVE_ABSOLUTE_POSITIONING,
   RESIZE_TO_FIT,
+  JUMP_TO_PARENT_SHORTCUT_BACKSLASH,
 } from './shortcut-definitions'
 import { DerivedState, EditorState, getOpenFile, RightMenuTab } from './store/editor-state'
 import { CanvasMousePositionRaw, WindowMousePositionRaw } from '../../utils/global-positions'
@@ -447,6 +448,13 @@ export function handleKeyDown(
         return []
       },
       [JUMP_TO_PARENT_SHORTCUT]: () => {
+        if (isSelectMode(editor.mode)) {
+          return jumpToParentActions(editor.selectedViews, editor.jsxMetadata)
+        } else {
+          return []
+        }
+      },
+      [JUMP_TO_PARENT_SHORTCUT_BACKSLASH]: () => {
         if (isSelectMode(editor.mode)) {
           return jumpToParentActions(editor.selectedViews, editor.jsxMetadata)
         } else {

--- a/editor/src/components/editor/shortcut-definitions.ts
+++ b/editor/src/components/editor/shortcut-definitions.ts
@@ -30,6 +30,7 @@ export const ZOOM_UI_OUT_SHORTCUT = 'zoom-ui-out'
 export const ZOOM_CANVAS_OUT_SHORTCUT = 'zoom-canvas-out'
 export const FIRST_CHILD_OR_EDIT_TEXT_SHORTCUT = 'first-child-or-edit-text'
 export const JUMP_TO_PARENT_SHORTCUT = 'jump-to-parent'
+export const JUMP_TO_PARENT_SHORTCUT_BACKSLASH = 'jump-to-parent-backslash'
 export const CANCEL_EVERYTHING_SHORTCUT = 'cancel-everything'
 export const CYCLE_HIERACHY_TARGETS_SHORTCUT = 'cycle-hierachy-targets'
 export const CYCLE_FORWARD_SIBLING_TARGETS_SHORTCUT = 'cycle-forward-sibling-targets'
@@ -102,6 +103,10 @@ const shortcutDetailsWithDefaults: ShortcutDetails = {
     key('enter', []),
   ),
   [JUMP_TO_PARENT_SHORTCUT]: shortcut('Jump to parent element.', key('enter', 'shift')),
+  [JUMP_TO_PARENT_SHORTCUT_BACKSLASH]: shortcut(
+    'Jump to parent element, with backslash.',
+    key('backslash', []),
+  ),
   [CANCEL_EVERYTHING_SHORTCUT]: shortcut(
     'Exit insert mode, dragging or anything else back to default.',
     key('esc', []),

--- a/editor/src/components/editor/shortcuts.spec.browser2.tsx
+++ b/editor/src/components/editor/shortcuts.spec.browser2.tsx
@@ -1,6 +1,6 @@
 import { BakedInStoryboardUID, BakedInStoryboardVariableName } from '../../core/model/scene-utils'
 import * as EP from '../../core/shared/element-path'
-import { altCmdModifier, cmdModifier, ctrlModifier } from '../../utils/modifiers'
+import { altCmdModifier, cmdModifier, ctrlModifier, shiftModifier } from '../../utils/modifiers'
 import {
   expectNoAction,
   expectSingleUndoStep,
@@ -178,6 +178,56 @@ describe('shortcuts', () => {
       expect(groupContainer.style.height).toEqual('311px')
     })
   })
+
+  describe('jump to parent', () => {
+    it('with esc', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithChildInFlexLayout,
+        'await-first-dom-report',
+      )
+      await selectComponentsForTest(editor, [
+        EP.fromString(`${StoryBoardId}/${ParentId}/${TestIdOne}`),
+      ])
+
+      await pressKey('esc')
+      await editor.getDispatchFollowUpActionsFinished()
+      expect(editor.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
+        `${StoryBoardId}/${ParentId}`,
+      ])
+    })
+
+    it('with backslash', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithChildInFlexLayout,
+        'await-first-dom-report',
+      )
+      await selectComponentsForTest(editor, [
+        EP.fromString(`${StoryBoardId}/${ParentId}/${TestIdOne}`),
+      ])
+
+      await pressKey('\\')
+      await editor.getDispatchFollowUpActionsFinished()
+      expect(editor.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
+        `${StoryBoardId}/${ParentId}`,
+      ])
+    })
+
+    it('with shift + enter', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithChildInFlexLayout,
+        'await-first-dom-report',
+      )
+      await selectComponentsForTest(editor, [
+        EP.fromString(`${StoryBoardId}/${ParentId}/${TestIdOne}`),
+      ])
+
+      await pressKey('enter', { modifiers: shiftModifier })
+      await editor.getDispatchFollowUpActionsFinished()
+      expect(editor.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
+        `${StoryBoardId}/${ParentId}`,
+      ])
+    })
+  })
 })
 
 const project = `import * as React from 'react'
@@ -230,15 +280,16 @@ export var storyboard = (
         padding: '47px 20px 20px 50px',
       }}
       data-uid='${ParentId}'
+      data-testid='${ParentId}'
     >
       <div
-        data-testid='${TestIdOne}'
         style={{
           backgroundColor: '#aaaaaa33',
           contain: 'layout',
           height: '100%',
           flexGrow: 1
         }}
+        data-testid='${TestIdOne}'
         data-uid='${TestIdOne}'
       />
     </div>


### PR DESCRIPTION
## Description
This PR adds a shortcut to jump to the parent of the selected element by pressing `\\` (same as with `esc`)