### PR TITLE
Cleaning up dom walker

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -320,6 +320,18 @@ interface RunDomWalkerParams {
   rootMetadataInStateRef: { readonly current: ElementInstanceMetadataMap }
 }
 
+interface DomWalkerInternalGlobalProps {
+  validPaths: Array<ElementPath>
+  rootMetadataInStateRef: React.MutableRefObject<ElementInstanceMetadataMap>
+  invalidatedPaths: Set<string>
+  invalidatedPathsForStylesheetCache: Set<string>
+  selectedViews: Array<ElementPath>
+  forceInvalidated: boolean
+  scale: number
+  containerRectLazy: () => CanvasRectangle
+  additionalElementsToUpdate: Array<ElementPath>
+}
+
 function runSelectiveDomWalker(
   elementsToFocusOn: Array<ElementPath>,
   globalProps: DomWalkerInternalGlobalProps,
@@ -1103,18 +1115,6 @@ function walkScene(
     }
   }
   return { metadata: {}, cachedPaths: [] } // verify
-}
-
-interface DomWalkerInternalGlobalProps {
-  validPaths: Array<ElementPath>
-  rootMetadataInStateRef: React.MutableRefObject<ElementInstanceMetadataMap>
-  invalidatedPaths: Set<string>
-  invalidatedPathsForStylesheetCache: Set<string>
-  selectedViews: Array<ElementPath>
-  forceInvalidated: boolean
-  scale: number
-  containerRectLazy: () => CanvasRectangle
-  additionalElementsToUpdate: Array<ElementPath>
 }
 
 function walkSceneInner(

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -1078,7 +1078,10 @@ function walkScene(
         childPaths: rootElements,
         rootMetadata,
         cachedPaths,
-      } = walkSceneInner(scene, instancePath, globalProps)
+      } = walkSceneInner(scene, instancePath, {
+        ...globalProps,
+        forceInvalidated: invalidatedScene,
+      })
 
       const { collectedMetadata: sceneMetadata, cachedPaths: sceneCachedPaths } = collectMetadata(
         scene,


### PR DESCRIPTION
**Problem:**
The DOM-walker is near unmaintanable because there are a dozen props being passed around among 5 recursive functions. To make matters worse, even the type safety is pretty bad, because lots of the params have similar type signatures, meaning TS can't catch if you mix them up. To make matters worse, these values really should not be altered during the recursion, they should be treated as a global props or data object. 

**Fix**
Turns these values into a global data object that is passed around in the recursive functions.
IMO this improves the maintainability for two reasons:
1. adding to this object is now easier and safer: there is only one place creating this object, all the other places are just consuming it and passing it along.
2. it would be now very visible if some function would try to alter the values before passing it down for recursion.
