### PR TITLE
Make the switch branches button nicer

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -41,16 +41,16 @@ import {
 } from '../../editor/actions/action-creators'
 import { DefaultPackageJson, StoryboardFilePath } from '../../editor/store/editor-state'
 import {
-  ConditionalOverrideControlDisableTestId,
+  ConditionalOverrideControlToggleTestId,
   ConditionalOverrideControlTestIdPrefix,
 } from '../controls/conditional-override-control'
 import { getOptionControlTestId } from '../controls/option-chain-control'
 import {
-  ConditionalsControlBranchFalse,
-  ConditionalsControlBranchTrue,
+  ConditionalsControlBranchFalseTestId,
+  ConditionalsControlBranchTrueTestId,
   ConditionalsControlSectionExpressionTestId,
   ConditionalsControlSectionOpenTestId,
-  ConditionalsControlSwitchBranches,
+  ConditionalsControlSwitchBranchesTestId,
 } from '../sections/layout-section/conditional-section'
 async function getControl(
   controlTestId: string,
@@ -2344,7 +2344,7 @@ describe('inspector tests with real metadata', () => {
 
       // disable override
       {
-        await clickButtonAndSelectTarget(renderResult, ConditionalOverrideControlDisableTestId, [
+        await clickButtonAndSelectTarget(renderResult, ConditionalOverrideControlToggleTestId, [
           targetPath,
         ])
 
@@ -2390,7 +2390,7 @@ describe('inspector tests with real metadata', () => {
 
       // override to the current condition value
       {
-        await clickButtonAndSelectTarget(renderResult, ConditionalOverrideControlDisableTestId, [
+        await clickButtonAndSelectTarget(renderResult, ConditionalOverrideControlToggleTestId, [
           targetPath,
         ])
 
@@ -2461,7 +2461,7 @@ describe('inspector tests with real metadata', () => {
 
       // switch branches
       {
-        await clickButtonAndSelectTarget(renderResult, ConditionalsControlSwitchBranches, [
+        await clickButtonAndSelectTarget(renderResult, ConditionalsControlSwitchBranchesTestId, [
           targetPath,
         ])
 
@@ -2775,9 +2775,11 @@ describe('inspector tests with real metadata', () => {
         await renderResult.dispatch([selectComponents([targetPath], false)], false)
       })
 
-      const branchElementTrue = renderResult.renderedDOM.getByTestId(ConditionalsControlBranchTrue)
+      const branchElementTrue = renderResult.renderedDOM.getByTestId(
+        ConditionalsControlBranchTrueTestId,
+      )
       const branchElementFalse = renderResult.renderedDOM.getByTestId(
-        ConditionalsControlBranchFalse,
+        ConditionalsControlBranchFalseTestId,
       )
 
       expect(branchElementTrue.innerText).toEqual('div')

--- a/editor/src/components/inspector/controls/conditional-override-control.tsx
+++ b/editor/src/components/inspector/controls/conditional-override-control.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import { ConditionValue } from '../../../core/shared/element-template'
-import { when } from '../../../utils/react-conditionals'
-import { ButtonProps, FlexRow, Icons, Tooltip, useColorTheme } from '../../../uuiui'
+import { ButtonProps, FlexRow, Icons, Tooltip } from '../../../uuiui'
 import { SquareButton } from '../../titlebar/buttons'
 import { ControlStatus, ControlStyles } from '../common/control-status'
 import { UIGridRow } from '../widgets/ui-grid-row'
 import { OptionChainControl, OptionChainOption } from './option-chain-control'
 
 export const ConditionalOverrideControlTestIdPrefix = 'conditional-override-control'
-export const ConditionalOverrideControlDisableTestId = 'conditional-override-control-disable'
+export const ConditionalOverrideControlToggleTestId = 'conditional-override-control-toggle'
 
 export interface ConditionalOverrideControlProps extends ButtonProps {
   controlStatus: ControlStatus
@@ -50,7 +49,7 @@ export const ConditionalOverrideControl: React.FunctionComponent<
       Result
       <FlexRow>
         <Tooltip title={'Override'}>
-          <SquareButton onClick={toggleOverride} testId={ConditionalOverrideControlDisableTestId}>
+          <SquareButton onClick={toggleOverride} testId={ConditionalOverrideControlToggleTestId}>
             {getPinIcon(controlStatus, controlStyles)}
           </SquareButton>
         </Tooltip>

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -57,9 +57,9 @@ import { UIGridRow } from '../../widgets/ui-grid-row'
 export const ConditionalsControlSectionOpenTestId = 'conditionals-control-section-open'
 export const ConditionalsControlSectionCloseTestId = 'conditionals-control-section-close'
 export const ConditionalsControlSectionExpressionTestId = 'conditionals-control-expression'
-export const ConditionalsControlSwitchBranches = 'conditionals-control-switch-branches'
-export const ConditionalsControlBranchTrue = 'conditionals-control-branch-true'
-export const ConditionalsControlBranchFalse = 'conditionals-control-branch-false'
+export const ConditionalsControlSwitchBranchesTestId = 'conditionals-control-switch-branches'
+export const ConditionalsControlBranchTrueTestId = 'conditionals-control-branch-true'
+export const ConditionalsControlBranchFalseTestId = 'conditionals-control-branch-false'
 
 export type ConditionOverride = boolean | 'mixed' | 'not-overridden' | 'not-a-conditional'
 type ConditionExpression = string | 'multiselect' | 'not-a-conditional'
@@ -392,7 +392,10 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
           />
         </FlexColumn>
         <Tooltip title={'Switch branches'}>
-          <SquareButton onClick={replaceBranches} data-testid={ConditionalsControlSwitchBranches}>
+          <SquareButton
+            onClick={replaceBranches}
+            data-testid={ConditionalsControlSwitchBranchesTestId}
+          >
             <Icons.Flip category={'element'} width={18} height={18} />
           </SquareButton>
         </Tooltip>
@@ -439,8 +442,8 @@ const BranchRow = ({
         <span
           data-testid={
             conditionalCase === 'true-case'
-              ? ConditionalsControlBranchTrue
-              : ConditionalsControlBranchFalse
+              ? ConditionalsControlBranchTrueTestId
+              : ConditionalsControlBranchFalseTestId
           }
         >
           {getNavigatorEntryLabel(navigatorEntry, label)}


### PR DESCRIPTION
**Description:**

New design for the "Switch branches" button.
Note: this is not the original design (the position of the button is at the end of the line, for the sake of implementation simplicity).

<img width="260" alt="image" src="https://user-images.githubusercontent.com/127662/226955617-8ee893eb-3856-4448-a97b-7223b8124860.png">

I also renamed some inconsistent variable names

