### PR TITLE
fix(paste) paste into groups as absolute

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
@@ -15,6 +15,7 @@ import {
 import { flattenSelection } from '../shared-move-strategies-helpers'
 import { Direction } from '../../../../inspector/common/css-utils'
 import { ElementSupportsChildren } from '../../../../../core/model/element-template-utils'
+import { AllElementProps } from '../../../../editor/store/editor-state'
 
 export type ReparentStrategy = 'REPARENT_AS_ABSOLUTE' | 'REPARENT_AS_STATIC'
 
@@ -26,6 +27,7 @@ export type FindReparentStrategyResult = {
 
 export function reparentStrategyForPaste(
   targetMetadata: ElementInstanceMetadataMap,
+  allElementProps: AllElementProps,
   parent: ElementPath,
 ): {
   strategy: ReparentStrategy
@@ -34,7 +36,7 @@ export function reparentStrategyForPaste(
   const newParentMetadata = MetadataUtils.findElementByElementPath(targetMetadata, parent)
   const parentIsFlexLayout = MetadataUtils.isFlexLayoutedContainer(newParentMetadata)
 
-  const flowParentReparentType = flowParentAbsoluteOrStatic(targetMetadata, parent)
+  const flowParentReparentType = flowParentAbsoluteOrStatic(targetMetadata, allElementProps, parent)
   const reparentAsStatic = parentIsFlexLayout || flowParentReparentType === 'REPARENT_AS_STATIC'
   if (reparentAsStatic) {
     return {

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -952,7 +952,7 @@ describe('actions', () => {
         // @utopia/uid=conditional
         true ? null : <div data-uid='aaa'>foo</div>
       }
-      <div data-uid='aab' style={{ display: 'block' }}>foo</div>
+      <div data-uid='aab'>foo</div>
     </div>
 		`,
       },
@@ -1099,6 +1099,46 @@ describe('actions', () => {
         data-uid='element-to-paste'
       />
       </React.Fragment>
+		`,
+      },
+      {
+        name: 'paste absolute element into a size-less div',
+        startingCode: `
+      <div data-uid='root'>
+        <div data-uid='sizeless'>
+          <div data-uid='aaa' style={{position: 'absolute'}}>hi</div>
+        </div>
+        <div
+          style={{position: 'absolute', top: 50, left: 10}}
+          data-uid='element-to-paste'
+        >hello</div>
+      </div>
+		`,
+        elements: (renderResult) => {
+          const path = EP.appendNewElementPath(TestScenePath, ['root', 'element-to-paste'])
+          return [
+            {
+              element: getElementFromRenderResult(renderResult, path),
+              originalElementPath: path,
+              importsToAdd: {},
+            },
+          ]
+        },
+        pasteInto: childInsertionPath(EP.appendNewElementPath(TestScenePath, ['root', 'sizeless'])),
+        want: `
+      <div data-uid='root'>
+        <div data-uid='sizeless'>
+          <div data-uid='aaa' style={{position: 'absolute'}}>hi</div>
+          <div
+            style={{position: 'absolute', top: 50, left: 10}}
+            data-uid='ele'
+          >hello</div>
+        </div>
+        <div
+          style={{position: 'absolute', top: 50, left: 10}}
+          data-uid='element-to-paste'
+        >hello</div>
+      </div>
 		`,
       },
     ]

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -1102,7 +1102,7 @@ describe('actions', () => {
 		`,
       },
       {
-        name: 'paste absolute element into a size-less div',
+        name: 'paste absolute element into a sizeless div',
         startingCode: `
       <div data-uid='root'>
         <div data-uid='sizeless'>

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2877,6 +2877,7 @@ export const UPDATE_FNS = {
 
           const reparentStrategy = reparentStrategyForPaste(
             workingEditorState.jsxMetadata,
+            workingEditorState.allElementProps,
             resolvedTarget,
           )
 


### PR DESCRIPTION
**Problem:**
Pasting an absolutely positioned element into a group should keep it visually where it is.

**Fix:**
Paste elements into a group like layout as absolute.

**Commit Details:**
- extend `flowParentAbsoluteOrStatic` with checking if the element is a sizeless div
- add one test
