### PR TITLE
Editing condition value disables override

### DIFF
--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -304,6 +304,7 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
 
   function onExpressionChange(e: React.ChangeEvent<HTMLInputElement>) {
     setConditionExpression(e.target.value)
+    setConditionOverride(null)
   }
 
   function onExpressionKeyUp(e: React.KeyboardEvent) {


### PR DESCRIPTION
**Description:**
Editing the condition value in the conditional inspector section should disable the condition override.

