### PR TITLE
Show snap lines when resizing a multiselection

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -392,6 +392,61 @@ export var storyboard = (
 )
 `
 
+const projectForMultiSelectResize = `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        left: 146,
+        top: 118,
+        width: 305,
+        height: 233,
+      }}
+      data-uid='one'
+    />
+    <div
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        left: 213,
+        top: 377,
+        width: 178,
+        height: 179,
+      }}
+      data-uid='two'
+    />
+    <div
+      style={{
+        backgroundColor: '#00acff',
+        position: 'absolute',
+        left: 759,
+        top: 155,
+        width: 228,
+        height: 254,
+      }}
+      data-uid='horizontal'
+      data-testid='horizontal'
+    />
+    <div
+      style={{
+        backgroundColor: '#2b8f65',
+        position: 'absolute',
+        left: 70,
+        top: 779,
+        width: 267,
+        height: 275,
+      }}
+      data-uid='vertical'
+      data-testid='vertical'
+    />
+  </Storyboard>
+)
+`
+
 const projectForEdgeDblClickWithPosition = (
   leftPos: CSSProperties['position'],
   rightPos: CSSProperties['position'],
@@ -1182,6 +1237,113 @@ export var storyboard = (
     const supportsStyleRect = supportsStyleDiv.getBoundingClientRect()
     expect(supportsStyleRect.width).toEqual(100)
     expect(supportsStyleRect.height).toEqual(100)
+  })
+  describe('snap lines', () => {
+    it('horizontal snap lines are shown when resizing a multiselection', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectForMultiSelectResize,
+        'await-first-dom-report',
+      )
+      await selectComponentsForTest(editor, [EP.fromString('sb/one'), EP.fromString('sb/two')])
+
+      const canvasControl = editor.renderedDOM.getByTestId(
+        `resize-control-${EdgePositionBottomRight.x}-${EdgePositionBottomRight.y}`,
+      )
+
+      const resizeCornerBounds = canvasControl.getBoundingClientRect()
+      const startPoint = windowPoint({
+        x: resizeCornerBounds.x + 2,
+        y: resizeCornerBounds.y + 2,
+      })
+
+      await mouseDragFromPointWithDelta(
+        canvasControl,
+        startPoint,
+        { x: 0, y: -147 },
+        {
+          modifiers: emptyModifiers,
+          midDragCallback: async () => {
+            expect(
+              editor.getEditorState().editor.canvas.controls.snappingGuidelines.length,
+            ).toEqual(1)
+            expect(
+              editor.getEditorState().editor.canvas.controls.snappingGuidelines[0].guideline.type,
+            ).toEqual('YAxisGuideline')
+          },
+        },
+      )
+    })
+    it('vertical snap lines are shown when resizing a multiselection', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectForMultiSelectResize,
+        'await-first-dom-report',
+      )
+      await selectComponentsForTest(editor, [EP.fromString('sb/one'), EP.fromString('sb/two')])
+
+      const canvasControl = editor.renderedDOM.getByTestId(
+        `resize-control-${EdgePositionBottomRight.x}-${EdgePositionBottomRight.y}`,
+      )
+
+      const resizeCornerBounds = canvasControl.getBoundingClientRect()
+      const startPoint = windowPoint({
+        x: resizeCornerBounds.x + 2,
+        y: resizeCornerBounds.y + 2,
+      })
+
+      await mouseDragFromPointWithDelta(
+        canvasControl,
+        startPoint,
+        { x: -114, y: 0 },
+        {
+          modifiers: emptyModifiers,
+          midDragCallback: async () => {
+            expect(
+              editor.getEditorState().editor.canvas.controls.snappingGuidelines.length,
+            ).toEqual(1)
+            expect(
+              editor.getEditorState().editor.canvas.controls.snappingGuidelines[0].guideline.type,
+            ).toEqual('XAxisGuideline')
+          },
+        },
+      )
+    })
+    it('both vertical and horizontal snap lines are shown when resizing a multiselection', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectForMultiSelectResize,
+        'await-first-dom-report',
+      )
+      await selectComponentsForTest(editor, [EP.fromString('sb/one'), EP.fromString('sb/two')])
+
+      const canvasControl = editor.renderedDOM.getByTestId(
+        `resize-control-${EdgePositionBottomRight.x}-${EdgePositionBottomRight.y}`,
+      )
+
+      const resizeCornerBounds = canvasControl.getBoundingClientRect()
+      const startPoint = windowPoint({
+        x: resizeCornerBounds.x + 2,
+        y: resizeCornerBounds.y + 2,
+      })
+
+      await mouseDragFromPointWithDelta(
+        canvasControl,
+        startPoint,
+        { x: -114, y: -147 },
+        {
+          modifiers: emptyModifiers,
+          midDragCallback: async () => {
+            expect(
+              editor.getEditorState().editor.canvas.controls.snappingGuidelines.length,
+            ).toEqual(2)
+            expect(
+              editor.getEditorState().editor.canvas.controls.snappingGuidelines[0].guideline.type,
+            ).toEqual('XAxisGuideline')
+            expect(
+              editor.getEditorState().editor.canvas.controls.snappingGuidelines[1].guideline.type,
+            ).toEqual('YAxisGuideline')
+          },
+        },
+      )
+    })
   })
 })
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -11,6 +11,7 @@ import {
   canvasRectangleToLocalRectangle,
   isInfinityRectangle,
   rectangleDifference,
+  roundRectangleToNearestWhole,
   roundTo,
   SimpleRectangle,
   transformFrameUsingBoundingBox,
@@ -171,10 +172,12 @@ export function absoluteResizeBoundingBoxStrategy(
                   return []
                 }
 
-                const newFrame = transformFrameUsingBoundingBox(
-                  snappedBoundingBox,
-                  originalBoundingBox,
-                  originalFrame,
+                const newFrame = roundRectangleToNearestWhole(
+                  transformFrameUsingBoundingBox(
+                    snappedBoundingBox,
+                    originalBoundingBox,
+                    originalFrame,
+                  ),
                 )
                 const metadata = MetadataUtils.findElementByElementPath(
                   canvasState.startingMetadata,

--- a/editor/src/components/canvas/controls/guideline-controls.tsx
+++ b/editor/src/components/canvas/controls/guideline-controls.tsx
@@ -43,10 +43,7 @@ export const GuidelineControls = React.memo(() => {
           if (measuredFrame == null || isInfinityRectangle(measuredFrame)) {
             return false
           } else {
-            return rectanglesEqual(
-              roundRectangleToNearestWhole(measuredFrame),
-              roundRectangleToNearestWhole(frame),
-            )
+            return rectanglesEqual(measuredFrame, frame)
           }
         })
       )

--- a/editor/src/components/canvas/controls/guideline-controls.tsx
+++ b/editor/src/components/canvas/controls/guideline-controls.tsx
@@ -8,7 +8,9 @@ import {
   CanvasRectangle,
   canvasSegment,
   CanvasSegment,
+  isInfinityRectangle,
   rectanglesEqual,
+  roundRectangleToNearestWhole,
   segmentIntersection,
 } from '../../../core/shared/math-utils'
 import { bold, useColorTheme } from '../../../uuiui'
@@ -38,10 +40,13 @@ export const GuidelineControls = React.memo(() => {
             target,
             store.editor.jsxMetadata,
           )
-          if (measuredFrame == null) {
+          if (measuredFrame == null || isInfinityRectangle(measuredFrame)) {
             return false
           } else {
-            return rectanglesEqual(measuredFrame, frame)
+            return rectanglesEqual(
+              roundRectangleToNearestWhole(measuredFrame),
+              roundRectangleToNearestWhole(frame),
+            )
           }
         })
       )

--- a/editor/src/core/shared/math-utils.ts
+++ b/editor/src/core/shared/math-utils.ts
@@ -730,6 +730,19 @@ export function rectSizeToVector<C extends CoordinateMarker>(sizeOfVector: Size)
   } as Point<C>
 }
 
+const roundToNearestWhole = (x: number) => roundTo(x, 0)
+
+export function roundRectangleToNearestWhole<C extends CoordinateMarker>(
+  rectangle: Rectangle<C>,
+): Rectangle<C> {
+  return {
+    x: roundToNearestWhole(rectangle.x),
+    y: roundToNearestWhole(rectangle.y),
+    width: roundToNearestWhole(rectangle.width),
+    height: roundToNearestWhole(rectangle.height),
+  } as Rectangle<C>
+}
+
 export function transformFrameUsingBoundingBox<C extends CoordinateMarker>(
   newBoundingBox: Rectangle<C>,
   currentBoundingBox: Rectangle<C>,


### PR DESCRIPTION
## Problem
Snap lines weren't shown when a multiselection was resized using the absolute resize strategy.

## Fix
The root cause of the problem was that resized frames of the elements comprising the multiselection had rounding errors in their `x`, `y`, `width`, and `height` fields. We have a check to prevent rendering snap lines if the intended bounds of a resized element don't match its actual bounds (https://github.com/concrete-utopia/utopia/blob/9359b55a7f6305f7e619f5e7cd15a11226a6f149/editor/src/components/canvas/controls/guideline-controls.tsx#L33-L52), and the rounding errors prevented this check from succeeding when they should have been OK.

The fix was to round the `x`, `y`, `width`, and `height` fields of the resized bounds to integer values.