### PR TITLE
Experiment: Canvas zoom, but with scale

### DIFF
--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -714,9 +714,9 @@ function createNodeConnectorsDiv(offset: CanvasPoint, scale: number) {
       position: 'absolute',
       left: 0,
       top: 0,
-      zoom: scale >= 1 ? `${scale * 100}%` : 1,
+      // zoom: scale >= 1 ? `${scale * 100}%` : 1,
       transform:
-        (scale < 1 ? `scale(${scale})` : '') + ` translate3d(${offset.x}px, ${offset.y}px, 0)`,
+        (scale !== 1 ? `scale(${scale})` : '') + ` translate3d(${offset.x}px, ${offset.y}px, 0)`,
     },
   })
 }


### PR DESCRIPTION
**Problem:**
Chrome intends to sunset and remove the `zoom` property. Our editor zoom relies on it today. We don't know enough about what consequences this would have, and how to mitigate them.

**Fix:**
This creates a trivially simple experiment so we can gauge the effect. It doesn't change the _un-zoom_ for our various canvas controls, so those will not work.