### PR TITLE
paste image in the middle of the viewport

### DIFF
--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -1594,7 +1594,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
         // needs testing if it's any help for other platforms
       } else {
         const canvasWrapperRect = this.canvasWrapperRef?.getBoundingClientRect() ?? zeroCanvasRect
-        const offset = canvasPoint({
+        const canvasViewportCenter = canvasPoint({
           x:
             -editor.canvas.roundedCanvasOffset.x +
             canvasWrapperRect.width / this.props.model.scale / 2,
@@ -1607,7 +1607,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
             editor.projectContents,
             editor.nodeModules.files,
             editor.canvas.openFile?.filename ?? null,
-            offset,
+            canvasViewportCenter,
             result.utopiaData,
             result.files,
             selectedViews,

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -85,6 +85,7 @@ import {
   WindowPoint,
   WindowRectangle,
   zeroCanvasPoint,
+  zeroCanvasRect,
 } from '../core/shared/math-utils'
 import { ElementPath } from '../core/shared/project-file-types'
 import { getActionsForClipboardItems, Clipboard } from '../utils/clipboard'
@@ -1592,11 +1593,21 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
         // on macOS it seems like alt prevents the 'paste' event from being ever fired, so this is dead code here
         // needs testing if it's any help for other platforms
       } else {
+        const canvasWrapperRect = this.canvasWrapperRef?.getBoundingClientRect() ?? zeroCanvasRect
+        const offset = canvasPoint({
+          x:
+            -editor.canvas.roundedCanvasOffset.x +
+            canvasWrapperRect.width / this.props.model.scale / 2,
+          y:
+            -editor.canvas.roundedCanvasOffset.y +
+            canvasWrapperRect.height / this.props.model.scale / 2,
+        })
         void Clipboard.parseClipboardData(event.clipboardData).then((result) => {
           const actions = getActionsForClipboardItems(
             editor.projectContents,
             editor.nodeModules.files,
             editor.canvas.openFile?.filename ?? null,
+            offset,
             result.utopiaData,
             result.files,
             selectedViews,

--- a/editor/src/utils/clipboard.spec.browser2.tsx
+++ b/editor/src/utils/clipboard.spec.browser2.tsx
@@ -57,8 +57,8 @@ describe('Pasting an image onto the canvas', () => {
           src='./assets/clipboard/chucknorris.png'
           style={{
             position: 'absolute',
-            left: 99.5,
-            top: 99.5,
+            left: 591.5,
+            top: 419.5,
             width: 1,
             height: 1,
           }}

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -109,6 +109,7 @@ export function getActionsForClipboardItems(
   projectContents: ProjectContentTreeRoot,
   nodeModules: NodeModules,
   openFile: string | null,
+  canvasViewportCenter: CanvasPoint,
   clipboardData: Array<CopyData>,
   pastedFiles: Array<FileResult>,
   selectedViews: Array<ElementPath>,
@@ -147,9 +148,10 @@ export function getActionsForClipboardItems(
     if (pastedFiles.length > 0 && componentMetadata != null) {
       const parentFrame =
         target != null ? MetadataUtils.getFrameInCanvasCoords(targetPath, componentMetadata) : null
+
       const parentCenter =
         parentFrame == null || isInfinityRectangle(parentFrame)
-          ? (Utils.point(100, 100) as CanvasPoint) // We should instead paste the top left at 0,0
+          ? canvasViewportCenter
           : Utils.getRectCenter(parentFrame)
       let pastedImages: Array<ImageResult> = []
       fastForEach(pastedFiles, (pastedFile) => {


### PR DESCRIPTION
## Problem
When pasting images from the system clipboard, with no parent selected, the image ends up at a "random" position, potentially way off screen.

## Fix
Always position pasted images in the middle of the viewport.