### PR TITLE
Fix/inspector size section unset

### DIFF
--- a/editor/src/components/context-menu-wrapper.tsx
+++ b/editor/src/components/context-menu-wrapper.tsx
@@ -187,6 +187,24 @@ export class ContextMenuWrapper<T> extends ReactComponent<
   }
 }
 
+export const InspectorRowHoverCSS = {
+  '--control-styles-interactive-unset-main-color': colorTheme.fg7.value,
+  '--control-styles-interactive-unset-secondary-color': colorTheme.fg7.value,
+  '--control-styles-interactive-unset-track-color': colorTheme.bg5.value,
+  '--control-styles-interactive-unset-rail-color': colorTheme.bg3.value,
+  '&:hover': {
+    '--control-styles-interactive-unset-main-color': getControlStyles('simple').mainColor,
+    '--control-styles-interactive-unset-secondary-color': getControlStyles('simple').secondaryColor,
+    '--control-styles-interactive-unset-track-color': getControlStyles('simple').trackColor,
+    '--control-styles-interactive-unset-rail-color': getControlStyles('simple').railColor,
+  },
+  '&:focus-within': {
+    '--control-styles-interactive-unset-main-color': getControlStyles('simple').mainColor,
+    '--control-styles-interactive-unset-secondary-color': getControlStyles('simple').secondaryColor,
+    '--control-styles-interactive-unset-track-color': getControlStyles('simple').trackColor,
+    '--control-styles-interactive-unset-rail-color': getControlStyles('simple').railColor,
+  },
+}
 export class InspectorContextMenuWrapper<T> extends ReactComponent<
   React.PropsWithChildren<ContextMenuWrapperProps<T>>
 > {
@@ -200,24 +218,7 @@ export class InspectorContextMenuWrapper<T> extends ReactComponent<
         css={{
           width: '100%',
           ...(this.props.style as any), // TODO Emotion and React 18 types don't like each other
-          '--control-styles-interactive-unset-main-color': colorTheme.fg7.value,
-          '--control-styles-interactive-unset-secondary-color': colorTheme.fg7.value,
-          '--control-styles-interactive-unset-track-color': colorTheme.bg5.value,
-          '--control-styles-interactive-unset-rail-color': colorTheme.bg3.value,
-          '&:hover': {
-            '--control-styles-interactive-unset-main-color': getControlStyles('simple').mainColor,
-            '--control-styles-interactive-unset-secondary-color':
-              getControlStyles('simple').secondaryColor,
-            '--control-styles-interactive-unset-track-color': getControlStyles('simple').trackColor,
-            '--control-styles-interactive-unset-rail-color': getControlStyles('simple').railColor,
-          },
-          '&:focus-within': {
-            '--control-styles-interactive-unset-main-color': getControlStyles('simple').mainColor,
-            '--control-styles-interactive-unset-secondary-color':
-              getControlStyles('simple').secondaryColor,
-            '--control-styles-interactive-unset-track-color': getControlStyles('simple').trackColor,
-            '--control-styles-interactive-unset-rail-color': getControlStyles('simple').railColor,
-          },
+          ...InspectorRowHoverCSS,
         }}
       >
         <React.Fragment>

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -1401,14 +1401,14 @@ describe('inspector tests with real metadata', () => {
     matchInlineSnapshotBrowser(laterWidthControl.value, `"203px"`)
     matchInlineSnapshotBrowser(
       laterWidthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"simple"`,
+      `"unset"`,
     )
 
     matchInlineSnapshotBrowser(laterMetadata.computedStyle?.['height'], `"102px"`)
     matchInlineSnapshotBrowser(laterHeightControl.value, `"102px"`)
     matchInlineSnapshotBrowser(
       laterHeightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"simple"`,
+      `"unset"`,
     )
 
     matchInlineSnapshotBrowser(laterPaddingLeftControl.value, `"16"`)

--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -32,6 +32,7 @@ import {
   FixedHugFill,
   FixedHugFillMode,
   getFixedFillHugOptionsForElement,
+  isFixedHugFillEqual,
 } from './inspector-common'
 import {
   setPropFillStrategies,
@@ -45,22 +46,6 @@ import {
 
 export const FillFixedHugControlId = (segment: 'width' | 'height'): string =>
   `hug-fixed-fill-${segment}`
-
-function isFixedHugFillEqual(a: FixedHugFill | undefined, b: FixedHugFill | undefined): boolean {
-  if (a === undefined && b === undefined) {
-    return true
-  }
-
-  if (a?.type !== b?.type) {
-    return false
-  }
-
-  if ((a?.type === 'fixed' && b?.type === 'fixed') || (a?.type === 'fill' && b?.type === 'fill')) {
-    return a.value.value === b.value.value && a.value.unit === b.value.unit
-  }
-
-  return true
-}
 
 export const FillContainerLabel = 'Fill container' as const
 export const FixedLabel = 'Fixed' as const

--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -1,3 +1,6 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { jsx } from '@emotion/react'
 import React from 'react'
 import { createSelector } from 'reselect'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
@@ -7,7 +10,12 @@ import { ElementPath } from '../../core/shared/project-file-types'
 import { intersection } from '../../core/shared/set-utils'
 import { assertNever, NO_OP } from '../../core/shared/utils'
 import { NumberInput, PopupList, SimpleCSSNumberInput } from '../../uuiui'
-import { getControlStyles, SelectOption } from '../../uuiui-deps'
+import {
+  ControlStatus,
+  getControlStyles,
+  InspectorRowHoverCSS,
+  SelectOption,
+} from '../../uuiui-deps'
 import { useDispatch } from '../editor/store/dispatch-context'
 import { Substores, useEditorState, useRefEditorState } from '../editor/store/store-hook'
 import {
@@ -91,8 +99,6 @@ function elementComputedDimension(
   return localFrame[prop]
 }
 
-const simpleControlStyles = getControlStyles('simple')
-
 interface FillHugFixedControlProps {}
 
 const optionsSelector = createSelector(
@@ -129,6 +135,18 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
     'FillHugFixedControl widthCurrentValue',
     isFixedHugFillEqual,
   )
+  const widthControlStatus = React.useMemo(
+    () => (widthCurrentValue == null ? 'unset' : widthCurrentValue.status),
+    [widthCurrentValue],
+  )
+  const widthControlStyles = React.useMemo(
+    () => getControlStyles(widthControlStatus),
+    [widthControlStatus],
+  )
+  const widthInputControlStatus = React.useMemo(
+    () => (isNumberInputEnabled(widthCurrentValue) ? widthControlStatus : 'disabled'),
+    [widthCurrentValue, widthControlStatus],
+  )
 
   const fillsContainerHorizontallyRef = useRefEditorState(
     (store) =>
@@ -158,6 +176,18 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
       ) ?? undefined,
     'FillHugFixedControl heightCurrentValue',
     isFixedHugFillEqual,
+  )
+  const heightControlStatus = React.useMemo(
+    () => (heightCurrentValue == null ? 'unset' : heightCurrentValue.status),
+    [heightCurrentValue],
+  )
+  const heightControlStyles = React.useMemo(
+    () => getControlStyles(heightControlStatus),
+    [heightControlStatus],
+  )
+  const heightInputControlStatus = React.useMemo(
+    () => (isNumberInputEnabled(heightCurrentValue) ? heightControlStatus : 'disabled'),
+    [heightCurrentValue, heightControlStatus],
   )
 
   const fillsContainerVerticallyRef = useRefEditorState(
@@ -298,57 +328,75 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
       style={{
         display: 'grid',
         gridTemplateRows: '1fr 1fr',
-        gridTemplateColumns: '1fr 1fr',
-        gap: 4,
-        padding: 4,
+        gridTemplateColumns: '1fr',
       }}
     >
-      <PopupList
-        value={optionalMap(selectOption, widthCurrentValue?.type) ?? undefined}
-        options={options}
-        onSubmitValue={onSubmitWidth}
-        controlStyles={simpleControlStyles}
-      />
-      <NumberInput
-        id={FillFixedHugControlId('width')}
-        testId={FillFixedHugControlId('width')}
-        value={widthValue}
-        onSubmitValue={onAdjustWidth}
-        onTransientSubmitValue={NO_OP}
-        onForcedSubmitValue={NO_OP}
-        controlStatus={isNumberInputEnabled(widthCurrentValue) ? undefined : 'disabled'}
-        numberType={pickNumberType(widthCurrentValue)}
-        incrementControls={true}
-        stepSize={1}
-        minimum={0}
-        maximum={Infinity}
-        labelInner={'W'}
-        defaultUnitToHide={null}
-        focusOnMount={false}
-      />
-      <PopupList
-        value={optionalMap(selectOption, heightCurrentValue?.type) ?? undefined}
-        options={options}
-        onSubmitValue={onSubmitHeight}
-        controlStyles={simpleControlStyles}
-      />
-      <NumberInput
-        id={FillFixedHugControlId('height')}
-        testId={FillFixedHugControlId('height')}
-        value={heightValue}
-        onSubmitValue={onAdjustHeight}
-        onTransientSubmitValue={NO_OP}
-        onForcedSubmitValue={NO_OP}
-        controlStatus={isNumberInputEnabled(heightCurrentValue) ? undefined : 'disabled'}
-        numberType={pickNumberType(heightCurrentValue)}
-        incrementControls={true}
-        stepSize={1}
-        minimum={0}
-        maximum={Infinity}
-        labelInner={'H'}
-        defaultUnitToHide={null}
-        focusOnMount={false}
-      />
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gap: 4,
+          padding: 4,
+        }}
+        css={InspectorRowHoverCSS}
+      >
+        <PopupList
+          value={optionalMap(selectOption, widthCurrentValue?.type) ?? undefined}
+          options={options}
+          onSubmitValue={onSubmitWidth}
+          controlStyles={widthControlStyles}
+        />
+        <NumberInput
+          id={FillFixedHugControlId('width')}
+          testId={FillFixedHugControlId('width')}
+          value={widthValue}
+          onSubmitValue={onAdjustWidth}
+          onTransientSubmitValue={NO_OP}
+          onForcedSubmitValue={NO_OP}
+          controlStatus={widthInputControlStatus}
+          numberType={pickNumberType(widthCurrentValue)}
+          incrementControls={true}
+          stepSize={1}
+          minimum={0}
+          maximum={Infinity}
+          labelInner={'W'}
+          defaultUnitToHide={null}
+          focusOnMount={false}
+        />
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gap: 4,
+          padding: 4,
+        }}
+        css={InspectorRowHoverCSS}
+      >
+        <PopupList
+          value={optionalMap(selectOption, heightCurrentValue?.type) ?? undefined}
+          options={options}
+          onSubmitValue={onSubmitHeight}
+          controlStyles={heightControlStyles}
+        />
+        <NumberInput
+          id={FillFixedHugControlId('height')}
+          testId={FillFixedHugControlId('height')}
+          value={heightValue}
+          onSubmitValue={onAdjustHeight}
+          onTransientSubmitValue={NO_OP}
+          onForcedSubmitValue={NO_OP}
+          controlStatus={heightInputControlStatus}
+          numberType={pickNumberType(heightCurrentValue)}
+          incrementControls={true}
+          stepSize={1}
+          minimum={0}
+          maximum={Infinity}
+          labelInner={'H'}
+          defaultUnitToHide={null}
+          focusOnMount={false}
+        />
+      </div>
     </div>
   )
 })

