### PR TITLE
Conditionals without siblings and only expression in them receive globalFrame from parent

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -1497,7 +1497,7 @@ describe('Absolute Resize Strategy Canvas Controls', () => {
     expectElementWithTestIdToBeRendered(renderResult, AbsoluteResizeControlTestId([target]))
   })
 
-  it('when a condition is overriden to one without an element, the bounding box disappears', async () => {
+  it('when a condition is overriden to one without an element, the bounding box disappears (when the conditional has siblings)', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
         <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
@@ -1511,6 +1511,7 @@ describe('Absolute Resize Strategy Canvas Controls', () => {
               />
             ) : null
           }
+          <div />
         </div>
       `),
       'await-first-dom-report',

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -1542,10 +1542,7 @@ describe('Absolute Resize Strategy Canvas Controls', () => {
       renderResult,
       AbsoluteResizeControlTestId([childOfConditional]),
     )
-    expectElementWithTestIdToBeRenderedWithDisplayNone(
-      renderResult,
-      AbsoluteResizeControlTestId([conditional]),
-    )
+    expectElementWithTestIdNotToBeRendered(renderResult, AbsoluteResizeControlTestId([conditional]))
   })
 
   it('when an absolute positioned element is resized the parent outlines become visible', async () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -597,7 +597,7 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         {
           'scene-aaa/app-entity:aaa/bbb': {
             elementPath: fromString('scene-aaa/app-entity:aaa/bbb'),
-            element: right(jsxElement(jsxElementName(q, []), 'bbb', [], [])),
+            element: right(jsxElement(jsxElementName('div', []), 'bbb', [], [])),
             specialSizeMeasurements: {
               position: 'absolute',
               immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -1,9 +1,11 @@
-import { left } from '../../../../core/shared/either'
+import { left, right } from '../../../../core/shared/either'
 import { elementPath, fromString } from '../../../../core/shared/element-path'
 import {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
   SpecialSizeMeasurements,
+  jsxElement,
+  jsxElementName,
 } from '../../../../core/shared/element-template'
 import { CanvasPoint, canvasPoint, canvasRectangle } from '../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
@@ -83,7 +85,7 @@ function multiselectResizeElements(
 const testMetadata: ElementInstanceMetadataMap = {
   'scene-aaa/app-entity:aaa/bbb': {
     elementPath: fromString('scene-aaa/app-entity:aaa/bbb'),
-    element: left('div'),
+    element: right(jsxElement(jsxElementName('div', []), 'bbb', [], [])),
     specialSizeMeasurements: {
       position: 'absolute',
       immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
@@ -93,7 +95,7 @@ const testMetadata: ElementInstanceMetadataMap = {
   } as ElementInstanceMetadata,
   'scene-aaa/app-entity:aaa/ccc': {
     elementPath: fromString('scene-aaa/app-entity:aaa/ccc'),
-    element: left('div'),
+    element: right(jsxElement(jsxElementName('div', []), 'bbb', [], [])),
     specialSizeMeasurements: {
       position: 'absolute',
       immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
@@ -595,7 +597,7 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         {
           'scene-aaa/app-entity:aaa/bbb': {
             elementPath: fromString('scene-aaa/app-entity:aaa/bbb'),
-            element: left('div'),
+            element: right(jsxElement(jsxElementName(q, []), 'bbb', [], [])),
             specialSizeMeasurements: {
               position: 'absolute',
               immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
@@ -1478,7 +1480,7 @@ describe('Absolute Resize Strategy with missing props', () => {
       {
         'scene-aaa/app-entity:aaa/bbb': {
           elementPath: fromString('scene-aaa/app-entity:aaa/bbb'),
-          element: left('div'),
+          element: right(jsxElement(jsxElementName('div', []), 'bbb', [], [])),
           specialSizeMeasurements: {
             position: 'absolute',
             immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
@@ -1488,7 +1490,7 @@ describe('Absolute Resize Strategy with missing props', () => {
         } as ElementInstanceMetadata,
         'scene-aaa/app-entity:aaa/bbb/ccc': {
           elementPath: fromString('scene-aaa/app-entity:aaa/bbb/ccc'),
-          element: left('div'),
+          element: right(jsxElement(jsxElementName('div', []), 'bbb', [], [])),
           specialSizeMeasurements: {
             position: 'absolute',
             immediateParentBounds: canvasRectangle({ x: 30, y: 50, width: 100, height: 80 }),
@@ -1563,7 +1565,7 @@ describe('Absolute Resize Strategy with missing props', () => {
       {
         'scene-aaa/app-entity:aaa/bbb': {
           elementPath: fromString('scene-aaa/app-entity:aaa/bbb'),
-          element: left('div'),
+          element: right(jsxElement(jsxElementName('div', []), 'bbb', [], [])),
           specialSizeMeasurements: {
             position: 'absolute',
             immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
@@ -1572,7 +1574,7 @@ describe('Absolute Resize Strategy with missing props', () => {
         } as ElementInstanceMetadata,
         'scene-aaa/app-entity:aaa/bbb/ccc': {
           elementPath: fromString('scene-aaa/app-entity:aaa/bbb/ccc'),
-          element: left('div'),
+          element: right(jsxElement(jsxElementName('div', []), 'bbb', [], [])),
           specialSizeMeasurements: {
             position: 'absolute',
             immediateParentBounds: canvasRectangle({ x: 30, y: 50, width: 100, height: 80 }),
@@ -1643,7 +1645,7 @@ describe('Absolute Resize Strategy with missing props', () => {
       {
         'scene-aaa/app-entity:aaa/bbb': {
           elementPath: fromString('scene-aaa/app-entity:aaa/bbb'),
-          element: left('div'),
+          element: right(jsxElement(jsxElementName('div', []), 'bbb', [], [])),
           specialSizeMeasurements: {
             position: 'absolute',
             immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
@@ -1653,7 +1655,7 @@ describe('Absolute Resize Strategy with missing props', () => {
         } as ElementInstanceMetadata,
         'scene-aaa/app-entity:aaa/bbb/ccc': {
           elementPath: fromString('scene-aaa/app-entity:aaa/bbb/ccc'),
-          element: left('div'),
+          element: right(jsxElement(jsxElementName('div', []), 'bbb', [], [])),
           specialSizeMeasurements: {
             position: 'absolute',
             immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 100, height: 80 }),

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-interaction.test-utils.tsx
@@ -1,9 +1,12 @@
 import { createBuiltInDependenciesList } from '../../../../core/es-modules/package-manager/built-in-dependencies-list'
+import { right } from '../../../../core/shared/either'
 import { elementPath } from '../../../../core/shared/element-path'
 import {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
   SpecialSizeMeasurements,
+  jsxElement,
+  jsxElementName,
 } from '../../../../core/shared/element-template'
 import { canvasRectangle } from '../../../../core/shared/math-utils'
 import { KeyCharacter } from '../../../../utils/keyboard'
@@ -42,6 +45,7 @@ export function pressKeys(
         ['scene-aaa', 'app-entity'],
         ['aaa', 'bbb'],
       ]),
+      element: right(jsxElement(jsxElementName('View', []), 'bbb', [], [])),
       specialSizeMeasurements: {
         position: 'absolute',
         immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -2280,7 +2280,17 @@ function fillSpyOnlyMetadata(
 }
 
 function fillMissingDataFromAncestors(mergedMetadata: ElementInstanceMetadataMap) {
-  let workingElements: ElementInstanceMetadataMap = { ...mergedMetadata }
+  const metadataWithGlobalContentBox = fillGlobalContentBoxFromAncestors(mergedMetadata)
+  const metadataWithConditionaGlobalFrames = fillConditionalGlobalFrameFromAncestors(
+    metadataWithGlobalContentBox,
+  )
+  return metadataWithConditionaGlobalFrames
+}
+
+function fillGlobalContentBoxFromAncestors(
+  metadata: ElementInstanceMetadataMap,
+): ElementInstanceMetadataMap {
+  const workingElements = { ...metadata }
 
   const elementsWithoutGlobalContentBox = Object.keys(workingElements).filter((p) => {
     return workingElements[p]?.specialSizeMeasurements.globalContentBoxForChildren == null
@@ -2305,9 +2315,16 @@ function fillMissingDataFromAncestors(mergedMetadata: ElementInstanceMetadataMap
       },
     }
   })
+  return workingElements
+}
 
-  // When a conditional has no siblings, and there is a js expression in its active branch, its globalFrame/localFrame
-  // should be inherited from its parent
+// When a conditional has no siblings, and there is a js expression in its active branch, its globalFrame/localFrame
+// should be inherited from its parent
+function fillConditionalGlobalFrameFromAncestors(
+  metadata: ElementInstanceMetadataMap,
+): ElementInstanceMetadataMap {
+  const workingElements = { ...metadata }
+
   const conditionalsWithNoSiblingsAndExpressionInActiveBranch = Object.keys(workingElements).filter(
     (p) => {
       const element = workingElements[p]

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -83,6 +83,7 @@ import {
   InfinityRectangle,
   CoordinateMarker,
   infinityRectangle,
+  infinityLocalRectangle,
 } from '../shared/math-utils'
 import { optionalMap } from '../shared/optional-utils'
 import { Imports, PropertyPath, ElementPath, NodeModules } from '../shared/project-file-types'
@@ -131,6 +132,7 @@ import {
 } from '../../components/inspector/common/css-utils'
 import {
   findFirstNonConditionalAncestor,
+  getConditionalActiveCase,
   getConditionalClausePath,
   maybeConditionalActiveBranch,
   maybeConditionalExpression,
@@ -966,17 +968,22 @@ export const MetadataUtils = {
   ): boolean {
     if (metadata == null) {
       return false
+    }
+    if (
+      isLeft(metadata.element) ||
+      (isRight(metadata.element) && !isJSXElement(metadata.element.value))
+    ) {
+      return false
+    }
+    const underlyingComponent = findUnderlyingTargetComponentImplementationFromImportInfo(
+      projectContents,
+      metadata.importInfo,
+    )
+    if (underlyingComponent == null) {
+      // Could be an external third party component, assuming true for now.
+      return true
     } else {
-      const underlyingComponent = findUnderlyingTargetComponentImplementationFromImportInfo(
-        projectContents,
-        metadata.importInfo,
-      )
-      if (underlyingComponent == null) {
-        // Could be an external third party component, assuming true for now.
-        return true
-      } else {
-        return componentHonoursPropsSize(underlyingComponent)
-      }
+      return componentHonoursPropsSize(underlyingComponent)
     }
   },
   targetHonoursPropsPosition(
@@ -985,17 +992,22 @@ export const MetadataUtils = {
   ): boolean {
     if (metadata == null) {
       return false
+    }
+    if (
+      isLeft(metadata.element) ||
+      (isRight(metadata.element) && !isJSXElement(metadata.element.value))
+    ) {
+      return false
+    }
+    const underlyingComponent = findUnderlyingTargetComponentImplementationFromImportInfo(
+      projectContents,
+      metadata.importInfo,
+    )
+    if (underlyingComponent == null) {
+      // Could be an external third party component, assuming true for now.
+      return true
     } else {
-      const underlyingComponent = findUnderlyingTargetComponentImplementationFromImportInfo(
-        projectContents,
-        metadata.importInfo,
-      )
-      if (underlyingComponent == null) {
-        // Could be an external third party component, assuming true for now.
-        return true
-      } else {
-        return componentHonoursPropsPosition(underlyingComponent)
-      }
+      return componentHonoursPropsPosition(underlyingComponent)
     }
   },
   targetTextEditable(metadata: ElementInstanceMetadataMap, target: ElementPath | null): boolean {
@@ -2296,6 +2308,72 @@ function fillMissingDataFromAncestors(mergedMetadata: ElementInstanceMetadataMap
         ...elem.specialSizeMeasurements,
         globalContentBoxForChildren: parentGlobalContentBoxForChildren,
       },
+    }
+  })
+
+  const conditionals = Object.keys(workingElements).filter((p) => {
+    const element = workingElements[p]
+    if (element.conditionValue === 'not-a-conditional') {
+      return false
+    }
+    const condElement =
+      isRight(element.element) && isJSXConditionalExpression(element.element.value)
+        ? element.element.value
+        : null
+
+    if (condElement == null) {
+      return false
+    }
+
+    const activeBranch = element.conditionValue.active
+      ? condElement.whenTrue
+      : condElement.whenFalse
+
+    if (!isJSExpression(activeBranch)) {
+      return false
+    }
+
+    const parentOfConditionalPath = EP.parentPath(EP.fromString(p))
+    const parentOfConditionalElement = workingElements[EP.toString(parentOfConditionalPath)]
+    const conditionalHasNoSiblings =
+      isRight(parentOfConditionalElement.element) &&
+      isJSXElementLike(parentOfConditionalElement.element.value) &&
+      parentOfConditionalElement.element.value.children.length === 1
+
+    return conditionalHasNoSiblings
+  })
+
+  // sorted, so that parents are fixed first
+  conditionals.sort()
+
+  fastForEach(conditionals, (pathStr) => {
+    const elem = workingElements[pathStr]
+
+    const condParentPathStr = EP.toString(EP.parentPath(EP.fromString(pathStr)))
+
+    const condParentGlobalFrame = workingElements[condParentPathStr]?.globalFrame
+    const condParentGlobalContentBoxForChildren =
+      workingElements[condParentPathStr]?.specialSizeMeasurements.globalContentBoxForChildren
+    const localFrameFromCondParent = (() => {
+      if (condParentGlobalFrame == null || condParentGlobalContentBoxForChildren == null) {
+        return null
+      }
+      if (
+        isInfinityRectangle(condParentGlobalFrame) ||
+        isInfinityRectangle(condParentGlobalContentBoxForChildren)
+      ) {
+        return infinityLocalRectangle
+      }
+      return canvasRectangleToLocalRectangle(
+        condParentGlobalFrame,
+        condParentGlobalContentBoxForChildren,
+      )
+    })()
+
+    workingElements[pathStr] = {
+      ...elem,
+      globalFrame: condParentGlobalFrame,
+      localFrame: localFrameFromCondParent,
     }
   })
 

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -2331,7 +2331,7 @@ function fillMissingDataFromAncestors(mergedMetadata: ElementInstanceMetadataMap
         return false
       }
 
-      const parentOfConditionalPath = EP.parentPath(EP.fromString(p))
+      const parentOfConditionalPath = EP.parentPath(element.elementPath)
       const parentOfConditionalElement = workingElements[EP.toString(parentOfConditionalPath)]
       const conditionalHasNoSiblings =
         isRight(parentOfConditionalElement.element) &&

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -2348,7 +2348,7 @@ function fillMissingDataFromAncestors(mergedMetadata: ElementInstanceMetadataMap
   fastForEach(conditionalsWithNoSiblingsAndExpressionInActiveBranch, (pathStr) => {
     const elem = workingElements[pathStr]
 
-    const condParentPathStr = EP.toString(EP.parentPath(EP.fromString(pathStr)))
+    const condParentPathStr = EP.toString(EP.parentPath(elem.elementPath))
 
     const condParentGlobalFrame = workingElements[condParentPathStr]?.globalFrame
     const condParentGlobalContentBoxForChildren =

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -992,22 +992,17 @@ export const MetadataUtils = {
   ): boolean {
     if (metadata == null) {
       return false
-    }
-    if (
-      isLeft(metadata.element) ||
-      (isRight(metadata.element) && !isJSXElement(metadata.element.value))
-    ) {
-      return false
-    }
-    const underlyingComponent = findUnderlyingTargetComponentImplementationFromImportInfo(
-      projectContents,
-      metadata.importInfo,
-    )
-    if (underlyingComponent == null) {
-      // Could be an external third party component, assuming true for now.
-      return true
     } else {
-      return componentHonoursPropsPosition(underlyingComponent)
+      const underlyingComponent = findUnderlyingTargetComponentImplementationFromImportInfo(
+        projectContents,
+        metadata.importInfo,
+      )
+      if (underlyingComponent == null) {
+        // Could be an external third party component, assuming true for now.
+        return true
+      } else {
+        return componentHonoursPropsPosition(underlyingComponent)
+      }
     }
   },
   targetTextEditable(metadata: ElementInstanceMetadataMap, target: ElementPath | null): boolean {

--- a/editor/src/core/model/element-metadata.spec.browser2.tsx
+++ b/editor/src/core/model/element-metadata.spec.browser2.tsx
@@ -391,7 +391,7 @@ describe('globalContentBoxForChildren calculation', () => {
         throw new Error('nullInstance should not be null')
       }
 
-      expect(conditionalInstance.globalFrame).toEqual(scontainerInstance.globalFrame)
+      expect(conditionalInstance.globalFrame).toEqual(containerInstance.globalFrame)
       expect(conditionalInstance.localFrame).toEqual({
         x: 0,
         y: 0,


### PR DESCRIPTION
**Description:**
This PR is part of a series of PRs to implement text editing for expressions in conditional branches.

To make it possible to select a conditional on the canvas, conditionals need a `globalFrame`.

However, normally conditionals receive their `globalFrame` from their active branch. And js expressions do not have `globalFrame` (or metadata), so when a conditional only has an expression in its active branch, the conditional itself doesn't have `globalFrame` neither. But this is the exact case when we want to allow text editing, and double click to text edit too!

In the simplest case, when the conditional doesn't have siblings in its parent, and only has an expression in its active branch, it makes sense to say that the globalFrame of the conditional should be the same as its parent. Because the real parent of the expression in the dom will be the parent element of the conditional.

So this PR handles this very simple special case and fills the `globalFrame` for these conditionals from their ancestor.

Note: `targetHonoursPropsSize` now returns false for non-jsxelements. I _think_ it doesn't make sense to set the size of any other type of elephants. This prevents the resize controls to appear for conditionals.