### PR TITLE
Prevent the persistence state machine from committing failed changes

### DIFF
--- a/editor/src/components/editor/persistence/generic/persistence-types.ts
+++ b/editor/src/components/editor/persistence/generic/persistence-types.ts
@@ -18,6 +18,16 @@ export interface ProjectModelWithId<ModelType> {
   projectModel: ProjectModel<ModelType>
 }
 
+export interface PersistenceContext<ModelType> {
+  projectId?: string
+  project?: ProjectModel<ModelType>
+  rollbackProjectId?: string
+  rollbackProject?: ProjectModel<ModelType>
+  queuedSave?: ProjectModel<ModelType>
+  projectOwned: boolean
+  loggedIn: boolean
+}
+
 export interface ProjectLoadSuccess<ModelType> extends ProjectModelWithId<ModelType> {
   type: 'PROJECT_LOAD_SUCCESS'
 }

--- a/editor/src/components/editor/persistence/persistence.spec.ts
+++ b/editor/src/components/editor/persistence/persistence.spec.ts
@@ -49,11 +49,11 @@ const SecondRevision = updateModel(FirstRevision)
 const ThirdRevision = updateModel(SecondRevision)
 const FourthRevision = updateModel(ThirdRevision)
 
-let forceNextProjectId: string | null = null
+let forcedNextProjectId: string | null = null
 
 function mockRandomProjectID(): string {
-  const newId = forceNextProjectId == null ? generateUID(allProjectIds) : forceNextProjectId
-  forceNextProjectId = null
+  const newId = forcedNextProjectId == null ? generateUID(allProjectIds) : forcedNextProjectId
+  forcedNextProjectId = null
   allProjectIds.push(newId)
   return newId
 }
@@ -360,8 +360,8 @@ describe('Saving', () => {
 
     // Deliberately fail to fork the project
     const forkFailureProjectID = 'ForkFailureProject'
-    forceNextProjectId = forkFailureProjectID
-    mockProjectsToError.add(forceNextProjectId)
+    forcedNextProjectId = forkFailureProjectID
+    mockProjectsToError.add(forcedNextProjectId)
 
     testMachine.save(ProjectName, FirstRevision, 'force')
     await delay(20)
@@ -387,7 +387,7 @@ describe('Saving', () => {
 
     // Now successfully fork the project
     const forkSuccessProjectID = 'ForkSuccessProject'
-    forceNextProjectId = forkSuccessProjectID
+    forcedNextProjectId = forkSuccessProjectID
 
     testMachine.save(ProjectName, SecondRevision, 'force')
     await delay(20)

--- a/editor/src/components/editor/persistence/persistence.ts
+++ b/editor/src/components/editor/persistence/persistence.ts
@@ -1,15 +1,6 @@
-import {
-  actions,
-  assign,
-  createMachine,
-  DoneInvokeEvent,
-  interpret,
-  Interpreter,
-  send,
-} from 'xstate'
-import type { Model } from 'xstate/lib/model.types'
+import { interpret, Interpreter } from 'xstate'
 import { ProjectFile } from '../../../core/shared/project-file-types'
-import { projectURLForProject } from '../../../core/shared/utils'
+import { NO_OP } from '../../../core/shared/utils'
 import { notice } from '../../common/notice'
 import { EditorAction, EditorDispatch } from '../action-types'
 import {
@@ -19,9 +10,8 @@ import {
   showToast,
   updateFile,
 } from '../actions/action-creators'
-import { createNewProjectName, PersistentModel } from '../store/editor-state'
+import { PersistentModel } from '../store/editor-state'
 import {
-  PersistenceContext,
   PersistenceEvent,
   SaveEvent,
   createPersistenceMachine,
@@ -36,12 +26,7 @@ import {
   userLogInEvent,
   userLogOutEvent,
 } from './generic/persistence-machine'
-import {
-  PersistenceBackendAPI,
-  ProjectLoadResult,
-  ProjectModel,
-  ProjectWithFileChanges,
-} from './generic/persistence-types'
+import { PersistenceBackendAPI, PersistenceContext } from './generic/persistence-types'
 
 export class PersistenceMachine {
   private interpreter: Interpreter<
@@ -64,6 +49,10 @@ export class PersistenceMachine {
       projectName: string,
       project: PersistentModel,
     ) => void,
+    onContextChange: (
+      newContext: PersistenceContext<PersistentModel>,
+      oldContext: PersistenceContext<PersistentModel> | undefined,
+    ) => void = NO_OP,
     private saveThrottle: number = 30000,
   ) {
     this.interpreter = interpret(createPersistenceMachine<PersistentModel, ProjectFile>(backendAPI))
@@ -112,6 +101,12 @@ export class PersistenceMachine {
             this.lastSavedTS = Date.now()
             // TODO Show toasts after first server save of a previously local project
             break
+          case 'BACKEND_ERROR':
+            // Clear the queued actions and instead show a toast with the error
+            const error = event.error
+            const message = typeof error === 'string' ? error : error.message
+            this.queuedActions = [showToast(notice(message, 'ERROR'))]
+            break
         }
 
         if (state.matches({ core: Ready })) {
@@ -133,6 +128,8 @@ export class PersistenceMachine {
         }
       }
     })
+
+    this.interpreter.onChange(onContextChange)
 
     this.interpreter.start()
 


### PR DESCRIPTION
**Problem:**
This is a follow up to #3776. If a save fails for whatever reason, the persistence machine would return to the Ready state, but still dispatch any queued up actions, meaning it would be committing any changes along the way. This meant that a failed fork would still dispatch an action updating the project name, ID and model (which in turn would enter an infinite loop of constantly failed forking)

**Fix:**
I've introduced a rollback state to the persistence machine's context, which we now use to rollback the project's ID and model stored in the context when reverting to the Ready state after a backend error.

Whilst the machine is transitioning between states, the interpreter will listen for certain events and use those to queue up actions to dispatch when it next enters the Ready state. Since we don't want to dispatch those after an error, I've updated the machine's interpreter to clear the queued actions on a backend error, and instead dispatch a toast informing the user of the error.

Finally, I've added a test that deliberately fails to fork a project the first time, and then successfully forks the second, so that we can check the dispatched actions and the context at each point.