### PR TITLE
Fix/navigator can drop over itself

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -121,10 +121,6 @@ function isDroppingToOriginalPosition(
   dropTargetElementPath: ElementPath,
   draggedElementPath: ElementPath,
 ): boolean {
-  if (EP.pathsEqual(dropTargetElementPath, draggedElementPath)) {
-    return true
-  }
-
   const parentMatches = EP.pathsEqual(
     EP.parentPath(draggedElementPath),
     dropTargetHint.targetParent.elementPath,
@@ -132,6 +128,10 @@ function isDroppingToOriginalPosition(
   if (!parentMatches) {
     // bail out if not dropping into the same parent
     return false
+  }
+
+  if (EP.pathsEqual(dropTargetElementPath, draggedElementPath)) {
+    return true
   }
 
   // dropping the element before itself
@@ -539,6 +539,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
         )
       },
       drop: (item: NavigatorItemDragAndDropWrapperProps, monitor) => {
+        let actions: Array<EditorAction> = [hideNavigatorDropTargetHint()]
         if (
           dropTargetHint != null &&
           !isDroppingToOriginalPosition(
@@ -549,8 +550,8 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
             item.elementPath,
           )
         ) {
-          props.editorDispatch(
-            onDrop(
+          actions.push(
+            ...onDrop(
               item,
               props,
               dropTargetHint.targetParent.elementPath,
@@ -559,6 +560,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
             ),
           )
         }
+        props.editorDispatch(actions)
       },
       canDrop: (item: NavigatorItemDragAndDropWrapperProps) => {
         const target = props.elementPath
@@ -592,6 +594,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
         )
       },
       drop: (item: NavigatorItemDragAndDropWrapperProps, monitor) => {
+        let actions: Array<EditorAction> = [hideNavigatorDropTargetHint()]
         if (
           dropTargetHint != null &&
           !isDroppingToOriginalPosition(
@@ -602,8 +605,8 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
             item.elementPath,
           )
         ) {
-          props.editorDispatch(
-            onDrop(
+          actions.push(
+            ...onDrop(
               item,
               props,
               dropTargetHint.targetParent.elementPath,
@@ -612,6 +615,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
             ),
           )
         }
+        props.editorDispatch(actions)
       },
       canDrop: (item: NavigatorItemDragAndDropWrapperProps) => {
         const target = props.elementPath
@@ -638,9 +642,10 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
         }
       },
       drop: (item: NavigatorItemDragAndDropWrapperProps, monitor) => {
+        let actions: Array<EditorAction> = [hideNavigatorDropTargetHint()]
         if (monitor.canDrop() && dropTargetHint != null) {
-          props.editorDispatch(
-            onDrop(
+          actions.push(
+            ...onDrop(
               item,
               props,
               dropTargetHint.targetParent.elementPath,
@@ -649,6 +654,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
             ),
           )
         }
+        props.editorDispatch(actions)
       },
       canDrop: (item: NavigatorItemDragAndDropWrapperProps) => {
         return canDropInto(editorStateRef.current, props.elementPath)
@@ -829,6 +835,7 @@ export const SyntheticNavigatorItemContainer = React.memo(
           props.editorDispatch([
             ...onDrop(item, props, props.elementPath, front(), canvasSize),
             ...maybeSetConditionalOverrideOnDrop(props.elementPath, jsxMetadata, spyMetadata),
+            hideNavigatorDropTargetHint(),
           ])
         },
         canDrop: () => {

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -1378,6 +1378,136 @@ describe('Navigator', () => {
       ])
     })
 
+    it('reparents to storyboard from the last sibling', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        getProjectCode(),
+        'await-first-dom-report',
+      )
+
+      const dragMeElement = await renderResult.renderedDOM.findByTestId(
+        `navigator-item-regular_utopia_storyboard_uid/scene_aaa/sceneroot/dragme`,
+      )
+      const dragMeElementRect = dragMeElement.getBoundingClientRect()
+      const dragMeElementCenter = getDomRectCenter(dragMeElementRect)
+
+      const targetElement = EP.fromString('utopia-storyboard-uid/scene-aaa/sceneroot/dragme')
+      await act(async () => {
+        const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+        await renderResult.dispatch([selectComponents([targetElement], false)], false)
+        await dispatchDone
+      })
+      await act(async () =>
+        dragElement(
+          renderResult,
+          `navigator-item-drag-regular_utopia_storyboard_uid/scene_aaa/sceneroot/dragme`,
+          `navigator-item-drop-after-regular_utopia_storyboard_uid/scene_aaa/parentsibling`,
+          windowPoint(dragMeElementCenter),
+          windowPoint({ x: -92, y: -35 }),
+          'apply-hover-events',
+          async () => {
+            expect(renderResult.getEditorState().editor.navigator.dropTargetHint?.type).toEqual(
+              'after',
+            )
+
+            // drop target line is shown in original location
+            const dropTarget = renderResult.renderedDOM.getByTestId(
+              `navigator-item-drop-after-regular_utopia_storyboard_uid/scene_aaa/parentsibling`,
+            )
+            expect(dropTarget.style.opacity).toEqual('1')
+          },
+        ),
+      )
+
+      await renderResult.getDispatchFollowUpActionsFinished()
+
+      expect(
+        renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey),
+      ).toEqual([
+        'regular-utopia-storyboard-uid/scene-aaa',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/firstdiv',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/seconddiv',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/thirddiv',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/notdrag',
+        'regular-utopia-storyboard-uid/scene-aaa/parentsibling',
+        'regular-utopia-storyboard-uid/dragme',
+      ])
+
+      expect(renderResult.getEditorState().editor.selectedViews).toEqual([
+        EP.fromString('utopia-storyboard-uid/dragme'),
+      ])
+      expect(
+        renderResult.getEditorState().editor.jsxMetadata['utopia-storyboard-uid/dragme']
+          ?.globalFrame,
+      ).toEqual({ height: 65, width: 66, x: 558, y: 386.5 })
+      expect(renderResult.getEditorState().editor.navigator.dropTargetHint).toEqual(null)
+    })
+
+    it('reparents the last element to storyboard', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        getProjectCode(),
+        'await-first-dom-report',
+      )
+
+      const dragMeElement = await renderResult.renderedDOM.findByTestId(
+        `navigator-item-regular_utopia_storyboard_uid/scene_aaa/parentsibling`,
+      )
+      const dragMeElementRect = dragMeElement.getBoundingClientRect()
+      const dragMeElementCenter = getDomRectCenter(dragMeElementRect)
+
+      const targetElement = EP.fromString('utopia-storyboard-uid/scene-aaa/parentsibling')
+      await act(async () => {
+        const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+        await renderResult.dispatch([selectComponents([targetElement], false)], false)
+        await dispatchDone
+      })
+      await act(async () =>
+        dragElement(
+          renderResult,
+          `navigator-item-drag-regular_utopia_storyboard_uid/scene_aaa/parentsibling`,
+          `navigator-item-drop-after-regular_utopia_storyboard_uid/scene_aaa/parentsibling`,
+          windowPoint(dragMeElementCenter),
+          windowPoint({ x: -32, y: 0 }),
+          'apply-hover-events',
+          async () => {
+            expect(renderResult.getEditorState().editor.navigator.dropTargetHint?.type).toEqual(
+              'after',
+            )
+
+            // drop target line is shown in original location
+            const dropTarget = renderResult.renderedDOM.getByTestId(
+              `navigator-item-drop-after-regular_utopia_storyboard_uid/scene_aaa/parentsibling`,
+            )
+            expect(dropTarget.style.opacity).toEqual('1')
+          },
+        ),
+      )
+
+      await renderResult.getDispatchFollowUpActionsFinished()
+
+      expect(
+        renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey),
+      ).toEqual([
+        'regular-utopia-storyboard-uid/scene-aaa',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/firstdiv',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/seconddiv',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/thirddiv',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/dragme',
+        'regular-utopia-storyboard-uid/scene-aaa/sceneroot/notdrag',
+        'regular-utopia-storyboard-uid/parentsibling',
+      ])
+
+      expect(renderResult.getEditorState().editor.selectedViews).toEqual([
+        EP.fromString('utopia-storyboard-uid/parentsibling'),
+      ])
+      expect(
+        renderResult.getEditorState().editor.jsxMetadata['utopia-storyboard-uid/parentsibling']
+          ?.globalFrame,
+      ).toEqual({ height: 200, width: 400, x: 391, y: 319 })
+      expect(renderResult.getEditorState().editor.navigator.dropTargetHint).toEqual(null)
+    })
+
     it('attempt to reparent non-reparentable item', async () => {
       const renderResult = await renderTestEditorWithCode(
         getProjectCode(),


### PR DESCRIPTION
**Problem:**
There is a bug when dragging and dropping the last element in the navigator over itself with dragged to the left targeting a grandparent or the storyboard.

**Fix:**
Fixing `isDroppingToOriginalPosition` to return false when the target parent is not the current parent.
Always clean droptargets in the editor model after dropping.

**Commit Details:**
- fixes in `navigator-item-dnd-container`
- test for this bug + one extra test for reparenting a different element to the storyboard 
