### PR TITLE
Rename conditional cases

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
@@ -91,10 +91,10 @@ describe('a project with conditionals', () => {
       'regular-storyboard/scene/app:app-root/conditional1/conditional2',
       'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2/div-inside-conditionals-then',
       'regular-storyboard/scene/app:app-root/conditional1/conditional2/div-inside-conditionals',
-      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2/else-case-else',
-      'synthetic-storyboard/scene/app:app-root/conditional1/conditional2/else-case-attribute',
-      'conditional-clause-storyboard/scene/app:app-root/conditional1/else-case-else',
-      'synthetic-storyboard/scene/app:app-root/conditional1/else-case-attribute',
+      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2/false-case-else',
+      'synthetic-storyboard/scene/app:app-root/conditional1/conditional2/false-case-attribute',
+      'conditional-clause-storyboard/scene/app:app-root/conditional1/false-case-else',
+      'synthetic-storyboard/scene/app:app-root/conditional1/false-case-attribute',
     ])
   })
 })

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
@@ -87,13 +87,13 @@ describe('a project with conditionals', () => {
       'regular-storyboard/scene/app',
       'regular-storyboard/scene/app:app-root',
       'regular-storyboard/scene/app:app-root/conditional1',
-      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2-then',
+      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2-true-case',
       'regular-storyboard/scene/app:app-root/conditional1/conditional2',
-      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2/div-inside-conditionals-then',
+      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2/div-inside-conditionals-true-case',
       'regular-storyboard/scene/app:app-root/conditional1/conditional2/div-inside-conditionals',
-      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2/false-case-else',
+      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2/false-case-false-case',
       'synthetic-storyboard/scene/app:app-root/conditional1/conditional2/false-case-attribute',
-      'conditional-clause-storyboard/scene/app:app-root/conditional1/false-case-else',
+      'conditional-clause-storyboard/scene/app:app-root/conditional1/false-case-false-case',
       'synthetic-storyboard/scene/app:app-root/conditional1/false-case-attribute',
     ])
   })

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
@@ -89,7 +89,7 @@ describe('a project with conditionals', () => {
       'regular-storyboard/scene/app:app-root/conditional1',
       'conditional-clause-storyboard/scene/app:app-root/conditional1-true-case',
       'regular-storyboard/scene/app:app-root/conditional1/conditional2',
-      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2-false-case',
+      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2-true-case',
       'regular-storyboard/scene/app:app-root/conditional1/conditional2/div-inside-conditionals',
       'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2-false-case',
       'synthetic-storyboard/scene/app:app-root/conditional1/conditional2/false-case-attribute',

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -78,7 +78,7 @@ describe('conditionals', () => {
         'await-first-dom-report',
       )
 
-      const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional', 'then-case'])
+      const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional', 'true-case'])
       await act(async () => {
         await renderResult.dispatch([selectComponents([targetPath], false)], false)
       })

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -185,7 +185,7 @@ import {
 import { getPreferredColorScheme, Theme } from '../../../uuiui/styles/theme'
 import type { ThemeSubstate } from './store-hook-substore-types'
 import { ValueAtPath } from '../../../core/shared/jsx-attributes'
-import { ThenOrElse } from '../../../core/model/conditionals'
+import { ConditionalCase } from '../../../core/model/conditionals'
 import { Optic } from '../../../core/shared/optics/optics'
 import { fromTypeGuard } from '../../../core/shared/optics/optic-creators'
 import { getNavigatorTargets } from '../../../components/navigator/navigator-utils'
@@ -2107,12 +2107,12 @@ export function regularNavigatorEntriesEqual(
 export interface ConditionalClauseNavigatorEntry {
   type: 'CONDITIONAL_CLAUSE'
   elementPath: ElementPath
-  clause: ThenOrElse
+  clause: ConditionalCase
 }
 
 export function conditionalClauseNavigatorEntry(
   elementPath: ElementPath,
-  clause: ThenOrElse,
+  clause: ConditionalCase,
 ): ConditionalClauseNavigatorEntry {
   return {
     type: 'CONDITIONAL_CLAUSE',

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -189,11 +189,6 @@ import { Optic } from '../../../core/shared/optics/optics'
 import { fromTypeGuard } from '../../../core/shared/optics/optic-creators'
 import { getNavigatorTargets } from '../../../components/navigator/navigator-utils'
 import { treatElementAsContentAffecting } from '../../canvas/canvas-strategies/strategies/group-like-helpers'
-import {
-  ConditionalClause,
-  dynamicReparentTargetParentToStaticReparentTargetParent,
-  ReparentTargetParent,
-} from './reparent-target'
 import { getUtopiaID } from '../../../core/shared/uid-utils'
 
 const ObjectPathImmutable: any = OPI

--- a/editor/src/components/editor/store/reparent-target.ts
+++ b/editor/src/components/editor/store/reparent-target.ts
@@ -1,15 +1,15 @@
-import type { ThenOrElse } from '../../../core/model/conditionals'
 import type { ElementPath, StaticElementPath } from '../../../core/shared/project-file-types'
 import * as EP from '../../../core/shared/element-path'
+import { ConditionalCase } from '../../../core/model/conditionals'
 
 export interface ConditionalClause<P extends ElementPath> {
   elementPath: P
-  clause: ThenOrElse
+  clause: ConditionalCase
 }
 
 export function conditionalClause<P extends ElementPath>(
   elementPath: P,
-  clause: ThenOrElse,
+  clause: ConditionalCase,
 ): ConditionalClause<P> {
   return {
     elementPath: elementPath,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -489,7 +489,7 @@ import {
   RepositoryEntryPermissions,
 } from '../../../core/shared/github/helpers'
 import { valueAtPath, ValueAtPath } from '../../../core/shared/jsx-attributes'
-import { ThenOrElse } from '../../../core/model/conditionals'
+import { ConditionalCase } from '../../../core/model/conditionals'
 
 export function TransientCanvasStateFilesStateKeepDeepEquality(
   oldValue: TransientFilesState,
@@ -538,7 +538,7 @@ export const ConditionalClauseNavigatorEntryKeepDeepEquality: KeepDeepEqualityCa
     (entry) => entry.elementPath,
     ElementPathKeepDeepEquality,
     (entry) => entry.clause,
-    createCallWithTripleEquals<ThenOrElse>(),
+    createCallWithTripleEquals<ConditionalCase>(),
     conditionalClauseNavigatorEntry,
   )
 

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -396,13 +396,13 @@ describe('conditionals in the navigator', () => {
     ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
     regular-utopia-storyboard-uid/scene-aaa/containing-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-then
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
           regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
               regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-else
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/false-case-attribute
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
 
@@ -467,13 +467,13 @@ describe('conditionals in the navigator', () => {
     ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
     regular-utopia-storyboard-uid/scene-aaa/containing-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-then
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
           regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
               regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-else
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/sibling-div-element-sibling-div
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/false-case-attribute
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div`)
   })
 
@@ -505,13 +505,13 @@ describe('conditionals in the navigator', () => {
     ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
     regular-utopia-storyboard-uid/scene-aaa/containing-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-then
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
           regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
               regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-else
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/false-case-attribute
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
 
@@ -585,14 +585,14 @@ describe('conditionals in the navigator', () => {
     ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
     regular-utopia-storyboard-uid/scene-aaa/containing-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-then
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
           regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
               regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-else
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-case-attribute
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/false-case-attribute
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/false-case-attribute
       regular-utopia-storyboard-uid/scene-aaa/containing-div/else-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
   })
@@ -625,13 +625,13 @@ describe('conditionals in the navigator', () => {
     ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
     regular-utopia-storyboard-uid/scene-aaa/containing-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-then
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
           regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
               regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-else
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/false-case-attribute
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
 
@@ -692,13 +692,13 @@ describe('conditionals in the navigator', () => {
     ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
     regular-utopia-storyboard-uid/scene-aaa/containing-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-then
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
           regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-case-attribute
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-else
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/true-case-attribute
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/false-case-attribute
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/then-then-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -288,13 +288,13 @@ describe('conditionals in the navigator', () => {
     ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
     regular-utopia-storyboard-uid/scene-aaa/containing-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-then
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
           regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-case-attribute
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-else
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/true-case-attribute
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/false-case-attribute
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
 
@@ -359,13 +359,13 @@ describe('conditionals in the navigator', () => {
     ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
     regular-utopia-storyboard-uid/scene-aaa/containing-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-then
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
           regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
               regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/sibling-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-else
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/false-case-attribute
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div`)
   })
   it('dragging into an empty inactive clause, takes the place of the empty value', async () => {

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -249,7 +249,7 @@ xdescribe('conditionals in the navigator', () => {
     )
     const navigatorEntryToTarget = await renderResult.renderedDOM.findByTestId(
       `navigator-item-${varSafeNavigatorEntryToKey(
-        conditionalClauseNavigatorEntry(elementPathToTarget, 'else'),
+        conditionalClauseNavigatorEntry(elementPathToTarget, 'false-case'),
       )}`,
     )
     const navigatorEntryToTargetRect = navigatorEntryToTarget.getBoundingClientRect()
@@ -265,7 +265,7 @@ xdescribe('conditionals in the navigator', () => {
         renderResult,
         `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToDrag))}`,
         `navigator-item-${varSafeNavigatorEntryToKey(
-          conditionalClauseNavigatorEntry(elementPathToTarget, 'else'),
+          conditionalClauseNavigatorEntry(elementPathToTarget, 'false-case'),
         )}`,
         windowPoint(navigatorEntryToDragCenter),
         windowPoint(dragDelta),

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -220,8 +220,8 @@ xdescribe('conditionals in the navigator', () => {
           regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
             conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div-then
               regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/false-case-else
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/false-case-attribute
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-else
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
         conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-else
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
@@ -245,11 +245,11 @@ xdescribe('conditionals in the navigator', () => {
 
     // Getting info relating to where the element will be dragged to.
     const elementPathToTarget = EP.fromString(
-      `${BakedInStoryboardUID}/${TestSceneUID}/containing-div/conditional1/conditional2/false-case`,
+      `${BakedInStoryboardUID}/${TestSceneUID}/containing-div/conditional1/conditional2/else-case`,
     )
     const navigatorEntryToTarget = await renderResult.renderedDOM.findByTestId(
       `navigator-item-${varSafeNavigatorEntryToKey(
-        conditionalClauseNavigatorEntry(elementPathToTarget, 'false-case'),
+        conditionalClauseNavigatorEntry(elementPathToTarget, 'else'),
       )}`,
     )
     const navigatorEntryToTargetRect = navigatorEntryToTarget.getBoundingClientRect()
@@ -265,7 +265,7 @@ xdescribe('conditionals in the navigator', () => {
         renderResult,
         `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToDrag))}`,
         `navigator-item-${varSafeNavigatorEntryToKey(
-          conditionalClauseNavigatorEntry(elementPathToTarget, 'false-case'),
+          conditionalClauseNavigatorEntry(elementPathToTarget, 'else'),
         )}`,
         windowPoint(navigatorEntryToDragCenter),
         windowPoint(dragDelta),
@@ -291,8 +291,8 @@ xdescribe('conditionals in the navigator', () => {
           regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
             conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div-then
               regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/false-case-else
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/false-case-attribute
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-else
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
         conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-else
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -220,8 +220,8 @@ xdescribe('conditionals in the navigator', () => {
           regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
             conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div-then
               regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-else
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/false-case-else
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/false-case-attribute
         conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-else
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
@@ -245,11 +245,11 @@ xdescribe('conditionals in the navigator', () => {
 
     // Getting info relating to where the element will be dragged to.
     const elementPathToTarget = EP.fromString(
-      `${BakedInStoryboardUID}/${TestSceneUID}/containing-div/conditional1/conditional2/else-case`,
+      `${BakedInStoryboardUID}/${TestSceneUID}/containing-div/conditional1/conditional2/false-case`,
     )
     const navigatorEntryToTarget = await renderResult.renderedDOM.findByTestId(
       `navigator-item-${varSafeNavigatorEntryToKey(
-        conditionalClauseNavigatorEntry(elementPathToTarget, 'else'),
+        conditionalClauseNavigatorEntry(elementPathToTarget, 'false-case'),
       )}`,
     )
     const navigatorEntryToTargetRect = navigatorEntryToTarget.getBoundingClientRect()
@@ -265,7 +265,7 @@ xdescribe('conditionals in the navigator', () => {
         renderResult,
         `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToDrag))}`,
         `navigator-item-${varSafeNavigatorEntryToKey(
-          conditionalClauseNavigatorEntry(elementPathToTarget, 'else'),
+          conditionalClauseNavigatorEntry(elementPathToTarget, 'false-case'),
         )}`,
         windowPoint(navigatorEntryToDragCenter),
         windowPoint(dragDelta),
@@ -291,8 +291,8 @@ xdescribe('conditionals in the navigator', () => {
           regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
             conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div-then
               regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-else
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/false-case-else
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/false-case-attribute
         conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-else
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -322,7 +322,7 @@ describe('conditionals in the navigator', () => {
     )
     const navigatorEntryToTarget = await renderResult.renderedDOM.findByTestId(
       `navigator-item-${varSafeNavigatorEntryToKey(
-        conditionalClauseNavigatorEntry(elementPathToTarget, 'then'),
+        conditionalClauseNavigatorEntry(elementPathToTarget, 'false-case'),
       )}`,
     )
     const navigatorEntryToTargetRect = navigatorEntryToTarget.getBoundingClientRect()
@@ -338,7 +338,7 @@ describe('conditionals in the navigator', () => {
         renderResult,
         `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToDrag))}`,
         `navigator-item-${varSafeNavigatorEntryToKey(
-          conditionalClauseNavigatorEntry(elementPathToTarget, 'then'),
+          conditionalClauseNavigatorEntry(elementPathToTarget, 'false-case'),
         )}`,
         windowPoint(navigatorEntryToDragCenter),
         windowPoint(dragDelta),

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -112,9 +112,9 @@ function getNavigatorEntryLabel(
       return labelForTheElement
     case 'CONDITIONAL_CLAUSE':
       switch (navigatorEntry.clause) {
-        case 'then':
+        case 'true-case':
           return 'true'
-        case 'else':
+        case 'false-case':
           return 'false'
         default:
           throw assertNever(navigatorEntry.clause)

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -35,7 +35,7 @@ import {
   JSXConditionalExpression,
 } from '../../../core/shared/element-template'
 import { findUtopiaCommentFlag } from '../../../core/shared/comment-flags'
-import { getConditionalClausePath, ThenOrElse } from '../../../core/model/conditionals'
+import { getConditionalClausePath, ConditionalCase } from '../../../core/model/conditionals'
 import { DerivedSubstate, MetadataSubstate } from '../../editor/store/store-hook-substore-types'
 import { navigatorDepth } from '../navigator-utils'
 import createCachedSelector from 're-reselect'
@@ -305,11 +305,15 @@ const isHiddenConditionalBranchSelector = createCachedSelector(
 
     // when the condition is true, then the 'then' branch is not hidden
     if (overriddenConditionValue) {
-      const trueClausePath = getConditionalClausePath(parentPath, conditional.whenTrue, 'then')
+      const trueClausePath = getConditionalClausePath(parentPath, conditional.whenTrue, 'true-case')
       return !EP.pathsEqual(elementPath, trueClausePath)
     }
     // when the condition is false, then the 'else' branch is not hidden
-    const falseClausePath = getConditionalClausePath(parentPath, conditional.whenFalse, 'else')
+    const falseClausePath = getConditionalClausePath(
+      parentPath,
+      conditional.whenFalse,
+      'false-case',
+    )
     return !EP.pathsEqual(elementPath, falseClausePath)
   },
 )((_, elementPath, parentPath) => `${EP.toString(elementPath)}_${EP.toString(parentPath)}`)
@@ -332,13 +336,13 @@ const isActiveBranchOfOverriddenConditionalSelector = createCachedSelector(
     return (
       matchesOverriddenBranch(elementPath, parentPath, {
         clause: conditionalParent.whenTrue,
-        branch: 'then',
+        branch: 'true-case',
         wantOverride: true,
         parentOverride: parentOverride,
       }) ||
       matchesOverriddenBranch(elementPath, parentPath, {
         clause: conditionalParent.whenFalse,
-        branch: 'else',
+        branch: 'false-case',
         wantOverride: false,
         parentOverride: parentOverride,
       })
@@ -699,7 +703,7 @@ function matchesOverriddenBranch(
   parentPath: ElementPath,
   params: {
     clause: ChildOrAttribute
-    branch: ThenOrElse
+    branch: ConditionalCase
     wantOverride: boolean
     parentOverride: boolean
   },

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -26,7 +26,7 @@ import {
 } from '../../core/shared/element-path-tree'
 import { objectValues } from '../../core/shared/object-utils'
 import { fastForEach } from '../../core/shared/utils'
-import { getConditionalClausePath, ThenOrElse } from '../../core/model/conditionals'
+import { getConditionalClausePath, ConditionalCase } from '../../core/model/conditionals'
 
 function baseNavigatorDepth(path: ElementPath): number {
   // The storyboard means that this starts at -1,
@@ -141,15 +141,16 @@ export function getNavigatorTargets(
       function walkConditionalClause(
         conditionalSubTree: ElementPathTree,
         conditional: JSXConditionalExpression,
-        thenOrElse: ThenOrElse,
+        conditionalCase: ConditionalCase,
       ): void {
-        const clauseValue = thenOrElse === 'then' ? conditional.whenTrue : conditional.whenFalse
+        const clauseValue =
+          conditionalCase === 'true-case' ? conditional.whenTrue : conditional.whenFalse
 
         // Get the clause path.
-        const clausePath = getConditionalClausePath(path, clauseValue, thenOrElse)
+        const clausePath = getConditionalClausePath(path, clauseValue, conditionalCase)
 
         // Create the entry for the name of the clause.
-        const clauseTitleEntry = conditionalClauseNavigatorEntry(clausePath, thenOrElse)
+        const clauseTitleEntry = conditionalClauseNavigatorEntry(clausePath, conditionalCase)
         navigatorTargets.push(clauseTitleEntry)
         visibleNavigatorTargets.push(clauseTitleEntry)
 
@@ -180,8 +181,8 @@ export function getNavigatorTargets(
         ) {
           const jsxConditionalElement: JSXConditionalExpression = elementMetadata.element.value
 
-          walkConditionalClause(subTree, jsxConditionalElement, 'then')
-          walkConditionalClause(subTree, jsxConditionalElement, 'else')
+          walkConditionalClause(subTree, jsxConditionalElement, 'true-case')
+          walkConditionalClause(subTree, jsxConditionalElement, 'false-case')
         } else {
           throw new Error(`Unexpected non-conditional expression retrieved at ${EP.toString(path)}`)
         }

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -7,35 +7,26 @@ import {
 } from '../shared/element-template'
 import { ElementPathTree } from '../shared/element-path-tree'
 import { getUtopiaID } from './element-template-utils'
-import { assertNever } from '../shared/utils'
 
-export type ThenOrElse = 'then' | 'else'
+export type ConditionalCase = 'true-case' | 'false-case'
 
-export function thenOrElsePathPart(thenOrElse: ThenOrElse): string {
-  switch (thenOrElse) {
-    case 'then':
-      return 'then-case'
-    case 'else':
-      return 'else-case'
-    default:
-      assertNever(thenOrElse)
-  }
+export function getConditionalCasePath(
+  elementPath: ElementPath,
+  conditionalCase: ConditionalCase,
+): ElementPath {
+  return EP.appendToPath(elementPath, conditionalCase)
 }
 
-export function getThenOrElsePath(elementPath: ElementPath, thenOrElse: ThenOrElse): ElementPath {
-  return EP.appendToPath(elementPath, thenOrElsePathPart(thenOrElse))
-}
-
-// Get the path for the clause (then or else) of a conditional.
+// Get the path for the clause (true case or false case) of a conditional.
 export function getConditionalClausePath(
   conditionalPath: ElementPath,
   conditionalClause: ChildOrAttribute,
-  thenOrElse: ThenOrElse,
+  conditionalCase: ConditionalCase,
 ): ElementPath {
   if (childOrBlockIsChild(conditionalClause)) {
     return EP.appendToPath(conditionalPath, getUtopiaID(conditionalClause))
   } else {
-    return getThenOrElsePath(conditionalPath, thenOrElse)
+    return getConditionalCasePath(conditionalPath, conditionalCase)
   }
 }
 
@@ -52,17 +43,29 @@ export function reorderConditionalChildPathTrees(
     let result: Array<ElementPathTree> = []
 
     // The whenTrue clause should be first.
-    const thenPath = getConditionalClausePath(conditionalPath, conditional.whenTrue, 'then')
-    const thenPathTree = childPaths.find((childPath) => EP.pathsEqual(childPath.path, thenPath))
-    if (thenPathTree != null) {
-      result.push(thenPathTree)
+    const trueCasePath = getConditionalClausePath(
+      conditionalPath,
+      conditional.whenTrue,
+      'true-case',
+    )
+    const trueCasePathTree = childPaths.find((childPath) =>
+      EP.pathsEqual(childPath.path, trueCasePath),
+    )
+    if (trueCasePathTree != null) {
+      result.push(trueCasePathTree)
     }
 
     // The whenFalse clause should be second.
-    const elsePath = getConditionalClausePath(conditionalPath, conditional.whenFalse, 'else')
-    const elsePathTree = childPaths.find((childPath) => EP.pathsEqual(childPath.path, elsePath))
-    if (elsePathTree != null) {
-      result.push(elsePathTree)
+    const falseCasePath = getConditionalClausePath(
+      conditionalPath,
+      conditional.whenFalse,
+      'false-case',
+    )
+    const falseCasePathTree = childPaths.find((childPath) =>
+      EP.pathsEqual(childPath.path, falseCasePath),
+    )
+    if (falseCasePathTree != null) {
+      result.push(falseCasePathTree)
     }
 
     return result

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -132,7 +132,7 @@ import { isFeatureEnabled } from '../../utils/feature-switches'
 import {
   getConditionalClausePath,
   reorderConditionalChildPathTrees,
-  ThenOrElse,
+  ConditionalCase,
 } from './conditionals'
 
 const ObjectPathImmutable: any = OPI

--- a/editor/src/core/model/element-template-utils.spec.tsx
+++ b/editor/src/core/model/element-template-utils.spec.tsx
@@ -957,7 +957,6 @@ describe('findJSXElementChildAtPath', () => {
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/ternary-false-root/ternary-false-child',
     ])
 
-    // !!!! Do I misunderstand something?? shouldn't the true-case and false-case return the true-root and false-root here?? these tests fail now...
     const elementAtTrueBranch = findElement(
       projectFile,
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/true-case',

--- a/editor/src/core/model/element-template-utils.spec.tsx
+++ b/editor/src/core/model/element-template-utils.spec.tsx
@@ -957,17 +957,17 @@ describe('findJSXElementChildAtPath', () => {
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/ternary-false-root/ternary-false-child',
     ])
 
-    // !!!! Do I misunderstand something?? shouldn't the then-case and else-case return the true-root and false-root here?? these tests fail now...
+    // !!!! Do I misunderstand something?? shouldn't the true-case and false-case return the true-root and false-root here?? these tests fail now...
     const elementAtTrueBranch = findElement(
       projectFile,
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/then-case',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/true-case',
     )
     expect(elementAtTrueBranch).not.toBeNull()
     expect(getUtopiaID(elementAtTrueBranch!)).toEqual('ternary-true-root')
 
     const elementAtFalseBranch = findElement(
       projectFile,
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/else-case',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/false-case',
     )
     expect(elementAtFalseBranch).not.toBeNull()
     expect(getUtopiaID(elementAtFalseBranch!)).toEqual('ternary-false-root')
@@ -1001,8 +1001,8 @@ describe('findJSXElementChildAtPath', () => {
     ])
 
     expectElementFoundNull(projectFile, [
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/then-case',
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/else-case',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/true-case',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/false-case',
     ])
   })
 
@@ -1039,13 +1039,13 @@ describe('findJSXElementChildAtPath', () => {
 
     const elementAtTrueBranch = findElement(
       projectFile,
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/then-case',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/true-case',
     )
     expect(elementAtTrueBranch).toBeNull()
 
     const elementAtFalseBranch = findElement(
       projectFile,
-      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/else-case',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/conditional-1/false-case',
     )
     expect(elementAtFalseBranch).not.toBeNull()
     expect(getUtopiaID(elementAtFalseBranch!)).toEqual('ternary-false-root')


### PR DESCRIPTION
**Problem:**
We started to use two distinct terminology for conditional cases: then/else and true/false.

**Fix:**
Unify the terminology by only using `true-case` and `false-case`.