### PR TITLE
Ensure unique ids when duplicating conditional branches

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.spec.browser2.tsx
@@ -137,7 +137,7 @@ describe('Absolute Duplicate Strategy', () => {
   describe('with content-affecting elements', () => {
     AllContentAffectingTypes.forEach((type) => {
       // TODO: reenable this after we know why does it destroy the test runner
-      xit(`duplicates the selected absolute element when pressing alt, even if it is a ${type}`, async () => {
+      it(`duplicates the selected absolute element when pressing alt, even if it is a ${type}`, async () => {
         const renderResult = await renderTestEditorWithCode(
           formatTestProjectCode(
             projectWithFragment(

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -47,7 +47,12 @@ import {
   isSceneElement,
   getZIndexOfElement,
 } from '../../core/model/element-template-utils'
-import { generateUID, getUtopiaID, setUtopiaID } from '../../core/shared/uid-utils'
+import {
+  fixUtopiaElement,
+  generateUID,
+  getUtopiaID,
+  setUtopiaID,
+} from '../../core/shared/uid-utils'
 import {
   setJSXValuesAtPaths,
   unsetJSXValuesAtPaths,
@@ -2739,7 +2744,18 @@ export function duplicate(
                   duplicateNewUID.newUID,
                 ]),
               }
-            }
+            } else if (isJSXConditionalExpression(newElement))
+              newElement = {
+                ...newElement,
+                whenTrue: fixUtopiaElement(newElement.whenTrue, [
+                  ...existingIDs,
+                  duplicateNewUID.newUID,
+                ]),
+                whenFalse: fixUtopiaElement(newElement.whenFalse, [
+                  ...existingIDs,
+                  duplicateNewUID.newUID,
+                ]),
+              }
             uid = duplicateNewUID.newUID
           }
           let newPath: ElementPath


### PR DESCRIPTION
## Problem
When conditionals are duplicated using the `duplicate` command (for example, when using the absolute duplicate strategy), no new element UIDs are generated for the subtrees in the conditional branches. The resulting project tree puts the editor into a "crash loop", because an error is thrown whenever a duplicate UID is found (https://github.com/concrete-utopia/utopia/blob/1a117d5240213c1b5f2215f51a5d5ce9e870a207/editor/src/core/model/element-template-utils.ts#L81-L110).

## Fix
In the `duplicate` command, check if the duplicated element is a conditional, and generate new UIDs for both the true and the false branches.