### PR TITLE
Generate consistent uid for conditional false branch

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.spec.browser2.tsx
@@ -280,7 +280,7 @@ describe('drag-to-insert', () => {
     it('Should insert a conditional into an absolute layout', async () => {
       const renderResult = await setupInsertTest(inputCode)
 
-      FOR_TESTS_setNextGeneratedUids(['ddd', 'skip1', 'skip2', 'false-branch'])
+      FOR_TESTS_setNextGeneratedUids(['ddd'])
 
       const targetParentElement = renderResult.renderedDOM.getByTestId('larger')
       const targetParentElementBounds = targetParentElement.getBoundingClientRect()
@@ -341,7 +341,7 @@ describe('drag-to-insert', () => {
                   width: 100,
                   height: 100,
                 }}
-                data-uid='false-branch'
+                data-uid='fal'
               >
                 False branch
               </div>

--- a/editor/src/components/canvas/commands/wrap-in-container-command.ts
+++ b/editor/src/components/canvas/commands/wrap-in-container-command.ts
@@ -23,7 +23,10 @@ import { InsertionSubjectWrapper } from '../../editor/editor-modes'
 import { assertNever } from '../../../core/shared/utils'
 import { mergeImports } from '../../../core/workers/common/project-file-utils'
 import { absolute } from '../../../utils/utils'
-import { generateUidWithExistingComponents } from '../../../core/model/element-template-utils'
+import {
+  generateUidWithExistingComponents,
+  getAllUniqueUids,
+} from '../../../core/model/element-template-utils'
 import { ProjectContentTreeRoot } from '../../assets'
 import { JSXAttributesEntry } from '../../../core/shared/element-template'
 import { getIndexInParent } from '../../../core/model/element-template-utils'
@@ -31,6 +34,7 @@ import { getInsertionPathWithSlotBehavior } from '../../editor/store/insertion-p
 import { jsxTextBlock } from '../../../core/shared/element-template'
 import { CSSProperties } from 'react'
 import { Property } from 'csstype'
+import { generateConsistentUID } from '../../../core/shared/uid-utils'
 
 type ContainerToWrapIn = InsertionSubjectWrapper
 
@@ -203,7 +207,7 @@ function getInsertionSubjectWrapperConditionalFalseBranch(
   projectContents: ProjectContentTreeRoot,
   trueBranch: JSXElementChild,
 ): JSXElementChild {
-  const uid = generateUidWithExistingComponents(projectContents)
+  const uid = generateConsistentUID(new Set(getAllUniqueUids(projectContents)), 'false-branch')
   const trueBranchStyle = getStyleAttributesEntry(trueBranch)
 
   let style: CSSProperties = {}


### PR DESCRIPTION
## Problem 
When wrapping an element in a conditional, we generate a placeholder in the conditional's false branch based on the element being wrapped. This element got a random-generated UID, which is prone to race conditions in tests (see https://github.com/concrete-utopia/utopia/pull/3671), and thus became flaky.

## Solution
Generate a consisitent UID for the false branch, so it stays consistent in tests. SInce UIDs are an under-the-hood thing for users, it makes no difference if the generated uid is random, or calculated from a seed + the already existing UIDs in the project.