### PR TITLE
fix(unwrap) when unwrapping conditionals with text convert them to text blocks if possible

### DIFF
--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -615,9 +615,7 @@ describe('conditionals', () => {
 
       expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
         makeTestProjectCodeWithSnippet(`
-            <div data-uid='aaa'>
-              {'hello'}
-            </div>
+            <div data-uid='aaa'>hello</div>
          `),
       )
     })
@@ -659,6 +657,32 @@ describe('conditionals', () => {
               )
             }
           </div>
+         `),
+      )
+    })
+    it('can unwrap a conditional with expression', async () => {
+      const startSnippet = `
+        <div data-uid='aaa'>
+        {
+          // @utopia/uid=conditional
+          true ? 5 + 5 + 15: 'bello'
+        }
+        </div>
+      `
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(startSnippet),
+        'await-first-dom-report',
+      )
+
+      const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional'])
+
+      await act(async () => {
+        await renderResult.dispatch([unwrapElement(targetPath)], true)
+      })
+
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        makeTestProjectCodeWithSnippet(`
+            <div data-uid='aaa'>{5 + 5 + 15}</div>
          `),
       )
     })


### PR DESCRIPTION
**Problem:**
Unwrapping a string literal inside a conditional keeps the expression instead of unwrapping it to text

**Fix:**
The issue is that these are js expression values inside the conditional, the fix is to convert them to jsx text blocks

**Commit Details:**
- update `unwrapTextContainingConditional`
- updated unwrapping test
- added extra tests for unwrapping an expression
