### PR TITLE
Flow insertion / reparenting should always be lower weight than absolute

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-flex-reparent-strategy-helpers.spec.browser2.tsx
@@ -13,6 +13,7 @@ import {
   mouseDownAtPoint,
   mouseDragFromPointToPoint,
   mouseMoveToPoint,
+  pressKey,
 } from '../../event-helpers.test-utils'
 import {
   EditorRenderResult,
@@ -31,6 +32,7 @@ async function dragElement(
   dragDelta: WindowPoint,
   modifiers: Modifiers,
   includeMouseUp: boolean,
+  midDragCallback?: () => Promise<void>,
 ): Promise<void> {
   const targetElement = renderResult.renderedDOM.getByTestId(targetTestId)
   const targetElementBounds = targetElement.getBoundingClientRect()
@@ -45,6 +47,7 @@ async function dragElement(
   if (includeMouseUp) {
     await mouseDragFromPointToPoint(canvasControlsLayer, startPoint, endPoint, {
       modifiers: modifiers,
+      midDragCallback: midDragCallback,
     })
   } else {
     await mouseDownAtPoint(canvasControlsLayer, startPoint, { modifiers: modifiers })
@@ -219,9 +222,11 @@ describe('Unified Reparent Fitness Function Tests', () => {
           <div
             style={{
               backgroundColor: '#aaaaaa33',
+              position: 'absolute',
+              left: 120,
+              top: 0,
               width: 200,
               height: 200,
-              contain: 'layout',
             }}
             data-uid='ccc'
             data-testid='ccc'
@@ -1240,7 +1245,7 @@ describe('Target parents with flow layout', () => {
   })
 
   describe('Reparent to Flow', () => {
-    it('if target parent is not a contianing block', async () => {
+    it('if target parent is not a containing block', async () => {
       const renderResult = await renderTestEditorWithCode(
         makeTestProjectCodeWithSnippet(`
           <div
@@ -1290,6 +1295,7 @@ describe('Target parents with flow layout', () => {
         dragDelta,
         emptyModifiers,
         true,
+        () => pressKey('2', { modifiers: cmdModifier }), // Switch to flow reparenting strategy
       )
 
       await renderResult.getDispatchFollowUpActionsFinished()
@@ -1415,6 +1421,7 @@ describe('Target parents with flow layout', () => {
         dragDelta,
         emptyModifiers,
         true,
+        () => pressKey('2', { modifiers: cmdModifier }), // Switch to flow reparenting strategy
       )
 
       await renderResult.getDispatchFollowUpActionsFinished()
@@ -1541,6 +1548,7 @@ describe('Target parents with flow layout', () => {
         dragDelta,
         cmdModifier,
         true,
+        () => pressKey('2', { modifiers: cmdModifier }), // Switch to flow reparenting strategy
       )
 
       await renderResult.getDispatchFollowUpActionsFinished()
@@ -2646,6 +2654,8 @@ describe('Reparent indicators', () => {
       false,
     )
 
+    await pressKey('2') // Switch to flow reparenting strategy
+
     await renderResult.getDispatchFollowUpActionsFinished()
 
     expect(renderResult.getEditorState().editor.displayNoneInstances).toEqual([
@@ -2741,6 +2751,8 @@ describe('Reparent indicators', () => {
       emptyModifiers,
       false,
     )
+
+    await pressKey('2') // Switch to flow reparenting strategy
 
     await renderResult.getDispatchFollowUpActionsFinished()
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flow-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flow-strategy.spec.browser2.tsx
@@ -13,7 +13,11 @@ import {
   BakedInStoryboardVariableName,
   BakedInStoryboardUID,
 } from '../../../../core/model/scene-utils'
-import { mouseClickAtPoint, mouseDragFromPointWithDelta } from '../../event-helpers.test-utils'
+import {
+  mouseClickAtPoint,
+  mouseDragFromPointWithDelta,
+  pressKey,
+} from '../../event-helpers.test-utils'
 
 async function dragElement(
   renderResult: EditorRenderResult,
@@ -34,6 +38,7 @@ async function dragElement(
   await mouseClickAtPoint(canvasControlsLayer, startPoint, { modifiers: cmdModifier })
   await mouseDragFromPointWithDelta(canvasControlsLayer, startPoint, dragDelta, {
     modifiers: modifiers,
+    midDragCallback: () => pressKey('2', { modifiers: modifiers }), // Switch to flow reparenting strategy
   })
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -712,9 +712,11 @@ describe('Inserting into absolute', () => {
             <div
               style={{
                 backgroundColor: '#aaaaaa33',
+                position: 'absolute',
+                left: 0,
+                top: 0,   
                 width: 40,
                 height: 50,
-                contain: 'layout',
               }}
               data-uid='ddd'
             />
@@ -790,9 +792,11 @@ describe('Inserting into absolute', () => {
             <div
               style={{
                 backgroundColor: '#aaaaaa33',
+                position: 'absolute',
+                left: -50,
+                top: -50,            
                 width: 100,
                 height: 100,
-                contain: 'layout',
               }}
               data-uid='ddd'
             />
@@ -968,7 +972,7 @@ describe('Inserting into absolute', () => {
   })
 })
 
-describe('Forced inserting into Static', () => {
+describe('Inserting into Static', () => {
   const inputCode = makeTestProjectCodeWithSnippet(`
     <div
       data-uid='aaa'
@@ -1001,7 +1005,7 @@ describe('Forced inserting into Static', () => {
     </div>
   `)
 
-  it('By default, it inserts as static into a flow parent', async () => {
+  it('By default, it inserts as absolute into a flow parent', async () => {
     const renderResult = await setupInsertTest(inputCode)
     await enterInsertModeFromInsertMenu(renderResult)
 
@@ -1054,9 +1058,11 @@ describe('Forced inserting into Static', () => {
             <div
               style={{
                 backgroundColor: '#aaaaaa33',
+                position: 'absolute',
+                left: 5,
+                top: 15,
                 width: 20,
                 height: 20,
-                contain: 'layout',
               }}
               data-uid='ddd'
             />
@@ -1103,7 +1109,7 @@ describe('Forced inserting into Static', () => {
 
     await mouseDragFromPointToPoint(canvasControlsLayer, startPoint, endPoint, {
       midDragCallback: async () => {
-        await pressKey('2') // this should select the 'Draw to Insert (Abs, Forced)' strategy
+        await pressKey('2') // this should select the 'Draw to Insert (Flow)' strategy
       },
     })
 
@@ -1134,11 +1140,9 @@ describe('Forced inserting into Static', () => {
           <div
             style={{
               backgroundColor: '#aaaaaa33',
-              position: 'absolute',
-              left: 5,
-              top: 15,
               width: 20,
               height: 20,
+              contain: 'layout',
             }}
             data-uid='ddd'
           />

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flow-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flow-strategy.spec.browser2.tsx
@@ -13,7 +13,11 @@ import {
   BakedInStoryboardVariableName,
   BakedInStoryboardUID,
 } from '../../../../core/model/scene-utils'
-import { mouseClickAtPoint, mouseDragFromPointWithDelta } from '../../event-helpers.test-utils'
+import {
+  mouseClickAtPoint,
+  mouseDragFromPointWithDelta,
+  pressKey,
+} from '../../event-helpers.test-utils'
 
 async function dragElement(
   renderResult: EditorRenderResult,
@@ -33,6 +37,7 @@ async function dragElement(
   await mouseClickAtPoint(canvasControlsLayer, startPoint, { modifiers: cmdModifier })
   await mouseDragFromPointWithDelta(canvasControlsLayer, startPoint, dragDelta, {
     modifiers: modifiers,
+    midDragCallback: () => pressKey('2', { modifiers: modifiers }), // Switch to flow reparenting strategy
   })
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/flow-reparent-to-flow-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flow-reparent-to-flow-strategy.spec.browser2.tsx
@@ -13,7 +13,11 @@ import {
   BakedInStoryboardVariableName,
   BakedInStoryboardUID,
 } from '../../../../core/model/scene-utils'
-import { mouseClickAtPoint, mouseDragFromPointWithDelta } from '../../event-helpers.test-utils'
+import {
+  mouseClickAtPoint,
+  mouseDragFromPointWithDelta,
+  pressKey,
+} from '../../event-helpers.test-utils'
 
 async function dragElement(
   renderResult: EditorRenderResult,
@@ -33,6 +37,7 @@ async function dragElement(
   await mouseClickAtPoint(canvasControlsLayer, startPoint, { modifiers: cmdModifier })
   await mouseDragFromPointWithDelta(canvasControlsLayer, startPoint, dragDelta, {
     modifiers: modifiers,
+    midDragCallback: () => pressKey('2', { modifiers: modifiers }), // Switch to flow reparenting strategy
   })
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/forced-absolute-reparent-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/forced-absolute-reparent-strategies.spec.browser2.tsx
@@ -292,7 +292,7 @@ describe('Fallback Absolute Reparent Strategies', () => {
     )
   })
 
-  it('Absolute to absolute as a fallback can be accessed by using the strategy selector', async () => {
+  it('Absolute to static can be accessed by using the strategy selector', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(defaultTestCode),
       'await-first-dom-report',
@@ -397,12 +397,10 @@ describe('Fallback Absolute Reparent Strategies', () => {
       >
         <div
           style={{
-            position: 'absolute',
-            left: 100,
-            top: 0,
             width: 100,
             height: 100,
             backgroundColor: 'yellow',
+            contain: 'layout',
           }}
           data-uid='absolutechild'
           data-testid='absolutechild'
@@ -413,7 +411,7 @@ describe('Fallback Absolute Reparent Strategies', () => {
     )
   })
 
-  it('Absolute to forced absolute is not the default choice', async () => {
+  it('Absolute to forced absolute is the default choice', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(defaultTestCode),
       'await-first-dom-report',
@@ -509,10 +507,12 @@ describe('Fallback Absolute Reparent Strategies', () => {
       >
         <div
           style={{
+            position: 'absolute',
+            left: 100,
+            top: 0,        
             width: 100,
             height: 100,
             backgroundColor: 'yellow',
-            contain: 'layout',
           }}
           data-uid='absolutechild'
           data-testid='absolutechild'
@@ -637,7 +637,7 @@ describe('Fallback Absolute Reparent Strategies', () => {
       </div>`),
     )
   })
-  it('Flex to forced absolute is not the default choice', async () => {
+  it('Flex to forced absolute is the default choice', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(defaultTestCode),
       'await-first-dom-report',
@@ -692,6 +692,9 @@ describe('Fallback Absolute Reparent Strategies', () => {
               width: 100,
               height: 100,
               backgroundColor: 'teal',
+              position: 'absolute',
+              left: 75,
+              top: 200,
             }}
             data-uid='flexchild1'
             data-testid='flexchild1'
@@ -802,10 +805,16 @@ describe('Fallback Absolute Reparent Strategies', () => {
     }
 
     const dragDelta = windowPoint({
-      x: zeroSizeParentTargetCenter.x - draggedElementRectCenter.x - 2, // TODO BALAZS remove these -2's once this is fixed https://github.com/concrete-utopia/utopia/issues/2739
-      y: zeroSizeParentTargetCenter.y - draggedElementRectCenter.y - 2,
+      x: zeroSizeParentTargetCenter.x - draggedElementRectCenter.x,
+      y: zeroSizeParentTargetCenter.y - draggedElementRectCenter.y,
     })
-    await dragElement(renderResult, 'ccc', dragDelta, cmdModifier)
+    await dragElement(
+      renderResult,
+      'ccc',
+      dragDelta,
+      cmdModifier,
+      () => pressKey('2', { modifiers: cmdModifier }), // Switch to flow reparenting before mouseup, as that won't be the default here
+    )
 
     await renderResult.getDispatchFollowUpActionsFinished()
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -42,6 +42,10 @@ interface ReparentFactoryAndDetails {
   factory: CanvasStrategyFactory
 }
 
+const DefaultReparentWeight = 4
+const FallbackReparentWeight = DefaultReparentWeight - 1
+const FlowReparentWeight = FallbackReparentWeight - 1
+
 export function getApplicableReparentFactories(
   canvasState: InteractionCanvasState,
   pointOnCanvas: CanvasPoint,
@@ -61,7 +65,7 @@ export function getApplicableReparentFactories(
   const factories: Array<ReparentFactoryAndDetails> = reparentStrategies.map((result) => {
     switch (result.strategy) {
       case 'REPARENT_AS_ABSOLUTE': {
-        const fitness = result.isFallback ? 2 : 3
+        const fitness = result.isFallback ? FallbackReparentWeight : DefaultReparentWeight
         if (allDraggedElementsAbsolute) {
           return {
             targetParent: result.target.newParent,
@@ -92,7 +96,12 @@ export function getApplicableReparentFactories(
         const targetParentDisplayType = parentLayoutSystem === 'flex' ? 'flex' : 'flow'
 
         // We likely never want flow insertion or re-parenting to be the default
-        const fitness = targetParentDisplayType === 'flow' ? 1 : result.isFallback ? 2 : 3
+        const fitness =
+          targetParentDisplayType === 'flow'
+            ? FlowReparentWeight
+            : result.isFallback
+            ? FallbackReparentWeight
+            : DefaultReparentWeight
 
         return {
           targetParent: result.target.newParent,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -85,11 +85,11 @@ export function getApplicableReparentFactories(
         }
       }
       case 'REPARENT_AS_STATIC': {
-        const parentLayoutSystems = MetadataUtils.findLayoutSystemForChildren(
+        const parentLayoutSystem = MetadataUtils.findLayoutSystemForChildren(
           canvasState.startingMetadata,
           result.target.newParent,
         )
-        const targetParentDisplayType = parentLayoutSystems.at(0) === 'flex' ? 'flex' : 'flow'
+        const targetParentDisplayType = parentLayoutSystem === 'flex' ? 'flex' : 'flow'
 
         // We likely never want flow insertion or re-parenting to be the default
         const fitness = targetParentDisplayType === 'flow' ? 1 : result.isFallback ? 2 : 3

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -85,14 +85,14 @@ export function getApplicableReparentFactories(
         }
       }
       case 'REPARENT_AS_STATIC': {
-        const fitness = result.isFallback ? 2 : 3
-
-        const parentLayouSystems = MetadataUtils.findLayoutSystemForChildren(
+        const parentLayoutSystems = MetadataUtils.findLayoutSystemForChildren(
           canvasState.startingMetadata,
           result.target.newParent,
         )
+        const targetParentDisplayType = parentLayoutSystems.at(0) === 'flex' ? 'flex' : 'flow'
 
-        const targetParentDisplayType = parentLayouSystems.at(0) === 'flex' ? 'flex' : 'flow'
+        // We likely never want flow insertion or re-parenting to be the default
+        const fitness = targetParentDisplayType === 'flow' ? 1 : result.isFallback ? 2 : 3
 
         return {
           targetParent: result.target.newParent,


### PR DESCRIPTION
**Problem:**
We most likely never want static (flow) to be the default `position` when inserting or re-parenting an element, as it goes against the ethos of direct manipulation.

**Fix:**
Reduce the weight of flow re-parenting (which is also used by insertion) so that it is lower than the other re-parenting options.

We take a different stance between flow and flex here since creating flex containers requires a more deliberate action, and so when inserting or re-parenting into a flex container we can be far more confident that the intention was for the inserted / re-parented element to laid out by that flex container.

