### PR TITLE
Chore/refactor ComponentElementToInsert

### DIFF
--- a/editor/src/components/canvas/canvas-globals.spec.ts
+++ b/editor/src/components/canvas/canvas-globals.spec.ts
@@ -217,6 +217,7 @@ describe('validateControlsToCheck', () => {
                           },
                         },
                       ],
+                      "type": "JSX_ELEMENT",
                     },
                     "importsToAdd": Object {
                       "/src/card": Object {
@@ -381,6 +382,7 @@ describe('validateControlsToCheck', () => {
                             },
                           },
                         ],
+                        "type": "JSX_ELEMENT",
                       },
                       "importsToAdd": Object {
                         "/src/card": Object {
@@ -462,6 +464,7 @@ describe('validateControlsToCheck', () => {
                           },
                         },
                       ],
+                      "type": "JSX_ELEMENT",
                     },
                     "importsToAdd": Object {
                       "/src/selector": Object {
@@ -566,6 +569,7 @@ describe('validateControlsToCheck', () => {
                           },
                         },
                       ],
+                      "type": "JSX_ELEMENT",
                     },
                     "importsToAdd": Object {
                       "/src/card": Object {
@@ -642,6 +646,7 @@ describe('validateControlsToCheck', () => {
                           },
                         },
                       ],
+                      "type": "JSX_ELEMENT",
                     },
                     "importsToAdd": Object {
                       "/src/card": Object {
@@ -694,6 +699,7 @@ describe('validateControlsToCheck', () => {
                           },
                         },
                       ],
+                      "type": "JSX_ELEMENT",
                     },
                     "importsToAdd": Object {
                       "/src/card": Object {

--- a/editor/src/components/canvas/controls/render-as.tsx
+++ b/editor/src/components/canvas/controls/render-as.tsx
@@ -6,7 +6,11 @@ import * as EP from '../../../core/shared/element-path'
 import * as EditorActions from '../../editor/actions/action-creators'
 import { UIGridRow } from '../../inspector/widgets/ui-grid-row'
 import { PopupList } from '../../../uuiui'
-import { JSXElementName, jsxElementNameEquals } from '../../../core/shared/element-template'
+import {
+  isJSXElement,
+  JSXElementName,
+  jsxElementNameEquals,
+} from '../../../core/shared/element-template'
 import { getElementsToTarget } from '../../inspector/common/inspector-utils'
 import { Imports } from '../../../core/shared/project-file-types'
 import {
@@ -48,7 +52,7 @@ export const RenderAsRow = React.memo(() => {
   const onSelect = React.useCallback(
     (selectOption: SelectOption) => {
       const value: InsertableComponent = selectOption.value
-      if (value.element === 'conditional' || value.element === 'fragment') {
+      if (!isJSXElement(value.element)) {
         return
       }
       onElementTypeChange(value.element.name, value.importsToAdd)
@@ -101,11 +105,7 @@ export const RenderAsRow = React.memo(() => {
       for (const selectOptionGroup of insertableComponents) {
         for (const selectOption of selectOptionGroup.options ?? []) {
           const insertableComponent: InsertableComponent = selectOption.value
-          if (
-            insertableComponent != null &&
-            insertableComponent.element !== 'conditional' &&
-            insertableComponent.element !== 'fragment'
-          ) {
+          if (insertableComponent != null && isJSXElement(insertableComponent.element)) {
             if (jsxElementNameEquals(insertableComponent.element.name, nameToSearchFor)) {
               return selectOption
             }

--- a/editor/src/components/canvas/controls/render-as.tsx
+++ b/editor/src/components/canvas/controls/render-as.tsx
@@ -6,11 +6,7 @@ import * as EP from '../../../core/shared/element-path'
 import * as EditorActions from '../../editor/actions/action-creators'
 import { UIGridRow } from '../../inspector/widgets/ui-grid-row'
 import { PopupList } from '../../../uuiui'
-import {
-  isJSXElement,
-  JSXElementName,
-  jsxElementNameEquals,
-} from '../../../core/shared/element-template'
+import { JSXElementName, jsxElementNameEquals } from '../../../core/shared/element-template'
 import { getElementsToTarget } from '../../inspector/common/inspector-utils'
 import { Imports } from '../../../core/shared/project-file-types'
 import {
@@ -52,7 +48,7 @@ export const RenderAsRow = React.memo(() => {
   const onSelect = React.useCallback(
     (selectOption: SelectOption) => {
       const value: InsertableComponent = selectOption.value
-      if (!isJSXElement(value.element)) {
+      if (value.element.type !== 'JSX_ELEMENT') {
         return
       }
       onElementTypeChange(value.element.name, value.importsToAdd)
@@ -105,7 +101,7 @@ export const RenderAsRow = React.memo(() => {
       for (const selectOptionGroup of insertableComponents) {
         for (const selectOption of selectOptionGroup.options ?? []) {
           const insertableComponent: InsertableComponent = selectOption.value
-          if (insertableComponent != null && isJSXElement(insertableComponent.element)) {
+          if (insertableComponent != null && insertableComponent.element.type === 'JSX_ELEMENT') {
             if (jsxElementNameEquals(insertableComponent.element.name, nameToSearchFor)) {
               return selectOption
             }

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -43,7 +43,6 @@ import {
 } from '../../../core/model/element-template-utils'
 import {
   emptyComments,
-  isJSXElement,
   jsxAttributeValue,
   JSXConditionalExpressionWithoutUID,
   jsxElement,
@@ -514,7 +513,7 @@ export var FloatingMenu = React.memo(() => {
 
   const onChangeElement = React.useCallback(
     (pickedInsertableComponent: InsertMenuItemValue): Array<EditorAction> => {
-      if (!isJSXElement(pickedInsertableComponent.element)) {
+      if (pickedInsertableComponent.element.type !== 'JSX_ELEMENT') {
         return []
       }
       const selectedViews = selectedViewsref.current

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -621,8 +621,10 @@ export var FloatingMenu = React.memo(() => {
             case 'JSX_CONDITIONAL_EXPRESSION':
             case 'JSX_FRAGMENT':
               return onChangeConditionalOrFragment(pickedInsertableComponent.element)
-            default:
+            case 'JSX_ELEMENT':
               return onChangeElement(pickedInsertableComponent)
+            default:
+              assertNever(pickedInsertableComponent.element)
           }
         }
 

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -34,8 +34,10 @@ import {
   isIntrinsicElement,
   isJSXAttributeOtherJavaScript,
   isUtopiaJSXComponent,
+  JSXConditionalExpressionWithoutUID,
   JSXElement,
   JSXElementWithoutUID,
+  JSXFragmentWithoutUID,
   UtopiaJSXComponent,
 } from '../../core/shared/element-template'
 import { findElementWithUID } from '../../core/shared/uid-utils'
@@ -94,7 +96,10 @@ export type UtopiaRequireFn = (
 
 export type CurriedUtopiaRequireFn = (projectContents: ProjectContentTreeRoot) => UtopiaRequireFn
 
-export type ComponentElementToInsert = JSXElementWithoutUID | 'conditional' | 'fragment'
+export type ComponentElementToInsert =
+  | JSXElementWithoutUID
+  | JSXConditionalExpressionWithoutUID
+  | JSXFragmentWithoutUID
 
 export interface ComponentInfo {
   insertMenuLabel: string

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -5049,7 +5049,7 @@ export const UPDATE_FNS = {
         editor,
         (element) => element,
         (success, _, underlyingFilePath) => {
-          if (action.toInsert.element === 'conditional' || action.toInsert.element === 'fragment') {
+          if (!isJSXElement(action.toInsert.element)) {
             return success
           }
 

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -5049,7 +5049,7 @@ export const UPDATE_FNS = {
         editor,
         (element) => element,
         (success, _, underlyingFilePath) => {
-          if (!isJSXElement(action.toInsert.element)) {
+          if (action.toInsert.element.type !== 'JSX_ELEMENT') {
             return success
           }
 

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -240,11 +240,11 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
             dependencyStatus={getInsertableGroupPackageStatus(insertableGroup.source)}
           >
             {insertableGroup.insertableComponents.map((component, componentIndex) => {
-              if (component.element.type != 'JSX_ELEMENT') {
+              if (component.element.type !== 'JSX_ELEMENT') {
                 return null
               }
               const insertItemOnMouseDown = (event: React.MouseEvent) => {
-                if (component.element.type != 'JSX_ELEMENT') {
+                if (component.element.type !== 'JSX_ELEMENT') {
                   return
                 }
 

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -13,7 +13,6 @@ import {
   JSXAttributesPart,
   isJSXAttributesEntry,
   getJSXAttribute,
-  isJSXElement,
 } from '../../core/shared/element-template'
 import { generateUID } from '../../core/shared/uid-utils'
 import {
@@ -241,11 +240,11 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
             dependencyStatus={getInsertableGroupPackageStatus(insertableGroup.source)}
           >
             {insertableGroup.insertableComponents.map((component, componentIndex) => {
-              if (!isJSXElement(component.element)) {
+              if (component.element.type != 'JSX_ELEMENT') {
                 return null
               }
               const insertItemOnMouseDown = (event: React.MouseEvent) => {
-                if (!isJSXElement(component.element)) {
+                if (component.element.type != 'JSX_ELEMENT') {
                   return
                 }
 

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -13,6 +13,7 @@ import {
   JSXAttributesPart,
   isJSXAttributesEntry,
   getJSXAttribute,
+  isJSXElement,
 } from '../../core/shared/element-template'
 import { generateUID } from '../../core/shared/uid-utils'
 import {
@@ -240,11 +241,11 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
             dependencyStatus={getInsertableGroupPackageStatus(insertableGroup.source)}
           >
             {insertableGroup.insertableComponents.map((component, componentIndex) => {
-              if (component.element === 'conditional' || component.element === 'fragment') {
+              if (!isJSXElement(component.element)) {
                 return null
               }
               const insertItemOnMouseDown = (event: React.MouseEvent) => {
-                if (component.element === 'conditional' || component.element === 'fragment') {
+                if (!isJSXElement(component.element)) {
                   return
                 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -173,6 +173,7 @@ import {
   childOrBlockIsAttribute,
   ChildOrAttribute,
   ConditionValue,
+  JSXConditionalExpressionWithoutUID,
 } from '../../../core/shared/element-template'
 import {
   CanvasRectangle,
@@ -2784,8 +2785,8 @@ export const ComponentElementToInsertKeepDeepEquality: KeepDeepEqualityCall<Comp
   unionDeepEquality(
     createCallWithTripleEquals<ComponentElementToInsert>(),
     JSXElementWithoutUIDKeepDeepEquality(),
-    (p): p is 'conditional' => p === 'conditional',
-    (p): p is JSXElementWithoutUID => (p as JSXElementWithoutUID).name != null,
+    (p): p is JSXConditionalExpressionWithoutUID => p.type === 'JSX_CONDITIONAL_EXPRESSION',
+    (p): p is JSXElementWithoutUID => isJSXElement(p),
   )
 
 export const ComponentInfoKeepDeepEquality: KeepDeepEqualityCall<ComponentInfo> =

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -2786,7 +2786,7 @@ export const ComponentElementToInsertKeepDeepEquality: KeepDeepEqualityCall<Comp
     createCallWithTripleEquals<ComponentElementToInsert>(),
     JSXElementWithoutUIDKeepDeepEquality(),
     (p): p is JSXConditionalExpressionWithoutUID => p.type === 'JSX_CONDITIONAL_EXPRESSION',
-    (p): p is JSXElementWithoutUID => isJSXElement(p),
+    (p): p is JSXElementWithoutUID => p.type === 'JSX_ELEMENT',
   )
 
 export const ComponentInfoKeepDeepEquality: KeepDeepEqualityCall<ComponentInfo> =

--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -15,6 +15,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {},
         "name": "App",
@@ -75,6 +76,7 @@ Array [
               },
             },
           ],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -100,6 +102,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -125,6 +128,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -150,6 +154,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -175,6 +180,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -200,6 +206,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -225,6 +232,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -335,6 +343,7 @@ Array [
               },
             },
           ],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -397,6 +406,7 @@ Array [
               },
             },
           ],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -420,7 +430,38 @@ Array [
     "insertableComponents": Array [
       Object {
         "defaultSize": null,
-        "element": "conditional",
+        "element": Object {
+          "comments": Object {
+            "leadingComments": Array [],
+            "trailingComments": Array [],
+          },
+          "condition": Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "type": "ATTRIBUTE_VALUE",
+            "value": true,
+          },
+          "originalConditionString": "true",
+          "type": "JSX_CONDITIONAL_EXPRESSION",
+          "whenFalse": Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "type": "ATTRIBUTE_VALUE",
+            "value": null,
+          },
+          "whenTrue": Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "type": "ATTRIBUTE_VALUE",
+            "value": null,
+          },
+        },
         "importsToAdd": Object {},
         "name": "Conditional",
         "stylePropOptions": Array [
@@ -436,7 +477,11 @@ Array [
     "insertableComponents": Array [
       Object {
         "defaultSize": null,
-        "element": "fragment",
+        "element": Object {
+          "children": Array [],
+          "longForm": false,
+          "type": "JSX_FRAGMENT",
+        },
         "importsToAdd": Object {},
         "name": "Fragment",
         "stylePropOptions": Array [
@@ -474,6 +519,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {},
         "name": "App",
@@ -534,6 +580,7 @@ Array [
               },
             },
           ],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -559,6 +606,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -584,6 +632,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -609,6 +658,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -634,6 +684,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -659,6 +710,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -684,6 +736,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -794,6 +847,7 @@ Array [
               },
             },
           ],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -856,6 +910,7 @@ Array [
               },
             },
           ],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "react": Object {
@@ -879,7 +934,38 @@ Array [
     "insertableComponents": Array [
       Object {
         "defaultSize": null,
-        "element": "conditional",
+        "element": Object {
+          "comments": Object {
+            "leadingComments": Array [],
+            "trailingComments": Array [],
+          },
+          "condition": Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "type": "ATTRIBUTE_VALUE",
+            "value": true,
+          },
+          "originalConditionString": "true",
+          "type": "JSX_CONDITIONAL_EXPRESSION",
+          "whenFalse": Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "type": "ATTRIBUTE_VALUE",
+            "value": null,
+          },
+          "whenTrue": Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "type": "ATTRIBUTE_VALUE",
+            "value": null,
+          },
+        },
         "importsToAdd": Object {},
         "name": "Conditional",
         "stylePropOptions": Array [
@@ -895,7 +981,11 @@ Array [
     "insertableComponents": Array [
       Object {
         "defaultSize": null,
-        "element": "fragment",
+        "element": Object {
+          "children": Array [],
+          "longForm": false,
+          "type": "JSX_FRAGMENT",
+        },
         "importsToAdd": Object {},
         "name": "Fragment",
         "stylePropOptions": Array [
@@ -920,6 +1010,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -1084,6 +1175,7 @@ Array [
               },
             },
           ],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -1119,6 +1211,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -1203,6 +1296,7 @@ Array [
               },
             },
           ],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -1415,6 +1509,7 @@ Array [
               },
             },
           ],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -1499,6 +1594,7 @@ Array [
               },
             },
           ],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -1679,6 +1775,7 @@ Array [
               },
             },
           ],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -1749,6 +1846,7 @@ Array [
               },
             },
           ],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -1803,6 +1901,7 @@ Array [
               },
             },
           ],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -1840,6 +1939,7 @@ Array [
             },
           },
           "props": Array [],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -2038,6 +2138,7 @@ Array [
               },
             },
           ],
+          "type": "JSX_ELEMENT",
         },
         "importsToAdd": Object {
           "antd": Object {

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -20,8 +20,10 @@ import {
   jsxAttributesEntry,
   jsxAttributesFromMap,
   jsxAttributeValue,
+  jsxConditionalExpressionWithoutUID,
   jsxElementName,
   jsxElementWithoutUID,
+  jsxFragmentWithoutUID,
   parsedComments,
   simpleAttribute,
 } from '../../core/shared/element-template'
@@ -334,7 +336,13 @@ const conditionalElementsDescriptors: ComponentDescriptorsForFile = {
     variants: [
       {
         insertMenuLabel: 'Conditional',
-        elementToInsert: 'conditional',
+        elementToInsert: jsxConditionalExpressionWithoutUID(
+          jsxAttributeValue(true, emptyComments),
+          'true',
+          jsxAttributeValue(null, emptyComments),
+          jsxAttributeValue(null, emptyComments),
+          emptyComments,
+        ),
         importsToAdd: {},
       },
     ],
@@ -347,7 +355,7 @@ const fragmentElementsDescriptors: ComponentDescriptorsForFile = {
     variants: [
       {
         insertMenuLabel: 'Fragment',
-        elementToInsert: 'fragment',
+        elementToInsert: jsxFragmentWithoutUID([], false),
         importsToAdd: {},
       },
     ],

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -986,11 +986,11 @@ export interface JSXElement {
   uid: string
 }
 
-export interface JSXElementWithoutUID {
-  name: JSXElementName
-  props: JSXAttributes
-  children: JSXElementChildren
-}
+export type JSXElementWithoutUID = Omit<JSXElement, 'uid'>
+
+export type JSXConditionalExpressionWithoutUID = Omit<JSXConditionalExpression, 'uid'>
+
+export type JSXFragmentWithoutUID = Omit<JSXFragment, 'uid'>
 
 export type ElementsWithin = { [uid: string]: JSXElement }
 
@@ -1133,19 +1133,23 @@ export type JSXElementChild =
   | JSXFragment
   | JSXConditionalExpression
 
-export function isJSXElement(element: JSXElementChild): element is JSXElement {
+export type WithJSXElementChildType = Pick<JSXElementChild, 'type'>
+
+export function isJSXElement(element: WithJSXElementChildType): element is JSXElement {
   return element.type === 'JSX_ELEMENT'
 }
 
-export function isJSXArbitraryBlock(element: JSXElementChild): element is JSXArbitraryBlock {
+export function isJSXArbitraryBlock(
+  element: WithJSXElementChildType,
+): element is JSXArbitraryBlock {
   return element.type === 'JSX_ARBITRARY_BLOCK'
 }
 
-export function isJSXTextBlock(element: JSXElementChild): element is JSXTextBlock {
+export function isJSXTextBlock(element: WithJSXElementChildType): element is JSXTextBlock {
   return element.type === 'JSX_TEXT_BLOCK'
 }
 
-export function isJSXFragment(element: JSXElementChild): element is JSXFragment {
+export function isJSXFragment(element: WithJSXElementChildType): element is JSXFragment {
   return element.type === 'JSX_FRAGMENT'
 }
 
@@ -1155,7 +1159,7 @@ export function isJSXConditionalExpression(
   return element.type === 'JSX_CONDITIONAL_EXPRESSION'
 }
 
-export function isJSXElementLike(element: JSXElementChild): element is JSXElementLike {
+export function isJSXElementLike(element: WithJSXElementChildType): element is JSXElementLike {
   return isJSXElement(element) || isJSXFragment(element)
 }
 
@@ -1255,9 +1259,38 @@ export function jsxElementWithoutUID(
   children: JSXElementChildren,
 ): JSXElementWithoutUID {
   return {
+    type: 'JSX_ELEMENT',
     name: typeof name === 'string' ? jsxElementName(name, []) : name,
     props: props,
     children: children,
+  }
+}
+
+export function jsxConditionalExpressionWithoutUID(
+  condition: JSXAttribute,
+  originalConditionString: string,
+  whenTrue: ChildOrAttribute,
+  whenFalse: ChildOrAttribute,
+  comments: ParsedComments,
+): JSXConditionalExpressionWithoutUID {
+  return {
+    type: 'JSX_CONDITIONAL_EXPRESSION',
+    condition: condition,
+    originalConditionString: originalConditionString,
+    whenTrue: whenTrue,
+    whenFalse: whenFalse,
+    comments: comments,
+  }
+}
+
+export function jsxFragmentWithoutUID(
+  children: JSXElementChildren,
+  longForm: boolean,
+): JSXFragmentWithoutUID {
+  return {
+    type: 'JSX_FRAGMENT',
+    children: children,
+    longForm: longForm,
   }
 }
 

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1133,23 +1133,19 @@ export type JSXElementChild =
   | JSXFragment
   | JSXConditionalExpression
 
-export type WithJSXElementChildType = Pick<JSXElementChild, 'type'>
-
-export function isJSXElement(element: WithJSXElementChildType): element is JSXElement {
+export function isJSXElement(element: JSXElementChild): element is JSXElement {
   return element.type === 'JSX_ELEMENT'
 }
 
-export function isJSXArbitraryBlock(
-  element: WithJSXElementChildType,
-): element is JSXArbitraryBlock {
+export function isJSXArbitraryBlock(element: JSXElementChild): element is JSXArbitraryBlock {
   return element.type === 'JSX_ARBITRARY_BLOCK'
 }
 
-export function isJSXTextBlock(element: WithJSXElementChildType): element is JSXTextBlock {
+export function isJSXTextBlock(element: JSXElementChild): element is JSXTextBlock {
   return element.type === 'JSX_TEXT_BLOCK'
 }
 
-export function isJSXFragment(element: WithJSXElementChildType): element is JSXFragment {
+export function isJSXFragment(element: JSXElementChild): element is JSXFragment {
   return element.type === 'JSX_FRAGMENT'
 }
 
@@ -1159,7 +1155,7 @@ export function isJSXConditionalExpression(
   return element.type === 'JSX_CONDITIONAL_EXPRESSION'
 }
 
-export function isJSXElementLike(element: WithJSXElementChildType): element is JSXElementLike {
+export function isJSXElementLike(element: JSXElementChild): element is JSXElementLike {
   return isJSXElement(element) || isJSXFragment(element)
 }
 


### PR DESCRIPTION
Continued from #3461 

This PR refactors `ComponentElementToInsert` to use concrete types and consequently simplifies insertion logic.