--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -3,32 +3,19 @@
 import { jsx } from '@emotion/react'
 import React from 'react'
 import { createSelector } from 'reselect'
-import { MetadataUtils } from '../../core/model/element-metadata-utils'
-import { ElementInstanceMetadataMap } from '../../core/shared/element-template'
 import { optionalMap } from '../../core/shared/optional-utils'
-import { ElementPath } from '../../core/shared/project-file-types'
 import { intersection } from '../../core/shared/set-utils'
 import { assertNever, NO_OP } from '../../core/shared/utils'
-import { NumberInput, PopupList, SimpleCSSNumberInput } from '../../uuiui'
-import {
-  ControlStatus,
-  getControlStyles,
-  InspectorRowHoverCSS,
-  SelectOption,
-} from '../../uuiui-deps'
+import { NumberInput, PopupList } from '../../uuiui'
+import { getControlStyles, InspectorRowHoverCSS, SelectOption } from '../../uuiui-deps'
 import { useDispatch } from '../editor/store/dispatch-context'
 import { Substores, useEditorState, useRefEditorState } from '../editor/store/store-hook'
-import {
-  CSSNumber,
-  cssNumber,
-  CSSNumberType,
-  EmptyInputValue,
-  UnknownOrEmptyInput,
-} from './common/css-utils'
+import { CSSNumber, cssNumber, CSSNumberType, UnknownOrEmptyInput } from './common/css-utils'
 import { metadataSelector, selectedViewsSelector, useComputedSizeRef } from './inpector-selectors'
 import {
   Axis,
   detectFillHugFixedState,
+  fillHugFixedStateToControlStatus,
   FixedHugFill,
   FixedHugFillMode,
   getFixedFillHugOptionsForElement,
@@ -108,7 +95,7 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
     isFixedHugFillEqual,
   )
   const widthControlStatus = React.useMemo(
-    () => (widthCurrentValue == null ? 'unset' : widthCurrentValue.status),
+    () => fillHugFixedStateToControlStatus(widthCurrentValue),
     [widthCurrentValue],
   )
   const widthControlStyles = React.useMemo(
@@ -143,7 +130,7 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
     isFixedHugFillEqual,
   )
   const heightControlStatus = React.useMemo(
-    () => (heightCurrentValue == null ? 'unset' : heightCurrentValue.status),
+    () => fillHugFixedStateToControlStatus(heightCurrentValue),
     [heightCurrentValue],
   )
   const heightControlStyles = React.useMemo(

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -813,3 +813,26 @@ export function removeExtraPinsWhenSettingSize(
     deleteProperties('always', elementMetadata.elementPath, [styleP(frameProp)]),
   )
 }
