### PR TITLE
Fix Navigator Order

### DIFF
--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -96,22 +96,6 @@ export function getNavigatorTargets(
       const isCollapsed = EP.containsPath(path, collapsedViews)
       const newCollapsedAncestor = collapsedAncestor || isCollapsed || isHiddenInNavigator
 
-      function walkSubTree(subTreeChildren: ElementPathTreeRoot): void {
-        let unfurledComponents: Array<ElementPathTree> = []
-
-        fastForEach(Object.values(subTreeChildren), (child) => {
-          if (EP.isRootElementOfInstance(child.path)) {
-            unfurledComponents.push(child)
-          } else {
-            walkAndAddKeys(child, newCollapsedAncestor)
-          }
-        })
-
-        fastForEach(unfurledComponents, (unfurledComponent) => {
-          walkAndAddKeys(unfurledComponent, newCollapsedAncestor)
-        })
-      }
-
       function walkConditionalClause(
         conditionalSubTree: ElementPathTree,
         conditional: JSXConditionalExpression,
@@ -170,7 +154,9 @@ export function getNavigatorTargets(
           throw new Error(`Unexpected non-conditional expression retrieved at ${EP.toString(path)}`)
         }
       } else {
-        walkSubTree(subTree.children)
+        fastForEach(Object.values(subTree.children), (child) => {
+          walkAndAddKeys(child, newCollapsedAncestor)
+        })
       }
     }
   }

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -12,6 +12,7 @@ import { BakedInStoryboardVariableName, BakedInStoryboardUID } from '../../core/
 import { getDomRectCenter } from '../../core/shared/dom-utils'
 import {
   selectComponents,
+  setFocusedElement,
   setNavigatorRenamingTarget,
   toggleCollapse,
 } from '../editor/actions/action-creators'
