### PR TITLE
Support reparenting into nested conditionals

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
@@ -1619,6 +1619,71 @@ export var ${BakedInStoryboardVariableName} = (props) => {
       `),
       )
     })
+    it('supports reparenting into nested conditionals', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(`
+        <div data-uid='root' style={{background: "#0ff"}}>
+          <div data-uid='aaa' style={{ width: 200, height: 200, position: "absolute", top: 0, left: 0, background: "#ccc" }}>
+            {true ? (
+              true ? (
+                true ? null : (
+                  <div data-uid='false-branch1' />
+                )
+              ) : (
+                <div data-uid='false-branch2' />
+              )
+            ) : (
+              <div data-uid='false-branch3' />
+            )}
+          </div>
+          <div
+            style={{ backgroundColor: '#f0f', position: 'absolute', width: 50, height: 50, top: 250, left: 250 }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+        'await-first-dom-report',
+      )
+
+      const dragDelta = windowPoint({ x: -150, y: -150 })
+      await dragElement(renderResult, 'bbb', dragDelta, emptyModifiers, null, null)
+
+      await renderResult.getDispatchFollowUpActionsFinished()
+
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        makeTestProjectCodeWithSnippet(`
+          <div data-uid='root' style={{background: "#0ff"}}>
+            <div data-uid='aaa' style={{ width: 200, height: 200, position: "absolute", top: 0, left: 0, background: "#ccc" }}>
+              {true ? (
+                true ? (
+                  true ? (
+                    <div
+                      style={{
+                        backgroundColor: '#f0f',
+                        position: 'absolute',
+                        width: 50,
+                        height: 50,
+                        top: 100,
+                        left: 100
+                      }}
+                      data-uid='bbb'
+                      data-testid='bbb'
+                    />
+                  ) : (
+                    <div data-uid='false-branch1' />
+                  )
+                ) : (
+                  <div data-uid='false-branch2' />
+                )
+              ) : (
+                <div data-uid='false-branch3' />
+              )}
+            </div>
+          </div>
+        `),
+      )
+    })
   })
 })
 

--- a/editor/src/components/canvas/controls/parent-outlines.tsx
+++ b/editor/src/components/canvas/controls/parent-outlines.tsx
@@ -10,7 +10,10 @@ import { isInsertMode } from '../../editor/editor-modes'
 import { Substores, useEditorState } from '../../editor/store/store-hook'
 import { controlForStrategyMemoized } from '../canvas-strategies/canvas-strategy-types'
 import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
-import { findMaybeConditionalExpression } from '../../../core/model/conditionals'
+import {
+  findMaybeConditionalExpression,
+  getActualReparentParentForConditional,
+} from '../../../core/model/conditionals'
 
 export const ImmediateParentOutlinesTestId = (targetPaths: Array<ElementPath>): string =>
   `${targetPaths.map(EP.toString).sort()}-immediate-parent-outlines-control`
@@ -65,6 +68,7 @@ export const ImmediateParentOutlines = controlForStrategyMemoized(
 interface ParentOutlinesProps {
   targetParent: ElementPath
 }
+
 export const ParentOutlines = controlForStrategyMemoized(
   ({ targetParent }: ParentOutlinesProps) => {
     const colorTheme = useColorTheme()
@@ -82,7 +86,9 @@ export const ParentOutlines = controlForStrategyMemoized(
         }
         const isSlotTarget =
           findMaybeConditionalExpression(targetParent, store.editor.jsxMetadata) != null
-        const target = isSlotTarget ? EP.parentPath(targetParent) : targetParent
+        const target = isSlotTarget
+          ? getActualReparentParentForConditional(targetParent, store.editor.jsxMetadata)
+          : targetParent
         return {
           parentFrame: MetadataUtils.getFrameInCanvasCoords(target, store.editor.jsxMetadata),
           isSlot: isSlotTarget,

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -274,3 +274,14 @@ export function isActiveOrDefaultBranchOfConditional(
     isActiveBranchOfConditional(clause, metadata) || isDefaultBranchOfConditional(clause, metadata)
   )
 }
+
+export function getActualReparentParentForConditional(
+  initial: ElementPath,
+  metadata: ElementInstanceMetadataMap,
+): ElementPath {
+  const parent = EP.parentPath(initial)
+  if (findMaybeConditionalExpression(parent, metadata) == null) {
+    return parent
+  }
+  return getActualReparentParentForConditional(parent, metadata)
+}


### PR DESCRIPTION
Fixes #3727 

This is a followup to #3722 that allows reparenting into nested conditionals.

![Kapture 2023-05-25 at 12 17 32](https://github.com/concrete-utopia/utopia/assets/1081051/e51f1492-d1a8-4f88-a343-cf6c58cafb24)
