### PR TITLE
Handle paste into conditionals.

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2861,7 +2861,8 @@ export const UPDATE_FNS = {
       }
 
       const existingIDs = getAllUniqueUids(editor.projectContents)
-      return elements.reduce((workingEditorState, currentValue, index) => {
+      let newPaths: Array<ElementPath> = []
+      const updatedEditorState = elements.reduce((workingEditorState, currentValue, index) => {
         const elementWithUniqueUID = fixUtopiaElement(currentValue.element, existingIDs)
         const outcomeResult = getReparentOutcome(
           builtInDependencies,
@@ -2877,6 +2878,7 @@ export const UPDATE_FNS = {
           return workingEditorState
         } else {
           const { commands: reparentCommands, newPath } = outcomeResult
+          newPaths.push(newPath)
 
           const reparentStrategy = reparentStrategyForPaste(
             workingEditorState.jsxMetadata,
@@ -2938,6 +2940,16 @@ export const UPDATE_FNS = {
           return foldAndApplyCommandsSimple(workingEditorState, allCommands)
         }
       }, editor)
+
+      // Update the selected views to what has just been created.
+      if (newPaths.length > 0) {
+        return {
+          ...updatedEditorState,
+          selectedViews: newPaths,
+        }
+      } else {
+        return updatedEditorState
+      }
     } else {
       const showToastAction = showToast(
         notice(`Unable to paste into a generated element.`, 'WARNING'),


### PR DESCRIPTION
**Problem:**
Pasting into conditionals wasn't selecting the newly created item.

**Fix:**
There were two parts to this:
- `selectedViews` weren't being updated by `PASTE_JSX_ELEMENTS` when the items were created in the first place.
- Fixing the above issue then surfaced that the paths being created for where those items were being inserted at were wrong, as they were inserting into the null value of the empty slot, not into the conditional clause which held that value. But some other logic ended up correcting that and it would still end up getting inserted. This was solved by using `InsertionPath` in place of `ElementPath` for more of the logic upstream in the paste handler.

**Notes:**
Tests will be added for this subsequently as part of a refactor of the copy-paste event handlers, so as to not pull that work into this PR as well.

**Commit Details:**
- Changed `target` in `getActionsForClipboardItems` to be typed to `InsertionPath` instead of `ElementPath`, so that conditional clauses can be targeted correctly by a paste. Previously `childInsertionPath` was used everywhere which then attempted to insert inside the null value in empty slots.
- `PASTE_JSX_ELEMENTS` now tracks the paths created from the commands and updates `selectedViews` to be inline with those.