### PR TITLE
Use js string and uid for function caching

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4515,14 +4515,25 @@ export const UPDATE_FNS = {
           return element
         }
 
+        // Use the values from the previous version in an attempt to stop a brief error screen
+        // from flashing between committing this change and re-parsing the file
+        const oldDefinedElsewhere =
+          element.condition.type === 'ATTRIBUTE_OTHER_JAVASCRIPT'
+            ? element.condition.definedElsewhere
+            : []
+        const oldElementsWithin =
+          element.condition.type === 'ATTRIBUTE_OTHER_JAVASCRIPT'
+            ? element.condition.elementsWithin
+            : {}
+
         return {
           ...element,
           condition: jsExpressionOtherJavaScript(
             action.expression,
             action.expression,
-            [],
+            oldDefinedElsewhere,
             null,
-            {},
+            oldElementsWithin,
           ),
           originalConditionString: action.expression,
         }

--- a/editor/src/core/shared/javascript-cache.ts
+++ b/editor/src/core/shared/javascript-cache.ts
@@ -51,7 +51,11 @@ function getOrUpdateFunctionCache(
   requireResult: MapLike<any>,
   handleError: (error: Error) => void,
 ): (...args: Array<unknown>) => unknown {
-  const cacheKey = `${javascript.uid}_${javascript.javascript}`
+  const uidPart = javascript.uid
+  const definedElsewherePart = javascript.definedElsewhere.join('_')
+  const elementsWithinPart = Object.keys(javascript.elementsWithin).join('_')
+  const codePart = javascript.javascript
+  const cacheKey = `uid${uidPart}_de${definedElsewherePart}_ew${elementsWithinPart}_code${codePart}`
   const fromCache = functionCache[cacheKey]
   if (fromCache == null) {
     const newCachedFunction = SafeFunctionCurriedErrorHandler(

--- a/editor/src/core/shared/javascript-cache.ts
+++ b/editor/src/core/shared/javascript-cache.ts
@@ -51,7 +51,8 @@ function getOrUpdateFunctionCache(
   requireResult: MapLike<any>,
   handleError: (error: Error) => void,
 ): (...args: Array<unknown>) => unknown {
-  const fromCache = functionCache[javascript.uid]
+  const cacheKey = `${javascript.uid}_${javascript.javascript}`
+  const fromCache = functionCache[cacheKey]
   if (fromCache == null) {
     const newCachedFunction = SafeFunctionCurriedErrorHandler(
       false,
@@ -61,7 +62,7 @@ function getOrUpdateFunctionCache(
       javascript.sourceMap,
       javascript.definedElsewhere,
     )
-    functionCache[javascript.uid] = newCachedFunction
+    functionCache[cacheKey] = newCachedFunction
     return newCachedFunction(handleError)
   } else {
     return fromCache(handleError)


### PR DESCRIPTION
**Problem:**
Since we use UIDs for caching arbitrary JS blocks, our recent change to retain UIDs means that we are running old cached code after making changes to arbitrary JS.

**Fix:**
To ensure we update the cache on actual code changes, we now include the actual code in the cache key. To also ensure that the cache entry is unique to that specific piece of code (i.e. so that we're not returning the same cache result for identical code coming from different contexts) we also include the UID in the cache key.