### PR TITLE
Introspective deep call tweak.

### DIFF
--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -234,7 +234,10 @@ import {
   ElementsToRerenderKeepDeepEquality,
   PropertyPathKeepDeepEquality,
 } from '../../../utils/deep-equality-instances'
-import { createCallFromIntrospectiveKeepDeep } from '../../../utils/react-performance'
+import {
+  createCallFromIntrospectiveKeepDeep,
+  getIntrospectiveKeepDeepResult,
+} from '../../../utils/react-performance'
 import {
   TransientCanvasState,
   TransientFilesState,
@@ -510,7 +513,7 @@ export function TransientCanvasStateFilesStateKeepDeepEquality(
   oldValue: TransientFilesState,
   newValue: TransientFilesState,
 ): KeepDeepEqualityResult<TransientFilesState> {
-  return createCallFromIntrospectiveKeepDeep<TransientFilesState>()(oldValue, newValue)
+  return getIntrospectiveKeepDeepResult<TransientFilesState>(oldValue, newValue)
 }
 
 export function TransientCanvasStateKeepDeepEquality(): KeepDeepEqualityCall<TransientCanvasState> {
@@ -706,10 +709,10 @@ export const ParsedCommentsKeepDeepEqualityCall: KeepDeepEqualityCall<ParsedComm
   )
 
 export function JSXAttributeValueValueKeepDeepEqualityCall(
-  oldValue: any,
-  newValue: any,
-): KeepDeepEqualityResult<any> {
-  return createCallFromIntrospectiveKeepDeep<any>()(oldValue, newValue)
+  oldValue: unknown,
+  newValue: unknown,
+): KeepDeepEqualityResult<unknown> {
+  return getIntrospectiveKeepDeepResult<unknown>(oldValue, newValue)
 }
 
 export const JSXAttributeValueKeepDeepEqualityCall: KeepDeepEqualityCall<JSExpressionValue<any>> =
@@ -2819,14 +2822,14 @@ export function ErrorKeepDeepEquality(
   oldValue: Error,
   newValue: Error,
 ): KeepDeepEqualityResult<Error> {
-  return createCallFromIntrospectiveKeepDeep<Error>()(oldValue, newValue)
+  return getIntrospectiveKeepDeepResult<Error>(oldValue, newValue)
 }
 
 export function FileEvaluationCacheExportsKeepDeepEquality(
   oldValue: any,
   newValue: any,
 ): KeepDeepEqualityResult<any> {
-  return createCallFromIntrospectiveKeepDeep<any>()(oldValue, newValue)
+  return getIntrospectiveKeepDeepResult<any>(oldValue, newValue)
 }
 
 export const FileEvaluationCacheKeepDeepEquality: KeepDeepEqualityCall<FileEvaluationCache> =
@@ -2890,7 +2893,7 @@ export function PropertyControlsKeepDeepEquality(
   oldValue: PropertyControls,
   newValue: PropertyControls,
 ): KeepDeepEqualityResult<PropertyControls> {
-  return createCallFromIntrospectiveKeepDeep<PropertyControls>()(oldValue, newValue) // Do these lazily for now.
+  return getIntrospectiveKeepDeepResult<PropertyControls>(oldValue, newValue) // Do these lazily for now.
 }
 
 export const ComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<ComponentDescriptor> =
@@ -3374,56 +3377,56 @@ export function CSSColorKeepDeepEquality(
   oldValue: CSSColor,
   newValue: CSSColor,
 ): KeepDeepEqualityResult<CSSColor> {
-  return createCallFromIntrospectiveKeepDeep<CSSColor>()(oldValue, newValue)
+  return getIntrospectiveKeepDeepResult<CSSColor>(oldValue, newValue)
 }
 
 export function CSSFontFamilyKeepDeepEquality(
   oldValue: CSSFontFamily,
   newValue: CSSFontFamily,
 ): KeepDeepEqualityResult<CSSFontFamily> {
-  return createCallFromIntrospectiveKeepDeep<CSSFontFamily>()(oldValue, newValue)
+  return getIntrospectiveKeepDeepResult<CSSFontFamily>(oldValue, newValue)
 }
 
 export function CSSFontWeightAndStyleKeepDeepEquality(
   oldValue: CSSFontWeightAndStyle,
   newValue: CSSFontWeightAndStyle,
 ): KeepDeepEqualityResult<CSSFontWeightAndStyle> {
-  return createCallFromIntrospectiveKeepDeep<CSSFontWeightAndStyle>()(oldValue, newValue)
+  return getIntrospectiveKeepDeepResult<CSSFontWeightAndStyle>(oldValue, newValue)
 }
 
 export function CSSFontSizeKeepDeepEquality(
   oldValue: CSSFontSize,
   newValue: CSSFontSize,
 ): KeepDeepEqualityResult<CSSFontSize> {
-  return createCallFromIntrospectiveKeepDeep<CSSFontSize>()(oldValue, newValue)
+  return getIntrospectiveKeepDeepResult<CSSFontSize>(oldValue, newValue)
 }
 
 export function CSSTextAlignKeepDeepEquality(
   oldValue: CSSTextAlign,
   newValue: CSSTextAlign,
 ): KeepDeepEqualityResult<CSSTextAlign> {
-  return createCallFromIntrospectiveKeepDeep<CSSTextAlign>()(oldValue, newValue)
+  return getIntrospectiveKeepDeepResult<CSSTextAlign>(oldValue, newValue)
 }
 
 export function CSSTextDecorationLineKeepDeepEquality(
   oldValue: CSSTextDecorationLine,
   newValue: CSSTextDecorationLine,
 ): KeepDeepEqualityResult<CSSTextDecorationLine> {
-  return createCallFromIntrospectiveKeepDeep<CSSTextDecorationLine>()(oldValue, newValue)
+  return getIntrospectiveKeepDeepResult<CSSTextDecorationLine>(oldValue, newValue)
 }
 
 export function CSSLetterSpacingKeepDeepEquality(
   oldValue: CSSLetterSpacing,
   newValue: CSSLetterSpacing,
 ): KeepDeepEqualityResult<CSSLetterSpacing> {
-  return createCallFromIntrospectiveKeepDeep<CSSLetterSpacing>()(oldValue, newValue)
+  return getIntrospectiveKeepDeepResult<CSSLetterSpacing>(oldValue, newValue)
 }
 
 export function CSSLineHeightKeepDeepEquality(
   oldValue: CSSLineHeight,
   newValue: CSSLineHeight,
 ): KeepDeepEqualityResult<CSSLineHeight> {
-  return createCallFromIntrospectiveKeepDeep<CSSLineHeight>()(oldValue, newValue)
+  return getIntrospectiveKeepDeepResult<CSSLineHeight>(oldValue, newValue)
 }
 
 export const FontSettingsKeepDeepEquality: KeepDeepEqualityCall<FontSettings> =
@@ -3834,7 +3837,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     oldValue.keysPressed,
     newValue.keysPressed,
   )
