### PR TITLE
Chore: remove insertElementAtPath_DEPRECATED from reparent

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
@@ -22,10 +22,7 @@ import {
 import { InteractionSession, UpdatedPathMap } from '../interaction-state'
 import { absoluteMoveStrategy } from './absolute-move-strategy'
 import { honoursPropsPosition } from './absolute-utils'
-import {
-  replaceContentAffectingPathsWithTheirChildrenRecursive,
-  retargetStrategyToChildrenOfContentAffectingElements,
-} from './group-like-helpers'
+import { replaceContentAffectingPathsWithTheirChildrenRecursive } from './group-like-helpers'
 import { ifAllowedToReparent, isAllowedToReparent } from './reparent-helpers/reparent-helpers'
 import { getAbsoluteReparentPropertyChanges } from './reparent-helpers/reparent-property-changes'
 import { ReparentTarget } from './reparent-helpers/reparent-strategy-helpers'
@@ -123,7 +120,6 @@ export function baseAbsoluteReparentStrategy(
                   pathToReparent(selectedElement),
                   childInsertionPath(newParent),
                   'always',
-                  'use-deprecated-insertJSXElementChild',
                 )
 
                 if (reparentResult == null) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
@@ -22,7 +22,10 @@ import {
 import { InteractionSession, UpdatedPathMap } from '../interaction-state'
 import { absoluteMoveStrategy } from './absolute-move-strategy'
 import { honoursPropsPosition } from './absolute-utils'
-import { replaceContentAffectingPathsWithTheirChildrenRecursive } from './group-like-helpers'
+import {
+  replaceContentAffectingPathsWithTheirChildrenRecursive,
+  retargetStrategyToChildrenOfContentAffectingElements,
+} from './group-like-helpers'
 import { ifAllowedToReparent, isAllowedToReparent } from './reparent-helpers/reparent-helpers'
 import { getAbsoluteReparentPropertyChanges } from './reparent-helpers/reparent-property-changes'
 import { ReparentTarget } from './reparent-helpers/reparent-strategy-helpers'

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -388,7 +388,6 @@ function collectReparentCommands(
     pathToReparent(path),
     childInsertionPath(targetParent),
     'always',
-    'use-deprecated-insertJSXElementChild',
   )
   if (outcomeResult == null) {
     return []

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -1,4 +1,5 @@
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import * as EP from '../../../../core/shared/element-path'
 import { zeroCanvasRect } from '../../../../core/shared/math-utils'
 import { assertNever } from '../../../../core/shared/utils'
 import { absolute } from '../../../../utils/utils'

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -1,5 +1,4 @@
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
-import * as EP from '../../../../core/shared/element-path'
 import { zeroCanvasRect } from '../../../../core/shared/math-utils'
 import { assertNever } from '../../../../core/shared/utils'
 import { absolute } from '../../../../utils/utils'
@@ -163,7 +162,6 @@ function applyStaticReparent(
             pathToReparent(target),
             childInsertionPath(newParent),
             'always',
-            'use-deprecated-insertJSXElementChild',
           )
           let duplicatedElementNewUids: { [elementPath: string]: string } = {}
           if (outcomeResult != null) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
@@ -1,14 +1,27 @@
 import { ProjectContentTreeRoot } from '../../../assets'
+import {
+  addImport,
+  emptyImports,
+  mergeImports,
+} from '../../../../core/workers/common/project-file-utils'
 import { withUnderlyingTarget } from '../../../editor/store/editor-state'
 import { ElementPath, Imports, NodeModules } from '../../../../core/shared/project-file-types'
 import { CanvasCommand } from '../../commands/commands'
 import { reparentElement } from '../../commands/reparent-element-command'
 import {
   ElementInstanceMetadataMap,
+  isIntrinsicElement,
+  isJSXElement,
+  JSXElement,
   JSXElementChild,
+  walkElement,
 } from '../../../../core/shared/element-template'
 import * as EP from '../../../../core/shared/element-path'
-import { getRequiredImportsForElement } from '../../../editor/import-utils'
+import {
+  getImportsFor,
+  getRequiredImportsForElement,
+  importedFromWhere,
+} from '../../../editor/import-utils'
 import { forceNotNull } from '../../../../core/shared/optional-utils'
 import { addImportsToFile } from '../../commands/add-imports-to-file-command'
 import { BuiltInDependencies } from '../../../../core/es-modules/package-manager/built-in-dependencies-list'
@@ -17,7 +30,11 @@ import { addToReparentedToPaths } from '../../commands/add-to-reparented-to-path
 import { getStoryboardElementPath } from '../../../../core/model/scene-utils'
 import { generateUidWithExistingComponents } from '../../../../core/model/element-template-utils'
 import { addElement } from '../../commands/add-element-command'
-import { CustomStrategyState, InteractionCanvasState } from '../canvas-strategy-types'
+import {
+  CustomStrategyState,
+  InteractionCanvasState,
+  InteractionLifecycle,
+} from '../canvas-strategy-types'
 import { duplicateElement } from '../../commands/duplicate-element-command'
 import { wildcardPatch } from '../../commands/wildcard-patch-command'
 import { hideInNavigatorCommand } from '../../commands/hide-in-navigator-command'

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
@@ -1,27 +1,14 @@
 import { ProjectContentTreeRoot } from '../../../assets'
-import {
-  addImport,
-  emptyImports,
-  mergeImports,
-} from '../../../../core/workers/common/project-file-utils'
 import { withUnderlyingTarget } from '../../../editor/store/editor-state'
 import { ElementPath, Imports, NodeModules } from '../../../../core/shared/project-file-types'
 import { CanvasCommand } from '../../commands/commands'
 import { reparentElement } from '../../commands/reparent-element-command'
 import {
   ElementInstanceMetadataMap,
-  isIntrinsicElement,
-  isJSXElement,
-  JSXElement,
   JSXElementChild,
-  walkElement,
 } from '../../../../core/shared/element-template'
 import * as EP from '../../../../core/shared/element-path'
-import {
-  getImportsFor,
-  getRequiredImportsForElement,
-  importedFromWhere,
-} from '../../../editor/import-utils'
+import { getRequiredImportsForElement } from '../../../editor/import-utils'
 import { forceNotNull } from '../../../../core/shared/optional-utils'
 import { addImportsToFile } from '../../commands/add-imports-to-file-command'
 import { BuiltInDependencies } from '../../../../core/es-modules/package-manager/built-in-dependencies-list'
@@ -30,11 +17,7 @@ import { addToReparentedToPaths } from '../../commands/add-to-reparented-to-path
 import { getStoryboardElementPath } from '../../../../core/model/scene-utils'
 import { generateUidWithExistingComponents } from '../../../../core/model/element-template-utils'
 import { addElement } from '../../commands/add-element-command'
-import {
-  CustomStrategyState,
-  InteractionCanvasState,
-  InteractionLifecycle,
-} from '../canvas-strategy-types'
+import { CustomStrategyState, InteractionCanvasState } from '../canvas-strategy-types'
 import { duplicateElement } from '../../commands/duplicate-element-command'
 import { wildcardPatch } from '../../commands/wildcard-patch-command'
 import { hideInNavigatorCommand } from '../../commands/hide-in-navigator-command'
@@ -46,7 +29,6 @@ import {
   isChildInsertionPath,
 } from '../../../editor/store/insertion-path'
 import { getUtopiaID } from '../../../../core/shared/uid-utils'
-import { UseNewInsertJsxElementChild } from '../../canvas-utils'
 
 interface GetReparentOutcomeResult {
   commands: Array<CanvasCommand>
@@ -89,7 +71,6 @@ export function getReparentOutcome(
   toReparent: ToReparent,
   targetParent: InsertionPath | null,
   whenToRun: 'always' | 'on-complete',
-  useNewInsertJSXElementChild: UseNewInsertJsxElementChild,
 ): GetReparentOutcomeResult | null {
   // Cater for something being reparented to the canvas.
   let newParent: InsertionPath
@@ -150,9 +131,7 @@ export function getReparentOutcome(
         builtInDependencies,
       )
       commands.push(addImportsToFile(whenToRun, newTargetFilePath, importsToAdd))
-      commands.push(
-        reparentElement(whenToRun, toReparent.target, newParent, useNewInsertJSXElementChild),
-      )
+      commands.push(reparentElement(whenToRun, toReparent.target, newParent))
       newPath = EP.appendToPath(newParentElementPath, EP.toUid(toReparent.target))
       break
     case 'ELEMENT_TO_REPARENT':

--- a/editor/src/components/canvas/commands/reparent-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/reparent-element-command.spec.tsx
@@ -28,12 +28,7 @@ describe('runReparentElement', () => {
     ])
     const originalEditorState = renderResult.getEditorState().editor
 
-    const reparentCommand = reparentElement(
-      'always',
-      targetPath,
-      childInsertionPath(newParentPath),
-      'use-deprecated-insertJSXElementChild',
-    )
+    const reparentCommand = reparentElement('always', targetPath, childInsertionPath(newParentPath))
 
     const result = runReparentElement(originalEditorState, reparentCommand)
 
@@ -83,12 +78,7 @@ describe('runReparentElement', () => {
     ])
     const originalEditorState = renderResult.getEditorState().editor
 
-    const reparentCommand = reparentElement(
-      'always',
-      targetPath,
-      childInsertionPath(newParentPath),
-      'use-deprecated-insertJSXElementChild',
-    )
+    const reparentCommand = reparentElement('always', targetPath, childInsertionPath(newParentPath))
 
     const result = runReparentElement(originalEditorState, reparentCommand)
 

--- a/editor/src/components/canvas/commands/reparent-element-command.ts
+++ b/editor/src/components/canvas/commands/reparent-element-command.ts
@@ -17,27 +17,23 @@ import {
   removeElementAtPath,
 } from '../../editor/store/editor-state'
 import { BaseCommand, CommandFunction, getPatchForComponentChange, WhenToRun } from './commands'
-import { UseNewInsertJsxElementChild } from '../canvas-utils'
 
 export interface ReparentElement extends BaseCommand {
   type: 'REPARENT_ELEMENT'
   target: ElementPath
   newParent: InsertionPath
-  useNewInsertJSXElementChild: UseNewInsertJsxElementChild
 }
 
 export function reparentElement(
   whenToRun: WhenToRun,
   target: ElementPath,
   newParent: InsertionPath,
-  useNewInsertJSXElementChild: UseNewInsertJsxElementChild,
 ): ReparentElement {
   return {
     type: 'REPARENT_ELEMENT',
     whenToRun: whenToRun,
     target: target,
     newParent: newParent,
-    useNewInsertJSXElementChild: useNewInsertJSXElementChild,
   }
 }
 
@@ -63,23 +59,13 @@ export const runReparentElement: CommandFunction<ReparentElement> = (
             const components = getUtopiaJSXComponentsFromSuccess(successTarget)
             const withElementRemoved = removeElementAtPath(command.target, components)
 
-            const insertionResult =
-              command.useNewInsertJSXElementChild === 'use-new-insertJSXElementChild'
-                ? insertElementAtPath(
-                    editorState.projectContents,
-                    command.newParent,
-                    underlyingElementTarget,
-                    withElementRemoved,
-                    null,
-                  )
-                : insertElementAtPath_DEPRECATED(
-                    editorState.projectContents,
-                    underlyingFilePathTarget,
-                    command.newParent,
-                    underlyingElementTarget,
-                    withElementRemoved,
-                    null,
-                  )
+            const insertionResult = insertElementAtPath(
+              editorState.projectContents,
+              command.newParent,
+              underlyingElementTarget,
+              withElementRemoved,
+              null,
+            )
             const editorStatePatchOldParentFile = getPatchForComponentChange(
               successTarget.topLevelElements,
               insertionResult.components,

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -37,6 +37,7 @@ import {
   expectNoAction,
   expectSingleUndo2Saves,
   selectComponentsForTest,
+  setFeatureForBrowserTests,
   wait,
 } from '../../../utils/utils.test-utils'
 import {
@@ -652,43 +653,6 @@ describe('actions', () => {
     	</div>
 		`,
       },
-      // commented out because the non-empty test is outside of the action now
-      //   {
-      //     name: 'an element inside a non-empty conditional branch (does nothing)',
-      //     generatesUndoStep: false,
-      //     startingCode: `
-      //     <div data-uid='root'>
-      //         {
-      //             // @utopia/uid=conditional
-      //             true ? <div data-uid='aaa'>foo</div> : <div data-uid='bbb'>bar</div>
-      //         }
-      //         <div data-uid='ccc'>baz</div>
-      //     </div>
-      // `,
-      //     elements: (renderResult) => {
-      //       const path = EP.appendNewElementPath(TestScenePath, ['root', 'ccc'])
-      //       return [
-      //         {
-      //           element: getElementFromRenderResult(renderResult, path),
-      //           originalElementPath: path,
-      //           importsToAdd: {},
-      //         },
-      //       ]
-      //     },
-      //     pasteInto: conditionalClauseInsertionPath(
-      //       EP.appendNewElementPath(TestScenePath, ['root', 'conditional']),
-      //       'true-case',
-      //     ),
-      //     want: `
-      //     <div data-uid='root'>
-      //         {
-      //             // @utopia/uid=conditional
-      //             true ? <div data-uid='aaa'>foo</div> : <div data-uid='bbb'>bar</div>
-      //         }
-      //         <div data-uid='ccc'>baz</div>
-      //     </div>
-      // `,
-      //   },
       {
         name: 'multiple elements into an empty conditional branch (true)',
         startingCode: `
@@ -1254,6 +1218,181 @@ describe('actions', () => {
           </div>
   `),
         )
+      })
+      describe('paste into a conditional', () => {
+        setFeatureForBrowserTests('Paste wraps into fragment', true)
+        describe('root', () => {
+          it('pastes the element below the conditional', async () => {
+            const testCode = `
+              <div data-uid='root'>
+                {
+                  // @utopia/uid=conditional
+                  true ? <div data-uid='aaa' /> : null
+                }
+                <div data-uid='bbb'>foo</div>
+              </div>
+            `
+            const renderResult = await renderTestEditorWithCode(
+              makeTestProjectCodeWithSnippet(testCode),
+              'await-first-dom-report',
+            )
+            await selectComponentsForTest(renderResult, [makeTargetPath('root/bbb')])
+            await pressKey('c', { modifiers: cmdModifier })
+
+            await selectComponentsForTest(renderResult, [makeTargetPath('root/conditional')])
+
+            const canvasRoot = renderResult.renderedDOM.getByTestId('canvas-root')
+
+            firePasteEvent(canvasRoot)
+
+            // Wait for the next frame
+            await clipboardMock.pasteDone
+            await renderResult.getDispatchFollowUpActionsFinished()
+
+            expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+              makeTestProjectCodeWithSnippet(`
+                <div data-uid='root'>
+                  {
+                    // @utopia/uid=conditional
+                    true ? <div data-uid='aaa' /> : null
+                  }
+                  <div data-uid='bbb'>foo</div>
+                  <div data-uid='aab'>foo</div>
+                </div>
+              `),
+            )
+          })
+        })
+        describe('non-empty branch', () => {
+          it(`when it supports children, it's inserted as a child`, async () => {
+            const testCode = `
+              <div data-uid='root'>
+                {
+                  // @utopia/uid=conditional
+                  true ? <div data-uid='aaa' /> : null
+                }
+                <div data-uid='bbb'>foo</div>
+              </div>
+            `
+            const renderResult = await renderTestEditorWithCode(
+              makeTestProjectCodeWithSnippet(testCode),
+              'await-first-dom-report',
+            )
+            await selectComponentsForTest(renderResult, [makeTargetPath('root/bbb')])
+            await pressKey('c', { modifiers: cmdModifier })
+
+            await selectComponentsForTest(renderResult, [makeTargetPath('root/conditional/aaa')])
+
+            const canvasRoot = renderResult.renderedDOM.getByTestId('canvas-root')
+
+            firePasteEvent(canvasRoot)
+
+            // Wait for the next frame
+            await clipboardMock.pasteDone
+            await renderResult.getDispatchFollowUpActionsFinished()
+
+            expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+              makeTestProjectCodeWithSnippet(`
+                <div data-uid='root'>
+                  {
+                    // @utopia/uid=conditional
+                    true ? (
+                      <div data-uid='aaa'>
+                        <div data-uid='aab'>foo</div>
+                      </div>
+                    ) : null
+                  }
+                  <div data-uid='bbb'>foo</div>
+                </div>
+              `),
+            )
+          })
+          it(`when it does not support children, it's wrapped in a fragment`, async () => {
+            const testCode = `
+              <div data-uid='root'>
+                {
+                  // @utopia/uid=conditional
+                  true ? <img data-uid='aaa' src='https://placekitten.com/100/100' /> : null
+                }
+                <div data-uid='bbb'>foo</div>
+              </div>
+            `
+            const renderResult = await renderTestEditorWithCode(
+              makeTestProjectCodeWithSnippet(testCode),
+              'await-first-dom-report',
+            )
+            await selectComponentsForTest(renderResult, [makeTargetPath('root/bbb')])
+            await pressKey('c', { modifiers: cmdModifier })
+
+            await selectComponentsForTest(renderResult, [makeTargetPath('root/conditional/aaa')])
+
+            const canvasRoot = renderResult.renderedDOM.getByTestId('canvas-root')
+
+            firePasteEvent(canvasRoot)
+
+            // Wait for the next frame
+            await clipboardMock.pasteDone
+            await renderResult.getDispatchFollowUpActionsFinished()
+
+            expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+              makeTestProjectCodeWithSnippet(`
+                <div data-uid='root'>
+                  {
+                    // @utopia/uid=conditional
+                    true ? (
+                      <React.Fragment>
+                        <div data-uid='aab'>foo</div>
+                        <img data-uid='aaa' src='https://placekitten.com/100/100' />
+                      </React.Fragment>
+                    ) : null
+                  }
+                  <div data-uid='bbb'>foo</div>
+                </div>
+              `),
+            )
+          })
+        })
+        describe('empty branch', () => {
+          it(`replaces the slot`, async () => {
+            const testCode = `
+              <div data-uid='root'>
+                {
+                  // @utopia/uid=conditional
+                  true ? <div data-uid='aaa' /> : null
+                }
+                <div data-uid='bbb'>foo</div>
+              </div>
+            `
+            const renderResult = await renderTestEditorWithCode(
+              makeTestProjectCodeWithSnippet(testCode),
+              'await-first-dom-report',
+            )
+            await selectComponentsForTest(renderResult, [makeTargetPath('root/bbb')])
+            await pressKey('c', { modifiers: cmdModifier })
+
+            await selectComponentsForTest(renderResult, [makeTargetPath('root/conditional/a25')])
+
+            const canvasRoot = renderResult.renderedDOM.getByTestId('canvas-root')
+
+            firePasteEvent(canvasRoot)
+
+            // Wait for the next frame
+            await clipboardMock.pasteDone
+            await renderResult.getDispatchFollowUpActionsFinished()
+
+            expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+              makeTestProjectCodeWithSnippet(`
+                <div data-uid='root'>
+                  {
+                    // @utopia/uid=conditional
+                    true ? <div data-uid='aaa' /> : <div data-uid='aab'>foo</div>
+                  }
+                  <div data-uid='bbb'>foo</div>
+                </div>
+              `),
+            )
+          })
+        })
       })
     })
   })

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -488,6 +488,7 @@ import {
   InsertionPath,
   isConditionalClauseInsertionPath,
   childInsertionPath,
+  conditionalClauseInsertionPath,
 } from '../store/insertion-path'
 import { findMaybeConditionalExpression } from '../../../core/model/conditionals'
 import { deleteProperties } from '../../canvas/commands/delete-properties-command'
