### PR TITLE
Fix reparenting into collapsed elements

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -310,9 +310,9 @@ function onHoverParentOutline(
     )
   }
 
-  const { collapsed, canReparentInto } = propsOfDropTargetItem
+  const { canReparentInto } = propsOfDropTargetItem
 
-  if (!collapsed && canReparentInto) {
+  if (canReparentInto) {
     return propsOfDraggedItem.editorDispatch([
       ...targetAction,
       showNavigatorDropTargetHint(

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -1687,6 +1687,7 @@ describe('Navigator', () => {
 
       expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(initialEditor)
     })
+
     it('reparenting an element to the storyboard between 2 scenes', async () => {
       const renderResult = await renderTestEditorWithCode(
         projectWithHierarchy,
@@ -1739,6 +1740,38 @@ describe('Navigator', () => {
       ])
       expect(renderResult.getEditorState().editor.selectedViews).toEqual([
         EP.fromString('sb/child1'),
+      ])
+    })
+
+    it('can reparent into collapsed element', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        getProjectCode(),
+        'await-first-dom-report',
+      )
+
+      await renderResult.dispatch(
+        [toggleCollapse(EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${SceneRootId}`))],
+        true,
+      )
+
+      await doBasicDrag(
+        renderResult,
+        EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/parentsibling`),
+        EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${SceneRootId}`),
+        ReparentDropTargetTestId,
+      )
+
+      expect(
+        renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey),
+      ).toEqual([
+        'regular-utopia-storyboard-uid/scene-aaa',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/parentsibling', // <- moved under sceneroot
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/firstdiv',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/seconddiv',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/thirddiv',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/dragme',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/notdrag',
       ])
     })
   })


### PR DESCRIPTION
## Problem
For some reason, we don't allow reparenting into collapsed elements in the navigator

## Fix
Allow it, and add a test for it