### PR TITLE
use withUnderlyingTarget instead of manual traverse

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1888,9 +1888,9 @@ export const UPDATE_FNS = {
 
               const branchPath = withUnderlyingTarget(
                 parentPath,
-                editor.projectContents,
-                editor.nodeModules.files,
-                editor.canvas.openFile?.filename ?? null,
+                withElementDeleted.projectContents,
+                withElementDeleted.nodeModules.files,
+                withElementDeleted.canvas.openFile?.filename ?? null,
                 null,
                 (_, element) => {
                   if (isJSXConditionalExpression(element) && element.uid === EP.toUid(parentPath)) {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1886,22 +1886,24 @@ export const UPDATE_FNS = {
             ) {
               const isTrueBranch = EP.toUid(view) === getUtopiaID(parent.element.value.whenTrue)
 
-              let newUID: string | null = null
-              walkContentsTreeForParseSuccess(withElementDeleted.projectContents, (_, success) => {
-                if (newUID != null) {
-                  return
-                }
-                walkElements(getUtopiaJSXComponentsFromSuccess(success), (element) => {
-                  if (newUID != null) {
-                    return
-                  }
+              const branchPath = withUnderlyingTarget(
+                parentPath,
+                editor.projectContents,
+                editor.nodeModules.files,
+                editor.canvas.openFile?.filename ?? null,
+                null,
+                (_, element) => {
                   if (isJSXConditionalExpression(element) && element.uid === EP.toUid(parentPath)) {
-                    newUID = getUtopiaID(isTrueBranch ? element.whenTrue : element.whenFalse)
+                    return EP.appendToPath(
+                      parentPath,
+                      getUtopiaID(isTrueBranch ? element.whenTrue : element.whenFalse),
+                    )
                   }
-                })
-              })
-              if (newUID != null) {
-                return EP.appendToPath(parentPath, newUID)
+                  return null
+                },
+              )
+              if (branchPath != null) {
+                return branchPath
               }
             }
             return EP.isStoryboardPath(parentPath) ? null : parentPath


### PR DESCRIPTION
Followup to https://github.com/concrete-utopia/utopia/pull/3482#discussion_r1149623638

This PR refactors the logic to detect the new UID of an empty conditional branch upon deletion, replacing it with a more succinct use of `withUnderlyingTarget`.