### PR TITLE
Accent on overridden conditional navigator labels

### DIFF
--- a/editor/src/components/navigator/navigator-item/item-label.tsx
+++ b/editor/src/components/navigator/navigator-item/item-label.tsx
@@ -35,36 +35,6 @@ interface ItemLabelProps {
   style?: CSSProperties
 }
 
-export const isActiveBranchOfOverriddenConditionalSelector = createCachedSelector(
-  (store: MetadataSubstate, _elementPath: ElementPath, parentPath: ElementPath) =>
-    MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, parentPath),
-  (_store: MetadataSubstate, elementPath: ElementPath, _parentPath: ElementPath) => elementPath,
-  (_store: MetadataSubstate, _elementPath: ElementPath, parentPath: ElementPath) => parentPath,
-  (parent: ElementInstanceMetadata | null, elementPath: ElementPath, parentPath: ElementPath) => {
-    const conditionalParent = maybeConditionalExpression(parent)
-    if (conditionalParent == null) {
-      return false
-    }
-    const parentOverride = getConditionalFlag(conditionalParent)
-    if (parentOverride == null) {
-      return false
-    }
-
-    return (
-      matchesOverriddenConditionalBranch(elementPath, parentPath, {
-        clause: conditionalParent.whenTrue,
-        wantOverride: true,
-        parentOverride: parentOverride,
-      }) ||
-      matchesOverriddenConditionalBranch(elementPath, parentPath, {
-        clause: conditionalParent.whenFalse,
-        wantOverride: false,
-        parentOverride: parentOverride,
-      })
-    )
-  },
-)((_, elementPath, parentPath) => `${EP.toString(elementPath)}_${EP.toString(parentPath)}`)
-
 export const ItemLabel = React.memo((props: ItemLabelProps) => {
   const {
     name: propsName,

--- a/editor/src/components/navigator/navigator-item/item-label.tsx
+++ b/editor/src/components/navigator/navigator-item/item-label.tsx
@@ -1,27 +1,21 @@
-import createCachedSelector from 're-reselect'
 import React, { CSSProperties } from 'react'
 import {
   isConditionalClauseNavigatorEntry,
   isRegularNavigatorEntry,
   NavigatorEntry,
+  varSafeNavigatorEntryToKey,
 } from '../../../components/editor/store/editor-state'
 import {
   findMaybeConditionalExpression,
   getConditionalActiveCase,
   getConditionalFlag,
-  matchesOverriddenConditionalBranch,
-  maybeConditionalExpression,
 } from '../../../core/model/conditionals'
-import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import * as EP from '../../../core/shared/element-path'
-import { ElementInstanceMetadata } from '../../../core/shared/element-template'
-import { ElementPath } from '../../../core/shared/project-file-types'
-import { colorTheme, flexRowStyle, Icons, StringInput } from '../../../uuiui'
+import { colorTheme, flexRowStyle, StringInput } from '../../../uuiui'
 import { EditorDispatch } from '../../editor/action-types'
 import * as EditorActions from '../../editor/actions/action-creators'
 import { Substores, useEditorState } from '../../editor/store/store-hook'
-import { MetadataSubstate } from '../../editor/store/store-hook-substore-types'
 import { renameComponent } from '../actions'
+import { NavigatorItemTestId } from './navigator-item'
 
 interface ItemLabelProps {
   testId: string
@@ -203,6 +197,7 @@ export const ItemLabel = React.memo((props: ItemLabelProps) => {
       ) : (
         <div
           key='item-label'
+          data-testid={`${NavigatorItemTestId(varSafeNavigatorEntryToKey(target))}-label`}
           style={{
             backgroundColor: 'transparent',
             paddingTop: 3,

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -1,16 +1,27 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/react'
+import createCachedSelector from 're-reselect'
 import React from 'react'
+import {
+  getConditionalClausePath,
+  getConditionalFlag,
+  maybeConditionalExpression,
+} from '../../../core/model/conditionals'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import * as EP from '../../../core/shared/element-path'
+import { ElementInstanceMetadata } from '../../../core/shared/element-template'
 import { ElementPath } from '../../../core/shared/project-file-types'
+import { getValueFromComplexMap } from '../../../utils/map'
+import { unless, when } from '../../../utils/react-conditionals'
+import { useKeepReferenceEqualityIfPossible } from '../../../utils/react-performance'
+import { FlexRow, IcnProps, useColorTheme, UtopiaTheme } from '../../../uuiui'
+import { ThemeObject } from '../../../uuiui/styles/theme/theme-helpers'
+import { isEntryAConditionalSlot } from '../../canvas/canvas-utils'
+import { ChildWithPercentageSize } from '../../common/size-warnings'
 import { EditorDispatch } from '../../editor/action-types'
 import * as EditorActions from '../../editor/actions/action-creators'
 import * as MetaActions from '../../editor/actions/meta-actions'
-import * as EP from '../../../core/shared/element-path'
-import { ExpandableIndicator } from './expandable-indicator'
-import { ItemLabel } from './item-label'
-import { ComponentPreview } from './component-preview'
-import { NavigatorItemActionSheet } from './navigator-item-components'
 import {
   defaultElementWarnings,
   isConditionalClauseNavigatorEntry,
@@ -19,32 +30,14 @@ import {
   navigatorEntryToKey,
   varSafeNavigatorEntryToKey,
 } from '../../editor/store/editor-state'
-import { ChildWithPercentageSize } from '../../common/size-warnings'
-import { useKeepReferenceEqualityIfPossible } from '../../../utils/react-performance'
-import { IcnProps, useColorTheme, UtopiaStyles, UtopiaTheme, FlexRow } from '../../../uuiui'
-import { LayoutIcon } from './layout-icon'
 import { Substores, useEditorState } from '../../editor/store/store-hook'
-import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { ThemeObject } from '../../../uuiui/styles/theme/theme-helpers'
-import { unless, when } from '../../../utils/react-conditionals'
-import { isLeft, isRight } from '../../../core/shared/either'
-import {
-  ElementInstanceMetadata,
-  isJSXAttributeValue,
-  isJSXConditionalExpression,
-  isNullJSXAttributeValue,
-  JSXConditionalExpression,
-} from '../../../core/shared/element-template'
-import {
-  getConditionalClausePath,
-  getConditionalFlag,
-  matchesOverriddenConditionalBranch,
-} from '../../../core/model/conditionals'
 import { DerivedSubstate, MetadataSubstate } from '../../editor/store/store-hook-substore-types'
 import { getConditionalClausePathForNavigatorEntry, navigatorDepth } from '../navigator-utils'
-import createCachedSelector from 're-reselect'
-import { getValueFromComplexMap } from '../../../utils/map'
-import { isEntryAConditionalSlot } from '../../canvas/canvas-utils'
+import { ComponentPreview } from './component-preview'
+import { ExpandableIndicator } from './expandable-indicator'
+import { ItemLabel } from './item-label'
+import { LayoutIcon } from './layout-icon'
+import { NavigatorItemActionSheet } from './navigator-item-components'
 
 export function getItemHeight(navigatorEntry: NavigatorEntry): number {
   if (isConditionalClauseNavigatorEntry(navigatorEntry)) {
@@ -319,7 +312,7 @@ const isHiddenConditionalBranchSelector = createCachedSelector(
       return false
     }
 
-    const conditional = asConditional(parent)
+    const conditional = maybeConditionalExpression(parent)
     if (conditional == null) {
       return false
     }
@@ -337,36 +330,6 @@ const isHiddenConditionalBranchSelector = createCachedSelector(
     // when the condition is false, then the 'else' branch is not hidden
     const falseClausePath = getConditionalClausePath(parentPath, conditional.whenFalse)
     return !EP.pathsEqual(elementPath, falseClausePath)
-  },
-)((_, elementPath, parentPath) => `${EP.toString(elementPath)}_${EP.toString(parentPath)}`)
-
-const isActiveBranchOfOverriddenConditionalSelector = createCachedSelector(
-  (store: MetadataSubstate, _elementPath: ElementPath, parentPath: ElementPath) =>
-    MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, parentPath),
-  (_store: MetadataSubstate, elementPath: ElementPath, _parentPath: ElementPath) => elementPath,
-  (_store: MetadataSubstate, _elementPath: ElementPath, parentPath: ElementPath) => parentPath,
-  (parent: ElementInstanceMetadata | null, elementPath: ElementPath, parentPath: ElementPath) => {
-    const conditionalParent = asConditional(parent)
-    if (conditionalParent == null) {
-      return false
-    }
-    const parentOverride = getConditionalFlag(conditionalParent)
-    if (parentOverride == null) {
-      return false
-    }
-
-    return (
-      matchesOverriddenConditionalBranch(elementPath, parentPath, {
-        clause: conditionalParent.whenTrue,
-        wantOverride: true,
-        parentOverride: parentOverride,
-      }) ||
-      matchesOverriddenConditionalBranch(elementPath, parentPath, {
-        clause: conditionalParent.whenFalse,
-        wantOverride: false,
-        parentOverride: parentOverride,
-      })
-    )
   },
 )((_, elementPath, parentPath) => `${EP.toString(elementPath)}_${EP.toString(parentPath)}`)
 
@@ -643,40 +606,6 @@ interface NavigatorRowLabelProps {
 export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
   const colorTheme = useColorTheme()
 
-  const element = useEditorState(
-    Substores.metadata,
-    (store) => {
-      return MetadataUtils.findElementByElementPath(
-        store.editor.jsxMetadata,
-        props.navigatorEntry.elementPath,
-      )
-    },
-    'NavigatorRowLabel element',
-  )
-
-  const conditionalOverride = React.useMemo(() => {
-    const conditional = asConditional(element)
-    if (conditional == null) {
-      return null
-    }
-    return getConditionalFlag(conditional)
-  }, [element])
-
-  const isActiveBranchOfOverriddenConditional = useEditorState(
-    Substores.metadata,
-    (store) => {
-      return (
-        isConditionalClauseNavigatorEntry(props.navigatorEntry) &&
-        isActiveBranchOfOverriddenConditionalSelector(
-          store,
-          props.navigatorEntry.elementPath,
-          EP.parentPath(props.navigatorEntry.elementPath),
-        )
-      )
-    },
-    'NavigatorRowLabel isActiveBranchOfOverriddenConditional',
-  )
-
   return (
     <React.Fragment>
       {when(
@@ -724,31 +653,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
             selected={props.selected}
             dispatch={props.dispatch}
             inputVisible={EP.pathsEqual(props.renamingTarget, props.navigatorEntry.elementPath)}
-            style={{
-              color:
-                !props.selected && isActiveBranchOfOverriddenConditional
-                  ? colorTheme.brandNeonPink.value
-                  : 'inherit',
-            }}
           />
-
-          {when(
-            conditionalOverride != null && props.navigatorEntry.type !== 'CONDITIONAL_CLAUSE',
-            <div
-              style={{
-                marginLeft: 10,
-                color: colorTheme.bg0.value,
-                background: colorTheme.brandNeonPink.value,
-                borderRadius: 10,
-                padding: '0px 6px',
-                fontWeight: 600,
-                textTransform: 'uppercase',
-                fontSize: 9,
-              }}
-            >
-              {conditionalOverride ? 'True' : 'False'}
-            </div>,
-          )}
         </React.Fragment>,
       )}
       <ComponentPreview
@@ -759,14 +664,3 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
     </React.Fragment>
   )
 })
-
-function asConditional(element: ElementInstanceMetadata | null): JSXConditionalExpression | null {
-  if (
-    element == null ||
-    isLeft(element.element) ||
-    !isJSXConditionalExpression(element.element.value)
-  ) {
-    return null
-  }
-  return element.element.value
-}


### PR DESCRIPTION
Fixes #3577 

This PR adjusts the navigator displaying of overridden conditional branches by removing the pill-shaped label from the conditional root and using the `brandNeonPink` color for the overridden branch.

| Old | New |
|-----|-----|
|<img width="842" alt="Screenshot 2023-04-24 at 2 26 30 PM" src="https://user-images.githubusercontent.com/1081051/233995880-e0cf0742-cd89-4827-af5d-48ee075c6537.png">|<img width="841" alt="Screenshot 2023-04-24 at 2 26 43 PM" src="https://user-images.githubusercontent.com/1081051/233995929-e2699907-b970-4e66-8203-909809884137.png">|
