### PR TITLE
Feat/additive area select

### DIFF
--- a/editor/src/components/canvas/controls/selection-area-helpers.ts
+++ b/editor/src/components/canvas/controls/selection-area-helpers.ts
@@ -135,7 +135,7 @@ export function isValidMouseEventForSelectionArea(
 ): boolean {
   return (
     e.button === 0 &&
-    !(e.shiftKey || e.metaKey || e.ctrlKey || e.altKey) &&
+    !(e.metaKey || e.ctrlKey || e.altKey) &&
     !isDragToPan(interactionSession, keysPressed['space'])
   )
 }


### PR DESCRIPTION
Fixes #3789 

This PR adds the ability to add or remove selected elements to/from the existing selection with the area selection.

The behavior should be familiar enough:
- if an element is not selected, it will be added to the selection
- if an element is already selected, it will be removed from the selection


https://github.com/concrete-utopia/utopia/assets/1081051/ab76b164-4665-4844-8ac2-dab05f30249a

