### PR TITLE
Improvements/insert menu

### DIFF
--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -428,7 +428,7 @@ export const InsertGroup: React.FunctionComponent<React.PropsWithChildren<Insert
     const colorTheme = useColorTheme()
     return (
       <div style={{ paddingBottom: 24 }}>
-        <div style={{ height: 22, fontSize: 10, color: 'black', fontWeight: 500 }}>
+        <div style={{ height: 22, fontSize: 10, color: colorTheme.fg0.value, fontWeight: 500 }}>
           <span>{props.label}</span>
           <span>{props.subLabel == null ? null : props.subLabel}</span>
           <NpmDependencyVersionAndStatusIndicator

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -427,26 +427,23 @@ export const InsertGroup: React.FunctionComponent<React.PropsWithChildren<Insert
   React.memo((props) => {
     const colorTheme = useColorTheme()
     return (
-      <div style={{ paddingBottom: 12 }}>
-        <UIRow rowHeight={'normal'}>
-          <InspectorSubsectionHeader>
-            <div style={{ color: colorTheme.emphasizedForeground.value, fontWeight: 500 }}>
-              {props.label}
-            </div>
-            {props.subLabel == null ? null : (
-              <div style={{ color: colorTheme.subduedForeground.value, paddingLeft: 10 }}>
-                {props.subLabel}
-              </div>
-            )}
-          </InspectorSubsectionHeader>
-          <div style={{ flexGrow: 1, textAlign: 'right' }}>
-            <NpmDependencyVersionAndStatusIndicator
-              status={props.dependencyStatus}
-              version={props.dependencyVersion}
-            />
-          </div>
-        </UIRow>
-        <div style={{ padding: 8, color: colorTheme.subduedForeground.value }}>
+      <div style={{ paddingBottom: 24 }}>
+        <div style={{ height: 22, fontSize: 10, color: 'black', fontWeight: 500 }}>
+          <span>{props.label}</span>
+          <span>{props.subLabel == null ? null : props.subLabel}</span>
+          <NpmDependencyVersionAndStatusIndicator
+            status={props.dependencyStatus}
+            version={props.dependencyVersion}
+          />
+        </div>
+        <div
+          style={{
+            fontSize: 10,
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 4,
+          }}
+        >
           {props.children}
         </div>
       </div>
@@ -481,23 +478,30 @@ export const InsertItem: React.FunctionComponent<React.PropsWithChildren<InsertI
     props.warningMessage == null ? regularIcon : <WarningIcon tooltipText={props.warningMessage} />
 
   return (
-    <UIRow
-      rowHeight={'normal'}
+    <div
       css={{
+        height: 22,
+        display: 'flex',
+        alignItems: 'center',
         background: props.selected ? colorTheme.primary.value : undefined,
         color: props.selected ? colorTheme.white.value : undefined,
         opacity: props.disabled ? 0.3 : 1,
-        gap: 8,
+        borderRadius: 5,
+        gap: 4,
+        cursor: 'pointer',
+        paddingLeft: 4,
+        paddingRight: 4,
+        margin: 0,
         '&:hover': {
-          border: `1px solid ${colorTheme.primary.value}`,
+          backgroundColor: props.selected ? colorTheme.primary.value : colorTheme.bg3.value,
         },
       }}
       onMouseDown={props.disabled ? Utils.NO_OP : props.onMouseDown}
       onMouseUp={props.disabled ? Utils.NO_OP : props.onMouseUp}
       data-testid={`insert-item-${props.label}`}
     >
-      {resultingIcon}
+      <span style={{ transform: 'scale(.8)' }}>{resultingIcon}</span>
       <span>{props.label}</span>
-    </UIRow>
+    </div>
   )
 }

--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -97,6 +97,71 @@ Array [
         "element": Object {
           "children": Array [],
           "name": Object {
+            "baseVariable": "img",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "style",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "uid": "",
+                "value": Object {
+                  "height": "64px",
+                  "position": "absolute",
+                  "width": "64px",
+                },
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "src",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "uid": "",
+                "value": "/editor/icons/favicons/favicon-128.png?hash=nocommit",
+              },
+            },
+          ],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "img",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
+      },
+      Object {
+        "defaultSize": null,
+        "element": Object {
+          "children": Array [],
+          "name": Object {
             "baseVariable": "span",
             "propertyPath": Object {
               "propertyElements": Array [],
@@ -113,6 +178,58 @@ Array [
           },
         },
         "name": "span",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
+      },
+      Object {
+        "defaultSize": null,
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "button",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "button",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
+      },
+      Object {
+        "defaultSize": null,
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "input",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "input",
         "stylePropOptions": Array [
           "do-not-add",
           "add-size",
@@ -191,58 +308,6 @@ Array [
           },
         },
         "name": "p",
-        "stylePropOptions": Array [
-          "do-not-add",
-          "add-size",
-        ],
-      },
-      Object {
-        "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "button",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
-        "importsToAdd": Object {
-          "react": Object {
-            "importedAs": "React",
-            "importedFromWithin": Array [],
-            "importedWithName": null,
-          },
-        },
-        "name": "button",
-        "stylePropOptions": Array [
-          "do-not-add",
-          "add-size",
-        ],
-      },
-      Object {
-        "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "input",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
-        "importsToAdd": Object {
-          "react": Object {
-            "importedAs": "React",
-            "importedFromWithin": Array [],
-            "importedWithName": null,
-          },
-        },
-        "name": "input",
         "stylePropOptions": Array [
           "do-not-add",
           "add-size",
@@ -364,71 +429,6 @@ Array [
           "add-size",
         ],
       },
-      Object {
-        "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "img",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": Object {
-                  "height": "64px",
-                  "position": "absolute",
-                  "width": "64px",
-                },
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "src",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": "/editor/icons/favicons/favicon-128.png?hash=nocommit",
-              },
-            },
-          ],
-          "type": "JSX_ELEMENT",
-        },
-        "importsToAdd": Object {
-          "react": Object {
-            "importedAs": "React",
-            "importedFromWithin": Array [],
-            "importedWithName": null,
-          },
-        },
-        "name": "img",
-        "stylePropOptions": Array [
-          "do-not-add",
-          "add-size",
-        ],
-      },
     ],
     "source": Object {
       "type": "HTML_GROUP",
@@ -479,13 +479,6 @@ Array [
           "do-not-add",
         ],
       },
