### PR TITLE
Fix: mirror position of true branch for false branch placeholders

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -1675,13 +1675,7 @@ describe('Inserting into flex row', () => {
             />
           ) : (
             <div
-              style={{
-                position: 'absolute',
-                left: 0,
-                top: 0,
-                width: 100,
-                height: 300,
-              }}
+              style={{ width: 100, height: 300 }}
               data-uid='false-branch'
             >
               False branch


### PR DESCRIPTION
Fixes #3590 

**Problem:**

When a conditional is inserted by drag/draw, the false branch is built with a placeholder div (https://github.com/concrete-utopia/utopia/pull/3564). The div is sized to be with at least the dimensions of the true branch (with a fallback of 100x100). 
The positioning is also set to match the true branch.

This was done so that there is visual consistency when swapping the branches or flipping the condition, avoiding the visible branch from jumping/warping around given that this is autogenerated code.

The problem is that the position of the false branch is forced to be `absolute`, regardless of the position of the true branch, which _can_ lead to inconsistent display when, for example, a conditional is inserted inside a flex container.

**Fix:**

1. Set the `position` attribute of the false branch to be matching the one of the true branch
2. Only if the position is not-null, then go ahead and also set the `left` and `top` props, defaulting them to `0` when not found.