### PR TITLE
`Wrap in container` command preserves index of wrapped element

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -46,7 +46,7 @@ import {
   getAllUniqueUids,
   guaranteeUniqueUids,
   isSceneElement,
-  getZIndexOfElement,
+  getIndexInParent,
 } from '../../core/model/element-template-utils'
 import {
   fixUtopiaElement,
@@ -2720,7 +2720,7 @@ export function duplicate(
           underlyingInstancePath,
           utopiaComponents,
         )
-        const elementIndex = getZIndexOfElement(
+        const elementIndex = getIndexInParent(
           success.topLevelElements,
           EP.dynamicPathToStaticPath(path),
         )

--- a/editor/src/components/canvas/commands/wrap-in-container-command.ts
+++ b/editor/src/components/canvas/commands/wrap-in-container-command.ts
@@ -19,7 +19,7 @@ import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-f
 import { InsertionSubjectWrapper } from '../../editor/editor-modes'
 import { assertNever } from '../../../core/shared/utils'
 import { absolute } from '../../../utils/utils'
-import { getZIndexOfElement } from '../../../core/model/element-template-utils'
+import { getIndexInParent } from '../../../core/model/element-template-utils'
 
 type ContainerToWrapIn = InsertionSubjectWrapper
 
@@ -58,7 +58,7 @@ export const runWrapInContainerCommand: CommandFunction<WrapInContainerCommand> 
     (success, elementToWrap, _underlyingTarget, underlyingFilePath) => {
       const components = getUtopiaJSXComponentsFromSuccess(success)
       const withElementRemoved = removeElementAtPath(command.target, components)
-      const indexInParent = getZIndexOfElement(
+      const indexInParent = getIndexInParent(
         success.topLevelElements,
         EP.dynamicPathToStaticPath(command.target),
       )

--- a/editor/src/components/canvas/commands/wrap-in-container-command.ts
+++ b/editor/src/components/canvas/commands/wrap-in-container-command.ts
@@ -18,6 +18,8 @@ import * as EP from '../../../core/shared/element-path'
 import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
 import { InsertionSubjectWrapper } from '../../editor/editor-modes'
 import { assertNever } from '../../../core/shared/utils'
+import { absolute } from '../../../utils/utils'
+import { getZIndexOfElement } from '../../../core/model/element-template-utils'
 
 type ContainerToWrapIn = InsertionSubjectWrapper
 
@@ -56,6 +58,11 @@ export const runWrapInContainerCommand: CommandFunction<WrapInContainerCommand> 
     (success, elementToWrap, _underlyingTarget, underlyingFilePath) => {
       const components = getUtopiaJSXComponentsFromSuccess(success)
       const withElementRemoved = removeElementAtPath(command.target, components)
+      const indexInParent = getZIndexOfElement(
+        success.topLevelElements,
+        EP.dynamicPathToStaticPath(command.target),
+      )
+      const index = indexInParent >= 0 ? absolute(indexInParent) : null
 
       const wrapper = getInsertionSubjectWrapper(command.wrapper, command.wrapperUID, elementToWrap)
 
@@ -67,7 +74,7 @@ export const runWrapInContainerCommand: CommandFunction<WrapInContainerCommand> 
         targetParent,
         wrapper,
         withElementRemoved,
-        null, // FIXME Find the index position of the original element
+        index,
       )
 
       editorStatePatches.push(

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -13,7 +13,7 @@ import { findElementAtPath, MetadataUtils } from '../../../core/model/element-me
 import {
   generateUidWithExistingComponents,
   getAllUniqueUids,
-  getZIndexOfElement,
+  getIndexInParent,
   insertChildAndDetails,
   InsertChildAndDetails,
   transformJSXComponentAtElementPath,
@@ -1155,7 +1155,7 @@ function indexPositionForAdjustment(
           openUIJSFileKey,
           0,
           (success) => {
-            return getZIndexOfElement(success.topLevelElements, EP.asStatic(target))
+            return getIndexInParent(success.topLevelElements, EP.asStatic(target))
           },
         )
         return {

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -603,7 +603,7 @@ export function getZIndexOfElement(
   if (parentElement != null) {
     const elementUID = EP.toUid(target)
     return parentElement.children.findIndex((child) => {
-      return isJSXElementLike(child) && getUtopiaID(child) === elementUID
+      return getUtopiaID(child) === elementUID
     })
   } else {
     return -1

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -591,7 +591,7 @@ export function insertJSXElementChild(
   }
 }
 
-export function getZIndexOfElement(
+export function getIndexInParent(
   topLevelElements: Array<TopLevelElement>,
   target: StaticElementPath,
 ): number {


### PR DESCRIPTION
## Problem
The `Wrap in container` command does not preserve the index of the element it wraps. Instead, it re-inserts the element as the last one among its siblings.

## Solution
Save the index of the element being wrapped before the command wraps it, and insert the wrapped element to that index.

### Extras
- Tests for inserting fragment/conditionals into flex hierarchies
- rename `getZIndexOfElement` to the more self-explanatory `getIndexInParent`