### PR TITLE
Restrict GITHUB_TOKEN permissions on all Discord workflows

### DIFF
--- a/.github/workflows/discord-discussion-comments.yml
+++ b/.github/workflows/discord-discussion-comments.yml
@@ -1,45 +1,59 @@
-# name: Discord Integration - Discussion Comments
-# on:
-#   discussion_comment:
-#     types: [created]
+name: Discord Integration - Discussion Comments
+on:
+  discussion_comment:
+    types: [created]
 
-# jobs:
-#   post-to-discord:
-#     name: Post Comment To Discord
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Build Embeds JSON
-#         env:
-#           TEMPLATE: >-
-#             [{
-#               "author": {
-#                 "name": $author_name,
-#                 "icon_url": $author_icon_url,
-#                 "url": $author_html_url
-#               },
-#               "title": $title,
-#               "color": 2369839,
-#               "url": $html_url,
-#               "description": $body,
-#               "footer": {
-#                 "text": $repo_full_name
-#               }
-#             }]
-#           AUTHOR: ${{ github.event.sender.login }}
-#           AUTHOR_ICON_URL: ${{ github.event.sender.avatar_url }}
-#           AUTHOR_HTML_URL: ${{ github.event.sender.html_url }}
-#           TITLE: 'Comment on #${{ github.event.discussion.number }} ${{ github.event.discussion.title }}'
-#           BODY: ${{ github.event.comment.body }}
-#           HTML_URL: ${{ github.event.comment.html_url }}
-#           REPO_FULL_NAME: ${{ github.event.repository.full_name }}
-#         run: |
-#           echo "DISCORD_EMBEDS=$(jq -nc --arg author_name "$AUTHOR" --arg author_icon_url "$AUTHOR_ICON_URL" --arg author_html_url "$AUTHOR_HTML_URL" --arg title "$TITLE" --arg html_url "$HTML_URL" --arg body "$BODY" --arg repo_full_name "$REPO_FULL_NAME" "$TEMPLATE")" >> $GITHUB_ENV
-#       - name: Send Notification
-#         uses: Ilshidur/action-discord@0.3.2
-#         env:
-#           DISCORD_WEBHOOK: ${{ secrets.DISCORD_DISCUSSIONS_WEBHOOK }}
-#           DISCORD_USERNAME: 'GitHub'
-#           DISCORD_AVATAR: https://octodex.github.com/images/socialite.jpg
-#           SENDER_NAME: ${{ github.event.sender.login }}
-#         with:
-#           args: 'New comment by ${{ env.SENDER_NAME }}'
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  post-to-discord:
+    name: Post Comment To Discord
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Embeds JSON
+        env:
+          TEMPLATE: >-
+            [{
+              "author": {
+                "name": $author_name,
+                "icon_url": $author_icon_url,
+                "url": $author_html_url
+              },
+              "title": $title,
+              "color": 2369839,
+              "url": $html_url,
+              "description": $body,
+              "footer": {
+                "text": $repo_full_name
+              }
+            }]
+          AUTHOR: ${{ github.event.sender.login }}
+          AUTHOR_ICON_URL: ${{ github.event.sender.avatar_url }}
+          AUTHOR_HTML_URL: ${{ github.event.sender.html_url }}
+          TITLE: 'Comment on #${{ github.event.discussion.number }} ${{ github.event.discussion.title }}'
+          BODY: ${{ github.event.comment.body }}
+          HTML_URL: ${{ github.event.comment.html_url }}
+          REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+        run: |
+          echo "DISCORD_EMBEDS=$(jq -nc --arg author_name "$AUTHOR" --arg author_icon_url "$AUTHOR_ICON_URL" --arg author_html_url "$AUTHOR_HTML_URL" --arg title "$TITLE" --arg html_url "$HTML_URL" --arg body "$BODY" --arg repo_full_name "$REPO_FULL_NAME" "$TEMPLATE")" >> $GITHUB_ENV
+      - name: Send Notification
+        uses: Ilshidur/action-discord@0.3.2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_DISCUSSIONS_WEBHOOK }}
+          DISCORD_USERNAME: 'GitHub'
+          DISCORD_AVATAR: https://octodex.github.com/images/socialite.jpg
+          SENDER_NAME: ${{ github.event.sender.login }}
+        with:
+          args: 'New comment by ${{ env.SENDER_NAME }}'

