### PR TITLE
Limit Github concurrency on the server.

### DIFF
--- a/server/package.yaml
+++ b/server/package.yaml
@@ -14,6 +14,7 @@ ghc-options:
   - -Wno-unused-imports
   - -Wno-deprecations
   - -rtsopts
+  - -O2
 
 default-extensions:
   - Strict

--- a/server/src/Utopia/Web/Utils/Limits.hs
+++ b/server/src/Utopia/Web/Utils/Limits.hs
@@ -2,10 +2,11 @@
 
 module Utopia.Web.Utils.Limits where
 
-import Control.Monad.Trans.Control
-import Control.Concurrent.QSem.Lifted
-import Control.Exception.Lifted
-import Protolude hiding (bracket_, waitQSem, signalQSem)
+import           Control.Concurrent.QSem.Lifted
+import           Control.Exception.Lifted
+import           Control.Monad.Trans.Control
+import           Protolude                      hiding (bracket_, signalQSem,
+                                                 waitQSem)
 
 limitWithSemaphore :: (MonadBaseControl IO m) => QSem -> m a -> m a
 limitWithSemaphore semaphore action = bracket_ (waitQSem semaphore) (signalQSem semaphore) action

--- a/server/src/Utopia/Web/Utils/Limits.hs
+++ b/server/src/Utopia/Web/Utils/Limits.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Utopia.Web.Utils.Limits where
+
+import Control.Monad.Trans.Control
+import Control.Concurrent.QSem.Lifted
+import Control.Exception.Lifted
+import Protolude hiding (bracket_, waitQSem, signalQSem)
+
+limitWithSemaphore :: (MonadBaseControl IO m) => QSem -> m a -> m a
+limitWithSemaphore semaphore action = bracket_ (waitQSem semaphore) (signalQSem semaphore) action

--- a/server/test/Test/Utopia/Web/Endpoints.hs
+++ b/server/test/Test/Utopia/Web/Endpoints.hs
@@ -25,7 +25,7 @@ import qualified Network.Socket.Wait            as W
 import           Prelude                        (String)
 import           Protolude
 import           Servant
-import           Servant.Client hiding ((//))
+import           Servant.Client                 hiding ((//))
 import           Servant.Client.Core
 import           Servant.RawM.Client
 import           System.Timeout

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -54,6 +54,7 @@ executable utopia-web
       Utopia.Web.ServiceTypes
       Utopia.Web.Types
       Utopia.Web.Utils.Files
+      Utopia.Web.Utils.Limits
       Paths_utopia_web
   hs-source-dirs:
       src
@@ -62,7 +63,7 @@ executable utopia-web
       Strict
       StrictData
       NoImplicitPrelude
-  ghc-options: -Wall -Werror -threaded -fno-warn-orphans -Wno-unused-imports -Wno-deprecations -rtsopts
+  ghc-options: -Wall -Werror -threaded -fno-warn-orphans -Wno-unused-imports -Wno-deprecations -rtsopts -O2
   extra-libraries:
       z
   build-depends:
@@ -194,6 +195,7 @@ test-suite utopia-web-test
       Utopia.Web.ServiceTypes
       Utopia.Web.Types
       Utopia.Web.Utils.Files
+      Utopia.Web.Utils.Limits
       Paths_utopia_web
   hs-source-dirs:
       test
@@ -202,7 +204,7 @@ test-suite utopia-web-test
       Strict
       StrictData
       NoImplicitPrelude
-  ghc-options: -Wall -Werror -threaded -fno-warn-orphans -Wno-unused-imports -Wno-deprecations -rtsopts +RTS -N1 -RTS
+  ghc-options: -Wall -Werror -threaded -fno-warn-orphans -Wno-unused-imports -Wno-deprecations -rtsopts -O2 +RTS -N1 -RTS
   extra-libraries:
       z
   build-depends:


### PR DESCRIPTION
Fixes #3689

**Problem:**
It was observed that when importing certain Github repositories that memory usage on the server would spike quite high triggering memory limits on our provider.

**Cause:**
As some Github calls take a surprising amount of time to respond, we had some quite aggressive concurrency which it turns out caused lots of requests to be made simultaneously consuming lots of memory.

**Fix:**
Now all of the calls to Github are limited server wide with a semaphore so that only a limited number of service calls are being made to Github at any one time. In tests this has resulted in 1/2 to 1/3rd of the memory being used while importing a project and shortly after that.

**Commit Details:**
- Added "-O2" optimisation option to GHC options because we really should just have that anyway.
- Added `_githubSemaphore` to the production and development server resources.
- Added `limitWithSemaphore` utility function.
- Added a `githubSemaphore` parameter to `callGithub` and threaded that through numerous other functions to reach `callGithub` and then wrapped the entire function with a call to `limitWithSemaphore`.
- Refactored some NPM code to use the new `limitWithSemaphore` function.
- Deleted some unused functions.