### PR TITLE
Paste into inactive clauses.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
@@ -1,7 +1,4 @@
-import {
-  ElementSupportsChildren,
-  MetadataUtils,
-} from '../../../../../core/model/element-metadata-utils'
+import { MetadataUtils } from '../../../../../core/model/element-metadata-utils'
 import { ElementInstanceMetadataMap } from '../../../../../core/shared/element-template'
 import { CanvasPoint, Size } from '../../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../../core/shared/project-file-types'
@@ -17,6 +14,7 @@ import {
 } from './reparent-strategy-parent-lookup'
 import { flattenSelection } from '../shared-move-strategies-helpers'
 import { Direction } from '../../../../inspector/common/css-utils'
+import { ElementSupportsChildren } from '../../../../../core/model/element-template-utils'
 
 export type ReparentStrategy = 'REPARENT_AS_ABSOLUTE' | 'REPARENT_AS_STATIC'
 
@@ -38,7 +36,6 @@ export function reparentStrategyForPaste(
 
   const flowParentReparentType = flowParentAbsoluteOrStatic(targetMetadata, parent)
   const reparentAsStatic = parentIsFlexLayout || flowParentReparentType === 'REPARENT_AS_STATIC'
-
   if (reparentAsStatic) {
     return {
       strategy: 'REPARENT_AS_STATIC',
@@ -67,6 +64,7 @@ export function findReparentStrategies(
     cmdPressed,
     canvasState,
     metadata,
+    canvasState.nodeModules,
     canvasState.startingAllElementProps,
     allowSmallerParent,
     elementSupportsChildren,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -1,7 +1,5 @@
-import {
-  ElementSupportsChildren,
-  MetadataUtils,
-} from '../../../../core/model/element-metadata-utils'
+import { ElementSupportsChildren } from '../../../../core/model/element-template-utils'
+import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { allElemsEqual, mapDropNulls } from '../../../../core/shared/array-utils'
 import * as EP from '../../../../core/shared/element-path'
 import { CanvasPoint, offsetPoint } from '../../../../core/shared/math-utils'
@@ -150,6 +148,7 @@ function getStartingTargetParentsToFilterOutInner(
     interactionData.modifiers.cmd,
     canvasState,
     canvasState.startingMetadata,
+    canvasState.nodeModules,
     canvasState.startingAllElementProps,
     allowSmallerParent,
     elementSupportsChildren,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
@@ -153,7 +153,7 @@ export function getReparentOutcome(
     case 'ELEMENT_TO_REPARENT':
       newPath = EP.appendToPath(newParentElementPath, getUtopiaID(toReparent.element))
       commands.push(addImportsToFile(whenToRun, newTargetFilePath, toReparent.imports))
-      commands.push(addElement(whenToRun, newParentElementPath, toReparent.element))
+      commands.push(addElement(whenToRun, newParent, toReparent.element))
       break
     default:
       const _exhaustiveCheck: never = toReparent

--- a/editor/src/components/canvas/commands/add-element-command.ts
+++ b/editor/src/components/canvas/commands/add-element-command.ts
@@ -1,16 +1,15 @@
 import {
   getElementPathFromReparentTargetParent,
   ReparentTargetParent,
+  reparentTargetToString,
 } from '../../../components/editor/store/reparent-target'
 import {
   EditorState,
   EditorStatePatch,
   forUnderlyingTargetFromEditorState,
   insertElementAtPath,
-  removeElementAtPath,
 } from '../../../components/editor/store/editor-state'
 import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
-import * as EP from '../../../core/shared/element-path'
 import { JSXElementChild } from '../../../core/shared/element-template'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { BaseCommand, CommandFunction, getPatchForComponentChange, WhenToRun } from './commands'
@@ -78,6 +77,6 @@ export const runAddElement: CommandFunction<AddElement> = (
 
   return {
     editorStatePatches: editorStatePatches,
-    commandDescription: `Add Element to ${JSON.stringify(command.parentPath)}`,
+    commandDescription: `Add Element to ${reparentTargetToString(command.parentPath)}`,
   }
 }

--- a/editor/src/components/canvas/commands/add-element-command.ts
+++ b/editor/src/components/canvas/commands/add-element-command.ts
@@ -1,4 +1,8 @@
 import {
+  getElementPathFromReparentTargetParent,
+  ReparentTargetParent,
+} from '../../../components/editor/store/reparent-target'
+import {
   EditorState,
   EditorStatePatch,
   forUnderlyingTargetFromEditorState,
@@ -10,16 +14,17 @@ import * as EP from '../../../core/shared/element-path'
 import { JSXElementChild } from '../../../core/shared/element-template'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { BaseCommand, CommandFunction, getPatchForComponentChange, WhenToRun } from './commands'
+import { includeToastPatch } from '../../../components/editor/actions/toast-helpers'
 
 export interface AddElement extends BaseCommand {
   type: 'ADD_ELEMENT'
-  parentPath: ElementPath
+  parentPath: ReparentTargetParent<ElementPath>
   element: JSXElementChild
 }
 
 export function addElement(
   whenToRun: WhenToRun,
-  parentPath: ElementPath,
+  parentPath: ReparentTargetParent<ElementPath>,
   element: JSXElementChild,
 ): AddElement {
   return {
@@ -36,7 +41,7 @@ export const runAddElement: CommandFunction<AddElement> = (
 ) => {
   let editorStatePatches: Array<EditorStatePatch> = []
   forUnderlyingTargetFromEditorState(
-    command.parentPath,
+    getElementPathFromReparentTargetParent(command.parentPath),
     editorState,
     (
       parentSuccess,
@@ -46,7 +51,7 @@ export const runAddElement: CommandFunction<AddElement> = (
     ) => {
       const componentsNewParent = getUtopiaJSXComponentsFromSuccess(parentSuccess)
 
-      const withElementInserted = insertElementAtPath(
+      const insertionResult = insertElementAtPath(
         editorState.projectContents,
         underlyingFilePathNewParent,
         command.parentPath,
@@ -55,6 +60,7 @@ export const runAddElement: CommandFunction<AddElement> = (
         null,
         editorState.spyMetadata,
       )
+      const withElementInserted = insertionResult.components
 
       const editorStatePatchNewParentFile = getPatchForComponentChange(
         parentSuccess.topLevelElements,
@@ -63,12 +69,15 @@ export const runAddElement: CommandFunction<AddElement> = (
         underlyingFilePathNewParent,
       )
 
-      editorStatePatches = [editorStatePatchNewParentFile]
+      editorStatePatches = [
+        editorStatePatchNewParentFile,
+        includeToastPatch(insertionResult.insertionDetails, editorState),
+      ]
     },
   )
 
   return {
     editorStatePatches: editorStatePatches,
-    commandDescription: `Add Element to ${EP.toString(command.parentPath)}`,
+    commandDescription: `Add Element to ${JSON.stringify(command.parentPath)}`,
   }
 }

--- a/editor/src/components/canvas/commands/insert-element-insertion-subject.ts
+++ b/editor/src/components/canvas/commands/insert-element-insertion-subject.ts
@@ -1,3 +1,4 @@
+import { includeToastPatch } from '../../../components/editor/actions/toast-helpers'
 import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
 import { getStoryboardElementPath } from '../../../core/model/scene-utils'
 import * as EP from '../../../core/shared/element-path'
@@ -57,7 +58,7 @@ export const runInsertElementInsertionSubject: CommandFunction<InsertElementInse
         return
       }
 
-      const withElementInserted = insertElementAtPath(
+      const insertionResult = insertElementAtPath(
         editor.projectContents,
         underlyingFilePath,
         targetParent,
@@ -72,11 +73,12 @@ export const runInsertElementInsertionSubject: CommandFunction<InsertElementInse
       editorStatePatches.push(
         getPatchForComponentChange(
           success.topLevelElements,
-          withElementInserted,
+          insertionResult.components,
           updatedImports,
           underlyingFilePath,
         ),
       )
+      editorStatePatches.push(includeToastPatch(insertionResult.insertionDetails, editor))
       selectedViews.push(EP.appendToPath(targetParent, subject.element.uid))
     },
   )

--- a/editor/src/components/canvas/commands/reparent-element-command.ts
+++ b/editor/src/components/canvas/commands/reparent-element-command.ts
@@ -1,3 +1,4 @@
+import { includeToastPatch } from '../../../components/editor/actions/toast-helpers'
 import {
   getElementPathFromReparentTargetParent,
   ReparentTargetParent,
@@ -56,7 +57,7 @@ export const runReparentElement: CommandFunction<ReparentElement> = (
             const components = getUtopiaJSXComponentsFromSuccess(successTarget)
             const withElementRemoved = removeElementAtPath(command.target, components)
 
-            const withElementInserted = insertElementAtPath(
+            const insertionResult = insertElementAtPath(
               editorState.projectContents,
               underlyingFilePathTarget,
               command.newParent,
@@ -67,18 +68,21 @@ export const runReparentElement: CommandFunction<ReparentElement> = (
             )
             const editorStatePatchOldParentFile = getPatchForComponentChange(
               successTarget.topLevelElements,
-              withElementInserted,
+              insertionResult.components,
               successTarget.imports,
               underlyingFilePathTarget,
             )
 
-            editorStatePatches = [editorStatePatchOldParentFile]
+            editorStatePatches = [
+              editorStatePatchOldParentFile,
+              includeToastPatch(insertionResult.insertionDetails, editorState),
+            ]
           } else {
             const componentsOldParent = getUtopiaJSXComponentsFromSuccess(successTarget)
             const withElementRemoved = removeElementAtPath(command.target, componentsOldParent)
             const componentsNewParent = getUtopiaJSXComponentsFromSuccess(successNewParent)
 
-            const withElementInserted = insertElementAtPath(
+            const insertionResult = insertElementAtPath(
               editorState.projectContents,
               underlyingFilePathNewParent,
               command.newParent,
@@ -97,12 +101,16 @@ export const runReparentElement: CommandFunction<ReparentElement> = (
 
             const editorStatePatchNewParentFile = getPatchForComponentChange(
               successNewParent.topLevelElements,
-              withElementInserted,
+              insertionResult.components,
               successNewParent.imports,
               underlyingFilePathNewParent,
             )
 
-            editorStatePatches = [editorStatePatchOldParentFile, editorStatePatchNewParentFile]
+            editorStatePatches = [
+              editorStatePatchOldParentFile,
+              editorStatePatchNewParentFile,
+              includeToastPatch(insertionResult.insertionDetails, editorState),
+            ]
           }
         },
       )

--- a/editor/src/components/canvas/controls/insert-mode/insert-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/insert-mode/insert-mode-hooks.tsx
@@ -20,11 +20,17 @@ function useGetHighlightableViewsForInsertMode() {
     }
   })
   return React.useCallback(() => {
-    const { componentMetadata, mode, projectContents } = storeRef.current
+    const { componentMetadata, mode, projectContents, nodeModules, openFile } = storeRef.current
     if (isInsertMode(mode)) {
       const allPaths = MetadataUtils.getAllPaths(componentMetadata)
       const insertTargets = allPaths.filter((path) => {
-        return MetadataUtils.targetSupportsChildren(projectContents, componentMetadata, path)
+        return MetadataUtils.targetSupportsChildren(
+          projectContents,
+          componentMetadata,
+          nodeModules,
+          openFile,
+          path,
+        )
       })
       return insertTargets
     } else {

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -77,6 +77,7 @@ import { BuildType } from '../../core/workers/common/worker-types'
 import { ProjectContentTreeRoot } from '../assets'
 import { GithubOperationType } from './actions/action-creators'
 import { CanvasCommand } from '../canvas/commands/commands'
+import { ReparentTargetParent } from './store/reparent-target'
 export { isLoggedIn, loggedInUser, notLoggedIn } from '../../common/user'
 export type { LoginState, UserDetails } from '../../common/user'
 
@@ -345,7 +346,7 @@ export interface ElementPaste {
 
 export interface PasteJSXElements {
   action: 'PASTE_JSX_ELEMENTS'
-  pasteInto: ElementPath
+  pasteInto: ReparentTargetParent<ElementPath>
   elements: Array<ElementPaste>
   targetOriginalContextMetadata: ElementInstanceMetadataMap
 }
@@ -465,7 +466,7 @@ export interface SaveImageDoNothing {
 
 export interface SaveImageInsertWith {
   type: 'SAVE_IMAGE_INSERT_WITH'
-  parentPath: ElementPath | null
+  parentPath: ReparentTargetParent<ElementPath> | null
   frame: CanvasRectangle
   multiplier: number
 }

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -253,6 +253,7 @@ import type {
   ThemeSetting,
   ColorSwatch,
 } from '../store/editor-state'
+import { ReparentTargetParent } from '../store/reparent-target'
 
 export function clearSelection(): EditorAction {
   return {
@@ -453,7 +454,7 @@ export function elementPaste(
 }
 
 export function pasteJSXElements(
-  pasteInto: ElementPath,
+  pasteInto: ReparentTargetParent<ElementPath>,
   elements: Array<ElementPaste>,
   targetOriginalContextMetadata: ElementInstanceMetadataMap,
 ): PasteJSXElements {
@@ -679,7 +680,7 @@ export function saveImageReplace(): SaveImageReplace {
 }
 
 export function saveImageInsertWith(
-  parentPath: ElementPath | null,
+  parentPath: ReparentTargetParent<ElementPath> | null,
   frame: CanvasRectangle,
   multiplier: number,
 ): SaveImageInsertWith {

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -1008,7 +1008,6 @@ describe('UPDATE_FILE_PATH', () => {
       updateFilePath('/src', '/src2'),
       editorState,
       defaultUserState,
-      NO_OP,
     )
     let filesAndTheirImports: { [filename: string]: Array<string> } = {}
     walkContentsTreeForParseSuccess(actualResult.projectContents, (fullPath, success) => {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -14,6 +14,8 @@ import {
   generateUidWithExistingComponents,
   getAllUniqueUids,
   getZIndexOfElement,
+  insertChildAndDetails,
+  InsertChildAndDetails,
   transformJSXComponentAtElementPath,
   transformJSXComponentAtPath,
 } from '../../../core/model/element-template-utils'
@@ -464,6 +466,7 @@ import { ShortcutConfiguration } from '../shortcut-definitions'
 import { ElementInstanceMetadataMapKeepDeepEquality } from '../store/store-deep-equality-instances'
 import {
   addImports,
+  addToast,
   clearImageFileBlob,
   enableInsertModeForJSXElement,
   finishCheckpointTimer,
@@ -481,7 +484,7 @@ import {
   updatePackageJson,
   updateThumbnailGenerated,
 } from './action-creators'
-import { uniqToasts } from './toast-helpers'
+import { addToastToState, includeToast, removeToastFromState, uniqToasts } from './toast-helpers'
 import { AspectRatioLockedProp } from '../../aspect-ratio'
 import {
   refreshDependencies,
@@ -1156,26 +1159,24 @@ function setZIndexOnSelected(
   index: 'back' | 'front' | 'backward' | 'forward',
 ): EditorModel {
   const selectedViews = editor.selectedViews
-  return selectedViews.reduce(
-    (working, selectedView) => {
-      const indexPosition = indexPositionForAdjustment(selectedView, working, index)
-      return editorMoveTemplate(
-        selectedView,
-        selectedView,
-        SkipFrameChange,
-        indexPosition,
-        EP.parentPath(selectedView),
-        null,
-        editor,
-        null,
-        null,
-      ).editor
-    },
-    {
-      ...editor,
-      selectedViews: [],
-    } as EditorModel,
-  )
+  const initialEditorState: EditorModel = {
+    ...editor,
+    selectedViews: [],
+  }
+  return selectedViews.reduce((working, selectedView) => {
+    const indexPosition = indexPositionForAdjustment(selectedView, working, index)
+    return editorMoveTemplate(
+      selectedView,
+      selectedView,
+      SkipFrameChange,
+      indexPosition,
+      EP.parentPath(selectedView),
+      null,
+      editor,
+      null,
+      null,
+    ).editor
+  }, initialEditorState)
 }
 
 function setModeState(mode: Mode, editor: EditorModel): EditorModel {
@@ -1438,7 +1439,7 @@ function toastOnGeneratedElementsTargeted(
   let result: EditorState = editor
   if (generatedElementsTargeted) {
     const showToastAction = showToast(notice(message))
-    result = UPDATE_FNS.ADD_TOAST(showToastAction, result, dispatch)
+    result = UPDATE_FNS.ADD_TOAST(showToastAction, result)
   }
 
   if (!generatedElementsTargeted || allowActionRegardless) {
@@ -1461,7 +1462,7 @@ function toastOnUncopyableElementsSelected(
   let result: EditorState = editor
   if (!isReparentable) {
     const showToastAction = showToast(notice(message))
-    result = UPDATE_FNS.ADD_TOAST(showToastAction, result, dispatch)
+    result = UPDATE_FNS.ADD_TOAST(showToastAction, result)
   }
 
   if (isReparentable || allowActionRegardless) {
@@ -1696,7 +1697,7 @@ export const UPDATE_FNS = {
     )
     if (unsetPropFailedMessage != null) {
       const toastAction = showToast(notice(unsetPropFailedMessage, 'ERROR'))
-      return UPDATE_FNS.ADD_TOAST(toastAction, editor, dispatch)
+      return UPDATE_FNS.ADD_TOAST(toastAction, editor)
     } else {
       return updatedEditor
     }
@@ -1728,7 +1729,7 @@ export const UPDATE_FNS = {
     )
     if (setPropFailedMessage != null) {
       const toastAction = showToast(notice(setPropFailedMessage, 'ERROR'))
-      return UPDATE_FNS.ADD_TOAST(toastAction, editor, dispatch)
+      return UPDATE_FNS.ADD_TOAST(toastAction, editor)
     } else {
       return updatedEditor
     }
@@ -2088,12 +2089,8 @@ export const UPDATE_FNS = {
       )
     }
   },
-  ADD_TOAST: (action: AddToast, editor: EditorModel, dispatch: EditorDispatch): EditorModel => {
-    const withOldToastRemoved = UPDATE_FNS.REMOVE_TOAST(removeToast(action.toast.id), editor)
-    return {
-      ...withOldToastRemoved,
-      toasts: uniqToasts([...withOldToastRemoved.toasts, action.toast]),
-    }
+  ADD_TOAST: (action: AddToast, editor: EditorModel): EditorModel => {
+    return addToastToState(editor, action.toast)
   },
   UPDATE_GITHUB_OPERATIONS: (action: UpdateGithubOperations, editor: EditorModel): EditorModel => {
     const operations = [...editor.githubOperations]
@@ -2160,10 +2157,7 @@ export const UPDATE_FNS = {
     }
   },
   REMOVE_TOAST: (action: RemoveToast, editor: EditorModel): EditorModel => {
-    return {
-      ...editor,
-      toasts: editor.toasts.filter((toast) => toast.id !== action.id),
-    }
+    return removeToastFromState(editor, action.id)
   },
   TOGGLE_HIDDEN: (action: ToggleHidden, editor: EditorModel): EditorModel => {
     const targets = action.targets.length > 0 ? action.targets : editor.selectedViews
@@ -2231,6 +2225,7 @@ export const UPDATE_FNS = {
   },
   INSERT_JSX_ELEMENT: (action: InsertJSXElement, editor: EditorModel): EditorModel => {
     let newSelectedViews: ElementPath[] = []
+    let detailsOfUpdate: string | null = null
     const withNewElement = modifyUnderlyingTargetElement(
       action.parent,
       forceNotNull('Should originate from a designer', editor.canvas.openFile?.filename),
@@ -2261,6 +2256,7 @@ export const UPDATE_FNS = {
           null,
           editor.spyMetadata,
         )
+        detailsOfUpdate = withInsertedElement.insertionDetails
 
         const uid = getUtopiaID(action.jsxElement)
         const newPath = EP.appendToPath(targetParent, uid)
@@ -2268,7 +2264,7 @@ export const UPDATE_FNS = {
 
         const updatedTopLevelElements = applyUtopiaJSXComponentsChanges(
           success.topLevelElements,
-          withInsertedElement,
+          withInsertedElement.components,
         )
 
         const updatedImports = mergeImports(
@@ -2391,6 +2387,7 @@ export const UPDATE_FNS = {
             }
           }
 
+          let detailsOfUpdate: string | null = null
           const withWrapperViewAddedNoFrame = modifyParseSuccessAtPath(
             targetSuccess.filePath,
             editor,
@@ -2405,7 +2402,7 @@ export const UPDATE_FNS = {
                 : setPositionAttribute(elementToInsert, 'absolute')
 
               if (targetThatIsRootElementOfCommonParent == null) {
-                withTargetAdded = insertElementAtPath(
+                const insertResult = insertElementAtPath(
                   editor.projectContents,
                   editor.canvas.openFile?.filename ?? null,
                   parentPath,
@@ -2420,6 +2417,8 @@ export const UPDATE_FNS = {
                   ),
                   editor.spyMetadata,
                 )
+                withTargetAdded = insertResult.components
+                detailsOfUpdate = insertResult.insertionDetails
               } else {
                 const staticTarget = EP.dynamicPathToStaticPath(
                   targetThatIsRootElementOfCommonParent,
@@ -2462,7 +2461,11 @@ export const UPDATE_FNS = {
             ? [] // if we are wrapping something in a Flex parent, try not adding frames here
             : [getFrameChange(viewPath, boundingBox, isParentFlex)]
           const withWrapperViewAdded = {
-            ...setCanvasFramesInnerNew(withWrapperViewAddedNoFrame, frameChanges, null),
+            ...setCanvasFramesInnerNew(
+              includeToast(detailsOfUpdate, withWrapperViewAddedNoFrame),
+              frameChanges,
+              null,
+            ),
           }
 
           // reparent targets to the view
@@ -2537,6 +2540,7 @@ export const UPDATE_FNS = {
           }
 
           let viewPath: ElementPath | null = null
+          let detailsOfUpdate: string | null = null
 
           const underlyingTarget = normalisePathToUnderlyingTarget(
             editor.projectContents,
@@ -2556,7 +2560,8 @@ export const UPDATE_FNS = {
               const elementToInsert = action.whatToWrapWith.element
 
               const utopiaJSXComponents = getUtopiaJSXComponentsFromSuccess(parseSuccess)
-              let withTargetAdded: Array<UtopiaJSXComponent>
+              let withTargetAdded: InsertChildAndDetails =
+                insertChildAndDetails(utopiaJSXComponents)
 
               function withInsertedElement() {
                 return insertElementAtPath(
@@ -2630,14 +2635,13 @@ export const UPDATE_FNS = {
                   const staticTarget = EP.dynamicPathToStaticPath(
                     targetThatIsRootElementOfCommonParent,
                   )
-                  withTargetAdded = transformJSXComponentAtPath(
-                    utopiaJSXComponents,
-                    staticTarget,
-                    (oldRoot) =>
+                  withTargetAdded = insertChildAndDetails(
+                    transformJSXComponentAtPath(utopiaJSXComponents, staticTarget, (oldRoot) =>
                       jsxElement(elementToInsert.name, elementToInsert.uid, elementToInsert.props, [
                         ...elementToInsert.children,
                         oldRoot,
                       ]),
+                    ),
                   )
                 }
               }
@@ -2648,10 +2652,11 @@ export const UPDATE_FNS = {
 
               const importsToAdd: Imports = action.whatToWrapWith.importsToAdd
 
+              detailsOfUpdate = withTargetAdded.insertionDetails
               return modifyParseSuccessWithSimple((success: SimpleParseSuccess) => {
                 return {
                   ...success,
-                  utopiaComponents: withTargetAdded,
+                  utopiaComponents: withTargetAdded.components,
                   imports: mergeImports(targetSuccess.filePath, success.imports, importsToAdd),
                 }
               }, parseSuccess)
@@ -2671,7 +2676,7 @@ export const UPDATE_FNS = {
             orderedActionTargets,
             indexPosition,
             viewPath,
-            withWrapperViewAddedNoFrame,
+            includeToast(detailsOfUpdate, withWrapperViewAddedNoFrame),
           )
 
           return {
@@ -3034,9 +3039,12 @@ export const UPDATE_FNS = {
     builtInDependencies: BuiltInDependencies,
   ): EditorModel => {
     let insertionAllowed: boolean = true
-    if (action.pasteInto != null) {
-      const pasteInto = action.pasteInto
-      const parentGenerated = MetadataUtils.isElementGenerated(pasteInto)
+    const resolvedTarget = MetadataUtils.resolveReparentTargetParentToPath(
+      editor.jsxMetadata,
+      action.pasteInto,
+    )
+    if (resolvedTarget != null) {
+      const parentGenerated = MetadataUtils.isElementGenerated(resolvedTarget)
       insertionAllowed = !parentGenerated
     }
     if (insertionAllowed) {
@@ -3060,7 +3068,7 @@ export const UPDATE_FNS = {
 
           const reparentStrategy = reparentStrategyForPaste(
             workingEditorState.jsxMetadata,
-            action.pasteInto,
+            resolvedTarget,
           )
           const pastedElementIsFlex =
             MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
@@ -3078,7 +3086,7 @@ export const UPDATE_FNS = {
 
           const pasteIntoParent = MetadataUtils.findElementByElementPath(
             editor.jsxMetadata,
-            action.pasteInto,
+            resolvedTarget,
           )
 
           const continueWithPaste =
@@ -3087,13 +3095,11 @@ export const UPDATE_FNS = {
             pastedElementIsConditional ||
             MetadataUtils.isConditionalFromMetadata(pasteIntoParent)
 
-          if (!continueWithPaste) {
-            return workingEditorState
-          } else {
+          if (continueWithPaste) {
             const propertyChangeCommands = getReparentPropertyChanges(
               reparentStrategy.strategy,
               newPath,
-              action.pasteInto,
+              resolvedTarget,
               action.targetOriginalContextMetadata,
               workingEditorState.jsxMetadata,
               workingEditorState.projectContents,
@@ -3105,6 +3111,8 @@ export const UPDATE_FNS = {
             const allCommands = [...reparentCommands, ...propertyChangeCommands]
 
             return foldAndApplyCommandsSimple(workingEditorState, allCommands)
+          } else {
+            return workingEditorState
           }
         }
       }, editor)
@@ -3112,7 +3120,7 @@ export const UPDATE_FNS = {
       const showToastAction = showToast(
         notice(`Unable to paste into a generated element.`, 'WARNING'),
       )
-      return UPDATE_FNS.ADD_TOAST(showToastAction, editor, dispatch)
+      return UPDATE_FNS.ADD_TOAST(showToastAction, editor)
     }
   },
   PASTE_PROPERTIES: (action: PasteProperties, editor: EditorModel): EditorModel => {
@@ -3297,7 +3305,7 @@ export const UPDATE_FNS = {
 
     const shouldShowToast = targetWidth < hideWidth && priorWidth > minWidth
     const updatedEditor = shouldShowToast
-      ? UPDATE_FNS.ADD_TOAST(showToast(notice('Code editor hidden')), editor, dispatch)
+      ? UPDATE_FNS.ADD_TOAST(showToast(notice('Code editor hidden')), editor)
       : editor
 
     return {
@@ -3331,7 +3339,7 @@ export const UPDATE_FNS = {
 
     const updatedEditor = codeEditorVisibleAfter
       ? editor
-      : UPDATE_FNS.ADD_TOAST(showToast(notice('Code editor hidden')), editor, dispatch)
+      : UPDATE_FNS.ADD_TOAST(showToast(notice('Code editor hidden')), editor)
 
     return {
       ...updatedEditor,
@@ -3393,7 +3401,7 @@ export const UPDATE_FNS = {
     if (errorMessage != null) {
       console.error(errorMessage)
       const toastAction = showToast(notice(errorMessage!, 'WARNING'))
-      return UPDATE_FNS.ADD_TOAST(toastAction, updatedEditor, dispatch)
+      return UPDATE_FNS.ADD_TOAST(toastAction, updatedEditor)
     } else {
       return updatedEditor
     }
@@ -3562,7 +3570,6 @@ export const UPDATE_FNS = {
       editorWithToast = UPDATE_FNS.ADD_TOAST(
         showToast(notice(`Please log in to upload assets`, 'ERROR', true)),
         editor,
-        dispatch,
       )
     }
 
@@ -3627,7 +3634,13 @@ export const UPDATE_FNS = {
           }
         }
         case 'SAVE_IMAGE_INSERT_WITH': {
-          const parent = action.imageDetails.afterSave.parentPath
+          const parent =
+            action.imageDetails.afterSave.parentPath == null
+              ? null
+              : MetadataUtils.resolveReparentTargetParentToPath(
+                  editor.jsxMetadata,
+                  action.imageDetails.afterSave.parentPath,
+                )
           const relativeFrame = MetadataUtils.getFrameRelativeTo(
             parent,
             editor.jsxMetadata,
@@ -3843,7 +3856,6 @@ export const UPDATE_FNS = {
     action: UpdateFilePath,
     editor: EditorModel,
     userState: UserState,
-    dispatch: EditorDispatch,
   ): EditorModel => {
     const replaceFilePathResults = replaceFilePath(
       action.oldPath,
@@ -3852,7 +3864,7 @@ export const UPDATE_FNS = {
     )
     if (replaceFilePathResults.type === 'FAILURE') {
       const toastAction = showToast(notice(replaceFilePathResults.errorMessage, 'ERROR', true))
-      return UPDATE_FNS.ADD_TOAST(toastAction, editor, dispatch)
+      return UPDATE_FNS.ADD_TOAST(toastAction, editor)
     } else {
       let currentDesignerFile = editor.canvas.openFile
       const { projectContents, updatedFiles } = replaceFilePathResults
@@ -5060,6 +5072,7 @@ export const UPDATE_FNS = {
       return editor
     } else {
       let newSelectedViews: ElementPath[] = []
+      let detailsOfUpdate: string | null = null
       const withNewElement = modifyUnderlyingTargetElement(
         action.targetParent,
         openFilename,
@@ -5131,13 +5144,14 @@ export const UPDATE_FNS = {
             action.indexPosition,
             editor.spyMetadata,
           )
+          detailsOfUpdate = withInsertedElement.insertionDetails
 
           const newPath = EP.appendToPath(action.targetParent, newUID)
           newSelectedViews.push(newPath)
 
           const updatedTopLevelElements = applyUtopiaJSXComponentsChanges(
             success.topLevelElements,
-            withInsertedElement,
+            withInsertedElement.components,
           )
 
           const updatedImports = mergeImports(
@@ -5152,10 +5166,13 @@ export const UPDATE_FNS = {
           }
         },
       )
-      return {
+      const updatedEditorState: EditorModel = {
         ...withNewElement,
         selectedViews: newSelectedViews,
       }
+
+      // Add the toast for the update details if necessary.
+      return includeToast(detailsOfUpdate, updatedEditorState)
     }
   },
   SET_PROP_TRANSIENT: (action: SetPropTransient, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/actions/toast-helpers.ts
+++ b/editor/src/components/editor/actions/toast-helpers.ts
@@ -1,6 +1,39 @@
+import { Spec } from 'immutability-helper'
 import { uniqBy } from '../../../core/shared/array-utils'
-import { Notice } from '../../common/notice'
+import { notice, Notice } from '../../common/notice'
+import { EditorState } from '../store/editor-state'
 
 export function uniqToasts(notices: ReadonlyArray<Notice>): ReadonlyArray<Notice> {
   return uniqBy(notices, (l, r) => l.id === r.id)
+}
+
+export function removeToastFromState(editorState: EditorState, noticeID: string): EditorState {
+  return {
+    ...editorState,
+    toasts: editorState.toasts.filter((toast) => toast.id !== noticeID),
+  }
+}
+
+export function addToastToState(editorState: EditorState, noticeToAdd: Notice): EditorState {
+  const withOldToastRemoved = removeToastFromState(editorState, noticeToAdd.id)
+  return {
+    ...withOldToastRemoved,
+    toasts: uniqToasts([...withOldToastRemoved.toasts, noticeToAdd]),
+  }
+}
+
+export function includeToast(toastText: string | null, editorState: EditorState): EditorState {
+  return toastText == null ? editorState : addToastToState(editorState, notice(toastText))
+}
+
+export function includeToastPatch(
+  toastText: string | null,
+  editorState: EditorState,
+): Spec<EditorState> {
+  const updatedEditorState = includeToast(toastText, editorState)
+  return {
+    toasts: {
+      $set: updatedEditorState.toasts,
+    },
+  }
 }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -24,6 +24,8 @@ import {
   transformJSXComponentAtPath,
   findJSXElementAtStaticPath,
   findJSXElementChildAtPath,
+  InsertChildAndDetails,
+  insertChildAndDetails,
 } from '../../../core/model/element-template-utils'
 import {
   correctProjectContentsPath,
@@ -1915,7 +1917,7 @@ export function addNewScene(model: EditorState, newSceneElement: JSXElement): Ed
         components,
         newSceneElement,
         model.spyMetadata,
-      ),
+      ).components,
     model,
   )
 }
@@ -1926,7 +1928,7 @@ export function addSceneToJSXComponents(
   components: UtopiaJSXComponent[],
   newSceneElement: JSXElement,
   spyMetadata: ElementInstanceMetadataMap,
-): UtopiaJSXComponent[] {
+): InsertChildAndDetails {
   const storyoardComponentRootElement = components.find(
     (c) => c.name === BakedInStoryboardVariableName,
   )?.rootElement
@@ -1946,7 +1948,7 @@ export function addSceneToJSXComponents(
       spyMetadata,
     )
   } else {
-    return components
+    return insertChildAndDetails(components)
   }
 }
 
@@ -1972,7 +1974,7 @@ export function insertElementAtPath(
   components: Array<UtopiaJSXComponent>,
   indexPosition: IndexPosition | null,
   spyMetadata: ElementInstanceMetadataMap,
-): Array<UtopiaJSXComponent> {
+): InsertChildAndDetails {
   const staticTarget =
     targetParent == null
       ? null

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -140,7 +140,7 @@ export function runSimpleLocalEditorAction(
     case 'TOGGLE_COLLAPSE':
       return UPDATE_FNS.TOGGLE_COLLAPSE(action, state)
     case 'ADD_TOAST':
-      return UPDATE_FNS.ADD_TOAST(action, state, dispatch)
+      return UPDATE_FNS.ADD_TOAST(action, state)
     case 'SET_REFRESHING_DEPENDENCIES':
       return UPDATE_FNS.SET_REFRESHING_DEPENDENCIES(action, state)
     case 'UPDATE_GITHUB_OPERATIONS':
@@ -202,7 +202,7 @@ export function runSimpleLocalEditorAction(
     case 'SEND_PREVIEW_MODEL':
       return UPDATE_FNS.SEND_PREVIEW_MODEL(action, state)
     case 'UPDATE_FILE_PATH':
-      return UPDATE_FNS.UPDATE_FILE_PATH(action, state, userState, dispatch)
+      return UPDATE_FNS.UPDATE_FILE_PATH(action, state, userState)
     case 'SET_FOCUS':
       return UPDATE_FNS.SET_FOCUS(action, state)
     case 'RESIZE_LEFTPANE':

--- a/editor/src/components/editor/store/reparent-target.ts
+++ b/editor/src/components/editor/store/reparent-target.ts
@@ -53,3 +53,13 @@ export function dynamicReparentTargetParentToStaticReparentTargetParent(
     return EP.dynamicPathToStaticPath(reparentTargetParent)
   }
 }
+
+export function reparentTargetToString<P extends ElementPath>(
+  reparentTargetParent: ReparentTargetParent<P>,
+): string {
+  if (reparentTargetParentIsConditionalClause(reparentTargetParent)) {
+    return `${reparentTargetParent.clause} of ${EP.toString(reparentTargetParent.elementPath)}`
+  } else {
+    return EP.toString(reparentTargetParent)
+  }
+}

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -1502,6 +1502,7 @@ describe('conditionals in the navigator', () => {
     pathToPasteInto: ElementPath
     expectedTargetPasteParent: ReparentTargetParent<ElementPath>
     expectedToasts: Array<string>
+    expectedNavigatorStructure: string
     postPasteValidation: (
       pasteTestCase: PasteTestCase,
       startingEditorState: EditorState,
@@ -1523,6 +1524,18 @@ describe('conditionals in the navigator', () => {
         `${BakedInStoryboardUID}/${TestSceneUID}/containing-div/conditional1/else-div`,
       ),
       expectedToasts: [],
+      expectedNavigatorStructure: `  regular-utopia-storyboard-uid/scene-aaa
+    regular-utopia-storyboard-uid/scene-aaa/containing-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/a25
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/a25-attribute
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`,
       postPasteValidation: (
         pasteTestCase: PasteTestCase,
         startingEditorState: EditorState,
@@ -1559,6 +1572,18 @@ describe('conditionals in the navigator', () => {
         'false-case',
       ),
       expectedToasts: [],
+      expectedNavigatorStructure: `  regular-utopia-storyboard-uid/scene-aaa
+    regular-utopia-storyboard-uid/scene-aaa/containing-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/sib
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/sib-element-sib
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`,
       postPasteValidation: (
         pasteTestCase: PasteTestCase,
         startingEditorState: EditorState,
@@ -1596,6 +1621,18 @@ describe('conditionals in the navigator', () => {
         'false-case',
       ),
       expectedToasts: ['Value in conditional replaced.'],
+      expectedNavigatorStructure: `  regular-utopia-storyboard-uid/scene-aaa
+    regular-utopia-storyboard-uid/scene-aaa/containing-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/sib
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/sib-element-sib
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`,
       postPasteValidation: (
         pasteTestCase: PasteTestCase,
         startingEditorState: EditorState,
@@ -1688,6 +1725,13 @@ describe('conditionals in the navigator', () => {
       expect(renderResult.getEditorState().editor.toasts.map((t) => t.message)).toEqual(
         pasteTestCase.expectedToasts,
       )
+
+      expect(
+        navigatorStructure(
+          renderResult.getEditorState().editor,
+          renderResult.getEditorState().derived,
+        ),
+      ).toEqual(pasteTestCase.expectedNavigatorStructure)
 
       pasteTestCase.postPasteValidation(
         pasteTestCase,

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -1551,6 +1551,7 @@ describe('conditionals in the navigator', () => {
         )
         const elementToPasteIntoAfterPaste = unsafeGet(elementToPasteIntoOptic, endingEditorState)
 
+        // The pasted item is added to `else-div` as a child.
         expect(elementToPasteIntoAfterPaste.children).toHaveLength(
           elementToPasteIntoBeforePaste.children.length + 1,
         )

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -100,6 +100,8 @@ function canDrop(
       MetadataUtils.targetSupportsChildren(
         editorState.projectContents,
         editorState.jsxMetadata,
+        editorState.nodeModules.files,
+        editorState.canvas.openFile?.filename,
         draggedOnto.navigatorEntry.elementPath,
       ))
   const notSelectedItem = draggedItem.getCurrentlySelectedEntries().every((selection) => {

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -89,6 +89,8 @@ import {
   componentUsesProperty,
   elementOnlyHasTextChildren,
   findJSXElementChildAtPath,
+  ElementSupportsChildren,
+  elementChildSupportsChildrenAlsoText,
 } from './element-template-utils'
 import {
   isImportedComponent,
@@ -134,6 +136,10 @@ import {
   ConditionalCase,
 } from './conditionals'
 import { getUtopiaID } from '../shared/uid-utils'
+import {
+  ReparentTargetParent,
+  reparentTargetParentIsElementPath,
+} from '../../components/editor/store/reparent-target'
 
 const ObjectPathImmutable: any = OPI
 
@@ -151,11 +157,6 @@ export const getChildrenOfCollapsedViews = (
 }
 
 const ElementsToDrillIntoForTextContent = ['div', 'span']
-
-export type ElementSupportsChildren =
-  | 'supportsChildren'
-  | 'hasOnlyTextChildren'
-  | 'doesNotSupportChildren'
 
 export const MetadataUtils = {
   isElementGenerated(target: ElementPath): boolean {
@@ -840,37 +841,26 @@ export const MetadataUtils = {
     instance: ElementInstanceMetadata,
   ): ElementSupportsChildren {
     return foldEither(
-      (elementString) =>
-        intrinsicHTMLElementNamesThatSupportChildren.includes(elementString)
+      (elementString) => {
+        return intrinsicHTMLElementNamesThatSupportChildren.includes(elementString)
           ? 'supportsChildren'
-          : 'doesNotSupportChildren',
+          : 'doesNotSupportChildren'
+      },
       (element) => {
-        if (elementOnlyHasTextChildren(element)) {
-          // Prevent re-parenting into an element that only has text children, as that is rarely a desired goal
-          return 'hasOnlyTextChildren'
+        const elementResult = elementChildSupportsChildrenAlsoText(element)
+        if (elementResult != null) {
+          return elementResult
+        } else if (isUtopiaAPIComponentFromMetadata(instance)) {
+          // Explicitly prevent components / elements that we *know* don't support children
+          return isViewLikeFromMetadata(instance) ||
+            isSceneFromMetadata(instance) ||
+            EP.isStoryboardPath(instance.elementPath)
+            ? 'supportsChildren'
+            : 'doesNotSupportChildren'
         } else {
-          if (isJSXElement(element)) {
-            if (isIntrinsicElement(element.name)) {
-              return intrinsicHTMLElementNamesThatSupportChildren.includes(
-                element.name.baseVariable,
-              )
-                ? 'supportsChildren'
-                : 'doesNotSupportChildren'
-            } else if (isUtopiaAPIComponentFromMetadata(instance)) {
-              // Explicitly prevent components / elements that we *know* don't support children
-              return isViewLikeFromMetadata(instance) ||
-                isSceneFromMetadata(instance) ||
-                EP.isStoryboardPath(instance.elementPath)
-                ? 'supportsChildren'
-                : 'doesNotSupportChildren'
-            } else {
-              return MetadataUtils.targetUsesProperty(projectContents, instance, 'children')
-                ? 'supportsChildren'
-                : 'doesNotSupportChildren'
-            }
-          }
-          // We don't know at this stage
-          return 'supportsChildren'
+          return MetadataUtils.targetUsesProperty(projectContents, instance, 'children')
+            ? 'supportsChildren'
+            : 'doesNotSupportChildren'
         }
       },
       instance.element,
@@ -879,16 +869,25 @@ export const MetadataUtils = {
   targetSupportsChildren(
     projectContents: ProjectContentTreeRoot,
     metadata: ElementInstanceMetadataMap,
+    nodeModules: NodeModules,
+    openFile: string | null | undefined,
     target: ElementPath | null,
   ): boolean {
     return (
-      this.targetSupportsChildrenAlsoText(projectContents, metadata, target) !==
-      'doesNotSupportChildren'
+      this.targetSupportsChildrenAlsoText(
+        projectContents,
+        metadata,
+        nodeModules,
+        openFile,
+        target,
+      ) !== 'doesNotSupportChildren'
     )
   },
   targetSupportsChildrenAlsoText(
     projectContents: ProjectContentTreeRoot,
     metadata: ElementInstanceMetadataMap,
+    nodeModules: NodeModules,
+    openFile: string | null | undefined,
     target: ElementPath | null,
   ): ElementSupportsChildren {
     if (target == null) {
@@ -896,9 +895,20 @@ export const MetadataUtils = {
       return 'supportsChildren'
     } else {
       const instance = MetadataUtils.findElementByElementPath(metadata, target)
-      return instance == null
-        ? 'doesNotSupportChildren'
-        : MetadataUtils.targetElementSupportsChildrenAlsoText(projectContents, instance)
+      if (instance == null) {
+        return withUnderlyingTarget(
+          target,
+          projectContents,
+          nodeModules,
+          openFile,
+          'doesNotSupportChildren',
+          (_, element) => {
+            return elementChildSupportsChildrenAlsoText(element) ?? 'doesNotSupportChildren'
+          },
+        )
+      } else {
+        return MetadataUtils.targetElementSupportsChildrenAlsoText(projectContents, instance)
+      }
     }
   },
   targetUsesProperty(
@@ -1849,6 +1859,49 @@ export const MetadataUtils = {
       isRight(element.element) &&
       isJSXConditionalExpression(element.element.value)
     )
+  },
+  resolveReparentTargetParentToPath(
+    metadata: ElementInstanceMetadataMap,
+    reparentTargetParent: ReparentTargetParent<ElementPath>,
+  ): ElementPath {
+    if (reparentTargetParentIsElementPath(reparentTargetParent)) {
+      // This is an element path, so return directly.
+      return reparentTargetParent
+    } else {
+      // Resolve this to the element in the clause.
+      const targetElement = this.findElementByElementPath(
+        metadata,
+        reparentTargetParent.elementPath,
+      )
+      if (targetElement == null) {
+        throw new Error(
+          `Did not find a conditional at ${EP.toString(reparentTargetParent.elementPath)}.`,
+        )
+      } else {
+        return foldEither(
+          () => {
+            throw new Error(
+              `Did not find a conditional at ${EP.toString(reparentTargetParent.elementPath)}.`,
+            )
+          },
+          (element) => {
+            if (isJSXConditionalExpression(element)) {
+              return getConditionalClausePath(
+                reparentTargetParent.elementPath,
+                reparentTargetParent.clause === 'true-case' ? element.whenTrue : element.whenFalse,
+              )
+            } else {
+              throw new Error(
+                `Found a ${element.type} at ${EP.toString(
+                  reparentTargetParent.elementPath,
+                )} instead of a conditional.`,
+              )
+            }
+          },
+          targetElement.element,
+        )
+      }
+    }
   },
   getConditionValueFromMetadata(element: ElementInstanceMetadata | null): ConditionValue {
     if (!this.isConditionalFromMetadata(element)) {

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -38,6 +38,7 @@ import {
   jsxArbitraryBlock,
   ElementInstanceMetadataMap,
   JSXConditionalExpression,
+  isIntrinsicElement,
 } from '../shared/element-template'
 import {
   isParseSuccess,
@@ -76,6 +77,7 @@ import {
   ReparentTargetParent,
   reparentTargetParentIsConditionalClause,
 } from '../../components/editor/store/reparent-target'
+import { intrinsicHTMLElementNamesThatSupportChildren } from '../shared/dom-utils'
 
 function getAllUniqueUidsInner(
   projectContents: ProjectContentTreeRoot,
@@ -495,6 +497,21 @@ export function removeJSXElementChild(
       ).elements
 }
 
+export interface InsertChildAndDetails {
+  components: Array<UtopiaJSXComponent>
+  insertionDetails: string | null
+}
+
+export function insertChildAndDetails(
+  components: Array<UtopiaJSXComponent>,
+  insertionDetails: string | null = null,
+): InsertChildAndDetails {
+  return {
+    components: components,
+    insertionDetails: insertionDetails,
+  }
+}
+
 export function insertJSXElementChild(
   projectContents: ProjectContentTreeRoot,
   openFile: string | null,
@@ -503,7 +520,7 @@ export function insertJSXElementChild(
   components: Array<UtopiaJSXComponent>,
   indexPosition: IndexPosition | null,
   spyMetadata: ElementInstanceMetadataMap,
-): Array<UtopiaJSXComponent> {
+): InsertChildAndDetails {
   const makeE = () => {
     // TODO delete me
     throw new Error('Should not attempt to create empty elements.')
@@ -511,158 +528,166 @@ export function insertJSXElementChild(
   const targetParentIncludingStoryboardRoot =
     targetParent ?? getStoryboardElementPath(projectContents, openFile)
   if (targetParentIncludingStoryboardRoot == null) {
-    return components
+    return insertChildAndDetails(components)
   } else {
     const parentPath = getElementPathFromReparentTargetParent(targetParentIncludingStoryboardRoot)
-    return transformJSXComponentAtPath(components, parentPath, (parentElement) => {
-      if (
-        reparentTargetParentIsConditionalClause(targetParentIncludingStoryboardRoot) &&
-        isJSXConditionalExpression(parentElement)
-      ) {
-        // Determine which clause of the conditional we want to modify.
-        const toClauseOptic =
-          targetParentIncludingStoryboardRoot.clause === 'true-case'
-            ? conditionalWhenTrueOptic
-            : conditionalWhenFalseOptic
-        // Update the clause if it currently holds a null value.
-        return modify(
-          toClauseOptic,
-          (clauseValue) => {
-            if (isJSXArbitraryBlock(clauseValue)) {
-              const simpleValue = jsxSimpleAttributeToValue(clauseValue)
-              return foldEither(
-                () => {
-                  // Not a simple value, so replacing it would be a bad thing.
-                  return clauseValue
-                },
-                (value) => {
-                  // Simple value of some kind.
-                  if (value == null) {
-                    // Simple value is null, so replace it with the new content.
+    let details: string | null = null
+    const updatedComponents = transformJSXComponentAtPath(
+      components,
+      parentPath,
+      (parentElement) => {
+        if (
+          reparentTargetParentIsConditionalClause(targetParentIncludingStoryboardRoot) &&
+          isJSXConditionalExpression(parentElement)
+        ) {
+          // Determine which clause of the conditional we want to modify.
+          const toClauseOptic =
+            targetParentIncludingStoryboardRoot.clause === 'true-case'
+              ? conditionalWhenTrueOptic
+              : conditionalWhenFalseOptic
+          // Update the clause if it currently holds a null value.
+          return modify(
+            toClauseOptic,
+            (clauseValue) => {
+              if (isJSXArbitraryBlock(clauseValue)) {
+                const simpleValue = jsxSimpleAttributeToValue(clauseValue)
+                return foldEither(
+                  () => {
+                    // Not a simple value, so replace it but do so while indicating that
+                    // the value was replaced.
+                    details = 'Value in conditional replaced.'
                     return elementToInsert
+                  },
+                  (value) => {
+                    // Simple value of some kind.
+                    if (value == null) {
+                      // Simple value is null, so replace it with the new content.
+                      return elementToInsert
+                    } else {
+                      // A simple non-null value, but one that we should replace with the new element
+                      // and indicate that it was replaced.
+                      details = 'Value in conditional replaced.'
+                      return elementToInsert
+                    }
+                  },
+                  simpleValue,
+                )
+              } else {
+                if (isJSXFragment(clauseValue)) {
+                  // Existing fragment, so add it in as appropriate.
+                  let updatedChildren: Array<JSXElementChild>
+                  if (indexPosition == null) {
+                    updatedChildren = clauseValue.children.concat(elementToInsert)
                   } else {
-                    // FIXME: We have a simple `JSXAttribute` value here which is not null/undefined.
-                    // Recent conversations have been about unifying attributes and arbitrary JSX elements,
-                    // which could result in this content being a valid child of any element.
-                    return clauseValue
+                    updatedChildren = Utils.addToArrayWithFill(
+                      elementToInsert,
+                      clauseValue.children,
+                      indexPosition,
+                      makeE,
+                    )
                   }
-                },
-                simpleValue,
-              )
-            } else {
-              if (isJSXFragment(clauseValue)) {
-                // Existing fragment, so add it in as appropriate.
-                let updatedChildren: Array<JSXElementChild>
-                if (indexPosition == null) {
-                  updatedChildren = clauseValue.children.concat(elementToInsert)
+                  return jsxFragment(clauseValue.uid, updatedChildren, clauseValue.longForm)
                 } else {
-                  updatedChildren = Utils.addToArrayWithFill(
-                    elementToInsert,
-                    clauseValue.children,
-                    indexPosition,
-                    makeE,
+                  // Something other than a fragment, so wrap that and the newly inserted element into a fragment.
+                  return jsxFragment(
+                    generateUidWithExistingComponents(projectContents),
+                    [clauseValue, elementToInsert],
+                    false,
                   )
                 }
-                return jsxFragment(clauseValue.uid, updatedChildren, clauseValue.longForm)
-              } else {
-                // Something other than a fragment, so wrap that and the newly inserted element into a fragment.
+              }
+            },
+            parentElement,
+          )
+        } else if (isJSXElementLike(parentElement)) {
+          let updatedChildren: Array<JSXElementChild>
+          if (indexPosition == null) {
+            updatedChildren = parentElement.children.concat(elementToInsert)
+          } else {
+            updatedChildren = Utils.addToArrayWithFill(
+              elementToInsert,
+              parentElement.children,
+              indexPosition,
+              makeE,
+            )
+          }
+          return {
+            ...parentElement,
+            children: updatedChildren,
+          }
+        } else if (isJSXConditionalExpression(parentElement)) {
+          function getNewBranch(branch: JSXElementChild): JSXElementChild {
+            switch (branch.type) {
+              case 'ATTRIBUTE_VALUE':
+                if (branch.value === null) {
+                  return elementToInsert
+                }
                 return jsxFragment(
                   generateUidWithExistingComponents(projectContents),
-                  [clauseValue, elementToInsert],
+                  [jsxTextBlock(`${branch.value}`), elementToInsert],
                   false,
                 )
-              }
+              case 'ATTRIBUTE_OTHER_JAVASCRIPT':
+                return jsxFragment(
+                  generateUidWithExistingComponents(projectContents),
+                  [
+                    jsxArbitraryBlock(
+                      branch.javascript,
+                      branch.javascript,
+                      branch.transpiledJavascript,
+                      branch.definedElsewhere,
+                      branch.sourceMap,
+                      branch.elementsWithin,
+                    ),
+                    elementToInsert,
+                  ],
+                  false,
+                )
+              case 'ATTRIBUTE_FUNCTION_CALL':
+              case 'ATTRIBUTE_NESTED_ARRAY':
+              case 'ATTRIBUTE_NESTED_OBJECT':
+                return branch
+              case 'JSX_FRAGMENT':
+                return { ...branch, children: [...branch.children, elementToInsert] }
+              case 'JSX_ELEMENT':
+              case 'JSX_TEXT_BLOCK':
+              case 'JSX_CONDITIONAL_EXPRESSION':
+                return jsxFragment(
+                  generateUidWithExistingComponents(projectContents),
+                  [branch, elementToInsert],
+                  false,
+                )
+              default:
+                assertNever(branch)
             }
-          },
-          parentElement,
-        )
-      } else if (isJSXElementLike(parentElement)) {
-        let updatedChildren: Array<JSXElementChild>
-        if (indexPosition == null) {
-          updatedChildren = parentElement.children.concat(elementToInsert)
+          }
+
+          function getIsTrueCase(conditional: JSXConditionalExpression): boolean {
+            const spyParentMetadata = spyMetadata[EP.toString(parentPath)] ?? null
+            if (spyParentMetadata == null) {
+              return true
+            }
+            const conditionalCase = getConditionalCase(
+              EP.appendToPath(parentPath, getUtopiaID(conditional.whenTrue)),
+              conditional,
+              spyParentMetadata,
+              parentPath,
+            )
+            return conditionalCase === 'true-case'
+          }
+          const isTrueCase = getIsTrueCase(parentElement)
+
+          const branch = getNewBranch(isTrueCase ? parentElement.whenTrue : parentElement.whenFalse)
+
+          return isTrueCase
+            ? { ...parentElement, whenTrue: branch }
+            : { ...parentElement, whenFalse: branch }
         } else {
-          updatedChildren = Utils.addToArrayWithFill(
-            elementToInsert,
-            parentElement.children,
-            indexPosition,
-            makeE,
-          )
+          return parentElement
         }
-        return {
-          ...parentElement,
-          children: updatedChildren,
-        }
-      } else if (isJSXConditionalExpression(parentElement)) {
-        function getNewBranch(branch: JSXElementChild): JSXElementChild {
-          switch (branch.type) {
-            case 'ATTRIBUTE_VALUE':
-              if (branch.value === null) {
-                return elementToInsert
-              }
-              return jsxFragment(
-                generateUidWithExistingComponents(projectContents),
-                [jsxTextBlock(`${branch.value}`), elementToInsert],
-                false,
-              )
-            case 'ATTRIBUTE_OTHER_JAVASCRIPT':
-              return jsxFragment(
-                generateUidWithExistingComponents(projectContents),
-                [
-                  jsxArbitraryBlock(
-                    branch.javascript,
-                    branch.javascript,
-                    branch.transpiledJavascript,
-                    branch.definedElsewhere,
-                    branch.sourceMap,
-                    branch.elementsWithin,
-                  ),
-                  elementToInsert,
-                ],
-                false,
-              )
-            case 'ATTRIBUTE_FUNCTION_CALL':
-            case 'ATTRIBUTE_NESTED_ARRAY':
-            case 'ATTRIBUTE_NESTED_OBJECT':
-              return branch
-            case 'JSX_FRAGMENT':
-              return { ...branch, children: [...branch.children, elementToInsert] }
-            case 'JSX_ELEMENT':
-            case 'JSX_TEXT_BLOCK':
-            case 'JSX_CONDITIONAL_EXPRESSION':
-              return jsxFragment(
-                generateUidWithExistingComponents(projectContents),
-                [branch, elementToInsert],
-                false,
-              )
-            default:
-              assertNever(branch)
-          }
-        }
-
-        function getIsTrueCase(conditional: JSXConditionalExpression): boolean {
-          const spyParentMetadata = spyMetadata[EP.toString(parentPath)] ?? null
-          if (spyParentMetadata == null) {
-            return true
-          }
-          const conditionalCase = getConditionalCase(
-            EP.appendToPath(parentPath, getUtopiaID(conditional.whenTrue)),
-            conditional,
-            spyParentMetadata,
-            parentPath,
-          )
-          return conditionalCase === 'true-case'
-        }
-        const isTrueCase = getIsTrueCase(parentElement)
-
-        const branch = getNewBranch(isTrueCase ? parentElement.whenTrue : parentElement.whenFalse)
-
-        return isTrueCase
-          ? { ...parentElement, whenTrue: branch }
-          : { ...parentElement, whenFalse: branch }
-      } else {
-        return parentElement
-      }
-    })
+      },
+    )
+    return insertChildAndDetails(updatedComponents, details)
   }
 }
 
@@ -1085,5 +1110,29 @@ export function attributePartUsesProperty(
     default:
       const _exhaustiveCheck: never = attributesPart
       throw new Error(`Unhandled attribute part: ${JSON.stringify(attributesPart)}`)
+  }
+}
+
+export type ElementSupportsChildren =
+  | 'supportsChildren'
+  | 'hasOnlyTextChildren'
+  | 'doesNotSupportChildren'
+
+export function elementChildSupportsChildrenAlsoText(
+  element: JSXElementChild,
+): ElementSupportsChildren | null {
+  if (elementOnlyHasTextChildren(element)) {
+    // Prevent re-parenting into an element that only has text children, as that is rarely a desired goal.
+    return 'hasOnlyTextChildren'
+  } else {
+    if (isJSXElement(element)) {
+      if (isIntrinsicElement(element.name)) {
+        return intrinsicHTMLElementNamesThatSupportChildren.includes(element.name.baseVariable)
+          ? 'supportsChildren'
+          : 'doesNotSupportChildren'
+      }
+    }
+    // We don't know at this stage.
+    return null
   }
 }

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -1595,6 +1595,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
         void Clipboard.parseClipboardData(event.clipboardData).then((result) => {
           const actions = getActionsForClipboardItems(
             editor.projectContents,
+            editor.nodeModules.files,
             editor.canvas.openFile?.filename ?? null,
             result.utopiaData,
             result.files,

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -1,13 +1,26 @@
 import { EditorAction, ElementPaste } from '../components/editor/action-types'
 import * as EditorActions from '../components/editor/actions/action-creators'
 import { EditorModes } from '../components/editor/editor-modes'
-import { EditorState, getOpenUIJSFileKey } from '../components/editor/store/editor-state'
+import {
+  EditorState,
+  getOpenUIJSFileKey,
+  withUnderlyingTarget,
+} from '../components/editor/store/editor-state'
 import { getFrameAndMultiplier } from '../components/images'
 import * as EP from '../core/shared/element-path'
 import { findElementAtPath, MetadataUtils } from '../core/model/element-metadata-utils'
-import { ElementInstanceMetadataMap } from '../core/shared/element-template'
+import {
+  ElementInstanceMetadataMap,
+  isJSXArbitraryBlock,
+  isJSXConditionalExpression,
+} from '../core/shared/element-template'
 import { getUtopiaJSXComponentsFromSuccess } from '../core/model/project-file-utils'
-import { isParseSuccess, ElementPath, isTextFile } from '../core/shared/project-file-types'
+import {
+  isParseSuccess,
+  ElementPath,
+  isTextFile,
+  NodeModules,
+} from '../core/shared/project-file-types'
 import { encodeUtopiaDataToHtml, parsePasteEvent, PasteResult } from './clipboard-utils'
 import { setLocalClipboardData } from './local-clipboard'
 import Utils from './utils'
@@ -27,6 +40,12 @@ import { mapValues, pick } from '../core/shared/object-utils'
 import { getStoryboardElementPath } from '../core/model/scene-utils'
 import { getRequiredImportsForElement } from '../components/editor/import-utils'
 import { BuiltInDependencies } from '../core/es-modules/package-manager/built-in-dependencies-list'
+import {
+  conditionalClause,
+  getElementPathFromReparentTargetParent,
+  ReparentTargetParent,
+} from '../components/editor/store/reparent-target'
+import { getConditionalClausePath, ConditionalCase } from '../core/model/conditionals'
 
 interface JSXElementCopyData {
   type: 'ELEMENT_COPY'
@@ -67,6 +86,7 @@ export function setClipboardData(
 
 export function getActionsForClipboardItems(
   projectContents: ProjectContentTreeRoot,
+  nodeModules: NodeModules,
   openFile: string | null,
   clipboardData: Array<CopyData>,
   pastedFiles: Array<FileResult>,
@@ -79,11 +99,15 @@ export function getActionsForClipboardItems(
     const possibleTarget = getTargetParentForPaste(
       projectContents,
       selectedViews,
+      nodeModules,
+      openFile,
       componentMetadata,
       pasteTargetsToIgnore,
     )
     const target =
-      possibleTarget == null ? getStoryboardElementPath(projectContents, openFile) : possibleTarget
+      possibleTarget == null
+        ? getStoryboardElementPath(projectContents, openFile)
+        : MetadataUtils.resolveReparentTargetParentToPath(componentMetadata, possibleTarget)
     if (target == null) {
       console.warn(`Unable to find the storyboard path.`)
       return []
@@ -132,7 +156,7 @@ export function createDirectInsertImageActions(
   images: Array<ImageResult>,
   centerPoint: CanvasPoint,
   scale: number,
-  parentPath: ElementPath | null,
+  parentPath: ReparentTargetParent<ElementPath> | null,
 ): Array<EditorAction> {
   if (images.length === 0) {
     return []
@@ -262,9 +286,44 @@ function filterMetadataForCopy(
 export function getTargetParentForPaste(
   projectContents: ProjectContentTreeRoot,
   selectedViews: Array<ElementPath>,
+  nodeModules: NodeModules,
+  openFile: string | null | undefined,
   metadata: ElementInstanceMetadataMap,
   pasteTargetsToIgnore: ElementPath[],
-): ElementPath | null {
+): ReparentTargetParent<ElementPath> | null {
+  // Handle "slot" like case of conditional clauses by inserting into them directly rather than their parent.
+  if (selectedViews.length === 1) {
+    const targetPath = selectedViews[0]
+    const parentPath = EP.parentPath(targetPath)
+    const parentElement = withUnderlyingTarget(
+      parentPath,
+      projectContents,
+      nodeModules,
+      openFile,
+      null,
+      (_, element) => {
+        return element
+      },
+    )
+
+    if (parentElement != null && isJSXConditionalExpression(parentElement)) {
+      // Check if the target parent is an attribute,
+      // if so replace the target parent instead of trying to insert into it.
+      const truePath = getConditionalClausePath(targetPath, parentElement.whenTrue)
+      const conditionalCase: ConditionalCase = EP.pathsEqual(truePath, targetPath)
+        ? 'true-case'
+        : 'false-case'
+      const clause =
+        conditionalCase === 'true-case' ? parentElement.whenTrue : parentElement.whenFalse
+      if (isJSXArbitraryBlock(clause)) {
+        return conditionalClause(parentPath, conditionalCase)
+      } else {
+        return targetPath
+      }
+    }
+  }
+
+  // Regular handling which attempts to find a common parent.
   if (selectedViews.length > 0) {
     const parentTarget = EP.getCommonParent(selectedViews, true)
     if (parentTarget == null) {
@@ -272,15 +331,28 @@ export function getTargetParentForPaste(
     } else {
       // we should not paste the source into itself
       const insertingSourceIntoItself = EP.containsPath(parentTarget, pasteTargetsToIgnore)
-
       if (
-        MetadataUtils.targetSupportsChildren(projectContents, metadata, parentTarget) &&
+        MetadataUtils.targetSupportsChildren(
+          projectContents,
+          metadata,
+          nodeModules,
+          openFile,
+          parentTarget,
+        ) &&
         !insertingSourceIntoItself
       ) {
         return parentTarget
       } else {
         const parentOfSelected = EP.parentPath(parentTarget)
-        if (MetadataUtils.targetSupportsChildren(projectContents, metadata, parentOfSelected)) {
+        if (
+          MetadataUtils.targetSupportsChildren(
+            projectContents,
+            metadata,
+            nodeModules,
+            openFile,
+            parentOfSelected,
+          )
+        ) {
           return parentOfSelected
         } else {
           return null


### PR DESCRIPTION
**Problem:**
Users will expect that they can paste into inactive clauses of a conditional in the navigator.

**Fix:**
The main changes to support this are:
- Using `ReparentTargetParent` in more of the logic for reparenting, extending into some utility functions so that it can target the clauses specifically, rather than an element within them.
- Permitting the handling of elements without metadata in the reparent strategies so that an element which is not rendered can be the target of a reparent operation.
- Detail of a potentially important change can be surfaced out of the insertion logic, which is then used to produce a toast informing the user that a value has been replaced instead of preserving it.

**Commit Details:**
- Refactored out the contents of the `ADD_TOAST` and `REMOVE_TOAST` editor actions into utility functions.
- Added `includeToast` and `includeToastPatch` functions.
- `flowParentAbsoluteOrStatic` now permits the `parentMetadata` to be null.
- `AddElement.parentPath` converted to using the `ReparentTargetParent` type.
- `PasteJSXElements.pasteInto` converted to using the `ReparentTargetParent` type.
- `SaveImageInsertWith.parentPath` converted to using the `ReparentTargetParent` type.
- Removed `dispatch` parameter from `ADD_TOAST` handler.
- Added `InsertChildAndDetails` type which holds the updated components and possibly a string which describes a change which may need raising to the user.
- `MetadataUtils.targetElementSupportsChildrenAlsoText` now calls `elementChildSupportsChildrenAlsoText` which contains the logic previously held in the former for checking a `JSXElementChild`.
- Added `MetadataUtils.resolveReparentTargetParentToPath` which handles finding the path of a conditional clause.
- `insertJSXElementChild` now returns `InsertChildAndDetails`, so that it can raise a message about a change which obliterated something.
- `getTargetParentForPaste` now has some special case handling to make dragging into an attribute at the root of a conditional clause target the clause instead.