### PR TITLE
Fix Navigator order when there is an expression

### DIFF
--- a/editor/src/core/shared/element-path-tree.ts
+++ b/editor/src/core/shared/element-path-tree.ts
@@ -1,7 +1,7 @@
 import { ElementPath, ElementPathPart } from './project-file-types'
 import * as EP from './element-path'
 import { fastForEach } from './utils'
-import { ElementInstanceMetadataMap, isUtopiaElement } from './element-template'
+import { ElementInstanceMetadataMap } from './element-template'
 import { MetadataUtils } from '../model/element-metadata-utils'
 import { foldEither } from './either'
 import { move } from './array-utils'

--- a/editor/src/core/shared/element-path-tree.ts
+++ b/editor/src/core/shared/element-path-tree.ts
@@ -82,31 +82,27 @@ export function reorderTree(
       (elementChild) => {
         switch (elementChild.type) {
           case 'JSX_ELEMENT': {
-            const allChildrenAreElements = elementChild.children.every(isUtopiaElement)
-            if (allChildrenAreElements) {
-              let updatedChildrenArray: Array<{ key: string; value: ElementPathTree }> =
-                Object.keys(tree.children).map((childKey) => {
-                  return { key: childKey, value: tree.children[childKey] }
-                })
-              elementChild.children.forEach((child, childIndex) => {
-                const uid = getUtopiaID(child)
-                const workingTreeIndex = updatedChildrenArray.findIndex((workingTreeChild) => {
-                  return EP.toUid(workingTreeChild.value.path) === uid
-                })
-                if (workingTreeIndex !== childIndex) {
-                  updatedChildrenArray = move(workingTreeIndex, childIndex, updatedChildrenArray)
-                }
+            let updatedChildrenArray: Array<{ key: string; value: ElementPathTree }> = Object.keys(
+              tree.children,
+            ).map((childKey) => {
+              return { key: childKey, value: tree.children[childKey] }
+            })
+            elementChild.children.forEach((child, childIndex) => {
+              const uid = getUtopiaID(child)
+              const workingTreeIndex = updatedChildrenArray.findIndex((workingTreeChild) => {
+                return EP.toUid(workingTreeChild.value.path) === uid
               })
-              let updatedChildren: ElementPathTreeRoot = {}
-              for (const { key, value } of updatedChildrenArray) {
-                updatedChildren[key] = reorderTree(value, metadata)
+              if (workingTreeIndex !== childIndex) {
+                updatedChildrenArray = move(workingTreeIndex, childIndex, updatedChildrenArray)
               }
-              return {
-                ...tree,
-                children: updatedChildren,
-              }
-            } else {
-              return tree
+            })
+            let updatedChildren: ElementPathTreeRoot = {}
+            for (const { key, value } of updatedChildrenArray) {
+              updatedChildren[key] = reorderTree(value, metadata)
+            }
+            return {
+              ...tree,
+              children: updatedChildren,
             }
           }
           default:

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1273,13 +1273,6 @@ export function isJSXElementLike(element: JSXElementChild): element is JSXElemen
   return isJSXElement(element) || isJSXFragment(element)
 }
 
-type UtopiaElement = JSXElement | JSXFragment | JSXConditionalExpression
-
-// A utopia element can be either a HTML DOM element or a React-only exotic element (ie the Fragment) or a Utopia-only element, aka Elefant (ie the Conditional Expression)
-export function isUtopiaElement(element: JSXElementChild): element is UtopiaElement {
-  return isJSXElementLike(element) || isJSXConditionalExpression(element)
-}
-
 interface ElementWithUid {
   uid: string
 }


### PR DESCRIPTION
**Problem:**
The inclusion of an expression high up in the tree will break the navigator order. This is especially noticeable when a conditional is present, due to the way we add metadata for those.

**Fix:**
The problem was a now unnecessary restriction that was included when reordering the element path tree. Whilst reordering the tree we were checking that all children of the current element were `UtopiaElement`s, (which was a subset of `JSXElementChild`). I _believe_ the reason for this restriction was because we were restricting to elements that had uids. Either way, this restriction is no longer necessary, so it has been removed (along with the `UtopiaElement` type).

[**Try it here**](https://utopia.pizza/p/c5d05ced-feline-donkey/?branch_name=fix-reorder-tree-restriction) (then open the same project in staging and compare the order of the navigators)