### PR TITLE
Chore: remove insertJSXElementChild_DEPRECATED from addSceneToJSXComponents

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -140,11 +140,6 @@ export type ClearSelection = {
   action: 'CLEAR_SELECTION'
 }
 
-export interface InsertScene {
-  action: 'INSERT_SCENE'
-  frame: CanvasRectangle
-}
-
 export interface InsertJSXElement {
   action: 'INSERT_JSX_ELEMENT'
   jsxElement: JSXElement
@@ -1098,7 +1093,6 @@ export interface SwitchConditionalBranches {
 
 export type EditorAction =
   | ClearSelection
-  | InsertScene
   | InsertJSXElement
   | DeleteSelected
   | DeleteView

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -75,7 +75,6 @@ import type {
   InsertDroppedImage,
   InsertImageIntoUI,
   InsertJSXElement,
-  InsertScene,
   MoveSelectedBackward,
   MoveSelectedForward,
   MoveSelectedToBack,
@@ -252,13 +251,6 @@ import { InsertionPath } from '../store/insertion-path'
 export function clearSelection(): EditorAction {
   return {
     action: 'CLEAR_SELECTION',
-  }
-}
-
-export function insertScene(frame: CanvasRectangle): InsertScene {
-  return {
-    action: 'INSERT_SCENE',
-    frame: frame,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -135,7 +135,6 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'DELETE_VIEW':
     case 'UNSET_PROPERTY':
     case 'SET_PROPERTY':
-    case 'INSERT_SCENE':
     case 'INSERT_JSX_ELEMENT':
     case 'MOVE_SELECTED_TO_BACK':
     case 'MOVE_SELECTED_TO_FRONT':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -216,7 +216,6 @@ import {
   InsertImageIntoUI,
   InsertInsertable,
   InsertJSXElement,
-  InsertScene,
   isLoggedIn,
   Load,
   MarkVSCodeBridgeReady,
@@ -361,7 +360,6 @@ import {
   updateAssetFileName,
 } from '../server'
 import {
-  addNewScene,
   areGeneratedElementsTargeted,
   BaseCanvasOffset,
   BaseCanvasOffsetLeftPane,
@@ -2260,26 +2258,6 @@ export const UPDATE_FNS = {
       },
       editor,
     )
-  },
-  INSERT_SCENE: (action: InsertScene, editor: EditorModel): EditorModel => {
-    const sceneUID = generateUidWithExistingComponents(editor.projectContents)
-    const newSceneLabel = getNewSceneName(editor)
-    const newScene: JSXElement = defaultSceneElement(
-      sceneUID,
-      canvasFrameToNormalisedFrame(action.frame),
-      newSceneLabel,
-      [],
-    )
-    const storyBoardPath = getStoryboardElementPath(
-      editor.projectContents,
-      editor.canvas.openFile?.filename ?? null,
-    )
-    const newSelection =
-      storyBoardPath != null ? [EP.elementPath([[EP.toUid(storyBoardPath), sceneUID]])] : []
-    return {
-      ...addNewScene(editor, newScene),
-      selectedViews: newSelection,
-    }
   },
   INSERT_JSX_ELEMENT: (action: InsertJSXElement, editor: EditorModel): EditorModel => {
     let newSelectedViews: ElementPath[] = []

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1900,49 +1900,6 @@ export function getJSXComponentsAndImportsForPath(
   }
 }
 
-function modifyOpenScenes_INTERNAL(
-  transform: (topLevelElementsIncludingScene: UtopiaJSXComponent[]) => UtopiaJSXComponent[],
-  model: EditorState,
-): EditorState {
-  return modifyOpenScenesAndJSXElements((componentsIncludingScenes) => {
-    return transform(componentsIncludingScenes)
-  }, model)
-}
-
-export function addNewScene(model: EditorState, newSceneElement: JSXElement): EditorState {
-  return modifyOpenScenes_INTERNAL(
-    (components) =>
-      addSceneToJSXComponents(model.projectContents, components, newSceneElement).components,
-    model,
-  )
-}
-
-export function addSceneToJSXComponents(
-  projectContents: ProjectContentTreeRoot,
-  components: UtopiaJSXComponent[],
-  newSceneElement: JSXElement,
-): InsertChildAndDetails {
-  const storyoardComponentRootElement = components.find(
-    (c) => c.name === BakedInStoryboardVariableName,
-  )?.rootElement
-  const storyboardComponentUID =
-    storyoardComponentRootElement != null ? getUtopiaID(storyoardComponentRootElement) : null
-  if (storyboardComponentUID != null) {
-    const storyboardComponentElementPath = EP.elementPath([
-      staticElementPath([storyboardComponentUID]),
-    ])
-    return insertJSXElementChild(
-      projectContents,
-      childInsertionPath(storyboardComponentElementPath),
-      newSceneElement,
-      components,
-      null,
-    )
-  } else {
-    return insertChildAndDetails(components)
-  }
-}
-
 export function removeElementAtPath(
   target: ElementPath,
   components: Array<UtopiaJSXComponent>,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1912,19 +1912,13 @@ function modifyOpenScenes_INTERNAL(
 export function addNewScene(model: EditorState, newSceneElement: JSXElement): EditorState {
   return modifyOpenScenes_INTERNAL(
     (components) =>
-      addSceneToJSXComponents(
-        model.projectContents,
-        model.canvas.openFile?.filename ?? null,
-        components,
-        newSceneElement,
-      ).components,
+      addSceneToJSXComponents(model.projectContents, components, newSceneElement).components,
     model,
   )
 }
 
 export function addSceneToJSXComponents(
   projectContents: ProjectContentTreeRoot,
-  openFile: string | null,
   components: UtopiaJSXComponent[],
   newSceneElement: JSXElement,
 ): InsertChildAndDetails {
@@ -1937,9 +1931,8 @@ export function addSceneToJSXComponents(
     const storyboardComponentElementPath = EP.elementPath([
       staticElementPath([storyboardComponentUID]),
     ])
-    return insertJSXElementChild_DEPRECATED(
+    return insertJSXElementChild(
       projectContents,
-      openFile,
       childInsertionPath(storyboardComponentElementPath),
       newSceneElement,
       components,

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -6,9 +6,6 @@ import { StateHistory } from '../history'
 import { UtopiaTsWorkers } from '../../../core/workers/common/worker-types'
 import { UiJsxCanvasContextData } from '../../canvas/ui-jsx-canvas'
 import type { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
-import { getAllUniqueUids } from '../../../core/model/element-template-utils'
-import { removePathsWithDeadUIDs } from '../../../core/shared/element-path'
-import { assertNever } from '../../../core/shared/utils'
 
 export function runLocalEditorAction(
   state: EditorState,
@@ -97,8 +94,6 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.TOGGLE_HIDDEN(action, state)
     case 'RENAME_COMPONENT':
       return UPDATE_FNS.RENAME_COMPONENT(action, state)
-    case 'INSERT_SCENE':
-      return UPDATE_FNS.INSERT_SCENE(action, state)
     case 'INSERT_JSX_ELEMENT':
       return UPDATE_FNS.INSERT_JSX_ELEMENT(action, state)
     case 'SET_PANEL_VISIBILITY':


### PR DESCRIPTION
Fixes #3651 

This removes `insertJSXElementChild_DEPRECATED` from `addSceneToJSXComponents` (which apparently is actually not used).