### PR TITLE
remove unnecessary eslint disable

### DIFF
--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/rules-of-hooks */
 import React from 'react'
 import create, { EqualityChecker, Mutate, StoreApi, UseBoundStore } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'


### PR DESCRIPTION
## Problem
The eslint rule for `react-hooks/rules-of-hooks` was disabled, even though it didn't actually affect any code in the file it was in.

## Fix
Remove the disable, so the eslint warnings can be shown for future code.