@@ -2364,11 +2365,15 @@ export const UPDATE_FNS = {
           type: 'back',
         }
 
+        const insertionPath = isJSXConditionalExpression(action.whatToWrapWith.element)
+          ? conditionalClauseInsertionPath(newPath, 'true-case', 'wrap-with-fragment')
+          : childInsertionPath(newPath)
+
         const withElementsAdded = editorMoveMultiSelectedTemplates(
           builtInDependencies,
           orderedActionTargets,
           indexPosition,
-          childInsertionPath(newPath),
+          insertionPath,
           includeToast(detailsOfUpdate, withWrapperViewAdded),
           'use-deprecated-insertJSXElementChild',
         )

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3,21 +3,18 @@ import update from 'immutability-helper'
 import localforage from 'localforage'
 import { LayoutSystem } from 'utopia-api/core'
 import { imagePathURL } from '../../../common/server'
-import { PinLayoutHelpers } from '../../../core/layout/layout-helpers'
 import {
   maybeSwitchChildrenLayoutProps,
   roundAttributeLayoutValues,
   switchLayoutMetadata,
 } from '../../../core/layout/layout-utils'
-import { findElementAtPath, MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import {
   generateUidWithExistingComponents,
   getAllUniqueUids,
   getIndexInParent,
-  insertChildAndDetails,
   InsertChildAndDetails,
   transformJSXComponentAtElementPath,
-  transformJSXComponentAtPath,
 } from '../../../core/model/element-template-utils'
 import {
   applyToAllUIJSFiles,
@@ -61,12 +58,10 @@ import {
   emptyComments,
   emptyJsxMetadata,
   getJSXAttribute,
-  isElementWithUid,
   isImportStatement,
   isJSXAttributeValue,
   isJSXConditionalExpression,
   isJSXElement,
-  isJSXFragment,
   modifiableAttributeIsPartOfAttributeValue,
   jsExpressionOtherJavaScript,
   JSXAttributes,
@@ -74,26 +69,20 @@ import {
   jsExpressionValue,
   JSExpressionValue,
   jsxConditionalExpression,
-  JSXConditionalExpression,
   JSXElement,
   jsxElement,
   JSXElementChild,
   JSXElementChildren,
   jsxElementName,
-  JSXFragment,
   jsxFragment,
   jsxTextBlock,
   SettableLayoutSystem,
-  singleLineComment,
   UtopiaJSXComponent,
   walkElements,
   modifiableAttributeIsAttributeValue,
-  isUtopiaJSXComponent,
-  isNullJSXAttributeValue,
 } from '../../../core/shared/element-template'
 import {
   getJSXAttributeAtPath,
-  jsxSimpleAttributeToValue,
   setJSXValueAtPath,
   setJSXValuesAtPaths,
   unsetJSXValueAtPath,
@@ -140,7 +129,7 @@ import {
 } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
 import { assertNever, fastForEach, getProjectLockedKey } from '../../../core/shared/utils'
-import { emptyImports, mergeImports } from '../../../core/workers/common/project-file-utils'
+import { mergeImports } from '../../../core/workers/common/project-file-utils'
 import { UtopiaTsWorkers } from '../../../core/workers/common/worker-types'
 import Utils, { IndexPosition, absolute } from '../../../utils/utils'
 import {
@@ -161,7 +150,6 @@ import {
   canvasFrameToNormalisedFrame,
   clearDragState,
   duplicate,
-  editorMultiselectReparentNoStyleChange,
   getFrameChange,
   moveTemplate,
   produceCanvasTransientState,
@@ -341,7 +329,7 @@ import {
   SwitchConditionalBranches,
   UpdateConditionalExpression,
 } from '../action-types'
-import { defaultSceneElement, defaultTransparentViewElement } from '../defaults'
+import { defaultSceneElement } from '../defaults'
 import { EditorModes, isLiveMode, isSelectMode, Mode } from '../editor-modes'
 import * as History from '../history'
 import { StateHistory } from '../history'
@@ -395,7 +383,6 @@ import {
   modifyUnderlyingTargetElement,
   packageJsonFileFromProjectContents,
   PersistentModel,
-  persistentModelFromEditorModel,
   removeElementAtPath,
   RightMenuTab,
   SimpleParseSuccess,
@@ -411,8 +398,6 @@ import {
   modifyOpenJsxElementOrConditionalAtPath,
   isRegularNavigatorEntry,
   NavigatorEntry,
-  regularNavigatorEntryOptic,
-  ConditionalClauseNavigatorEntry,
   reparentTargetFromNavigatorEntry,
 } from '../store/editor-state'
 import { loadStoredState } from '../stored-state'
@@ -467,13 +452,11 @@ import { ShortcutConfiguration } from '../shortcut-definitions'
 import { ElementInstanceMetadataMapKeepDeepEquality } from '../store/store-deep-equality-instances'
 import {
   addImports,
-  addToast,
   clearImageFileBlob,
   enableInsertModeForJSXElement,
   finishCheckpointTimer,
   insertJSXElement,
   openCodeEditorFile,
-  removeToast,
   selectComponents,
   setAssetChecksum,
   setPackageStatus,
@@ -495,29 +478,18 @@ import { getReparentPropertyChanges } from '../../canvas/canvas-strategies/strat
 import { styleStringInArray } from '../../../utils/common-constants'
 import { collapseTextElements } from '../../../components/text-editor/text-handling'
 import { LayoutPropsWithoutTLBR, StyleProperties } from '../../inspector/common/css-utils'
-import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { isUtopiaCommentFlag, makeUtopiaFlagComment } from '../../../core/shared/comment-flags'
-import { modify, toArrayOf } from '../../../core/shared/optics/optic-utilities'
-import { compose2Optics, compose3Optics, Optic } from '../../../core/shared/optics/optics'
+import { toArrayOf } from '../../../core/shared/optics/optic-utilities'
+import { compose2Optics, Optic } from '../../../core/shared/optics/optics'
 import { fromField, traverseArray } from '../../../core/shared/optics/optic-creators'
 import {
   commonInsertionPathFromArray,
   getElementPathFromInsertionPath,
   InsertionPath,
   isConditionalClauseInsertionPath,
-  isChildInsertionPath,
   childInsertionPath,
-  conditionalClauseInsertionPath,
-  getInsertionPathWithSlotBehavior,
 } from '../store/insertion-path'
-import {
-  findMaybeConditionalExpression,
-  getClauseOptic,
-  getConditionalCaseCorrespondingToBranchPath,
-  isEmptyConditionalBranch,
-  maybeBranchConditionalCase,
-  maybeConditionalExpression,
-} from '../../../core/model/conditionals'
+import { findMaybeConditionalExpression } from '../../../core/model/conditionals'
 import { deleteProperties } from '../../canvas/commands/delete-properties-command'
 import { treatElementAsContentAffecting } from '../../canvas/canvas-strategies/strategies/group-like-helpers'
 import {
@@ -526,7 +498,6 @@ import {
   unwrapTextContainingConditional,
   wrapElementInsertions,
 } from './wrap-unwrap-helpers'
-import { ConditionalClauseInsertionPath } from '../store/insertion-path'
 import { encodeUtopiaDataToHtml } from '../../../utils/clipboard-utils'
 
 export const MIN_CODE_PANE_REOPEN_WIDTH = 100
@@ -864,7 +835,6 @@ export function editorMoveMultiSelectedTemplates(
       pathToReparent(target),
       newParent,
       'on-complete', // TODO make sure this is the right pick here
-      useNewInsertJSXElementChild,
     )
     if (outcomeResult == null) {
       return working
@@ -2875,7 +2845,6 @@ export const UPDATE_FNS = {
           elementToReparent(elementWithUniqueUID, currentValue.importsToAdd),
           action.pasteInto,
           'always', // TODO Before merge make sure this is the right pick here
-          'use-new-insertJSXElementChild',
         )
 
         if (outcomeResult == null) {

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -47,7 +47,7 @@ describe('conditionals', () => {
       const editor = await renderTestEditorWithCode(
         `import * as React from 'react'
       import { Storyboard } from 'utopia-api'
-      
+
       export var storyboard = (
         <Storyboard data-uid='sb'>
           {
@@ -468,10 +468,10 @@ describe('conditionals', () => {
             <div data-uid='aaa'>
               {
                 true ? (
-                  <>
+                  <React.Fragment>
                     <div data-uid='bbb'>hello there</div>
                     <div data-uid='ccc'>another div</div>
-                  </>
+                  </React.Fragment>
                 ) : null
               }
               <div data-uid='ddd'>yet another one</div>


### PR DESCRIPTION
Fixes #3637 

Removed `insertElementAtPath_DEPRECATED` from `getReparentOutcome` and `runReparentElement`.