### PR TITLE
Fix/navigator select after reparent

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1801,25 +1801,28 @@ export const UPDATE_FNS = {
       newParentPath: InsertionPath,
       indexPosition: IndexPosition,
     ): EditorModel =>
-      dragSources.reduce((workingEditorState, dragSource) => {
-        const afterInsertion = insertWithReparentStrategies(
-          editor,
-          newParentPath,
-          {
-            elementPath: dragSource,
-            pathToReparent: pathToReparent(dragSource),
-          },
-          indexPosition,
-          builtInDependencies,
-        )
-        if (afterInsertion != null) {
-          return {
-            ...afterInsertion.updatedEditorState,
-            selectedViews: [afterInsertion.newPath, ...workingEditorState.selectedViews],
+      dragSources.reduce(
+        (workingEditorState, dragSource) => {
+          const afterInsertion = insertWithReparentStrategies(
+            workingEditorState,
+            newParentPath,
+            {
+              elementPath: dragSource,
+              pathToReparent: pathToReparent(dragSource),
+            },
+            indexPosition,
+            builtInDependencies,
+          )
+          if (afterInsertion != null) {
+            return {
+              ...afterInsertion.updatedEditorState,
+              selectedViews: [afterInsertion.newPath, ...workingEditorState.selectedViews],
+            }
           }
-        }
-        return workingEditorState
-      }, editor)
+          return workingEditorState
+        },
+        { ...editor, selectedViews: [] } as EditorState,
+      )
 
     if (dropTarget.type === 'MOVE_ROW_BEFORE' || dropTarget.type === 'MOVE_ROW_AFTER') {
       const newParentPath: ElementPath | null = EP.parentPath(dropTarget.target)

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -1336,6 +1336,9 @@ describe('Navigator', () => {
         'regular-sb/parent2/aab',
         'regular-sb/text',
       ])
+      expect(renderResult.getEditorState().editor.selectedViews).toEqual([
+        EP.fromString('sb/parent2/parent1'),
+      ])
     })
 
     it('cannot reparent parent element inside itself', async () => {
@@ -1573,6 +1576,9 @@ describe('Navigator', () => {
         'regular-sb/parent2/aaa',
         'regular-sb/parent2/aab',
         'regular-sb/text',
+      ])
+      expect(renderResult.getEditorState().editor.selectedViews).toEqual([
+        EP.fromString('sb/child1'),
       ])
     })
   })


### PR DESCRIPTION
**Problem:**
There is a regression in the editor that the navigator reparent and paste actions are not updating the selected elements.

**Commit Details:**
- fix `NAVIGATOR_REORDER` and `PASTE_JSX_ELEMENTS`
- extended test to check selection
