### PR TITLE
Text editing of conditional branches is not allowed with siblings

### DIFF
--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -928,6 +928,20 @@ describe('Use the text editor', () => {
       )
       expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('hi')
     })
+    it('editing is not allowed with siblings', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          true ? 'hello' : <div data-uid='33d' />
+        }<div />`),
+        'await-first-dom-report',
+      )
+
+      await editor.dispatch([selectComponents([EP.fromString('sb/39e/cond/409')], false)], true)
+      await pressKey('enter')
+      await editor.getDispatchFollowUpActionsFinished()
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
+    })
     it('editing the false clause', async () => {
       const editor = await renderTestEditorWithCode(
         projectWithSnippet(`{

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -130,6 +130,7 @@ import {
   SimpleFlexDirection,
 } from '../../components/inspector/common/css-utils'
 import {
+  findFirstNonConditionalAncestor,
   getConditionalClausePath,
   maybeConditionalActiveBranch,
   maybeConditionalExpression,
@@ -1013,6 +1014,15 @@ export const MetadataUtils = {
       if (conditionalParent == null) {
         return false
       }
+      const nonConditionalAncestor = findFirstNonConditionalAncestor(parent.elementPath, metadata)
+      const siblings = MetadataUtils.getChildrenUnordered(metadata, nonConditionalAncestor)
+
+      // we don't allow text editing of conditional branches when the conditional has siblings
+      // (or if the topmost nested conditional has siblings)
+      if (siblings.length > 1) {
+        return false
+      }
+
       const activeConditionalBranch = maybeConditionalActiveBranch(parent.elementPath, metadata)
       return activeConditionalBranch != null && isJSExpression(activeConditionalBranch)
     }


### PR DESCRIPTION
**Description:**
We don't want to allow text editing of expressions in conditional branches when the conditional has siblings.
Why?
1. We don't allow sibling elements even for text editing in non-conditionals.
2. We don't have a method to measure the size of a single expression, so we just use the size of the parent element for text editing. We plan to use this method later with conditionals too, but that is only doable if we disallow siblings.

Later on we can maybe remove this limitation, but that needs a more complex solution than what we plan to implement now.
