### PR TITLE
Edit conditional expressions in the inspector

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -811,6 +811,12 @@ export interface SetConditionalOverriddenCondition {
   condition: boolean | null
 }
 
+export interface UpdateConditionalExpression {
+  action: 'UPDATE_CONIDTIONAL_EXPRESSION'
+  target: ElementPath
+  expression: string
+}
+
 export interface AddImports {
   action: 'ADD_IMPORTS'
   target: ElementPath
@@ -1289,6 +1295,7 @@ export type EditorAction =
   | UpdateColorSwatches
   | SetConditionalOverriddenCondition
   | SwitchConditionalBranches
+  | UpdateConditionalExpression
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -229,6 +229,7 @@ import type {
   MergeWithPrevUndo,
   SetConditionalOverriddenCondition,
   SwitchConditionalBranches,
+  UpdateConditionalExpression,
 } from '../action-types'
 import { EditorModes, insertionSubject, Mode } from '../editor-modes'
 import type {
@@ -1758,6 +1759,17 @@ export function setConditionalOverriddenCondition(
     action: 'SET_CONDITIONAL_OVERRIDDEN_CONDITION',
     target: target,
     condition: condition,
+  }
+}
+
+export function updateConditionalExpression(
+  target: ElementPath,
+  expression: string,
+): UpdateConditionalExpression {
+  return {
+    action: 'UPDATE_CONIDTIONAL_EXPRESSION',
+    target: target,
+    expression: expression,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -194,6 +194,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_COLOR_SWATCHES':
     case 'SET_CONDITIONAL_OVERRIDDEN_CONDITION':
     case 'SWITCH_CONDITIONAL_BRANCHES':
+    case 'UPDATE_CONIDTIONAL_EXPRESSION':
       return false
     case 'SAVE_ASSET':
       return (

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -68,6 +68,7 @@ import {
   isJSXElement,
   isJSXFragment,
   isPartOfJSXAttributeValue,
+  jsxAttributeOtherJavaScript,
   JSXAttributes,
   jsxAttributesFromMap,
   jsxAttributeValue,
@@ -335,6 +336,7 @@ import {
   CopyProperties,
   SetConditionalOverriddenCondition,
   SwitchConditionalBranches,
+  UpdateConditionalExpression,
 } from '../action-types'
 import { defaultSceneElement, defaultTransparentViewElement } from '../defaults'
 import { EditorModes, isLiveMode, isSelectMode, Mode } from '../editor-modes'
@@ -4550,6 +4552,35 @@ export const UPDATE_FNS = {
         }
       },
       editor,
+    )
+  },
+  UPDATE_CONDITIONAL_EXPRESSION: (
+    action: UpdateConditionalExpression,
+    editor: EditorModel,
+  ): EditorModel => {
+    return modifyOpenJsxElementOrConditionalAtPath(
+      action.target,
+      (element) => {
+        if (!isJSXConditionalExpression(element)) {
+          return element
+        }
+
+        return {
+          ...element,
+          condition: jsxAttributeOtherJavaScript(
+            action.expression,
+            action.expression,
+            [],
+            null,
+            {},
+          ),
+          originalConditionString: action.expression,
+        }
+      },
+      editor,
+      RevisionsState.ParsedAheadNeedsReparsing,
+      // reparse needed because the new condition might be
+      // referencing variables from the outer scope
     )
   },
   ADD_IMPORTS: (action: AddImports, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -378,6 +378,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.UPDATE_COLOR_SWATCHES(action, state)
     case 'SET_CONDITIONAL_OVERRIDDEN_CONDITION':
       return UPDATE_FNS.SET_CONDITIONAL_OVERRIDDEN_CONDITION(action, state)
+    case 'UPDATE_CONIDTIONAL_EXPRESSION':
+      return UPDATE_FNS.UPDATE_CONDITIONAL_EXPRESSION(action, state)
     case 'SWITCH_CONDITIONAL_BRANCHES':
       return UPDATE_FNS.SWITCH_CONDITIONAL_BRANCHES(action, state)
     default:

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -2162,8 +2162,6 @@ describe('inspector tests with real metadata', () => {
           await renderResult.dispatch([selectComponents([targetPath], false)], false)
         })
 
-        // await wait(300000)
-
         const control = await getControl(t.controlTestID, renderResult.renderedDOM)
 
         // Check the controls show when hovering
@@ -2655,7 +2653,56 @@ describe('inspector tests with real metadata', () => {
       const expressionElement = renderResult.renderedDOM.getByTestId(
         ConditionalsControlSectionExpressionTestId,
       )
-      expect(expressionElement.textContent).toEqual('[].length === 0')
+      expect((expressionElement as HTMLInputElement).value).toEqual('[].length === 0')
+    })
+    it('allows changing the expression', async () => {
+      FOR_TESTS_setNextGeneratedUids([
+        'skip1',
+        'skip2',
+        'skip3',
+        'skip4',
+        'skip5',
+        'skip6',
+        'skip7',
+        'skip8',
+        'conditional',
+      ])
+      const startSnippet = `
+      <div data-uid='aaa'>
+        {[].length === 0 ? (
+          <div data-uid='bbb' data-testid='bbb'>foo</div>
+        ) : (
+          <div data-uid='ccc' data-testid='ccc'>bar</div>
+        )}
+      </div>
+      `
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(startSnippet),
+        'await-first-dom-report',
+      )
+
+      expect(renderResult.renderedDOM.getByTestId('bbb')).not.toBeNull()
+
+      const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional'])
+
+      await act(async () => {
+        await renderResult.dispatch([selectComponents([targetPath], false)], false)
+      })
+
+      await setControlValue(
+        ConditionalsControlSectionExpressionTestId,
+        '40 + 2 < 42',
+        renderResult.renderedDOM,
+      )
+      await renderResult.getDispatchFollowUpActionsFinished()
+
+      expect(renderResult.renderedDOM.queryByTestId('bbb')).toBeNull()
+      expect(renderResult.renderedDOM.queryByTestId('ccc')).not.toBeNull()
+
+      const expressionElement = renderResult.renderedDOM.getByTestId(
+        ConditionalsControlSectionExpressionTestId,
+      )
+      expect((expressionElement as HTMLInputElement).value).toEqual('40 + 2 < 42')
     })
   })
 })

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -34,6 +34,7 @@ import {
 import { useDispatch } from '../../../editor/store/dispatch-context'
 import { Substores, useEditorState } from '../../../editor/store/store-hook'
 import { MetadataSubstate } from '../../../editor/store/store-hook-substore-types'
+import { usePropControlledStateV2 } from '../../common/inspector-utils'
 import { UIGridRow } from '../../widgets/ui-grid-row'
 
 export const ConditionalsControlSectionOpenTestId = 'conditionals-control-section-open'
@@ -134,11 +135,9 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
     'ConditionalSection condition expression',
   )
 
