### PR TITLE
Basic parsing of text content to find js expressions

### DIFF
--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -69,7 +69,9 @@ export function escapeHTML(s: string): string {
   return encoded.replace(/\n/g, '\n<br />')
 }
 
-// This is a very veer
+// This is a very basic function to separate the real text content and the JS content in curly brackets
+// We only want to html encode in text content, but not in js content
+// E.g. we don't want to encode the < in `{ 2>3 ? "foo" : "bar" }
 function encodeHTMLWhenNotInJsCode(s: string): string {
   let result = ''
   let parenCounter = 0

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -94,12 +94,12 @@ function encodeHTMLWhenNotInJsCode(s: string): string {
         }
         break
       case '<':
-        if (isInJSExpression()) {
+        if (!isInJSExpression()) {
           characterToPrint = entities.lesserThan
         }
         break
       case '>':
-        if (isInJSExpression()) {
+        if (!isInJSExpression()) {
           characterToPrint = entities.greaterThan
         }
         break


### PR DESCRIPTION
**Problem:**
We are html encoding the edited expressions, which can destroy the JS expression in curly brackets. 

**Fix:**
The full solution to this would be to parse the text content as a jsx expression. As we agreed, my goal was just to very simply handle the basic cases. We'll see how far we can go with this in real life.

My solution is not really a parser, I just traverse the expression character by character and:
- I keep track when we are between quotation marks
- I keep track how deeply we are in curly bracketing
- replace the <> characters with their html encoded counterparts only when we are not in curly bracketing
- only count the curly bracket when we are not between quotation marks

I added a few tests to show what are the cases I optimized for.

