### PR TITLE
Feat/paste into conditionals

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -499,6 +499,7 @@ export function updateFramesOfScenesAndComponents(
                   components,
                   underlyingTarget,
                   absolute(frameAndTarget.newIndex),
+                  workingEditorState.spyMetadata,
                 )
                 return {
                   ...success,
@@ -2147,6 +2148,7 @@ function editorReparentNoStyleChange(
               updatedUnderlyingElement,
               updatedUtopiaComponents,
               indexPosition,
+              editor.spyMetadata,
             )
 
             return {
@@ -2269,6 +2271,7 @@ export function moveTemplate(
                     updatedUnderlyingElement,
                     updatedUtopiaComponents,
                     indexPosition,
+                    workingEditorState.spyMetadata,
                   )
 
                   return {
@@ -2773,6 +2776,7 @@ export function duplicate(
               newElement,
               utopiaComponents,
               position(),
+              editor.spyMetadata,
             )
 
             newSelectedViews.push(newPath)
@@ -2819,6 +2823,7 @@ export function reorderComponent(
   components: Array<UtopiaJSXComponent>,
   target: ElementPath,
   indexPosition: IndexPosition,
+  spyMetadata: ElementInstanceMetadataMap,
 ): Array<UtopiaJSXComponent> {
   let workingComponents = [...components]
 
@@ -2844,6 +2849,7 @@ export function reorderComponent(
       jsxElement,
       workingComponents,
       adjustedIndexPosition,
+      spyMetadata,
     )
   }
 

--- a/editor/src/components/canvas/commands/add-element-command.ts
+++ b/editor/src/components/canvas/commands/add-element-command.ts
@@ -53,6 +53,7 @@ export const runAddElement: CommandFunction<AddElement> = (
         command.element,
         componentsNewParent,
         null,
+        editorState.spyMetadata,
       )
 
       const editorStatePatchNewParentFile = getPatchForComponentChange(

--- a/editor/src/components/canvas/commands/insert-element-insertion-subject.ts
+++ b/editor/src/components/canvas/commands/insert-element-insertion-subject.ts
@@ -64,6 +64,7 @@ export const runInsertElementInsertionSubject: CommandFunction<InsertElementInse
         subject.element,
         utopiaComponents,
         null,
+        editor.spyMetadata,
       )
 
       const updatedImports = mergeImports(underlyingFilePath, success.imports, subject.importsToAdd)

--- a/editor/src/components/canvas/commands/reorder-element-command.ts
+++ b/editor/src/components/canvas/commands/reorder-element-command.ts
@@ -41,6 +41,7 @@ export const runReorderElement: CommandFunction<ReorderElement> = (
         components,
         command.target,
         command.indexPosition,
+        editorState.spyMetadata,
       )
       return getPatchForComponentChange(
         success.topLevelElements,

--- a/editor/src/components/canvas/commands/reparent-element-command.ts
+++ b/editor/src/components/canvas/commands/reparent-element-command.ts
@@ -63,6 +63,7 @@ export const runReparentElement: CommandFunction<ReparentElement> = (
               underlyingElementTarget,
               withElementRemoved,
               null,
+              editorState.spyMetadata,
             )
             const editorStatePatchOldParentFile = getPatchForComponentChange(
               successTarget.topLevelElements,
@@ -84,6 +85,7 @@ export const runReparentElement: CommandFunction<ReparentElement> = (
               underlyingElementTarget,
               componentsNewParent,
               null,
+              editorState.spyMetadata,
             )
 
             const editorStatePatchOldParentFile = getPatchForComponentChange(

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2246,6 +2246,7 @@ export const UPDATE_FNS = {
           action.jsxElement,
           utopiaComponents,
           null,
+          editor.spyMetadata,
         )
 
         const uid = getUtopiaID(action.jsxElement)
@@ -2456,6 +2457,7 @@ export const UPDATE_FNS = {
                         }),
                         indexInParent,
                       ),
+                      editor.spyMetadata,
                     )
                   }
                 } else {
@@ -2489,6 +2491,7 @@ export const UPDATE_FNS = {
                       }),
                       indexInParent,
                     ),
