### PR TITLE
Navigator reparent to flex

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
@@ -124,6 +124,7 @@ export function baseAbsoluteReparentStrategy(
                   childInsertionPath(newParent),
                   'always',
                   'use-deprecated-insertJSXElementChild',
+                  null,
                 )
 
                 if (reparentResult == null) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -389,6 +389,7 @@ function collectReparentCommands(
     childInsertionPath(targetParent),
     'always',
     'use-deprecated-insertJSXElementChild',
+    null,
   )
   if (outcomeResult == null) {
     return []

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -164,6 +164,7 @@ function applyStaticReparent(
             childInsertionPath(newParent),
             'always',
             'use-deprecated-insertJSXElementChild',
+            null,
           )
           let duplicatedElementNewUids: { [elementPath: string]: string } = {}
           if (outcomeResult != null) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
@@ -47,6 +47,7 @@ import {
 } from '../../../editor/store/insertion-path'
 import { getUtopiaID } from '../../../../core/shared/uid-utils'
 import { UseNewInsertJsxElementChild } from '../../canvas-utils'
+import { IndexPosition } from '../../../../utils/utils'
 
 interface GetReparentOutcomeResult {
   commands: Array<CanvasCommand>
@@ -90,6 +91,7 @@ export function getReparentOutcome(
   targetParent: InsertionPath | null,
   whenToRun: 'always' | 'on-complete',
   useNewInsertJSXElementChild: UseNewInsertJsxElementChild,
+  indexPosition: IndexPosition | null,
 ): GetReparentOutcomeResult | null {
   // Cater for something being reparented to the canvas.
   let newParent: InsertionPath
@@ -103,18 +105,6 @@ export function getReparentOutcome(
     }
   } else {
     newParent = targetParent
-  }
-
-  // Early exit if there's no need to make any change.
-  if (
-    toReparent.type === 'PATH_TO_REPARENT' &&
-    isChildInsertionPath(newParent) &&
-    EP.pathsEqual(newParent.intendedParentPath, EP.parentPath(toReparent.target))
-  ) {
-    return {
-      commands: [],
-      newPath: toReparent.target,
-    }
   }
 
   const newParentElementPath = getElementPathFromInsertionPath(newParent)
@@ -151,7 +141,13 @@ export function getReparentOutcome(
       )
       commands.push(addImportsToFile(whenToRun, newTargetFilePath, importsToAdd))
       commands.push(
-        reparentElement(whenToRun, toReparent.target, newParent, useNewInsertJSXElementChild),
+        reparentElement(
+          whenToRun,
+          toReparent.target,
+          newParent,
+          useNewInsertJSXElementChild,
+          indexPosition,
+        ),
       )
       newPath = EP.appendToPath(newParentElementPath, EP.toUid(toReparent.target))
       break

--- a/editor/src/components/canvas/commands/reparent-element-command.ts
+++ b/editor/src/components/canvas/commands/reparent-element-command.ts
@@ -18,12 +18,14 @@ import {
 } from '../../editor/store/editor-state'
 import { BaseCommand, CommandFunction, getPatchForComponentChange, WhenToRun } from './commands'
 import { UseNewInsertJsxElementChild } from '../canvas-utils'
+import { IndexPosition } from '../../../utils/utils'
 
 export interface ReparentElement extends BaseCommand {
   type: 'REPARENT_ELEMENT'
   target: ElementPath
   newParent: InsertionPath
   useNewInsertJSXElementChild: UseNewInsertJsxElementChild
+  indexPosition: IndexPosition | null
 }
 
 export function reparentElement(
@@ -31,6 +33,7 @@ export function reparentElement(
   target: ElementPath,
   newParent: InsertionPath,
   useNewInsertJSXElementChild: UseNewInsertJsxElementChild,
+  indexPosition?: IndexPosition | null,
 ): ReparentElement {
   return {
     type: 'REPARENT_ELEMENT',
@@ -38,6 +41,7 @@ export function reparentElement(
     target: target,
     newParent: newParent,
     useNewInsertJSXElementChild: useNewInsertJSXElementChild,
+    indexPosition: indexPosition ?? null,
   }
 }
 
@@ -70,7 +74,7 @@ export const runReparentElement: CommandFunction<ReparentElement> = (
                     command.newParent,
                     underlyingElementTarget,
                     withElementRemoved,
-                    null,
+                    command.indexPosition,
                   )
                 : insertElementAtPath_DEPRECATED(
                     editorState.projectContents,
@@ -78,7 +82,7 @@ export const runReparentElement: CommandFunction<ReparentElement> = (
                     command.newParent,
                     underlyingElementTarget,
                     withElementRemoved,
-                    null,
+                    command.indexPosition,
                   )
             const editorStatePatchOldParentFile = getPatchForComponentChange(
               successTarget.topLevelElements,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2920,6 +2920,7 @@ export const UPDATE_FNS = {
           action.pasteInto,
           'always', // TODO Before merge make sure this is the right pick here
           'use-new-insertJSXElementChild',
+          null,
         )
 
         if (outcomeResult == null) {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -451,7 +451,7 @@ import utils from '../../../utils/utils'
 import { pickCanvasStateFromEditorState } from '../../canvas/canvas-strategies/canvas-strategies'
 import { getEscapeHatchCommands } from '../../canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy'
 import { isAllowedToReparent } from '../../canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers'
-import { reparentStrategyForPaste } from '../../canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers'
+import { reparentStrategyForPaste as reparentStrategyForStaticReparent } from '../../canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers'
 import {
   elementToReparent,
   getReparentOutcome,
@@ -5608,7 +5608,7 @@ function insertWithReparentStrategies(
 
   const { commands: reparentCommands, newPath } = outcomeResult
 
-  const reparentStrategy = reparentStrategyForPaste(
+  const reparentStrategy = reparentStrategyForStaticReparent(
     editor.jsxMetadata,
     editor.allElementProps,
     parentPath.intendedParentPath,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -528,6 +528,8 @@ import {
 } from './wrap-unwrap-helpers'
 import { ConditionalClauseInsertionPath } from '../store/insertion-path'
 import { encodeUtopiaDataToHtml } from '../../../utils/clipboard-utils'
+import { wildcardPatch } from '../../canvas/commands/wildcard-patch-command'
+import { updateSelectedViews } from '../../canvas/commands/update-selected-views-command'
 
 export const MIN_CODE_PANE_REOPEN_WIDTH = 100
 
@@ -1881,14 +1883,14 @@ export const UPDATE_FNS = {
           switch (dropTarget.target.type) {
             case 'REGULAR':
             case 'CONDITIONAL_CLAUSE': {
-              const newParent = reparentTargetFromNavigatorEntry(
+              const newParentPath = reparentTargetFromNavigatorEntry(
                 dropTarget.target,
                 editor.projectContents,
                 editor.jsxMetadata,
                 editor.nodeModules.files,
                 editor.canvas.openFile?.filename,
               )
-              return reparentToIndexPosition(newParent, absolute(0))
+              return reparentToIndexPosition(newParentPath, absolute(0))
             }
             case 'SYNTHETIC': {
               // Find the containing conditional clause, which should be an immediate parent,
@@ -2913,6 +2915,7 @@ export const UPDATE_FNS = {
       let newPaths: Array<ElementPath> = []
       const updatedEditorState = elements.reduce((workingEditorState, currentValue, index) => {
         const elementWithUniqueUID = fixUtopiaElement(currentValue.element, existingIDs)
+
         const outcomeResult = getReparentOutcome(
           builtInDependencies,
           workingEditorState.projectContents,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -456,6 +456,7 @@ import {
   elementToReparent,
   getReparentOutcome,
   pathToReparent,
+  ToReparent,
 } from '../../canvas/canvas-strategies/strategies/reparent-utils'
 import { areAllSelectedElementsNonAbsolute } from '../../canvas/canvas-strategies/strategies/shared-move-strategies-helpers'
 import { foldAndApplyCommandsSimple } from '../../canvas/commands/commands'
@@ -530,6 +531,7 @@ import { ConditionalClauseInsertionPath } from '../store/insertion-path'
 import { encodeUtopiaDataToHtml } from '../../../utils/clipboard-utils'
 import { wildcardPatch } from '../../canvas/commands/wildcard-patch-command'
 import { updateSelectedViews } from '../../canvas/commands/update-selected-views-command'
+import { front } from '../../../utils/utils'
 
 export const MIN_CODE_PANE_REOPEN_WIDTH = 100
 
@@ -1804,54 +1806,24 @@ export const UPDATE_FNS = {
     const dropTarget = action.dropTarget
     const dragSources = action.dragSources
 
-    function reparentToIndexPosition(
+    const reparentToIndexPosition = (
       newParentPath: InsertionPath,
       indexPosition: IndexPosition,
-    ): EditorModel {
-      const outcomeResult = getReparentOutcome(
-        builtInDependencies,
-        editor.projectContents,
-        editor.nodeModules.files,
-        editor.canvas.openFile?.filename,
-        pathToReparent(dragSources[0]),
-        newParentPath,
-        'always',
-        indexPosition,
+    ): EditorModel =>
+      dragSources.reduce(
+        (workingEditorState, dragSource) =>
+          insertWithReparentStrategies(
+            editor,
+            newParentPath,
+            {
+              elementPath: dragSource,
+              pathToReparent: pathToReparent(dragSource),
+            },
+            indexPosition,
+            builtInDependencies,
+          )?.updatedEditorState ?? workingEditorState,
+        editor,
       )
-
-      if (outcomeResult == null) {
-        return editor
-      }
-
-      const { commands: reparentCommands, newPath } = outcomeResult
-
-      const reparentStrategy = reparentStrategyForPaste(
-        editor.jsxMetadata,
-        editor.allElementProps,
-        newParentPath.intendedParentPath,
-      )
-
-      const pastedElementMetadata = MetadataUtils.findElementByElementPath(
-        editor.jsxMetadata,
-        dragSources[0],
-      )
-
-      const propertyChangeCommands = getReparentPropertyChanges(
-        reparentStrategy.strategy,
-        newPath,
-        newParentPath.intendedParentPath,
-        editor.jsxMetadata,
-        editor.jsxMetadata,
-        editor.projectContents,
-        editor.canvas.openFile?.filename,
-        pastedElementMetadata?.specialSizeMeasurements.position ?? null,
-        pastedElementMetadata?.specialSizeMeasurements.display ?? null,
-      )
-
-      const allCommands = [...reparentCommands, ...propertyChangeCommands]
-
-      return foldAndApplyCommandsSimple(editor, allCommands)
-    }
 
     if (dropTarget.type === 'MOVE_ROW_BEFORE' || dropTarget.type === 'MOVE_ROW_AFTER') {
       const newParentPath: ElementPath | null = EP.parentPath(dropTarget.target)
@@ -2862,120 +2834,88 @@ export const UPDATE_FNS = {
     builtInDependencies: BuiltInDependencies,
   ): EditorModel => {
     let elements = [...action.elements]
-    let insertionAllowed: boolean = true
     const resolvedTarget = MetadataUtils.resolveReparentTargetParentToPath(
       editor.jsxMetadata,
       action.pasteInto,
     )
-    if (resolvedTarget != null) {
-      const parentGenerated = MetadataUtils.isElementGenerated(resolvedTarget)
-      insertionAllowed = !parentGenerated
-    }
-    if (insertionAllowed) {
-      function isConditionalTarget(): boolean {
-        if (isConditionalClauseInsertionPath(action.pasteInto)) {
-          return true
-        }
-        const parentPath = EP.parentPath(action.pasteInto.intendedParentPath)
-        if (findMaybeConditionalExpression(parentPath, editor.jsxMetadata) != null) {
-          // TODO invariant violation!
-          return true
-        }
-        return false
-      }
-      // when targeting a conditional, wrap multiple elements into a fragment
-      if (action.elements.length > 1 && isConditionalTarget()) {
-        const fragmentUID = generateUidWithExistingComponents(editor.projectContents)
-        const mergedImportsFromElements = elements
-          .map((e) => e.importsToAdd)
-          .reduce((merged, imports) => ({ ...merged, ...imports }), {})
-        const mergedImportsWithReactImport = {
-          ...mergedImportsFromElements,
-          react: {
-            importedAs: 'React',
-            importedFromWithin: [],
-            importedWithName: null,
-          },
-        }
-        const fragment = jsxFragment(
-          fragmentUID,
-          elements.map((e) => e.element),
-          true,
-        )
-        elements = [
-          {
-            element: fragment,
-            importsToAdd: mergedImportsWithReactImport,
-            originalElementPath: EP.fromString(fragmentUID),
-          },
-        ]
-      }
 
-      const existingIDs = getAllUniqueUids(editor.projectContents)
-      let newPaths: Array<ElementPath> = []
-      const updatedEditorState = elements.reduce((workingEditorState, currentValue, index) => {
-        const elementWithUniqueUID = fixUtopiaElement(currentValue.element, existingIDs)
+    const insertionAllowed: boolean =
+      resolvedTarget != null ? !MetadataUtils.isElementGenerated(resolvedTarget) : true
 
-        const outcomeResult = getReparentOutcome(
-          builtInDependencies,
-          workingEditorState.projectContents,
-          workingEditorState.nodeModules.files,
-          workingEditorState.canvas.openFile?.filename,
-          elementToReparent(elementWithUniqueUID, currentValue.importsToAdd),
-          action.pasteInto,
-          'always', // TODO Before merge make sure this is the right pick here
-          null,
-        )
-
-        if (outcomeResult == null) {
-          return workingEditorState
-        } else {
-          const { commands: reparentCommands, newPath } = outcomeResult
-          newPaths.push(newPath)
-
-          const reparentStrategy = reparentStrategyForPaste(
-            workingEditorState.jsxMetadata,
-            workingEditorState.allElementProps,
-            resolvedTarget,
-          )
-
-          const pastedElementMetadata = MetadataUtils.findElementByElementPath(
-            action.targetOriginalContextMetadata,
-            currentValue.originalElementPath,
-          )
-
-          const propertyChangeCommands = getReparentPropertyChanges(
-            reparentStrategy.strategy,
-            newPath,
-            resolvedTarget,
-            action.targetOriginalContextMetadata,
-            workingEditorState.jsxMetadata,
-            workingEditorState.projectContents,
-            workingEditorState.canvas.openFile?.filename,
-            pastedElementMetadata?.specialSizeMeasurements.position ?? null,
-            pastedElementMetadata?.specialSizeMeasurements.display ?? null,
-          )
-
-          const allCommands = [...reparentCommands, ...propertyChangeCommands]
-
-          return foldAndApplyCommandsSimple(workingEditorState, allCommands)
-        }
-      }, editor)
-
-      // Update the selected views to what has just been created.
-      if (newPaths.length > 0) {
-        return {
-          ...updatedEditorState,
-          selectedViews: newPaths,
-        }
-      } else {
-        return updatedEditorState
-      }
-    } else {
+    if (!insertionAllowed) {
       const showToastAction = showToast(
         notice(`Unable to paste into a generated element.`, 'WARNING'),
       )
       return UPDATE_FNS.ADD_TOAST(showToastAction, editor)
+    }
+
+    function isConditionalTarget(): boolean {
+      if (isConditionalClauseInsertionPath(action.pasteInto)) {
+        return true
+      }
+      const parentPath = EP.parentPath(action.pasteInto.intendedParentPath)
+      if (findMaybeConditionalExpression(parentPath, editor.jsxMetadata) != null) {
+        // TODO invariant violation!
+        return true
+      }
+      return false
+    }
+
+    // when targeting a conditional, wrap multiple elements into a fragment
+    if (action.elements.length > 1 && isConditionalTarget()) {
+      const fragmentUID = generateUidWithExistingComponents(editor.projectContents)
+      const mergedImportsFromElements = elements
+        .map((e) => e.importsToAdd)
+        .reduce((merged, imports) => ({ ...merged, ...imports }), {})
+      const mergedImportsWithReactImport = {
+        ...mergedImportsFromElements,
+        react: {
+          importedAs: 'React',
+          importedFromWithin: [],
+          importedWithName: null,
+        },
+      }
+      const fragment = jsxFragment(
+        fragmentUID,
+        elements.map((e) => e.element),
+        true,
+      )
+      elements = [
+        {
+          element: fragment,
+          importsToAdd: mergedImportsWithReactImport,
+          originalElementPath: EP.fromString(fragmentUID),
+        },
+      ]
+    }
+
+    const existingIDs = getAllUniqueUids(editor.projectContents)
+    let newPaths: Array<ElementPath> = []
+    const updatedEditorState = elements.reduce((workingEditorState, currentValue, index) => {
+      const elementWithUniqueUID = fixUtopiaElement(currentValue.element, existingIDs)
+
+      return (
+        insertWithReparentStrategies(
+          workingEditorState,
+          action.pasteInto,
+          {
+            elementPath: currentValue.originalElementPath,
+            pathToReparent: elementToReparent(elementWithUniqueUID, currentValue.importsToAdd),
+          },
+          front(),
+          builtInDependencies,
+        )?.updatedEditorState ?? workingEditorState
+      )
+    }, editor)
+
+    // Update the selected views to what has just been created.
+    if (newPaths.length > 0) {
+      return {
+        ...updatedEditorState,
+        selectedViews: newPaths,
+      }
+    } else {
+      return updatedEditorState
     }
   },
   PASTE_PROPERTIES: (action: PasteProperties, editor: EditorModel): EditorModel => {
@@ -5632,23 +5572,6 @@ export function isSendPreviewModel(action: any): action is SendPreviewModel {
   return action != null && (action as SendPreviewModel).action === 'SEND_PREVIEW_MODEL'
 }
 
-function revertFileInProjectContents(
-  projectContents: ProjectContentTreeRoot,
-  filePath: string,
-): ProjectContentTreeRoot {
-  const file = getContentsTreeFileFromString(projectContents, filePath)
-  if (file == null) {
-    return projectContents
-  } else {
-    const updatedProjectContents = addFileToProjectContents(
-      projectContents,
-      filePath,
-      revertFile(file),
-    )
-    return updatedProjectContents
-  }
-}
-
 function saveFileInProjectContents(
   projectContents: ProjectContentTreeRoot,
   filePath: string,
@@ -5659,4 +5582,56 @@ function saveFileInProjectContents(
   } else {
     return addFileToProjectContents(projectContents, filePath, saveFile(file))
   }
+}
+
+function insertWithReparentStrategies(
+  editor: EditorState,
+  parentPath: InsertionPath,
+  elementToInsert: { elementPath: ElementPath; pathToReparent: ToReparent },
+  indexPosition: IndexPosition,
+  builtInDependencies: BuiltInDependencies,
+): { updatedEditorState: EditorState; newPath: ElementPath } | null {
+  const outcomeResult = getReparentOutcome(
+    builtInDependencies,
+    editor.projectContents,
+    editor.nodeModules.files,
+    editor.canvas.openFile?.filename,
+    elementToInsert.pathToReparent,
+    parentPath,
+    'always',
+    indexPosition,
+  )
+
+  if (outcomeResult == null) {
+    return null
+  }
+
+  const { commands: reparentCommands, newPath } = outcomeResult
+
+  const reparentStrategy = reparentStrategyForPaste(
+    editor.jsxMetadata,
+    editor.allElementProps,
+    parentPath.intendedParentPath,
+  )
+
+  const pastedElementMetadata = MetadataUtils.findElementByElementPath(
+    editor.jsxMetadata,
+    elementToInsert.elementPath,
+  )
+
+  const propertyChangeCommands = getReparentPropertyChanges(
+    reparentStrategy.strategy,
+    newPath,
+    parentPath.intendedParentPath,
+    editor.jsxMetadata,
+    editor.jsxMetadata,
+    editor.projectContents,
+    editor.canvas.openFile?.filename,
+    pastedElementMetadata?.specialSizeMeasurements.position ?? null,
+    pastedElementMetadata?.specialSizeMeasurements.display ?? null,
+  )
+
+  const allCommands = [...reparentCommands, ...propertyChangeCommands]
+
+  return { updatedEditorState: foldAndApplyCommandsSimple(editor, allCommands), newPath: newPath }
 }

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -918,7 +918,6 @@ describe('conditionals', () => {
                       insert into this
                       <div
                         data-uid='aab'
-                        style={{ display: 'block' }}
                       >
                         copy me
                       </div>

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -195,7 +195,12 @@ import { fromTypeGuard } from '../../../core/shared/optics/optic-creators'
 import { getNavigatorTargets } from '../../../components/navigator/navigator-utils'
 import { treatElementAsContentAffecting } from '../../canvas/canvas-strategies/strategies/group-like-helpers'
 import { getUtopiaID } from '../../../core/shared/uid-utils'
-import { childInsertionPath, conditionalClauseInsertionPath, InsertionPath } from './insertion-path'
+import {
+  childInsertionPath,
+  conditionalClauseInsertionPath,
+  getInsertionPathWithWrapWithFragmentBehavior,
+  InsertionPath,
+} from './insertion-path'
 
 const ObjectPathImmutable: any = OPI
 
@@ -2267,9 +2272,9 @@ export function reparentTargetFromNavigatorEntry(
 
       if (clausePath == null) {
         return conditionalClauseInsertionPath(
-          navigatorEntry.elementPath,
+          EP.parentPath(navigatorEntry.elementPath),
           navigatorEntry.clause,
-          'replace',
+          'wrap-with-fragment',
         )
       }
 
@@ -2284,9 +2289,9 @@ export function reparentTargetFromNavigatorEntry(
       return supportsChildren
         ? childInsertionPath(clausePath)
         : conditionalClauseInsertionPath(
-            navigatorEntry.elementPath,
+            EP.parentPath(navigatorEntry.elementPath),
             navigatorEntry.clause,
-            'replace',
+            'wrap-with-fragment',
           )
     default:
       assertNever(navigatorEntry)

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -669,8 +669,9 @@ export const SyntheticNavigatorItemContainer = React.memo(
               conditionalClauseNavigatorEntry(props.elementPath, clause),
               'reparent',
             )
+          } else {
+            onDrop(item, props, regularNavigatorEntry(props.elementPath), 'reparent')
           }
-          onDrop(item, props, regularNavigatorEntry(props.elementPath), 'reparent')
         },
         canDrop: () => {
           const metadata = editorStateRef.current.jsxMetadata

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -23,7 +23,11 @@ import {
   varSafeNavigatorEntryToKey,
 } from '../editor/store/editor-state'
 import { NO_OP } from '../../core/shared/utils'
-import { DragItemTestId } from './navigator-item/navigator-item-dnd-container'
+import {
+  BottomDropTargetLineTestId,
+  DragItemTestId,
+} from './navigator-item/navigator-item-dnd-container'
+import { ElementPath } from '../../core/shared/project-file-types'
 
 const SceneRootId = 'sceneroot'
 const DragMeId = 'dragme'
@@ -423,6 +427,126 @@ export var storyboard = (
     </div>
   </Storyboard>
 )
+`
+
+const projectWithFlexContainerAndCanvas = `import * as React from 'react'
+import { Scene, Storyboard, View } from 'utopia-api'
+
+export var App = (props) => {
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        contain: 'layout',
+      }}
+      data-uid='root'
+    >
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 50.5,
+          top: 26,
+          width: 'max-content',
+          height: 'max-content',
+          display: 'flex',
+          flexDirection: 'row',
+          gap: 37,
+          padding: '21px 28.5px',
+          alignItems: 'flex-end',
+        }}
+        data-uid='container'
+      >
+        <div
+          style={{
+            backgroundColor: '#0075ff',
+            width: 58,
+            height: 75,
+            contain: 'layout',
+          }}
+          data-uid='flex-child'
+        />
+        <div
+          style={{
+            backgroundColor: '#f24e1d',
+            width: 65,
+            height: 63,
+            contain: 'layout',
+          }}
+          data-uid='663'
+        />
+      </div>
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 55,
+          top: 226,
+          width: 298,
+          height: 117,
+        }}
+        data-uid='abs-container'
+      >
+        <div
+          style={{
+            backgroundColor: '#35a853',
+            position: 'absolute',
+            left: 32,
+            top: 23,
+            width: 55,
+            height: 74,
+          }}
+          data-uid='abs-child'
+        />
+        <div
+          style={{
+            backgroundColor: '#fbbc07',
+            position: 'absolute',
+            left: 207,
+            top: 25,
+            width: 55,
+            height: 72,
+          }}
+          data-uid='8ae'
+        />
+      </div>
+    </div>
+  )
+}
+
+export var storyboard = (props) => {
+  return (
+    <Storyboard data-uid='sb'>
+      <Scene
+        style={{ left: 0, top: 0, width: 400, height: 400 }}
+        data-uid='scene'
+      >
+        <App
+          data-uid='app'
+          style={{
+            position: '',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            top: 0,
+          }}
+        />
+      </Scene>
+      <div
+        style={{
+          backgroundColor: '#09cf83',
+          position: 'absolute',
+          left: 456,
+          top: 26,
+          width: 96,
+          height: 95,
+        }}
+        data-uid='dragme'
+      />
+    </Storyboard>
+  )
+}
 `
 
 describe('Navigator', () => {
@@ -1267,6 +1391,204 @@ describe('Navigator', () => {
         'regular-sb/parent2/aab',
         'regular-sb/text',
       ])
+    })
+  })
+
+  describe('reparenting among layout systems', () => {
+    async function doBasicDrag(
+      editor: EditorRenderResult,
+      dragMeElementPath: ElementPath,
+      targetElementPath: ElementPath,
+    ): Promise<{ dragMeElement: HTMLElement; startingDragMeElementStyle: CSSStyleDeclaration }> {
+      const dragMeElement = await editor.renderedDOM.findByTestId(
+        `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(dragMeElementPath))}`,
+      )
+
+      const startingDragMeElementStyle = { ...dragMeElement.style }
+
+      const dragMeElementRect = dragMeElement.getBoundingClientRect()
+      const dragMeElementCenter = getDomRectCenter(dragMeElementRect)
+
+      const targetElement = await editor.renderedDOM.findByTestId(
+        `navigator-item-${varSafeNavigatorEntryToKey(regularNavigatorEntry(targetElementPath))}`,
+      )
+      const targetElementRect = targetElement.getBoundingClientRect()
+      const targetElementCenter = getDomRectCenter(targetElementRect)
+      const dragTo = {
+        x: targetElementCenter.x,
+        y: targetElementRect.y + 3,
+      }
+
+      const dragDelta = windowPoint({
+        x: dragTo.x - dragMeElementCenter.x,
+        y: dragTo.y - dragMeElementCenter.y,
+      })
+
+      await selectComponentsForTest(editor, [dragMeElementPath])
+
+      await act(async () =>
+        dragElement(
+          editor,
+          DragItemTestId(varSafeNavigatorEntryToKey(regularNavigatorEntry(dragMeElementPath))),
+          BottomDropTargetLineTestId(
+            varSafeNavigatorEntryToKey(regularNavigatorEntry(targetElementPath)),
+          ),
+          windowPoint(dragMeElementCenter),
+          dragDelta,
+          'apply-hover-events',
+        ),
+      )
+
+      await editor.getDispatchFollowUpActionsFinished()
+
+      return { dragMeElement, startingDragMeElementStyle }
+    }
+
+    it('reparenting from the canvas to a flex container', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithFlexContainerAndCanvas,
+        'await-first-dom-report',
+      )
+
+      const dragMeElementPath = EP.fromString('sb/dragme')
+      const targetElementPath = EP.fromString('sb/scene/app:root/container/flex-child')
+
+      const { dragMeElement, startingDragMeElementStyle } = await doBasicDrag(
+        editor,
+        dragMeElementPath,
+        targetElementPath,
+      )
+
+      expect(editor.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey)).toEqual([
+        'regular-sb/scene',
+        'regular-sb/scene/app',
+        'regular-sb/scene/app:root',
+        'regular-sb/scene/app:root/container',
+        'regular-sb/scene/app:root/container/flex-child',
+        'regular-sb/scene/app:root/container/dragme', // <- dragme moved here
+        'regular-sb/scene/app:root/container/663',
+        'regular-sb/scene/app:root/abs-container',
+        'regular-sb/scene/app:root/abs-container/abs-child',
+        'regular-sb/scene/app:root/abs-container/8ae',
+      ])
+
+      expect(dragMeElement.style.position).toEqual('')
+      expect(dragMeElement.style.top).toEqual('')
+      expect(dragMeElement.style.left).toEqual('')
+      expect(dragMeElement.style.bottom).toEqual('')
+      expect(dragMeElement.style.right).toEqual('')
+      expect(dragMeElement.style.width).toEqual(startingDragMeElementStyle.width)
+      expect(dragMeElement.style.height).toEqual(startingDragMeElementStyle.height)
+    })
+
+    it('reparenting from a flex container to the canvas', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithFlexContainerAndCanvas,
+        'await-first-dom-report',
+      )
+
+      const dragMeElementPath = EP.fromString('sb/scene/app:root/container/flex-child')
+      const targetElementPath = EP.fromString('sb/dragme')
+
+      const { dragMeElement, startingDragMeElementStyle } = await doBasicDrag(
+        editor,
+        dragMeElementPath,
+        targetElementPath,
+      )
+
+      expect(editor.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey)).toEqual([
+        'regular-sb/scene',
+        'regular-sb/scene/app',
+        'regular-sb/scene/app:root',
+        'regular-sb/scene/app:root/container',
+        'regular-sb/scene/app:root/container/663',
+        'regular-sb/scene/app:root/abs-container',
+        'regular-sb/scene/app:root/abs-container/abs-child',
+        'regular-sb/scene/app:root/abs-container/8ae',
+        'regular-sb/dragme',
+        'regular-sb/flex-child', // <- flex-child moved here
+      ])
+
+      expect(dragMeElement.style.position).toEqual('')
+      expect(dragMeElement.style.top).toEqual('')
+      expect(dragMeElement.style.left).toEqual('')
+      expect(dragMeElement.style.bottom).toEqual('')
+      expect(dragMeElement.style.right).toEqual('')
+      expect(dragMeElement.style.width).toEqual(startingDragMeElementStyle.width)
+      expect(dragMeElement.style.height).toEqual(startingDragMeElementStyle.height)
+    })
+
+    it('reparenting from an absolute container to a flex container', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithFlexContainerAndCanvas,
+        'await-first-dom-report',
+      )
+
+      const dragMeElementPath = EP.fromString('sb/scene/app:root/abs-container/abs-child')
+      const targetElementPath = EP.fromString('sb/scene/app:root/container/flex-child')
+
+      const { dragMeElement, startingDragMeElementStyle } = await doBasicDrag(
+        editor,
+        dragMeElementPath,
+        targetElementPath,
+      )
+
+      expect(editor.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey)).toEqual([
+        'regular-sb/scene',
+        'regular-sb/scene/app',
+        'regular-sb/scene/app:root',
+        'regular-sb/scene/app:root/container',
+        'regular-sb/scene/app:root/container/flex-child',
+        'regular-sb/scene/app:root/container/abs-child', // <- abs-child moved here
+        'regular-sb/scene/app:root/container/663',
+        'regular-sb/scene/app:root/abs-container',
+        'regular-sb/scene/app:root/abs-container/8ae',
+        'regular-sb/dragme',
+      ])
+
+      expect(dragMeElement.style.position).toEqual('')
+      expect(dragMeElement.style.top).toEqual('')
+      expect(dragMeElement.style.left).toEqual('')
+      expect(dragMeElement.style.bottom).toEqual('')
+      expect(dragMeElement.style.right).toEqual('')
+      expect(dragMeElement.style.width).toEqual(startingDragMeElementStyle.width)
+      expect(dragMeElement.style.height).toEqual(startingDragMeElementStyle.height)
+    })
+
+    it('reparenting from a flex container to an absolute container', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithFlexContainerAndCanvas,
+        'await-first-dom-report',
+      )
+
+      const dragMeElementPath = EP.fromString('sb/scene/app:root/container/flex-child')
+      const targetElementPath = EP.fromString('sb/scene/app:root/abs-container/abs-child')
+      const { dragMeElement, startingDragMeElementStyle } = await doBasicDrag(
+        editor,
+        dragMeElementPath,
+        targetElementPath,
+      )
+
+      expect(editor.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey)).toEqual([
+        'regular-sb/scene',
+        'regular-sb/scene/app',
+        'regular-sb/scene/app:root',
+        'regular-sb/scene/app:root/container',
+        'regular-sb/scene/app:root/container/663',
+        'regular-sb/scene/app:root/abs-container',
+        'regular-sb/scene/app:root/abs-container/abs-child',
+        'regular-sb/scene/app:root/abs-container/flex-child', // <- flex-child moved here
+        'regular-sb/scene/app:root/abs-container/8ae',
+        'regular-sb/dragme',
+      ])
+
+      expect(dragMeElement.style.position).toEqual('')
+      expect(dragMeElement.style.top).toEqual('')
+      expect(dragMeElement.style.left).toEqual('')
+      expect(dragMeElement.style.bottom).toEqual('')
+      expect(dragMeElement.style.right).toEqual('')
+      expect(dragMeElement.style.width).toEqual(startingDragMeElementStyle.width)
+      expect(dragMeElement.style.height).toEqual(startingDragMeElementStyle.height)
     })
   })
 

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -554,9 +554,7 @@ describe('Navigator', () => {
         y: dragTo.y - dragMeElementCenter.y,
       })
 
-      const targetElement = EP.fromString(
-        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/dragme',
-      )
+      const targetElement = EP.fromString('utopia-storyboard-uid/scene-aaa/sceneroot/dragme')
       await act(async () => {
         const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
         await renderResult.dispatch([selectComponents([targetElement], false)], false)
@@ -632,9 +630,7 @@ describe('Navigator', () => {
         y: dragTo.y - dragMeElementCenter.y,
       })
 
-      const targetElement = EP.fromString(
-        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/dragme',
-      )
+      const targetElement = EP.fromString('utopia-storyboard-uid/scene-aaa/sceneroot/dragme')
       await act(async () => {
         const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
         await renderResult.dispatch([selectComponents([targetElement], false)], false)
@@ -710,9 +706,7 @@ describe('Navigator', () => {
         y: dragTo.y - dragMeElementCenter.y,
       })
 
-      const targetElement = EP.fromString(
-        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/dragme',
-      )
+      const targetElement = EP.fromString('utopia-storyboard-uid/scene-aaa/sceneroot/dragme')
       await act(async () => {
         const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
         await renderResult.dispatch([selectComponents([targetElement], false)], false)


### PR DESCRIPTION
## Problem
When reparenting an absolute positioned element into a flex container via the navigator, the element does not become a flex sibling. Instead, the element is absolutely positioned in a weird way above the flex siblings.

## Solution
The problem above is already fixed with copy/paste. This PR extracts code behind copy/paste, and makes the navigator reorder action call the same code.

This PR also adds tests that check layout property changes after reparenting via the navigator. Since a lot of functionality is still far from ideal (e.g., when reparenting from flex to absolute, no absolute positioning props are applied), these tests are primarily there as documentation.