### PR TITLE
Prettify code before tests

### DIFF
--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -331,7 +331,7 @@ export function walkContentsTree(
   })
 }
 
-interface PathAndFileEntry {
+export interface PathAndFileEntry {
   fullPath: string
   file: ProjectFile
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
@@ -681,7 +681,7 @@ describe('Absolute Move Strategy', () => {
 
     await renderResult.getDispatchFollowUpActionsFinished()
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
-      projectDoesNotHonourPositionProperties,
+      formatTestProjectCode(projectDoesNotHonourPositionProperties),
     )
   })
   it('moves absolute positioned element', async () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-multi-file.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-multi-file.spec.browser2.tsx
@@ -10,7 +10,11 @@ import { cmdModifier } from '../../../../utils/modifiers'
 import { selectComponents, setFocusedElement } from '../../../editor/actions/action-creators'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import { mouseDragFromPointToPoint } from '../../event-helpers.test-utils'
-import { EditorRenderResult, renderTestEditorWithProjectContent } from '../../ui-jsx.test-utils'
+import {
+  EditorRenderResult,
+  formatTestProjectCode,
+  renderTestEditorWithProjectContent,
+} from '../../ui-jsx.test-utils'
 
 const defaultAbsoluteChildCode = `
 import * as React from 'react'
@@ -265,9 +269,11 @@ describe('Absolute Reparent Strategy (Multi-File)', () => {
     })
 
     await renderResult.getDispatchFollowUpActionsFinished()
-    expect(getFileCode(renderResult, '/src/absolutechild.js')).toEqual(defaultAbsoluteChildCode)
+    expect(getFileCode(renderResult, '/src/absolutechild.js')).toEqual(
+      formatTestProjectCode(defaultAbsoluteChildCode),
+    )
     expect(getFileCode(renderResult, '/src/absoluteparent.js')).toEqual(
-      `import * as React from 'react'
+      formatTestProjectCode(`import * as React from 'react'
 import { AbsoluteChild } from './absolutechild'
 export const AbsoluteParent = () => {
   return (
@@ -285,10 +291,10 @@ export const AbsoluteParent = () => {
     />
   )
 }
-`,
+`),
     )
     expect(getFileCode(renderResult, '/src/app.js')).toEqual(
-      `import * as React from 'react'
+      formatTestProjectCode(`import * as React from 'react'
 import { AbsoluteParent } from './absoluteparent'
 import { FlexParent } from './flexparent'
 import { AbsoluteChild } from '/src/absolutechild.js'
@@ -314,9 +320,13 @@ export var App = () => {
     </div>
   )
 }
-`,
+`),
     )
-    expect(getFileCode(renderResult, '/src/flexchild.js')).toEqual(defaultFlexChildCode)
-    expect(getFileCode(renderResult, '/src/flexparent.js')).toEqual(defaultFlexParentCode)
+    expect(getFileCode(renderResult, '/src/flexchild.js')).toEqual(
+      formatTestProjectCode(defaultFlexChildCode),
+    )
+    expect(getFileCode(renderResult, '/src/flexparent.js')).toEqual(
+      formatTestProjectCode(defaultFlexParentCode),
+    )
   })
 })

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -1,5 +1,6 @@
 import {
   EditorRenderResult,
+  formatTestProjectCode,
   getPrintedUiJsCode,
   makeTestProjectCodeWithSnippet,
   renderTestEditorWithCode,
@@ -657,7 +658,7 @@ describe('Absolute Resize Strategy', () => {
 
     await renderResult.getDispatchFollowUpActionsFinished()
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
-      projectDoesNotHonourSizeProperties,
+      formatTestProjectCode(projectDoesNotHonourSizeProperties),
     )
   })
   it('resizes absolute positioned element from bottom right edge', async () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flex-strategy.spec.browser2.tsx
@@ -119,7 +119,7 @@ const defaultTestCode = `
   </div>
 `
 
-const TestProjectWithFragment = formatTestProjectCode(`
+const TestProjectWithFragment = `
 import * as React from 'react'
 import { Storyboard } from 'utopia-api'
 
@@ -215,7 +215,7 @@ export var storyboard = (
     </div>
   </Storyboard>
 )
-`)
+`
 
 function makeTestProjectCodeWithComponentInnards(componentInnards: string): string {
   const code = `

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -3,6 +3,7 @@ import { act } from 'react-dom/test-utils'
 import {
   EditorRenderResult,
   TestSceneUID,
+  formatTestProjectCode,
   getPrintedUiJsCode,
   renderTestEditorWithCode,
 } from '../../components/canvas/ui-jsx.test-utils'
@@ -120,7 +121,7 @@ function dragElement(
 }
 
 function getProjectCode(): string {
-  return `import * as React from 'react'
+  return formatTestProjectCode(`import * as React from 'react'
 import { Scene, Storyboard } from 'utopia-api'
 
 export var ${BakedInStoryboardVariableName} = (
@@ -192,7 +193,7 @@ export var ${BakedInStoryboardVariableName} = (
     </Scene>
   </Storyboard>
 )
-`
+`)
 }
 
 function getProjectCodeTree(): string {
@@ -300,7 +301,7 @@ export var ${BakedInStoryboardVariableName} = (
 }
 
 function getProjectCodeNotEmpty(): string {
-  return `import * as React from 'react'
+  return formatTestProjectCode(`import * as React from 'react'
 import { Scene, Storyboard } from 'utopia-api'
 
 export var ${BakedInStoryboardVariableName} = (
@@ -350,7 +351,7 @@ export var ${BakedInStoryboardVariableName} = (
     </Scene>
   </Storyboard>
 )
-`
+`)
 }
 
 function getProjectCodeEmptySingleConditional(): string {


### PR DESCRIPTION
**Problem:**
This is a follow up to #3524, where it was discovered that the code used in browser tests should be prettified before running them, as otherwise a re-print and re-parse could alter the model.

**Fix:**
I've added a function `formatAllCodeInModel` which will traverse the project contents and call `formatTestProjectCode` on any code files, which is then used at the start of `renderTestEditorWithModel`. Then I've fixed up some of the tests that check the before and after code in cases where re-printing and re-parsing aren't triggered.