### PR TITLE
Protect Editor UI from user-loaded fonts

### DIFF
--- a/editor/resources/editor/css/ReactContexify.css
+++ b/editor/resources/editor/css/ReactContexify.css
@@ -8,6 +8,7 @@
   box-sizing: border-box;
   box-shadow: rgb(218 218 218 / 30%) -1px 3px 4px 0px, inset 0px 0px 0px 1px hsl(0deg 0% 90%);
   padding: 4px 0px;
+  font-family: 'utopian-inter';
 }
 .react-contexify .react-contexify__submenu {
   position: absolute;

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -294,8 +294,6 @@ const DesignPanelRootInner = React.memo(() => {
               flexGrow: 1,
               overflow: 'hidden',
               position: 'relative',
-              // the following line prevents a user-set font from applying to the navigator and floating menus
-              fontFamily: 'utopian-inter',
             }}
           >
             {isCanvasVisible && navigatorVisible ? (
@@ -416,8 +414,6 @@ const ResizableInspectorPane = React.memo<ResizableInspectorPaneProps>((props) =
           flexGrow: 0,
           flexShrink: 0,
           paddingBottom: 100,
-          // the following line prevents a user-set font from applying to the inspector
-          fontFamily: 'utopian-inter',
         }}
       >
         {props.isInsertMenuSelected ? <InsertMenuPane /> : <InspectorEntryPoint />}

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -294,6 +294,8 @@ const DesignPanelRootInner = React.memo(() => {
               flexGrow: 1,
               overflow: 'hidden',
               position: 'relative',
+              // the following line prevents a user-set font from applying to the navigator and floating menus
+              fontFamily: 'utopian-inter',
             }}
           >
             {isCanvasVisible && navigatorVisible ? (
@@ -414,6 +416,8 @@ const ResizableInspectorPane = React.memo<ResizableInspectorPaneProps>((props) =
           flexGrow: 0,
           flexShrink: 0,
           paddingBottom: 100,
+          // the following line prevents a user-set font from applying to the inspector
+          fontFamily: 'utopian-inter',
         }}
       >
         {props.isInsertMenuSelected ? <InsertMenuPane /> : <InspectorEntryPoint />}

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -317,6 +317,8 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
           width: '100vw',
           overscrollBehaviorX: 'contain',
           color: colorTheme.fg1.value,
+          // the following line prevents user css overriding the editor font
+          fontFamily: 'utopian-inter',
         }}
         onDragEnter={startDragInsertion}
       >


### PR DESCRIPTION
**Problem:**
Describe the problem being addressed as succinctly as possible:
<img width="1056" alt="image" src="https://user-images.githubusercontent.com/2945037/234706859-86096fae-fc10-420c-9ef5-ad185b926d06.png">

**Fix:**
Describe the fix you have made as succinctly as possible.
<img width="1056" alt="image" src="https://user-images.githubusercontent.com/2945037/234708686-c12b7b8d-d5ed-48b2-b34d-d39b404df367.png">


