### PR TITLE
Allow reparenting into conditional slots

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
@@ -2,7 +2,6 @@ import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../../core/shared/array-utils'
 import * as EP from '../../../../core/shared/element-path'
 import { ElementPath } from '../../../../core/shared/project-file-types'
-import { childInsertionPath } from '../../../editor/store/insertion-path'
 import { CSSCursor } from '../../canvas-types'
 import { setCursorCommand } from '../../commands/set-cursor-command'
 import { setElementsToRerenderCommand } from '../../commands/set-elements-to-rerender-command'
@@ -22,11 +21,12 @@ import {
 import { InteractionSession, UpdatedPathMap } from '../interaction-state'
 import { absoluteMoveStrategy } from './absolute-move-strategy'
 import { honoursPropsPosition } from './absolute-utils'
+import { replaceContentAffectingPathsWithTheirChildrenRecursive } from './group-like-helpers'
 import {
-  replaceContentAffectingPathsWithTheirChildrenRecursive,
-  retargetStrategyToChildrenOfContentAffectingElements,
-} from './group-like-helpers'
-import { ifAllowedToReparent, isAllowedToReparent } from './reparent-helpers/reparent-helpers'
+  getInsertionPathForReparentTarget,
+  ifAllowedToReparent,
+  isAllowedToReparent,
+} from './reparent-helpers/reparent-helpers'
 import { getAbsoluteReparentPropertyChanges } from './reparent-helpers/reparent-property-changes'
 import { ReparentTarget } from './reparent-helpers/reparent-strategy-helpers'
 import { getReparentOutcome, pathToReparent } from './reparent-utils'
@@ -121,7 +121,7 @@ export function baseAbsoluteReparentStrategy(
                   nodeModules,
                   openFile,
                   pathToReparent(selectedElement),
-                  childInsertionPath(newParent),
+                  getInsertionPathForReparentTarget(newParent, canvasState.startingMetadata),
                   'always',
                   null,
                 )

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -3,7 +3,6 @@ import * as EP from '../../../../core/shared/element-path'
 import { zeroCanvasRect } from '../../../../core/shared/math-utils'
 import { assertNever } from '../../../../core/shared/utils'
 import { absolute } from '../../../../utils/utils'
-import { childInsertionPath } from '../../../editor/store/insertion-path'
 import { CSSCursor } from '../../canvas-types'
 import { CanvasCommand } from '../../commands/commands'
 import { reorderElement } from '../../commands/reorder-element-command'
@@ -29,7 +28,10 @@ import {
   StrategyApplicationResult,
 } from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
-import { ifAllowedToReparent } from './reparent-helpers/reparent-helpers'
+import {
+  getInsertionPathForReparentTarget,
+  ifAllowedToReparent,
+} from './reparent-helpers/reparent-helpers'
 import { getStaticReparentPropertyChanges } from './reparent-helpers/reparent-property-changes'
 import { ReparentTarget } from './reparent-helpers/reparent-strategy-helpers'
 import { getReparentOutcome, pathToReparent, placeholderCloneCommands } from './reparent-utils'
@@ -161,7 +163,7 @@ function applyStaticReparent(
             canvasState.nodeModules,
             canvasState.openFile,
             pathToReparent(target),
-            childInsertionPath(newParent),
+            getInsertionPathForReparentTarget(newParent, canvasState.startingMetadata),
             'always',
             null,
           )

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
@@ -1,5 +1,6 @@
 import {
   findMaybeConditionalExpression,
+  getConditionalActiveCase,
   maybeBranchConditionalCase,
 } from '../../../../../core/model/conditionals'
 import { MetadataUtils } from '../../../../../core/model/element-metadata-utils'
@@ -11,6 +12,11 @@ import {
 } from '../../../../../core/shared/element-template'
 import { ElementPath } from '../../../../../core/shared/project-file-types'
 import { ProjectContentTreeRoot } from '../../../../assets'
