### PR TITLE
Allow collapsing navigator conditionals

### DIFF
--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -1353,7 +1353,9 @@ describe('conditionals in the navigator', () => {
   it('can be collapsed', async () => {
     const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
 
-    const collapseButton = await screen.findByTestId(`navigator-item-collapse-conditional1-button`)
+    const collapseButton = await screen.findByTestId(
+      `navigator-item-collapse-regular-${BakedInStoryboardUID}/${TestSceneUID}/containing-div/conditional1-button`,
+    )
     const collapseButtonRect = collapseButton.getBoundingClientRect()
     const collapseButtonCenter = getDomRectCenter(collapseButtonRect)
 

--- a/editor/src/components/navigator/navigator-item/expandable-indicator.tsx
+++ b/editor/src/components/navigator/navigator-item/expandable-indicator.tsx
@@ -30,6 +30,7 @@ export const ExpandableIndicator: React.FunctionComponent<
         }}
         onMouseDown={props.onMouseDown}
         onClick={props.onClick}
+        testId={`${props.testId}-button`}
       />
     </div>
   )

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -545,6 +545,7 @@ export const NavigatorItem: React.FunctionComponent<
             selected={selected && !isInsideComponent}
             onMouseDown={collapse}
             style={{ transform: 'scale(0.6)', opacity: 'var(--paneHoverOpacity)' }}
+            testId={`navigator-item-collapse-${EP.toUid(props.navigatorEntry.elementPath)}`}
           />
           <NavigatorRowLabel
             navigatorEntry={navigatorEntry}

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -545,7 +545,7 @@ export const NavigatorItem: React.FunctionComponent<
             selected={selected && !isInsideComponent}
             onMouseDown={collapse}
             style={{ transform: 'scale(0.6)', opacity: 'var(--paneHoverOpacity)' }}
-            testId={`navigator-item-collapse-${EP.toUid(props.navigatorEntry.elementPath)}`}
+            testId={`navigator-item-collapse-${navigatorEntryToKey(props.navigatorEntry)}`}
           />
           <NavigatorRowLabel
             navigatorEntry={navigatorEntry}

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -124,20 +124,26 @@ export function getNavigatorTargets(
         const clauseValue =
           conditionalCase === 'true-case' ? conditional.whenTrue : conditional.whenFalse
 
+        function addNavigatorTargetUnlessCollapsed(entry: NavigatorEntry) {
+          if (newCollapsedAncestor) {
+            return
+          }
+          navigatorTargets.push(entry)
+          visibleNavigatorTargets.push(entry)
+        }
+
         // Get the clause path.
         const clausePath = getConditionalClausePath(path, clauseValue)
 
         // Create the entry for the name of the clause.
         const clauseTitleEntry = conditionalClauseNavigatorEntry(clausePath, conditionalCase)
-        navigatorTargets.push(clauseTitleEntry)
-        visibleNavigatorTargets.push(clauseTitleEntry)
+        addNavigatorTargetUnlessCollapsed(clauseTitleEntry)
 
         // Create the entry for the value of the clause.
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, clausePath)
         if (elementMetadata == null) {
           const clauseValueEntry = syntheticNavigatorEntry(clausePath, clauseValue)
-          navigatorTargets.push(clauseValueEntry)
-          visibleNavigatorTargets.push(clauseValueEntry)
+          addNavigatorTargetUnlessCollapsed(clauseValueEntry)
         }
 
         // Walk the clause of the conditional.
@@ -145,7 +151,7 @@ export function getNavigatorTargets(
           return EP.pathsEqual(childPath.path, clausePath)
         })
         if (clausePathTree != null) {
-          walkAndAddKeys(clausePathTree, collapsedAncestor)
+          walkAndAddKeys(clausePathTree, newCollapsedAncestor)
         }
       }
 

--- a/editor/src/uuiui/icn.tsx
+++ b/editor/src/uuiui/icn.tsx
@@ -116,6 +116,7 @@ export interface IcnProps extends IcnPropsBase {
   onMouseUp?: (event: React.MouseEvent<HTMLImageElement>) => void
   onMouseOver?: (event: React.MouseEvent<HTMLImageElement>) => void
   onMouseLeave?: (event: React.MouseEvent<HTMLImageElement>) => void
+  testId?: string
 }
 
 const defaultIcnWidth = 16
@@ -183,6 +184,7 @@ export const Icn = React.memo(
         onMouseUp={isDisabled ? undefined : props.onMouseUp}
         onMouseOver={props.onMouseOver}
         onMouseLeave={props.onMouseLeave}
+        data-testid={props.testId}
       />
     )
     if (props.tooltipText == null) {


### PR DESCRIPTION
Fixes #3486 

**Problem:**

Collapsing conditional items in the navigator does not hide the branches of the conditional expression.

**Fix:**

When generating the navigator items, make conditional clauses honor the `collapsedAncestor` flag correctly.

![Kapture 2023-03-28 at 13 07 40](https://user-images.githubusercontent.com/1081051/228217435-f5ef27f1-8984-407f-9396-a48574d3c9f7.gif)
