### PR TITLE
Convert to visual size when pasting form flex to flex

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes.ts
@@ -44,6 +44,7 @@ import {
 import { ReparentStrategy } from './reparent-strategy-helpers'
 import {
   convertRelativeSizingToVisualSize,
+  convertSizingToVisualSizeWhenPastingFromFlexToFlex,
   runReparentPropertyStrategies,
   stripPinsConvertToVisualSize,
 } from './reparent-property-strategies'
@@ -252,7 +253,7 @@ export function getReparentPropertyChanges(
         targetOriginalDisplayProp,
         convertDisplayInline,
       )
-      const edgeCaseCommands = runReparentPropertyStrategies([
+      const strategyCommands = runReparentPropertyStrategies([
         stripPinsConvertToVisualSize(
           { oldPath: originalElementPath, newPath: newPath },
           newParent,
@@ -262,8 +263,13 @@ export function getReparentPropertyChanges(
           { oldPath: originalElementPath, newPath: newPath },
           metadata,
         ),
+        convertSizingToVisualSizeWhenPastingFromFlexToFlex(
+          { oldPath: originalElementPath, newPath: newPath },
+          newParent,
+          metadata,
+        ),
       ])
 
-      return [...basicCommads, ...edgeCaseCommands]
+      return [...basicCommads, ...strategyCommands]
   }
 }

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -1055,9 +1055,9 @@ describe('actions', () => {
         <div
           style={{
             backgroundColor: '#b2a0cf',
+            contain: 'layout',
             width: 162,
             height: 67,
-            contain: 'layout',
           }}
           data-uid='ele'
         />

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -1827,6 +1827,126 @@ describe('Navigator', () => {
       expect(dragMeElement.style.width).toEqual(startingDragMeElementStyle.width)
       expect(dragMeElement.style.height).toEqual(startingDragMeElementStyle.height)
     })
+
+    it('reparenting between flex containers hardcodes width/height', async () => {
+      const editor = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(`
+      <div
+      style={{
+        height: '100%',
+        width: '100%',
+        contain: 'layout',
+      }}
+      data-uid='root'
+    >
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 69,
+          top: 65,
+          width: 383,
+          height: 579,
+          display: 'flex',
+          flexDirection: 'row',
+          gap: 29,
+          padding: '18px 27px',
+          alignItems: 'flex-end',
+        }}
+        data-uid='flex1'
+      >
+        <div
+          style={{
+            backgroundColor: '#aaaaaa33',
+            height: '100%',
+            contain: 'layout',
+            flexGrow: 1,
+          }}
+          data-uid='flexchild1'
+          data-testid='flexchild1'
+        />
+        <div
+          style={{
+            backgroundColor: '#aaaaaa33',
+            height: '100%',
+            contain: 'layout',
+            flexGrow: 1,
+          }}
+          data-uid='c8e'
+        />
+      </div>
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 592,
+          top: 40,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 29,
+          padding: '18px 27px',
+          alignItems: 'flex-end',
+          width: 195,
+          height: 771,
+        }}
+        data-uid='flex2'
+      >
+        <div
+          style={{
+            backgroundColor: '#aaaaaa33',
+            contain: 'layout',
+            width: 141,
+            height: 353,
+          }}
+          data-uid='flexchild2'
+        />
+        <div
+          style={{
+            backgroundColor: '#aaaaaa33',
+            contain: 'layout',
+            width: '100%',
+            flexGrow: 1,
+          }}
+          data-uid='aaf'
+        />
+      </div>
+    </div>
+      `),
+        'await-first-dom-report',
+      )
+
+      const dragMeElementPath = EP.fromString(
+        `${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:root/flex1/flexchild1`,
+      )
+
+      const targetElementPath = EP.fromString(
+        `${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:root/flex2/flexchild2`,
+      )
+
+      await doBasicDrag(editor, dragMeElementPath, targetElementPath)
+
+      expect(editor.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey)).toEqual([
+        'regular-utopia-storyboard-uid/scene-aaa',
+        'regular-utopia-storyboard-uid/scene-aaa/app-entity',
+        'regular-utopia-storyboard-uid/scene-aaa/app-entity:root',
+        'regular-utopia-storyboard-uid/scene-aaa/app-entity:root/flex1',
+        'regular-utopia-storyboard-uid/scene-aaa/app-entity:root/flex1/c8e',
+        'regular-utopia-storyboard-uid/scene-aaa/app-entity:root/flex2',
+        'regular-utopia-storyboard-uid/scene-aaa/app-entity:root/flex2/flexchild2',
+        'regular-utopia-storyboard-uid/scene-aaa/app-entity:root/flex2/flexchild1',
+        'regular-utopia-storyboard-uid/scene-aaa/app-entity:root/flex2/aaf',
+      ])
+
+      const element = editor.renderedDOM.getByTestId('flexchild1')
+
+      expect(element.style.position).toEqual('')
+      expect(element.style.top).toEqual('')
+      expect(element.style.left).toEqual('')
+      expect(element.style.bottom).toEqual('')
+      expect(element.style.right).toEqual('')
+      expect(element.style.width).toEqual('150px')
+      expect(element.style.height).toEqual('543px')
+    })
   })
 
   describe('derived data', () => {

--- a/editor/src/core/layout/layout-utils.spec.browser2.tsx
+++ b/editor/src/core/layout/layout-utils.spec.browser2.tsx
@@ -90,7 +90,7 @@ describe('pasteJSXElements', () => {
             style={{ backgroundColor: '#ffcccc', left: 52, top: 61, width: 150, height: 120, display: 'flex' }}
             data-uid='paste-target'
           >
-            <View style={{ width: 100, height: 100, contain: 'layout' }} data-uid='aab' />
+            <View style={{ contain: 'layout', width: 100, height: 100,  }} data-uid='aab' />
           </View>
         </View>`,
       ),


### PR DESCRIPTION
## Problem
When pasting/navigator reparenting an element from a flex container to another flex container, the context can wildy change compared to what the element was sized to, which can lead to the pasted element drastically changing size (inflating, collapsing, etc)

## Fix
To make paste/reparent behaviour consistent and avoid surprises, we opted for converting the width/height of the pasted/reparented element to its visually observed size, and remove all other sizing props (`flex...`, `min...`, `max...`, etc). 

