### PR TITLE
Empty labels in conditional inspector

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -40,6 +40,7 @@ import {
   jsxElementNameEquals,
   isJSXElementLike,
   isJSXConditionalExpression,
+  isNullJSXAttributeValue,
 } from '../../core/shared/element-template'
 import {
   getAllUniqueUids,
@@ -124,6 +125,8 @@ import {
   ResizeOptions,
   AllElementProps,
   ElementProps,
+  NavigatorEntry,
+  isSyntheticNavigatorEntry,
 } from '../editor/store/editor-state'
 import * as Frame from '../frame'
 import { getImageSizeFromMetadata, MultipliersForImages, scaleImageDimensions } from '../images'
@@ -3428,4 +3431,27 @@ export function elementHasOnlyTextChildren(element: ElementInstanceMetadata): bo
   )
   const hasTextChildren = textChildren.length > 0
   return hasTextChildren && allChildrenText
+}
+
+export function isEntryAConditionalSlot(
+  metadata: ElementInstanceMetadataMap,
+  navigatorEntry: NavigatorEntry,
+): boolean {
+  const parentPath = EP.parentPath(navigatorEntry.elementPath)
+  const parentElement = MetadataUtils.findElementByElementPath(metadata, parentPath)
+
+  if (parentElement == null) {
+    return false
+  }
+
+  const isParentConditional =
+    parentElement != null &&
+    isRight(parentElement.element) &&
+    isJSXConditionalExpression(parentElement.element.value)
+
+  const isNullValue =
+    isSyntheticNavigatorEntry(navigatorEntry) &&
+    isNullJSXAttributeValue(navigatorEntry.childOrAttribute)
+
+  return isParentConditional && isNullValue
 }

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jest/expect-expect */
-import { act } from '@testing-library/react'
+import { act, within } from '@testing-library/react'
 import { forElementOptic } from '../../core/model/common-optics'
 import { conditionalWhenTrueOptic } from '../../core/model/conditionals'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
@@ -34,8 +34,107 @@ import { EditorState } from './store/editor-state'
 import { ReparentTargetParent } from './store/reparent-target'
 import { ElementPaste } from './action-types'
 import { forceNotNull } from '../../core/shared/optional-utils'
