### PR TITLE
Use getChildrenOrdered in treatElementAsGroupLike.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/fragment-like-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/fragment-like-helpers.ts
@@ -186,7 +186,7 @@ export function getElementFragmentLikeType(
 
   const elementProps = allElementProps[EP.toString(path)]
 
-  if (treatElementAsGroupLike(metadata, path)) {
+  if (treatElementAsGroupLike(metadata, pathTrees, path)) {
     // to ensure mutual exclusivity
     return null
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/group-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-helpers.ts
@@ -1,12 +1,14 @@
+import { ElementPathTrees } from '../../../../core/shared/element-path-tree'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
 import { ElementPath } from '../../../../core/shared/project-file-types'
 
 export function treatElementAsGroupLike(
   metadata: ElementInstanceMetadataMap,
+  pathTrees: ElementPathTrees,
   path: ElementPath,
 ): boolean {
-  const allChildrenAreAbsolute = MetadataUtils.getChildrenUnordered(metadata, path).every(
+  const allChildrenAreAbsolute = MetadataUtils.getChildrenOrdered(metadata, pathTrees, path).every(
     (child) => child.specialSizeMeasurements.position === 'absolute',
   )
   return (

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -185,7 +185,7 @@ function findValidTargetsUnderPoint(
       return null
     }
 
-    if (treatElementAsGroupLike(metadata, target)) {
+    if (treatElementAsGroupLike(metadata, elementPathTree, target)) {
       // we disallow reparenting into Group-like elements
       return null
     }

--- a/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
+++ b/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
@@ -111,7 +111,11 @@ function getGroupUpdateCommands(
 
   for (const frameAndTarget of targets) {
     const parentPath = EP.parentPath(frameAndTarget.target)
-    const parentIsGroup = treatElementAsGroupLike(editor.jsxMetadata, parentPath)
+    const parentIsGroup = treatElementAsGroupLike(
+      editor.jsxMetadata,
+      editor.elementPathTree,
+      parentPath,
+    )
 
     if (!parentIsGroup || parentPath == null) {
       // bail out


### PR DESCRIPTION
**Problem:**
`treatElementAsGroupLike` uses `MetadataUtils.getChildrenUnordered`, which is much slower than `MetadataUtils.getChildrenOrdered`.

**Fix:**
`treatElementAsGroupLike` now uses `MetadataUtils.getChildrenOrdered` in place of `MetadataUtils.getChildrenUnordered`.

**Results:**
Before:
![before](https://github.com/concrete-utopia/utopia/assets/217400/67b814ce-9fb0-4bd9-bd08-b28b84eb52e4)
After:
![after](https://github.com/concrete-utopia/utopia/assets/217400/86b0b5df-850e-40c8-b055-90655d2728fb)
`getElementWarningsInner` goes from 7ms to 0.63ms.

**Notes:**
I was going to private `MetadataUtils.getChildrenUnordered`, but it caused issues in the browser tests when I replaced it in `isTextEditableConditional`. Which makes me think the two definitions have gone out of sync.

**Commit Details:**
- `treatElementAsGroupLike` now uses `MetadataUtils.getChildrenOrdered` in place of `MetadataUtils.getChildrenUnordered`.