### PR TITLE
Fix area select scaling

### DIFF
--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -553,9 +553,10 @@ const SelectionAreaRectangle = React.memo(
           pointerEvents: 'none',
           width: rectangle.width,
           height: rectangle.height,
-          left: rectangle.x,
-          top: rectangle.y,
-          zoom: 1 / canvasScale,
+          left: rectangle.x / canvasScale,
+          top: rectangle.y / canvasScale,
+          transformOrigin: 'top left',
+          transform: `scale(${1 / canvasScale})`,
         }}
       />
     )

--- a/editor/src/components/canvas/controls/selection-area-helpers.ts
+++ b/editor/src/components/canvas/controls/selection-area-helpers.ts
@@ -116,13 +116,15 @@ export const filterUnderSelectionArea = (
 export function getSelectionAreaRenderedRect(
   selectionArea: WindowRectangle | null,
   boundingRect: DOMRect | null,
+  scale: number,
 ): WindowRectangle | null {
   if (selectionArea == null || boundingRect == null) {
     return null
   }
+  const scaleFactor = scale > 1 ? scale : 1
   return {
-    x: selectionArea.x - boundingRect.x,
-    y: selectionArea.y - boundingRect.y,
+    x: selectionArea.x - boundingRect.x * scaleFactor,
+    y: selectionArea.y - boundingRect.y * scaleFactor,
     width: selectionArea.width,
     height: selectionArea.height,
   } as WindowRectangle

--- a/editor/src/components/canvas/controls/selection-area-hooks.tsx
+++ b/editor/src/components/canvas/controls/selection-area-hooks.tsx
@@ -148,6 +148,7 @@ export function useSelectionArea(
         const selectionAreaRectangle = getSelectionAreaRenderedRect(
           selectionArea,
           ref.current?.getBoundingClientRect() ?? null,
+          storeRef.current.scale,
         )
 
         // the canvas area for selecting elements


### PR DESCRIPTION
Fixes #3791

**Problem:**

The area selection rectangle scaling is not really working for positive zoom levels, ending up with a skewed rectangle.

**Fix:**

Apply the scaling on the rectangle correctly.