+import { selectComponentsForTest } from '../../utils/utils.test-utils'
+import { ConditionalSectionTestId } from '../inspector/sections/layout-section/conditional-section'
 
 describe('conditionals', () => {
+  describe('inspector', () => {
+    it('labels for empty', async () => {
+      const editor = await renderTestEditorWithCode(
+        `import * as React from 'react'
+      import { Storyboard } from 'utopia-api'
+      
+      export var storyboard = (
+        <Storyboard data-uid='sb'>
+          {
+            // @utopia/uid=cond1
+            true ? null : null
+          }
+          {
+            // @utopia/uid=cond2
+            true ? 'hello' : null
+          }
+          {
+            // @utopia/uid=cond3
+            true ? null : 'world'
+          }
+          {
+            // @utopia/uid=cond4
+            true ? 'hello' : 'world'
+          }
+          </Storyboard>
+      )
+      `,
+        'await-first-dom-report',
+      )
+
+      await selectComponentsForTest(editor, [EP.fromString('sb/cond1')])
+      {
+        const emptyLabelsInConditionalInspector = within(
+          editor.renderedDOM.getByTestId(ConditionalSectionTestId),
+        ).queryAllByText('Empty')
+
+        expect(emptyLabelsInConditionalInspector.length).toEqual(2)
+
+        const helloLabelsInInspector = within(
+          editor.renderedDOM.getByTestId(ConditionalSectionTestId),
+        ).queryAllByText('hello')
+
+        expect(helloLabelsInInspector.length).toEqual(0)
+      }
+
+      await selectComponentsForTest(editor, [EP.fromString('sb/cond2')])
+      {
+        const emptyLabelsInConditionalInspector = within(
+          editor.renderedDOM.getByTestId(ConditionalSectionTestId),
+        ).queryAllByText('Empty')
+
+        expect(emptyLabelsInConditionalInspector.length).toEqual(1)
+
+        const helloLabelsInInspector = within(
+          editor.renderedDOM.getByTestId(ConditionalSectionTestId),
+        ).queryAllByText('hello')
+
+        expect(helloLabelsInInspector.length).toEqual(1)
+      }
+
+      await selectComponentsForTest(editor, [EP.fromString('sb/cond3')])
+      {
+        const emptyLabelsInConditionalInspector = within(
+          editor.renderedDOM.getByTestId(ConditionalSectionTestId),
+        ).queryAllByText('Empty')
+
+        expect(emptyLabelsInConditionalInspector.length).toEqual(1)
+
+        const worldLabelsInInspector = within(
+          editor.renderedDOM.getByTestId(ConditionalSectionTestId),
+        ).queryAllByText('world')
+
+        expect(worldLabelsInInspector.length).toEqual(1)
+      }
+
+      await selectComponentsForTest(editor, [EP.fromString('sb/cond4')])
+      {
+        const emptyLabelsInConditionalInspector = within(
+          editor.renderedDOM.getByTestId(ConditionalSectionTestId),
+        ).queryAllByText('Empty')
+
+        expect(emptyLabelsInConditionalInspector.length).toEqual(0)
+
+        const helloLabelsInInspector = within(
+          editor.renderedDOM.getByTestId(ConditionalSectionTestId),
+        ).queryAllByText('hello')
+
+        expect(helloLabelsInInspector.length).toEqual(1)
+
+        const worldLabelsInInspector = within(
+          editor.renderedDOM.getByTestId(ConditionalSectionTestId),
+        ).queryAllByText('world')
+
+        expect(worldLabelsInInspector.length).toEqual(1)
+      }
+    })
+  })
   describe('deletion', () => {
     it('replaces a branch with null', async () => {
       const startSnippet = `

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -19,6 +19,7 @@ import {
   JSXConditionalExpression,
   JSXElementChild,
 } from '../../../../core/shared/element-template'
+import { optionalMap } from '../../../../core/shared/optional-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import { unless } from '../../../../utils/react-conditionals'
 import {
@@ -33,6 +34,7 @@ import {
   useColorTheme,
   UtopiaStyles,
 } from '../../../../uuiui'
+import { isEntryAConditionalSlot } from '../../../canvas/canvas-utils'
 import { EditorAction } from '../../../editor/action-types'
 import {
   setConditionalOverriddenCondition,
@@ -220,6 +222,8 @@ function getConditionalMetadata(
   return elementMetadatas[0]
 }
 
+export const ConditionalSectionTestId = 'conditional-section-test-id'
+
 export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] }) => {
   const dispatch = useDispatch()
   const colorTheme = useColorTheme()
@@ -322,7 +326,7 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
   const controlStyles = getControlStyles(controlStatus)
 
   return (
-    <div style={{ paddingBottom: 8 }}>
+    <div style={{ paddingBottom: 8 }} data-testid={ConditionalSectionTestId}>
       <InspectorSubsectionHeader
         css={{
           transition: 'color .1s ease-in-out',
@@ -409,6 +413,14 @@ const BranchRow = ({
 }) => {
   const colorTheme = useColorTheme()
 
+  const isSlot = useEditorState(
+    Substores.metadata,
+    (store) =>
+      optionalMap((e) => isEntryAConditionalSlot(store.editor.jsxMetadata, e), navigatorEntry) ??
+      false,
+    'NavigatorItem parentElement',
+  )
+
   if (label == null || navigatorEntry == null) {
     return null
   }
@@ -433,21 +445,35 @@ const BranchRow = ({
           whiteSpace: 'nowrap',
         }}
       >
-        <LayoutIcon
-          key={`layout-type-${label}`}
-          navigatorEntry={navigatorEntry}
-          color='main'
-          warningText={null}
-        />
-        <span
-          data-testid={
-            conditionalCase === 'true-case'
-              ? ConditionalsControlBranchTrueTestId
-              : ConditionalsControlBranchFalseTestId
-          }
-        >
-          {getNavigatorEntryLabel(navigatorEntry, label)}
-        </span>
+        {isSlot ? (
+          <div
+            style={{
+              padding: '0px 6px',
+              textTransform: 'lowercase',
+              color: colorTheme.fg7.value,
+            }}
+          >
+            Empty
+          </div>
+        ) : (
+          <React.Fragment>
+            <LayoutIcon
+              key={`layout-type-${label}`}
+              navigatorEntry={navigatorEntry}
+              color='main'
+              warningText={null}
+            />
+            <span
+              data-testid={
+                conditionalCase === 'true-case'
+                  ? ConditionalsControlBranchTrueTestId
+                  : ConditionalsControlBranchFalseTestId
+              }
+            >
+              {getNavigatorEntryLabel(navigatorEntry, label)}
+            </span>
+          </React.Fragment>
+        )}
       </div>
     </UIGridRow>
   )

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -46,6 +46,7 @@ import createCachedSelector from 're-reselect'
 import { getValueFromComplexMap } from '../../../utils/map'
 import { isSyntheticNavigatorEntry } from '../../editor/store/editor-state'
 import { getElementContentAffectingType } from '../../canvas/canvas-strategies/strategies/group-like-helpers'
+import { isEntryAConditionalSlot } from '../../canvas/canvas-utils'
 
 export function getItemHeight(navigatorEntry: NavigatorEntry): number {
   if (isConditionalClauseNavigatorEntry(navigatorEntry)) {
@@ -551,27 +552,11 @@ export const NavigatorItem: React.FunctionComponent<
     'NavigatorItem isHiddenConditionalBranch',
   )
 
-  const parentElement = useEditorState(
+  const isSlot = useEditorState(
     Substores.metadata,
-    (store) => {
-      const parentPath = EP.parentPath(props.navigatorEntry.elementPath)
-      return MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, parentPath)
-    },
+    (store) => isEntryAConditionalSlot(store.editor.jsxMetadata, props.navigatorEntry),
     'NavigatorItem parentElement',
   )
-
-  const isSlot = React.useMemo(() => {
-    const isParentConditional =
-      parentElement != null &&
-      isRight(parentElement.element) &&
-      isJSXConditionalExpression(parentElement.element.value)
-
-    const isNullValue =
-      isSyntheticNavigatorEntry(props.navigatorEntry) &&
-      isNullJSXAttributeValue(props.navigatorEntry.childOrAttribute)
-
-    return isParentConditional && isNullValue
-  }, [parentElement, props.navigatorEntry])
 
   const containerStyle: React.CSSProperties = React.useMemo(() => {
     return {


### PR DESCRIPTION
## Before
<img width="786" alt="image" src="https://user-images.githubusercontent.com/16385508/231723567-ba2e62f5-32f8-47fb-8936-07a0c5451ef2.png">

## After
<img width="800" alt="image" src="https://user-images.githubusercontent.com/16385508/231723141-15b92451-db99-4531-b1fc-311b956344b8.png">

## Description
Instead of displaying 🔲 `null` for empty branches of a conditional, the conditional inspector displays an empty slot marker similar to what we have in the navigator.
