### PR TITLE
fix(floating-menu) show toast without selection

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2779,6 +2779,10 @@ export const UPDATE_FNS = {
     )
   },
   OPEN_FLOATING_INSERT_MENU: (action: OpenFloatingInsertMenu, editor: EditorModel): EditorModel => {
+    if (action.mode.insertMenuMode !== 'closed' && editor.selectedViews.length === 0) {
+      const showToastAction = showToast(notice(`There are no elements selected`, 'WARNING'))
+      return UPDATE_FNS.ADD_TOAST(showToastAction, editor)
+    }
     return {
       ...editor,
       floatingInsertMenu: action.mode,


### PR DESCRIPTION
**Fix:**
Allow opening the floating insert menu only when an element is selected.

**Commit Details:**
- a toast is shown when trying to open it with 0 selected elements.
