### PR TITLE
Fix: navigator range selection with shift+click when there are collapsed items.

### DIFF
--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -56,6 +56,8 @@ async function dragElement(
 
   const endPoint = offsetPoint(startPoint, dragDelta)
 
+  await wait(50)
+
   await act(async () => {
     fireEvent(
       dragTarget,
@@ -83,6 +85,8 @@ async function dragElement(
       }),
     )
   })
+
+  await wait(50)
 
   if (hoverEvents === 'apply-hover-events') {
     await act(async () => {
@@ -115,6 +119,7 @@ async function dragElement(
       )
     })
 
+    await wait(50)
     await midDragCallback()
 
     await act(async () => {

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -56,7 +56,7 @@ async function dragElement(
 
   const endPoint = offsetPoint(startPoint, dragDelta)
 
-  await wait(50)
+  await wait(0)
 
   await act(async () => {
     fireEvent(
@@ -86,7 +86,7 @@ async function dragElement(
     )
   })
 
-  await wait(50)
+  await wait(0)
 
   if (hoverEvents === 'apply-hover-events') {
     await act(async () => {
@@ -119,7 +119,7 @@ async function dragElement(
       )
     })
 
-    await wait(50)
+    await wait(0)
     await midDragCallback()
 
     await act(async () => {


### PR DESCRIPTION
Fixes #3677 

**Problem:**

Selecting multiple items with shift (range selection) is broken when there are collapsed items.

**Fix:**

The problem here is that the indexes in the navigator are relative to the visible items, instead of being absolute to the whole tree. Hence, if there's a collapsed item at index 3, containing two siblings, the following item would have index 4 instead of 6 if 3 is collapsed. This breaks the whole range selection logic, which is per-se correct.

The fix in this PR works by using the entire tree inside the `react-window` component (and not rendering the non-visible entries); performance-wise this should basically be unnoticeable even for huge project, since the viewport is fixed and the worst case would be exactly the same (all non-collapsed).