+
+export function isFixedHugFillEqual(
+  a: FixedHugFill | undefined,
+  b: FixedHugFill | undefined,
+): boolean {
+  if (a === undefined && b === undefined) {
+    return true
+  }
+
+  if (a?.type !== b?.type) {
+    return false
+  }
+
+  if (a?.status !== b?.status) {
+    return false
+  }
+
+  if ((a?.type === 'fixed' && b?.type === 'fixed') || (a?.type === 'fill' && b?.type === 'fill')) {
+    return a.value.value === b.value.value && a.value.unit === b.value.unit
+  }
+
+  return true
+}

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -516,9 +516,9 @@ export const nukeAllAbsolutePositioningPropsCommands = (
 }
 
 export type FixedHugFill =
-  | { type: 'fixed'; value: CSSNumber; status: ControlStatus }
-  | { type: 'fill'; value: CSSNumber; status: ControlStatus }
-  | { type: 'hug'; status: ControlStatus }
+  | { type: 'fixed'; value: CSSNumber; source: 'parsed' | 'fallback' }
+  | { type: 'fill'; value: CSSNumber; source: 'parsed' | 'fallback' }
+  | { type: 'hug'; source: 'parsed' | 'fallback' }
 
 export type FixedHugFillMode = FixedHugFill['type']
 
