### PR TITLE
Allow turning on conditional override on default branch via the navigator

### DIFF
--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -1601,44 +1601,44 @@ describe('Navigator conditional override toggling', () => {
             // @utopia/conditional=${conditionalClauseAsBoolean(override)}`
 
     return formatTestProjectCode(`
-        import * as React from 'react'
-        import { Scene, Storyboard } from 'utopia-api'
-        
-        export var ${BakedInStoryboardVariableName} = (
-          <Storyboard data-uid='${BakedInStoryboardUID}'>
-            {
-              ${commentFlags}
-              [].length === 0 ? (
-                <div
-                  style={{
-                    height: 150,
-                    width: 150,
-                    position: 'absolute',
-                    left: 154,
-                    top: 134,
-                    backgroundColor: 'lightblue',
-                  }}
-                  data-uid='true-div'
-                  data-testid='true-div'
-                />
-              ) : (
-                <div
-                  style={{
-                    height: 150,
-                    width: 150,
-                    position: 'absolute',
-                    left: 154,
-                    top: 134,
-                    backgroundColor: 'red',
-                  }}
-                  data-uid='false-div'
-                  data-testid='false-div'
-                />
-              )
-            }
-          </Storyboard>
-        )
-      `)
+      import * as React from 'react'
+      import { Scene, Storyboard } from 'utopia-api'
+      
+      export var ${BakedInStoryboardVariableName} = (
+        <Storyboard data-uid='${BakedInStoryboardUID}'>
+          {
+            ${commentFlags}
+            [].length === 0 ? (
+              <div
+                style={{
+                  height: 150,
+                  width: 150,
+                  position: 'absolute',
+                  left: 154,
+                  top: 134,
+                  backgroundColor: 'lightblue',
+                }}
+                data-uid='true-div'
+                data-testid='true-div'
+              />
+            ) : (
+              <div
+                style={{
+                  height: 150,
+                  width: 150,
+                  position: 'absolute',
+                  left: 154,
+                  top: 134,
+                  backgroundColor: 'red',
+                }}
+                data-uid='false-div'
+                data-testid='false-div'
+              />
+            )
+          }
+        </Storyboard>
+      )
+    `)
   }
   const codeWithoutOverride = codeWithOverride()
 

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -1598,7 +1598,7 @@ describe('Navigator conditional override toggling', () => {
       override == null
         ? uidFlag
         : `${uidFlag}
-            // @utopia/conditional=${conditionalClauseAsBoolean(override)}`
+          // @utopia/conditional=${conditionalClauseAsBoolean(override)}`
 
     return formatTestProjectCode(`
       import * as React from 'react'

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -1598,47 +1598,47 @@ describe('Navigator conditional override toggling', () => {
       override == null
         ? uidFlag
         : `${uidFlag}
-          // @utopia/conditional=${conditionalClauseAsBoolean(override)}`
+            // @utopia/conditional=${conditionalClauseAsBoolean(override)}`
 
     return formatTestProjectCode(`
-      import * as React from 'react'
-      import { Scene, Storyboard } from 'utopia-api'
-      
-      export var ${BakedInStoryboardVariableName} = (
-        <Storyboard data-uid='${BakedInStoryboardUID}'>
-          {
-            ${commentFlags}
-            [].length === 0 ? (
-              <div
-                style={{
-                  height: 150,
-                  width: 150,
-                  position: 'absolute',
-                  left: 154,
-                  top: 134,
-                  backgroundColor: 'lightblue',
-                }}
-                data-uid='true-div'
-                data-testid='true-div'
-              />
-            ) : (
-              <div
-                style={{
-                  height: 150,
-                  width: 150,
-                  position: 'absolute',
-                  left: 154,
-                  top: 134,
-                  backgroundColor: 'red',
-                }}
-                data-uid='false-div'
-                data-testid='false-div'
-              />
-            )
-          }
-        </Storyboard>
-      )
-    `)
+        import * as React from 'react'
+        import { Scene, Storyboard } from 'utopia-api'
+        
+        export var ${BakedInStoryboardVariableName} = (
+          <Storyboard data-uid='${BakedInStoryboardUID}'>
+            {
+              ${commentFlags}
+              [].length === 0 ? (
+                <div
+                  style={{
+                    height: 150,
+                    width: 150,
+                    position: 'absolute',
+                    left: 154,
+                    top: 134,
+                    backgroundColor: 'lightblue',
+                  }}
+                  data-uid='true-div'
+                  data-testid='true-div'
+                />
+              ) : (
+                <div
+                  style={{
+                    height: 150,
+                    width: 150,
+                    position: 'absolute',
+                    left: 154,
+                    top: 134,
+                    backgroundColor: 'red',
+                  }}
+                  data-uid='false-div'
+                  data-testid='false-div'
+                />
+              )
+            }
+          </Storyboard>
+        )
+      `)
   }
   const codeWithoutOverride = codeWithOverride()
 
@@ -1706,17 +1706,25 @@ describe('Navigator conditional override toggling', () => {
     return clickNavigatorRow(navigatorEntry, renderResult, [elementPath])
   }
 
-  it('active clause label does nothing if it IS the default clause', async () => {
+  it('the default clause can be turned on and toggled', async () => {
     const renderResult = await renderTestEditorWithCode(
       codeWithoutOverride,
       'await-first-dom-report',
     )
 
-    // The true case is the default and active case
-    await clickLabelForCase('true-case', renderResult)
+    // The true case is the default and active case, override is set
+    {
+      await clickLabelForCase('true-case', renderResult)
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        codeWithOverride('true-case'),
+      )
+    }
 
-    // No override should have been added
-    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(codeWithoutOverride)
+    // The true case is the default and active case, override is removed
+    {
+      await clickLabelForCase('true-case', renderResult)
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(codeWithoutOverride)
+    }
   })
 
   it('active clause label clears override if it IS NOT the default clause', async () => {
@@ -1738,11 +1746,27 @@ describe('Navigator conditional override toggling', () => {
       'await-first-dom-report',
     )
 
-    // The true case is the default, but isn't active
-    await clickLabelForCase('true-case', renderResult)
+    // The false override is set, clicking on true activates the true override
+    {
+      await clickLabelForCase('true-case', renderResult)
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        codeWithOverride('true-case'),
+      )
+    }
 
-    // The override should have been removed
-    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(codeWithoutOverride)
+    // The true override is set, clicking on false activates the false override
+    {
+      await clickLabelForCase('false-case', renderResult)
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        codeWithOverride('false-case'),
+      )
+    }
+
+    // Clicking again on false removes the override
+    {
+      await clickLabelForCase('false-case', renderResult)
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(codeWithoutOverride)
+    }
   })
 
   it('inactive clause label sets the override if it IS NOT the default clause', async () => {

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -51,12 +51,7 @@ import {
 } from '../actions'
 import { baseNavigatorDepth, navigatorDepth } from '../navigator-utils'
 import { ExpansionArrowWidth } from './expandable-indicator'
-import {
-  BasePaddingUnit,
-  NavigatorItem,
-  ParentOutline,
-  getSelectionActions,
-} from './navigator-item'
+import { BasePaddingUnit, NavigatorItem, ParentOutline } from './navigator-item'
 import {
   NavigatorHintBottom,
   NavigatorHintCircleDiameter,
@@ -848,7 +843,7 @@ export const ConditionalClauseNavigatorItemContainer = React.memo(
   (props: ConditionalClauseNavigatorItemContainerProps) => {
     const safeComponentId = varSafeNavigatorEntryToKey(props.navigatorEntry)
 
-    const { navigatorEntry, getSelectedViewsInRange, index, selected } = props
+    const { navigatorEntry } = props
 
     const dispatch = useDispatch()
 
@@ -892,30 +887,16 @@ export const ConditionalClauseNavigatorItemContainer = React.memo(
     )
 
     const onMouseDown = React.useCallback(
-      (event: React.MouseEvent<HTMLDivElement>) => {
+      (_event: React.MouseEvent<HTMLDivElement>) => {
         const elementPath = navigatorEntry.elementPath
-        const selectionActions = getSelectionActions(
-          getSelectedViewsInRange,
-          index,
-          elementPath,
-          selected,
-          event,
-        )
 
         const conditionalOverrideActions = isConditionalClauseNavigatorEntry(navigatorEntry)
           ? getConditionalOverrideActions(elementPath, conditionalOverrideUpdate)
           : getConditionalOverrideActions(EP.parentPath(elementPath), conditionalOverrideUpdate)
 
-        dispatch([...selectionActions, ...conditionalOverrideActions], 'leftpane')
+        dispatch(conditionalOverrideActions, 'leftpane')
       },
-      [
-        dispatch,
-        navigatorEntry,
-        conditionalOverrideUpdate,
-        index,
-        selected,
-        getSelectedViewsInRange,
-      ],
+      [dispatch, navigatorEntry, conditionalOverrideUpdate],
     )
 
     return (

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -1,56 +1,67 @@
+import { atom, useAtom } from 'jotai'
 import React from 'react'
 import { DropTargetMonitor, useDrag, useDrop } from 'react-dnd'
-import { ElementPath } from '../../../core/shared/project-file-types'
-import { EditorAction, EditorDispatch } from '../../editor/action-types'
-import * as EditorActions from '../../editor/actions/action-creators'
-import * as MetaActions from '../../editor/actions/meta-actions'
-import * as EP from '../../../core/shared/element-path'
-import {
-  hideNavigatorDropTargetHint,
-  reorderComponents,
-  showNavigatorDropTargetHint,
-} from '../actions'
-import { ExpansionArrowWidth } from './expandable-indicator'
-import { BasePaddingUnit, NavigatorItem, ParentOutline } from './navigator-item'
-import {
-  NavigatorHintBottom,
-  NavigatorHintCircleDiameter,
-  NavigatorHintTop,
-} from './navigator-item-components'
-import {
-  ConditionalClauseNavigatorEntry,
-  DropTargetHint,
-  DropTargetType,
-  EditorState,
-  navigatorEntriesEqual,
-  NavigatorEntry,
-  regularNavigatorEntry,
-  syntheticNavigatorEntry,
-  varSafeNavigatorEntryToKey,
-} from '../../editor/store/editor-state'
+import { getEmptyImage } from 'react-dnd-html5-backend'
 import {
   Substores,
   useEditorState,
   useRefEditorState,
 } from '../../../components/editor/store/store-hook'
-import { isAllowedToReparent } from '../../canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers'
-import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { getEmptyImage } from 'react-dnd-html5-backend'
-import { when } from '../../../utils/react-conditionals'
-import { metadataSelector } from '../../inspector/inpector-selectors'
-import { baseNavigatorDepth, navigatorDepth } from '../navigator-utils'
-import { ElementInstanceMetadataMap, JSXElementChild } from '../../../core/shared/element-template'
 import {
+  ConditionalCase,
   findMaybeConditionalExpression,
   getConditionalActiveCase,
   getConditionalCaseCorrespondingToBranchPath,
+  isActiveBranchOfConditional,
+  isDefaultBranchOfConditional,
   isEmptyConditionalBranch,
   isNonEmptyConditionalBranch,
+  isOverriddenConditional,
 } from '../../../core/model/conditionals'
-import { IndexPosition, after, before, front } from '../../../utils/utils'
-import { assertNever } from '../../../core/shared/utils'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import * as EP from '../../../core/shared/element-path'
 import { ElementPathTreeRoot } from '../../../core/shared/element-path-tree'
-import { useAtom, atom } from 'jotai'
+import { ElementInstanceMetadataMap, JSXElementChild } from '../../../core/shared/element-template'
+import { ElementPath } from '../../../core/shared/project-file-types'
+import { assertNever } from '../../../core/shared/utils'
+import { when } from '../../../utils/react-conditionals'
+import { IndexPosition, after, before, front } from '../../../utils/utils'
+import { isAllowedToReparent } from '../../canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers'
+import { EditorAction, EditorDispatch } from '../../editor/action-types'
+import * as EditorActions from '../../editor/actions/action-creators'
+import * as MetaActions from '../../editor/actions/meta-actions'
+import { useDispatch } from '../../editor/store/dispatch-context'
+import {
+  ConditionalClauseNavigatorEntry,
+  DropTargetHint,
+  DropTargetType,
+  EditorState,
+  NavigatorEntry,
+  isConditionalClauseNavigatorEntry,
+  navigatorEntriesEqual,
+  regularNavigatorEntry,
+  syntheticNavigatorEntry,
+  varSafeNavigatorEntryToKey,
+} from '../../editor/store/editor-state'
+import { metadataSelector } from '../../inspector/inpector-selectors'
+import {
+  hideNavigatorDropTargetHint,
+  reorderComponents,
+  showNavigatorDropTargetHint,
+} from '../actions'
+import { baseNavigatorDepth, navigatorDepth } from '../navigator-utils'
+import { ExpansionArrowWidth } from './expandable-indicator'
+import {
+  BasePaddingUnit,
+  NavigatorItem,
+  ParentOutline,
+  getSelectionActions,
+} from './navigator-item'
+import {
+  NavigatorHintBottom,
+  NavigatorHintCircleDiameter,
+  NavigatorHintTop,
+} from './navigator-item-components'
 
 const WiggleUnit = BasePaddingUnit * 1.5
 
@@ -813,9 +824,100 @@ export const SyntheticNavigatorItemContainer = React.memo(
   },
 )
 
+type ConditionalOverrideUpdate = ConditionalCase | 'clear-override' | 'no-update'
+
+function getConditionalOverrideActions(
+  targetPath: ElementPath,
+  conditionalOverrideUpdate: ConditionalOverrideUpdate,
+): Array<EditorAction> {
+  switch (conditionalOverrideUpdate) {
+    case 'no-update':
+      return []
+    case 'clear-override':
+      return [EditorActions.setConditionalOverriddenCondition(targetPath, null)]
+    case 'true-case':
+      return [EditorActions.setConditionalOverriddenCondition(targetPath, true)]
+    case 'false-case':
+      return [EditorActions.setConditionalOverriddenCondition(targetPath, false)]
+    default:
+      assertNever(conditionalOverrideUpdate)
+  }
+}
+
 export const ConditionalClauseNavigatorItemContainer = React.memo(
   (props: ConditionalClauseNavigatorItemContainerProps) => {
     const safeComponentId = varSafeNavigatorEntryToKey(props.navigatorEntry)
+
+    const { navigatorEntry, getSelectedViewsInRange, index, selected } = props
+
+    const dispatch = useDispatch()
+
+    const conditionalOverrideUpdate = useEditorState(
+      Substores.metadata,
+      (store): ConditionalOverrideUpdate => {
+        const path = navigatorEntry.elementPath
+        const metadata = store.editor.jsxMetadata
+        const elementMetadata = MetadataUtils.findElementByElementPath(
+          store.editor.jsxMetadata,
+          navigatorEntry.elementPath,
+        )
+        if (isConditionalClauseNavigatorEntry(navigatorEntry)) {
+          if (isActiveBranchOfConditional(navigatorEntry.clause, elementMetadata)) {
+            if (isOverriddenConditional(elementMetadata)) {
+              return 'clear-override'
+            } else {
+              return navigatorEntry.clause
+            }
+          } else {
+            return navigatorEntry.clause
+          }
+        } else {
+          const conditionalCase = getConditionalCaseCorrespondingToBranchPath(path, metadata)
+          if (conditionalCase != null) {
+            const parentPath = EP.parentPath(path)
+            const parentMetadata = MetadataUtils.findElementByElementPath(metadata, parentPath)
+            if (isActiveBranchOfConditional(conditionalCase, parentMetadata)) {
+              return 'no-update'
+            } else if (isDefaultBranchOfConditional(conditionalCase, parentMetadata)) {
+              return 'clear-override'
+            } else {
+              return conditionalCase
+            }
+          }
+
+          return 'no-update'
+        }
+      },
+      'ConditionalClauseNavigatorItemContainer conditionalOverrideUpdate',
+    )
+
+    const onMouseDown = React.useCallback(
+      (event: React.MouseEvent<HTMLDivElement>) => {
+        const elementPath = navigatorEntry.elementPath
+        const selectionActions = getSelectionActions(
+          getSelectedViewsInRange,
+          index,
+          elementPath,
+          selected,
+          event,
+        )
+
+        const conditionalOverrideActions = isConditionalClauseNavigatorEntry(navigatorEntry)
+          ? getConditionalOverrideActions(elementPath, conditionalOverrideUpdate)
+          : getConditionalOverrideActions(EP.parentPath(elementPath), conditionalOverrideUpdate)
+
+        dispatch([...selectionActions, ...conditionalOverrideActions], 'leftpane')
+      },
+      [
+        dispatch,
+        navigatorEntry,
+        conditionalOverrideUpdate,
+        index,
+        selected,
+        getSelectedViewsInRange,
+      ],
+    )
+
     return (
       <div
         style={{
@@ -841,6 +943,7 @@ export const ConditionalClauseNavigatorItemContainer = React.memo(
             selected={props.selected}
             parentOutline={'none'}
             visibleNavigatorTargets={props.visibleNavigatorTargets}
+            onMouseDown={onMouseDown}
           />
         </div>
       </div>

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -108,6 +108,22 @@ export function getSelectionActions(
   }
 }
 
+function selectItem(
+  dispatch: EditorDispatch,
+  getSelectedViewsInRange: (i: number) => Array<ElementPath>,
+  navigatorEntry: NavigatorEntry,
+  index: number,
+  selected: boolean,
+  event: React.MouseEvent<HTMLDivElement>,
+) {
+  const elementPath = navigatorEntry.elementPath
+
+  dispatch(
+    getSelectionActions(getSelectedViewsInRange, index, elementPath, selected, event),
+    'leftpane',
+  )
+}
+
 const highlightItem = (
   dispatch: EditorDispatch,
   elementPath: ElementPath,
@@ -352,6 +368,8 @@ export const NavigatorItem: React.FunctionComponent<
     selected,
     collapsed,
     navigatorEntry,
+    getSelectedViewsInRange,
+    index,
     onMouseDown,
   } = props
 
@@ -465,6 +483,15 @@ export const NavigatorItem: React.FunctionComponent<
     [dispatch, navigatorEntry.elementPath],
   )
 
+  const select = React.useCallback(
+    (event: any) => {
+      selectItem(dispatch, getSelectedViewsInRange, navigatorEntry, index, selected, event)
+      if (onMouseDown != null) {
+        onMouseDown(event)
+      }
+    },
+    [dispatch, getSelectedViewsInRange, navigatorEntry, index, selected, onMouseDown],
+  )
   const highlight = React.useCallback(
     () => highlightItem(dispatch, navigatorEntry.elementPath, selected, isHighlighted),
     [dispatch, navigatorEntry.elementPath, selected, isHighlighted],
@@ -534,7 +561,7 @@ export const NavigatorItem: React.FunctionComponent<
       <FlexRow
         data-testid={NavigatorItemTestId(varSafeNavigatorEntryToKey(navigatorEntry))}
         style={rowStyle}
-        onMouseDown={onMouseDown}
+        onMouseDown={select}
         onMouseMove={highlight}
         onDoubleClick={focusComponent}
       >

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -13,7 +13,7 @@ import { getUtopiaID } from '../shared/uid-utils'
 import { Optic } from '../shared/optics/optics'
 import { fromField, fromTypeGuard } from '../shared/optics/optic-creators'
 import { findUtopiaCommentFlag, isUtopiaCommentFlagConditional } from '../shared/comment-flags'
-import { isRight } from '../shared/either'
+import { isLeft, isRight } from '../shared/either'
 import { MetadataUtils } from './element-metadata-utils'
 import { forceNotNull } from '../shared/optional-utils'
 
@@ -249,6 +249,17 @@ export function getConditionalClausePathFromMetadata(
     conditionalPath,
     clause === 'true-case' ? conditionalElement.whenTrue : conditionalElement.whenFalse,
   )
+}
+
+export function isOverriddenConditional(element: ElementInstanceMetadata | null): boolean {
+  if (
+    element == null ||
+    isLeft(element.element) ||
+    !isJSXConditionalExpression(element.element.value)
+  ) {
+    return false
+  }
+  return getConditionalFlag(element.element.value) != null
 }
 
 export function getConditionalActiveCase(


### PR DESCRIPTION
Fixes #3739 

**Problem:**

Clicking the `TRUE` label in the navigator does not allow setting the override (it can only be done via the inspector), which feels in contradiction with the false branch.

**Fix:**

Toggle the conditional overrides via the label in a consistent way.
Note: this affects the labels _only_: clicking on the branch contents still keeps the old behavior.

![Kapture 2023-05-26 at 15 51 29](https://github.com/concrete-utopia/utopia/assets/1081051/c2305123-da76-4fa8-961e-fc6da1f728b7)