--- a/.github/workflows/discord-discussion-opened.yml
+++ b/.github/workflows/discord-discussion-opened.yml
@@ -1,47 +1,61 @@
-# name: Discord Integration - Discussion Opened
-# on:
-#   discussion:
-#     types: [created]
+name: Discord Integration - Discussion Opened
+on:
+  discussion:
+    types: [created]
 
-# jobs:
-#   post-to-discord:
-#     name: Post Notification To Discord
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Build Embeds JSON
-#         env:
-#           TEMPLATE: >-
-#             [{
-#               "author": {
-#                 "name": $author_name,
-#                 "icon_url": $author_icon_url,
-#                 "url": $author_html_url
-#               },
-#               "title": $title,
-#               "color": 3581519,
-#               "url": $html_url,
-#               "description": $description,
-#               "footer": {
-#                 "text": $repo_full_name
-#               }
-#             }]
-#           AUTHOR: ${{ github.event.sender.login }}
-#           AUTHOR_ICON_URL: ${{ github.event.sender.avatar_url }}
-#           AUTHOR_HTML_URL: ${{ github.event.sender.html_url }}
-#           TITLE: '#${{ github.event.discussion.number }} ${{ github.event.discussion.title }}'
-#           HTML_URL: ${{ github.event.discussion.html_url }}
-#           DESCRIPTION: ${{ github.event.discussion.body }}
-#           REPO_FULL_NAME: ${{ github.event.repository.full_name }}
-#         run: |
-#           # This provides the env variable used by the next step
-#           # We have to do it like this to prevent any of the values screwing up the json
-#           echo "DISCORD_EMBEDS=$(jq -nc --arg author_name "$AUTHOR" --arg author_icon_url "$AUTHOR_ICON_URL" --arg author_html_url "$AUTHOR_HTML_URL" --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" "$TEMPLATE")" >> $GITHUB_ENV
-#       - name: Send Notification
-#         uses: Ilshidur/action-discord@0.3.2
-#         env:
-#           DISCORD_WEBHOOK: ${{ secrets.DISCORD_DISCUSSIONS_WEBHOOK }}
-#           DISCORD_USERNAME: 'GitHub'
-#           DISCORD_AVATAR: https://octodex.github.com/images/socialite.jpg
-#           SENDER_NAME: ${{ github.event.sender.login }}
-#         with:
-#           args: 'Discussion started by ${{ env.SENDER_NAME }}'
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  post-to-discord:
+    name: Post Notification To Discord
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Embeds JSON
+        env:
+          TEMPLATE: >-
+            [{
+              "author": {
+                "name": $author_name,
+                "icon_url": $author_icon_url,
+                "url": $author_html_url
+              },
+              "title": $title,
+              "color": 3581519,
+              "url": $html_url,
+              "description": $description,
+              "footer": {
+                "text": $repo_full_name
+              }
+            }]
+          AUTHOR: ${{ github.event.sender.login }}
+          AUTHOR_ICON_URL: ${{ github.event.sender.avatar_url }}
+          AUTHOR_HTML_URL: ${{ github.event.sender.html_url }}
+          TITLE: '#${{ github.event.discussion.number }} ${{ github.event.discussion.title }}'
+          HTML_URL: ${{ github.event.discussion.html_url }}
+          DESCRIPTION: ${{ github.event.discussion.body }}
+          REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+        run: |
+          # This provides the env variable used by the next step
+          # We have to do it like this to prevent any of the values screwing up the json
+          echo "DISCORD_EMBEDS=$(jq -nc --arg author_name "$AUTHOR" --arg author_icon_url "$AUTHOR_ICON_URL" --arg author_html_url "$AUTHOR_HTML_URL" --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" "$TEMPLATE")" >> $GITHUB_ENV
+      - name: Send Notification
+        uses: Ilshidur/action-discord@0.3.2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_DISCUSSIONS_WEBHOOK }}
+          DISCORD_USERNAME: 'GitHub'
+          DISCORD_AVATAR: https://octodex.github.com/images/socialite.jpg
+          SENDER_NAME: ${{ github.event.sender.login }}
+        with:
+          args: 'Discussion started by ${{ env.SENDER_NAME }}'

--- a/.github/workflows/discord-issue-closed.yml
+++ b/.github/workflows/discord-issue-closed.yml
@@ -1,45 +1,59 @@
-# name: Discord Integration - Issue Closed
-# on:
-#   issues:
-#     types: [closed]
+name: Discord Integration - Issue Closed
+on:
+  issues:
+    types: [closed]
 
