### PR TITLE
Show a persistent toast on Live mode

### DIFF
--- a/editor/src/components/common/notices.tsx
+++ b/editor/src/components/common/notices.tsx
@@ -7,6 +7,7 @@ import { UtopiaStyles, SimpleFlexRow, UtopiaTheme, SimpleFlexColumn } from '../.
 import { Notice, NoticeLevel } from './notice'
 import { useDispatch } from '../editor/store/dispatch-context'
 import { assertNever } from '../../core/shared/utils'
+import { when } from '../../utils/react-conditionals'
 
 interface NoticeProps extends Notice {
   style?: React.CSSProperties
@@ -102,7 +103,8 @@ export const Toast: React.FunctionComponent<React.PropsWithChildren<NoticeProps>
         {getPrefixForLevel(props.level)}&nbsp;
         {props.message}
       </div>
-      {props.persistent ? (
+      {when(
+        props.persistent,
         <div
           css={{
             display: 'flex',
@@ -120,8 +122,8 @@ export const Toast: React.FunctionComponent<React.PropsWithChildren<NoticeProps>
           id='toast-button'
         >
           ×
-        </div>
-      ) : null}
+        </div>,
+      )}
     </div>
   )
 }

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -55,6 +55,9 @@ import { LowPriorityStoreProvider } from './store/store-context-providers'
 import { useDispatch } from './store/dispatch-context'
 import { EditorAction } from './action-types'
 import { EditorCommon } from './editor-component-common'
+import { notice } from '../common/notice'
+
+const liveModeToastId = 'play-mode-toast'
 
 function pushProjectURLToBrowserHistory(projectId: string, projectName: string): void {
   // Make sure we don't replace the query params
@@ -138,6 +141,24 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
   }, [editorStoreRef])
 
   const setClearKeyboardInteraction = useClearKeyboardInteraction(editorStoreRef)
+
+  const mode = useEditorState(Substores.restOfEditor, (store) => store.editor.mode, 'mode')
+  React.useEffect(() => {
+    if (mode.type === 'live') {
+      dispatch([
+        EditorActions.showToast(
+          notice(
+            'You are in Live mode. Use ⌘ to select and scroll.',
+            'NOTICE',
+            true,
+            liveModeToastId,
+          ),
+        ),
+      ])
+    } else {
+      dispatch([EditorActions.removeToast(liveModeToastId)])
+    }
+  }, [mode, dispatch])
 
   const onWindowKeyDown = React.useCallback(
     (event: KeyboardEvent) => {

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -158,7 +158,7 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
     } else {
       dispatch([EditorActions.removeToast(liveModeToastId)])
     }
-  }, [mode, dispatch])
+  }, [mode.type, dispatch])
 
   const onWindowKeyDown = React.useCallback(
     (event: KeyboardEvent) => {


### PR DESCRIPTION
Fixes #3745 

This PR adds a persistent toast displayed while in Live mode, suggesting the user to press `cmd` to select and pan around.

https://github.com/concrete-utopia/utopia/assets/1081051/bb1435b5-1832-4dbf-8274-8c634e7db604

