### PR TITLE
Do not cut element that cannot be copied

### DIFF
--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -93,9 +93,7 @@ export const cutElements: ContextMenuItem<CanvasData> = {
   enabled: true,
   shortcut: '⌘X',
   action: (data, dispatch?: EditorDispatch) => {
-    const deleteTargets = data.selectedViews
-    const deleteActions = deleteTargets.map(deleteView)
-    requireDispatch(dispatch)([copySelectionToClipboard(), ...deleteActions], 'noone')
+    requireDispatch(dispatch)([EditorActions.cutSelectionToClipboard()], 'noone')
   },
 }
 

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -352,6 +352,10 @@ export interface CopySelectionToClipboard {
   action: 'COPY_SELECTION_TO_CLIPBOARD'
 }
 
+export interface CutSelectionToClipboard {
+  action: 'CUT_SELECTION_TO_CLIPBOARD'
+}
+
 export interface CopyProperties {
   action: 'COPY_PROPERTIES'
 }
@@ -1135,6 +1139,7 @@ export type EditorAction =
   | OpenPopup
   | PasteJSXElements
   | CopySelectionToClipboard
+  | CutSelectionToClipboard
   | CopyProperties
   | PasteProperties
   | SetProjectID

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -225,6 +225,7 @@ import type {
   SetConditionalOverriddenCondition,
   SwitchConditionalBranches,
   UpdateConditionalExpression,
+  CutSelectionToClipboard,
 } from '../action-types'
 import { EditorModes, insertionSubject, InsertionSubjectWrapper, Mode } from '../editor-modes'
 import type {
@@ -459,6 +460,12 @@ export function pasteJSXElements(
 export function copySelectionToClipboard(): CopySelectionToClipboard {
   return {
     action: 'COPY_SELECTION_TO_CLIPBOARD',
+  }
+}
+
+export function cutSelectionToClipboard(): CutSelectionToClipboard {
+  return {
+    action: 'CUT_SELECTION_TO_CLIPBOARD',
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -33,6 +33,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'TOGGLE_FOCUSED_OMNIBOX_TAB':
     case 'TOGGLE_PANE':
     case 'COPY_SELECTION_TO_CLIPBOARD':
+    case 'CUT_SELECTION_TO_CLIPBOARD':
     case 'COPY_PROPERTIES':
     case 'OPEN_TEXT_EDITOR':
     case 'CLOSE_TEXT_EDITOR':

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -2674,6 +2674,71 @@ export var storyboard = (props) => {
       })
     })
   })