-# jobs:
-#   post-to-discord:
-#     name: Post Notification To Discord
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Build Embeds JSON
-#         env:
-#           TEMPLATE: >-
-#             [{
-#               "author": {
-#                 "name": $author_name,
-#                 "icon_url": $author_icon_url,
-#                 "url": $author_html_url
-#               },
-#               "title": $title,
-#               "color": 13313073,
-#               "url": $html_url,
-#               "footer": {
-#                 "text": $repo_full_name
-#               }
-#             }]
-#           AUTHOR: ${{ github.event.sender.login }}
-#           AUTHOR_ICON_URL: ${{ github.event.sender.avatar_url }}
-#           AUTHOR_HTML_URL: ${{ github.event.sender.html_url }}
-#           TITLE: 'Closed #${{ github.event.issue.number }} ${{ github.event.issue.title }}'
-#           HTML_URL: ${{ github.event.issue.html_url }}
-#           REPO_FULL_NAME: ${{ github.event.repository.full_name }}
-#         run: |
-#           # This provides the env variable used by the next step
-#           # We have to do it like this to prevent any of the values screwing up the json
-#           echo "DISCORD_EMBEDS=$(jq -nc --arg author_name "$AUTHOR" --arg author_icon_url "$AUTHOR_ICON_URL" --arg author_html_url "$AUTHOR_HTML_URL" --arg title "$TITLE" --arg html_url "$HTML_URL" --arg repo_full_name "$REPO_FULL_NAME" "$TEMPLATE")" >> $GITHUB_ENV
-#       - name: Send Notification
-#         uses: Ilshidur/action-discord@0.3.2
-#         env:
-#           DISCORD_WEBHOOK: ${{ secrets.DISCORD_ISSUES_WEBHOOK }}
-#           DISCORD_USERNAME: 'GitHub'
-#           DISCORD_AVATAR: https://octodex.github.com/images/original.png
-#           SENDER_NAME: ${{ github.event.sender.login }}
-#         with:
-#           args: 'Issue closed by ${{ env.SENDER_NAME }}'
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  post-to-discord:
+    name: Post Notification To Discord
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Embeds JSON
+        env:
+          TEMPLATE: >-
+            [{
+              "author": {
+                "name": $author_name,
+                "icon_url": $author_icon_url,
+                "url": $author_html_url
+              },
+              "title": $title,
+              "color": 13313073,
+              "url": $html_url,
+              "footer": {
+                "text": $repo_full_name
+              }
+            }]
+          AUTHOR: ${{ github.event.sender.login }}
+          AUTHOR_ICON_URL: ${{ github.event.sender.avatar_url }}
+          AUTHOR_HTML_URL: ${{ github.event.sender.html_url }}
+          TITLE: 'Closed #${{ github.event.issue.number }} ${{ github.event.issue.title }}'
+          HTML_URL: ${{ github.event.issue.html_url }}
+          REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+        run: |
+          # This provides the env variable used by the next step
+          # We have to do it like this to prevent any of the values screwing up the json
+          echo "DISCORD_EMBEDS=$(jq -nc --arg author_name "$AUTHOR" --arg author_icon_url "$AUTHOR_ICON_URL" --arg author_html_url "$AUTHOR_HTML_URL" --arg title "$TITLE" --arg html_url "$HTML_URL" --arg repo_full_name "$REPO_FULL_NAME" "$TEMPLATE")" >> $GITHUB_ENV
+      - name: Send Notification
+        uses: Ilshidur/action-discord@0.3.2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_ISSUES_WEBHOOK }}
+          DISCORD_USERNAME: 'GitHub'
+          DISCORD_AVATAR: https://octodex.github.com/images/original.png
+          SENDER_NAME: ${{ github.event.sender.login }}
+        with:
+          args: 'Issue closed by ${{ env.SENDER_NAME }}'

--- a/.github/workflows/discord-issue-comments.yml
+++ b/.github/workflows/discord-issue-comments.yml
@@ -1,46 +1,60 @@
-# name: Discord Integration - Issue Comments
-# on:
-#   issue_comment:
-#     types: [created]
+name: Discord Integration - Issue Comments
+on:
+  issue_comment:
+    types: [created]
 
