### PR TITLE
Interaction session for static reparenting

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -514,6 +514,7 @@ export function interactionInProgress(interactionSession: InteractionSession | n
         )
       case 'KEYBOARD':
       case 'HOVER':
+      case 'STATIC_REPARENT':
         return true
       default:
         const _exhaustiveCheck: never = interactionSession.interactionData

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -55,6 +55,7 @@ import { flexResizeStrategy } from './strategies/flex-resize-strategy'
 import { basicResizeStrategy } from './strategies/basic-resize-strategy'
 import { InsertionSubject, InsertionSubjectWrapper } from '../../editor/editor-modes'
 import { generateUidWithExistingComponents } from '../../../core/model/element-template-utils'
+import { testStaticReparentStrategy } from './strategies/test-static-reparent-strategy'
 
 export type CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
@@ -152,6 +153,16 @@ const keyboardShortcutStrategies: MetaCanvasStrategy = (
   )
 }
 
+const staticReparentStrategies: MetaCanvasStrategy = (
+  canvasState: InteractionCanvasState,
+  interactionSession: InteractionSession | null,
+): Array<CanvasStrategy> => {
+  return mapDropNulls(
+    (factory) => factory(canvasState, interactionSession),
+    [testStaticReparentStrategy],
+  )
+}
+
 export const RegisteredCanvasStrategies: Array<MetaCanvasStrategy> = [
   ...AncestorCompatibleStrategies,
   preventOnRootElements(resizeStrategies),
@@ -161,6 +172,7 @@ export const RegisteredCanvasStrategies: Array<MetaCanvasStrategy> = [
   ancestorMetaStrategy(AncestorCompatibleStrategies, 1),
   keyboardShortcutStrategies,
   drawToInsertTextStrategy,
+  staticReparentStrategies,
 ]
 
 export function pickCanvasStateFromEditorState(

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -60,7 +60,14 @@ export interface KeyboardInteractionData {
   keyStates: Array<KeyState>
 }
 
-export type InputData = KeyboardInteractionData | MouseInteractionData
+export type StaticReparentInteractionData = {
+  type: 'STATIC_REPARENT'
+}
+
+export type InputData =
+  | KeyboardInteractionData
+  | MouseInteractionData
+  | StaticReparentInteractionData
 
 export type MouseInteractionData = DragInteractionData | HoverInteractionData
 
@@ -200,6 +207,20 @@ export function createInteractionViaMouse(
       zeroDragPermitted: zeroDragPermitted,
     },
     activeControl: activeControl,
+    lastInteractionTime: Date.now(),
+    userPreferredStrategy: null,
+    startedAt: Date.now(),
+    updatedTargetPaths: {},
+    aspectRatioLock: null,
+  }
+}
+
+export function createInteractionViaPaste(): InteractionSessionWithoutMetadata {
+  return {
+    interactionData: {
+      type: 'STATIC_REPARENT',
+    },
+    activeControl: staticReparentControl(),
     lastInteractionTime: Date.now(),
     userPreferredStrategy: null,
     startedAt: Date.now(),
@@ -464,6 +485,9 @@ export function updateInteractionViaKeyboard(
         aspectRatioLock: currentState.aspectRatioLock,
       }
     }
+    case 'STATIC_REPARENT': {
+      return currentState
+    }
     default:
       const _exhaustiveCheck: never = currentState.interactionData
       throw new Error(`Unhandled interaction type ${JSON.stringify(currentState.interactionData)}`)
@@ -495,6 +519,9 @@ export function interactionDataHardReset(interactionData: InputData): InputData 
         ...interactionData,
         keyStates: lastKeyState == null ? [] : [lastKeyState],
       }
+    case 'STATIC_REPARENT': {
+      return interactionData
+    }
     default:
       const _exhaustiveCheck: never = interactionData
       throw new Error(`Unhandled interaction type ${JSON.stringify(interactionData)}`)
@@ -602,6 +629,14 @@ export function reorderSlider(): ReorderSlider {
   }
 }
 
+export interface StaticReparentControl {
+  type: 'STATIC_REPARENT_CONTROL'
+}
+
+export function staticReparentControl(): StaticReparentControl {
+  return { type: 'STATIC_REPARENT_CONTROL' }
+}
+
 export type CanvasControlType =
   | BoundingArea
   | ResizeHandle
@@ -610,6 +645,7 @@ export type CanvasControlType =
   | KeyboardCatcherControl
   | ReorderSlider
   | BorderRadiusResizeHandle
