### PR TITLE
fix(navigator) canvas size atom

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes.ts
@@ -236,7 +236,7 @@ export function getReparentPropertyChanges(
   openFile: string | null | undefined,
   targetOriginalStylePosition: CSSPosition | null,
   targetOriginalDisplayProp: string | null,
-  canvasViewportCenter: CanvasPoint | null,
+  canvasViewportCenter: CanvasPoint,
 ): Array<CanvasCommand> {
   const newPath = EP.appendToPath(newParent, EP.toUid(target))
   switch (reparentStrategy) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-strategies.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-strategies.ts
@@ -336,7 +336,7 @@ export const positionAbsoluteElementOnStoryboard =
     elementToReparent: ElementPathSnapshots,
     targetParent: ElementPath,
     metadata: MetadataSnapshots,
-    canvasViewportCenter: CanvasPoint | null,
+    canvasViewportCenter: CanvasPoint,
   ): ReparentPropertyStrategy =>
   () => {
     const elementBounds = MetadataUtils.getFrameInCanvasCoords(
@@ -349,12 +349,8 @@ export const positionAbsoluteElementOnStoryboard =
     }
 
     if (EP.isStoryboardPath(targetParent)) {
-      let newLeft = 100
-      let newTop = 100
-      if (canvasViewportCenter != null) {
-        newLeft = canvasViewportCenter.x - elementBounds.width / 2
-        newTop = canvasViewportCenter.y - elementBounds.height / 2
-      }
+      const newLeft = canvasViewportCenter.x - elementBounds.width / 2
+      const newTop = canvasViewportCenter.y - elementBounds.height / 2
       return right([
         ...pruneFlexPropsCommands(flexChildProps, elementToReparent.newPath),
         setCssLengthProperty(

--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -15,6 +15,7 @@ import {
   getOpenUIJSFileKey,
   parseFailureAsErrorMessages,
   NavigatorWidthAtom,
+  CanvasSizeAtom,
 } from '../editor/store/editor-state'
 import { Substores, useEditorState } from '../editor/store/store-hook'
 import ErrorOverlay from '../../third-party/react-error-overlay/components/ErrorOverlay'
@@ -25,7 +26,11 @@ import Header from '../../third-party/react-error-overlay/components/Header'
 import { FlexColumn, Button, UtopiaTheme, FlexRow } from '../../uuiui'
 import { useReadOnlyRuntimeErrors } from '../../core/shared/runtime-report-logs'
 import StackFrame from '../../third-party/react-error-overlay/utils/stack-frame'
-import { AlwaysTrue, usePubSubAtomReadOnly } from '../../core/shared/atom-with-pub-sub'
+import {
+  AlwaysTrue,
+  usePubSubAtomReadOnly,
+  usePubSubAtomWriteOnly,
+} from '../../core/shared/atom-with-pub-sub'
 import { ErrorMessage } from '../../core/shared/error-messages'
 import CanvasActions from './canvas-actions'
 import { EditorModes } from '../editor/editor-modes'
@@ -92,6 +97,7 @@ export const CanvasWrapperComponent = React.memo(() => {
   )
 
   const navigatorWidth = usePubSubAtomReadOnly(NavigatorWidthAtom, AlwaysTrue)
+  const updateCanvasSize = usePubSubAtomWriteOnly(CanvasSizeAtom)
 
   return (
     <FlexColumn
@@ -111,6 +117,7 @@ export const CanvasWrapperComponent = React.memo(() => {
           userState={userState}
           editor={editorState}
           model={createCanvasModelKILLME(editorState, derivedState)}
+          updateCanvasSize={updateCanvasSize}
           dispatch={dispatch}
         />
       ) : null}

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -131,6 +131,7 @@ export type NavigatorReorder = {
   dragSources: Array<ElementPath>
   targetParent: ElementPath
   indexPosition: IndexPosition
+  canvasSize: Size
 }
 
 export type RenameComponent = {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -5618,7 +5618,7 @@ function insertWithReparentStrategies(
   },
   indexPosition: IndexPosition,
   builtInDependencies: BuiltInDependencies,
-  canvasViewportCenter: CanvasPoint | null,
+  canvasViewportCenter: CanvasPoint,
 ): { updatedEditorState: EditorState; newPath: ElementPath } | null {
   const outcomeResult = getReparentOutcome(
     builtInDependencies,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -108,6 +108,7 @@ import {
   LocalRectangle,
   rectangleIntersection,
   Size,
+  canvasPoint,
 } from '../../../core/shared/math-utils'
 import {
   PackageStatusMap,
@@ -1813,6 +1814,11 @@ export const UPDATE_FNS = {
       )
     }
 
+    const canvasViewportCenter = canvasPoint({
+      x: -editor.canvas.roundedCanvasOffset.x + action.canvasSize.width / editor.canvas.scale / 2,
+      y: -editor.canvas.roundedCanvasOffset.y + action.canvasSize.height / editor.canvas.scale / 2,
+    })
+
     const updatedEditor = dragSources.reduce(
       (workingEditorState, dragSource) => {
         const afterInsertion = insertWithReparentStrategies(
@@ -1825,7 +1831,7 @@ export const UPDATE_FNS = {
           },
           action.indexPosition,
           builtInDependencies,
-          null,
+          canvasViewportCenter,
         )
         if (afterInsertion != null) {
           return {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -43,6 +43,7 @@ import {
   LocalRectangle,
   WindowPoint,
   isFiniteRectangle,
+  size,
 } from '../../../core/shared/math-utils'
 import type { PackageStatus, PackageStatusMap } from '../../../core/shared/npm-dependency-types'
 import {
@@ -179,6 +180,10 @@ const DefaultNavigatorWidth = 280
 export const NavigatorWidthAtom = atomWithPubSub({
   key: 'NavigatorWidthAtom',
   defaultValue: DefaultNavigatorWidth,
+})
+export const CanvasSizeAtom = atomWithPubSub({
+  key: 'CanvasSizeAtom',
+  defaultValue: size(0, 0),
 })
 
 export enum RightMenuTab {

--- a/editor/src/components/navigator/actions/index.ts
+++ b/editor/src/components/navigator/actions/index.ts
@@ -1,3 +1,4 @@
+import { Size } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { IndexPosition } from '../../../utils/utils'
 import { NavigatorReorder, RenameComponent } from '../../editor/action-types'
@@ -7,12 +8,14 @@ export function reorderComponents(
   dragSources: Array<ElementPath>,
   targetParent: ElementPath,
   indexPosition: IndexPosition,
+  canvasSize: Size,
 ): NavigatorReorder {
   return {
     action: 'NAVIGATOR_REORDER',
     dragSources: dragSources,
     targetParent: targetParent,
     indexPosition: indexPosition,
+    canvasSize: canvasSize,
   }
 }
 

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -52,11 +52,7 @@ import { IndexPosition, after, before, front } from '../../../utils/utils'
 import { assertNever } from '../../../core/shared/utils'
 import { ElementPathTreeRoot } from '../../../core/shared/element-path-tree'
 import { useAtom, atom } from 'jotai'
-import {
-  AlwaysFalse,
-  AlwaysTrue,
-  usePubSubAtomReadOnly,
-} from '../../../core/shared/atom-with-pub-sub'
+import { AlwaysFalse, usePubSubAtomReadOnly } from '../../../core/shared/atom-with-pub-sub'
 import { Size } from '../../../core/shared/math-utils'
 
 const WiggleUnit = BasePaddingUnit * 1.5

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -52,7 +52,11 @@ import { IndexPosition, after, before, front } from '../../../utils/utils'
 import { assertNever } from '../../../core/shared/utils'
 import { ElementPathTreeRoot } from '../../../core/shared/element-path-tree'
 import { useAtom, atom } from 'jotai'
-import { AlwaysTrue, usePubSubAtomReadOnly } from '../../../core/shared/atom-with-pub-sub'
+import {
+  AlwaysFalse,
+  AlwaysTrue,
+  usePubSubAtomReadOnly,
+} from '../../../core/shared/atom-with-pub-sub'
 import { Size } from '../../../core/shared/math-utils'
 
 const WiggleUnit = BasePaddingUnit * 1.5
@@ -444,7 +448,7 @@ function isHintDisallowed(elementPath: ElementPath | null, metadata: ElementInst
 
 export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDropWrapperProps) => {
   const editorStateRef = useRefEditorState((store) => store.editor)
-  const canvasSize = usePubSubAtomReadOnly(CanvasSizeAtom, AlwaysTrue)
+  const canvasSize = usePubSubAtomReadOnly(CanvasSizeAtom, AlwaysFalse)
 
   const [isDragSessionInProgress, updateDragSessionInProgress] = useAtom(DragSessionInProgressAtom)
 
@@ -801,7 +805,7 @@ function maybeSetConditionalOverrideOnDrop(
 export const SyntheticNavigatorItemContainer = React.memo(
   (props: SyntheticNavigatorItemContainerProps) => {
     const editorStateRef = useRefEditorState((store) => store.editor)
-    const canvasSize = usePubSubAtomReadOnly(CanvasSizeAtom, AlwaysTrue)
+    const canvasSize = usePubSubAtomReadOnly(CanvasSizeAtom, AlwaysFalse)
 
     const [, updateDragSessionInProgress] = useAtom(DragSessionInProgressAtom)
 

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -18,6 +18,7 @@ import {
   NavigatorHintTop,
 } from './navigator-item-components'
 import {
+  CanvasSizeAtom,
   ConditionalClauseNavigatorEntry,
   DropTargetHint,
   DropTargetType,
@@ -51,6 +52,8 @@ import { IndexPosition, after, before, front } from '../../../utils/utils'
 import { assertNever } from '../../../core/shared/utils'
 import { ElementPathTreeRoot } from '../../../core/shared/element-path-tree'
 import { useAtom, atom } from 'jotai'
+import { AlwaysTrue, usePubSubAtomReadOnly } from '../../../core/shared/atom-with-pub-sub'
+import { Size } from '../../../core/shared/math-utils'
 
 const WiggleUnit = BasePaddingUnit * 1.5
 
@@ -236,6 +239,7 @@ function onDrop(
   propsOfDropTargetItem: NavigatorItemDragAndDropWrapperProps,
   targetParent: ElementPath,
   indexPosition: IndexPosition,
+  canvasSize: Size,
 ): Array<EditorAction> {
   const dragSelections = propsOfDraggedItem.getCurrentlySelectedEntries()
   const filteredSelections = dragSelections.filter((selection) =>
@@ -244,7 +248,7 @@ function onDrop(
   const draggedElements = filteredSelections.map((selection) => selection.elementPath)
 
   return [
-    reorderComponents(draggedElements, targetParent, indexPosition),
+    reorderComponents(draggedElements, targetParent, indexPosition, canvasSize),
     hideNavigatorDropTargetHint(),
   ]
 }
@@ -440,6 +444,7 @@ function isHintDisallowed(elementPath: ElementPath | null, metadata: ElementInst
 
 export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDropWrapperProps) => {
   const editorStateRef = useRefEditorState((store) => store.editor)
+  const canvasSize = usePubSubAtomReadOnly(CanvasSizeAtom, AlwaysTrue)
 
   const [isDragSessionInProgress, updateDragSessionInProgress] = useAtom(DragSessionInProgressAtom)
 
@@ -550,6 +555,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
               props,
               dropTargetHint.targetParent.elementPath,
               dropTargetHint.targetIndexPosition,
+              canvasSize,
             ),
           )
         }
@@ -602,6 +608,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
               props,
               dropTargetHint.targetParent.elementPath,
               dropTargetHint.targetIndexPosition,
+              canvasSize,
             ),
           )
         }
@@ -638,6 +645,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
               props,
               dropTargetHint.targetParent.elementPath,
               dropTargetHint.targetIndexPosition,
+              canvasSize,
             ),
           )
         }
@@ -793,6 +801,7 @@ function maybeSetConditionalOverrideOnDrop(
 export const SyntheticNavigatorItemContainer = React.memo(
   (props: SyntheticNavigatorItemContainerProps) => {
     const editorStateRef = useRefEditorState((store) => store.editor)
+    const canvasSize = usePubSubAtomReadOnly(CanvasSizeAtom, AlwaysTrue)
 
     const [, updateDragSessionInProgress] = useAtom(DragSessionInProgressAtom)
 
@@ -818,7 +827,7 @@ export const SyntheticNavigatorItemContainer = React.memo(
         drop: (item: NavigatorItemDragAndDropWrapperProps): void => {
           const { jsxMetadata, spyMetadata } = editorStateRef.current
           props.editorDispatch([
-            ...onDrop(item, props, props.elementPath, front()),
+            ...onDrop(item, props, props.elementPath, front(), canvasSize),
             ...maybeSetConditionalOverrideOnDrop(props.elementPath, jsxMetadata, spyMetadata),
           ])
         },

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -31,7 +31,6 @@ import { EditorAction, EditorDispatch } from '../../editor/action-types'
 import * as EditorActions from '../../editor/actions/action-creators'
 import * as MetaActions from '../../editor/actions/meta-actions'
 import {
-  CanvasSizeAtom,
   defaultElementWarnings,
   isConditionalClauseNavigatorEntry,
   isRegularNavigatorEntry,
@@ -48,7 +47,6 @@ import { ItemLabel } from './item-label'
 import { LayoutIcon } from './layout-icon'
 import { NavigatorItemActionSheet } from './navigator-item-components'
 import { assertNever } from '../../../core/shared/utils'
-import { AlwaysTrue, usePubSubAtomReadOnly } from '../../../core/shared/atom-with-pub-sub'
 
 export function getItemHeight(navigatorEntry: NavigatorEntry): number {
   if (isConditionalClauseNavigatorEntry(navigatorEntry)) {
@@ -403,8 +401,6 @@ export const NavigatorItem: React.FunctionComponent<
     getSelectedViewsInRange,
     index,
   } = props
-
-  const canvasSize = usePubSubAtomReadOnly(CanvasSizeAtom, AlwaysTrue)
 
   const colorTheme = useColorTheme()
   const isFocusedComponent = useEditorState(

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -31,6 +31,7 @@ import { EditorAction, EditorDispatch } from '../../editor/action-types'
 import * as EditorActions from '../../editor/actions/action-creators'
 import * as MetaActions from '../../editor/actions/meta-actions'
 import {
+  CanvasSizeAtom,
   defaultElementWarnings,
   isConditionalClauseNavigatorEntry,
   isRegularNavigatorEntry,
@@ -47,6 +48,7 @@ import { ItemLabel } from './item-label'
 import { LayoutIcon } from './layout-icon'
 import { NavigatorItemActionSheet } from './navigator-item-components'
 import { assertNever } from '../../../core/shared/utils'
+import { AlwaysTrue, usePubSubAtomReadOnly } from '../../../core/shared/atom-with-pub-sub'
 
 export function getItemHeight(navigatorEntry: NavigatorEntry): number {
   if (isConditionalClauseNavigatorEntry(navigatorEntry)) {
@@ -401,6 +403,8 @@ export const NavigatorItem: React.FunctionComponent<
     getSelectedViewsInRange,
     index,
   } = props
+
+  const canvasSize = usePubSubAtomReadOnly(CanvasSizeAtom, AlwaysTrue)
 
   const colorTheme = useColorTheme()
   const isFocusedComponent = useEditorState(

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -103,6 +103,8 @@ import { UtopiaStyles } from '../uuiui'
 import { DropHandlers } from './image-drop'
 import { EditorCommon } from '../components/editor/editor-component-common'
 import { CursorComponent } from '../components/canvas/controls/select-mode/cursor-component'
+import * as ResizeObserverSyntheticDefault from 'resize-observer-polyfill'
+const ResizeObserver = ResizeObserverSyntheticDefault.default ?? ResizeObserverSyntheticDefault
 
 const webFrame = PROBABLY_ELECTRON ? requireElectron().webFrame : null
 
@@ -782,7 +784,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
       this.canvasWrapperRef.addEventListener('wheel', this.suppressBrowserNavigation, {
         passive: false,
       })
-      this.resizeObserver = new ResizeObserver((entries) => {
+      this.resizeObserver = new ResizeObserver((entries: Array<ResizeObserverEntry>) => {
         if (entries.length === 0) {
           return
         } else {
@@ -793,7 +795,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
           this.props.updateCanvasSize(size)
         }
       })
-      this.resizeObserver.observe(this.canvasWrapperRef)
+      this.resizeObserver!.observe(this.canvasWrapperRef)
       this.props.updateCanvasSize(this.canvasWrapperRef.getBoundingClientRect())
     }
   }


### PR DESCRIPTION
**Problem:**
The size of the canvas is sometimes needed to calculate the visible center position, now it's only available from the editor-canvas.
There is a bug when reparenting to the storyboard using the navigator the element jumps to top: 100, left: 100.

**Fix:**
To store the canvas size this PR adds an atom, the size is updated through a resize observer.

Since the different ways of static reparenting should create the same result (navigator reparent, paste), with this change it's possible to fix positioning when reparenting in the navigator to the storyboard directly.

**Commit Details:**
- added a resize observer to `EditorCanvas` component
- use resize observer in the navigator, pass canvas size to `reorderComponents` action
- `insertWithReparentStrategies` receives the center point instead of null
