### PR TITLE
fix(canvas-resize) resize control area for small elements

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -51,6 +51,7 @@ import { MaxContent } from '../../../inspector/inspector-common'
 import {
   SizeLabelTestId,
   ResizePointTestId,
+  SmallElementSize,
 } from '../../controls/select-mode/absolute-resize-control'
 import { AllContentAffectingTypes, ContentAffectingType } from './group-like-helpers'
 import { getClosingGroupLikeTag, getOpeningGroupLikeTag } from './group-like-helpers.test-utils'
@@ -1755,5 +1756,118 @@ describe('Absolute Resize Group-like behaviors', () => {
         expect(groupResizeResult).toEqual(multiselectResult)
       })
     })
+  })
+})
+
+describe('Absolute Resize Control', () => {
+  it('Resize control is placed on small elements outside of the draggable frame area', async () => {
+    const width = SmallElementSize
+    const height = SmallElementSize
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+            style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 0, top: 0, width: ${width}, height: ${height} }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    const target = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
+    await selectComponentsForTest(renderResult, [target])
+
+    const resizeControlTop = renderResult.renderedDOM.getByTestId(
+      `resize-control-${EdgePositionTop.x}-${EdgePositionTop.y}`,
+    )
+    expect(resizeControlTop.style.transform).toEqual('translate(0px, -5px)')
+    expect(resizeControlTop.style.top).toEqual('')
+    expect(resizeControlTop.style.left).toEqual('')
+    expect(resizeControlTop.style.width).toEqual(`${width}px`)
+    expect(resizeControlTop.style.height).toEqual('5px')
+
+    const resizeControlRight = renderResult.renderedDOM.getByTestId(
+      `resize-control-${EdgePositionRight.x}-${EdgePositionRight.y}`,
+    )
+    expect(resizeControlRight.style.transform).toEqual('translate(0px, 0px)')
+    expect(resizeControlRight.style.top).toEqual('')
+    expect(resizeControlRight.style.left).toEqual(`${width}px`)
+    expect(resizeControlRight.style.width).toEqual('5px')
+    expect(resizeControlRight.style.height).toEqual(`${height}px`)
+
+    const resizeControlBottom = renderResult.renderedDOM.getByTestId(
+      `resize-control-${EdgePositionBottom.x}-${EdgePositionBottom.y}`,
+    )
+    expect(resizeControlBottom.style.transform).toEqual('translate(0px, 0px)')
+    expect(resizeControlBottom.style.top).toEqual(`${height}px`)
+    expect(resizeControlBottom.style.left).toEqual('')
+    expect(resizeControlBottom.style.width).toEqual(`${width}px`)
+    expect(resizeControlBottom.style.height).toEqual('5px')
+
+    const resizeControlLeft = renderResult.renderedDOM.getByTestId(
+      `resize-control-${EdgePositionLeft.x}-${EdgePositionLeft.y}`,
+    )
+    expect(resizeControlLeft.style.transform).toEqual('translate(-5px, 0px)')
+    expect(resizeControlLeft.style.top).toEqual('')
+    expect(resizeControlLeft.style.left).toEqual('')
+    expect(resizeControlLeft.style.width).toEqual('5px')
+    expect(resizeControlLeft.style.height).toEqual(`${height}px`)
+  })
+  it('Resize control on non-small elements extend into the draggable frame area', async () => {
+    const width = SmallElementSize + 1
+    const height = SmallElementSize + 1
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+            style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 0, top: 0, width: ${width}, height: ${height} }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    const target = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
+    await selectComponentsForTest(renderResult, [target])
+
+    const resizeControlTop = renderResult.renderedDOM.getByTestId(
+      `resize-control-${EdgePositionTop.x}-${EdgePositionTop.y}`,
+    )
+    expect(resizeControlTop.style.transform).toEqual('translate(0px, -5px)')
+    expect(resizeControlTop.style.top).toEqual('')
+    expect(resizeControlTop.style.left).toEqual('')
+    expect(resizeControlTop.style.width).toEqual(`${width}px`)
+    expect(resizeControlTop.style.height).toEqual('10px')
+
+    const resizeControlRight = renderResult.renderedDOM.getByTestId(
+      `resize-control-${EdgePositionRight.x}-${EdgePositionRight.y}`,
+    )
+    expect(resizeControlRight.style.transform).toEqual('translate(-5px, 0px)')
+    expect(resizeControlRight.style.top).toEqual('')
+    expect(resizeControlRight.style.left).toEqual(`${width}px`)
+    expect(resizeControlRight.style.width).toEqual('10px')
+    expect(resizeControlRight.style.height).toEqual(`${height}px`)
+
+    const resizeControlBottom = renderResult.renderedDOM.getByTestId(
+      `resize-control-${EdgePositionBottom.x}-${EdgePositionBottom.y}`,
+    )
+    expect(resizeControlBottom.style.transform).toEqual('translate(0px, -5px)')
+    expect(resizeControlBottom.style.top).toEqual(`${height}px`)
+    expect(resizeControlBottom.style.left).toEqual('')
+    expect(resizeControlBottom.style.width).toEqual(`${width}px`)
+    expect(resizeControlBottom.style.height).toEqual('10px')
+
+    const resizeControlLeft = renderResult.renderedDOM.getByTestId(
+      `resize-control-${EdgePositionLeft.x}-${EdgePositionLeft.y}`,
+    )
+    expect(resizeControlLeft.style.transform).toEqual('translate(-5px, 0px)')
+    expect(resizeControlLeft.style.top).toEqual('')
+    expect(resizeControlLeft.style.left).toEqual('')
+    expect(resizeControlLeft.style.width).toEqual('10px')
+    expect(resizeControlLeft.style.height).toEqual(`${height}px`)
   })
 })

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -43,6 +43,10 @@ interface AbsoluteResizeControlProps {
 export const SizeLabelTestId = 'SizeLabelTestId'
 export const SmallElementSize = 20
 
+function shouldUseSmallElementResizeControl(size: number, scale: number): boolean {
+  return size <= SmallElementSize / scale
+}
+
 export const AbsoluteResizeControl = controlForStrategyMemoized(
   ({ targets }: AbsoluteResizeControlProps) => {
     const scale = useEditorState(
@@ -64,8 +68,9 @@ export const AbsoluteResizeControl = controlForStrategyMemoized(
     })
 
     const leftRef = useBoundingBox(targets, (ref, boundingBox) => {
+      const isSmallElement = shouldUseSmallElementResizeControl(boundingBox.width, scale)
       const lineSize = ResizeMouseAreaSize / scale
-      const width = boundingBox.width <= SmallElementSize ? lineSize / 2 : lineSize
+      const width = isSmallElement ? lineSize / 2 : lineSize
       const offsetLeft = `${-lineSize / 2}px`
       const offsetTop = `0px`
 
@@ -74,8 +79,9 @@ export const AbsoluteResizeControl = controlForStrategyMemoized(
       ref.current.style.height = boundingBox.height + 'px'
     })
     const topRef = useBoundingBox(targets, (ref, boundingBox) => {
+      const isSmallElement = shouldUseSmallElementResizeControl(boundingBox.height, scale)
       const lineSize = ResizeMouseAreaSize / scale
-      const height = boundingBox.height <= SmallElementSize ? lineSize / 2 : lineSize
+      const height = isSmallElement ? lineSize / 2 : lineSize
       const offsetLeft = `0px`
       const offsetTop = `${-lineSize / 2}px`
 
@@ -84,9 +90,10 @@ export const AbsoluteResizeControl = controlForStrategyMemoized(
       ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
     })
     const rightRef = useBoundingBox(targets, (ref, boundingBox) => {
+      const isSmallElement = shouldUseSmallElementResizeControl(boundingBox.width, scale)
       const lineSize = ResizeMouseAreaSize / scale
-      const width = boundingBox.width <= SmallElementSize ? lineSize / 2 : lineSize
-      const offsetLeft = boundingBox.width <= SmallElementSize ? `0px` : `${-lineSize / 2}px`
+      const width = isSmallElement ? lineSize / 2 : lineSize
+      const offsetLeft = isSmallElement ? `0px` : `${-lineSize / 2}px`
       const offsetTop = `0px`
 
       ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
@@ -96,10 +103,11 @@ export const AbsoluteResizeControl = controlForStrategyMemoized(
     })
 
     const bottomRef = useBoundingBox(targets, (ref, boundingBox) => {
+      const isSmallElement = shouldUseSmallElementResizeControl(boundingBox.height, scale)
       const lineSize = ResizeMouseAreaSize / scale
-      const height = boundingBox.height <= SmallElementSize ? lineSize / 2 : lineSize
+      const height = isSmallElement ? lineSize / 2 : lineSize
       const offsetLeft = `0px`
-      const offsetTop = boundingBox.height <= SmallElementSize ? `0px` : `${-lineSize / 2}px`
+      const offsetTop = isSmallElement ? `0px` : `${-lineSize / 2}px`
 
       ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
       ref.current.style.top = boundingBox.height + 'px'

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -41,6 +41,7 @@ interface AbsoluteResizeControlProps {
 }
 
 export const SizeLabelTestId = 'SizeLabelTestId'
+export const SmallElementSize = 20
 
 export const AbsoluteResizeControl = controlForStrategyMemoized(
   ({ targets }: AbsoluteResizeControlProps) => {
@@ -63,93 +64,47 @@ export const AbsoluteResizeControl = controlForStrategyMemoized(
     })
 
     const leftRef = useBoundingBox(targets, (ref, boundingBox) => {
-      if (boundingBox.width <= 20) {
-        const lineSize = ResizeMouseAreaSize / scale
-        const width = lineSize / 2
-        const offsetLeft = `${-lineSize / 2}px`
-        const offsetTop = `0px`
+      const lineSize = ResizeMouseAreaSize / scale
+      const width = boundingBox.width <= SmallElementSize ? lineSize / 2 : lineSize
+      const offsetLeft = `${-lineSize / 2}px`
+      const offsetTop = `0px`
 
-        ref.current.style.width = `${width}px`
-        ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
-        ref.current.style.height = boundingBox.height + 'px'
-      } else {
-        const lineSize = ResizeMouseAreaSize / scale
-        const width = lineSize
-        const offsetLeft = `${-lineSize / 2}px`
-        const offsetTop = `0px`
-
-        ref.current.style.width = `${width}px`
-        ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
-        ref.current.style.height = boundingBox.height + 'px'
-      }
+      ref.current.style.width = `${width}px`
+      ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
+      ref.current.style.height = boundingBox.height + 'px'
     })
     const topRef = useBoundingBox(targets, (ref, boundingBox) => {
-      if (boundingBox.height <= 20) {
-        const lineSize = ResizeMouseAreaSize / scale
-        const height = lineSize / 2
-        const offsetLeft = `0px`
-        const offsetTop = `${-lineSize / 2}px`
+      const lineSize = ResizeMouseAreaSize / scale
+      const height = boundingBox.height <= SmallElementSize ? lineSize / 2 : lineSize
+      const offsetLeft = `0px`
+      const offsetTop = `${-lineSize / 2}px`
 
-        ref.current.style.width = boundingBox.width + 'px'
-        ref.current.style.height = height + 'px'
-        ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
-      } else {
-        const lineSize = ResizeMouseAreaSize / scale
-        const height = lineSize
-        const offsetLeft = `0px`
-        const offsetTop = `${-lineSize / 2}px`
-
-        ref.current.style.width = boundingBox.width + 'px'
-        ref.current.style.height = height + 'px'
-        ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
-      }
+      ref.current.style.width = boundingBox.width + 'px'
+      ref.current.style.height = height + 'px'
+      ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
     })
     const rightRef = useBoundingBox(targets, (ref, boundingBox) => {
-      if (boundingBox.width <= 20) {
-        const lineSize = ResizeMouseAreaSize / scale
-        const width = lineSize / 2
-        const offsetLeft = `0px`
-        const offsetTop = `0px`
+      const lineSize = ResizeMouseAreaSize / scale
+      const width = boundingBox.width <= SmallElementSize ? lineSize / 2 : lineSize
+      const offsetLeft = boundingBox.width <= SmallElementSize ? `0px` : `${-lineSize / 2}px`
+      const offsetTop = `0px`
 
-        ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
-        ref.current.style.left = boundingBox.width + 'px'
-        ref.current.style.width = width + 'px'
-        ref.current.style.height = boundingBox.height + 'px'
-      } else {
-        const lineSize = ResizeMouseAreaSize / scale
-        const width = lineSize
-        const offsetLeft = `${-lineSize / 2}px`
-        const offsetTop = `0px`
-
-        ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
-        ref.current.style.left = boundingBox.width + 'px'
-        ref.current.style.width = width + 'px'
-        ref.current.style.height = boundingBox.height + 'px'
-      }
+      ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
+      ref.current.style.left = boundingBox.width + 'px'
+      ref.current.style.width = width + 'px'
+      ref.current.style.height = boundingBox.height + 'px'
     })
 
     const bottomRef = useBoundingBox(targets, (ref, boundingBox) => {
-      if (boundingBox.height <= 20) {
-        const lineSize = ResizeMouseAreaSize / scale
-        const height = lineSize / 2
-        const offsetLeft = `0px`
-        const offsetTop = `0px`
+      const lineSize = ResizeMouseAreaSize / scale
+      const height = boundingBox.height <= SmallElementSize ? lineSize / 2 : lineSize
+      const offsetLeft = `0px`
+      const offsetTop = boundingBox.height <= SmallElementSize ? `0px` : `${-lineSize / 2}px`
 
-        ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
-        ref.current.style.top = boundingBox.height + 'px'
-        ref.current.style.width = boundingBox.width + 'px'
-        ref.current.style.height = height + 'px'
-      } else {
-        const lineSize = ResizeMouseAreaSize / scale
-        const height = lineSize
-        const offsetLeft = `0px`
-        const offsetTop = `${-lineSize / 2}px`
-
-        ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
-        ref.current.style.top = boundingBox.height + 'px'
-        ref.current.style.width = boundingBox.width + 'px'
-        ref.current.style.height = height + 'px'
-      }
+      ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
+      ref.current.style.top = boundingBox.height + 'px'
+      ref.current.style.width = boundingBox.width + 'px'
+      ref.current.style.height = height + 'px'
     })
 
     const topLeftRef = useBoundingBox(targets, NO_OP)

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -63,14 +63,25 @@ export const AbsoluteResizeControl = controlForStrategyMemoized(
     })
 
     const leftRef = useBoundingBox(targets, (ref, boundingBox) => {
-      const lineSize = ResizeMouseAreaSize / scale
-      const width = lineSize
-      const offsetLeft = `${-lineSize / 2}px`
-      const offsetTop = `0px`
+      if (boundingBox.width <= 20) {
+        const lineSize = ResizeMouseAreaSize / scale
+        const width = lineSize / 2
+        const offsetLeft = `${-lineSize / 2}px`
+        const offsetTop = `0px`
 
-      ref.current.style.width = `${width}px`
-      ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
-      ref.current.style.height = boundingBox.height + 'px'
+        ref.current.style.width = `${width}px`
+        ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
+        ref.current.style.height = boundingBox.height + 'px'
+      } else {
+        const lineSize = ResizeMouseAreaSize / scale
+        const width = lineSize
+        const offsetLeft = `${-lineSize / 2}px`
+        const offsetTop = `0px`
+
+        ref.current.style.width = `${width}px`
+        ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
+        ref.current.style.height = boundingBox.height + 'px'
+      }
     })
     const topRef = useBoundingBox(targets, (ref, boundingBox) => {
       if (boundingBox.height <= 20) {
@@ -94,15 +105,27 @@ export const AbsoluteResizeControl = controlForStrategyMemoized(
       }
     })
     const rightRef = useBoundingBox(targets, (ref, boundingBox) => {
-      const lineSize = ResizeMouseAreaSize / scale
-      const width = lineSize
-      const offsetLeft = `${-lineSize / 2}px`
-      const offsetTop = `0px`
+      if (boundingBox.width <= 20) {
+        const lineSize = ResizeMouseAreaSize / scale
+        const width = lineSize / 2
+        const offsetLeft = `0px`
+        const offsetTop = `0px`
 
-      ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
-      ref.current.style.left = boundingBox.width + 'px'
-      ref.current.style.width = width + 'px'
-      ref.current.style.height = boundingBox.height + 'px'
+        ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
+        ref.current.style.left = boundingBox.width + 'px'
+        ref.current.style.width = width + 'px'
+        ref.current.style.height = boundingBox.height + 'px'
+      } else {
+        const lineSize = ResizeMouseAreaSize / scale
+        const width = lineSize
+        const offsetLeft = `${-lineSize / 2}px`
+        const offsetTop = `0px`
+
+        ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
+        ref.current.style.left = boundingBox.width + 'px'
+        ref.current.style.width = width + 'px'
+        ref.current.style.height = boundingBox.height + 'px'
+      }
     })
 
     const bottomRef = useBoundingBox(targets, (ref, boundingBox) => {

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -44,6 +44,12 @@ export const SizeLabelTestId = 'SizeLabelTestId'
 
 export const AbsoluteResizeControl = controlForStrategyMemoized(
   ({ targets }: AbsoluteResizeControlProps) => {
+    const scale = useEditorState(
+      Substores.canvasOffset,
+      (store) => store.editor.canvas.scale,
+      'AbsoluteResizeControl scale',
+    )
+
     const controlRef = useBoundingBox(targets, (ref, boundingBox) => {
       if (isZeroSizedElement(boundingBox)) {
         ref.current.style.display = 'none'
@@ -57,19 +63,70 @@ export const AbsoluteResizeControl = controlForStrategyMemoized(
     })
 
     const leftRef = useBoundingBox(targets, (ref, boundingBox) => {
+      const lineSize = ResizeMouseAreaSize / scale
+      const width = lineSize
+      const offsetLeft = `${-lineSize / 2}px`
+      const offsetTop = `0px`
+
+      ref.current.style.width = `${width}px`
+      ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
       ref.current.style.height = boundingBox.height + 'px'
     })
     const topRef = useBoundingBox(targets, (ref, boundingBox) => {
-      ref.current.style.width = boundingBox.width + 'px'
+      if (boundingBox.height <= 20) {
+        const lineSize = ResizeMouseAreaSize / scale
+        const height = lineSize / 2
+        const offsetLeft = `0px`
+        const offsetTop = `${-lineSize / 2}px`
+
+        ref.current.style.width = boundingBox.width + 'px'
+        ref.current.style.height = height + 'px'
+        ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
+      } else {
+        const lineSize = ResizeMouseAreaSize / scale
+        const height = lineSize
+        const offsetLeft = `0px`
+        const offsetTop = `${-lineSize / 2}px`
+
+        ref.current.style.width = boundingBox.width + 'px'
+        ref.current.style.height = height + 'px'
+        ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
+      }
     })
     const rightRef = useBoundingBox(targets, (ref, boundingBox) => {
+      const lineSize = ResizeMouseAreaSize / scale
+      const width = lineSize
+      const offsetLeft = `${-lineSize / 2}px`
+      const offsetTop = `0px`
+
+      ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
       ref.current.style.left = boundingBox.width + 'px'
+      ref.current.style.width = width + 'px'
       ref.current.style.height = boundingBox.height + 'px'
     })
 
     const bottomRef = useBoundingBox(targets, (ref, boundingBox) => {
-      ref.current.style.top = boundingBox.height + 'px'
-      ref.current.style.width = boundingBox.width + 'px'
+      if (boundingBox.height <= 20) {
+        const lineSize = ResizeMouseAreaSize / scale
+        const height = lineSize / 2
+        const offsetLeft = `0px`
+        const offsetTop = `0px`
+
+        ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
+        ref.current.style.top = boundingBox.height + 'px'
+        ref.current.style.width = boundingBox.width + 'px'
+        ref.current.style.height = height + 'px'
+      } else {
+        const lineSize = ResizeMouseAreaSize / scale
+        const height = lineSize
+        const offsetLeft = `0px`
+        const offsetTop = `${-lineSize / 2}px`
+
+        ref.current.style.transform = `translate(${offsetLeft}, ${offsetTop})`
+        ref.current.style.top = boundingBox.height + 'px'
+        ref.current.style.width = boundingBox.width + 'px'
+        ref.current.style.height = height + 'px'
+      }
     })
 
     const topLeftRef = useBoundingBox(targets, NO_OP)
@@ -281,23 +338,15 @@ const ResizeEdge = React.memo(
       )
     }, [dispatch, metadataRef, props.direction, selectedElementsRef])
 
-    const lineSize = ResizeMouseAreaSize / scale
-    const width = props.direction === 'horizontal' ? undefined : lineSize
-    const height = props.direction === 'vertical' ? undefined : lineSize
-    const offsetLeft = props.direction === 'horizontal' ? `0px` : `${-lineSize / 2}px`
-    const offsetTop = props.direction === 'vertical' ? `0px` : `${-lineSize / 2}px`
     return (
       <div
         onDoubleClick={onEdgeDblClick}
         ref={ref}
         style={{
           position: 'absolute',
-          width: width,
-          height: height,
           backgroundColor: 'transparent',
           cursor: props.cursor,
           pointerEvents: 'initial',
-          transform: `translate(${offsetLeft}, ${offsetTop})`,
         }}
         onMouseDown={onEdgeMouseDown}
         onMouseMove={onMouseMove}


### PR DESCRIPTION
**Problem:**
It is difficult to drag small elements (like spans with 1 line of text).

https://utopia.pizza/p/410e0b3f-adventurous-spandex/?branch_name=fix-canvas-resize-small-elements

**Fix:**
Draw the resize edge controls outside of the element frame for small elements.

**Commit Details:**
- update canvas resize control
- tests
