### PR TITLE
Correct the inner uid values when fixing highlight bounds.

### DIFF
--- a/editor/src/core/workers/parser-printer/uid-fix.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.ts
@@ -106,7 +106,10 @@ export function fixParseSuccessUIDs(
     if (originalUID in fixedHighlightBounds) {
       const bounds = fixedHighlightBounds[originalUID]
       delete fixedHighlightBounds[originalUID]
-      fixedHighlightBounds[newUID] = bounds
+      fixedHighlightBounds[newUID] = {
+        ...bounds,
+        uid: newUID,
+      }
     }
   }
 


### PR DESCRIPTION
**Problem:**
When editing code, sometimes the highlight bounds would end up not quite looking correct for the added element.

**Cause:**
When fixing the UIDs for the highlight bounds in `fixParseSuccessUIDs`, the key was changed, but the UID is also held inside the value and that was not updated.

**Fix:**
`fixParseSuccessUIDs` now updates the value in the dictionary object as well as the key against which it is stored. Extra validation was added to the tests to ensure that any regression in this will be caught.

**Commit Details:**
- `fixParseSuccessUIDs` now updates the uid in the `HighlightBounds` object when the mapping is applied.
- Refactored the test code in `uid-fix.spec.ts` to always call `validateParsedTextFileElementUIDs` and the newly created `validateHighlightBoundsForUIDs` in a wrapper function `lintAndParseAndValidateResult`.