### PR TITLE
fix(unwrap) unwrap nested conditionals

### DIFF
--- a/editor/src/components/editor/actions/wrap-unwrap-helpers.tsx
+++ b/editor/src/components/editor/actions/wrap-unwrap-helpers.tsx
@@ -89,6 +89,17 @@ export function unwrapConditionalClause(
                     newSelection.push(EP.appendToPath(parentPath.intendedParentPath, newUID))
                     return jsxFragment(newUID, clauseElement.children, false)
                   }
+                } else if (isJSXConditionalExpression(clauseElement)) {
+                  const activeCase = getConditionalActiveCase(
+                    target,
+                    clauseElement,
+                    editor.spyMetadata,
+                  )
+                  if (activeCase != null) {
+                    return activeCase === 'true-case'
+                      ? clauseElement.whenTrue
+                      : clauseElement.whenFalse
+                  }
                 }
                 return clauseElement
               },

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -686,6 +686,46 @@ describe('conditionals', () => {
          `),
       )
     })
+    it('can unwrap a nested conditional clause', async () => {
+      const startSnippet = `
+        <div data-uid='aaa'>
+          {
+            // @utopia/uid=conditional
+            true ? (
+              // @utopia/uid=conditional-inner
+              (true ? <div data-uid='bbb'>hello</div> : null)
+            ) : (
+              'bello'
+            )
+          }
+        </div>
+      `
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(startSnippet),
+        'await-first-dom-report',
+      )
+
+      const targetPath = EP.appendNewElementPath(TestScenePath, [
+        'aaa',
+        'conditional',
+        'conditional-inner',
+      ])
+
+      await act(async () => {
+        await renderResult.dispatch([unwrapElement(targetPath)], true)
+      })
+
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        makeTestProjectCodeWithSnippet(`
+          <div data-uid='aaa'>
+          {
+            // @utopia/uid=conditional
+            true ? <div data-uid='bbb'>hello</div> : 'bello'
+          }
+          </div>
+         `),
+      )
+    })
   })
   describe('paste', () => {
     it('can paste a single element into a conditional', async () => {


### PR DESCRIPTION
**Problem:**
When using nested conditionals unwrapping the inner conditional doesn't do anything.

**Fix:**
This part was missing from the unwrap conditional helper, now I added a test too.

**Commit Details:**
- update `unwrapConditionalClause`
- added test
