### PR TITLE
fix(inspector) show multiselect status in size section

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -283,6 +283,110 @@ describe('inspector tests with real metadata', () => {
       `"detected"`,
     )
   })
+  it('TLWH layout controls in multiselect', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          style={{ ...props.style, position: 'absolute', backgroundColor: '#FFFFFF' }}
+          data-uid={'aaa'}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              backgroundColor: '#DDDDDD',
+              left: 55,
+              top: 98,
+              width: 266,
+              height: 124,
+            }}
+            data-uid={'bbb'}
+          ></div>
+          <div
+          style={{
+            position: 'absolute',
+            backgroundColor: '#DDDDDD',
+            left: 100,
+            top: 100,
+            width: 150,
+            height: 160,
+          }}
+          data-uid={'ccc'}
+        ></div>
+        </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    const targetPath1 = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
+    const targetPath2 = EP.appendNewElementPath(TestScenePath, ['aaa', 'ccc'])
+
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      await renderResult.dispatch([selectComponents([targetPath1, targetPath2], false)], false)
+      await dispatchDone
+    })
+
+    const metadata = renderResult.getEditorState().editor.jsxMetadata[EP.toString(targetPath1)]
+
+    const widthControl = (await renderResult.renderedDOM.findByTestId(
+      'hug-fixed-fill-width',
+    )) as HTMLInputElement
+    const heightControl = (await renderResult.renderedDOM.findByTestId(
+      'hug-fixed-fill-height',
+    )) as HTMLInputElement
+    const topControl = (await renderResult.renderedDOM.findByTestId(
+      'position-top-number-input',
+    )) as HTMLInputElement
+    const leftControl = (await renderResult.renderedDOM.findByTestId(
+      'position-left-number-input',
+    )) as HTMLInputElement
+    const bottomControl = (await renderResult.renderedDOM.findByTestId(
+      'position-bottom-number-input',
+    )) as HTMLInputElement
+    const rightControl = (await renderResult.renderedDOM.findByTestId(
+      'position-right-number-input',
+    )) as HTMLInputElement
+
+    matchInlineSnapshotBrowser(metadata.computedStyle?.['width'], `"266px"`)
+    matchInlineSnapshotBrowser(widthControl.value, `"266"`)
+    matchInlineSnapshotBrowser(
+      widthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+      `"multiselect-mixed-simple-or-unset"`,
+    )
+
+    matchInlineSnapshotBrowser(metadata.computedStyle?.['height'], `"124px"`)
+    matchInlineSnapshotBrowser(heightControl.value, `"124"`)
+    matchInlineSnapshotBrowser(
+      heightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+      `"multiselect-mixed-simple-or-unset"`,
+    )
+
+    matchInlineSnapshotBrowser(metadata.computedStyle?.['top'], `"98px"`)
+    matchInlineSnapshotBrowser(topControl.value, `"98"`)
+    matchInlineSnapshotBrowser(
+      topControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+      `"multiselect-mixed-simple-or-unset"`,
+    )
+
+    matchInlineSnapshotBrowser(metadata.computedStyle?.['left'], `"55px"`)
+    matchInlineSnapshotBrowser(leftControl.value, `"55"`)
+    matchInlineSnapshotBrowser(
+      leftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+      `"multiselect-mixed-simple-or-unset"`,
+    )
+
+    matchInlineSnapshotBrowser(bottomControl.value, `"178"`)
+    matchInlineSnapshotBrowser(
+      bottomControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+      `"multiselect-identical-unset"`,
+    )
+
+    matchInlineSnapshotBrowser(rightControl.value, `"79"`)
+    matchInlineSnapshotBrowser(
+      rightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+      `"multiselect-identical-unset"`,
+    )
+  })
   it('TLBR layout controls', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`

--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -14,7 +14,7 @@ import { CSSNumber, cssNumber, CSSNumberType, UnknownOrEmptyInput } from './comm
 import { metadataSelector, selectedViewsSelector, useComputedSizeRef } from './inpector-selectors'
 import {
   Axis,
-  detectFillHugFixedState,
+  detectFillHugFixedStateMultiselect,
   FixedHugFill,
   FixedHugFillMode,
   getFixedFillHugOptionsForElement,
@@ -85,10 +85,10 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
   const widthCurrentValue = useEditorState(
     Substores.metadata,
     (store) =>
-      detectFillHugFixedState(
+      detectFillHugFixedStateMultiselect(
         'horizontal',
         metadataSelector(store),
-        selectedViewsSelector(store)[0] ?? null,
+        selectedViewsSelector(store),
       ),
     'FillHugFixedControl widthCurrentValue',
     isFixedHugFillEqual,
@@ -108,10 +108,10 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
 
   const fillsContainerHorizontallyRef = useRefEditorState(
     (store) =>
-      detectFillHugFixedState(
+      detectFillHugFixedStateMultiselect(
         'horizontal',
         metadataSelector(store),
-        selectedViewsSelector(store)[0] ?? null,
+        selectedViewsSelector(store),
       ).fixedHugFill?.type === 'fill',
   )
 
@@ -120,10 +120,10 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
   const heightCurrentValue = useEditorState(
     Substores.metadata,
     (store) =>
-      detectFillHugFixedState(
+      detectFillHugFixedStateMultiselect(
         'vertical',
         metadataSelector(store),
-        selectedViewsSelector(store)[0] ?? null,
+        selectedViewsSelector(store),
       ),
     'FillHugFixedControl heightCurrentValue',
     isFixedHugFillEqual,
@@ -143,10 +143,10 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
 
   const fillsContainerVerticallyRef = useRefEditorState(
     (store) =>
-      detectFillHugFixedState(
+      detectFillHugFixedStateMultiselect(
         'vertical',
         metadataSelector(store),
-        selectedViewsSelector(store)[0] ?? null,
+        selectedViewsSelector(store),
       ).fixedHugFill?.type === 'fill',
   )
 

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -1,7 +1,13 @@
 import * as PP from '../../core/shared/property-path'
 import * as EP from '../../core/shared/element-path'
 import { getSimpleAttributeAtPath, MetadataUtils } from '../../core/model/element-metadata-utils'
-import { allElemsEqual, mapDropNulls, strictEvery, stripNulls } from '../../core/shared/array-utils'
+import {
+  allElemsEqual,
+  mapDropNulls,
+  strictEvery,
+  stripNulls,
+  uniq,
+} from '../../core/shared/array-utils'
 import {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
@@ -18,7 +24,7 @@ import {
   parseCSSLengthPercent,
   parseCSSNumber,
 } from './common/css-utils'
-import { assertNever } from '../../core/shared/utils'
+import { assertNever, fastForEach } from '../../core/shared/utils'
 import { defaultEither, foldEither, isLeft, isRight, right } from '../../core/shared/either'
 import { elementOnlyHasTextChildren } from '../../core/model/element-template-utils'
 import { optionalMap } from '../../core/shared/optional-utils'
@@ -526,7 +532,7 @@ export type FixedHugFillMode = FixedHugFill['type']
 export function detectFillHugFixedState(
   axis: Axis,
   metadata: ElementInstanceMetadataMap,
-  elementPath: ElementPath | null,
+  elementPath: ElementPath,
 ): { fixedHugFill: FixedHugFill | null; controlStatus: ControlStatus } {
   const element = MetadataUtils.findElementByElementPath(metadata, elementPath)
   if (element == null || isLeft(element.element) || !isJSXElement(element.element.value)) {
@@ -628,6 +634,35 @@ export function detectFillHugFixedState(
   }
 
   return { fixedHugFill: null, controlStatus: 'unset' }
+}
+
+export function detectFillHugFixedStateMultiselect(
+  axis: Axis,
+  metadata: ElementInstanceMetadataMap,
+  elementPaths: Array<ElementPath>,
+): { fixedHugFill: FixedHugFill | null; controlStatus: ControlStatus } {
+  if (elementPaths.length === 1) {
+    return detectFillHugFixedState(axis, metadata, elementPaths[0])
+  } else {
+    const results = elementPaths.map((path) => detectFillHugFixedState(axis, metadata, path))
+    let controlStatus: ControlStatus = results[0]?.controlStatus ?? 'off'
+    let value: FixedHugFill | null = results[0]?.fixedHugFill
+
+    fastForEach(results, (result) => {
+      if (!isFixedHugFillEqual(result, results[0])) {
+        controlStatus = 'multiselect-mixed-simple-or-unset'
+      }
+    })
+
+    const allControlStatus = uniq(results.map((result) => result.controlStatus))
+    if (allControlStatus.includes('unoverwritable')) {
+      controlStatus = 'multiselect-unoverwritable'
+    } else if (allControlStatus.includes('controlled')) {
+      controlStatus = 'multiselect-controlled'
+    }
+
+    return { fixedHugFill: value, controlStatus: controlStatus }
+  }
 }
 
 export const MaxContent = 'max-content' as const

--- a/editor/src/components/inspector/sections/style-section/text-subsection/text-auto-sizing-control.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/text-auto-sizing-control.tsx
@@ -14,7 +14,7 @@ import {
   useComputedSizeRef,
 } from '../../../inpector-selectors'
 import {
-  detectFillHugFixedState,
+  detectFillHugFixedStateMultiselect,
   FixedHugFill,
   isFixedHugFillEqual,
 } from '../../../inspector-common'
@@ -40,8 +40,11 @@ function useAutoSizingTypeAndStatus(): { status: ControlStatus; type: 'fixed' | 
   const widthFillHugFixedState = useEditorState(
     Substores.metadata,
     (store) => {
-      const target = store.editor.selectedViews[0]
-      return detectFillHugFixedState('horizontal', store.editor.jsxMetadata, target)
+      return detectFillHugFixedStateMultiselect(
+        'horizontal',
+        store.editor.jsxMetadata,
+        store.editor.selectedViews,
+      )
     },
     'TextAutoSizingControl fixedHugFillState width',
     isFixedHugFillEqual,
@@ -50,8 +53,11 @@ function useAutoSizingTypeAndStatus(): { status: ControlStatus; type: 'fixed' | 
   const heightFillHugFixedState = useEditorState(
     Substores.metadata,
     (store) => {
-      const target = store.editor.selectedViews[0]
-      return detectFillHugFixedState('vertical', store.editor.jsxMetadata, target)
+      return detectFillHugFixedStateMultiselect(
+        'vertical',
+        store.editor.jsxMetadata,
+        store.editor.selectedViews,
+      )
     },
     'TextAutoSizingControl fixedHugFillState height',
     isFixedHugFillEqual,


### PR DESCRIPTION
**Problem:**
New size section doesn't use the correct control style on multiselect.

**Fix:**
When multiselecting elements create multiselect controlStatuses. I think the most important here is seeing the control style for 'mixed' values.

**Commit Details:**
- update new size section control hooks and the font size section hook
- added test
