### PR TITLE
Feature/insert sample text

### DIFF
--- a/editor/src/components/canvas/ui/floating-insert-menu.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.spec.browser2.tsx
@@ -149,6 +149,50 @@ describe('Floating insert menu', () => {
   </div>`),
     )
   })
+
+  it('can insert a span with sample text', async () => {
+    const editor = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`<div
+    style={{
+      backgroundColor: '#aaaaaa33',
+      position: 'absolute',
+      left: 57,
+      top: 168,
+      width: 247,
+      height: 402,
+    }}
+    data-uid='container'
+  >
+    <div data-uid='a3d' />
+  </div>`),
+      'await-first-dom-report',
+    )
+
+    await selectComponentsForTest(editor, [
+      EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:container`),
+    ])
+
+    FOR_TESTS_setNextGeneratedUid('sample-text')
+
+    await insertViaAddElementPopup(editor, 'sampl')
+
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`<div
+    style={{
+      backgroundColor: '#aaaaaa33',
+      position: 'absolute',
+      left: 57,
+      top: 168,
+      width: 247,
+      height: 402,
+    }}
+    data-uid='container'
+  >
+    <div data-uid='a3d' />
+    <span data-uid='sample-text'>Utopia rules</span>
+  </div>`),
+    )
+  })
 })
 
 async function insertViaAddElementPopup(editor: EditorRenderResult, query: string) {

--- a/editor/src/components/canvas/ui/floating-insert-menu.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.spec.browser2.tsx
@@ -189,7 +189,7 @@ describe('Floating insert menu', () => {
     data-uid='container'
   >
     <div data-uid='a3d' />
-    <span data-uid='sample-text'>Utopia rules</span>
+    <span data-uid='sample-text'>Sample text</span>
   </div>`),
     )
   })

--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -505,6 +505,38 @@ Array [
     },
   },
   Object {
+    "insertableComponents": Array [
+      Object {
+        "defaultSize": null,
+        "element": Object {
+          "children": Array [
+            Object {
+              "text": "Utopia rules",
+              "type": "JSX_TEXT_BLOCK",
+              "uid": "",
+            },
+          ],
+          "name": Object {
+            "baseVariable": "span",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {},
+        "name": "Sample text",
+        "stylePropOptions": Array [
+          "do-not-add",
+        ],
+      },
+    ],
+    "source": Object {
+      "type": "SAMPLES_GROUP",
+    },
+  },
+  Object {
     "insertableComponents": Array [],
     "source": Object {
       "dependencyName": "@heroicons/react",
@@ -1017,6 +1049,38 @@ Array [
     ],
     "source": Object {
       "type": "FRAGMENT_GROUP",
+    },
+  },
+  Object {
+    "insertableComponents": Array [
+      Object {
+        "defaultSize": null,
+        "element": Object {
+          "children": Array [
+            Object {
+              "text": "Utopia rules",
+              "type": "JSX_TEXT_BLOCK",
+              "uid": "",
+            },
+          ],
+          "name": Object {
+            "baseVariable": "span",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {},
+        "name": "Sample text",
+        "stylePropOptions": Array [
+          "do-not-add",
+        ],
+      },
+    ],
+    "source": Object {
+      "type": "SAMPLES_GROUP",
     },
   },
   Object {

--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -511,7 +511,7 @@ Array [
         "element": Object {
           "children": Array [
             Object {
-              "text": "Utopia rules",
+              "text": "Sample text",
               "type": "JSX_TEXT_BLOCK",
               "uid": "",
             },
@@ -1058,7 +1058,7 @@ Array [
         "element": Object {
           "children": Array [
             Object {
-              "text": "Utopia rules",
+              "text": "Sample text",
               "type": "JSX_TEXT_BLOCK",
               "uid": "",
             },

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -78,7 +78,7 @@ export function clearInsertableComponentUniqueIDs(
   }
 }
 
-export interface InsertableComponentSamples {
+export interface InsertableComponentGroupSamples {
   type: 'SAMPLES_GROUP'
 }
 
@@ -149,7 +149,7 @@ export type InsertableComponentGroupType =
   | InsertableComponentGroupProjectDependency
   | InsertableComponentGroupConditionals
   | InsertableComponentGroupFragment
-  | InsertableComponentSamples
+  | InsertableComponentGroupSamples
 
 export interface InsertableComponentGroup {
   source: InsertableComponentGroupType

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -12,6 +12,7 @@ import {
   jsxConditionalExpressionWithoutUID,
   jsxElementWithoutUID,
   jsxFragmentWithoutUID,
+  jsxTextBlock,
   simpleAttribute,
 } from '../../core/shared/element-template'
 import { dropFileExtension } from '../../core/shared/file-utils'
@@ -75,6 +76,10 @@ export function clearInsertableComponentUniqueIDs(
     ...insertableComponentToFix,
     element: updatedElement,
   }
+}
+
+export interface InsertableComponentSamples {
+  type: 'SAMPLES_GROUP'
 }
 
 export interface InsertableComponentGroupHTML {
@@ -144,6 +149,7 @@ export type InsertableComponentGroupType =
   | InsertableComponentGroupProjectDependency
   | InsertableComponentGroupConditionals
   | InsertableComponentGroupFragment
+  | InsertableComponentSamples
 
 export interface InsertableComponentGroup {
   source: InsertableComponentGroupType
@@ -173,6 +179,8 @@ export function clearInsertableComponentGroupUniqueIDs(
 
 export function getInsertableGroupLabel(insertableType: InsertableComponentGroupType): string {
   switch (insertableType.type) {
+    case 'SAMPLES_GROUP':
+      return 'Sample elements'
     case 'HTML_GROUP':
       return 'HTML Elements'
     case 'PROJECT_DEPENDENCY_GROUP':
@@ -193,6 +201,7 @@ export function getInsertableGroupPackageStatus(
   insertableType: InsertableComponentGroupType,
 ): PackageStatus {
   switch (insertableType.type) {
+    case 'SAMPLES_GROUP':
     case 'HTML_GROUP':
     case 'PROJECT_COMPONENT_GROUP':
     case 'CONDITIONALS_GROUP':
@@ -360,6 +369,19 @@ const fragmentElementsDescriptors: ComponentDescriptorsForFile = {
       {
         insertMenuLabel: 'Fragment',
         elementToInsert: jsxFragmentWithoutUID([], false),
+        importsToAdd: {},
+      },
+    ],
+  },
+}
+
+const samplesDescriptors: ComponentDescriptorsForFile = {
+  sampleText: {
+    properties: {},
+    variants: [
+      {
+        insertMenuLabel: 'Sample text',
+        elementToInsert: jsxElementWithoutUID('span', [], [jsxTextBlock('Utopia rules')]),
         importsToAdd: {},
       },
     ],
@@ -549,6 +571,9 @@ export function getComponentGroups(
 
   // Add fragment group.
   addDependencyDescriptor(null, insertableComponentGroupFragment(), fragmentElementsDescriptors)
+
+  // Add samples group
+  addDependencyDescriptor(null, { type: 'SAMPLES_GROUP' }, samplesDescriptors)
 
   // Add entries for dependencies of the project.
   for (const dependency of dependencies) {

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -381,7 +381,7 @@ const samplesDescriptors: ComponentDescriptorsForFile = {
     variants: [
       {
         insertMenuLabel: 'Sample text',
-        elementToInsert: jsxElementWithoutUID('span', [], [jsxTextBlock('Utopia rules')]),
+        elementToInsert: jsxElementWithoutUID('span', [], [jsxTextBlock('Sample text')]),
         importsToAdd: {},
       },
     ],


### PR DESCRIPTION
## Description
This PR enables inserting sample text in a single step from the `Add element` menu and the insert menu. Currently, this can only be done by selecting `span` and checking `Add content`.

## Details
- a new insertable group is added (`SAMPLE_ELEMENT`) with a single entry (`Sample text`)
- a new test is added to the test suite corresponding to the floating insert menu

## Limitations
- no ChatGPT support