### PR TITLE
Spike: Show UID mocking race conditions in tests

### DIFF
--- a/editor/src/core/model/element-template-utils.test-utils.ts
+++ b/editor/src/core/model/element-template-utils.test-utils.ts
@@ -1,11 +1,17 @@
 import { MOCK_NEXT_GENERATED_UIDS, MOCK_NEXT_GENERATED_UIDS_IDX } from '../shared/uid-utils'
 
 export function FOR_TESTS_setNextGeneratedUid(nextUid: string): void {
+  if (MOCK_NEXT_GENERATED_UIDS.current.length > 0) {
+    throw new Error('Uids are already mocked')
+  }
   MOCK_NEXT_GENERATED_UIDS.current = [nextUid]
   MOCK_NEXT_GENERATED_UIDS_IDX.current = 0
 }
 
 export function FOR_TESTS_setNextGeneratedUids(uids: Array<string>): void {
+  if (MOCK_NEXT_GENERATED_UIDS.current.length > 0) {
+    throw new Error('Uids are already mocked')
+  }
   MOCK_NEXT_GENERATED_UIDS.current = uids
   MOCK_NEXT_GENERATED_UIDS_IDX.current = 0
 }

--- a/editor/src/core/model/element-template-utils.test-utils.ts
+++ b/editor/src/core/model/element-template-utils.test-utils.ts
@@ -17,6 +17,7 @@ export function FOR_TESTS_setNextGeneratedUids(uids: Array<string>): void {
 }
 
 export function FOR_TESTS_CLEAR_MOCK_NEXT_GENERATED_UIDS(): void {
+  console.info('UID CLEANUP!') // TODO do not merge, spike only
   MOCK_NEXT_GENERATED_UIDS.current = []
   MOCK_NEXT_GENERATED_UIDS_IDX.current = 0
 }


### PR DESCRIPTION
This PR changes `FOR_TESTS_setNextGeneratedUid(s)` so that an exception is thrown when `FOR_TESTS_setNextGeneratedUid(s)` is called with mocked UIDs still present (i.e., when `MOCK_NEXT_GENERATED_UIDS.current` is a nonempty array).

The hypothesis is that `FOR_TESTS_setNextGeneratedUid(s)` should only be called when `MOCK_NEXT_GENERATED_UIDS.current` is an empty array (either because uids haven't been mocked yet by anyone, or `FOR_TESTS_CLEAR_MOCK_NEXT_GENERATED_UIDS` has been called). It seems like that with sharded tests, this assumption doesn't hold true.