### PR TITLE
No text edit on void html elements

### DIFF
--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
@@ -105,6 +105,16 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
       expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
     })
+    it('Does not entering text edit mode with pressing enter on a selected void html element', async () => {
+      const editor = await renderTestEditorWithCode(projectWithImg, 'await-first-dom-report')
+      await selectElement(editor, EP.fromString('sb/39e/b0e'))
+      await pressKey('enter')
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e/b0e')
+    })
     it('Entering text edit mode with pressing enter on a multiline text editable selected element', async () => {
       const editor = await renderTestEditorWithCode(
         projectWithMultilineText,
@@ -237,6 +247,34 @@ export var storyboard = (
       data-uid='39e'
     >
       Hello
+    </div>
+  </Storyboard>
+)
+`)
+const projectWithImg = formatTestProjectCode(`import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      data-testid='div'
+      style={{
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 288,
+        height: 362,
+      }}
+      data-uid='39e'
+    >
+      <img
+        src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
+        alt='Utopia logo'
+        style={{ height: '100%' }}
+        data-uid='b0e'
+      />
     </div>
   </Storyboard>
 )

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -15,6 +15,7 @@ import { fromField, fromTypeGuard } from '../shared/optics/optic-creators'
 import { findUtopiaCommentFlag, isUtopiaCommentFlagConditional } from '../shared/comment-flags'
 import { isRight } from '../shared/either'
 import { MetadataUtils } from './element-metadata-utils'
+import { forceNotNull } from '../shared/optional-utils'
 
 export type ConditionalCase = 'true-case' | 'false-case'
 
@@ -140,6 +141,27 @@ export function maybeBranchConditionalCase(
   } else {
     return null
   }
+}
+
+export function maybeConditionalActiveBranch(
+  elementPath: ElementPath | null,
+  jsxMetadata: ElementInstanceMetadataMap,
+): JSXElementChild | null {
+  if (elementPath == null) {
+    return null
+  }
+  const conditional = maybeConditionalExpression(
+    MetadataUtils.findElementByElementPath(jsxMetadata, elementPath),
+  )
+  if (conditional == null) {
+    return null
+  }
+
+  const activeCase = forceNotNull(
+    'conditional should have an active case',
+    getConditionalActiveCase(elementPath, conditional, jsxMetadata),
+  )
+  return getConditionalBranch(conditional, activeCase)
 }
 
 export function getConditionalCaseCorrespondingToBranchPath(

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -995,6 +995,18 @@ export const MetadataUtils = {
     if (target == null) {
       return false
     }
+    const element = MetadataUtils.findElementByElementPath(metadata, target)
+    if (element == null || isLeft(element.element)) {
+      return false
+    }
+    const elementValue = element.element.value
+    if (
+      isJSXElement(elementValue) &&
+      isIntrinsicHTMLElement(elementValue.name) &&
+      !intrinsicHTMLElementNamesThatSupportChildren.includes(elementValue.name.baseVariable)
+    ) {
+      return false
+    }
     const children = MetadataUtils.getChildrenUnordered(metadata, target)
     const hasNonEditableChildren = children
       .map((c) =>

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -57,6 +57,7 @@ import {
   ConditionValue,
   isJSXElementLike,
   JSXElementLike,
+  isJSExpression,
 } from '../shared/element-template'
 import {
   getModifiableJSXAttributeAtPath,
@@ -128,7 +129,12 @@ import {
   ForwardOrReverse,
   SimpleFlexDirection,
 } from '../../components/inspector/common/css-utils'
-import { getConditionalClausePath, reorderConditionalChildPathTrees } from './conditionals'
+import {
+  getConditionalClausePath,
+  maybeConditionalActiveBranch,
+  maybeConditionalExpression,
+  reorderConditionalChildPathTrees,
+} from './conditionals'
 import { getUtopiaID } from '../shared/uid-utils'
 import {
   childInsertionPath,
@@ -996,9 +1002,24 @@ export const MetadataUtils = {
       return false
     }
     const element = MetadataUtils.findElementByElementPath(metadata, target)
-    if (element == null || isLeft(element.element)) {
+    if (element == null) {
+      // this case is necessary for expressions in conditional branches
+      // these do not have metadata, but we still want them to be text editable
+      const parent = MetadataUtils.findElementByElementPath(metadata, EP.parentPath(target))
+      if (parent == null) {
+        return false
+      }
+      const conditionalParent = maybeConditionalExpression(parent)
+      if (conditionalParent == null) {
+        return false
+      }
+      const activeConditionalBranch = maybeConditionalActiveBranch(parent.elementPath, metadata)
+      return activeConditionalBranch != null && isJSExpression(activeConditionalBranch)
+    }
+    if (isLeft(element.element)) {
       return false
     }
+
     const elementValue = element.element.value
     if (
       isJSXElement(elementValue) &&


### PR DESCRIPTION
**Problem:**
It is possible to initiate text editing on void html elements, which do not support children (so no text content neither).

**Fix:**
Filter the void html elements out in `MetadataUtils.targetTextEditable`