### PR TITLE
Fix tests: use ContentAffectingType

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
@@ -28,6 +28,7 @@ import { setFeatureForBrowserTests, wait } from '../../../../utils/utils.test-ut
 import { selectComponents } from '../../../editor/actions/meta-actions'
 import * as EP from '../../../../core/shared/element-path'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import { ContentAffectingType, AllContentAffectingTypes } from './group-like-helpers'
 
 interface CheckCursor {
   cursor: CSSCursor | null
@@ -988,7 +989,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
 
 describe('children-affecting reparent tests', () => {
   setFeatureForBrowserTests('Fragment support', true)
-  ;(['div', 'fragment'] as const).forEach((divOrFragment) => {
+  AllContentAffectingTypes.forEach((divOrFragment) => {
     describe(`Absolute reparent with children-affecting element ${divOrFragment} in the mix`, () => {
       it('cannot reparent into a children-affecting div', async () => {
         const renderResult = await renderTestEditorWithCode(
@@ -1171,7 +1172,31 @@ describe('children-affecting reparent tests', () => {
   })
 })
 
-function testProjectWithUnstyledDivOrFragment(divOrFragment: 'div' | 'fragment'): string {
+function getOpeningTag(type: ContentAffectingType): string {
+  switch (type) {
+    case 'sizeless-div':
+      return `<div data-uid='children-affecting' data-testid='children-affecting'>`
+    case 'fragment':
+      return `<React.Fragment data-uid='children-affecting' data-testid='children-affecting'>`
+    default:
+      const _exhaustiveCheck: never = type
+      throw new Error(`Unhandled ContentAffectingType ${JSON.stringify(type)}.`)
+  }
+}
+
+function getClosingTag(type: ContentAffectingType): string {
+  switch (type) {
+    case 'sizeless-div':
+      return `</div>`
+    case 'fragment':
+      return `</React.Fragment>`
+    default:
+      const _exhaustiveCheck: never = type
+      throw new Error(`Unhandled ContentAffectingType ${JSON.stringify(type)}.`)
+  }
+}
+
+function testProjectWithUnstyledDivOrFragment(type: ContentAffectingType): string {
   return makeTestProjectCodeWithSnippet(`
       <div
         style={{
@@ -1192,11 +1217,7 @@ function testProjectWithUnstyledDivOrFragment(divOrFragment: 'div' | 'fragment')
           }}
           data-uid='bbb'
         >
-          ${
-            divOrFragment === 'div'
-              ? `<div data-uid='children-affecting' data-testid='children-affecting'>`
-              : `<React.Fragment data-uid='children-affecting' data-testid='children-affecting'>`
-          }
+          ${getOpeningTag(type)}
             <div
               style={{
                 backgroundColor: '#aaaaaa33',
@@ -1221,7 +1242,7 @@ function testProjectWithUnstyledDivOrFragment(divOrFragment: 'div' | 'fragment')
               data-uid='child-2'
               data-testid='child-2'
             />
-          ${divOrFragment === 'div' ? `</div>` : `</React.Fragment>`}
+          ${getClosingTag(type)}
           <div
             style={{
               backgroundColor: '#aaaaaa33',

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.spec.browser2.tsx
@@ -18,6 +18,7 @@ import { mouseClickAtPoint, mouseDragFromPointWithDelta } from '../../event-help
 import { setFeatureForBrowserTests, wait } from '../../../../utils/utils.test-utils'
 import { selectComponents } from '../../../editor/actions/meta-actions'
 import * as EP from '../../../../core/shared/element-path'
+import { AllContentAffectingTypes, ContentAffectingType } from './group-like-helpers'
 
 async function dragElement(
   renderResult: EditorRenderResult,
@@ -261,11 +262,11 @@ describe('Flex Reparent To Absolute Strategy', () => {
 
 describe('Flex Reparent to Absolute – children affecting elements', () => {
   setFeatureForBrowserTests('Fragment support', true)
-  ;(['fragment', 'div'] as const).forEach((divOrFragment) => {
-    describe(`– ${divOrFragment} parents`, () => {
+  AllContentAffectingTypes.forEach((type) => {
+    describe(`– ${type} parents`, () => {
       it('reparents regular child from a children-affecting flex parent to absolute', async () => {
         const renderResult = await renderTestEditorWithCode(
-          makeTestProjectCodeWithSnippet(fragmentTestCode(divOrFragment)),
+          makeTestProjectCodeWithSnippet(fragmentTestCode(type)),
           'await-first-dom-report',
         )
 
@@ -307,7 +308,7 @@ describe('Flex Reparent to Absolute – children affecting elements', () => {
 
       it('reparents children-affecting element from flex to absolute', async () => {
         const renderResult = await renderTestEditorWithCode(
-          makeTestProjectCodeWithSnippet(fragmentTestCode(divOrFragment)),
+          makeTestProjectCodeWithSnippet(fragmentTestCode(type)),
           'await-first-dom-report',
         )
 
@@ -369,7 +370,31 @@ describe('Flex Reparent to Absolute – children affecting elements', () => {
   })
 })
 
-function fragmentTestCode(divOrFragment: 'div' | 'fragment') {
+function getOpeningTag(type: ContentAffectingType): string {
+  switch (type) {
+    case 'sizeless-div':
+      return `<div data-uid='children-affecting' data-testid='children-affecting'>`
+    case 'fragment':
+      return `<React.Fragment data-uid='children-affecting' data-testid='children-affecting'>`
+    default:
+      const _exhaustiveCheck: never = type
+      throw new Error(`Unhandled ContentAffectingType ${JSON.stringify(type)}.`)
+  }
+}
+
+function getClosingTag(type: ContentAffectingType): string {
+  switch (type) {
+    case 'sizeless-div':
+      return `</div>`
+    case 'fragment':
+      return `</React.Fragment>`
+    default:
+      const _exhaustiveCheck: never = type
+      throw new Error(`Unhandled ContentAffectingType ${JSON.stringify(type)}.`)
+  }
+}
+
+function fragmentTestCode(type: ContentAffectingType) {
   return `
   <div
     style={{
@@ -419,11 +444,7 @@ function fragmentTestCode(divOrFragment: 'div' | 'fragment') {
       data-uid='flexparent'
       data-testid='flexparent'
     >
-      ${
-        divOrFragment === 'div'
-          ? `<div data-uid='children-affecting' data-testid='children-affecting'>`
-          : `<React.Fragment data-uid='children-affecting' data-testid='children-affecting'>`
-      }
+      ${getOpeningTag(type)}
         <div
           style={{
             width: 100,
@@ -442,7 +463,7 @@ function fragmentTestCode(divOrFragment: 'div' | 'fragment') {
           data-uid='flexchild2'
           data-testid='flexchild2'
         />
-      ${divOrFragment === 'div' ? `</div>` : `</React.Fragment>`}
+      ${getClosingTag(type)}
     </div>
   </div>
 `

--- a/editor/src/components/canvas/canvas-strategies/strategies/group-like-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-like-helpers.ts
@@ -66,7 +66,8 @@ function replaceContentAffectingPathsWithTheirChildrenRecursiveInner(
   return pathsWereReplaced ? updatedPaths : paths
 }
 
-type ContentAffectingType = 'fragment' | 'sizeless-div'
+export const AllContentAffectingTypes = ['fragment', 'sizeless-div'] as const
+export type ContentAffectingType = typeof AllContentAffectingTypes[number] // <- this gives us the union type of the Array's entries
 
 export function getElementContentAffectingType(
   metadata: ElementInstanceMetadataMap,


### PR DESCRIPTION
This PR changes the group-like tests to use a new const `AllContentAffectingTypes` instead of manually enumerating 'div', 'fragment', etc... 

This is a small change, but allows us to extend test coverage as we include more and more of these types