-    ],
-    "source": Object {
-      "type": "CONDITIONALS_GROUP",
-    },
-  },
-  Object {
-    "insertableComponents": Array [
       Object {
         "defaultSize": null,
         "element": Object {
@@ -507,7 +500,7 @@ Array [
       },
     ],
     "source": Object {
-      "type": "FRAGMENT_GROUP",
+      "type": "CODE_CONSTRUCTS_GROUP",
     },
   },
   Object {
@@ -650,6 +643,71 @@ Array [
         "element": Object {
           "children": Array [],
           "name": Object {
+            "baseVariable": "img",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "style",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "uid": "",
+                "value": Object {
+                  "height": "64px",
+                  "position": "absolute",
+                  "width": "64px",
+                },
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "src",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "uid": "",
+                "value": "/editor/icons/favicons/favicon-128.png?hash=nocommit",
+              },
+            },
+          ],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "img",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
+      },
+      Object {
+        "defaultSize": null,
+        "element": Object {
+          "children": Array [],
+          "name": Object {
             "baseVariable": "span",
             "propertyPath": Object {
               "propertyElements": Array [],
@@ -666,6 +724,58 @@ Array [
           },
         },
         "name": "span",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
+      },
+      Object {
+        "defaultSize": null,
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "button",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "button",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
+      },
+      Object {
+        "defaultSize": null,
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "input",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "input",
         "stylePropOptions": Array [
           "do-not-add",
           "add-size",
@@ -744,58 +854,6 @@ Array [
           },
         },
         "name": "p",
-        "stylePropOptions": Array [
-          "do-not-add",
-          "add-size",
-        ],
-      },
-      Object {
-        "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "button",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
-        "importsToAdd": Object {
-          "react": Object {
-            "importedAs": "React",
-            "importedFromWithin": Array [],
-            "importedWithName": null,
-          },
-        },
-        "name": "button",
-        "stylePropOptions": Array [
-          "do-not-add",
-          "add-size",
-        ],
-      },
-      Object {
-        "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "input",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
-        "importsToAdd": Object {
-          "react": Object {
-            "importedAs": "React",
-            "importedFromWithin": Array [],
-            "importedWithName": null,
-          },
-        },
-        "name": "input",
         "stylePropOptions": Array [
           "do-not-add",
           "add-size",
@@ -917,71 +975,6 @@ Array [
           "add-size",
         ],
       },
-      Object {
-        "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "img",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": Object {
-                  "height": "64px",
-                  "position": "absolute",
-                  "width": "64px",
-                },
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "src",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": "/editor/icons/favicons/favicon-128.png?hash=nocommit",
-              },
-            },
-          ],
-          "type": "JSX_ELEMENT",
-        },
-        "importsToAdd": Object {
-          "react": Object {
-            "importedAs": "React",
-            "importedFromWithin": Array [],
-            "importedWithName": null,
-          },
-        },
-        "name": "img",
-        "stylePropOptions": Array [
-          "do-not-add",
-          "add-size",
-        ],
-      },
     ],
     "source": Object {
       "type": "HTML_GROUP",
@@ -1032,13 +1025,6 @@ Array [
           "do-not-add",
         ],
       },
