### PR TITLE
reset navigator heights if visibleNavigatorTargets updates

### DIFF
--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -147,6 +147,10 @@ export const NavigatorComponent = React.memo(() => {
     }
   }, [selectionIndex, itemListRef])
 
+  React.useEffect(() => {
+    itemListRef.current?.resetAfterIndex(0, false)
+  }, [visibleNavigatorTargets, itemListRef])
+
   const onFocus = React.useCallback(
     (e: React.FocusEvent<HTMLElement>) => {
       dispatch([setFocus('navigator')])

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -148,6 +148,13 @@ export const NavigatorComponent = React.memo(() => {
   }, [selectionIndex, itemListRef])
 
   React.useEffect(() => {
+    /**
+     * VariableSizeList caches the item sizes returned by itemSize={getItemSize}
+     * When a reorder happens, the items are offset, and the cached sizes are not applied to the right items anymore
+     * resetAfterIndex(0, false) clears the cached size of all items, and false means it does not force a re-render
+     *
+     * as a first approximation, this useEffect runs on any change to visibleNavigatorTargets
+     */
     itemListRef.current?.resetAfterIndex(0, false)
   }, [visibleNavigatorTargets, itemListRef])
 


### PR DESCRIPTION
**Problem:**
The navigator heights are all sorts of wrong after a reparent involving conditional expressions https://screenshot.click/21-42-5n7xc-e5tle.mp4

**Fix:**
Reset the VariableSizeList heights when visibleNavigatorTargets changes