### PR TITLE
Tweak canvas padding control catchment

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
@@ -70,7 +70,7 @@ const PaddingResizeControlHeight = 12
 const PaddingResizeControlBorder = 1
 const PaddingResizeDragBorder = 1
 const PaddingResizeControlHitAreaPaddingMainSide = 5
-const PaddingResizeControlHitAreaPaddingUnaffectedSide = 2
+const PaddingResizeControlHitAreaPaddingUnaffectedSide = 1
 
 type StoreSelector<T> = (s: CanvasSubstate) => T
 


### PR DESCRIPTION
**Problem:**
It is far too easy to accidentally trigger the padding resize control on the canvas.

**Fix:**
I have tweaked the catchment area of the padding resize control as follows:

1. The catchment area can no longer overflow the element beyond the visible pill control
2. It only extends past the long side of the pill by 1px on both sides
3. It now extends past the short side of the pill by 5px on both sides (obviously except for when it would overflow the element)
4. The number label was previously included as part of the catchment area, so that has been fixed

I have also fixed an incorrect use of `useRefEditorState`, which meant that the the number label would show the starting value after a drag had been completed until you would mouseleave and then mouseenter the padding area.

To demonstrate the catchment area I have given it a background colour in the below screenshots.

**Before:**
<img width="51" alt="image" src="https://user-images.githubusercontent.com/1044774/226345622-a4886080-6721-45ce-a976-4e9ed3c4e668.png">

**After:**
When the padding value is low:
<img width="49" alt="image" src="https://user-images.githubusercontent.com/1044774/226345363-9a9a98ba-6e6a-425a-bb18-40c00722f4b1.png">

When fully inside the element:
<img width="53" alt="image" src="https://user-images.githubusercontent.com/1044774/226345199-2b5aa620-14bb-4f30-b46b-01bfd09c3b2a.png">
