### PR TITLE
Show current condition value in condition override control

### DIFF
--- a/editor/src/components/inspector/controls/conditional-override-control.tsx
+++ b/editor/src/components/inspector/controls/conditional-override-control.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ConditionalValue } from '../../../core/shared/element-template'
+import { ConditionValue } from '../../../core/shared/element-template'
 import { when } from '../../../utils/react-conditionals'
 import { ButtonProps, FlexRow, Icons, Tooltip } from '../../../uuiui'
 import { SquareButton } from '../../titlebar/buttons'
@@ -13,7 +13,7 @@ export const ConditionalOverrideControlDisableTestId = 'conditional-override-con
 export interface ConditionalOverrideControlProps extends ButtonProps {
   controlStatus: ControlStatus
   controlStyles: ControlStyles
-  conditionValue: ConditionalValue
+  conditionValue: ConditionValue
   setConditionOverride: (override: boolean | null) => void
 }
 

--- a/editor/src/components/inspector/controls/conditional-override-control.tsx
+++ b/editor/src/components/inspector/controls/conditional-override-control.tsx
@@ -22,11 +22,13 @@ const OverrideControlOptions: Array<OptionChainOption<boolean>> = [
     tooltip: 'True',
     label: 'True',
     value: true,
+    forceCallOnSubmitValue: true,
   },
   {
     tooltip: 'False',
     label: 'False',
     value: false,
+    forceCallOnSubmitValue: true,
   },
 ]
 

--- a/editor/src/components/inspector/controls/conditional-override-control.tsx
+++ b/editor/src/components/inspector/controls/conditional-override-control.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
+import { ConditionalValue } from '../../../core/shared/element-template'
 import { when } from '../../../utils/react-conditionals'
 import { ButtonProps, FlexRow, Icons, Tooltip } from '../../../uuiui'
 import { SquareButton } from '../../titlebar/buttons'
 import { ControlStatus, ControlStyles } from '../common/control-status'
-import { ConditionOverride } from '../sections/layout-section/conditional-section'
 import { UIGridRow } from '../widgets/ui-grid-row'
 import { OptionChainControl, OptionChainOption } from './option-chain-control'
 
@@ -13,7 +13,7 @@ export const ConditionalOverrideControlDisableTestId = 'conditional-override-con
 export interface ConditionalOverrideControlProps extends ButtonProps {
   controlStatus: ControlStatus
   controlStyles: ControlStyles
-  conditionOverride: ConditionOverride
+  conditionValue: ConditionalValue
   setConditionOverride: (override: boolean | null) => void
 }
 
@@ -62,7 +62,7 @@ export const ConditionalOverrideControl: React.FunctionComponent<
           testId={ConditionalOverrideControlTestIdPrefix}
           key={'conditional-override-control'}
           onSubmitValue={props.setConditionOverride}
-          value={props.conditionOverride}
+          value={props.conditionValue}
           options={OverrideControlOptions}
           controlStatus={controlStatus}
           controlStyles={controlStyles}

--- a/editor/src/components/inspector/controls/option-chain-control.tsx
+++ b/editor/src/components/inspector/controls/option-chain-control.tsx
@@ -12,6 +12,7 @@ export interface OptionChainOption<T> {
   icon?: IcnProps
   label?: string
   tooltip?: string
+  forceCallOnSubmitValue?: boolean // Call the onSubmitValue again even when the control is already on that value
 }
 
 export function getOptionControlTestId(testIdPrefix: string, postfix: string): string {
@@ -87,7 +88,7 @@ export const OptionChainControl: React.FunctionComponent<
             value={props.value === option.value}
             // eslint-disable-next-line react/jsx-no-bind
             onSubmitValue={(value: boolean) => {
-              if (value) {
+              if (value || option.forceCallOnSubmitValue) {
                 props.onSubmitValue(option.value)
               }
             }}

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -22,11 +22,8 @@ import { unless, when } from '../../../../utils/react-conditionals'
 import {
   Button,
   FlexRow,
-  FunctionIcons,
-  Icons,
   InspectorSectionIcons,
   InspectorSubsectionHeader,
-  SquareButton,
   StringInput,
   useColorTheme,
   UtopiaStyles,


### PR DESCRIPTION
**Problem:**
In the condition override control we show the current overridden value, but we do not highlight the current value when it is not overridden.

Before my PR when there is no override:
<img width="258" alt="image" src="https://user-images.githubusercontent.com/127662/226609834-646fb49a-c0a8-4065-9476-4b58245fbe63.png">

After the PR when there is no override:
<img width="253" alt="image" src="https://user-images.githubusercontent.com/127662/226609939-9313e971-961b-4b46-9eb2-bb7274dd8e0c.png">

**Fix:**
Pass the current condition value to the control (and not the current override)