### PR TITLE
Remove strict conditions for pasting elements

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
@@ -1,18 +1,23 @@
+import {
+  findMaybeConditionalExpression,
+  maybeBranchConditionalCase,
+} from '../../../../../core/model/conditionals'
+import { MetadataUtils } from '../../../../../core/model/element-metadata-utils'
 import { foldEither } from '../../../../../core/shared/either'
+import * as EP from '../../../../../core/shared/element-path'
 import {
   ElementInstanceMetadataMap,
   elementReferencesElsewhere,
 } from '../../../../../core/shared/element-template'
-import { MetadataUtils } from '../../../../../core/model/element-metadata-utils'
 import { ElementPath } from '../../../../../core/shared/project-file-types'
+import { ProjectContentTreeRoot } from '../../../../assets'
 import { CSSCursor } from '../../../canvas-types'
 import { setCursorCommand } from '../../../commands/set-cursor-command'
 import {
   InteractionCanvasState,
-  strategyApplicationResult,
   StrategyApplicationResult,
+  strategyApplicationResult,
 } from '../../canvas-strategy-types'
-import { ProjectContentTreeRoot } from '../../../../assets'
 
 export function isAllowedToReparent(
   projectContents: ProjectContentTreeRoot,
@@ -24,6 +29,11 @@ export function isAllowedToReparent(
   } else {
     const metadata = MetadataUtils.findElementByElementPath(startingMetadata, target)
     if (metadata == null) {
+      const parentPath = EP.parentPath(target)
+      const conditional = findMaybeConditionalExpression(parentPath, startingMetadata)
+      if (conditional != null) {
+        return maybeBranchConditionalCase(parentPath, conditional, target) != null
+      }
       return false
     } else {
       return foldEither(

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -293,7 +293,7 @@ describe('actions', () => {
         <div data-uid='aaa'>
             <div data-uid='bbb'>foo</div>
             <div data-uid='ccc'>bar</div>
-		</div>
+        </div>
 		`,
         elements: (renderResult) => {
           const path = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
@@ -311,7 +311,7 @@ describe('actions', () => {
             <div data-uid='bbb'>foo</div>
             <div data-uid='ccc'>bar</div>
             <div data-uid='aab'>foo</div>
-		</div>
+        </div>
 		`,
       },
       {
@@ -321,7 +321,7 @@ describe('actions', () => {
             <div data-uid='bbb'>foo</div>
             <div data-uid='ccc'>bar</div>
             <div data-uid='ddd'>baz</div>
-		</div>
+        </div>
 		`,
         elements: (renderResult) => {
           const fooPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
@@ -347,13 +347,13 @@ describe('actions', () => {
             <div data-uid='ddd'>baz</div>
             <div data-uid='aab'>foo</div>
             <div data-uid='aac'>bar</div>
-		</div>
+        </div>
 		`,
       },
       {
         name: 'a fragment',
         startingCode: `
-		<div data-uid='root'>
+        <div data-uid='root'>
             <div data-uid='aaa'>
                 <div data-uid='bbb'>foo</div>
                 <div data-uid='ccc'>bar</div>
@@ -362,7 +362,7 @@ describe('actions', () => {
                 <div data-uid='ddd'>hello</div>
                 <div data-uid='eee'>there</div>
             </>
-		</div>
+        </div>
 		`,
         elements: (renderResult) => {
           const path = EP.appendNewElementPath(TestScenePath, ['root', '38e'])
@@ -376,7 +376,7 @@ describe('actions', () => {
         },
         pasteInto: EP.appendNewElementPath(TestScenePath, ['root', 'aaa']),
         want: `
-		<div data-uid='root'>
+		    <div data-uid='root'>
             <div data-uid='aaa'>
             <div data-uid='bbb'>foo</div>
             <div data-uid='ccc'>bar</div>
@@ -879,13 +879,13 @@ describe('actions', () => {
         },
         pasteInto: EP.appendNewElementPath(TestScenePath, ['root']),
         want: `
-    <div data-uid='root'>
-      {
-        // @utopia/uid=conditional
-        true ? <div data-uid='aaa'>foo</div> : null
-      }
-      <div data-uid='aab'>foo</div>
-		</div>
+      <div data-uid='root'>
+        {
+          // @utopia/uid=conditional
+          true ? <div data-uid='aaa'>foo</div> : null
+        }
+        <div data-uid='aab'>foo</div>
+      </div>
 		`,
       },
       {

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -290,9 +290,9 @@ describe('actions', () => {
       {
         name: 'a single element',
         startingCode: `
-		<div data-uid='aaa'>
-			<div data-uid='bbb'>foo</div>
-			<div data-uid='ccc'>bar</div>
+        <div data-uid='aaa'>
+            <div data-uid='bbb'>foo</div>
+            <div data-uid='ccc'>bar</div>
 		</div>
 		`,
         elements: (renderResult) => {
@@ -307,20 +307,20 @@ describe('actions', () => {
         },
         pasteInto: EP.appendNewElementPath(TestScenePath, ['aaa']),
         want: `
-		<div data-uid='aaa'>
-			<div data-uid='bbb'>foo</div>
-			<div data-uid='ccc'>bar</div>
-			<div data-uid='aab'>foo</div>
+        <div data-uid='aaa'>
+            <div data-uid='bbb'>foo</div>
+            <div data-uid='ccc'>bar</div>
+            <div data-uid='aab'>foo</div>
 		</div>
 		`,
       },
       {
         name: 'multiple elements',
         startingCode: `
-		<div data-uid='aaa'>
-			<div data-uid='bbb'>foo</div>
-			<div data-uid='ccc'>bar</div>
-			<div data-uid='ddd'>baz</div>
+        <div data-uid='aaa'>
+            <div data-uid='bbb'>foo</div>
+            <div data-uid='ccc'>bar</div>
+            <div data-uid='ddd'>baz</div>
 		</div>
 		`,
         elements: (renderResult) => {
@@ -341,12 +341,12 @@ describe('actions', () => {
         },
         pasteInto: EP.appendNewElementPath(TestScenePath, ['aaa']),
         want: `
-		<div data-uid='aaa'>
-			<div data-uid='bbb'>foo</div>
-			<div data-uid='ccc'>bar</div>
-			<div data-uid='ddd'>baz</div>
-			<div data-uid='aab'>foo</div>
-			<div data-uid='aac'>bar</div>
+        <div data-uid='aaa'>
+            <div data-uid='bbb'>foo</div>
+            <div data-uid='ccc'>bar</div>
+            <div data-uid='ddd'>baz</div>
+            <div data-uid='aab'>foo</div>
+            <div data-uid='aac'>bar</div>
 		</div>
 		`,
       },
@@ -354,14 +354,14 @@ describe('actions', () => {
         name: 'a fragment',
         startingCode: `
 		<div data-uid='root'>
-			<div data-uid='aaa'>
-				<div data-uid='bbb'>foo</div>
-				<div data-uid='ccc'>bar</div>
-			</div>
-			<>
-				<div data-uid='ddd'>hello</div>
-				<div data-uid='eee'>there</div>
-			</>
+            <div data-uid='aaa'>
+                <div data-uid='bbb'>foo</div>
+                <div data-uid='ccc'>bar</div>
+            </div>
+            <>
+                <div data-uid='ddd'>hello</div>
+                <div data-uid='eee'>there</div>
+            </>
 		</div>
 		`,
         elements: (renderResult) => {
@@ -377,31 +377,31 @@ describe('actions', () => {
         pasteInto: EP.appendNewElementPath(TestScenePath, ['root', 'aaa']),
         want: `
 		<div data-uid='root'>
-			<div data-uid='aaa'>
-				<div data-uid='bbb'>foo</div>
-				<div data-uid='ccc'>bar</div>
-				<>
-					<div data-uid='aab'>hello</div>
-					<div data-uid='aac'>there</div>
-				</>
-			</div>
-			<>
-				<div data-uid='ddd'>hello</div>
-				<div data-uid='eee'>there</div>
-			</>
-		</div>
+            <div data-uid='aaa'>
+            <div data-uid='bbb'>foo</div>
+            <div data-uid='ccc'>bar</div>
+                <>
+                    <div data-uid='aab'>hello</div>
+                    <div data-uid='aac'>there</div>
+                </>
+            </div>
+            <>
+                <div data-uid='ddd'>hello</div>
+                <div data-uid='eee'>there</div>
+            </>
+        </div>
 		`,
       },
       {
         name: 'an empty fragment',
         startingCode: `
-		<div data-uid='root'>
-			<div data-uid='aaa'>
-				<div data-uid='bbb'>foo</div>
-				<div data-uid='ccc'>bar</div>
-			</div>
-			<></>
-		</div>
+        <div data-uid='root'>
+            <div data-uid='aaa'>
+                <div data-uid='bbb'>foo</div>
+                <div data-uid='ccc'>bar</div>
+            </div>
+            <></>
+        </div>
 		`,
         elements: (renderResult) => {
           const path = EP.appendNewElementPath(TestScenePath, ['root', '38e'])
@@ -415,33 +415,33 @@ describe('actions', () => {
         },
         pasteInto: EP.appendNewElementPath(TestScenePath, ['root', 'aaa']),
         want: `
-		<div data-uid='root'>
-			<div data-uid='aaa'>
-				<div data-uid='bbb'>foo</div>
-				<div data-uid='ccc'>bar</div>
-				<></>
-			</div>
-			<></>
-		</div>
+        <div data-uid='root'>
+            <div data-uid='aaa'>
+                <div data-uid='bbb'>foo</div>
+                <div data-uid='ccc'>bar</div>
+                <></>
+            </div>
+            <></>
+        </div>
 		`,
       },
       {
         name: 'a conditional',
         startingCode: `
 		<div data-uid='root'>
-			<div data-uid='aaa'>
-				<div data-uid='bbb'>foo</div>
-				<div data-uid='ccc'>bar</div>
-			</div>
-			{
-				// @utopia/uid=conditional
-				true ? (
-					<div data-uid='ddd'>true</div>
-				): (
-					<div data-uid='eee'>false</div>
-				)
-			}
-		</div>
+            <div data-uid='aaa'>
+            <div data-uid='bbb'>foo</div>
+            <div data-uid='ccc'>bar</div>
+            </div>
+            {
+                // @utopia/uid=conditional
+                true ? (
+                    <div data-uid='ddd'>true</div>
+                ): (
+                    <div data-uid='eee'>false</div>
+                )
+            }
+        </div>
 		`,
         elements: (renderResult) => {
           const path = EP.appendNewElementPath(TestScenePath, ['root', 'conditional'])
@@ -456,38 +456,38 @@ describe('actions', () => {
         pasteInto: EP.appendNewElementPath(TestScenePath, ['root', 'aaa']),
         want: `
 		<div data-uid='root'>
-			<div data-uid='aaa'>
-				<div data-uid='bbb'>foo</div>
-				<div data-uid='ccc'>bar</div>
-				{
-					// @utopia/uid=conditional
-					true ? (
-						<div data-uid='aab'>true</div>
-					): (
-						<div data-uid='aac'>false</div>
-					)
-				}
-			</div>
-			{
-				// @utopia/uid=conditional
-				true ? (
-					<div data-uid='ddd'>true</div>
-				): (
-					<div data-uid='eee'>false</div>
-				)
-			}
-		</div>
+            <div data-uid='aaa'>
+            <div data-uid='bbb'>foo</div>
+            <div data-uid='ccc'>bar</div>
+                {
+                    // @utopia/uid=conditional
+                    true ? (
+                        <div data-uid='aab'>true</div>
+                    ): (
+                        <div data-uid='aac'>false</div>
+                    )
+                }
+            </div>
+            {
+                // @utopia/uid=conditional
+                true ? (
+                    <div data-uid='ddd'>true</div>
+                ): (
+                    <div data-uid='eee'>false</div>
+                )
+            }
+        </div>
 		`,
       },
       {
         name: 'an element inside a fragment',
         startingCode: `
-		<div data-uid='root'>
-			<>
-				<div data-uid='aaa'>foo</div>
-			</>
-			<div data-uid='bbb'>bar</div>
-		</div>
+        <div data-uid='root'>
+            <>
+                <div data-uid='aaa'>foo</div>
+            </>
+            <div data-uid='bbb'>bar</div>
+        </div>
 		`,
         elements: (renderResult) => {
           const path = EP.appendNewElementPath(TestScenePath, ['root', 'bbb'])
@@ -501,25 +501,25 @@ describe('actions', () => {
         },
         pasteInto: EP.appendNewElementPath(TestScenePath, ['root', '38e']),
         want: `
-		<div data-uid='root'>
-			<>
-				<div data-uid='aaa'>foo</div>
-				<div data-uid='aab'>bar</div>
-			</>
-			<div data-uid='bbb'>bar</div>
-		</div>
+        <div data-uid='root'>
+            <>
+                <div data-uid='aaa'>foo</div>
+                <div data-uid='aab'>bar</div>
+            </>
+            <div data-uid='bbb'>bar</div>
+        </div>
 		`,
       },
       {
         name: 'multiple elements inside a fragment',
         startingCode: `
-		<div data-uid='root'>
-			<>
-				<div data-uid='aaa'>foo</div>
-			</>
-			<div data-uid='bbb'>bar</div>
-			<div data-uid='ccc'>baz</div>
-		</div>
+        <div data-uid='root'>
+            <>
+                <div data-uid='aaa'>foo</div>
+            </>
+            <div data-uid='bbb'>bar</div>
+            <div data-uid='ccc'>baz</div>
+        </div>
 		`,
         elements: (renderResult) => {
           const fooPath = EP.appendNewElementPath(TestScenePath, ['root', 'bbb'])
@@ -539,27 +539,27 @@ describe('actions', () => {
         },
         pasteInto: EP.appendNewElementPath(TestScenePath, ['root', '38e']),
         want: `
-		<div data-uid='root'>
-			<>
-				<div data-uid='aaa'>foo</div>
-				<div data-uid='aab'>bar</div>
-				<div data-uid='aac'>baz</div>
-			</>
-			<div data-uid='bbb'>bar</div>
-			<div data-uid='ccc'>baz</div>
-		</div>
+        <div data-uid='root'>
+            <>
+            	<div data-uid='aaa'>foo</div>
+                <div data-uid='aab'>bar</div>
+                <div data-uid='aac'>baz</div>
+            </>
+            <div data-uid='bbb'>bar</div>
+            <div data-uid='ccc'>baz</div>
+        </div>
 		`,
       },
       {
         name: 'an element inside an empty conditional branch (true)',
         startingCode: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? null : <div data-uid='aaa'>foo</div>
-			}
-			<div data-uid='bbb'>bar</div>
-		</div>
+        <div data-uid='root'>
+        	{
+                // @utopia/uid=conditional
+                true ? null : <div data-uid='aaa'>foo</div>
+            }
+            <div data-uid='bbb'>bar</div>
+        </div>
 		`,
         elements: (renderResult) => {
           const path = EP.appendNewElementPath(TestScenePath, ['root', 'bbb'])
@@ -573,25 +573,25 @@ describe('actions', () => {
         },
         pasteInto: EP.appendNewElementPath(TestScenePath, ['root', 'conditional', 'a25']),
         want: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? <div data-uid='aab'>bar</div> : <div data-uid='aaa'>foo</div>
-			}
-			<div data-uid='bbb'>bar</div>
-		</div>
+        <div data-uid='root'>
+            {
+            	// @utopia/uid=conditional
+                true ? <div data-uid='aab'>bar</div> : <div data-uid='aaa'>foo</div>
+            }
+            <div data-uid='bbb'>bar</div>
+        </div>
 		`,
       },
       {
         name: 'an element inside an empty conditional branch (false)',
         startingCode: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? <div data-uid='aaa'>foo</div> : null
-			}
-			<div data-uid='bbb'>bar</div>
-		</div>
+        <div data-uid='root'>
+            {
+            	// @utopia/uid=conditional
+                true ? <div data-uid='aaa'>foo</div> : null
+            }
+            <div data-uid='bbb'>bar</div>
+        </div>
 		`,
         elements: (renderResult) => {
           const path = EP.appendNewElementPath(TestScenePath, ['root', 'bbb'])
@@ -605,25 +605,25 @@ describe('actions', () => {
         },
         pasteInto: EP.appendNewElementPath(TestScenePath, ['root', 'conditional', 'a25']),
         want: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? <div data-uid='aaa'>foo</div> : <div data-uid='aab'>bar</div>
-			}
-			<div data-uid='bbb'>bar</div>
-		</div>
+        <div data-uid='root'>
+            {
+                // @utopia/uid=conditional
+                true ? <div data-uid='aaa'>foo</div> : <div data-uid='aab'>bar</div>
+            }
+            <div data-uid='bbb'>bar</div>
+    	</div>
 		`,
       },
       {
         name: 'an element inside a non-empty conditional branch (does nothing)',
         startingCode: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? <div data-uid='aaa'>foo</div> : <div data-uid='bbb'>bar</div>
-			}
-			<div data-uid='ccc'>baz</div>
-		</div>
+        <div data-uid='root'>
+            {
+                // @utopia/uid=conditional
+                true ? <div data-uid='aaa'>foo</div> : <div data-uid='bbb'>bar</div>
+            }
+            <div data-uid='ccc'>baz</div>
+        </div>
 		`,
         elements: (renderResult) => {
           const path = EP.appendNewElementPath(TestScenePath, ['root', 'ccc'])
@@ -640,26 +640,26 @@ describe('actions', () => {
           elementPath: EP.appendNewElementPath(TestScenePath, ['root', 'conditional']),
         },
         want: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? <div data-uid='aaa'>foo</div> : <div data-uid='bbb'>bar</div>
-			}
-			<div data-uid='ccc'>baz</div>
-		</div>
+        <div data-uid='root'>
+            {
+                // @utopia/uid=conditional
+                true ? <div data-uid='aaa'>foo</div> : <div data-uid='bbb'>bar</div>
+            }
+            <div data-uid='ccc'>baz</div>
+        </div>
 		`,
       },
       {
         name: 'multiple elements into an empty conditional branch (true)',
         startingCode: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? null : <div data-uid='aaa'>foo</div>
-			}
-			<div data-uid='bbb'>bar</div>
-			<div data-uid='ccc'>baz</div>
-		</div>
+        <div data-uid='root'>
+            {
+            	// @utopia/uid=conditional
+                true ? null : <div data-uid='aaa'>foo</div>
+            }
+            <div data-uid='bbb'>bar</div>
+            <div data-uid='ccc'>baz</div>
+        </div>
 		`,
         elements: (renderResult) => {
           const barPath = EP.appendNewElementPath(TestScenePath, ['root', 'bbb'])
@@ -682,32 +682,32 @@ describe('actions', () => {
           elementPath: EP.appendNewElementPath(TestScenePath, ['root', 'conditional']),
         },
         want: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? (
-					<>
-						<div data-uid='aab'>bar</div>
-						<div data-uid='aac'>baz</div>
-					</>
-				) : <div data-uid='aaa'>foo</div>
-			}
-			<div data-uid='bbb'>bar</div>
-			<div data-uid='ccc'>baz</div>
-		</div>
+        <div data-uid='root'>
+            {
+            	// @utopia/uid=conditional
+                true ? (
+                    <>
+                    	<div data-uid='aab'>bar</div>
+                    	<div data-uid='aac'>baz</div>
+                    </>
+                ) : <div data-uid='aaa'>foo</div>
+            }
+            <div data-uid='bbb'>bar</div>
+            <div data-uid='ccc'>baz</div>
+        </div>
 		`,
       },
       {
         name: 'multiple elements into an empty conditional branch (false)',
         startingCode: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? <div data-uid='aaa'>foo</div> : null
-			}
-			<div data-uid='bbb'>bar</div>
-			<div data-uid='ccc'>baz</div>
-		</div>
+        <div data-uid='root'>
+            {
+                // @utopia/uid=conditional
+                true ? <div data-uid='aaa'>foo</div> : null
+            }
+            <div data-uid='bbb'>bar</div>
+            <div data-uid='ccc'>baz</div>
+        </div>
 		`,
         elements: (renderResult) => {
           const barPath = EP.appendNewElementPath(TestScenePath, ['root', 'bbb'])
@@ -730,34 +730,34 @@ describe('actions', () => {
           elementPath: EP.appendNewElementPath(TestScenePath, ['root', 'conditional']),
         },
         want: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? <div data-uid='aaa'>foo</div> : (
-					<>
-						<div data-uid='aab'>bar</div>
-						<div data-uid='aac'>baz</div>
-					</>
-				)
-			}
-			<div data-uid='bbb'>bar</div>
-			<div data-uid='ccc'>baz</div>
-		</div>
+        <div data-uid='root'>
+        	{
+            	// @utopia/uid=conditional
+                true ? <div data-uid='aaa'>foo</div> : (
+                    <>
+                    	<div data-uid='aab'>bar</div>
+                    	<div data-uid='aac'>baz</div>
+                    </>
+                )
+            }
+            <div data-uid='bbb'>bar</div>
+            <div data-uid='ccc'>baz</div>
+        </div>
 		`,
       },
       {
         name: 'an fragment inside an empty conditional branch',
         startingCode: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? null : <div data-uid='aaa'>foo</div>
-			}
-			<>
-				<div data-uid='bbb'>bar</div>
-				<div data-uid='ccc'>baz</div>
-			</>
-		</div>
+        <div data-uid='root'>
+            {
+                // @utopia/uid=conditional
+                true ? null : <div data-uid='aaa'>foo</div>
+            }
+            <>
+            	<div data-uid='bbb'>bar</div>
+                <div data-uid='ccc'>baz</div>
+            </>
+        </div>
 		`,
         elements: (renderResult) => {
           const path = EP.appendNewElementPath(TestScenePath, ['root', '38e'])
@@ -774,40 +774,40 @@ describe('actions', () => {
           elementPath: EP.appendNewElementPath(TestScenePath, ['root', 'conditional']),
         },
         want: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? (
-					<>
-						<div data-uid='aab'>bar</div>
-						<div data-uid='aac'>baz</div>
-					</>
-				) : <div data-uid='aaa'>foo</div>
-			}
-			<>
-				<div data-uid='bbb'>bar</div>
-				<div data-uid='ccc'>baz</div>
-			</>
-		</div>
+        <div data-uid='root'>
+            {
+                // @utopia/uid=conditional
+                true ? (
+                    <>
+                    	<div data-uid='aab'>bar</div>
+                    	<div data-uid='aac'>baz</div>
+                    </>
+                ) : <div data-uid='aaa'>foo</div>
+            }
+            <>
+                <div data-uid='bbb'>bar</div>
+                <div data-uid='ccc'>baz</div>
+            </>
+        </div>
 		`,
       },
       {
         name: 'multiple fragments inside an empty conditional branch',
         startingCode: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? null : <div data-uid='aaa'>foo</div>
-			}
-			<>
-				<div data-uid='bbb'>bar</div>
-				<div data-uid='ccc'>baz</div>
-			</>
-			<>
-				<div data-uid='ddd'>qux</div>
-				<div data-uid='eee'>waldo</div>
-			</>
-		</div>
+        <div data-uid='root'>
+            {
+                // @utopia/uid=conditional
+                true ? null : <div data-uid='aaa'>foo</div>
+            }
+            <>
+            	<div data-uid='bbb'>bar</div>
+                <div data-uid='ccc'>baz</div>
+            </>
+            <>
+                <div data-uid='ddd'>qux</div>
+                <div data-uid='eee'>waldo</div>
+            </>
+        </div>
 		`,
         elements: (renderResult) => {
           const firstPath = EP.appendNewElementPath(TestScenePath, ['root', '38e'])
@@ -830,42 +830,42 @@ describe('actions', () => {
           elementPath: EP.appendNewElementPath(TestScenePath, ['root', 'conditional']),
         },
         want: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? (
-					<>
-						<>
-							<div data-uid='aab'>bar</div>
-							<div data-uid='aac'>baz</div>
-						</>
-						<>
-							<div data-uid='aae'>qux</div>
-							<div data-uid='aaf'>waldo</div>
-						</>
-					</>
-				) : <div data-uid='aaa'>foo</div>
-			}
-			<>
-				<div data-uid='bbb'>bar</div>
-				<div data-uid='ccc'>baz</div>
-			</>
-			<>
-				<div data-uid='ddd'>qux</div>
-				<div data-uid='eee'>waldo</div>
-			</>
-		</div>
+      <div data-uid='root'>
+      {
+        // @utopia/uid=conditional
+        true ? (
+          <>
+            <>
+              <div data-uid='aab'>bar</div>
+              <div data-uid='aac'>baz</div>
+            </>
+            <>
+              <div data-uid='aae'>qux</div>
+              <div data-uid='aaf'>waldo</div>
+            </>
+          </>
+        ) : <div data-uid='aaa'>foo</div>
+      }
+      <>
+        <div data-uid='bbb'>bar</div>
+        <div data-uid='ccc'>baz</div>
+      </>
+      <>
+        <div data-uid='ddd'>qux</div>
+        <div data-uid='eee'>waldo</div>
+      </>
+    </div>
 		`,
       },
       {
         name: 'an active conditional branch',
         startingCode: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? <div data-uid='aaa'>foo</div> : null
-			}
-		</div>
+    <div data-uid='root'>
+      {
+        // @utopia/uid=conditional
+        true ? <div data-uid='aaa'>foo</div> : null
+      }
+    </div>
 		`,
         elements: (renderResult) => {
           const path = EP.appendNewElementPath(TestScenePath, ['root', 'conditional', 'aaa'])
@@ -879,24 +879,24 @@ describe('actions', () => {
         },
         pasteInto: EP.appendNewElementPath(TestScenePath, ['root']),
         want: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? <div data-uid='aaa'>foo</div> : null
-			}
-			<div data-uid='aab'>foo</div>
+    <div data-uid='root'>
+      {
+        // @utopia/uid=conditional
+        true ? <div data-uid='aaa'>foo</div> : null
+      }
+      <div data-uid='aab'>foo</div>
 		</div>
 		`,
       },
       {
         name: 'an inactive conditional branch',
         startingCode: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? null : <div data-uid='aaa'>foo</div>
-			}
-		</div>
+    <div data-uid='root'>
+      {
+        // @utopia/uid=conditional
+        true ? null : <div data-uid='aaa'>foo</div>
+      }
+    </div>
 		`,
         elements: (renderResult) => {
           const path = EP.appendNewElementPath(TestScenePath, ['root', 'conditional', 'a25'])
@@ -914,13 +914,13 @@ describe('actions', () => {
         },
         pasteInto: EP.appendNewElementPath(TestScenePath, ['root']),
         want: `
-		<div data-uid='root'>
-			{
-				// @utopia/uid=conditional
-				true ? null : <div data-uid='aaa'>foo</div>
-			}
-			<div data-uid='aab' style={{ display: 'block' }}>foo</div>
-		</div>
+    <div data-uid='root'>
+      {
+        // @utopia/uid=conditional
+        true ? null : <div data-uid='aaa'>foo</div>
+      }
+      <div data-uid='aab' style={{ display: 'block' }}>foo</div>
+    </div>
 		`,
       },
     ]

--- a/editor/src/components/editor/actions/actions.test-utils.ts
+++ b/editor/src/components/editor/actions/actions.test-utils.ts
@@ -1,0 +1,19 @@
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { isLeft } from '../../../core/shared/either'
+import { JSXElementChild } from '../../../core/shared/element-template'
+import { ElementPath } from '../../../core/shared/project-file-types'
+import { EditorRenderResult } from '../../canvas/ui-jsx.test-utils'
+
+export function getElementFromRenderResult(
+  renderResult: EditorRenderResult,
+  path: ElementPath,
+): JSXElementChild {
+  const element = MetadataUtils.findElementByElementPath(
+    renderResult.getEditorState().editor.jsxMetadata,
+    path,
+  )
+  if (element == null || isLeft(element.element)) {
+    throw new Error('element is invalid')
+  }
+  return element.element.value
+}

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3200,23 +3200,10 @@ export const UPDATE_FNS = {
             workingEditorState.jsxMetadata,
             resolvedTarget,
           )
-          const pastedElementIsFlex =
-            MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
-              currentValue.originalElementPath,
-              action.targetOriginalContextMetadata,
-            )
 
           const pastedElementMetadata = MetadataUtils.findElementByElementPath(
             action.targetOriginalContextMetadata,
             currentValue.originalElementPath,
-          )
-          const pastedElementIsAbsolute = MetadataUtils.isPositionAbsolute(pastedElementMetadata)
-          const pastedElementIsConditional =
-            MetadataUtils.isConditionalFromMetadata(pastedElementMetadata)
-
-          const parentOfPasteInto = MetadataUtils.findElementByElementPath(
-            editor.jsxMetadata,
-            resolvedTarget,
           )
 
           function maybePasteIntoConditionalBranch(
@@ -3244,34 +3231,29 @@ export const UPDATE_FNS = {
 
           const pasteIntoConditionalBranch = maybePasteIntoConditionalBranch(resolvedTarget)
 
-          const continueWithPaste =
-            pasteIntoConditionalBranch != null
-              ? isNullJSXAttributeValue(pasteIntoConditionalBranch)
-              : pastedElementIsAbsolute ||
-                pastedElementIsFlex ||
-                pastedElementIsConditional ||
-                MetadataUtils.isConditionalFromMetadata(parentOfPasteInto) ||
-                isJSXFragment(currentValue.element)
-
-          if (continueWithPaste) {
-            const propertyChangeCommands = getReparentPropertyChanges(
-              reparentStrategy.strategy,
-              newPath,
-              resolvedTarget,
-              action.targetOriginalContextMetadata,
-              workingEditorState.jsxMetadata,
-              workingEditorState.projectContents,
-              workingEditorState.canvas.openFile?.filename,
-              pastedElementMetadata?.specialSizeMeasurements.position ?? null,
-              pastedElementMetadata?.specialSizeMeasurements.display ?? null,
-            )
-
-            const allCommands = [...reparentCommands, ...propertyChangeCommands]
-
-            return foldAndApplyCommandsSimple(workingEditorState, allCommands)
-          } else {
+          if (
+            pasteIntoConditionalBranch != null &&
+            !isNullJSXAttributeValue(pasteIntoConditionalBranch)
+          ) {
+            // do not allow pasting into non-empty conditional branches
             return workingEditorState
           }
+
+          const propertyChangeCommands = getReparentPropertyChanges(
+            reparentStrategy.strategy,
+            newPath,
+            resolvedTarget,
+            action.targetOriginalContextMetadata,
+            workingEditorState.jsxMetadata,
+            workingEditorState.projectContents,
+            workingEditorState.canvas.openFile?.filename,
+            pastedElementMetadata?.specialSizeMeasurements.position ?? null,
+            pastedElementMetadata?.specialSizeMeasurements.display ?? null,
+          )
+
+          const allCommands = [...reparentCommands, ...propertyChangeCommands]
+
+          return foldAndApplyCommandsSimple(workingEditorState, allCommands)
         }
       }, editor)
     } else {

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -18,7 +18,6 @@ import { unsafeGet } from '../../core/shared/optics/optic-utilities'
 import { Optic, compose6Optics } from '../../core/shared/optics/optics'
 import { ElementPath } from '../../core/shared/project-file-types'
 import {
-  EditorRenderResult,
   TestScenePath,
   getPrintedUiJsCode,
   makeTestProjectCodeWithSnippet,
@@ -34,6 +33,7 @@ import { EditorState } from './store/editor-state'
 import { ReparentTargetParent } from './store/reparent-target'
 import { ElementPaste } from './action-types'
 import { forceNotNull } from '../../core/shared/optional-utils'
+import { getElementFromRenderResult } from './actions/actions.test-utils'
 
 describe('conditionals', () => {
   describe('deletion', () => {
@@ -771,18 +771,4 @@ async function runPaste({
   })
 
   return getPrintedUiJsCode(renderResult.getEditorState())
-}
-
-function getElementFromRenderResult(
-  renderResult: EditorRenderResult,
-  path: ElementPath,
-): JSXElementChild {
-  const element = MetadataUtils.findElementByElementPath(
-    renderResult.getEditorState().editor.jsxMetadata,
-    path,
-  )
-  if (element == null || isLeft(element.element)) {
-    throw new Error('element is invalid')
-  }
-  return element.element.value
 }


### PR DESCRIPTION
Fixes #3543

This PR removes the strict conditions on the paste action, and adds tests for the different paste combinations, and updates the `isAllowedToReparent` helper to allow copying the contents of an inactive conditional branch.

As a side effect of this, the PR also fixes copy-paste for conditional branches which would not satisfy the original conditions (e.g. having a `position: absolute` prop).