### PR TITLE
Show conditional branches in the inspector

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -50,6 +50,8 @@ import {
 } from '../controls/conditional-override-control'
 import { getOptionControlTestId } from '../controls/option-chain-control'
 import {
+  ConditionalsControlBranchFalse,
+  ConditionalsControlBranchTrue,
   ConditionalsControlSectionExpressionTestId,
   ConditionalsControlSectionOpenTestId,
   ConditionalsControlSwitchBranches,
@@ -2620,6 +2622,38 @@ describe('inspector tests with real metadata', () => {
         ConditionalsControlSectionExpressionTestId,
       )
       expect((expressionElement as HTMLInputElement).value).toEqual('40 + 2 < 42')
+    })
+    it('shows the branches in the inspector', async () => {
+      const startSnippet = `
+      <div data-uid='aaa'>
+        {
+          // @utopia/uid=conditional
+          [].length === 0 ? (
+          <div data-uid='bbb' data-testid='bbb'><div>Another div</div></div>
+        ) : (
+          <h1 data-uid='ccc' data-testid='ccc'>hello there</h1>
+        )}
+      </div>
+      `
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(startSnippet),
+        'await-first-dom-report',
+      )
+
+      expect(renderResult.renderedDOM.getByTestId('bbb')).not.toBeNull()
+
+      const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional'])
+      await act(async () => {
+        await renderResult.dispatch([selectComponents([targetPath], false)], false)
+      })
+
+      const branchElementTrue = renderResult.renderedDOM.getByTestId(ConditionalsControlBranchTrue)
+      const branchElementFalse = renderResult.renderedDOM.getByTestId(
+        ConditionalsControlBranchFalse,
+      )
+
+      expect(branchElementTrue.innerText).toEqual('div')
+      expect(branchElementFalse.innerText).toEqual('h1')
     })
   })
 })

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -59,7 +59,7 @@ export const ConditionalsControlSwitchBranches = 'conditionals-control-switch=br
 export type ConditionOverride = boolean | 'mixed' | 'not-overridden' | 'not-a-conditional'
 type ConditionExpression = string | 'multiselect' | 'not-a-conditional'
 
-const branchesSelector = createCachedSelector(
+const branchNavigatorEntriesSelector = createCachedSelector(
   (store: MetadataSubstate) => store.editor.jsxMetadata,
   (_store: MetadataSubstate, paths: ElementPath[]) => paths,
   (jsxMetadata, paths): { true: NavigatorEntry | null; false: NavigatorEntry | null } | null => {
@@ -285,7 +285,7 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
 
   const branchNavigatorEntries = useEditorState(
     Substores.metadata,
-    (store) => branchesSelector(store, paths),
+    (store) => branchNavigatorEntriesSelector(store, paths),
     'ConditionalSection branches',
   )
 

--- a/editor/src/components/inspector/widgets/ui-grid-row.tsx
+++ b/editor/src/components/inspector/widgets/ui-grid-row.tsx
@@ -67,6 +67,10 @@ const gridTemplates = {
     gridColumnGap: 4,
     gridTemplateColumns: '16px auto',
   },
+  '|--67px--|<--------1fr-------->': {
+    gridColumnGap: 4,
+    gridTemplateColumns: '67px 1fr',
+  },
 } as const
 
 export interface GridRowProps extends React.InputHTMLAttributes<HTMLDivElement> {

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -76,7 +76,7 @@ const elementSupportsChildrenSelector = createCachedSelector(
   },
 )((_, navigatorEntry) => navigatorEntryToKey(navigatorEntry))
 
-const labelSelector = createCachedSelector(
+export const labelSelector = createCachedSelector(
   targetElementMetadataSelector,
   (store: MetadataSubstate) => store.editor.allElementProps,
   (elementMetadata, allElementProps) => {
@@ -104,7 +104,7 @@ const noOfChildrenSelector = createCachedSelector(
   },
 )((_, navigatorEntry) => navigatorEntryToKey(navigatorEntry))
 
-function getNavigatorEntryLabel(
+export function getNavigatorEntryLabel(
   navigatorEntry: NavigatorEntry,
   labelForTheElement: string,
 ): string {


### PR DESCRIPTION
Fixes #3467 

This PR shows the conditional branches in the inspector pane, similarly to how they appear in the navigator.
<img width="835" alt="Screenshot 2023-03-22 at 10 43 25 AM" src="https://user-images.githubusercontent.com/1081051/226863828-48797dc5-f024-4ba8-b136-b20de1482357.png">

Note: the branch contents can still be "jumpy" with the inner contents and icons, like it's currently in the navigator - so if we wanna fix that we should probably do that separately.
