### PR TITLE
Drag in and out of conditional clauses 2: The Vitefixening.

### DIFF
--- a/editor/.dependency-cruiser.js
+++ b/editor/.dependency-cruiser.js
@@ -153,8 +153,7 @@ module.exports = {
       severity: 'error',
       from: {},
       to: {
-        path:
-          '\\.(spec|test|spec.browser|spec.browser2)\\.(js|mjs|cjs|ts|tsx|ls|coffee|litcoffee|coffee\\.md)$',
+        path: '\\.(spec|test|spec.browser|spec.browser2)\\.(js|mjs|cjs|ts|tsx|ls|coffee|litcoffee|coffee\\.md)$',
       },
     },
     {
@@ -237,6 +236,23 @@ module.exports = {
       },
       to: {
         path: ['typescript'],
+        reachable: true,
+      },
+    },
+    {
+      name: 'not-from-workers-to-specific-files',
+      comment: 'Stop the workers from reaching down to certain files.',
+      severity: 'error',
+      from: {
+        path: '\\.(worker)\\.(ts|tsx)$',
+      },
+      to: {
+        path: [
+          '^src/components/editor/store/store-deep-equality-instances.ts',
+          '^src/sample-projects/sample-project-utils.ts',
+          '^src/utils/deep-equality-instances.ts',
+          '^src/utils/deep-equality.ts',
+        ],
         reachable: true,
       },
     },

--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -18,7 +18,7 @@ import { mapValues, propOrNull } from '../core/shared/object-utils'
 import { emptySet } from '../core/shared/set-utils'
 import { sha1 } from 'sha.js'
 import { GithubFileChanges, TreeConflicts } from '../core/shared/github/helpers'
