### PR TITLE
Clicking on a conditional clause label should select the clause

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
@@ -73,13 +73,13 @@ describe('a project with conditionals', () => {
       'regular-storyboard/scene/app',
       'regular-storyboard/scene/app:app-root',
       'regular-storyboard/scene/app:app-root/conditional1',
-      'conditional-clause-storyboard/scene/app:app-root/conditional1-true-case',
-      'regular-storyboard/scene/app:app-root/conditional1/conditional2',
       'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2-true-case',
+      'regular-storyboard/scene/app:app-root/conditional1/conditional2',
+      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2/div-inside-conditionals-true-case',
       'regular-storyboard/scene/app:app-root/conditional1/conditional2/div-inside-conditionals',
-      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2-false-case',
+      'conditional-clause-storyboard/scene/app:app-root/conditional1/conditional2/60c-false-case',
       'synthetic-storyboard/scene/app:app-root/conditional1/conditional2/60c-attribute',
-      'conditional-clause-storyboard/scene/app:app-root/conditional1-false-case',
+      'conditional-clause-storyboard/scene/app:app-root/conditional1/30e-false-case',
       'synthetic-storyboard/scene/app:app-root/conditional1/30e-attribute',
     ])
   })

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -40,7 +40,10 @@ import {
   updateConditionalExpression,
 } from '../../../editor/actions/action-creators'
 import { useDispatch } from '../../../editor/store/dispatch-context'
-import { NavigatorEntry } from '../../../editor/store/editor-state'
+import {
+  isConditionalClauseNavigatorEntry,
+  NavigatorEntry,
+} from '../../../editor/store/editor-state'
 import { Substores, useEditorState } from '../../../editor/store/store-hook'
 import { MetadataSubstate } from '../../../editor/store/store-hook-substore-types'
 import { LayoutIcon } from '../../../navigator/navigator-item/layout-icon'
