### PR TITLE
adding test cases for findJSXElementChildAtPath

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1082,21 +1082,16 @@ function deleteElements(targets: ElementPath[], editor: EditorModel): EditorMode
 
       function deleteElementFromParseSuccess(parseSuccess: ParseSuccess): ParseSuccess {
         const utopiaComponents = getUtopiaJSXComponentsFromSuccess(parseSuccess)
-        const element = findElementAtPath(targetPath, utopiaComponents)
-        if (element == null) {
-          return parseSuccess
-        } else {
-          const withTargetRemoved: Array<UtopiaJSXComponent> = removeElementAtPath(
-            targetPath,
-            utopiaComponents,
-          )
-          return modifyParseSuccessWithSimple((success: SimpleParseSuccess) => {
-            return {
-              ...success,
-              utopiaComponents: withTargetRemoved,
-            }
-          }, parseSuccess)
-        }
+        const withTargetRemoved: Array<UtopiaJSXComponent> = removeElementAtPath(
+          targetPath,
+          utopiaComponents,
+        )
+        return modifyParseSuccessWithSimple((success: SimpleParseSuccess) => {
+          return {
+            ...success,
+            utopiaComponents: withTargetRemoved,
+          }
+        }, parseSuccess)
       }
       return modifyParseSuccessAtPath(
         targetSuccess.filePath,

--- a/editor/src/core/model/element-template-utils.spec.tsx
+++ b/editor/src/core/model/element-template-utils.spec.tsx
@@ -50,6 +50,7 @@ import {
 } from '../shared/element-path'
 import { getComponentsFromTopLevelElements } from './project-file-utils'
 import { setFeatureForUnitTests } from '../../utils/utils.test-utils'
+import { FOR_TESTS_setNextGeneratedUids } from './element-template-utils.test-utils'
 
 describe('guaranteeUniqueUids', () => {
   it('if two siblings have the same ID, one will be replaced', () => {
@@ -765,7 +766,7 @@ describe('findJSXElementChildAtPath', () => {
   function expectElementAtPathHasMatchingUID(file: ParseSuccess, pathString: string) {
     const foundElement = findElement(file, pathString)
 
-    expect(foundElement).toBeDefined()
+    expect(foundElement).not.toBeNull()
     expect(getUtopiaID(foundElement!)).toEqual(toUid(fromStringStatic(pathString)))
   }
 
@@ -922,6 +923,7 @@ describe('findJSXElementChildAtPath', () => {
   })
 
   it('conditional expressions', () => {
+    FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'skip3', 'skip4', 'skip5', 'conditional-1'])
     const projectFile = getParseSuccessForStoryboardCode(
       makeTestProjectCodeWithSnippet(`
         <div style={{ ...props.style }} data-uid='aaa'>
@@ -948,30 +950,31 @@ describe('findJSXElementChildAtPath', () => {
     expectElementAtPathHasMatchingUIDForPaths(projectFile, [
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent',
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0',
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/ternary-true-root',
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/ternary-true-root/ternary-true-child',
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/ternary-false-root',
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/ternary-false-root/ternary-false-child',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/ternary-true-root',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/ternary-true-root/ternary-true-child',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/ternary-false-root',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/ternary-false-root/ternary-false-child',
     ])
 
     // !!!! Do I misunderstand something?? shouldn't the then-case and else-case return the true-root and false-root here?? these tests fail now...
     const elementAtTrueBranch = findElement(
       projectFile,
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/then-case',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/then-case',
     )
     expect(elementAtTrueBranch).not.toBeNull()
     expect(getUtopiaID(elementAtTrueBranch!)).toEqual('ternary-true-root')
 
     const elementAtFalseBranch = findElement(
       projectFile,
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/else-case',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/else-case',
     )
     expect(elementAtFalseBranch).not.toBeNull()
     expect(getUtopiaID(elementAtFalseBranch!)).toEqual('ternary-false-root')
   })
 
   it('conditional expressions with branches that are JSXAttribute', () => {
+    FOR_TESTS_setNextGeneratedUids(['skip1', 'conditional-1'])
     const projectFile = getParseSuccessForStoryboardCode(
       makeTestProjectCodeWithSnippet(`
         <div style={{ ...props.style }} data-uid='aaa'>
@@ -994,16 +997,17 @@ describe('findJSXElementChildAtPath', () => {
     expectElementAtPathHasMatchingUIDForPaths(projectFile, [
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent',
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1',
     ])
 
     expectElementFoundNull(projectFile, [
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/then-case',
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/else-case',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/then-case',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/else-case',
     ])
   })
 
   it('conditional expressions with branches that are mixed JSXAttribute and JSXElementChild', () => {
+    FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'skip3', 'conditional-1'])
     const projectFile = getParseSuccessForStoryboardCode(
       makeTestProjectCodeWithSnippet(`
         <div style={{ ...props.style }} data-uid='aaa'>
@@ -1028,20 +1032,20 @@ describe('findJSXElementChildAtPath', () => {
     expectElementAtPathHasMatchingUIDForPaths(projectFile, [
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent',
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0',
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/ternary-false-root',
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/ternary-false-root/ternary-false-child',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/ternary-false-root',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/ternary-false-root/ternary-false-child',
     ])
 
     const elementAtTrueBranch = findElement(
       projectFile,
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/then-case',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/then-case',
     )
     expect(elementAtTrueBranch).toBeNull()
 
     const elementAtFalseBranch = findElement(
       projectFile,
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/else-case',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/else-case',
     )
     expect(elementAtFalseBranch).not.toBeNull()
     expect(getUtopiaID(elementAtFalseBranch!)).toEqual('ternary-false-root')

--- a/editor/src/core/model/element-template-utils.spec.tsx
+++ b/editor/src/core/model/element-template-utils.spec.tsx
@@ -972,7 +972,7 @@ describe('findJSXElementChildAtPath', () => {
     expect(getUtopiaID(elementAtFalseBranch!)).toEqual('ternary-false-root')
   })
 
-  it('conditional expressions with children that are JSXAttribute', () => {
+  it('conditional expressions with branches that are JSXAttribute', () => {
     const projectFile = getParseSuccessForStoryboardCode(
       makeTestProjectCodeWithSnippet(`
         <div style={{ ...props.style }} data-uid='aaa'>
@@ -1004,5 +1004,51 @@ describe('findJSXElementChildAtPath', () => {
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/then-case',
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/else-case',
     ])
+  })
+
+  it('conditional expressions with branches that are mixed JSXAttribute and JSXElementChild', () => {
+    const projectFile = getParseSuccessForStoryboardCode(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ ...props.style }} data-uid='aaa'>
+          <div data-uid='parent' >
+            <div data-uid='child-d' />
+            {true ? 
+              (
+                "hello"
+              ) : (
+                <div data-uid='ternary-false-root'>
+                  <div data-uid='ternary-false-child' />
+                </div> 
+              )
+            }
+            <div data-uid='child-b' />
+            <div data-uid='child-a' />
+          </div>
+        </div>
+      `),
+    )
+
+    expectElementAtPathHasMatchingUIDForPaths(projectFile, [
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/ternary-false-root',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/ternary-false-root/ternary-false-child',
+    ])
+
+    // !!! what to do with the then-case and else-case "uid" behaviors? how do we proceed from here?
+
+    const elementAtTrueBranch = findElement(
+      projectFile,
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/then-case',
+    )
+    expect(elementAtTrueBranch).toBeNull()
+
+    const elementAtFalseBranch = findElement(
+      projectFile,
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/else-case',
+    )
+    expect(elementAtFalseBranch).not.toBeNull()
+    expect(getUtopiaID(elementAtFalseBranch!)).toEqual('ternary-false-root')
   })
 })

--- a/editor/src/core/model/element-template-utils.spec.tsx
+++ b/editor/src/core/model/element-template-utils.spec.tsx
@@ -955,6 +955,19 @@ describe('findJSXElementChildAtPath', () => {
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/ternary-false-root',
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/ternary-false-root/ternary-false-child',
     ])
+
+    // !!!! Do I misunderstand something?? shouldn't the then-case and else-case return the true-root and false-root here?? these tests fail now...
+    const elementAtTrueBranch = findElement(
+      projectFile,
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/then-case',
+    )
+    expect(getUtopiaID(elementAtTrueBranch!)).toEqual('ternary-true-root')
+
+    const elementAtFalseBranch = findElement(
+      projectFile,
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/else-case',
+    )
+    expect(getUtopiaID(elementAtFalseBranch!)).toEqual('ternary-false-root')
   })
 
   it('conditional expressions with children that are JSXAttribute', () => {

--- a/editor/src/core/model/element-template-utils.spec.tsx
+++ b/editor/src/core/model/element-template-utils.spec.tsx
@@ -961,12 +961,14 @@ describe('findJSXElementChildAtPath', () => {
       projectFile,
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/then-case',
     )
+    expect(elementAtTrueBranch).not.toBeNull()
     expect(getUtopiaID(elementAtTrueBranch!)).toEqual('ternary-true-root')
 
     const elementAtFalseBranch = findElement(
       projectFile,
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/else-case',
     )
+    expect(elementAtFalseBranch).not.toBeNull()
     expect(getUtopiaID(elementAtFalseBranch!)).toEqual('ternary-false-root')
   })
 

--- a/editor/src/core/model/element-template-utils.spec.tsx
+++ b/editor/src/core/model/element-template-utils.spec.tsx
@@ -836,7 +836,6 @@ describe('findJSXElementChildAtPath', () => {
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a',
     ])
 
-    // !!!! This is a deliberately failing test to demonstrate the issue Berci found
     expectElementFoundNull(projectFile, [
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/not-existing-child',
     ])
@@ -998,8 +997,6 @@ describe('findJSXElementChildAtPath', () => {
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0',
     ])
 
-    // !!! what to do with the then-case and else-case "uid" behaviors? how do we proceed from here?
-
     expectElementFoundNull(projectFile, [
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/then-case',
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/else-case',
@@ -1035,8 +1032,6 @@ describe('findJSXElementChildAtPath', () => {
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/ternary-false-root',
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/ca0/ternary-false-root/ternary-false-child',
     ])
-
-    // !!! what to do with the then-case and else-case "uid" behaviors? how do we proceed from here?
 
     const elementAtTrueBranch = findElement(
       projectFile,

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -38,6 +38,7 @@ import {
   emptyComments,
   ChildOrAttribute,
   jsxAttributeValue,
+  childOrBlockIsAttribute,
 } from '../shared/element-template'
 import {
   isParseSuccess,
@@ -425,12 +426,18 @@ export function findJSXElementChildAtPath(
           clause: ChildOrAttribute,
           branch: ThenOrElse,
         ): JSXElementChild | null {
-          // if it's an attribute, match its path with the right branch
-          if (!childOrBlockIsChild(clause)) {
-            return tailPath[0] === thenOrElsePathPart(branch) ? element : null
+          // handle the special cased then-case / else-case path element first
+          if (tailPath.length === 1 && tailPath[0] === thenOrElsePathPart(branch)) {
+            // return null in case this is a JSXAttribute, since this function is looking for a JSXElementChild
+            return childOrBlockIsAttribute(clause) ? null : clause
           }
-          // if it's a child, get its inner element
-          return findAtPathInner(clause, tailPath)
+
+          if (childOrBlockIsChild(clause)) {
+            // if it's a child, get its inner element
+            return findAtPathInner(clause, tailPath)
+          }
+
+          return null
         }
         return (
           elementOrNullFromClause(element.whenTrue, 'then') ??

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -394,33 +394,28 @@ export function findJSXElementChildAtPath(
     workingPath: Array<string>,
   ): JSXElementChild | null {
     const firstUIDOrIndex = workingPath[0]
-    if (isJSXElementLike(element)) {
-      const uid = getUtopiaID(element)
-      if (uid === firstUIDOrIndex) {
-        const tailPath = workingPath.slice(1)
-        if (tailPath.length === 0) {
-          // this is the element we want
-          return element
-        } else {
-          // we will want to delve into the children
-          const children = element.children
-          for (const child of children) {
-            const childResult = findAtPathInner(child, tailPath)
-            if (childResult != null) {
-              return childResult
-            }
+    if (isJSXElementLike(element) && getUtopiaID(element) === firstUIDOrIndex) {
+      const tailPath = workingPath.slice(1)
+      if (tailPath.length === 0) {
+        // this is the element we want
+        return element
+      } else {
+        // we will want to delve into the children
+        const children = element.children
+        for (const child of children) {
+          const childResult = findAtPathInner(child, tailPath)
+          if (childResult != null) {
+            return childResult
           }
         }
       }
-    } else if (isJSXArbitraryBlock(element)) {
-      if (firstUIDOrIndex in element.elementsWithin) {
-        const elementWithin = element.elementsWithin[firstUIDOrIndex]
-        const withinResult = findAtPathInner(elementWithin, workingPath)
-        if (withinResult != null) {
-          return withinResult
-        }
+    } else if (isJSXArbitraryBlock(element) && firstUIDOrIndex in element.elementsWithin) {
+      const elementWithin = element.elementsWithin[firstUIDOrIndex]
+      const withinResult = findAtPathInner(elementWithin, workingPath)
+      if (withinResult != null) {
+        return withinResult
       }
-    } else if (isJSXConditionalExpression(element)) {
+    } else if (isJSXConditionalExpression(element) && getUtopiaID(element) === firstUIDOrIndex) {
       const tailPath = workingPath.slice(1)
       if (tailPath.length === 0) {
         // this is the element we want


### PR DESCRIPTION
This PR adds jest test for `findJSXElementChildAtPath`.

They are capturing expected behavior which I believe should be true, there were two tests that failed:

**1 The conditional handling missed a UID check. this meant that if the conditional was present as a sibling, it would "win" the logic and we'd walk into the conditional, even if the current visited UID was not matching the conditional's UID at all.**
Berci already fixed this bug in #3412 and I copied it over. To make it easier to avoid this mistake in the future, I moved the UID check to the same IF statements where we check the visited element's type. So hopefully if someone adds further code here, they will see that they also have to include the uid check too.

**2 When asking for aaa/parent/ca0/then-case, `findJSXElementChildAtPath` would return the conditional itself at `aaa/parent/ca0`.** 
After consulting in Discord, I changed this so it returns the actual JSXElementChild at the correct branch, or returns null if the branch's content is a JSXAttribute. 

**3 Fix No 2. broke `deleteElements` if the selected element was a JSXAttribute.** 
I fixed that by removing the actually not necessary `findJSXElementChildAtPath` check in the `deleteElements` code.

**Note:**
The ONLY case `findJSXElementChildAtPath` supports the special-cased `then-branch` or `else-branch` syntax if those are the last path elements. You can not address something with a path like `aaa/parent/conditional/then-branch/some-child-uid`. This is expected, but now it's explicit.

**Note 2:**
I think the consensus is that we probably don't want to keep the then-branch / else-branch code alive for too long, but I fixed it up for now. However I am very much looking for it to be replaced with real UIDs because now ElementPath is an array of UIDs plus this special-cased magic string, increasing the mental load, maintenance cost etc. One example: `ElementPath.toUID()` is simply broken for these special-cased paths, as it will return a string like `"then-branch"` which is certainly not unique.

