### PR TITLE
Remove duplicated code

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -191,6 +191,12 @@ import { fromTypeGuard } from '../../../core/shared/optics/optic-creators'
 import { getNavigatorTargets } from '../../../components/navigator/navigator-utils'
 import { treatElementAsContentAffecting } from '../../canvas/canvas-strategies/strategies/group-like-helpers'
 import { getUtopiaID } from '../../../core/shared/uid-utils'
+import {
+  conditionalClause,
+  ConditionalClause,
+  dynamicReparentTargetParentToStaticReparentTargetParent,
+  ReparentTargetParent,
+} from './reparent-target'
 
 const ObjectPathImmutable: any = OPI
 
@@ -2105,59 +2111,6 @@ export function regularNavigatorEntriesEqual(
 ): boolean {
   return EP.pathsEqual(first.elementPath, second.elementPath)
 }
-
-export interface ConditionalClause<P extends ElementPath> {
-  elementPath: P
-  clause: ConditionalCase
-}
-
-export function conditionalClause<P extends ElementPath>(
-  elementPath: P,
-  clause: ConditionalCase,
-): ConditionalClause<P> {
-  return {
-    elementPath: elementPath,
-    clause: clause,
-  }
-}
-
-export type ReparentTargetParent<P extends ElementPath> = P | ConditionalClause<P>
-
-export function reparentTargetParentIsConditionalClause<P extends ElementPath>(
-  reparentTargetParent: ReparentTargetParent<P>,
-): reparentTargetParent is ConditionalClause<P> {
-  return 'elementPath' in reparentTargetParent && 'clause' in reparentTargetParent
-}
-
-export function reparentTargetParentIsElementPath<P extends ElementPath>(
-  reparentTargetParent: ReparentTargetParent<P>,
-): reparentTargetParent is P {
-  return !reparentTargetParentIsConditionalClause(reparentTargetParent)
-}
-
-export function getElementPathFromReparentTargetParent<P extends ElementPath>(
-  reparentTargetParent: ReparentTargetParent<P>,
-): P {
-  if (reparentTargetParentIsConditionalClause(reparentTargetParent)) {
-    return reparentTargetParent.elementPath
-  } else {
-    return reparentTargetParent
-  }
-}
-
-export function dynamicReparentTargetParentToStaticReparentTargetParent(
-  reparentTargetParent: ReparentTargetParent<ElementPath>,
-): ReparentTargetParent<StaticElementPath> {
-  if (reparentTargetParentIsConditionalClause(reparentTargetParent)) {
-    return conditionalClause(
-      EP.dynamicPathToStaticPath(reparentTargetParent.elementPath),
-      reparentTargetParent.clause,
-    )
-  } else {
-    return EP.dynamicPathToStaticPath(reparentTargetParent)
-  }
-}
-
 export interface ConditionalClauseNavigatorEntry extends ConditionalClause<ElementPath> {
   type: 'CONDITIONAL_CLAUSE'
 }


### PR DESCRIPTION
**Problem:**
The same `ReparentTargetParent` type (and other related types and functions) are defined in two places, in https://github.com/concrete-utopia/utopia/blob/master/editor/src/components/editor/store/reparent-target.ts#L22 and in https://github.com/concrete-utopia/utopia/blob/master/editor/src/components/editor/store/editor-state.ts#L2124

**Fix:**
Remove these from `editor-state.ts`