### PR TITLE
Feat/conditionals navigator active branch checkmark

### DIFF
--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -173,19 +173,13 @@ export function getConditionalActiveCase(
   conditional: JSXConditionalExpression,
   spyMetadata: ElementInstanceMetadataMap,
 ): ConditionalCase | null {
-  function fromBoolean(v: boolean): ConditionalCase {
-    return v ? 'true-case' : 'false-case'
-  }
-
   const override = getConditionalFlag(conditional)
   if (override != null) {
-    return fromBoolean(override)
+    return override ? 'true-case' : 'false-case'
   }
-
   const spy = spyMetadata[EP.toString(path)] ?? true
   if (spy.conditionValue === 'not-a-conditional') {
     return null
   }
-
-  return fromBoolean(spy.conditionValue)
+  return spy.conditionValue ? 'true-case' : 'false-case'
 }

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -167,3 +167,19 @@ export function maybeBranchConditionalCase(
     return null
   }
 }
+
+export function getConditionalActiveCase(
+  path: ElementPath,
+  conditional: JSXConditionalExpression,
+  spyMetadata: ElementInstanceMetadataMap,
+): ConditionalCase | null {
+  const override = getConditionalFlag(conditional)
+  if (override != null) {
+    return override ? 'true-case' : 'false-case'
+  }
+  const spy = spyMetadata[EP.toString(path)] ?? true
+  if (spy.conditionValue === 'not-a-conditional') {
+    return null
+  }
+  return spy.conditionValue ? 'true-case' : 'false-case'
+}

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -173,13 +173,19 @@ export function getConditionalActiveCase(
   conditional: JSXConditionalExpression,
   spyMetadata: ElementInstanceMetadataMap,
 ): ConditionalCase | null {
+  function fromBoolean(v: boolean): ConditionalCase {
+    return v ? 'true-case' : 'false-case'
+  }
+
   const override = getConditionalFlag(conditional)
   if (override != null) {
-    return override ? 'true-case' : 'false-case'
+    return fromBoolean(override)
   }
+
   const spy = spyMetadata[EP.toString(path)] ?? true
   if (spy.conditionValue === 'not-a-conditional') {
     return null
   }
-  return spy.conditionValue ? 'true-case' : 'false-case'
+
+  return fromBoolean(spy.conditionValue)
 }


### PR DESCRIPTION
Fixes #3573 

This PR adds a checkmark displayed to the left side of a conditional clause label in the navigator.

Also, since the original label component was a class component and pretty hard to deal with, this PR also refactors that component to be a functional one.

Also, added a test for the existing renaming feature which was untested.

![Kapture 2023-04-21 at 15 41 11](https://user-images.githubusercontent.com/1081051/233651019-a532f967-8042-40de-be10-3c067212e772.gif)
