### PR TITLE
Make template strings work in text editor

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -428,9 +428,7 @@ function trimAndJoinTextFromJSXElements(elements: Array<JSXElementChild>): strin
         }
         break
       case 'ATTRIBUTE_OTHER_JAVASCRIPT':
-        if (c.transpiledJavascript === `return ${c.javascript}`) {
-          combinedText += `{${c.originalJavascript}}`
-        }
+        combinedText += `{${c.originalJavascript}}`
         break
       case 'JSX_FRAGMENT':
       case 'JSX_CONDITIONAL_EXPRESSION':

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -848,6 +848,14 @@ describe('Use the text editor', () => {
         codeResult: 'The username is {1 >= 1 ? "Bob" : "Sam}" + ">"}',
         renderedText: 'The username is Bob',
       },
+      {
+        label: 'handles expressions with formatted strings inside',
+        // eslint-disable-next-line no-template-curly-in-string
+        writtenText: 'The username is {1 >= 1 ? `${"Bob"}` : "Sam"}',
+        // eslint-disable-next-line no-template-curly-in-string
+        codeResult: 'The username is {1 >= 1 ? `${"Bob"}` : "Sam"}',
+        renderedText: 'The username is Bob',
+      },
     ]
     tests.forEach((t) => {
       it(`${t.label}`, async () => {


### PR DESCRIPTION
**Problem:**
Template strings disappear from the content when you try to text edit it

**Fix:**
There was a condition to only allow editing of javascript code when the transpiled code equals to the original code.
This is not true for template strings, so I removed this condition. This means we will allow text editing of any javascript code, but I think this is OK for now.
