### PR TITLE
Don't render the Navigator drag layer at all when hidden

### DIFF
--- a/editor/src/components/navigator/navigator-drag-layer.tsx
+++ b/editor/src/components/navigator/navigator-drag-layer.tsx
@@ -54,7 +54,7 @@ export const NavigatorDragLayer = React.memo(() => {
   const label = item?.label ?? ''
   const selected = item?.selected ?? false
 
-  return (
+  return hidden ? null : (
     <div
       style={{
         position: 'fixed',
@@ -67,7 +67,6 @@ export const NavigatorDragLayer = React.memo(() => {
     >
       <FlexRow
         style={{
-          display: hidden ? 'none' : undefined,
           paddingLeft: getElementPadding(entryNavigatorDepth),
           width: '300px',
           transform: `translate(${offset.x}px, ${offset.y}px)`,


### PR DESCRIPTION
**Problem:**
The system test and screenshot test await a navigator row click, but #3675 was preventing puppeteer from doing that, causing them to bail early.

**Fix:**
Rather than set `display: 'none'` when the drag layer was hidden, we now don't render it at all.