-    ],
-    "source": Object {
-      "type": "CONDITIONALS_GROUP",
-    },
-  },
-  Object {
-    "insertableComponents": Array [
       Object {
         "defaultSize": null,
         "element": Object {
@@ -1060,7 +1046,7 @@ Array [
       },
     ],
     "source": Object {
-      "type": "FRAGMENT_GROUP",
+      "type": "CODE_CONSTRUCTS_GROUP",
     },
   },
   Object {

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -92,23 +92,13 @@ export function insertableComponentGroupHTML(): InsertableComponentGroupHTML {
   }
 }
 
-export interface InsertableComponentGroupConditionals {
-  type: 'CONDITIONALS_GROUP'
+export interface InsertableComponentGroupCodeConstructs {
+  type: 'CODE_CONSTRUCTS_GROUP'
 }
 
-export function insertableComponentGroupConditionals(): InsertableComponentGroupConditionals {
+export function insertableComponentGroupCodeConstructs(): InsertableComponentGroupCodeConstructs {
   return {
-    type: 'CONDITIONALS_GROUP',
-  }
-}
-
-export interface InsertableComponentGroupFragment {
-  type: 'FRAGMENT_GROUP'
-}
-
-export function insertableComponentGroupFragment(): InsertableComponentGroupFragment {
-  return {
-    type: 'FRAGMENT_GROUP',
+    type: 'CODE_CONSTRUCTS_GROUP',
   }
 }
 
@@ -147,8 +137,7 @@ export type InsertableComponentGroupType =
   | InsertableComponentGroupHTML
   | InsertableComponentGroupProjectComponent
   | InsertableComponentGroupProjectDependency
-  | InsertableComponentGroupConditionals
-  | InsertableComponentGroupFragment
+  | InsertableComponentGroupCodeConstructs
   | InsertableComponentGroupSamples
 
 export interface InsertableComponentGroup {
@@ -187,10 +176,8 @@ export function getInsertableGroupLabel(insertableType: InsertableComponentGroup
       return insertableType.dependencyName
     case 'PROJECT_COMPONENT_GROUP':
       return insertableType.path
-    case 'CONDITIONALS_GROUP':
-      return 'Conditionals'
-    case 'FRAGMENT_GROUP':
-      return 'Fragment'
+    case 'CODE_CONSTRUCTS_GROUP':
+      return 'Code'
     default:
       const _exhaustiveCheck: never = insertableType
       throw new Error(`Unhandled insertable type ${JSON.stringify(insertableType)}`)
@@ -204,8 +191,7 @@ export function getInsertableGroupPackageStatus(
     case 'SAMPLES_GROUP':
     case 'HTML_GROUP':
     case 'PROJECT_COMPONENT_GROUP':
-    case 'CONDITIONALS_GROUP':
-    case 'FRAGMENT_GROUP':
+    case 'CODE_CONSTRUCTS_GROUP':
       return 'loaded'
     case 'PROJECT_DEPENDENCY_GROUP':
       return insertableType.dependencyStatus
@@ -292,12 +278,24 @@ const basicHTMLElementsDescriptors = {
       style: defaultViewElementStyle(),
     }),
   ),
+  img: makeHTMLDescriptor(
+    'img',
+    {
+      src: {
+        control: 'string-input',
+      },
+      style: {
+        control: 'style-controls',
+      },
+    },
+    defaultImageAttributes,
+  ),
   span: makeHTMLDescriptor('span', {}),
+  button: makeHTMLDescriptor('button', {}),
+  input: makeHTMLDescriptor('input', {}),
   h1: makeHTMLDescriptor('h1', {}),
   h2: makeHTMLDescriptor('h2', {}),
   p: makeHTMLDescriptor('p', {}),
-  button: makeHTMLDescriptor('button', {}),
-  input: makeHTMLDescriptor('input', {}),
   video: makeHTMLDescriptor(
     'video',
     {
@@ -329,21 +327,9 @@ const basicHTMLElementsDescriptors = {
       simpleAttribute('src', 'https://dl8.webmfiles.org/big-buck-bunny_trailer.webm'),
     ],
   ),
-  img: makeHTMLDescriptor(
-    'img',
-    {
-      src: {
-        control: 'string-input',
-      },
-      style: {
-        control: 'style-controls',
-      },
-    },
-    defaultImageAttributes,
-  ),
 }
 
-const conditionalElementsDescriptors: ComponentDescriptorsForFile = {
+const codeConstructsElementsDescriptors: ComponentDescriptorsForFile = {
   conditional: {
     properties: {},
     variants: [
@@ -360,9 +346,6 @@ const conditionalElementsDescriptors: ComponentDescriptorsForFile = {
       },
     ],
   },
-}
-
-const fragmentElementsDescriptors: ComponentDescriptorsForFile = {
   fragment: {
     properties: {},
     variants: [
@@ -571,12 +554,9 @@ export function getComponentGroups(
   // Add conditionals group.
   addDependencyDescriptor(
     null,
-    insertableComponentGroupConditionals(),
-    conditionalElementsDescriptors,
+    insertableComponentGroupCodeConstructs(),
+    codeConstructsElementsDescriptors,
   )
-
-  // Add fragment group.
-  addDependencyDescriptor(null, insertableComponentGroupFragment(), fragmentElementsDescriptors)
 
   // Add samples group
   addDependencyDescriptor(null, { type: 'SAMPLES_GROUP' }, samplesDescriptors)


### PR DESCRIPTION
**Problem:**
The insert menu in the right-hand column was painful to use, and far too long

**Fix:**
Condensed things, and also grouped fragments and conditionals in a 'Code' group.
<img width="260" alt="image" src="https://user-images.githubusercontent.com/2945037/235136227-b9580d3f-d134-44da-be3e-d5e5e48da5de.png">
<img width="259" alt="image" src="https://user-images.githubusercontent.com/2945037/235152619-9d686552-0129-4d16-b65f-7da9624b38be.png">