### PR TITLE
Fix: handle missing spy value for conditionals

### DIFF
--- a/editor/src/core/model/conditionals.spec.tsx
+++ b/editor/src/core/model/conditionals.spec.tsx
@@ -1,0 +1,135 @@
+import {
+  ElementInstanceMetadata,
+  ElementInstanceMetadataMap,
+  JSXConditionalExpression,
+  emptyComments,
+  jsExpressionValue,
+  jsxConditionalExpression,
+  singleLineComment,
+} from '../shared/element-template'
+import { ConditionalCase, getConditionalActiveCase } from './conditionals'
+import * as EP from '../../core/shared/element-path'
+import { generateUUID } from '../../utils/utils'
+
+describe('conditionals', () => {
+  describe('getConditionalActiveCase', () => {
+    const path = EP.fromString('foo')
+    const tests: {
+      name: string
+      spy: ElementInstanceMetadataMap
+      conditional: JSXConditionalExpression
+      want: ConditionalCase | null
+    }[] = [
+      {
+        name: 'no override, no spy',
+        spy: {},
+        conditional: jsxConditionalExpression(
+          'foo',
+          jsExpressionValue(true, emptyComments),
+          'true',
+          jsExpressionValue(null, emptyComments),
+          jsExpressionValue(null, emptyComments),
+          emptyComments,
+        ),
+        want: 'true-case',
+      },
+      {
+        name: 'with override (true)',
+        spy: {},
+        conditional: jsxConditionalExpression(
+          'foo',
+          jsExpressionValue(true, emptyComments),
+          'true',
+          jsExpressionValue(null, emptyComments),
+          jsExpressionValue(null, emptyComments),
+          {
+            leadingComments: [
+              singleLineComment(
+                '@utopia/conditional=true',
+                '// @utopia/conditional=true',
+                false,
+                null,
+              ),
+            ],
+            trailingComments: [],
+          },
+        ),
+        want: 'true-case',
+      },
+      {
+        name: 'with override (false)',
+        spy: {},
+        conditional: jsxConditionalExpression(
+          'foo',
+          jsExpressionValue(true, emptyComments),
+          'true',
+          jsExpressionValue(null, emptyComments),
+          jsExpressionValue(null, emptyComments),
+          {
+            leadingComments: [
+              singleLineComment(
+                '@utopia/conditional=false',
+                '// @utopia/conditional=false',
+                false,
+                null,
+              ),
+            ],
+            trailingComments: [],
+          },
+        ),
+        want: 'false-case',
+      },
+      {
+        name: 'no override, not a conditional',
+        spy: {
+          foo: { conditionValue: 'not-a-conditional' } as ElementInstanceMetadata,
+        },
+        conditional: jsxConditionalExpression(
+          'foo',
+          jsExpressionValue(true, emptyComments),
+          'true',
+          jsExpressionValue(null, emptyComments),
+          jsExpressionValue(null, emptyComments),
+          emptyComments,
+        ),
+        want: null,
+      },
+      {
+        name: 'no override, spy (true)',
+        spy: {
+          foo: { conditionValue: { active: true } } as ElementInstanceMetadata,
+        },
+        conditional: jsxConditionalExpression(
+          'foo',
+          jsExpressionValue(true, emptyComments),
+          'true',
+          jsExpressionValue(null, emptyComments),
+          jsExpressionValue(null, emptyComments),
+          emptyComments,
+        ),
+        want: 'true-case',
+      },
+      {
+        name: 'no override, spy (false)',
+        spy: {
+          foo: { conditionValue: { active: false } } as ElementInstanceMetadata,
+        },
+        conditional: jsxConditionalExpression(
+          'foo',
+          jsExpressionValue(true, emptyComments),
+          'true',
+          jsExpressionValue(null, emptyComments),
+          jsExpressionValue(null, emptyComments),
+          emptyComments,
+        ),
+        want: 'false-case',
+      },
+    ]
+    tests.forEach((test, index) => {
+      it(`${index + 1}/${tests.length} ${test.name}`, async () => {
+        const got = getConditionalActiveCase(path, test.conditional, test.spy)
+        expect(got).toEqual(test.want)
+      })
+    })
+  })
+})

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -212,7 +212,10 @@ export function getConditionalActiveCase(
   if (override != null) {
     return override ? 'true-case' : 'false-case'
   }
-  const spy = spyMetadata[EP.toString(path)] ?? true
+  const spy = spyMetadata[EP.toString(path)] ?? null
+  if (spy == null) {
+    return 'true-case'
+  }
   if (spy.conditionValue === 'not-a-conditional') {
     return null
   }


### PR DESCRIPTION
Fixes #3698 

**Problem:**

If a conditional is not overridden and has no spy value, the editor goes kaboom 💣 

https://github.com/concrete-utopia/utopia/assets/1081051/c009a088-69e1-4c36-b28e-ee3a2e8c13d1

**Fix:**

Handle correctly the missing spy data for the conditional, which were not updated after we introduced the `ConditionValue` type to support switching conditional branches via the navigator.