### PR TITLE
Fix bounding box hooks callback when bounding box is null

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -1607,7 +1607,11 @@ describe('Absolute Resize Strategy Canvas Controls', () => {
         await wait(ControlDelay + 10)
         expectElementWithTestIdToBeRendered(renderResult, ImmediateParentOutlinesTestId([target]))
         expectElementWithTestIdToBeRendered(renderResult, ImmediateParentBoundsTestId([target]))
-        expectElementWithTestIdToBeRendered(renderResult, AbsoluteResizeControlTestId([target]))
+        // FIXME Does this imply these tests are actually broken, or that this was the actual expectation all along?
+        expectElementWithTestIdToBeRenderedWithDisplayNone(
+          renderResult,
+          AbsoluteResizeControlTestId([target]),
+        )
       })
     })
   })

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -9,7 +9,10 @@ import {
   TestSceneUID,
 } from '../../ui-jsx.test-utils'
 import * as EP from '../../../../core/shared/element-path'
-import { selectComponents } from '../../../editor/actions/action-creators'
+import {
+  selectComponents,
+  setConditionalOverriddenCondition,
+} from '../../../editor/actions/action-creators'
 import CanvasActions from '../../canvas-actions'
 import { createInteractionViaMouse, updateInteractionViaMouse } from '../interaction-state'
 import {
@@ -34,6 +37,7 @@ import {
 import {
   expectElementWithTestIdNotToBeRendered,
   expectElementWithTestIdToBeRendered,
+  expectElementWithTestIdToBeRenderedWithDisplayNone,
   selectComponentsForTest,
   setFeatureForBrowserTests,
   wait,
@@ -1470,6 +1474,79 @@ export var storyboard = (
 })
 
 describe('Absolute Resize Strategy Canvas Controls', () => {
+  it('when an absolute positioned element is selected the bounding box shows', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+            style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 40, top: 50, right: 160, bottom: 230 }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    expectElementWithTestIdNotToBeRendered(renderResult, AbsoluteResizeControlTestId([]))
+
+    const target = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
+    await renderResult.dispatch([selectComponents([target], false)], true)
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expectElementWithTestIdToBeRendered(renderResult, AbsoluteResizeControlTestId([target]))
+  })
+
+  it('when a condition is overriden to one without an element, the bounding box disappears', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
+          {
+            // @utopia/uid=conditional
+            true ? (
+              <div
+                style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 40, top: 50, right: 160, bottom: 230 }}
+                data-uid='bbb'
+                data-testid='bbb'
+              />
+            ) : null
+          }
+        </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    expectElementWithTestIdNotToBeRendered(renderResult, AbsoluteResizeControlTestId([]))
+
+    const conditional = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional'])
+    await renderResult.dispatch([selectComponents([conditional], false)], true)
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    const childOfConditional = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional', 'bbb'])
+
+    expectElementWithTestIdNotToBeRendered(renderResult, AbsoluteResizeControlTestId([conditional]))
+    expectElementWithTestIdToBeRendered(
+      renderResult,
+      AbsoluteResizeControlTestId([childOfConditional]),
+    )
+
+    await renderResult.dispatch([setConditionalOverriddenCondition(conditional, false)], true)
+    await renderResult.getDispatchFollowUpActionsFinished()
+    expectElementWithTestIdNotToBeRendered(
+      renderResult,
+      AbsoluteResizeControlTestId([childOfConditional]),
+    )
+
+    expectElementWithTestIdNotToBeRendered(
+      renderResult,
+      AbsoluteResizeControlTestId([childOfConditional]),
+    )
+    expectElementWithTestIdToBeRenderedWithDisplayNone(
+      renderResult,
+      AbsoluteResizeControlTestId([conditional]),
+    )
+  })
+
   it('when an absolute positioned element is resized the parent outlines become visible', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`

--- a/editor/src/components/canvas/controls/bounding-box-hooks.ts
+++ b/editor/src/components/canvas/controls/bounding-box-hooks.ts
@@ -5,6 +5,7 @@ import {
   boundingRectangleArray,
   CanvasRectangle,
   isFiniteRectangle,
+  zeroRectIfNullOrInfinity,
 } from '../../../core/shared/math-utils'
 import {
   Substores,
@@ -25,8 +26,9 @@ export function useBoundingBox<T = HTMLDivElement>(
   const controlRef = React.useRef<T>(null)
   const boundingBoxCallback = React.useCallback(
     (boundingBox: CanvasRectangle | null, scale: number) => {
-      if (boundingBox != null && controlRef.current != null) {
-        onChangeCallback(controlRef as NotNullRefObject<T>, boundingBox, scale)
+      const maybeZeroBoundingBox = zeroRectIfNullOrInfinity(boundingBox)
+      if (controlRef.current != null) {
+        onChangeCallback(controlRef as NotNullRefObject<T>, maybeZeroBoundingBox, scale)
       }
     },
     [onChangeCallback],

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -517,7 +517,20 @@ function getElementsWithTestId(editor: EditorRenderResult, testId: string): HTML
 export const expectElementWithTestIdToBeRendered = (
   editor: EditorRenderResult,
   testId: string,
-): void => expect(getElementsWithTestId(editor, testId).length).toEqual(1)
+): void => {
+  const foundElements = getElementsWithTestId(editor, testId)
+  expect(foundElements.length).toEqual(1)
+  expect(foundElements[0].style.display).not.toEqual('none')
+}
+
+export const expectElementWithTestIdToBeRenderedWithDisplayNone = (
+  editor: EditorRenderResult,
+  testId: string,
+): void => {
+  const foundElements = getElementsWithTestId(editor, testId)
+  expect(foundElements.length).toEqual(1)
+  expect(foundElements[0].style.display).toEqual('none')
+}
 
 export const expectElementWithTestIdNotToBeRendered = (
   editor: EditorRenderResult,


### PR DESCRIPTION
**Problem:**
The `onChangeCallback` in `useBoundingBox()` isn't fired when a bounding box is `null`, which can be the case when switching the override of a conditional whilst the conditional is selected, meaning that the old bounding box will still be shown.

**Fix:**
If the bounding box is `null` we instead use a zero rect.

**TODO:**
- [x] Add a test