### PR TITLE
Show right icon for literal strings in navigator while in edit mode

### DIFF
--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -187,7 +187,7 @@ function isConditionalBranchText(
   navigatorEntry: NavigatorEntry | null,
   metadata: ElementInstanceMetadataMap,
 ): boolean {
-  function getElement(): JSXElementChild | null {
+  function getNavigatorEntryConditionalElementOrNull(): JSXElementChild | null {
     if (navigatorEntry == null) {
       return null
     }
@@ -212,7 +212,7 @@ function isConditionalBranchText(
     return null
   }
 
-  const element = getElement()
+  const element = getNavigatorEntryConditionalElementOrNull()
   return element != null && isJSXAttributeValue(element) && typeof element.value === 'string'
 }
 

--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -5,6 +5,7 @@ import {
   ElementInstanceMetadataMap,
   ElementInstanceMetadata,
   isJSXAttributeValue,
+  JSXElementChild,
 } from '../../core/shared/element-template'
 import * as EP from '../../core/shared/element-path'
 import { ElementPath } from '../../core/shared/project-file-types'
@@ -185,8 +186,8 @@ function createLayoutIconProps(
 function isConditionalBranchText(
   navigatorEntry: NavigatorEntry | null,
   metadata: ElementInstanceMetadataMap,
-) {
-  function getElement() {
+): boolean {
+  function getElement(): JSXElementChild | null {
     if (navigatorEntry == null) {
       return null
     }


### PR DESCRIPTION
Fixes #3735 

**Problem:**

The navigator icon for literal text elements inside conditionals is not shown during text edit mode.

![Kapture 2023-05-26 at 12 55 26](https://github.com/concrete-utopia/utopia/assets/1081051/30ee7735-6ae6-4db9-b5c3-d90650ce42c7)


**Fix:**

Make sure to correctly detect text-only children for conditional branches.

![Kapture 2023-05-26 at 12 56 20](https://github.com/concrete-utopia/utopia/assets/1081051/7efcfb51-4ec2-4a9a-99f2-bb6f6c821b8b)
