### PR TITLE
only show conditional inspector when a conditional is selected

### DIFF
--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -248,12 +248,13 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
   const onlyConditionalsSelected = useEditorState(
     Substores.metadata,
     (store) =>
+      store.editor.selectedViews.length > 0 &&
       store.editor.selectedViews.every((path) =>
         MetadataUtils.isConditionalFromMetadata(
           MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, path),
         ),
       ),
-    'Inspector isConditionalSelected',
+    'Inspector onlyConditionalsSelected',
   )
 
   React.useEffect(() => {

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -69,7 +69,7 @@ import {
 import { Icn, useColorTheme, UtopiaTheme, FlexRow, Button } from '../../uuiui'
 import { getElementsToTarget } from './common/inspector-utils'
 import { ElementPath, PropertyPath } from '../../core/shared/project-file-types'
-import { when } from '../../utils/react-conditionals'
+import { unless, when } from '../../utils/react-conditionals'
 import { createSelector } from 'reselect'
 import { isTwindEnabled } from '../../core/tailwind/tailwind'
 import {
@@ -84,7 +84,10 @@ import { useDispatch } from '../editor/store/dispatch-context'
 import { styleStringInArray } from '../../utils/common-constants'
 import { SizingSection } from './sizing-section'
 import { PositionSection } from './sections/layout-section/position-section'
-import { ConditionalSection } from './sections/layout-section/conditional-section'
+import {
+  ConditionalSection,
+  getConditionOverrideSelector,
+} from './sections/layout-section/conditional-section'
 import { GroupSection } from './convert-to-group-dropdown'
 
 export interface ElementPathElement {
@@ -244,6 +247,15 @@ export function shouldInspectorUpdate(
 export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
   const colorTheme = useColorTheme()
   const { selectedViews, setSelectedTarget, targets } = props
+
+  const isConditionalSelected = useEditorState(
+    Substores.metadata,
+    (store) =>
+      getConditionOverrideSelector(store.editor.jsxMetadata, store.editor.selectedViews) !==
+      'not-a-conditional',
+    'Inspector isConditionalSelected',
+  )
+
   React.useEffect(() => {
     setSelectedTarget(targets[0].path)
   }, [selectedViews, targets, setSelectedTarget])
@@ -348,29 +360,37 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
             display: shouldShowInspector ? undefined : 'none',
           }}
         >
-          <AlignmentButtons numberOfTargets={selectedViews.length} />
+          {unless(
+            isConditionalSelected,
+            <AlignmentButtons numberOfTargets={selectedViews.length} />,
+          )}
           {when(isTwindEnabled(), <ClassNameSubsection />)}
           {anyComponents ? <ComponentSection isScene={false} /> : null}
           <ConditionalSection paths={selectedViews} />
-          <TargetSelectorSection
-            targets={props.targets}
-            selectedTargetPath={props.selectedTargetPath}
-            onSelectTarget={props.onSelectTarget}
-            onStyleSelectorRename={props.onStyleSelectorRename}
-            onStyleSelectorDelete={props.onStyleSelectorDelete}
-            onStyleSelectorInsert={props.onStyleSelectorInsert}
-          />
-          <PositionSection
-            hasNonDefaultPositionAttributes={hasNonDefaultPositionAttributes}
-            aspectRatioLocked={aspectRatioLocked}
-            toggleAspectRatioLock={toggleAspectRatioLock}
-          />
-          <SizingSection />
-          <FlexSection />
-          <StyleSection />
-          <WarningSubsection />
-          <ImgSection />
-          <EventHandlersSection />
+          {unless(
+            isConditionalSelected,
+            <>
+              <TargetSelectorSection
+                targets={props.targets}
+                selectedTargetPath={props.selectedTargetPath}
+                onSelectTarget={props.onSelectTarget}
+                onStyleSelectorRename={props.onStyleSelectorRename}
+                onStyleSelectorDelete={props.onStyleSelectorDelete}
+                onStyleSelectorInsert={props.onStyleSelectorInsert}
+              />
+              <PositionSection
+                hasNonDefaultPositionAttributes={hasNonDefaultPositionAttributes}
+                aspectRatioLocked={aspectRatioLocked}
+                toggleAspectRatioLock={toggleAspectRatioLock}
+              />
+              <SizingSection />
+              <FlexSection />
+              <StyleSection />
+              <WarningSubsection />
+              <ImgSection />
+              <EventHandlersSection />
+            </>,
+          )}
         </div>
       </React.Fragment>
     )

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -84,10 +84,7 @@ import { useDispatch } from '../editor/store/dispatch-context'
 import { styleStringInArray } from '../../utils/common-constants'
 import { SizingSection } from './sizing-section'
 import { PositionSection } from './sections/layout-section/position-section'
-import {
-  ConditionalSection,
-  getConditionOverrideSelector,
-} from './sections/layout-section/conditional-section'
+import { ConditionalSection } from './sections/layout-section/conditional-section'
 import { GroupSection } from './convert-to-group-dropdown'
 
 export interface ElementPathElement {
@@ -248,11 +245,14 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
   const colorTheme = useColorTheme()
   const { selectedViews, setSelectedTarget, targets } = props
 
-  const isConditionalSelected = useEditorState(
+  const onlyConditionalsSelected = useEditorState(
     Substores.metadata,
     (store) =>
-      getConditionOverrideSelector(store.editor.jsxMetadata, store.editor.selectedViews) !==
-      'not-a-conditional',
+      store.editor.selectedViews.every((path) =>
+        MetadataUtils.isConditionalFromMetadata(
+          MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, path),
+        ),
+      ),
     'Inspector isConditionalSelected',
   )
 
@@ -361,14 +361,16 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
           }}
         >
           {unless(
-            isConditionalSelected,
-            <AlignmentButtons numberOfTargets={selectedViews.length} />,
+            onlyConditionalsSelected,
+            <>
+              <AlignmentButtons numberOfTargets={selectedViews.length} />
+              {when(isTwindEnabled(), <ClassNameSubsection />)}
+              {anyComponents ? <ComponentSection isScene={false} /> : null}
+            </>,
           )}
-          {when(isTwindEnabled(), <ClassNameSubsection />)}
-          {anyComponents ? <ComponentSection isScene={false} /> : null}
           <ConditionalSection paths={selectedViews} />
           {unless(
-            isConditionalSelected,
+            onlyConditionalsSelected,
             <>
               <TargetSelectorSection
                 targets={props.targets}

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -106,50 +106,44 @@ const branchNavigatorEntriesSelector = createCachedSelector(
   },
 )((_, paths) => paths.map(EP.toString).join(','))
 
-export function getConditionOverrideSelector(
-  jsxMetadata: ElementInstanceMetadataMap,
-  paths: ElementPath[],
-): ConditionOverride {
-  const elements = mapDropNulls((path) => {
-    const elementMetadata = MetadataUtils.findElementByElementPath(jsxMetadata, path)
-    if (
-      elementMetadata == null ||
-      isLeft(elementMetadata.element) ||
-      !isJSXConditionalExpression(elementMetadata.element.value)
-    ) {
-      return null
-    }
-
-    return elementMetadata.element.value
-  }, paths)
-
-  if (elements.length === 0) {
-    return 'not-a-conditional'
-  }
-
-  let conditions = new Set<boolean | null>()
-  elements.forEach((element) => {
-    const flag = findUtopiaCommentFlag(element.comments, 'conditional')
-    if (isUtopiaCommentFlagConditional(flag)) {
-      conditions.add(flag.value)
-    }
-  })
-
-  switch (conditions.size) {
-    case 0:
-      return 'not-overridden'
-    case 1:
-      return conditions.values().next().value ?? 'not-overridden'
-    default:
-      return 'mixed'
-  }
-}
-
 const conditionOverrideSelector = createCachedSelector(
   (store: MetadataSubstate) => store.editor.jsxMetadata,
   (_store: MetadataSubstate, paths: ElementPath[]) => paths,
-  (jsxMetadata: ElementInstanceMetadataMap, paths: ElementPath[]): ConditionOverride =>
-    getConditionOverrideSelector(jsxMetadata, paths),
+  (jsxMetadata: ElementInstanceMetadataMap, paths: ElementPath[]): ConditionOverride => {
+    const elements = mapDropNulls((path) => {
+      const elementMetadata = MetadataUtils.findElementByElementPath(jsxMetadata, path)
+      if (
+        elementMetadata == null ||
+        isLeft(elementMetadata.element) ||
+        !isJSXConditionalExpression(elementMetadata.element.value)
+      ) {
+        return null
+      }
+
+      return elementMetadata.element.value
+    }, paths)
+
+    if (elements.length === 0) {
+      return 'not-a-conditional'
+    }
+
+    let conditions = new Set<boolean | null>()
+    elements.forEach((element) => {
+      const flag = findUtopiaCommentFlag(element.comments, 'conditional')
+      if (isUtopiaCommentFlagConditional(flag)) {
+        conditions.add(flag.value)
+      }
+    })
+
+    switch (conditions.size) {
+      case 0:
+        return 'not-overridden'
+      case 1:
+        return conditions.values().next().value ?? 'not-overridden'
+      default:
+        return 'mixed'
+    }
+  },
 )((_, paths) => paths.map(EP.toString).join(','))
 
 const conditionOverrideToControlStatus = (conditionOverride: ConditionOverride): ControlStatus => {

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`578`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`579`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`650`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`651`)
   })
 })

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`577`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`578`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`649`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`650`)
   })
 })


### PR DESCRIPTION
# Try it [here](https://utopia.pizza/p/ac9485df-indecisive-peridot/?branch_name=feature-hide-inspector-sections-when-conditional-selected)

## Description
This PR takes the first step towards separating control structures from DOM elements in the inspector, by hiding all inspector sections other than conditional when a conditional is selected.