### PR TITLE
Tweaking canvas selection logic

### DIFF
--- a/editor/src/components/canvas/canvas-selection.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-selection.spec.browser2.tsx
@@ -148,8 +148,6 @@ const blueDivElementPath = EP.elementPath([
   ['other-app-root', 'div-blue'],
 ])
 
-const scene1ElementPath = EP.elementPath([['storyboard', 'scene-1']])
-
 const otherAppRootElementPath = EP.elementPath([
   ['storyboard', 'scene-1', 'app'],
   ['other-app-root'],
@@ -174,9 +172,9 @@ const overlappingElementTestCases: Array<
   ['absolute', zeroElementTopShifts, null, 'div-red', true, 5, 5, [redDivElementPath]],
   ['absolute', zeroElementTopShifts, null, 'div-green', true, 5, 5, [greenDivElementPath]],
   ['absolute', zeroElementTopShifts, null, 'div-blue', true, 5, 5, [blueDivElementPath]],
-  ['absolute', zeroElementTopShifts, null, 'div-red', false, 5, 5, [scene1ElementPath]],
-  ['absolute', zeroElementTopShifts, null, 'div-green', false, 5, 5, [scene1ElementPath]],
-  ['absolute', zeroElementTopShifts, null, 'div-blue', false, 5, 5, [scene1ElementPath]],
+  ['absolute', zeroElementTopShifts, null, 'div-red', false, 5, 5, [redDivElementPath]],
+  ['absolute', zeroElementTopShifts, null, 'div-green', false, 5, 5, [greenDivElementPath]],
+  ['absolute', zeroElementTopShifts, null, 'div-blue', false, 5, 5, [blueDivElementPath]],
   [
     'absolute',
     zeroElementTopShifts,
@@ -210,9 +208,9 @@ const overlappingElementTestCases: Array<
   ['relative', relativeElementTopShifts, null, 'div-red', true, 5, 5, [redDivElementPath]],
   ['relative', relativeElementTopShifts, null, 'div-green', true, 5, 5, [greenDivElementPath]],
   ['relative', relativeElementTopShifts, null, 'div-blue', true, 5, 5, [blueDivElementPath]],
-  ['relative', relativeElementTopShifts, null, 'div-red', false, 5, 5, [scene1ElementPath]],
-  ['relative', relativeElementTopShifts, null, 'div-green', false, 5, 5, [scene1ElementPath]],
-  ['relative', relativeElementTopShifts, null, 'div-blue', false, 5, 5, [scene1ElementPath]],
+  ['relative', relativeElementTopShifts, null, 'div-red', false, 5, 5, [redDivElementPath]],
+  ['relative', relativeElementTopShifts, null, 'div-green', false, 5, 5, [greenDivElementPath]],
+  ['relative', relativeElementTopShifts, null, 'div-blue', false, 5, 5, [blueDivElementPath]],
   [
     'relative',
     relativeElementTopShifts,
@@ -246,9 +244,9 @@ const overlappingElementTestCases: Array<
   [null, zeroElementTopShifts, null, 'div-red', true, 5, 5, [redDivElementPath]],
   [null, zeroElementTopShifts, null, 'div-green', true, 5, 5, [greenDivElementPath]],
   [null, zeroElementTopShifts, null, 'div-blue', true, 5, 5, [blueDivElementPath]],
-  [null, zeroElementTopShifts, null, 'div-red', false, 5, 5, [scene1ElementPath]],
-  [null, zeroElementTopShifts, null, 'div-green', false, 5, 5, [scene1ElementPath]],
-  [null, zeroElementTopShifts, null, 'div-blue', false, 5, 5, [scene1ElementPath]],
+  [null, zeroElementTopShifts, null, 'div-red', false, 5, 5, [redDivElementPath]],
+  [null, zeroElementTopShifts, null, 'div-green', false, 5, 5, [greenDivElementPath]],
+  [null, zeroElementTopShifts, null, 'div-blue', false, 5, 5, [blueDivElementPath]],
   [null, zeroElementTopShifts, otherAppRootElementPath, 'div-red', true, 5, 5, [redDivElementPath]],
   [
     null,

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size.spec.browser2.tsx
@@ -257,12 +257,12 @@ export var storyboard = (
 `
 
 const projectWithHierarchy = `import * as React from 'react'
-import { Scene, Storyboard } from 'utopia-api'
+import { Storyboard } from 'utopia-api'
 import { App } from '/src/app.js'
 
 export var storyboard = (
   <Storyboard data-uid='0cd'>
-    <Scene
+    <div
       style={{
         width: 700,
         height: 759,
@@ -300,8 +300,8 @@ export var storyboard = (
         }}
         data-uid='f30'
       />
-    </Scene>
-    <Scene
+    </div>
+    <div
       style={{
         width: 744,
         height: 1133,
@@ -313,7 +313,7 @@ export var storyboard = (
       data-uid='2c5'
     >
       <App style={{}} data-uid='a28' />
-    </Scene>
+    </div>
   </Storyboard>
 )
 `

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -256,7 +256,12 @@ export function getSelectableViews(
   let candidateViews: Array<ElementPath>
 
   if (allElementsDirectlySelectable) {
-    candidateViews = MetadataUtils.getAllPathsIncludingUnfurledFocusedComponents(componentMetadata)
+    const unfilteredCandidates =
+      MetadataUtils.getAllPathsIncludingUnfurledFocusedComponents(componentMetadata)
+    candidateViews = unfilteredCandidates.filter(
+      (path) =>
+        path.parts.length > 2 || (path.parts.length > 1 && !EP.isRootElementOfInstance(path)),
+    )
   } else {
     const allRoots = MetadataUtils.getAllCanvasRootPathsUnordered(componentMetadata)
     const siblings = collectSelectableSiblings(

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -256,14 +256,9 @@ export function getSelectableViews(
   let candidateViews: Array<ElementPath>
 
   if (allElementsDirectlySelectable) {
-    const unfilteredCandidates =
-      MetadataUtils.getAllPathsIncludingUnfurledFocusedComponents(componentMetadata)
-    candidateViews = unfilteredCandidates.filter(
-      (path) =>
-        path.parts.length > 2 || (path.parts.length > 1 && !EP.isRootElementOfInstance(path)),
-    )
+    candidateViews = MetadataUtils.getAllPathsIncludingUnfurledFocusedComponents(componentMetadata)
   } else {
-    const allRoots = MetadataUtils.getAllCanvasRootPathsUnordered(componentMetadata)
+    const allRoots = MetadataUtils.getAllCanvasSelectablePathsUnordered(componentMetadata)
     const siblings = collectSelectableSiblings(
       componentMetadata,
       selectedViews,

--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
@@ -29,6 +29,7 @@ import {
 import { cmdModifier, shiftCmdModifier } from '../../../../utils/modifiers'
 import { setFeatureForBrowserTests } from '../../../../utils/utils.test-utils'
 import { FOR_TESTS_setNextGeneratedUids } from '../../../../core/model/element-template-utils.test-utils'
+import { ElementPath } from '../../../../core/shared/project-file-types'
 
 async function fireSingleClickEvents(
   target: HTMLElement,
@@ -141,45 +142,38 @@ describe('Select Mode Selection', () => {
       areaControlBounds.top + 20,
     )
 
+    const getSelectedViews = () => renderResult.getEditorState().editor.selectedViews
+
+    expect(getSelectedViews()).toEqual([])
+
+    await fireSingleClickEvents(
+      canvasControlsLayer,
+      areaControlBounds.left + 20,
+      areaControlBounds.top + 20,
+    )
+
+    expect(getSelectedViews()).toEqual([EP.appendNewElementPath(TestScenePath, ['a', 'b'])])
+
     await doubleClick()
 
-    const selectedViews2 = renderResult.getEditorState().editor.selectedViews
-    expect(selectedViews2).toEqual([
-      EP.elementPath([[BakedInStoryboardUID, TestSceneUID, TestAppUID]]),
+    expect(getSelectedViews()).toEqual([EP.appendNewElementPath(TestScenePath, ['a', 'b', 'c'])])
+
+    await doubleClick()
+
+    expect(getSelectedViews()).toEqual([
+      EP.appendNewElementPath(TestScenePath, ['a', 'b', 'c', 'd']),
     ])
 
     await doubleClick()
 
-    const selectedViews3 = renderResult.getEditorState().editor.selectedViews
-    expect(selectedViews3).toEqual([EP.appendNewElementPath(TestScenePath, ['a'])])
-
-    await doubleClick()
-
-    const selectedViews4 = renderResult.getEditorState().editor.selectedViews
-    expect(selectedViews4).toEqual([EP.appendNewElementPath(TestScenePath, ['a', 'b'])])
-
-    await doubleClick()
-
-    const selectedViews5 = renderResult.getEditorState().editor.selectedViews
-    expect(selectedViews5).toEqual([EP.appendNewElementPath(TestScenePath, ['a', 'b', 'c'])])
-
-    await doubleClick()
-
-    const selectedViews6 = renderResult.getEditorState().editor.selectedViews
-    expect(selectedViews6).toEqual([EP.appendNewElementPath(TestScenePath, ['a', 'b', 'c', 'd'])])
-
-    await doubleClick()
-
-    const selectedViews7 = renderResult.getEditorState().editor.selectedViews
-    expect(selectedViews7).toEqual([
+    expect(getSelectedViews()).toEqual([
       EP.appendNewElementPath(TestScenePath, ['a', 'b', 'c', 'd', 'e']),
     ])
 
     await doubleClick()
 
-    // after 8 "double clicks", the `targetdiv` div should be selected
-    const selectedViews8 = renderResult.getEditorState().editor.selectedViews
-    expect(selectedViews8).toEqual([
+    // after 5 "double clicks", the `targetdiv` div should be selected
+    expect(getSelectedViews()).toEqual([
       EP.appendNewElementPath(TestScenePath, ['a', 'b', 'c', 'd', 'e', 'targetdiv']),
     ])
   })
@@ -226,10 +220,9 @@ describe('Select Mode Selection', () => {
     ])
   })
   it('Doubleclick on a child element selects it, with custom cursors set', async () => {
-    const targetElementUid = 'aaa'
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-        <div data-uid='aaa' data-testid='${targetElementUid}' style={{ position: 'absolute', width: 200, height: 200 }}>
+        <div data-uid='aaa' data-testid='aaa' style={{ position: 'absolute', width: 200, height: 200 }}>
           <div data-uid='bbb' data-testid='bbb' style={{ width: 100, height: 100 }}></div>
         </div>
       `),
@@ -242,7 +235,7 @@ describe('Select Mode Selection', () => {
       true,
     )
 
-    const areaControl = renderResult.renderedDOM.getByTestId(targetElementUid)
+    const areaControl = renderResult.renderedDOM.getByTestId('aaa')
     const areaControlBounds = areaControl.getBoundingClientRect()
 
     const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
@@ -255,7 +248,7 @@ describe('Select Mode Selection', () => {
     await doubleClick()
 
     const selectedViews = renderResult.getEditorState().editor.selectedViews
-    expect(selectedViews).toEqual([EP.appendNewElementPath(appElementPath, [targetElementUid])])
+    expect(selectedViews).toEqual([EP.appendNewElementPath(appElementPath, ['aaa', 'bbb'])])
   })
 })
 
@@ -286,83 +279,54 @@ describe('Select Mode Advanced Cases', () => {
   })
 })
 
-describe('Select Mode Double Clicking', () => {
+describe('Select Mode Clicking', () => {
   // The below tests are to ensure we're not inadvertently handling clicks too many times,
   // which could either mean focusing something that wasn't meant to be focused, or skipping
   // over the target element and selecting something further down the hierarchy.
   // Each double click should _either_ select the next element down the hierarchy, _or_ focus
-  // the currently selected element. Also, we specifically skip over Scenes, meaning a single
-  // double click with nothing selected will select the first child of a Scene
+  // the currently selected element. Also, we specifically skip over Scenes, component children
+  // of those, and root elements, meaning if nothing is selected a single click can skip right
+  // to the child of the root element of a component
 
-  it('One double clicks to select Card Instance', async () => {
-    // prettier-ignore
-    const desiredPath = EP.fromString(
-      'sb' +            // Skipped as it's the storyboard
-      '/scene-2' +      // Skipped because we skip over Scenes
-      '/Card-instance', // <- First double click
-    )
-
-    const renderResult = await renderTestEditorWithCode(
-      TestProjectAlpineClimb,
-      'await-first-dom-report',
-    )
-
-    const cardSceneRoot = renderResult.renderedDOM.getByTestId('card-scene')
-    const cardSceneRootBounds = cardSceneRoot.getBoundingClientRect()
-
-    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
-
-    const doubleClick = createDoubleClicker(
-      canvasControlsLayer,
-      cardSceneRootBounds.left + 130,
-      cardSceneRootBounds.top + 220,
-    )
-
-    await doubleClick()
-
-    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
-  })
-
-  it('Two double clicks to select Card Scene Root', async () => {
-    // prettier-ignore
-    const desiredPath = EP.fromString(
-      'sb' +             // Skipped as it's the storyboard
-      '/scene-2' +       // Skipped because we skip over Scenes
-      '/Card-instance' + // <- First double click
-      ':Card-Root',      // <- Second double click, as the instance is automatically focused by the scene
-    )
-
-    const renderResult = await renderTestEditorWithCode(
-      TestProjectAlpineClimb,
-      'await-first-dom-report',
-    )
-
-    const cardSceneRoot = renderResult.renderedDOM.getByTestId('card-scene')
-    const cardSceneRootBounds = cardSceneRoot.getBoundingClientRect()
-
-    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
-
-    const doubleClick = createDoubleClicker(
-      canvasControlsLayer,
-      cardSceneRootBounds.left + 130,
-      cardSceneRootBounds.top + 220,
-    )
-
-    await doubleClick()
-    await doubleClick()
-
-    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
-  })
-
-  it('Four double clicks to select Button on a Card Scene Root', async () => {
+  it('One click to select child of Card Scene Root', async () => {
     // prettier-ignore
     const desiredPath = EP.fromString(
       'sb' +                // Skipped as it's the storyboard
       '/scene-2' +          // Skipped because we skip over Scenes
-      '/Card-instance' +    // <- First double click
-      ':Card-Root' +        // <- Second double click, as the instance is automatically focused by the scene
-      '/Card-Row-Buttons' + // <- Third double click
-      '/Card-Button-3',     // <- Fourth double click
+      '/Card-instance' +    // Skipped because we skip component children of Scenes
+      ':Card-Root' +        // Skipped because we skip over root elements
+      '/Card-Row-Buttons',  // <- Single click
+    )
+
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectAlpineClimb,
+      'await-first-dom-report',
+    )
+
+    const cardSceneRoot = renderResult.renderedDOM.getByTestId('card-scene')
+    const cardSceneRootBounds = cardSceneRoot.getBoundingClientRect()
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    await fireSingleClickEvents(
+      canvasControlsLayer,
+      cardSceneRootBounds.left + 130,
+      cardSceneRootBounds.top + 220,
+    )
+
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPath])
+  })
+
+  it('Single click and then double click to select Button on a Card Scene Root', async () => {
+    // prettier-ignore
+    const desiredPaths = createConsecutivePaths(
+      'sb' +                // Skipped as it's the storyboard
+      '/scene-2' +          // Skipped because we skip over Scenes
+      '/Card-instance' +    // Skipped because we skip component children of Scenes
+      ':Card-Root' +        // Skipped because we skip over root elements
+      '/Card-Row-Buttons',  // <- Single click
+      '/Card-Button-3',     // <- Double click
     )
 
     const renderResult = await renderTestEditorWithCode(
@@ -381,23 +345,29 @@ describe('Select Mode Double Clicking', () => {
       cardSceneRootBounds.top + 220,
     )
 
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
+    await fireSingleClickEvents(
+      canvasControlsLayer,
+      cardSceneRootBounds.left + 130,
+      cardSceneRootBounds.top + 220,
+    )
 
-    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPaths[0]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPaths[1]])
   })
 
-  it('Five double clicks will focus a generated Card and select its root element', async () => {
+  it('Single click and two double clicks will focus a generated Card', async () => {
     // prettier-ignore
-    const desiredPath = EP.fromString(
+    const desiredPaths = createConsecutivePaths(
       'sb' +                 // Skipped as it's the storyboard
       '/scene-CardList' +    // Skipped because we skip over Scenes
-      '/CardList-instance' + // <- First double click
-      ':CardList-Root' +     // <- Second double click, as the instance is automatically focused by the scene
-      '/CardList-Col' +      // <- Third double click
-      '/CardList-Card~~~1'   // <- Fourth *and* Fifth double click, as the Fifth is required to focus it
+      '/CardList-instance' + // Skipped because we skip component children of Scenes
+      ':CardList-Root' +     // Skipped because we skip over root elements
+      '/CardList-Col',      // <- Single click
+      '/CardList-Card~~~1', // <- First *and* Second double click, as the Second is required to focus it
     )
 
     const renderResult = await renderTestEditorWithCode(
@@ -416,26 +386,37 @@ describe('Select Mode Double Clicking', () => {
       cardSceneRootBounds.top + 220,
     )
 
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
+    await fireSingleClickEvents(
+      canvasControlsLayer,
+      cardSceneRootBounds.left + 130,
+      cardSceneRootBounds.top + 220,
+    )
 
-    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPaths[0]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPaths[1]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, desiredPaths[1])
+    checkSelectedPaths(renderResult, [desiredPaths[1]])
   })
 
-  it('Six double clicks will focus a generated Card and select its root element (with fragments FS on)', async () => {
+  it('Single click and four double clicks will focus a generated Card and select the Button inside', async () => {
     // prettier-ignore
-    const desiredPath = EP.fromString(
-      'sb' +                 // Skipped as it's the storyboard
-      '/scene-CardList' +    // Skipped because we skip over Scenes
-      '/CardList-instance' + // <- First double click
-      ':CardList-Root' +     // <- Second double click, as the instance is automatically focused by the scene
-      '/CardList-Col' +      // <- Third double click
-      '/CardList-Card~~~1' + // <- Fourth *and* Fifth double click, as the Fifth is required to focus it
-      ':Card-Root',          // <- Sixth double click
-    )
+    const desiredPaths = createConsecutivePaths(
+        'sb' +                 // Skipped as it's the storyboard
+        '/scene-CardList' +    // Skipped because we skip over Scenes
+        '/CardList-instance' + // Skipped because we skip component children of Scenes
+        ':CardList-Root' +     // Skipped because we skip over root elements
+        '/CardList-Col',       // <- Single click
+        '/CardList-Card~~~1',  // <- First *and* Second double click, as the Second is required to focus it
+        ':Card-Root' +         // Skipped because we skip over root elements
+        '/Card-Row-Buttons',   // <- Third double click
+        '/Card-Button-3',      // <- Fourth double click
+      )
 
     const renderResult = await renderTestEditorWithCode(
       TestProjectAlpineClimb,
@@ -453,61 +434,30 @@ describe('Select Mode Double Clicking', () => {
       cardSceneRootBounds.top + 220,
     )
 
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-
-    expect(renderResult.getEditorState().editor.focusedElementPath).toEqual(
-      EP.parentPath(desiredPath),
-    )
-
-    await doubleClick()
-
-    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
-  })
-
-  it('Eight double clicks will focus a generated Card and select the Button inside', async () => {
-    // prettier-ignore
-    const desiredPath = EP.fromString(
-      'sb' +                 // Skipped as it's the storyboard
-      '/scene-CardList' +    // Skipped because we skip over Scenes
-      '/CardList-instance' + // <- First double click
-      ':CardList-Root' +     // <- Second double click, as the instance is automatically focused by the scene
-      '/CardList-Col' +      // <- Third double click
-      '/CardList-Card~~~1' + // <- Fourth *and* Fifth double click, as the Fifth is required to focus it
-      ':Card-Root' +         // <- Sixth double click
-      '/Card-Row-Buttons' +  // <- Seventh double click
-      '/Card-Button-3',      // <- Eight double click
-    )
-
-    const renderResult = await renderTestEditorWithCode(
-      TestProjectAlpineClimb,
-      'await-first-dom-report',
-    )
-
-    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
-
-    const cardSceneRoot = renderResult.renderedDOM.getByTestId('generated-card-1')
-    const cardSceneRootBounds = cardSceneRoot.getBoundingClientRect()
-
-    const doubleClick = createDoubleClicker(
+    await fireSingleClickEvents(
       canvasControlsLayer,
       cardSceneRootBounds.left + 130,
       cardSceneRootBounds.top + 220,
     )
 
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPaths[0]])
 
-    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
+    await doubleClick()
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPaths[1]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, desiredPaths[1])
+    checkSelectedPaths(renderResult, [desiredPaths[1]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, desiredPaths[1])
+    checkSelectedPaths(renderResult, [desiredPaths[2]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, desiredPaths[1])
+    checkSelectedPaths(renderResult, [desiredPaths[3]])
   })
 })
 
@@ -518,7 +468,8 @@ describe('Select Mode Double Clicking With Fragments', () => {
   // do not appear in the dom.
 
   setFeatureForBrowserTests('Fragment support', true)
-  it('One double clicks to select Card Instance', async () => {
+
+  it('One click to select child of Card Scene Root', async () => {
     FOR_TESTS_setNextGeneratedUids([
       'cardlistfragment',
       'manuallistfragment',
@@ -527,10 +478,12 @@ describe('Select Mode Double Clicking With Fragments', () => {
     ])
     // prettier-ignore
     const desiredPath = EP.fromString(
-      'sb' +            // Skipped as it's the storyboard
-      '/scene-2' +      // Skipped because we skip over Scenes
-      '/Card-instance', // <- First double click
-    )
+        'sb' +                // Skipped as it's the storyboard
+        '/scene-2' +          // Skipped because we skip over Scenes
+        '/Card-instance' +    // Skipped because we skip component children of Scenes
+        ':Card-Root' +        // Skipped because we skip over root elements
+        '/Card-Row-Buttons',  // <- Single click
+      )
 
     const renderResult = await renderTestEditorWithCode(
       TestProjectAlpineClimbWithFragments,
@@ -542,18 +495,17 @@ describe('Select Mode Double Clicking With Fragments', () => {
 
     const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
 
-    const doubleClick = createDoubleClicker(
+    await fireSingleClickEvents(
       canvasControlsLayer,
       cardSceneRootBounds.left + 130,
       cardSceneRootBounds.top + 220,
     )
 
-    await doubleClick()
-
-    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPath])
   })
 
-  it('Two double clicks to select Card Scene Root', async () => {
+  it('Single click and then double click to select Button on a Card Scene Root', async () => {
     FOR_TESTS_setNextGeneratedUids([
       'cardlistfragment',
       'manuallistfragment',
@@ -561,50 +513,13 @@ describe('Select Mode Double Clicking With Fragments', () => {
       'manuallistfragment',
     ])
     // prettier-ignore
-    const desiredPath = EP.fromString(
-      'sb' +             // Skipped as it's the storyboard
-      '/scene-2' +       // Skipped because we skip over Scenes
-      '/Card-instance' + // <- First double click
-      ':Card-Root',      // <- Second double click, as the instance is automatically focused by the scene
-    )
-
-    const renderResult = await renderTestEditorWithCode(
-      TestProjectAlpineClimbWithFragments,
-      'await-first-dom-report',
-    )
-
-    const cardSceneRoot = renderResult.renderedDOM.getByTestId('card-scene')
-    const cardSceneRootBounds = cardSceneRoot.getBoundingClientRect()
-
-    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
-
-    const doubleClick = createDoubleClicker(
-      canvasControlsLayer,
-      cardSceneRootBounds.left + 130,
-      cardSceneRootBounds.top + 220,
-    )
-
-    await doubleClick()
-    await doubleClick()
-
-    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
-  })
-
-  it('Four double clicks to select Button on a Card Scene Root', async () => {
-    FOR_TESTS_setNextGeneratedUids([
-      'cardlistfragment',
-      'manuallistfragment',
-      'cardlistfragment',
-      'manuallistfragment',
-    ])
-    // prettier-ignore
-    const desiredPath = EP.fromString(
+    const desiredPaths = createConsecutivePaths(
       'sb' +                // Skipped as it's the storyboard
       '/scene-2' +          // Skipped because we skip over Scenes
-      '/Card-instance' +    // <- First double click
-      ':Card-Root' +        // <- Second double click, as the instance is automatically focused by the scene
-      '/Card-Row-Buttons' + // <- Third double click
-      '/Card-Button-3',     // <- Fourth double click
+      '/Card-instance' +    // Skipped because we skip component children of Scenes
+      ':Card-Root' +        // Skipped because we skip over root elements
+      '/Card-Row-Buttons',  // <- Single click
+      '/Card-Button-3',     // <- Double click
     )
 
     const renderResult = await renderTestEditorWithCode(
@@ -623,15 +538,21 @@ describe('Select Mode Double Clicking With Fragments', () => {
       cardSceneRootBounds.top + 220,
     )
 
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
+    await fireSingleClickEvents(
+      canvasControlsLayer,
+      cardSceneRootBounds.left + 130,
+      cardSceneRootBounds.top + 220,
+    )
 
-    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPaths[0]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPaths[1]])
   })
 
-  it('Six double clicks will focus a generated Card and select its root element', async () => {
+  it('Single click and two double clicks will focus a generated Card', async () => {
     FOR_TESTS_setNextGeneratedUids([
       'cardlistfragment',
       'manuallistfragment',
@@ -639,14 +560,13 @@ describe('Select Mode Double Clicking With Fragments', () => {
       'manuallistfragment',
     ])
     // prettier-ignore
-    const desiredPath = EP.fromString(
+    const desiredPaths = createConsecutivePaths(
       'sb' +                  // Skipped as it's the storyboard
       '/scene-CardList' +     // Skipped because we skip over Scenes
-      '/CardList-instance' +  // <- First double click
-      ':manuallistfragment' + // <- Second double click, which leads to a fragment, with a generated data-uid.
-      '/CardList-Col' +       // <- Third double click
-      '/CardList-Card~~~1' +  // <- Fourth *and* Fifth double click, as the Fifth is required to focus it
-      ':Card-Root',           // <- Sixth double click
+      '/CardList-instance' +  // Skipped because we skip component children of Scenes
+      ':manuallistfragment' + // Skipped because we skip over root elements
+      '/CardList-Col',        // <- Single click
+      '/CardList-Card~~~1',  // <- First *and* Second double click, as the Second is required to focus it
     )
 
     const renderResult = await renderTestEditorWithCode(
@@ -665,21 +585,24 @@ describe('Select Mode Double Clicking With Fragments', () => {
       cardSceneRootBounds.top + 50,
     )
 
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-
-    expect(renderResult.getEditorState().editor.focusedElementPath).toEqual(
-      EP.parentPath(desiredPath),
+    await fireSingleClickEvents(
+      canvasControlsLayer,
+      cardSceneRootBounds.left + 50,
+      cardSceneRootBounds.top + 50,
     )
 
-    await doubleClick()
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPaths[0]])
 
-    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
+    await doubleClick()
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPaths[1]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, desiredPaths[1])
+    checkSelectedPaths(renderResult, [desiredPaths[1]])
   })
-  it('Eight double clicks will focus a generated Card and select the Button inside', async () => {
+  it('Single click and four double clicks will focus a generated Card and select the Button inside', async () => {
     FOR_TESTS_setNextGeneratedUids([
       'cardlistfragment',
       'manuallistfragment',
@@ -687,16 +610,16 @@ describe('Select Mode Double Clicking With Fragments', () => {
       'manuallistfragment',
     ])
     // prettier-ignore
-    const desiredPath = EP.fromString(
+    const desiredPaths = createConsecutivePaths(
       'sb' +                  // Skipped as it's the storyboard
       '/scene-CardList' +     // Skipped because we skip over Scenes
-      '/CardList-instance' +  // <- First double click
-      ':manuallistfragment' + // <- Second double click, which leads to a fragment, with a generated data-uid.
-      '/CardList-Col' +       // <- Third double click
-      '/CardList-Card~~~1' +  // <- Fourth *and* Fifth double click, as the Sixth is required to focus it
-      ':Card-Root' +          // <- Sixth double click
-      '/Card-Row-Buttons' +   // <- Seventh double click
-      '/Card-Button-3',       // <- Eighth double click
+      '/CardList-instance' +  // Skipped because we skip component children of Scenes
+      ':manuallistfragment' + // Skipped because we skip over root elements
+      '/CardList-Col',        // <- Single click
+      '/CardList-Card~~~1',   // <- First *and* Second double click, as the Second is required to focus it
+      ':Card-Root' +          // Skipped because we skip over root elements
+      '/Card-Row-Buttons',    // <- Third double click
+      '/Card-Button-3',       // <- Fourth double click
     )
 
     const renderResult = await renderTestEditorWithCode(
@@ -715,30 +638,44 @@ describe('Select Mode Double Clicking With Fragments', () => {
       cardSceneRootBounds.top + 220,
     )
 
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
+    await fireSingleClickEvents(
+      canvasControlsLayer,
+      cardSceneRootBounds.left + 130,
+      cardSceneRootBounds.top + 220,
+    )
 
-    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPaths[0]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPaths[1]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, desiredPaths[1])
+    checkSelectedPaths(renderResult, [desiredPaths[1]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, desiredPaths[1])
+    checkSelectedPaths(renderResult, [desiredPaths[2]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, desiredPaths[1])
+    checkSelectedPaths(renderResult, [desiredPaths[3]])
   })
 })
 
 describe('Selection with locked elements', () => {
-  it('Double click selection skips locked elements', async () => {
+  it('Click selection skips locked elements', async () => {
     // prettier-ignore
     const desiredPath = EP.fromString(
-      'sb' +                // Skipped as it's the storyboard
-      '/scene-2' +          // Skipped because we skip over Scenes
-      '/Card-instance' +    // <- First double click
-      ':Card-Root' +        // <- Second double click, as the instance is automatically focused by the scene
-      '/Card-Row-Buttons' + // <- Locked element is skipped
-      '/Card-Button-3',     // <- Third double click
-    )
+        'sb' +                // Skipped as it's the storyboard
+        '/scene-2' +          // Skipped because we skip over Scenes
+        '/Card-instance' +    // Skipped because we skip component children of Scenes
+        ':Card-Root' +        // Skipped because we skip over root elements
+        '/Card-Row-Buttons' + // <- Locked element is skipped
+        '/Card-Button-3',     // <- Single click
+      )
 
     const renderResult = await renderTestEditorWithCode(
       TestProjectAlpineClimbWithFragments,
@@ -761,26 +698,24 @@ describe('Selection with locked elements', () => {
 
     const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
 
-    const doubleClick = createDoubleClicker(
+    await fireSingleClickEvents(
       canvasControlsLayer,
       cardSceneRootBounds.left + 130,
       cardSceneRootBounds.top + 220,
     )
 
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-
-    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPath])
   })
   it('Double click selection stops when reaching hierarchy locked elements', async () => {
     // prettier-ignore
     const desiredPath = EP.fromString(
-      'sb' +                // Skipped as it's the storyboard
-      '/scene-2' +          // Skipped because we skip over Scenes
-      '/Card-instance' +    // <- First double click
-      ':Card-Root'          // <- Second double click, as the instance is automatically focused by the scene
-    )
+        'sb' +                // Skipped as it's the storyboard
+        '/scene-2' +          // Skipped because we skip over Scenes
+        '/Card-instance' +    // Skipped because we skip component children of Scenes
+        ':Card-Root' +        // Skipped because we skip over root elements
+        '/Card-Row-Buttons'   // <- Single click
+      )
 
     const renderResult = await renderTestEditorWithCode(
       TestProjectAlpineClimbWithFragments,
@@ -791,7 +726,7 @@ describe('Selection with locked elements', () => {
     await renderResult.dispatch(
       [
         toggleSelectionLock(
-          [EP.fromString('sb/scene-2/Card-instance:Card-Root/Card-Row-Buttons')],
+          [EP.fromString('sb/scene-2/Card-instance:Card-Root/Card-Row-Buttons/Card-Button-3')],
           'locked-hierarchy',
         ),
       ],
@@ -809,60 +744,66 @@ describe('Selection with locked elements', () => {
       cardSceneRootBounds.top + 220,
     )
 
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
-    await doubleClick()
+    await fireSingleClickEvents(
+      canvasControlsLayer,
+      cardSceneRootBounds.left + 130,
+      cardSceneRootBounds.top + 220,
+    )
 
-    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPath])
+
+    // We can't descend any further
+    await doubleClick()
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPath])
   })
 })
 
 describe('mouseup selection', () => {
   const MouseupTestProject = makeTestProjectCodeWithSnippet(`
-    <div
-      style={{ width: '100%', height: '100%' }}
-      data-uid='app-root'
-    >
       <div
-        data-uid='red'
-        data-testid='red'
-        style={{
-          position: 'absolute',
-          left: 0,
-          width: 50,
-          top: 0,
-          height: 50,
-          backgroundColor: 'red',
-        }}
-      />
-      <div
-        data-uid='blue'
-        data-testid='blue'
-        style={{
-          position: 'absolute',
-          left: 75,
-          width: 50,
-          top: 0,
-          height: 50,
-          backgroundColor: 'blue',
-        }}
-      />
-      <div
-        data-uid='green'
-        data-testid='green'
-        style={{
-          position: 'absolute',
-          left: 150,
-          width: 50,
-          top: 0,
-          height: 50,
-          backgroundColor: 'green',
-        }}
-      />
-    </div>
-  `)
+        style={{ width: '100%', height: '100%' }}
+        data-uid='app-root'
+      >
+        <div
+          data-uid='red'
+          data-testid='red'
+          style={{
+            position: 'absolute',
+            left: 0,
+            width: 50,
+            top: 0,
+            height: 50,
+            backgroundColor: 'red',
+          }}
+        />
+        <div
+          data-uid='blue'
+          data-testid='blue'
+          style={{
+            position: 'absolute',
+            left: 75,
+            width: 50,
+            top: 0,
+            height: 50,
+            backgroundColor: 'blue',
+          }}
+        />
+        <div
+          data-uid='green'
+          data-testid='green'
+          style={{
+            position: 'absolute',
+            left: 150,
+            width: 50,
+            top: 0,
+            height: 50,
+            backgroundColor: 'green',
+          }}
+        />
+      </div>
+    `)
 
   const RedPath = EP.elementPath([
     [BakedInStoryboardUID, TestSceneUID, TestAppUID],
@@ -1036,6 +977,31 @@ describe('mouseup selection', () => {
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(MouseupTestProject)
   })
 })
+
+function createConsecutivePaths(...partialPathStrings: Array<string>): Array<ElementPath> {
+  return partialPathStrings.map((_value, index, arr) => {
+    const joinedParts = arr.slice(0, index + 1).join('')
+    return EP.fromString(joinedParts)
+  })
+}
+
+function checkFocusedPath(renderResult: EditorRenderResult, expected: ElementPath | null) {
+  checkWithKey('focusedPath', renderResult.getEditorState().editor.focusedElementPath, expected)
+}
+
+function checkSelectedPaths(renderResult: EditorRenderResult, expected: Array<ElementPath>) {
+  checkWithKey('selectedPaths', renderResult.getEditorState().editor.selectedViews, expected)
+}
+
+function checkWithKey<T>(key: string, actual: T, expected: T) {
+  expect({
+    check: key,
+    value: actual,
+  }).toEqual({
+    check: key,
+    value: expected,
+  })
+}
 
 const TestProjectAlpineClimb = `
 import * as React from "react";

--- a/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
@@ -723,12 +723,12 @@ async function setSelectedElementsToFill(editor: EditorRenderResult, axis: Axis)
 }
 
 const projectWithWidth = (flexDirection: FlexDirection) => `import * as React from 'react'
-import { Scene, Storyboard } from 'utopia-api'
+import { Storyboard } from 'utopia-api'
 import { App } from '/src/app.js'
 
 export var storyboard = (
   <Storyboard>
-    <Scene
+    <div
       data-testid='parent'
       style={{
         width: 700,
@@ -752,19 +752,19 @@ export var storyboard = (
           contain: 'layout',
         }}
       />
-    </Scene>
+    </div>
   </Storyboard>
 )
 
 `
 
 const projectWithHeight = (flexDirection: FlexDirection) => `import * as React from 'react'
-import { Scene, Storyboard } from 'utopia-api'
+import { Storyboard } from 'utopia-api'
 import { App } from '/src/app.js'
 
 export var storyboard = (
   <Storyboard data-uid='0cd'>
-    <Scene
+    <div
       data-testid='parent'
       style={{
         width: 700,
@@ -788,18 +788,18 @@ export var storyboard = (
           contain: 'layout',
         }}
       />
-    </Scene>
+    </div>
   </Storyboard>
 )
 `
 
 const projectWithChildSetToHorizontalFill = `import * as React from 'react'
-import { Scene, Storyboard } from 'utopia-api'
+import { Storyboard } from 'utopia-api'
 import { App } from '/src/app.js'
 
 export var storyboard = (
   <Storyboard data-uid='0cd'>
-    <Scene
+    <div
       data-testid='parent'
       style={{
         width: 700,
@@ -820,18 +820,18 @@ export var storyboard = (
           contain: 'layout',
         }}
       />
-    </Scene>
+    </div>
   </Storyboard>
 )
 `
 
 const projectWithChildSetToVerticalFill = `import * as React from 'react'
-import { Scene, Storyboard } from 'utopia-api'
+import { Storyboard } from 'utopia-api'
 import { App } from '/src/app.js'
 
 export var storyboard = (
   <Storyboard data-uid='0cd'>
-    <Scene
+    <div
       data-testid='parent'
       style={{
         width: 700,
@@ -853,18 +853,18 @@ export var storyboard = (
           contain: 'layout',
         }}
       />
-    </Scene>
+    </div>
   </Storyboard>
 )
 `
 
 const projectWithChildSetToFixed = (flexDirection: FlexDirection) => `import * as React from 'react'
-import { Scene, Storyboard } from 'utopia-api'
+import { Storyboard } from 'utopia-api'
 import { App } from '/src/app.js'
 
 export var storyboard = (
   <Storyboard data-uid='33d'>
-    <Scene
+    <div
       data-testid='parent'
       style={{
         width: 700,
@@ -888,7 +888,7 @@ export var storyboard = (
         }}
         data-uid='744'
       />
-    </Scene>
+    </div>
   </Storyboard>
 )
 `
@@ -896,12 +896,12 @@ export var storyboard = (
 const projectWithChildSetToHugContents = (
   flexDirection: FlexDirection,
 ) => `import * as React from 'react'
-import { Scene, Storyboard } from 'utopia-api'
+import { Storyboard } from 'utopia-api'
 import { App } from '/src/app.js'
 
 export var storyboard = (
   <Storyboard data-uid='0cd'>
-    <Scene
+    <div
       data-testid='parent'
       style={{
         height: 751,
@@ -945,7 +945,7 @@ export var storyboard = (
           data-uid='741'
         />
       </div>
-    </Scene>
+    </div>
   </Storyboard>
 )
 `
@@ -1004,7 +1004,7 @@ export var storyboard = (
 `
 
 const projectWithChildInFlowLayout = `import * as React from 'react'
-import { Scene, Storyboard } from 'utopia-api'
+import { Storyboard } from 'utopia-api'
 
 export var storyboard = (
   <Storyboard data-uid='0cd'>
@@ -1056,10 +1056,10 @@ export var storyboard = (
 const absoluteProjectWithInjectedStyle = (stylePropsAsString: string) =>
   formatTestProjectCode(`
 import * as React from 'react'
-import { Scene, Storyboard } from 'utopia-api'
+import { Storyboard } from 'utopia-api'
 export var storyboard = (
   <Storyboard>
-    <Scene
+    <div
       data-testid='parent'
       style={{
         position: 'absolute',
@@ -1074,17 +1074,17 @@ export var storyboard = (
         data-testid='child'
         style={{${stylePropsAsString}}}
       />
-    </Scene>
+    </div>
   </Storyboard>
 )`)
 
 const flexProjectWithInjectedStyle = (stylePropsAsString: string) =>
   formatTestProjectCode(`
 import * as React from 'react'
-import { Scene, Storyboard } from 'utopia-api'
+import { Storyboard } from 'utopia-api'
 export var storyboard = (
   <Storyboard>
-    <Scene
+    <div
       data-testid='parent'
       style={{
         position: 'absolute',
@@ -1100,7 +1100,7 @@ export var storyboard = (
         data-testid='child'
         style={{${stylePropsAsString}}}
       />
-    </Scene>
+    </div>
   </Storyboard>
 )`)
 

--- a/editor/src/core/model/element-metadata-utils.spec.tsx
+++ b/editor/src/core/model/element-metadata-utils.spec.tsx
@@ -851,10 +851,13 @@ describe('getting the root paths', () => {
     expect(actualResult).toEqual(expectedResult)
   })
 
-  it('getAllCanvasRootPaths returns paths of the top level children of the storyboard, replacing scenes with their root views', () => {
+  it('getAllCanvasSelectablePathsUnordered returns paths of the top level children of the storyboard, replacing scenes with their root views', () => {
     const actualResult = MetadataUtils.getAllCanvasSelectablePathsUnordered(testJsxMetadata)
     const expectedResult: Array<ElementPath> = [
-      testComponentRoot1.elementPath,
+      testComponentMetadataChild1.elementPath,
+      testComponentMetadataChild2.elementPath,
+      testComponentMetadataChild3.elementPath,
+      testComponentSceneChildElement.elementPath,
       testStoryboardChildElement.elementPath,
     ]
     expect(actualResult).toEqual(expectedResult)

--- a/editor/src/core/model/element-metadata-utils.spec.tsx
+++ b/editor/src/core/model/element-metadata-utils.spec.tsx
@@ -852,7 +852,7 @@ describe('getting the root paths', () => {
   })
 
   it('getAllCanvasRootPaths returns paths of the top level children of the storyboard, replacing scenes with their root views', () => {
-    const actualResult = MetadataUtils.getAllCanvasRootPathsUnordered(testJsxMetadata)
+    const actualResult = MetadataUtils.getAllCanvasSelectablePathsUnordered(testJsxMetadata)
     const expectedResult: Array<ElementPath> = [
       testComponentRoot1.elementPath,
       testStoryboardChildElement.elementPath,

--- a/editor/src/core/model/element-metadata-utils.spec.tsx
+++ b/editor/src/core/model/element-metadata-utils.spec.tsx
@@ -842,15 +842,6 @@ describe('getStoryboardMetadata', () => {
 })
 
 describe('getting the root paths', () => {
-  it('getAllStoryboardChildren returns instance metadata of all children of the storyboard', () => {
-    const actualResult = MetadataUtils.getAllStoryboardChildrenUnordered(testJsxMetadata)
-    const expectedResult: Array<ElementInstanceMetadata> = [
-      testComponentSceneElement,
-      testStoryboardChildElement,
-    ]
-    expect(actualResult).toEqual(expectedResult)
-  })
-
   it('getAllStoryboardChildrenPaths returns paths of all children of the storyboard', () => {
     const actualResult = MetadataUtils.getAllStoryboardChildrenPathsUnordered(testJsxMetadata)
     const expectedResult: Array<ElementPath> = [

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -672,14 +672,6 @@ export const MetadataUtils = {
     }
     return null
   },
-  getAllStoryboardChildrenUnordered(
-    metadata: ElementInstanceMetadataMap,
-  ): ElementInstanceMetadata[] {
-    const storyboardMetadata = MetadataUtils.getStoryboardMetadata(metadata)
-    return storyboardMetadata == null
-      ? []
-      : MetadataUtils.getImmediateChildrenUnordered(metadata, storyboardMetadata.elementPath)
-  },
   getAllStoryboardChildrenPathsUnordered(metadata: ElementInstanceMetadataMap): ElementPath[] {
     const storyboardMetadata = MetadataUtils.getStoryboardMetadata(metadata)
     return storyboardMetadata == null
@@ -687,15 +679,18 @@ export const MetadataUtils = {
       : MetadataUtils.getImmediateChildrenPathsUnordered(metadata, storyboardMetadata.elementPath)
   },
   getAllCanvasRootPathsUnordered(metadata: ElementInstanceMetadataMap): ElementPath[] {
-    const rootScenesAndElements = MetadataUtils.getAllStoryboardChildrenUnordered(metadata)
-    return flatMapArray<ElementInstanceMetadata, ElementPath>((root) => {
-      const rootElements = MetadataUtils.getRootViewPathsUnordered(metadata, root.elementPath)
-      if (rootElements.length > 0) {
-        return rootElements
+    const allPaths = objectValues(metadata).map((m) => m.elementPath)
+    const rootPaths = allPaths.filter(EP.isRootElementOfInstance)
+    const rootsOfStoryboardChildren = rootPaths.filter((path) => path.parts.length === 2)
+
+    return flatMapArray((root) => {
+      const childrenOfRoot = MetadataUtils.getChildrenPathsUnordered(metadata, root)
+      if (childrenOfRoot.length > 0) {
+        return childrenOfRoot
       } else {
-        return [root.elementPath]
+        return [root]
       }
-    }, rootScenesAndElements)
+    }, rootsOfStoryboardChildren)
   },
   getAllPaths: memoize(
     (metadata: ElementInstanceMetadataMap): ElementPath[] => {


### PR DESCRIPTION
**Problem:**
It is too easy to accidentally select elements on the canvas that you do not wish to make changes to, leading to accidentally making changes to those elements rather than the ones you _actually_ wanted to update.

**Fix:**
Tweak the canvas selection logic to follow these rules:
1) Skip over the immediate `Scene` children of the `Storyboard` (but no other element types)
2) Skip over component children of `Scenes` (replacing with their root paths and children paths)
3) Skip over root element paths

Where a path cannot be skipped over (because it has no children) we will permit selection of that path (so e.g. a `Scene` at the very top level will become selectable if it has no children).

As a "bonus" I have also invested some time in improving the selection tests, as fixing them was an absolute nightmare, especially when it came to finding where the tests were actually breaking. Part of that was the inclusion of these functions that will likely come in handy for other browser tests:

```ts
function checkFocusedPath(renderResult: EditorRenderResult, expected: ElementPath | null) {
  checkWithKey('focusedPath', renderResult.getEditorState().editor.focusedElementPath, expected)
}

function checkSelectedPaths(renderResult: EditorRenderResult, expected: Array<ElementPath>) {
  checkWithKey('selectedPaths', renderResult.getEditorState().editor.selectedViews, expected)
}

function checkWithKey<T>(key: string, actual: T, expected: T) {
  expect({
    check: key,
    value: actual,
  }).toEqual({
    check: key,
    value: expected,
  })
}
```
This way we can see in the diff the value of that `check` string, giving us a clue which check is actually failing (which in this case was particularly helpful)