### PR TITLE
Fix misplaced conditionals in the navigator root

### DIFF
--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -171,6 +171,9 @@ import {
   importedOrigin,
   ConditionValue,
   JSXConditionalExpressionWithoutUID,
+  isJSXConditionalExpression,
+  JSXConditionalExpression,
+  jsxConditionalExpression,
 } from '../../../core/shared/element-template'
 import {
   CanvasRectangle,
@@ -1035,6 +1038,8 @@ export function JSXElementChildKeepDeepEquality(): KeepDeepEqualityCall<JSXEleme
       return JSXTextBlockKeepDeepEquality(oldElement, newElement)
     } else if (isJSXFragment(oldElement) && isJSXFragment(newElement)) {
       return JSXFragmentKeepDeepEquality(oldElement, newElement)
+    } else if (isJSXConditionalExpression(oldElement) && isJSXConditionalExpression(newElement)) {
+      return JSXConditionalExpressionKeepDeepEquality(oldElement, newElement)
     } else if (oldElement.type === 'ATTRIBUTE_VALUE' && newElement.type === 'ATTRIBUTE_VALUE') {
       return JSXAttributeValueKeepDeepEqualityCall(oldElement, newElement)
     } else if (
@@ -1169,6 +1174,39 @@ export const JSXFragmentKeepDeepEquality: KeepDeepEqualityCall<JSXFragment> = co
     }
   },
 )
+
+export const JSXConditionalExpressionKeepDeepEquality: KeepDeepEqualityCall<JSXConditionalExpression> =
+  combine6EqualityCalls(
+    (conditional) => conditional.uid,
+    StringKeepDeepEquality,
+    (conditional) => conditional.condition,
+    JSXAttributeKeepDeepEqualityCall,
+    (conditional) => conditional.originalConditionString,
+    StringKeepDeepEquality,
+    (conditional) => conditional.whenTrue,
+    JSXElementChildKeepDeepEquality(),
+    (conditional) => conditional.whenFalse,
+    JSXElementChildKeepDeepEquality(),
+    (conditional) => conditional.comments,
+    ParsedCommentsKeepDeepEqualityCall,
+    (
+      uid,
+      condition,
+      originalConditionString,
+      whenTrue,
+      whenFalse,
+      comments,
+    ): JSXConditionalExpression => {
+      return jsxConditionalExpression(
+        uid,
+        condition,
+        originalConditionString,
+        whenTrue,
+        whenFalse,
+        comments,
+      )
+    },
+  )
 
 export const RegularParamKeepDeepEquality: KeepDeepEqualityCall<RegularParam> =
   combine2EqualityCalls(

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -195,6 +195,46 @@ export var ${BakedInStoryboardVariableName} = (
 `
 }
 
+function getProjectCodeTree(): string {
+  return `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export var ${BakedInStoryboardVariableName} = (
+  <Storyboard data-uid='${BakedInStoryboardUID}'>
+    <div data-uid='aaa'>foo</div>
+    {
+      // @utopia/uid=cond1
+      true ? <div data-uid='bbb'>bbb</div> : null
+    }
+    <div data-uid='ccc'>
+      <div data-uid='ddd'>ddd</div>
+      {
+        // @utopia/uid=cond2
+        true ? (
+          <div data-uid='eee'>
+            {
+              // @utopia/uid=cond3
+              true ? <div data-uid='fff'>fff</div> : null
+            }
+            <div data-uid='ggg'>ggg</div>
+          </div>
+        ) : null
+      }
+    </div>
+    {
+      // @utopia/uid=cond4
+      true ? <div data-uid='hhh'>hhh</div> : null
+    }
+    {
+      // @utopia/uid=cond5
+      true ? <div data-uid='iii'>iii</div> : null
+    }
+    <div data-uid='jjj'>jjj</div>
+  </Storyboard>
+)
+`
+}
+
 function getProjectCodeEmptyActive(): string {
   return `import * as React from 'react'
 import { Scene, Storyboard } from 'utopia-api'
@@ -428,6 +468,48 @@ async function ensureNoopDrag({
 }
 
 describe('conditionals in the navigator', () => {
+  it('keeps conditionals position', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      getProjectCodeTree(),
+      'await-first-dom-report',
+    )
+    const want = `  regular-utopia-storyboard-uid/aaa
+  regular-utopia-storyboard-uid/cond1
+    conditional-clause-utopia-storyboard-uid/cond1-true-case
+      regular-utopia-storyboard-uid/cond1/bbb
+    conditional-clause-utopia-storyboard-uid/cond1-false-case
+      synthetic-utopia-storyboard-uid/cond1/a25-attribute
+  regular-utopia-storyboard-uid/ccc
+    regular-utopia-storyboard-uid/ccc/ddd
+    regular-utopia-storyboard-uid/ccc/cond2
+      conditional-clause-utopia-storyboard-uid/ccc/cond2-true-case
+        regular-utopia-storyboard-uid/ccc/cond2/eee
+          regular-utopia-storyboard-uid/ccc/cond2/eee/cond3
+            conditional-clause-utopia-storyboard-uid/ccc/cond2/eee/cond3-true-case
+              regular-utopia-storyboard-uid/ccc/cond2/eee/cond3/fff
+            conditional-clause-utopia-storyboard-uid/ccc/cond2/eee/cond3-false-case
+              synthetic-utopia-storyboard-uid/ccc/cond2/eee/cond3/129-attribute
+          regular-utopia-storyboard-uid/ccc/cond2/eee/ggg
+      conditional-clause-utopia-storyboard-uid/ccc/cond2-false-case
+        synthetic-utopia-storyboard-uid/ccc/cond2/328-attribute
+  regular-utopia-storyboard-uid/cond4
+    conditional-clause-utopia-storyboard-uid/cond4-true-case
+      regular-utopia-storyboard-uid/cond4/hhh
+    conditional-clause-utopia-storyboard-uid/cond4-false-case
+      synthetic-utopia-storyboard-uid/cond4/5ea-attribute
+  regular-utopia-storyboard-uid/cond5
+    conditional-clause-utopia-storyboard-uid/cond5-true-case
+      regular-utopia-storyboard-uid/cond5/iii
+    conditional-clause-utopia-storyboard-uid/cond5-false-case
+      synthetic-utopia-storyboard-uid/cond5/658-attribute
+  regular-utopia-storyboard-uid/jjj`
+    expect(
+      navigatorStructure(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().derived,
+      ),
+    ).toEqual(want)
+  })
   it('can not drag into a conditional', async () => {
     const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
 

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -179,7 +179,20 @@ export function getNavigatorTargets(
     }
   }
 
-  const canvasRoots = MetadataUtils.getAllStoryboardChildrenPathsUnordered(metadata)
+  function getCanvasRoots(trees: ElementPathTree[]): ElementPath[] {
+    if (projectTree.length <= 0) {
+      return []
+    }
+
+    const storyboardTree = trees.find((e) => EP.isStoryboardPath(e.path))
+    if (storyboardTree == null) {
+      return []
+    }
+
+    return storyboardTree.children.map((c) => c.path)
+  }
+
+  const canvasRoots = getCanvasRoots(projectTree)
   fastForEach(canvasRoots, (childElement) => {
     const subTree = getSubTree(projectTree, childElement)
 


### PR DESCRIPTION
Fixes #3554 

**Problem:**

Conditional elements at the root of the navigator would be displayed always at the top regardless of their position in the actual tree.

For example, this tree
```
div1
conditional
div2
```

would result in the navigator displaying
```
conditional
div1
div2
```

**Fix:**

Use the (ordered) project tree as a base when populating the navigator items.