### PR TITLE
Expose original element metadata for static reparent strategies

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes.ts
@@ -78,7 +78,7 @@ export function getAbsoluteReparentPropertyChanges(
     EP.parentPath(target),
   )
   const newParentInstance = MetadataUtils.findElementByElementPath(
-    targetStartingMetadata,
+    newParentStartingMetadata,
     newParent,
   )
 
@@ -225,7 +225,8 @@ export function getReparentPropertyChanges(
   originalElementPath: ElementPath,
   target: ElementPath,
   newParent: ElementPath,
-  metadata: ElementInstanceMetadataMap,
+  originalContextMetadata: ElementInstanceMetadataMap,
+  currentMetadata: ElementInstanceMetadataMap,
   projectContents: ProjectContentTreeRoot,
   openFile: string | null | undefined,
   targetOriginalStylePosition: CSSPosition | null,
@@ -237,34 +238,36 @@ export function getReparentPropertyChanges(
       const basicCommads = getAbsoluteReparentPropertyChanges(
         target,
         newParent,
-        metadata,
-        metadata,
+        originalContextMetadata,
+        currentMetadata,
         projectContents,
         openFile,
       )
 
       const strategyCommands = runReparentPropertyStrategies([
-        stripPinsConvertToVisualSize({ oldPath: originalElementPath, newPath: newPath }, metadata),
+        stripPinsConvertToVisualSize(
+          { oldPath: originalElementPath, newPath: newPath },
+          { originalTargetMetadata: originalContextMetadata, currentMetadata: currentMetadata },
+        ),
         convertRelativeSizingToVisualSize(
           { oldPath: originalElementPath, newPath: newPath },
-          metadata,
+          { originalTargetMetadata: originalContextMetadata, currentMetadata: currentMetadata },
         ),
         positionAbsoluteElementComparedToNewParent(
           { oldPath: originalElementPath, newPath: newPath },
           newParent,
-          metadata,
+          { originalTargetMetadata: originalContextMetadata, currentMetadata: currentMetadata },
         ),
-        setZIndexOnPastedElement(
-          { oldPath: originalElementPath, newPath: newPath },
-          newParent,
-          metadata,
-        ),
+        setZIndexOnPastedElement({ oldPath: originalElementPath, newPath: newPath }, newParent, {
+          originalTargetMetadata: originalContextMetadata,
+          currentMetadata: currentMetadata,
+        }),
       ])
 
       return [...basicCommads, ...strategyCommands]
     }
     case 'REPARENT_AS_STATIC': {
-      const directions = singleAxisAutoLayoutContainerDirections(newParent, metadata)
+      const directions = singleAxisAutoLayoutContainerDirections(newParent, currentMetadata)
 
       const convertDisplayInline =
         directions === 'non-single-axis-autolayout' || directions.flexOrFlow === 'flex'
@@ -278,15 +281,18 @@ export function getReparentPropertyChanges(
         convertDisplayInline,
       )
       const strategyCommands = runReparentPropertyStrategies([
-        stripPinsConvertToVisualSize({ oldPath: originalElementPath, newPath: newPath }, metadata),
+        stripPinsConvertToVisualSize(
+          { oldPath: originalElementPath, newPath: newPath },
+          { originalTargetMetadata: originalContextMetadata, currentMetadata: currentMetadata },
+        ),
         convertRelativeSizingToVisualSize(
           { oldPath: originalElementPath, newPath: newPath },
-          metadata,
+          { originalTargetMetadata: originalContextMetadata, currentMetadata: currentMetadata },
         ),
         convertSizingToVisualSizeWhenPastingFromFlexToFlex(
           { oldPath: originalElementPath, newPath: newPath },
           newParent,
-          metadata,
+          { originalTargetMetadata: originalContextMetadata, currentMetadata: currentMetadata },
         ),
       ])
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-strategies.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-strategies.ts
@@ -42,13 +42,26 @@ const hasPin = (pin: LayoutPinnedProp, element: JSXElement) => {
   return isRight(rawPin) && rawPin.value != null
 }
 
+interface ElementPathSnapshots {
+  oldPath: ElementPath
+  newPath: ElementPath
+}
+
+interface MetadataSnapshots {
+  originalTargetMetadata: ElementInstanceMetadataMap
+  currentMetadata: ElementInstanceMetadataMap
+}
+
 export const stripPinsConvertToVisualSize =
   (
-    elementToReparent: { oldPath: ElementPath; newPath: ElementPath },
-    metadata: ElementInstanceMetadataMap,
+    elementToReparent: ElementPathSnapshots,
+    metadata: MetadataSnapshots,
   ): ReparentPropertyStrategy =>
   () => {
-    const instance = MetadataUtils.findElementByElementPath(metadata, elementToReparent.oldPath)
+    const instance = MetadataUtils.findElementByElementPath(
+      metadata.originalTargetMetadata,
+      elementToReparent.oldPath,
+    )
     if (instance == null) {
       return left('Cannot find metadata for reparented element')
     }
@@ -97,11 +110,14 @@ export const stripPinsConvertToVisualSize =
 
 export const convertRelativeSizingToVisualSize =
   (
-    elementToReparent: { oldPath: ElementPath; newPath: ElementPath },
-    metadata: ElementInstanceMetadataMap,
+    elementToReparent: ElementPathSnapshots,
+    metadata: MetadataSnapshots,
   ): ReparentPropertyStrategy =>
   () => {
-    const instance = MetadataUtils.findElementByElementPath(metadata, elementToReparent.oldPath)
+    const instance = MetadataUtils.findElementByElementPath(
+      metadata.originalTargetMetadata,
+      elementToReparent.oldPath,
+    )
     if (instance == null) {
       return left('Cannot find metadata for reparented element')
     }
@@ -141,12 +157,15 @@ export const convertRelativeSizingToVisualSize =
 
 export const convertSizingToVisualSizeWhenPastingFromFlexToFlex =
   (
-    elementToReparent: { oldPath: ElementPath; newPath: ElementPath },
+    elementToReparent: ElementPathSnapshots,
     targetParent: ElementPath,
-    metadata: ElementInstanceMetadataMap,
+    metadata: MetadataSnapshots,
   ): ReparentPropertyStrategy =>
   () => {
-    const targetParentInstance = MetadataUtils.findElementByElementPath(metadata, targetParent)
+    const targetParentInstance = MetadataUtils.findElementByElementPath(
+      metadata.currentMetadata,
+      targetParent,
+    )
     if (targetParentInstance == null) {
       return left('Target parent has no metadata')
     }
@@ -156,7 +175,7 @@ export const convertSizingToVisualSizeWhenPastingFromFlexToFlex =
     }
 
     const elementToReparentInstance = MetadataUtils.findElementByElementPath(
-      metadata,
+      metadata.originalTargetMetadata,
       elementToReparent.oldPath,
     )
 
@@ -188,25 +207,34 @@ export const convertSizingToVisualSizeWhenPastingFromFlexToFlex =
 
 export const positionAbsoluteElementComparedToNewParent =
   (
-    elementToReparent: { oldPath: ElementPath; newPath: ElementPath },
+    elementToReparent: ElementPathSnapshots,
     targetParent: ElementPath,
-    metadata: ElementInstanceMetadataMap,
+    metadata: MetadataSnapshots,
   ): ReparentPropertyStrategy =>
   () => {
     if (
       !MetadataUtils.isPositionAbsolute(
-        MetadataUtils.findElementByElementPath(metadata, elementToReparent.oldPath),
+        MetadataUtils.findElementByElementPath(
+          metadata.originalTargetMetadata,
+          elementToReparent.oldPath,
+        ),
       )
     ) {
       return left('Element is not position: absolute')
     }
 
-    const targetParentBounds = MetadataUtils.getFrameInCanvasCoords(targetParent, metadata)
+    const targetParentBounds = MetadataUtils.getFrameInCanvasCoords(
+      targetParent,
+      metadata.currentMetadata,
+    )
     if (targetParentBounds == null || isInfinityRectangle(targetParentBounds)) {
       return left('Target parent bounds are invalid')
     }
 
-    const elementBounds = MetadataUtils.getFrameInCanvasCoords(elementToReparent.oldPath, metadata)
+    const elementBounds = MetadataUtils.getFrameInCanvasCoords(
+      elementToReparent.oldPath,
+      metadata.originalTargetMetadata,
+    )
     if (elementBounds == null || isInfinityRectangle(elementBounds)) {
       return left('Element bounds are invalid')
     }
@@ -254,12 +282,12 @@ const getZIndex = (element: JSXElement): number | null => {
 
 export const setZIndexOnPastedElement =
   (
-    elementToReparent: { oldPath: ElementPath; newPath: ElementPath },
+    elementToReparent: ElementPathSnapshots,
     targetParent: ElementPath,
-    metadata: ElementInstanceMetadataMap,
+    metadata: MetadataSnapshots,
   ): ReparentPropertyStrategy =>
   () => {
-    const siblings = MetadataUtils.getChildrenUnordered(metadata, targetParent)
+    const siblings = MetadataUtils.getChildrenUnordered(metadata.currentMetadata, targetParent)
     const maximumZIndexOfOverlappingElements = mapDropNulls((sibling) => {
       return foldEither(
         () => null,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
@@ -26,17 +26,21 @@ export type FindReparentStrategyResult = {
 }
 
 export function reparentStrategyForPaste(
-  targetMetadata: ElementInstanceMetadataMap,
+  currentMetadata: ElementInstanceMetadataMap,
   allElementProps: AllElementProps,
   parent: ElementPath,
 ): {
   strategy: ReparentStrategy
   isFallback: boolean
 } {
-  const newParentMetadata = MetadataUtils.findElementByElementPath(targetMetadata, parent)
+  const newParentMetadata = MetadataUtils.findElementByElementPath(currentMetadata, parent)
   const parentIsFlexLayout = MetadataUtils.isFlexLayoutedContainer(newParentMetadata)
 
-  const flowParentReparentType = flowParentAbsoluteOrStatic(targetMetadata, allElementProps, parent)
+  const flowParentReparentType = flowParentAbsoluteOrStatic(
+    currentMetadata,
+    allElementProps,
+    parent,
+  )
   const reparentAsStatic = parentIsFlexLayout || flowParentReparentType === 'REPARENT_AS_STATIC'
   if (reparentAsStatic) {
     return {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1804,11 +1804,11 @@ export const UPDATE_FNS = {
         (workingEditorState, dragSource) => {
           const afterInsertion = insertWithReparentStrategies(
             workingEditorState,
+            workingEditorState.jsxMetadata,
             newParentPath,
             {
               elementPath: dragSource,
               pathToReparent: pathToReparent(dragSource),
-              extraMetadata: {},
             },
             indexPosition,
             builtInDependencies,
@@ -2875,11 +2875,11 @@ export const UPDATE_FNS = {
 
       const insertionResult = insertWithReparentStrategies(
         workingEditorState,
+        action.targetOriginalContextMetadata,
         action.pasteInto,
         {
           elementPath: currentValue.originalElementPath,
           pathToReparent: elementToReparent(elementWithUniqueUID, currentValue.importsToAdd),
-          extraMetadata: action.targetOriginalContextMetadata,
         },
         front(),
         builtInDependencies,
@@ -5615,11 +5615,11 @@ function saveFileInProjectContents(
 
 function insertWithReparentStrategies(
   editor: EditorState,
+  originalContextMetadata: ElementInstanceMetadataMap,
   parentPath: InsertionPath,
   elementToInsert: {
     elementPath: ElementPath
     pathToReparent: ToReparent
-    extraMetadata: ElementInstanceMetadataMap
   },
   indexPosition: IndexPosition,
   builtInDependencies: BuiltInDependencies,
@@ -5641,19 +5641,15 @@ function insertWithReparentStrategies(
 
   const { commands: reparentCommands, newPath } = outcomeResult
 
-  const metadataWithOriginalElementMetadata: ElementInstanceMetadataMap = {
-    ...editor.jsxMetadata,
-    ...elementToInsert.extraMetadata,
-  }
-
   const reparentStrategy = reparentStrategyForStaticReparent(
-    metadataWithOriginalElementMetadata,
+    originalContextMetadata,
+    editor.jsxMetadata,
     editor.allElementProps,
     parentPath.intendedParentPath,
   )
 
   const pastedElementMetadata = MetadataUtils.findElementByElementPath(
-    metadataWithOriginalElementMetadata,
+    originalContextMetadata,
     elementToInsert.elementPath,
   )
 
@@ -5662,7 +5658,8 @@ function insertWithReparentStrategies(
     elementToInsert.elementPath,
     newPath,
     parentPath.intendedParentPath,
-    metadataWithOriginalElementMetadata,
+    originalContextMetadata,
+    editor.jsxMetadata,
     editor.projectContents,
     editor.canvas.openFile?.filename,
     pastedElementMetadata?.specialSizeMeasurements.position ?? null,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -5642,7 +5642,6 @@ function insertWithReparentStrategies(
   const { commands: reparentCommands, newPath } = outcomeResult
 
   const reparentStrategy = reparentStrategyForStaticReparent(
-    originalContextMetadata,
     editor.jsxMetadata,
     editor.allElementProps,
     parentPath.intendedParentPath,

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -833,7 +833,7 @@ describe('conditionals', () => {
                 {
                   // @utopia/uid=cond
                   true ? (
-                    <div data-uid='aad'>copy me</div>
+                    <div data-uid='aad' style={{ display: 'block' }}>copy me</div>
                   ) : null
                 }
                 <div data-uid='bbb'>copy me</div>
@@ -916,7 +916,7 @@ describe('conditionals', () => {
                   true ? (
                     <div data-uid='eee'>
                       insert into this
-                      <div data-uid='aad'>copy me</div>
+                      <div data-uid='aad' style={{ display: 'block' }}>copy me</div>
                     </div>
                   ) : null
                 }
@@ -955,7 +955,7 @@ describe('conditionals', () => {
             <div data-uid='aaa'>
             {
               // @utopia/uid=cond
-              true ? <div data-uid='aad'>copy me</div> : null
+              true ? <div data-uid='aad' style={{ display: 'block' }}>copy me</div> : null
             }
             <div data-uid='bbb'>copy me</div>
             <div data-uid='ccc'>another div</div>
@@ -1036,7 +1036,7 @@ describe('conditionals', () => {
                 {
                   // @utopia/uid=cond
                   true ? null : (
-                    <div data-uid='aad'>copy me</div>
+                    <div data-uid='aad' style={{ display: 'block' }}>copy me</div>
                   )
                 }
                 <div data-uid='bbb'>copy me</div>
@@ -1158,7 +1158,7 @@ describe('conditionals', () => {
               <div data-uid='aaa'>
                 {
                   // @utopia/uid=cond
-                  true ? null : <div data-uid='aad'>copy me</div>
+                  true ? null : <div data-uid='aad' style={{ display: 'block' }}>copy me</div>
                 }
                 <div data-uid='bbb'>copy me</div>
                 <div data-uid='ccc'>another div</div>


### PR DESCRIPTION
## Problem
The current element metadata and the element metadata from the clipboard were merged together, which might have lead to erroneous results when pasting (such as when the original context is modified after copying).

For example, if an absolute positioned element was copied/cut from its parent, and the parent was moved before the paste, the element would end up in its original place, since the move was "erased" by merging the parent's old data over the new data.

## Fix
Expose the original metadata and the current metadata as separate parameters for the static reparent strategies (plus tests).