### PR TITLE
Handle arrow functions that just return an identifier

### DIFF
--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -885,6 +885,10 @@ function parseOtherJavaScript<E extends TS.Node, T extends { uid: string }>(
               if (node.expression != null) {
                 addIfDefinedElsewhere(scope, node.expression, false)
               }
+            } else if (TS.isArrowFunction(node)) {
+              addIfDefinedElsewhere(scope, node.body, false)
+            } else if (TS.isReturnStatement(node) && node.expression != null) {
+              addIfDefinedElsewhere(scope, node.expression, false)
             }
             const newScope = addToInScope(scope, node)
             TS.visitEachChild(node, walkTree(innerInsideJSXElement, newScope), context)


### PR DESCRIPTION
**Problem:**
There were a pair of very specific edge cases in the parser where a JS expression contained a function (arrow or regular) that just returned an identifier that was defined outside of that function, e.g.:

```ts
const hello = 'hi'
function sayHi() { return hello }
const sayHiAgain = () => hello 
```

Neither of these two would add the identifier `hello` to their array of `definedElsewhere`.

**Fix:**
Add those specific cases to the parser-printer.