### PR TITLE
Forking uses passed model rather than stale context

### DIFF
--- a/editor/src/components/editor/persistence-hooks.ts
+++ b/editor/src/components/editor/persistence-hooks.ts
@@ -1,10 +1,11 @@
 import React from 'react'
 import { useRefEditorState } from './store/store-hook'
+import { persistentModelFromEditorModel } from './store/editor-state'
 
 export function useTriggerForkProject(): () => void {
   const storeRef = useRefEditorState((store) => store)
   return React.useCallback(async () => {
     const store = storeRef.current
-    store.persistence.fork()
+    store.persistence.fork(store.editor.projectName, persistentModelFromEditorModel(store.editor))
   }, [storeRef])
 }

--- a/editor/src/components/editor/persistence/persistence.spec.ts
+++ b/editor/src/components/editor/persistence/persistence.spec.ts
@@ -439,7 +439,7 @@ describe('Forking a project', () => {
     expect(capturedData.newProjectId).toBeDefined()
     const startProjectId = capturedData.newProjectId!
 
-    testMachine.fork()
+    testMachine.fork(ProjectName, startProject)
     await delay(20)
     testMachine.stop()
 
@@ -470,7 +470,7 @@ describe('Forking a project', () => {
 
     testMachine.logout()
     await delay(20)
-    testMachine.fork()
+    testMachine.fork(ProjectName, startProject)
     await delay(20)
     testMachine.stop()
 
@@ -508,7 +508,7 @@ describe('Forking a project', () => {
     const startProjectId = capturedData.newProjectId!
 
     await delay(20)
-    testMachine.fork()
+    testMachine.fork(ProjectName, startProjectIncludingBase64)
     await delay(20)
     testMachine.stop()
 

--- a/editor/src/components/editor/persistence/persistence.ts
+++ b/editor/src/components/editor/persistence/persistence.ts
@@ -199,8 +199,8 @@ export class PersistenceMachine {
     this.interpreter.send(newEvent({ name: projectName, content: project }))
   }
 
-  fork = (): void => {
-    this.interpreter.send(forkEvent())
+  fork = (projectName: string, project: PersistentModel): void => {
+    this.interpreter.send(forkEvent({ name: projectName, content: project }))
   }
 
   login = (): void => {


### PR DESCRIPTION
**Problem:**
The forking process in our persistence state machine uses the version of the project that is stored in the machine's context rather than the model that was passed in when asking the machine to save the model, meaning there is an edge case where auto-forking an old project could fail if migration steps were required.

**Fix:**
Use the model that was passed in as part of the save event when performing the fork. I've also added a test to ensure that the fork uses the latest version of the project.