### PR TITLE
wrap in a fragment if target does not support children

### DIFF
--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -600,6 +600,15 @@ export function insertJSXElementChild(
             parentElement,
           )
         } else if (isJSXElementLike(parentElement)) {
+          if (elementChildSupportsChildrenAlsoText(parentElement) === 'doesNotSupportChildren') {
+            // the element cannot contain children, so we need to wrap it and the new element in a fragment
+            return jsxFragment(
+              generateUidWithExistingComponents(projectContents),
+              [parentElement, elementToInsert],
+              false,
+            )
+          }
+
           let updatedChildren: Array<JSXElementChild>
           if (indexPosition == null) {
             updatedChildren = parentElement.children.concat(elementToInsert)


### PR DESCRIPTION
Fixes #3499 

**Problem:**

Reparenting _directly_ into a conditional clause with an image inserts the element _into_ the image.

**Fix:**

This is due to a more broad issue, caused by reparenting into elements which don't support children. This PR fixes it by creating a fragment for the insertion target and the inserted element when the parent `doesNotSupportChildren`.

Before:
![Kapture 2023-03-31 at 10 32 10](https://user-images.githubusercontent.com/1081051/229068846-87966a6d-3551-4942-87d2-b7e4efc28a3e.gif)

After:
![Kapture 2023-03-31 at 10 33 29](https://user-images.githubusercontent.com/1081051/229069182-34fe5461-6d48-4579-868a-be22ab9fbac3.gif)
