### PR TITLE
Better toasts

### DIFF
--- a/editor/src/components/common/notices.tsx
+++ b/editor/src/components/common/notices.tsx
@@ -27,6 +27,18 @@ export const getStylesForLevel = (level: NoticeLevel): React.CSSProperties => {
   return resultingStyle
 }
 
+export const getPrefixForLevel = (level: NoticeLevel): string => {
+  let resultingPrefix = ''
+  if (level === 'WARNING') {
+    resultingPrefix = '﹗'
+  } else if (level === 'ERROR') {
+    resultingPrefix = '⚠️'
+  } else if (level === 'SUCCESS') {
+    resultingPrefix = '✓'
+  }
+  return resultingPrefix
+}
+
 const ToastTimeout = 5500
 
 /**
@@ -53,11 +65,18 @@ export const Toast: React.FunctionComponent<React.PropsWithChildren<NoticeProps>
     <div
       key={'toast-item'}
       style={{
+        background: '#111',
         ...getStylesForLevel(props.level ?? 'INFO'),
-        boxShadow: UtopiaStyles.shadowStyles.medium.boxShadow,
-        borderRadius: 3,
-        width: 270,
+        borderRadius: 6,
+        boxShadow:
+          '0px 0px .5px rgba(0, 0, 0, .12), 0px 10px 16px rgba(0, 0, 0, .12), 0px 2px 5px rgba(0, 0, 0, .15), 0px 2px 14px rgba(0, 0, 0, .15), 0px 0px 0px 0.5px rgba(0, 0, 0, .2)',
+        color: 'white',
+        width: 290,
         minHeight: 27,
+        fontSize: 12,
+        fontWeight: 400,
+        letterSpacing: 0.2,
+        fontFamily: 'utopian-Inter',
         overflow: 'hidden',
         overflowWrap: 'break-word',
         wordWrap: 'break-word',
@@ -69,33 +88,32 @@ export const Toast: React.FunctionComponent<React.PropsWithChildren<NoticeProps>
       }}
     >
       <div
-        style={{ flexGrow: 1, fontWeight: 500, padding: 8, display: 'flex', alignItems: 'center' }}
+        style={{ flexGrow: 1, padding: 8, display: 'flex', alignItems: 'center' }}
         id='toast-message'
       >
+        {getPrefixForLevel(props.level)}&nbsp;
         {props.message}
       </div>
-
-      <div
-        css={{
-          backgroundColor: 'hsl(0,0%,0%,3%)',
-          display: 'flex',
-          flex: '0 0 24px',
-          alignItems: 'center',
-          justifyContent: 'center',
-          fontSize: 14,
-          cursor: 'pointer',
-          '&:hover': {
-            backgroundColor: 'hsl(0,0%,0%,5%)',
-          },
-          '&:active': {
-            backgroundColor: 'hsl(0,0%,0%,6%)',
-          },
-        }}
-        onClick={deleteToast}
-        id='toast-button'
-      >
-        ×
-      </div>
+      {props.persistent ? (
+        <div
+          css={{
+            display: 'flex',
+            flex: '0 0 24px',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: 14,
+            cursor: 'pointer',
+            opacity: 0.3,
+            '&:hover': {
+              opacity: 1,
+            },
+          }}
+          onClick={deleteToast}
+          id='toast-button'
+        >
+          ×
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/editor/src/components/common/notices.tsx
+++ b/editor/src/components/common/notices.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import { UtopiaStyles, SimpleFlexRow, UtopiaTheme, SimpleFlexColumn } from '../../uuiui'
 import { Notice, NoticeLevel } from './notice'
 import { useDispatch } from '../editor/store/dispatch-context'
+import { assertNever } from '../../core/shared/utils'
 
 interface NoticeProps extends Notice {
   style?: React.CSSProperties
@@ -15,28 +16,35 @@ interface NoticeProps extends Notice {
 export const getStylesForLevel = (level: NoticeLevel): React.CSSProperties => {
   let resultingStyle = UtopiaStyles.noticeStyles.info
 
-  if (level === 'WARNING') {
-    resultingStyle = UtopiaStyles.noticeStyles.warning
-  } else if (level === 'ERROR') {
-    resultingStyle = UtopiaStyles.noticeStyles.error
-  } else if (level === 'SUCCESS') {
-    resultingStyle = UtopiaStyles.noticeStyles.success
-  } else if (level === 'PRIMARY') {
-    resultingStyle = UtopiaStyles.noticeStyles.primary
+  switch (level) {
+    case 'WARNING':
+      return UtopiaStyles.noticeStyles.warning
+    case 'ERROR':
+      return UtopiaStyles.noticeStyles.error
+    case 'SUCCESS':
+      return UtopiaStyles.noticeStyles.success
+    case 'PRIMARY':
+      return UtopiaStyles.noticeStyles.primary
+    case 'INFO':
+      return UtopiaStyles.noticeStyles.info
+    case 'NOTICE':
+      return UtopiaStyles.noticeStyles.notice
+    default:
+      assertNever(level)
   }
-  return resultingStyle
 }
 
 export const getPrefixForLevel = (level: NoticeLevel): string => {
-  let resultingPrefix = ''
-  if (level === 'WARNING') {
-    resultingPrefix = '﹗'
-  } else if (level === 'ERROR') {
-    resultingPrefix = '⚠️'
-  } else if (level === 'SUCCESS') {
-    resultingPrefix = '✓'
+  switch (level) {
+    case 'WARNING':
+      return '﹗'
+    case 'ERROR':
+      return '⚠️'
+    case 'SUCCESS':
+      return '✓'
+    default:
+      return ''
   }
-  return resultingPrefix
 }
 
 const ToastTimeout = 5500

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -494,12 +494,14 @@ const ToastRenderer = React.memo(() => {
       key={'toast-stack'}
       style={{
         position: 'fixed',
-        bottom: 40,
+        bottom: 8,
         justifyContent: 'center',
-        left: '30%',
-        overflow: 'scroll',
-        maxHeight: '50%',
+        right: 260,
         zIndex: 100,
+        // padding required to not cut off the boxShadow on each toast
+        paddingTop: 50,
+        paddingLeft: 50,
+        paddingRight: 50,
       }}
     >
       {toasts.map((toast, index) => (

--- a/editor/src/uuiui/styles/theme/base.ts
+++ b/editor/src/uuiui/styles/theme/base.ts
@@ -11,6 +11,7 @@ export const base = {
   jsYellow: createUtopiColor('#b7b73b'),
   almostBlack: createUtopiColor('hsl(0,0%,10%)'),
   white: createUtopiColor('white'),
+  offWhite: createUtopiColor('#eee'),
   black: createUtopiColor('black'),
   darkgray: createUtopiColor('hsl(0, 0%, 50%)'),
   darkorange: createUtopiColor('#D05300'),

--- a/editor/src/uuiui/styles/theme/utopia-theme.ts
+++ b/editor/src/uuiui/styles/theme/utopia-theme.ts
@@ -115,39 +115,33 @@ const backgroundURLs = {
 // see type AlertLevel in editor-state.ts
 
 const noticeStyles: { [styleName: string]: React.CSSProperties } = {
-  success: {
-    backgroundColor: base.neongreen.cssValue,
-    backgroundImage: backgroundURLs.green,
-    color: 'white',
-  },
   info: {
-    backgroundColor: '#f1f1f1',
-    color: colorTheme.darkPrimary.value,
+    backgroundColor: base.almostBlack.cssValue,
+    color: base.offWhite.cssValue,
   },
-  primary: {
-    backgroundColor: base.blue.cssValue,
-    backgroundImage: backgroundURLs.blue,
-    color: 'white',
+  warning: {
+    backgroundColor: base.almostBlack.cssValue,
+    color: base.offWhite.cssValue,
   },
   notice: {
     backgroundColor: base.blue.cssValue,
-    backgroundImage: backgroundURLs.paleblue,
     color: 'white',
   },
-  warning: {
-    backgroundColor: base.red.cssValue,
-    backgroundImage: backgroundURLs.red,
-    color: 'white',
+  success: {
+    backgroundColor: base.blue.cssValue,
+    color: base.offWhite.cssValue,
+  },
+  primary: {
+    backgroundColor: base.blue.cssValue,
+    color: base.offWhite.cssValue,
   },
   error: {
-    backgroundColor: base.almostBlack.cssValue,
-    backgroundImage: backgroundURLs.almostBlack,
-    color: 'white',
+    backgroundColor: base.red.cssValue,
+    color: base.offWhite.cssValue,
   },
   disconnected: {
     backgroundColor: base.almostBlack.cssValue,
-    backgroundImage: backgroundURLs.noise,
-    color: 'white',
+    color: base.offWhite.cssValue,
   },
 }
 


### PR DESCRIPTION
**Problem:**
Our toast visibility was both too low (from afar) and too visually distracting (from up close)

**Fix:**
Redesigned toasts. 

- Lower levels (info, warning) now look v similar to each other
- Higher levels (primary, notice, error) look more pronounced and get icons
- Shadows blend in more, and x-to-dismiss is substantially de-emphasized

NB this does not address (prior) z-index issues (eg toasts should be below toolbar), pending the other changes to editor layout.

<img width="697" alt="image" src="https://user-images.githubusercontent.com/2945037/233629915-dd53955d-28c3-4314-ad89-a8497c234b97.png">

