### PR TITLE
Oooops. Fixing the ConditionalClauseNavigatorEntry

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -2104,7 +2104,7 @@ export function regularNavigatorEntriesEqual(
 }
 export interface ConditionalClauseNavigatorEntry {
   type: 'CONDITIONAL_CLAUSE'
-  elementPath: StaticElementPath
+  elementPath: ElementPath
   clause: ConditionalCase
 }
 
@@ -2114,7 +2114,7 @@ export function conditionalClauseNavigatorEntry(
 ): ConditionalClauseNavigatorEntry {
   return {
     type: 'CONDITIONAL_CLAUSE',
-    elementPath: EP.dynamicPathToStaticPath(elementPath),
+    elementPath: elementPath,
     clause: clause,
   }
 }

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -457,7 +457,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
       if (clause != null) {
         fixedProps.navigatorEntry = {
           type: 'CONDITIONAL_CLAUSE',
-          elementPath: EP.dynamicPathToStaticPath(parentPath),
+          elementPath: parentPath,
           clause: clause,
         }
       }


### PR DESCRIPTION
**Problem:**
I made the `ConditionalClauseNavigatorEntry` contain a static path, but that's a big mistake because the navigator entries should be dynamic paths so they can point at generated element instances.

**Fix:**
Undo the change