-# jobs:
-#   post-to-discord:
-#     name: Post Comment To Discord
-#     runs-on: ubuntu-latest
-#     if: ${{ !github.event.issue.pull_request }}
-#     steps:
-#       - name: Build Embeds JSON
-#         env:
-#           TEMPLATE: >-
-#             [{
-#               "author": {
-#                 "name": $author_name,
-#                 "icon_url": $author_icon_url,
-#                 "url": $author_html_url
-#               },
-#               "title": $title,
-#               "color": 2369839,
-#               "url": $html_url,
-#               "description": $body,
-#               "footer": {
-#                 "text": $repo_full_name
-#               }
-#             }]
-#           AUTHOR: ${{ github.event.sender.login }}
-#           AUTHOR_ICON_URL: ${{ github.event.sender.avatar_url }}
-#           AUTHOR_HTML_URL: ${{ github.event.sender.html_url }}
-#           TITLE: 'Comment on #${{ github.event.issue.number }} ${{ github.event.issue.title }}'
-#           BODY: ${{ github.event.comment.body }}
-#           HTML_URL: ${{ github.event.issue.html_url }}
-#           REPO_FULL_NAME: ${{ github.event.repository.full_name }}
-#         run: |
-#           echo "DISCORD_EMBEDS=$(jq -nc --arg author_name "$AUTHOR" --arg author_icon_url "$AUTHOR_ICON_URL" --arg author_html_url "$AUTHOR_HTML_URL" --arg title "$TITLE" --arg html_url "$HTML_URL" --arg body "$BODY" --arg repo_full_name "$REPO_FULL_NAME" "$TEMPLATE")" >> $GITHUB_ENV
-#       - name: Send Notification
-#         uses: Ilshidur/action-discord@0.3.2
-#         env:
-#           DISCORD_WEBHOOK: ${{ secrets.DISCORD_ISSUES_WEBHOOK }}
-#           DISCORD_USERNAME: 'GitHub'
-#           DISCORD_AVATAR: https://octodex.github.com/images/original.png
-#           SENDER_NAME: ${{ github.event.sender.login }}
-#         with:
-#           args: 'New comment by ${{ env.SENDER_NAME }}'
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  post-to-discord:
+    name: Post Comment To Discord
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.issue.pull_request }}
+    steps:
+      - name: Build Embeds JSON
+        env:
+          TEMPLATE: >-
+            [{
+              "author": {
+                "name": $author_name,
+                "icon_url": $author_icon_url,
+                "url": $author_html_url
+              },
+              "title": $title,
+              "color": 2369839,
+              "url": $html_url,
+              "description": $body,
+              "footer": {
+                "text": $repo_full_name
+              }
+            }]
+          AUTHOR: ${{ github.event.sender.login }}
+          AUTHOR_ICON_URL: ${{ github.event.sender.avatar_url }}
+          AUTHOR_HTML_URL: ${{ github.event.sender.html_url }}
+          TITLE: 'Comment on #${{ github.event.issue.number }} ${{ github.event.issue.title }}'
+          BODY: ${{ github.event.comment.body }}
+          HTML_URL: ${{ github.event.issue.html_url }}
+          REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+        run: |
+          echo "DISCORD_EMBEDS=$(jq -nc --arg author_name "$AUTHOR" --arg author_icon_url "$AUTHOR_ICON_URL" --arg author_html_url "$AUTHOR_HTML_URL" --arg title "$TITLE" --arg html_url "$HTML_URL" --arg body "$BODY" --arg repo_full_name "$REPO_FULL_NAME" "$TEMPLATE")" >> $GITHUB_ENV
+      - name: Send Notification
+        uses: Ilshidur/action-discord@0.3.2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_ISSUES_WEBHOOK }}
+          DISCORD_USERNAME: 'GitHub'
+          DISCORD_AVATAR: https://octodex.github.com/images/original.png
+          SENDER_NAME: ${{ github.event.sender.login }}
+        with:
+          args: 'New comment by ${{ env.SENDER_NAME }}'

--- a/.github/workflows/discord-issue-opened.yml
+++ b/.github/workflows/discord-issue-opened.yml
@@ -1,47 +1,61 @@
-# name: Discord Integration - Issue Opened
-# on:
-#   issues:
-#     types: [opened]
+name: Discord Integration - Issue Opened
+on:
+  issues:
+    types: [opened]
 
