### PR TITLE
fix(navigator) disable reparenting a root div

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -461,10 +461,12 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
       end: () => updateDragSessionInProgress(false),
       canDrag: () => {
         const editorState = editorStateRef.current
-        return isAllowedToReparent(
-          editorState.projectContents,
-          editorState.jsxMetadata,
-          props.elementPath,
+        return (
+          isAllowedToReparent(
+            editorState.projectContents,
+            editorState.jsxMetadata,
+            props.elementPath,
+          ) && !EP.isRootElementOfInstance(props.elementPath)
         )
       },
     }),


### PR DESCRIPTION
**Problem:**
When trying to reparent a root div in the navigator we throw errors. On the canvas when dragging a root div it's not possible to reparent it.

**Fix:**
Disable dragging root elements in the navigator.

**Commit Details:**
- update `canDrag` for navigator items to return false on root elements
