### PR TITLE
Rename `getDragTargets` to `flattenSelection`

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -45,7 +45,7 @@ import { ancestorMetaStrategy } from './strategies/ancestor-metastrategy'
 import { keyboardReorderStrategy } from './strategies/keyboard-reorder-strategy'
 import { setFlexGapStrategy } from './strategies/set-flex-gap-strategy'
 import { setBorderRadiusStrategy } from './strategies/set-border-radius-strategy'
-import { getDragTargets } from './strategies/shared-move-strategies-helpers'
+import { flattenSelection } from './strategies/shared-move-strategies-helpers'
 import * as EP from '../../../core/shared/element-path'
 import { keyboardSetFontSizeStrategy } from './strategies/keyboard-set-font-size-strategy'
 import { keyboardSetFontWeightStrategy } from './strategies/keyboard-set-font-weight-strategy'
@@ -119,7 +119,7 @@ const preventOnRootElements: (metaStrategy: MetaCanvasStrategy) => MetaCanvasStr
     interactionSession: InteractionSession | null,
     customStrategyState: CustomStrategyState,
   ): Array<CanvasStrategy> => {
-    const selectedElements = getDragTargets(
+    const selectedElements = flattenSelection(
       getTargetPathsFromInteractionTarget(canvasState.interactionTarget),
     )
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.tsx
@@ -23,7 +23,7 @@ import {
   strategyApplicationResult,
 } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
-import { getDragTargets } from './shared-move-strategies-helpers'
+import { flattenSelection } from './shared-move-strategies-helpers'
 import {
   replaceContentAffectingPathsWithTheirChildrenRecursive,
   treatElementAsContentAffecting,
@@ -46,7 +46,7 @@ export function absoluteDuplicateStrategy(
   }
 
   const isDragging = interactionSession.interactionData.drag != null
-  const filteredSelectedElements = getDragTargets(selectedElements)
+  const filteredSelectedElements = flattenSelection(selectedElements)
 
   if (!isApplicable(canvasState, filteredSelectedElements)) {
     return null

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
@@ -15,7 +15,7 @@ import { retargetStrategyToChildrenOfContentAffectingElements } from './group-li
 import {
   applyMoveCommon,
   getAdjustMoveCommands,
-  getDragTargets,
+  flattenSelection,
 } from './shared-move-strategies-helpers'
 
 export function absoluteMoveStrategy(
@@ -26,7 +26,7 @@ export function absoluteMoveStrategy(
 
   const isApplicable =
     targets.length > 0 &&
-    getDragTargets(targets).every((element) => {
+    flattenSelection(targets).every((element) => {
       const elementMetadata = MetadataUtils.findElementByElementPath(
         canvasState.startingMetadata,
         element,

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
@@ -29,7 +29,7 @@ import { ifAllowedToReparent, isAllowedToReparent } from './reparent-helpers/rep
 import { getAbsoluteReparentPropertyChanges } from './reparent-helpers/reparent-property-changes'
 import { ReparentTarget } from './reparent-helpers/reparent-strategy-helpers'
 import { getReparentOutcome, pathToReparent } from './reparent-utils'
-import { getDragTargets } from './shared-move-strategies-helpers'
+import { flattenSelection } from './shared-move-strategies-helpers'
 
 export function baseAbsoluteReparentStrategy(
   reparentTarget: ReparentTarget,
@@ -49,7 +49,7 @@ export function baseAbsoluteReparentStrategy(
     }
 
     const dragInteractionData = interactionSession.interactionData // Why TypeScript?!
-    const filteredSelectedElements = getDragTargets(selectedElements)
+    const filteredSelectedElements = flattenSelection(selectedElements)
     const isApplicable = replaceContentAffectingPathsWithTheirChildrenRecursive(
       canvasState.startingMetadata,
       canvasState.startingAllElementProps,

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -58,7 +58,7 @@ import {
   supportsAbsoluteResize,
 } from './resize-helpers'
 import { runLegacyAbsoluteResizeSnapping } from './shared-absolute-resize-strategy-helpers'
-import { getDragTargets, getMultiselectBounds } from './shared-move-strategies-helpers'
+import { flattenSelection, getMultiselectBounds } from './shared-move-strategies-helpers'
 import { FlexDirection } from '../../../inspector/common/css-utils'
 import { retargetStrategyToChildrenOfContentAffectingElements } from './group-like-helpers'
 
@@ -67,7 +67,7 @@ export function absoluteResizeBoundingBoxStrategy(
   interactionSession: InteractionSession | null,
 ): CanvasStrategy | null {
   const targets = retargetStrategyToChildrenOfContentAffectingElements(canvasState)
-  const filteredSelectedElements = getDragTargets(targets)
+  const filteredSelectedElements = flattenSelection(targets)
   if (
     filteredSelectedElements.length === 0 ||
     !filteredSelectedElements.every((element) => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -57,7 +57,7 @@ import {
 } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
 import { getReparentOutcome, pathToReparent } from './reparent-utils'
-import { applyMoveCommon, getDragTargets } from './shared-move-strategies-helpers'
+import { applyMoveCommon, flattenSelection } from './shared-move-strategies-helpers'
 import { wildcardPatch } from '../../commands/wildcard-patch-command'
 import { styleStringInArray } from '../../../../utils/common-constants'
 import {
@@ -74,7 +74,7 @@ export function convertToAbsoluteAndMoveStrategy(
   interactionSession: InteractionSession | null,
 ): CanvasStrategy | null {
   const targets = retargetStrategyToChildrenOfContentAffectingElements(canvasState)
-  const filteredSelectedElements = getDragTargets(targets)
+  const filteredSelectedElements = flattenSelection(targets)
   if (
     filteredSelectedElements.length === 0 ||
     !filteredSelectedElements.every((element) => {
@@ -247,7 +247,7 @@ export function getEscapeHatchCommands(
   commands: Array<CanvasCommand>
   intendedBounds: Array<CanvasFrameAndTarget>
 } {
-  const selectedElements = getDragTargets(_selectedElements)
+  const selectedElements = flattenSelection(_selectedElements)
   if (selectedElements.length === 0) {
     return { commands: [], intendedBounds: [] }
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-move-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-move-metastrategy.tsx
@@ -24,7 +24,7 @@ import { flexReorderStrategy } from './flex-reorder-strategy'
 import { flowReorderStrategy } from './flow-reorder-strategy'
 import { relativeMoveStrategy } from './relative-move-strategy'
 import { reparentMetaStrategy } from './reparent-metastrategy'
-import { getDragTargets } from './shared-move-strategies-helpers'
+import { flattenSelection } from './shared-move-strategies-helpers'
 import * as EP from '../../../../core/shared/element-path'
 
 type MoveStrategyFactory = (
@@ -45,7 +45,7 @@ export const dragToMoveMetaStrategy: MetaCanvasStrategy = (
   interactionSession: InteractionSession | null,
   customStrategyState: CustomStrategyState,
 ): Array<CanvasStrategy> => {
-  const selectedElements = getDragTargets(
+  const selectedElements = flattenSelection(
     getTargetPathsFromInteractionTarget(canvasState.interactionTarget),
   )
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
@@ -22,7 +22,7 @@ import { treatElementAsContentAffecting } from './group-like-helpers'
 import { ifAllowedToReparent } from './reparent-helpers/reparent-helpers'
 import { ReparentTarget } from './reparent-helpers/reparent-strategy-helpers'
 import { placeholderCloneCommands } from './reparent-utils'
-import { getDragTargets } from './shared-move-strategies-helpers'
+import { flattenSelection } from './shared-move-strategies-helpers'
 
 export function baseFlexReparentToAbsoluteStrategy(
   reparentTarget: ReparentTarget,
@@ -60,7 +60,7 @@ export function baseFlexReparentToAbsoluteStrategy(
       ],
       fitness: fitness,
       apply: (strategyLifecycle) => {
-        const filteredSelectedElements = getDragTargets(selectedElements)
+        const filteredSelectedElements = flattenSelection(selectedElements)
         return ifAllowedToReparent(
           canvasState,
           canvasState.startingMetadata,

--- a/editor/src/components/canvas/canvas-strategies/strategies/group-like-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-like-helpers.ts
@@ -10,14 +10,14 @@ import {
   getTargetPathsFromInteractionTarget,
   InteractionCanvasState,
 } from '../canvas-strategy-types'
-import { getDragTargets } from './shared-move-strategies-helpers'
+import { flattenSelection } from './shared-move-strategies-helpers'
 
 export function retargetStrategyToChildrenOfContentAffectingElements(
   canvasState: InteractionCanvasState,
 ): Array<ElementPath> {
   const targets = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
 
-  const targetsWithoutDescedants = getDragTargets(targets)
+  const targetsWithoutDescedants = flattenSelection(targets)
 
   return replaceContentAffectingPathsWithTheirChildrenRecursive(
     canvasState.startingMetadata,

--- a/editor/src/components/canvas/canvas-strategies/strategies/relative-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/relative-move-strategy.tsx
@@ -16,7 +16,7 @@ import { InteractionSession } from '../interaction-state'
 import {
   applyMoveCommon,
   getAdjustMoveCommands,
-  getDragTargets,
+  flattenSelection,
 } from './shared-move-strategies-helpers'
 import { styleStringInArray } from '../../../../utils/common-constants'
 
@@ -28,7 +28,7 @@ export function relativeMoveStrategy(
   if (selectedElements.length === 0) {
     return null
   }
-  const filteredSelectedElements = getDragTargets(selectedElements)
+  const filteredSelectedElements = flattenSelection(selectedElements)
   const last = filteredSelectedElements[filteredSelectedElements.length - 1]
   const metadata = MetadataUtils.findElementByElementPath(canvasState.startingMetadata, last)
   if (

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -32,7 +32,7 @@ import { ifAllowedToReparent } from './reparent-helpers/reparent-helpers'
 import { getStaticReparentPropertyChanges } from './reparent-helpers/reparent-property-changes'
 import { ReparentTarget } from './reparent-helpers/reparent-strategy-helpers'
 import { getReparentOutcome, pathToReparent, placeholderCloneCommands } from './reparent-utils'
-import { getDragTargets } from './shared-move-strategies-helpers'
+import { flattenSelection } from './shared-move-strategies-helpers'
 
 export function baseReparentAsStaticStrategy(
   reparentTarget: ReparentTarget,
@@ -45,7 +45,7 @@ export function baseReparentAsStaticStrategy(
     customStrategyState: CustomStrategyState,
   ): CanvasStrategy | null => {
     const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
-    const filteredSelectedElements = getDragTargets(selectedElements)
+    const filteredSelectedElements = flattenSelection(selectedElements)
     if (
       filteredSelectedElements.length !== 1 ||
       interactionSession == null ||
@@ -128,7 +128,7 @@ function applyStaticReparent(
   reparentResult: ReparentTarget,
 ): StrategyApplicationResult {
   const selectedElements = getTargetPathsFromInteractionTarget(canvasState.interactionTarget)
-  const filteredSelectedElements = getDragTargets(selectedElements)
+  const filteredSelectedElements = flattenSelection(selectedElements)
 
   return ifAllowedToReparent(
     canvasState,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
@@ -15,7 +15,7 @@ import {
   flowParentAbsoluteOrStatic,
   getReparentTargetUnified,
 } from './reparent-strategy-parent-lookup'
-import { getDragTargets } from '../shared-move-strategies-helpers'
+import { flattenSelection } from '../shared-move-strategies-helpers'
 import { Direction } from '../../../../inspector/common/css-utils'
 
 export type ReparentStrategy = 'REPARENT_AS_ABSOLUTE' | 'REPARENT_AS_STATIC'
@@ -156,7 +156,7 @@ export function reparentSubjectsForInteractionTarget(
       return newReparentSubjects(interactionTarget.subjects[0].defaultSize)
     case 'TARGET_PATHS':
       return existingReparentSubjects(
-        getDragTargets(getTargetPathsFromInteractionTarget(interactionTarget)),
+        flattenSelection(getTargetPathsFromInteractionTarget(interactionTarget)),
       )
     default:
       const _exhaustiveCheck: never = interactionTarget

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -30,7 +30,7 @@ import {
   ReparentTarget,
 } from './reparent-helpers/reparent-strategy-helpers'
 import { getReparentTargetUnified } from './reparent-helpers/reparent-strategy-parent-lookup'
-import { getDragTargets } from './shared-move-strategies-helpers'
+import { flattenSelection } from './shared-move-strategies-helpers'
 
 interface ReparentFactoryAndDetails {
   targetParent: ElementPath
@@ -180,7 +180,7 @@ export const reparentMetaStrategy: MetaCanvasStrategy = (
   interactionSession: InteractionSession | null,
   customStrategyState: CustomStrategyState,
 ) => {
-  const reparentSubjects = getDragTargets(
+  const reparentSubjects = flattenSelection(
     getTargetPathsFromInteractionTarget(canvasState.interactionTarget),
   )
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -46,7 +46,7 @@ import {
   strategyApplicationResult,
 } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
-import { getDragTargets, getMultiselectBounds } from './shared-move-strategies-helpers'
+import { flattenSelection, getMultiselectBounds } from './shared-move-strategies-helpers'
 import {
   canvasPoint,
   CanvasPoint,
@@ -159,7 +159,7 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
         return emptyStrategyApplicationResult
       }
 
-      const filteredSelectedElements = getDragTargets(selectedElements)
+      const filteredSelectedElements = flattenSelection(selectedElements)
       const originalBoundingBox = getMultiselectBounds(
         canvasState.startingMetadata,
         filteredSelectedElements,
@@ -368,7 +368,7 @@ function paddingValueIndicatorProps(
   interactionSession: InteractionSession | null,
   selectedElement: ElementPath,
 ): FloatingIndicatorProps | null {
-  const filteredSelectedElements = getDragTargets([selectedElement])
+  const filteredSelectedElements = flattenSelection([selectedElement])
 
   if (
     interactionSession == null ||

--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
@@ -79,7 +79,7 @@ export const getAdjustMoveCommands =
     commands: Array<AdjustCssLengthProperty>
     intendedBounds: Array<CanvasFrameAndTarget>
   } => {
-    const filteredSelectedElements = getDragTargets(targets)
+    const filteredSelectedElements = flattenSelection(targets)
     let commands: Array<AdjustCssLengthProperty> = []
     let intendedBounds: Array<CanvasFrameAndTarget> = []
     filteredSelectedElements.forEach((selectedElement) => {
@@ -294,14 +294,14 @@ export function getFileOfElement(
   )
 }
 
-export const getDragTargets = memoize(getDragTargetsInner, {
+export const flattenSelection = memoize(flattenSelectionInner, {
   maxSize: 1,
   equals: is,
 })
 
 // No need to include descendants in multiselection when dragging
 // Note: this maybe slow when there are lot of selected views
-function getDragTargetsInner(selectedViews: Array<ElementPath>): Array<ElementPath> {
+function flattenSelectionInner(selectedViews: Array<ElementPath>): Array<ElementPath> {
   const filteredTargets = selectedViews.filter((view) =>
     selectedViews.every((otherView) => !EP.isDescendantOf(view, otherView)),
   )


### PR DESCRIPTION
## Problem
`getDragTargets` has a nondescript name that obscures both its function and its importance.

## Solution
Rename `getDragTargets` to `flattenSelection`