### PR TITLE
fix(canvas) fix contextmenu for unwrap

### DIFF
--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -33,6 +33,7 @@ import {
 import { areAllSelectedElementsNonAbsolute } from './canvas/canvas-strategies/strategies/shared-move-strategies-helpers'
 import { generateUidWithExistingComponents } from '../core/model/element-template-utils'
 import { defaultTransparentViewElement } from './editor/defaults'
+import { treatElementAsContentAffecting } from './canvas/canvas-strategies/strategies/group-like-helpers'
 
 export interface ContextMenuItem<T> {
   name: string | React.ReactNode
@@ -56,6 +57,7 @@ export interface CanvasData {
   scale: number
   focusedElementPath: ElementPath | null
   allElementProps: AllElementProps
+  openFile: string | null
 }
 
 export function requireDispatch(dispatch: EditorDispatch | null | undefined): EditorDispatch {
@@ -307,7 +309,18 @@ export const group: ContextMenuItem<CanvasData> = {
 export const unwrap: ContextMenuItem<CanvasData> = {
   name: 'Unwrap',
   shortcut: '⇧⌘G',
-  enabled: true,
+  enabled: (data) => {
+    return data.selectedViews.some(
+      (path) =>
+        MetadataUtils.targetSupportsChildren(
+          data.projectContents,
+          data.jsxMetadata,
+          data.nodeModules,
+          data.openFile,
+          path,
+        ) || treatElementAsContentAffecting(data.jsxMetadata, data.allElementProps, path),
+    )
+  },
   action: (data, dispatch?: EditorDispatch) => {
     if (data.selectedViews.length > 0) {
       requireDispatch(dispatch)([EditorActions.unwrapElement(data.selectedViews[0])], 'everyone')

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -199,6 +199,7 @@ export const ElementContextMenu = React.memo(({ contextMenuInstance }: ElementCo
       scale: store.editor.canvas.scale,
       focusedElementPath: store.editor.focusedElementPath,
       allElementProps: store.editor.allElementProps,
+      openFile: store.editor.canvas.openFile?.filename ?? null,
     }
   })
 
@@ -216,6 +217,7 @@ export const ElementContextMenu = React.memo(({ contextMenuInstance }: ElementCo
       scale: currentEditor.scale,
       focusedElementPath: currentEditor.focusedElementPath,
       allElementProps: currentEditor.allElementProps,
+      openFile: currentEditor.openFile,
     }
   }, [editorSliceRef])
 


### PR DESCRIPTION
**Fix:**
Unwrap:  hide from contextmenu if child elements are not supported.

**Commit Details:**
- update context-menu item unwrap