@@ -560,12 +560,12 @@ export function detectFillHugFixedState(
 
     const isFlexDirectionHorizontal = flexDirection === 'row' || flexDirection === 'row-reverse'
     if (axis === 'horizontal' && isFlexDirectionHorizontal) {
-      return { type: 'fill', value: flexGrow, status: 'simple' }
+      return { type: 'fill', value: flexGrow, source: 'parsed' }
     }
 
     const isFlexDirectionVertical = flexDirection === 'column' || flexDirection === 'column-reverse'
     if (axis === 'vertical' && isFlexDirectionVertical) {
-      return { type: 'fill', value: flexGrow, status: 'simple' }
+      return { type: 'fill', value: flexGrow, source: 'parsed' }
     }
   }
 
@@ -577,23 +577,23 @@ export function detectFillHugFixedState(
   )
 
   if (prop === MaxContent) {
-    return { type: 'hug', status: 'simple' }
+    return { type: 'hug', source: 'parsed' }
   }
 
   const parsed = defaultEither(null, parseCSSLengthPercent(prop))
 
   if (parsed != null && parsed.unit === '%') {
-    return { type: 'fill', value: parsed, status: 'simple' }
+    return { type: 'fill', value: parsed, source: 'parsed' }
   }
 
   if (parsed != null) {
-    return { type: 'fixed', value: parsed, status: 'simple' }
+    return { type: 'fixed', value: parsed, source: 'parsed' }
   }
 
   const frame = element.globalFrame
   if (frame != null && isFiniteRectangle(frame)) {
     const dimension = widthHeightFromAxis(axis)
-    return { type: 'fixed', value: cssNumber(frame[dimension], 'px'), status: 'unset' }
+    return { type: 'fixed', value: cssNumber(frame[dimension], 'px'), source: 'fallback' }
   }
 
   return null
