### PR TITLE
fix - warning icon in dark mode

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -214,7 +214,7 @@ const componentUnselected = (colorTheme: any): ComputedLook => ({
     background: 'transparent',
     color: colorTheme.componentOrange.value,
   },
-  iconColor: 'warning',
+  iconColor: 'component-orange',
 })
 
 const componentSelected = (colorTheme: ThemeObject): ComputedLook => ({
@@ -222,7 +222,7 @@ const componentSelected = (colorTheme: ThemeObject): ComputedLook => ({
     background: colorTheme.denimBlue.value,
     color: colorTheme.componentOrange.value,
   },
-  iconColor: 'warning',
+  iconColor: 'component-orange',
 })
 
 const componentDescendantOfSelected = (colorTheme: ThemeObject): ComputedLook => ({
@@ -230,7 +230,7 @@ const componentDescendantOfSelected = (colorTheme: ThemeObject): ComputedLook =>
     background: colorTheme.lightDenimBlue.value,
     color: colorTheme.componentOrange.value,
   },
-  iconColor: 'warning',
+  iconColor: 'component-orange',
 })
 
 const componentInstanceSelected = (colorTheme: ThemeObject): ComputedLook => ({

--- a/editor/src/uuiui/icn.tsx
+++ b/editor/src/uuiui/icn.tsx
@@ -14,6 +14,7 @@ export type IcnColor =
   | 'warning'
   | 'error'
   | 'component'
+  | 'component-orange'
   | 'on-highlight-main'
   | 'on-highlight-secondary'
   | 'on-light-main'
@@ -56,6 +57,8 @@ function useIconColor(intent: IcnColor): IcnResultingColor {
         return 'blue'
       case 'warning':
         return 'orange'
+      case 'component-orange':
+        return 'orange'
       case 'dynamic':
         return 'blue'
       case 'error':
@@ -90,6 +93,8 @@ function useIconColor(intent: IcnColor): IcnResultingColor {
       case 'overridden':
         return 'pink'
       case 'warning':
+        return 'orange'
+      case 'component-orange':
         return 'lightorange'
       case 'dynamic':
         return 'lightblue'


### PR DESCRIPTION
### Problem:
All of the orange icons in the navigator were actually using the "warning" `IcnColor`. This was fine before but now that I introduced the new `lightOrange` color (and others) for navigator icons in dark mode, the actual warning icons were looking for a lightOrange version of themselves that does not exist.

### Fix:
I created a separate `component-orange` color in `IcnColor` to use for the appropriate navigator icons, so that the true warning icons ⚠ can still always be orange by using the `warning` IcnColor, and stand out. This will also make it easier for me to introduce a different styling for editing the component itself, not just the instance, in the future
