### PR TITLE
fix(canvas) keyboard resize shouldn't result in negative width height

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-resize.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-resize.spec.browser2.tsx
@@ -214,6 +214,38 @@ describe('Keyboard Absolute Resize E2E', () => {
       height: 101,
     })
   })
+  it('Pressing Shift + Cmd + ArrowLeft 3 times, then pressing Shift + Cmd + ArrowRight once', async () => {
+    const width = 5
+    const {
+      expectElementWidthOnScreen,
+      expectElementPropertiesInPrintedCode,
+      getCanvasGuidelines,
+    } = await setupTest({
+      left: 10,
+      top: 100,
+      width: width,
+      height: 101,
+    })
+
+    await pressKey('ArrowLeft', { modifiers: shiftCmdModifier })
+    await pressKey('ArrowLeft', { modifiers: shiftCmdModifier })
+    await pressKey('ArrowLeft', { modifiers: shiftCmdModifier })
+
+    expectElementWidthOnScreen(-width)
+    expect(getCanvasGuidelines()).toEqual([])
+
+    await pressKey('ArrowRight', { modifiers: shiftCmdModifier })
+    await cmdKeyUp()
+
+    // tick the clock so useClearKeyboardInteraction is fired
+    clock.current.tick(KeyboardInteractionTimeout)
+    await expectElementPropertiesInPrintedCode({
+      left: 10,
+      top: 100,
+      width: 10,
+      height: 101,
+    })
+  })
 })
 
 describe('Keyboard switching back and forth between absolute move and absolute resize', () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-resize.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-resize.spec.browser2.tsx
@@ -19,6 +19,7 @@ import { pressKey, keyDown, keyUp } from '../../event-helpers.test-utils'
 import { GuidelineWithSnappingVectorAndPointsOfRelevance } from '../../guideline'
 import { getPrintedUiJsCode, renderTestEditorWithCode } from '../../ui-jsx.test-utils'
 import { KeyboardInteractionTimeout } from '../interaction-state'
+import { ResizeMinimumValue } from './keyboard-absolute-resize-strategy'
 
 const defaultBBBProperties = {
   left: 0,
@@ -231,7 +232,7 @@ describe('Keyboard Absolute Resize E2E', () => {
     await pressKey('ArrowLeft', { modifiers: shiftCmdModifier })
     await pressKey('ArrowLeft', { modifiers: shiftCmdModifier })
 
-    expectElementWidthOnScreen(-width)
+    expectElementWidthOnScreen(-width + ResizeMinimumValue) // the expected size is the min value
     expect(getCanvasGuidelines()).toEqual([])
 
     await pressKey('ArrowRight', { modifiers: shiftCmdModifier })
@@ -242,7 +243,7 @@ describe('Keyboard Absolute Resize E2E', () => {
     await expectElementPropertiesInPrintedCode({
       left: 10,
       top: 100,
-      width: 10,
+      width: 11,
       height: 101,
     })
   })

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
@@ -112,6 +112,8 @@ function getFitness(interactionSession: InteractionSession | null): number {
   return 0
 }
 
+export const ResizeMinimumValue = 1
+
 export function keyboardAbsoluteResizeStrategy(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
@@ -145,8 +147,8 @@ export function keyboardAbsoluteResizeStrategy(
           canvasRectangle(zeroRectangle)
         const accumulatedPresses = accumulatePresses(interactionSession.interactionData.keyStates)
         const maxNegativeMovement = canvasVector({
-          x: -originalFrame.width,
-          y: -originalFrame.height,
+          x: -originalFrame.width + ResizeMinimumValue,
+          y: -originalFrame.height + ResizeMinimumValue,
         })
         const movementsWithEdges = pressesToVectorAndEdges(accumulatedPresses, maxNegativeMovement)
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
@@ -2,6 +2,7 @@ import { isJSXElement } from '../../../../core/shared/element-template'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import {
   canvasRectangle,
+  canvasVector,
   CanvasVector,
   nullIfInfinity,
   offsetPoint,
@@ -10,7 +11,12 @@ import {
 } from '../../../../core/shared/math-utils'
 import Keyboard, { KeyCharacter } from '../../../../utils/keyboard'
 import { withUnderlyingTarget } from '../../../editor/store/editor-state'
-import { CanvasFrameAndTarget, EdgePosition } from '../../canvas-types'
+import {
+  CanvasFrameAndTarget,
+  EdgePosition,
+  EdgePositionBottom,
+  EdgePositionRight,
+} from '../../canvas-types'
 import { CanvasCommand } from '../../commands/commands'
 import { pushIntendedBounds } from '../../commands/push-intended-bounds-command'
 import { setElementsToRerenderCommand } from '../../commands/set-elements-to-rerender-command'
@@ -43,6 +49,7 @@ interface VectorAndEdge {
 
 function pressesToVectorAndEdges(
   accumulatedPresses: Array<AccumulatedPresses>,
+  maxNegativeMovement: CanvasVector,
 ): Array<VectorAndEdge> {
   let result: Array<VectorAndEdge> = []
 
@@ -62,17 +69,28 @@ function pressesToVectorAndEdges(
         }
         if (foundVectorAndEdge == null) {
           result.push({
-            movement: keyPressMovement,
+            movement: getLimitedMovement(keyPressMovement, maxNegativeMovement),
             edge: edgePosition,
           })
         } else {
-          foundVectorAndEdge.movement = offsetPoint(foundVectorAndEdge.movement, keyPressMovement)
+          const accumulatedMovement = offsetPoint(foundVectorAndEdge.movement, keyPressMovement)
+          foundVectorAndEdge.movement = getLimitedMovement(accumulatedMovement, maxNegativeMovement)
         }
       }
     })
   })
 
   return result
+}
+
+function getLimitedMovement(
+  movement: CanvasVector,
+  maxNegativeMovement: CanvasVector,
+): CanvasVector {
+  return {
+    x: Math.max(movement.x, maxNegativeMovement.x),
+    y: Math.max(movement.y, maxNegativeMovement.y),
+  } as CanvasVector
 }
 
 function getFitness(interactionSession: InteractionSession | null): number {
@@ -122,13 +140,18 @@ export function keyboardAbsoluteResizeStrategy(
     fitness: getFitness(interactionSession),
     apply: () => {
       if (interactionSession != null && interactionSession.interactionData.type === 'KEYBOARD') {
-        const accumulatedPresses = accumulatePresses(interactionSession.interactionData.keyStates)
-        const movementsWithEdges = pressesToVectorAndEdges(accumulatedPresses)
-
-        // Start with the frame as it is at the start of the interaction.
-        let newFrame =
+        const originalFrame =
           getMultiselectBounds(canvasState.startingMetadata, selectedElements) ??
           canvasRectangle(zeroRectangle)
+        const accumulatedPresses = accumulatePresses(interactionSession.interactionData.keyStates)
+        const maxNegativeMovement = canvasVector({
+          x: -originalFrame.width,
+          y: -originalFrame.height,
+        })
+        const movementsWithEdges = pressesToVectorAndEdges(accumulatedPresses, maxNegativeMovement)
+
+        // Start with the frame as it is at the start of the interaction.
+        let newFrame = originalFrame
 
         let commands: Array<CanvasCommand> = []
         let intendedBounds: Array<CanvasFrameAndTarget> = []
@@ -194,16 +217,10 @@ function getEdgePositionFromKey(key: KeyCharacter): EdgePosition | null {
   switch (key) {
     case 'left':
     case 'right':
-      return {
-        x: 1,
-        y: 0.5,
-      } as EdgePosition
+      return EdgePositionRight
     case 'up':
     case 'down':
-      return {
-        x: 0.5,
-        y: 1,
-      } as EdgePosition
+      return EdgePositionBottom
     default:
       return null
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-interaction.test-utils.tsx
@@ -47,6 +47,7 @@ export function pressKeys(
         immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
         coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
       } as SpecialSizeMeasurements,
+      globalFrame: { x: 50, y: 50, width: 250, height: 300 },
     } as ElementInstanceMetadata,
   }
   const interactionSession: InteractionSession = {


### PR DESCRIPTION
**Problem:**
When using keyboard resize it's possible to end up with negative width and height values. It's very visible since the keyboard strategy updates the inspector on all keypress.

**Fix:**
Compare the original size to the accumulated keypress vectors to avoid negative width/height results. Minimum width/height is limited to 1px.

**Commit Details:**
- pass width/height to `pressesToVectorAndEdges`
- added 1 test that uses a tiny element 
- update tests
