### PR TITLE
Absolute Resize Group-like tests now test for all group-like elements

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
@@ -31,6 +31,7 @@ import {
   TestSceneUID,
 } from '../../ui-jsx.test-utils'
 import { AllContentAffectingTypes, ContentAffectingType } from './group-like-helpers'
+import { getClosingGroupLikeTag, getOpeningGroupLikeTag } from './group-like-helpers.test-utils'
 
 interface CheckCursor {
   cursor: CSSCursor | null
@@ -1196,34 +1197,6 @@ describe('children-affecting reparent tests', () => {
   })
 })
 
-function getOpeningTag(type: ContentAffectingType): string {
-  switch (type) {
-    case 'sizeless-div':
-      return `<div data-uid='children-affecting' data-testid='children-affecting'><>`
-    case 'fragment':
-      return `<React.Fragment data-uid='children-affecting' data-testid='children-affecting'><>`
-    case 'conditional':
-      return `{ true ? ( <>`
-    default:
-      const _exhaustiveCheck: never = type
-      throw new Error(`Unhandled ContentAffectingType ${JSON.stringify(type)}.`)
-  }
-}
-
-function getClosingTag(type: ContentAffectingType): string {
-  switch (type) {
-    case 'sizeless-div':
-      return `</></div>`
-    case 'fragment':
-      return `</></React.Fragment>`
-    case 'conditional':
-      return `</> ) : null }`
-    default:
-      const _exhaustiveCheck: never = type
-      throw new Error(`Unhandled ContentAffectingType ${JSON.stringify(type)}.`)
-  }
-}
-
 function testProjectWithUnstyledDivOrFragment(type: ContentAffectingType): string {
   if (type === 'conditional') {
     FOR_TESTS_setNextGeneratedUids([
@@ -1263,7 +1236,7 @@ function testProjectWithUnstyledDivOrFragment(type: ContentAffectingType): strin
           }}
           data-uid='bbb'
         >
-          ${getOpeningTag(type)}
+          ${getOpeningGroupLikeTag(type)}
             <div
               style={{
                 backgroundColor: '#aaaaaa33',
@@ -1288,7 +1261,7 @@ function testProjectWithUnstyledDivOrFragment(type: ContentAffectingType): strin
               data-uid='child-2'
               data-testid='child-2'
             />
-          ${getClosingTag(type)}
+          ${getClosingGroupLikeTag(type)}
           <div
             style={{
               backgroundColor: '#aaaaaa33',

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.spec.browser2.tsx
@@ -20,6 +20,7 @@ import {
   TestSceneUID,
 } from '../../ui-jsx.test-utils'
 import { AllContentAffectingTypes, ContentAffectingType } from './group-like-helpers'
+import { getClosingGroupLikeTag, getOpeningGroupLikeTag } from './group-like-helpers.test-utils'
 
 async function dragElement(
   renderResult: EditorRenderResult,
@@ -397,34 +398,6 @@ describe('Flex Reparent to Absolute – children affecting elements', () => {
   })
 })
 
-function getOpeningTag(type: ContentAffectingType): string {
-  switch (type) {
-    case 'sizeless-div':
-      return `<div data-uid='children-affecting' data-testid='children-affecting'><>`
-    case 'fragment':
-      return `<React.Fragment data-uid='children-affecting' data-testid='children-affecting'><>`
-    case 'conditional':
-      return `{ true ? ( <>`
-    default:
-      const _exhaustiveCheck: never = type
-      throw new Error(`Unhandled ContentAffectingType ${JSON.stringify(type)}.`)
-  }
-}
-
-function getClosingTag(type: ContentAffectingType): string {
-  switch (type) {
-    case 'sizeless-div':
-      return `</></div>`
-    case 'fragment':
-      return `</></React.Fragment>`
-    case 'conditional':
-      return `</> ) : null }`
-    default:
-      const _exhaustiveCheck: never = type
-      throw new Error(`Unhandled ContentAffectingType ${JSON.stringify(type)}.`)
-  }
-}
-
 function fragmentTestCode(type: ContentAffectingType) {
   if (type === 'conditional') {
     FOR_TESTS_setNextGeneratedUids([
@@ -499,7 +472,7 @@ function fragmentTestCode(type: ContentAffectingType) {
       data-uid='flexparent'
       data-testid='flexparent'
     >
-      ${getOpeningTag(type)}
+      ${getOpeningGroupLikeTag(type)}
         <div
           style={{
             width: 100,
@@ -518,7 +491,7 @@ function fragmentTestCode(type: ContentAffectingType) {
           data-uid='flexchild2'
           data-testid='flexchild2'
         />
-      ${getClosingTag(type)}
+      ${getClosingGroupLikeTag(type)}
     </div>
   </div>
 `

--- a/editor/src/components/canvas/canvas-strategies/strategies/group-like-helpers.test-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-like-helpers.test-utils.ts
@@ -3,11 +3,11 @@ import { ContentAffectingType } from './group-like-helpers'
 export function getOpeningGroupLikeTag(type: ContentAffectingType): string {
   switch (type) {
     case 'sizeless-div':
-      return `<div data-uid='children-affecting' data-testid='children-affecting'><>`
+      return `<div data-uid='children-affecting' data-testid='children-affecting'><React.Fragment data-uid='inner-fragment'>`
     case 'fragment':
-      return `<React.Fragment data-uid='children-affecting' data-testid='children-affecting'><>`
+      return `<React.Fragment data-uid='children-affecting' data-testid='children-affecting'><React.Fragment data-uid='inner-fragment'>`
     case 'conditional':
-      return `{ true ? ( <>`
+      return `{ true ? ( <React.Fragment data-uid='inner-fragment'>`
     default:
       const _exhaustiveCheck: never = type
       throw new Error(`Unhandled ContentAffectingType ${JSON.stringify(type)}.`)
@@ -17,11 +17,11 @@ export function getOpeningGroupLikeTag(type: ContentAffectingType): string {
 export function getClosingGroupLikeTag(type: ContentAffectingType): string {
   switch (type) {
     case 'sizeless-div':
-      return `</></div>`
+      return `</React.Fragment></div>`
     case 'fragment':
-      return `</></React.Fragment>`
+      return `</React.Fragment></React.Fragment>`
     case 'conditional':
-      return `</> ) : null }`
+      return `</React.Fragment> ) : null }`
     default:
       const _exhaustiveCheck: never = type
       throw new Error(`Unhandled ContentAffectingType ${JSON.stringify(type)}.`)

--- a/editor/src/components/canvas/canvas-strategies/strategies/group-like-helpers.test-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-like-helpers.test-utils.ts
@@ -1,0 +1,29 @@
+import { ContentAffectingType } from './group-like-helpers'
+
+export function getOpeningGroupLikeTag(type: ContentAffectingType): string {
+  switch (type) {
+    case 'sizeless-div':
+      return `<div data-uid='children-affecting' data-testid='children-affecting'><>`
+    case 'fragment':
+      return `<React.Fragment data-uid='children-affecting' data-testid='children-affecting'><>`
+    case 'conditional':
+      return `{ true ? ( <>`
+    default:
+      const _exhaustiveCheck: never = type
+      throw new Error(`Unhandled ContentAffectingType ${JSON.stringify(type)}.`)
+  }
+}
+
+export function getClosingGroupLikeTag(type: ContentAffectingType): string {
+  switch (type) {
+    case 'sizeless-div':
+      return `</></div>`
+    case 'fragment':
+      return `</></React.Fragment>`
+    case 'conditional':
+      return `</> ) : null }`
+    default:
+      const _exhaustiveCheck: never = type
+      throw new Error(`Unhandled ContentAffectingType ${JSON.stringify(type)}.`)
+  }
+}


### PR DESCRIPTION
**What:**
We already had two reparent tests that were written in a way that enumerate over all possible types of group-like elements (currently: unstyled div, fragment, conditional expression). This PR makes `Absolute Resize Group-like tests` enumerate as well.

**Commit Details:**
- Moved getOpeningGroupLikeTag and getClosingGroupLikeTag to a shared helper
- Removed `cake` from `fridge-contents.ts`
- Made `Absolute Resize Group-like tests` iterate over AllContentAffectingTypes
- Made the test a little bit less brittle by making sure it always checks that the resize ended up changing _something_ in the code
