### PR TITLE
Allow editing text of the active branch when the conditional is selected

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -263,8 +263,7 @@ export function renderCoreElement(
       const elementIsTextEdited = elementPath != null && EP.pathsEqual(elementPath, editedText)
 
       if (elementIsTextEdited) {
-        const text = trimAndJoinTextFromJSXElements([element])
-        const textContent = unescapeHTML(text ?? '')
+        const textContent = trimJoinUnescapeTextFromJSXElements([element])
         const textEditorProps: TextEditorProps = {
           elementPath: elementPath,
           filePath: filePath,
@@ -404,8 +403,7 @@ export function renderCoreElement(
       const elementIsTextEdited = elementPath != null && EP.pathsEqual(elementPath, editedText)
 
       if (elementIsTextEdited) {
-        const text = trimAndJoinTextFromJSXElements([actualElement])
-        const textContent = unescapeHTML(text ?? '')
+        const textContent = trimJoinUnescapeTextFromJSXElements([actualElement])
         const textEditorProps: TextEditorProps = {
           elementPath: elementPath,
           filePath: filePath,
@@ -463,8 +461,7 @@ export function renderCoreElement(
       const elementIsTextEdited = elementPath != null && EP.pathsEqual(elementPath, editedText)
 
       if (elementIsTextEdited) {
-        const text = trimAndJoinTextFromJSXElements([element])
-        const textContent = unescapeHTML(text ?? '')
+        const textContent = trimJoinUnescapeTextFromJSXElements([element])
         const textEditorProps: TextEditorProps = {
           elementPath: elementPath,
           filePath: filePath,
@@ -497,7 +494,7 @@ export function renderCoreElement(
   }
 }
 
-function trimAndJoinTextFromJSXElements(elements: Array<JSXElementChild>): string | null {
+function trimJoinUnescapeTextFromJSXElements(elements: Array<JSXElementChild>): string {
   let combinedText = ''
   for (let i = 0; i < elements.length; i++) {
     const c = elements[i]
@@ -529,7 +526,7 @@ function trimAndJoinTextFromJSXElements(elements: Array<JSXElementChild>): strin
         assertNever(c)
     }
   }
-  return combinedText
+  return unescapeHTML(combinedText)
 }
 
 function trimWhitespaces(
@@ -691,8 +688,7 @@ function renderJSXElement(
 
   if (elementPath != null && validPaths.has(EP.makeLastPartOfPathStatic(elementPath))) {
     if (elementIsTextEdited) {
-      const text = trimAndJoinTextFromJSXElements(childrenWithNewTextBlock)
-      const textContent = unescapeHTML(text ?? '')
+      const textContent = trimJoinUnescapeTextFromJSXElements(childrenWithNewTextBlock)
       const textEditorProps: TextEditorProps = {
         elementPath: elementPath,
         filePath: filePath,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -271,7 +271,7 @@ export function renderCoreElement(
           text: textContent,
           component: React.Fragment,
           passthroughProps: {},
-          editingItselfOrChild: 'itself',
+          textProp: 'itself',
         }
 
         return buildSpyWrappedElement(
@@ -401,6 +401,36 @@ export function renderCoreElement(
         elementPath,
       )
 
+      const elementIsTextEdited = elementPath != null && EP.pathsEqual(elementPath, editedText)
+
+      if (elementIsTextEdited) {
+        const text = trimAndJoinTextFromJSXElements([actualElement])
+        const textContent = unescapeHTML(text ?? '')
+        const textEditorProps: TextEditorProps = {
+          elementPath: elementPath,
+          filePath: filePath,
+          text: textContent,
+          component: React.Fragment,
+          passthroughProps: {},
+          textProp: activeConditionValue ? 'whenTrue' : 'whenFalse',
+        }
+
+        return buildSpyWrappedElement(
+          actualElement,
+          textEditorProps,
+          childPath!,
+          metadataContext,
+          updateInvalidatedPaths,
+          [],
+          TextEditorWrapper,
+          inScope,
+          jsxFactoryFunctionName,
+          shouldIncludeCanvasRootInTheSpy,
+          imports,
+          filePath,
+        )
+      }
+
       return renderCoreElement(
         actualElement,
         childPath,
@@ -441,7 +471,7 @@ export function renderCoreElement(
           text: textContent,
           component: React.Fragment,
           passthroughProps: {},
-          editingItselfOrChild: 'itself',
+          textProp: 'itself',
         }
 
         return buildSpyWrappedElement(
@@ -669,7 +699,7 @@ function renderJSXElement(
         text: textContent,
         component: FinalElement,
         passthroughProps: finalProps,
-        editingItselfOrChild: 'child',
+        textProp: 'child',
       }
 
       return buildSpyWrappedElement(

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -74,7 +74,7 @@ import { ProjectContentTreeRoot } from '../assets'
 import { GithubOperationType } from './actions/action-creators'
 import { CanvasCommand } from '../canvas/commands/commands'
 import { InsertionPath } from './store/insertion-path'
-import { ItselfOrChild } from '../text-editor/text-editor'
+import { TextProp } from '../text-editor/text-editor'
 export { isLoggedIn, loggedInUser, notLoggedIn } from '../../common/user'
 export type { LoginState, UserDetails } from '../../common/user'
 
@@ -888,7 +888,7 @@ export interface UpdateText {
   action: 'UPDATE_TEXT'
   target: ElementPath
   text: string
-  editingItselfOrChild: ItselfOrChild
+  textProp: TextProp
 }
 
 export interface MarkVSCodeBridgeReady {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -247,7 +247,7 @@ import type {
   ColorSwatch,
 } from '../store/editor-state'
 import { InsertionPath } from '../store/insertion-path'
-import { ItselfOrChild } from '../../text-editor/text-editor'
+import { TextProp } from '../../text-editor/text-editor'
 
 export function clearSelection(): EditorAction {
   return {
@@ -1410,16 +1410,12 @@ export function sendLinterRequestMessage(
   }
 }
 
-export function updateText(
-  target: ElementPath,
-  text: string,
-  editingItselfOrChild: ItselfOrChild,
-): UpdateText {
+export function updateText(target: ElementPath, text: string, textProp: TextProp): UpdateText {
   return {
     action: 'UPDATE_TEXT',
     target: target,
     text: text,
-    editingItselfOrChild: editingItselfOrChild,
+    textProp: textProp,
   }
 }
 

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -928,6 +928,33 @@ describe('Use the text editor', () => {
       )
       expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('hi')
     })
+    it('editing the active true clause from the selected conditional', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          true ? 'hello' : <div data-uid='33d' />
+        }`),
+        'await-first-dom-report',
+      )
+
+      await editor.dispatch([selectComponents([EP.fromString('sb/39e/cond')], false)], true)
+      await pressKey('enter')
+      await editor.getDispatchFollowUpActionsFinished()
+
+      typeText('hi')
+      await closeTextEditor()
+
+      await editor.getDispatchFollowUpActionsFinished()
+      await wait(50)
+
+      expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          true ? 'hi' : <div data-uid='33d' />
+        }`),
+      )
+      expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('hi')
+    })
     it('editing is not allowed with siblings', async () => {
       const editor = await renderTestEditorWithCode(
         projectWithSnippet(`{
@@ -952,6 +979,33 @@ describe('Use the text editor', () => {
       )
 
       await editor.dispatch([selectComponents([EP.fromString('sb/39e/cond/409')], false)], true)
+      await pressKey('enter')
+      await editor.getDispatchFollowUpActionsFinished()
+
+      typeText('hi')
+      await closeTextEditor()
+
+      await editor.getDispatchFollowUpActionsFinished()
+      await wait(50)
+
+      expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          false ? <div data-uid='33d' /> : 'hi'
+        }`),
+      )
+      expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('hi')
+    })
+    it('editing the active false clause from the selected conditional', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          false ? <div data-uid='33d' /> : 'hello'
+        }`),
+        'await-first-dom-report',
+      )
+
+      await editor.dispatch([selectComponents([EP.fromString('sb/39e/cond')], false)], true)
       await pressKey('enter')
       await editor.getDispatchFollowUpActionsFinished()
 
@@ -996,7 +1050,61 @@ describe('Use the text editor', () => {
       )
       expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('content of myvar2')
     })
+    it('editing expression in the active true clause from the selected conditional', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          true ? myvar1 : <div data-uid='33d' />
+        }`),
+        'await-first-dom-report',
+      )
+
+      await editor.dispatch([selectComponents([EP.fromString('sb/39e/cond')], false)], true)
+      await pressKey('enter')
+      await editor.getDispatchFollowUpActionsFinished()
+
+      typeText('{myvar2}')
+      await closeTextEditor()
+
+      await editor.getDispatchFollowUpActionsFinished()
+      await wait(50)
+
+      expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          true ? myvar2 : <div data-uid='33d' />
+        }`),
+      )
+      expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('content of myvar2')
+    })
     it('editing expression in the false clause', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          false ? <div data-uid='33d' /> : myvar1
+        }`),
+        'await-first-dom-report',
+      )
+
+      await editor.dispatch([selectComponents([EP.fromString('sb/39e/cond/536')], false)], true)
+      await pressKey('enter')
+      await editor.getDispatchFollowUpActionsFinished()
+
+      typeText('{myvar2}')
+      await closeTextEditor()
+
+      await editor.getDispatchFollowUpActionsFinished()
+      await wait(50)
+
+      expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          false ? <div data-uid='33d' /> : myvar2
+        }`),
+      )
+      expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('content of myvar2')
+    })
+    it('editing expression in the false clause from the selected conditional', async () => {
       const editor = await renderTestEditorWithCode(
         projectWithSnippet(`{
           // @utopia/uid=cond


### PR DESCRIPTION
**Description:**
This PR is a step towards making double-click to text edit work for expressions in conditionals.
The goal of this specific PR is to make text edit work when the conditional itself is selected. Why is this useful? This will make it possible to edit the text content without adding metadata for js expressions (the conditional already have metadata, and that will make it easier to activate editing on double click).

The result of the PR is already usable, you can select the conditional in the navigator, and press enter to edit the text content of the active branch (if the active branch is text-only)