### PR TITLE
Set Z index on element

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2300,7 +2300,7 @@ export function moveTemplate(
                   )
 
                   const insertionPath = getInsertionPathWithSlotBehavior(
-                    underlyingNewParentPath,
+                    newParentPath,
                     workingEditorState.projectContents,
                     workingEditorState.nodeModules.files,
                     workingEditorState.canvas.openFile?.filename ?? null,


### PR DESCRIPTION
## Problem

Moving elements back/forward was partially regressed by using `getInsertionPathWithSlotBehavior` with the wrong parent element path. See https://github.com/concrete-utopia/utopia/pull/3643 for more details. In particular, when moving a child element that was the descendant of a component not in `storyboard.js`, the result was either an exception, or a superficially correct result driven by a fallback.

## Fix

`moveTemplate`, which implements the behaviour of moving elements back/forward is already passed the path of the new parent, which can be used to get the insertion path for the element being moved, without triggering silent bugs or exceptions.