@@ -89,23 +92,19 @@ const branchNavigatorEntriesSelector = createCachedSelector(
 
     const navigatorEntries = getNavigatorTargets(jsxMetadata, [], []).navigatorTargets
 
-    function getNavigatorEntry(
-      clause: JSXElementChild,
-      conditionalCase: ConditionalCase,
-    ): NavigatorEntry | null {
+    function getNavigatorEntry(clause: JSXElementChild): NavigatorEntry | null {
       return (
-        navigatorEntries.find((entry) =>
-          EP.pathsEqual(
-            entry.elementPath,
-            getConditionalClausePath(paths[0], clause, conditionalCase),
-          ),
+        navigatorEntries.find(
+          (entry) =>
+            EP.pathsEqual(entry.elementPath, getConditionalClausePath(paths[0], clause)) &&
+            !isConditionalClauseNavigatorEntry(entry),
         ) ?? null
       )
     }
 
     return {
-      true: getNavigatorEntry(conditional.whenTrue, 'true-case'),
-      false: getNavigatorEntry(conditional.whenFalse, 'false-case'),
+      true: getNavigatorEntry(conditional.whenTrue),
+      false: getNavigatorEntry(conditional.whenFalse),
     }
   },
 )((_, paths) => paths.map(EP.toString).join(','))

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -1288,4 +1288,62 @@ describe('conditionals in the navigator', () => {
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/${removedOriginalUID}-attribute
       regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
   })
+  it('can select the true case clause by its label', async () => {
+    const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
+
+    // Determine the entry we want to select.
+    const elementPathToSelect = EP.fromString(
+      `${BakedInStoryboardUID}/${TestSceneUID}/containing-div/conditional1/conditional2/then-then-div`,
+    )
+
+    // Getting info relating to what element will be selected.
+    const navigatorEntryToSelect = await renderResult.renderedDOM.findByTestId(
+      NavigatorItemTestId(
+        varSafeNavigatorEntryToKey(
+          conditionalClauseNavigatorEntry(elementPathToSelect, 'true-case'),
+        ),
+      ),
+    )
+    const navigatorEntryToSelectRect = navigatorEntryToSelect.getBoundingClientRect()
+    const navigatorEntryToSelectCenter = getDomRectCenter(navigatorEntryToSelectRect)
+
+    // Select the false label entry in the navigator.
+    await act(async () => {
+      await mouseClickAtPoint(navigatorEntryToSelect, navigatorEntryToSelectCenter)
+    })
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    const selectedViewPaths = renderResult.getEditorState().editor.selectedViews.map(EP.toString)
+    expect(selectedViewPaths).toEqual([EP.toString(elementPathToSelect)])
+  })
+  it('can select the false case clause by its label', async () => {
+    const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
+
+    // Determine the entry we want to select.
+    const elementPathToSelect = EP.fromString(
+      `${BakedInStoryboardUID}/${TestSceneUID}/containing-div/conditional1/else-div`,
+    )
+
+    // Getting info relating to what element will be selected.
+    const navigatorEntryToSelect = await renderResult.renderedDOM.findByTestId(
+      NavigatorItemTestId(
+        varSafeNavigatorEntryToKey(
+          conditionalClauseNavigatorEntry(elementPathToSelect, 'false-case'),
+        ),
+      ),
+    )
+    const navigatorEntryToSelectRect = navigatorEntryToSelect.getBoundingClientRect()
+    const navigatorEntryToSelectCenter = getDomRectCenter(navigatorEntryToSelectRect)
+
+    // Select the false label entry in the navigator.
+    await act(async () => {
+      await mouseClickAtPoint(navigatorEntryToSelect, navigatorEntryToSelectCenter)
+    })
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    const selectedViewPaths = renderResult.getEditorState().editor.selectedViews.map(EP.toString)
+    expect(selectedViewPaths).toEqual([EP.toString(elementPathToSelect)])
+  })
 })

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -309,15 +309,11 @@ const isHiddenConditionalBranchSelector = createCachedSelector(
 
     // when the condition is true, then the 'then' branch is not hidden
     if (overriddenConditionValue) {
-      const trueClausePath = getConditionalClausePath(parentPath, conditional.whenTrue, 'true-case')
+      const trueClausePath = getConditionalClausePath(parentPath, conditional.whenTrue)
       return !EP.pathsEqual(elementPath, trueClausePath)
     }
     // when the condition is false, then the 'else' branch is not hidden
-    const falseClausePath = getConditionalClausePath(
-      parentPath,
-      conditional.whenFalse,
-      'false-case',
-    )
+    const falseClausePath = getConditionalClausePath(parentPath, conditional.whenFalse)
     return !EP.pathsEqual(elementPath, falseClausePath)
   },
 )((_, elementPath, parentPath) => `${EP.toString(elementPath)}_${EP.toString(parentPath)}`)
