### PR TITLE
Chore: remove insertElementAtPath_DEPRECATED from unwrap text containing conditional

### DIFF
--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -1322,6 +1322,101 @@ describe('actions', () => {
       `),
       )
     })
+    describe('conditionals', () => {
+      it(`Unwraps a conditional`, async () => {
+        const testCode = `
+        <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+          {
+            // @utopia/uid=conditional
+            true ? <div data-uid='bbb'>foo</div> : <div>bar</div>
+          }
+        </div>
+      `
+        const renderResult = await renderTestEditorWithCode(
+          makeTestProjectCodeWithSnippet(testCode),
+          'await-first-dom-report',
+        )
+        await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/conditional'))], true)
+
+        expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+          makeTestProjectCodeWithSnippet(`
+            <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+              <div data-uid='bbb'>foo</div>
+            </div>
+          `),
+        )
+      })
+      it(`Unwraps a conditional (false)`, async () => {
+        const testCode = `
+        <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+          {
+            // @utopia/uid=conditional
+            false ? <div data-uid='bbb'>foo</div> : <div data-uid='ccc'>bar</div>
+          }
+        </div>
+      `
+        const renderResult = await renderTestEditorWithCode(
+          makeTestProjectCodeWithSnippet(testCode),
+          'await-first-dom-report',
+        )
+        await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/conditional'))], true)
+
+        expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+          makeTestProjectCodeWithSnippet(`
+            <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+              <div data-uid='ccc'>bar</div>
+            </div>
+          `),
+        )
+      })
+      it(`Unwraps a conditional (override)`, async () => {
+        const testCode = `
+        <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+          {
+            // @utopia/uid=conditional
+            // @utopia/conditional=false
+            true ? <div data-uid='bbb'>foo</div> : <div data-uid='ccc'>bar</div>
+          }
+        </div>
+      `
+        const renderResult = await renderTestEditorWithCode(
+          makeTestProjectCodeWithSnippet(testCode),
+          'await-first-dom-report',
+        )
+        await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/conditional'))], true)
+
+        expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+          makeTestProjectCodeWithSnippet(`
+            <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+              <div data-uid='ccc'>bar</div>
+            </div>
+          `),
+        )
+      })
+      it(`Unwraps a conditional with inline content`, async () => {
+        const testCode = `
+          <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+            {
+              // @utopia/uid=conditional
+              true ? 'hello' : 'goodbye'
+            }
+          </div>
+        `
+        const renderResult = await renderTestEditorWithCode(
+          makeTestProjectCodeWithSnippet(testCode),
+          'await-first-dom-report',
+        )
+        await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/conditional'))], true)
+
+        expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+          makeTestProjectCodeWithSnippet(`
+            <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+              hello
+            </div>
+          `),
+        )
+      })
+    })
   })
   describe('WRAP_IN_ELEMENT', () => {
     it(`Wraps 2 elements`, async () => {

--- a/editor/src/components/editor/actions/wrap-unwrap-helpers.tsx
+++ b/editor/src/components/editor/actions/wrap-unwrap-helpers.tsx
@@ -37,7 +37,6 @@ import { EditorDispatch } from '../action-types'
 import {
   EditorState,
   insertElementAtPath,
-  insertElementAtPath_DEPRECATED,
   modifyUnderlyingTargetElement,
 } from '../store/editor-state'
 import {
@@ -159,9 +158,7 @@ export function unwrapTextContainingConditional(
     (success) => {
       if (elementToInsert != null) {
         const components = getUtopiaJSXComponentsFromSuccess(success)
-        const updatedComponents = insertElementAtPath_DEPRECATED(
-          editor.projectContents,
-          editor.canvas.openFile?.filename ?? null,
+        const updatedComponents = insertElementAtPath(
           childInsertionPath(targetParent),
           elementToInsert,
           components,


### PR DESCRIPTION
Fixes #3616 

Removed `insertElementAtPath_DEPRECATED` from `unwrapTextContainingConditional` and added a couple of tests for it.