### PR TITLE
T press text edit/insert mode for conditionals

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -32,7 +32,7 @@ import { getElementFragmentLikeType, treatElementAsFragmentLike } from '../fragm
 import { ReparentStrategy, ReparentSubjects, ReparentTarget } from './reparent-strategy-helpers'
 import { drawTargetRectanglesForChildrenOfElement } from './reparent-strategy-sibling-position-helpers'
 import { ElementPathTrees } from '../../../../../core/shared/element-path-tree'
-import { isConditionalWithEmptyActiveBranch as isConditionalWithEmptyOrTextEditableActiveBranch } from '../../../../../core/model/conditionals'
+import { isConditionalWithEmptyOrTextEditableActiveBranch } from '../../../../../core/model/conditionals'
 import { getInsertionPathForReparentTarget } from './reparent-helpers'
 import { treatElementAsGroupLike } from '../group-helpers'
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -95,6 +95,8 @@ export const setBorderRadiusStrategy: CanvasStrategyFactory = (
     canvasState.projectContents,
     element,
     canvasState.scale,
+    canvasState.startingMetadata,
+    canvasState.startingElementPathTree,
   ).has('borderRadius')
   if (!canShowBorderRadiusControls) {
     return null

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -93,7 +93,7 @@ export const setBorderRadiusStrategy: CanvasStrategyFactory = (
 
   const canShowBorderRadiusControls = canShowCanvasPropControl(
     canvasState.projectContents,
-    element,
+    selectedElement,
     canvasState.scale,
     canvasState.startingMetadata,
     canvasState.startingElementPathTree,

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -99,17 +99,9 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
     return null
   }
 
-  const element = MetadataUtils.findElementByElementPath(
-    canvasState.startingMetadata,
-    selectedElements[0],
-  )
-  if (element == null) {
-    return null
-  }
-
   const canShowPadding = canShowCanvasPropControl(
     canvasState.projectContents,
-    element,
+    selectedElements[0],
     canvasState.scale,
     canvasState.startingMetadata,
     canvasState.startingElementPathTree,

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -111,6 +111,8 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
     canvasState.projectContents,
     element,
     canvasState.scale,
+    canvasState.startingMetadata,
+    canvasState.startingElementPathTree,
   ).has('padding')
   if (!canShowPadding) {
     return null

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2091,6 +2091,7 @@ export function getReparentTarget(
       nodeModules,
       openFile,
       possibleNewParent,
+      elementPathTree,
     )
   }
   const hasNoCurrentParentsButHasANewParent =
@@ -2227,6 +2228,7 @@ export function moveTemplate(
                     workingEditorState.nodeModules.files,
                     workingEditorState.canvas.openFile?.filename ?? null,
                     workingEditorState.jsxMetadata,
+                    workingEditorState.elementPathTree,
                   )
 
                   if (insertionPath == null) {

--- a/editor/src/components/canvas/commands/wrap-in-container-command.ts
+++ b/editor/src/components/canvas/commands/wrap-in-container-command.ts
@@ -94,6 +94,7 @@ export const runWrapInContainerCommand: CommandFunction<WrapInContainerCommand> 
         editor.nodeModules.files,
         editor.canvas.openFile?.filename,
         editor.jsxMetadata,
+        editor.elementPathTree,
       )
       if (insertionPath == null) {
         return // maybe this should throw instead?

--- a/editor/src/components/canvas/controls/insert-mode/insert-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/insert-mode/insert-mode-hooks.tsx
@@ -32,6 +32,7 @@ function useGetHighlightableViewsForInsertMode() {
           nodeModules,
           openFile,
           path,
+          elementPathTree,
         )
       })
       return insertTargets

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -407,20 +407,21 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
     if (strategy?.currentStrategy !== DRAW_TO_INSERT_TEXT_STRATEGY_ID) {
       return []
     }
-    return Object.keys(allElementProps)
+    return Object.keys(componentMetadata)
       .filter((p) => {
-        const metadata = componentMetadata[p]
-        if (metadata == null) {
-          return false
-        }
         return (
           MetadataUtils.targetTextEditableAndHasText(
             componentMetadata,
             pathTrees,
             EP.fromString(p),
           ) &&
-          ['hasOnlyTextChildren', 'supportsChildren'].includes(
-            MetadataUtils.targetElementSupportsChildrenAlsoText(projectContents, metadata),
+          ['hasOnlyTextChildren', 'supportsChildren', 'conditionalWithText'].includes(
+            MetadataUtils.targetElementSupportsChildrenAlsoText(
+              projectContents,
+              EP.fromString(p),
+              componentMetadata,
+              pathTrees,
+            ),
           )
         )
       })

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -1,12 +1,16 @@
 import React from 'react'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
-import { ElementInstanceMetadata } from '../../../../core/shared/element-template'
+import {
+  ElementInstanceMetadata,
+  ElementInstanceMetadataMap,
+} from '../../../../core/shared/element-template'
 import { roundTo, size, zeroRectIfNullOrInfinity } from '../../../../core/shared/math-utils'
 import { Modifiers } from '../../../../utils/modifiers'
 import { ProjectContentTreeRoot } from '../../../assets'
 import { colorTheme } from '../../../../uuiui'
 import { CSSNumber, CSSNumberUnit, printCSSNumber } from '../../../inspector/common/css-utils'
 import { elementHasOnlyTextChildren } from '../../canvas-utils'
+import { ElementPathTrees } from '../../../../core/shared/element-path-tree'
 
 export const Emdash: string = '\u2014'
 
@@ -193,6 +197,8 @@ export function canShowCanvasPropControl(
   projectContents: ProjectContentTreeRoot,
   element: ElementInstanceMetadata,
   scale: number,
+  metadata: ElementInstanceMetadataMap,
+  elementPathTree: ElementPathTrees,
 ): Set<CanvasPropControl> {
   const frame = zeroRectIfNullOrInfinity(element.globalFrame)
 
@@ -210,7 +216,14 @@ export function canShowCanvasPropControl(
     return new Set<CanvasPropControl>(['padding'])
   }
 
-  if (!MetadataUtils.targetElementSupportsChildren(projectContents, element)) {
+  if (
+    !MetadataUtils.targetElementSupportsChildren(
+      projectContents,
+      element.elementPath,
+      metadata,
+      elementPathTree,
+    )
+  ) {
     return new Set<CanvasPropControl>(['borderRadius', 'gap'])
   }
 

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -11,6 +11,7 @@ import { colorTheme } from '../../../../uuiui'
 import { CSSNumber, CSSNumberUnit, printCSSNumber } from '../../../inspector/common/css-utils'
 import { elementHasOnlyTextChildren } from '../../canvas-utils'
 import { ElementPathTrees } from '../../../../core/shared/element-path-tree'
+import { ElementPath } from '../../../../core/shared/project-file-types'
 
 export const Emdash: string = '\u2014'
 
@@ -195,11 +196,15 @@ const SHOW_NO_CONTROLS_THRESHOLD = 60
 
 export function canShowCanvasPropControl(
   projectContents: ProjectContentTreeRoot,
-  element: ElementInstanceMetadata,
+  path: ElementPath,
   scale: number,
   metadata: ElementInstanceMetadataMap,
   elementPathTree: ElementPathTrees,
 ): Set<CanvasPropControl> {
+  const element = MetadataUtils.findElementByElementPath(metadata, path)
+  if (element == null) {
+    return new Set<CanvasPropControl>([])
+  }
   const frame = zeroRectIfNullOrInfinity(element.globalFrame)
 
   const { width, height } = size((frame.width ?? 0) * scale, (frame.height ?? 0) * scale)

--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
@@ -254,6 +254,26 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
       expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
     })
+    it('Click to select conditional text editable target', async () => {
+      const editor = await renderTestEditorWithCode(
+        project(`{
+        // @utopia/uid=cond
+        true ? 'Hello' : <div />
+      }`),
+
+        'await-first-dom-report',
+      )
+
+      await pressKey('t')
+      await clickOnElement(editor, 'div')
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
+      expect(
+        EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
+      ).toEqual('sb/39e/cond')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e/cond')
+    })
   })
 })
 

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -86,7 +86,12 @@ export const ZeroSizedElementControls = controlForStrategyMemoized(
               element.globalFrame != null &&
               isFiniteRectangle(element.globalFrame) &&
               isZeroSizedElement(element.globalFrame) &&
-              MetadataUtils.targetElementSupportsChildren(projectContents, element)
+              MetadataUtils.targetElementSupportsChildren(
+                projectContents,
+                element.elementPath,
+                store.editor.jsxMetadata,
+                store.editor.elementPathTree,
+              )
             )
           })
         } else {
@@ -103,7 +108,12 @@ export const ZeroSizedElementControls = controlForStrategyMemoized(
                 return (
                   isFiniteRectangle(child.globalFrame) &&
                   isZeroSizedElement(child.globalFrame) &&
-                  MetadataUtils.targetElementSupportsChildren(projectContents, child)
+                  MetadataUtils.targetElementSupportsChildren(
+                    projectContents,
+                    child.elementPath,
+                    store.editor.jsxMetadata,
+                    store.editor.elementPathTree,
+                  )
                 )
               }
             })