@@ -2915,5 +2916,140 @@ describe('Navigator', () => {
         `),
       )
     })
+  })
+})
+
+describe('Navigator row order', () => {
+  const TestCode = `
+    import * as React from 'react'
+    import { Scene, Storyboard } from 'utopia-api'
+
+    export var Card = (props) => {
+      return (
+        <div
+          style={{
+            height: 100,
+            width: 100,
+            backgroundColor: 'white',
+          }}
+          data-uid='card-root'
+        >
+          <span data-uid='card-span'>Top of Card</span>
+          {props.children}
+        </div>
+      )
+    }
+
+    export var App = (props) => {
+      return (
+        <div
+          style={{
+            height: '100%',
+            width: '100%',
+            contain: 'layout',
+          }}
+          data-uid='app-root'
+        >
+          <Card data-uid='card'>
+            <span data-uid='card-child'>Child of Card</span>
+          </Card>
+          <React.Fragment data-uid='frag'>
+            <div data-uid='frag-child'>Before Conditional</div>
+            {
+              // @utopia/uid=cond-1
+              true ? (
+                <div
+                  style={{
+                    backgroundColor: '#aaaaaa33',
+                    width: 300,
+                    height: 300,
+                  }}
+                  data-uid='cond-1-true'
+                >
+                  <div
+                    style={{
+                      backgroundColor: '#aaaaaa33',
+                      width: 100,
+                      height: 100,
+                    }}
+                    data-uid='cond-1-true-child'
+                  >
+                    Top
+                  </div>
+                  {
+                    // @utopia/uid=cond-2
+                    true ? (
+                      <div
+                        style={{
+                          backgroundColor: '#aaaaaa33',
+                          width: 100,
+                          height: 100,
+                        }}
+                        data-uid='cond-2-child'
+                      >
+                        Bottom
+                      </div>
+                    ) : null
+                  }
+                </div>
+              ) : null
+            }
+          </React.Fragment>
+          {props.children}
+        </div>
+      )
+    }
+
+    export var storyboard = (
+      <Storyboard data-uid='sb'>
+        <Scene
+          style={{
+            width: 700,
+            height: 759,
+            position: 'absolute',
+            left: 10,
+            top: 10,
+          }}
+          data-uid='sc'
+        >
+          <App data-uid='app'>
+            <span data-uid='app-child'>Child of App</span>
+          </App>
+        </Scene>
+        {}
+      </Storyboard>
+    )
+  `
+
+  it('Is correct for a test project with synthetic elements', async () => {
+    const renderResult = await renderTestEditorWithCode(TestCode, 'await-first-dom-report')
+
+    await renderResult.dispatch([setFocusedElement(EP.fromString('sb/sc/app:app-root/card'))], true)
+    await renderResult.getDispatchFollowUpActionsFinished()
+    expect(renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey)).toEqual(
+      [
+        'regular-sb/sc',
+        'regular-sb/sc/app',
+        'regular-sb/sc/app:app-root',
+        'regular-sb/sc/app:app-root/card',
+        'regular-sb/sc/app:app-root/card:card-root',
+        'regular-sb/sc/app:app-root/card:card-root/card-span',
+        'regular-sb/sc/app:app-root/card/card-child',
+        'regular-sb/sc/app:app-root/frag',
+        'regular-sb/sc/app:app-root/frag/frag-child',
+        'regular-sb/sc/app:app-root/frag/cond-1',
+        'conditional-clause-sb/sc/app:app-root/frag/cond-1-true-case',
+        'regular-sb/sc/app:app-root/frag/cond-1/cond-1-true',
+        'regular-sb/sc/app:app-root/frag/cond-1/cond-1-true/cond-1-true-child',
+        'regular-sb/sc/app:app-root/frag/cond-1/cond-1-true/cond-2',
+        'conditional-clause-sb/sc/app:app-root/frag/cond-1/cond-1-true/cond-2-true-case',
+        'regular-sb/sc/app:app-root/frag/cond-1/cond-1-true/cond-2/cond-2-child',
+        'conditional-clause-sb/sc/app:app-root/frag/cond-1/cond-1-true/cond-2-false-case',
+        'synthetic-sb/sc/app:app-root/frag/cond-1/cond-1-true/cond-2/a25-attribute',
+        'conditional-clause-sb/sc/app:app-root/frag/cond-1-false-case',
+        'synthetic-sb/sc/app:app-root/frag/cond-1/129-attribute',
+        'regular-sb/sc/app/app-child',
+      ],
+    )
   })
 })

--- a/editor/src/components/titlebar/test-menu.tsx
+++ b/editor/src/components/titlebar/test-menu.tsx
@@ -18,6 +18,7 @@ import { useReParseOpenProjectFile } from '../../core/model/project-file-helper-
 import { isFeatureEnabled } from '../../utils/feature-switches'
 
 import { Substores, useEditorState, useRefEditorState } from '../editor/store/store-hook'
+import { printTree } from '../../core/shared/element-path-tree'
 
 interface TileProps {
   size: 'smaller' | 'normal' | 'large' | 'max'
@@ -42,6 +43,10 @@ export const TestMenu = React.memo(() => {
     console.info('Current Editor State:', entireStateRef.current)
     console.info('Latest metadata:', jsxMetadata.current)
   }, [entireStateRef, jsxMetadata])
+
+  const printElementPathTree = React.useCallback(() => {
+    console.info('Tree:\n', printTree(entireStateRef.current.editor.elementPathTree))
+  }, [entireStateRef])
 
   function useRequestVSCodeStatus(): () => void {
     const vscodeState = useEditorState(
@@ -101,6 +106,9 @@ export const TestMenu = React.memo(() => {
         <React.Fragment>
           <Tile style={{ cursor: 'pointer', marginRight: 10 }} size='large'>
             <a onClick={printEditorState}>PPP</a>
+          </Tile>
+          <Tile style={{ cursor: 'pointer', marginRight: 10 }} size='large'>
+            <a onClick={printElementPathTree}>PT</a>
           </Tile>
           <Tile style={{ cursor: 'pointer', marginRight: 10 }} size='large'>
             <a onClick={onTriggerScrollTest}>P S</a>

--- a/editor/src/core/shared/element-path-tree.spec.browser2.tsx
+++ b/editor/src/core/shared/element-path-tree.spec.browser2.tsx
@@ -1,0 +1,134 @@
+import { renderTestEditorWithCode } from '../../components/canvas/ui-jsx.test-utils'
+import { setFocusedElement } from '../../components/editor/actions/action-creators'
+import { printTree } from './element-path-tree'
+import * as EP from './element-path'
+
+const TestCode = `
+import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export var Card = (props) => {
+  return (
+    <div
+      style={{
+        height: 100,
+        width: 100,
+        backgroundColor: 'white',
+      }}
+      data-uid='card-root'
+    >
+      <span data-uid='card-span'>Top of Card</span>
+      {props.children}
+    </div>
+  )
+}
+
+export var App = (props) => {
+  return (
+    <div
+      style={{
+        height: '100%',
+        width: '100%',
+        contain: 'layout',
+      }}
+      data-uid='app-root'
+    >
+      <Card data-uid='card'>
+        <span data-uid='card-child'>Child of Card</span>
+      </Card>
+      <React.Fragment data-uid='frag'>
+        <div data-uid='frag-child'>Before Conditional</div>
+        {
+          // @utopia/uid=cond-1
+          true ? (
+            <div
+              style={{
+                backgroundColor: '#aaaaaa33',
+                width: 300,
+                height: 300,
+              }}
+              data-uid='cond-1-true'
+            >
+              <div
+                style={{
+                  backgroundColor: '#aaaaaa33',
+                  width: 100,
+                  height: 100,
+                }}
+                data-uid='cond-1-true-child'
+              >
+                Top
+              </div>
+              {
+                // @utopia/uid=cond-2
+                true ? (
+                  <div
+                    style={{
+                      backgroundColor: '#aaaaaa33',
+                      width: 100,
+                      height: 100,
+                    }}
+                    data-uid='cond-2-child'
+                  >
+                    Bottom
+                  </div>
+                ) : null
+              }
+            </div>
+          ) : null
+        }
+      </React.Fragment>
+      {props.children}
+    </div>
+  )
+}
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <Scene
+      style={{
+        width: 700,
+        height: 759,
+        position: 'absolute',
+        left: 10,
+        top: 10,
+      }}
+      data-uid='sc'
+    >
+      <App data-uid='app'>
+        <span data-uid='app-child'>Child of App</span>
+      </App>
+    </Scene>
+    {}
+  </Storyboard>
+)
+`
+
+describe('Building and ordering the element path tree for a real project', () => {
+  it('Correctly orders for the test project', async () => {
+    const renderResult = await renderTestEditorWithCode(TestCode, 'await-first-dom-report')
+
+    await renderResult.dispatch([setFocusedElement(EP.fromString('sb/sc/app:app-root/card'))], true)
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(printTree(renderResult.getEditorState().editor.elementPathTree)).toEqual(
+      `sb
+  sb/sc
+    sb/sc/app
+      sb/sc/app:app-root
+        sb/sc/app:app-root/card
+          sb/sc/app:app-root/card:card-root
+            sb/sc/app:app-root/card:card-root/card-span
+          sb/sc/app:app-root/card/card-child
+        sb/sc/app:app-root/frag
+          sb/sc/app:app-root/frag/frag-child
+          sb/sc/app:app-root/frag/cond-1
+            sb/sc/app:app-root/frag/cond-1/cond-1-true
+              sb/sc/app:app-root/frag/cond-1/cond-1-true/cond-1-true-child
+              sb/sc/app:app-root/frag/cond-1/cond-1-true/cond-2
+                sb/sc/app:app-root/frag/cond-1/cond-1-true/cond-2/cond-2-child
+      sb/sc/app/app-child
+`,
+    )
+  })
+})

--- a/editor/src/core/shared/element-path-tree.ts
+++ b/editor/src/core/shared/element-path-tree.ts
@@ -88,13 +88,23 @@ export function reorderTree(
             ).map((childKey) => {
               return { key: childKey, value: tree.children[childKey] }
             })
+
+            // We want to explicitly keep the root element of an instance first
+            const firstChild = updatedChildrenArray[0]
+            const hasRootElement =
+              firstChild != null && EP.isRootElementOfInstance(firstChild.value.path)
             elementChild.children.forEach((child, childIndex) => {
               const uid = getUtopiaID(child)
               const workingTreeIndex = updatedChildrenArray.findIndex((workingTreeChild) => {
                 return EP.toUid(workingTreeChild.value.path) === uid
               })
-              if (workingTreeIndex !== childIndex) {
-                updatedChildrenArray = move(workingTreeIndex, childIndex, updatedChildrenArray)
+              const adjustedChildIndex = hasRootElement ? childIndex + 1 : childIndex
+              if (workingTreeIndex !== adjustedChildIndex) {
+                updatedChildrenArray = move(
+                  workingTreeIndex,
+                  adjustedChildIndex,
+                  updatedChildrenArray,
+                )
               }
             })
             let updatedChildren: ElementPathTreeRoot = {}

--- a/editor/src/core/shared/element-path-tree.ts
+++ b/editor/src/core/shared/element-path-tree.ts
@@ -81,7 +81,8 @@ export function reorderTree(
       },
       (elementChild) => {
         switch (elementChild.type) {
-          case 'JSX_ELEMENT': {
+          case 'JSX_ELEMENT':
+          case 'JSX_FRAGMENT': {
             let updatedChildrenArray: Array<{ key: string; value: ElementPathTree }> = Object.keys(
               tree.children,
             ).map((childKey) => {
@@ -105,6 +106,17 @@ export function reorderTree(
               children: updatedChildren,
             }
           }
+          case 'JSX_CONDITIONAL_EXPRESSION': {
+            let updatedChildren: ElementPathTreeRoot = {}
+            Object.entries(tree.children).map(([childKey, childTree]) => {
+              updatedChildren[childKey] = reorderTree(childTree, metadata)
+            })
+            return {
+              ...tree,
+              children: updatedChildren,
+            }
+          }
+          // TODO Add in handling of the various attribute types once those become selectable
           default:
             return tree
         }


### PR DESCRIPTION
**Problem:**
There were some cases where the `reorderTree` function was either returning the incorrect order, or silently bailing early, causing the row order in the Navigator to become incorrect.

**Fix:**

1. The silent failures were occurring when we reached a node that represented an element that wasn't a `JSXElement` (so e.g. a `JSXFragment` or a `JSXConditionalExpression`). I've added handling for those missing cases to `reorderTree`.
2. When a given node had both a root element and children, the children were accidentally being moved before the root element, as we weren't taking the root element into consideration when comparing the real order of the children (from the captured element) with the order of the subtree, so I've added a check for root elements to ensure they stay at the front.
3. I also fixed `getNavigatorTargets`, as that was moving the root elements after the children. I'm pretty sure this was happening in error, but I'm happy to revert that if I've missed something there.

I've also added tests for both the built tree and the navigator order

[**Try me**](https://utopia.pizza/p/e84049e4-clumsy-larch/?branch_name=fix-reorder-tree-other-types)

**Screenshots from the above project:**
Before:
<img width="225" alt="image" src="https://github.com/concrete-utopia/utopia/assets/1044774/0c1dca2e-d8fb-4180-ad19-2d66c017c255">
After:
<img width="226" alt="image" src="https://github.com/concrete-utopia/utopia/assets/1044774/4fb35e6c-e0a8-46cd-a35e-bf72ce824213">
