### PR TITLE
fix(inspector) keyboard strategies should update the inspector

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -488,6 +488,19 @@ export function isResizableStrategy(canvasStrategy: CanvasStrategy): boolean {
   }
 }
 
+export function isKeyboardAbsoluteStrategy(currentStrategy: string | null): boolean {
+  if (currentStrategy == null) {
+    return false
+  }
+  switch (currentStrategy) {
+    case 'KEYBOARD_ABSOLUTE_RESIZE':
+    case 'KEYBOARD_ABSOLUTE_MOVE':
+      return true
+    default:
+      return false
+  }
+}
+
 export function interactionInProgress(interactionSession: InteractionSession | null): boolean {
   if (interactionSession == null) {
     return false

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -72,7 +72,10 @@ import { ElementPath, PropertyPath } from '../../core/shared/project-file-types'
 import { when } from '../../utils/react-conditionals'
 import { createSelector } from 'reselect'
 import { isTwindEnabled } from '../../core/tailwind/tailwind'
-import { isStrategyActive } from '../canvas/canvas-strategies/canvas-strategies'
+import {
+  isKeyboardAbsoluteStrategy,
+  isStrategyActive,
+} from '../canvas/canvas-strategies/canvas-strategies'
 import type { StrategyState } from '../canvas/canvas-strategies/interaction-state'
 import { LowPriorityStoreProvider } from '../editor/store/store-context-providers'
 import { isFeatureEnabled } from '../../utils/feature-switches'
@@ -231,7 +234,10 @@ export function shouldInspectorUpdate(
   strategyState: StrategyState,
   elementsToRerender: ElementsToRerender,
 ): boolean {
-  return !isStrategyActive(strategyState) && elementsToRerender === 'rerender-all-elements'
+  return (
+    (!isStrategyActive(strategyState) && elementsToRerender === 'rerender-all-elements') ||
+    isKeyboardAbsoluteStrategy(strategyState.currentStrategy)
+  )
 }
 
 export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {


### PR DESCRIPTION
**Fix:**
Keyboard absolute strategies should update the inspector during interaction.

**Commit Details:**
- update the low-priority store when a keyboard absolute strategy is active
