### PR TITLE
UID comment flag

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.spec.browser2.tsx
@@ -6,10 +6,7 @@ import {
   renderTestEditorWithCode,
 } from '../../ui-jsx.test-utils'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
-import {
-  FOR_TESTS_setNextGeneratedUid,
-  FOR_TESTS_setNextGeneratedUids,
-} from '../../../../core/model/element-template-utils.test-utils'
+import { FOR_TESTS_setNextGeneratedUid } from '../../../../core/model/element-template-utils.test-utils'
 import { offsetPoint, windowPoint, WindowPoint } from '../../../../core/shared/math-utils'
 import { altModifier, cmdModifier, Modifiers } from '../../../../utils/modifiers'
 import { mouseClickAtPoint, mouseDragFromPointToPoint } from '../../event-helpers.test-utils'

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.spec.browser2.tsx
@@ -409,9 +409,6 @@ function fragmentTestCode(type: ContentAffectingType) {
       'skip6',
       'inner-fragment',
       'inner-fragment-2',
-      'skip8',
-      'skip10',
-      'children-affecting',
     ])
   } else {
     FOR_TESTS_setNextGeneratedUids([

--- a/editor/src/components/canvas/canvas-strategies/strategies/group-like-helpers.test-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-like-helpers.test-utils.ts
@@ -7,7 +7,7 @@ export function getOpeningGroupLikeTag(type: ContentAffectingType): string {
     case 'fragment':
       return `<React.Fragment data-uid='children-affecting' data-testid='children-affecting'><React.Fragment data-uid='inner-fragment'>`
     case 'conditional':
-      return `{ true ? ( <React.Fragment data-uid='inner-fragment'>`
+      return `{ true /* @utopia/uid=children-affecting */ ? ( <React.Fragment data-uid='inner-fragment'>`
     default:
       const _exhaustiveCheck: never = type
       throw new Error(`Unhandled ContentAffectingType ${JSON.stringify(type)}.`)

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
@@ -1,8 +1,6 @@
 import { createModifiedProject } from '../../../sample-projects/sample-project-utils.test-utils'
 import { navigatorEntryToKey, StoryboardFilePath } from '../../editor/store/editor-state'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
-import * as EP from '../../../core/shared/element-path'
-import { FOR_TESTS_setNextGeneratedUids } from '../../../core/model/element-template-utils.test-utils'
 import { setFeatureForBrowserTests } from '../../../utils/utils.test-utils'
 
 const appFilePath = '/src/app.js'
@@ -21,13 +19,16 @@ export var App = (props) => {
         height: '100%'
       }}
     >
-      {[0, 1].length > 1 ? (
-        [0, 1].length === 2 ? (
-          <div data-uid='div-inside-conditionals' />
-        ) : null
-      ) : (
-        5
-      )}
+      {
+        // @utopia/uid=conditional1
+        [0, 1].length > 1 ? (
+            // @utopia/uid=conditional2
+            [0, 1].length === 2 ? (
+            <div data-uid='div-inside-conditionals' />
+          ) : null
+        ) : (
+          5
+        )}
     </div>
   )
 }
@@ -65,20 +66,6 @@ async function createAndRenderProject() {
 describe('a project with conditionals', () => {
   setFeatureForBrowserTests('Conditional support', true)
   it('fills the content of the navigator', async () => {
-    FOR_TESTS_setNextGeneratedUids([
-      'mock1',
-      'mock2',
-      'mock3',
-      'mock4',
-      'conditional1',
-      'conditional2',
-      'mock1',
-      'mock2',
-      'mock3',
-      'mock4',
-      'conditional1',
-      'conditional2',
-    ])
     const renderedProject = await createAndRenderProject()
     const navigatorTargets = renderedProject.getEditorState().derived.visibleNavigatorTargets
     const pathStrings = navigatorTargets.map(navigatorEntryToKey)

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -97,7 +97,8 @@ describe('conditionals', () => {
       const startSnippet = `
         <div data-uid='aaa'>
         {
-          [].length === 0 /* @utopia/uid=conditional */ ? (
+          // @utopia/uid=conditional
+          [].length === 0 ? (
             <div data-uid='bbb' data-testid='bbb'>foo</div>
           ) : (
             <div data-uid='ccc' data-testid='ccc'>bar</div>

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable jest/expect-expect */
 import { act } from '@testing-library/react'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
-import { FOR_TESTS_setNextGeneratedUids } from '../../core/model/element-template-utils.test-utils'
 import { isRight } from '../../core/shared/either'
 import * as EP from '../../core/shared/element-path'
 import { isJSXConditionalExpression } from '../../core/shared/element-template'
@@ -19,20 +18,10 @@ describe('conditionals', () => {
   after(() => setFeatureEnabled('Conditional support', false))
   describe('deletion', () => {
     it('replaces a branch with null', async () => {
-      FOR_TESTS_setNextGeneratedUids([
-        'skip1',
-        'skip2',
-        'skip3',
-        'skip4',
-        'skip5',
-        'skip6',
-        'skip7',
-        'skip8',
-        'conditional',
-      ])
       const startSnippet = `
         <div data-uid='aaa'>
         {
+          // @utopia/uid=conditional
           true ? (
             <div data-uid='bbb' data-testid='bbb'>foo</div>
           ) : (
@@ -59,6 +48,8 @@ describe('conditionals', () => {
         makeTestProjectCodeWithSnippet(`
             <div data-uid='aaa'>
               {
+                // @utopia/uid=conditional
+                // @utopia/uid=conditional
                 true ? null : (
                   <div data-uid='ccc' data-testid='ccc'>bar</div>
                 )
@@ -68,10 +59,10 @@ describe('conditionals', () => {
       )
     })
     it('replaces a text string branch with null', async () => {
-      FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'skip3', 'skip4', 'conditional'])
       const startSnippet = `
         <div data-uid='aaa'>
         {
+          // @utopia/uid=conditional
           true ? 'hello' : 'there'
         }
         </div>
@@ -94,6 +85,8 @@ describe('conditionals', () => {
         makeTestProjectCodeWithSnippet(`
             <div data-uid='aaa'>
               {
+                // @utopia/uid=conditional
+                // @utopia/uid=conditional
                 true ? null : 'there'
               }
             </div>
@@ -103,21 +96,10 @@ describe('conditionals', () => {
   })
   describe('expressions', () => {
     it('stores the string expression', async () => {
-      FOR_TESTS_setNextGeneratedUids([
-        'skip1',
-        'skip2',
-        'skip3',
-        'skip4',
-        'skip5',
-        'skip6',
-        'skip7',
-        'skip8',
-        'conditional',
-      ])
       const startSnippet = `
         <div data-uid='aaa'>
         {
-          [].length === 0 ? (
+          [].length === 0 /* @utopia/uid=conditional */ ? (
             <div data-uid='bbb' data-testid='bbb'>foo</div>
           ) : (
             <div data-uid='ccc' data-testid='ccc'>bar</div>

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -49,7 +49,6 @@ describe('conditionals', () => {
             <div data-uid='aaa'>
               {
                 // @utopia/uid=conditional
-                // @utopia/uid=conditional
                 true ? null : (
                   <div data-uid='ccc' data-testid='ccc'>bar</div>
                 )
@@ -85,7 +84,6 @@ describe('conditionals', () => {
         makeTestProjectCodeWithSnippet(`
             <div data-uid='aaa'>
               {
-                // @utopia/uid=conditional
                 // @utopia/uid=conditional
                 true ? null : 'there'
               }

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -2457,7 +2457,6 @@ describe('inspector tests with real metadata', () => {
               {
                 // @utopia/uid=conditional1
                 // @utopia/conditional=true
-                // @utopia/uid=conditional1
                 true ? (
                   <div data-uid='bbb' data-testid='bbb'>foo</div>
                 ) : (
@@ -2465,7 +2464,6 @@ describe('inspector tests with real metadata', () => {
                 )
               }
               {
-                // @utopia/uid=conditional2
                 // @utopia/uid=conditional2
                 true ? (
                 <div data-uid='ddd' data-testid='ddd'>baz</div>
@@ -2502,7 +2500,6 @@ describe('inspector tests with real metadata', () => {
             {
               // @utopia/uid=conditional1
               // @utopia/conditional=false
-              // @utopia/uid=conditional1
               true ? (
                   <div data-uid='bbb' data-testid='bbb'>foo</div>
                 ) : (
@@ -2512,7 +2509,6 @@ describe('inspector tests with real metadata', () => {
               {
                 // @utopia/uid=conditional2
                 // @utopia/conditional=false
-                // @utopia/uid=conditional2
                 true ? (
                   <div data-uid='ddd' data-testid='ddd'>baz</div>
                   ) : (
@@ -2542,7 +2538,6 @@ describe('inspector tests with real metadata', () => {
               {
                 // @utopia/uid=conditional1
                 // @utopia/conditional=true
-                // @utopia/uid=conditional1
                 true ? (
                   <div data-uid='bbb' data-testid='bbb'>foo</div>
                 ) : (
@@ -2552,7 +2547,6 @@ describe('inspector tests with real metadata', () => {
               {
                 // @utopia/uid=conditional2
                 // @utopia/conditional=true
-                // @utopia/uid=conditional2
                 true ? (
                 <div data-uid='ddd' data-testid='ddd'>baz</div>
               ) : (
@@ -2580,14 +2574,12 @@ describe('inspector tests with real metadata', () => {
             <div data-uid='aaa'>
               {
                 // @utopia/uid=conditional1
-                // @utopia/uid=conditional1
                 true ? (
                 <div data-uid='bbb' data-testid='bbb'>foo</div>
               ) : (
                 <div data-uid='ccc' data-testid='ccc'>bar</div>
               )}
               {
-                // @utopia/uid=conditional2
                 // @utopia/uid=conditional2
                 true ? (
                 <div data-uid='ddd' data-testid='ddd'>baz</div>

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -2595,7 +2595,8 @@ describe('inspector tests with real metadata', () => {
       const startSnippet = `
       <div data-uid='aaa'>
         {
-          [].length === 0 /* @utopia/uid=conditional */ ? (
+          // @utopia/uid=conditional
+          [].length === 0 ? (
           <div data-uid='bbb' data-testid='bbb'>foo</div>
         ) : (
           <div data-uid='ccc' data-testid='ccc'>bar</div>
@@ -2622,11 +2623,13 @@ describe('inspector tests with real metadata', () => {
     it('allows changing the expression', async () => {
       const startSnippet = `
       <div data-uid='aaa'>
-        {[].length === 0 /* @utopia/uid=conditional */ ? (
-          <div data-uid='bbb' data-testid='bbb'>foo</div>
-        ) : (
-          <div data-uid='ccc' data-testid='ccc'>bar</div>
-        )}
+        {
+          // @utopia/uid=conditional
+          [].length === 0 ? (
+            <div data-uid='bbb' data-testid='bbb'>foo</div>
+          ) : (
+            <div data-uid='ccc' data-testid='ccc'>bar</div>
+          )}
       </div>
       `
       const renderResult = await renderTestEditorWithCode(

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -3,7 +3,6 @@ import { act, fireEvent, RenderResult, screen } from '@testing-library/react'
 import * as Prettier from 'prettier/standalone'
 import { PrettierConfig } from 'utopia-vscode-common'
 import { matchInlineSnapshotBrowser } from '../../../../test/karma-snapshots'
-import { FOR_TESTS_setNextGeneratedUids } from '../../../core/model/element-template-utils.test-utils'
 import { directory } from '../../../core/model/project-file-utils'
 import {
   BakedInStoryboardUID,
@@ -2189,20 +2188,11 @@ describe('inspector tests with real metadata', () => {
     before(() => setFeatureEnabled('Conditional support', true))
     after(() => setFeatureEnabled('Conditional support', false))
     it('toggles conditional branch', async () => {
-      FOR_TESTS_setNextGeneratedUids([
-        'skip1',
-        'skip2',
-        'skip3',
-        'skip4',
-        'skip5',
-        'skip6',
-        'skip7',
-        'skip8',
-        'conditional',
-      ])
       const startSnippet = `
         <div data-uid='aaa'>
-        {[].length === 0 ? (
+        {
+          // @utopia/uid=conditional
+          [].length === 0 ? (
           <div data-uid='bbb' data-testid='bbb'>foo</div>
         ) : (
           <div data-uid='ccc' data-testid='ccc'>bar</div>
@@ -2233,6 +2223,7 @@ describe('inspector tests with real metadata', () => {
           makeTestProjectCodeWithSnippet(`
             <div data-uid='aaa'>
               {
+                // @utopia/uid=conditional
                 // @utopia/conditional=true
                 [].length === 0 ? (
                   <div data-uid='bbb' data-testid='bbb'>foo</div>
@@ -2258,6 +2249,7 @@ describe('inspector tests with real metadata', () => {
           makeTestProjectCodeWithSnippet(`
             <div data-uid='aaa'>
               {
+                // @utopia/uid=conditional
                 // @utopia/conditional=false
                 [].length === 0 ? (
                   <div data-uid='bbb' data-testid='bbb'>foo</div>
@@ -2283,6 +2275,7 @@ describe('inspector tests with real metadata', () => {
           makeTestProjectCodeWithSnippet(`
             <div data-uid='aaa'>
               {
+                // @utopia/uid=conditional
                 // @utopia/conditional=true
                 [].length === 0 ? (
                   <div data-uid='bbb' data-testid='bbb'>foo</div>
@@ -2306,6 +2299,7 @@ describe('inspector tests with real metadata', () => {
           makeTestProjectCodeWithSnippet(`
             <div data-uid='aaa'>
               {
+                // @utopia/uid=conditional
                 [].length === 0 ? (
                   <div data-uid='bbb' data-testid='bbb'>foo</div>
                 ) : (
@@ -2318,20 +2312,11 @@ describe('inspector tests with real metadata', () => {
       }
     })
     it('switches conditional branches', async () => {
-      FOR_TESTS_setNextGeneratedUids([
-        'skip1',
-        'skip2',
-        'skip3',
-        'skip4',
-        'skip5',
-        'skip6',
-        'skip7',
-        'skip8',
-        'conditional',
-      ])
       const startSnippet = `
         <div data-uid='aaa'>
-        {[].length === 0 ? (
+        {
+          // @utopia/uid=conditional
+          [].length === 0 ? (
           <div data-uid='bbb' data-testid='bbb'>foo</div>
         ) : (
           <div data-uid='ccc' data-testid='ccc'>bar</div>
@@ -2359,7 +2344,9 @@ describe('inspector tests with real metadata', () => {
         expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
           makeTestProjectCodeWithSnippet(`
             <div data-uid='aaa'>
-            {[].length === 0 ? (
+            {
+              // @utopia/uid=conditional
+              [].length === 0 ? (
               <div data-uid='ccc' data-testid='ccc'>bar</div>
             ) : (
               <div data-uid='bbb' data-testid='bbb'>foo</div>
@@ -2370,20 +2357,10 @@ describe('inspector tests with real metadata', () => {
       }
     })
     it('rearranges comments so that the conditional flag is at the top', async () => {
-      FOR_TESTS_setNextGeneratedUids([
-        'skip1',
-        'skip2',
-        'skip3',
-        'skip4',
-        'skip5',
-        'skip6',
-        'skip7',
-        'skip8',
-        'conditional',
-      ])
       const startSnippet = `
         <div data-uid='aaa'>
         {
+          // @utopia/uid=conditional
           // hello
           [].length === 0 /*inside*/ ? (
           <div data-uid='bbb' data-testid='bbb'>foo</div>
@@ -2417,6 +2394,7 @@ describe('inspector tests with real metadata', () => {
         makeTestProjectCodeWithSnippet(`
             <div data-uid='aaa'>
               {
+                // @utopia/uid=conditional
                 // hello
                 // @utopia/conditional=false
                 [].length === 0 /*inside*/ ? (
@@ -2431,33 +2409,18 @@ describe('inspector tests with real metadata', () => {
       )
     })
     it('toggles multiple conditional branches', async () => {
-      FOR_TESTS_setNextGeneratedUids([
-        'skip1',
-        'skip2',
-        'skip3',
-        'skip4',
-        'skip5',
-        'skip6',
-        'skip7',
-        'skip8',
-        'skip9',
-        'skip10',
-        'skip11',
-        'skip12',
-        'skip13',
-        'skip14',
-        'skip15',
-        'conditional1',
-        'conditional2',
-      ])
       const startSnippet = `
         <div data-uid='aaa'>
-          {true ? (
+          {
+            // @utopia/uid=conditional1
+            true ? (
             <div data-uid='bbb' data-testid='bbb'>foo</div>
           ) : (
             <div data-uid='ccc' data-testid='ccc'>bar</div>
           )}
-          {true ? (
+          {
+            // @utopia/uid=conditional2
+            true ? (
             <div data-uid='ddd' data-testid='ddd'>baz</div>
           ) : (
             <div data-uid='eee' data-testid='eee'>qux</div>
@@ -2492,14 +2455,19 @@ describe('inspector tests with real metadata', () => {
           makeTestProjectCodeWithSnippet(`
             <div data-uid='aaa'>
               {
+                // @utopia/uid=conditional1
                 // @utopia/conditional=true
+                // @utopia/uid=conditional1
                 true ? (
                   <div data-uid='bbb' data-testid='bbb'>foo</div>
                 ) : (
                   <div data-uid='ccc' data-testid='ccc'>bar</div>
                 )
               }
-              {true ? (
+              {
+                // @utopia/uid=conditional2
+                // @utopia/uid=conditional2
+                true ? (
                 <div data-uid='ddd' data-testid='ddd'>baz</div>
               ) : (
                 <div data-uid='eee' data-testid='eee'>qux</div>
@@ -2532,7 +2500,9 @@ describe('inspector tests with real metadata', () => {
           makeTestProjectCodeWithSnippet(`
             <div data-uid='aaa'>
             {
+              // @utopia/uid=conditional1
               // @utopia/conditional=false
+              // @utopia/uid=conditional1
               true ? (
                   <div data-uid='bbb' data-testid='bbb'>foo</div>
                 ) : (
@@ -2540,7 +2510,9 @@ describe('inspector tests with real metadata', () => {
                 )
               }
               {
+                // @utopia/uid=conditional2
                 // @utopia/conditional=false
+                // @utopia/uid=conditional2
                 true ? (
                   <div data-uid='ddd' data-testid='ddd'>baz</div>
                   ) : (
@@ -2568,7 +2540,9 @@ describe('inspector tests with real metadata', () => {
           makeTestProjectCodeWithSnippet(`
             <div data-uid='aaa'>
               {
+                // @utopia/uid=conditional1
                 // @utopia/conditional=true
+                // @utopia/uid=conditional1
                 true ? (
                   <div data-uid='bbb' data-testid='bbb'>foo</div>
                 ) : (
@@ -2576,7 +2550,9 @@ describe('inspector tests with real metadata', () => {
                 )
               }
               {
+                // @utopia/uid=conditional2
                 // @utopia/conditional=true
+                // @utopia/uid=conditional2
                 true ? (
                 <div data-uid='ddd' data-testid='ddd'>baz</div>
               ) : (
@@ -2602,12 +2578,18 @@ describe('inspector tests with real metadata', () => {
         expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
           makeTestProjectCodeWithSnippet(`
             <div data-uid='aaa'>
-              {true ? (
+              {
+                // @utopia/uid=conditional1
+                // @utopia/uid=conditional1
+                true ? (
                 <div data-uid='bbb' data-testid='bbb'>foo</div>
               ) : (
                 <div data-uid='ccc' data-testid='ccc'>bar</div>
               )}
-              {true ? (
+              {
+                // @utopia/uid=conditional2
+                // @utopia/uid=conditional2
+                true ? (
                 <div data-uid='ddd' data-testid='ddd'>baz</div>
               ) : (
                 <div data-uid='eee' data-testid='eee'>qux</div>
@@ -2618,20 +2600,10 @@ describe('inspector tests with real metadata', () => {
       }
     })
     it('displays the condition', async () => {
-      FOR_TESTS_setNextGeneratedUids([
-        'skip1',
-        'skip2',
-        'skip3',
-        'skip4',
-        'skip5',
-        'skip6',
-        'skip7',
-        'skip8',
-        'conditional',
-      ])
       const startSnippet = `
       <div data-uid='aaa'>
-        {[].length === 0 ? (
+        {
+          [].length === 0 /* @utopia/uid=conditional */ ? (
           <div data-uid='bbb' data-testid='bbb'>foo</div>
         ) : (
           <div data-uid='ccc' data-testid='ccc'>bar</div>
@@ -2656,20 +2628,9 @@ describe('inspector tests with real metadata', () => {
       expect((expressionElement as HTMLInputElement).value).toEqual('[].length === 0')
     })
     it('allows changing the expression', async () => {
-      FOR_TESTS_setNextGeneratedUids([
-        'skip1',
-        'skip2',
-        'skip3',
-        'skip4',
-        'skip5',
-        'skip6',
-        'skip7',
-        'skip8',
-        'conditional',
-      ])
       const startSnippet = `
       <div data-uid='aaa'>
-        {[].length === 0 ? (
+        {[].length === 0 /* @utopia/uid=conditional */ ? (
           <div data-uid='bbb' data-testid='bbb'>foo</div>
         ) : (
           <div data-uid='ccc' data-testid='ccc'>bar</div>

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -75,7 +75,7 @@ const conditionOverrideSelector = createCachedSelector(
     elements.forEach((element) => {
       const flag = findUtopiaCommentFlag(element.comments, 'conditional')
       if (isUtopiaCommentFlagConditional(flag)) {
-        conditions.add(flag?.value ?? null)
+        conditions.add(flag.value)
       }
     })
 

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -4,7 +4,10 @@ import createCachedSelector from 're-reselect'
 import React from 'react'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../../core/shared/array-utils'
-import { findUtopiaCommentFlag } from '../../../../core/shared/comment-flags'
+import {
+  findUtopiaCommentFlag,
+  isUtopiaCommentFlagConditional,
+} from '../../../../core/shared/comment-flags'
 import { isLeft } from '../../../../core/shared/either'
 import * as EP from '../../../../core/shared/element-path'
 import {
@@ -71,7 +74,9 @@ const conditionOverrideSelector = createCachedSelector(
     let conditions = new Set<boolean | null>()
     elements.forEach((element) => {
       const flag = findUtopiaCommentFlag(element.comments, 'conditional')
-      conditions.add(flag?.value ?? null)
+      if (isUtopiaCommentFlagConditional(flag)) {
+        conditions.add(flag?.value ?? null)
+      }
     })
 
     switch (conditions.size) {

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -20,7 +20,6 @@ import {
   varSafeNavigatorEntryToKey,
 } from '../editor/store/editor-state'
 import { getDomRectCenter } from '../../core/shared/dom-utils'
-import { FOR_TESTS_setNextGeneratedUids } from '../../core/model/element-template-utils.test-utils'
 import { setFeatureForBrowserTests } from '../../utils/utils.test-utils'
 import { navigatorDepth } from './navigator-utils'
 import { compose3Optics, Optic } from '../../core/shared/optics/optics'
@@ -136,33 +135,36 @@ export var ${BakedInStoryboardVariableName} = (
         data-uid='containing-div'
         data-testid='containing-div'
       >
-        {[].length === 0 ? (
+        {
+          // @utopia/uid=conditional1
           [].length === 0 ? (
+            // @utopia/uid=conditional2
+            [].length === 0 ? (
+              <div
+                style={{
+                  height: 150,
+                  width: 150,
+                  position: 'absolute',
+                  left: 154,
+                  top: 134,
+                  backgroundColor: 'lightblue',
+                }}
+                data-uid='then-then-div'
+                data-testid='then-then-div'
+              />
+            ) : null
+          ) : (
             <div
               style={{
                 height: 150,
-                width: 150,
                 position: 'absolute',
                 left: 154,
                 top: 134,
-                backgroundColor: 'lightblue',
               }}
-              data-uid='then-then-div'
-              data-testid='then-then-div'
+              data-uid='else-div'
+              data-testid='else-div'
             />
-          ) : null
-        ) : (
-          <div
-            style={{
-              height: 150,
-              position: 'absolute',
-              left: 154,
-              top: 134,
-            }}
-            data-uid='else-div'
-            data-testid='else-div'
-          />
-        )}
+          )}
         <div
           style={{
             height: 150,
@@ -209,20 +211,24 @@ export var ${BakedInStoryboardVariableName} = (
         data-uid='containing-div'
         data-testid='containing-div'
       >
-        {[].length === 0 ? (
-          [].length === 0 ? null : null
-        ) : (
-          <div
-            style={{
-              height: 150,
-              position: 'absolute',
-              left: 154,
-              top: 134,
-            }}
-            data-uid='else-div'
-            data-testid='else-div'
-          />
-        )}
+        {
+          // @utopia/uid=conditional1
+          [].length === 0 ? (
+            // @utopia/uid=conditional2
+            [].length === 0 ? null : null
+          ) : (
+            <div
+              style={{
+                height: 150,
+                position: 'absolute',
+                left: 154,
+                top: 134,
+              }}
+              data-uid='else-div'
+              data-testid='else-div'
+            />
+          )
+        }
         <div
           style={{
             height: 150,
@@ -262,19 +268,6 @@ describe('conditionals in the navigator', () => {
     // TODO: Fill this out.
   })
   it('dragging into an empty active clause, takes the place of the empty value', async () => {
-    FOR_TESTS_setNextGeneratedUids([
-      'skip1',
-      'skip2',
-      'skip3',
-      'skip4',
-      'skip5',
-      'skip6',
-      'skip7',
-      'skip8',
-      'skip9',
-      'conditional1',
-      'conditional2',
-    ])
     const renderResult = await renderTestEditorWithCode(
       getProjectCodeEmptyActive(),
       'await-first-dom-report',
@@ -369,23 +362,6 @@ describe('conditionals in the navigator', () => {
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div`)
   })
   it('dragging into an empty inactive clause, takes the place of the empty value', async () => {
-    FOR_TESTS_setNextGeneratedUids([
-      'skip1',
-      'skip2',
-      'skip3',
-      'skip4',
-      'skip5',
-      'skip6',
-      'skip7',
-      'skip8',
-      'skip9',
-      'skip10',
-      'skip11',
-      'skip12',
-      'skip13',
-      'conditional1',
-      'conditional2',
-    ])
     const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
 
     expect(
@@ -476,25 +452,7 @@ describe('conditionals in the navigator', () => {
         conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-else
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div`)
   })
-
   it('dragging out of an inactive clause, replaces with null', async () => {
-    FOR_TESTS_setNextGeneratedUids([
-      'skip1',
-      'skip2',
-      'skip3',
-      'skip4',
-      'skip5',
-      'skip6',
-      'skip7',
-      'skip8',
-      'skip9',
-      'skip10',
-      'skip11',
-      'skip12',
-      'skip13',
-      'conditional1',
-      'conditional2',
-    ])
     const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
 
     expect(
@@ -596,25 +554,7 @@ describe('conditionals in the navigator', () => {
       regular-utopia-storyboard-uid/scene-aaa/containing-div/else-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
   })
-
   it('dragging out of an active clause, replaces with null', async () => {
-    FOR_TESTS_setNextGeneratedUids([
-      'skip1',
-      'skip2',
-      'skip3',
-      'skip4',
-      'skip5',
-      'skip6',
-      'skip7',
-      'skip8',
-      'skip9',
-      'skip10',
-      'skip11',
-      'skip12',
-      'skip13',
-      'conditional1',
-      'conditional2',
-    ])
     const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
 
     expect(
@@ -703,7 +643,6 @@ describe('conditionals in the navigator', () => {
       regular-utopia-storyboard-uid/scene-aaa/containing-div/then-then-div
       regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
   })
-
   xit('dragging into child of an active clause, works as it would without the conditional', () => {
     // TODO: Fill this out.
   })

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -30,6 +30,7 @@ import {
   conditionalWhenFalseOptic,
   jsxConditionalExpressionOptic,
 } from '../../core/model/conditionals'
+import { FOR_TESTS_setNextGeneratedUids } from '../../core/model/element-template-utils.test-utils'
 
 function dragElement(
   renderResult: EditorRenderResult,
@@ -211,23 +212,26 @@ export var ${BakedInStoryboardVariableName} = (
         data-uid='containing-div'
         data-testid='containing-div'
       >
-        {[].length === 0 ? (
+        {
+          // @utopia/uid=conditional1
           [].length === 0 ? (
-            <>
-              <div
-                style={{
-                  height: 150,
-                  width: 150,
-                  position: 'absolute',
-                  left: 154,
-                  top: 134,
-                  backgroundColor: 'lightblue',
-                }}
-                data-uid='then-then-div'
-                data-testid='then-then-div'
-              />
-            </>
-          ) : null
+            // @utopia/uid=conditional2
+            [].length === 0 ? (
+              <>
+                <div
+                  style={{
+                    height: 150,
+                    width: 150,
+                    position: 'absolute',
+                    left: 154,
+                    top: 134,
+                    backgroundColor: 'lightblue',
+                  }}
+                  data-uid='then-then-div'
+                  data-testid='then-then-div'
+                />
+              </>
+            ) : null
         ) : (
           <div
             style={{
@@ -286,21 +290,24 @@ export var ${BakedInStoryboardVariableName} = (
         data-uid='containing-div'
         data-testid='containing-div'
       >
-        {[].length === 0 ? (
+        {
+          // @utopia/uid=conditional1
           [].length === 0 ? (
-            <div
-              style={{
-                height: 150,
-                width: 150,
-                position: 'absolute',
-                left: 154,
-                top: 134,
-                backgroundColor: 'lightblue',
-              }}
-              data-uid='then-then-div'
-              data-testid='then-then-div'
-            />
-          ) : null
+            // @utopia/uid=conditional2
+            [].length === 0 ? (
+              <div
+                style={{
+                  height: 150,
+                  width: 150,
+                  position: 'absolute',
+                  left: 154,
+                  top: 134,
+                  backgroundColor: 'lightblue',
+                }}
+                data-uid='then-then-div'
+                data-testid='then-then-div'
+              />
+            ) : null
         ) : (
           <>
             <div
@@ -423,14 +430,6 @@ describe('conditionals in the navigator', () => {
       'skip5',
       'skip6',
       'skip7',
-      'skip8',
-      'skip9',
-      'skip10',
-      'skip11',
-      'skip12',
-      'skip13',
-      'conditional1',
-      'conditional2',
       'fragment',
     ])
     const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
@@ -527,25 +526,7 @@ describe('conditionals in the navigator', () => {
   })
 
   it('dragging into a non-empty active clause with a fragment wrapper, inserts into a wrapper', async () => {
-    FOR_TESTS_setNextGeneratedUids([
-      'skip1',
-      'skip2',
-      'skip3',
-      'skip4',
-      'skip5',
-      'skip6',
-      'skip7',
-      'skip8',
-      'skip9',
-      'fragment',
-      'skip10',
-      'skip11',
-      'skip12',
-      'skip13',
-      'skip14',
-      'conditional1',
-      'conditional2',
-    ])
+    FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'skip3', 'skip4', 'skip5', 'fragment'])
     const renderResult = await renderTestEditorWithCode(
       getProjectCodeWithExistingFragment(),
       'await-first-dom-report',
@@ -652,16 +633,8 @@ describe('conditionals in the navigator', () => {
       'skip3',
       'skip4',
       'skip5',
-      'skip6',
       'skip7',
       'skip8',
-      'skip9',
-      'skip10',
-      'skip11',
-      'skip12',
-      'skip13',
-      'conditional1',
-      'conditional2',
       'fragment',
     ])
     const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
@@ -764,16 +737,7 @@ describe('conditionals in the navigator', () => {
       'skip5',
       'skip6',
       'skip7',
-      'skip8',
-      'skip9',
-      'skip10',
-      'skip11',
-      'skip12',
       'fragment',
-      'skip13',
-      'skip14',
-      'conditional1',
-      'conditional2',
     ])
     const renderResult = await renderTestEditorWithCode(
       getProjectCodeWithExistingInactiveFragment(),

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -702,7 +702,7 @@ function getConditionalFlag(element: JSXConditionalExpression) {
   if (!isUtopiaCommentFlagConditional(flag)) {
     return null
   }
-  return flag?.value ?? null
+  return flag.value
 }
 
 function matchesOverriddenBranch(

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -34,7 +34,10 @@ import {
   isJSXConditionalExpression,
   JSXConditionalExpression,
 } from '../../../core/shared/element-template'
-import { findUtopiaCommentFlag } from '../../../core/shared/comment-flags'
+import {
+  findUtopiaCommentFlag,
+  isUtopiaCommentFlagConditional,
+} from '../../../core/shared/comment-flags'
 import { getConditionalClausePath, ConditionalCase } from '../../../core/model/conditionals'
 import { DerivedSubstate, MetadataSubstate } from '../../editor/store/store-hook-substore-types'
 import { navigatorDepth } from '../navigator-utils'
@@ -695,7 +698,11 @@ function asConditional(element: ElementInstanceMetadata | null): JSXConditionalE
 }
 
 function getConditionalFlag(element: JSXConditionalExpression) {
-  return findUtopiaCommentFlag(element.comments, 'conditional')?.value ?? null
+  const flag = findUtopiaCommentFlag(element.comments, 'conditional')
+  if (!isUtopiaCommentFlagConditional(flag)) {
+    return null
+  }
+  return flag?.value ?? null
 }
 
 function matchesOverriddenBranch(

--- a/editor/src/core/model/element-metadata.spec.browser2.tsx
+++ b/editor/src/core/model/element-metadata.spec.browser2.tsx
@@ -72,8 +72,6 @@ describe('Frame calculation for fragments', () => {
     )
   })
   it('Conditionals have metadata and their frame is the frame of the active branch', async () => {
-    FOR_TESTS_setNextGeneratedUids(['foo1', 'foo2', 'foo3', 'foo4', 'foo5', 'foo6', 'cond']) // ugly, but the conditional is the 5th uid which is generated
-
     const condComponentPath = 'story/scene/app:root/cond'
     const trueBranchComponentPath = 'story/scene/app:root/cond/truebranch'
 
@@ -268,7 +266,9 @@ export var App = (props) => {
       }}
       data-uid='root'
     >
-      {[].length === 0 ? (
+      {
+        // @utopia/uid=cond
+        [].length === 0 ? (
         <div
           style={{
             left: 33,

--- a/editor/src/core/model/element-template-utils.spec.tsx
+++ b/editor/src/core/model/element-template-utils.spec.tsx
@@ -923,13 +923,12 @@ describe('findJSXElementChildAtPath', () => {
   })
 
   it('conditional expressions', () => {
-    FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'skip3', 'skip4', 'skip5', 'conditional-1'])
     const projectFile = getParseSuccessForStoryboardCode(
       makeTestProjectCodeWithSnippet(`
         <div style={{ ...props.style }} data-uid='aaa'>
           <div data-uid='parent' >
             <div data-uid='child-d' />
-            {true ? 
+            {true /* @utopia/uid=conditional-1 */ ? 
               (
                 <div data-uid='ternary-true-root'>
                   <div data-uid='ternary-true-child' />
@@ -974,13 +973,12 @@ describe('findJSXElementChildAtPath', () => {
   })
 
   it('conditional expressions with branches that are JSXAttribute', () => {
-    FOR_TESTS_setNextGeneratedUids(['skip1', 'conditional-1'])
     const projectFile = getParseSuccessForStoryboardCode(
       makeTestProjectCodeWithSnippet(`
         <div style={{ ...props.style }} data-uid='aaa'>
           <div data-uid='parent' >
             <div data-uid='child-d' />
-            {true ? 
+            {true /* @utopia/uid=conditional-1 */? 
               (
                 "hello"
               ) : (
@@ -1007,13 +1005,12 @@ describe('findJSXElementChildAtPath', () => {
   })
 
   it('conditional expressions with branches that are mixed JSXAttribute and JSXElementChild', () => {
-    FOR_TESTS_setNextGeneratedUids(['skip1', 'skip2', 'skip3', 'conditional-1'])
     const projectFile = getParseSuccessForStoryboardCode(
       makeTestProjectCodeWithSnippet(`
         <div style={{ ...props.style }} data-uid='aaa'>
           <div data-uid='parent' >
             <div data-uid='child-d' />
-            {true ? 
+            {true /* @utopia/uid=conditional-1 */ ? 
               (
                 "hello"
               ) : (

--- a/editor/src/core/model/element-template-utils.spec.tsx
+++ b/editor/src/core/model/element-template-utils.spec.tsx
@@ -928,7 +928,9 @@ describe('findJSXElementChildAtPath', () => {
         <div style={{ ...props.style }} data-uid='aaa'>
           <div data-uid='parent' >
             <div data-uid='child-d' />
-            {true /* @utopia/uid=conditional-1 */ ? 
+            {
+              // @utopia/uid=conditional-1
+              true ? 
               (
                 <div data-uid='ternary-true-root'>
                   <div data-uid='ternary-true-child' />
@@ -977,7 +979,9 @@ describe('findJSXElementChildAtPath', () => {
         <div style={{ ...props.style }} data-uid='aaa'>
           <div data-uid='parent' >
             <div data-uid='child-d' />
-            {true /* @utopia/uid=conditional-1 */? 
+            {
+              // @utopia/uid=conditional-1
+              true ? 
               (
                 "hello"
               ) : (
@@ -1009,7 +1013,9 @@ describe('findJSXElementChildAtPath', () => {
         <div style={{ ...props.style }} data-uid='aaa'>
           <div data-uid='parent' >
             <div data-uid='child-d' />
-            {true /* @utopia/uid=conditional-1 */ ? 
+            {
+              // @utopia/uid=conditional-1
+              true ? 
               (
                 "hello"
               ) : (

--- a/editor/src/core/model/element-template-utils.test-utils.ts
+++ b/editor/src/core/model/element-template-utils.test-utils.ts
@@ -1,4 +1,8 @@
-import { MOCK_NEXT_GENERATED_UIDS, MOCK_NEXT_GENERATED_UIDS_IDX } from '../shared/uid-utils'
+import {
+  COMMENT_FLAG_UIDS,
+  MOCK_NEXT_GENERATED_UIDS,
+  MOCK_NEXT_GENERATED_UIDS_IDX,
+} from '../shared/uid-utils'
 
 export function FOR_TESTS_setNextGeneratedUid(nextUid: string): void {
   MOCK_NEXT_GENERATED_UIDS.current = [nextUid]
@@ -13,6 +17,7 @@ export function FOR_TESTS_setNextGeneratedUids(uids: Array<string>): void {
 export function FOR_TESTS_CLEAR_MOCK_NEXT_GENERATED_UIDS(): void {
   MOCK_NEXT_GENERATED_UIDS.current = []
   MOCK_NEXT_GENERATED_UIDS_IDX.current = 0
+  COMMENT_FLAG_UIDS.current.clear()
 }
 
 // automatic cleanup after tests

--- a/editor/src/core/model/element-template-utils.test-utils.ts
+++ b/editor/src/core/model/element-template-utils.test-utils.ts
@@ -1,8 +1,4 @@
-import {
-  COMMENT_FLAG_UIDS,
-  MOCK_NEXT_GENERATED_UIDS,
-  MOCK_NEXT_GENERATED_UIDS_IDX,
-} from '../shared/uid-utils'
+import { MOCK_NEXT_GENERATED_UIDS, MOCK_NEXT_GENERATED_UIDS_IDX } from '../shared/uid-utils'
 
 export function FOR_TESTS_setNextGeneratedUid(nextUid: string): void {
   MOCK_NEXT_GENERATED_UIDS.current = [nextUid]
@@ -17,7 +13,6 @@ export function FOR_TESTS_setNextGeneratedUids(uids: Array<string>): void {
 export function FOR_TESTS_CLEAR_MOCK_NEXT_GENERATED_UIDS(): void {
   MOCK_NEXT_GENERATED_UIDS.current = []
   MOCK_NEXT_GENERATED_UIDS_IDX.current = 0
-  COMMENT_FLAG_UIDS.current.clear()
 }
 
 // automatic cleanup after tests

--- a/editor/src/core/shared/comment-flags.ts
+++ b/editor/src/core/shared/comment-flags.ts
@@ -1,23 +1,37 @@
 import { mapDropNulls } from './array-utils'
-import { Comment, ParsedComments, singleLineComment } from './element-template'
+import { Comment, emptyComments, ParsedComments, singleLineComment } from './element-template'
+import { assertNever } from './utils'
 
 const UtopiaCommentFlagPrefix = '@utopia/'
 
 export type UtopiaCommentFlagTypeConditional = 'conditional'
+
+export type UtopiaCommentFlagTypeUid = 'uid'
 
 export type UtopiaCommentFlagConditional = {
   type: UtopiaCommentFlagTypeConditional
   value: boolean | null
 }
 
-export type UtopiaCommentFlagType = UtopiaCommentFlagTypeConditional
+export type UtopiaCommentFlagUid = {
+  type: UtopiaCommentFlagTypeUid
+  value: string
+}
 
-export type UtopiaCommentFlag = UtopiaCommentFlagConditional
+export type UtopiaCommentFlagType = UtopiaCommentFlagTypeConditional | UtopiaCommentFlagTypeUid
+
+export type UtopiaCommentFlag = UtopiaCommentFlagConditional | UtopiaCommentFlagUid
 
 export function isUtopiaCommentFlagConditional(
   flag: UtopiaCommentFlag | null,
 ): flag is UtopiaCommentFlagConditional {
   return flag?.type === 'conditional'
+}
+
+export function isUtopiaCommentFlagUid(
+  flag: UtopiaCommentFlag | null,
+): flag is UtopiaCommentFlagUid {
+  return flag?.type === 'uid'
 }
 
 function utopiaCommentFlagKey(type: UtopiaCommentFlagType): string {
@@ -59,6 +73,13 @@ function getUtopiaCommentFlag(c: Comment, type: UtopiaCommentFlagType): UtopiaCo
           type: 'conditional',
           value: parseBooleanOrNull(value),
         }
+      case 'uid':
+        return {
+          type: 'uid',
+          value,
+        }
+      default:
+        assertNever(type)
     }
   }
   return null
@@ -72,5 +93,36 @@ export function findUtopiaCommentFlag(
     (c) => getUtopiaCommentFlag(c, key),
     [...comments.leadingComments, ...comments.trailingComments],
   )
+  return commentConds.length > 0 ? commentConds[0] : null
+}
+
+function allComments(comments: ParsedComments | null): Comment[] {
+  if (comments == null) {
+    return []
+  }
+  return [
+    ...comments.leadingComments,
+    ...comments.trailingComments,
+    ...allComments(comments.questionTokenComments ?? null),
+  ]
+}
+
+export function mergeComments(comments: ParsedComments[]): ParsedComments {
+  if (comments.length === 0) {
+    return emptyComments
+  }
+  const leadingComments = comments.flatMap((c) => c.leadingComments)
+  const trailingComments = comments.flatMap((c) => c.trailingComments)
+  const questionTokenComments = mergeComments(
+    comments.flatMap((c) => c.questionTokenComments ?? []),
+  )
+  return { leadingComments, trailingComments, questionTokenComments }
+}
+
+export function deepFindUtopiaCommentFlag(
+  comments: ParsedComments | null,
+  key: UtopiaCommentFlagType,
+): UtopiaCommentFlag | null {
+  const commentConds = mapDropNulls((c) => getUtopiaCommentFlag(c, key), allComments(comments))
   return commentConds.length > 0 ? commentConds[0] : null
 }

--- a/editor/src/core/shared/comment-flags.ts
+++ b/editor/src/core/shared/comment-flags.ts
@@ -96,7 +96,7 @@ export function findUtopiaCommentFlag(
   return commentConds.length > 0 ? commentConds[0] : null
 }
 
-function allComments(comments: ParsedComments | null): Comment[] {
+export function allComments(comments: ParsedComments | null): Comment[] {
   if (comments == null) {
     return []
   }

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1099,10 +1099,10 @@ function fixJSXConditionalExpressionCondition(
     ...condition,
     comments: {
       ...fixBaseComments(condition.comments, flatComments),
-      questionTokenComments: fixBaseComments(
-        condition.comments.questionTokenComments ?? emptyComments,
-        flatComments,
-      ),
+      questionTokenComments:
+        condition.comments.questionTokenComments != null
+          ? fixBaseComments(condition.comments.questionTokenComments, flatComments)
+          : undefined,
     },
   }
 }

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -28,6 +28,7 @@ import { intrinsicHTMLElementNamesAsStrings } from './dom-utils'
 import type { MapLike } from 'typescript'
 import { forceNotNull } from './optional-utils'
 import type { FlexAlignment, FlexJustifyContent } from '../../components/inspector/inspector-common'
+import { allComments } from './comment-flags'
 
 export interface ParsedComments {
   leadingComments: Array<Comment>
@@ -111,6 +112,10 @@ export function isSingleLineComment(comment: Comment): comment is SingleLineComm
 
 export interface WithComments {
   comments: ParsedComments
+}
+
+export function isWithComments(e: unknown): e is WithComments {
+  return (e as WithComments).comments != null
 }
 
 export interface JSXAttributeValue<T> extends WithComments {
@@ -1065,6 +1070,43 @@ export interface JSXConditionalExpression extends WithComments {
   whenFalse: ChildOrAttribute
 }
 
+function fixBaseComments(comments: ParsedComments, parentComments: Comment[]): ParsedComments {
+  function commentIsNotIncluded(comment: Comment) {
+    return !parentComments.some(
+      (other) =>
+        other.comment === comment.comment &&
+        other.rawText === comment.rawText &&
+        other.pos === comment.pos,
+    )
+  }
+  return {
+    leadingComments: comments.leadingComments.filter(commentIsNotIncluded),
+    trailingComments: comments.trailingComments.filter(commentIsNotIncluded),
+  }
+}
+
+function fixJSXConditionalExpressionCondition(
+  condition: JSXAttribute,
+  comments: ParsedComments,
+): JSXAttribute {
+  if (!isWithComments(condition)) {
+    return condition
+  }
+
+  const flatComments = allComments(comments)
+
+  return {
+    ...condition,
+    comments: {
+      ...fixBaseComments(condition.comments, flatComments),
+      questionTokenComments: fixBaseComments(
+        condition.comments.questionTokenComments ?? emptyComments,
+        flatComments,
+      ),
+    },
+  }
+}
+
 export function jsxConditionalExpression(
   uid: string,
   condition: JSXAttribute,
@@ -1077,7 +1119,7 @@ export function jsxConditionalExpression(
     type: 'JSX_CONDITIONAL_EXPRESSION',
     uid: uid,
     originalConditionString: originalConditionString,
-    condition: condition,
+    condition: fixJSXConditionalExpressionCondition(condition, comments), // remove any duplicate comments shared with the element
     whenTrue: whenTrue,
     whenFalse: whenFalse,
     comments: comments,

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -44,7 +44,6 @@ import * as PP from './property-path'
 
 export const MOCK_NEXT_GENERATED_UIDS: { current: Array<string> } = { current: [] }
 export const MOCK_NEXT_GENERATED_UIDS_IDX = { current: 0 }
-export const COMMENT_FLAG_UIDS: { current: Set<string> } = { current: new Set<string>() }
 
 export function generateMockNextGeneratedUID(): string | null {
   if (
@@ -95,10 +94,6 @@ export function generateConsistentUID(
   existingIDs: Set<string>,
   possibleStartingValue: string,
 ): string {
-  if (COMMENT_FLAG_UIDS.current.has(possibleStartingValue)) {
-    return possibleStartingValue
-  }
-
   const mockUID = generateMockNextGeneratedUID()
   if (mockUID == null) {
     if (possibleStartingValue.length >= 3) {
@@ -199,7 +194,6 @@ export function parseUID(
   const commentFlag = deepFindUtopiaCommentFlag(comments ?? null, 'uid')
   if (commentFlag != null && isUtopiaCommentFlagUid(commentFlag)) {
     const { value } = commentFlag
-    COMMENT_FLAG_UIDS.current.add(value)
     return right(value)
   }
 
@@ -274,7 +268,7 @@ export function fixUtopiaElement(
   function fixJSXConditionalExpression(
     conditional: JSXConditionalExpression,
   ): JSXConditionalExpression {
-    const fixedUID = uniqueIDs.concat(conditional.uid).includes(conditional.uid)
+    const fixedUID = uniqueIDs.includes(conditional.uid)
       ? generateConsistentUID(new Set(uniqueIDs), conditional.uid)
       : conditional.uid
     uniqueIDs.push(fixedUID)

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -94,14 +94,7 @@ const atoz = [
 export function generateConsistentUID(
   existingIDs: Set<string>,
   possibleStartingValue: string,
-  comments: ParsedComments = emptyComments,
 ): string {
-  const commentFlag = deepFindUtopiaCommentFlag(comments ?? null, 'uid')
-  if (commentFlag != null && isUtopiaCommentFlagUid(commentFlag)) {
-    const { value } = commentFlag
-    COMMENT_FLAG_UIDS.current.add(value)
-    return value
-  }
   if (COMMENT_FLAG_UIDS.current.has(possibleStartingValue)) {
     return possibleStartingValue
   }
@@ -199,7 +192,17 @@ export function setUtopiaIDOnJSXElement(element: JSXElementChild, uid: string): 
   }
 }
 
-export function parseUID(attributes: JSXAttributes): Either<string, string> {
+export function parseUID(
+  attributes: JSXAttributes,
+  comments: ParsedComments,
+): Either<string, string> {
+  const commentFlag = deepFindUtopiaCommentFlag(comments ?? null, 'uid')
+  if (commentFlag != null && isUtopiaCommentFlagUid(commentFlag)) {
+    const { value } = commentFlag
+    COMMENT_FLAG_UIDS.current.add(value)
+    return right(value)
+  }
+
   const uidAttribute = getModifiableJSXAttributeAtPath(attributes, UtopiaIDPropertyPath)
   const uidValue = flatMapEither(jsxSimpleAttributeToValue, uidAttribute)
   return flatMapEither((uid) => {

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -682,6 +682,10 @@ Object {
       "rootElement": Object {
         "comments": Object {
           "leadingComments": Array [],
+          "questionTokenComments": Object {
+            "leadingComments": Array [],
+            "trailingComments": Array [],
+          },
           "trailingComments": Array [],
         },
         "condition": Object {
@@ -874,6 +878,10 @@ const b = (n) => n > 0 ? n : a(10)
       "rootElement": Object {
         "comments": Object {
           "leadingComments": Array [],
+          "questionTokenComments": Object {
+            "leadingComments": Array [],
+            "trailingComments": Array [],
+          },
           "trailingComments": Array [],
         },
         "condition": Object {

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -588,26 +588,26 @@ Object {
     },
   ],
   "highlightBounds": Object {
-    "7dd": Object {
-      "endCol": 34,
-      "endLine": 4,
-      "startCol": 17,
-      "startLine": 4,
-      "uid": "7dd",
-    },
-    "aa0": Object {
-      "endCol": 34,
-      "endLine": 6,
-      "startCol": 17,
-      "startLine": 6,
-      "uid": "aa0",
-    },
     "aaa": Object {
       "endCol": 56,
       "endLine": 5,
       "startCol": 33,
       "startLine": 5,
       "uid": "aaa",
+    },
+    "abc": Object {
+      "endCol": 34,
+      "endLine": 6,
+      "startCol": 17,
+      "startLine": 6,
+      "uid": "abc",
+    },
+    "f82": Object {
+      "endCol": 34,
+      "endLine": 4,
+      "startCol": 17,
+      "startLine": 4,
+      "uid": "f82",
     },
   },
   "imports": Object {
@@ -724,7 +724,7 @@ const b = (n) => n > 0 ? n : a(10)
         },
         "originalConditionString": "n > 0",
         "type": "JSX_CONDITIONAL_EXPRESSION",
-        "uid": "7dd",
+        "uid": "f82",
         "whenFalse": Object {
           "definedElsewhere": Array [
             "b",
@@ -920,7 +920,7 @@ const b = (n) => n > 0 ? n : a(10)
         },
         "originalConditionString": "n > 0",
         "type": "JSX_CONDITIONAL_EXPRESSION",
-        "uid": "aa0",
+        "uid": "abc",
         "whenFalse": Object {
           "definedElsewhere": Array [
             "a",

--- a/editor/src/core/workers/parser-printer/parser-printer-conditionals.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-conditionals.spec.ts
@@ -12,16 +12,6 @@ import { printCode, printCodeOptions } from './parser-printer'
 describe('JSX parser', () => {
   setFeatureForUnitTests('Conditional support', true)
   it('ensure that conditionals get the same UID each time', () => {
-    FOR_TESTS_setNextGeneratedUids([
-      'mock1',
-      'mock2',
-      'mock3',
-      'conditional',
-      'mock4',
-      'mock5',
-      'mock6',
-      'conditional',
-    ])
     const code = applyPrettier(SimpleConditionalsExample, false).formatted
     const firstParseResult = testParseCode(code)
     if (isParseSuccess(firstParseResult)) {
@@ -58,20 +48,6 @@ describe('JSX parser', () => {
     }
   })
   it('handles nested ternaries', () => {
-    FOR_TESTS_setNextGeneratedUids([
-      'mock1',
-      'mock2',
-      'mock3',
-      'mock4',
-      'conditional1',
-      'conditional2',
-      'mock1',
-      'mock2',
-      'mock3',
-      'mock4',
-      'conditional1',
-      'conditional2',
-    ])
     const code = applyPrettier(NestedTernariesExample, false).formatted
     const firstParseResult = testParseCode(code)
     if (isParseSuccess(firstParseResult)) {
@@ -109,14 +85,6 @@ describe('JSX parser', () => {
 
 describe('JSX printer', () => {
   it('handles nested ternaries', () => {
-    FOR_TESTS_setNextGeneratedUids([
-      'mock1',
-      'mock2',
-      'mock3',
-      'mock4',
-      'conditional1',
-      'conditional2',
-    ])
     const code = applyPrettier(NestedTernariesExample, false).formatted
     const parseResult = testParseCode(code)
     if (isParseSuccess(parseResult)) {
@@ -152,11 +120,15 @@ describe('JSX printer', () => {
         export var App = (props) => {
           return (
             <div data-uid='div'>
-              {[0, 1].length > 1 ? (
-                [0, 1].length === 0 ? (
-                  <div data-uid='middle' />
+              {
+                // @utopia/uid=conditional1
+                [0, 1].length > 1 ? (
+                  // @utopia/uid=conditional2
+                  [0, 1].length === 0 ? (
+                    <div data-uid='middle' />
+                  ) : null
                 ) : null
-              ) : null}
+              }
             </div>
           )
         }

--- a/editor/src/core/workers/parser-printer/parser-printer-conditionals.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-conditionals.test-utils.ts
@@ -5,7 +5,7 @@ import * as React from 'react'
 import { Scene, Storyboard, View } from 'utopia-api'
 export var App = (props) => {
   return <div data-uid={'div'}>
-    {1 === 2 ? <div data-uid={'hello'}>Hello</div> : <div data-uid={'world'}>World</div>}
+    {1 === 2 /* @utopia/uid=conditional */ ? <div data-uid={'hello'}>Hello</div> : <div data-uid={'world'}>World</div>}
   </div>
 }
 export var ${BakedInStoryboardVariableName} = (
@@ -25,11 +25,14 @@ import * as React from 'react'
 import { Scene, Storyboard, View } from 'utopia-api'
 export var App = (props) => {
   return <div data-uid={'div'}>
-    {[0, 1].length > 1 ? (
-      [0, 1].length === 0 ? (
-        <div data-uid='middle'/>
-      ) : null
-    ) : null}
+    {
+      // @utopia/uid=conditional1
+      [0, 1].length > 1 ? (
+        // @utopia/uid=conditional2
+        [0, 1].length === 0 ? (
+          <div data-uid='middle'/>
+        ) : null
+      ) : null}
   </div>
 }
 export var ${BakedInStoryboardVariableName} = (

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -101,6 +101,7 @@ import Hash from 'object-hash'
 import { getComments, getLeadingComments, getTrailingComments } from './parser-printer-comments'
 import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../shared/dom-utils'
 import { isEmptyString } from '../../shared/string-utils'
+import { mergeComments } from '../../shared/comment-flags'
 
 function inPositionToElementsWithin(elements: ElementsWithinInPosition): ElementsWithin {
   let result: ElementsWithin = {}
@@ -1648,6 +1649,7 @@ function getUIDBasedOnElement(
   elementName: JSXElementName | string | null,
   props: JSXAttributes | JSXAttribute,
   alreadyExistingUIDs: Set<string>,
+  comments: ParsedComments = emptyComments,
 ): string {
   const cleansedProps = Array.isArray(props)
     ? clearAttributesSourceMaps(clearAttributesUniqueIDs(props))
@@ -1657,7 +1659,7 @@ function getUIDBasedOnElement(
     name: elementName,
     props: cleansedProps,
   })
-  const uid = generateConsistentUID(alreadyExistingUIDs, hash)
+  const uid = generateConsistentUID(alreadyExistingUIDs, hash, comments)
   alreadyExistingUIDs.add(uid)
   return uid
 }
@@ -1670,7 +1672,13 @@ function forciblyUpdateDataUID(
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
   alreadyExistingUIDs: Set<string>,
 ): UpdateUIDResult {
-  const uid = getUIDBasedOnElement(sourceFile, elementName, props, alreadyExistingUIDs)
+  const uid = getUIDBasedOnElement(
+    sourceFile,
+    elementName,
+    props,
+    alreadyExistingUIDs,
+    mergeComments(props.map((p) => p.comments)),
+  )
   const updatedProps = setJSXAttributesAttribute(
     props,
     'data-uid',
@@ -1818,6 +1826,31 @@ export function parseOutJSXElements(
         }, possibleConditional)
       }
 
+      function getConditionalExpressionComments(
+        expression: TS.ConditionalExpression,
+      ): ParsedComments {
+        return {
+          leadingComments: getLeadingComments(sourceText, expression.condition),
+          trailingComments: getTrailingComments(sourceText, expression),
+          questionTokenComments: {
+            leadingComments: getTrailingComments(sourceText, expression.condition),
+            trailingComments: [],
+          },
+        }
+      }
+
+      function getConditionalElementComments(elem: TS.JsxExpression): ParsedComments {
+        if (elem.expression == null || !TS.isConditionalExpression(elem.expression)) {
+          return emptyComments
+        }
+        const comments = getConditionalExpressionComments(elem.expression)
+        const childrenOfExpression = elem.getChildren(sourceFile)
+        const lastChild = childrenOfExpression[childrenOfExpression.length - 1]
+        comments.trailingComments.push(...getLeadingComments(sourceText, lastChild))
+
+        return comments
+      }
+
       for (const elem of toParse) {
         switch (elem.kind) {
           case TS.SyntaxKind.JsxFragment:
@@ -1832,7 +1865,10 @@ export function parseOutJSXElements(
             break
           }
           case TS.SyntaxKind.ConditionalExpression: {
-            const possibleCondition = handleConditionalExpression(elem, emptyComments)
+            const possibleCondition = handleConditionalExpression(
+              elem,
+              getConditionalExpressionComments(elem),
+            )
             if (isLeft(possibleCondition)) {
               return possibleCondition
             } else {
@@ -1845,25 +1881,10 @@ export function parseOutJSXElements(
               left('Expression fallback.')
             // Handle ternaries.
             if (elem.expression != null && TS.isConditionalExpression(elem.expression)) {
-              const leadingComments = [...getLeadingComments(sourceText, elem.expression.condition)]
-
-              const questionTokenComments = {
-                leadingComments: [...getTrailingComments(sourceText, elem.expression.condition)],
-                trailingComments: [],
-              }
-
-              const childrenOfExpression = elem.getChildren(sourceFile)
-              const lastChild = childrenOfExpression[childrenOfExpression.length - 1]
-              const trailingComments = [
-                ...getTrailingComments(sourceText, elem.expression),
-                ...getLeadingComments(sourceText, lastChild),
-              ]
-
-              parseResult = handleConditionalExpression(elem.expression, {
-                leadingComments: leadingComments,
-                trailingComments: trailingComments,
-                questionTokenComments: questionTokenComments,
-              })
+              parseResult = handleConditionalExpression(
+                elem.expression,
+                getConditionalElementComments(elem),
+              )
             }
             // Fallback to arbitrary block parsing.
             if (isLeft(parseResult)) {
@@ -2092,11 +2113,17 @@ export function parseOutJSXElements(
       WithParserMetadata<SuccessfullyParsedElement>
     >(
       (condition, whenTrue, whenFalse) => {
-        const uid = getUIDBasedOnElement(sourceFile, null, condition.value, alreadyExistingUIDs)
+        const uid = getUIDBasedOnElement(
+          sourceFile,
+          null,
+          condition.value,
+          alreadyExistingUIDs,
+          comments,
+        )
         const conditionalExpression = jsxConditionalExpression(
           uid,
           condition.value,
-          expression.condition.getFullText(sourceFile).trim(),
+          expression.condition.getText(sourceFile).trim(), // getText does not include comments
           whenTrue.value,
           whenFalse.value,
           comments,


### PR DESCRIPTION
Fixes #3444 

**Problem:**

To set the generated UID of conditional elements (or any other non-dom-elements) during tests we rely on `FOR_TESTS_setNextGeneratedUids` but it has the ugly downside of requiring to set a number of throwaway UIDs.

E.g., this monstrosity:

```ts
FOR_TESTS_setNextGeneratedUids([
  'skip1',
  'skip2',
  'skip3',
  'skip4',
  'skip5',
  'skip6',
  'skip7',
  'skip8',
  'skip9',
  'skip10',
  'skip11',
  'skip12',
  'skip13',
  'skip14',
  'skip15',
  'conditional1',
  'conditional2',
])
```

This is super brittle and _very_ hard to debug if something does not work.

**Fix:**

This PR adds a new comment flag, `@utopia/uid` that allows setting the UID of an element, so that we can get rid of `FOR_TESTS_setNextGeneratedUids` when dealing with conditionals and use instead inline comments.

E.g.:
```ts
{
  // @utopia/uid=conditional1
  [].length === 0 ? // ...
```

Notes:
- this approach would work fine with other non-dom elements as well, but for scope's sake I just hooked it to the conditional elements parsing.
- the new comment flag is just used for tests for now, but it's looking like it can have nice additional uses as well, since it plays along with the current UIDs generation.