### PR TITLE
Consistent conditional labels navigator height + string literals icons

### DIFF
--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -1,15 +1,13 @@
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { isAnimatedElement, isImg, isImportedComponent } from '../../core/model/project-file-utils'
 import {
-  isIntrinsicHTMLElement,
   isJSXElement,
   ElementInstanceMetadataMap,
-  UtopiaJSXComponent,
   ElementInstanceMetadata,
-  isJSXFragment,
+  isJSXAttributeValue,
 } from '../../core/shared/element-template'
 import * as EP from '../../core/shared/element-path'
-import { Imports, ElementPath } from '../../core/shared/project-file-types'
+import { ElementPath } from '../../core/shared/project-file-types'
 import { Substores, useEditorState } from '../editor/store/store-hook'
 import { isRight, maybeEitherToMaybe } from '../../core/shared/either'
 import { IcnPropsBase } from '../../uuiui'
@@ -17,13 +15,10 @@ import { shallowEqual } from '../../core/shared/equality-utils'
 import {
   AllElementProps,
   isRegularNavigatorEntry,
+  isSyntheticNavigatorEntry,
   NavigatorEntry,
 } from '../editor/store/editor-state'
-import { isSpawnedActor } from 'xstate/lib/Actor'
-import {
-  getElementContentAffectingType,
-  treatElementAsContentAffecting,
-} from '../canvas/canvas-strategies/strategies/group-like-helpers'
+import { getElementContentAffectingType } from '../canvas/canvas-strategies/strategies/group-like-helpers'
 
 interface LayoutIconResult {
   iconProps: IcnPropsBase

--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -212,7 +212,14 @@ export function createElementIconPropsFromMetadata(
       height: 18,
     }
   }
-  const isText = MetadataUtils.isTextFromMetadata(element)
+
+  const isConditionalBranchText =
+    navigatorEntry != null &&
+    isSyntheticNavigatorEntry(navigatorEntry) &&
+    isJSXAttributeValue(navigatorEntry.childOrAttribute) &&
+    typeof navigatorEntry.childOrAttribute.value === 'string'
+
+  const isText = MetadataUtils.isTextFromMetadata(element) || isConditionalBranchText
   if (isText) {
     return {
       category: 'element',

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -44,20 +44,11 @@ import { DerivedSubstate, MetadataSubstate } from '../../editor/store/store-hook
 import { getConditionalClausePathForNavigatorEntry, navigatorDepth } from '../navigator-utils'
 import createCachedSelector from 're-reselect'
 import { getValueFromComplexMap } from '../../../utils/map'
-import { isSyntheticNavigatorEntry } from '../../editor/store/editor-state'
-import { getElementContentAffectingType } from '../../canvas/canvas-strategies/strategies/group-like-helpers'
 import { isEntryAConditionalSlot } from '../../canvas/canvas-utils'
 
 export function getItemHeight(navigatorEntry: NavigatorEntry): number {
   if (isConditionalClauseNavigatorEntry(navigatorEntry)) {
-    if (navigatorEntry.clause === 'true-case') {
-      // The TRUE label row will be the shortest size.
-      return UtopiaTheme.layout.rowHeight.smallest
-    } else {
-      // The FALSE label row should visually appear to be the shortest size.
-      // The size difference (against the TRUE label row) will be a top margin.
-      return UtopiaTheme.layout.rowHeight.smaller
-    }
+    return UtopiaTheme.layout.rowHeight.smallest
   } else {
     // Default size for everything else.
     return UtopiaTheme.layout.rowHeight.smaller
@@ -570,11 +561,6 @@ export const NavigatorItem: React.FunctionComponent<
   const rowStyle = useKeepReferenceEqualityIfPossible({
     paddingLeft: getElementPadding(entryNavigatorDepth),
     height: getItemHeight(navigatorEntry),
-    // This matches up with the implementation of `getItemHeight`.
-    marginTop:
-      isConditionalClauseNavigatorEntry(navigatorEntry) && navigatorEntry.clause === 'false-case'
-        ? '8px'
-        : undefined,
     ...resultingStyle.style,
   })
 


### PR DESCRIPTION
Fixes #3558 and #3559 

**Problem:**

1. `TRUE` and `FALSE` conditional clauses in the navigator have inconsistent heights
2. String literal conditional branches are displayed with a `div` icon instead of `text`

**Fix:**
<img width="284" alt="Screenshot 2023-04-19 at 2 52 32 PM" src="https://user-images.githubusercontent.com/1081051/233080788-0dc2a1dd-3d45-4efa-a1ec-97a8cbd3dac7.png">
