### PR TITLE
Fix/reparent wiggle 2

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -41,35 +41,41 @@ export const NavigatorHintTop = React.forwardRef<HTMLDivElement, NavigatorHintPr
         <div
           style={{
             opacity: props.shouldBeShown ? 1 : 0,
-            marginLeft: props.margin,
             position: 'absolute',
             top: -6,
             width: '100%',
-            display: 'flex',
-            flexDirection: 'row',
-            alignItems: 'center',
-            justifyContent: 'flex-start',
             height: 16,
           }}
         >
           <div
             style={{
-              backgroundColor: colorTheme.navigatorResizeHintBorder.value,
-              height: 2,
-              flexGrow: 1,
+              marginLeft: props.margin,
+              height: '100%',
+              display: 'flex',
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'flex-start',
             }}
-          />
-          <div
-            style={{
-              position: 'absolute',
-              backgroundColor: colorTheme.bg0.value,
-              width: NavigatorHintCircleDiameter,
-              height: NavigatorHintCircleDiameter,
-              contain: 'layout',
-              border: `2px solid ${colorTheme.navigatorResizeHintBorder.value}`,
-              borderRadius: '50%',
-            }}
-          />
+          >
+            <div
+              style={{
+                backgroundColor: colorTheme.navigatorResizeHintBorder.value,
+                height: 2,
+                flexGrow: 1,
+              }}
+            />
+            <div
+              style={{
+                position: 'absolute',
+                backgroundColor: colorTheme.bg0.value,
+                width: NavigatorHintCircleDiameter,
+                height: NavigatorHintCircleDiameter,
+                contain: 'layout',
+                border: `2px solid ${colorTheme.navigatorResizeHintBorder.value}`,
+                borderRadius: '50%',
+              }}
+            />
+          </div>
         </div>
       </div>
     )
@@ -92,35 +98,41 @@ export const NavigatorHintBottom = React.forwardRef<HTMLDivElement, NavigatorHin
         <div
           style={{
             opacity: props.shouldBeShown ? 1 : 0,
-            marginLeft: props.margin,
             position: 'absolute',
             bottom: -8,
             width: '100%',
-            display: 'flex',
-            flexDirection: 'row',
-            alignItems: 'center',
-            justifyContent: 'flex-start',
             height: 16,
           }}
         >
           <div
             style={{
-              backgroundColor: colorTheme.navigatorResizeHintBorder.value,
-              height: 2,
-              flexGrow: 1,
+              marginLeft: props.margin,
+              height: '100%',
+              display: 'flex',
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'flex-start',
             }}
-          />
-          <div
-            style={{
-              position: 'absolute',
-              backgroundColor: colorTheme.bg0.value,
-              width: NavigatorHintCircleDiameter,
-              height: NavigatorHintCircleDiameter,
-              contain: 'layout',
-              border: `2px solid ${colorTheme.navigatorResizeHintBorder.value}`,
-              borderRadius: '50%',
-            }}
-          />
+          >
+            <div
+              style={{
+                backgroundColor: colorTheme.navigatorResizeHintBorder.value,
+                height: 2,
+                flexGrow: 1,
+              }}
+            />
+            <div
+              style={{
+                position: 'absolute',
+                backgroundColor: colorTheme.bg0.value,
+                width: NavigatorHintCircleDiameter,
+                height: NavigatorHintCircleDiameter,
+                contain: 'layout',
+                border: `2px solid ${colorTheme.navigatorResizeHintBorder.value}`,
+                borderRadius: '50%',
+              }}
+            />
+          </div>
         </div>
       </div>
     )

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -411,7 +411,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
       }),
       item: props,
       beginDrag: beginDrag,
-      canDrag: (monitor) => {
+      canDrag: () => {
         const editorState = editorStateRef.current
         const regularCanReparent =
           isRegularNavigatorEntry(props.navigatorEntry) &&
@@ -519,7 +519,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
     [props],
   )
 
-  const [{ isOver: isOverParentOutline }, reparentDropRef] = useDrop<
+  const [, reparentDropRef] = useDrop<
     NavigatorItemDragAndDropWrapperProps,
     unknown,
     DropCollectedProps
@@ -600,7 +600,10 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
 
   const parentOutline = React.useMemo((): ParentOutline => {
     if (dropTargetHintType !== 'reparent') {
-      return 'none'
+      return moveToEntry != null &&
+        EP.pathsEqual(EP.parentPath(moveToEntry.elementPath), props.navigatorEntry.elementPath)
+        ? 'solid'
+        : 'none'
     }
 
     if (isConditionalRoot(moveToEntry, metadata)) {
@@ -635,12 +638,8 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
       return 'solid'
     }
 
-    if (isOverParentOutline) {
-      return 'solid'
-    }
-
     return 'none'
-  }, [dropTargetHintType, moveToEntry, metadata, props.navigatorEntry, isOverParentOutline])
+  }, [dropTargetHintType, moveToEntry, metadata, props.navigatorEntry])
 
   const isFirstSibling = React.useMemo(() => {
     if (!isRegularNavigatorEntry(props.navigatorEntry)) {


### PR DESCRIPTION
## Problem
The reparent outline in the navigator is shown in a confusing way.

## Fix 

The drop target lines/parent outline should work according to the following:
- The parent outline should always be active on the new parent of a dragged item. This implies that it should always be visible during the drag and drop interaction (either when dropping the element being dragged "into" another element, or when inserting the dragged element between two siblings).
- The drop target lines should be active if
    - the dragged item will be dropped between two siblings
    - the dragged item is positioned between two siblings, but the pointer is dragged to the side so that the dragged item is reparented into higher up the hierarchy.

We also support moving the pointer sideways to reparent up the hierarchy (the "reparent wiggle"). This should work like so:
- we only support moving the cursor left to reparent up the hierarchy. The opposite direction, reparenting down the hierarchy is not supported.
- when a reparent line is shown, the wiggle can be activated by dragging the pointer to the left by a preset amount (20px currently)
- when the wiggle is active, the target line is shown in its original place, and the parent outline is shown on the parent-to-be, further up the hierarchy
- this will reparent the dragged element so that it becomes the first sibling among the children of its new parent

## TODO: tests