### PR TITLE
Feature/chatgpt-integration

### DIFF
--- a/editor/src/components/code-editor/code-chat.tsx
+++ b/editor/src/components/code-editor/code-chat.tsx
@@ -13,6 +13,7 @@ import {
   unparsed,
 } from '../../core/shared/project-file-types'
 import { NO_OP } from '../../core/shared/utils'
+import { StoryboardFilePath } from '../editor/store/editor-state'
 
 const ChatMessagesAtom = atom<string[]>([])
 
@@ -91,7 +92,9 @@ export const ChatTab = React.memo((props: ChatTabProps) => {
     const newMessages = [...chatMessages, composedMessage]
     setChatMessages(newMessages)
     setComposedMessage('')
-    void promptGPT(PROMPT(openFileContentsRef.current ?? '', newMessages))
+    void promptGPT(
+      PROMPT(openFileContentsRef.current ?? '', newMessages, openFilePath === StoryboardFilePath),
+    )
       .then(
         (result) =>
           result != null &&
@@ -163,12 +166,18 @@ export const ChatTab = React.memo((props: ChatTabProps) => {
   )
 })
 
-const PROMPT = (openFileContents: string, messages: string[]) => `Instructions:
+const PROMPT = (
+  openFileContents: string,
+  messages: string[],
+  isStoryboardPath: boolean,
+) => `Instructions:
 - only output code, no prose is needed
 - use React and Javascript in the generated code
 - only use inline styles in the generated code
 - the generated code should use \`flex\` or \`position: absolute\` when possible
-- the generated code should look like the following:
+${
+  isStoryboardPath
+    ? `- the generated code should look like the following:
 \`\`\`
 import * as React from 'react'
 import { Scene, Storyboard } from 'utopia-api'
@@ -189,7 +198,9 @@ export var storyboard = (
     </Scene>
   </Storyboard>
 )
-\`\`\`
+\`\`\``
+    : ''
+}
 - Some code already exists that you can use to create your response:
 \`\`\`
 ${openFileContents}

--- a/editor/src/components/code-editor/code-chat.tsx
+++ b/editor/src/components/code-editor/code-chat.tsx
@@ -1,14 +1,98 @@
 import React from 'react'
-import { SimpleFlexColumn } from '../../uuiui'
+import { FlexColumn, FlexRow, SimpleFlexColumn, StringInput, useColorTheme } from '../../uuiui'
+import { atom, useAtom } from 'jotai'
+import { Substores, useEditorState } from '../editor/store/store-hook'
+import { ProjectContentTreeRoot, getContentsTreeFileFromElements } from '../assets'
+
+const ChatMessagesAtom = atom<string[]>([])
 
 interface ChatTabProps {
   height: number
 }
 
 export const ChatTab = React.memo((props: ChatTabProps) => {
+  const [chatMessages, setChatMessages] = useAtom(ChatMessagesAtom)
+  const [composedMessage, setComposedMessage] = React.useState<string>('')
   const { height } = props
 
-  const style = React.useMemo(() => ({ height: height, width: '100%' }), [height])
+  const colorTheme = useColorTheme()
 
-  return <SimpleFlexColumn style={style}>Hello</SimpleFlexColumn>
+  const endMarkerRef = React.useRef<HTMLDivElement | null>(null)
+  const inputRef = React.useRef<HTMLInputElement | null>(null)
+
+  const containerStyle: React.CSSProperties = React.useMemo(
+    () => ({ height: height - 32, width: '100%', border: '1px solid red' }),
+    [height],
+  )
+
+  const messagesContainerStyle: React.CSSProperties = React.useMemo(
+    () => ({ overflow: 'scroll', flexShrink: 1, flexGrow: 1 }),
+    [],
+  )
+
+  const inputRowContainerStyle: React.CSSProperties = React.useMemo(() => ({ flex: 0, gap: 5 }), [])
+
+  const sendButtonStyles = React.useMemo(
+    () => ({
+      backgroundColor: colorTheme.buttonBackground.value,
+      color: colorTheme.fg0.value,
+      cursor: 'pointer',
+      padding: '5px 5px 5px 5px',
+      width: 'max-content',
+      height: 'max-content',
+      borderRadius: 6,
+    }),
+    [colorTheme.buttonBackground.value, colorTheme.fg0.value],
+  )
+
+  const updateComposedMessage = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setComposedMessage(event.currentTarget.value)
+  }, [])
+
+  const sendMessage = React.useCallback(() => {
+    const newMessages = [...chatMessages, composedMessage]
+    setChatMessages(newMessages)
+    setComposedMessage('')
+  }, [chatMessages, composedMessage, setChatMessages])
+
+  const onInputKeyDown = React.useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key !== 'Enter') {
+        return
+      }
+
+      sendMessage()
+    },
+    [sendMessage],
+  )
+
+  React.useEffect(() => {
+    inputRef.current?.focus()
+    endMarkerRef.current?.scrollIntoView({ behavior: 'auto' })
+  }, [])
+
+  return (
+    <FlexColumn style={containerStyle}>
+      <FlexColumn style={messagesContainerStyle}>
+        {chatMessages.map((m, idx) => (
+          <div key={idx}>{m}</div>
+        ))}
+        <div ref={endMarkerRef} />
+      </FlexColumn>
+      <FlexRow style={inputRowContainerStyle}>
+        <StringInput // TODO: maybe Textarea?
+          ref={inputRef}
+          testId='chat-input'
+          placeholder='Type prompt...'
+          value={composedMessage}
+          onChange={updateComposedMessage}
+          onKeyDown={onInputKeyDown}
+          style={{ flexGrow: 1 }}
+        />
+        <div style={sendButtonStyles} onClick={sendMessage}>
+          Send
+        </div>
+      </FlexRow>
+    </FlexColumn>
+  )
 })

--- a/editor/src/components/code-editor/code-chat.tsx
+++ b/editor/src/components/code-editor/code-chat.tsx
@@ -33,7 +33,7 @@ export const ChatTab = React.memo((props: ChatTabProps) => {
   const inputRef = React.useRef<HTMLInputElement | null>(null)
 
   const containerStyle: React.CSSProperties = React.useMemo(
-    () => ({ height: height - 32, width: '100%', border: '1px solid red' }),
+    () => ({ height: height - 32, width: '100%' }),
     [height],
   )
 

--- a/editor/src/components/code-editor/code-chat.tsx
+++ b/editor/src/components/code-editor/code-chat.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { SimpleFlexColumn } from '../../uuiui'
+
+interface ChatTabProps {
+  height: number
+}
+
+export const ChatTab = React.memo((props: ChatTabProps) => {
+  const { height } = props
+
+  const style = React.useMemo(() => ({ height: height, width: '100%' }), [height])
+
+  return <SimpleFlexColumn style={style}>Hello</SimpleFlexColumn>
+})

--- a/editor/src/components/code-editor/code-problems.tsx
+++ b/editor/src/components/code-editor/code-problems.tsx
@@ -17,12 +17,13 @@ import { WarningIcon } from '../../uuiui/warning-icon'
 import { VariableSizeList as List } from 'react-window'
 import { useColorTheme, UtopiaTheme } from '../../uuiui/styles/theme'
 import { FlexRow } from '../../uuiui/widgets/layout/flex-row'
-import { NO_OP } from '../../core/shared/utils'
+import { NO_OP, assertNever } from '../../core/shared/utils'
 import { TabComponent } from '../../uuiui/tab'
 import { Icons } from '../../uuiui/icons'
 import { SimpleFlexColumn } from '../../uuiui/widgets/layout/flex-column'
 import { UIRow } from '../../uuiui'
 import { groupBy } from '../../core/shared/array-utils'
+import { ChatTab } from './code-chat'
 
 interface ErrorMessageRowProps {
   errorMessage: ErrorMessage
@@ -148,7 +149,7 @@ interface CodeEditorTabPaneProps {
 const ProblemRowHeight = 29
 const ProblemTabBarHeight = 32
 
-type OpenCodeEditorTab = 'problems' | 'console'
+type OpenCodeEditorTab = 'problems' | 'console' | 'chat'
 
 export const CodeEditorTabPane = React.memo<CodeEditorTabPaneProps>(
   ({ errorMessages, onOpenFile, canvasConsoleLogs }) => {
@@ -197,6 +198,13 @@ export const CodeEditorTabPane = React.memo<CodeEditorTabPaneProps>(
         toggleIsOpen()
       }
       setSelectedTab('console')
+    }, [setSelectedTab, isOpen, toggleIsOpen])
+
+    const selectChatTap = React.useCallback(() => {
+      if (!isOpen) {
+        toggleIsOpen()
+      }
+      setSelectedTab('chat')
     }, [setSelectedTab, isOpen, toggleIsOpen])
 
     const problemsTabBackgroundColor = getTabStyleForErrors(
@@ -249,6 +257,10 @@ export const CodeEditorTabPane = React.memo<CodeEditorTabPaneProps>(
       )
     }, [colorTheme, consoleTabBackgroundColor, canvasConsoleLogs.length])
 
+    const ChatTabLabel = React.useMemo(() => {
+      return <span>UtopiAI</span>
+    }, [])
+
     function getTabContents() {
       switch (selectedTab) {
         case 'problems':
@@ -259,6 +271,8 @@ export const CodeEditorTabPane = React.memo<CodeEditorTabPaneProps>(
               onOpenFile={onOpenFile}
             />
           )
+        case 'chat':
+          return <ChatTab height={heightWhenOpen} />
         case 'console':
           return (
             <div
@@ -305,7 +319,7 @@ export const CodeEditorTabPane = React.memo<CodeEditorTabPaneProps>(
             </div>
           )
         default:
-          return null
+          assertNever(selectedTab)
       }
     }
 
@@ -346,6 +360,14 @@ export const CodeEditorTabPane = React.memo<CodeEditorTabPaneProps>(
             showCloseIndicator={false}
             showModifiedIndicator={false}
             label={ConsoleTabLabel}
+          />
+          <TabComponent
+            onClick={selectChatTap}
+            onDoubleClick={toggleIsOpen}
+            selected={selectedTab == 'chat'}
+            showCloseIndicator={false}
+            showModifiedIndicator={false}
+            label={ChatTabLabel}
           />
         </UIRow>
         {isOpen ? getTabContents() : null}

--- a/editor/src/components/code-editor/code-problems.tsx
+++ b/editor/src/components/code-editor/code-problems.tsx
@@ -184,7 +184,7 @@ export const CodeEditorTabPane = React.memo<CodeEditorTabPaneProps>(
       }
     }, [])
 
-    const [selectedTab, setSelectedTab] = React.useState<OpenCodeEditorTab>('problems')
+    const [selectedTab, setSelectedTab] = React.useState<OpenCodeEditorTab>('chat')
 
     const selectProblemsTab = React.useCallback(() => {
       if (!isOpen) {


### PR DESCRIPTION

<img width="1486" alt="image" src="https://github.com/concrete-utopia/utopia/assets/16385508/c270b010-3c24-4ba0-b8e0-4847dd1962fb">


## Problem
When I use ChatGPT to generate React code, I want to tweak it by slightly changing layouts/colors/sizings. Typing all this out and then having to wait for the new code to be generated is very boring. Also, it would be nice if the code would be visualized after being generated, but sadly the stock ChatGPT site doesn't support that.

## Solution
Integrate ChatGPT into Utopia

### TODOs
- [ ] The design of the chat tab is super basic, should be upgraded
- [ ] There's no loading screen yet and completions are **really** slow, maybe it should use streaming?
- [ ] The OpenAI API call will have to be moved to the backend, so that the API key is not exposed