### PR TITLE
Fix useDelayedEditorState

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -115,7 +115,7 @@ export const drawToInsertMetaStrategy: MetaCanvasStrategy = (
   }, applicableReparentFactories)
 }
 
-function getDrawToInsertStrategyName(
+export function getDrawToInsertStrategyName(
   strategyType: ReparentStrategy,
   parentDisplayType: 'flex' | 'flow',
 ) {

--- a/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.tsx
@@ -116,7 +116,13 @@ export const CanvasStrategyPicker = React.memo(() => {
                   }}
                 >
                   <KeyIndicator keyNumber={index + 1} />
-                  {name}
+                  <span
+                    data-testId={
+                      strategy.id === activeStrategy ? 'strategy-picker-active-row' : undefined
+                    }
+                  >
+                    {name}
+                  </span>
                 </FlexRow>
               )
             })}


### PR DESCRIPTION
**Problem:**
`useDelayedEditorState` is used to show the strategy picker after a delay, but can easily be accidentally tricked into showing an incorrect picked strategy during insertion (pressing `d` whilst over the canvas and moving the cursor over a flex element before the picker shows up will result in the picker highlighting "Draw to Insert (Abs)" as the chosen strategy, even though flex insertion will be the actual result).

**Fix:**
The issue was that the hook would be capturing the value at the point it was first called, and then returning that after a timeout, meaning the final return value would be stale if the true value had changed during that timeout. To fix this we now create that timeout under the same conditions, but use a ref to store the actual value so that we can update that between the timeout starting and the value being returned.

I also noticed we were creating 2 selectors here that could fire under the same conditions, so I've rolled them into one instead.

Plus a test, for good measure.