@@ -835,4 +835,10 @@ export function isFixedHugFillEqual(
   }
 
   return true
+}
+
+export function fillHugFixedStateToControlStatus(
+  fillHugFixedState: FixedHugFill | undefined | null,
+): ControlStatus {
+  return fillHugFixedState == null || fillHugFixedState.source === 'fallback' ? 'unset' : 'simple'
 }

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -45,6 +45,7 @@ import { LayoutPinnedProps } from '../../core/layout/layout-helpers-new'
 import { getLayoutLengthValueOrKeyword } from '../../core/layout/getLayoutProperty'
 import { Frame } from 'utopia-api/core'
 import { getPinsToDelete } from './common/layout-property-path-hooks'
+import { ControlStatus } from '../../uuiui-deps'
 
 export type StartCenterEnd = 'flex-start' | 'center' | 'flex-end'
 
@@ -515,9 +516,9 @@ export const nukeAllAbsolutePositioningPropsCommands = (
 }
 
 export type FixedHugFill =
-  | { type: 'fixed'; value: CSSNumber }
-  | { type: 'fill'; value: CSSNumber }
-  | { type: 'hug' }
+  | { type: 'fixed'; value: CSSNumber; status: ControlStatus }
+  | { type: 'fill'; value: CSSNumber; status: ControlStatus }
+  | { type: 'hug'; status: ControlStatus }
 
 export type FixedHugFillMode = FixedHugFill['type']
 
@@ -559,12 +560,12 @@ export function detectFillHugFixedState(
 
     const isFlexDirectionHorizontal = flexDirection === 'row' || flexDirection === 'row-reverse'
     if (axis === 'horizontal' && isFlexDirectionHorizontal) {
-      return { type: 'fill', value: flexGrow }
+      return { type: 'fill', value: flexGrow, status: 'simple' }
     }
 
     const isFlexDirectionVertical = flexDirection === 'column' || flexDirection === 'column-reverse'
     if (axis === 'vertical' && isFlexDirectionVertical) {
-      return { type: 'fill', value: flexGrow }
+      return { type: 'fill', value: flexGrow, status: 'simple' }
     }
   }
 