+                    editor.spyMetadata,
                   )
                 } else {
                   const staticTarget = EP.dynamicPathToStaticPath(
@@ -2644,6 +2647,7 @@ export const UPDATE_FNS = {
                     }),
                     indexInParent,
                   ),
+                  editor.spyMetadata,
                 )
               } else {
                 const staticTarget = EP.dynamicPathToStaticPath(
@@ -3094,8 +3098,16 @@ export const UPDATE_FNS = {
           const pastedElementIsConditional =
             MetadataUtils.isConditionalFromMetadata(pastedElementMetadata)
 
+          const parent = MetadataUtils.findElementByElementPath(
+            action.targetOriginalContextMetadata,
+            action.pasteInto,
+          )
+
           const continueWithPaste =
-            pastedElementIsAbsolute || pastedElementIsFlex || pastedElementIsConditional
+            pastedElementIsAbsolute ||
+            pastedElementIsFlex ||
+            pastedElementIsConditional ||
+            MetadataUtils.isConditionalFromMetadata(parent)
 
           if (!continueWithPaste) {
             return workingEditorState
@@ -5135,6 +5147,7 @@ export const UPDATE_FNS = {
             element,
             withMaybeUpdatedParent,
             action.indexPosition,
+            editor.spyMetadata,
           )
 
           const newPath = EP.appendToPath(action.targetParent, newUID)

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3098,8 +3098,8 @@ export const UPDATE_FNS = {
           const pastedElementIsConditional =
             MetadataUtils.isConditionalFromMetadata(pastedElementMetadata)
 
-          const parent = MetadataUtils.findElementByElementPath(
-            action.targetOriginalContextMetadata,
+          const pasteIntoParent = MetadataUtils.findElementByElementPath(
+            editor.jsxMetadata,
             action.pasteInto,
           )
 
@@ -3107,7 +3107,7 @@ export const UPDATE_FNS = {
             pastedElementIsAbsolute ||
             pastedElementIsFlex ||
             pastedElementIsConditional ||
-            MetadataUtils.isConditionalFromMetadata(parent)
+            MetadataUtils.isConditionalFromMetadata(pasteIntoParent)
 
           if (!continueWithPaste) {
             return workingEditorState

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -150,7 +150,7 @@ describe('conditionals', () => {
       return {
         importsToAdd: {},
         originalElementPath: EP.appendNewElementPath(TestScenePath, ['000']),
-        element: makeDiv('ddd', 'HELLO'),
+        element: element,
       }
     }
     const tests: {
@@ -160,7 +160,7 @@ describe('conditionals', () => {
       want: string
     }[] = [
       {
-        name: 'element (true branch)',
+        name: 'into element (true branch)',
         code: `
           <div data-uid='aaa'>
             {
@@ -191,7 +191,7 @@ describe('conditionals', () => {
         `,
       },
       {
-        name: 'element (false branch)',
+        name: 'into element (false branch)',
         code: `
           <div data-uid='aaa'>
             {
@@ -222,7 +222,7 @@ describe('conditionals', () => {
         `,
       },
       {
-        name: 'null',
+        name: 'into null',
         code: `
           <div data-uid='aaa'>
             {
@@ -250,7 +250,7 @@ describe('conditionals', () => {
         `,
       },
       {
-        name: 'fragment',
+        name: 'into fragment',
         code: `
           <div data-uid='aaa'>
             {
@@ -285,7 +285,7 @@ describe('conditionals', () => {
         `,
       },
       {
-        name: 'empty fragment',
+        name: 'into empty fragment',
         code: `
           <div data-uid='aaa'>
             {
@@ -315,7 +315,7 @@ describe('conditionals', () => {
         `,
       },
       {
-        name: 'attribute (string)',
+        name: 'into attribute (string)',
         code: `
           <div data-uid='aaa'>
             {
@@ -345,7 +345,7 @@ describe('conditionals', () => {
         `,
       },
       {
-        name: 'attribute (number)',
+        name: 'into attribute (number)',
         code: `
           <div data-uid='aaa'>
             {
@@ -375,7 +375,7 @@ describe('conditionals', () => {
         `,
       },
       {
-        name: 'attribute (function)',
+        name: 'into attribute (function)',
         code: `
           <div data-uid='aaa'>
             {
@@ -406,7 +406,7 @@ describe('conditionals', () => {
         `,
       },
       {
-        name: 'attribute (expression)',
+        name: 'into attribute (expression)',
         code: `
           <div data-uid='aaa'>
             {
@@ -436,9 +436,44 @@ describe('conditionals', () => {
           </div>
         `,
       },
+      {
+        name: 'multiple elements',
+        code: `
+          <div data-uid='aaa'>
+            {
+              // @utopia/uid=conditional
+              true ? (
+                <div data-uid='bbb' data-testid='bbb'>bar</div>
+              ) : (
+                <div data-uid='ccc' data-testid='ccc'>baz</div>
+              )
+            }
+          </div>
+        `,
+        paste: [
+          makeElementPaste(makeDiv('ddd', 'HELLO')),
+          makeElementPaste(makeDiv('eee', 'THERE')),
+        ],
+        want: `
+          <div data-uid='aaa'>
+            {
+              // @utopia/uid=conditional
+              true ? (
+                <>
+                  <div data-uid='bbb' data-testid='bbb'>bar</div>
+                  <div data-uid='ddd'>HELLO</div>
+                  <div data-uid='eee'>THERE</div>
+                </>
+              ) : (
+                <div data-uid='ccc' data-testid='ccc'>baz</div>
+              )
+            }
+          </div>
+        `,
+      },
     ]
     tests.forEach((t) => {
-      it(`paste into ${t.name}`, async () => {
+      it(`paste ${t.name}`, async () => {
         const renderResult = await renderTestEditorWithCode(
           makeTestProjectCodeWithSnippet(t.code),
           'await-first-dom-report',

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1915,6 +1915,7 @@ export function addNewScene(model: EditorState, newSceneElement: JSXElement): Ed
         model.canvas.openFile?.filename ?? null,
         components,
         newSceneElement,
+        model.spyMetadata,
       ),
     model,
   )
@@ -1925,6 +1926,7 @@ export function addSceneToJSXComponents(
   openFile: string | null,
   components: UtopiaJSXComponent[],
   newSceneElement: JSXElement,
+  spyMetadata: ElementInstanceMetadataMap,
 ): UtopiaJSXComponent[] {
   const storyoardComponentRootElement = components.find(
     (c) => c.name === BakedInStoryboardVariableName,
@@ -1942,6 +1944,7 @@ export function addSceneToJSXComponents(
       newSceneElement,
       components,
       null,
+      spyMetadata,
     )
   } else {
     return components
@@ -1969,6 +1972,7 @@ export function insertElementAtPath(
   elementToInsert: JSXElementChild,
   components: Array<UtopiaJSXComponent>,
   indexPosition: IndexPosition | null,
+  spyMetadata: ElementInstanceMetadataMap,
 ): Array<UtopiaJSXComponent> {
   const staticTarget =
     targetParent == null
@@ -1981,6 +1985,7 @@ export function insertElementAtPath(
     elementToInsert,
     components,
     indexPosition,
+    spyMetadata,
   )
 }
 

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -29,16 +29,15 @@ import { ThemeObject } from '../../../uuiui/styles/theme/theme-helpers'
 import { when } from '../../../utils/react-conditionals'
 import { isLeft } from '../../../core/shared/either'
 import {
-  ChildOrAttribute,
   ElementInstanceMetadata,
   isJSXConditionalExpression,
   JSXConditionalExpression,
 } from '../../../core/shared/element-template'
 import {
-  findUtopiaCommentFlag,
-  isUtopiaCommentFlagConditional,
-} from '../../../core/shared/comment-flags'
-import { getConditionalClausePath, ConditionalCase } from '../../../core/model/conditionals'
+  getConditionalClausePath,
+  getConditionalFlag,
+  matchesOverriddenConditionalBranch,
+} from '../../../core/model/conditionals'
 import { DerivedSubstate, MetadataSubstate } from '../../editor/store/store-hook-substore-types'
 import { navigatorDepth } from '../navigator-utils'
 import createCachedSelector from 're-reselect'
@@ -337,13 +336,13 @@ const isActiveBranchOfOverriddenConditionalSelector = createCachedSelector(
     }
 
     return (
-      matchesOverriddenBranch(elementPath, parentPath, {
+      matchesOverriddenConditionalBranch(elementPath, parentPath, {
         clause: conditionalParent.whenTrue,
         branch: 'true-case',
         wantOverride: true,
         parentOverride: parentOverride,
       }) ||
-      matchesOverriddenBranch(elementPath, parentPath, {
+      matchesOverriddenConditionalBranch(elementPath, parentPath, {
         clause: conditionalParent.whenFalse,
         branch: 'false-case',
         wantOverride: false,
@@ -695,29 +694,4 @@ function asConditional(element: ElementInstanceMetadata | null): JSXConditionalE
     return null
   }
   return element.element.value
-}
-
-function getConditionalFlag(element: JSXConditionalExpression) {
-  const flag = findUtopiaCommentFlag(element.comments, 'conditional')
-  if (!isUtopiaCommentFlagConditional(flag)) {
-    return null
-  }
-  return flag.value
-}
-
-function matchesOverriddenBranch(
-  elementPath: ElementPath,
-  parentPath: ElementPath,
-  params: {
-    clause: ChildOrAttribute
-    branch: ConditionalCase
-    wantOverride: boolean
-    parentOverride: boolean
-  },
-): boolean {
-  const { clause, branch, wantOverride, parentOverride } = params
-  return (
-    wantOverride === parentOverride &&
-    EP.pathsEqual(elementPath, getConditionalClausePath(parentPath, clause, branch))
-  )
 }

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -78,7 +78,6 @@ import {
   ReparentTargetParent,
   reparentTargetParentIsConditionalClause,
 } from '../../components/editor/store/reparent-target'
-import { MetadataUtils } from './element-metadata-utils'
 
 function getAllUniqueUidsInner(
   projectContents: ProjectContentTreeRoot,
@@ -630,7 +629,7 @@ export function insertJSXElementChild(
         }
       } else if (isJSXConditionalExpression(parentElement)) {
         const trueCase = getConditionalCasePath(parentPath, 'true-case')
-        const parentMetadata = MetadataUtils.findElementByElementPath(spyMetadata, parentPath)
+        const parentMetadata = spyMetadata[EP.toString(parentPath)] ?? null
         const isTrueCase =
           getConditionalCase(trueCase, parentElement, parentMetadata, parentPath) === 'true-case'
         let branch = isTrueCase ? { ...parentElement.whenTrue } : { ...parentElement.whenFalse }


### PR DESCRIPTION
Fixes #3452 

This PR allows to paste into conditional elements.

The paste will happen into the active branch of the conditional (whether it's overridden or not).

The paste behavior is as follows:
- If the target branch is `null`, its replaced with the pasted element
- If the target branch is a `JSXElement` or an attribute, the existing branch is wrapped in a new fragment and the pasted element is appended to it
- If the target branch is a fragment, the pasted element is appended to it

https://user-images.githubusercontent.com/1081051/225950056-411487a2-77d1-498c-b96d-116bc2f48361.mp4

