### PR TITLE
Fix absolute reparent offseting when pins are missing

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../../../core/layout/layout-helpers-new'
 import { MetadataUtils } from '../../../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../../../core/shared/array-utils'
-import { isRight, right } from '../../../../../core/shared/either'
+import { eitherToMaybe, isRight, right } from '../../../../../core/shared/either'
 import * as EP from '../../../../../core/shared/element-path'
 import { ElementInstanceMetadataMap, JSXElement } from '../../../../../core/shared/element-template'
 import {
@@ -28,6 +28,7 @@ import { stylePropPathMappingFn } from '../../../../inspector/common/property-pa
 import {
   AdjustCssLengthProperty,
   adjustCssLengthProperty,
+  CreateIfNotExistant,
 } from '../../../commands/adjust-css-length-command'
 import { CanvasCommand } from '../../../commands/commands'
 import {
@@ -100,27 +101,28 @@ export function getAbsoluteReparentPropertyChanges(
     ),
   )
 
+  const newParentFrame = nullIfInfinity(
+    MetadataUtils.getFrameInCanvasCoords(newParent, newParentStartingMetadata),
+  )
+  const newParentFlexDirection =
+    MetadataUtils.findElementByElementPath(newParentStartingMetadata, newParent)
+      ?.specialSizeMeasurements.flexDirection ?? null
+
   const createAdjustCssLengthProperty = (
     pin: LayoutPinnedProp,
     newValue: number,
     parentDimension: number | undefined,
-    elementParentFlexDirection: FlexDirection | null,
-  ): AdjustCssLengthProperty | null => {
-    const value = getLayoutProperty(pin, right(element.props), styleStringInArray)
-    if (isRight(value) && value.value != null) {
-      // TODO what to do about missing properties?
-      return adjustCssLengthProperty(
-        'always',
-        target,
-        stylePropPathMappingFn(pin, styleStringInArray),
-        newValue,
-        parentDimension,
-        elementParentFlexDirection,
-        'create-if-not-existing',
-      )
-    } else {
-      return null
-    }
+    createIfNonExistant: CreateIfNotExistant,
+  ): AdjustCssLengthProperty => {
+    return adjustCssLengthProperty(
+      'always',
+      target,
+      stylePropPathMappingFn(pin, styleStringInArray),
+      newValue,
+      parentDimension,
+      newParentFlexDirection,
+      createIfNonExistant,
+    )
   }
 
   const createConvertCssPercentToPx = (pin: LayoutPinnedProp): ConvertCssPercentToPx | null => {
@@ -139,21 +141,24 @@ export function getAbsoluteReparentPropertyChanges(
     }
   }
 
-  const newParentFrame = nullIfInfinity(
-    MetadataUtils.getFrameInCanvasCoords(newParent, newParentStartingMetadata),
-  )
-  const newParentFlexDirection =
-    MetadataUtils.findElementByElementPath(newParentStartingMetadata, newParent)
-      ?.specialSizeMeasurements.flexDirection ?? null
+  // We need at least one position prop offset in each dimension
+  const hasPin = (pin: LayoutPinnedProp) => {
+    const rawPin = getLayoutProperty(pin, right(element.props), styleStringInArray)
+    return isRight(rawPin) && rawPin.value != null
+  }
+
+  const needsLeftPin = !hasPin('left') && !hasPin('right')
+  const needsTopPin = !hasPin('top') && !hasPin('bottom')
 
   const topLeftCommands = mapDropNulls(
     (pin) => {
       const horizontal = isHorizontalPoint(framePointForPinnedProp(pin))
+      const needsPin = (pin === 'left' && needsLeftPin) || (pin === 'top' && needsTopPin)
       return createAdjustCssLengthProperty(
         pin,
         horizontal ? offsetTL.x : offsetTL.y,
         horizontal ? newParentFrame?.width : newParentFrame?.height,
-        newParentFlexDirection,
+        needsPin ? 'create-if-not-existing' : 'do-not-create-if-doesnt-exist',
       )
     },
     ['top', 'left'] as const,
@@ -166,7 +171,7 @@ export function getAbsoluteReparentPropertyChanges(
         pin,
         horizontal ? offsetBR.x : offsetBR.y,
         horizontal ? newParentFrame?.width : newParentFrame?.height,
-        newParentFlexDirection,
+        'do-not-create-if-doesnt-exist',
       )
     },
     ['bottom', 'right'] as const,

--- a/editor/src/components/canvas/commands/adjust-css-length-command.ts
+++ b/editor/src/components/canvas/commands/adjust-css-length-command.ts
@@ -26,7 +26,7 @@ import { applyValuesAtPath } from './adjust-number-command'
 import { BaseCommand, CommandFunction, CommandFunctionResult, WhenToRun } from './commands'
 import { deleteValuesAtPath } from './delete-properties-command'
 
-type CreateIfNotExistant = 'create-if-not-existing' | 'do-not-create-if-doesnt-exist'
+export type CreateIfNotExistant = 'create-if-not-existing' | 'do-not-create-if-doesnt-exist'
 
 export interface AdjustCssLengthProperty extends BaseCommand {
   type: 'ADJUST_CSS_LENGTH_PROPERTY'


### PR DESCRIPTION
**Problem:**
When performing an absolute reparent for an element with missing horizontal or vertical pins we will act as though they started at 0,0 on the new parent, incorrectly offsetting the result.

**Fix:**
During the reparent we were only providing the offsets for existing pins, so now we check to see if we are missing pins in one dimension and use `create-if-not-existing` for the relevant pin in that direction.