+  | StaticReparentControl
 
 export function isDragToPan(
   interaction: InteractionSession | null,

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
@@ -1,6 +1,6 @@
 import { shallowEqual } from '../../../../core/shared/equality-utils'
 import * as PP from '../../../../core/shared/property-path'
-import Keyboard, { KeyCharacter } from '../../../../utils/keyboard'
+import Keyboard, { isDigit, KeyCharacter } from '../../../../utils/keyboard'
 import { emptyModifiers, Modifier, Modifiers } from '../../../../utils/modifiers'
 import { setProperty } from '../../commands/set-property-command'
 import {
@@ -53,8 +53,6 @@ export function keyboardSetOpacityStrategy(
 function getKeySequence(keyStates: Array<KeyState>): string {
   return keyStates.flatMap((s) => Array.from(s.keysPressed.values())).join('')
 }
-
-const isDigit = (c: string) => ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'].includes(c)
 
 export function parseOpacityFromKeyboard(keys: string): string | null {
   let tail = keys.slice(-3)

--- a/editor/src/components/canvas/canvas-strategies/strategies/test-static-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/test-static-reparent-strategy.tsx
@@ -1,10 +1,15 @@
-import { CanvasStrategy, emptyStrategyApplicationResult } from '../canvas-strategy-types'
+import {
+  CanvasStrategy,
+  InteractionCanvasState,
+  emptyStrategyApplicationResult,
+} from '../canvas-strategy-types'
 import { InteractionSession } from '../interaction-state'
 
-export const TestStaticReparentStrategy = (
-  interactionSession: InteractionSession,
+export const testStaticReparentStrategy = (
+  canvasState: InteractionCanvasState,
+  interactionSession: InteractionSession | null,
 ): CanvasStrategy | null => {
-  if (interactionSession.interactionData.type !== 'STATIC_REPARENT') {
+  if (interactionSession?.interactionData.type !== 'STATIC_REPARENT') {
     return null
   }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/test-static-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/test-static-reparent-strategy.tsx
@@ -1,0 +1,18 @@
+import { CanvasStrategy, emptyStrategyApplicationResult } from '../canvas-strategy-types'
+import { InteractionSession } from '../interaction-state'
+
+export const TestStaticReparentStrategy = (
+  interactionSession: InteractionSession,
+): CanvasStrategy | null => {
+  if (interactionSession.interactionData.type !== 'STATIC_REPARENT') {
+    return null
+  }
+
+  return {
+    id: 'test-static-reparent-strategy',
+    name: 'Test Static Reparent Strategy',
+    fitness: 1,
+    controlsToRender: [],
+    apply: () => emptyStrategyApplicationResult,
+  }
+}

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -14,7 +14,7 @@ import {
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import * as EP from '../../../../core/shared/element-path'
 import { fastForEach } from '../../../../core/shared/utils'
-import Keyboard, { KeysPressed } from '../../../../utils/keyboard'
+import Keyboard, { KeysPressed, isDigit } from '../../../../utils/keyboard'
 import Utils from '../../../../utils/utils'
 import {
   clearHighlightedViews,
@@ -974,7 +974,10 @@ export function useClearStaticReparentInteraction(editorStoreRef: {
       capture: true,
     })
 
-    const clearStaticReparentInteractionOnKeydown = () => {
+    const clearStaticReparentInteractionOnKeydown = (e: KeyboardEvent) => {
+      if (isDigit(e.key) || e.key === 'Tab') {
+        return
+      }
       window.removeEventListener('keydown', clearStaticReparentInteractionOnKeydown)
       if (
         editorStoreRef.current.editor.canvas.interactionSession?.interactionData.type ===

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -14,7 +14,7 @@ import {
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import * as EP from '../../../../core/shared/element-path'
 import { fastForEach } from '../../../../core/shared/utils'
-import { KeysPressed } from '../../../../utils/keyboard'
+import Keyboard, { KeysPressed } from '../../../../utils/keyboard'
 import Utils from '../../../../utils/utils'
 import {
   clearHighlightedViews,
@@ -923,7 +923,7 @@ export function useSelectAndHover(
 
 export function useClearKeyboardInteraction(editorStoreRef: {
   readonly current: EditorStorePatched
-}) {
+}): () => void {
   const dispatch = useDispatch()
   const keyboardTimeoutHandler = React.useRef<NodeJS.Timeout | null>(null)
   return React.useCallback(() => {
@@ -951,6 +951,42 @@ export function useClearKeyboardInteraction(editorStoreRef: {
     )
 
     window.addEventListener('mousedown', clearKeyboardInteraction, { once: true, capture: true })
+  }, [dispatch, editorStoreRef])
+}
+
+export function useClearStaticReparentInteraction(editorStoreRef: {
+  readonly current: EditorStorePatched
+}): () => void {
+  const dispatch = useDispatch()
+  return React.useCallback(() => {
+    const clearStaticReparentInteractionOnMouseDown = () => {
+      window.removeEventListener('mousedown', clearStaticReparentInteractionOnMouseDown)
+      if (
+        editorStoreRef.current.editor.canvas.interactionSession?.interactionData.type ===
+        'STATIC_REPARENT'
+      ) {
+        dispatch([CanvasActions.clearInteractionSession(true)], 'everyone')
+      }
+    }
+
+    window.addEventListener('mousedown', clearStaticReparentInteractionOnMouseDown, {
+      once: true,
+      capture: true,
+    })
+
+    const clearStaticReparentInteractionOnKeydown = () => {
+      window.removeEventListener('keydown', clearStaticReparentInteractionOnKeydown)
+      if (
+        editorStoreRef.current.editor.canvas.interactionSession?.interactionData.type ===
+        'STATIC_REPARENT'
+      ) {
+        dispatch([CanvasActions.clearInteractionSession(true)], 'everyone')
+      }
+    }
+
+    window.addEventListener('keydown', clearStaticReparentInteractionOnKeydown, {
+      capture: true,
+    })
   }, [dispatch, editorStoreRef])
 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -386,6 +386,9 @@ import {
   ResizeHandle,
   BorderRadiusResizeHandle,
   ZeroDragPermitted,
+  staticReparentControl,
+  StaticReparentControl,
+  StaticReparentInteractionData,
 } from '../../canvas/canvas-strategies/interaction-state'
 import { Modifiers } from '../../../utils/modifiers'
 import {
@@ -1999,6 +2002,12 @@ export const HoverInteractionDataKeepDeepEquality: KeepDeepEqualityCall<HoverInt
     },
   )
 
+export const StaticReparentInteractionSessionDataKeepDeepEquality: KeepDeepEqualityCall<
+  StaticReparentInteractionData
+> = (oldValue, newValue) => {
+  return keepDeepEqualityResult(oldValue, true)
+}
+
 export const KeyStateKeepDeepEquality: KeepDeepEqualityCall<KeyState> = combine2EqualityCalls(
   (keyState) => keyState.keysPressed,
   createCallWithDeepEquals(),
@@ -2041,6 +2050,11 @@ export const InputDataKeepDeepEquality: KeepDeepEqualityCall<InputData> = (oldVa
         return HoverInteractionDataKeepDeepEquality(oldValue, newValue)
       }
       break
+    case 'STATIC_REPARENT':
+      if (newValue.type === oldValue.type) {
+        return StaticReparentInteractionSessionDataKeepDeepEquality(oldValue, newValue)
+      }
+      break
     default:
       const _exhaustiveCheck: never = oldValue
       throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
@@ -2058,6 +2072,14 @@ export const EdgePositionKeepDeepEquality: KeepDeepEqualityCall<EdgePosition> =
   )
 boundingArea() // this is here to break if the definition of boundingArea changes
 export const BoundingAreaKeepDeepEquality: KeepDeepEqualityCall<BoundingArea> = (oldValue, _) => {
+  return keepDeepEqualityResult(oldValue, true)
+}
+
+staticReparentControl()
+export const StaticReparentControlKeepDeepEquality: KeepDeepEqualityCall<StaticReparentControl> = (
+  oldValue,
+  _,
+) => {
   return keepDeepEqualityResult(oldValue, true)
 }
 
@@ -2141,6 +2163,11 @@ export const CanvasControlTypeKeepDeepEquality: KeepDeepEqualityCall<CanvasContr
     case 'BORDER_RADIUS_RESIZE_HANDLE':
       if (newValue.type === oldValue.type) {
         return BorderRadiusResizeHandleKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'STATIC_REPARENT_CONTROL':
+      if (newValue.type === oldValue.type) {
+        return StaticReparentControlKeepDeepEquality(oldValue, newValue)
       }
       break
     default:

--- a/editor/src/components/titlebar/test-menu.tsx
+++ b/editor/src/components/titlebar/test-menu.tsx
@@ -19,6 +19,9 @@ import { isFeatureEnabled } from '../../utils/feature-switches'
 
 import { Substores, useEditorState, useRefEditorState } from '../editor/store/store-hook'
 import { printTree } from '../../core/shared/element-path-tree'
+import { useDispatch } from '../editor/store/dispatch-context'
+import CanvasActions from '../canvas/canvas-actions'
+import { createInteractionViaPaste } from '../canvas/canvas-strategies/interaction-state'
 
 interface TileProps {
   size: 'smaller' | 'normal' | 'large' | 'max'
@@ -35,6 +38,8 @@ const Tile = styled.div<TileProps>((props) => ({
 export const TestMenu = React.memo(() => {
   const entireStateRef = useRefEditorState((store) => store)
 
+  const dispatch = useDispatch()
+
   const jsxMetadata = useRefEditorState((store) => {
     return store.editor.jsxMetadata
   })
@@ -47,6 +52,10 @@ export const TestMenu = React.memo(() => {
   const printElementPathTree = React.useCallback(() => {
     console.info('Tree:\n', printTree(entireStateRef.current.editor.elementPathTree))
   }, [entireStateRef])
+
+  const startStaticReparentSession = React.useCallback(() => {
+    dispatch([CanvasActions.createInteractionSession(createInteractionViaPaste())])
+  }, [dispatch])
 
   function useRequestVSCodeStatus(): () => void {
     const vscodeState = useEditorState(
@@ -106,6 +115,9 @@ export const TestMenu = React.memo(() => {
         <React.Fragment>
           <Tile style={{ cursor: 'pointer', marginRight: 10 }} size='large'>
             <a onClick={printEditorState}>PPP</a>
+          </Tile>
+          <Tile style={{ cursor: 'pointer', marginRight: 10 }} size='large'>
+            <a onClick={startStaticReparentSession}>SSRS</a>
           </Tile>
           <Tile style={{ cursor: 'pointer', marginRight: 10 }} size='large'>
             <a onClick={printElementPathTree}>PT</a>

--- a/editor/src/components/titlebar/test-menu.tsx
+++ b/editor/src/components/titlebar/test-menu.tsx
@@ -22,6 +22,7 @@ import { printTree } from '../../core/shared/element-path-tree'
 import { useDispatch } from '../editor/store/dispatch-context'
 import CanvasActions from '../canvas/canvas-actions'
 import { createInteractionViaPaste } from '../canvas/canvas-strategies/interaction-state'
+import { useClearStaticReparentInteraction } from '../canvas/controls/select-mode/select-mode-hooks'
 
 interface TileProps {
   size: 'smaller' | 'normal' | 'large' | 'max'
@@ -53,9 +54,11 @@ export const TestMenu = React.memo(() => {
     console.info('Tree:\n', printTree(entireStateRef.current.editor.elementPathTree))
   }, [entireStateRef])
 
+  const setClearStaticReparentInteraction = useClearStaticReparentInteraction(entireStateRef)
   const startStaticReparentSession = React.useCallback(() => {
+    setClearStaticReparentInteraction()
     dispatch([CanvasActions.createInteractionSession(createInteractionViaPaste())])
-  }, [dispatch])
+  }, [setClearStaticReparentInteraction, dispatch])
 
   function useRequestVSCodeStatus(): () => void {
     const vscodeState = useEditorState(

--- a/editor/src/utils/keyboard.ts
+++ b/editor/src/utils/keyboard.ts
@@ -28,7 +28,12 @@ export type Letter =
   | 'x'
   | 'y'
   | 'z'
-export type Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
+
+const Digits = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'] as const
+export type Digit = typeof Digits[number]
+
+export const isDigit = (c: string): c is Digit => (Digits as readonly string[]).includes(c)
+
 export type Bracket = '[' | ']'
 
 export type KeyCharacter =
@@ -284,7 +289,7 @@ export const Keyboard = {
     }
   },
   keyTriggersOpacityStrategy: function (keyChar: KeyCharacter): boolean {
-    return ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'].includes(keyChar)
+    return isDigit(keyChar)
   },
   // This needs to be extended when we introduce new keys in canvas strategies
   keyIsInteraction: function (keyChar: KeyCharacter): boolean {


### PR DESCRIPTION
## Description 

This PR adds the necessary scaffolding for paste strategies. This PR itself doesn't introduce any new features, because
1. the paste strategies depend on https://github.com/concrete-utopia/utopia/pull/3778
2. the new interaction session can be tested the best when the actual paste strategies are in place.

The PR adds a placeholder strategy and a debug button to trigger it, and a way to set event listeners to commit the interaction session on `mousedown` and `keydown`.