### PR TITLE
Feature/paste to replace

### DIFF
--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -22,7 +22,11 @@ import {
   duplicateSelected,
   toggleHidden,
 } from './editor/actions/action-creators'
-import { AllElementProps, TransientFilesState } from './editor/store/editor-state'
+import {
+  AllElementProps,
+  InternalClipboard,
+  TransientFilesState,
+} from './editor/store/editor-state'
 import {
   toggleBackgroundLayers,
   toggleBorder,
@@ -58,6 +62,7 @@ export interface CanvasData {
   focusedElementPath: ElementPath | null
   allElementProps: AllElementProps
   openFile: string | null
+  internalClipboard: InternalClipboard
 }
 
 export function requireDispatch(dispatch: EditorDispatch | null | undefined): EditorDispatch {
@@ -135,6 +140,14 @@ export const pasteLayout: ContextMenuItem<CanvasData> = {
   shortcut: '',
   action: (data, dispatch?: EditorDispatch) => {
     requireDispatch(dispatch)([EditorActions.pasteProperties('layout')], 'noone')
+  },
+}
+export const pasteToReplace: ContextMenuItem<CanvasData> = {
+  name: 'Paste to Replace',
+  enabled: (data) => data.internalClipboard.elements.length === 1,
+  shortcut: '',
+  action: (data, dispatch?: EditorDispatch) => {
+    requireDispatch(dispatch)([EditorActions.pasteToReplace()], 'noone')
   },
 }
 

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -146,7 +146,7 @@ export const pasteLayout: ContextMenuItem<CanvasData> = {
 }
 export const pasteToReplace: ContextMenuItem<CanvasData> = {
   name: 'Paste to Replace',
-  enabled: true,
+  enabled: (data) => data.internalClipboard.elements.length !== 0,
   shortcut: '',
   action: (data, dispatch?: EditorDispatch) => {
     requireDispatch(dispatch)([EditorActions.pasteToReplace()], 'noone')

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -146,7 +146,7 @@ export const pasteLayout: ContextMenuItem<CanvasData> = {
 }
 export const pasteToReplace: ContextMenuItem<CanvasData> = {
   name: 'Paste to Replace',
-  enabled: (data) => data.internalClipboard.elements.length === 1,
+  enabled: true,
   shortcut: '',
   action: (data, dispatch?: EditorDispatch) => {
     requireDispatch(dispatch)([EditorActions.pasteToReplace()], 'noone')

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -147,7 +147,7 @@ export const pasteLayout: ContextMenuItem<CanvasData> = {
 export const pasteToReplace: ContextMenuItem<CanvasData> = {
   name: 'Paste to Replace',
   enabled: (data) => data.internalClipboard.elements.length !== 0,
-  shortcut: '',
+  shortcut: '⇧⌘V',
   action: (data, dispatch?: EditorDispatch) => {
     requireDispatch(dispatch)([EditorActions.pasteToReplace()], 'noone')
   },

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -357,6 +357,9 @@ export interface PasteProperties {
   action: 'PASTE_PROPERTIES'
   type: 'style' | 'layout'
 }
+export interface PasteToReplace {
+  action: 'PASTE_TO_REPLACE'
+}
 
 export interface SetProjectID {
   action: 'SET_PROJECT_ID'
@@ -1135,6 +1138,7 @@ export type EditorAction =
   | CopySelectionToClipboard
   | CopyProperties
   | PasteProperties
+  | PasteToReplace
   | SetProjectID
   | SetForkedFromProjectID
   | OpenTextEditor

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -225,6 +225,7 @@ import type {
   SetConditionalOverriddenCondition,
   SwitchConditionalBranches,
   UpdateConditionalExpression,
+  PasteToReplace,
 } from '../action-types'
 import { EditorModes, insertionSubject, InsertionSubjectWrapper, Mode } from '../editor-modes'
 import type {
@@ -469,6 +470,11 @@ export function pasteProperties(type: 'style' | 'layout'): PasteProperties {
   return {
     action: 'PASTE_PROPERTIES',
     type: type,
+  }
+}
+export function pasteToReplace(): PasteToReplace {
+  return {
+    action: 'PASTE_TO_REPLACE',
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -148,6 +148,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'RENAME_COMPONENT':
     case 'PASTE_JSX_ELEMENTS':
     case 'PASTE_PROPERTIES':
+    case 'PASTE_TO_REPLACE':
     case 'TOGGLE_PROPERTY':
     case 'deprecated_TOGGLE_ENABLED_PROPERTY':
     case 'RESET_PINS':

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -46,7 +46,7 @@ import {
   mouseDragFromPointWithDelta,
   pressKey,
 } from '../../canvas/event-helpers.test-utils'
-import { cmdModifier } from '../../../utils/modifiers'
+import { cmdModifier, shiftCmdModifier } from '../../../utils/modifiers'
 import { FOR_TESTS_setNextGeneratedUids } from '../../../core/model/element-template-utils.test-utils'
 import { createTestProjectWithMultipleFiles } from '../../../sample-projects/sample-project-utils.test-utils'
 import { navigatorEntryToKey, PlaygroundFilePath, StoryboardFilePath } from '../store/editor-state'
@@ -2669,6 +2669,121 @@ export var storyboard = (props) => {
               `),
               )
             })
+          })
+        })
+      })
+      describe('Paste to Replace', () => {
+        const pasteToReplaceTestCases: Array<{
+          name: string
+          input: string
+          copyTargets: Array<ElementPath>
+          pasteTargets: Array<ElementPath>
+          result: string
+        }> = [
+          {
+            name: `paste to replace an absolute element`,
+            input: `<div data-uid='root'>
+              <div data-uid='bbb' style={{backgroundColor: 'lavender', outline: '1px solid black'}}>
+                <span data-uid='ccc'>Hello!</span>
+              </div>
+              <div data-uid='ddd' style={{position: 'absolute', width: 50, height: 40, top: 100, left: 100}}>
+                <div data-uid='eee'>Hi!</div>
+              </div>
+            </div>`,
+            copyTargets: [makeTargetPath('root/bbb')],
+            pasteTargets: [makeTargetPath('root/ddd')],
+            result: `<div data-uid='root'>
+              <div data-uid='bbb' style={{backgroundColor: 'lavender', outline: '1px solid black'}}>
+                <span data-uid='ccc'>Hello!</span>
+              </div>
+              <div data-uid='aai' style={{backgroundColor: 'lavender', outline: '1px solid black', top: 100, left: 100, position: 'absolute', }}>
+                <span data-uid='aac'>Hello!</span>
+              </div>
+            </div>`,
+          },
+          {
+            name: `paste to replace a flex child`,
+            input: `<div data-uid='root'>
+              <div data-uid='bbb' style={{backgroundColor: 'lavender', outline: '1px solid black', width: 50, height: 20}}>
+                <span data-uid='ccc'>Hello!</span>
+              </div>
+              <div data-uid='ddd' style={{position: 'absolute', top: 100, left: 100, display: 'flex'}}>
+                <div data-uid='eee'/>
+                <div data-uid='fff'>
+                  <div data-uid='ggg'>Hi!</div>
+                </div>
+                <div data-uid='hhh'/>
+              </div>
+            </div>`,
+            copyTargets: [makeTargetPath('root/bbb')],
+            pasteTargets: [makeTargetPath('root/ddd/fff')],
+            result: `<div data-uid='root'>
+              <div data-uid='bbb' style={{backgroundColor: 'lavender', outline: '1px solid black', width: 50, height: 20}}>
+                <span data-uid='ccc'>Hello!</span>
+              </div>
+              <div data-uid='ddd' style={{position: 'absolute', top: 100, left: 100, display: 'flex'}}>
+                <div data-uid='eee'/>
+                <div data-uid='aak' style={{backgroundColor: 'lavender', outline: '1px solid black', width: 50, height: 20}}>
+                  <span data-uid='aac'>Hello!</span>
+                </div>
+                <div data-uid='hhh'/>
+              </div>
+            </div>`,
+          },
+          {
+            name: `paste to replace an absolute element with multiselection`,
+            input: `<div data-uid='root'>
+              <div data-uid='bbb' style={{backgroundColor: 'lavender', outline: '1px solid black', width: 40, height: 40}}>
+                <span data-uid='ccc'>Hello!</span>
+              </div>
+              <div data-uid='ddd' style={{position: 'absolute', width: 50, height: 40, top: 100, left: 100}}>
+                <div data-uid='eee'>Hi!</div>
+              </div>
+              <div data-uid='fff'>
+                <div data-uid='ggg' style={{position: 'absolute', top: 40, left: 40, backgroundColor: 'plum', outline: '1px solid white'}}>
+                  <span data-uid='hhh' style={{color: 'white'}}>second element</span>
+                </div>
+              </div>
+            </div>`,
+            copyTargets: [makeTargetPath('root/bbb'), makeTargetPath('root/fff/ggg')],
+            pasteTargets: [makeTargetPath('root/ddd')],
+            result: `<div data-uid='root'>
+              <div data-uid='bbb' style={{backgroundColor: 'lavender', outline: '1px solid black', width: 40, height: 40}}>
+                <span data-uid='ccc'>Hello!</span>
+              </div>
+              <div data-uid='aar' style={{backgroundColor: 'lavender', outline: '1px solid black', width: 40, height: 40, top: 100, left: 100, position: 'absolute' }}>
+                <span data-uid='aah'>Hello!</span>
+              </div>
+              <div data-uid='aan' style={{position: 'absolute', top: 140, left: 140, backgroundColor: 'plum', outline: '1px solid white'}}>
+                  <span data-uid='aae' style={{color: 'white'}}>second element</span>
+                </div>
+              <div data-uid='fff'>
+                <div data-uid='ggg' style={{position: 'absolute', top: 40, left: 40, backgroundColor: 'plum', outline: '1px solid white'}}>
+                  <span data-uid='hhh' style={{color: 'white'}}>second element</span>
+                </div>
+              </div>
+            </div>`,
+          },
+        ]
+
+        pasteToReplaceTestCases.forEach((tt, idx) => {
+          it(`(${idx + 1}) ${tt.name}`, async () => {
+            const renderResult = await renderTestEditorWithCode(
+              makeTestProjectCodeWithSnippet(tt.input),
+              'await-first-dom-report',
+            )
+            await selectComponentsForTest(renderResult, tt.copyTargets)
+            await pressKey('c', { modifiers: cmdModifier })
+
+            await selectComponentsForTest(renderResult, tt.pasteTargets)
+            await pressKey('v', { modifiers: shiftCmdModifier })
+
+            // Wait for the next frame
+            await renderResult.getDispatchFollowUpActionsFinished()
+
+            expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+              makeTestProjectCodeWithSnippet(tt.result),
+            )
           })
         })
       })

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -558,7 +558,6 @@ import { updateSelectedViews } from '../../canvas/commands/update-selected-views
 import { front } from '../../../utils/utils'
 import { MetadataSnapshots } from '../../canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-strategies'
 import { getAllUniqueUids } from '../../../core/model/get-unique-ids'
-import json5 from 'json5'
 import { ElementPathTrees } from '../../../core/shared/element-path-tree'
 
 export const MIN_CODE_PANE_REOPEN_WIDTH = 100

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -455,6 +455,7 @@ import {
   Clipboard,
   getTargetParentForPaste,
   ReparentTargetForPaste,
+  parseCopyData,
 } from '../../../utils/clipboard'
 import { NavigatorStateKeepDeepEquality } from '../store/store-deep-equality-instances'
 import { addButtonPressed, MouseButtonsPressed, removeButtonPressed } from '../../../utils/mouse'
@@ -3004,10 +3005,9 @@ export const UPDATE_FNS = {
     }
 
     let newPaths: Array<ElementPath> = []
-    const elementToPaste = json5.parse(
-      editor.internalClipboard.elements[0].elements,
-    ) as Array<ElementPaste>
-    const originalMetadata = editor.internalClipboard.elements[0].targetOriginalContextMetadata
+    const parsedCopyData = editor.internalClipboard.elements.map(parseCopyData)
+    const elementToPaste = parsedCopyData[0].elementPaste
+    const originalMetadata = parsedCopyData[0].originalContextMetadata
 
     const withInsertedElements = editor.selectedViews.reduce((workingEditorState, target) => {
       const parentInsertionPath = MetadataUtils.getReparentTargetOfTarget(

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3149,7 +3149,10 @@ export const UPDATE_FNS = {
           {
             ...editor,
             pasteTargetsToIgnore: editor.selectedViews,
-            styleClipboard: [],
+            internalClipboard: {
+              styleClipboard: [],
+              elements: copyData?.data ?? [],
+            },
           },
           dispatch,
         )

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3029,12 +3029,12 @@ export const UPDATE_FNS = {
 
       const targetMetadata = MetadataUtils.findElementByElementPath(editor.jsxMetadata, target)
       const isAbsolute = MetadataUtils.isPositionAbsolute(targetMetadata)
-      const topLeft =
+      const targetElementPosition =
         targetMetadata?.localFrame != null && !isInfinityRectangle(targetMetadata.localFrame)
           ? canvasPoint({ x: targetMetadata?.localFrame.x, y: targetMetadata?.localFrame.y })
           : zeroCanvasPoint
 
-      const pasteBoundingBox = boundingRectangleArray(
+      const copiedElementsBoundingBox = boundingRectangleArray(
         elementToPaste.map((element) =>
           MetadataUtils.getFrameOrZeroRectInCanvasCoords(
             element.originalElementPath,
@@ -3054,11 +3054,11 @@ export const UPDATE_FNS = {
           elementPaste.originalElementPath,
           originalMetadata,
         )
-        const localPositionInBoundingBox =
-          pasteBoundingBox != null
+        const offsetPositionInBoundingBox =
+          copiedElementsBoundingBox != null
             ? canvasPoint({
-                x: frame.x - pasteBoundingBox.x,
-                y: frame.y - pasteBoundingBox.y,
+                x: frame.x - copiedElementsBoundingBox.x,
+                y: frame.y - copiedElementsBoundingBox.y,
               })
             : zeroCanvasPoint
 
@@ -3066,7 +3066,7 @@ export const UPDATE_FNS = {
           ? {
               strategy: 'REPARENT_AS_ABSOLUTE',
               insertionPath: childInsertionPath(parentTarget),
-              intendedCoordinates: offsetPoint(topLeft, localPositionInBoundingBox),
+              intendedCoordinates: offsetPoint(targetElementPosition, offsetPositionInBoundingBox),
             }
           : { strategy: 'REPARENT_AS_STATIC', insertionPath: childInsertionPath(parentTarget) }
 

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3020,7 +3020,10 @@ export const UPDATE_FNS = {
     const originalMetadata = editor.internalClipboard.elements[0].targetOriginalContextMetadata
 
     const withInsertedElements = editor.selectedViews.reduce((workingEditorState, target) => {
-      const parentTarget = EP.parentPath(target)
+      const parentInsertionPath = MetadataUtils.getReparentTargetOfTarget(
+        editor.jsxMetadata,
+        target,
+      )
       const indexPosition = MetadataUtils.getIndexInParent(
         editor.jsxMetadata,
         editor.elementPathTree,
@@ -3065,10 +3068,10 @@ export const UPDATE_FNS = {
         const reparentTarget: StaticReparentTarget = isAbsolute
           ? {
               strategy: 'REPARENT_AS_ABSOLUTE',
-              insertionPath: childInsertionPath(parentTarget),
+              insertionPath: parentInsertionPath,
               intendedCoordinates: offsetPoint(targetElementPosition, offsetPositionInBoundingBox),
             }
-          : { strategy: 'REPARENT_AS_STATIC', insertionPath: childInsertionPath(parentTarget) }
+          : { strategy: 'REPARENT_AS_STATIC', insertionPath: parentInsertionPath }
 
         const insertionResult = insertWithReparentStrategies(
           working,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3024,6 +3024,10 @@ export const UPDATE_FNS = {
         editor.jsxMetadata,
         target,
       )
+      if (parentInsertionPath == null) {
+        return workingEditorState
+      }
+
       const indexPosition = MetadataUtils.getIndexInParent(
         editor.jsxMetadata,
         editor.elementPathTree,
@@ -3046,7 +3050,7 @@ export const UPDATE_FNS = {
         ),
       )
 
-      return elementToPaste.reduce((working, elementPaste) => {
+      return elementToPaste.reverse().reduce((working, elementPaste) => {
         const existingIDs = getAllUniqueUids(working.projectContents).allIDs
         const elementWithUniqueUID = fixUtopiaElement(
           elementPaste.element,

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -105,6 +105,7 @@ import {
   RESIZE_TO_FIT,
   JUMP_TO_PARENT_SHORTCUT_BACKSLASH,
   OPEN_INSERT_MENU,
+  PASTE_TO_REPLACE,
 } from './shortcut-definitions'
 import { DerivedState, EditorState, getOpenFile, RightMenuTab } from './store/editor-state'
 import { CanvasMousePositionRaw, WindowMousePositionRaw } from '../../utils/global-positions'
@@ -866,6 +867,13 @@ export function handleKeyDown(
           })
         }
         return []
+      },
+      [PASTE_TO_REPLACE]: () => {
+        return isSelectMode(editor.mode)
+          ? editor.selectedViews.map((target) => {
+              return EditorActions.pasteToReplace()
+            })
+          : []
       },
       [PASTE_STYLE_PROPERTIES]: () => {
         return isSelectMode(editor.mode)

--- a/editor/src/components/editor/shortcut-definitions.ts
+++ b/editor/src/components/editor/shortcut-definitions.ts
@@ -78,6 +78,7 @@ export const TOGGLE_TEXT_BOLD = 'toggle-text-bold'
 export const TOGGLE_TEXT_ITALIC = 'toggle-text-italic'
 export const TOGGLE_TEXT_UNDERLINE = 'toggle-text-underline'
 export const TOGGLE_TEXT_STRIKE_THROUGH = 'toggle-text-strike-through'
+export const PASTE_TO_REPLACE = 'paste-to-replace'
 export const PASTE_STYLE_PROPERTIES = 'paste-style-properties'
 export const COPY_STYLE_PROPERTIES = 'copy-style-properties'
 
@@ -247,6 +248,7 @@ const shortcutDetailsWithDefaults: ShortcutDetails = {
   [REMOVE_ABSOLUTE_POSITIONING]: shortcut(`Strip absolute sizing props props`, key('x', [])),
   [COPY_STYLE_PROPERTIES]: shortcut('Copy style properties', key('c', ['alt', 'cmd'])),
   [PASTE_STYLE_PROPERTIES]: shortcut('Paste style properties', key('v', ['alt', 'cmd'])),
+  [PASTE_TO_REPLACE]: shortcut('Paste to replace', key('v', ['shift', 'cmd'])),
   [RESIZE_TO_FIT]: shortcut('Resize selected elements to fit', key('r', ['alt', 'cmd', 'shift'])),
   [OPEN_INSERT_MENU]: shortcut('Open insert menu', key('k', ['cmd'])),
 }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -162,6 +162,7 @@ import { PersistenceMachine } from '../persistence/persistence'
 import { InsertionPath, childInsertionPath, conditionalClauseInsertionPath } from './insertion-path'
 import type { ThemeSubstate } from './store-hook-substore-types'
 import { ElementPathTrees } from '../../../core/shared/element-path-tree'
+import { JSXElementCopyData } from '../../../utils/clipboard'
 
 const ObjectPathImmutable: any = OPI
 
@@ -869,6 +870,21 @@ export function editorStateCanvasControls(
 
 export type ElementsToRerender = Array<ElementPath> | 'rerender-all-elements'
 
+export interface InternalClipboard {
+  styleClipboard: Array<ValueAtPath>
+  elements: Array<JSXElementCopyData>
+}
+
+export function internalClipboard(
+  styleClipboard: Array<ValueAtPath>,
+  elements: Array<JSXElementCopyData>,
+): InternalClipboard {
+  return {
+    styleClipboard,
+    elements,
+  }
+}
+
 export interface EditorStateCanvas {
   elementsToRerender: ElementsToRerender
   visible: boolean
@@ -1320,7 +1336,7 @@ export interface EditorState {
   refreshingDependencies: boolean
   assetChecksums: FileChecksums
   colorSwatches: Array<ColorSwatch>
-  styleClipboard: Array<ValueAtPath>
+  internalClipboard: InternalClipboard
 }
 
 export function editorState(
@@ -1399,7 +1415,7 @@ export function editorState(
   refreshingDependencies: boolean,
   assetChecksums: FileChecksums,
   colorSwatches: Array<ColorSwatch>,
-  styleClipboard: Array<ValueAtPath>,
+  internalClipboardData: InternalClipboard,
 ): EditorState {
   return {
     id: id,
@@ -1477,7 +1493,7 @@ export function editorState(
     refreshingDependencies: refreshingDependencies,
     assetChecksums: assetChecksums,
     colorSwatches: colorSwatches,
-    styleClipboard: styleClipboard,
+    internalClipboard: internalClipboardData,
   }
 }
 
@@ -2500,7 +2516,10 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     refreshingDependencies: false,
     assetChecksums: {},
     colorSwatches: [],
-    styleClipboard: [],
+    internalClipboard: {
+      styleClipboard: [],
+      elements: [],
+    },
   }
 }
 
@@ -2817,7 +2836,10 @@ export function editorModelFromPersistentModel(
     githubData: emptyGithubData(),
     assetChecksums: {},
     colorSwatches: persistentModel.colorSwatches,
-    styleClipboard: [],
+    internalClipboard: {
+      styleClipboard: [],
+      elements: [],
+    },
   }
   return editor
 }

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -116,6 +116,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.PASTE_JSX_ELEMENTS(action, state, dispatch, builtInDependencies)
     case 'PASTE_PROPERTIES':
       return UPDATE_FNS.PASTE_PROPERTIES(action, state)
+    case 'PASTE_TO_REPLACE':
+      return UPDATE_FNS.PASTE_TO_REPLACE(action, state, dispatch, builtInDependencies)
     case 'COPY_SELECTION_TO_CLIPBOARD':
       return UPDATE_FNS.COPY_SELECTION_TO_CLIPBOARD(action, state, dispatch, builtInDependencies)
     case 'COPY_PROPERTIES':

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -347,6 +347,8 @@ import {
   syntheticNavigatorEntry,
   DropTargetHint,
   NavigatorState,
+  InternalClipboard,
+  internalClipboard,
 } from './editor-state'
 import {
   CornerGuideline,
@@ -505,6 +507,7 @@ import {
   ElementPathTree,
   ElementPathTrees,
 } from '../../../core/shared/element-path-tree'
+import { jsxElementCopyData, JSXElementCopyData } from '../../../utils/clipboard'
 
 export function TransientCanvasStateFilesStateKeepDeepEquality(
   oldValue: TransientFilesState,
@@ -3735,6 +3738,24 @@ export const ValueAtPathDeepEquality: KeepDeepEqualityCall<ValueAtPath> = combin
   valueAtPath,
 )
 
+export const JSXElementsCopyDataDeepEquality: KeepDeepEqualityCall<JSXElementCopyData> =
+  combine2EqualityCalls(
+    (c) => c.elements,
+    StringKeepDeepEquality,
+    (c) => c.targetOriginalContextMetadata,
+    ElementInstanceMetadataMapKeepDeepEquality,
+    jsxElementCopyData,
+  )
+
+export const InternalClipboardKeepDeepEquality: KeepDeepEqualityCall<InternalClipboard> =
+  combine2EqualityCalls(
+    (data) => data.styleClipboard,
+    arrayDeepEquality(ValueAtPathDeepEquality),
+    (data) => data.elements,
+    arrayDeepEquality(JSXElementsCopyDataDeepEquality),
+    internalClipboard,
+  )
+
 export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
   oldValue,
   newValue,
@@ -4005,9 +4026,9 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     oldValue.colorSwatches,
     newValue.colorSwatches,
   )
-  const styleClipboardResults = arrayDeepEquality(ValueAtPathDeepEquality)(
-    oldValue.styleClipboard,
-    newValue.styleClipboard,
+  const internalClipboardResults = InternalClipboardKeepDeepEquality(
+    oldValue.internalClipboard,
+    newValue.internalClipboard,
   )
 
   const areEqual =
@@ -4086,7 +4107,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     refreshingDependenciesResults.areEqual &&
     assetChecksumsResults.areEqual &&
     colorSwatchesResults.areEqual &&
-    styleClipboardResults.areEqual
+    internalClipboardResults.areEqual
 
   if (areEqual) {
     return keepDeepEqualityResult(oldValue, true)
@@ -4167,7 +4188,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
       refreshingDependenciesResults.value,
       assetChecksumsResults.value,
       colorSwatchesResults.value,
-      styleClipboardResults.value,
+      internalClipboardResults.value,
     )
 
     return keepDeepEqualityResult(newEditorState, false)

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -3742,11 +3742,13 @@ export const ValueAtPathDeepEquality: KeepDeepEqualityCall<ValueAtPath> = combin
 )
 
 export const JSXElementsCopyDataDeepEquality: KeepDeepEqualityCall<JSXElementCopyData> =
-  combine2EqualityCalls(
+  combine3EqualityCalls(
     (c) => c.elements,
     StringKeepDeepEquality,
     (c) => c.targetOriginalContextMetadata,
     ElementInstanceMetadataMapKeepDeepEquality,
+    (c) => c.targetOriginalContextElementPathTrees,
+    ElementPathTreesKeepDeepEquality(),
     jsxElementCopyData,
   )
 

--- a/editor/src/components/editor/store/store-hook-substore-helpers.ts
+++ b/editor/src/components/editor/store/store-hook-substore-helpers.ts
@@ -172,5 +172,8 @@ export const EmptyEditorStateForKeysOnly: EditorState = {
   refreshingDependencies: false,
   assetChecksums: {},
   colorSwatches: [],
-  styleClipboard: [],
+  internalClipboard: {
+    styleClipboard: [],
+    elements: [],
+  },
 }

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -29,6 +29,7 @@ import {
   pasteStyle,
   pasteLayout,
   copyPropertiesMenuItem,
+  pasteToReplace,
 } from './context-menu-items'
 import { MomentumContextMenu } from './context-menu-wrapper'
 import { useRefEditorState, useEditorState, Substores } from './editor/store/store-hook'
@@ -64,6 +65,7 @@ const ElementContextMenuItems: Array<ContextMenuItem<CanvasData>> = [
   copyPropertiesMenuItem,
   pasteStyle,
   pasteLayout,
+  pasteToReplace,
   duplicateElement,
   lineSeparator,
   insert,
@@ -200,6 +202,7 @@ export const ElementContextMenu = React.memo(({ contextMenuInstance }: ElementCo
       focusedElementPath: store.editor.focusedElementPath,
       allElementProps: store.editor.allElementProps,
       openFile: store.editor.canvas.openFile?.filename ?? null,
+      internalClipboard: store.editor.internalClipboard,
     }
   })
 
@@ -218,6 +221,7 @@ export const ElementContextMenu = React.memo(({ contextMenuInstance }: ElementCo
       focusedElementPath: currentEditor.focusedElementPath,
       allElementProps: currentEditor.allElementProps,
       openFile: currentEditor.openFile,
+      internalClipboard: currentEditor.internalClipboard,
     }
   }, [editorSliceRef])
 

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -90,7 +90,7 @@ interface ParsedCopyData {
   originalContextElementPathTrees: ElementPathTrees
 }
 
-function parseCopyData(data: CopyData): ParsedCopyData {
+export function parseCopyData(data: CopyData): ParsedCopyData {
   const elements = json5.parse(data.elements)
   const metadata = data.targetOriginalContextMetadata
   const pathTrees = data.targetOriginalContextElementPathTrees

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -59,10 +59,21 @@ import { maybeBranchConditionalCase } from '../core/model/conditionals'
 import { optionalMap } from '../core/shared/optional-utils'
 import { isFeatureEnabled } from './feature-switches'
 
-interface JSXElementCopyData {
+export interface JSXElementCopyData {
   type: 'ELEMENT_COPY'
   elements: JSXElementsJson
   targetOriginalContextMetadata: ElementInstanceMetadataMap
+}
+
+export function jsxElementCopyData(
+  elements: JSXElementsJson,
+  targetOriginalContextMetadata: ElementInstanceMetadataMap,
+): JSXElementCopyData {
+  return {
+    type: 'ELEMENT_COPY',
+    elements: elements,
+    targetOriginalContextMetadata: targetOriginalContextMetadata,
+  }
 }
 
 type JSXElementsJson = string

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -70,11 +70,13 @@ export interface JSXElementCopyData {
 export function jsxElementCopyData(
   elements: JSXElementsJson,
   targetOriginalContextMetadata: ElementInstanceMetadataMap,
+  targetOriginalContextElementPathTrees: ElementPathTrees,
 ): JSXElementCopyData {
   return {
     type: 'ELEMENT_COPY',
     elements: elements,
     targetOriginalContextMetadata: targetOriginalContextMetadata,
+    targetOriginalContextElementPathTrees: targetOriginalContextElementPathTrees,
   }
 }
 


### PR DESCRIPTION
**Fix:**
Introducing "Paste to Replace" functionality in the context menu. Accessible with shortcut `shift+cmd+v`. It works only inside the same project. Copying an element for paste to replace is the same as a normal copy with `cmd+c`.

https://utopia.pizza/p/d88f27fa?branch_name=feature/paste-to-replace

**Commit Details:**
- added a new shortcut, context-menu item with a new action
- extended the internal clipboard object in the editorstate to store copied element data
- added tests
