### PR TITLE
Fix/conditionals wrap in conditional

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2668,7 +2668,33 @@ export const UPDATE_FNS = {
               }
 
               if (isJSXConditionalExpression(elementToInsert)) {
-                withTargetAdded = withInsertedElement()
+                const staticTarget = dynamicReparentTargetParentToStaticReparentTargetParent(
+                  targetThatIsRootElementOfCommonParent ?? parentPath,
+                )
+                if (reparentTargetParentIsConditionalClause(staticTarget)) {
+                  withTargetAdded = insertChildAndDetails(
+                    transformJSXComponentAtPath(
+                      utopiaJSXComponents,
+                      getElementPathFromReparentTargetParent(staticTarget),
+                      (oldRoot) => {
+                        if (isJSXConditionalExpression(oldRoot)) {
+                          const clauseOptic = getClauseOptic(staticTarget.clause)
+                          return modify(
+                            clauseOptic,
+                            (clauseElement) => {
+                              return { ...elementToInsert, whenTrue: clauseElement }
+                            },
+                            oldRoot,
+                          )
+                        } else {
+                          return { ...oldRoot }
+                        }
+                      },
+                    ),
+                  )
+                } else {
+                  withTargetAdded = withInsertedElement()
+                }
               } else if (isJSXFragment(elementToInsert)) {
                 const children = mapDropNulls(getTargetElement, pathsToBeWrappedInFragment())
                 if (children.length === 0) {


### PR DESCRIPTION
**Problem:**
When wrapping in an element in a conditional that is already in a conditional clause it creates a fragment and doesn't do the wrapping.

**Fix:**
Changed the action handler to instead of using the default `withInsertedElement` helper now this is a special case where the the wrapper conditional `whenTrue` contains the original element.

**Commit Details:**
- update `WRAP_IN_ELEMENT`
- added a test
