### PR TITLE
fix(navigator) droptarget area

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -3,7 +3,7 @@ import { ElementPath } from '../../../core/shared/project-file-types'
 import { EditorDispatch } from '../../editor/action-types'
 import * as EditorActions from '../../editor/actions/action-creators'
 import * as EP from '../../../core/shared/element-path'
-import { useColorTheme, Button, Icons, SectionActionSheet } from '../../../uuiui'
+import { useColorTheme, Button, Icons, SectionActionSheet, UtopiaTheme } from '../../../uuiui'
 import { stopPropagation } from '../../inspector/common/inspector-utils'
 import { when } from '../../../utils/react-conditionals'
 import { Substores, useEditorState, useRefEditorState } from '../../editor/store/store-hook'
@@ -24,6 +24,7 @@ interface NavigatorHintProps {
   shouldBeShown: boolean
   shouldAcceptMouseEvents: boolean
   margin: number
+  hintSize: 'small' | 'large'
 }
 
 export const NavigatorHintTop = React.forwardRef<HTMLDivElement, NavigatorHintProps>(
@@ -86,6 +87,7 @@ export const NavigatorHintTop = React.forwardRef<HTMLDivElement, NavigatorHintPr
 export const NavigatorHintBottom = React.forwardRef<HTMLDivElement, NavigatorHintProps>(
   (props, ref) => {
     const colorTheme = useColorTheme()
+    const height = props.hintSize === 'large' ? UtopiaTheme.layout.rowHeight.smaller : 16
     return (
       <div
         data-testid={props.testId}
@@ -100,9 +102,9 @@ export const NavigatorHintBottom = React.forwardRef<HTMLDivElement, NavigatorHin
         <div
           style={{
             position: 'absolute',
-            bottom: -8,
+            bottom: -height / 2,
             width: '100%',
-            height: 16,
+            height: height,
           }}
         >
           <div

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -581,6 +581,11 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
     return EP.pathsEqual(firstSibling.elementPath, props.elementPath)
   }, [metadata, elementPathTree, props.elementPath])
 
+  const isPossibleReparentTarget = React.useMemo(
+    () => canDrop(editorStateRef.current, props.elementPath, 'reparent'),
+    [editorStateRef, props.elementPath],
+  )
+
   // Drop target lines should only intercept mouse events if a drag session is in progress
   const isDragSessionInProgress = dropTargetHintType != null
   const shouldTopDropLineInterceptMouseEvents = isDragSessionInProgress
@@ -612,6 +617,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
           shouldBeShown={shouldShowTopHint}
           shouldAcceptMouseEvents={shouldTopDropLineInterceptMouseEvents}
           margin={margin}
+          hintSize={isPossibleReparentTarget ? 'large' : 'small'}
         />,
       )}
       <div
@@ -642,6 +648,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
         shouldBeShown={shouldShowBottomHint}
         shouldAcceptMouseEvents={shouldBottomDropLineInterceptMouseEvents}
         margin={margin}
+        hintSize={isPossibleReparentTarget ? 'small' : 'large'}
       />
     </div>
   )


### PR DESCRIPTION
**Problem:**
While dragging in the navigator droptarget line between sibling shows up slowly.

**Fix:**
Change droptarget areas for elements where reparent is not available: dropline mouse catcher cover 50% of the navigator height, where reparent is available the droptarget mouse catcher is sized ~30%.

**Commit Details:**
- needs tests
