### PR TITLE
reorder inspector section components

### DIFF
--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -344,6 +344,10 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
           <AlignmentButtons numberOfTargets={selectedViews.length} />
           {when(isTwindEnabled(), <ClassNameSubsection />)}
           {anyComponents ? <ComponentSection isScene={false} /> : null}
+          {when(
+            isFeatureEnabled('Conditional support'),
+            <ConditionalSection paths={selectedViews} />,
+          )}
           <TargetSelectorSection
             targets={props.targets}
             selectedTargetPath={props.selectedTargetPath}
@@ -352,17 +356,13 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
             onStyleSelectorDelete={props.onStyleSelectorDelete}
             onStyleSelectorInsert={props.onStyleSelectorInsert}
           />
-          <FlexSection />
-          <SizingSection />
           <PositionSection
             hasNonDefaultPositionAttributes={hasNonDefaultPositionAttributes}
             aspectRatioLocked={aspectRatioLocked}
             toggleAspectRatioLock={toggleAspectRatioLock}
           />
-          {when(
-            isFeatureEnabled('Conditional support'),
-            <ConditionalSection paths={selectedViews} />,
-          )}
+          <SizingSection />
+          <FlexSection />
           <StyleSection />
           <WarningSubsection />
           <ImgSection />

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -830,7 +830,7 @@ export const ComponentSectionInner = React.memo((props: ComponentSectionProps) =
       <InspectorSectionHeader>
         <FlexRow style={{ flexGrow: 1, color: colorTheme.primary.value, gap: 8 }}>
           <Icons.Component color='primary' />
-          <InlineLink onClick={OpenFile}>Component</InlineLink>{' '}
+          <InlineLink onClick={OpenFile}>Component</InlineLink>
         </FlexRow>
         <SquareButton highlight onClick={toggleSection}>
           <ExpandableIndicator
@@ -844,9 +844,6 @@ export const ComponentSectionInner = React.memo((props: ComponentSectionProps) =
       {when(
         sectionExpanded,
         <React.Fragment>
-          {/* Information about the component as a whole */}
-
-          {/* List of component props with controls */}
           {propertyControlsAndTargets.map((controlsAndTargets) => (
             <PropertyControlsSection
               key={EP.toString(controlsAndTargets.targets[0])}

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -69,7 +69,6 @@ import {
   StringInputPropertyControl,
   VectorPropertyControl,
 } from './property-control-controls'
-import { ComponentInfoBox } from './component-info-box'
 import { ExpandableIndicator } from '../../../navigator/navigator-item/expandable-indicator'
 import { unless, when } from '../../../../utils/react-conditionals'
 import { PropertyControlsSection } from './property-controls-section'
@@ -79,11 +78,7 @@ import { normalisePathToUnderlyingTarget } from '../../../custom-code/code-file'
 import { openCodeEditorFile } from '../../../editor/actions/action-creators'
 import { Substores, useEditorState } from '../../../editor/store/store-hook'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
-import {
-  getFilePathForImportedComponent,
-  isAnimatedElement,
-  isImportedComponentNPM,
-} from '../../../../core/model/project-file-utils'
+import { getFilePathForImportedComponent } from '../../../../core/model/project-file-utils'
 import { safeIndex } from '../../../../core/shared/array-utils'
 import { useDispatch } from '../../../editor/store/dispatch-context'
 
@@ -835,10 +830,7 @@ export const ComponentSectionInner = React.memo((props: ComponentSectionProps) =
       <InspectorSectionHeader>
         <FlexRow style={{ flexGrow: 1, color: colorTheme.primary.value, gap: 8 }}>
           <Icons.Component color='primary' />
-          <InlineLink onClick={OpenFile}>
-            {/* {locationOfComponentInstance} */}
-            Component
-          </InlineLink>{' '}
+          <InlineLink onClick={OpenFile}>Component</InlineLink>{' '}
         </FlexRow>
         <SquareButton highlight onClick={toggleSection}>
           <ExpandableIndicator

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -845,7 +845,7 @@ export const ComponentSectionInner = React.memo((props: ComponentSectionProps) =
         sectionExpanded,
         <React.Fragment>
           {/* Information about the component as a whole */}
-          {/* <ComponentInfoBox /> */}
+
           {/* List of component props with controls */}
           {propertyControlsAndTargets.map((controlsAndTargets) => (
             <PropertyControlsSection

--- a/editor/src/components/inspector/sections/header-section/target-selector.tsx
+++ b/editor/src/components/inspector/sections/header-section/target-selector.tsx
@@ -102,9 +102,9 @@ export const TargetSelectorPanel = React.memo((props: TargetSelectorPanelProps) 
     <FlexColumn
       style={{
         position: 'relative',
-        paddingTop: '8px',
         userSelect: 'none',
         WebkitUserSelect: 'none',
+        borderTop: '1px solid var(--utopitheme-bg4)',
       }}
     >
       <TargetListHeader

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`451`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`450`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`462`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`461`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`583`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`582`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`655`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`654`)
   })
 })


### PR DESCRIPTION
Some small structural improvements to the Inspector:
• Reordered the sections to keep conditionals and component props in the upper section, everything else in the lower part
• removed the "This component is imported from ..." text, and added the link to the file that it's imported from onto the "Component" text in the section header
• styling adjustments to TargetSelector section

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/47405698/225422475-8bfd988b-cdde-431e-88ae-f5d0d84050e4.png)  | ![image](https://user-images.githubusercontent.com/47405698/225422563-117ec029-3854-4b66-b1e6-c142f5f816e4.png)  |
| ![image](https://user-images.githubusercontent.com/47405698/225422852-9037abde-3bae-4a02-869b-379ab82aad40.png)  | ![image](https://user-images.githubusercontent.com/47405698/225422745-b85e61bf-1bd5-477c-bd66-3dd6be7fc2fa.png)  |