### PR TITLE
Fix fragment wrapping edge cases

### DIFF
--- a/editor/src/core/model/element-template-utils.spec.tsx
+++ b/editor/src/core/model/element-template-utils.spec.tsx
@@ -1289,7 +1289,7 @@ describe('insertJSXElementChild', () => {
           (
             "hello"
           ) : (
-            "world"
+            <span>"world"</span>
           )
         }
         <div data-uid='child-d' />
@@ -1379,6 +1379,49 @@ describe('insertJSXElementChild', () => {
     ])
   })
 
+  it("inserting into the conditional's true branch is working with replace behavior when branch is empty", () => {
+    const { components, projectContents } = createTestComponentsForSnippet(`
+    <div style={{ ...props.style }} data-uid='aaa'>
+      <div data-uid='parent' >
+        <div data-uid='child-a' />
+        <div data-uid='child-b' />
+        {
+          // @utopia/uid=child-c
+          true ? 
+          (
+            null
+          ) : (
+            <span>"world"</span>
+          )
+        }
+        <div data-uid='child-d' />
+      </div>
+    </div>
+    `)
+
+    const withInsertedElement = insertJSXElementChild(
+      projectContents,
+      conditionalClauseInsertionPath(
+        EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c'),
+        'true-case',
+        'replace',
+      ),
+      jsxElement('div', 'hello', [], []),
+      components,
+      null,
+    )
+
+    expectElementAtPathHasMatchingUIDForPaths(withInsertedElement.components, [
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-b',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/hello', // <- the inserted element!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-d',
+    ])
+  })
+
   it("inserting into the conditional's true branch is working with wrap into fragment behavior", () => {
     const { components, projectContents } = createTestComponentsForSnippet(`
     <div style={{ ...props.style }} data-uid='aaa'>
@@ -1425,12 +1468,56 @@ describe('insertJSXElementChild', () => {
     ])
   })
 
-  it("inserting into the conditional's false branch is working with replace behavior", () => {
+  it("inserting into the conditional's true branch is working with wrap into fragment behavior when branch is empty", () => {
     const { components, projectContents } = createTestComponentsForSnippet(`
     <div style={{ ...props.style }} data-uid='aaa'>
       <div data-uid='parent' >
         <div data-uid='child-a' />
         <div data-uid='child-b' />
+        {
+          // @utopia/uid=child-c
+          true ? 
+          (
+            null
+          ) : (
+            <div>"world"</div>
+          )
+        }
+        <div data-uid='child-d' />
+      </div>
+    </div>
+    `)
+
+    FOR_TESTS_setNextGeneratedUid('fragment')
+    const withInsertedElement = insertJSXElementChild(
+      projectContents,
+      conditionalClauseInsertionPath(
+        EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c'),
+        'true-case',
+        'wrap-with-fragment',
+      ),
+      jsxElement('div', 'hello', [], []),
+      components,
+      null,
+    )
+
+    expectElementAtPathHasMatchingUIDForPaths(withInsertedElement.components, [
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-b',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/hello', // <- the inserted element, no fragment was needed because the branch was empty
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-d',
+    ])
+  })
+
+  it("inserting into the conditional's false branch is working with replace behavior", () => {
+    const { components, projectContents } = createTestComponentsForSnippet(`
+      <div style={{ ...props.style }} data-uid='aaa'>
+        <div data-uid='parent' >
+          <div data-uid='child-a' />
+          <div data-uid='child-b' />
         {
           // @utopia/uid=child-c
           true ? 
@@ -1467,6 +1554,50 @@ describe('insertJSXElementChild', () => {
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-d',
     ])
   })
+
+  it("inserting into the conditional's false branch is working with replace behavior when branch is empty", () => {
+    const { components, projectContents } = createTestComponentsForSnippet(`
+      <div style={{ ...props.style }} data-uid='aaa'>
+        <div data-uid='parent' >
+          <div data-uid='child-a' />
+          <div data-uid='child-b' />
+        {
+          // @utopia/uid=child-c
+          true ? 
+          (
+            <span>"world-will be deleted"</span>
+          ) : (
+            null
+          )
+        }
+        <div data-uid='child-d' />
+      </div>
+    </div>
+    `)
+
+    const withInsertedElement = insertJSXElementChild(
+      projectContents,
+      conditionalClauseInsertionPath(
+        EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c'),
+        'false-case',
+        'replace',
+      ),
+      jsxElement('div', 'hello', [], []),
+      components,
+      null,
+    )
+
+    expectElementAtPathHasMatchingUIDForPaths(withInsertedElement.components, [
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-b',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/hello', // <- the inserted element!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-d',
+    ])
+  })
+
   it("inserting into the conditional's false branch is working with wrap into fragment behavior", () => {
     const { components, projectContents } = createTestComponentsForSnippet(`
     <div style={{ ...props.style }} data-uid='aaa'>
@@ -1508,6 +1639,49 @@ describe('insertJSXElementChild', () => {
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/fragment/', // <- the new fragment!
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/fragment/hello', // <- the inserted hello!
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/fragment/831', // <- the original world!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-d',
+    ])
+  })
+  it("inserting into the conditional's false branch is working with wrap into fragment behavior when branch is empty", () => {
+    const { components, projectContents } = createTestComponentsForSnippet(`
+    <div style={{ ...props.style }} data-uid='aaa'>
+      <div data-uid='parent' >
+        <div data-uid='child-a' />
+        <div data-uid='child-b' />
+        {
+          // @utopia/uid=child-c
+          true ? 
+          (
+            <div>"hello"</div>
+          ) : (
+            null
+          )
+        }
+        <div data-uid='child-d' />
+      </div>
+    </div>
+    `)
+
+    FOR_TESTS_setNextGeneratedUid('fragment')
+    const withInsertedElement = insertJSXElementChild(
+      projectContents,
+      conditionalClauseInsertionPath(
+        EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c'),
+        'false-case',
+        'wrap-with-fragment',
+      ),
+      jsxElement('div', 'hello', [], []),
+      components,
+      null,
+    )
+
+    expectElementAtPathHasMatchingUIDForPaths(withInsertedElement.components, [
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-b',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/hello', // <- the inserted element, no fragment was needed because the branch was empty
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-d',
     ])
   })

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -3,7 +3,7 @@ import {
   ProjectContentTreeRoot,
   walkContentsTreeForParseSuccess,
 } from '../../components/assets'
-import Utils, { addToArrayAtIndexPosition, IndexPosition } from '../../utils/utils'
+import Utils, { addToArrayAtIndexPosition, front, IndexPosition } from '../../utils/utils'
 import {
   ElementsWithin,
   isJSExpressionOtherJavaScript,
@@ -518,7 +518,15 @@ export function insertJSXElementChild(
             return elementToInsert
           }
           if (isJSXFragment(clauseValue)) {
-            return parentElement
+            return jsxFragment(
+              clauseValue.uid,
+              addToArrayAtIndexPosition(
+                elementToInsert,
+                clauseValue.children,
+                indexPosition ?? front(),
+              ),
+              true,
+            )
           } else {
             // for wrapping multiple elements
             importsToAdd = {
@@ -531,7 +539,7 @@ export function insertJSXElementChild(
 
             return jsxFragment(
               generateUidWithExistingComponents(projectContents),
-              [elementToInsert, clauseValue],
+              addToArrayAtIndexPosition(elementToInsert, [clauseValue], indexPosition ?? front()),
               true,
             )
           }

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -511,6 +511,7 @@ export function insertJSXElementChild(
       return modify(
         toClauseOptic,
         (clauseValue) => {
+          // console.log('clauseValue', clauseValue)
           if (targetParent.insertBehavior === 'replace') {
             return elementToInsert
           }

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -517,32 +517,19 @@ export function insertJSXElementChild(
           if (isNullJSXAttributeValue(clauseValue)) {
             return elementToInsert
           }
-          if (isJSXFragment(clauseValue)) {
-            return jsxFragment(
-              clauseValue.uid,
-              addToArrayAtIndexPosition(
-                elementToInsert,
-                clauseValue.children,
-                indexPosition ?? front(),
-              ),
-              true,
-            )
-          } else {
-            // for wrapping multiple elements
-            importsToAdd = {
-              react: {
-                importedAs: 'React',
-                importedFromWithin: [],
-                importedWithName: null,
-              },
-            }
-
-            return jsxFragment(
-              generateUidWithExistingComponents(projectContents),
-              addToArrayAtIndexPosition(elementToInsert, [clauseValue], indexPosition ?? front()),
-              true,
-            )
+          importsToAdd = {
+            react: {
+              importedAs: 'React',
+              importedFromWithin: [],
+              importedWithName: null,
+            },
           }
+
+          return jsxFragment(
+            generateUidWithExistingComponents(projectContents),
+            [elementToInsert, clauseValue],
+            true,
+          )
         },
         parentElement,
       )

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -511,7 +511,6 @@ export function insertJSXElementChild(
       return modify(
         toClauseOptic,
         (clauseValue) => {
-          // console.log('clauseValue', clauseValue)
           if (targetParent.insertBehavior === 'replace') {
             return elementToInsert
           }


### PR DESCRIPTION
**Description**

The new `InsertionPath` based `insertJSXElementChild` API had a bug: when it was called with the `wrap-with-fragment` option and the existing element in the clause was a fragment itself, it did not insert anything.

We decided that this low-level API itself should not behave differently when there is already a fragment there, and just wrap the inserted content into a fragment anyway.
Later we can probably remove the whole `wrap-to-fragment` option, because it is better and more flexible if it is decided on the caller's side how to handle existing and multiple elements.

The bug was possible because there were no tests coverage for the problematic lines. I added some new tests to increase the test coverage to 100%.