### PR TITLE
Wrap in div inside conditionals.

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -470,7 +470,7 @@ export function updateFramesOfScenesAndComponents(
     const elementMetadata = MetadataUtils.findElementByElementPath(editorState.jsxMetadata, target)
     const elementProps = editorState.allElementProps[EP.toString(target)] ?? {}
 
-    const elementAttributes = isJSXConditionalExpression(element) ? [] : element.props
+    const elementAttributes = isJSXElement(element) ? element.props : []
 
     const isFlexContainer =
       frameAndTarget.type !== 'PIN_FRAME_CHANGE' &&

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -508,6 +508,42 @@ ${snippet}
 `)
 }
 
+export function makeTestProjectCodeWithComponentInnardsWithoutUIDs(
+  componentInnards: string,
+): string {
+  const code = `
+  import * as React from 'react'
+  import { Scene, Storyboard, View } from 'utopia-api'
+
+  export var App = (props) => {
+${componentInnards}
+  }
+
+  export var ${BakedInStoryboardVariableName} = (props) => {
+    return (
+      <Storyboard>
+        <Scene
+          style={{ left: 0, top: 0, width: 400, height: 400 }}
+        >
+          <App
+            style={{ position: 'absolute', bottom: 0, left: 0, right: 0, top: 0 }}
+          />
+        </Scene>
+      </Storyboard>
+    )
+  }
+`
+  return formatTestProjectCode(code)
+}
+
+export function makeTestProjectCodeWithSnippetWithoutUIDs(snippet: string): string {
+  return makeTestProjectCodeWithComponentInnardsWithoutUIDs(`
+  return (
+${snippet}
+  )
+`)
+}
+
 export function makeTestProjectCodeWithSnippetStyledComponents(snippet: string): string {
   const code = `
   /** @jsx jsx */

--- a/editor/src/components/editor/store/reparent-target.ts
+++ b/editor/src/components/editor/store/reparent-target.ts
@@ -82,8 +82,10 @@ export function commonReparentTarget(
     } else {
       if (EP.pathsEqual(first.elementPath, second.elementPath)) {
         if (first.clause === second.clause) {
+          // If the clauses are the same (both 'true-case' or both 'false-case'), then refer specifically to that case.
           return first
         } else {
+          // As the clauses are not the same, but this is the same conditional refer to the conditional instead.
           return first.elementPath
         }
       } else {

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -74,6 +74,16 @@ export const conditionalWhenTrueOptic: Optic<JSXConditionalExpression, JSXElemen
 export const conditionalWhenFalseOptic: Optic<JSXConditionalExpression, JSXElementChild> =
   fromField('whenFalse')
 
+export function getClauseOptic(
+  clause: ConditionalCase,
+): Optic<JSXConditionalExpression, JSXElementChild> {
+  if (clause === 'true-case') {
+    return conditionalWhenTrueOptic
+  } else {
+    return conditionalWhenFalseOptic
+  }
+}
+
 export function getConditionalCase(
   elementPath: ElementPath,
   parent: JSXConditionalExpression,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -137,6 +137,7 @@ import {
 } from './conditionals'
 import { getUtopiaID } from '../shared/uid-utils'
 import {
+  conditionalClause,
   ReparentTargetParent,
   reparentTargetParentIsElementPath,
 } from '../../components/editor/store/reparent-target'
@@ -1962,6 +1963,28 @@ export const MetadataUtils = {
       return fallbackFlexDirection
     }
     return flexDirections[0]
+  },
+  getReparentTargetOfTarget(
+    metadata: ElementInstanceMetadataMap,
+    target: ElementPath,
+  ): ReparentTargetParent<ElementPath> | null {
+    const parentElement = this.getParent(metadata, target)
+    if (parentElement == null) {
+      return null
+    } else {
+      if (
+        isRight(parentElement.element) &&
+        isJSXConditionalExpression(parentElement.element.value)
+      ) {
+        const conditionalExpression: JSXConditionalExpression = parentElement.element.value
+        if (getUtopiaID(conditionalExpression.whenTrue) === EP.toUid(target)) {
+          return conditionalClause(parentElement.elementPath, 'true-case')
+        } else if (getUtopiaID(conditionalExpression.whenFalse) === EP.toUid(target)) {
+          return conditionalClause(parentElement.elementPath, 'false-case')
+        }
+      }
+      return parentElement.elementPath
+    }
   },
 }
 


### PR DESCRIPTION
**Problem:**
Wrapping in a div (or other elements) is not handled correctly when targeting the element at the root of a conditional clause, with it replacing the item to be wrapped entirely.

**Fix:**
So that it is possible to target a conditional clause specifically, the `ReparentTargetParent` type has been utilised in place of `ElementPath` for these cases, with the parent to be manipulated being identified using that type and some new functions implemented in this PR.

The reason why the original elements were being lost was due to the new parent being inserted and then the target being moved in a separate step afterwards. But in the case of a conditional clause there can't be multiple elements in that position, so when the new parent was inserted the target was eliminated by default.

**Notes:**
`ReparentTargetParent` is increasingly being used as an alternative to `ElementPath` with some special case logic that handles it being implemented on a case by case basis. Which implies that `ElementPath` should really be extended to cover the cases that `ReparentTargetParent` covers.

**Commit Details:**
- Added `commonReparentTarget` to attempt to find a common reparent between two instances of `ReparentTargetParent`, akin to `closestSharedAncestor` for `ElementPath`.
- Implemented `commonReparentTargetFromArray` which utilises `commonReparentTarget` across multiple entries as well as null ones.
- `getClauseOptic` added to cover a recurring case of needing one or the other optic.
- `getReparentTargetOfTarget` implemented to identify a `ReparentTargetParent` for a particular `ElementPath`, which handles finding the appropriate clause of a conditional should the element be an immediate "child" of the condtional.
- For both `WRAP_IN_VIEW` and `WRAP_IN_ELEMENT` actions, use functions operating on `ReparentTargetParent` so as to cater for conditional clauses correctly. With a check on the type of where the reparenting is being applied.