### PR TITLE
Clean up `NavigatorEntry` from actions

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -119,7 +119,7 @@ export type MoveRowAfter = {
 
 export type ReparentRow = {
   type: 'REPARENT_ROW'
-  target: NavigatorEntry
+  target: ElementPath
 }
 
 export type DropTarget = MoveRowBefore | MoveRowAfter | ReparentRow

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -509,6 +509,7 @@ import {
   childInsertionPath,
   conditionalClauseInsertionPath,
   getInsertionPathWithSlotBehavior,
+  getInsertionPathWithWrapWithFragmentBehavior,
 } from '../store/insertion-path'
 import {
   findMaybeConditionalExpression,
@@ -1854,26 +1855,17 @@ export const UPDATE_FNS = {
     } else {
       switch (dropTarget.type) {
         case 'REPARENT_ROW': {
-          switch (dropTarget.target.type) {
-            case 'REGULAR':
-            case 'CONDITIONAL_CLAUSE': {
-              const newParent = reparentTargetFromNavigatorEntry(
-                dropTarget.target,
-                editor.projectContents,
-                editor.jsxMetadata,
-                editor.nodeModules.files,
-                editor.canvas.openFile?.filename,
-              )
-              return reparentToIndexPosition(newParent, absolute(0))
-            }
-            case 'SYNTHETIC': {
-              // Find the containing conditional clause, which should be an immediate parent,
-              // then use the reparenting logic for there.
-              // As currently this is the only case where a SYNTHETIC entry is currently used.
-              throw new Error(`Currently not implemented.`)
-            }
+          const newParent = getInsertionPathWithWrapWithFragmentBehavior(
+            dropTarget.target,
+            editor.projectContents,
+            editor.nodeModules.files,
+            editor.canvas.openFile?.filename,
+            editor.jsxMetadata,
+          )
+          if (newParent == null) {
+            return editor
           }
-          break
+          return reparentToIndexPosition(newParent, absolute(0))
         }
         default:
           assertNever(dropTarget)

--- a/editor/src/components/editor/store/editor-update.spec.tsx
+++ b/editor/src/components/editor/store/editor-update.spec.tsx
@@ -313,7 +313,7 @@ describe('action NAVIGATOR_REORDER', () => {
     const { editor, derivedState, dispatch } = createEditorStates()
     const reparentAction = reparentComponents(
       [EP.appendNewElementPath(ScenePath1ForTestUiJsFile, ['jjj'])],
-      regularNavigatorEntry(EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa'])),
+      EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa']),
     )
     const mainUIJSFile = getContentsTreeFileFromString(editor.projectContents, StoryboardFilePath)
     if (

--- a/editor/src/components/navigator/actions/index.ts
+++ b/editor/src/components/navigator/actions/index.ts
@@ -4,7 +4,7 @@ import { DropTargetType, NavigatorEntry } from '../../editor/store/editor-state'
 
 export function reparentComponents(
   draggedComponents: Array<ElementPath>,
-  targetParent: NavigatorEntry,
+  targetParent: ElementPath,
 ): NavigatorReorder {
   return {
     action: 'NAVIGATOR_REORDER',

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -142,7 +142,7 @@ function canDrop(
 function onDrop(
   propsOfDraggedItem: NavigatorItemDragAndDropWrapperProps,
   propsOfDropTargetItem: NavigatorItemDragAndDropWrapperProps,
-  moveToEntry: NavigatorEntry,
+  moveToElementPath: ElementPath,
   dropTargetHintType: DropTargetType,
 ): void {
   const dragSelections = propsOfDraggedItem.getCurrentlySelectedEntries()
@@ -155,19 +155,19 @@ function onDrop(
   switch (dropTargetHintType) {
     case 'before':
       propsOfDraggedItem.editorDispatch(
-        [placeComponentsBefore(draggedElements, moveToEntry.elementPath), clearHintAction],
+        [placeComponentsBefore(draggedElements, moveToElementPath), clearHintAction],
         'everyone',
       )
       break
     case 'after':
       propsOfDraggedItem.editorDispatch(
-        [placeComponentsAfter(draggedElements, moveToEntry.elementPath), clearHintAction],
+        [placeComponentsAfter(draggedElements, moveToElementPath), clearHintAction],
         'everyone',
       )
       break
     case 'reparent':
       propsOfDraggedItem.editorDispatch(
-        [reparentComponents(draggedElements, moveToEntry), clearHintAction],
+        [reparentComponents(draggedElements, moveToElementPath), clearHintAction],
         'everyone',
       )
       break
@@ -399,7 +399,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
       },
       drop: (item: NavigatorItemDragAndDropWrapperProps) => {
         if (moveToEntry != null) {
-          onDrop(item, props, moveToEntry, dropTargetHintType)
+          onDrop(item, props, moveToEntry.elementPath, dropTargetHintType)
         }
       },
       canDrop: (item: NavigatorItemDragAndDropWrapperProps) => {
@@ -426,7 +426,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
       },
       drop: (item: NavigatorItemDragAndDropWrapperProps) => {
         if (moveToEntry != null) {
-          onDrop(item, props, moveToEntry, dropTargetHintType)
+          onDrop(item, props, moveToEntry.elementPath, dropTargetHintType)
         }
       },
       canDrop: (item: NavigatorItemDragAndDropWrapperProps) => {
@@ -453,7 +453,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
       },
       drop: (item: NavigatorItemDragAndDropWrapperProps) => {
         if (moveToEntry != null) {
-          onDrop(item, props, moveToEntry, dropTargetHintType)
+          onDrop(item, props, moveToEntry.elementPath, dropTargetHintType)
         }
       },
       canDrop: (item: NavigatorItemDragAndDropWrapperProps) => {
@@ -663,14 +663,9 @@ export const SyntheticNavigatorItemContainer = React.memo(
             if (clause == null) {
               return
             }
-            onDrop(
-              item,
-              props,
-              conditionalClauseNavigatorEntry(props.elementPath, clause),
-              'reparent',
-            )
+            onDrop(item, props, props.elementPath, 'reparent')
           }
-          onDrop(item, props, regularNavigatorEntry(props.elementPath), 'reparent')
+          onDrop(item, props, props.elementPath, 'reparent')
         },
         canDrop: () => {
           const metadata = editorStateRef.current.jsxMetadata


### PR DESCRIPTION
## Description

This PR removes the `NavigatorEntry` type from `NavigatorReorder` and refactors the code used to find the insertion path for the target parent to use `getInsertionPathWithWrapWithFragmentBehavior`.

The reason this code has become obsolete is that we have separate drag-and-drop components for each type of navigator entry (implemented in https://github.com/concrete-utopia/utopia/pull/3600), which gives us fine-grained control over where we call the reorder/reparent related actions from, eliminating the edge cases coming from not being able to reparent into certain types of `NavigatorEntry`.