### PR TITLE
fix(canvas) show drag outline control only for non-absolute strategies

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
@@ -2,10 +2,6 @@ import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { toString } from '../../../../core/shared/element-path'
 import { ImmediateParentBounds } from '../../controls/parent-bounds'
 import { ImmediateParentOutlines } from '../../controls/parent-outlines'
-import {
-  DragOutlineControl,
-  dragTargetsElementPathsLive,
-} from '../../controls/select-mode/drag-outline-control'
 import { ZeroSizedElementControls } from '../../controls/zero-sized-element-controls'
 import {
   controlWithProps,
@@ -67,12 +63,6 @@ export function absoluteMoveStrategy(
           key: 'zero-size-control',
           show: 'visible-only-while-active',
         }),
-        {
-          control: DragOutlineControl,
-          props: dragTargetsElementPathsLive(targets),
-          key: 'ghost-outline-control',
-          show: 'visible-only-while-active',
-        },
       ], // Uses existing hooks in select-mode-hooks.tsx
       fitness:
         interactionSession?.interactionData.type === 'DRAG' &&

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.spec.browser2.tsx
@@ -69,10 +69,15 @@ async function dragFromInsertMenuDivButtonToPoint(
   targetPoint: { x: number; y: number },
   modifiers: Modifiers,
   renderResult: EditorRenderResult,
+  showDragOutline: 'show-drag-outline' | 'no-drag-outline',
 ) {
   await startDraggingFromInsertMenuDivButtonToPoint(targetPoint, modifiers, renderResult)
-  const dragOutlineControl = renderResult.renderedDOM.getByTestId(DragOutlineControlTestId)
-  expect(dragOutlineControl).not.toBeNull()
+  const dragOutlineControl = await renderResult.renderedDOM.queryByTestId(DragOutlineControlTestId)
+  if (showDragOutline === 'show-drag-outline') {
+    expect(dragOutlineControl).not.toBeNull()
+  } else {
+    expect(dragOutlineControl).toBeNull()
+  }
   await finishDraggingToPoint(targetPoint, modifiers, renderResult)
 
   await renderResult.getDispatchFollowUpActionsFinished()
@@ -126,7 +131,12 @@ describe('Dragging from the insert menu into an absolute layout', () => {
       y: targetParentElementBounds.y + targetParentElementBounds.height / 2,
     }
 
-    await dragFromInsertMenuDivButtonToPoint(targetPoint, emptyModifiers, renderResult)
+    await dragFromInsertMenuDivButtonToPoint(
+      targetPoint,
+      emptyModifiers,
+      renderResult,
+      'no-drag-outline',
+    )
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
@@ -190,7 +200,12 @@ describe('Dragging from the insert menu into an absolute layout', () => {
       y: targetParentElementBounds.y + targetParentElementBounds.height / 2,
     }
 
-    await dragFromInsertMenuDivButtonToPoint(targetPoint, emptyModifiers, renderResult)
+    await dragFromInsertMenuDivButtonToPoint(
+      targetPoint,
+      emptyModifiers,
+      renderResult,
+      'no-drag-outline',
+    )
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
@@ -292,7 +307,12 @@ describe('Dragging from the insert menu into a flex layout', () => {
       y: targetNextSiblingBounds.y + 5,
     }
 
-    await dragFromInsertMenuDivButtonToPoint(targetPoint, emptyModifiers, renderResult)
+    await dragFromInsertMenuDivButtonToPoint(
+      targetPoint,
+      emptyModifiers,
+      renderResult,
+      'show-drag-outline',
+    )
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
@@ -483,7 +503,12 @@ describe('Dragging from the insert menu into a flex layout', () => {
       y: targetPrevSiblingBounds.y + targetPrevSiblingBounds.height - 5,
     }
 
-    await dragFromInsertMenuDivButtonToPoint(targetPoint, emptyModifiers, renderResult)
+    await dragFromInsertMenuDivButtonToPoint(
+      targetPoint,
+      emptyModifiers,
+      renderResult,
+      'show-drag-outline',
+    )
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
@@ -543,7 +568,12 @@ describe('Dragging from the insert menu into a flex layout', () => {
       y: targetParentElementBounds.y + targetParentElementBounds.height / 2,
     }
 
-    await dragFromInsertMenuDivButtonToPoint(targetPoint, emptyModifiers, renderResult)
+    await dragFromInsertMenuDivButtonToPoint(
+      targetPoint,
+      emptyModifiers,
+      renderResult,
+      'no-drag-outline',
+    )
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
@@ -31,10 +31,6 @@ import { setCursorCommand } from '../../commands/set-cursor-command'
 import { updateFunctionCommand } from '../../commands/update-function-command'
 import { ParentBounds } from '../../controls/parent-bounds'
 import { ParentOutlines } from '../../controls/parent-outlines'
-import {
-  DragOutlineControl,
-  dragTargetsFrame,
-} from '../../controls/select-mode/drag-outline-control'
 import { FlexReparentTargetIndicator } from '../../controls/select-mode/flex-reparent-target-indicator'
 import {
   CanvasStrategyFactory,
@@ -159,11 +155,6 @@ function dragToInsertStrategyFactory(
     }))
   })()
 
-  // we don't want outline for images for now
-  const nonImageInsertionSubjectsWithFrames = insertionSubjectsWithFrames.filter(
-    (s) => getJSXElementNameLastPart(s.subject.element.name) !== 'img',
-  )
-
   return {
     id: name,
     name: name,
@@ -178,12 +169,6 @@ function dragToInsertStrategyFactory(
         control: ParentBounds,
         props: { targetParent: targetParent },
         key: 'parent-bounds-control',
-        show: 'visible-only-while-active',
-      }),
-      controlWithProps({
-        control: DragOutlineControl,
-        props: dragTargetsFrame(nonImageInsertionSubjectsWithFrames.map((s) => s.frame)),
-        key: 'ghost-outline-control',
         show: 'visible-only-while-active',
       }),
       controlWithProps({

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
@@ -52,6 +52,10 @@ import { InteractionSession } from '../interaction-state'
 import { getApplicableReparentFactories } from './reparent-metastrategy'
 import { ReparentStrategy } from './reparent-helpers/reparent-strategy-helpers'
 import { styleStringInArray } from '../../../../utils/common-constants'
+import {
+  DragOutlineControl,
+  dragTargetsFrame,
+} from '../../controls/select-mode/drag-outline-control'
 
 export const dragToInsertMetaStrategy: MetaCanvasStrategy = (
   canvasState: InteractionCanvasState,
@@ -155,6 +159,11 @@ function dragToInsertStrategyFactory(
     }))
   })()
 
+  // we don't want outline for images for now
+  const nonImageInsertionSubjectsWithFrames = insertionSubjectsWithFrames.filter(
+    (s) => getJSXElementNameLastPart(s.subject.element.name) !== 'img',
+  )
+
   return {
     id: name,
     name: name,
@@ -175,6 +184,12 @@ function dragToInsertStrategyFactory(
         control: FlexReparentTargetIndicator,
         props: {},
         key: 'flex-reparent-target-indicator',
+        show: 'visible-only-while-active',
+      }),
+      controlWithProps({
+        control: DragOutlineControl,
+        props: dragTargetsFrame(nonImageInsertionSubjectsWithFrames.map((s) => s.frame)),
+        key: 'ghost-outline-control',
         show: 'visible-only-while-active',
       }),
     ],

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -35,10 +35,6 @@ import { updateFunctionCommand } from '../../commands/update-function-command'
 import { updateHighlightedViews } from '../../commands/update-highlighted-views-command'
 import { ParentBounds } from '../../controls/parent-bounds'
 import { ParentOutlines } from '../../controls/parent-outlines'
-import {
-  DragOutlineControl,
-  dragTargetsElementPaths,
-} from '../../controls/select-mode/drag-outline-control'
 import { FlexReparentTargetIndicator } from '../../controls/select-mode/flex-reparent-target-indicator'
 import {
   CanvasStrategyFactory,
@@ -160,7 +156,6 @@ export function drawToInsertStrategyFactory(
     return null
   }
   const insertionSubject = insertionSubjects[0]
-  const predictedElementPath = EP.appendToPath(targetParent, insertionSubject.uid)
   return {
     id: name,
     name: name,
@@ -175,12 +170,6 @@ export function drawToInsertStrategyFactory(
         control: ParentBounds,
         props: { targetParent: targetParent },
         key: 'parent-bounds-control',
-        show: 'visible-only-while-active',
-      }),
-      controlWithProps({
-        control: DragOutlineControl,
-        props: dragTargetsElementPaths([predictedElementPath]),
-        key: 'ghost-outline-control',
         show: 'visible-only-while-active',
       }),
       controlWithProps({

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
@@ -4,10 +4,6 @@ import { foldAndApplyCommandsInner } from '../../commands/commands'
 import { updateFunctionCommand } from '../../commands/update-function-command'
 import { ParentBounds } from '../../controls/parent-bounds'
 import { ParentOutlines } from '../../controls/parent-outlines'
-import {
-  DragOutlineControl,
-  dragTargetsElementPaths,
-} from '../../controls/select-mode/drag-outline-control'
 import { ZeroSizedElementControls } from '../../controls/zero-sized-element-controls'
 import { CanvasStrategyFactory, pickCanvasStateFromEditorState } from '../canvas-strategies'
 import {
@@ -43,12 +39,6 @@ export function baseFlexReparentToAbsoluteStrategy(
       id: `FLEX_REPARENT_TO_ABSOLUTE`,
       name: `Reparent (Abs)`,
       controlsToRender: [
-        controlWithProps({
-          control: DragOutlineControl,
-          props: dragTargetsElementPaths(selectedElements),
-          key: 'ghost-outline-control',
-          show: 'visible-only-while-active',
-        }),
         controlWithProps({
           control: ParentOutlines,
           props: { targetParent: reparentTarget.newParent },

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -14,10 +14,6 @@ import { updateSelectedViews } from '../../commands/update-selected-views-comman
 import { wildcardPatch } from '../../commands/wildcard-patch-command'
 import { ParentBounds } from '../../controls/parent-bounds'
 import { ParentOutlines } from '../../controls/parent-outlines'
-import {
-  DragOutlineControl,
-  dragTargetsElementPaths,
-} from '../../controls/select-mode/drag-outline-control'
 import { FlexReparentTargetIndicator } from '../../controls/select-mode/flex-reparent-target-indicator'
 import { StaticReparentTargetOutlineIndicator } from '../../controls/select-mode/static-reparent-target-outline'
 import { ZeroSizedElementControls } from '../../controls/zero-sized-element-controls'
@@ -61,12 +57,6 @@ export function baseReparentAsStaticStrategy(
     return {
       ...getIdAndNameOfReparentToStaticStrategy(targetLayout),
       controlsToRender: [
-        controlWithProps({
-          control: DragOutlineControl,
-          props: dragTargetsElementPaths(filteredSelectedElements),
-          key: 'ghost-outline-control',
-          show: 'visible-only-while-active',
-        }),
         controlWithProps({
           control: ParentOutlines,
           props: { targetParent: reparentTarget.newParent },

--- a/editor/src/components/canvas/controls/select-mode/drag-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/drag-outline-control.tsx
@@ -64,10 +64,21 @@ export const DragOutlineControl = controlForStrategyMemoized((props: DragOutline
     'OutlineControl scale',
   )
   const frame = useFrameFromProps(props)
+  const isAbsoluteStrategy = useEditorState(
+    Substores.restOfStore,
+    (store) =>
+      store.strategyState.sortedApplicableStrategies != null &&
+      store.strategyState.sortedApplicableStrategies?.length > 0
+        ? store.strategyState.sortedApplicableStrategies[0].strategy.id
+            .toLowerCase()
+            .includes('abs')
+        : false,
+    'DragOutlineControl isAbsoluteStrategy',
+  )
 
   const colorTheme = useColorTheme()
 
-  if (frame == null) {
+  if (frame == null || isAbsoluteStrategy) {
     return null
   }
 


### PR DESCRIPTION
**Problem:**
When dragging an absolute element there are 2 outlines.

**Fix:**
I removed the 'DragOutline' canvas control from absolute strategies. This control is still very useful for reorders when the element is not directly moving with the outline, the drag outline follows the cursor.
Because the insertion strategy only uses the commands but not the controls I filter for absolute strategies inside the 'DragOutline' component too. 

**Commit Details:**
- updated absolute and insert strategies
