### PR TITLE
Stricter text editing requirements for conditionals

### DIFF
--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
@@ -102,7 +102,7 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
       expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
     })
-    it('Can not entering text edit mode with double click on conditional with element in active branch', async () => {
+    it('Can not enter text edit mode with double click on conditional with element in active branch', async () => {
       const editor = await renderTestEditorWithCode(
         project(`{
           // @utopia/uid=cond
@@ -118,6 +118,23 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.mode.type).toEqual('select')
       expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
       expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
+    })
+    it('Can not enter text edit mode with double click on conditional with expression in active branch which returns an element', async () => {
+      const editor = await renderTestEditorWithCode(
+        project(`{
+          // @utopia/uid=cond
+          true ? (() => <div>hello</div>)() : <div />
+        }`),
+        'await-first-dom-report',
+      )
+      await selectElement(editor, EP.fromString('sb/39e/cond'))
+      await clickOnElement(editor, 'div', 'double-click')
+      // wait for the next frame
+      await wait(1)
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e/cond')
     })
     it('Entering text edit mode with double click on selected multiline text editable element', async () => {
       const editor = await renderTestEditorWithCode(

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -1050,6 +1050,20 @@ describe('Use the text editor', () => {
       )
       expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('content of myvar2')
     })
+    it('editing expression in the true clause is not allowed when the expression returns elements', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          true ? (() => <div>hello</div>)() : <div data-uid='33d' />
+        }`),
+        'await-first-dom-report',
+      )
+
+      await editor.dispatch([selectComponents([EP.fromString('sb/39e/cond/536')], false)], true)
+      await pressKey('enter')
+      await editor.getDispatchFollowUpActionsFinished()
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
+    })
     it('editing expression in the active true clause from the selected conditional', async () => {
       const editor = await renderTestEditorWithCode(
         projectWithSnippet(`{
@@ -1076,6 +1090,21 @@ describe('Use the text editor', () => {
         }`),
       )
       expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('content of myvar2')
+    })
+    it('editing expression in the active true clause from the selected conditional is not allowed when the expression returns elements', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          true ? (() => <div>hello</div>)() : <div data-uid='33d' />
+        }`),
+        'await-first-dom-report',
+      )
+
+      await editor.dispatch([selectComponents([EP.fromString('sb/39e/cond')], false)], true)
+      await pressKey('enter')
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
     })
     it('editing expression in the false clause', async () => {
       const editor = await renderTestEditorWithCode(
@@ -1104,6 +1133,21 @@ describe('Use the text editor', () => {
       )
       expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('content of myvar2')
     })
+    it('editing expression in the false clause is not allowed when the expression returns elements', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          false ? <div data-uid='33d' /> : (() => <div>hello</div>)()
+        }`),
+        'await-first-dom-report',
+      )
+
+      await editor.dispatch([selectComponents([EP.fromString('sb/39e/cond/536')], false)], true)
+      await pressKey('enter')
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
+    })
     it('editing expression in the false clause from the selected conditional', async () => {
       const editor = await renderTestEditorWithCode(
         projectWithSnippet(`{
@@ -1130,6 +1174,19 @@ describe('Use the text editor', () => {
         }`),
       )
       expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('content of myvar2')
+    })
+    it('editing expression in the false clause from the selected conditional is not allowed when the expression returns elements', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          false ? <div data-uid='33d' /> : (() => <div>hello</div>)()
+        }`),
+        'await-first-dom-report',
+      )
+
+      await editor.dispatch([selectComponents([EP.fromString('sb/39e/cond/536')], false)], true)
+      await pressKey('enter')
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
     })
   })
   it('editing expression (in the true clause) and deleting curly braces converts it to string literal', async () => {

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -353,7 +353,7 @@ export function isTextEditableConditional(
     elementPathTree,
     nonConditionalAncestor,
   )
-  if (siblings.length > 1) {
+  if (siblings.length !== 1) {
     // we don't allow text editing of conditional branches when the conditional has siblings
     // (or if the topmost nested conditional has siblings)
     return false

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -3,12 +3,13 @@ import * as EP from '../shared/element-path'
 import {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
+  isJSExpression,
   isJSXConditionalExpression,
   isNullJSXAttributeValue,
   JSXConditionalExpression,
   JSXElementChild,
 } from '../shared/element-template'
-import { ElementPathTree } from '../shared/element-path-tree'
+import { ElementPathTree, ElementPathTrees } from '../shared/element-path-tree'
 import { getUtopiaID } from '../shared/uid-utils'
 import { Optic } from '../shared/optics/optics'
 import { fromField, fromTypeGuard } from '../shared/optics/optic-creators'
@@ -329,4 +330,44 @@ export function findFirstNonConditionalAncestor(
     return parent
   }
   return findFirstNonConditionalAncestor(parent, metadata)
+}
+
+export function isTextEditableConditional(
+  path: ElementPath,
+  metadata: ElementInstanceMetadataMap,
+  elementPathTree: ElementPathTrees,
+): boolean {
+  const element = MetadataUtils.findElementByElementPath(metadata, path)
+  if (element == null) {
+    // element doesn't exist
+    return false
+  }
+  const conditional = maybeConditionalExpression(element)
+  if (conditional == null) {
+    // element is not a conditional
+    return false
+  }
+  const nonConditionalAncestor = findFirstNonConditionalAncestor(path, metadata)
+  const siblings = MetadataUtils.getChildrenOrdered(
+    metadata,
+    elementPathTree,
+    nonConditionalAncestor,
+  )
+  if (siblings.length > 1) {
+    // we don't allow text editing of conditional branches when the conditional has siblings
+    // (or if the topmost nested conditional has siblings)
+    return false
+  }
+
+  const childrenInMetadata = MetadataUtils.getChildrenUnordered(metadata, path)
+  if (childrenInMetadata.length > 0) {
+    // we don't allow text editing of conditional branches when the conditional have children in metadata
+    // that would mean there are elefants in the active branch, which should not be text editable
+    return false
+  }
+
+  // Finally we check if the active conditional branch is a js expression. Maybe this is an overkill,
+  // because the earlier checks already prove this is a leaf element.
+  const activeConditionalBranch = maybeConditionalActiveBranch(path, metadata)
+  return activeConditionalBranch != null && isJSExpression(activeConditionalBranch)
 }


### PR DESCRIPTION
**Problem:**
We allow text editing of an expression inside the active conditional branch.
However, we should _not_ allow text editing when that expressions returns real elements/elefants, which appear in the metadata. Text editing only makes sense for leaf elements (which basically mean they just return text content).

**Fix:**
I created a new function called `isTextEditableConditional` which clearly lists all the requirement for a conditional to be text editable, and use that in the necessary helper functions.