-import { FileChecksums } from './editor/store/editor-state'
+import type { FileChecksums } from './editor/store/editor-state'
 import { memoize } from '../core/shared/memoize'
 
 export interface AssetFileWithFileName {

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
@@ -28,10 +28,7 @@ import { BuiltInDependencies } from '../../../../core/es-modules/package-manager
 import { CSSCursor } from '../../canvas-types'
 import { addToReparentedToPaths } from '../../commands/add-to-reparented-to-paths-command'
 import { getStoryboardElementPath } from '../../../../core/model/scene-utils'
-import {
-  generateUidWithExistingComponents,
-  getUtopiaID,
-} from '../../../../core/model/element-template-utils'
+import { generateUidWithExistingComponents } from '../../../../core/model/element-template-utils'
 import { addElement } from '../../commands/add-element-command'
 import {
   CustomStrategyState,
@@ -42,6 +39,12 @@ import { duplicateElement } from '../../commands/duplicate-element-command'
 import { wildcardPatch } from '../../commands/wildcard-patch-command'
 import { hideInNavigatorCommand } from '../../commands/hide-in-navigator-command'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import {
+  getElementPathFromReparentTargetParent,
+  ReparentTargetParent,
+  reparentTargetParentIsElementPath,
+} from '../../../../components/editor/store/reparent-target'
+import { getUtopiaID } from '../../../../core/shared/uid-utils'
 
 interface GetReparentOutcomeResult {
   commands: Array<CanvasCommand>
@@ -82,11 +85,11 @@ export function getReparentOutcome(
   nodeModules: NodeModules,
   openFile: string | null | undefined,
   toReparent: ToReparent,
-  targetParent: ElementPath | null,
+  targetParent: ReparentTargetParent<ElementPath> | null,
   whenToRun: 'always' | 'on-complete',
 ): GetReparentOutcomeResult | null {
   // Cater for something being reparented to the canvas.
-  let newParent: ElementPath
+  let newParent: ReparentTargetParent<ElementPath>
   if (targetParent == null) {
     const storyboardElementPath = getStoryboardElementPath(projectContents, openFile)
     if (storyboardElementPath == null) {
@@ -102,6 +105,7 @@ export function getReparentOutcome(
   // Early exit if there's no need to make any change.
   if (
     toReparent.type === 'PATH_TO_REPARENT' &&
+    reparentTargetParentIsElementPath(newParent) &&
     EP.pathsEqual(newParent, EP.parentPath(toReparent.target))
   ) {
     return {
@@ -110,11 +114,15 @@ export function getReparentOutcome(
     }
   }
 
+  const newParentElementPath = getElementPathFromReparentTargetParent(newParent)
+
   // Lookup the filename that will be added to.
   const newTargetFilePath = forceNotNull(
-    `Unable to determine target path for ${newParent == null ? null : EP.toString(newParent)}`,
+    `Unable to determine target path for ${
+      newParent == null ? null : EP.toString(newParentElementPath)
+    }`,
     withUnderlyingTarget(
-      newParent,
+      newParentElementPath,
       projectContents,
       nodeModules,
       openFile,
@@ -140,12 +148,12 @@ export function getReparentOutcome(
       )
       commands.push(addImportsToFile(whenToRun, newTargetFilePath, importsToAdd))
       commands.push(reparentElement(whenToRun, toReparent.target, newParent))
-      newPath = EP.appendToPath(newParent, EP.toUid(toReparent.target))
+      newPath = EP.appendToPath(newParentElementPath, EP.toUid(toReparent.target))
       break
     case 'ELEMENT_TO_REPARENT':
-      newPath = EP.appendToPath(newParent, getUtopiaID(toReparent.element))
+      newPath = EP.appendToPath(newParentElementPath, getUtopiaID(toReparent.element))
       commands.push(addImportsToFile(whenToRun, newTargetFilePath, toReparent.imports))
-      commands.push(addElement(whenToRun, newParent, toReparent.element))
+      commands.push(addElement(whenToRun, newParentElementPath, toReparent.element))
       break
     default:
       const _exhaustiveCheck: never = toReparent

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -44,13 +44,11 @@ import {
 } from '../../core/shared/element-template'
 import {
   getAllUniqueUids,
-  getUtopiaID,
   guaranteeUniqueUids,
-  setUtopiaID,
   isSceneElement,
   getZIndexOfElement,
 } from '../../core/model/element-template-utils'
-import { generateUID } from '../../core/shared/uid-utils'
+import { generateUID, getUtopiaID, setUtopiaID } from '../../core/shared/uid-utils'
 import {
   setJSXValuesAtPaths,
   unsetJSXValuesAtPaths,

--- a/editor/src/components/canvas/commands/reorder-element-command.ts
+++ b/editor/src/components/canvas/commands/reorder-element-command.ts
@@ -52,8 +52,8 @@ export const runReorderElement: CommandFunction<ReorderElement> = (
   )
   return {
     editorStatePatches: [patch],
-    commandDescription: `Reorder Element ${EP.toUid(command.target)} to new index ${
-      command.indexPosition
-    }`,
+    commandDescription: `Reorder Element ${EP.toUid(command.target)} to new index ${JSON.stringify(
+      command.indexPosition,
+    )}`,
   }
 }

--- a/editor/src/components/canvas/commands/reparent-element-command.ts
+++ b/editor/src/components/canvas/commands/reparent-element-command.ts
@@ -1,3 +1,8 @@
+import {
+  getElementPathFromReparentTargetParent,
+  ReparentTargetParent,
+  reparentTargetParentIsConditionalClause,
+} from '../../../components/editor/store/reparent-target'
 import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
 import * as EP from '../../../core/shared/element-path'
 import { ElementPath } from '../../../core/shared/project-file-types'
@@ -13,13 +18,13 @@ import { BaseCommand, CommandFunction, getPatchForComponentChange, WhenToRun } f
 export interface ReparentElement extends BaseCommand {
   type: 'REPARENT_ELEMENT'
   target: ElementPath
-  newParent: ElementPath
+  newParent: ReparentTargetParent<ElementPath>
 }
 
 export function reparentElement(
   whenToRun: WhenToRun,
   target: ElementPath,
-  newParent: ElementPath,
+  newParent: ReparentTargetParent<ElementPath>,
 ): ReparentElement {
   return {
     type: 'REPARENT_ELEMENT',
@@ -39,7 +44,7 @@ export const runReparentElement: CommandFunction<ReparentElement> = (
     editorState,
     (successTarget, underlyingElementTarget, _underlyingTarget, underlyingFilePathTarget) => {
       forUnderlyingTargetFromEditorState(
-        command.newParent,
+        getElementPathFromReparentTargetParent(command.newParent),
         editorState,
         (
           successNewParent,
@@ -102,10 +107,19 @@ export const runReparentElement: CommandFunction<ReparentElement> = (
     },
   )
 
+  let parentDescription: string
+  if (reparentTargetParentIsConditionalClause(command.newParent)) {
+    parentDescription = `${EP.toUid(command.newParent.elementPath)} (${
+      command.newParent.clause
+    } clause)`
+  } else {
+    parentDescription = EP.toUid(command.newParent)
+  }
+
   return {
     editorStatePatches: editorStatePatches,
-    commandDescription: `Reparent Element ${EP.toUid(command.target)} to new parent ${EP.toUid(
-      command.newParent,
-    )}`,
+    commandDescription: `Reparent Element ${EP.toUid(
+      command.target,
+    )} to new parent ${parentDescription}`,
   }
 }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { MapLike } from 'typescript'
 import { PropertyControls } from 'utopia-api/core'
-import { getUtopiaID } from '../../../core/model/element-template-utils'
 import {
   JSXElementChild,
   isUtopiaJSXComponent,
@@ -31,7 +30,7 @@ import {
 import { useContextSelector } from 'use-context-selector'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { UTOPIA_INSTANCE_PATH, UTOPIA_PATH_KEY } from '../../../core/model/utopia-constants'
-import { getPathsFromString } from '../../../core/shared/uid-utils'
+import { getPathsFromString, getUtopiaID } from '../../../core/shared/uid-utils'
 import { useGetTopLevelElementsAndImports } from './ui-jsx-canvas-top-level-elements'
 import { useGetCodeAndHighlightBounds } from './ui-jsx-canvas-execution-scope'
 import { usePubSubAtomReadOnly } from '../../../core/shared/atom-with-pub-sub'

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
@@ -87,13 +87,13 @@ describe('a project with conditionals', () => {
       'regular-storyboard/scene/app',
       'regular-storyboard/scene/app:app-root',
       'regular-storyboard/scene/app:app-root/conditional1',
-      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2-then',
+      'conditional-clause-storyboard/scene/app:app-root/conditional1-then',
       'regular-storyboard/scene/app:app-root/conditional1/conditional2',
-      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2/div-inside-conditionals-then',
+      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2-then',
       'regular-storyboard/scene/app:app-root/conditional1/conditional2/div-inside-conditionals',
-      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2/else-case-else',
+      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2-else',
       'synthetic-storyboard/scene/app:app-root/conditional1/conditional2/else-case-attribute',
-      'conditional-clause-storyboard/scene/app:app-root/conditional1/else-case-else',
+      'conditional-clause-storyboard/scene/app:app-root/conditional1-else',
       'synthetic-storyboard/scene/app:app-root/conditional1/else-case-attribute',
     ])
   })

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { MapLike } from 'typescript'
-import { getUtopiaID } from '../../../core/model/element-template-utils'
 import {
   UTOPIA_PATH_KEY,
   UTOPIA_SCENE_ID_KEY,
@@ -47,7 +46,7 @@ import { objectMap } from '../../../core/shared/object-utils'
 import { cssValueOnlyContainsComments } from '../../../printer-parsers/css/css-parser-utils'
 import { filterDataProps } from '../../../utils/canvas-react-utils'
 import { addFakeSpyEntry, buildSpyWrappedElement } from './ui-jsx-canvas-spy-wrapper'
-import { createIndexedUid } from '../../../core/shared/uid-utils'
+import { createIndexedUid, getUtopiaID } from '../../../core/shared/uid-utils'
 import { isComponentRendererComponent } from './ui-jsx-canvas-component-renderer'
 import { optionalMap } from '../../../core/shared/optional-utils'
 import { canvasMissingJSXElementError } from './canvas-render-errors'

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -13,7 +13,6 @@ import { findElementAtPath, MetadataUtils } from '../../../core/model/element-me
 import {
   generateUidWithExistingComponents,
   getAllUniqueUids,
-  getUtopiaID,
   getZIndexOfElement,
   transformJSXComponentAtElementPath,
   transformJSXComponentAtPath,
@@ -407,6 +406,8 @@ import {
   isRegularNavigatorEntry,
   NavigatorEntry,
   regularNavigatorEntryOptic,
+  ConditionalClauseNavigatorEntry,
+  reparentTargetFromNavigatorEntry,
 } from '../store/editor-state'
 import { loadStoredState } from '../stored-state'
 import { applyMigrations } from './migrations/migrations'
@@ -421,7 +422,7 @@ import { UTOPIA_UID_KEY } from '../../../core/model/utopia-constants'
 import { mapDropNulls, reverse, uniqBy } from '../../../core/shared/array-utils'
 import { mergeProjectContents, TreeConflicts } from '../../../core/shared/github/helpers'
 import { emptySet } from '../../../core/shared/set-utils'
-import { fixUtopiaElement } from '../../../core/shared/uid-utils'
+import { fixUtopiaElement, getUtopiaID } from '../../../core/shared/uid-utils'
 import {
   DefaultPostCSSConfig,
   DefaultTailwindConfig,
@@ -489,15 +490,11 @@ import { collapseTextElements } from '../../../components/text-editor/text-handl
 import { LayoutPropsWithoutTLBR, StyleProperties } from '../../inspector/common/css-utils'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { isUtopiaCommentFlag, makeUtopiaFlagComment } from '../../../core/shared/comment-flags'
-import { set, toArrayOf, unsafeGet } from '../../../core/shared/optics/optic-utilities'
-import { compose2Optics, compose3Optics, Optic } from '../../../core/shared/optics/optics'
+import { toArrayOf } from '../../../core/shared/optics/optic-utilities'
+import { compose3Optics, Optic } from '../../../core/shared/optics/optics'
 import { fromField, traverseArray } from '../../../core/shared/optics/optic-creators'
-import {
-  conditionalWhenFalseOptic,
-  conditionalWhenTrueOptic,
-  forElementOptic,
-  jsxConditionalExpressionOptic,
-} from '../../../core/model/common-optics'
+import { reparentElement } from '../../../components/canvas/commands/reparent-element-command'
+import { ReparentTargetParent } from '../store/reparent-target'
 
 export const MIN_CODE_PANE_REOPEN_WIDTH = 100
 
@@ -814,7 +811,7 @@ export function editorMoveMultiSelectedTemplates(
   builtInDependencies: BuiltInDependencies,
   targets: ElementPath[],
   indexPosition: IndexPosition,
-  newParentPath: ElementPath | null,
+  newParent: ReparentTargetParent<ElementPath> | null,
   editor: EditorModel,
 ): {
   editor: EditorModel
@@ -831,7 +828,7 @@ export function editorMoveMultiSelectedTemplates(
       editor.nodeModules.files,
       editor.canvas.openFile?.filename,
       pathToReparent(target),
-      newParentPath,
+      newParent,
       'on-complete', // TODO make sure this is the right pick here
     )
     if (outcomeResult == null) {
@@ -996,8 +993,8 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
     navigator: {
       minimised: currentEditor.navigator.minimised,
       dropTargetHint: {
-        displayAtElementPath: null,
-        moveToElementPath: null,
+        displayAtEntry: null,
+        moveToEntry: null,
         type: null,
       },
       collapsedViews: poppedEditor.navigator.collapsedViews,
@@ -1752,7 +1749,7 @@ export const UPDATE_FNS = {
     const toReparent = reverse(getZIndexOrderedViewsWithoutDirectChildren(dragSources, derived))
 
     function reparentToIndexPosition(
-      newParentPath: ElementPath,
+      newParentPath: ReparentTargetParent<ElementPath>,
       indexPosition: IndexPosition,
     ): EditorModel {
       const { editor: withMovedTemplate, newPaths } = editorMoveMultiSelectedTemplates(
@@ -1802,55 +1799,10 @@ export const UPDATE_FNS = {
       switch (dropTarget.type) {
         case 'REPARENT_ROW': {
           switch (dropTarget.target.type) {
-            case 'REGULAR': {
-              const newParentPath: ElementPath | null = dropTarget.target.elementPath
-              return reparentToIndexPosition(newParentPath, absolute(0))
-            }
+            case 'REGULAR':
             case 'CONDITIONAL_CLAUSE': {
-              throw new Error(`Currently not implemented.`)
-              /*
-              const getConditionalOptic: Optic<EditorState, JSXConditionalExpression> =
-                compose2Optics(
-                  forElementOptic(dropTarget.target.elementPath),
-                  jsxConditionalExpressionOptic,
-                )
-              // If this fails, then somehow the element has moved.
-              const conditional = unsafeGet(getConditionalOptic, editor)
-              const clauseValue =
-                dropTarget.target.clause === 'then' ? conditional.whenTrue : conditional.whenFalse
-              // If the value within the clause is null or undefined, then swap the
-              // value into this "slot".
-              // Otherwise if the value is a fragment, put it into the fragment.
-              // If it's not a fragment, wrap both the existing and reparented values into a fragment.
-              const toClauseOptic = compose2Optics(
-                getConditionalOptic,
-                dropTarget.target.clause === 'then'
-                  ? conditionalWhenTrueOptic
-                  : conditionalWhenFalseOptic,
-              )
-              if (childOrBlockIsAttribute(clauseValue)) {
-                const simpleValue = jsxSimpleAttributeToValue(clauseValue)
-                return foldEither(
-                  () => {
-                    return editor
-                  },
-                  (value) => {
-                    if (value == null) {
-                      return set(
-                        toClauseOptic,
-                        unsafeGet(forElementOptic(toReparent[0]), editor),
-                        editor,
-                      )
-                    } else {
-                      return editor
-                    }
-                  },
-                  simpleValue,
-                )
-              } else {
-                return editor
-              }
-              */
+              const newParent = reparentTargetFromNavigatorEntry(dropTarget.target)
+              return reparentToIndexPosition(newParent, absolute(0))
             }
             case 'SYNTHETIC': {
               // Find the containing conditional clause, which should be an immediate parent,

--- a/editor/src/components/editor/store/editor-update.spec.tsx
+++ b/editor/src/components/editor/store/editor-update.spec.tsx
@@ -8,7 +8,7 @@ import {
   jsxElement,
   jsxElementName,
 } from '../../../core/shared/element-template'
-import { findJSXElementChildAtPath, getUtopiaID } from '../../../core/model/element-template-utils'
+import { findJSXElementChildAtPath } from '../../../core/model/element-template-utils'
 import {
   directory,
   getUtopiaJSXComponentsFromSuccess,
@@ -95,6 +95,7 @@ import { NO_OP } from '../../../core/shared/utils'
 import { cssNumber } from '../../inspector/common/css-utils'
 import { testStaticElementPath } from '../../../core/shared/element-path.test-utils'
 import { styleStringInArray } from '../../../utils/common-constants'
+import { getUtopiaID } from '../../../core/shared/uid-utils'
 
 const chaiExpect = Chai.expect
 

--- a/editor/src/components/editor/store/reparent-target.ts
+++ b/editor/src/components/editor/store/reparent-target.ts
@@ -1,0 +1,55 @@
+import type { ThenOrElse } from '../../../core/model/conditionals'
+import type { ElementPath, StaticElementPath } from '../../../core/shared/project-file-types'
+import * as EP from '../../../core/shared/element-path'
+
+export interface ConditionalClause<P extends ElementPath> {
+  elementPath: P
+  clause: ThenOrElse
+}
+
+export function conditionalClause<P extends ElementPath>(
+  elementPath: P,
+  clause: ThenOrElse,
+): ConditionalClause<P> {
+  return {
+    elementPath: elementPath,
+    clause: clause,
+  }
+}
+
+export type ReparentTargetParent<P extends ElementPath> = P | ConditionalClause<P>
+
+export function reparentTargetParentIsConditionalClause<P extends ElementPath>(
+  reparentTargetParent: ReparentTargetParent<P>,
+): reparentTargetParent is ConditionalClause<P> {
+  return 'elementPath' in reparentTargetParent && 'clause' in reparentTargetParent
+}
+
+export function reparentTargetParentIsElementPath<P extends ElementPath>(
+  reparentTargetParent: ReparentTargetParent<P>,
+): reparentTargetParent is P {
+  return !reparentTargetParentIsConditionalClause(reparentTargetParent)
+}
+
+export function getElementPathFromReparentTargetParent<P extends ElementPath>(
+  reparentTargetParent: ReparentTargetParent<P>,
+): P {
+  if (reparentTargetParentIsConditionalClause(reparentTargetParent)) {
+    return reparentTargetParent.elementPath
+  } else {
+    return reparentTargetParent
+  }
+}
+
+export function dynamicReparentTargetParentToStaticReparentTargetParent(
+  reparentTargetParent: ReparentTargetParent<ElementPath>,
+): ReparentTargetParent<StaticElementPath> {
+  if (reparentTargetParentIsConditionalClause(reparentTargetParent)) {
+    return conditionalClause(
+      EP.dynamicPathToStaticPath(reparentTargetParent.elementPath),
+      reparentTargetParent.clause,
+    )
+  } else {
+    return EP.dynamicPathToStaticPath(reparentTargetParent)
+  }
+}

--- a/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
@@ -1010,18 +1010,18 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
 
 describe('DropTargetHintKeepDeepEquality', () => {
   const oldValue: DropTargetHint = {
-    displayAtElementPath: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
-    moveToElementPath: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
+    displayAtEntry: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
+    moveToEntry: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
     type: 'before',
   }
   const newSameValue: DropTargetHint = {
-    displayAtElementPath: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
-    moveToElementPath: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
+    displayAtEntry: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
+    moveToEntry: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
     type: 'before',
   }
   const newDifferentValue: DropTargetHint = {
-    displayAtElementPath: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
-    moveToElementPath: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
+    displayAtEntry: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
+    moveToEntry: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
     type: 'after',
   }
 
@@ -1037,7 +1037,7 @@ describe('DropTargetHintKeepDeepEquality', () => {
   })
   it('different but similar value handled appropriately', () => {
     const result = DropTargetHintKeepDeepEquality(oldValue, newDifferentValue)
-    expect(result.value.displayAtElementPath).toBe(oldValue.displayAtElementPath)
+    expect(result.value.displayAtEntry).toBe(oldValue.displayAtEntry)
     expect(result.value.type).toBe(newDifferentValue.type)
     expect(result.value).toEqual(newDifferentValue)
     expect(result.areEqual).toEqual(false)
@@ -1048,8 +1048,8 @@ describe('NavigatorStateKeepDeepEquality', () => {
   const oldValue: NavigatorState = {
     minimised: false,
     dropTargetHint: {
-      displayAtElementPath: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
-      moveToElementPath: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
+      displayAtEntry: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
+      moveToEntry: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
       type: 'before',
     },
     collapsedViews: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
@@ -1060,8 +1060,8 @@ describe('NavigatorStateKeepDeepEquality', () => {
   const newSameValue: NavigatorState = {
     minimised: false,
     dropTargetHint: {
-      displayAtElementPath: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
-      moveToElementPath: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
+      displayAtEntry: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
+      moveToEntry: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
       type: 'before',
     },
     collapsedViews: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
@@ -1072,8 +1072,8 @@ describe('NavigatorStateKeepDeepEquality', () => {
   const newDifferentValue: NavigatorState = {
     minimised: true,
     dropTargetHint: {
-      displayAtElementPath: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
-      moveToElementPath: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
+      displayAtEntry: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
+      moveToEntry: regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']])),
       type: 'before',
     },
     collapsedViews: [EP.elementPath([['scene'], ['aaa', 'bbb']])],

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -579,16 +579,16 @@ export const NavigatorEntryKeepDeepEquality: KeepDeepEqualityCall<NavigatorEntry
 
 export const DropTargetHintKeepDeepEquality: KeepDeepEqualityCall<DropTargetHint> =
   combine3EqualityCalls(
-    (hint) => hint.displayAtElementPath,
+    (hint) => hint.displayAtEntry,
     nullableDeepEquality(NavigatorEntryKeepDeepEquality),
-    (hint) => hint.moveToElementPath,
+    (hint) => hint.moveToEntry,
     nullableDeepEquality(NavigatorEntryKeepDeepEquality),
     (hint) => hint.type,
     createCallWithTripleEquals(),
     (displayAtElementPath, moveToElementPath, type) => {
       return {
-        displayAtElementPath: displayAtElementPath,
-        moveToElementPath: moveToElementPath,
+        displayAtEntry: displayAtElementPath,
+        moveToEntry: moveToElementPath,
         type: type,
       }
     },

--- a/editor/src/components/editor/store/store-hook-substore-helpers.ts
+++ b/editor/src/components/editor/store/store-hook-substore-helpers.ts
@@ -122,8 +122,8 @@ export const EmptyEditorStateForKeysOnly: EditorState = {
   navigator: {
     minimised: false,
     dropTargetHint: {
-      displayAtElementPath: null,
-      moveToElementPath: null,
+      displayAtEntry: null,
+      moveToEntry: null,
       type: null,
     },
     collapsedViews: [],

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -16,12 +16,22 @@ import {
   EditorState,
   navigatorEntryToKey,
   regularNavigatorEntry,
+  syntheticNavigatorEntry,
   varSafeNavigatorEntryToKey,
 } from '../editor/store/editor-state'
 import { getDomRectCenter } from '../../core/shared/dom-utils'
 import { FOR_TESTS_setNextGeneratedUids } from '../../core/model/element-template-utils.test-utils'
 import { setFeatureForBrowserTests } from '../../utils/utils.test-utils'
 import { navigatorDepth } from './navigator-utils'
+import { compose3Optics, Optic } from '../../core/shared/optics/optics'
+import { ChildOrAttribute } from '../../core/shared/element-template'
+import {
+  forElementOptic,
+  jsxConditionalExpressionOptic,
+  conditionalWhenFalseOptic,
+} from '../../core/model/common-optics'
+import { unsafeGet } from '../../core/shared/optics/optic-utilities'
+import { MOCK_NEXT_GENERATED_UIDS, MOCK_NEXT_GENERATED_UIDS_IDX } from '../../core/shared/uid-utils'
 
 function dragElement(
   renderResult: EditorRenderResult,
@@ -173,6 +183,66 @@ export var ${BakedInStoryboardVariableName} = (
 `
 }
 
+function getProjectCodeEmptyActive(): string {
+  return `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export var ${BakedInStoryboardVariableName} = (
+  <Storyboard data-uid='${BakedInStoryboardUID}'>
+    <Scene
+      style={{
+        backgroundColor: 'white',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 700,
+      }}
+      data-uid='${TestSceneUID}'
+      data-testid='${TestSceneUID}'
+    >
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          contain: 'layout',
+        }}
+        data-uid='containing-div'
+        data-testid='containing-div'
+      >
+        {[].length === 0 ? (
+          [].length === 0 ? null : null
+        ) : (
+          <div
+            style={{
+              height: 150,
+              position: 'absolute',
+              left: 154,
+              top: 134,
+            }}
+            data-uid='else-div'
+            data-testid='else-div'
+          />
+        )}
+        <div
+          style={{
+            height: 150,
+            width: 150,
+            position: 'absolute',
+            left: 300,
+            top: 300,
+            backgroundColor: 'darkblue',
+          }}
+          data-uid='sibling-div'
+          data-testid='sibling-div'
+        />
+      </div>
+    </Scene>
+  </Storyboard>
+)
+`
+}
+
 function navigatorStructure(editorState: EditorState, deriveState: DerivedState): string {
   const lines = deriveState.visibleNavigatorTargets.map((target) => {
     const targetAsText = navigatorEntryToKey(target)
@@ -186,27 +256,30 @@ function navigatorStructure(editorState: EditorState, deriveState: DerivedState)
   return lines.join('\n')
 }
 
-xdescribe('conditionals in the navigator', () => {
+describe('conditionals in the navigator', () => {
   setFeatureForBrowserTests('Conditional support', true)
   setFeatureForBrowserTests('Fragment support', true)
-  it('dragging into a non-empty clause, creates a fragment wrapper', async () => {
+  xit('dragging into a non-empty clause, creates a fragment wrapper', async () => {
     // TODO: Fill this out.
   })
-  it('dragging into an empty clause, creates a fragment wrapper', async () => {
+  it('dragging into an empty active clause, takes the place of the empty value', async () => {
     FOR_TESTS_setNextGeneratedUids([
+      'skip1',
+      'skip2',
+      'skip3',
+      'skip4',
+      'skip5',
+      'skip6',
+      'skip7',
+      'skip8',
+      'skip9',
       'conditional1',
       'conditional2',
-      'conditional1',
-      'conditional2',
-      'conditional1',
-      'conditional2',
-      'conditional1',
-      'conditional2',
-      'conditional1',
-      'conditional2',
-      'conditional1',
     ])
-    const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
+    const renderResult = await renderTestEditorWithCode(
+      getProjectCodeEmptyActive(),
+      'await-first-dom-report',
+    )
 
     expect(
       navigatorStructure(
@@ -216,13 +289,13 @@ xdescribe('conditionals in the navigator', () => {
     ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
     regular-utopia-storyboard-uid/scene-aaa/containing-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-then
           regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div-then
-              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-else
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-case-attribute
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-else
               synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-else
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
 
@@ -245,7 +318,115 @@ xdescribe('conditionals in the navigator', () => {
 
     // Getting info relating to where the element will be dragged to.
     const elementPathToTarget = EP.fromString(
-      `${BakedInStoryboardUID}/${TestSceneUID}/containing-div/conditional1/conditional2/else-case`,
+      `${BakedInStoryboardUID}/${TestSceneUID}/containing-div/conditional1/conditional2`,
+    )
+    const navigatorEntryToTarget = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-${varSafeNavigatorEntryToKey(
+        conditionalClauseNavigatorEntry(elementPathToTarget, 'then'),
+      )}`,
+    )
+    const navigatorEntryToTargetRect = navigatorEntryToTarget.getBoundingClientRect()
+    const navigatorEntryToTargetCenter = getDomRectCenter(navigatorEntryToTargetRect)
+
+    const dragDelta = {
+      x: navigatorEntryToTargetCenter.x - navigatorEntryToDragCenter.x,
+      y: navigatorEntryToTargetCenter.y - navigatorEntryToDragCenter.y,
+    }
+
+    await act(async () =>
+      dragElement(
+        renderResult,
+        `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToDrag))}`,
+        `navigator-item-${varSafeNavigatorEntryToKey(
+          conditionalClauseNavigatorEntry(elementPathToTarget, 'then'),
+        )}`,
+        windowPoint(navigatorEntryToDragCenter),
+        windowPoint(dragDelta),
+        'apply-hover-events',
+      ),
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    if (getPrintedUiJsCode(renderResult.getEditorState()) === getProjectCodeEmptyActive()) {
+      throw new Error(`Code is unchanged.`)
+    }
+
+    expect(
+      navigatorStructure(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().derived,
+      ),
+    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
+    regular-utopia-storyboard-uid/scene-aaa/containing-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-then
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
+              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/sibling-div
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-else
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div`)
+  })
+  it('dragging into an empty inactive clause, takes the place of the empty value', async () => {
+    FOR_TESTS_setNextGeneratedUids([
+      'skip1',
+      'skip2',
+      'skip3',
+      'skip4',
+      'skip5',
+      'skip6',
+      'skip7',
+      'skip8',
+      'skip9',
+      'skip10',
+      'skip11',
+      'skip12',
+      'skip13',
+      'conditional1',
+      'conditional2',
+    ])
+    const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
+
+    expect(
+      navigatorStructure(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().derived,
+      ),
+    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
+    regular-utopia-storyboard-uid/scene-aaa/containing-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-then
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
+              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-else
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
+
+    // Select the entry we plan to drag.
+    const elementPathToDrag = EP.fromString(
+      `${BakedInStoryboardUID}/${TestSceneUID}/containing-div/sibling-div`,
+    )
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      await renderResult.dispatch(selectComponents([elementPathToDrag], false), false)
+      await dispatchDone
+    })
+
+    // Getting info relating to what element will be dragged.
+    const navigatorEntryToDrag = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToDrag))}`,
+    )
+    const navigatorEntryToDragRect = navigatorEntryToDrag.getBoundingClientRect()
+    const navigatorEntryToDragCenter = getDomRectCenter(navigatorEntryToDragRect)
+
+    // Getting info relating to where the element will be dragged to.
+    const elementPathToTarget = EP.fromString(
+      `${BakedInStoryboardUID}/${TestSceneUID}/containing-div/conditional1/conditional2`,
     )
     const navigatorEntryToTarget = await renderResult.renderedDOM.findByTestId(
       `navigator-item-${varSafeNavigatorEntryToKey(
@@ -260,7 +441,7 @@ xdescribe('conditionals in the navigator', () => {
       y: navigatorEntryToTargetCenter.y - navigatorEntryToDragCenter.y,
     }
 
-    act(() =>
+    await act(async () =>
       dragElement(
         renderResult,
         `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToDrag))}`,
@@ -287,17 +468,244 @@ xdescribe('conditionals in the navigator', () => {
     ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
     regular-utopia-storyboard-uid/scene-aaa/containing-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-then
           regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div-then
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
               regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-else
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-else
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/sibling-div-element-sibling-div
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div`)
+  })
+
+  it('dragging out of an inactive clause, replaces with null', async () => {
+    FOR_TESTS_setNextGeneratedUids([
+      'skip1',
+      'skip2',
+      'skip3',
+      'skip4',
+      'skip5',
+      'skip6',
+      'skip7',
+      'skip8',
+      'skip9',
+      'skip10',
+      'skip11',
+      'skip12',
+      'skip13',
+      'conditional1',
+      'conditional2',
+    ])
+    const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
+
+    expect(
+      navigatorStructure(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().derived,
+      ),
+    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
+    regular-utopia-storyboard-uid/scene-aaa/containing-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-then
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
+              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-else
               synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-else
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
+
+    // Select the entry we plan to drag.
+    const elementPathToDrag = EP.fromString(
+      `${BakedInStoryboardUID}/${TestSceneUID}/containing-div/conditional1/else-div`,
+    )
+
+    // Need the underlying value in the clause to be able to construct the navigator entry.
+    const inactiveElementOptic: Optic<EditorState, ChildOrAttribute> = compose3Optics(
+      forElementOptic(EP.parentPath(elementPathToDrag)),
+      jsxConditionalExpressionOptic,
+      conditionalWhenFalseOptic,
+    )
+    const inactiveElement = unsafeGet(inactiveElementOptic, renderResult.getEditorState().editor)
+
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      await renderResult.dispatch(selectComponents([elementPathToDrag], false), false)
+      await dispatchDone
+    })
+
+    // Getting info relating to what element will be dragged.
+    const navigatorEntryToDrag = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-${varSafeNavigatorEntryToKey(
+        syntheticNavigatorEntry(elementPathToDrag, inactiveElement),
+      )}`,
+    )
+    const navigatorEntryToDragRect = navigatorEntryToDrag.getBoundingClientRect()
+    const navigatorEntryToDragCenter = getDomRectCenter(navigatorEntryToDragRect)
+
+    // Getting info relating to where the element will be dragged to.
+    const elementPathToTarget = EP.fromString(
+      `${BakedInStoryboardUID}/${TestSceneUID}/containing-div`,
+    )
+    const navigatorEntryToTarget = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToTarget))}`,
+    )
+    const navigatorEntryToTargetRect = navigatorEntryToTarget.getBoundingClientRect()
+    const navigatorEntryToTargetCenter = getDomRectCenter(navigatorEntryToTargetRect)
+
+    const dragDelta = {
+      x: navigatorEntryToTargetCenter.x - navigatorEntryToDragCenter.x,
+      y: navigatorEntryToTargetCenter.y - navigatorEntryToDragCenter.y,
+    }
+
+    await act(async () =>
+      dragElement(
+        renderResult,
+        `navigator-item-${varSafeNavigatorEntryToKey(
+          syntheticNavigatorEntry(elementPathToDrag, inactiveElement),
+        )}`,
+        `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToTarget))}`,
+        windowPoint(navigatorEntryToDragCenter),
+        windowPoint(dragDelta),
+        'apply-hover-events',
+      ),
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    if (getPrintedUiJsCode(renderResult.getEditorState()) === getProjectCode()) {
+      throw new Error(`Code is unchanged.`)
+    }
+
+    expect(
+      navigatorStructure(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().derived,
+      ),
+    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
+    regular-utopia-storyboard-uid/scene-aaa/containing-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-then
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
+              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-else
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-case-attribute
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/else-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
   })
-  it('dragging into child of an active clause, works as it would without the conditional', () => {
+
+  it('dragging out of an active clause, replaces with null', async () => {
+    FOR_TESTS_setNextGeneratedUids([
+      'skip1',
+      'skip2',
+      'skip3',
+      'skip4',
+      'skip5',
+      'skip6',
+      'skip7',
+      'skip8',
+      'skip9',
+      'skip10',
+      'skip11',
+      'skip12',
+      'skip13',
+      'conditional1',
+      'conditional2',
+    ])
+    const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
+
+    expect(
+      navigatorStructure(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().derived,
+      ),
+    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
+    regular-utopia-storyboard-uid/scene-aaa/containing-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-then
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
+              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-else
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
+
+    // Select the entry we plan to drag.
+    const elementPathToDrag = EP.fromString(
+      `${BakedInStoryboardUID}/${TestSceneUID}/containing-div/conditional1/conditional2/then-then-div`,
+    )
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      await renderResult.dispatch(selectComponents([elementPathToDrag], false), false)
+      await dispatchDone
+    })
+
+    // Getting info relating to what element will be dragged.
+    const navigatorEntryToDrag = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToDrag))}`,
+    )
+    const navigatorEntryToDragRect = navigatorEntryToDrag.getBoundingClientRect()
+    const navigatorEntryToDragCenter = getDomRectCenter(navigatorEntryToDragRect)
+
+    // Getting info relating to where the element will be dragged to.
+    const elementPathToTarget = EP.fromString(
+      `${BakedInStoryboardUID}/${TestSceneUID}/containing-div`,
+    )
+    const navigatorEntryToTarget = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToTarget))}`,
+    )
+    const navigatorEntryToTargetRect = navigatorEntryToTarget.getBoundingClientRect()
+    const navigatorEntryToTargetCenter = getDomRectCenter(navigatorEntryToTargetRect)
+
+    const dragDelta = {
+      x: navigatorEntryToTargetCenter.x - navigatorEntryToDragCenter.x,
+      y: navigatorEntryToTargetCenter.y - navigatorEntryToDragCenter.y,
+    }
+
+    await act(async () =>
+      dragElement(
+        renderResult,
+        `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToDrag))}`,
+        `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToTarget))}`,
+        windowPoint(navigatorEntryToDragCenter),
+        windowPoint(dragDelta),
+        'apply-hover-events',
+      ),
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    if (getPrintedUiJsCode(renderResult.getEditorState()) === getProjectCode()) {
+      throw new Error(`Code is unchanged.`)
+    }
+
+    expect(
+      navigatorStructure(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().derived,
+      ),
+    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
+    regular-utopia-storyboard-uid/scene-aaa/containing-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-then
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-then
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-case-attribute
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-else
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/else-case-attribute
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/then-then-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
+  })
+
+  xit('dragging into child of an active clause, works as it would without the conditional', () => {
     // TODO: Fill this out.
   })
 })

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -25,13 +25,13 @@ import { setFeatureForBrowserTests } from '../../utils/utils.test-utils'
 import { navigatorDepth } from './navigator-utils'
 import { compose3Optics, Optic } from '../../core/shared/optics/optics'
 import { ChildOrAttribute } from '../../core/shared/element-template'
-import {
-  forElementOptic,
-  jsxConditionalExpressionOptic,
-  conditionalWhenFalseOptic,
-} from '../../core/model/common-optics'
+import { forElementOptic } from '../../core/model/common-optics'
 import { unsafeGet } from '../../core/shared/optics/optic-utilities'
 import { MOCK_NEXT_GENERATED_UIDS, MOCK_NEXT_GENERATED_UIDS_IDX } from '../../core/shared/uid-utils'
+import {
+  conditionalWhenFalseOptic,
+  jsxConditionalExpressionOptic,
+} from 'src/core/model/conditionals'
 
 function dragElement(
   renderResult: EditorRenderResult,

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -27,11 +27,10 @@ import { compose3Optics, Optic } from '../../core/shared/optics/optics'
 import { ChildOrAttribute } from '../../core/shared/element-template'
 import { forElementOptic } from '../../core/model/common-optics'
 import { unsafeGet } from '../../core/shared/optics/optic-utilities'
-import { MOCK_NEXT_GENERATED_UIDS, MOCK_NEXT_GENERATED_UIDS_IDX } from '../../core/shared/uid-utils'
 import {
   conditionalWhenFalseOptic,
   jsxConditionalExpressionOptic,
-} from 'src/core/model/conditionals'
+} from '../../core/model/conditionals'
 
 function dragElement(
   renderResult: EditorRenderResult,

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -20,9 +20,11 @@ import {
 } from './navigator-item-components'
 import {
   DropTargetHint,
+  EditorState,
   ElementWarnings,
   isConditionalClauseNavigatorEntry,
   isRegularNavigatorEntry,
+  isSyntheticNavigatorEntry,
   navigatorEntriesEqual,
   NavigatorEntry,
   regularNavigatorEntry,
@@ -39,6 +41,7 @@ import { getEmptyImage } from 'react-dnd-html5-backend'
 import { when } from '../../../utils/react-conditionals'
 import { metadataSelector } from '../../inspector/inpector-selectors'
 import { navigatorDepth } from '../navigator-utils'
+import { childOrBlockIsChild } from '../../../core/shared/element-template'
 
 export const TopDropTargetLineTestId = (safeComponentId: string): string =>
   `navigator-item-drop-before-${safeComponentId}`
@@ -66,7 +69,7 @@ export interface NavigatorItemDragAndDropWrapperProps {
   selected: boolean
   highlighted: boolean // TODO are we sure about this?
   collapsed: boolean // TODO are we sure about this?
-  getDragSelections: () => Array<DragSelection>
+  getCurrentlySelectedEntries: () => Array<NavigatorEntry>
   getSelectedViewsInRange: (index: number) => Array<ElementPath> // TODO remove me
   canReparentInto: boolean
   noOfChildren: number
@@ -77,8 +80,33 @@ export interface NavigatorItemDragAndDropWrapperProps {
   visibleNavigatorTargets: Array<NavigatorEntry>
 }
 
-function canDrop(props: NavigatorItemDragAndDropWrapperProps, dropSource: ElementPath): boolean {
-  return !EP.isDescendantOfOrEqualTo(props.navigatorEntry.elementPath, dropSource)
+function notDescendant(
+  draggedOnto: NavigatorItemDragAndDropWrapperProps,
+  draggedItem: ElementPath,
+): boolean {
+  return !EP.isDescendantOfOrEqualTo(draggedOnto.navigatorEntry.elementPath, draggedItem)
+}
+
+function canDrop(
+  editorState: EditorState,
+  draggedItem: NavigatorItemDragAndDropWrapperProps,
+  draggedOnto: NavigatorItemDragAndDropWrapperProps,
+): boolean {
+  const isReparentTarget = draggedItem.appropriateDropTargetHint?.type === 'reparent'
+  const childrenSupportedIfRequired =
+    !isReparentTarget ||
+    isConditionalClauseNavigatorEntry(draggedOnto.navigatorEntry) ||
+    (isRegularNavigatorEntry(draggedOnto.navigatorEntry) &&
+      MetadataUtils.targetSupportsChildren(
+        editorState.projectContents,
+        editorState.jsxMetadata,
+        draggedOnto.navigatorEntry.elementPath,
+      ))
+  const notSelectedItem = draggedItem.getCurrentlySelectedEntries().every((selection) => {
+    return notDescendant(draggedOnto, selection.elementPath)
+  })
+  const result = childrenSupportedIfRequired && notSelectedItem
+  return result
 }
 
 function onDrop(
@@ -89,14 +117,14 @@ function onDrop(
   if (monitor == null) {
     return
   }
-  const dragSelections = propsOfDraggedItem.getDragSelections()
+  const dragSelections = propsOfDraggedItem.getCurrentlySelectedEntries()
   const filteredSelections = dragSelections.filter((selection) =>
-    canDrop(propsOfDropTargetItem, selection.elementPath),
+    notDescendant(propsOfDropTargetItem, selection.elementPath),
   )
   const draggedElements = filteredSelections.map((selection) => selection.elementPath)
   const clearHintAction = showNavigatorDropTargetHint(null, null, null)
   const target =
-    propsOfDropTargetItem.appropriateDropTargetHint?.moveToElementPath ??
+    propsOfDropTargetItem.appropriateDropTargetHint?.moveToEntry ??
     propsOfDropTargetItem.navigatorEntry
 
   switch (propsOfDropTargetItem.appropriateDropTargetHint?.type) {
@@ -145,8 +173,8 @@ function onHoverDropTargetLine(
   if (
     monitor == null ||
     !propsOfDraggedItem
-      .getDragSelections()
-      .every((selection) => canDrop(propsOfDropTargetItem, selection.elementPath)) ||
+      .getCurrentlySelectedEntries()
+      .every((selection) => notDescendant(propsOfDropTargetItem, selection.elementPath)) ||
     EP.pathsEqual(
       propsOfDraggedItem.navigatorEntry.elementPath,
       propsOfDropTargetItem.navigatorEntry.elementPath,
@@ -171,12 +199,12 @@ function onHoverDropTargetLine(
     )
   }
 
-  const targetPathWithReparentWiggle = (() => {
+  const targetEntryWithReparentWiggle: NavigatorEntry = (() => {
     if (
       cursorDelta.x >= -BasePaddingUnit ||
       EP.parentPath(propsOfDraggedItem.navigatorEntry.elementPath) == null
     ) {
-      return propsOfDropTargetItem.navigatorEntry.elementPath
+      return propsOfDropTargetItem.navigatorEntry
     }
 
     const maximumTargetDepth = propsOfDropTargetItem.entryDepth - 1
@@ -184,7 +212,9 @@ function onHoverDropTargetLine(
 
     const targetDepth = Math.min(cursorTargetDepth, maximumTargetDepth)
 
-    return EP.dropNPathParts(propsOfDropTargetItem.navigatorEntry.elementPath, targetDepth)
+    return regularNavigatorEntry(
+      EP.dropNPathParts(propsOfDropTargetItem.navigatorEntry.elementPath, targetDepth),
+    )
   })()
 
   const { collapsed, canReparentInto } = propsOfDropTargetItem
@@ -194,7 +224,7 @@ function onHoverDropTargetLine(
       ...targetAction,
       showNavigatorDropTargetHint(
         'reparent',
-        regularNavigatorEntry(targetPathWithReparentWiggle),
+        targetEntryWithReparentWiggle,
         propsOfDropTargetItem.navigatorEntry,
       ),
     ])
@@ -203,7 +233,7 @@ function onHoverDropTargetLine(
   if (
     propsOfDraggedItem.appropriateDropTargetHint?.type !== position ||
     !navigatorEntriesEqual(
-      propsOfDraggedItem.appropriateDropTargetHint?.displayAtElementPath,
+      propsOfDraggedItem.appropriateDropTargetHint?.displayAtEntry,
       propsOfDropTargetItem.navigatorEntry,
     )
   ) {
@@ -212,7 +242,7 @@ function onHoverDropTargetLine(
         ...targetAction,
         showNavigatorDropTargetHint(
           position,
-          regularNavigatorEntry(targetPathWithReparentWiggle),
+          targetEntryWithReparentWiggle,
           propsOfDropTargetItem.navigatorEntry,
         ),
       ],
@@ -234,12 +264,9 @@ function onHoverParentOutline(
   if (
     monitor == null ||
     !propsOfDraggedItem
-      .getDragSelections()
-      .every((selection) => canDrop(propsOfDropTargetItem, selection.elementPath)) ||
-    EP.pathsEqual(
-      propsOfDraggedItem.navigatorEntry.elementPath,
-      propsOfDropTargetItem.navigatorEntry.elementPath,
-    )
+      .getCurrentlySelectedEntries()
+      .every((selection) => notDescendant(propsOfDropTargetItem, selection.elementPath)) ||
+    navigatorEntriesEqual(propsOfDraggedItem.navigatorEntry, propsOfDropTargetItem.navigatorEntry)
   ) {
     return propsOfDraggedItem.editorDispatch(
       [showNavigatorDropTargetHint(null, null, null)],
@@ -309,14 +336,17 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
       beginDrag: beginDrag,
       canDrag: (monitor) => {
         const editorState = editorStateRef.current
-        const result =
+        const regularCanReparent =
           isRegularNavigatorEntry(props.navigatorEntry) &&
           isAllowedToReparent(
             editorState.projectContents,
             editorState.jsxMetadata,
             props.navigatorEntry.elementPath,
           )
-        return result
+        const syntheticCanReparent =
+          isSyntheticNavigatorEntry(props.navigatorEntry) &&
+          childOrBlockIsChild(props.navigatorEntry.childOrAttribute)
+        return regularCanReparent || syntheticCanReparent
       },
     }),
     [props],
@@ -341,20 +371,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
       },
       canDrop: (item: NavigatorItemDragAndDropWrapperProps, monitor) => {
         const editorState = editorStateRef.current
-        const isReparentTarget = item.appropriateDropTargetHint?.type === 'reparent'
-        const childrenSupportedIfRequired =
-          !isReparentTarget ||
-          isConditionalClauseNavigatorEntry(props.navigatorEntry) ||
-          (isRegularNavigatorEntry(props.navigatorEntry) &&
-            MetadataUtils.targetSupportsChildren(
-              editorState.projectContents,
-              editorState.jsxMetadata,
-              props.navigatorEntry.elementPath,
-            ))
-        const notSelectedItem = item.getDragSelections().every((selection) => {
-          return canDrop(props, selection.elementPath)
-        })
-        return childrenSupportedIfRequired && notSelectedItem
+        return canDrop(editorState, item, props)
       },
     }),
     [props],
@@ -379,20 +396,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
       },
       canDrop: (item: NavigatorItemDragAndDropWrapperProps, monitor) => {
         const editorState = editorStateRef.current
-        const isReparentTarget = item.appropriateDropTargetHint?.type === 'reparent'
-        const childrenSupportedIfRequired =
-          !isReparentTarget ||
-          isConditionalClauseNavigatorEntry(props.navigatorEntry) ||
-          (isRegularNavigatorEntry(props.navigatorEntry) &&
-            MetadataUtils.targetSupportsChildren(
-              editorState.projectContents,
-              editorState.jsxMetadata,
-              props.navigatorEntry.elementPath,
-            ))
-        const notSelectedItem = item.getDragSelections().every((selection) => {
-          return canDrop(props, selection.elementPath)
-        })
-        return childrenSupportedIfRequired && notSelectedItem
+        return canDrop(editorState, item, props)
       },
     }),
     [props],
@@ -417,20 +421,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
       },
       canDrop: (item: NavigatorItemDragAndDropWrapperProps, monitor) => {
         const editorState = editorStateRef.current
-        const isReparentTarget = item.appropriateDropTargetHint?.type === 'reparent'
-        const childrenSupportedIfRequired =
-          !isReparentTarget ||
-          isConditionalClauseNavigatorEntry(props.navigatorEntry) ||
-          (isRegularNavigatorEntry(props.navigatorEntry) &&
-            MetadataUtils.targetSupportsChildren(
-              editorState.projectContents,
-              editorState.jsxMetadata,
-              props.navigatorEntry.elementPath,
-            ))
-        const notSelectedItem = item.getDragSelections().every((selection) => {
-          return canDrop(props, selection.elementPath)
-        })
-        return childrenSupportedIfRequired && notSelectedItem
+        return canDrop(editorState, item, props)
       },
     }),
     [props],
@@ -444,7 +435,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
 
   const moveToElementPath = useEditorState(
     Substores.navigator,
-    (store) => store.editor.navigator.dropTargetHint.moveToElementPath,
+    (store) => store.editor.navigator.dropTargetHint.moveToEntry,
     'NavigatorItemDndWrapper moveToElementPath',
   )
 
@@ -462,11 +453,11 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
   const appropriateDropTargetHintDepth = useEditorState(
     Substores.metadata,
     (store) => {
-      if (props.appropriateDropTargetHint?.moveToElementPath == null) {
+      if (props.appropriateDropTargetHint?.moveToEntry == null) {
         return 0
       } else {
         return navigatorDepth(
-          regularNavigatorEntry(props.appropriateDropTargetHint.moveToElementPath.elementPath),
+          regularNavigatorEntry(props.appropriateDropTargetHint.moveToEntry.elementPath),
           store.editor.jsxMetadata,
         )
       }
@@ -477,13 +468,13 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
   const margin = (() => {
     if (
       props.appropriateDropTargetHint?.type === 'reparent' &&
-      props.appropriateDropTargetHint.moveToElementPath != null
+      props.appropriateDropTargetHint.moveToEntry != null
     ) {
       return getHintPaddingForDepth(appropriateDropTargetHintDepth)
     }
     if (
       props.appropriateDropTargetHint?.type != null &&
-      props.appropriateDropTargetHint.moveToElementPath != null
+      props.appropriateDropTargetHint.moveToEntry != null
     ) {
       return getHintPaddingForDepth(appropriateDropTargetHintDepth - 1)
     }
@@ -495,11 +486,9 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
     dropTargetHintType === 'reparent'
       ? isOverBottomHint || isOverParentOutline
       : moveToElementPath != null &&
-        isRegularNavigatorEntry(moveToElementPath) &&
-        EP.pathsEqual(
-          props.navigatorEntry.elementPath,
-          EP.parentPath(moveToElementPath.elementPath),
-        )
+        (isRegularNavigatorEntry(moveToElementPath) ||
+          isConditionalClauseNavigatorEntry(moveToElementPath)) &&
+        navigatorEntriesEqual(props.navigatorEntry, moveToElementPath)
 
   const metadata = useEditorState(
     Substores.metadata,

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -75,7 +75,7 @@ export function navigatorDepth(
     isFeatureEnabled('Conditional support') &&
     isConditionalClauseNavigatorEntry(navigatorEntry)
   ) {
-    result = result - 1
+    result = result + 1
   }
 
   return result
@@ -149,7 +149,10 @@ export function getNavigatorTargets(
         const clausePath = getConditionalClausePath(path, clauseValue, thenOrElse)
 
         // Create the entry for the name of the clause.
-        const clauseTitleEntry = conditionalClauseNavigatorEntry(clausePath, thenOrElse)
+        const clauseTitleEntry = conditionalClauseNavigatorEntry(
+          conditionalSubTree.path,
+          thenOrElse,
+        )
         navigatorTargets.push(clauseTitleEntry)
         visibleNavigatorTargets.push(clauseTitleEntry)
 

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -861,9 +861,9 @@ describe('Navigator', () => {
       )
 
       expect(renderResult.getEditorState().editor.navigator.dropTargetHint.type).toEqual(null)
-      expect(
-        renderResult.getEditorState().editor.navigator.dropTargetHint.displayAtElementPath,
-      ).toEqual(null)
+      expect(renderResult.getEditorState().editor.navigator.dropTargetHint.displayAtEntry).toEqual(
+        null,
+      )
 
       await renderResult.getDispatchFollowUpActionsFinished()
 

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -11,7 +11,7 @@ import { DragSelection } from './navigator-item/navigator-item-dnd-container'
 import { NavigatorItemWrapper } from './navigator-item/navigator-item-wrapper'
 import { Substores, useEditorState, useRefEditorState } from '../editor/store/store-hook'
 import { ElementContextMenu } from '../element-context-menu'
-import { createDragSelections } from '../../templates/editor-navigator'
+import { getSelectedNavigatorEntries } from '../../templates/editor-navigator'
 import { FixedSizeList, ListChildComponentProps } from 'react-window'
 import AutoSizer, { Size } from 'react-virtualized-auto-sizer'
 import { Section, SectionBodyArea, FlexColumn } from '../../uuiui'
@@ -20,7 +20,11 @@ import { UtopiaTheme } from '../../uuiui/styles/theme/utopia-theme'
 import { useKeepReferenceEqualityIfPossible } from '../../utils/react-performance'
 import { useDispatch } from '../editor/store/dispatch-context'
 import { css } from '@emotion/react'
-import { isRegularNavigatorEntry, navigatorEntryToKey } from '../editor/store/editor-state'
+import {
+  isRegularNavigatorEntry,
+  NavigatorEntry,
+  navigatorEntryToKey,
+} from '../editor/store/editor-state'
 
 interface ItemProps extends ListChildComponentProps {}
 
@@ -33,19 +37,18 @@ const Item = React.memo(({ index, style }: ItemProps) => {
     'Item visibleNavigatorTargets',
   )
   const editorSliceRef = useRefEditorState((store) => {
-    const dragSelections = createDragSelections(
-      store.derived.navigatorTargets,
+    const currentlySelectedNavigatorEntries = getSelectedNavigatorEntries(
       store.editor.selectedViews,
     )
     return {
       selectedViews: store.editor.selectedViews,
       navigatorTargets: store.derived.navigatorTargets,
-      dragSelections: dragSelections,
+      currentlySelectedNavigatorEntries: currentlySelectedNavigatorEntries,
     }
   })
 
-  const getDragSelections = React.useCallback((): Array<DragSelection> => {
-    return editorSliceRef.current.dragSelections
+  const getCurrentlySelectedNavigatorEntries = React.useCallback((): Array<NavigatorEntry> => {
+    return editorSliceRef.current.currentlySelectedNavigatorEntries
   }, [editorSliceRef])
 
   // Used to determine the views that will be selected by starting with the last selected item
@@ -102,7 +105,7 @@ const Item = React.memo(({ index, style }: ItemProps) => {
       index={index}
       targetComponentKey={componentKey}
       navigatorEntry={targetEntry}
-      getDragSelections={getDragSelections}
+      getCurrentlySelectedEntries={getCurrentlySelectedNavigatorEntries}
       getSelectedViewsInRange={getSelectedViewsInRange}
       windowStyle={deepKeptStyle}
     />

--- a/editor/src/components/text-editor/text-handling.ts
+++ b/editor/src/components/text-editor/text-handling.ts
@@ -18,9 +18,9 @@ import {
   isJSXConditionalExpression,
 } from '../../core/shared/element-template'
 import { jsxSimpleAttributeToValue } from '../../core/shared/jsx-attributes'
-import { getUtopiaID } from '../../core/model/element-template-utils'
 import { foldEither } from '../../core/shared/either'
 import fastDeepEquals from 'fast-deep-equal'
+import { getUtopiaID } from '../../core/shared/uid-utils'
 
 // Validate this by making the type `Set<keyof CSSProperties>`.
 export const stylePropertiesEligibleForMerge: Set<string> = new Set([

--- a/editor/src/core/model/common-optics.ts
+++ b/editor/src/core/model/common-optics.ts
@@ -3,13 +3,7 @@ import {
   modifyUnderlyingForOpenFile,
   withUnderlyingTargetFromEditorState,
 } from '../../components/editor/store/editor-state'
-import {
-  ChildOrAttribute,
-  isJSXConditionalExpression,
-  JSXConditionalExpression,
-  JSXElementChild,
-} from '../shared/element-template'
-import { fromField, fromTypeGuard } from '../shared/optics/optic-creators'
+import { JSXElementChild } from '../shared/element-template'
 import { Optic, traversal } from '../shared/optics/optics'
 import { ElementPath } from '../shared/project-file-types'
 
@@ -27,12 +21,3 @@ export function forElementOptic(target: ElementPath): Optic<EditorState, JSXElem
   }
   return traversal(from, update)
 }
-
-export const jsxConditionalExpressionOptic: Optic<JSXElementChild, JSXConditionalExpression> =
-  fromTypeGuard(isJSXConditionalExpression)
-
-export const conditionalWhenTrueOptic: Optic<JSXConditionalExpression, ChildOrAttribute> =
-  fromField('whenTrue')
-
-export const conditionalWhenFalseOptic: Optic<JSXConditionalExpression, ChildOrAttribute> =
-  fromField('whenFalse')

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -3,11 +3,15 @@ import * as EP from '../shared/element-path'
 import {
   ChildOrAttribute,
   childOrBlockIsChild,
+  isJSXConditionalExpression,
   JSXConditionalExpression,
+  JSXElementChild,
 } from '../shared/element-template'
 import { ElementPathTree } from '../shared/element-path-tree'
 import { assertNever } from '../shared/utils'
 import { getUtopiaID } from '../shared/uid-utils'
+import { Optic } from '../shared/optics/optics'
+import { fromField, fromTypeGuard } from '../shared/optics/optic-creators'
 
 export type ThenOrElse = 'then' | 'else'
 
@@ -68,3 +72,12 @@ export function reorderConditionalChildPathTrees(
     return result
   }
 }
+
+export const jsxConditionalExpressionOptic: Optic<JSXElementChild, JSXConditionalExpression> =
+  fromTypeGuard(isJSXConditionalExpression)
+
+export const conditionalWhenTrueOptic: Optic<JSXConditionalExpression, ChildOrAttribute> =
+  fromField('whenTrue')
+
+export const conditionalWhenFalseOptic: Optic<JSXConditionalExpression, ChildOrAttribute> =
+  fromField('whenFalse')

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -6,8 +6,8 @@ import {
   JSXConditionalExpression,
 } from '../shared/element-template'
 import { ElementPathTree } from '../shared/element-path-tree'
-import { getUtopiaID } from './element-template-utils'
 import { assertNever } from '../shared/utils'
+import { getUtopiaID } from '../shared/uid-utils'
 
 export type ThenOrElse = 'then' | 'else'
 

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -89,7 +89,6 @@ import {
   componentUsesProperty,
   elementOnlyHasTextChildren,
   findJSXElementChildAtPath,
-  getUtopiaID,
 } from './element-template-utils'
 import {
   isImportedComponent,
@@ -134,6 +133,7 @@ import {
   reorderConditionalChildPathTrees,
   ThenOrElse,
 } from './conditionals'
+import { getUtopiaID } from '../shared/uid-utils'
 
 const ObjectPathImmutable: any = OPI
 

--- a/editor/src/core/model/element-template-utils.spec.tsx
+++ b/editor/src/core/model/element-template-utils.spec.tsx
@@ -19,7 +19,6 @@ import {
   componentHonoursPropsSize,
   componentUsesProperty,
   findJSXElementChildAtPath,
-  getUtopiaID,
   guaranteeUniqueUids,
   rearrangeJsxChildren,
   removeJSXElementChild,
@@ -51,6 +50,7 @@ import {
 import { getComponentsFromTopLevelElements } from './project-file-utils'
 import { setFeatureForUnitTests } from '../../utils/utils.test-utils'
 import { FOR_TESTS_setNextGeneratedUids } from './element-template-utils.test-utils'
+import { getUtopiaID } from '../shared/uid-utils'
 
 describe('guaranteeUniqueUids', () => {
   it('if two siblings have the same ID, one will be replaced', () => {

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -52,15 +52,28 @@ import {
   fixUtopiaElement,
   generateMockNextGeneratedUID,
   generateUID,
+  getUtopiaID,
   getUtopiaIDFromJSXElement,
   setUtopiaIDOnJSXElement,
 } from '../shared/uid-utils'
 import { assertNever, fastForEach } from '../shared/utils'
 import { getComponentsFromTopLevelElements, isSceneAgainstImports } from './project-file-utils'
 import { getStoryboardElementPath } from './scene-utils'
-import { getJSXAttributeAtPath, GetJSXAttributeResult } from '../shared/jsx-attributes'
+import {
+  getJSXAttributeAtPath,
+  GetJSXAttributeResult,
+  jsxSimpleAttributeToValue,
+} from '../shared/jsx-attributes'
 import { forceNotNull } from '../shared/optional-utils'
 import { getConditionalClausePath, ThenOrElse, thenOrElsePathPart } from './conditionals'
+import { conditionalWhenFalseOptic, conditionalWhenTrueOptic } from './common-optics'
+import { modify } from '../shared/optics/optic-utilities'
+import { foldEither } from '../shared/either'
+import {
+  getElementPathFromReparentTargetParent,
+  ReparentTargetParent,
+  reparentTargetParentIsConditionalClause,
+} from '../../components/editor/store/reparent-target'
 
 function getAllUniqueUidsInner(
   projectContents: ProjectContentTreeRoot,
@@ -157,64 +170,6 @@ export function isSceneElement(
   } else {
     return false
   }
-}
-
-// THIS IS SUPER UGLY, DO NOT USE OUTSIDE OF FILE
-function isUtopiaJSXElement(
-  element: JSXElementChild | ElementInstanceMetadata,
-): element is JSXElement {
-  return isJSXElement(element as any)
-}
-
-function isUtopiaJSXArbitraryBlock(
-  element: JSXElementChild | ElementInstanceMetadata,
-): element is JSXArbitraryBlock {
-  return isJSXArbitraryBlock(element as any)
-}
-
-function isUtopiaJSXTextBlock(
-  element: JSXElementChild | ElementInstanceMetadata,
-): element is JSXTextBlock {
-  return isJSXTextBlock(element as any)
-}
-
-function isUtopiaJSXFragment(
-  element: JSXElementChild | ElementInstanceMetadata,
-): element is JSXFragment {
-  return isJSXFragment(element as any)
-}
-
-function isElementInstanceMetadata(
-  element: JSXElementChild | ElementInstanceMetadata,
-): element is ElementInstanceMetadata {
-  return (element as any).elementPath != null
-}
-
-export function setUtopiaID(element: JSXElementChild, uid: string): JSXElementChild {
-  if (isUtopiaJSXElement(element)) {
-    return setUtopiaIDOnJSXElement(element, uid)
-  } else if (isUtopiaJSXFragment(element)) {
-    return jsxFragment(uid, element.children, element.longForm)
-  } else {
-    throw new Error(`Unable to set utopia id on ${element.type}`)
-  }
-}
-
-export function getUtopiaID(element: JSXElementChild | ElementInstanceMetadata): string {
-  if (isUtopiaJSXElement(element)) {
-    return getUtopiaIDFromJSXElement(element)
-  } else if (isUtopiaJSXArbitraryBlock(element)) {
-    return element.uniqueID
-  } else if (isUtopiaJSXTextBlock(element)) {
-    return element.uniqueID
-  } else if (isElementInstanceMetadata(element)) {
-    return EP.toUid(element.elementPath)
-  } else if (isJSXFragment(element)) {
-    return element.uid
-  } else if (isJSXConditionalExpression(element)) {
-    return element.uid
-  }
-  throw new Error(`Cannot recognize element ${JSON.stringify(element)}`)
 }
 
 export function transformJSXComponentAtPath(
@@ -570,7 +525,7 @@ export function removeJSXElementChild(
 export function insertJSXElementChild(
   projectContents: ProjectContentTreeRoot,
   openFile: string | null,
-  targetParent: StaticElementPath | null,
+  targetParent: ReparentTargetParent<StaticElementPath> | null,
   elementToInsert: JSXElementChild,
   components: Array<UtopiaJSXComponent>,
   indexPosition: IndexPosition | null,
@@ -586,9 +541,43 @@ export function insertJSXElementChild(
   } else {
     return transformJSXComponentAtPath(
       components,
-      targetParentIncludingStoryboardRoot,
+      getElementPathFromReparentTargetParent(targetParentIncludingStoryboardRoot),
       (parentElement) => {
-        if (isJSXElementLike(parentElement)) {
+        if (
+          reparentTargetParentIsConditionalClause(targetParentIncludingStoryboardRoot) &&
+          isJSXConditionalExpression(parentElement)
+        ) {
+          // Determine which clause of the conditional we want to modify.
+          const toClauseOptic =
+            targetParentIncludingStoryboardRoot.clause === 'then'
+              ? conditionalWhenTrueOptic
+              : conditionalWhenFalseOptic
+          // Update the clause if it currently holds a null value.
+          return modify(
+            toClauseOptic,
+            (clauseValue) => {
+              if (childOrBlockIsAttribute(clauseValue)) {
+                const simpleValue = jsxSimpleAttributeToValue(clauseValue)
+                return foldEither(
+                  () => {
+                    return clauseValue
+                  },
+                  (value) => {
+                    if (value == null) {
+                      return elementToInsert
+                    } else {
+                      return clauseValue
+                    }
+                  },
+                  simpleValue,
+                )
+              } else {
+                return clauseValue
+              }
+            },
+            parentElement,
+          )
+        } else if (isJSXElementLike(parentElement)) {
           let updatedChildren: Array<JSXElementChild>
           if (indexPosition == null) {
             updatedChildren = parentElement.children.concat(elementToInsert)

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -65,8 +65,13 @@ import {
   jsxSimpleAttributeToValue,
 } from '../shared/jsx-attributes'
 import { forceNotNull } from '../shared/optional-utils'
-import { getConditionalClausePath, ThenOrElse, thenOrElsePathPart } from './conditionals'
-import { conditionalWhenFalseOptic, conditionalWhenTrueOptic } from './common-optics'
+import {
+  conditionalWhenFalseOptic,
+  conditionalWhenTrueOptic,
+  getConditionalClausePath,
+  ThenOrElse,
+  thenOrElsePathPart,
+} from './conditionals'
 import { modify } from '../shared/optics/optic-utilities'
 import { foldEither } from '../shared/either'
 import {

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -43,10 +43,9 @@ import {
 } from '../shared/jsx-attributes'
 import { stripNulls } from '../shared/array-utils'
 import { UTOPIA_UID_KEY } from './utopia-constants'
-import { getUtopiaID } from './element-template-utils'
 import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../../components/assets'
 import { getUtopiaJSXComponentsFromSuccess } from './project-file-utils'
-import { generateConsistentUID, generateUID } from '../shared/uid-utils'
+import { generateConsistentUID, generateUID, getUtopiaID } from '../shared/uid-utils'
 import { emptySet } from '../shared/set-utils'
 
 export const PathForSceneComponent = PP.create('component')

--- a/editor/src/core/shared/element-path-tree.ts
+++ b/editor/src/core/shared/element-path-tree.ts
@@ -4,8 +4,8 @@ import { fastForEach } from './utils'
 import { ElementInstanceMetadataMap, isJSXElement } from './element-template'
 import { MetadataUtils } from '../model/element-metadata-utils'
 import { foldEither } from './either'
-import { getUtopiaID } from '../model/element-template-utils'
 import { move } from './array-utils'
+import { getUtopiaID } from './uid-utils'
 
 export interface ElementPathTree {
   path: ElementPath

--- a/editor/src/core/shared/optics/optic-utilities.ts
+++ b/editor/src/core/shared/optics/optic-utilities.ts
@@ -196,3 +196,23 @@ export function forEachOf<S, A>(withOptic: Optic<S, A>, s: S, withEach: (a: A) =
       assertNever(withOptic)
   }
 }
+
+// If we can obtain a value from `getFrom` using `getWithOptic`,
+// then attempt to set that value into `setInto` using `setWithOptic`.
+export function getAndSet<S1, S2, A2, A1 extends A2>(
+  getWithOptic: Optic<S1, A1>,
+  setWithOptic: Optic<S2, A2>,
+  getFrom: S1,
+  setInto: S2,
+): S2 {
+  const valueToSet = toFirst(getWithOptic, getFrom)
+  return foldEither(
+    () => {
+      return setInto
+    },
+    (value) => {
+      return set(setWithOptic, value, setInto)
+    },
+    valueToSet,
+  )
+}

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -19,6 +19,11 @@ import {
   JSXFragment,
   isJSXConditionalExpression,
   JSXConditionalExpression,
+  ElementInstanceMetadata,
+  JSXArbitraryBlock,
+  JSXTextBlock,
+  isJSXTextBlock,
+  jsxFragment,
 } from './element-template'
 import { shallowEqual } from './equality-utils'
 import {
@@ -404,4 +409,62 @@ export function findElementWithUID(
     case 'IMPORT_STATEMENT':
       return null
   }
+}
+
+// THIS IS SUPER UGLY, DO NOT USE OUTSIDE OF FILE
+function isUtopiaJSXElement(
+  element: JSXElementChild | ElementInstanceMetadata,
+): element is JSXElement {
+  return isJSXElement(element as any)
+}
+
+function isUtopiaJSXArbitraryBlock(
+  element: JSXElementChild | ElementInstanceMetadata,
+): element is JSXArbitraryBlock {
+  return isJSXArbitraryBlock(element as any)
+}
+
+function isUtopiaJSXTextBlock(
+  element: JSXElementChild | ElementInstanceMetadata,
+): element is JSXTextBlock {
+  return isJSXTextBlock(element as any)
+}
+
+function isUtopiaJSXFragment(
+  element: JSXElementChild | ElementInstanceMetadata,
+): element is JSXFragment {
+  return isJSXFragment(element as any)
+}
+
+function isElementInstanceMetadata(
+  element: JSXElementChild | ElementInstanceMetadata,
+): element is ElementInstanceMetadata {
+  return (element as any).elementPath != null
+}
+
+export function setUtopiaID(element: JSXElementChild, uid: string): JSXElementChild {
+  if (isUtopiaJSXElement(element)) {
+    return setUtopiaIDOnJSXElement(element, uid)
+  } else if (isUtopiaJSXFragment(element)) {
+    return jsxFragment(uid, element.children, element.longForm)
+  } else {
+    throw new Error(`Unable to set utopia id on ${element.type}`)
+  }
+}
+
+export function getUtopiaID(element: JSXElementChild | ElementInstanceMetadata): string {
+  if (isUtopiaJSXElement(element)) {
+    return getUtopiaIDFromJSXElement(element)
+  } else if (isUtopiaJSXArbitraryBlock(element)) {
+    return element.uniqueID
+  } else if (isUtopiaJSXTextBlock(element)) {
+    return element.uniqueID
+  } else if (isElementInstanceMetadata(element)) {
+    return EP.toUid(element.elementPath)
+  } else if (isJSXFragment(element)) {
+    return element.uid
+  } else if (isJSXConditionalExpression(element)) {
+    return element.uid
+  }
+  throw new Error(`Cannot recognize element ${JSON.stringify(element)}`)
 }

--- a/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
@@ -87,11 +87,10 @@ import {
   exportVariables,
 } from '../../shared/project-file-types'
 import { lintAndParse, printCode, printCodeOptions } from './parser-printer'
-import { getUtopiaIDFromJSXElement } from '../../shared/uid-utils'
+import { getUtopiaID, getUtopiaIDFromJSXElement } from '../../shared/uid-utils'
 import { fastForEach } from '../../shared/utils'
 import { addUniquely, flatMapArray } from '../../shared/array-utils'
 import { optionalMap } from '../../shared/optional-utils'
-import { getUtopiaID } from '../../model/element-template-utils'
 import { emptySet } from '../../shared/set-utils'
 
 export const singleLineCommentArbitrary: Arbitrary<SingleLineComment> =

--- a/editor/src/core/workers/parser-printer/uid-fix.spec.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.spec.ts
@@ -1,4 +1,4 @@
-import { getUtopiaID } from '../../model/element-template-utils'
+import { getUtopiaID } from '../../../core/shared/uid-utils'
 import { getComponentsFromTopLevelElements } from '../../model/project-file-utils'
 import {
   isJSXElement,

--- a/editor/src/core/workers/parser-printer/uid-fix.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.ts
@@ -17,10 +17,9 @@ import {
   StaticElementPathPart,
 } from '../../shared/project-file-types'
 import * as EP from '../../shared/element-path'
-import { setUtopiaIDOnJSXElement } from '../../shared/uid-utils'
+import { getUtopiaID, setUtopiaIDOnJSXElement } from '../../shared/uid-utils'
 import {
   findJSXElementChildAtPath,
-  getUtopiaID,
   transformJSXComponentAtElementPath,
 } from '../../model/element-template-utils'
 import {

--- a/editor/src/templates/editor-navigator.ts
+++ b/editor/src/templates/editor-navigator.ts
@@ -4,6 +4,7 @@ import {
   EditorState,
   isRegularNavigatorEntry,
   NavigatorEntry,
+  regularNavigatorEntry,
 } from '../components/editor/store/editor-state'
 import { LocalNavigatorAction } from '../components/navigator/actions'
 import { DragSelection } from '../components/navigator/navigator-item/navigator-item-dnd-container'
@@ -11,21 +12,12 @@ import * as EP from '../core/shared/element-path'
 import Utils from '../utils/utils'
 import { NavigatorStateKeepDeepEquality } from '../components/editor/store/store-deep-equality-instances'
 
-export function createDragSelections(
-  navigatorEntries: Array<NavigatorEntry>,
-  selectedViews: ElementPath[],
-): Array<DragSelection> {
-  let selections: Array<DragSelection> = []
-  Utils.fastForEach(selectedViews, (selectedView) => {
-    selections.push({
-      elementPath: selectedView,
-      index: navigatorEntries.findIndex(
-        (entry) => isRegularNavigatorEntry(entry) && EP.pathsEqual(entry.elementPath, selectedView),
-      ),
-    })
-  })
-  selections.sort((a, b) => b.index - a.index)
-  return selections
+// Currently only "real" elements can be selected, we produce the selected entries
+// directly from `selectedViews`.
+export function getSelectedNavigatorEntries(
+  selectedViews: Array<ElementPath>,
+): Array<NavigatorEntry> {
+  return selectedViews.map(regularNavigatorEntry)
 }
 
 export const runLocalNavigatorAction = function (
@@ -40,8 +32,8 @@ export const runLocalNavigatorAction = function (
         navigator: NavigatorStateKeepDeepEquality(model.navigator, {
           ...model.navigator,
           dropTargetHint: {
-            displayAtElementPath: action.displayAtElementPath,
-            moveToElementPath: action.moveToElementPath,
+            displayAtEntry: action.displayAtElementPath,
+            moveToEntry: action.moveToElementPath,
             type: action.type,
           },
         }).value,

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -33,7 +33,6 @@ import {
   walkElements,
   emptyComments,
 } from '../core/shared/element-template'
-import { getUtopiaID } from '../core/model/element-template-utils'
 import { jsxAttributesToProps } from '../core/shared/jsx-attributes'
 import { getUtopiaJSXComponentsFromSuccess } from '../core/model/project-file-utils'
 import {
@@ -74,6 +73,7 @@ import { EditorRenderResult } from '../components/canvas/ui-jsx.test-utils'
 import { selectComponents } from '../components/editor/actions/action-creators'
 import { fireEvent } from '@testing-library/react'
 import { FeatureName, isFeatureEnabled, setFeatureEnabled } from './feature-switches'
+import { getUtopiaID } from 'src/core/shared/uid-utils'
 
 export function delay(time: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, time))

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -73,7 +73,7 @@ import { EditorRenderResult } from '../components/canvas/ui-jsx.test-utils'
 import { selectComponents } from '../components/editor/actions/action-creators'
 import { fireEvent } from '@testing-library/react'
 import { FeatureName, isFeatureEnabled, setFeatureEnabled } from './feature-switches'
-import { getUtopiaID } from 'src/core/shared/uid-utils'
+import { getUtopiaID } from '../core/shared/uid-utils'
 
 export function delay(time: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, time))


### PR DESCRIPTION
**Problem:**
Users will want to drag in and out of conditional clauses as if they were just regular children within the hierarchy.

**Fix:**
There are two main tranches to the changes to support this kind of change:
- Changing some of our reparenting logic to handle the case where the target location to be reparented into can be a clause in a conditional as well as a regular element path. This has required some small changes in the strategies support code as that currently handles all reparenting.
- Tweaks to the navigator drag-and-drop handling which drives the actual reparenting, expanding the existing code to cater for the conditional clause entries.

**Notes:**
This is a reworking of https://github.com/concrete-utopia/utopia/pull/3426 to handle an issue that arose with Vite.

**Limitations:**
This does not handle the case of dragging into a clause which already has an element within it, primarily to keep the scope of this work to the minimal amount possible.

**Commit Details:**
- Added `ReparentTargetParent` to cover reparenting to an `ElementPath` or into a conditional clause.
- Implemented some support functions for `ReparentTargetParent`, like `getElementPathFromReparentTargetParent` to help integrate it into existing code.
- Altered `getReparentOutcome` to use a `targetParent` of `ReparentTargetElement`.
- `ReparentElement` command now uses `ReparentTargetParent`.
- `editorMoveMultiSelectedTemplates` uses `ReparentTargetParent` for the `targetParent`.
- Created `ConditionalClause` type which can be used to "target" a specific clause in a non-navigator specific way.
- Renamed `displayAtElementPath` to `displayAtEntry` and `moveToElementPath` to `moveToEntry`.
- Renamed `getDragSelections` to `getCurrentlySelectedEntries` as that more accurately describes what it now does.
- Renamed `canDrop` function to `notDescendant`, so that a new function called `canDrop` can use the name.
- `canDrag` in `NavigatorItemContainer` allows for synthetic navigator entries to be dragged.
- `canBeReparentedIntoSelector` renamed to `elementSupportsChildrenSelector` and a new value of `canReparentInto` uses the result of that and a check for conditional clauses into account.
- Incorporated fix from PR #3412 for `findJSXElementChildAtPath`, because it was necessary for this PR to work correctly.
- `insertJSXElementChild` now caters for inserting into conditional clauses.
- Modified the dependency cruiser configuration to prevent workers from importing certain files.