-# jobs:
-#   post-to-discord:
-#     name: Post Notification To Discord
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Build Embeds JSON
-#         env:
-#           TEMPLATE: >-
-#             [{
-#               "author": {
-#                 "name": $author_name,
-#                 "icon_url": $author_icon_url,
-#                 "url": $author_html_url
-#               },
-#               "title": $title,
-#               "color": 3581519,
-#               "url": $html_url,
-#               "description": $description,
-#               "footer": {
-#                 "text": $repo_full_name
-#               }
-#             }]
-#           AUTHOR: ${{ github.event.sender.login }}
-#           AUTHOR_ICON_URL: ${{ github.event.sender.avatar_url }}
-#           AUTHOR_HTML_URL: ${{ github.event.sender.html_url }}
-#           TITLE: '#${{ github.event.issue.number }} ${{ github.event.issue.title }}'
-#           HTML_URL: ${{ github.event.issue.html_url }}
-#           DESCRIPTION: ${{ github.event.issue.body }}
-#           REPO_FULL_NAME: ${{ github.event.repository.full_name }}
-#         run: |
-#           # This provides the env variable used by the next step
-#           # We have to do it like this to prevent any of the values screwing up the json
-#           echo "DISCORD_EMBEDS=$(jq -nc --arg author_name "$AUTHOR" --arg author_icon_url "$AUTHOR_ICON_URL" --arg author_html_url "$AUTHOR_HTML_URL" --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" "$TEMPLATE")" >> $GITHUB_ENV
-#       - name: Send Notification
-#         uses: Ilshidur/action-discord@0.3.2
-#         env:
-#           DISCORD_WEBHOOK: ${{ secrets.DISCORD_ISSUES_WEBHOOK }}
-#           DISCORD_USERNAME: 'GitHub'
-#           DISCORD_AVATAR: https://octodex.github.com/images/original.png
-#           SENDER_NAME: ${{ github.event.sender.login }}
-#         with:
-#           args: 'Issue opened by ${{ env.SENDER_NAME }}'
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  post-to-discord:
+    name: Post Notification To Discord
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Embeds JSON
+        env:
+          TEMPLATE: >-
+            [{
+              "author": {
+                "name": $author_name,
+                "icon_url": $author_icon_url,
+                "url": $author_html_url
+              },
+              "title": $title,
+              "color": 3581519,
+              "url": $html_url,
+              "description": $description,
+              "footer": {
+                "text": $repo_full_name
+              }
+            }]
+          AUTHOR: ${{ github.event.sender.login }}
+          AUTHOR_ICON_URL: ${{ github.event.sender.avatar_url }}
+          AUTHOR_HTML_URL: ${{ github.event.sender.html_url }}
+          TITLE: '#${{ github.event.issue.number }} ${{ github.event.issue.title }}'
+          HTML_URL: ${{ github.event.issue.html_url }}
+          DESCRIPTION: ${{ github.event.issue.body }}
+          REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+        run: |
+          # This provides the env variable used by the next step
+          # We have to do it like this to prevent any of the values screwing up the json
+          echo "DISCORD_EMBEDS=$(jq -nc --arg author_name "$AUTHOR" --arg author_icon_url "$AUTHOR_ICON_URL" --arg author_html_url "$AUTHOR_HTML_URL" --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" "$TEMPLATE")" >> $GITHUB_ENV
+      - name: Send Notification
+        uses: Ilshidur/action-discord@0.3.2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_ISSUES_WEBHOOK }}
+          DISCORD_USERNAME: 'GitHub'
+          DISCORD_AVATAR: https://octodex.github.com/images/original.png
+          SENDER_NAME: ${{ github.event.sender.login }}
+        with:
+          args: 'Issue opened by ${{ env.SENDER_NAME }}'

--- a/.github/workflows/discord-pr-closed.yml
+++ b/.github/workflows/discord-pr-closed.yml
@@ -3,6 +3,20 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   post-to-discord:
     name: Post Notification To Discord

--- a/.github/workflows/discord-pr-comments.yml
+++ b/.github/workflows/discord-pr-comments.yml
@@ -5,6 +5,20 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   post-to-discord:
     name: Post Notification To Discord

--- a/.github/workflows/discord-pr-opened.yml
+++ b/.github/workflows/discord-pr-opened.yml
@@ -3,6 +3,20 @@ on:
   pull_request:
     types: [opened, ready_for_review]
 
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   post-to-discord:
     name: Post Notification To Discord

--- a/.github/workflows/discord-pr-review.yml
+++ b/.github/workflows/discord-pr-review.yml
@@ -3,6 +3,20 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   post-to-discord:
     name: Post Notification To Discord


### PR DESCRIPTION
Lock down the GITHUB_TOKEN access for all workflows that don't need the token, so that we can re-enable the Discord integration for issues and discussions.