+import {
+  InsertionPath,
+  childInsertionPath,
+  conditionalClauseInsertionPath,
+} from '../../../../editor/store/insertion-path'
 import { CSSCursor } from '../../../canvas-types'
 import { setCursorCommand } from '../../../commands/set-cursor-command'
 import {
@@ -64,4 +70,19 @@ export function ifAllowedToReparent(
   } else {
     return strategyApplicationResult([setCursorCommand(CSSCursor.NotPermitted)], {}, 'failure')
   }
+}
+
+export function getInsertionPathForReparentTarget(
+  newParent: ElementPath,
+  metadata: ElementInstanceMetadataMap,
+): InsertionPath {
+  const conditional = findMaybeConditionalExpression(newParent, metadata)
+  if (conditional == null) {
+    return childInsertionPath(newParent)
+  }
+  const clause = getConditionalActiveCase(newParent, conditional, metadata)
+  if (clause == null) {
+    return childInsertionPath(newParent)
+  }
+  return conditionalClauseInsertionPath(newParent, clause, 'replace')
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -36,6 +36,7 @@ import {
 import { ReparentStrategy, ReparentSubjects, ReparentTarget } from './reparent-strategy-helpers'
 import { drawTargetRectanglesForChildrenOfElement } from './reparent-strategy-sibling-position-helpers'
 import { ElementPathTreeRoot } from '../../../../../core/shared/element-path-tree'
+import { isConditionalWithEmptyActiveBranch } from '../../../../../core/model/conditionals'
 
 export type FindReparentStrategyResult = {
   strategy: ReparentStrategy
@@ -146,6 +147,9 @@ function findValidTargetsUnderPoint(
   ]
 
   const possibleTargetParentsUnderPoint = allElementsUnderPoint.filter((target) => {
+    if (isConditionalWithEmptyActiveBranch(target, metadata, metadata)) {
+      return true
+    }
     if (treatElementAsContentAffecting(metadata, allElementProps, target)) {
       // we disallow reparenting into sizeless ContentAffecting (group-like) elements
       return false

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -161,6 +161,23 @@ export function getConditionalBranch(
   return clause === 'true-case' ? conditional.whenTrue : conditional.whenFalse
 }
 
+export function isConditionalWithEmptyActiveBranch(
+  path: ElementPath,
+  metadata: ElementInstanceMetadataMap,
+  spyMetadata: ElementInstanceMetadataMap,
+): boolean {
+  const conditional = findMaybeConditionalExpression(path, metadata)
+  if (conditional == null) {
+    return false
+  }
+  const clause = getConditionalActiveCase(path, conditional, spyMetadata)
+  if (clause == null) {
+    return false
+  }
+  const branch = clause === 'true-case' ? conditional.whenTrue : conditional.whenFalse
+  return isNullJSXAttributeValue(branch)
+}
+
 export function isNonEmptyConditionalBranch(
   elementPath: ElementPath,
   jsxMetadata: ElementInstanceMetadataMap,

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -13,6 +13,7 @@ const darkBase = {
   black: base.black,
   brandPurple: base.purple,
   brandNeonPink: base.neonpink,
+  brandNeonGreen: base.neongreen,
   jsYellow: base.jsYellow,
   secondaryBlue: createUtopiColor('#679AD1'),
   secondaryOrange: createUtopiColor('#E89A74'),

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -13,6 +13,7 @@ const lightBase = {
   black: base.black,
   brandPurple: base.purple,
   brandNeonPink: base.neonpink,
+  brandNeonGreen: base.neongreen,
   jsYellow: base.jsYellow,
   secondaryBlue: createUtopiColor('#49B6FF'),
   secondaryOrange: createUtopiColor('#EEA544'),


### PR DESCRIPTION
Fixes #3703 

This PR implements reparenting into a conditional slot on the canvas.
When dragging into a conditional which **a)** has a parent, and **b)** has a slot in its active branch, the reparenting is allowed and a neon green outline is shown instead of the regular dotted blue one.