### PR TITLE
Fix/paste repeated paste indexposition

### DIFF
--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -1529,6 +1529,14 @@ export var storyboard = (
                 }}
                 data-uid='div'
               />
+              <div
+                style={{
+                  backgroundColor: '#0075ff',
+                  width: 50,
+                  height: 50,
+                }}
+                data-uid='last'
+              />
             </div>
           </div>`),
             'await-first-dom-report',
@@ -1561,9 +1569,10 @@ export var storyboard = (
               'regular-utopia-storyboard-uid/scene-aaa/app-entity:root/container',
               'regular-utopia-storyboard-uid/scene-aaa/app-entity:root/container/div',
               'regular-utopia-storyboard-uid/scene-aaa/app-entity:root/container/aad',
-              'regular-utopia-storyboard-uid/scene-aaa/app-entity:root/container/aaj',
-              'regular-utopia-storyboard-uid/scene-aaa/app-entity:root/container/aal',
-              'regular-utopia-storyboard-uid/scene-aaa/app-entity:root/container/aan',
+              'regular-utopia-storyboard-uid/scene-aaa/app-entity:root/container/aak',
+              'regular-utopia-storyboard-uid/scene-aaa/app-entity:root/container/aam',
+              'regular-utopia-storyboard-uid/scene-aaa/app-entity:root/container/aao',
+              'regular-utopia-storyboard-uid/scene-aaa/app-entity:root/container/last',
             ],
           )
           expect(getPrintedUiJsCode(editor.getEditorState()))
@@ -1620,7 +1629,7 @@ export var App = (props) => {
             width: 100,
             height: 100,
           }}
-          data-uid='aaj'
+          data-uid='aak'
         />
         <div
           style={{
@@ -1629,7 +1638,7 @@ export var App = (props) => {
             width: 100,
             height: 100,
           }}
-          data-uid='aal'
+          data-uid='aam'
         />
         <div
           style={{
@@ -1638,7 +1647,15 @@ export var App = (props) => {
             width: 100,
             height: 100,
           }}
-          data-uid='aan'
+          data-uid='aao'
+        />
+        <div
+          style={{
+            backgroundColor: '#0075ff',
+            width: 50,
+            height: 50,
+          }}
+          data-uid='last'
         />
       </div>
     </div>

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2919,6 +2919,17 @@ export const UPDATE_FNS = {
             }
           : { strategy: strategy, insertionPath: target.parentPath }
 
+      const indexPosition =
+        target.type === 'sibling'
+          ? absolute(
+              MetadataUtils.getIndexInParent(
+                editor.jsxMetadata,
+                editor.elementPathTree,
+                target.siblingPath,
+              ) + 1,
+            )
+          : front()
+
       const insertionResult = insertWithReparentStrategies(
         workingEditorState,
         action.targetOriginalContextMetadata,
@@ -2928,7 +2939,7 @@ export const UPDATE_FNS = {
           elementPath: currentValue.originalElementPath,
           pathToReparent: elementToReparent(elementWithUniqueUID, currentValue.importsToAdd),
         },
-        front(),
+        indexPosition,
         builtInDependencies,
       )
       if (insertionResult != null) {


### PR DESCRIPTION
**Problem:**
When repeatedly pasting into a flex layout with the first child already selected the pasted elements are all pushed as last siblings instead of next.

**Fix:**
Update `PASTE_JSX_ELEMENTS` to use the next sibling indexposition when the target type is 'sibling'.

**Commit Details:**
- update `PASTE_JSX_ELEMENTS`
- add extra sibling to flex tests
