### PR TITLE
Design: better toolbar and shadows

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/strategy-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/strategy-indicator.tsx
@@ -27,6 +27,7 @@ export const StrategyIndicator = React.memo(() => {
   return (
     <FlexRow
       style={{
+        ...UtopiaStyles.popup,
         pointerEvents: 'none',
         position: 'absolute',
         top: 4,
@@ -38,16 +39,13 @@ export const StrategyIndicator = React.memo(() => {
         alignItems: 'flex-end',
         gap: 8,
         backgroundColor: colorTheme.bg0.value,
-        boxShadow: UtopiaStyles.shadowStyles.medium.boxShadow,
         opacity:
           indicatorFlagsInfo.dragStarted && indicatorFlagsInfo.indicatorFlags.showIndicator ? 1 : 0,
       }}
       data-testid='drag-strategy-indicator'
     >
       <MoveIndicatorItem dragType={indicatorFlagsInfo.indicatorFlags.dragType} />
-      <Divider />
       <ReparentIndicatorItem status={indicatorFlagsInfo.indicatorFlags.reparent} />
-      <Divider />
       <AncestorIndicatorItem enabled={indicatorFlagsInfo.indicatorFlags.ancestor} />
     </FlexRow>
   )
@@ -177,11 +175,6 @@ const ReparentIndicatorItem = React.memo<ReparentIndicatorItemProps>(({ status }
       </div>
     </FlexColumn>
   )
-})
-
-const Divider = React.memo(() => {
-  const colorTheme = useColorTheme()
-  return <div style={{ height: '100%', width: 1, backgroundColor: colorTheme.fg8.value }} />
 })
 
 interface VisibilityWrapperProps {

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -172,6 +172,7 @@ export const CanvasToolbar = React.memo(() => {
         position: 'absolute',
         top: 12,
         left: 12,
+        gap: 6,
         alignItems: 'stretch',
         width: 64,
         borderRadius: 4,
@@ -183,10 +184,9 @@ export const CanvasToolbar = React.memo(() => {
       onClick={stopPropagation}
     >
       <FlexColumn style={{ padding: 4 }}>
-        <FlexRow style={{ flexWrap: 'wrap', gap: 4, padding: 4, marginBottom: 4 }}></FlexRow>
         {/* ------------------------------------ */}
         <header style={{ paddingLeft: 4, fontSize: 10, fontWeight: 500 }}>Tools</header>
-        <FlexRow style={{ flexWrap: 'wrap', gap: 4, padding: 4, marginBottom: 6 }}>
+        <FlexRow style={{ flexWrap: 'wrap', gap: 4, padding: 4 }}>
           <Tooltip title='Select' placement='bottom'>
             <InsertModeButton
               iconType='pointer'
@@ -228,7 +228,7 @@ export const CanvasToolbar = React.memo(() => {
       </FlexColumn>
 
       {/* ------------------------------------ */}
-      <FlexColumn style={{ padding: 4, marginBottom: 6 }}>
+      <FlexColumn style={{ padding: 4 }}>
         <header style={{ paddingLeft: 4, fontSize: 10, fontWeight: 500 }}>Insert</header>
         <FlexRow style={{ flexWrap: 'wrap', gap: 4, padding: 4 }}>
           <Tooltip title='Insert div' placement='bottom'>
@@ -270,7 +270,7 @@ export const CanvasToolbar = React.memo(() => {
         </FlexRow>
       </FlexColumn>
       {/* ------------------------------------ */}
-      <FlexColumn style={{ padding: 4, marginBottom: 6 }}>
+      <FlexColumn style={{ padding: 4 }}>
         <header style={{ paddingLeft: 4, fontSize: 10, fontWeight: 500 }}>Convert</header>
         <FlexRow style={{ flexWrap: 'wrap', gap: 4, padding: 4 }}>
           <Tooltip title='Converts an element or component into another' placement='bottom'>
@@ -285,7 +285,7 @@ export const CanvasToolbar = React.memo(() => {
       </FlexColumn>
 
       {/* ------------------------------------ */}
-      <FlexColumn style={{ padding: 4, marginBottom: 6 }}>
+      <FlexColumn style={{ padding: 4 }}>
         <header style={{ paddingLeft: 4, fontSize: 10, fontWeight: 500 }}>Organise</header>
         <FlexRow style={{ flexWrap: 'wrap', gap: 4, padding: 4 }}>
           <Tooltip title='Wrap selection in div' placement='bottom'>
@@ -302,7 +302,7 @@ export const CanvasToolbar = React.memo(() => {
         </FlexRow>
       </FlexColumn>
       {/* ------------------------------------ */}
-      <FlexColumn style={{ padding: 4, marginBottom: 6 }}>
+      <FlexColumn style={{ padding: 4 }}>
         <header style={{ paddingLeft: 4, fontSize: 10, fontWeight: 500 }}>Editor</header>
         <FlexRow style={{ flexWrap: 'wrap', gap: 4, padding: 4 }}>
           <Tooltip title='Toggle Live Mode' placement='bottom'>

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -183,35 +183,10 @@ export const CanvasToolbar = React.memo(() => {
       onClick={stopPropagation}
     >
       <FlexColumn style={{ padding: 4 }}>
-        <header style={{ paddingLeft: 4, fontSize: 10, fontWeight: 500 }}>Scale</header>
-        <FlexRow style={{ flexWrap: 'wrap', gap: 4, padding: 4 }}>
-          <Tooltip title='Zoom to 100%' placement='bottom'>
-            <SquareButton highlight style={{ textAlign: 'center', width: 32 }} onClick={zoom100pct}>
-              {zoomLevel * 100}%
-            </SquareButton>
-          </Tooltip>
-        </FlexRow>
-
-        <FlexRow style={{ flexWrap: 'wrap', gap: 4, padding: 4 }}>
-          <Tooltip title='Zoom in' placement='bottom'>
-            <InsertModeButton
-              iconType='magnifyingglass-plus'
-              iconCategory='semantic'
-              onClick={zoomIn}
-            />
-          </Tooltip>
-          <Tooltip title='Zoom out' placement='bottom'>
-            <InsertModeButton
-              iconType='magnifyingglass-minus'
-              iconCategory='semantic'
-              onClick={zoomOut}
-            />
-          </Tooltip>
-        </FlexRow>
-        <Divider />
+        <FlexRow style={{ flexWrap: 'wrap', gap: 4, padding: 4, marginBottom: 4 }}></FlexRow>
         {/* ------------------------------------ */}
         <header style={{ paddingLeft: 4, fontSize: 10, fontWeight: 500 }}>Tools</header>
-        <FlexRow style={{ flexWrap: 'wrap', gap: 4, padding: 4 }}>
+        <FlexRow style={{ flexWrap: 'wrap', gap: 4, padding: 4, marginBottom: 6 }}>
           <Tooltip title='Select' placement='bottom'>
             <InsertModeButton
               iconType='pointer'
@@ -226,11 +201,34 @@ export const CanvasToolbar = React.memo(() => {
               onClick={insertTextCallback}
             />
           </Tooltip>
+          <Tooltip title='Zoom in' placement='bottom'>
+            <InsertModeButton
+              iconType='magnifyingglass-plus'
+              iconCategory='semantic'
+              onClick={zoomIn}
+            />
+          </Tooltip>
+          <Tooltip title='Zoom out' placement='bottom'>
+            <InsertModeButton
+              iconType='magnifyingglass-minus'
+              iconCategory='semantic'
+              onClick={zoomOut}
+            />
+          </Tooltip>
+          <Tooltip title='Zoom to 100%' placement='bottom'>
+            <SquareButton
+              highlight
+              style={{ textAlign: 'center', width: '100%' }}
+              onClick={zoom100pct}
+            >
+              {zoomLevel * 100}%
+            </SquareButton>
+          </Tooltip>
         </FlexRow>
       </FlexColumn>
-      <Divider />
+
       {/* ------------------------------------ */}
-      <FlexColumn style={{ padding: 4 }}>
+      <FlexColumn style={{ padding: 4, marginBottom: 6 }}>
         <header style={{ paddingLeft: 4, fontSize: 10, fontWeight: 500 }}>Insert</header>
         <FlexRow style={{ flexWrap: 'wrap', gap: 4, padding: 4 }}>
           <Tooltip title='Insert div' placement='bottom'>
@@ -271,9 +269,8 @@ export const CanvasToolbar = React.memo(() => {
           </Tooltip>
         </FlexRow>
       </FlexColumn>
-      <Divider />
       {/* ------------------------------------ */}
-      <FlexColumn style={{ padding: 4 }}>
+      <FlexColumn style={{ padding: 4, marginBottom: 6 }}>
         <header style={{ paddingLeft: 4, fontSize: 10, fontWeight: 500 }}>Convert</header>
         <FlexRow style={{ flexWrap: 'wrap', gap: 4, padding: 4 }}>
           <Tooltip title='Converts an element or component into another' placement='bottom'>
@@ -286,9 +283,9 @@ export const CanvasToolbar = React.memo(() => {
           </Tooltip>
         </FlexRow>
       </FlexColumn>
-      <Divider />
+
       {/* ------------------------------------ */}
-      <FlexColumn style={{ padding: 4 }}>
+      <FlexColumn style={{ padding: 4, marginBottom: 6 }}>
         <header style={{ paddingLeft: 4, fontSize: 10, fontWeight: 500 }}>Organise</header>
         <FlexRow style={{ flexWrap: 'wrap', gap: 4, padding: 4 }}>
           <Tooltip title='Wrap selection in div' placement='bottom'>
@@ -304,9 +301,8 @@ export const CanvasToolbar = React.memo(() => {
           </Tooltip>
         </FlexRow>
       </FlexColumn>
-      <Divider />
       {/* ------------------------------------ */}
-      <FlexColumn style={{ padding: 4 }}>
+      <FlexColumn style={{ padding: 4, marginBottom: 6 }}>
         <header style={{ paddingLeft: 4, fontSize: 10, fontWeight: 500 }}>Editor</header>
         <FlexRow style={{ flexWrap: 'wrap', gap: 4, padding: 4 }}>
           <Tooltip title='Toggle Live Mode' placement='bottom'>
@@ -398,18 +394,5 @@ const Tooltip = (props: TooltipProps) => {
       {/* TODO why do we need to wrap the children in a span? */}
       <span>{props.children}</span>
     </TooltipWithoutSpanFixme>
-  )
-}
-
-const Divider = () => {
-  return (
-    <div
-      style={{
-        height: 1,
-        width: '100%',
-        marginTop: 8,
-        backgroundColor: colorTheme.fg9.value,
-      }}
-    />
   )
 }


### PR DESCRIPTION
**Problem:**
- Our toolbar has a weird ordering and info hierarchy (w/ zoom at the top). It does, however, have good shadows
- Our strategy indicator looks ok, but had simple shadows that did not convey its true depth (of character, and otherwise)

**Fix:**
- Move zoom back into tools
- Use the standard drop shadow everywhere

(some design debt here @lankaukk: we do not have a good, layered shadow system yet. Our `theme` shadows are poor and now hardly used anywhere. Nothing to fix right now, but something to be aware of)


<img width="647" alt="image" src="https://user-images.githubusercontent.com/2945037/235178185-d005f6cf-df38-42ec-a431-07e911e8f247.png">
