### PR TITLE
fix(copy) remove json5.stringify for elements when creating a copydata

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3039,7 +3039,7 @@ export const UPDATE_FNS = {
         ),
       )
 
-      return elementToPaste.reverse().reduce((working, elementPaste) => {
+      return [...elementToPaste].reverse().reduce((working, elementPaste) => {
         const existingIDs = getAllUniqueUids(working.projectContents).allIDs
         const elementWithUniqueUID = fixUtopiaElement(
           elementPaste.element,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -472,7 +472,7 @@ import {
   fontSettings,
   FontSettings,
 } from '../../inspector/common/css-utils'
-import { projectListing, ProjectListing } from '../action-types'
+import { ElementPaste, projectListing, ProjectListing } from '../action-types'
 import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
 import { MouseButtonsPressed } from '../../../utils/mouse'
 import { assertNever } from '../../../core/shared/utils'
@@ -511,6 +511,7 @@ import {
   ElementPathTrees,
 } from '../../../core/shared/element-path-tree'
 import { jsxElementCopyData, JSXElementCopyData } from '../../../utils/clipboard'
+import { elementPaste } from '../actions/action-creators'
 
 export function TransientCanvasStateFilesStateKeepDeepEquality(
   oldValue: TransientFilesState,
@@ -3741,10 +3742,21 @@ export const ValueAtPathDeepEquality: KeepDeepEqualityCall<ValueAtPath> = combin
   valueAtPath,
 )
 
+export const ElementPasteKeepDeepEquality: KeepDeepEqualityCall<ElementPaste> =
+  combine3EqualityCalls(
+    (c) => c.element,
+    JSXElementChildKeepDeepEquality(),
+    (c) => c.importsToAdd,
+    objectDeepEquality(ImportDetailsKeepDeepEquality),
+    (c) => c.originalElementPath,
+    ElementPathKeepDeepEquality,
+    elementPaste,
+  )
+
 export const JSXElementsCopyDataDeepEquality: KeepDeepEqualityCall<JSXElementCopyData> =
   combine3EqualityCalls(
     (c) => c.elements,
-    StringKeepDeepEquality,
+    arrayDeepEquality(ElementPasteKeepDeepEquality),
     (c) => c.targetOriginalContextMetadata,
     ElementInstanceMetadataMapKeepDeepEquality,
     (c) => c.targetOriginalContextElementPathTrees,

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -37,7 +37,6 @@ import {
   pressKey,
 } from '../canvas/event-helpers.test-utils'
 import {
-  elementPaste,
   pasteJSXElements,
   setConditionalOverriddenCondition,
 } from '../editor/actions/action-creators'

--- a/editor/src/utils/clipboard.spec.tsx
+++ b/editor/src/utils/clipboard.spec.tsx
@@ -97,8 +97,7 @@ export var Card = (props) => {
     expect(clipboardData?.data.length).toEqual(1)
     expect(clipboardData?.data[0].type).toEqual('ELEMENT_COPY')
     expect(clipboardData?.data[0].elements).not.toBeNull()
-    const elements = json5.parse(clipboardData?.data[0].elements ?? '')
-    expect(json5.stringify(elements, null, 2)).toMatchInlineSnapshot(`
+    expect(json5.stringify(clipboardData?.data[0].elements, null, 2)).toMatchInlineSnapshot(`
       "[
         {
           element: {

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -62,13 +62,13 @@ import { ElementPathTrees } from '../core/shared/element-path-tree'
 
 export interface JSXElementCopyData {
   type: 'ELEMENT_COPY'
-  elements: JSXElementsJson
+  elements: Array<ElementPaste>
   targetOriginalContextMetadata: ElementInstanceMetadataMap
   targetOriginalContextElementPathTrees: ElementPathTrees
 }
 
 export function jsxElementCopyData(
-  elements: JSXElementsJson,
+  elements: Array<ElementPaste>,
   targetOriginalContextMetadata: ElementInstanceMetadataMap,
   targetOriginalContextElementPathTrees: ElementPathTrees,
 ): JSXElementCopyData {
@@ -80,8 +80,6 @@ export function jsxElementCopyData(
   }
 }
 
-type JSXElementsJson = string
-
 export type CopyData = JSXElementCopyData
 
 interface ParsedCopyData {
@@ -91,7 +89,7 @@ interface ParsedCopyData {
 }
 
 export function parseCopyData(data: CopyData): ParsedCopyData {
-  const elements = json5.parse(data.elements)
+  const elements = data.elements
   const metadata = data.targetOriginalContextMetadata
   const pathTrees = data.targetOriginalContextElementPathTrees
 
@@ -333,7 +331,7 @@ export function createClipboardDataFromSelection(
     data: [
       {
         type: 'ELEMENT_COPY',
-        elements: json5.stringify(jsxElements),
+        elements: jsxElements,
         targetOriginalContextMetadata: filterMetadataForCopy(
           editor.selectedViews,
           editor.jsxMetadata,


### PR DESCRIPTION
**Fix:**
Cleaning up the `JSXElementCopyData`. It stored the elements as a string, but actually the whole copydata is later using JSON.stringify, so I think there is no need to double stringify it.

**Commit Details:**
- update JSXElementCopyData
- remove json5 parse/stringify from `parseCopyData` and `createClipboardDataFromSelection`
