### PR TITLE
fix(canvas) hide original canvas selection while inserting

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -65,6 +65,7 @@ import { LayoutPinnedProp, LayoutPinnedProps } from '../../../../core/layout/lay
 import { MapLike } from 'typescript'
 import { FullFrame } from '../../../frame'
 import { MaxContent } from '../../../inspector/inspector-common'
+import { wildcardPatch } from '../../commands/wildcard-patch-command'
 
 export const drawToInsertMetaStrategy: MetaCanvasStrategy = (
   canvasState: InteractionCanvasState,
@@ -285,14 +286,22 @@ function getHighlightAndReorderIndicatorCommands(
     const highlightParentCommand = updateHighlightedViews('mid-interaction', [targetParent])
 
     if (targetIndex != null && targetIndex > -1) {
-      return [highlightParentCommand, showReorderIndicator(targetParent, targetIndex)]
+      return [
+        highlightParentCommand,
+        showReorderIndicator(targetParent, targetIndex),
+        clearSelectionCommand,
+      ]
     } else {
-      return [highlightParentCommand]
+      return [highlightParentCommand, clearSelectionCommand]
     }
   } else {
-    return []
+    return [clearSelectionCommand]
   }
 }
+
+const clearSelectionCommand: CanvasCommand = wildcardPatch('mid-interaction', {
+  selectedViews: { $set: [] },
+})
 
 function getInsertionCommands(
   subject: InsertionSubject,

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -42,6 +42,7 @@ import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { PERFORMANCE_MARKS_ALLOWED } from '../../../common/env-vars'
 import { last } from '../../../core/shared/array-utils'
 import { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
+import { isInsertMode } from '../editor-modes'
 
 interface HandleStrategiesResult {
   unpatchedEditorState: EditorState
@@ -224,7 +225,8 @@ export function interactionUpdate(
   const interactionSession = newEditorState.canvas.interactionSession
   if (
     interactionSession == null ||
-    isNotYetStartedDragInteraction(interactionSession.interactionData)
+    (isNotYetStartedDragInteraction(interactionSession.interactionData) &&
+      !isInsertMode(storedState.unpatchedEditor.mode))
   ) {
     return {
       unpatchedEditorState: newEditorState,


### PR DESCRIPTION
**Problem:**
There is a bug in insert mode you can see the selection outline of your original selection before pressing mousedown.

**Fix:**
Clearing selection while the hover interaction is active and while the mouse is pressed but not moved yet.

**Commit Details:**
- add clear selection command to `getHighlightAndReorderIndicatorCommands`
- keep running `interactionUpdate` as usual on mousedown in insert mode, the hover interaction switches to a drag interaction on mousedown so the drag delta is null, but we want to keep modifying the visible controls
