### PR TITLE
Fix after/before hints for conditionals

### DIFF
--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -833,13 +833,13 @@ describe('conditionals in the navigator', () => {
     const dragMeElementRect = dragMeElement.getBoundingClientRect()
     const dragMeElementCenter = getDomRectCenter(dragMeElementRect)
     const firstDivElement = await renderResult.renderedDOM.findByTestId(
-      `navigator-item-drag-synthetic_utopia_storyboard_uid/scene_aaa/containing_div/conditional/129_attribute`,
+      `navigator-item-drag-synthetic_utopia_storyboard_uid/scene_aaa/containing_div/conditional/a25_attribute`,
     )
     const firstDivElementRect = firstDivElement.getBoundingClientRect()
     const firstDivElementCenter = getDomRectCenter(firstDivElementRect)
     const dragTo = {
       x: firstDivElementCenter.x,
-      y: firstDivElementRect.y - 3,
+      y: firstDivElementRect.y + 3,
     }
 
     const dragDelta = windowPoint({
@@ -860,7 +860,7 @@ describe('conditionals in the navigator', () => {
       dragElement(
         renderResult,
         `navigator-item-regular_utopia_storyboard_uid/scene_aaa/containing_div/sibling_div`,
-        `navigator-item-drop-after-conditional_clause_utopia_storyboard_uid/scene_aaa/containing_div/conditional_false-case`,
+        `navigator-item-drop-after-conditional_clause_utopia_storyboard_uid/scene_aaa/containing_div/conditional_true-case`,
         windowPoint(dragMeElementCenter),
         dragDelta,
         'apply-hover-events',

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -1,50 +1,46 @@
-import { BakedInStoryboardUID, BakedInStoryboardVariableName } from '../../core/model/scene-utils'
-import {
-  TestSceneUID,
-  renderTestEditorWithCode,
-  EditorRenderResult,
-  getPrintedUiJsCode,
-} from '../../components/canvas/ui-jsx.test-utils'
-import { offsetPoint, windowPoint, WindowPoint } from '../../core/shared/math-utils'
 import { fireEvent, screen } from '@testing-library/react'
-import { selectComponents } from '../editor/actions/meta-actions'
-import * as EP from '../../core/shared/element-path'
 import { act } from 'react-dom/test-utils'
 import {
-  conditionalClauseNavigatorEntry,
-  DerivedState,
-  EditorState,
-  navigatorEntryToKey,
-  regularNavigatorEntry,
-  syntheticNavigatorEntry,
-  varSafeNavigatorEntryToKey,
-} from '../editor/store/editor-state'
-import { getDomRectCenter } from '../../core/shared/dom-utils'
-import { navigatorDepth } from './navigator-utils'
-import { compose2Optics, compose3Optics, Optic } from '../../core/shared/optics/optics'
+  EditorRenderResult,
+  TestSceneUID,
+  getPrintedUiJsCode,
+  renderTestEditorWithCode,
+} from '../../components/canvas/ui-jsx.test-utils'
 import { forElementOptic } from '../../core/model/common-optics'
-import { unsafeGet } from '../../core/shared/optics/optic-utilities'
 import {
   conditionalWhenFalseOptic,
   conditionalWhenTrueOptic,
   jsxConditionalExpressionOptic,
 } from '../../core/model/conditionals'
 import { FOR_TESTS_setNextGeneratedUids } from '../../core/model/element-template-utils.test-utils'
-import {
-  isJSXConditionalExpression,
-  isJSXElement,
-  JSXElementChild,
-} from '../../core/shared/element-template'
+import { BakedInStoryboardUID, BakedInStoryboardVariableName } from '../../core/model/scene-utils'
+import { getDomRectCenter } from '../../core/shared/dom-utils'
+import * as EP from '../../core/shared/element-path'
+import { JSXElementChild, isJSXConditionalExpression } from '../../core/shared/element-template'
+import { WindowPoint, offsetPoint, windowPoint } from '../../core/shared/math-utils'
+import { fromTypeGuard } from '../../core/shared/optics/optic-creators'
+import { unsafeGet } from '../../core/shared/optics/optic-utilities'
+import { Optic, compose3Optics } from '../../core/shared/optics/optics'
+import { ElementPath } from '../../core/shared/project-file-types'
 import { getUtopiaID } from '../../core/shared/uid-utils'
-import { mouseClickAtPoint } from '../canvas/event-helpers.test-utils'
-import { pressKey } from '../canvas/event-helpers.test-utils'
-import { NavigatorItemTestId } from './navigator-item/navigator-item'
-import { elementPaste, pasteJSXElements } from '../editor/actions/action-creators'
 import { emptyImports } from '../../core/workers/common/project-file-utils'
 import { getTargetParentForPaste } from '../../utils/clipboard'
-import { fromTypeGuard } from '../../core/shared/optics/optic-creators'
-import { ElementPath } from '../../core/shared/project-file-types'
-import { conditionalClause, ReparentTargetParent } from '../editor/store/reparent-target'
+import { mouseClickAtPoint, pressKey } from '../canvas/event-helpers.test-utils'
+import { elementPaste, pasteJSXElements } from '../editor/actions/action-creators'
+import { selectComponents } from '../editor/actions/meta-actions'
+import {
+  DerivedState,
+  EditorState,
+  conditionalClauseNavigatorEntry,
+  navigatorEntryToKey,
+  regularNavigatorEntry,
+  syntheticNavigatorEntry,
+  varSafeNavigatorEntryToKey,
+} from '../editor/store/editor-state'
+import { ReparentTargetParent, conditionalClause } from '../editor/store/reparent-target'
+import { NavigatorItemTestId } from './navigator-item/navigator-item'
+import { navigatorDepth } from './navigator-utils'
+import { TopDropTargetLineTestId } from './navigator-item/navigator-item-dnd-container'
 
 function dragElement(
   renderResult: EditorRenderResult,
@@ -604,6 +600,100 @@ describe('conditionals in the navigator', () => {
               regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/sibling-div
             conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
               synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/129-attribute
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div`)
+  })
+  it('can reorder to before the conditional', async () => {
+    const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
+
+    const expectedNavigatorStructure = `  regular-utopia-storyboard-uid/scene-aaa
+    regular-utopia-storyboard-uid/scene-aaa/containing-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
+              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/a25-attribute
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`
+
+    expect(
+      navigatorStructure(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().derived,
+      ),
+    ).toEqual(expectedNavigatorStructure)
+
+    // Select the entry we plan to drag.
+    const elementPathToDrag = EP.fromString(
+      `${BakedInStoryboardUID}/${TestSceneUID}/containing-div/sibling-div`,
+    )
+
+    await act(async () => {
+      await renderResult.dispatch(selectComponents([elementPathToDrag], false), false)
+      await renderResult.getDispatchFollowUpActionsFinished()
+    })
+
+    // Getting info relating to what element will be dragged.
+    const navigatorEntryToDrag = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToDrag))}`,
+    )
+    const navigatorEntryToDragRect = navigatorEntryToDrag.getBoundingClientRect()
+    const navigatorEntryToDragCenter = getDomRectCenter(navigatorEntryToDragRect)
+
+    // Getting info relating to where the element will be dragged to.
+    const elementPathToTarget = EP.fromString(
+      `${BakedInStoryboardUID}/${TestSceneUID}/containing-div/conditional1`,
+    )
+    const navigatorEntryToTarget = await renderResult.renderedDOM.findByTestId(
+      `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToTarget))}`,
+    )
+    const navigatorEntryToTargetRect = navigatorEntryToTarget.getBoundingClientRect()
+    const navigatorEntryToTargetCenter = getDomRectCenter(navigatorEntryToTargetRect)
+    const dragTo = {
+      x: navigatorEntryToTargetCenter.x,
+      y: navigatorEntryToTargetCenter.y + 3,
+    }
+
+    const dragDelta = {
+      x: dragTo.x - navigatorEntryToDragCenter.x,
+      y: dragTo.y - navigatorEntryToDragCenter.y,
+    }
+
+    FOR_TESTS_setNextGeneratedUids(['fragment'])
+
+    await act(async () =>
+      dragElement(
+        renderResult,
+        `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToDrag))}`,
+        TopDropTargetLineTestId(
+          varSafeNavigatorEntryToKey(regularNavigatorEntry(elementPathToTarget)),
+        ),
+        windowPoint(navigatorEntryToDragCenter),
+        windowPoint(dragDelta),
+        'apply-hover-events',
+      ),
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(
+      navigatorStructure(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().derived,
+      ),
+    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
+    regular-utopia-storyboard-uid/scene-aaa/containing-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
+              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/a25-attribute
         conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
           synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div`)
   })

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -140,6 +140,7 @@ function canDrop(
     (dropTarget === 'bottom' || dropTarget === 'top') &&
     isInsideConditional(draggedOnto.navigatorEntry, editorState.jsxMetadata)
   ) {
+    // do nothing when trying to drop in between entries inside a conditional
     return true
   } else {
     const childrenSupportedIfRequired =

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -401,14 +401,10 @@ function isInsideConditional(
   entry: NavigatorEntry | null,
   jsxMetadata: ElementInstanceMetadataMap,
 ) {
-  if (entry == null) {
-    return false
-  }
-  const conditional = findMaybeConditionalExpression(EP.parentPath(entry.elementPath), jsxMetadata)
-  if (conditional == null) {
-    return false
-  }
-  return true
+  return (
+    entry != null &&
+    findMaybeConditionalExpression(EP.parentPath(entry.elementPath), jsxMetadata) != null
+  )
 }
 
 function getConditionalBranch(conditional: JSXConditionalExpression, clause: ConditionalCase) {

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -120,8 +120,9 @@ function canDrop(
   draggedOnto: NavigatorItemDragAndDropWrapperProps,
   dropTarget: 'top' | 'bottom' | 'hover',
 ): boolean {
-  if (isConditionalRoot(draggedOnto.navigatorEntry, editorState.jsxMetadata)) {
-    // target is a conditional
+  const isReparentTarget = draggedItem.appropriateDropTargetHint?.type === 'reparent'
+  if (isConditionalRoot(draggedOnto.navigatorEntry, editorState.jsxMetadata) && isReparentTarget) {
+    // reparent target is the conditional root
     return false
   } else if (
     isConditionalClauseNavigatorEntry(draggedOnto.navigatorEntry) &&
@@ -141,7 +142,6 @@ function canDrop(
   ) {
     return true
   } else {
-    const isReparentTarget = draggedItem.appropriateDropTargetHint?.type === 'reparent'
     const childrenSupportedIfRequired =
       !isReparentTarget ||
       isConditionalClauseNavigatorEntry(draggedOnto.navigatorEntry) ||

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -256,7 +256,7 @@ export const NavigatorItemWrapper: React.FunctionComponent<
           maybeConditionalExpression(parentElement) != null
         ) {
           possiblyAppropriateDropTargetHint = {
-            type: 'reparent',
+            type: store.editor.navigator.dropTargetHint.type ?? 'reparent',
             displayAtEntry: null,
             moveToEntry: null,
           }


### PR DESCRIPTION
Fixes #3538 

1. Make sure not to display before/after hints inside conditionals
2. Do nothing when dropping in those areas
3. Allow dropping after/before _entire_ conditionals