### PR TITLE
Don't invalidate SVG root elements triggering the DOM walker.

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -5,6 +5,8 @@ import {
   JSXElementChild,
   isUtopiaJSXComponent,
   UtopiaJSXComponent,
+  isSVGElement,
+  isJSXElement,
 } from '../../../core/shared/element-template'
 import { optionalMap } from '../../../core/shared/optional-utils'
 import {
@@ -172,7 +174,13 @@ export function createComponentRendererComponent(params: {
     // either this updateInvalidatedPaths or the one in SpyWrapper is probably redundant
     if (shouldUpdate()) {
       updateInvalidatedPaths((invalidPaths) => {
-        if (rootElementPath != null) {
+        // Do not add `svg` elements that are the root element of a component.
+        // As they will not be cleared by the DOM walker as they are not instances
+        // of HTMLElement.
+        const isSVGJSXElement =
+          isJSXElement(utopiaJsxComponent.rootElement) &&
+          isSVGElement(utopiaJsxComponent.rootElement.name)
+        if (rootElementPath != null && !isSVGJSXElement) {
           return invalidPaths.add(EP.toString(rootElementPath))
         } else {
           return invalidPaths

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -101,7 +101,7 @@ import {
   treeToContents,
 } from '../assets'
 import { testStaticElementPath } from '../../core/shared/element-path.test-utils'
-import { createFakeMetadataForParseSuccess } from '../../utils/utils.test-utils'
+import { createFakeMetadataForParseSuccess, wait } from '../../utils/utils.test-utils'
 import {
   saveDOMReport,
   setPanelVisibility,
@@ -121,6 +121,7 @@ import { clearAllRegisteredControls } from './canvas-globals'
 import { createEmptyStrategyState } from './canvas-strategies/interaction-state'
 import {
   createDomWalkerMutableState,
+  DomWalkerMutableStateData,
   invalidateDomWalkerIfNecessary,
   runDomWalker,
 } from './dom-walker'
@@ -186,6 +187,7 @@ export interface EditorRenderResult {
   getRenderInfo: () => Array<string>
   clearRecordedActions: () => void
   getRecordedActions: () => ReadonlyArray<EditorAction>
+  getDomWalkerState: () => DomWalkerMutableStateData
 }
 
 function formatAllCodeInModel(model: PersistentModel): PersistentModel {
@@ -215,7 +217,7 @@ export async function renderTestEditorWithCode(
   appUiJsFileCode: string,
   awaitFirstDomReport: 'await-first-dom-report' | 'dont-await-first-dom-report',
   strategiesToUse: Array<MetaCanvasStrategy> = RegisteredCanvasStrategies,
-) {
+): Promise<EditorRenderResult> {
   return renderTestEditorWithModel(
     createTestProjectWithCode(appUiJsFileCode),
     awaitFirstDomReport,
@@ -228,7 +230,7 @@ export async function renderTestEditorWithProjectContent(
   awaitFirstDomReport: 'await-first-dom-report' | 'dont-await-first-dom-report',
   strategiesToUse: Array<MetaCanvasStrategy> = RegisteredCanvasStrategies,
   loginState: LoginState = notLoggedIn,
-) {
+): Promise<EditorRenderResult> {
   return renderTestEditorWithModel(
     persistentModelForProjectContents(projectContent),
     awaitFirstDomReport,
@@ -506,6 +508,7 @@ label {
       recordedActions = []
     },
     getRecordedActions: () => recordedActions,
+    getDomWalkerState: () => domWalkerMutableState,
   }
 }
 

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1039,6 +1039,10 @@ export function isIntrinsicElement(name: JSXElementName): boolean {
   return PP.depth(name.propertyPath) === 0 && isIntrinsicElementFromString(name.baseVariable)
 }
 
+export function isSVGElement(name: JSXElementName): boolean {
+  return PP.depth(name.propertyPath) === 0 && name.baseVariable === 'svg'
+}
+
 export function isIntrinsicHTMLElementString(name: string): boolean {
   return intrinsicHTMLElementNamesAsStrings.includes(name)
 }


### PR DESCRIPTION
**Problem:**
It was observed that any and every action were triggering the DOM walker, even some that make no relevant changes like the mouseover handler for highlighting.

**Cause:**
An entry for a `svg` element at the root of a component ended up in `invalidatedPaths` but the DOM walker ignores elements which aren't instances of `HTMLElement`. Instead as they are `SVGElement` instances, the entry in `invalidatedPaths` never gets cleared by the DOM walker.

**Fix:**
At the point in which the component is rendered and the root element path is added to `invalidatedPaths` an extra check was inserted which ensures that no `svg` elements are added.

**Commit Details:**
- Added a check in `createComponentRendererComponent` which ensures that `svg` component root elements are not added to the invalidated paths.
- Added `getDomWalkerState` to `EditorRenderResult`.
- Added `isSVGElement` utility function.