@@ -340,13 +336,11 @@ const isActiveBranchOfOverriddenConditionalSelector = createCachedSelector(
     return (
       matchesOverriddenConditionalBranch(elementPath, parentPath, {
         clause: conditionalParent.whenTrue,
-        branch: 'true-case',
         wantOverride: true,
         parentOverride: parentOverride,
       }) ||
       matchesOverriddenConditionalBranch(elementPath, parentPath, {
         clause: conditionalParent.whenFalse,
-        branch: 'false-case',
         wantOverride: false,
         parentOverride: parentOverride,
       })

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -56,7 +56,7 @@ export function navigatorDepth(
 
   // For the clause entry itself, this needs to step back by 1.
   if (isConditionalClauseNavigatorEntry(navigatorEntry)) {
-    result = result + 1
+    result = result - 1
   }
 
   return result
@@ -125,13 +125,10 @@ export function getNavigatorTargets(
           conditionalCase === 'true-case' ? conditional.whenTrue : conditional.whenFalse
 
         // Get the clause path.
-        const clausePath = getConditionalClausePath(path, clauseValue, conditionalCase)
+        const clausePath = getConditionalClausePath(path, clauseValue)
 
         // Create the entry for the name of the clause.
-        const clauseTitleEntry = conditionalClauseNavigatorEntry(
-          conditionalSubTree.path,
-          conditionalCase,
-        )
+        const clauseTitleEntry = conditionalClauseNavigatorEntry(clausePath, conditionalCase)
         navigatorTargets.push(clauseTitleEntry)
         visibleNavigatorTargets.push(clauseTitleEntry)
 

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -18,7 +18,6 @@ export type ConditionalCase = 'true-case' | 'false-case'
 export function getConditionalClausePath(
   conditionalPath: ElementPath,
   conditionalClause: JSXElementChild,
-  conditionalCase: ConditionalCase,
 ): ElementPath {
   return EP.appendToPath(conditionalPath, getUtopiaID(conditionalClause))
 }
@@ -36,11 +35,7 @@ export function reorderConditionalChildPathTrees(
     let result: Array<ElementPathTree> = []
 
     // The whenTrue clause should be first.
-    const trueCasePath = getConditionalClausePath(
-      conditionalPath,
-      conditional.whenTrue,
-      'true-case',
-    )
+    const trueCasePath = getConditionalClausePath(conditionalPath, conditional.whenTrue)
     const trueCasePathTree = childPaths.find((childPath) =>
       EP.pathsEqual(childPath.path, trueCasePath),
     )
@@ -49,11 +44,7 @@ export function reorderConditionalChildPathTrees(
     }
 
     // The whenFalse clause should be second.
-    const falseCasePath = getConditionalClausePath(
-      conditionalPath,
-      conditional.whenFalse,
-      'false-case',
-    )
+    const falseCasePath = getConditionalClausePath(conditionalPath, conditional.whenFalse)
     const falseCasePathTree = childPaths.find((childPath) =>
       EP.pathsEqual(childPath.path, falseCasePath),
     )
@@ -90,7 +81,6 @@ export function getConditionalCase(
   if (
     matchesOverriddenConditionalBranch(elementPath, parentPath, {
       clause: parent.whenTrue,
-      branch: 'true-case',
       wantOverride: true,
       parentOverride: parentOverride,
     })
@@ -113,14 +103,13 @@ export function matchesOverriddenConditionalBranch(
   parentPath: ElementPath,
   params: {
     clause: JSXElementChild
-    branch: ConditionalCase
     wantOverride: boolean
     parentOverride: boolean
   },
 ): boolean {
-  const { clause, branch, wantOverride, parentOverride } = params
+  const { clause, wantOverride, parentOverride } = params
   return (
     wantOverride === parentOverride &&
-    EP.pathsEqual(elementPath, getConditionalClausePath(parentPath, clause, branch))
+    EP.pathsEqual(elementPath, getConditionalClausePath(parentPath, clause))
   )
 }

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -468,12 +468,8 @@ export function removeJSXElementChild(
         children: updatedChildren,
       }
     } else if (isJSXConditionalExpression(parentElement)) {
-      const trueCasePath = getConditionalClausePath(parentPath, parentElement.whenTrue, 'true-case')
-      const falseCasePath = getConditionalClausePath(
-        parentPath,
-        parentElement.whenFalse,
-        'false-case',
-      )
+      const trueCasePath = getConditionalClausePath(parentPath, parentElement.whenTrue)
+      const falseCasePath = getConditionalClausePath(parentPath, parentElement.whenFalse)
 
       const nullAttribute = jsExpressionValue(null, emptyComments)
 


### PR DESCRIPTION
**Problem:**
If you click on a clause label (true/false) in the navigator, the conditional expression gets selected. Instead of that the conditional clause should be selected.

Before the PR:
![27-19-ulavb-6yvj9](https://user-images.githubusercontent.com/127662/227914495-e499b5d1-9dd8-4fe8-9f15-e9086475ac7a.gif)

After the PR:
![27-19-nt1um-hrlnx](https://user-images.githubusercontent.com/127662/227914547-d178d304-996f-4c1e-89b3-610679950c08.gif)

**Fix:**
The `ConditionalClauseNavigatorEntry` gets the conditional element path. I changed to the element path of the actual clause. This was not possible earlier, because the clause did not necessarily have an element path (when it contained an expression).

Next step: after this I think we can just remove the `true-case`/`end-case` from the end of the clause element path, it is not needed anymore. But in my opinion that should be in a subsequent refactor-only PR.