### PR TITLE
Show override pin all the time

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -2391,6 +2391,53 @@ describe('inspector tests with real metadata', () => {
           'simple',
         )
       }
+
+      // override to the current condition value
+      {
+        await clickButtonAndSelectTarget(renderResult, ConditionalOverrideControlDisableTestId, [
+          targetPath,
+        ])
+
+        expect(renderResult.renderedDOM.queryByTestId('ccc')).toBeNull()
+        expect(renderResult.renderedDOM.getByTestId('bbb')).not.toBeNull()
+
+        expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+          makeTestProjectCodeWithSnippet(`
+                  <div data-uid='aaa'>
+                    {
+                      // @utopia/uid=conditional
+                      // @utopia/conditional=true
+                      [].length === 0 ? (
+                        <div data-uid='bbb' data-testid='bbb'>foo</div>
+                      ) : (
+                        <div data-uid='ccc' data-testid='ccc'>bar</div>
+                      )
+                    }
+                  </div>
+                `),
+        )
+
+        const trueButton = await renderResult.renderedDOM.findByTestId(
+          getOptionControlTestId(ConditionalOverrideControlTestIdPrefix, 'true'),
+        )
+        const falseButton = await renderResult.renderedDOM.findByTestId(
+          getOptionControlTestId(ConditionalOverrideControlTestIdPrefix, 'false'),
+        )
+
+        // the `true` button should be checked because that is the override
+        expect(trueButton.attributes.getNamedItemNS(null, 'data-ischecked')?.value).toEqual('true')
+        expect(falseButton.attributes.getNamedItemNS(null, 'data-ischecked')?.value).toEqual(
+          'false',
+        )
+
+        // the button status is "overridden"
+        expect(trueButton.attributes.getNamedItemNS(null, 'data-controlstatus')?.value).toEqual(
+          'overridden',
+        )
+        expect(falseButton.attributes.getNamedItemNS(null, 'data-controlstatus')?.value).toEqual(
+          'overridden',
+        )
+      }
     })
     it('switches conditional branches', async () => {
       const startSnippet = `

--- a/editor/src/components/inspector/controls/conditional-override-control.tsx
+++ b/editor/src/components/inspector/controls/conditional-override-control.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ConditionValue } from '../../../core/shared/element-template'
 import { when } from '../../../utils/react-conditionals'
-import { ButtonProps, FlexRow, Icons, Tooltip } from '../../../uuiui'
+import { ButtonProps, FlexRow, Icons, Tooltip, useColorTheme } from '../../../uuiui'
 import { SquareButton } from '../../titlebar/buttons'
 import { ControlStatus, ControlStyles } from '../common/control-status'
 import { UIGridRow } from '../widgets/ui-grid-row'
@@ -35,39 +35,31 @@ const OverrideControlOptions: Array<OptionChainOption<boolean>> = [
 export const ConditionalOverrideControl: React.FunctionComponent<
   React.PropsWithChildren<ConditionalOverrideControlProps>
 > = (props) => {
-  const { controlStatus, controlStyles, setConditionOverride } = props
+  const { controlStatus, controlStyles, setConditionOverride, conditionValue } = props
 
-  const disableOverride = React.useCallback(() => {
+  const toggleOverride = React.useCallback(() => {
     if (controlStatus === 'overridden') {
       setConditionOverride(null)
+    } else if (conditionValue !== 'not-a-conditional') {
+      setConditionOverride(conditionValue)
     }
-  }, [controlStatus, setConditionOverride])
+  }, [controlStatus, setConditionOverride, conditionValue])
 
   return (
-    <UIGridRow
-      padded={true}
-      variant='<---1fr--->|------172px-------|'
-      style={{ color: props.controlStyles.mainColor }}
-    >
+    <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
       Result
-      <FlexRow style={{ flexGrow: 1, gap: 4 }}>
-        {when(
-          controlStatus === 'overridden',
-          <Tooltip title={'Override'}>
-            <SquareButton
-              onClick={disableOverride}
-              testId={ConditionalOverrideControlDisableTestId}
-            >
-              {getPinIcon(controlStatus, controlStyles)}
-            </SquareButton>
-          </Tooltip>,
-        )}
+      <FlexRow>
+        <Tooltip title={'Override'}>
+          <SquareButton onClick={toggleOverride} testId={ConditionalOverrideControlDisableTestId}>
+            {getPinIcon(controlStatus, controlStyles)}
+          </SquareButton>
+        </Tooltip>
         <OptionChainControl
           id={'conditional-override-control'}
           testId={ConditionalOverrideControlTestIdPrefix}
           key={'conditional-override-control'}
           onSubmitValue={props.setConditionOverride}
-          value={props.conditionValue}
+          value={conditionValue}
           options={OverrideControlOptions}
           controlStatus={controlStatus}
           controlStyles={controlStyles}

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -349,24 +349,22 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
       </InspectorSubsectionHeader>
       {unless(
         originalConditionExpression === 'multiselect',
-        <UIGridRow padded={true} variant='<-auto-><----------1fr--------->'>
-          Condition
-          <StringInput
-            testId={ConditionalsControlSectionExpressionTestId}
-            value={conditionExpression}
-            onChange={onExpressionChange}
-            onKeyUp={onExpressionKeyUp}
-            onBlur={onUpdateExpression}
-            css={{
-              ...UtopiaStyles.fontStyles.monospaced,
-              textAlign: 'center',
-              fontWeight: 600,
-            }}
-          />
-        </UIGridRow>,
-      )}
-      {originalConditionExpression !== 'multiselect' && conditionValue !== 'multiselect' ? (
         <React.Fragment>
+          <UIGridRow padded={true} variant='<-auto-><----------1fr--------->'>
+            Condition
+            <StringInput
+              testId={ConditionalsControlSectionExpressionTestId}
+              value={conditionExpression}
+              onChange={onExpressionChange}
+              onKeyUp={onExpressionKeyUp}
+              onBlur={onUpdateExpression}
+              css={{
+                ...UtopiaStyles.fontStyles.monospaced,
+                textAlign: 'center',
+                fontWeight: 600,
+              }}
+            />
+          </UIGridRow>
           <UIGridRow padded={true} variant='<-------------1fr------------->'>
             <Button
               style={{ flex: 1 }}
@@ -378,14 +376,16 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
               Switch branches
             </Button>
           </UIGridRow>
-          <ConditionalOverrideControl
-            controlStatus={controlStatus}
-            controlStyles={controlStyles}
-            setConditionOverride={setConditionOverride}
-            conditionValue={conditionValue}
-          />
-        </React.Fragment>
-      ) : null}
+          {conditionValue !== 'multiselect' ? (
+            <ConditionalOverrideControl
+              controlStatus={controlStatus}
+              controlStyles={controlStyles}
+              setConditionOverride={setConditionOverride}
+              conditionValue={conditionValue}
+            />
+          ) : null}
+        </React.Fragment>,
+      )}
       <BranchRow
         label={branchLabels.true}
         navigatorEntry={branchNavigatorEntries?.true ?? null}


### PR DESCRIPTION
**Problem:**
Make the override pin visible all the time.
When there is no override the clicking on the pin will enable an override to the current condition value.
When there is an existing override, clicking on the pin will disable the override.

![22-27-tb9i2-lrooz](https://user-images.githubusercontent.com/127662/226890872-8c8be0d8-81c2-4b84-90f5-95f7d07551f6.gif)