-  const [conditionExpression, setConditionExpression] = React.useState(originalConditionExpression)
-
-  React.useEffect(() => {
-    setConditionExpression(originalConditionExpression)
-  }, [originalConditionExpression])
+  const [conditionExpression, setConditionExpression] = usePropControlledStateV2(
+    originalConditionExpression,
+  )
 
   const setConditionOverride = React.useCallback(
     (value: boolean | null) => () => {
@@ -178,7 +177,7 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
       return
     }
     dispatch([updateConditionalExpression(paths[0], expression)], 'everyone')
-  }, [paths, conditionExpression, originalConditionExpression, dispatch])
+  }, [paths, conditionExpression, setConditionExpression, originalConditionExpression, dispatch])
 
   function onExpressionChange(e: React.ChangeEvent<HTMLInputElement>) {
     setConditionExpression(e.target.value)
@@ -271,7 +270,7 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
             highlight
             spotlight
             onClick={replaceBranches()}
-            data-testId={ConditionalsControlSwitchBranches}
+            data-testid={ConditionalsControlSwitchBranches}
           >
             Switch branches
           </Button>

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -12,7 +12,6 @@ import {
   isJSXConditionalExpression,
 } from '../../../../core/shared/element-template'
 import { ElementPath } from '../../../../core/shared/project-file-types'
-import { codeStyle } from '../../../../third-party/react-error-overlay/components/CodeBlock'
 import { unless } from '../../../../utils/react-conditionals'
 import {
   Button,
@@ -24,6 +23,7 @@ import {
   SquareButton,
   StringInput,
   useColorTheme,
+  UtopiaStyles,
 } from '../../../../uuiui'
 import { EditorAction } from '../../../editor/action-types'
 import {
@@ -256,7 +256,7 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
             onKeyUp={onExpressionKeyUp}
             onBlur={onUpdateExpression}
             css={{
-              ...codeStyle,
+              ...UtopiaStyles.fontStyles.monospaced,
               textAlign: 'center',
               fontWeight: 600,
             }}

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -19,6 +19,7 @@ import {
   JSXFragment,
   isJSXConditionalExpression,
   JSXConditionalExpression,
+  jsxConditionalExpression,
 } from './element-template'
 import { shallowEqual } from './equality-utils'
 import {
@@ -163,6 +164,15 @@ export function setUtopiaIDOnJSXElement(element: JSXElementChild, uid: string): 
       uid,
       setJSXAttributesAttribute(element.props, 'data-uid', jsxAttributeValue(uid, emptyComments)),
       element.children,
+    )
+  } else if (isJSXConditionalExpression(element)) {
+    return jsxConditionalExpression(
+      uid,
+      element.condition,
+      element.originalConditionString,
+      element.whenTrue,
+      element.whenFalse,
+      element.comments,
     )
   } else {
     // TODO: Do other cases need this?

--- a/editor/src/core/workers/parser-printer/uid-fix.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.ts
@@ -1,6 +1,8 @@
 import {
+  childOrBlockIsChild,
   ElementsWithin,
   isJSXArbitraryBlock,
+  isJSXConditionalExpression,
   isJSXElement,
   isJSXElementLike,
   isJSXFragment,
@@ -260,6 +262,21 @@ function compareAndWalkElements(
       )
     } else if (isJSXTextBlock(oldElement) && isJSXTextBlock(newElement)) {
       return true
+    } else if (isJSXConditionalExpression(oldElement) && isJSXConditionalExpression(newElement)) {
+      const oldUID = getUtopiaID(oldElement)
+      const newUid = getUtopiaID(newElement)
+      const path = EP.appendToElementPath(pathSoFar, newUid)
+      const oldPathToRestore = EP.appendToElementPath(pathSoFar, oldUID)
+      onElement(oldUID, newUid, oldPathToRestore, path)
+      const whenTrue =
+        childOrBlockIsChild(oldElement.whenTrue) && childOrBlockIsChild(newElement.whenTrue)
+          ? compareAndWalkElements(oldElement.whenTrue, newElement.whenTrue, path, onElement)
+          : false
+      const whenFalse =
+        childOrBlockIsChild(oldElement.whenFalse) && childOrBlockIsChild(newElement.whenFalse)
+          ? compareAndWalkElements(oldElement.whenFalse, newElement.whenFalse, path, onElement)
+          : false
+      return whenTrue && whenFalse
     }
   }
 

--- a/editor/src/third-party/react-error-overlay/components/CodeBlock.tsx
+++ b/editor/src/third-party/react-error-overlay/components/CodeBlock.tsx
@@ -30,7 +30,7 @@ const secondaryPreStyle = {
   backgroundColor: yellowTransparent,
 }
 
-const codeStyle = {
+export const codeStyle = {
   fontFamily: 'Consolas, Menlo, monospace',
 }
 

--- a/editor/src/third-party/react-error-overlay/components/CodeBlock.tsx
+++ b/editor/src/third-party/react-error-overlay/components/CodeBlock.tsx
@@ -30,7 +30,7 @@ const secondaryPreStyle = {
   backgroundColor: yellowTransparent,
 }
 
-export const codeStyle = {
+const codeStyle = {
   fontFamily: 'Consolas, Menlo, monospace',
 }
 

--- a/editor/src/uuiui/styles/theme/utopia-theme.ts
+++ b/editor/src/uuiui/styles/theme/utopia-theme.ts
@@ -160,6 +160,12 @@ const textNoticeStyles = {
   disconnected: { background: backgroundURLs.noise, color: 'white' },
 }
 
+const fontStyles = {
+  monospaced: {
+    fontFamily: 'Consolas, Menlo, monospace',
+  },
+}
+
 const shadowStyles = {
   small: {
     boxShadow: `0px 1p 3px 0px rgba(0,0,0,.2)`,
@@ -214,4 +220,5 @@ export const UtopiaStyles = {
   flexCenter,
   scene,
   canvas,
+  fontStyles,
 } as const


### PR DESCRIPTION
Fixes #3435 

This PR adds the ability to inline-edit conditional expressions via the inspector.

https://user-images.githubusercontent.com/1081051/225343429-e9640374-f81e-44d2-840c-2d8f7bc4aaa0.mp4

The `condition` of the `JSXConditionalElement` is set by creating a `JSXAttributeOtherJavascript` with the verbatim string entered in the text input, which then triggers a reparse.