### PR TITLE
Feat/jsx conditional expression string

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2426,6 +2426,7 @@ export const UPDATE_FNS = {
                 return jsxConditionalExpression(
                   newUID,
                   jsxAttributeValue(true, emptyComments),
+                  'true',
                   jsxAttributeValue(null, emptyComments),
                   jsxAttributeValue(null, emptyComments),
                   emptyComments,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -5456,6 +5456,7 @@ export const UPDATE_FNS = {
         return jsxConditionalExpression(
           element.uid,
           element.condition,
+          element.originalConditionString,
           element.whenFalse,
           element.whenTrue,
           element.comments,

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -1,7 +1,10 @@
 /* eslint-disable jest/expect-expect */
 import { act } from '@testing-library/react'
+import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { FOR_TESTS_setNextGeneratedUids } from '../../core/model/element-template-utils.test-utils'
+import { isRight } from '../../core/shared/either'
 import * as EP from '../../core/shared/element-path'
+import { isJSXConditionalExpression } from '../../core/shared/element-template'
 import { setFeatureEnabled } from '../../utils/feature-switches'
 import {
   getPrintedUiJsCode,
@@ -96,6 +99,48 @@ describe('conditionals', () => {
             </div>
          `),
       )
+    })
+  })
+  describe('expressions', () => {
+    it('stores the string expression', async () => {
+      FOR_TESTS_setNextGeneratedUids([
+        'skip1',
+        'skip2',
+        'skip3',
+        'skip4',
+        'skip5',
+        'skip6',
+        'skip7',
+        'skip8',
+        'conditional',
+      ])
+      const startSnippet = `
+        <div data-uid='aaa'>
+        {
+          [].length === 0 ? (
+            <div data-uid='bbb' data-testid='bbb'>foo</div>
+          ) : (
+            <div data-uid='ccc' data-testid='ccc'>bar</div>
+          )
+        }
+        </div>
+      `
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(startSnippet),
+        'await-first-dom-report',
+      )
+
+      const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional'])
+
+      const meta = MetadataUtils.findElementByElementPath(
+        renderResult.getEditorState().editor.jsxMetadata,
+        targetPath,
+      )
+      if (meta != null && isRight(meta.element) && isJSXConditionalExpression(meta.element.value)) {
+        expect(meta.element.value.originalConditionString).toEqual('[].length === 0')
+      } else {
+        throw new Error('invalid element')
+      }
     })
   })
 })

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -43,6 +43,7 @@ import {
 import { DefaultPackageJson, StoryboardFilePath } from '../../editor/store/editor-state'
 import {
   ConditionalsControlSectionCloseTestId,
+  ConditionalsControlSectionExpressionTestId,
   ConditionalsControlSectionOpenTestId,
   ConditionalsControlToggleFalseTestId,
   ConditionalsControlToggleTrueTestId,
@@ -2565,6 +2566,44 @@ describe('inspector tests with real metadata', () => {
         )
       }
     })
+  })
+  it('displays the condition', async () => {
+    FOR_TESTS_setNextGeneratedUids([
+      'skip1',
+      'skip2',
+      'skip3',
+      'skip4',
+      'skip5',
+      'skip6',
+      'skip7',
+      'skip8',
+      'conditional',
+    ])
+    const startSnippet = `
+        <div data-uid='aaa'>
+        {[].length === 0 ? (
+          <div data-uid='bbb' data-testid='bbb'>foo</div>
+        ) : (
+          <div data-uid='ccc' data-testid='ccc'>bar</div>
+        )}
+        </div>
+      `
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(startSnippet),
+      'await-first-dom-report',
+    )
+
+    expect(renderResult.renderedDOM.getByTestId('bbb')).not.toBeNull()
+
+    const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional'])
+    await act(async () => {
+      await renderResult.dispatch([selectComponents([targetPath], false)], false)
+    })
+
+    const expressionElement = renderResult.renderedDOM.getByTestId(
+      ConditionalsControlSectionExpressionTestId,
+    )
+    expect(expressionElement.textContent).toEqual('[].length === 0')
   })
 })
 

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -2619,44 +2619,44 @@ describe('inspector tests with real metadata', () => {
         )
       }
     })
-  })
-  it('displays the condition', async () => {
-    FOR_TESTS_setNextGeneratedUids([
-      'skip1',
-      'skip2',
-      'skip3',
-      'skip4',
-      'skip5',
-      'skip6',
-      'skip7',
-      'skip8',
-      'conditional',
-    ])
-    const startSnippet = `
-        <div data-uid='aaa'>
+    it('displays the condition', async () => {
+      FOR_TESTS_setNextGeneratedUids([
+        'skip1',
+        'skip2',
+        'skip3',
+        'skip4',
+        'skip5',
+        'skip6',
+        'skip7',
+        'skip8',
+        'conditional',
+      ])
+      const startSnippet = `
+      <div data-uid='aaa'>
         {[].length === 0 ? (
           <div data-uid='bbb' data-testid='bbb'>foo</div>
         ) : (
           <div data-uid='ccc' data-testid='ccc'>bar</div>
         )}
-        </div>
+      </div>
       `
-    const renderResult = await renderTestEditorWithCode(
-      makeTestProjectCodeWithSnippet(startSnippet),
-      'await-first-dom-report',
-    )
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(startSnippet),
+        'await-first-dom-report',
+      )
 
-    expect(renderResult.renderedDOM.getByTestId('bbb')).not.toBeNull()
+      expect(renderResult.renderedDOM.getByTestId('bbb')).not.toBeNull()
 
-    const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional'])
-    await act(async () => {
-      await renderResult.dispatch([selectComponents([targetPath], false)], false)
+      const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional'])
+      await act(async () => {
+        await renderResult.dispatch([selectComponents([targetPath], false)], false)
+      })
+
+      const expressionElement = renderResult.renderedDOM.getByTestId(
+        ConditionalsControlSectionExpressionTestId,
+      )
+      expect(expressionElement.textContent).toEqual('[].length === 0')
     })
-
-    const expressionElement = renderResult.renderedDOM.getByTestId(
-      ConditionalsControlSectionExpressionTestId,
-    )
-    expect(expressionElement.textContent).toEqual('[].length === 0')
   })
 })
 

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -107,7 +107,7 @@ const conditionExpressionSelector = createCachedSelector(
 
     const element = elements[0]
 
-    return jsxAttributeToString(element.element.condition)
+    return element.element.expression
   },
 )((_, paths) => paths.map(EP.toString).join(','))
 

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -35,6 +35,7 @@ export const ConditionalsControlSectionOpenTestId = 'conditionals-control-sectio
 export const ConditionalsControlSectionCloseTestId = 'conditionals-control-section-close'
 export const ConditionalsControlToggleTrueTestId = 'conditionals-control-toggle-true'
 export const ConditionalsControlToggleFalseTestId = 'conditionals-control-toggle-false'
+export const ConditionalsControlSectionExpressionTestId = 'conditionals-control-expression'
 
 type ConditionOverride = boolean | 'mixed' | 'not-overridden' | 'not-conditional'
 type ConditionExpression = string | 'multiselect' | 'not-conditional'
@@ -201,7 +202,12 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
         >
           Condition
           <FlexRow style={{ flexGrow: 1, gap: 4 }}>
-            <span style={{ flex: 1, textAlign: 'center' }}>{conditionExpression}</span>
+            <span
+              style={{ flex: 1, textAlign: 'center' }}
+              data-testId={ConditionalsControlSectionExpressionTestId}
+            >
+              {conditionExpression}
+            </span>
           </FlexRow>
         </UIGridRow>,
       )}
@@ -235,18 +241,3 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
     </React.Fragment>
   )
 })