--- a/editor/src/components/canvas/ui/floating-insert-menu.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.spec.browser2.tsx
@@ -2,7 +2,11 @@ import { act, fireEvent, queryByAttribute } from '@testing-library/react'
 import { FOR_TESTS_setNextGeneratedUid } from '../../../core/model/element-template-utils.test-utils'
 import { BakedInStoryboardUID } from '../../../core/model/scene-utils'
 import * as EP from '../../../core/shared/element-path'
-import { expectSingleUndo2Saves, selectComponentsForTest } from '../../../utils/utils.test-utils'
+import {
+  expectSingleUndo2Saves,
+  selectComponentsForTest,
+  wait,
+} from '../../../utils/utils.test-utils'
 import { mouseClickAtPoint, pressKey } from '../event-helpers.test-utils'
 import {
   EditorRenderResult,
@@ -178,6 +182,7 @@ describe('Floating insert menu', () => {
       expect(editor.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
         'utopia-storyboard-uid/scene-aaa/app-entity:container/conditional',
       ])
+      // await wait(1000000)
 
       await expectNoAction(editor, () => insertViaAddElementPopup(editor, 'img'))
 

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -460,6 +460,12 @@ export var FloatingMenu = React.memo(() => {
     'FloatingMenu jsxMetadata',
   )
 
+  const elementPathTree = useEditorState(
+    Substores.metadata,
+    (store) => store.editor.elementPathTree,
+    'FloatingMenu elementPathTree',
+  )
+
   const insertableComponents = useGetInsertableComponents()
 
   const [addContentForInsertion, setAddContentForInsertion] = React.useState(false)
@@ -473,9 +479,10 @@ export var FloatingMenu = React.memo(() => {
         nodeModules,
         openFile,
         jsxMetadata,
+        elementPathTree,
       )
     },
-    [nodeModules, openFile, jsxMetadata, projectContentsRef],
+    [nodeModules, openFile, jsxMetadata, projectContentsRef, elementPathTree],
   )
 
   const onChangeConditionalOrFragment = React.useCallback(

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -331,6 +331,7 @@ export const unwrap: ContextMenuItem<CanvasData> = {
           data.nodeModules,
           data.openFile,
           path,
+          data.pathTrees,
         ) ||
         treatElementAsFragmentLike(data.jsxMetadata, data.allElementProps, data.pathTrees, path),
     )

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1832,6 +1832,7 @@ export const UPDATE_FNS = {
       editor.nodeModules.files,
       editor.canvas.openFile?.filename,
       editor.jsxMetadata,
+      editor.elementPathTree,
     )
 
     if (newParentPath == null) {
@@ -2471,6 +2472,7 @@ export const UPDATE_FNS = {
           editor.nodeModules.files,
           editor.canvas.openFile?.filename,
           action.target,
+          editor.elementPathTree,
         )
 
         const elementIsFragmentLike = treatElementAsFragmentLike(
@@ -2849,6 +2851,7 @@ export const UPDATE_FNS = {
         originalContextMetadata: action.targetOriginalContextMetadata,
         originalContextElementPathTrees: action.targetOriginalElementPathTree,
       },
+      editor.elementPathTree,
     )
     if (target == null) {
       return addToastToState(

--- a/editor/src/components/editor/actions/wrap-unwrap-helpers.tsx
+++ b/editor/src/components/editor/actions/wrap-unwrap-helpers.tsx
@@ -166,6 +166,7 @@ export function unwrapTextContainingConditional(
         editor.nodeModules.files,
         editor.canvas.openFile?.filename,
         editor.jsxMetadata,
+        editor.elementPathTree,
       )
       if (insertionPath == null) {
         throw new Error('Invalid unwrap insertion path')

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -2194,6 +2194,7 @@ export function reparentTargetFromNavigatorEntry(
   metadata: ElementInstanceMetadataMap,
   nodeModules: NodeModules,
   openFile: string | null | undefined,
+  elementPathTree: ElementPathTrees,
 ): InsertionPath {
   switch (navigatorEntry.type) {
     case 'REGULAR':
@@ -2219,6 +2220,7 @@ export function reparentTargetFromNavigatorEntry(
         nodeModules,
         openFile,
         clausePath,
+        elementPathTree,
       )
 
       return supportsChildren

--- a/editor/src/components/editor/store/insertion-path.ts
+++ b/editor/src/components/editor/store/insertion-path.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../core/shared/element-template'
 import { isRight } from '../../../core/shared/either'
 import { ProjectContentTreeRoot } from '../../assets'
+import { ElementPathTrees } from '../../../core/shared/element-path-tree'
 
 export type InsertionPath = ChildInsertionPath | ConditionalClauseInsertionPath
 
@@ -158,6 +159,7 @@ export function getInsertionPathWithSlotBehavior(
   nodeModules: NodeModules,
   openFile: string | null | undefined,
   metadata: ElementInstanceMetadataMap,
+  elementPathTree: ElementPathTrees,
 ): InsertionPath | null {
   const conditionalClause = getConditionalCaseCorrespondingToBranchPath(target, metadata)
 
@@ -167,6 +169,7 @@ export function getInsertionPathWithSlotBehavior(
     nodeModules,
     openFile,
     target,
+    elementPathTree,
   )
     ? childInsertionPath(target)
     : conditionalClause != null && isEmptyConditionalBranch(target, metadata)
@@ -180,6 +183,7 @@ export function getInsertionPathWithWrapWithFragmentBehavior(
   nodeModules: NodeModules,
   openFile: string | null | undefined,
   metadata: ElementInstanceMetadataMap,
+  elementPathTree: ElementPathTrees,
 ): InsertionPath | null {
   const conditionalClause = getConditionalCaseCorrespondingToBranchPath(target, metadata)
 
@@ -189,6 +193,7 @@ export function getInsertionPathWithWrapWithFragmentBehavior(
     nodeModules,
     openFile,
     target,
+    elementPathTree,
   )
     ? childInsertionPath(target)
     : conditionalClause != null

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -220,6 +220,7 @@ function canDropInto(editorState: EditorState, moveToEntry: ElementPath): boolea
     editorState.nodeModules.files,
     editorState.canvas.openFile?.filename,
     moveToEntry,
+    editorState.elementPathTree,
   )
   return targetSupportsChildren && notSelectedItem
 }

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -68,13 +68,20 @@ const targetInNavigatorItemsSelector = createCachedSelector(
 
 const elementSupportsChildrenSelector = createCachedSelector(
   (store: EditorStorePatched) => store.editor.projectContents,
+  (store: MetadataSubstate) => store.editor.jsxMetadata,
   targetElementMetadataSelector,
+  (store: MetadataSubstate) => store.editor.elementPathTree,
   targetInNavigatorItemsSelector,
-  (projectContents, elementMetadata, elementInNavigatorTargets) => {
+  (projectContents, metadata, elementMetadata, pathTrees, elementInNavigatorTargets) => {
     if (!elementInNavigatorTargets || elementMetadata == null) {
       return false
     }
-    return MetadataUtils.targetElementSupportsChildren(projectContents, elementMetadata)
+    return MetadataUtils.targetElementSupportsChildren(
+      projectContents,
+      elementMetadata.elementPath,
+      metadata,
+      pathTrees,
+    )
   },
 )((_, navigatorEntry) => navigatorEntryToKey(navigatorEntry))
 

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -184,7 +184,7 @@ export function getConditionalBranch(
   return clause === 'true-case' ? conditional.whenTrue : conditional.whenFalse
 }
 
-export function isConditionalWithEmptyActiveBranch(
+export function isConditionalWithEmptyOrTextEditableActiveBranch(
   path: ElementPath,
   metadata: ElementInstanceMetadataMap,
   elementPathTree: ElementPathTrees,

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -187,10 +187,12 @@ export function getConditionalBranch(
 export function isConditionalWithEmptyActiveBranch(
   path: ElementPath,
   metadata: ElementInstanceMetadataMap,
+  elementPathTree: ElementPathTrees,
 ): {
   element: JSXConditionalExpression
   clause: ConditionalCase | null
   isEmpty: boolean
+  textEditable: boolean
 } | null {
   const conditional = findMaybeConditionalExpression(path, metadata)
   if (conditional == null) {
@@ -201,14 +203,16 @@ export function isConditionalWithEmptyActiveBranch(
     return {
       element: conditional,
       isEmpty: false,
-      clause,
+      textEditable: false,
+      clause: clause,
     }
   }
   const branch = clause === 'true-case' ? conditional.whenTrue : conditional.whenFalse
   return {
     element: conditional,
     isEmpty: isNullJSXAttributeValue(branch),
-    clause,
+    textEditable: isTextEditableConditional(path, metadata, elementPathTree),
+    clause: clause,
   }
 }
 

--- a/editor/src/core/model/element-metadata-utils.spec.tsx
+++ b/editor/src/core/model/element-metadata-utils.spec.tsx
@@ -381,187 +381,237 @@ function parseResultFromCode(filename: string, code: string): ParsedTextFile {
 
 describe('targetElementSupportsChildren', () => {
   it('returns true for a utopia-api View', () => {
-    const element = dummyInstanceDataForElementType(
-      'View',
-      EP.elementPath([
-        [BakedInStoryboardUID, TestScenePath],
-        ['Dummy', 'Element'],
-      ]),
+    const path = EP.elementPath([
+      [BakedInStoryboardUID, TestScenePath],
+      ['Dummy', 'Element'],
+    ])
+    const element = dummyInstanceDataForElementType('View', path)
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      path,
+      { [EP.toString(path)]: element },
+      {},
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren({}, element)
     expect(actualResult).toEqual(true)
   })
   it('returns true for an unparsed button', () => {
-    const element = dummyInstanceDataForElementType(
-      'button',
-      EP.elementPath([
-        [BakedInStoryboardUID, TestScenePath],
-        ['Dummy', 'Element'],
-      ]),
+    const path = EP.elementPath([
+      [BakedInStoryboardUID, TestScenePath],
+      ['Dummy', 'Element'],
+    ])
+    const element = dummyInstanceDataForElementType('button', path)
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      path,
+      { [EP.toString(path)]: element },
+      {},
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren({}, element)
     expect(actualResult).toEqual(true)
   })
   it('returns true for a parsed button', () => {
-    const element = dummyInstanceDataForElementType(
-      jsxElementName('button', []),
-      EP.elementPath([
-        [BakedInStoryboardUID, TestScenePath],
-        ['Dummy', 'Element'],
-      ]),
+    const path = EP.elementPath([
+      [BakedInStoryboardUID, TestScenePath],
+      ['Dummy', 'Element'],
+    ])
+    const element = dummyInstanceDataForElementType(jsxElementName('button', []), path)
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      path,
+      { [EP.toString(path)]: element },
+      {},
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren({}, element)
     expect(actualResult).toEqual(true)
   })
   it('returns true for an unparsed div', () => {
-    const element = dummyInstanceDataForElementType(
-      'div',
-      EP.elementPath([
-        [BakedInStoryboardUID, TestScenePath],
-        ['Dummy', 'Element'],
-      ]),
+    const path = EP.elementPath([
+      [BakedInStoryboardUID, TestScenePath],
+      ['Dummy', 'Element'],
+    ])
+    const element = dummyInstanceDataForElementType('div', path)
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      path,
+      { [EP.toString(path)]: element },
+      {},
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren({}, element)
     expect(actualResult).toEqual(true)
   })
   it('returns true for a parsed div', () => {
-    const element = dummyInstanceDataForElementType(
-      jsxElementName('div', []),
-      EP.elementPath([
-        [BakedInStoryboardUID, TestScenePath],
-        ['Dummy', 'Element'],
-      ]),
+    const path = EP.elementPath([
+      [BakedInStoryboardUID, TestScenePath],
+      ['Dummy', 'Element'],
+    ])
+    const element = dummyInstanceDataForElementType(jsxElementName('div', []), path)
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      path,
+      { [EP.toString(path)]: element },
+      {},
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren({}, element)
     expect(actualResult).toEqual(true)
   })
   it('returns true for a parsed div with an arbitrary jsx block child', () => {
+    const path = EP.elementPath([
+      [BakedInStoryboardUID, TestScenePath],
+      ['Dummy', 'Element'],
+    ])
     const element = dummyInstanceDataForElementType(
       jsxElementName('div', []),
-      EP.elementPath([
-        [BakedInStoryboardUID, TestScenePath],
-        ['Dummy', 'Element'],
-      ]),
+      path,
       [jsExpression('<div />', '<div />;', 'return <div />;', [], null, {})], // Whatever, close enough
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren({}, element)
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      path,
+      { [EP.toString(path)]: element },
+      {},
+    )
     expect(actualResult).toEqual(true)
   })
   it('returns true for a parsed div with another parsed div child', () => {
-    const element = dummyInstanceDataForElementType(
-      jsxElementName('div', []),
-      EP.elementPath([
-        [BakedInStoryboardUID, TestScenePath],
-        ['Dummy', 'Element'],
-      ]),
-      [jsxTestElement('div', [], [])],
+    const path = EP.elementPath([
+      [BakedInStoryboardUID, TestScenePath],
+      ['Dummy', 'Element'],
+    ])
+    const element = dummyInstanceDataForElementType(jsxElementName('div', []), path, [
+      jsxTestElement('div', [], []),
+    ])
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      path,
+      { [EP.toString(path)]: element },
+      {},
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren({}, element)
     expect(actualResult).toEqual(true)
   })
   it('returns true for a parsed div with an empty fragment child', () => {
-    const element = dummyInstanceDataForElementType(
-      jsxElementName('div', []),
-      EP.elementPath([
-        [BakedInStoryboardUID, TestScenePath],
-        ['Dummy', 'Element'],
-      ]),
-      [jsxFragment('fff', [], true)],
+    const path = EP.elementPath([
+      [BakedInStoryboardUID, TestScenePath],
+      ['Dummy', 'Element'],
+    ])
+    const element = dummyInstanceDataForElementType(jsxElementName('div', []), path, [
+      jsxFragment('fff', [], true),
+    ])
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      path,
+      { [EP.toString(path)]: element },
+      {},
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren({}, element)
     expect(actualResult).toEqual(true)
   })
   it('returns true for a parsed div with a fragment child containing another parsed div', () => {
-    const element = dummyInstanceDataForElementType(
-      jsxElementName('div', []),
-      EP.elementPath([
-        [BakedInStoryboardUID, TestScenePath],
-        ['Dummy', 'Element'],
-      ]),
-      [jsxFragment('fff', [jsxTestElement('div', [], [])], true)],
+    const path = EP.elementPath([
+      [BakedInStoryboardUID, TestScenePath],
+      ['Dummy', 'Element'],
+    ])
+    const element = dummyInstanceDataForElementType(jsxElementName('div', []), path, [
+      jsxFragment('fff', [jsxTestElement('div', [], [])], true),
+    ])
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      path,
+      { [EP.toString(path)]: element },
+      {},
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren({}, element)
     expect(actualResult).toEqual(true)
   })
   it('returns true for a parsed div with a fragment child containing an arbitrary jsx block', () => {
-    const element = dummyInstanceDataForElementType(
-      jsxElementName('div', []),
-      EP.elementPath([
-        [BakedInStoryboardUID, TestScenePath],
-        ['Dummy', 'Element'],
-      ]),
-      [
-        jsxFragment(
-          'fff',
-          [
-            jsxTestElement(
-              'div',
-              [],
-              [
-                jsExpression('<div />', '<div />;', 'return <div />;', [], null, {}), // Whatever, close enough
-              ],
-            ),
-          ],
-          true,
-        ),
-      ],
+    const path = EP.elementPath([
+      [BakedInStoryboardUID, TestScenePath],
+      ['Dummy', 'Element'],
+    ])
+    const element = dummyInstanceDataForElementType(jsxElementName('div', []), path, [
+      jsxFragment(
+        'fff',
+        [
+          jsxTestElement(
+            'div',
+            [],
+            [
+              jsExpression('<div />', '<div />;', 'return <div />;', [], null, {}), // Whatever, close enough
+            ],
+          ),
+        ],
+        true,
+      ),
+    ])
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      path,
+      { [EP.toString(path)]: element },
+      {},
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren({}, element)
     expect(actualResult).toEqual(true)
   })
   it('returns true for an unparsed span', () => {
-    const element = dummyInstanceDataForElementType(
-      'span',
-      EP.elementPath([
-        [BakedInStoryboardUID, TestScenePath],
-        ['Dummy', 'Element'],
-      ]),
+    const path = EP.elementPath([
+      [BakedInStoryboardUID, TestScenePath],
+      ['Dummy', 'Element'],
+    ])
+    const element = dummyInstanceDataForElementType('span', path)
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      path,
+      { [EP.toString(path)]: element },
+      {},
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren({}, element)
     expect(actualResult).toEqual(true)
   })
   it('returns true for a parsed span', () => {
-    const element = dummyInstanceDataForElementType(
-      jsxElementName('span', []),
-      EP.elementPath([
-        [BakedInStoryboardUID, TestScenePath],
-        ['Dummy', 'Element'],
-      ]),
+    const path = EP.elementPath([
+      [BakedInStoryboardUID, TestScenePath],
+      ['Dummy', 'Element'],
+    ])
+    const element = dummyInstanceDataForElementType(jsxElementName('span', []), path)
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      path,
+      { [EP.toString(path)]: element },
+      {},
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren({}, element)
     expect(actualResult).toEqual(true)
   })
   it('returns true for an animated.div', () => {
-    const element = dummyInstanceDataForElementType(
-      jsxElementName('animated', ['div']),
-      EP.elementPath([
-        [BakedInStoryboardUID, TestScenePath],
-        ['Dummy', 'Element'],
-      ]),
+    const path = EP.elementPath([
+      [BakedInStoryboardUID, TestScenePath],
+      ['Dummy', 'Element'],
+    ])
+    const element = dummyInstanceDataForElementType(jsxElementName('animated', ['div']), path)
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      path,
+      { [EP.toString(path)]: element },
+      {},
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren({}, element)
     expect(actualResult).toEqual(true)
   })
   it('returns false for an unparsed img', () => {
-    const element = dummyInstanceDataForElementType(
-      'img',
-      EP.elementPath([
-        [BakedInStoryboardUID, TestScenePath],
-        ['Dummy', 'Element'],
-      ]),
+    const path = EP.elementPath([
+      [BakedInStoryboardUID, TestScenePath],
+      ['Dummy', 'Element'],
+    ])
+    const element = dummyInstanceDataForElementType('img', path)
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      path,
+      { [EP.toString(path)]: element },
+      {},
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren({}, element)
     expect(actualResult).toEqual(false)
   })
   it('returns false for a parsed img', () => {
-    const element = dummyInstanceDataForElementType(
-      jsxElementName('img', []),
-      EP.elementPath([
-        [BakedInStoryboardUID, TestScenePath],
-        ['Dummy', 'Element'],
-      ]),
+    const path = EP.elementPath([
+      [BakedInStoryboardUID, TestScenePath],
+      ['Dummy', 'Element'],
+    ])
+    const element = dummyInstanceDataForElementType(jsxElementName('img', []), path)
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      {},
+      path,
+      { [EP.toString(path)]: element },
+      {},
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren({}, element)
     expect(actualResult).toEqual(false)
   })
   it('returns true for a component used from a different file that uses props.children', () => {
@@ -599,11 +649,14 @@ export const App = (props) => {
         0,
       ),
     })
-    const element = dummyInstanceDataForElementType(
-      jsxElementName('App', []),
-      EP.elementPath([[BakedInStoryboardUID, TestScenePath, TestAppUID]]),
+    const path = EP.elementPath([[BakedInStoryboardUID, TestScenePath, TestAppUID]])
+    const element = dummyInstanceDataForElementType(jsxElementName('App', []), path)
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      projectContents,
+      path,
+      { [EP.toString(path)]: element },
+      {},
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren(projectContents, element)
     expect(actualResult).toEqual(true)
   })
   it('returns false for a component used from a different file that uses props.children but has only text children', () => {
@@ -655,12 +708,16 @@ export const App = (props) => {
     expect(isJSXElement(parsedElement!)).toBeTruthy()
     const parsedChildren = (parsedElement! as JSXElement).children
 
-    const element = dummyInstanceDataForElementType(
-      jsxElementName('App', []),
-      EP.elementPath([[BakedInStoryboardUID, TestScenePath, TestAppUID]]),
-      parsedChildren,
+    const path = EP.elementPath([[BakedInStoryboardUID, TestScenePath, TestAppUID]])
+    const element = dummyInstanceDataForElementType(jsxElementName('App', []), path, parsedChildren)
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      projectContents,
+      path,
+      {
+        [EP.toString(path)]: element,
+      },
+      {},
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren(projectContents, element)
     expect(actualResult).toEqual(false)
   })
   it('returns false for a component used from a different file that does not use props.children', () => {
@@ -698,13 +755,22 @@ export const App = (props) => {
         0,
       ),
     })
+    const path = EP.elementPath([[BakedInStoryboardUID, TestScenePath, TestAppUID]])
     const element = dummyInstanceDataForElementType(
       jsxElementName('App', []),
-      EP.elementPath([[BakedInStoryboardUID, TestScenePath, TestAppUID]]),
+      path,
       [],
       importedOrigin('/src/app.js', 'App', 'App'),
     )
-    const actualResult = MetadataUtils.targetElementSupportsChildren(projectContents, element)
+
+    const actualResult = MetadataUtils.targetElementSupportsChildren(
+      projectContents,
+      path,
+      {
+        [EP.toString(path)]: element,
+      },
+      {},
+    )
     expect(actualResult).toEqual(false)
   })
 })

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -37,6 +37,7 @@ import {
   JSXConditionalExpression,
   isJSExpression,
   ArbitraryJSBlock,
+  ElementInstanceMetadataMap,
 } from '../shared/element-template'
 import {
   isParseSuccess,
@@ -65,6 +66,7 @@ import {
   conditionalWhenFalseOptic,
   conditionalWhenTrueOptic,
   getConditionalClausePath,
+  isTextEditableConditional,
 } from './conditionals'
 import { modify } from '../shared/optics/optic-utilities'
 import {
@@ -75,6 +77,7 @@ import {
 import { intrinsicHTMLElementNamesThatSupportChildren } from '../shared/dom-utils'
 import { isNullJSXAttributeValue } from '../shared/element-template'
 import { getAllUniqueUids } from './get-unique-ids'
+import { ElementPathTrees } from '../shared/element-path-tree'
 
 export function generateUidWithExistingComponents(projectContents: ProjectContentTreeRoot): string {
   const mockUID = generateMockNextGeneratedUID()
@@ -972,11 +975,21 @@ export type ElementSupportsChildren =
   | 'supportsChildren'
   | 'hasOnlyTextChildren'
   | 'doesNotSupportChildren'
+  | 'conditionalWithText'
 
 export function elementChildSupportsChildrenAlsoText(
   element: JSXElementChild,
+  path: ElementPath,
+  metadata: ElementInstanceMetadataMap,
+  elementPathTree: ElementPathTrees,
 ): ElementSupportsChildren | null {
-  if (isJSExpression(element) || isJSXConditionalExpression(element)) {
+  if (isJSExpression(element)) {
+    return 'doesNotSupportChildren'
+  }
+  if (isJSXConditionalExpression(element)) {
+    if (isTextEditableConditional(path, metadata, elementPathTree)) {
+      return 'conditionalWithText'
+    }
     return 'doesNotSupportChildren'
   }
   if (elementOnlyHasTextChildren(element)) {

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -1637,6 +1637,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
             editor.pasteTargetsToIgnore,
             editor.jsxMetadata,
             this.props.model.scale,
+            editor.elementPathTree,
           )
           this.props.dispatch(actions, 'everyone')
         })

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -171,6 +171,7 @@ function getFilePasteActions(
   pasteTargetsToIgnore: ElementPath[],
   componentMetadata: ElementInstanceMetadataMap,
   canvasScale: number,
+  elementPathTree: ElementPathTrees,
 ): Array<EditorAction> {
   if (pastedFiles.length == 0) {
     return []
@@ -183,6 +184,7 @@ function getFilePasteActions(
     componentMetadata,
     pasteTargetsToIgnore,
     { elementPaste: [], originalContextMetadata: {}, originalContextElementPathTrees: {} }, // TODO: get rid of this when refactoring pasting images
+    elementPathTree,
   )
 
   if (target == null) {
@@ -226,6 +228,7 @@ export function getActionsForClipboardItems(
   pasteTargetsToIgnore: ElementPath[],
   componentMetadata: ElementInstanceMetadataMap,
   canvasScale: number,
+  elementPathTree: ElementPathTrees,
 ): Array<EditorAction> {
   return [
     ...getJSXElementPasteActions(clipboardData, canvasViewportCenter),
@@ -239,6 +242,7 @@ export function getActionsForClipboardItems(
       pasteTargetsToIgnore,
       componentMetadata,
       canvasScale,
+      elementPathTree,
     ),
   ]
 }
@@ -407,6 +411,7 @@ export function getTargetParentForPaste(
   metadata: ElementInstanceMetadataMap,
   pasteTargetsToIgnore: ElementPath[],
   copyData: ParsedCopyData,
+  elementPathTree: ElementPathTrees,
 ): ReparentTargetForPaste | null {
   const pastedElementNames = mapDropNulls(
     (element) => MetadataUtils.getJSXElementName(element.element),
@@ -447,6 +452,7 @@ export function getTargetParentForPaste(
               nodeModules,
               openFile,
               metadata,
+              elementPathTree,
             )
           : getInsertionPathWithSlotBehavior(
               targetPath,
@@ -454,6 +460,7 @@ export function getTargetParentForPaste(
               nodeModules,
               openFile,
               metadata,
+              elementPathTree,
             )
 
         return optionalMap((path) => ({ type: 'parent', parentPath: path }), parentInsertionPath)
@@ -530,6 +537,7 @@ export function getTargetParentForPaste(
       nodeModules,
       openFile,
       parentTarget,
+      elementPathTree,
     ) &&
     targetElementSupportsInsertedElement &&
     !insertingSourceIntoItself
@@ -545,6 +553,7 @@ export function getTargetParentForPaste(
       nodeModules,
       openFile,
       parentOfSelected,
+      elementPathTree,
     )
   ) {
     return { type: 'parent', parentPath: childInsertionPath(parentOfSelected) }


### PR DESCRIPTION
**Problem:**
Even though text editing already works for conditionals with expressions, the text insert/edit mode (accessible with the T keyboard shortcut) doesn't work yet.

**Fix:**
- Potential text editing targets were found by the reparent helpers (because for all previous elements text was a child of the containing element). However, for conditionals this is not true, so I added a new parameter to the helpers whether the target is searched for text editing or not.
- I needed to extend some `Metadatautils.targetElementSupportsChildrenAlsoText` so it can return a new value for the case of text editable conditionals (they don't support children but they support text).
Note: For this I needed to extend a huge bunch of functions with the `elementPathTree` parameter, most of the diff is because of this change.