@@ -576,23 +577,23 @@ export function detectFillHugFixedState(
   )
 
   if (prop === MaxContent) {
-    return { type: 'hug' }
+    return { type: 'hug', status: 'simple' }
   }
 
   const parsed = defaultEither(null, parseCSSLengthPercent(prop))
 
   if (parsed != null && parsed.unit === '%') {
-    return { type: 'fill', value: parsed }
+    return { type: 'fill', value: parsed, status: 'simple' }
   }
 
   if (parsed != null) {
-    return { type: 'fixed', value: parsed }
+    return { type: 'fixed', value: parsed, status: 'simple' }
   }
 
   const frame = element.globalFrame
   if (frame != null && isFiniteRectangle(frame)) {
     const dimension = widthHeightFromAxis(axis)
-    return { type: 'fixed', value: cssNumber(frame[dimension], 'px') }
+    return { type: 'fixed', value: cssNumber(frame[dimension], 'px'), status: 'unset' }
   }
 
   return null

--- a/editor/src/components/inspector/sections/style-section/text-subsection/text-auto-sizing-control.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/text-auto-sizing-control.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../../inpector-selectors'
 import {
   detectFillHugFixedState,
+  fillHugFixedStateToControlStatus,
   FixedHugFill,
   isFixedHugFillEqual,
 } from '../../../inspector-common'
@@ -73,7 +74,7 @@ function useAutoSizingTypeAndStatus(): { status: ControlStatus; type: 'fixed' | 
     if (!isEditableText) {
       return 'disabled'
     } else {
-      return fixedHugState == null ? 'unset' : fixedHugState.status
+      return fillHugFixedStateToControlStatus(fixedHugState)
     }
   }, [fixedHugState, isEditableText])
 

--- a/editor/src/components/inspector/sections/style-section/text-subsection/text-auto-sizing-control.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/text-auto-sizing-control.tsx
@@ -5,7 +5,7 @@ import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { applyCommandsAction } from '../../../../editor/actions/action-creators'
 import { useDispatch } from '../../../../editor/store/dispatch-context'
 import { Substores, useEditorState, useRefEditorState } from '../../../../editor/store/store-hook'
