### PR TITLE
`a` to insert in conditional slot

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4876,7 +4876,7 @@ export const UPDATE_FNS = {
         : null
 
       if (insertionPath == null) {
-        return includeToast(detailsOfUpdate, editor)
+        return includeToast('Selected element does not support children', editor)
       }
 
       function addNewSelectedView(parentPath: ElementPath, newUID: string) {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -514,7 +514,7 @@ import {
 import {
   findMaybeConditionalExpression,
   getClauseOptic,
-  getConditionalCaseFromMetadata,
+  getConditionalCaseCorrespondingToBranchPath,
   maybeBranchConditionalCase,
   maybeConditionalExpression,
 } from '../../../core/model/conditionals'
@@ -4856,7 +4856,7 @@ export const UPDATE_FNS = {
       let detailsOfUpdate: string | null = null
       let withInsertedElement: InsertChildAndDetails | null = null
 
-      const conditionalClause = getConditionalCaseFromMetadata(
+      const conditionalClause = getConditionalCaseCorrespondingToBranchPath(
         action.targetParent,
         editor.jsxMetadata,
       )

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -51,6 +51,8 @@ import {
 import {
   ConditionalCase,
   findMaybeConditionalExpression,
+  getConditionalBranch,
+  isNonEmptyConditionalBranch,
   maybeBranchConditionalCase,
 } from '../../../core/model/conditionals'
 import { isRight } from '../../../core/shared/either'
@@ -97,23 +99,6 @@ function notDescendant(
   draggedItem: ElementPath,
 ): boolean {
   return !EP.isDescendantOfOrEqualTo(draggedOnto.navigatorEntry.elementPath, draggedItem)
-}
-
-function isNonEmptyConditionalBranch(
-  elementPath: ElementPath,
-  jsxMetadata: ElementInstanceMetadataMap,
-): boolean {
-  const parentPath = EP.parentPath(elementPath)
-  const conditionalParent = findMaybeConditionalExpression(parentPath, jsxMetadata)
-  if (conditionalParent == null) {
-    return false
-  }
-  const clause = maybeBranchConditionalCase(parentPath, conditionalParent, elementPath)
-  if (clause == null) {
-    return false
-  }
-  const branch = getConditionalBranch(conditionalParent, clause)
-  return !isNullJSXAttributeValue(branch)
 }
 
 function canDrop(
@@ -409,10 +394,6 @@ function isInsideConditional(
     entry != null &&
     findMaybeConditionalExpression(EP.parentPath(entry.elementPath), jsxMetadata) != null
   )
-}
-
-function getConditionalBranch(conditional: JSXConditionalExpression, clause: ConditionalCase) {
-  return clause === 'true-case' ? conditional.whenTrue : conditional.whenFalse
 }
 
 export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDropWrapperProps) => {

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -4,6 +4,7 @@ import {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
   isJSXConditionalExpression,
+  isNullJSXAttributeValue,
   JSXConditionalExpression,
   JSXElementChild,
 } from '../shared/element-template'
@@ -153,6 +154,37 @@ export function getConditionalCaseCorrespondingToBranchPath(
   }
 
   return maybeBranchConditionalCase(EP.parentPath(branchPath), conditionalElement, branchPath)
+}
+
+export function getConditionalBranch(
+  conditional: JSXConditionalExpression,
+  clause: ConditionalCase,
+): JSXElementChild {
+  return clause === 'true-case' ? conditional.whenTrue : conditional.whenFalse
+}
+
+export function isNonEmptyConditionalBranch(
+  elementPath: ElementPath,
+  jsxMetadata: ElementInstanceMetadataMap,
+): boolean {
+  const parentPath = EP.parentPath(elementPath)
+  const conditionalParent = findMaybeConditionalExpression(parentPath, jsxMetadata)
+  if (conditionalParent == null) {
+    return false
+  }
+  const clause = maybeBranchConditionalCase(parentPath, conditionalParent, elementPath)
+  if (clause == null) {
+    return false
+  }
+  const branch = getConditionalBranch(conditionalParent, clause)
+  return !isNullJSXAttributeValue(branch)
+}
+
+export function isEmptyConditionalBranch(
+  elementPath: ElementPath,
+  jsxMetadata: ElementInstanceMetadataMap,
+): boolean {
+  return !isNonEmptyConditionalBranch(elementPath, jsxMetadata)
 }
 
 export function getConditionalClausePathFromMetadata(

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -78,31 +78,6 @@ export function getClauseOptic(
   }
 }
 
-export function getConditionalCase(
-  elementPath: ElementPath,
-  parent: JSXConditionalExpression,
-  spyParentMetadata: ElementInstanceMetadata,
-  parentPath: ElementPath,
-): ConditionalCase | 'not-a-conditional' {
-  if (spyParentMetadata.conditionValue === 'not-a-conditional') {
-    return 'not-a-conditional'
-  }
-  const parentOverride = getConditionalFlag(parent)
-  if (parentOverride == null) {
-    return spyParentMetadata.conditionValue ? 'true-case' : 'false-case'
-  }
-  if (
-    matchesOverriddenConditionalBranch(elementPath, parentPath, {
-      clause: parent.whenTrue,
-      wantOverride: true,
-      parentOverride: parentOverride,
-    })
-  ) {
-    return 'true-case'
-  }
-  return 'false-case'
-}
-
 export function getConditionalFlag(element: JSXConditionalExpression): boolean | null {
   const flag = findUtopiaCommentFlag(element.comments, 'conditional')
   if (!isUtopiaCommentFlagConditional(flag)) {
@@ -168,7 +143,7 @@ export function maybeBranchConditionalCase(
   }
 }
 
-export function getConditionalCaseFromMetadata(
+export function getConditionalCaseCorrespondingToBranchPath(
   branchPath: ElementPath,
   metadata: ElementInstanceMetadataMap,
 ): ConditionalCase | null {

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -168,6 +168,18 @@ export function maybeBranchConditionalCase(
   }
 }
 
+export function getConditionalCaseFromMetadata(
+  branchPath: ElementPath,
+  metadata: ElementInstanceMetadataMap,
+): ConditionalCase | null {
+  const conditionalElement = findMaybeConditionalExpression(EP.parentPath(branchPath), metadata)
+  if (conditionalElement == null) {
+    return null
+  }
+
+  return maybeBranchConditionalCase(EP.parentPath(branchPath), conditionalElement, branchPath)
+}
+
 export function getConditionalClausePathFromMetadata(
   conditionalPath: ElementPath,
   metadata: ElementInstanceMetadataMap,


### PR DESCRIPTION
## Problem
When inserting an element into a conditional slot from the floating insert menu, the inserted element isn't selected after insertion.

## Fix
The action used to perform the insertion (`INSERT_INSERTABLE`) wasn't aware of the distinction between normal element paths and conditional slots, so it simply appended the UID of the new element to the target parent path, which resulted in an invalid element path. The insertion still succeeded because `insertJSXElementChild_DEPRECATED` checked the target parent path, and special cased conditional slots.

To fix the problem, `insertJSXElementChild_DEPRECATED` was swapped out for its new version, `insertJSXElementChild`. The behaviour of `insertJSXElementChild` is controlled by the `InsertionPath` passed in, so the logic to check if the target parent is a conditional slot was naturally propagated up to `INSERT_INSERTABLE`. The same logic can be used to create the element path for the newly inserted element, so the fix simply "fell out" of the refactor.