### PR TITLE
fix(reparent) reparent changes element to flow too often, switch fallback to absolute

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -498,18 +498,12 @@ export function flowParentAbsoluteOrStatic(
     return 'REPARENT_AS_STATIC'
   }
 
-  const anyChildrenFlow = children.some(
-    (child) => child.specialSizeMeasurements.position === 'static',
-  )
-  if (anyChildrenFlow) {
-    return 'REPARENT_AS_STATIC'
-  }
-
-  const allChildrenPositionedAbsolutely =
+  const allChildrenFlow =
     children.length > 0 &&
-    children.every((child) => child.specialSizeMeasurements.position === 'absolute')
-  if (allChildrenPositionedAbsolutely) {
-    return 'REPARENT_AS_ABSOLUTE'
+    children.every((child) => child.specialSizeMeasurements.position === 'static')
+
+  if (allChildrenFlow) {
+    return 'REPARENT_AS_STATIC'
   }
 
   const parentFrame = parentMetadata?.globalFrame ?? null
@@ -533,8 +527,8 @@ export function flowParentAbsoluteOrStatic(
     return 'REPARENT_AS_STATIC'
   }
 
-  // the fallback is reparent as static
-  return 'REPARENT_AS_STATIC'
+  // the fallback is reparent as absolute
+  return 'REPARENT_AS_ABSOLUTE'
 
   // should there be a DO_NOT_REPARENT return type here?
 }

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -1826,6 +1826,25 @@ export var Playground = () => {
             />
           </div>`,
             },
+            {
+              name: 'paste an absolute element into a flow layout - element will be absolute',
+              input: `<div data-uid='root'>
+              <div data-uid='ccc' style={{ contain: 'layout' }}>
+                <div data-uid='ddd' style={{ position: 'absolute', top: 10, left: 10 }}>hi</div>
+                <div data-uid='eee' style={{ width: 20, height: 20 }}/>
+              </div>
+              <div data-uid='bbb' style={{ position: 'absolute', top: 20, left: 50, contain: 'layout' }}>hello</div>
+            </div>`,
+              targets: [makeTargetPath('root/bbb')],
+              result: `<div data-uid='root'>
+              <div data-uid='ccc' style={{ contain: 'layout' }}>
+                <div data-uid='ddd' style={{ position: 'absolute', top: 10, left: 10 }}>hi</div>
+                <div data-uid='eee' style={{ width: 20, height: 20 }}/>
+                <div data-uid='aah' style={{ position: 'absolute', top: 20, left: 50, contain: 'layout' }}>hello</div>
+              </div>
+              <div data-uid='bbb' style={{ position: 'absolute', top: 20, left: 50, contain: 'layout' }}>hello</div>
+            </div>`,
+            },
           ]
 
           copyPasteLayoutTestCases.forEach((tt, idx) => {


### PR DESCRIPTION
**Problem:**
Reparent in the 'Before I Go' project 'Moodboard' component converts element to flow.
Pasting an absolute element sometimes converts them flow.

**Fix:**
Update `flowParentAbsoluteOrStatic` to prefer `absolute` in more cases. When checking the sibling layouts only reparent as static if all siblings are `static`. Switch fallback to `absolute`.

**Commit Details:**
- update `flowParentAbsoluteOrStatic`
