### PR TITLE
Fix: support conditional branches with expressions returning multiple values

### DIFF
--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -384,7 +384,7 @@ export var ${BakedInStoryboardVariableName} = (
 `)
 }
 
-function getProjectCodeEmptySingleConditional(): string {
+function getProjectCodeExpressionWithMultipleValues(): string {
   return `import * as React from 'react'
 import { Scene, Storyboard } from 'utopia-api'
 
@@ -413,20 +413,8 @@ export var ${BakedInStoryboardVariableName} = (
       >
         {
           // @utopia/uid=conditional
-          true ? null : null
+          true ? [0, 1, 2].map(i => <div><div>hello {i}</div></div>) : <div data-uid='else-div' />
         }
-        <div
-          style={{
-            height: 150,
-            width: 150,
-            position: 'absolute',
-            left: 300,
-            top: 300,
-            backgroundColor: 'darkblue',
-          }}
-          data-uid='sibling-div'
-          data-testid='sibling-div'
-        />
       </div>
     </Scene>
   </Storyboard>
@@ -1585,7 +1573,6 @@ describe('conditionals in the navigator', () => {
 
     expect(label.innerText).toEqual('HELLO!')
   })
-
   it('shows js expression values in blue', async () => {
     await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
@@ -1606,6 +1593,30 @@ describe('conditionals in the navigator', () => {
     ).style.color
 
     expect(labelColor).toEqual('var(--utopitheme-dynamicBlue)')
+  })
+  it('supports expressions that return multiple values', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      getProjectCodeExpressionWithMultipleValues(),
+      'await-first-dom-report',
+    )
+
+    expect(
+      navigatorStructure(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().derived,
+      ),
+    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
+    regular-utopia-storyboard-uid/scene-aaa/containing-div
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional-true-case
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/46a~~~1
+            regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/46a~~~1/33d
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/46a~~~2
+            regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/46a~~~2/33d
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/46a~~~3
+            regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/46a~~~3/33d
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional-false-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional/else-div-element-else-div`)
   })
 })
 

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -134,7 +134,7 @@ export function getNavigatorTargets(
           conditionalCase === 'true-case' ? conditional.whenTrue : conditional.whenFalse
 
         // Walk the clause of the conditional.
-        const clausePathTree = Object.values(conditionalSubTree.children).find((childPath) => {
+        const clausePathTrees = Object.values(conditionalSubTree.children).filter((childPath) => {
           if (isDynamic(childPath.path) && hasElementsWithin(branch)) {
             for (const element of Object.values(branch.elementsWithin)) {
               const firstChildPath = EP.appendToPath(EP.parentPath(clausePath), element.uid)
@@ -148,15 +148,15 @@ export function getNavigatorTargets(
           }
           return EP.pathsEqual(childPath.path, clausePath)
         })
-        if (clausePathTree != null) {
-          walkAndAddKeys(clausePathTree, newCollapsedAncestor)
+        if (clausePathTrees.length > 0) {
+          clausePathTrees.map((t) => walkAndAddKeys(t, newCollapsedAncestor))
         }
 
         // Create the entry for the value of the clause.
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, clausePath)
         if (
           elementMetadata == null &&
-          (clausePathTree == null || !isDynamic(clausePathTree.path))
+          (clausePathTrees.length === 0 || !clausePathTrees.some((t) => isDynamic(t.path)))
         ) {
           const clauseValueEntry = syntheticNavigatorEntry(clausePath, clauseValue)
           addNavigatorTargetUnlessCollapsed(clauseValueEntry)

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -35,29 +35,25 @@ export function reorderConditionalChildPathTrees(
   conditionalPath: ElementPath,
   children: Array<ElementPathTree>,
 ): Array<ElementPathTree> {
-  if (children.length > 2) {
-    throw new Error(`Too many child paths.`)
-  } else {
-    let result: Array<ElementPathTree> = []
+  let result: Array<ElementPathTree> = []
 
-    // The whenTrue clause should be first.
-    const trueCasePath = getConditionalClausePath(conditionalPath, conditional.whenTrue)
-    const trueCasePathString = EP.toString(trueCasePath)
-    const trueCasePathTree = children.find((child) => child.pathString === trueCasePathString)
-    if (trueCasePathTree != null) {
-      result.push(trueCasePathTree)
-    }
-
-    // The whenFalse clause should be second.
-    const falseCasePath = getConditionalClausePath(conditionalPath, conditional.whenFalse)
-    const falseCasePathString = EP.toString(falseCasePath)
-    const falseCasePathTree = children.find((child) => child.pathString === falseCasePathString)
-    if (falseCasePathTree != null) {
-      result.push(falseCasePathTree)
-    }
-
-    return result
+  // The whenTrue clause should be first.
+  const trueCasePath = getConditionalClausePath(conditionalPath, conditional.whenTrue)
+  const trueCasePathString = EP.toString(trueCasePath)
+  const trueCasePathTree = children.find((child) => child.pathString === trueCasePathString)
+  if (trueCasePathTree != null) {
+    result.push(trueCasePathTree)
   }
+
+  // The whenFalse clause should be second.
+  const falseCasePath = getConditionalClausePath(conditionalPath, conditional.whenFalse)
+  const falseCasePathString = EP.toString(falseCasePath)
+  const falseCasePathTree = children.find((child) => child.pathString === falseCasePathString)
+  if (falseCasePathTree != null) {
+    result.push(falseCasePathTree)
+  }
+
+  return result
 }
 
 export const jsxConditionalExpressionOptic: Optic<JSXElementChild, JSXConditionalExpression> =


### PR DESCRIPTION
Fixes #3804 

**Problem:**

Conditional branches that return multiple values via expressions (e.g. `{ true ? [0, 1, 2].map(() => <div />) : <div /> }`) crash the editor.

**Fix:**

Remove the hard requirement for conditional path trees to have exactly two children, and adjust the navigator so that multiple items are shown.

https://github.com/concrete-utopia/utopia/assets/1081051/44f9f43b-8ee5-4410-9e24-0756a0d80fb5

**Notes:**

- As incremental changes, we should fix the navigator ordering for when the inactive branch is `null`, as it's shown out of order:
<img width="791" alt="Screenshot 2023-06-12 at 5 45 13 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/b27af5a1-c030-42a9-a149-1d930b86fe28">

- As we already know, since expressions don't have metadata directly, only `(code)` will appear if the inactive branch is not `null` and the expression returns inline values:
<img width="788" alt="Screenshot 2023-06-12 at 5 46 53 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/2ec69849-6f29-45ca-bdc0-88d30cdefd65">
