### PR TITLE
drag preview update

### DIFF
--- a/editor/src/components/navigator/navigator-drag-layer.tsx
+++ b/editor/src/components/navigator/navigator-drag-layer.tsx
@@ -77,8 +77,7 @@ export const NavigatorDragLayer = React.memo(() => {
         <FlexRow
           style={{
             width: 'min-content',
-            backgroundColor: colorTheme.bg1transparent.value,
-            boxShadow: '0px 3px 10px 1px #80808040',
+            background: colorTheme.bg1transparentgradient.value,
             padding: 3,
             borderRadius: 2,
           }}

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -40,7 +40,7 @@ const darkBase = {
   border1: createUtopiColor('#181C20'),
   border2: createUtopiColor('#181C20'),
   border3: createUtopiColor('#181C20'),
-  bg1transparent: createUtopiColor('lch(9.98% 3.6 253 / 85%)'),
+  bg1transparentgradient: createUtopiColor('radial-gradient(circle, #000000 15%, #00000000 80%)'),
 }
 
 const darkPrimitives = {

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -40,7 +40,7 @@ const darkBase = {
   border1: createUtopiColor('#181C20'),
   border2: createUtopiColor('#181C20'),
   border3: createUtopiColor('#181C20'),
-  bg1transparentgradient: createUtopiColor('radial-gradient(circle, #000000 15%, #00000000 80%)'),
+  bg1transparentgradient: createUtopiColor('radial-gradient(circle, #181C20 15%, #181C2000 80%)'),
 }
 
 const darkPrimitives = {

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -40,7 +40,7 @@ const lightBase = {
   border1: createUtopiColor('hsl(0,0%,91%)'),
   border2: createUtopiColor('hsl(0,0%,86%)'),
   border3: createUtopiColor('hsl(0,0%,83%)'),
-  bg1transparent: createUtopiColor('lch(99.5 0.01 0 / 85%)'),
+  bg1transparentgradient: createUtopiColor('radial-gradient(circle, #ffffff 15%, #ffffff00 80%)'),
 }
 
 const lightPrimitives = {


### PR DESCRIPTION
**Problem:**
_Oh the drag preview..._ 
The drag preview for navigator elements when dragging had poor legibility / visibility, but adding a drop shadow and a background that was too opaque was obscuring the indentation indicator on the reparent line.

**Fix:**
Removing the drop shadow. 
Changing the background to a radial gradient.

Hopefully this is a fair compromise between legibility of the drag preview and visibility of the navigator.

|dark mode | light mode |
| ------------- | ------------- |
| ![dark-drag-preview](https://github.com/concrete-utopia/utopia/assets/47405698/652f46ec-16c7-4952-ae18-5762e9ccb696) | ![light-drag-preview](https://github.com/concrete-utopia/utopia/assets/47405698/59104c60-5c8f-4d95-8984-6219733a0207) |




