### PR TITLE
Group label and fragment icon in the navigator

### DIFF
--- a/editor/src/components/editor/store/editor-update.spec.tsx
+++ b/editor/src/components/editor/store/editor-update.spec.tsx
@@ -245,7 +245,7 @@ describe('action RENAME_COMPONENT', () => {
 
   it('renames an existing scene', () => checkRename(ScenePathForTestUiJsFile, 'Test'))
   it('renames an existing element', () =>
-    checkRename(EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa']), 'View'))
+    checkRename(EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa']), 'Group'))
 })
 
 describe('action TOGGLE_PANE', () => {

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -2935,7 +2935,7 @@ describe('inspector tests with real metadata', () => {
         {
           // @utopia/uid=conditional
           [].length === 0 ? (
-          <div data-uid='bbb' data-testid='bbb'><div>Another div</div></div>
+          <div data-uid='bbb' data-testid='bbb' style={{ position: 'absolute', width: 22, height: 22 }}><div>Another div</div></div>
         ) : (
           <h1 data-uid='ccc' data-testid='ccc'>hello there</h1>
         )}

--- a/editor/src/components/inspector/common/name-and-icon-hook.ts
+++ b/editor/src/components/inspector/common/name-and-icon-hook.ts
@@ -36,7 +36,7 @@ const namesAndIconsAllPathsResultSelector = createSelector(
   (metadata, allElementProps) => {
     let result: Array<NameAndIconResult> = []
     for (const metadataElement of objectValues(metadata)) {
-      const nameAndIconResult = getNameAndIconResult(allElementProps, metadataElement)
+      const nameAndIconResult = getNameAndIconResult(metadata, allElementProps, metadataElement)
       result.push(nameAndIconResult)
     }
     return result
@@ -56,14 +56,21 @@ export function useNamesAndIconsAllPaths(): NameAndIconResult[] {
 }
 
 function getNameAndIconResult(
+  metadata: ElementInstanceMetadataMap,
   allElementProps: AllElementProps,
-  metadata: ElementInstanceMetadata,
+  elementInstanceMetadata: ElementInstanceMetadata,
 ): NameAndIconResult {
-  const elementName = MetadataUtils.getJSXElementName(eitherToMaybe(metadata.element))
+  const elementName = MetadataUtils.getJSXElementName(
+    eitherToMaybe(elementInstanceMetadata.element),
+  )
   return {
-    path: metadata.elementPath,
+    path: elementInstanceMetadata.elementPath,
     name: elementName,
-    label: MetadataUtils.getElementLabelFromMetadata(allElementProps, metadata),
-    iconProps: createComponentOrElementIconProps(metadata),
+    label: MetadataUtils.getElementLabelFromMetadata(
+      metadata,
+      allElementProps,
+      elementInstanceMetadata,
+    ),
+    iconProps: createComponentOrElementIconProps(elementInstanceMetadata),
   }
 }

--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -20,7 +20,10 @@ import {
   NavigatorEntry,
 } from '../editor/store/editor-state'
 import { isSpawnedActor } from 'xstate/lib/Actor'
-import { treatElementAsContentAffecting } from '../canvas/canvas-strategies/strategies/group-like-helpers'
+import {
+  getElementContentAffectingType,
+  treatElementAsContentAffecting,
+} from '../canvas/canvas-strategies/strategies/group-like-helpers'
 
 interface LayoutIconResult {
   iconProps: IcnPropsBase
@@ -84,11 +87,25 @@ export function createLayoutOrElementIconResult(
     }
   }
 
-  if (treatElementAsContentAffecting(metadata, allElementProps, path)) {
+  const contentAffectingType = getElementContentAffectingType(metadata, allElementProps, path)
+  if (contentAffectingType === 'sizeless-div') {
     return {
       iconProps: {
         category: 'element',
         type: 'group-open',
+        width: 18,
+        height: 18,
+      },
+
+      isPositionAbsolute: false,
+    }
+  }
+
+  if (contentAffectingType === 'fragment') {
+    return {
+      iconProps: {
+        category: 'element',
+        type: 'fragment',
         width: 18,
         height: 18,
       },

--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -88,11 +88,12 @@ export function createLayoutOrElementIconResult(
   }
 
   const contentAffectingType = getElementContentAffectingType(metadata, allElementProps, path)
-  if (contentAffectingType === 'sizeless-div') {
+
+  if (contentAffectingType === 'fragment') {
     return {
       iconProps: {
         category: 'element',
-        type: 'group-open',
+        type: 'fragment',
         width: 18,
         height: 18,
       },
@@ -101,11 +102,11 @@ export function createLayoutOrElementIconResult(
     }
   }
 
-  if (contentAffectingType === 'fragment') {
+  if (contentAffectingType !== null) {
     return {
       iconProps: {
         category: 'element',
-        type: 'fragment',
+        type: 'group-open',
         width: 18,
         height: 18,
       },

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -73,13 +73,14 @@ const elementSupportsChildrenSelector = createCachedSelector(
 )((_, navigatorEntry) => navigatorEntryToKey(navigatorEntry))
 
 export const labelSelector = createCachedSelector(
+  (store: MetadataSubstate) => store.editor.jsxMetadata,
   targetElementMetadataSelector,
   (store: MetadataSubstate) => store.editor.allElementProps,
-  (elementMetadata, allElementProps) => {
+  (metadata, elementMetadata, allElementProps) => {
     if (elementMetadata == null) {
       return 'Element 👻'
     }
-    return MetadataUtils.getElementLabelFromMetadata(allElementProps, elementMetadata)
+    return MetadataUtils.getElementLabelFromMetadata(metadata, allElementProps, elementMetadata)
   },
 )((_, navigatorEntry) => navigatorEntryToKey(navigatorEntry))
 

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -45,6 +45,7 @@ import { getConditionalClausePathForNavigatorEntry, navigatorDepth } from '../na
 import createCachedSelector from 're-reselect'
 import { getValueFromComplexMap } from '../../../utils/map'
 import { isSyntheticNavigatorEntry } from '../../editor/store/editor-state'
+import { getElementContentAffectingType } from '../../canvas/canvas-strategies/strategies/group-like-helpers'
 
 export const NavigatorItemTestId = (pathString: string): string =>
   `NavigatorItemTestId-${pathString}`
@@ -661,6 +662,17 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
     'NavigatorRowLabel element',
   )
 
+  const isElementGroup = useEditorState(
+    Substores.metadata,
+    (store) =>
+      getElementContentAffectingType(
+        store.editor.jsxMetadata,
+        store.editor.allElementProps,
+        props.navigatorEntry.elementPath,
+      ) === 'sizeless-div',
+    'NavigatorRowLabel element',
+  )
+
   const conditionalOverride = React.useMemo(() => {
     const conditional = asConditional(element)
     if (conditional == null) {
@@ -683,6 +695,8 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
     },
     'NavigatorRowLabel isActiveBranchOfOverriddenConditional',
   )
+
+  const label = isElementGroup ? 'Group' : props.label
 
   return (
     <React.Fragment>

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -662,17 +662,6 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
     'NavigatorRowLabel element',
   )
 
-  const isElementGroup = useEditorState(
-    Substores.metadata,
-    (store) =>
-      getElementContentAffectingType(
-        store.editor.jsxMetadata,
-        store.editor.allElementProps,
-        props.navigatorEntry.elementPath,
-      ) === 'sizeless-div',
-    'NavigatorRowLabel element',
-  )
-
   const conditionalOverride = React.useMemo(() => {
     const conditional = asConditional(element)
     if (conditional == null) {
@@ -695,8 +684,6 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
     },
     'NavigatorRowLabel isActiveBranchOfOverriddenConditional',
   )
-
-  const label = isElementGroup ? 'Group' : props.label
 
   return (
     <React.Fragment>

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1324,10 +1324,10 @@ export const MetadataUtils = {
     )
     if (dataLabelProp != null) {
       return dataLabelProp
-    } else if (isElementGroup) {
-      return 'Group'
     } else if (sceneLabel != null) {
       return sceneLabel
+    } else if (isElementGroup) {
+      return 'Group'
     } else {
       const possibleName: string = foldEither(
         (tagName) => {

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -131,6 +131,7 @@ import {
   ReparentTargetParent,
   reparentTargetParentIsElementPath,
 } from '../../components/editor/store/reparent-target'
+import { getElementContentAffectingType } from '../../components/canvas/canvas-strategies/strategies/group-like-helpers'
 
 const ObjectPathImmutable: any = OPI
 
@@ -1302,10 +1303,14 @@ export const MetadataUtils = {
     }
   },
   getElementLabelFromMetadata(
+    metadata: ElementInstanceMetadataMap,
     allElementProps: AllElementProps,
     element: ElementInstanceMetadata,
     staticName: JSXElementName | null = null,
   ): string {
+    const isElementGroup =
+      getElementContentAffectingType(metadata, allElementProps, element.elementPath) ===
+      'sizeless-div'
     const sceneLabel = element.label // KILLME?
     const dataLabelProp = MetadataUtils.getElementLabelFromProps(
       allElementProps,
@@ -1313,6 +1318,8 @@ export const MetadataUtils = {
     )
     if (dataLabelProp != null) {
       return dataLabelProp
+    } else if (isElementGroup) {
+      return 'Group'
     } else if (sceneLabel != null) {
       return sceneLabel
     } else {
@@ -1398,7 +1405,12 @@ export const MetadataUtils = {
   ): string {
     const element = this.findElementByElementPath(metadata, path)
     if (element != null) {
-      return MetadataUtils.getElementLabelFromMetadata(allElementProps, element, staticName)
+      return MetadataUtils.getElementLabelFromMetadata(
+        metadata,
+        allElementProps,
+        element,
+        staticName,
+      )
     }
 
     // Default catch all name, will probably avoid some odd cases in the future.

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1308,9 +1308,15 @@ export const MetadataUtils = {
     element: ElementInstanceMetadata,
     staticName: JSXElementName | null = null,
   ): string {
+    const elementContentAffectingType = getElementContentAffectingType(
+      metadata,
+      allElementProps,
+      element.elementPath,
+    )
+
     const isElementGroup =
-      getElementContentAffectingType(metadata, allElementProps, element.elementPath) ===
-      'sizeless-div'
+      elementContentAffectingType != null && elementContentAffectingType !== 'fragment'
+
     const sceneLabel = element.label // KILLME?
     const dataLabelProp = MetadataUtils.getElementLabelFromProps(
       allElementProps,


### PR DESCRIPTION

<img width="234" alt="image" src="https://user-images.githubusercontent.com/16385508/230367702-b932c69d-ba95-4604-9573-0c63bc15c6aa.png">
<img width="231" alt="image" src="https://user-images.githubusercontent.com/16385508/230367773-c375af93-0c3f-46fd-88dd-c965b9653208.png">


## Description

This PR adds a dedicated icon for Fragments (instead of the folder icon), and when an element is deemed to be a group (ie, it's a sizeless div), the corresponding label in the navigator becomes `Group` (but if a `data-label` prop is present, the value of the `data-label` prop is used).
