### PR TITLE
Nulls in conditional clauses should have metadata

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -40,6 +40,7 @@ import {
   isJSXElementLike,
   isJSXConditionalExpression,
   isNullJSXAttributeValue,
+  isJSXArbitraryBlock,
 } from '../../core/shared/element-template'
 import {
   getAllUniqueUids,
@@ -3015,7 +3016,10 @@ export function getValidElementPathsFromElement(
     //     <AppAsVariable />
     //   </div>
     // }
-    let paths: Array<ElementPath> = []
+    const path = parentIsInstance
+      ? EP.appendNewElementPath(parentPath, element.uid)
+      : EP.appendToPath(parentPath, element.uid)
+    let paths: Array<ElementPath> = [path]
     fastForEach(Object.values(element.elementsWithin), (e) =>
       paths.push(
         ...getValidElementPathsFromElement(
@@ -3054,6 +3058,11 @@ export function getValidElementPathsFromElement(
       )
     })
     return paths
+  } else if (isJSXArbitraryBlock(element)) {
+    const path = parentIsInstance
+      ? EP.appendNewElementPath(parentPath, element.uid)
+      : EP.appendToPath(parentPath, element.uid)
+    return [path]
   } else {
     return []
   }

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -40,8 +40,6 @@ import {
   isJSXElementLike,
   isJSXConditionalExpression,
   isNullJSXAttributeValue,
-  isJSXArbitraryBlock,
-  isJSXAttributeValue,
 } from '../../core/shared/element-template'
 import {
   getAllUniqueUids,
@@ -3062,8 +3060,7 @@ export function getValidElementPathsFromElement(
       )
     })
     return paths
-  } else if (isJSXAttributeValue(element)) {
-    const isNull = element.value === null
+  } else if (isNullJSXAttributeValue(element)) {
     const parentIsConditional = withUnderlyingTarget(
       parentPath,
       projectContents,
@@ -3074,7 +3071,7 @@ export function getValidElementPathsFromElement(
         return isJSXConditionalExpression(elem)
       },
     )
-    if (isNull && parentIsConditional) {
+    if (parentIsConditional) {
       const path = parentIsInstance
         ? EP.appendNewElementPath(parentPath, element.uid)
         : EP.appendToPath(parentPath, element.uid)

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2934,6 +2934,7 @@ export function getValidElementPaths(
           instancePath,
           projectContents,
           resolvedFilePath,
+          filePath,
           false,
           true,
           transientFilesState,
@@ -2951,6 +2952,7 @@ export function getValidElementPathsFromElement(
   parentPath: ElementPath,
   projectContents: ProjectContentTreeRoot,
   filePath: string,
+  uiFilePath: string,
   parentIsScene: boolean,
   parentIsInstance: boolean,
   transientFilesState: TransientFilesState | null,
@@ -2971,6 +2973,7 @@ export function getValidElementPathsFromElement(
           path,
           projectContents,
           filePath,
+          uiFilePath,
           isScene,
           false,
           transientFilesState,
@@ -3027,6 +3030,7 @@ export function getValidElementPathsFromElement(
           parentPath,
           projectContents,
           filePath,
+          uiFilePath,
           parentIsScene,
           parentIsInstance,
           transientFilesState,
@@ -3049,6 +3053,7 @@ export function getValidElementPathsFromElement(
           path,
           projectContents,
           filePath,
+          uiFilePath,
           false,
           false,
           transientFilesState,
@@ -3063,14 +3068,13 @@ export function getValidElementPathsFromElement(
       parentPath,
       projectContents,
       {},
-      filePath,
+      uiFilePath,
       null,
       (_, elem) => {
         return isJSXConditionalExpression(elem)
       },
     )
-    // TODO: this should be if (isNull && parentIsConditional) {
-    if (isNull) {
+    if (isNull && parentIsConditional) {
       const path = parentIsInstance
         ? EP.appendNewElementPath(parentPath, element.uid)
         : EP.appendToPath(parentPath, element.uid)

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -432,6 +432,18 @@ export function renderCoreElement(
     case 'ATTRIBUTE_NESTED_ARRAY':
     case 'ATTRIBUTE_NESTED_OBJECT':
     case 'ATTRIBUTE_FUNCTION_CALL':
+      if (elementPath != null) {
+        addFakeSpyEntry(
+          validPaths,
+          metadataContext,
+          elementPath,
+          element,
+          filePath,
+          imports,
+          'not-a-conditional',
+        )
+      }
+
       const elementIsTextEdited = elementPath != null && EP.pathsEqual(elementPath, editedText)
 
       if (elementIsTextEdited) {

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -143,18 +143,24 @@ export function getNavigatorTargets(
         addNavigatorTargetUnlessCollapsed(clauseTitleEntry)
 
         // Create the entry for the value of the clause.
-        const elementMetadata = MetadataUtils.findElementByElementPath(metadata, clausePath)
-        if (elementMetadata == null) {
+        const clauseElementMetadata = MetadataUtils.findElementByElementPath(metadata, clausePath)
+        const isEmptyClause =
+          clauseElementMetadata == null ||
+          (isLeft(clauseElementMetadata.element) && clauseElementMetadata.element.value === 'null')
+        if (isEmptyClause) {
           const clauseValueEntry = syntheticNavigatorEntry(clausePath, clauseValue)
           addNavigatorTargetUnlessCollapsed(clauseValueEntry)
         }
 
         // Walk the clause of the conditional.
-        const clausePathTree = conditionalSubTree.children.find((childPath) => {
-          return EP.pathsEqual(childPath.path, clausePath)
-        })
-        if (clausePathTree != null) {
-          walkAndAddKeys(clausePathTree, newCollapsedAncestor)
+        if (!isEmptyClause) {
+          // avoid rendering `null` as an extra navigator entry if the slot synthetic item has been added already
+          const clausePathTree = conditionalSubTree.children.find((childPath) => {
+            return EP.pathsEqual(childPath.path, clausePath)
+          })
+          if (clausePathTree != null) {
+            walkAndAddKeys(clausePathTree, newCollapsedAncestor)
+          }
         }
       }
 

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -2143,6 +2143,19 @@ function fillSpyOnlyMetadata(
 
     const children = findChildrenInDomRecursively(pathStr)
     if (children.length === 0) {
+      let parentPath = EP.parentPath(EP.fromString(pathStr))
+      let globalFrame: MaybeInfinityCanvasRectangle | null = null
+      while (globalFrame == null && !EP.isEmptyPath(parentPath)) {
+        const parentPathStr = EP.toString(parentPath)
+        globalFrame =
+          fromDOM[parentPathStr]?.globalFrame ?? workingElements[parentPathStr]?.globalFrame ?? null
+        parentPath = EP.parentPath(parentPath)
+      }
+
+      workingElements[pathStr] = {
+        ...spyElem,
+        globalFrame: globalFrame,
+      }
       return
     }
 

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -2290,36 +2290,32 @@ function fillMissingDataFromAncestors(mergedMetadata: ElementInstanceMetadataMap
   fastForEach(nullsInConditional, (pathStr) => {
     const elem = workingElements[pathStr]
 
-    const parentPathStr = EP.toString(EP.parentPath(EP.fromString(pathStr)))
+    // get the globalFrame from the grandparent (the parent of the conditional parent)
+    const condParentPathStr = EP.toString(EP.parentPath(EP.parentPath(EP.fromString(pathStr))))
 
-    let parentGlobalFrame: MaybeInfinityCanvasRectangle | null = null
-    let parentPath: ElementPath = EP.parentPath(EP.fromString(pathStr))
-    while (parentGlobalFrame == null && !EP.isEmptyPath(parentPath)) {
-      parentGlobalFrame = workingElements[EP.toString(parentPath)]?.globalFrame
-      parentPath = EP.parentPath(parentPath)
-    }
-    if (parentGlobalFrame == null) {
-      parentGlobalFrame = infinityCanvasRectangle
-    }
-    const parentGlobalContentBoxForChildren =
-      workingElements[parentPathStr]?.specialSizeMeasurements.globalContentBoxForChildren
-    const localFrameFromParent = (() => {
-      if (parentGlobalContentBoxForChildren == null) {
+    const condParentGlobalFrame = workingElements[condParentPathStr]?.globalFrame
+    const condParentGlobalContentBoxForChildren =
+      workingElements[condParentPathStr]?.specialSizeMeasurements.globalContentBoxForChildren
+    const localFrameFromCondParent = (() => {
+      if (condParentGlobalFrame == null || condParentGlobalContentBoxForChildren == null) {
         return null
       }
       if (
-        isInfinityRectangle(parentGlobalFrame) ||
-        isInfinityRectangle(parentGlobalContentBoxForChildren)
+        isInfinityRectangle(condParentGlobalFrame) ||
+        isInfinityRectangle(condParentGlobalContentBoxForChildren)
       ) {
         return infinityLocalRectangle
       }
-      return canvasRectangleToLocalRectangle(parentGlobalFrame, parentGlobalContentBoxForChildren)
+      return canvasRectangleToLocalRectangle(
+        condParentGlobalFrame,
+        condParentGlobalContentBoxForChildren,
+      )
     })()
 
     workingElements[pathStr] = {
       ...elem,
-      globalFrame: parentGlobalFrame,
-      localFrame: localFrameFromParent,
+      globalFrame: condParentGlobalFrame,
+      localFrame: localFrameFromCondParent,
     }
   })
 


### PR DESCRIPTION
**Problem:**
We would like to be able to reparent into an empty conditional slot on the canvas. 
The bounds shown should be the bounds of the parent of the conditional.

**Fix:**
This PR only implements the necessary changes in the metadata for the feature.
This is a minimal solution which does not affect any other expressions, just nulls inside conditional branches.

- I added nulls inside conditional clauses into validPaths
- I made sure a fake spy entry is created for expressions (it checks if the element path is in validPaths)
- I gathered globalFrame and localFrame from the parent of the conditional from these elements.

