### PR TITLE
Conditional navigator tweaks.

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -112,9 +112,9 @@ export function getNavigatorEntryLabel(
     case 'CONDITIONAL_CLAUSE':
       switch (navigatorEntry.clause) {
         case 'true-case':
-          return 'true'
+          return 'TRUE'
         case 'false-case':
-          return 'false'
+          return 'FALSE'
         default:
           throw assertNever(navigatorEntry.clause)
       }

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -552,6 +552,11 @@ export const NavigatorItem: React.FunctionComponent<
   const rowStyle = useKeepReferenceEqualityIfPossible({
     paddingLeft: getElementPadding(entryNavigatorDepth),
     height: getItemHeight(navigatorEntry),
+    // This matches up with the implementation of `getItemHeight`.
+    marginTop:
+      isConditionalClauseNavigatorEntry(navigatorEntry) && navigatorEntry.clause === 'false-case'
+        ? '8px'
+        : undefined,
     ...resultingStyle.style,
   })
 

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -40,7 +40,11 @@ import {
   matchesOverriddenConditionalBranch,
 } from '../../../core/model/conditionals'
 import { DerivedSubstate, MetadataSubstate } from '../../editor/store/store-hook-substore-types'
-import { getConditionalClausePathForNavigatorEntry, navigatorDepth } from '../navigator-utils'
+import {
+  getConditionalClausePathForNavigatorEntry,
+  getItemHeight,
+  navigatorDepth,
+} from '../navigator-utils'
 import createCachedSelector from 're-reselect'
 import { getValueFromComplexMap } from '../../../utils/map'
 
@@ -547,7 +551,7 @@ export const NavigatorItem: React.FunctionComponent<
 
   const rowStyle = useKeepReferenceEqualityIfPossible({
     paddingLeft: getElementPadding(entryNavigatorDepth),
-    height: UtopiaTheme.layout.rowHeight.smaller,
+    height: getItemHeight(navigatorEntry),
     ...resultingStyle.style,
   })
 

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -40,13 +40,25 @@ import {
   matchesOverriddenConditionalBranch,
 } from '../../../core/model/conditionals'
 import { DerivedSubstate, MetadataSubstate } from '../../editor/store/store-hook-substore-types'
-import {
-  getConditionalClausePathForNavigatorEntry,
-  getItemHeight,
-  navigatorDepth,
-} from '../navigator-utils'
+import { getConditionalClausePathForNavigatorEntry, navigatorDepth } from '../navigator-utils'
 import createCachedSelector from 're-reselect'
 import { getValueFromComplexMap } from '../../../utils/map'
+
+export function getItemHeight(navigatorEntry: NavigatorEntry): number {
+  if (isConditionalClauseNavigatorEntry(navigatorEntry)) {
+    if (navigatorEntry.clause === 'true-case') {
+      // The TRUE label row will be the shortest size.
+      return UtopiaTheme.layout.rowHeight.smallest
+    } else {
+      // The FALSE label row should visually appear to be the shortest size.
+      // The size difference (against the TRUE label row) will be a top margin.
+      return UtopiaTheme.layout.rowHeight.smaller
+    }
+  } else {
+    // Default size for everything else.
+    return UtopiaTheme.layout.rowHeight.smaller
+  }
+}
 
 export const NavigatorItemTestId = (pathString: string): string =>
   `NavigatorItemTestId-${pathString}`

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -29,6 +29,7 @@ import {
 import { objectValues } from '../../core/shared/object-utils'
 import { fastForEach } from '../../core/shared/utils'
 import { ConditionalCase, getConditionalClausePath } from '../../core/model/conditionals'
+import { UtopiaTheme } from '../../uuiui'
 
 function baseNavigatorDepth(path: ElementPath): number {
   // The storyboard means that this starts at -1,
@@ -212,4 +213,10 @@ export function getConditionalClausePathForNavigatorEntry(
   const clauseElement =
     navigatorEntry.clause === 'true-case' ? jsxElement.whenTrue : jsxElement.whenFalse
   return getConditionalClausePath(navigatorEntry.elementPath, clauseElement, navigatorEntry.clause)
+}
+
+export function getItemHeight(navigatorEntry: NavigatorEntry): number {
+  return isConditionalClauseNavigatorEntry(navigatorEntry)
+    ? UtopiaTheme.layout.rowHeight.smallest
+    : UtopiaTheme.layout.rowHeight.smaller
 }

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -216,7 +216,17 @@ export function getConditionalClausePathForNavigatorEntry(
 }
 
 export function getItemHeight(navigatorEntry: NavigatorEntry): number {
-  return isConditionalClauseNavigatorEntry(navigatorEntry)
-    ? UtopiaTheme.layout.rowHeight.smallest
-    : UtopiaTheme.layout.rowHeight.smaller
+  if (isConditionalClauseNavigatorEntry(navigatorEntry)) {
+    if (navigatorEntry.clause === 'true-case') {
+      // The TRUE label row will be the shortest size.
+      return UtopiaTheme.layout.rowHeight.smallest
+    } else {
+      // The FALSE label row should visually appear to be the shortest size.
+      // The size difference (against the TRUE label row) will be a top margin.
+      return UtopiaTheme.layout.rowHeight.smaller
+    }
+  } else {
+    // Default size for everything else.
+    return UtopiaTheme.layout.rowHeight.smaller
+  }
 }

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -214,19 +214,3 @@ export function getConditionalClausePathForNavigatorEntry(
     navigatorEntry.clause === 'true-case' ? jsxElement.whenTrue : jsxElement.whenFalse
   return getConditionalClausePath(navigatorEntry.elementPath, clauseElement, navigatorEntry.clause)
 }
-
-export function getItemHeight(navigatorEntry: NavigatorEntry): number {
-  if (isConditionalClauseNavigatorEntry(navigatorEntry)) {
-    if (navigatorEntry.clause === 'true-case') {
-      // The TRUE label row will be the shortest size.
-      return UtopiaTheme.layout.rowHeight.smallest
-    } else {
-      // The FALSE label row should visually appear to be the shortest size.
-      // The size difference (against the TRUE label row) will be a top margin.
-      return UtopiaTheme.layout.rowHeight.smaller
-    }
-  } else {
-    // Default size for everything else.
-    return UtopiaTheme.layout.rowHeight.smaller
-  }
-}

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -25,7 +25,7 @@ import {
   NavigatorEntry,
   navigatorEntryToKey,
 } from '../editor/store/editor-state'
-import { getItemHeight } from './navigator-utils'
+import { getItemHeight } from './navigator-item/navigator-item'
 
 interface ItemProps extends ListChildComponentProps {}
 

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -12,10 +12,10 @@ import { NavigatorItemWrapper } from './navigator-item/navigator-item-wrapper'
 import { Substores, useEditorState, useRefEditorState } from '../editor/store/store-hook'
 import { ElementContextMenu } from '../element-context-menu'
 import { getSelectedNavigatorEntries } from '../../templates/editor-navigator'
-import { FixedSizeList, ListChildComponentProps } from 'react-window'
+import { VariableSizeList, ListChildComponentProps } from 'react-window'
 import AutoSizer, { Size } from 'react-virtualized-auto-sizer'
 import { Section, SectionBodyArea, FlexColumn } from '../../uuiui'
-import { last } from '../../core/shared/array-utils'
+import { last, safeIndex } from '../../core/shared/array-utils'
 import { UtopiaTheme } from '../../uuiui/styles/theme/utopia-theme'
 import { useKeepReferenceEqualityIfPossible } from '../../utils/react-performance'
 import { useDispatch } from '../editor/store/dispatch-context'
@@ -25,6 +25,7 @@ import {
   NavigatorEntry,
   navigatorEntryToKey,
 } from '../editor/store/editor-state'
+import { getItemHeight } from './navigator-utils'
 
 interface ItemProps extends ListChildComponentProps {}
 
@@ -138,7 +139,7 @@ export const NavigatorComponent = React.memo(() => {
     'NavigatorComponent',
   )
 
-  const itemListRef = React.createRef<FixedSizeList>()
+  const itemListRef = React.createRef<VariableSizeList>()
 
   React.useEffect(() => {
     if (selectionIndex > 0) {
@@ -167,22 +168,34 @@ export const NavigatorComponent = React.memo(() => {
     [dispatch],
   )
 
+  const getItemSize = React.useCallback(
+    (entryIndex: number) => {
+      const navigatorTarget = safeIndex(visibleNavigatorTargets, entryIndex)
+      if (navigatorTarget == null) {
+        throw new Error(`Could not find navigator entry at index ${entryIndex}`)
+      } else {
+        return getItemHeight(navigatorTarget)
+      }
+    },
+    [visibleNavigatorTargets],
+  )
+
   const ItemList = (size: Size) => {
     if (size.height == null) {
       return null
     } else {
       return (
-        <FixedSizeList
+        <VariableSizeList
           ref={itemListRef}
           width={'100%'}
           height={size.height}
-          itemSize={UtopiaTheme.layout.rowHeight.smaller}
+          itemSize={getItemSize}
           itemCount={visibleNavigatorTargets.length}
           layout={'vertical'}
           style={{ overflowX: 'hidden' }}
         >
           {Item}
-        </FixedSizeList>
+        </VariableSizeList>
       )
     }
   }

--- a/editor/src/uuiui/styles/theme/utopia-theme.ts
+++ b/editor/src/uuiui/styles/theme/utopia-theme.ts
@@ -29,6 +29,7 @@ export const UtopiaTheme = {
     rowHorizontalPadding: 8,
     rowButtonSpacing: 4,
     rowHeight: {
+      smallest: 21,
       smaller: 29,
       normal: 34,
       large: 42,


### PR DESCRIPTION
**Changes:**
- Smaller rows for conditional labels.
- 8px “margin” before the second conditional label (‘false’).                                                 
- Uppercase label for each branch.                                                                                                                                                                                                  

**Commit Details:**
- Added `rowHeight.smallest` to the theme.
- Extracted out `getItemHeight` for the navigator items.
- Capitalised the conditional clause title.
- Used `getItemHeight` in `NavigatorItem`.
- Changed the navigator list component from `FixedSizeList` to `VariableSizeList`.
- Added `getItemSize` callback for `VariableSizeList`.
- Added a specific `marginTop` case for `NavigatorItem`.