### PR TITLE
Refactoring findFirstParentWithValidElementPath

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
@@ -649,6 +649,68 @@ describe('Select Mode Double Clicking With Fragments', () => {
     checkFocusedPath(renderResult, desiredPaths[1])
     checkSelectedPaths(renderResult, [desiredPaths[3]])
   })
+  // This test fails because there is a generated component there with a root fragment, which case is not supported
+  // See comments in function firstAncestorOrItselfWithValidElementPath
+  xit('Single click and four double clicks will focus a generated Card with a root fragment and select the Button inside', async () => {
+    // prettier-ignore
+    const desiredPaths = createConsecutivePaths(
+      'sb' +                  // Skipped as it's the storyboard
+      '/scene-CardList' +     // Skipped because we skip over Scenes
+      '/CardList-instance' +  // Skipped because we skip component children of Scenes
+      ':dbc' +                // Skipped because we skip over root elements
+      '/CardList-Col',        // <- Single click
+      '/CardList-Card~~~1',   // <- First *and* Second double click, as the Second is required to focus it
+      ':Card-Fragment-Root' +          // Skipped because we skip over root elements
+      '/Card-Root',           // <- Third double click
+      '/Card-Row-Buttons',    // <- Fourth double click
+      '/Card-Button-3',       // <- Fifth double clic
+    )
+
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectAlpineClimbWithCardWithRootFragment,
+      'await-first-dom-report',
+    )
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    const cardSceneRoot = renderResult.renderedDOM.getByTestId('generated-card-1')
+    const cardSceneRootBounds = cardSceneRoot.getBoundingClientRect()
+
+    const doubleClick = createDoubleClicker(
+      canvasControlsLayer,
+      cardSceneRootBounds.left + 130,
+      cardSceneRootBounds.top + 220,
+    )
+
+    await fireSingleClickEvents(
+      canvasControlsLayer,
+      cardSceneRootBounds.left + 130,
+      cardSceneRootBounds.top + 220,
+    )
+
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPaths[0]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPaths[1]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, desiredPaths[1])
+    checkSelectedPaths(renderResult, [desiredPaths[1]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, desiredPaths[1])
+    checkSelectedPaths(renderResult, [desiredPaths[2]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, desiredPaths[1])
+    checkSelectedPaths(renderResult, [desiredPaths[3]])
+
+    await doubleClick()
+    checkFocusedPath(renderResult, desiredPaths[1])
+    checkSelectedPaths(renderResult, [desiredPaths[4]])
+  })
 })
 
 describe('Selection with locked elements', () => {
@@ -1488,6 +1550,397 @@ export const Card = (props) => (
       <Button data-uid="Card-Button-3">Button</Button>
     </Row>
   </div>
+);
+
+export const FlexRow = styled.div({
+  display: "flex",
+  alignItems: "center",
+});
+
+export const Row = styled(FlexRow)({});
+export const UIRow = styled.div({
+  minHeight: 34,
+  paddingLeft: 8,
+  paddingRight: 8,
+  display: "flex",
+  alignItems: "center",
+});
+
+export const UIListRow = styled(UIRow)({
+  height: 27,
+  minHeight: "initial",
+  "&:hover": {
+    color: "white",
+    background: "#007AFF",
+  },
+});
+export const UIListGridRow = styled(UIRow)({
+  height: 27,
+  minHeight: "initial",
+  display: "grid",
+  gridTemplateColumns: "28px 1fr",
+  minHeight: "initial",
+  "&:hover": {
+    color: "white",
+    background: "#007AFF",
+  },
+});
+
+export const UIContextMenuRow = styled(UIRow)({
+  height: 22,
+  borderRadius: 2,
+  minHeight: "initial",
+  display: "grid",
+  gridTemplateColumns: "1fr auto",
+  minHeight: "initial",
+  "&:hover": {
+    color: "white",
+    background: "#007AFF",
+  },
+});
+
+export const ContextMenu = (props) => {
+  return (
+    <div
+      style={{
+        borderRadius: 4,
+        padding: 4,
+        backgroundColor: "hsl(0,0%,95%)",
+        paddingTop: 4,
+        paddingBottom: 4,
+        width: 202,
+        fontFamily: "Inter",
+        fontSize: 11,
+        fontWeight: 400,
+        boxShadow:
+          "0px 2px 7px rgb(0, 0, 0, 0.12), 0px 0px 0px 1px rgb(0, 0, 0, 0.12)",
+      }}
+      data-uid="ContextMenu-Root"
+    >
+      <UIContextMenuRow data-uid="ContextMenu-Copy">
+        <span data-uid="918">Copy</span>
+        <span style={{ color: "hsl(0,0%,60%)" }} data-uid="f49">
+          ⌘+C
+        </span>
+      </UIContextMenuRow>
+      <UIContextMenuRow data-uid="ContextMenu-Cut">
+        <span data-uid="a3e">Cut</span>
+        <span style={{ color: "hsl(0,0%,60%)" }} data-uid="b34">
+          ⌘+X
+        </span>
+      </UIContextMenuRow>
+      <UIContextMenuRow data-uid="ContextMenu-Paste">
+        <span data-uid="09d">Paste</span>
+        <span style={{ color: "hsl(0,0%,60%)" }} data-uid="706">
+          ⌘+V
+        </span>
+      </UIContextMenuRow>
+      <UIContextMenuRow data-uid="ContextMenu-">
+        <span data-uid="821">Paste</span>
+        <span style={{ color: "hsl(0,0%,60%)" }} data-uid="46d">
+          ⌘+V
+        </span>
+      </UIContextMenuRow>
+      <hr
+        style={{
+          color: "yello",
+          background: "purple",
+          stroke: "grey",
+          backgroundColor: "/*rgb(128, 0, 128, 1)*/",
+          border: "0.5px solid rgb(255, 20, 20, 1)",
+          height: 1,
+        }}
+        data-uid="ContextMenu-hr"
+      />
+      <UIContextMenuRow data-uid="ContextMenu-Backward">
+        <span data-uid="ab9">Bring Backward</span>
+        <span style={{ color: "hsl(0,0%,60%)" }} data-uid="c2b">
+          ⌘+V
+        </span>
+      </UIContextMenuRow>
+      <UIContextMenuRow data-uid="ContextMenu-Forward">
+        <span data-uid="cb2">Bring Forward</span>
+        <span style={{ color: "hsl(0,0%,60%)" }} data-uid="07c">
+          ⌘+V
+        </span>
+      </UIContextMenuRow>
+    </div>
+  );
+};
+
+export var App = (props) => {
+  return (
+    <div
+      style={{
+        padding: 20,
+        width: "100%",
+        height: "100%",
+        backgroundColor: "#FFFFFF",
+        position: "relative",
+        fontFamily: "Inter",
+        fontSize: 11,
+        fontWeight: 400,
+        WebkitTextRendering: "subpixel-antialiased",
+      }}
+      data-uid="App-root"
+    >
+      <div
+        style={{
+          width: 270,
+          height: 215,
+          background: "hsl(0,0%,97%)",
+          backgroundColor: "rgb(247, 247, 247, 1)",
+          boxShadow:
+            "0px 2px 7px rgb(0, 0, 0, 0.12), 0px 0px 0px 1px rgb(0, 0, 0, 0.12)",
+          borderRadius: 3,
+        }}
+        data-uid="App-div"
+      >
+        <div
+          style={{
+            paddingLeft: 8,
+            paddingRight: 8,
+            fontFamily: "Inter",
+            fontSize: 11,
+            color: "hsl(0,0%,10%)",
+            display: "flex",
+            alignItems: "center",
+            height: 34,
+          }}
+          data-uid="App-div-div"
+        >
+          <span style={{ fontWeight: 600 }} data-uid="App-div-div-span">
+            Popup Menu
+          </span>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            paddingLeft: 8,
+            paddingRight: 8,
+          }}
+          data-uid="57e"
+        >
+          <UIListGridRow
+            style={{ gap: 8, borderRadius: 2, flexGrow: 1 }}
+            data-uid="App-Select"
+          >
+            <Row data-uid="681" />
+            <Row data-uid="04c">Select Elements</Row>
+          </UIListGridRow>
+          <UIListGridRow
+            style={{ gap: 8, borderRadius: 2, flexGrow: 1 }}
+            data-uid="App-Copy"
+          >
+            <div data-uid="2a2" />
+            <div data-uid="329">Copy</div>
+          </UIListGridRow>
+          <UIListGridRow
+            style={{ gap: 8, borderRadius: 2, flexGrow: 1 }}
+            data-uid="App-Pase"
+          >
+            <div data-uid="2ce" />
+            <div data-uid="1a3">Paste</div>
+          </UIListGridRow>
+          <UIListGridRow data-uid="App-Check">
+            <Row style={{ justifyContent: "center" }} data-uid="a1d">
+              ✓
+            </Row>
+            <Row data-uid="2d9">A little label</Row>
+          </UIListGridRow>
+          <UIListGridRow
+            style={{ gap: 8, borderRadius: 2, flexGrow: 1 }}
+            data-uid="App-Magic"
+          >
+            <div data-uid="765" />
+            <div data-uid="a20">Magic</div>
+          </UIListGridRow>
+        </div>
+      </div>
+    </div>
+  );
+};
+export var storyboard = (
+  <Storyboard data-uid="sb" >
+    <Scene
+      style={{ position: "absolute", left: 0, top: 0, width: 313, height: 261 }}
+      data-uid="scene-App"
+    >
+      <App data-uid="App-instance" />
+    </Scene>
+    <Scene
+      data-label="Scene 1"
+      style={{
+        position: "absolute",
+        padding: 20,
+        left: 0,
+        top: 299,
+        width: 280,
+        height: 196,
+      }}
+      data-uid="scene-1"
+    >
+      <ContextMenu data-uid="ContextMenu-instance" />
+    </Scene>
+    <Scene
+      data-label="Scene 2"
+      style={{
+        position: "absolute",
+        padding: 20,
+        left: 420,
+        top: -19,
+        width: 400,
+        height: 300,
+      }}
+      data-uid="scene-2"
+    >
+      <Card data-uid="Card-instance" testid="card-scene" />
+    </Scene>
+    <Scene
+      data-label="List of Cards"
+      style={{
+        position: "absolute",
+        padding: 20,
+        left: 420,
+        top: 350,
+        width: 500,
+        height: 400,
+      }}
+      data-uid="scene-CardList"
+    >
+      <CardList data-uid="CardList-instance" />
+    </Scene>
+    <Scene
+      data-label="Card component out of place for focus mode"
+      style={{
+        position: "absolute",
+        padding: 20,
+        left: 1060,
+        top: -31,
+        width: 500,
+        height: 400,
+      }}
+      data-uid="scene-ManualCardList"
+    >
+      <ManualCardList data-uid="ManualCardList-uid" />
+    </Scene>
+  </Storyboard>
+);
+`
+
+const TestProjectAlpineClimbWithCardWithRootFragment = `
+import * as React from "react";
+import { Scene, Storyboard } from "utopia-api";
+import styled from "@emotion/styled";
+
+export const Col = (props) => (
+  <div
+    style={{
+      display: "flex",
+      flexDirection: "column",
+      gap: 34,
+      padding: 12,
+      alignItems: "stretch",
+      backgroundColor: "yellow",
+    }}
+    data-uid="Col-Root"
+  >
+    {props.children}
+  </div>
+);
+
+export const LabelRow = (props) => (
+  <div
+    style={{
+      color: "white",
+      display: "flex",
+      alignItems: "center",
+      fontFamily: "sans-serif",
+      backdropFilter: "blur(6px) brightness(120%)",
+      paddingLeft: 12,
+      paddingRight: 12,
+      position: "absolute",
+      bottom: 0,
+      left: 0,
+      height: 34,
+      right: 0,
+    }}
+    data-uid="LabelRow-Root"
+  >
+    <div style={{ flex: "1 0 150px" }} data-uid="LabelRow-div">
+      Beautiful Hackney Street Arrrrt
+    </div>
+    <Button data-uid="LabelRow-Button">Hello</Button>
+  </div>
+);
+
+export const Button = styled.button({
+  minWidth: 40,
+  minHeight: 22,
+  boxShadow: "1px 1px 0px 1px black",
+  backgroundColor: "#00FFAA",
+  color: "black",
+});
+
+export const CardList = (props) => {
+  cards = [1, 2, 3, 4, 5];
+
+  return (
+    <>
+      <h2 data-uid="CardList-h2">List of available street art</h2>
+      <Col data-uid="CardList-Col">
+        {cards.map((card) => (
+          <Card data-uid="CardList-Card" testid={'generated-card-'+ card} />
+        ))}
+      </Col>
+    </>
+  );
+};
+
+export const ManualCardList = (props) => {
+  return (
+    <>
+      <h2 data-uid="ManualCardList-h2">List of available street art</h2>
+      <Col data-uid="ManualCardList-Col">
+        <Card data-uid="ManualCardList-Card-1" />
+        <Card data-uid="ManualCardList-Card-2" />
+      </Col>
+    </>
+  );
+};
+
+export const Card = (props) => (
+  <React.Fragment data-uid="Card-Fragment-Root">
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: 364,
+        height: 250,
+        backgroundColor: "hsl(0,0%,95%)",
+        boxShadow: "0px 0px 0px 1px black",
+      }}
+      data-testid={props.testid}
+      data-uid="Card-Root"
+    >
+      <Row
+        style={{ minHeight: 200, position: "relative", overflow: "hidden" }}
+        data-uid="Card-Row"
+      >
+        <img
+          src="https://www.hackneycitizen.co.uk/wp-content/uploads/nerone-1-620.jpg"
+          data-uid="Card-img"
+        />
+        <LabelRow data-uid="Card-LabelRow" />
+      </Row>
+      <Row style={{ minHeight: 40, gap: 12 }} data-uid="Card-Row-Buttons">
+        <Button data-uid="Card-Button-1">Hello</Button>
+        <Button data-uid="Card-Button-2">Button</Button>
+        <Button data-uid="Card-Button-3">Button</Button>
+      </Row>
+    </div>
+  </React.Fragment>
 );
 
 export const FlexRow = styled.div({

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -50,7 +50,11 @@ export function findParentSceneValidPaths(
   }
 }
 
-function getStaticAndDynamicElementPathsForDomElement(target: Element) {
+function getStaticAndDynamicElementPathsForDomElement(target: Element): {
+  static: string
+  staticPath: ElementPath
+  dynamic: ElementPath
+}[] {
   const dynamicElementPaths = getPathsOnDomElement(target)
   return dynamicElementPaths.map((p) => {
     return {
@@ -118,35 +122,20 @@ export function findFirstParentWithValidElementPath(
       }
     }
 
-    const findValidPathInDom = (
-      staticAndDynamicPaths: {
-        static: string
-        staticPath: ElementPath
-        dynamic: ElementPath
-      }[],
-      t: Element,
-    ): ElementPath | null => {
-      const pathToAdd = staticAndDynamicPaths.find(
+    let currentElement: Element | null = target
+    while (currentElement != null) {
+      const paths = getStaticAndDynamicElementPathsForDomElement(currentElement)
+
+      const pathToAdd = paths.find(
         (staticAndDynamic) => staticAndDynamic.static === validPath,
       )?.dynamic
-      if (pathToAdd != null) {
-        if (maxDepth < EP.fullDepth(pathToAdd)) {
-          maxDepth = EP.fullDepth(pathToAdd)
-          return pathToAdd
-        }
+
+      if (pathToAdd != null && maxDepth < EP.fullDepth(pathToAdd)) {
+        maxDepth = EP.fullDepth(pathToAdd)
+        resultPath = pathToAdd
       }
-      const parentElement = t.parentElement
-      if (parentElement != null) {
-        return findValidPathInDom(
-          getStaticAndDynamicElementPathsForDomElement(parentElement),
-          parentElement,
-        )
-      }
-      return null
-    }
-    const domResult = findValidPathInDom(staticAndDynamicTargetElementPaths, target)
-    if (domResult != null) {
-      resultPath = domResult
+
+      currentElement = currentElement.parentElement
     }
   }
 

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -96,8 +96,8 @@ function getValidStaticElementPathsForDomElement(
   return validStaticElementPaths
 }
 
-// Take a DOM element, and try to find the nearest selectable path for it
-export function findFirstParentWithValidElementPath(
+// Take a DOM element, return that if it has a valid element path, or find the closest ancestor with a valid path
+export function firstAncestorOrItselfWithValidElementPath(
   validDynamicElementPathsForLookup: Set<string> | 'no-filter',
   target: Element,
   parentSceneValidPathsCache: FindParentSceneValidPathsCache,
@@ -204,7 +204,7 @@ function findFirstValidParentForSingleElementUncached(
           validElementPathsForLookup.map((path) => EP.toString(EP.makeLastPartOfPathStatic(path))),
         )
   for (const element of elementsUnderPoint) {
-    const foundValidElementPath = findFirstParentWithValidElementPath(
+    const foundValidElementPath = firstAncestorOrItselfWithValidElementPath(
       validPathsSet,
       element,
       parentSceneValidPathsCache,
@@ -233,7 +233,7 @@ function findFirstValidParentsForAllElementsUncached(
         )
   const elementsFromDOM = stripNulls(
     elementsUnderPoint.map((element) => {
-      const foundValidElementPath = findFirstParentWithValidElementPath(
+      const foundValidElementPath = firstAncestorOrItselfWithValidElementPath(
         validPathsSet,
         element,
         parentSceneValidPathsCache,
@@ -304,7 +304,7 @@ export function getSelectionOrAllTargetsAtPoint(
         )
   const elementsFromDOM: Array<ElementPath> = []
   for (const element of elementsUnderPoint) {
-    const foundValidElementPath = findFirstParentWithValidElementPath(
+    const foundValidElementPath = firstAncestorOrItselfWithValidElementPath(
       validPathsSet,
       element,
       parentSceneValidPathsCache,

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -120,6 +120,10 @@ export function firstAncestorOrItselfWithValidElementPath(
     // 1. Go through all element paths from DOM and find the closest ancestor of the static paths which are also a valid path.
     // When this ancestor is found, get the dynamic element path version of the static path, and step upwards
     // the same number of steps in the hierarchy from there: this dynamic path can be the a valid target.
+    // Why is this necessary?
+    // When a component has a root fragment, than neither the component, nor the root fragment is available in the dom.
+    // So without this search it would be not possible to double click into that component.
+    // This would make all tests in the describe block 'Select Mode Double Clicking With Fragments' in select-mode.spec.browser2.tsx fail.
     for (const staticAndDynamic of staticAndDynamicTargetElementPaths) {
       if (EP.isDescendantOfOrEqualTo(staticAndDynamic.staticPath, validPathFromString)) {
         const depthDiff =
@@ -134,7 +138,10 @@ export function firstAncestorOrItselfWithValidElementPath(
 
     // 2. Start to traverse the DOM elements upwards in the hierarchy.
     // When we find an element which is attached to a static path which is also in the valid path list,
-    // the dynamic version of that path is a valid target
+    // the dynamic version of that path is a valid target.
+    // This search is necessary so we can find generated components and focus in them.
+    // So without this search the 'Single click and four double clicks will focus a generated Card' and the
+    // 'Single click and four double clicks will focus a generated Card and select the Button inside' tests would fail
     let currentElement: Element | null = target
     let deeperResultPossible = true
     while (currentElement != null && deeperResultPossible) {
@@ -153,6 +160,9 @@ export function firstAncestorOrItselfWithValidElementPath(
         }
       }
 
+      // IMPORTANT: Neither algorithm 1 or 2 can find the contents of generated components which root fragments.
+      // See disabled test which fails today:
+      // 'Single click and four double clicks will focus a generated Card with a root fragment and select the Button inside'
       currentElement = currentElement.parentElement
     }
   }

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -136,16 +136,21 @@ export function firstAncestorOrItselfWithValidElementPath(
     // When we find an element which is attached to a static path which is also in the valid path list,
     // the dynamic version of that path is a valid target
     let currentElement: Element | null = target
-    while (currentElement != null) {
+    let deeperResultPossible = true
+    while (currentElement != null && deeperResultPossible) {
       const paths = getStaticAndDynamicElementPathsForDomElement(currentElement)
 
       const pathToAdd = paths.find(
         (staticAndDynamic) => staticAndDynamic.static === validPath,
       )?.dynamic
 
-      if (pathToAdd != null && maxDepth < EP.fullDepth(pathToAdd)) {
-        maxDepth = EP.fullDepth(pathToAdd)
-        resultPath = pathToAdd
+      if (pathToAdd != null) {
+        if (maxDepth > EP.fullDepth(pathToAdd)) {
+          deeperResultPossible = false
+        } else {
+          maxDepth = EP.fullDepth(pathToAdd)
+          resultPath = pathToAdd
+        }
       }
 
       currentElement = currentElement.parentElement

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -124,9 +124,10 @@ export function findFirstParentWithValidElementPath(
       if (EP.isDescendantOfOrEqualTo(staticAndDynamic.staticPath, validPathFromString)) {
         const depthDiff =
           EP.fullDepth(staticAndDynamic.staticPath) - EP.fullDepth(validPathFromString)
-        if (maxDepth < EP.fullDepth(EP.nthParentPath(staticAndDynamic.dynamic, depthDiff))) {
-          maxDepth = EP.fullDepth(EP.nthParentPath(staticAndDynamic.dynamic, depthDiff))
-          resultPath = EP.nthParentPath(staticAndDynamic.dynamic, depthDiff)
+        const pathToAdd = EP.nthParentPath(staticAndDynamic.dynamic, depthDiff)
+        if (maxDepth < EP.fullDepth(pathToAdd)) {
+          maxDepth = EP.fullDepth(pathToAdd)
+          resultPath = pathToAdd
         }
       }
     }


### PR DESCRIPTION
**Problem:**
`findFirstParentWithValidElementPath` us very hard to read and reason about.

**Why is it hard to read:**
I identified the following problems in the code:

We have two separate algorithms to find the best parent with a valid element path, and how they are mixed together is quite confusing. The `allowDescendantsFromPath` parameter describes the two cases, and the function contains a long and complex recursive search, which runs for both cases.
In both searches we collect a list of potential targets (`filteredValidPathsMappedToDynamic`), and then we choose the deepest one from these. Then in the final step we choose the deeper result from the two `allowDescendantsFromPath` runs.

These two cases can be merged quite seamlessly. Both do an iteration over the valid paths, and both do a maximum search for depth after collecting all results. It seems like both do resursive search, but in real life only the `'search-dom-only'` case is really recursive.

**My solution to clean up the code**

1. There is no reason to run the two `allowDescendantsFromPath` algorithms separately. We can just do a single iteration and for all valid path items do both searches. This means we can also omit choosing the deeper path result from the two runs, moreover, we can remove the `inner` version (`findFirstParentWithValidElementPathInner`) of the function.
2. There is no reason to collect all potential valid targets and then iterate again to choose the deepest one among them:  we can just do the maximum search simultaneously with the search itself and always store the currently deepest result in a variable.
3. There is no reason to have a recursion for the whole search, when the recursion in only needed for the `'search-dom-only'` version of the search, and only when searching for a single element path (inside the loop).
4. Even that recursion can easily be converted to an iteration.