-
-function jsxAttributeToString(attribute: JSXAttribute): string {
-  switch (attribute.type) {
-    case 'ATTRIBUTE_VALUE':
-      if (typeof attribute.value === 'string') {
-        return attribute.value
-      } else {
-        return attribute.value.toString()
-      }
-    case 'ATTRIBUTE_OTHER_JAVASCRIPT':
-      return attribute.javascript
-    default:
-      return 'Not supported yet'
-  }
-}

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -107,7 +107,7 @@ const conditionExpressionSelector = createCachedSelector(
 
     const element = elements[0]
 
-    return element.element.expression
+    return element.element.originalConditionString
   },
 )((_, paths) => paths.map(EP.toString).join(','))
 

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -225,7 +225,7 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
               style={{ flex: 1 }}
               highlight
               onClick={replaceBranches()}
-              data-testid={ConditionalsControlSwitchBranches}
+              data-testId={ConditionalsControlSwitchBranches}
             >
               Switch branches
             </Button>

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1060,6 +1060,7 @@ export interface JSXConditionalExpression extends WithComments {
   type: 'JSX_CONDITIONAL_EXPRESSION'
   uid: string
   condition: JSXAttribute
+  expression: string
   whenTrue: ChildOrAttribute
   whenFalse: ChildOrAttribute
 }
