### PR TITLE
Fix/paste insert elements

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -4,7 +4,6 @@ import {
   InsertChildAndDetails,
   findJSXElementChildAtPath,
   insertJSXElementChild,
-  insertJSXElementChildren,
   removeJSXElementChild,
   transformJSXComponentAtPath,
 } from '../../../core/model/element-template-utils'
@@ -1934,10 +1933,10 @@ export function insertElementAtPath(
   components: Array<UtopiaJSXComponent>,
   indexPosition: IndexPosition | null,
 ): InsertChildAndDetails {
-  return insertJSXElementChildren(
+  return insertJSXElementChild(
     projectContents,
     targetParent,
-    [elementToInsert],
+    elementToInsert,
     components,
     indexPosition,
   )

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -4,6 +4,7 @@ import {
   InsertChildAndDetails,
   findJSXElementChildAtPath,
   insertJSXElementChild,
+  insertJSXElementChildren,
   removeJSXElementChild,
   transformJSXComponentAtPath,
 } from '../../../core/model/element-template-utils'
@@ -1933,10 +1934,10 @@ export function insertElementAtPath(
   components: Array<UtopiaJSXComponent>,
   indexPosition: IndexPosition | null,
 ): InsertChildAndDetails {
-  return insertJSXElementChild(
+  return insertJSXElementChildren(
     projectContents,
     targetParent,
-    elementToInsert,
+    [elementToInsert],
     components,
     indexPosition,
   )

--- a/editor/src/core/model/element-template-utils.spec.tsx
+++ b/editor/src/core/model/element-template-utils.spec.tsx
@@ -17,7 +17,7 @@ import {
   createTestProjectWithCode,
   getParseSuccessForStoryboardCode,
 } from '../../sample-projects/sample-project-utils.test-utils'
-import Utils, { after, before } from '../../utils/utils'
+import Utils, { absolute, after, before } from '../../utils/utils'
 import * as EP from '../shared/element-path'
 import {
   dynamicPathToStaticPath,
@@ -67,6 +67,7 @@ import {
   findJSXElementChildAtPath,
   guaranteeUniqueUids,
   insertJSXElementChild,
+  insertJSXElementChildren,
   rearrangeJsxChildren,
   removeJSXElementChild,
   transformJSXComponentAtPath,
@@ -1674,6 +1675,486 @@ describe('insertJSXElementChild', () => {
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-b',
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c',
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/hello', // <- the inserted element, no fragment was needed because the branch was empty
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-d',
+    ])
+  })
+})
+
+describe('insertJSXElementChildren', () => {
+  function createTestComponentsForSnippet(snippet: string) {
+    const projectContents = createTestProjectWithCode(
+      makeTestProjectCodeWithSnippet(snippet),
+    ).projectContents
+
+    const file = getContentsTreeFileFromString(projectContents, StoryboardFilePath)
+
+    if (file?.type !== 'TEXT_FILE' || file.lastParseSuccess == null) {
+      throw new Error('failed parsing the test project file')
+    }
+
+    const components = getComponentsFromTopLevelElements(file.lastParseSuccess.topLevelElements)
+
+    return { components, projectContents }
+  }
+
+  function findElement(components: Array<UtopiaJSXComponent>, pathString: string) {
+    const path = fromStringStatic(pathString)
+    const foundElement = findJSXElementChildAtPath(
+      getComponentsFromTopLevelElements(components),
+      path,
+    )
+    return foundElement
+  }
+
+  function expectElementAtPathHasMatchingUID(
+    components: Array<UtopiaJSXComponent>,
+    pathString: string,
+  ) {
+    const foundElement = findElement(components, pathString)
+    expect(foundElement).not.toBeNull()
+    expect(getUtopiaID(foundElement!)).toEqual(toUid(fromStringStatic(pathString)))
+  }
+
+  function expectElementAtPathHasMatchingUIDForPaths(
+    components: Array<UtopiaJSXComponent>,
+    paths: Array<string>,
+  ) {
+    paths.forEach((path) => expectElementAtPathHasMatchingUID(components, path))
+  }
+
+  function expectIndexInParent(
+    components: Array<UtopiaJSXComponent>,
+    pathString: string,
+    expectedIndex: number,
+  ) {
+    const path = EP.fromString(pathString)
+    const parentPathString = EP.toString(EP.parentPath(path))
+    const foundParent = findElement(components, parentPathString)
+    if (foundParent == null || !isJSXElementLike(foundParent)) {
+      throw new Error(`parent found at ${parentPathString} is not JsxElementLike`)
+    }
+    const childUid = EP.toUid(path)
+    const foundChildIndex = foundParent.children.findIndex((child) => child.uid === childUid)
+
+    expect(foundChildIndex).toBe(expectedIndex)
+  }
+  it('inserts simple elements as children', () => {
+    const { components, projectContents } = createTestComponentsForSnippet(`
+    <div style={{ ...props.style }} data-uid='aaa'>
+      <div data-uid='parent' >
+        <div data-uid='child-a' />
+        <div data-uid='child-b' />
+        <div data-uid='child-c'>
+          <div data-uid='grandchild-c' />
+        </div>
+        <div data-uid='child-d' />
+      </div>
+    </div>
+    `)
+
+    const withInsertedElement = insertJSXElementChildren(
+      projectContents,
+      childInsertionPath(
+        EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a'),
+      ),
+      [jsxElement('div', 'hello1', [], []), jsxElement('div', 'hello2', [], [])],
+      components,
+      null,
+    )
+
+    expectElementAtPathHasMatchingUIDForPaths(withInsertedElement.components, [
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a/hello1', // <- the inserted element!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a/hello2', // <- the inserted element!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-b',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/grandchild-c',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-d',
+    ])
+  })
+
+  it('inserts simple elements as children with index position', () => {
+    const { components, projectContents } = createTestComponentsForSnippet(`
+    <div style={{ ...props.style }} data-uid='aaa'>
+      <div data-uid='parent' >
+        <div data-uid='child-a' />
+        <div data-uid='child-b' />
+        <div data-uid='child-c'>
+          <div data-uid='grandchild-c' />
+          <div data-uid='grandchild-d' />
+        </div>
+        <div data-uid='child-d' />
+      </div>
+    </div>
+    `)
+
+    const withInsertedElement = insertJSXElementChildren(
+      projectContents,
+      childInsertionPath(
+        EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c'),
+      ),
+      [jsxElement('div', 'hello1', [], []), jsxElement('div', 'hello2', [], [])],
+      components,
+      absolute(1),
+    )
+
+    expectIndexInParent(
+      withInsertedElement.components,
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/hello1',
+      2,
+    )
+    expectIndexInParent(
+      withInsertedElement.components,
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/hello2',
+      1,
+    )
+
+    expectElementAtPathHasMatchingUIDForPaths(withInsertedElement.components, [
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-b',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/grandchild-c',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/hello1', // <- the inserted element!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/hello2', // <- the inserted element!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/grandchild-d',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-d',
+    ])
+  })
+
+  it('inserts simple elements as last with index position pointing to larger index than possible', () => {
+    const { components, projectContents } = createTestComponentsForSnippet(`
+    <div style={{ ...props.style }} data-uid='aaa'>
+      <div data-uid='parent' >
+        <div data-uid='child-a' />
+        <div data-uid='child-b' />
+        <div data-uid='child-c'>
+          <div data-uid='grandchild-c-1' />
+          <div data-uid='grandchild-c-2' />
+        </div>
+        <div data-uid='child-d' />
+      </div>
+    </div>
+    `)
+
+    const withInsertedElement = insertJSXElementChildren(
+      projectContents,
+      childInsertionPath(
+        EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c'),
+      ),
+      [jsxElement('div', 'hello1', [], []), jsxElement('div', 'hello2', [], [])],
+      components,
+      after(15), // this means it should come after element index 15, but the array is only 2 long. the resulting index will be 2 (zero based)
+    )
+
+    expectIndexInParent(
+      withInsertedElement.components,
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/hello1',
+      2,
+    )
+    expectIndexInParent(
+      withInsertedElement.components,
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/hello2',
+      3,
+    )
+
+    expectElementAtPathHasMatchingUIDForPaths(withInsertedElement.components, [
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-b',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/grandchild-c-1',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/grandchild-c-2',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/hello1', // <- the inserted element!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/hello2', // <- the inserted element!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-d',
+    ])
+  })
+
+  it('array insertion throws error if trying to insert into a conditional expression', () => {
+    const { components, projectContents } = createTestComponentsForSnippet(`
+    <div style={{ ...props.style }} data-uid='aaa'>
+      <div data-uid='parent' >
+        <div data-uid='child-a' />
+        <div data-uid='child-b' />
+        {
+          // @utopia/uid=child-c
+          true ?
+          (
+            "hello"
+          ) : (
+            <span>"world"</span>
+          )
+        }
+        <div data-uid='child-d' />
+      </div>
+    </div>
+    `)
+
+    expect(() =>
+      insertJSXElementChildren(
+        projectContents,
+        childInsertionPath(
+          EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c'),
+        ),
+        [jsxElement('div', 'hello', [], [])],
+        components,
+        null,
+      ),
+    ).toThrow()
+  })
+
+  it('conditional clause insertion throws error if the parent is not a conditional expression', () => {
+    const { components, projectContents } = createTestComponentsForSnippet(`
+    <div style={{ ...props.style }} data-uid='aaa'>
+      <div data-uid='parent' >
+        <div data-uid='child-a' />
+        <div data-uid='child-b' />
+        <div data-uid='child-c' />
+      </div>
+    </div>
+    `)
+
+    expect(() =>
+      insertJSXElementChildren(
+        projectContents,
+        conditionalClauseInsertionPath(
+          EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a'),
+          'true-case',
+          'replace',
+        ),
+        [jsxElement('div', 'hello', [], [])],
+        components,
+        null,
+      ),
+    ).toThrow()
+  })
+
+  it("inserting a single element into the conditional's true branch is working with replace behavior when branch is empty", () => {
+    const { components, projectContents } = createTestComponentsForSnippet(`
+    <div style={{ ...props.style }} data-uid='aaa'>
+      <div data-uid='parent' >
+        <div data-uid='child-a' />
+        <div data-uid='child-b' />
+        {
+          // @utopia/uid=child-c
+          true ?
+          (
+            null
+          ) : (
+            <span>"world"</span>
+          )
+        }
+        <div data-uid='child-d' />
+      </div>
+    </div>
+    `)
+
+    const withInsertedElement = insertJSXElementChildren(
+      projectContents,
+      conditionalClauseInsertionPath(
+        EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c'),
+        'true-case',
+        'replace',
+      ),
+      [jsxElement('div', 'hello1', [], [])],
+      components,
+      null,
+    )
+
+    expectElementAtPathHasMatchingUIDForPaths(withInsertedElement.components, [
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-b',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/hello1', // <- the inserted element!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-d',
+    ])
+  })
+  it("inserting multiple elements into the conditional's true branch is working with replace behavior when branch is empty, adds fragment", () => {
+    const { components, projectContents } = createTestComponentsForSnippet(`
+    <div style={{ ...props.style }} data-uid='aaa'>
+      <div data-uid='parent' >
+        <div data-uid='child-a' />
+        <div data-uid='child-b' />
+        {
+          // @utopia/uid=child-c
+          true ?
+          (
+            null
+          ) : (
+            <span>"world"</span>
+          )
+        }
+        <div data-uid='child-d' />
+      </div>
+    </div>
+    `)
+
+    FOR_TESTS_setNextGeneratedUid('fragment')
+    const withInsertedElement = insertJSXElementChildren(
+      projectContents,
+      conditionalClauseInsertionPath(
+        EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c'),
+        'true-case',
+        'replace',
+      ),
+      [jsxElement('div', 'hello1', [], []), jsxElement('div', 'hello2', [], [])],
+      components,
+      null,
+    )
+
+    expectElementAtPathHasMatchingUIDForPaths(withInsertedElement.components, [
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-b',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/fragment/hello1', // <- the inserted element!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/fragment/hello2', // <- the inserted element!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-d',
+    ])
+  })
+
+  it("inserting an element into the conditional's true branch is working with wrap into fragment behavior", () => {
+    const { components, projectContents } = createTestComponentsForSnippet(`
+    <div style={{ ...props.style }} data-uid='aaa'>
+      <div data-uid='parent' >
+        <div data-uid='child-a' />
+        <div data-uid='child-b' />
+        {
+          // @utopia/uid=child-c
+          true ?
+          (
+            "hello"
+          ) : (
+            <div>"world"</div>
+          )
+        }
+        <div data-uid='child-d' />
+      </div>
+    </div>
+    `)
+
+    FOR_TESTS_setNextGeneratedUid('fragment')
+    const withInsertedElement = insertJSXElementChildren(
+      projectContents,
+      conditionalClauseInsertionPath(
+        EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c'),
+        'true-case',
+        'wrap-with-fragment',
+      ),
+      [jsxElement('div', 'hello2', [], [])],
+      components,
+      null,
+    )
+
+    expectElementAtPathHasMatchingUIDForPaths(withInsertedElement.components, [
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-b',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/fragment/', // <- the new fragment!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/fragment/409', // <- the original hello!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/fragment/hello2', // <- the inserted hello!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-d',
+    ])
+  })
+
+  it("inserting into the conditional's false branch is working with replace behavior", () => {
+    const { components, projectContents } = createTestComponentsForSnippet(`
+      <div style={{ ...props.style }} data-uid='aaa'>
+        <div data-uid='parent' >
+          <div data-uid='child-a' />
+          <div data-uid='child-b' />
+        {
+          // @utopia/uid=child-c
+          true ?
+          (
+            "hello"
+          ) : (
+            <span>"world-will be deleted"</span>
+          )
+        }
+        <div data-uid='child-d' />
+      </div>
+    </div>
+    `)
+
+    FOR_TESTS_setNextGeneratedUid('fragment')
+    const withInsertedElement = insertJSXElementChildren(
+      projectContents,
+      conditionalClauseInsertionPath(
+        EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c'),
+        'false-case',
+        'replace',
+      ),
+      [jsxElement('div', 'hello1', [], []), jsxElement('div', 'hello2', [], [])],
+      components,
+      null,
+    )
+
+    expectElementAtPathHasMatchingUIDForPaths(withInsertedElement.components, [
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-b',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/fragment/hello1', // <- the inserted element!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/fragment/hello2', // <- the inserted element!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-d',
+    ])
+  })
+
+  it("inserting into the conditional's false branch with an existing fragment", () => {
+    const { components, projectContents } = createTestComponentsForSnippet(`
+      <div style={{ ...props.style }} data-uid='aaa'>
+        <div data-uid='parent' >
+          <div data-uid='child-a' />
+          <div data-uid='child-b' />
+        {
+          // @utopia/uid=child-c
+          true ?
+          (
+            null
+          ) : (
+            <React.Fragment data-uid='fragment'>
+              <span data-uid='child-e'>hello in a fragment</span>
+            </React.Fragment>
+          )
+        }
+        <div data-uid='child-d' />
+      </div>
+    </div>
+    `)
+
+    const withInsertedElement = insertJSXElementChildren(
+      projectContents,
+      conditionalClauseInsertionPath(
+        EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c'),
+        'false-case',
+        'wrap-with-fragment',
+      ),
+      [jsxElement('div', 'hello1', [], []), jsxElement('div', 'hello2', [], [])],
+      components,
+      null,
+    )
+
+    expectElementAtPathHasMatchingUIDForPaths(withInsertedElement.components, [
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-a',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-b',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/fragment/child-e',
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/fragment/hello1', // <- the inserted element!
+      'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-c/fragment/hello2', // <- the inserted element!
       'utopia-storyboard-uid/scene-aaa/app-entity:aaa/parent/child-d',
     ])
   })

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -37,6 +37,7 @@ import {
   JSXConditionalExpression,
   isJSExpression,
   ArbitraryJSBlock,
+  JSXFragment,
 } from '../shared/element-template'
 import {
   isParseSuccess,
@@ -530,6 +531,99 @@ export function insertJSXElementChild(
             [elementToInsert, clauseValue],
             true,
           )
+        },
+        parentElement,
+      )
+    } else {
+      assertNever(targetParent)
+    }
+  })
+  return insertChildAndDetails(updatedComponents, null, importsToAdd) // TODO is this wrapper type needed?
+}
+
+export function insertJSXElementChildren(
+  projectContents: ProjectContentTreeRoot,
+  targetParent: InsertionPath,
+  elementsToInsert: Array<JSXElementChild>,
+  components: Array<UtopiaJSXComponent>,
+  indexPosition: IndexPosition | null,
+): InsertChildAndDetails {
+  const parentPath: StaticElementPath = targetParent.intendedParentPath
+  let importsToAdd: Imports = {}
+  const updatedComponents = transformJSXComponentAtPath(components, parentPath, (parentElement) => {
+    if (isChildInsertionPath(targetParent)) {
+      if (!isJSXElementLike(parentElement)) {
+        throw new Error("Target parent for array insertion doesn't support children")
+      }
+      let updatedChildren: Array<JSXElementChild>
+      if (indexPosition == null) {
+        updatedChildren = [...parentElement.children, ...elementsToInsert]
+      } else {
+        updatedChildren = elementsToInsert.reduce((working, elementToInsert) => {
+          return addToArrayAtIndexPosition(elementToInsert, working, indexPosition)
+        }, parentElement.children)
+      }
+      return {
+        ...parentElement,
+        children: updatedChildren,
+      }
+    } else if (isConditionalClauseInsertionPath(targetParent)) {
+      if (!isJSXConditionalExpression(parentElement)) {
+        throw new Error('Target parent for conditional insertion is not conditional expression')
+      }
+      // Determine which clause of the conditional we want to modify.
+      const conditionalCase = targetParent.clause
+      const toClauseOptic =
+        conditionalCase === 'true-case' ? conditionalWhenTrueOptic : conditionalWhenFalseOptic
+
+      function wrapIntoFragment(clauseValue: JSXElementChild | null): JSXFragment {
+        importsToAdd = {
+          react: {
+            importedAs: 'React',
+            importedFromWithin: [],
+            importedWithName: null,
+          },
+        }
+
+        if (clauseValue == null) {
+          return jsxFragment(
+            generateUidWithExistingComponents(projectContents),
+            elementsToInsert,
+            true,
+          )
+        }
+        if (isJSXFragment(clauseValue)) {
+          return {
+            ...clauseValue,
+            children: [...elementsToInsert, ...clauseValue.children],
+          }
+        } else {
+          return jsxFragment(
+            generateUidWithExistingComponents(projectContents),
+            [...elementsToInsert, clauseValue],
+            true,
+          )
+        }
+      }
+
+      return modify(
+        toClauseOptic,
+        (clauseValue) => {
+          if (targetParent.insertBehavior === 'replace') {
+            if (elementsToInsert.length === 1) {
+              return elementsToInsert[0]
+            } else {
+              return wrapIntoFragment(null)
+            }
+          }
+          if (isNullJSXAttributeValue(clauseValue)) {
+            if (elementsToInsert.length === 1) {
+              return elementsToInsert[0]
+            } else {
+              return wrapIntoFragment(null)
+            }
+          }
+          return wrapIntoFragment(clauseValue)
         },
         parentElement,
       )

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -612,14 +612,7 @@ export function insertJSXElementChildren(
       return modify(
         toClauseOptic,
         (clauseValue) => {
-          if (targetParent.insertBehavior === 'replace') {
-            if (elementsToInsert.length === 1) {
-              return elementsToInsert[0]
-            } else {
-              return wrapIntoFragment(null)
-            }
-          }
-          if (isNullJSXAttributeValue(clauseValue)) {
+          if (targetParent.insertBehavior === 'replace' || isNullJSXAttributeValue(clauseValue)) {
             if (elementsToInsert.length === 1) {
               return elementsToInsert[0]
             } else {


### PR DESCRIPTION
**Problem:**
There are multiple bugs when pasting more than one element into conditionals. The classic paste action just accidentally skips adjusting the layout because it manually wraps into fragment first, and it's easy to end up with nested fragments when there is a fragment originally in the conditional clause. The new "paste to replace" is in a bit worse shape because it misses the manual wrapping too, but it would have the same problems.

**Fix:**
First step of the fixes is to introduce `insertJSXElementChildren` which accepts an array of child elements. With that it's easier to figure out if a wrapper fragment is required.
It is not used anywhere now, because #3798 is changing the action to a strategy. I temporarly switched it in `insertElementAtPath` to try it locally and run the tests.

**Commit Details:**
- made a new version of `insertJSXElementChild` called `insertJSXElementChildren`
- added tests, based on the original one
