### PR TITLE
Fix: remove duplicate callback from insert menu

### DIFF
--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -407,25 +407,11 @@ function getMenuTitle(insertMenuMode: 'closed' | 'insert' | 'convert' | 'wrap'):
 export var FloatingMenu = React.memo(() => {
   const colorTheme = useColorTheme()
 
-  // This is a ref so that changing the highlighted element does not trigger a re-render loop
-  // This is FINE because we only use the value in callbacks
-  const activelySelectedInsertOptionRef = React.useRef<InsertMenuItem | null>(null)
-
-  const ariaLiveMessages = React.useMemo(
-    () => ({
-      onFocus: ({ focused }: { focused: InsertMenuItem }) => {
-        activelySelectedInsertOptionRef.current = focused
-      },
-    }),
-    [],
-  )
-
   const [filterInputValue, setFilterInputValue] = React.useState('')
   const onInputValueChange = React.useCallback((newValue: string, actionMeta: InputActionMeta) => {
     // when the user "tabs out" to the checkboxes, prevent react-select from clearing the input text
     if (actionMeta.action !== 'input-blur' && actionMeta.action !== 'menu-close') {
       setFilterInputValue(newValue)
-      activelySelectedInsertOptionRef.current = null
     }
   }, [])
 
@@ -628,8 +614,8 @@ export var FloatingMenu = React.memo(() => {
   )
 
   const onChange = React.useCallback(
-    (value: ValueType<InsertMenuItem, false>) => {
-      if (value != null && !Array.isArray(value)) {
+    (value: InsertMenuItem | null) => {
+      if (value != null) {
         const pickedInsertableComponent = (value as InsertMenuItem).value
 
         function getActionsToDispatch() {
@@ -657,11 +643,9 @@ export var FloatingMenu = React.memo(() => {
       (key: 'Escape' | 'Enter') => {
         if (key === 'Escape') {
           dispatch([closeFloatingInsertMenu()])
-        } else {
-          onChange(activelySelectedInsertOptionRef.current)
         }
       },
-      [dispatch, onChange],
+      [dispatch],
     ),
   )
 
@@ -695,7 +679,6 @@ export var FloatingMenu = React.memo(() => {
         </div>
 
         <WindowedSelect
-          ariaLiveMessages={ariaLiveMessages}
           inputValue={filterInputValue}
           onInputChange={onInputValueChange}
           autoFocus


### PR DESCRIPTION
Fixes #3799 

**Problem:**

When using the keyboard to confirm a selection in the floating insert menu, the `onChange` callback would (sometimes?) be triggered twice because of the `onChange` event of `react-select` _and_ the one triggered manually in the `useHandleCloseOnESCOrEnter`.

This would cause, for example, conditionals being wrapped twice instead of once.

**Fix:**

Remove the duplicated call and the unused `ref`.