@@ -1067,6 +1068,7 @@ export interface JSXConditionalExpression extends WithComments {
 export function jsxConditionalExpression(
   uid: string,
   condition: JSXAttribute,
+  expression: string,
   whenTrue: ChildOrAttribute,
   whenFalse: ChildOrAttribute,
   comments: ParsedComments,
@@ -1074,6 +1076,7 @@ export function jsxConditionalExpression(
   return {
     type: 'JSX_CONDITIONAL_EXPRESSION',
     uid: uid,
+    expression: expression,
     condition: condition,
     whenTrue: whenTrue,
     whenFalse: whenFalse,

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1060,7 +1060,7 @@ export interface JSXConditionalExpression extends WithComments {
   type: 'JSX_CONDITIONAL_EXPRESSION'
   uid: string
   condition: JSXAttribute
-  expression: string
+  originalConditionString: string
   whenTrue: ChildOrAttribute
   whenFalse: ChildOrAttribute
 }
@@ -1068,7 +1068,7 @@ export interface JSXConditionalExpression extends WithComments {
 export function jsxConditionalExpression(
   uid: string,
   condition: JSXAttribute,
-  expression: string,
+  originalConditionString: string,
   whenTrue: ChildOrAttribute,
   whenFalse: ChildOrAttribute,
   comments: ParsedComments,
@@ -1076,7 +1076,7 @@ export function jsxConditionalExpression(
   return {
     type: 'JSX_CONDITIONAL_EXPRESSION',
     uid: uid,
-    expression: expression,
+    originalConditionString: originalConditionString,
     condition: condition,
     whenTrue: whenTrue,
     whenFalse: whenFalse,

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -718,6 +718,7 @@ const b = (n) => n > 0 ? n : a(10)
           "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
           "uniqueID": "",
         },
+        "expression": "n > 0",
         "type": "JSX_CONDITIONAL_EXPRESSION",
         "uid": "7dd",
         "whenFalse": Object {
@@ -909,6 +910,7 @@ const b = (n) => n > 0 ? n : a(10)
           "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
           "uniqueID": "",
         },
+        "expression": "n > 0",
         "type": "JSX_CONDITIONAL_EXPRESSION",
         "uid": "aa0",
         "whenFalse": Object {

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -718,7 +718,7 @@ const b = (n) => n > 0 ? n : a(10)
           "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
           "uniqueID": "",
         },
-        "expression": "n > 0",
+        "originalConditionString": "n > 0",
         "type": "JSX_CONDITIONAL_EXPRESSION",
         "uid": "7dd",
         "whenFalse": Object {
@@ -910,7 +910,7 @@ const b = (n) => n > 0 ? n : a(10)
           "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
           "uniqueID": "",
         },
-        "expression": "n > 0",
+        "originalConditionString": "n > 0",
         "type": "JSX_CONDITIONAL_EXPRESSION",
         "uid": "aa0",
         "whenFalse": Object {

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -2096,7 +2096,7 @@ export function parseOutJSXElements(
         const conditionalExpression = jsxConditionalExpression(
           uid,
           condition.value,
-          expression.condition.getFullText(sourceFile),
+          expression.condition.getFullText(sourceFile).trim(),
           whenTrue.value,
           whenFalse.value,
           comments,

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -2096,6 +2096,7 @@ export function parseOutJSXElements(
         const conditionalExpression = jsxConditionalExpression(
           uid,
           condition.value,
+          expression.condition.getFullText(sourceFile),
           whenTrue.value,
           whenFalse.value,
           comments,


### PR DESCRIPTION
**This PR branched-out from #3423**

Fixes #3422

**Problem:**

Trying to derive a conditional element's condition string from the code is kind of complicated because:

doing it with something like `jsxAttributeToString` is cumbersome and requires a lot of checks. Maybe it's not worth it given the purpose of this.
doing it with something like `jsxAttributeToExpression` has the problem of finding the location of the attribute in the source code. I wrote a function and all the similar stuff to retrieve the source file etc. but what you need to do anyways is kind of a re-parse.

**Fix:**

This PR stores the expression's string in the element itself. As much as we store condition: `JSXAttribute` in the `JSXConditionalExpression`, its expression's string is also stored in the element as the output of the parsed expression's `fullText()` value. This value has the same output it would have in point 2. above, with the crucial benefit of immediately knowing the element's offset inside the source file.