-import { getControlStyles } from '../../../common/control-status'
+import { ControlStatus, getControlStyles } from '../../../common/control-status'
 import { cssNumber } from '../../../common/css-utils'
 import { OptionChainControl, OptionChainOption } from '../../../controls/option-chain-control'
 import {
@@ -13,7 +13,11 @@ import {
   selectedViewsSelector,
   useComputedSizeRef,
 } from '../../../inpector-selectors'
-import { detectFillHugFixedState } from '../../../inspector-common'
+import {
+  detectFillHugFixedState,
+  FixedHugFill,
+  isFixedHugFillEqual,
+} from '../../../inspector-common'
 import {
   setPropFixedStrategies,
   setPropHugStrategies,
@@ -22,11 +26,7 @@ import { commandsForFirstApplicableStrategy } from '../../../inspector-strategie
 
 export const TextAutoSizingTestId = 'textAutoSizing'
 
-export const TextAutoSizingControl = React.memo(() => {
-  const dispatch = useDispatch()
-  const metadataRef = useRefEditorState(metadataSelector)
-  const selectedViewsRef = useRefEditorState(selectedViewsSelector)
-
+function useAutoSizingTypeAndStatus(): { status: ControlStatus; type: 'fixed' | 'hug' | null } {
   const isEditableText = useEditorState(
     Substores.metadata,
     (store) => {
@@ -37,29 +37,62 @@ export const TextAutoSizingControl = React.memo(() => {
     'TextAutoSizingControl isEditableText',
   )
 
-  const fixedHugFillState = useEditorState(
+  const widthFillHugFixedState = useEditorState(
     Substores.metadata,
     (store) => {
       const target = store.editor.selectedViews[0]
-      const width = detectFillHugFixedState('horizontal', store.editor.jsxMetadata, target)
-      const height = detectFillHugFixedState('vertical', store.editor.jsxMetadata, target)
-
-      if (width?.type === height?.type) {
-        return width?.type
-      }
-      return null
+      return detectFillHugFixedState('horizontal', store.editor.jsxMetadata, target) ?? undefined
     },
-    'TextAutoSizingControl fixedHugFillState',
+    'TextAutoSizingControl fixedHugFillState width',
+    isFixedHugFillEqual,
   )
+
+  const heightFillHugFixedState = useEditorState(
+    Substores.metadata,
+    (store) => {
+      const target = store.editor.selectedViews[0]
+      return detectFillHugFixedState('vertical', store.editor.jsxMetadata, target) ?? undefined
+    },
+    'TextAutoSizingControl fixedHugFillState height',
+    isFixedHugFillEqual,
+  )
+
+  let fixedHugState: FixedHugFill | null = null
+  if (
+    widthFillHugFixedState != null &&
+    widthFillHugFixedState.type !== 'fill' &&
+    heightFillHugFixedState != null &&
+    heightFillHugFixedState.type !== 'fill'
+  ) {
+    if (widthFillHugFixedState.type === heightFillHugFixedState.type) {
+      fixedHugState = widthFillHugFixedState
+    }
+  }
 
   const controlStatus = React.useMemo(() => {
     if (!isEditableText) {
       return 'disabled'
     } else {
-      return fixedHugFillState != null && fixedHugFillState !== 'fill' ? 'simple' : 'unset'
+      return fixedHugState == null ? 'unset' : fixedHugState.status
     }
-  }, [fixedHugFillState, isEditableText])
-  const controlStyles = React.useMemo(() => getControlStyles(controlStatus), [controlStatus])
+  }, [fixedHugState, isEditableText])
+
+  const type =
+    controlStatus === 'disabled' || controlStatus === 'unset' ? null : fixedHugState?.type ?? null
+
+  return { status: controlStatus, type: type }
+}
+
+export const TextAutoSizingControl = React.memo(() => {
+  const dispatch = useDispatch()
+  const metadataRef = useRefEditorState(metadataSelector)
+  const selectedViewsRef = useRefEditorState(selectedViewsSelector)
+
+  const controlStatusAndValueType = useAutoSizingTypeAndStatus()
+  const controlStyles = React.useMemo(
+    () => getControlStyles(controlStatusAndValueType.status),
+    [controlStatusAndValueType],
+  )
 
   const widthComputedValue = useComputedSizeRef('width')
   const heightComputedValue = useComputedSizeRef('height')
@@ -118,10 +151,10 @@ export const TextAutoSizingControl = React.memo(() => {
         id='textAutoSizing'
         key='textAutoSizing'
         testId={TextAutoSizingTestId}
-        controlStatus={controlStatus}
+        controlStatus={controlStatusAndValueType.status}
         controlStyles={controlStyles}
         onSubmitValue={onSubmitValue}
-        value={fixedHugFillState}
+        value={controlStatusAndValueType.type}
         options={
           [
             {

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`450`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`454`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`461`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`465`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`574`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`578`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`646`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`650`)
   })
 })


### PR DESCRIPTION
**Problem:**
New inspector size section looks the same when using fallback values as set values. 

**Fix:**
Show fallback values with 'unset' controlstatus. This change is in the new Size section (fill, hug, fixed) and the Text size section.
When using the 'unset' style the hover effect was missing, I wrapped the row divs together to use the same css as other rows.

**Commit Details:**
- update fill-hug-fixed control and text-autosizing-control
- export css for mouseover effects in context-menu-wrapper

It looks like this when the width is not set.
<img width="257" alt="Screenshot 2023-03-28 at 16 42 42" src="https://user-images.githubusercontent.com/4403069/228275432-1ac22a91-c950-4ecf-af43-3850dc8135c7.png">

