### PR TITLE
Dropping an element next to/onto itself

### DIFF
--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -21,7 +21,7 @@ import {
   mouseClickAtPoint,
 } from '../canvas/event-helpers.test-utils'
 import { NavigatorItemTestId } from './navigator-item/navigator-item'
-import { selectComponentsForTest, wait } from '../../utils/utils.test-utils'
+import { expectNoAction, selectComponentsForTest, wait } from '../../utils/utils.test-utils'
 import {
   navigatorEntryToKey,
   regularNavigatorEntry,
@@ -1834,6 +1834,84 @@ describe('Navigator', () => {
         'regular-utopia-storyboard-uid/scene-aaa/sceneroot/notdrag',
         'regular-utopia-storyboard-uid/scene-aaa/sceneroot/parentsibling', // <- moved under sceneroot
       ])
+    })
+
+    describe('reordering into the same place', () => {
+      it('before itself', async () => {
+        const renderResult = await renderTestEditorWithCode(
+          getProjectCode(),
+          'await-first-dom-report',
+        )
+
+        const initialOrder = renderResult
+          .getEditorState()
+          .derived.navigatorTargets.map(navigatorEntryToKey)
+
+        const target = EP.fromString(
+          `${BakedInStoryboardUID}/${TestSceneUID}/${SceneRootId}/firstdiv`,
+        )
+
+        await selectComponentsForTest(renderResult, [target])
+
+        // check if all selected elements are actually in the metadata
+        expect(
+          renderResult
+            .getEditorState()
+            .editor.selectedViews.map((path) =>
+              MetadataUtils.findElementByElementPath(
+                renderResult.getEditorState().editor.jsxMetadata,
+                path,
+              ),
+            )
+            .every((i) => i != null),
+        ).toEqual(true)
+
+        await expectNoAction(renderResult, async () => {
+          await doBasicDrag(renderResult, target, target, TopDropTargetLineTestId)
+        })
+
+        expect(
+          renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey),
+        ).toEqual(initialOrder)
+      })
+    })
+
+    it('after itself', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        getProjectCode(),
+        'await-first-dom-report',
+      )
+
+      const initialOrder = renderResult
+        .getEditorState()
+        .derived.navigatorTargets.map(navigatorEntryToKey)
+
+      const target = EP.fromString(
+        `${BakedInStoryboardUID}/${TestSceneUID}/${SceneRootId}/firstdiv`,
+      )
+
+      await selectComponentsForTest(renderResult, [target])
+
+      // check if all selected elements are actually in the metadata
+      expect(
+        renderResult
+          .getEditorState()
+          .editor.selectedViews.map((path) =>
+            MetadataUtils.findElementByElementPath(
+              renderResult.getEditorState().editor.jsxMetadata,
+              path,
+            ),
+          )
+          .every((i) => i != null),
+      ).toEqual(true)
+
+      await expectNoAction(renderResult, async () => {
+        await doBasicDrag(renderResult, target, target, BottomDropTargetLineTestId)
+      })
+
+      expect(
+        renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey),
+      ).toEqual(initialOrder)
     })
   })
 

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -1913,6 +1913,49 @@ describe('Navigator', () => {
         renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey),
       ).toEqual(initialOrder)
     })
+
+    it('after the previous entry', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        getProjectCode(),
+        'await-first-dom-report',
+      )
+
+      const initialOrder = renderResult
+        .getEditorState()
+        .derived.navigatorTargets.map(navigatorEntryToKey)
+
+      const target = EP.fromString(
+        `${BakedInStoryboardUID}/${TestSceneUID}/${SceneRootId}/seconddiv`,
+      )
+
+      await selectComponentsForTest(renderResult, [target])
+
+      // check if all selected elements are actually in the metadata
+      expect(
+        renderResult
+          .getEditorState()
+          .editor.selectedViews.map((path) =>
+            MetadataUtils.findElementByElementPath(
+              renderResult.getEditorState().editor.jsxMetadata,
+              path,
+            ),
+          )
+          .every((i) => i != null),
+      ).toEqual(true)
+
+      await expectNoAction(renderResult, async () => {
+        await doBasicDrag(
+          renderResult,
+          target,
+          EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${SceneRootId}/firstdiv`),
+          BottomDropTargetLineTestId,
+        )
+      })
+
+      expect(
+        renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey),
+      ).toEqual(initialOrder)
+    })
   })
 
   describe('reparenting among layout systems', () => {


### PR DESCRIPTION
## Problem
Dropping a navigator entry right before or after itself should be a NOOP, and shouldn't generate undo frames. Neither of these hold up as of this PR.

## Fix
Disable dropping an element into itself via the parent outline, and check the boundary conditions of dropping an elements on a drop line.

