### PR TITLE
Drag preview styling

### DIFF
--- a/editor/src/components/navigator/navigator-drag-layer.tsx
+++ b/editor/src/components/navigator/navigator-drag-layer.tsx
@@ -69,29 +69,32 @@ export const NavigatorDragLayer = React.memo(() => {
       <FlexRow
         style={{
           paddingLeft: getElementPadding(entryNavigatorDepth),
-          // width: '280px',
+          width: '300px',
           transform: `translate(${offset.x}px, ${offset.y}px)`,
           fontWeight: 600,
-
-          width: 'min-content',
-          backgroundColor: colorTheme.bg1transparent.value,
-          boxShadow: '0px 3px 10px 1px #80808040',
-          padding: 3,
-          borderRadius: 2,
-          // transform: `translate(${getElementPadding(entryNavigatorDepth)})`,
         }}
       >
-        <Icn {...icon} color={'main'} />
-        <ItemLabel
-          key={`label-${label}`}
-          testId={`navigator-item-label-${label}`}
-          name={label}
-          isDynamic={false}
-          target={navigatorEntry}
-          selected={selected}
-          dispatch={NO_OP}
-          inputVisible={false}
-        />
+        <FlexRow
+          style={{
+            width: 'min-content',
+            backgroundColor: colorTheme.bg1transparent.value,
+            boxShadow: '0px 3px 10px 1px #80808040',
+            padding: 3,
+            borderRadius: 2,
+          }}
+        >
+          <Icn {...icon} color={'main'} />
+          <ItemLabel
+            key={`label-${label}`}
+            testId={`navigator-item-label-${label}`}
+            name={label}
+            isDynamic={false}
+            target={navigatorEntry}
+            selected={selected}
+            dispatch={NO_OP}
+            inputVisible={false}
+          />
+        </FlexRow>
       </FlexRow>
     </div>
   )

--- a/editor/src/components/navigator/navigator-drag-layer.tsx
+++ b/editor/src/components/navigator/navigator-drag-layer.tsx
@@ -9,7 +9,7 @@ import { NavigatorItemDragAndDropWrapperProps } from './navigator-item/navigator
 import { WindowPoint, windowPoint, zeroPoint } from '../../core/shared/math-utils'
 import { ItemLabel } from './navigator-item/item-label'
 import { NO_OP } from '../../core/shared/utils'
-import { FlexRow, Icn } from '../../uuiui'
+import { colorTheme, FlexRow, Icn } from '../../uuiui'
 import { useLayoutOrElementIcon } from './layout-element-icons'
 import { emptyElementPath } from '../../core/shared/element-path'
 import { Substores, useEditorState } from '../editor/store/store-hook'
@@ -63,14 +63,22 @@ export const NavigatorDragLayer = React.memo(() => {
         top: 0,
         width: '100%',
         height: '100%',
+        zIndex: 100,
       }}
     >
       <FlexRow
         style={{
           paddingLeft: getElementPadding(entryNavigatorDepth),
-          width: '300px',
+          // width: '280px',
           transform: `translate(${offset.x}px, ${offset.y}px)`,
           fontWeight: 600,
+
+          width: 'min-content',
+          backgroundColor: colorTheme.bg1transparent.value,
+          boxShadow: '0px 3px 10px 1px #80808040',
+          padding: 3,
+          borderRadius: 2,
+          // transform: `translate(${getElementPadding(entryNavigatorDepth)})`,
         }}
       >
         <Icn {...icon} color={'main'} />

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -19,6 +19,7 @@ const darkBase = {
   secondaryOrange: createUtopiColor('#E89A74'),
   transparent: base.transparent,
   error: base.red,
+  greytransparent: createUtopiColor('lch(50% 0 0 / 50%)'),
 
   bg0: createUtopiColor('#000000'),
   bg1: createUtopiColor('#181C20'),
@@ -40,6 +41,7 @@ const darkBase = {
   border1: createUtopiColor('#181C20'),
   border2: createUtopiColor('#181C20'),
   border3: createUtopiColor('#181C20'),
+  bg1transparent: createUtopiColor('lch(9.98% 3.6 253 / 85%)'),
 }
 
 const darkPrimitives = {

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -19,7 +19,6 @@ const darkBase = {
   secondaryOrange: createUtopiColor('#E89A74'),
   transparent: base.transparent,
   error: base.red,
-  greytransparent: createUtopiColor('lch(50% 0 0 / 50%)'),
 
   bg0: createUtopiColor('#000000'),
   bg1: createUtopiColor('#181C20'),

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -19,6 +19,7 @@ const lightBase = {
   secondaryOrange: createUtopiColor('#EEA544'),
   transparent: base.transparent,
   error: base.red,
+  greytransparent: createUtopiColor('lch(50% 0 0 / 50%)'),
 
   bg0: createUtopiColor('hsl(0,0%,100%)'),
   bg1: createUtopiColor('lch(99.5 0.01 0)'),
@@ -40,6 +41,7 @@ const lightBase = {
   border1: createUtopiColor('hsl(0,0%,91%)'),
   border2: createUtopiColor('hsl(0,0%,86%)'),
   border3: createUtopiColor('hsl(0,0%,83%)'),
+  bg1transparent: createUtopiColor('lch(99.5 0.01 0 / 85%)'),
 }
 
 const lightPrimitives = {

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -19,7 +19,6 @@ const lightBase = {
   secondaryOrange: createUtopiColor('#EEA544'),
   transparent: base.transparent,
   error: base.red,
-  greytransparent: createUtopiColor('lch(50% 0 0 / 50%)'),
 
   bg0: createUtopiColor('hsl(0,0%,100%)'),
   bg1: createUtopiColor('lch(99.5 0.01 0)'),


### PR DESCRIPTION
**Problem:**
The drag preview for navigator elements when dragging had poor legibility / visibility

**Fix:**
Adding a translucent background, drop shadow, and border radius

|Before | After |
| ------------- | ------------- |
| <img width="299" alt="Screenshot 2023-05-22 at 3 28 42 PM (2)" src="https://github.com/concrete-utopia/utopia/assets/47405698/1eaf6c07-e6cf-4216-8d0c-d8d258ebacd4">  | <img width="299" alt="Screenshot 2023-05-22 at 3 27 40 PM (2)" src="https://github.com/concrete-utopia/utopia/assets/47405698/12d5b9e9-1306-4491-990f-399bb7b3c124">  |