### PR TITLE
Pin data.aeson version in the server plus a shell.nix tweak

### DIFF
--- a/server/package.yaml
+++ b/server/package.yaml
@@ -26,7 +26,7 @@ flags:
     manual: true
     default: true
 dependencies:
-  - aeson >=2.0
+  - aeson ==2.0.3.0
   - aeson-pretty
   - aws
   - base >= 4.7 && < 5
@@ -60,7 +60,7 @@ dependencies:
   - http-types
   - JuicyPixels
   - lens
-  - lens-aeson 
+  - lens-aeson
   - lifted-async
   - lifted-base
   - magic
@@ -82,14 +82,14 @@ dependencies:
   - protolude
   - resource-pool
   - rio
-  - servant 
+  - servant
   - servant-blaze
-  - servant-client 
+  - servant-client
   - servant-conduit
   - servant-rawm-client
   - servant-rawm-server
   - servant-server
-  - servant-websockets 
+  - servant-websockets
   - serversession ==1.0.2
   - split
   - string-conversions
@@ -121,8 +121,8 @@ extra-libraries:
 executable:
   main: Main.hs
   source-dirs:
-      - src
-      - app
+    - src
+    - app
 tests:
   utopia-web-test:
     when:

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -67,7 +67,7 @@ executable utopia-web
       z
   build-depends:
       JuicyPixels
-    , aeson >=2.0
+    , aeson ==2.0.3.0
     , aeson-pretty
     , aws
     , base >=4.7 && <5
@@ -207,7 +207,7 @@ test-suite utopia-web-test
       z
   build-depends:
       JuicyPixels
-    , aeson >=2.0
+    , aeson ==2.0.3.0
     , aeson-pretty
     , aws
     , base >=4.7 && <5

--- a/shell.nix
+++ b/shell.nix
@@ -613,4 +613,6 @@ in pkgs.mkShell {
   ELECTRON_OVERRIDE_DIST_PATH = if stdenv.isLinux then "${pkgs.electron}/bin" else null;
   # Required for webpack builds
   NODE_OPENSSL_OPTION = "--openssl-legacy-provider";
+  # Required for node-gyp, apparently
+  npm_config_force_process_config = true;
 }


### PR DESCRIPTION
We need to use 2.0.3.0 of data.aeson as the next minor version introduced a change in one of the types we use that breaks the build.

This PR also includes an environment variable `npm_config_force_process_config = true;` which suddenly became necessary for me locally. This is something that was already fixed in the docker build used for deploying, but I hadn't added to the shell.nix as it didn't seem to be necessary locally. It seems it actually was needed locally. This is for fixing a node-gyp issue that crops up as part of building the version of VS Code we use:
```name 'openssl_fips' is not defined while evaluating condition 'openssl_fips != ""' in binding.gyp```
The fix for this is for individual packages to specify an empty variable `"openssl_fips": "",` in their binding.gyp file, but that is missing in a dependency of that version of VS Code, so the above env var forces node-gyp to use the runtime's process.config object to generate the config.gypi file, which will set that empty variable.

This PR is going to be merged immediately, and only exists for posterity.