-  const mouseButtonsPressedResult = createCallFromIntrospectiveKeepDeep<MouseButtonsPressed>()(
+  const mouseButtonsPressedResult = getIntrospectiveKeepDeepResult<MouseButtonsPressed>(
     oldValue.mouseButtonsPressed,
     newValue.mouseButtonsPressed,
   )

--- a/editor/src/utils/deep-equality-instances.ts
+++ b/editor/src/utils/deep-equality-instances.ts
@@ -21,7 +21,10 @@ import * as PP from '../core/shared/property-path'
 import { HigherOrderControl } from '../components/canvas/canvas-types'
 import { JSXElementName } from '../core/shared/element-template'
 import { ElementPath, PropertyPath, StaticElementPath } from '../core/shared/project-file-types'
-import { createCallFromIntrospectiveKeepDeep } from './react-performance'
+import {
+  createCallFromIntrospectiveKeepDeep,
+  getIntrospectiveKeepDeepResult,
+} from './react-performance'
 import { Either, foldEither, isLeft, left, right } from '../core/shared/either'
 import { NameAndIconResult } from '../components/inspector/common/name-and-icon-hook'
 import {
@@ -57,7 +60,7 @@ export function HigherOrderControlKeepDeepEquality(
   oldValue: HigherOrderControl,
   newValue: HigherOrderControl,
 ): KeepDeepEqualityResult<HigherOrderControl> {
-  return createCallFromIntrospectiveKeepDeep<HigherOrderControl>()(oldValue, newValue)
+  return getIntrospectiveKeepDeepResult<HigherOrderControl>(oldValue, newValue)
 }
 
 export const HigherOrderControlArrayKeepDeepEquality: KeepDeepEqualityCall<

--- a/editor/src/utils/react-performance.ts
+++ b/editor/src/utils/react-performance.ts
@@ -1,7 +1,11 @@
 import React from 'react'
 import fastDeepEqual from 'fast-deep-equal'
 import { PRODUCTION_ENV } from '../common/env-vars'
-import { KeepDeepEqualityCall, keepDeepEqualityResult } from './deep-equality'
+import {
+  KeepDeepEqualityCall,
+  KeepDeepEqualityResult,
+  keepDeepEqualityResult,
+} from './deep-equality'
 import { shallowEqual } from '../core/shared/equality-utils'
 
 export function useHookUpdateAnalysisStrictEquals<P>(name: string, newValue: P) {
@@ -441,11 +445,16 @@ export function useFlasher<T extends HTMLElement>() {
   return ref
 }
 
+export function getIntrospectiveKeepDeepResult<T>(
+  oldValue: T,
+  newValue: T,
+): KeepDeepEqualityResult<T> {
+  const value = keepDeepReferenceEqualityIfPossible(oldValue, newValue)
+  return keepDeepEqualityResult(value, value === oldValue)
+}
+
 export function createCallFromIntrospectiveKeepDeep<T>(): KeepDeepEqualityCall<T> {
-  return (oldValue, newValue) => {
-    const value = keepDeepReferenceEqualityIfPossible(oldValue, newValue)
-    return keepDeepEqualityResult(value, value === oldValue)
-  }
+  return getIntrospectiveKeepDeepResult
 }
 
 export function useKeepShallowReferenceEquality<T>(possibleNewValue: T, measure = false): T {


### PR DESCRIPTION
**Problem:**
Often `createCallFromIntrospectiveKeepDeep` is called and then the function it returns is then immediately invoked, which is a little wasteful.

**Fix:**
Where it would be immediately invoked, `createCallFromIntrospectiveKeepDeep` has been changed out for `getIntrospectiveKeepDeepResult`.

**Commit Details:**
- Extracted out the core of `createCallFromIntrospectiveKeepDeep` into `getIntrospectiveKeepDeepResult`.
- Used `getIntrospectiveKeepDeepResult` where possible to replace invoking `createCallFromIntrospectiveKeepDeep`.