### PR TITLE
fix(wrap) when wrapping in root elements show toast instead of throwing errors

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2355,8 +2355,12 @@ export const UPDATE_FNS = {
             EP.isRootElementOfInstance(elementPath) &&
             EP.isParentOf(getElementPathFromInsertionPath(parentPath), elementPath),
         )
-        if (anyTargetIsARootElement && targetThatIsRootElementOfCommonParent == null) {
-          return editor
+
+        if (anyTargetIsARootElement) {
+          const showToastAction = showToast(
+            notice(`Root elements can't be wrapped into other elements.`),
+          )
+          return UPDATE_FNS.ADD_TOAST(showToastAction, editor)
         }
 
         const detailsOfUpdate = null


### PR DESCRIPTION
**Problem:**
When wrapping in root elements nothing happens on the canvas. There are errors in the console.

**Fix:**
Show toast when wrapping in a root div

**Commit Details:**
- update `WRAP_IN_ELEMENT`
