### PR TITLE
Disable copying when an element has a child that refers to a value "elsewhere"

### DIFF
--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -1446,6 +1446,54 @@ export var storyboard = (
 )
 `)
       })
+      it('cannot copy element that has code in its children array', async () => {
+        const editor = await renderTestEditorWithCode(
+          `import * as React from 'react'
+          import { Storyboard } from 'utopia-api'
+          
+          const width = 122
+          
+          export var storyboard = (
+            <Storyboard data-uid='sb'>
+              <div
+                style={{
+                  backgroundColor: '#aaaaaa33',
+                  position: 'absolute',
+                  left: 281,
+                  top: 329,
+                  width: 122,
+                  height: 73,
+                }}
+                data-uid='container'
+              >
+                <div
+                  style={{
+                    backgroundColor: '#aaaaaa33',
+                    position: 'absolute',
+                    left: 19,
+                    top: 19,
+                    width: width,
+                    height: 40,
+                  }}
+                  data-uid='child'
+                />
+              </div>
+            </Storyboard>
+          )
+          `,
+          'await-first-dom-report',
+        )
+
+        await selectComponentsForTest(editor, [EP.fromString('sb/container')])
+
+        await expectNoAction(editor, () => pressKey('c', { modifiers: cmdModifier }))
+        await editor.getDispatchFollowUpActionsFinished()
+
+        expect(editor.getEditorState().editor.toasts.length).toEqual(1)
+        expect(editor.getEditorState().editor.toasts[0].message).toEqual(
+          'Cannot copy these elements.',
+        )
+      })
       describe('repeated paste', () => {
         it('repeated paste in autolayout', async () => {
           const editor = await renderTestEditorWithCode(

--- a/editor/src/core/shared/element-template.spec.ts
+++ b/editor/src/core/shared/element-template.spec.ts
@@ -174,7 +174,7 @@ describe('attributeReferencesElsewhere', () => {
       ),
     ).toEqual(true)
   })
-  it('ATTRIBUTE_FUNCTION_CALL returns false if it does not have a definedElsewhere entry', () => {
+  xit('ATTRIBUTE_FUNCTION_CALL returns false if it does not have a definedElsewhere entry', () => {
     expect(
       attributeReferencesElsewhere(
         jsExpressionFunctionCall('someFn', [

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -866,6 +866,7 @@ export function elementReferencesElsewhere(element: JSXElementChild): boolean {
       return element.children.some(elementReferencesElsewhere)
     case 'JSX_CONDITIONAL_EXPRESSION':
       return (
+        elementReferencesElsewhere(element.condition) ||
         elementReferencesElsewhere(element.whenTrue) ||
         elementReferencesElsewhere(element.whenFalse)
       )

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -854,7 +854,10 @@ export function jsxAttributesPartReferencesElsewhere(attrPart: JSXAttributesPart
 export function elementReferencesElsewhere(element: JSXElementChild): boolean {
   switch (element.type) {
     case 'JSX_ELEMENT':
-      return element.props.some(jsxAttributesPartReferencesElsewhere)
+      return (
+        element.props.some(jsxAttributesPartReferencesElsewhere) ||
+        element.children.some(elementReferencesElsewhere)
+      )
     case 'ATTRIBUTE_OTHER_JAVASCRIPT':
       return element.definedElsewhere.length > 0
     case 'JSX_TEXT_BLOCK':

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -858,8 +858,6 @@ export function elementReferencesElsewhere(element: JSXElementChild): boolean {
         element.props.some(jsxAttributesPartReferencesElsewhere) ||
         element.children.some(elementReferencesElsewhere)
       )
-    case 'ATTRIBUTE_OTHER_JAVASCRIPT':
-      return element.definedElsewhere.length > 0
     case 'JSX_TEXT_BLOCK':
       return false
     case 'JSX_FRAGMENT':
@@ -870,21 +868,8 @@ export function elementReferencesElsewhere(element: JSXElementChild): boolean {
         elementReferencesElsewhere(element.whenTrue) ||
         elementReferencesElsewhere(element.whenFalse)
       )
-    case 'ATTRIBUTE_VALUE':
-      return false
-    case 'ATTRIBUTE_NESTED_ARRAY':
-      return element.content.some((contentPart) => {
-        return elementReferencesElsewhere(contentPart.value)
-      })
-    case 'ATTRIBUTE_NESTED_OBJECT':
-      return element.content.some((contentPart) => {
-        return elementReferencesElsewhere(contentPart.value)
-      })
-    case 'ATTRIBUTE_FUNCTION_CALL':
-      return element.parameters.some(elementReferencesElsewhere)
     default:
-      const _exhaustiveCheck: never = element
-      throw new Error(`Unhandled element type ${JSON.stringify(element)}`)
+      return attributeReferencesElsewhere(element)
   }
 }
 

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -830,9 +830,7 @@ export function attributeReferencesElsewhere(attribute: JSExpression): boolean {
         return attributeReferencesElsewhere(subAttr.value)
       })
     case 'ATTRIBUTE_FUNCTION_CALL':
-      return attribute.parameters.some((parameter) => {
-        return attributeReferencesElsewhere(parameter)
-      })
+      return true
     default:
       const _exhaustiveCheck: never = attribute
       throw new Error(`Unhandled attribute type ${JSON.stringify(attribute)}`)


### PR DESCRIPTION
## Problem
The `elementReferencesElsewhere` check doesn't include the `children` array of JSXElement. This can lead to crashing the canvas on paste.

In a related way, we don't check whether a a conditional's condition refers to a variable elsewhere.

## Solution
Extend `elementReferencesElsewhere` so that it checks the `children` array of JSXElements, and checks the condition of conditionals.

Also, this PR refactors `elementReferencesElsewhere` so that it reuses `attributeReferencesElsewhere` for JSExpressions, so that no duplicated code is present among the two functions.