### PR TITLE
Rename `getViewZIndexFromMetadata` to `getIndexInParent`

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/yoga-utils.ts
+++ b/editor/src/components/canvas/controls/select-mode/yoga-utils.ts
@@ -66,7 +66,7 @@ export function getNewIndex(
   // if the target is not yet a children of the parent, we set currentIndex to Infinity so the logic below acts as if it would be the last sibling
   let alreadyAChild: boolean = true
   let currentIndex: number = Infinity
-  const viewZIndex = MetadataUtils.getViewZIndexFromMetadata(componentMetadata, target)
+  const viewZIndex = MetadataUtils.getIndexInParent(componentMetadata, target)
   if (viewZIndex >= 0) {
     currentIndex = viewZIndex
   } else {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1791,7 +1791,7 @@ export const UPDATE_FNS = {
 
     if (dropTarget.type === 'MOVE_ROW_BEFORE' || dropTarget.type === 'MOVE_ROW_AFTER') {
       const newParentPath: ElementPath | null = EP.parentPath(dropTarget.target)
-      const index = MetadataUtils.getViewZIndexFromMetadata(editor.jsxMetadata, dropTarget.target)
+      const index = MetadataUtils.getIndexInParent(editor.jsxMetadata, dropTarget.target)
       let indexPosition: IndexPosition
       switch (dropTarget.type) {
         case 'MOVE_ROW_BEFORE': {
@@ -2341,10 +2341,7 @@ export const UPDATE_FNS = {
           if (reparentTargetParentIsElementPath(parentPath)) {
             indexInParent = optionalMap(
               (firstPathMatchingCommonParent) =>
-                MetadataUtils.getViewZIndexFromMetadata(
-                  editor.jsxMetadata,
-                  firstPathMatchingCommonParent,
-                ),
+                MetadataUtils.getIndexInParent(editor.jsxMetadata, firstPathMatchingCommonParent),
               orderedActionTargets.find((target) =>
                 EP.pathsEqual(EP.parentPath(target), parentPath),
               ),
@@ -2580,10 +2577,7 @@ export const UPDATE_FNS = {
         if (parentPath != null && reparentTargetParentIsElementPath(parentPath)) {
           indexInParent = optionalMap(
             (firstPathMatchingCommonParent) =>
-              MetadataUtils.getViewZIndexFromMetadata(
-                editor.jsxMetadata,
-                firstPathMatchingCommonParent,
-              ),
+              MetadataUtils.getIndexInParent(editor.jsxMetadata, firstPathMatchingCommonParent),
             orderedActionTargets.find((target) => EP.pathsEqual(EP.parentPath(target), parentPath)),
           )
         }

--- a/editor/src/components/editor/store/editor-update.spec.browser2.tsx
+++ b/editor/src/components/editor/store/editor-update.spec.browser2.tsx
@@ -1,0 +1,182 @@
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { ScenePathForTestUiJsFile } from '../../../core/model/test-ui-js-file.test-utils'
+import * as EP from '../../../core/shared/element-path'
+import { selectComponentsForTest } from '../../../utils/utils.test-utils'
+import { renderTestEditorWithCode } from '../../canvas/ui-jsx.test-utils'
+import { moveSelectedBackward } from '../actions/action-creators'
+
+describe('actions', () => {
+  it('MOVE_SELECTED_BACKWARD', async () => {
+    const editor = await renderTestEditorWithCode(
+      `import * as React from 'react'
+        import {
+          UtopiaUtils,
+          Ellipse,
+          Image,
+          Rectangle,
+          Storyboard,
+          Text,
+          View,
+          Scene,
+        } from 'utopia-api'
+        
+        var Test = (props) => {
+          return (
+            <View
+              layout={{
+                left: props.style.left,
+                top: props.style.top,
+                width: props.style.width,
+                height: props.style.height,
+              }}
+              style={{
+                position: 'absolute',
+                backgroundColor: 'lightgrey',
+              }}
+              data-uid='aaa'
+            >
+              <React.Fragment>
+                <Ellipse
+                  layout={{
+                    left: 150,
+                    top: 25,
+                    width: 100,
+                    height: 100,
+                  }}
+                  style={{ backgroundColor: 'lightgreen' }}
+                  data-uid='bbb'
+                />
+                <Rectangle
+                  layout={{
+                    left: 25,
+                    top: 25,
+                    width: 100,
+                    height: 100,
+                  }}
+                  style={{ backgroundColor: 'orange' }}
+                  data-uid='ccc'
+                />
+              </React.Fragment>
+              <View
+                layout={{
+                  left: 150,
+                  top: 150,
+                  width: 100,
+                  height: 100,
+                  layoutSystem: 'group',
+                }}
+                style={{
+                  position: 'absolute',
+                  backgroundColor: 'red',
+                  boxShadow: '10px 10px 8px #888888',
+                }}
+                data-uid='ddd'
+              >
+                <Rectangle
+                  layout={{
+                    left: 220,
+                    top: 220,
+                    width: 20,
+                    height: 20,
+                  }}
+                  style={{ backgroundColor: 'orange' }}
+                  data-uid='eee'
+                />
+                <Rectangle
+                  layout={{
+                    left: 90,
+                    top: 90,
+                    width: 100,
+                    height: 100,
+                  }}
+                  style={{ backgroundColor: 'orange' }}
+                  data-uid='fff'
+                />
+              </View>
+              <View
+                layout={{
+                  left: 50,
+                  top: 250,
+                  width: 100,
+                  height: 200,
+                }}
+                style={{
+                  position: 'absolute',
+                  backgroundColor: 'blue',
+                }}
+                data-uid='ggg'
+              />
+              <MyComponent data-uid='mycomponent' />
+            </View>
+          )
+        }
+        var MyComponent = (props) => {
+          return (
+            <View
+              style={{ backgroundColor: 'green' }}
+              data-uid='jjj'
+            />
+          )
+        }
+        var storyboard = (
+          <Storyboard data-uid='utopia-storyboard-uid'>
+            <Scene
+              data-uid='scene-0'
+              data-label='Test Scene'
+              style={{
+                position: 'absolute',
+                left: 0,
+                top: 0,
+                width: 375,
+                height: 812,
+              }}
+            >
+              <Test
+                data-uid='main-component-0'
+                style={{
+                  position: 'absolute',
+                  left: 0,
+                  top: 0,
+                  width: 375,
+                  height: 812,
+                }}
+              />
+            </Scene>
+            <Scene
+              data-uid='scene-1'
+              data-label='Test Scene 2'
+              style={{
+                position: 'absolute',
+                left: 500,
+                top: 0,
+                width: 375,
+                height: 812,
+              }}
+            />
+          </Storyboard>
+        )
+        `,
+      'await-first-dom-report',
+    )
+
+    const elementPathToMove = EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa', 'ddd'])
+
+    await selectComponentsForTest(editor, [elementPathToMove])
+
+    const oldIndexInParent = MetadataUtils.getIndexInParent(
+      editor.getEditorState().editor.jsxMetadata,
+      elementPathToMove,
+    )
+
+    expect(oldIndexInParent).toBe(1)
+
+    await editor.dispatch([moveSelectedBackward()], true)
+
+    const newIndexInParent = MetadataUtils.getIndexInParent(
+      editor.getEditorState().editor.jsxMetadata,
+      elementPathToMove,
+    )
+
+    expect(newIndexInParent).toBe(0)
+  })
+})

--- a/editor/src/components/editor/store/editor-update.spec.tsx
+++ b/editor/src/components/editor/store/editor-update.spec.tsx
@@ -96,6 +96,7 @@ import { cssNumber } from '../../inspector/common/css-utils'
 import { testStaticElementPath } from '../../../core/shared/element-path.test-utils'
 import { styleStringInArray } from '../../../utils/common-constants'
 import { getUtopiaID } from '../../../core/shared/uid-utils'
+import { printCode, printCodeOptions } from '../../../core/workers/parser-printer/parser-printer'
 
 const chaiExpect = Chai.expect
 
@@ -789,39 +790,6 @@ describe('INSERT_JSX_ELEMENT', () => {
     )
     expect(updatedComponents.length).toEqual(componentsBeforeInsert.length + 1)
     expect(insertedElement).toBeDefined()
-  })
-})
-
-describe('action MOVE_SELECTED_BACKWARD', () => {
-  it('moves the element backward', () => {
-    const { editor, derivedState, dispatch } = createEditorStates()
-    const editorWithSelectedView = {
-      ...editor,
-      selectedViews: [EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa', 'ddd'])],
-    }
-    const actionToRun = moveSelectedBackward()
-    const updatedEditor = runLocalEditorAction(
-      editorWithSelectedView,
-      derivedState,
-      defaultUserState,
-      workers,
-      actionToRun,
-      History.init(editor, derivedState),
-      dispatch,
-      emptyUiJsxCanvasContextData(),
-      builtInDependencies,
-    )
-    const updatedMetadata = createFakeMetadataForEditor(updatedEditor)
-
-    const updatedZIndex = MetadataUtils.getIndexInParent(
-      updatedMetadata,
-      EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa', 'ddd']),
-    )
-    const oldZIndex = MetadataUtils.getIndexInParent(
-      editor.jsxMetadata,
-      EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa', 'ddd']),
-    )
-    expect(updatedZIndex).toBe(oldZIndex - 2)
   })
 })
 

--- a/editor/src/components/editor/store/editor-update.spec.tsx
+++ b/editor/src/components/editor/store/editor-update.spec.tsx
@@ -813,11 +813,11 @@ describe('action MOVE_SELECTED_BACKWARD', () => {
     )
     const updatedMetadata = createFakeMetadataForEditor(updatedEditor)
 
-    const updatedZIndex = MetadataUtils.getViewZIndexFromMetadata(
+    const updatedZIndex = MetadataUtils.getIndexInParent(
       updatedMetadata,
       EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa', 'ddd']),
     )
-    const oldZIndex = MetadataUtils.getViewZIndexFromMetadata(
+    const oldZIndex = MetadataUtils.getIndexInParent(
       editor.jsxMetadata,
       EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa', 'ddd']),
     )

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -184,7 +184,7 @@ export const MetadataUtils = {
     const elementMetadata = MetadataUtils.findElementByElementPath(jsxMetadata, path)
     return MetadataUtils.isProbablySceneFromMetadata(elementMetadata)
   },
-  getViewZIndexFromMetadata(metadata: ElementInstanceMetadataMap, target: ElementPath): number {
+  getIndexInParent(metadata: ElementInstanceMetadataMap, target: ElementPath): number {
     const siblings = MetadataUtils.getSiblingsUnordered(metadata, target)
     return siblings.findIndex((child) => {
       return getUtopiaID(child) === EP.toUid(target)
@@ -1972,12 +1972,6 @@ export const MetadataUtils = {
       return fallbackFlexDirection
     }
     return flexDirections[0]
-  },
-  getIndexInParent(metadata: ElementInstanceMetadataMap, elementPath: ElementPath): number {
-    const siblingPaths = MetadataUtils.getSiblingsOrdered(metadata, elementPath).map(
-      (instance) => instance.elementPath,
-    )
-    return siblingPaths.findIndex((path) => EP.pathsEqual(path, elementPath))
   },
   getReparentTargetOfTarget(
     metadata: ElementInstanceMetadataMap,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -185,7 +185,7 @@ export const MetadataUtils = {
     return MetadataUtils.isProbablySceneFromMetadata(elementMetadata)
   },
   getIndexInParent(metadata: ElementInstanceMetadataMap, target: ElementPath): number {
-    const siblings = MetadataUtils.getSiblingsUnordered(metadata, target)
+    const siblings = MetadataUtils.getSiblingsOrdered(metadata, target)
     return siblings.findIndex((child) => {
       return getUtopiaID(child) === EP.toUid(target)
     })


### PR DESCRIPTION
## Description

This PR renames the confusingly named `MetadataUtils.getViewZIndexFromMetadata` to `MetadataUtils.getIndexInParent`, and updates its implementation to use `getSiblingsOrdered` internally (instead of `getSiblingsUnordered`).