+  describe('CUT_SELECTION_TO_CLIPBOARD', () => {
+    it('cannot cut elements that reference variables elsewhere', async () => {
+      const editor = await renderTestEditorWithCode(
+        `import * as React from 'react'
+      import { Storyboard } from 'utopia-api'
+      
+      const width = 237
+      const height = 298
+      
+      export var storyboard = (
+        <Storyboard data-uid='sb'>
+          <div
+            style={{
+              backgroundColor: '#aaaaaa33',
+              position: 'absolute',
+              left: 287,
+              top: 411,
+              width: 'max-content',
+              height: 'max-content',
+              display: 'flex',
+              flexDirection: 'row',
+            }}
+            data-uid='container'
+          >
+            <div
+              style={{
+                backgroundColor: '#088658',
+                width: width,
+                height: height,
+                contain: 'layout',
+              }}
+              data-uid='green'
+            />
+            <div
+              style={{
+                backgroundColor: '#fdfdfd',
+                contain: 'layout',
+                width: width,
+                height: height,
+              }}
+              data-uid='white'
+            />
+            <div
+              style={{
+                backgroundColor: '#ff0000',
+                contain: 'layout',
+                width: width,
+                height: height,
+              }}
+              data-uid='blue'
+            />
+          </div>
+        </Storyboard>
+      )
+      `,
+        'await-first-dom-report',
+      )
+
+      await selectComponentsForTest(editor, [EP.fromString('sb/container/green')])
+      await expectNoAction(editor, () => pressKey('x', { modifiers: cmdModifier }))
+      await editor.getDispatchFollowUpActionsFinished()
+      expect(editor.getEditorState().editor.toasts.length).toEqual(1)
+      expect(editor.getEditorState().editor.toasts[0].message).toEqual('Cannot cut these elements.')
+    })
+  })
   describe('UNWRAP_ELEMENT', () => {
     it(`Unwraps a fragment-like element`, async () => {
       const testCode = `

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1913,12 +1913,7 @@ export const UPDATE_FNS = {
       null,
     ).editor
   },
-  DELETE_SELECTED: (
-    action: DeleteSelected,
-    editorForAction: EditorModel,
-    derived: DerivedState,
-    dispatch: EditorDispatch,
-  ): EditorModel => {
+  DELETE_SELECTED: (editorForAction: EditorModel, dispatch: EditorDispatch): EditorModel => {
     return toastOnGeneratedElementsSelected(
       'Generated elements can only be deleted in code.',
       editorForAction,
@@ -1926,11 +1921,6 @@ export const UPDATE_FNS = {
       (editor) => {
         const staticSelectedElements = editor.selectedViews
           .filter((selectedView) => {
-            const { components } = getJSXComponentsAndImportsForPathFromState(
-              selectedView,
-              editorForAction,
-              derived,
-            )
             return !MetadataUtils.isElementGenerated(selectedView)
           })
           .map((path, _, allSelectedPaths) => {
@@ -3017,6 +3007,36 @@ export const UPDATE_FNS = {
           pasteTargetsToIgnore: editor.selectedViews,
           styleClipboard: [],
         }
+      },
+      dispatch,
+    )
+  },
+  CUT_SELECTION_TO_CLIPBOARD: (
+    editorForAction: EditorModel,
+    dispatch: EditorDispatch,
+    builtInDependencies: BuiltInDependencies,
+  ): EditorModel => {
+    return toastOnUncopyableElementsSelected(
+      'Cannot copy these elements.',
+      editorForAction,
+      false,
+      (editor) => {
+        // side effect 😟
+        const copyData = createClipboardDataFromSelection(editorForAction, builtInDependencies)
+        if (copyData != null) {
+          Clipboard.setClipboardData({
+            plainText: copyData.plaintext,
+            html: encodeUtopiaDataToHtml(copyData.data),
+          })
+        }
+        return UPDATE_FNS.DELETE_SELECTED(
+          {
+            ...editor,
+            pasteTargetsToIgnore: editor.selectedViews,
+            styleClipboard: [],
+          },
+          dispatch,
+        )
       },
       dispatch,
     )

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3017,7 +3017,7 @@ export const UPDATE_FNS = {
     builtInDependencies: BuiltInDependencies,
   ): EditorModel => {
     return toastOnUncopyableElementsSelected(
-      'Cannot copy these elements.',
+      'Cannot cut these elements.',
       editorForAction,
       false,
       (editor) => {

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -694,9 +694,7 @@ export function handleKeyDown(
         )
       },
       [CUT_SELECTION_SHORTCUT]: () => {
-        return isSelectMode(editor.mode)
-          ? [EditorActions.copySelectionToClipboard(), EditorActions.deleteSelected()]
-          : []
+        return isSelectMode(editor.mode) ? [EditorActions.cutSelectionToClipboard()] : []
       },
       [UNDO_CHANGES_SHORTCUT]: () => {
         return [EditorActions.undo()]

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -118,6 +118,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.PASTE_PROPERTIES(action, state)
     case 'COPY_SELECTION_TO_CLIPBOARD':
       return UPDATE_FNS.COPY_SELECTION_TO_CLIPBOARD(action, state, dispatch, builtInDependencies)
+    case 'CUT_SELECTION_TO_CLIPBOARD':
+      return UPDATE_FNS.CUT_SELECTION_TO_CLIPBOARD(state, dispatch, builtInDependencies)
     case 'COPY_PROPERTIES':
       return UPDATE_FNS.COPY_PROPERTIES(action, state)
     case 'OPEN_TEXT_EDITOR':
@@ -253,7 +255,7 @@ export function runSimpleLocalEditorAction(
     case 'DELETE_VIEW':
       return UPDATE_FNS.DELETE_VIEW(action, state, dispatch)
     case 'DELETE_SELECTED':
-      return UPDATE_FNS.DELETE_SELECTED(action, state, derivedState, dispatch)
+      return UPDATE_FNS.DELETE_SELECTED(state, dispatch)
     case 'WRAP_IN_ELEMENT':
       return UPDATE_FNS.WRAP_IN_ELEMENT(action, state, derivedState, dispatch, builtInDependencies)
     case 'OPEN_FLOATING_INSERT_MENU':


### PR DESCRIPTION
## Problem
When cutting an element (either via the keyboard shortcut or the context menu), we cut the element if it's uncopiable (for example if it references properties elsewhere). This can lead to crashing the canvas on paste, if the said elsewhere-defined variables are not in scope.

## Fix
Create a dedicated cut action that only performs the cut if the elements to be cut are copiable.