### PR TITLE
Chore/test import groups

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -39436,7 +39436,7 @@ Object {
                       "sourcesContent": Array [
                         "
 import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 export var App = (props) => {
   return (
     <View

--- a/editor/src/components/canvas/canvas-actions.spec.tsx
+++ b/editor/src/components/canvas/canvas-actions.spec.tsx
@@ -68,7 +68,7 @@ xdescribe('createDragState', () => {
       Prettier.format(
         `
       import * as React from 'react'
-      import { Scene, Storyboard, View } from 'utopia-api'
+      import { Scene, Storyboard, View, Group } from 'utopia-api'
     
       export var App = (props) => {
         return (

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
@@ -79,7 +79,7 @@ async function dragElement(
 
 const projectDoesNotHonourPositionProperties = `
 import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 
 export const App2 = (props) => {
   return (
@@ -125,7 +125,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
 
 function projectDoesHonourPositionProperties(left: number, top: number): string {
   return `import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 
 export const App2 = (props) => {
   return (

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-canvas.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-canvas.spec.tsx
@@ -216,7 +216,7 @@ xdescribe('Absolute Reparent Strategy', () => {
       Prettier.format(
         `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
     return (

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
@@ -311,7 +311,7 @@ describe('Absolute Reparent Strategy', () => {
       Prettier.format(
         `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
     return (
@@ -386,7 +386,7 @@ describe('Absolute Reparent Strategy', () => {
       Prettier.format(
         `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
     return (
@@ -452,7 +452,7 @@ describe('Absolute Reparent Strategy', () => {
       Prettier.format(
         `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
     return (
@@ -517,7 +517,7 @@ describe('Absolute Reparent Strategy', () => {
       Prettier.format(
         `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
     return (
@@ -554,7 +554,7 @@ describe('Absolute Reparent Strategy', () => {
     const renderResult = await renderTestEditorWithCode(
       formatTestProjectCode(`
 import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 
 export var App = (props) => {
   return (<div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
@@ -599,7 +599,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
       Prettier.format(
         `
     import * as React from 'react'
-    import { Scene, Storyboard, View } from 'utopia-api'
+    import { Scene, Storyboard, View, Group } from 'utopia-api'
 
     export var App = (props) => {
       return (<div style={{ width: '100%', height: '100%' }} data-uid='aaa' />)
@@ -665,7 +665,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
       Prettier.format(
         `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
     return (
@@ -736,7 +736,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
       Prettier.format(
         `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
     return (
@@ -807,7 +807,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
       Prettier.format(
         `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
     return (
@@ -877,7 +877,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
       Prettier.format(
         `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
     return (
@@ -922,7 +922,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
       return Prettier.format(
         `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
     const elementWidth = 200
@@ -975,7 +975,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
       const renderResult = await renderTestEditorWithCode(
         formatTestProjectCode(`
 import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 
 export var App = (props) => {
   return (<div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
@@ -1043,7 +1043,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
         Prettier.format(
           `
 import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 
 export var App = (props) => {
   return (<div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
@@ -1092,7 +1092,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
       const renderResult = await renderTestEditorWithCode(
         formatTestProjectCode(`
 import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 
 export var App = (props) => {
   return (<div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
@@ -1160,7 +1160,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
         Prettier.format(
           `
 import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 
 export var App = (props) => {
   return (<div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
@@ -1824,7 +1824,7 @@ function testProjectWithUnstyledDivOrFragmentOnCanvas(type: FragmentLikeType): s
 
   const code = `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
     return (<div

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
@@ -167,7 +167,7 @@ const defaultTestCode = `
 function makeTestProjectCodeWithComponentInnards(componentInnards: string): string {
   const code = `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
 ${componentInnards}

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flow-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flow-strategy.spec.browser2.tsx
@@ -45,7 +45,7 @@ async function dragElement(
 function makeTestProjectCodeWithComponentInnards(componentInnards: string): string {
   const code = `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
 ${componentInnards}

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -224,7 +224,7 @@ export var storyboard = (
 
 const projectDoesNotHonourSizeProperties = `
 import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 
 export const App2 = (props) => {
   return (
@@ -270,7 +270,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
 
 function projectDoesHonourSizeProperties(width: number, height: number): string {
   return `import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 
 export const App2 = (props) => {
   return (

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
@@ -62,7 +62,7 @@ import {
 const complexProject = () => {
   const code = `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export const Card = (props) => {
     return (

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.spec.browser2.tsx
@@ -124,7 +124,7 @@ const defaultTestCode = `
 function makeTestProjectCodeWithComponentInnards(componentInnards: string): string {
   const code = `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
 ${componentInnards}

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flex-strategy.spec.browser2.tsx
@@ -219,7 +219,7 @@ export var storyboard = (
 function makeTestProjectCodeWithComponentInnards(componentInnards: string): string {
   const code = `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
 ${componentInnards}

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flow-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-flow-strategy.spec.browser2.tsx
@@ -44,7 +44,7 @@ async function dragElement(
 function makeTestProjectCodeWithComponentInnards(componentInnards: string): string {
   const code = `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
 ${componentInnards}

--- a/editor/src/components/canvas/canvas-strategies/strategies/flow-reparent-to-absolute-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flow-reparent-to-absolute-strategy.spec.browser2.tsx
@@ -39,7 +39,7 @@ async function dragElement(
 function makeTestProjectCodeWithComponentInnards(componentInnards: string): string {
   const code = `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
 ${componentInnards}

--- a/editor/src/components/canvas/canvas-strategies/strategies/flow-reparent-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flow-reparent-to-flex-strategy.spec.browser2.tsx
@@ -39,7 +39,7 @@ async function dragElement(
 function makeTestProjectCodeWithComponentInnards(componentInnards: string): string {
   const code = `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
 ${componentInnards}

--- a/editor/src/components/canvas/canvas-strategies/strategies/flow-reparent-to-flow-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flow-reparent-to-flow-strategy.spec.browser2.tsx
@@ -44,7 +44,7 @@ async function dragElement(
 function makeTestProjectCodeWithComponentInnards(componentInnards: string): string {
   const code = `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
 ${componentInnards}

--- a/editor/src/components/canvas/canvas-strategies/strategies/forced-absolute-reparent-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/forced-absolute-reparent-strategies.spec.browser2.tsx
@@ -130,7 +130,7 @@ const defaultTestCode = `
 function makeTestProjectCodeWithComponentInnards(componentInnards: string): string {
   const code = `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
 ${componentInnards}

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -851,7 +851,7 @@ export { ToBeDefaultExported as default }`,
       null,
       `
       import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 export var App = (props) => {
   return <Widget data-uid={'bbb'} />
 }
@@ -1527,7 +1527,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
     testCanvasRender(
       null,
       `import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 
 export var Cat = (props) => {
   return (

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -594,7 +594,7 @@ export function formatTestProjectCode(code: string): string {
 export function makeTestProjectCodeWithComponentInnards(componentInnards: string): string {
   const code = `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
 ${componentInnards}

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -632,7 +632,7 @@ export function makeTestProjectCodeWithComponentInnardsWithoutUIDs(
 ): string {
   const code = `
   import * as React from 'react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
 ${componentInnards}
@@ -668,7 +668,7 @@ export function makeTestProjectCodeWithSnippetStyledComponents(snippet: string):
   /** @jsx jsx */
   import * as React from 'react'
   import { css, jsx } from '@emotion/react'
-  import { Scene, Storyboard, View } from 'utopia-api'
+  import { Scene, Storyboard, View, Group } from 'utopia-api'
 
   export var App = (props) => {
     return (

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -1520,7 +1520,7 @@ export var storyboard = (
           )
           expect(getPrintedUiJsCode(editor.getEditorState()))
             .toEqual(`import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 
 export var App = (props) => {
   return (
@@ -2644,7 +2644,7 @@ export var storyboard = (props) => {
               expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
                 formatTestProjectCode(`
                 import * as React from 'react'
-                import { Scene, Storyboard, View } from 'utopia-api'
+                import { Scene, Storyboard, View, Group } from 'utopia-api'
               
                 export var App = (props) => {
                   return (${tt.input})

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -1693,7 +1693,7 @@ export var storyboard = (props) => {
           ])
           expect(getPrintedUiJsCode(renderResult.getEditorState()))
             .toEqual(`import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 
 export var App = (props) => {
   return (

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -1246,7 +1246,7 @@ describe('inspector tests with real metadata', () => {
       Prettier.format(
         `
       import * as React from 'react'
-      import { Scene, Storyboard, View } from 'utopia-api'
+      import { Scene, Storyboard, View, Group } from 'utopia-api'
 
       export var App = (props) => {
         return (
@@ -1618,7 +1618,7 @@ describe('inspector tests with real metadata', () => {
       Prettier.format(
         `
       import * as React from 'react'
-      import { Scene, Storyboard, View } from 'utopia-api'
+      import { Scene, Storyboard, View, Group } from 'utopia-api'
 
       export var App = (props) => {
         return (
@@ -1730,7 +1730,7 @@ describe('inspector tests with real metadata', () => {
       Prettier.format(
         `
       import * as React from 'react'
-      import { Scene, Storyboard, View } from 'utopia-api'
+      import { Scene, Storyboard, View, Group } from 'utopia-api'
 
       export var App = (props) => {
         return (
@@ -1852,7 +1852,7 @@ describe('inspector tests with real metadata', () => {
       Prettier.format(
         `
       import * as React from 'react'
-      import { Scene, Storyboard, View } from 'utopia-api'
+      import { Scene, Storyboard, View, Group } from 'utopia-api'
 
       export var App = (props) => {
         return (

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -445,7 +445,7 @@ export var storyboard = (
 `
 
 const projectWithFlexContainerAndCanvas = `import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 
 export var App = (props) => {
   return (

--- a/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
@@ -247,7 +247,7 @@ function Picker() {
         Multiple,
         Lines
       } from 'some-library'
-      import { Scene, Storyboard, View } from 'utopia-api'
+      import { Scene, Storyboard, View, Group } from 'utopia-api'
       
       const { m } = require('./thing')
       const { n } = require('./thing')

--- a/editor/src/core/workers/parser-printer/parser-printer-conditionals.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-conditionals.spec.ts
@@ -122,7 +122,7 @@ describe('Conditonals JSX printer', () => {
       )
       expect(printedCode).toMatchInlineSnapshot(`
         "import * as React from 'react'
-        import { Scene, Storyboard, View } from 'utopia-api'
+        import { Scene, Storyboard, View, Group } from 'utopia-api'
         export var App = (props) => {
           return (
             <div data-uid='div'>

--- a/editor/src/core/workers/parser-printer/parser-printer-conditionals.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-conditionals.test-utils.ts
@@ -2,7 +2,7 @@ import { BakedInStoryboardVariableName } from '../../model/scene-utils'
 
 export const SimpleConditionalsExample = `
 import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 export var App = (props) => {
   return <div data-uid={'div'}>
     {1 === 2 /* @utopia/uid=conditional */ ? <div data-uid={'hello'}>Hello</div> : <div data-uid={'world'}>World</div>}
@@ -22,7 +22,7 @@ export var ${BakedInStoryboardVariableName} = (
 
 export const NestedTernariesExample = `
 import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 export var App = (props) => {
   return <div data-uid={'div'}>
     {

--- a/editor/src/core/workers/parser-printer/parser-printer-dot-notation.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-dot-notation.spec.tsx
@@ -83,7 +83,7 @@ export var storyboard = (props) => {
 }`
     const printedCode = `import * as React from 'react'
 import * as Utopia from 'utopia-api'
-import { Scene, Storyboard, View, Group } from 'utopia-api'
+import { Scene, Storyboard, View } from 'utopia-api'
 
 export var App = (props) => {
   return (

--- a/editor/src/core/workers/parser-printer/parser-printer-dot-notation.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-dot-notation.spec.tsx
@@ -83,7 +83,7 @@ export var storyboard = (props) => {
 }`
     const printedCode = `import * as React from 'react'
 import * as Utopia from 'utopia-api'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 
 export var App = (props) => {
   return (

--- a/editor/src/core/workers/parser-printer/parser-printer-fragments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-fragments.spec.ts
@@ -42,7 +42,7 @@ describe('JSX parser', () => {
 
       expect(printedCode).toMatchInlineSnapshot(`
         "import * as React from 'react'
-        import { Scene, Storyboard, View } from 'utopia-api'
+        import { Scene, Storyboard, View, Group } from 'utopia-api'
         export var App = (props) => {
           return (
             <View

--- a/editor/src/core/workers/parser-printer/parser-printer-fragments.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-fragments.test-utils.ts
@@ -2,7 +2,7 @@ import { BakedInStoryboardVariableName } from '../../model/scene-utils'
 
 export const AwkwardFragmentsCode = `
 import * as React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 export var App = (props) => {
   return (
     <View

--- a/editor/src/core/workers/parser-printer/parser-printer-uids.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-uids.spec.tsx
@@ -324,7 +324,7 @@ describe('printCode', () => {
   it('applies changes back into the original code', () => {
     const startingCode = `
 import * as react from 'react'
-import { scene, storyboard, view } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 
 export var app = (props) => {
   return (
@@ -427,7 +427,7 @@ export var app = (props) => {
     const expectedResult = applyPrettier(
       `
 import * as react from 'react'
-import { scene, storyboard, view } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 
 export var app = (props) => {
   return (

--- a/editor/src/test-cases/majestic-broker.ts
+++ b/editor/src/test-cases/majestic-broker.ts
@@ -1,6 +1,6 @@
 export const MajesticBrokerTestCaseCode = `
 import React from 'react'
-import { Scene, Storyboard, View } from 'utopia-api'
+import { Scene, Storyboard, View, Group } from 'utopia-api'
 export var User = (props) => {
   return <span style={{ ...props.style, fontWeight: 600 }}>{props.children}</span>
 }


### PR DESCRIPTION
This PR changes the Standard Default Project Skeleton used by `makeTestProjectCodeWithSnippet` to go from this:

```
import { Scene, Storyboard, View } from 'utopia-api'
```

to this

```
import { Scene, Storyboard, View, Group } from 'utopia-api'
```

So that future tests can easily reference Groups without having to write any special-cased test code.

Groups don't exist yet – but that is not a problem since in JS you are allowed to import something that doesn't exist. It will be resolved as `undefined`.