### PR TITLE
Improve the performance of core PropertyPath code.

### DIFF
--- a/editor/src/benchmarks.benchmark.ts
+++ b/editor/src/benchmarks.benchmark.ts
@@ -1,5 +1,7 @@
 import { benchmarkBuildTree } from './core/shared/element-path-tree.benchmark'
 import { benchmarkElementPathFunction } from './core/shared/element-path.benchmark'
+import { benchmarkPropertyPathFunction } from './core/shared/property-path.benchmark'
 
 await benchmarkBuildTree()
 await benchmarkElementPathFunction()
+await benchmarkPropertyPathFunction()

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { createSelector } from 'reselect'
 import { addAllUniquelyBy, mapDropNulls, sortBy } from '../../../core/shared/array-utils'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
-import { arrayEquals, assertNever } from '../../../core/shared/utils'
+import { arrayEqualsByReference, assertNever } from '../../../core/shared/utils'
 import { AllElementProps, EditorState, EditorStorePatched } from '../../editor/store/editor-state'
 import { Substores, useEditorState, useSelectorWithCallback } from '../../editor/store/store-hook'
 import {
@@ -271,7 +271,7 @@ function useGetApplicableStrategies(): Array<CanvasStrategy> {
     Substores.fullStore,
     getApplicableStrategiesSelector,
     'useGetApplicableStrategies',
-    arrayEquals,
+    arrayEqualsByReference,
   )
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -5,7 +5,7 @@ import * as EP from '../../../../core/shared/element-path'
 import { CanvasPoint, offsetPoint } from '../../../../core/shared/math-utils'
 import { memoize } from '../../../../core/shared/memoize'
 import { ElementPath } from '../../../../core/shared/project-file-types'
-import { arrayEquals, assertNever } from '../../../../core/shared/utils'
+import { arrayEqualsByValue, assertNever } from '../../../../core/shared/utils'
 import { wildcardPatch } from '../../commands/wildcard-patch-command'
 import { CanvasStrategyFactory, MetaCanvasStrategy } from '../canvas-strategies'
 import {
@@ -175,7 +175,7 @@ const getStartingTargetParentsToFilterOut = memoize(getStartingTargetParentsToFi
         const rTargets = getTargetPathsFromInteractionTarget(r.interactionTarget)
         return (
           l.startingMetadata === r.startingMetadata &&
-          arrayEquals(lTargets, rTargets, EP.pathsEqual)
+          arrayEqualsByValue(lTargets, rTargets, EP.pathsEqual)
         )
       }
     }

--- a/editor/src/components/canvas/controls/reorder-slider-control.tsx
+++ b/editor/src/components/canvas/controls/reorder-slider-control.tsx
@@ -11,7 +11,7 @@ import {
   zeroCanvasRect,
   zeroRectIfNullOrInfinity,
 } from '../../../core/shared/math-utils'
-import { arrayEquals } from '../../../core/shared/utils'
+import { arrayEqualsByValue } from '../../../core/shared/utils'
 import { Modifier } from '../../../utils/modifiers'
 import { when } from '../../../utils/react-conditionals'
 import { Icons, useColorTheme } from '../../../uuiui'
@@ -107,7 +107,7 @@ export const ReorderSliderControl = controlForStrategyMemoized(
       },
       'ReorderSliderControl',
       (oldValue, newValue) =>
-        arrayEquals(oldValue.siblings, newValue.siblings, EP.pathsEqual) &&
+        arrayEqualsByValue(oldValue.siblings, newValue.siblings, EP.pathsEqual) &&
         oldValue.latestIndex === newValue.latestIndex &&
         oldValue.startingIndex === newValue.startingIndex &&
         rectanglesEqual(oldValue.startingFrame, newValue.startingFrame),

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -70,7 +70,7 @@ import { ProjectContentTreeRoot, getContentsTreeFileFromString } from '../assets
 import { createExecutionScope } from './ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope'
 import { applyUIDMonkeyPatch } from '../../utils/canvas-react-utils'
 import { getParseSuccessOrTransientForFilePath, getValidElementPaths } from './canvas-utils'
-import { arrayEquals, fastForEach, NO_OP } from '../../core/shared/utils'
+import { arrayEqualsByValue, fastForEach, NO_OP } from '../../core/shared/utils'
 import { useTwind } from '../../core/tailwind/tailwind'
 import {
   AlwaysFalse,
@@ -344,7 +344,11 @@ export const UiJsxCanvas = React.memo<UiJsxCanvasPropsWithErrorCallback>((props)
   shouldRerenderRef.current =
     ElementsToRerenderGLOBAL.current === 'rerender-all-elements' ||
     elementsToRerenderRef.current === 'rerender-all-elements' || // TODO this means the first drag frame will still be slow, figure out a nicer way to immediately switch to true. probably this should live in a dedicated a function
-    !arrayEquals(ElementsToRerenderGLOBAL.current, elementsToRerenderRef.current, EP.pathsEqual) // once we get here, we know that both `ElementsToRerenderGLOBAL.current` and `elementsToRerenderRef.current` are arrays
+    !arrayEqualsByValue(
+      ElementsToRerenderGLOBAL.current,
+      elementsToRerenderRef.current,
+      EP.pathsEqual,
+    ) // once we get here, we know that both `ElementsToRerenderGLOBAL.current` and `elementsToRerenderRef.current` are arrays
   elementsToRerenderRef.current = ElementsToRerenderGLOBAL.current
 
   const maybeOldProjectContents = React.useRef(projectContents)

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
@@ -4,7 +4,7 @@ import { flatMapArray, last, mapArrayToDictionary } from '../../../core/shared/a
 import { emptyComments, jsExpressionValue } from '../../../core/shared/element-template'
 import { objectMap } from '../../../core/shared/object-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
-import { arrayEquals, NO_OP } from '../../../core/shared/utils'
+import { arrayEqualsByReference, NO_OP } from '../../../core/shared/utils'
 import { useKeepReferenceEqualityIfPossible } from '../../../utils/react-performance'
 import {
   setProp_UNSAFE,
@@ -43,7 +43,7 @@ function getShadowedLonghandShorthandValue<
   orderedPropKeys: (LonghandKey | ShorthandKey)[][], // multiselect
 ): { value: ParsedProperties[LonghandKey]; propertyStatus: PropertyStatus } {
   const allPropKeysEqual = orderedPropKeys.every((propKeys) => {
-    return arrayEquals(propKeys, orderedPropKeys[0])
+    return arrayEqualsByReference(propKeys, orderedPropKeys[0])
   })
 
   const propKeys = orderedPropKeys[0] ?? []
@@ -157,7 +157,7 @@ export function useInspectorInfoLonghandShorthand<
       transient?: boolean | undefined,
     ) => {
       const allPropKeysEqual = orderedPropKeys.every((propKeys) => {
-        return arrayEquals(propKeys, orderedPropKeys[0])
+        return arrayEqualsByReference(propKeys, orderedPropKeys[0])
       })
       if (!allPropKeysEqual) {
         // we do nothing for now. we cannot ensure that we can make a sensible update and surface it on the UI as well
@@ -234,7 +234,7 @@ export function useInspectorInfoLonghandShorthand<
   const longhandResultsWithUnset = objectMap((longhandResult, longhandToUnset) => {
     const onUnsetValues = () => {
       const allPropKeysEqual = allOrderedPropKeys.every((propKeys) => {
-        return arrayEquals(propKeys, allOrderedPropKeys[0])
+        return arrayEqualsByReference(propKeys, allOrderedPropKeys[0])
       })
       if (!allPropKeysEqual) {
         // we do nothing for now. we cannot ensure that we can make a sensible update and surface it on the UI as well

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -5,7 +5,7 @@ import {
   StaticElementPathPart,
   StaticElementPath,
 } from './project-file-types'
-import { arrayEquals, longestCommonArray, identity, fastForEach } from './utils'
+import { arrayEqualsByReference, longestCommonArray, identity, fastForEach } from './utils'
 import { replaceAll } from './string-utils'
 import { last, dropLastN, drop, splitAt, flattenArray, dropLast } from './array-utils'
 import { forceNotNull } from './optional-utils'
@@ -524,7 +524,7 @@ export function appendPartToPath(path: ElementPath, next: ElementPathPart): Elem
 }
 
 function elementPathPartsEqual(l: ElementPathPart, r: ElementPathPart): boolean {
-  return arrayEquals(l, r)
+  return arrayEqualsByReference(l, r)
 }
 
 function stringifiedPathsEqual(l: ElementPath, r: ElementPath): boolean {

--- a/editor/src/core/shared/github/helpers.ts
+++ b/editor/src/core/shared/github/helpers.ts
@@ -54,7 +54,7 @@ import {
 } from '../project-file-types'
 import { emptySet } from '../set-utils'
 import { trimUpToAndIncluding } from '../string-utils'
-import { arrayEquals } from '../utils'
+import { arrayEqualsByReference } from '../utils'
 import { getBranchesForGithubRepository } from './operations/list-branches'
 import { updatePullRequestsForBranch } from './operations/list-pull-requests-for-branch'
 import { getUsersPublicGithubRepositories } from './operations/load-repositories'
@@ -401,10 +401,10 @@ export function githubFileChangesEquals(
     return false
   }
   return (
-    arrayEquals(a.untracked, b.untracked) &&
-    arrayEquals(a.modified, b.modified) &&
-    arrayEquals(a.deleted, b.deleted) &&
-    arrayEquals(a.conflicted, b.conflicted)
+    arrayEqualsByReference(a.untracked, b.untracked) &&
+    arrayEqualsByReference(a.modified, b.modified) &&
+    arrayEqualsByReference(a.deleted, b.deleted) &&
+    arrayEqualsByReference(a.conflicted, b.conflicted)
   )
 }
 

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -7,7 +7,7 @@ import {
   TopLevelElement,
 } from './element-template'
 import { ErrorMessage } from './error-messages'
-import { arrayEquals, objectEquals } from './utils'
+import { arrayEqualsByValue, objectEquals } from './utils'
 
 export type id = string
 enum StaticModifier {}
@@ -144,7 +144,7 @@ export function importStatementFromImportDetails(
 export function importDetailsEquals(first: ImportDetails, second: ImportDetails): boolean {
   return (
     first.importedWithName === second.importedWithName &&
-    arrayEquals(first.importedFromWithin, second.importedFromWithin, importAliasEquals) &&
+    arrayEqualsByValue(first.importedFromWithin, second.importedFromWithin, importAliasEquals) &&
     first.importedAs === second.importedAs
   )
 }

--- a/editor/src/core/shared/property-path.benchmark.ts
+++ b/editor/src/core/shared/property-path.benchmark.ts
@@ -1,0 +1,138 @@
+import * as Benny from 'benny'
+import { PropertyPath } from './project-file-types'
+import * as PP from './property-path'
+
+export async function benchmarkPropertyPathFunction(): Promise<void> {
+  await Benny.suite(
+    'creating a property path, same path repeated',
+    Benny.add('create', () => {
+      PP.clearPropertyPathCache()
+      return () => {
+        PP.create('step-1', 3)
+      }
+    }),
+    Benny.cycle(),
+    Benny.complete(),
+    Benny.save({ file: 'creating a property path, same path repeated', details: true }),
+  )
+  await Benny.suite(
+    'creating a property path, new path each time',
+    Benny.add('create', () => {
+      PP.clearPropertyPathCache()
+      let counter: number = 3
+      return () => {
+        PP.create('step-2', counter++)
+      }
+    }),
+    Benny.cycle(),
+    Benny.complete(),
+    Benny.save({ file: 'creating a property path, new path each time', details: true }),
+  )
+  await Benny.suite(
+    'creating a property path from an array, same path repeated',
+    Benny.add('createFromArray', () => {
+      PP.clearPropertyPathCache()
+      return () => {
+        PP.createFromArray(['step-3', 'step-4'])
+      }
+    }),
+    Benny.cycle(),
+    Benny.complete(),
+    Benny.save({
+      file: 'creating a property path from an array, same path repeated',
+      details: true,
+    }),
+  )
+  await Benny.suite(
+    'creating a property path from an array, new path each time',
+    Benny.add('createFromArray', () => {
+      PP.clearPropertyPathCache()
+      let counter: number = 3
+      return () => {
+        PP.createFromArray(['step-4', counter++])
+      }
+    }),
+    Benny.cycle(),
+    Benny.complete(),
+    Benny.save({
+      file: 'creating a property path from an array, new path each time',
+      details: true,
+    }),
+  )
+  await Benny.suite(
+    'toString a property path, same path repeated',
+    Benny.add('toString', () => {
+      PP.clearPropertyPathCache()
+      const path = PP.create('step-5', 3)
+      return () => {
+        PP.toString(path)
+      }
+    }),
+    Benny.cycle(),
+    Benny.complete(),
+    Benny.save({ file: 'toString a property path, same path repeated', details: true }),
+  )
+  await Benny.suite(
+    'toString a property path, new path each time',
+    Benny.add('toString', () => {
+      PP.clearPropertyPathCache()
+      let counter: number = 0
+      return () => {
+        // Includes the creation, which will distort things a little, but the alternative
+        // is construction an array with a bajillion paths in it.
+        PP.toString(PP.create('step-6', counter))
+      }
+    }),
+    Benny.cycle(),
+    Benny.complete(),
+    Benny.save({
+      file: 'creating a property path from an array, new path each time',
+      details: true,
+    }),
+  )
+  await Benny.suite(
+    'pathsEqual, same instance',
+    Benny.add('pathsEqual', () => {
+      PP.clearPropertyPathCache()
+      const path = PP.create('step-7', 3)
+      return () => {
+        PP.pathsEqual(path, path)
+      }
+    }),
+    Benny.cycle(),
+    Benny.complete(),
+    Benny.save({ file: 'pathsEqual, same instance', details: true }),
+  )
+  await Benny.suite(
+    'pathsEqual, same path different instance',
+    Benny.add('pathsEqual', () => {
+      PP.clearPropertyPathCache()
+      const path1: PropertyPath = {
+        propertyElements: ['step-8', 'path'],
+      }
+      const path2: PropertyPath = {
+        propertyElements: ['step-8', 'path'],
+      }
+      return () => {
+        PP.pathsEqual(path1, path2)
+      }
+    }),
+    Benny.cycle(),
+    Benny.complete(),
+    Benny.save({ file: 'pathsEqual, same path different instance', details: true }),
+  )
+  await Benny.suite(
+    'pathsEqual, different paths',
+    Benny.add('pathsEqual', () => {
+      PP.clearPropertyPathCache()
+      const path1 = PP.create('step-9', 'first')
+      const path2 = PP.create('step-9', 'second')
+      return () => {
+        PP.pathsEqual(path1, path2)
+      }
+    }),
+    Benny.cycle(),
+    Benny.complete(),
+    Benny.save({ file: 'pathsEqual, different paths', details: true }),
+  )
+}

--- a/editor/src/core/shared/utils.ts
+++ b/editor/src/core/shared/utils.ts
@@ -30,11 +30,31 @@ export function fastForEach<T>(a: readonly T[], fn: (t: T, index: number) => voi
   }
 }
 
-export function arrayEquals<T>(a: Array<T>, b: Array<T>, eq?: (l: T, r: T) => boolean): boolean {
+export function arrayEqualsByReference<T>(a: Array<T>, b: Array<T>): boolean {
   if (a === b) {
     return true
   } else {
-    const equals = eq == null ? (l: T, r: T) => l === r : eq
+    if (a.length === b.length) {
+      for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) {
+          return false
+        }
+      }
+      return true
+    } else {
+      return false
+    }
+  }
+}
+
+export function arrayEqualsByValue<T>(
+  a: Array<T>,
+  b: Array<T>,
+  equals: (l: T, r: T) => boolean,
+): boolean {
+  if (a === b) {
+    return true
+  } else {
     if (a.length === b.length) {
       for (let i = 0; i < a.length; i++) {
         if (!equals(a[i], b[i])) {

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -14,7 +14,7 @@ import {
   PRODUCTION_ENV,
   requireElectron,
 } from '../common/env-vars'
-import { arrayEquals, EditorID } from '../core/shared/utils'
+import { EditorID } from '../core/shared/utils'
 import CanvasActions from '../components/canvas/canvas-actions'
 import {
   DispatchPriority,


### PR DESCRIPTION
**Problem:**
`PropertyPath` is similar to `ElementPath` in a few ways, so we can probably apply what we've learnt with the latter to the former.

**Fix:**
Improvements were as follows:
- Split apart `arrayEquals` into two versions that have more specific functionality which appears to make it more amenable to optimisations.
- Handle strings and numbers in property paths by having a cache value for each instead of templating a string to use as a key.
- Removed the null handling from `pathsEqual` as we never actually utilised it.

**Results:**
```
creating a property path, same path repeated:
4,317,459 ops/s, ±0.49% -> 89,242,985 ops/s, ±1.26%
creating a property path, new path each time:
672,713 ops/s, ±25.69% -> 2,276,563 ops/s, ±40.46%
creating a property path from an array, same path repeated:
3,486,147 ops/s, ±0.44% -> 22,118,001 ops/s, ±2.17%
creating a property path from an array, new path each time:
951,396 ops/s, ±17.46% -> 1,649,162 ops/s, ±52.37%
toString a property path, same path repeated:
2,494,425 ops/s, ±26.26% -> 32,971,920 ops/s, ±2.34%
toString a property path, new path each time:
1,536,574 ops/s, ±1.36% -> 2,198,471 ops/s, ±4.22%
pathsEqual, same instance:
1,287,738,732 ops/s, ±0.24% -> 1,241,210,081 ops/s, ±0.76%
pathsEqual, same path different instance:
30,391,699 ops/s, ±0.62% -> 180,323,832 ops/s, ±0.79%
pathsEqual, different paths:
32,415,262 ops/s, ±0.55% -> 186,843,290 ops/s, ±2.99%
```

**Commit Details:**
- Split `arrayEquals` into `arrayEqualsByReference` and `arrayEqualsByValue`.
- `PropertyPathCache` now has `stringChildCaches` and `numberChildCaches`, to maintain the difference of indexing by strings or numbers.
- Simplified `pathsEqual` as it doesn't actually need to handle nulls.