### PR TITLE
Conditional inspector: Condition expression

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -2339,7 +2339,7 @@ describe('inspector tests with real metadata', () => {
           <div data-uid='ccc' data-testid='ccc'>bar</div>
         )
           /* this is a test */
-          // @utopia/conditional=false
+          // @utopia/conditional=true
           // and another comment
         }
         </div>

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../../core/shared/element-template'
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import { jsxAttributeToString } from '../../../../core/workers/parser-printer/parser-printer'
+import { unless } from '../../../../utils/react-conditionals'
 import {
   Button,
   FlexRow,
@@ -201,7 +202,8 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
           </SquareButton>
         )}
       </InspectorSubsectionHeader>
-      {conditionExpression !== 'multiselect' ? (
+      {unless(
+        conditionExpression === 'multiselect',
         <UIGridRow
           padded={true}
           variant='<---1fr--->|------172px-------|'
@@ -213,8 +215,8 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
           <FlexRow style={{ flexGrow: 1, gap: 4 }}>
             <span style={{ flex: 1, textAlign: 'center' }}>{conditionExpression}</span>
           </FlexRow>
-        </UIGridRow>
-      ) : null}
+        </UIGridRow>,
+      )}
       <UIGridRow
         padded={true}
         variant='<---1fr--->|------172px-------|'

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -140,19 +140,7 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
 
   const toggleConditionOverride = React.useCallback(
     (whichButton: boolean) => () => {
-      const newCond = (() => {
-        if (whichButton === true) {
-          if (conditionOverride === true) {
-            return null
-          }
-          return true
-        }
-
-        if (conditionOverride === false) {
-          return null
-        }
-        return false
-      })()
+      const newCond = whichButton === conditionOverride ? null : whichButton
       setConditionOverride(newCond)()
     },
     [conditionOverride, setConditionOverride],

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../../core/shared/array-utils'
 import { findUtopiaCommentFlag } from '../../../../core/shared/comment-flags'
-import { isRight } from '../../../../core/shared/either'
+import { isLeft } from '../../../../core/shared/either'
 import * as EP from '../../../../core/shared/element-path'
 import {
   ElementInstanceMetadataMap,
@@ -47,7 +47,7 @@ const conditionOverrideSelector = createCachedSelector(
       const elementMetadata = MetadataUtils.findElementByElementPath(jsxMetadata, path)
       if (
         elementMetadata == null ||
-        !isRight(elementMetadata.element) ||
+        isLeft(elementMetadata.element) ||
         !isJSXConditionalExpression(elementMetadata.element.value)
       ) {
         return null
@@ -85,7 +85,7 @@ const conditionExpressionSelector = createCachedSelector(
       const elementMetadata = MetadataUtils.findElementByElementPath(jsxMetadata, path)
       if (
         elementMetadata == null ||
-        !isRight(elementMetadata.element) ||
+        isLeft(elementMetadata.element) ||
         !isJSXConditionalExpression(elementMetadata.element.value)
       ) {
         return null

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -10,9 +10,9 @@ import * as EP from '../../../../core/shared/element-path'
 import {
   ElementInstanceMetadataMap,
   isJSXConditionalExpression,
+  JSXAttribute,
 } from '../../../../core/shared/element-template'
 import { ElementPath } from '../../../../core/shared/project-file-types'
-import { jsxAttributeToString } from '../../../../core/workers/parser-printer/parser-printer'
 import { unless } from '../../../../utils/react-conditionals'
 import {
   Button,
@@ -235,3 +235,18 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
     </React.Fragment>
   )
 })
+
+function jsxAttributeToString(attribute: JSXAttribute): string {
+  switch (attribute.type) {
+    case 'ATTRIBUTE_VALUE':
+      if (typeof attribute.value === 'string') {
+        return attribute.value
+      } else {
+        return attribute.value.toString()
+      }
+    case 'ATTRIBUTE_OTHER_JAVASCRIPT':
+      return attribute.javascript
+    default:
+      return 'Not supported yet'
+  }
+}

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -182,7 +182,7 @@ function rawCodeToExpressionStatement(
   }
 }
 
-function jsxAttributeToExpression(attribute: JSXAttribute): TS.Expression {
+export function jsxAttributeToExpression(attribute: JSXAttribute): TS.Expression {
   function createExpression(): TS.Expression {
     switch (attribute.type) {
       case 'ATTRIBUTE_VALUE':
@@ -2025,5 +2025,20 @@ export function lintAndParse(
     return result
   } else {
     return parseFailure(null, null, null, lintResult)
+  }
+}
+
+export function jsxAttributeToString(attribute: JSXAttribute): string {
+  switch (attribute.type) {
+    case 'ATTRIBUTE_VALUE':
+      if (typeof attribute.value === 'string') {
+        return attribute.value
+      } else {
+        return attribute.value.toString()
+      }
+    case 'ATTRIBUTE_OTHER_JAVASCRIPT':
+      return attribute.javascript
+    default:
+      return 'Not supported yet'
   }
 }

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -182,7 +182,7 @@ function rawCodeToExpressionStatement(
   }
 }
 
-export function jsxAttributeToExpression(attribute: JSXAttribute): TS.Expression {
+function jsxAttributeToExpression(attribute: JSXAttribute): TS.Expression {
   function createExpression(): TS.Expression {
     switch (attribute.type) {
       case 'ATTRIBUTE_VALUE':

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -2027,18 +2027,3 @@ export function lintAndParse(
     return parseFailure(null, null, null, lintResult)
   }
 }
-
-export function jsxAttributeToString(attribute: JSXAttribute): string {
-  switch (attribute.type) {
-    case 'ATTRIBUTE_VALUE':
-      if (typeof attribute.value === 'string') {
-        return attribute.value
-      } else {
-        return attribute.value.toString()
-      }
-    case 'ATTRIBUTE_OTHER_JAVASCRIPT':
-      return attribute.javascript
-    default:
-      return 'Not supported yet'
-  }
-}


### PR DESCRIPTION
**Description:**
Add the condition expression of the selected conditional to the conditional inspector section.

<img width="259" alt="image" src="https://user-images.githubusercontent.com/127662/224376477-d6fdb93f-ae9c-4690-ad8e-2a233169afd7.png">

**Notes**
- No design, just POC implementation
- We did not have a function to convert any kind of attributes to string, I implemented a simple one just for `JSXAttributeValue` and `JSXAttrbibuteOtherJavascript`, this can be improved later if we need it
- No multiselection support, we need a more complex ui for that
- Modified the condition override implementation so that the `True` and `False` buttons are toggles. Before that you could only remove an override by closing the whole section, but now we need the section for the condition expression even when there is no override. So you can just press on any of the active buttons again to remove the override.