### PR TITLE
Extend group-like support to conditionals

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
@@ -30,6 +30,8 @@ import * as EP from '../../../../core/shared/element-path'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { ContentAffectingType, AllContentAffectingTypes } from './group-like-helpers'
 import { FOR_TESTS_setNextGeneratedUids } from '../../../../core/model/element-template-utils.test-utils'
+import { pluck } from '../../../../core/shared/array-utils'
+import { NavigatorEntry } from '../../../editor/store/editor-state'
 
 interface CheckCursor {
   cursor: CSSCursor | null
@@ -988,12 +990,37 @@ export var ${BakedInStoryboardVariableName} = (props) => {
   })
 })
 
+function getRegularNavigatorTargets(entries: Array<NavigatorEntry>): Array<string> {
+  return entries
+    .filter((t) => t.type === 'REGULAR')
+    .map((t) => t.elementPath)
+    .map(EP.toString)
+}
+
 describe('children-affecting reparent tests', () => {
   setFeatureForBrowserTests('Fragment support', true)
   setFeatureForBrowserTests('Conditional support', true)
   AllContentAffectingTypes.forEach((target) => {
     describe(`Absolute reparent with children-affecting element ${target} in the mix`, () => {
       it('cannot reparent into a children-affecting div', async () => {
+        if (target === 'conditional') {
+          FOR_TESTS_setNextGeneratedUids([
+            'skip1',
+            'skip2',
+            'skip3',
+            'skip4',
+            'skip5',
+            'skip6',
+            'inner-fragment',
+            'skip8',
+            'skip9',
+            'skip10',
+            'children-affecting',
+          ])
+        } else {
+          FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'inner-fragment', 'children-affecting'])
+        }
+
         const renderResult = await renderTestEditorWithCode(
           testProjectWithUnstyledDivOrFragment(target),
           'await-first-dom-report',
@@ -1013,15 +1040,17 @@ describe('children-affecting reparent tests', () => {
 
         await renderResult.getDispatchFollowUpActionsFinished()
 
-        expect(Object.keys(renderResult.getEditorState().editor.spyMetadata)).toEqual([
-          'utopia-storyboard-uid',
+        expect(
+          getRegularNavigatorTargets(renderResult.getEditorState().derived.navigatorTargets),
+        ).toEqual([
           'utopia-storyboard-uid/scene-aaa',
           'utopia-storyboard-uid/scene-aaa/app-entity',
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb',
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/children-affecting',
-          'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/children-affecting/child-1',
-          'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/children-affecting/child-2',
+          'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/children-affecting/inner-fragment',
+          'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/children-affecting/inner-fragment/child-1',
+          'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/children-affecting/inner-fragment/child-2',
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/child-3',
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/ccc', // <- ccc becomes a child of aaa/bbb, even though it was dragged over the globalFrame of children-affecting
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa/otherparent',
@@ -1029,6 +1058,24 @@ describe('children-affecting reparent tests', () => {
       })
 
       it('drag-to-moving a child of a children-affecting element does not change the parent if the drag starts over the ancestor', async () => {
+        if (target === 'conditional') {
+          FOR_TESTS_setNextGeneratedUids([
+            'skip1',
+            'skip2',
+            'skip3',
+            'skip4',
+            'skip5',
+            'skip6',
+            'inner-fragment',
+            'skip8',
+            'skip9',
+            'skip10',
+            'children-affecting',
+          ])
+        } else {
+          FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'inner-fragment', 'children-affecting'])
+        }
+
         const renderResult = await renderTestEditorWithCode(
           testProjectWithUnstyledDivOrFragment(target),
           'await-first-dom-report',
@@ -1048,6 +1095,23 @@ describe('children-affecting reparent tests', () => {
       })
 
       it('drag-to-moving a child of a children-affecting element DOES change the parent if the drag leaves the ancestor', async () => {
+        if (target === 'conditional') {
+          FOR_TESTS_setNextGeneratedUids([
+            'skip1',
+            'skip2',
+            'skip3',
+            'skip4',
+            'skip5',
+            'skip6',
+            'inner-fragment',
+            'skip8',
+            'skip9',
+            'skip10',
+            'children-affecting',
+          ])
+        } else {
+          FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'inner-fragment', 'children-affecting'])
+        }
         const renderResult = await renderTestEditorWithCode(
           testProjectWithUnstyledDivOrFragment(target),
           'await-first-dom-report',
@@ -1059,14 +1123,16 @@ describe('children-affecting reparent tests', () => {
         await renderResult.getDispatchFollowUpActionsFinished()
 
         // no reparent have happened
-        expect(Object.keys(renderResult.getEditorState().editor.spyMetadata)).toEqual([
-          'utopia-storyboard-uid',
+        expect(
+          getRegularNavigatorTargets(renderResult.getEditorState().derived.navigatorTargets),
+        ).toEqual([
           'utopia-storyboard-uid/scene-aaa',
           'utopia-storyboard-uid/scene-aaa/app-entity',
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb',
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/children-affecting',
-          'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/children-affecting/child-1',
+          'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/children-affecting/inner-fragment',
+          'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/children-affecting/inner-fragment/child-1',
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/child-3',
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa/ccc',
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa/otherparent',
@@ -1075,6 +1141,24 @@ describe('children-affecting reparent tests', () => {
       })
 
       it('is possible to reparent a fragment-child into the parent of the fragment, if the drag starts out of the grandparent bounds', async () => {
+        if (target === 'conditional') {
+          FOR_TESTS_setNextGeneratedUids([
+            'skip1',
+            'skip2',
+            'skip3',
+            'skip4',
+            'skip5',
+            'skip6',
+            'inner-fragment',
+            'skip8',
+            'skip9',
+            'skip10',
+            'children-affecting',
+          ])
+        } else {
+          FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'inner-fragment', 'children-affecting'])
+        }
+
         const renderResult = await renderTestEditorWithCode(
           testProjectWithUnstyledDivOrFragment(target),
           'await-first-dom-report',
@@ -1085,14 +1169,16 @@ describe('children-affecting reparent tests', () => {
 
         await renderResult.getDispatchFollowUpActionsFinished()
 
-        expect(Object.keys(renderResult.getEditorState().editor.spyMetadata)).toEqual([
-          'utopia-storyboard-uid',
+        expect(
+          getRegularNavigatorTargets(renderResult.getEditorState().derived.navigatorTargets),
+        ).toEqual([
           'utopia-storyboard-uid/scene-aaa',
           'utopia-storyboard-uid/scene-aaa/app-entity',
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb',
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/children-affecting',
-          'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/children-affecting/child-2',
+          'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/children-affecting/inner-fragment',
+          'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/children-affecting/inner-fragment/child-2',
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/child-3',
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/child-1', // <child-1 is not the direct child of bbb
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa/ccc',
@@ -1101,7 +1187,7 @@ describe('children-affecting reparent tests', () => {
       })
     })
 
-    it(`reparenting the children-affecting ${divOrFragment} to an absolute parent works`, async () => {
+    it(`reparenting the children-affecting ${target} to an absolute parent works`, async () => {
       if (target === 'conditional') {
         FOR_TESTS_setNextGeneratedUids([
           'skip1',
@@ -1119,6 +1205,7 @@ describe('children-affecting reparent tests', () => {
       } else {
         FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'inner-fragment', 'children-affecting'])
       }
+
       const renderResult = await renderTestEditorWithCode(
         testProjectWithUnstyledDivOrFragment(target),
         'await-first-dom-report',
@@ -1147,8 +1234,9 @@ describe('children-affecting reparent tests', () => {
 
       await renderResult.getDispatchFollowUpActionsFinished()
 
-      expect(Object.keys(renderResult.getEditorState().editor.spyMetadata).sort()).toEqual([
-        'utopia-storyboard-uid',
+      expect(
+        getRegularNavigatorTargets(renderResult.getEditorState().derived.navigatorTargets),
+      ).toEqual([
         'utopia-storyboard-uid/scene-aaa',
         'utopia-storyboard-uid/scene-aaa/app-entity',
         'utopia-storyboard-uid/scene-aaa/app-entity:aaa',

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
@@ -1000,29 +1000,11 @@ function getRegularNavigatorTargets(entries: Array<NavigatorEntry>): Array<strin
 describe('children-affecting reparent tests', () => {
   setFeatureForBrowserTests('Fragment support', true)
   setFeatureForBrowserTests('Conditional support', true)
-  AllContentAffectingTypes.forEach((target) => {
-    describe(`Absolute reparent with children-affecting element ${target} in the mix`, () => {
+  AllContentAffectingTypes.forEach((type) => {
+    describe(`Absolute reparent with children-affecting element ${type} in the mix`, () => {
       it('cannot reparent into a children-affecting div', async () => {
-        if (target === 'conditional') {
-          FOR_TESTS_setNextGeneratedUids([
-            'skip1',
-            'skip2',
-            'skip3',
-            'skip4',
-            'skip5',
-            'skip6',
-            'inner-fragment',
-            'skip8',
-            'skip9',
-            'skip10',
-            'children-affecting',
-          ])
-        } else {
-          FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'inner-fragment', 'children-affecting'])
-        }
-
         const renderResult = await renderTestEditorWithCode(
-          testProjectWithUnstyledDivOrFragment(target),
+          testProjectWithUnstyledDivOrFragment(type),
           'await-first-dom-report',
         )
 
@@ -1058,26 +1040,8 @@ describe('children-affecting reparent tests', () => {
       })
 
       it('drag-to-moving a child of a children-affecting element does not change the parent if the drag starts over the ancestor', async () => {
-        if (target === 'conditional') {
-          FOR_TESTS_setNextGeneratedUids([
-            'skip1',
-            'skip2',
-            'skip3',
-            'skip4',
-            'skip5',
-            'skip6',
-            'inner-fragment',
-            'skip8',
-            'skip9',
-            'skip10',
-            'children-affecting',
-          ])
-        } else {
-          FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'inner-fragment', 'children-affecting'])
-        }
-
         const renderResult = await renderTestEditorWithCode(
-          testProjectWithUnstyledDivOrFragment(target),
+          testProjectWithUnstyledDivOrFragment(type),
           'await-first-dom-report',
         )
 
@@ -1095,25 +1059,8 @@ describe('children-affecting reparent tests', () => {
       })
 
       it('drag-to-moving a child of a children-affecting element DOES change the parent if the drag leaves the ancestor', async () => {
-        if (target === 'conditional') {
-          FOR_TESTS_setNextGeneratedUids([
-            'skip1',
-            'skip2',
-            'skip3',
-            'skip4',
-            'skip5',
-            'skip6',
-            'inner-fragment',
-            'skip8',
-            'skip9',
-            'skip10',
-            'children-affecting',
-          ])
-        } else {
-          FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'inner-fragment', 'children-affecting'])
-        }
         const renderResult = await renderTestEditorWithCode(
-          testProjectWithUnstyledDivOrFragment(target),
+          testProjectWithUnstyledDivOrFragment(type),
           'await-first-dom-report',
         )
 
@@ -1141,26 +1088,8 @@ describe('children-affecting reparent tests', () => {
       })
 
       it('is possible to reparent a fragment-child into the parent of the fragment, if the drag starts out of the grandparent bounds', async () => {
-        if (target === 'conditional') {
-          FOR_TESTS_setNextGeneratedUids([
-            'skip1',
-            'skip2',
-            'skip3',
-            'skip4',
-            'skip5',
-            'skip6',
-            'inner-fragment',
-            'skip8',
-            'skip9',
-            'skip10',
-            'children-affecting',
-          ])
-        } else {
-          FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'inner-fragment', 'children-affecting'])
-        }
-
         const renderResult = await renderTestEditorWithCode(
-          testProjectWithUnstyledDivOrFragment(target),
+          testProjectWithUnstyledDivOrFragment(type),
           'await-first-dom-report',
         )
 
@@ -1187,27 +1116,9 @@ describe('children-affecting reparent tests', () => {
       })
     })
 
-    it(`reparenting the children-affecting ${target} to an absolute parent works`, async () => {
-      if (target === 'conditional') {
-        FOR_TESTS_setNextGeneratedUids([
-          'skip1',
-          'skip2',
-          'skip3',
-          'skip4',
-          'skip5',
-          'skip6',
-          'inner-fragment',
-          'skip8',
-          'skip9',
-          'skip10',
-          'children-affecting',
-        ])
-      } else {
-        FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'inner-fragment', 'children-affecting'])
-      }
-
+    it(`reparenting the children-affecting ${type} to an absolute parent works`, async () => {
       const renderResult = await renderTestEditorWithCode(
-        testProjectWithUnstyledDivOrFragment(target),
+        testProjectWithUnstyledDivOrFragment(type),
         'await-first-dom-report',
       )
 
@@ -1309,6 +1220,24 @@ function getClosingTag(type: ContentAffectingType): string {
 }
 
 function testProjectWithUnstyledDivOrFragment(type: ContentAffectingType): string {
+  if (type === 'conditional') {
+    FOR_TESTS_setNextGeneratedUids([
+      'skip1',
+      'skip2',
+      'skip3',
+      'skip4',
+      'skip5',
+      'skip6',
+      'inner-fragment',
+      'skip8',
+      'skip9',
+      'skip10',
+      'children-affecting',
+    ])
+  } else {
+    FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'inner-fragment', 'children-affecting'])
+  }
+
   return makeTestProjectCodeWithSnippet(`
       <div
         style={{

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
@@ -1,3 +1,26 @@
+import * as Prettier from 'prettier/standalone'
+import { PrettierConfig } from 'utopia-vscode-common'
+import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import { FOR_TESTS_setNextGeneratedUids } from '../../../../core/model/element-template-utils.test-utils'
+import {
+  BakedInStoryboardUID,
+  BakedInStoryboardVariableName,
+} from '../../../../core/model/scene-utils'
+import * as EP from '../../../../core/shared/element-path'
+import {
+  canvasVector,
+  offsetRect,
+  windowPoint,
+  WindowPoint,
+} from '../../../../core/shared/math-utils'
+import { cmdModifier, emptyModifiers, Modifiers } from '../../../../utils/modifiers'
+import { setFeatureForBrowserTests } from '../../../../utils/utils.test-utils'
+import { selectComponents } from '../../../editor/actions/meta-actions'
+import { NavigatorEntry } from '../../../editor/store/editor-state'
+import { CSSCursor } from '../../canvas-types'
+import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
+import { getCursorFromEditor } from '../../controls/select-mode/cursor-component'
+import { mouseClickAtPoint, mouseDragFromPointWithDelta } from '../../event-helpers.test-utils'
 import {
   EditorRenderResult,
   formatTestProjectCode,
@@ -7,31 +30,7 @@ import {
   TestAppUID,
   TestSceneUID,
 } from '../../ui-jsx.test-utils'
-import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
-import {
-  canvasVector,
-  offsetRect,
-  windowPoint,
-  WindowPoint,
-} from '../../../../core/shared/math-utils'
-import { cmdModifier, emptyModifiers, Modifiers } from '../../../../utils/modifiers'
-import { PrettierConfig } from 'utopia-vscode-common'
-import * as Prettier from 'prettier/standalone'
-import {
-  BakedInStoryboardVariableName,
-  BakedInStoryboardUID,
-} from '../../../../core/model/scene-utils'
-import { getCursorFromEditor } from '../../controls/select-mode/cursor-component'
-import { CSSCursor } from '../../canvas-types'
-import { mouseClickAtPoint, mouseDragFromPointWithDelta } from '../../event-helpers.test-utils'
-import { setFeatureForBrowserTests, wait } from '../../../../utils/utils.test-utils'
-import { selectComponents } from '../../../editor/actions/meta-actions'
-import * as EP from '../../../../core/shared/element-path'
-import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
-import { ContentAffectingType, AllContentAffectingTypes } from './group-like-helpers'
-import { FOR_TESTS_setNextGeneratedUids } from '../../../../core/model/element-template-utils.test-utils'
-import { pluck } from '../../../../core/shared/array-utils'
-import { NavigatorEntry } from '../../../editor/store/editor-state'
+import { AllContentAffectingTypes, ContentAffectingType } from './group-like-helpers'
 
 interface CheckCursor {
   cursor: CSSCursor | null
@@ -1166,7 +1165,13 @@ describe('children-affecting reparent tests', () => {
           'utopia-storyboard-uid/scene-aaa/app-entity:aaa/otherparent/children-affecting'
         ]
       // the fragment-like element continues to have no style prop
-      expect(propsOfFragment?.style).not.toBeDefined()
+      expect(propsOfFragment?.style == null).toBeTruthy()
+      const propsOfInnerFragment =
+        renderResult.getEditorState().editor.allElementProps[
+          'utopia-storyboard-uid/scene-aaa/app-entity:aaa/otherparent/children-affecting/inner-fragment'
+        ]
+      // the inner fragment-like element continues to have no style prop
+      expect(propsOfInnerFragment?.style == null).toBeTruthy()
 
       const child1GlobalFrameAfter = MetadataUtils.getFrameOrZeroRectInCanvasCoords(
         EP.fromString(

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.spec.browser2.tsx
@@ -376,6 +376,8 @@ function getOpeningTag(type: ContentAffectingType): string {
       return `<div data-uid='children-affecting' data-testid='children-affecting'>`
     case 'fragment':
       return `<React.Fragment data-uid='children-affecting' data-testid='children-affecting'>`
+    case 'conditional':
+      return `{ true ? ( <>`
     default:
       const _exhaustiveCheck: never = type
       throw new Error(`Unhandled ContentAffectingType ${JSON.stringify(type)}.`)
@@ -388,6 +390,8 @@ function getClosingTag(type: ContentAffectingType): string {
       return `</div>`
     case 'fragment':
       return `</React.Fragment>`
+    case 'conditional':
+      return `</> ) : null }`
     default:
       const _exhaustiveCheck: never = type
       throw new Error(`Unhandled ContentAffectingType ${JSON.stringify(type)}.`)

--- a/editor/src/components/canvas/canvas-strategies/strategies/group-like-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-like-helpers.ts
@@ -66,7 +66,7 @@ function replaceContentAffectingPathsWithTheirChildrenRecursiveInner(
   return pathsWereReplaced ? updatedPaths : paths
 }
 
-export const AllContentAffectingTypes = ['fragment', 'sizeless-div'] as const
+export const AllContentAffectingTypes = ['fragment', 'sizeless-div', 'conditional'] as const
 export type ContentAffectingType = typeof AllContentAffectingTypes[number] // <- this gives us the union type of the Array's entries
 
 export function getElementContentAffectingType(
@@ -78,15 +78,12 @@ export function getElementContentAffectingType(
 
   const elementProps = allElementProps[EP.toString(path)]
 
-  if (
-    elementMetadata?.element != null &&
-    foldEither(
-      () => false,
-      (e) => isJSXFragment(e),
-      elementMetadata.element,
-    )
-  ) {
+  if (MetadataUtils.isFragmentFromMetadata(elementMetadata)) {
     return 'fragment'
+  }
+
+  if (MetadataUtils.isConditionalFromMetadata(elementMetadata)) {
+    return 'conditional'
   }
 
   if (MetadataUtils.isFlexLayoutedContainer(elementMetadata)) {

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -480,15 +480,6 @@ function renderJSXElement(
   highlightBounds: HighlightBoundsForUids | null,
   editedText: ElementPath | null,
 ): React.ReactElement {
-  let elementProps = { key: key, ...passthroughProps }
-  if (isHidden(hiddenInstances, elementPath)) {
-    elementProps = hideElement(elementProps)
-  }
-  if (elementIsDisplayNone(displayNoneInstances, elementPath)) {
-    elementProps = displayNoneElement(elementProps)
-  }
-  elementProps = streamlineInFileBlobs(elementProps, fileBlobs)
-
   const createChildrenElement = (child: JSXElementChild): React.ReactChild => {
     const childPath = optionalMap((path) => EP.appendToPath(path, getUtopiaID(child)), elementPath)
     return renderCoreElement(
@@ -548,6 +539,18 @@ function renderJSXElement(
 
   const FinalElement = elementIsIntrinsic ? jsx.name.baseVariable : elementOrScene
   const FinalElementOrFragment = elementIsFragment ? React.Fragment : FinalElement
+
+  let elementProps = { key: key, ...passthroughProps }
+  if (!elementIsFragment) {
+    if (isHidden(hiddenInstances, elementPath)) {
+      elementProps = hideElement(elementProps)
+    }
+    if (elementIsDisplayNone(displayNoneInstances, elementPath)) {
+      elementProps = displayNoneElement(elementProps)
+    }
+    elementProps = streamlineInFileBlobs(elementProps, fileBlobs)
+  }
+
   const elementPropsWithScenePath = isComponentRendererComponent(FinalElement)
     ? { ...elementProps, [UTOPIA_INSTANCE_PATH]: elementPath }
     : elementProps

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -890,7 +890,7 @@ export function handleKeyDown(
             elementPath,
           )
 
-          if (contentAffectingType === 'fragment') {
+          if (contentAffectingType === 'fragment' || contentAffectingType === 'conditional') {
             return []
           }
 

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -39,6 +39,7 @@ import {
   ChildOrAttribute,
   jsxAttributeValue,
   childOrBlockIsAttribute,
+  jsxConditionalExpression,
 } from '../shared/element-template'
 import {
   isParseSuccess,
@@ -195,6 +196,14 @@ export function setUtopiaID(element: JSXElementChild, uid: string): JSXElementCh
     return setUtopiaIDOnJSXElement(element, uid)
   } else if (isUtopiaJSXFragment(element)) {
     return jsxFragment(uid, element.children, element.longForm)
+  } else if (isJSXConditionalExpression(element)) {
+    return jsxConditionalExpression(
+      uid,
+      element.condition,
+      element.whenTrue,
+      element.whenFalse,
+      element.comments,
+    )
   } else {
     throw new Error(`Unable to set utopia id on ${element.type}`)
   }


### PR DESCRIPTION
**Problem:**
We had a half-official strategy support for conditionals. 

**Fix:**
Now they are included in the `ContentAffectingType` enumeration!
This meant that I had to extend the two existing content-affecting test suites, the absolute reparent and the flex-> absolute reparent. As part of fixing these tests, I actually found two bugs in the code which I also amended.

**Commit Details:**
- Added 'conditional' to ContentAffectingType
- Fixed 'children-affecting reparent tests'
- Fixed 'Flex Reparent to Absolute – children affecting elements' tests
- Fixed setUtopiaID to work with conditional expressions
- Fixed renderJSXElement to not put a style tag on display none / hidden fragments to avoid throwing a big noisy warning
