### PR TITLE
More easily compose optics.

### DIFF
--- a/editor/src/components/canvas/canvas-context-menu.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-context-menu.spec.browser2.tsx
@@ -6,7 +6,7 @@ import {
 } from '../../core/model/conditionals'
 import { JSXElementChild } from '../../core/shared/element-template'
 import { unsafeGet } from '../../core/shared/optics/optic-utilities'
-import { compose3Optics, Optic } from '../../core/shared/optics/optics'
+import { Optic } from '../../core/shared/optics/optics'
 import { BakedInStoryboardUID } from '../../core/model/scene-utils'
 import * as EP from '../../core/shared/element-path'
 import { altCmdModifier, cmdModifier } from '../../utils/modifiers'
@@ -778,11 +778,9 @@ describe('canvas context menu', () => {
       const conditionalPath = EP.fromString(
         `${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/conditional`,
       )
-      const inactiveElementOptic: Optic<EditorState, JSXElementChild> = compose3Optics(
-        forElementOptic(conditionalPath),
-        jsxConditionalExpressionOptic,
-        conditionalWhenFalseOptic,
-      )
+      const inactiveElementOptic = forElementOptic(conditionalPath)
+        .compose(jsxConditionalExpressionOptic)
+        .compose(conditionalWhenFalseOptic)
       const inactiveElement = unsafeGet(inactiveElementOptic, renderResult.getEditorState().editor)
       const testValuePath = EP.appendToPath(conditionalPath, inactiveElement.uid)
 

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -135,7 +135,7 @@ import {
 import { createStoresAndState, UtopiaStoreAPI } from '../editor/store/store-hook'
 import { isTransientAction } from '../editor/actions/action-utils'
 import { modify } from '../../core/shared/optics/optic-utilities'
-import { compose2Optics, Optic } from '../../core/shared/optics/optics'
+import { Optic } from '../../core/shared/optics/optics'
 import { fromField } from '../../core/shared/optics/optic-creators'
 import { memoEqualityCheckAnalysis } from '../../utils/react-performance'
 
@@ -191,8 +191,7 @@ export interface EditorRenderResult {
 function formatAllCodeInModel(model: PersistentModel): PersistentModel {
   // Call formatTestProjectCode on every code file to ensure that simply re-printing and
   // re-parsing the file will have no effect
-  const combinedOptic: Optic<PersistentModel, PathAndFileEntry> = compose2Optics(
-    fromField('projectContents'),
+  const combinedOptic = fromField<PersistentModel, 'projectContents'>('projectContents').compose(
     contentsTreeOptic,
   )
   return modify(

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -140,12 +140,7 @@ import { cssNumber } from '../../inspector/common/css-utils'
 import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { styleStringInArray } from '../../../utils/common-constants'
 import { childInsertionPath } from '../store/insertion-path'
-import {
-  compose5Optics,
-  compose2Optics,
-  compose4Optics,
-  Optic,
-} from '../../../core/shared/optics/optics'
+import { Optic } from '../../../core/shared/optics/optics'
 import { fromField, filtered, fromTypeGuard } from '../../../core/shared/optics/optic-creators'
 import { contentsTreeOptic } from '../../../components/assets'
 import { unsafeGet } from '../../../core/shared/optics/optic-utilities'
@@ -1559,25 +1554,21 @@ describe('SET_FOCUSED_ELEMENT', () => {
 })
 
 function textFileFromEditorStateOptic(filename: string): Optic<EditorState, TextFile> {
-  return compose5Optics(
-    fromField('projectContents'),
-    contentsTreeOptic,
-    filtered(({ fullPath }) => fullPath === filename),
-    fromField('file'),
-    fromTypeGuard(isTextFile),
-  )
+  return fromField<EditorState, 'projectContents'>('projectContents')
+    .compose(contentsTreeOptic)
+    .compose(filtered(({ fullPath }) => fullPath === filename))
+    .compose(fromField('file'))
+    .compose(fromTypeGuard(isTextFile))
 }
 
 function versionNumberOptic(filename: string): Optic<EditorState, number> {
-  return compose2Optics(textFileFromEditorStateOptic(filename), fromField('versionNumber'))
+  return textFileFromEditorStateOptic(filename).compose(fromField('versionNumber'))
 }
 function parsedTextFileOptic(filename: string): Optic<EditorState, ParseSuccess> {
-  return compose4Optics(
-    textFileFromEditorStateOptic(filename),
-    fromField('fileContents'),
-    fromField('parsed'),
-    fromTypeGuard(isParseSuccess),
-  )
+  return textFileFromEditorStateOptic(filename)
+    .compose(fromField('fileContents'))
+    .compose(fromField('parsed'))
+    .compose(fromTypeGuard(isParseSuccess))
 }
 
 describe('UPDATE_FROM_WORKER', () => {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -522,7 +522,7 @@ import { LayoutPropsWithoutTLBR, StyleProperties } from '../../inspector/common/
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { isUtopiaCommentFlag, makeUtopiaFlagComment } from '../../../core/shared/comment-flags'
 import { modify, toArrayOf } from '../../../core/shared/optics/optic-utilities'
-import { compose2Optics, compose3Optics, Optic } from '../../../core/shared/optics/optics'
+import { Optic } from '../../../core/shared/optics/optics'
 import { fromField, traverseArray } from '../../../core/shared/optics/optic-creators'
 import {
   commonInsertionPathFromArray,
@@ -1574,10 +1574,7 @@ function updateSelectedComponentsFromEditorPosition(
     return editor
   } else {
     const highlightBoundsForUids = getHighlightBoundsForFile(editor, filePath)
-    const allElementPathsOptic: Optic<Array<NavigatorEntry>, ElementPath> = compose2Optics(
-      traverseArray(),
-      fromField('elementPath'),
-    )
+    const allElementPathsOptic = traverseArray<NavigatorEntry>().compose(fromField('elementPath'))
     const newlySelectedElements = getElementPathsInBounds(
       line,
       highlightBoundsForUids,

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../core/shared/element-template'
 import { filtered, fromField, fromTypeGuard } from '../../core/shared/optics/optic-creators'
 import { unsafeGet } from '../../core/shared/optics/optic-utilities'
-import { Optic, compose6Optics } from '../../core/shared/optics/optics'
+import { Optic } from '../../core/shared/optics/optics'
 import { forceNotNull } from '../../core/shared/optional-utils'
 import { ElementPath } from '../../core/shared/project-file-types'
 import { selectComponentsForTest, wait } from '../../utils/utils.test-utils'
@@ -197,14 +197,14 @@ describe('conditionals', () => {
         'await-first-dom-report',
       )
 
-      const helloWorldUIDOptic: Optic<EditorState, string> = compose6Optics(
-        forElementOptic(EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional'])),
-        fromTypeGuard(isJSXConditionalExpression),
-        conditionalWhenTrueOptic,
-        fromTypeGuard(isJSExpressionValue),
-        filtered((value) => value.value === 'hello'),
-        fromField('uid'),
+      const helloWorldUIDOptic: Optic<EditorState, string> = forElementOptic(
+        EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional']),
       )
+        .compose(fromTypeGuard(isJSXConditionalExpression))
+        .compose(conditionalWhenTrueOptic)
+        .compose(fromTypeGuard(isJSExpressionValue))
+        .compose(filtered((value) => value.value === 'hello'))
+        .compose(fromField('uid'))
       const helloWorldUID: string = unsafeGet(
         helloWorldUIDOptic,
         renderResult.getEditorState().editor,

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -105,7 +105,7 @@ import fastDeepEquals from 'fast-deep-equal'
 import { getPropertyControlNames } from '../../../core/property-controls/property-control-values'
 import { EditorAction } from '../../editor/action-types'
 import { useDispatch } from '../../editor/store/dispatch-context'
-import { compose2Optics, Optic } from '../../../core/shared/optics/optics'
+import { Optic } from '../../../core/shared/optics/optics'
 import { eitherRight, fromTypeGuard } from '../../../core/shared/optics/optic-creators'
 import { modify } from '../../../core/shared/optics/optic-utilities'
 
@@ -748,10 +748,10 @@ function useGetSpiedProps<P extends ParsedPropertiesKeys>(
   )
 }
 
-const getModifiableAttributeResultToExpressionOptic: Optic<
-  GetModifiableAttributeResult,
-  JSExpression
-> = compose2Optics(eitherRight(), fromTypeGuard(isRegularJSXAttribute))
+const getModifiableAttributeResultToExpressionOptic = eitherRight<
+  string,
+  ModifiableAttribute
+>().compose(fromTypeGuard(isRegularJSXAttribute))
 
 export function useGetMultiselectedProps<P extends ParsedPropertiesKeys>(
   pathMappingFn: PathMappingFn<P>,

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -25,7 +25,7 @@ import { JSXElementChild, isJSXConditionalExpression } from '../../core/shared/e
 import { WindowPoint, canvasPoint, offsetPoint, windowPoint } from '../../core/shared/math-utils'
 import { fromTypeGuard } from '../../core/shared/optics/optic-creators'
 import { unsafeGet } from '../../core/shared/optics/optic-utilities'
-import { Optic, compose3Optics } from '../../core/shared/optics/optics'
+import { Optic } from '../../core/shared/optics/optics'
 import { ElementPath } from '../../core/shared/project-file-types'
 import { getUtopiaID } from '../../core/shared/uid-utils'
 import { emptyImports } from '../../core/workers/common/project-file-utils'
@@ -1023,11 +1023,9 @@ describe('conditionals in the navigator', () => {
     )
 
     // Need the underlying value in the clause to be able to construct the navigator entry.
-    const inactiveElementOptic: Optic<EditorState, JSXElementChild> = compose3Optics(
-      forElementOptic(EP.parentPath(elementPathToDrag)),
-      jsxConditionalExpressionOptic,
-      conditionalWhenFalseOptic,
-    )
+    const inactiveElementOptic = forElementOptic(EP.parentPath(elementPathToDrag))
+      .compose(jsxConditionalExpressionOptic)
+      .compose(conditionalWhenFalseOptic)
     const inactiveElement = unsafeGet(inactiveElementOptic, renderResult.getEditorState().editor)
 
     await act(async () => {
@@ -1076,11 +1074,9 @@ describe('conditionals in the navigator', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     // Need the underlying value in the clause to be able to construct the navigator entry.
-    const removedOriginalLocationOptic: Optic<EditorState, JSXElementChild> = compose3Optics(
-      forElementOptic(EP.parentPath(elementPathToDrag)),
-      jsxConditionalExpressionOptic,
-      conditionalWhenFalseOptic,
-    )
+    const removedOriginalLocationOptic = forElementOptic(EP.parentPath(elementPathToDrag))
+      .compose(jsxConditionalExpressionOptic)
+      .compose(conditionalWhenFalseOptic)
     const removedOriginalLocation = unsafeGet(
       removedOriginalLocationOptic,
       renderResult.getEditorState().editor,
@@ -1177,11 +1173,9 @@ describe('conditionals in the navigator', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     // Need the underlying value in the clause to be able to construct the navigator entry.
-    const removedOriginalLocationOptic: Optic<EditorState, JSXElementChild> = compose3Optics(
-      forElementOptic(EP.parentPath(elementPathToDrag)),
-      jsxConditionalExpressionOptic,
-      conditionalWhenTrueOptic,
-    )
+    const removedOriginalLocationOptic = forElementOptic(EP.parentPath(elementPathToDrag))
+      .compose(jsxConditionalExpressionOptic)
+      .compose(conditionalWhenTrueOptic)
     const removedOriginalLocation = unsafeGet(
       removedOriginalLocationOptic,
       renderResult.getEditorState().editor,
@@ -1317,11 +1311,9 @@ describe('conditionals in the navigator', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
 
     // Need the underlying value in the clause to be able to construct the navigator entry.
-    const removedOriginalLocationOptic: Optic<EditorState, JSXElementChild> = compose3Optics(
-      forElementOptic(EP.parentPath(elementPathToDelete)),
-      jsxConditionalExpressionOptic,
-      conditionalWhenFalseOptic,
-    )
+    const removedOriginalLocationOptic = forElementOptic(EP.parentPath(elementPathToDelete))
+      .compose(jsxConditionalExpressionOptic)
+      .compose(conditionalWhenFalseOptic)
     const removedOriginalLocation = unsafeGet(
       removedOriginalLocationOptic,
       renderResult.getEditorState().editor,
@@ -1449,11 +1441,11 @@ describe('conditionals in the navigator', () => {
         startingEditorState: EditorState,
         endingEditorState: EditorState,
       ) => {
-        const expectedPasteTargetOptic = compose3Optics(
-          forElementOptic(EP.parentPath(pasteTestCase.pathToPasteInto)),
-          fromTypeGuard(isJSXConditionalExpression),
-          conditionalWhenFalseOptic,
+        const expectedPasteTargetOptic = forElementOptic(
+          EP.parentPath(pasteTestCase.pathToPasteInto),
         )
+          .compose(fromTypeGuard(isJSXConditionalExpression))
+          .compose(conditionalWhenFalseOptic)
         const expectedPasteTargetBeforePaste = unsafeGet(
           expectedPasteTargetOptic,
           startingEditorState,
@@ -1682,11 +1674,9 @@ describe('Navigator conditional override toggling', () => {
     const elementPath = EP.fromString(`${BakedInStoryboardUID}/conditional/${elementUID}`)
 
     // Need the underlying value in the clause to be able to construct the navigator entry.
-    const inactiveElementOptic: Optic<EditorState, JSXElementChild> = compose3Optics(
-      forElementOptic(EP.parentPath(elementPath)),
-      jsxConditionalExpressionOptic,
-      elementUID === 'true-div' ? conditionalWhenTrueOptic : conditionalWhenFalseOptic,
-    )
+    const inactiveElementOptic = forElementOptic(EP.parentPath(elementPath))
+      .compose(jsxConditionalExpressionOptic)
+      .compose(elementUID === 'true-div' ? conditionalWhenTrueOptic : conditionalWhenFalseOptic)
 
     const navigatorEntry = isActive
       ? regularNavigatorEntry(elementPath)

--- a/editor/src/core/model/element-template-utils.spec.tsx
+++ b/editor/src/core/model/element-template-utils.spec.tsx
@@ -55,7 +55,7 @@ import {
   fromTypeGuard,
 } from '../shared/optics/optic-creators'
 import { unsafeGet } from '../shared/optics/optic-utilities'
-import { compose2Optics, compose3Optics, Optic } from '../shared/optics/optics'
+import { Optic } from '../shared/optics/optics'
 import { ParseSuccess, StaticElementPath } from '../shared/project-file-types'
 import { emptySet } from '../shared/set-utils'
 import { getUtopiaID } from '../shared/uid-utils'
@@ -95,19 +95,15 @@ describe('guaranteeUniqueUids', () => {
     ]
     const fixedElements = guaranteeUniqueUids(exampleElements, emptySet())
 
-    const child0PropsOptic: Optic<Array<JSXElementChild>, JSXAttributes> = compose3Optics(
-      fromArrayIndex(0),
-      fromTypeGuard(isJSXElement),
-      fromField('props'),
-    )
+    const child0PropsOptic = fromArrayIndex<JSXElementChild>(0)
+      .compose(fromTypeGuard(isJSXElement))
+      .compose(fromField('props'))
     const child0Props = unsafeGet(child0PropsOptic, fixedElements.value)
     const child0UID = getJSXAttribute(child0Props, 'data-uid')
     expect(child0UID).toEqual(jsExpressionValue('aab', emptyComments, 'aac'))
-    const child1PropsOptic: Optic<Array<JSXElementChild>, JSXAttributes> = compose3Optics(
-      fromArrayIndex(1),
-      fromTypeGuard(isJSXElement),
-      fromField('props'),
-    )
+    const child1PropsOptic = fromArrayIndex<JSXElementChild>(1)
+      .compose(fromTypeGuard(isJSXElement))
+      .compose(fromField('props'))
     const child1Props = unsafeGet(child1PropsOptic, fixedElements.value)
     const child1UID = getJSXAttribute(child1Props, 'data-uid')
     expect(child1UID).not.toEqual(jsExpressionValue('aaa', emptyComments, 'aaa'))
@@ -131,18 +127,14 @@ describe('guaranteeUniqueUids', () => {
 
     const existingIDs = new Set(['aab', 'bbb'])
     const fixedElements = guaranteeUniqueUids(exampleElements, existingIDs)
-    const child0PropsOptic: Optic<Array<JSXElementChild>, JSXAttributes> = compose3Optics(
-      fromArrayIndex(0),
-      fromTypeGuard(isJSXElement),
-      fromField('props'),
-    )
+    const child0PropsOptic = fromArrayIndex<JSXElementChild>(0)
+      .compose(fromTypeGuard(isJSXElement))
+      .compose(fromField('props'))
     const child0Props = unsafeGet(child0PropsOptic, fixedElements.value)
     const child0UID = getJSXAttribute(child0Props, 'data-uid')
-    const child1PropsOptic: Optic<Array<JSXElementChild>, JSXAttributes> = compose3Optics(
-      fromArrayIndex(1),
-      fromTypeGuard(isJSXElement),
-      fromField('props'),
-    )
+    const child1PropsOptic = fromArrayIndex<JSXElementChild>(1)
+      .compose(fromTypeGuard(isJSXElement))
+      .compose(fromField('props'))
     const child1Props = unsafeGet(child1PropsOptic, fixedElements.value)
     const child1UID = getJSXAttribute(child1Props, 'data-uid')
     expect(child0UID).toEqual(jsExpressionValue('aaa', emptyComments, 'axa'))

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -59,7 +59,7 @@ import { LargeProjectContents } from '../../test-cases/large-project'
 import { v4 as UUID } from 'uuid'
 import { SmallSingleDivProjectContents } from '../../test-cases/simple-single-div-project'
 import { useDispatch } from '../../components/editor/store/dispatch-context'
-import { compose5Optics, Optic } from '../shared/optics/optics'
+import { Optic } from '../shared/optics/optics'
 import { ElementPath } from '../shared/project-file-types'
 import { fromField, traverseArray } from '../shared/optics/optic-creators'
 import { toArrayOf } from '../shared/optics/optic-utilities'
@@ -184,13 +184,11 @@ async function loadProject(
   return editorReady
 }
 
-const storeToAllRegularPaths: Optic<EditorStorePatched, ElementPath> = compose5Optics(
-  fromField('derived'),
-  fromField('navigatorTargets'),
-  traverseArray(),
-  regularNavigatorEntryOptic,
-  fromField('elementPath'),
-)
+const storeToAllRegularPaths = fromField<EditorStorePatched, 'derived'>('derived')
+  .compose(fromField('navigatorTargets'))
+  .compose(traverseArray())
+  .compose(regularNavigatorEntryOptic)
+  .compose(fromField('elementPath'))
 
 export function useTriggerScrollPerformanceTest(): () => void {
   const dispatch = useDispatch() as DebugDispatch

--- a/editor/src/core/shared/optics/optics-examples.spec.ts
+++ b/editor/src/core/shared/optics/optics-examples.spec.ts
@@ -1,15 +1,10 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "FastCheck.assert"] }] */
 import * as FastCheck from 'fast-check'
 import fastDeepEquals from 'fast-deep-equal'
 import { Either, left, mapEither, right } from '../either'
 import { eitherRight, fromField, logOptic, traverseArray } from './optic-creators'
 import { modify, toArrayOf } from './optic-utilities'
-import {
-  compose2Optics,
-  compose3Optics,
-  compose6Optics,
-  compose7Optics,
-  compose8Optics,
-} from './optics'
+import { Optic } from './optics'
 
 describe('optics examples', () => {
   it('flattening arrays', () => {
@@ -17,7 +12,7 @@ describe('optics examples', () => {
       FastCheck.array(FastCheck.array(FastCheck.integer())),
       (array: Array<Array<number>>) => {
         const actualResult: Array<number> = toArrayOf(
-          compose2Optics(traverseArray<Array<number>>(), traverseArray<number>()),
+          traverseArray<Array<number>>().compose(traverseArray<number>()),
           array,
         )
         const expectedResult: Array<number> = array.flat()
@@ -74,22 +69,12 @@ describe('optics examples', () => {
       }
     })
     // We can reuse this.
-    const filesToElementNameLens = compose6Optics<
-      Array<ProjectFile>,
-      ProjectFile,
-      Either<string, ParseSuccess>,
-      ParseSuccess,
-      Array<JSXElement>,
-      JSXElement,
-      string
-    >(
-      traverseArray(),
-      fromField('parseResult'),
-      eitherRight(),
-      fromField('elements'),
-      traverseArray(),
-      fromField('name'),
-    )
+    const filesToElementNameLens: Optic<Array<ProjectFile>, string> = traverseArray<ProjectFile>()
+      .compose(fromField('parseResult'))
+      .compose(eitherRight())
+      .compose(fromField('elements'))
+      .compose(traverseArray())
+      .compose(fromField('name'))
     it('pulls values from deep within a structure', () => {
       const property = FastCheck.property(
         FastCheck.array(projectFileArbitrary).noShrink(),

--- a/editor/src/core/shared/optics/optics.ts
+++ b/editor/src/core/shared/optics/optics.ts
@@ -1,14 +1,4 @@
-import {
-  defaultEither,
-  Either,
-  foldEither,
-  traverseEither,
-  mapEither,
-  flatMapEither,
-  right,
-  left,
-  forEachRight,
-} from '../either'
+import { Either, foldEither, mapEither, flatMapEither, forEachRight } from '../either'
 import { assertNever } from '../utils'
 
 // An optic that represents an isomorphism between two types.
@@ -21,55 +11,55 @@ export interface Iso<S, A> {
   to: (a: A) => S
 }
 
-export function iso<S, A>(from: (s: S) => A, to: (a: A) => S): Iso<S, A> {
-  return {
+export function iso<S, A>(from: (s: S) => A, to: (a: A) => S): Optic<S, A> {
+  return addComposeToRawOptic<S, A>({
     type: 'ISO',
     from: from,
     to: to,
-  }
+  })
 }
 
 // An optic which represents a view into a part of a type, often in relation to product types.
 // Inspiration: https://hackage.haskell.org/package/lens-5.2/docs/Control-Lens-Lens.html#t:Lens
 // The value can always be retrieved from the original, but as it will only be a part, the
 // original value is required to reconstruct it via the `update` function.
-export interface Lens<S, A> {
+interface Lens<S, A> {
   type: 'LENS'
   from: (s: S) => A
   update: (s: S, a: A) => S
 }
 
-export function lens<S, A>(from: (s: S) => A, update: (s: S, a: A) => S): Lens<S, A> {
-  return {
+export function lens<S, A>(from: (s: S) => A, update: (s: S, a: A) => S): Optic<S, A> {
+  return addComposeToRawOptic<S, A>({
     type: 'LENS',
     from: from,
     update: update,
-  }
+  })
 }
 
 // An optic which represents a possible case of a value, often in relation to sum types.
 // Inspiration: https://hackage.haskell.org/package/lens-5.2/docs/Control-Lens-Prism.html#t:Prism
 // The value may not always be representable as the `A` case, but if we have a value of that type
 // we can always get back to the original.
-export interface Prism<S, A> {
+interface Prism<S, A> {
   type: 'PRISM'
   from: (s: S) => Either<string, A>
   to: (a: A) => S
 }
 
-export function prism<S, A>(from: (s: S) => Either<string, A>, to: (a: A) => S): Prism<S, A> {
-  return {
+export function prism<S, A>(from: (s: S) => Either<string, A>, to: (a: A) => S): Optic<S, A> {
+  return addComposeToRawOptic<S, A>({
     type: 'PRISM',
     from: from,
     to: to,
-  }
+  })
 }
 
 // An optic which can represent any case, going from a value to possibly many others.
 // Inspiration: https://hackage.haskell.org/package/lens-5.2/docs/Control-Lens-Type.html#t:Traversal
 // This has the weakest set of guarantees as it may not produce any values and always
 // requires the original to do any updates.
-export interface Traversal<S, A> {
+interface Traversal<S, A> {
   type: 'TRAVERSAL'
   from: (s: S) => Array<A>
   update: (s: S, modify: (a: A) => A) => S
@@ -78,17 +68,48 @@ export interface Traversal<S, A> {
 export function traversal<S, A>(
   from: (s: S) => Array<A>,
   update: (s: S, modify: (a: A) => A) => S,
-): Traversal<S, A> {
-  return {
+): Optic<S, A> {
+  return addComposeToRawOptic<S, A>({
     type: 'TRAVERSAL',
     from: from,
     update: update,
+  })
+}
+
+export interface OpticCompose<S, A1> {
+  compose<A2>(withOptic: Optic<A1, A2>): Optic<S, A2>
+}
+
+type RawOptic<S, A> = Iso<S, A> | Lens<S, A> | Prism<S, A> | Traversal<S, A>
+
+export type Optic<S, A> = RawOptic<S, A> & OpticCompose<S, A>
+
+function compose2Optics<A, B, C>(first: RawOptic<A, B>, second: RawOptic<B, C>): RawOptic<A, C> {
+  switch (first.type) {
+    case 'ISO':
+      return composeOpticToIso(first, second)
+    case 'LENS':
+      return composeOpticToLens(first, second)
+    case 'PRISM':
+      return composeOpticToPrism(first, second)
+    case 'TRAVERSAL':
+      return composeOpticToTraversal(first, second)
+    default:
+      assertNever(first)
   }
 }
 
-export type Optic<S, A> = Iso<S, A> | Lens<S, A> | Prism<S, A> | Traversal<S, A>
+function addComposeToRawOptic<S, A>(rawOptic: RawOptic<S, A>): Optic<S, A> {
+  function compose<A2>(withOptic: Optic<A, A2>): Optic<S, A2> {
+    return addComposeToRawOptic(compose2Optics(rawOptic, withOptic))
+  }
+  return {
+    ...rawOptic,
+    compose: compose,
+  }
+}
 
-function composeOpticToIso<A, B, C>(first: Iso<A, B>, second: Optic<B, C>): Optic<A, C> {
+function composeOpticToIso<A, B, C>(first: Iso<A, B>, second: RawOptic<B, C>): RawOptic<A, C> {
   switch (second.type) {
     case 'ISO':
       return iso(
@@ -131,7 +152,7 @@ function composeOpticToIso<A, B, C>(first: Iso<A, B>, second: Optic<B, C>): Opti
   }
 }
 
-function composeOpticToLens<A, B, C>(first: Lens<A, B>, second: Optic<B, C>): Optic<A, C> {
+function composeOpticToLens<A, B, C>(first: Lens<A, B>, second: RawOptic<B, C>): RawOptic<A, C> {
   switch (second.type) {
     case 'ISO':
       return lens(
@@ -190,7 +211,7 @@ function composeOpticToLens<A, B, C>(first: Lens<A, B>, second: Optic<B, C>): Op
   }
 }
 
-function composeOpticToPrism<A, B, C>(first: Prism<A, B>, second: Optic<B, C>): Optic<A, C> {
+function composeOpticToPrism<A, B, C>(first: Prism<A, B>, second: RawOptic<B, C>): RawOptic<A, C> {
   switch (second.type) {
     case 'ISO':
       return prism(
@@ -267,8 +288,8 @@ function composeOpticToPrism<A, B, C>(first: Prism<A, B>, second: Optic<B, C>): 
 
 function composeOpticToTraversal<A, B, C>(
   first: Traversal<A, B>,
-  second: Optic<B, C>,
-): Optic<A, C> {
+  second: RawOptic<B, C>,
+): RawOptic<A, C> {
   switch (second.type) {
     case 'ISO':
       return traversal(
@@ -328,82 +349,4 @@ function composeOpticToTraversal<A, B, C>(
     default:
       assertNever(second)
   }
-}
-
-export function compose2Optics<A, B, C>(first: Optic<A, B>, second: Optic<B, C>): Optic<A, C> {
-  switch (first.type) {
-    case 'ISO':
-      return composeOpticToIso(first, second)
-    case 'LENS':
-      return composeOpticToLens(first, second)
-    case 'PRISM':
-      return composeOpticToPrism(first, second)
-    case 'TRAVERSAL':
-      return composeOpticToTraversal(first, second)
-    default:
-      assertNever(first)
-  }
-}
-
-export function compose3Optics<A, B, C, D>(
-  first: Optic<A, B>,
-  second: Optic<B, C>,
-  third: Optic<C, D>,
-): Optic<A, D> {
-  return compose2Optics(compose2Optics(first, second), third)
-}
-
-export function compose4Optics<A, B, C, D, E>(
-  first: Optic<A, B>,
-  second: Optic<B, C>,
-  third: Optic<C, D>,
-  fourth: Optic<D, E>,
-): Optic<A, E> {
-  return compose2Optics(compose3Optics(first, second, third), fourth)
-}
-
-export function compose5Optics<A, B, C, D, E, F>(
-  first: Optic<A, B>,
-  second: Optic<B, C>,
-  third: Optic<C, D>,
-  fourth: Optic<D, E>,
-  fifth: Optic<E, F>,
-): Optic<A, F> {
-  return compose2Optics(compose4Optics(first, second, third, fourth), fifth)
-}
-
-export function compose6Optics<A, B, C, D, E, F, G>(
-  first: Optic<A, B>,
-  second: Optic<B, C>,
-  third: Optic<C, D>,
-  fourth: Optic<D, E>,
-  fifth: Optic<E, F>,
-  sixth: Optic<F, G>,
-): Optic<A, G> {
-  return compose2Optics(compose5Optics(first, second, third, fourth, fifth), sixth)
-}
-
-export function compose7Optics<A, B, C, D, E, F, G, H>(
-  first: Optic<A, B>,
-  second: Optic<B, C>,
-  third: Optic<C, D>,
-  fourth: Optic<D, E>,
-  fifth: Optic<E, F>,
-  sixth: Optic<F, G>,
-  seventh: Optic<G, H>,
-): Optic<A, H> {
-  return compose2Optics(compose6Optics(first, second, third, fourth, fifth, sixth), seventh)
-}
-
-export function compose8Optics<A, B, C, D, E, F, G, H, I>(
-  first: Optic<A, B>,
-  second: Optic<B, C>,
-  third: Optic<C, D>,
-  fourth: Optic<D, E>,
-  fifth: Optic<E, F>,
-  sixth: Optic<F, G>,
-  seventh: Optic<G, H>,
-  eighth: Optic<H, I>,
-): Optic<A, I> {
-  return compose2Optics(compose7Optics(first, second, third, fourth, fifth, sixth, seventh), eighth)
 }


### PR DESCRIPTION
**Problem:**
Composing optics is a bit fiddly, because you need to know upfront the number of optics that you want to compose together for some helpful code completion, which isn't necessarily obvious when you start.

**Fix:**
Now all the optics have a `compose` function which returns a composed optic as its result.

This means that:
```typescript
compose2Optics(textFileFromEditorStateOptic(filename), fromField('versionNumber'))
```
becomes:
```typescript
textFileFromEditorStateOptic(filename).compose(fromField('versionNumber'))
```

With it being possible to call `compose` again on the result of that to form another optic and so on potentially many more times than was previously possible.

**Commit Details:**
- Factory functions for optics like `iso` and `prism` now return `Optic<S, A>` instead of their more specific type.
- Factory functions for optics like `iso` and `prism` now invoke `addComposeToRawOptic` on the value they've built to add the `compose` function.
- `Optic` type now also pulls in the `OpticCompose` interface.
- Added `addComposeToRawOptic` which adds the `compose` function to an instance of `RawOptic<S, A>`.
- Rejigged the type of `compose2Optics` and the functions it calls slightly.
- Removed all the other `composeNOptics` functions completely.
- Rewrote all the existing optics to use the new `compose` function.