### PR TITLE
Clear down conditional inactive branch metadata.

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -45,7 +45,11 @@ import { resolveParamsAndRunJsCode } from '../../../core/shared/javascript-cache
 import { objectMap } from '../../../core/shared/object-utils'
 import { cssValueOnlyContainsComments } from '../../../printer-parsers/css/css-parser-utils'
 import { filterDataProps } from '../../../utils/canvas-react-utils'
-import { addFakeSpyEntry, buildSpyWrappedElement } from './ui-jsx-canvas-spy-wrapper'
+import {
+  addFakeSpyEntry,
+  buildSpyWrappedElement,
+  clearOpposingConditionalSpyValues,
+} from './ui-jsx-canvas-spy-wrapper'
 import { createIndexedUid, getUtopiaID } from '../../../core/shared/uid-utils'
 import { isComponentRendererComponent } from './ui-jsx-canvas-component-renderer'
 import { optionalMap } from '../../../core/shared/optional-utils'
@@ -347,6 +351,8 @@ export function renderCoreElement(
       const actualElement = conditionValue ? element.whenTrue : element.whenFalse
 
       if (elementPath != null) {
+        clearOpposingConditionalSpyValues(metadataContext, element, conditionValue, elementPath)
+
         addFakeSpyEntry(metadataContext, elementPath, element, filePath, imports, conditionValue)
       }
 

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -2218,6 +2218,8 @@ describe('inspector tests with real metadata', () => {
       expect(renderResult.renderedDOM.getByTestId('bbb')).not.toBeNull()
 
       const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional'])
+      const bbbPath = EP.appendToPath(targetPath, 'bbb')
+      const cccPath = EP.appendToPath(targetPath, 'ccc')
       await act(async () => {
         await renderResult.dispatch([selectComponents([targetPath], false)], false)
       })
@@ -2243,6 +2245,14 @@ describe('inspector tests with real metadata', () => {
         )
         expect(falseButton.attributes.getNamedItemNS(null, 'data-controlstatus')?.value).toEqual(
           'simple',
+        )
+
+        // 'bbb' should be present in the metadata and 'ccc' should not.
+        expect(renderResult.getEditorState().editor.jsxMetadata).toHaveProperty(
+          EP.toString(bbbPath),
+        )
+        expect(renderResult.getEditorState().editor.jsxMetadata).not.toHaveProperty(
+          EP.toString(cccPath),
         )
       }
 
@@ -2291,6 +2301,14 @@ describe('inspector tests with real metadata', () => {
         expect(falseButton.attributes.getNamedItemNS(null, 'data-controlstatus')?.value).toEqual(
           'overridden',
         )
+
+        // 'ccc' should be present in the metadata and 'bbb' should not.
+        expect(renderResult.getEditorState().editor.jsxMetadata).not.toHaveProperty(
+          EP.toString(bbbPath),
+        )
+        expect(renderResult.getEditorState().editor.jsxMetadata).toHaveProperty(
+          EP.toString(cccPath),
+        )
       }
 
       // override to true
@@ -2338,6 +2356,14 @@ describe('inspector tests with real metadata', () => {
         expect(falseButton.attributes.getNamedItemNS(null, 'data-controlstatus')?.value).toEqual(
           'overridden',
         )
+
+        // 'bbb' should be present in the metadata and 'ccc' should not.
+        expect(renderResult.getEditorState().editor.jsxMetadata).toHaveProperty(
+          EP.toString(bbbPath),
+        )
+        expect(renderResult.getEditorState().editor.jsxMetadata).not.toHaveProperty(
+          EP.toString(cccPath),
+        )
       }
 
       // disable override
@@ -2383,6 +2409,14 @@ describe('inspector tests with real metadata', () => {
         )
         expect(falseButton.attributes.getNamedItemNS(null, 'data-controlstatus')?.value).toEqual(
           'simple',
+        )
+
+        // 'bbb' should be present in the metadata and 'ccc' should not.
+        expect(renderResult.getEditorState().editor.jsxMetadata).toHaveProperty(
+          EP.toString(bbbPath),
+        )
+        expect(renderResult.getEditorState().editor.jsxMetadata).not.toHaveProperty(
+          EP.toString(cccPath),
         )
       }
 
@@ -2430,6 +2464,14 @@ describe('inspector tests with real metadata', () => {
         )
         expect(falseButton.attributes.getNamedItemNS(null, 'data-controlstatus')?.value).toEqual(
           'overridden',
+        )
+
+        // 'bbb' should be present in the metadata and 'ccc' should not.
+        expect(renderResult.getEditorState().editor.jsxMetadata).toHaveProperty(
+          EP.toString(bbbPath),
+        )
+        expect(renderResult.getEditorState().editor.jsxMetadata).not.toHaveProperty(
+          EP.toString(cccPath),
         )
       }
     })


### PR DESCRIPTION
**Problem:**
When toggling the condition of a conditional expression, the navigator still shows the content of the now unrendered branch as if it was still being rendered.

**Fix:**
Nothing was performing any cleanup on the metadata for the entries being created when those entries ceased to exist, which resulted in the navigator logic finding them and populating additional navigator entries from those.

Now if any metadata exists for the conditional clause that is not rendered, we run a small process that sweeps up those spy entries for any descendants of that clause.

**Commit Details:**
- Implemented `clearOpposingConditionalSpyValues` to remove any metadata which is a descendant of the unrendered branch of a conditional.
- Added call to `clearOpposingConditionalSpyValues` to `renderCoreElement`.