### PR TITLE
fix(common) Add production script back to utopia-vscode-common module

### DIFF
--- a/utopia-vscode-common/package.json
+++ b/utopia-vscode-common/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "tsc && pnpx webpack-cli",
+    "production": "tsc && pnpx webpack-cli --mode production",
     "watch": "tsc --watch",
     "watch-dev": "tsc --watch",
     "preinstall": "npx only-allow pnpm"


### PR DESCRIPTION
**Problem:**
Production deploy failed because of a missing `production` npm script.

**Fix:**
Add the production script back in.

I'll be merging this immediately. This PR exists for posterity.