### PR TITLE
Set conditional override on navigator reparent

### DIFF
--- a/editor/src/components/inspector/inpector-selectors.tsx
+++ b/editor/src/components/inspector/inpector-selectors.tsx
@@ -15,9 +15,6 @@ import {
 export const metadataSelector = (store: MetadataSubstate): ElementInstanceMetadataMap =>
   store.editor.jsxMetadata
 
-export const spyMetadataSelector = (store: MetadataSubstate): ElementInstanceMetadataMap =>
-  store.editor.spyMetadata
-
 export const selectedViewsSelector = (store: SelectedViewsSubstate): ElementPath[] =>
   store.editor.selectedViews
 

--- a/editor/src/components/inspector/inpector-selectors.tsx
+++ b/editor/src/components/inspector/inpector-selectors.tsx
@@ -15,6 +15,9 @@ import {
 export const metadataSelector = (store: MetadataSubstate): ElementInstanceMetadataMap =>
   store.editor.jsxMetadata
 
+export const spyMetadataSelector = (store: MetadataSubstate): ElementInstanceMetadataMap =>
+  store.editor.spyMetadata
+
 export const selectedViewsSelector = (store: SelectedViewsSubstate): ElementPath[] =>
   store.editor.selectedViews
 


### PR DESCRIPTION
Fixes #3733 

**Problem:**

When reparenting into an inactive branch via the navigator, the override should be set to that branch, similarly to what happens by clicking the conditional labels.

**Fix:**

If the target branch does not match the active clause, set the override.

![Kapture 2023-05-26 at 10 50 10](https://github.com/concrete-utopia/utopia/assets/1081051/dc14fdd8-8396-46b6-95b5-d1989fd4a9b2)
