### PR TITLE
Permit multiple properties to be updated by AdjustCssLengthProperty.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes.ts
@@ -57,7 +57,6 @@ import { assertNever } from '../../../../../core/shared/utils'
 import { flexChildProps, pruneFlexPropsCommands } from '../../../../inspector/inspector-common'
 import { setCssLengthProperty } from '../../../commands/set-css-length-command'
 import { ElementPathTrees } from '../../../../../core/shared/element-path-tree'
-import { Pack } from 'tar'
 
 const propertiesToRemove: Array<PropertyPath> = [
   PP.create('style', 'left'),

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -72,8 +72,8 @@ import { elementHasOnlyTextChildren } from '../../canvas-utils'
 import { Modifiers } from '../../../../utils/modifiers'
 import { Axis, detectFillHugFixedState } from '../../../inspector/inspector-common'
 import {
-  AdjustCssLengthProperty,
-  adjustCssLengthProperty,
+  AdjustCssLengthProperties,
+  adjustCssLengthProperties,
 } from '../../commands/adjust-css-length-command'
 import { ElementPathTrees } from '../../../../core/shared/element-path-tree'
 
@@ -228,7 +228,7 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
         canvasState.startingMetadata,
       )
 
-      const adjustSizeCommands = getSizeUpdateCommandsForNewPadding(
+      const adjustSizeCommand = getSizeUpdateCommandsForNewPadding(
         combinedXPadding,
         combinedYPadding,
         targetFrame,
@@ -237,7 +237,7 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
         canvasState.startingElementPathTree,
       )
 
-      basicCommands.push(...adjustSizeCommands)
+      basicCommands.push(adjustSizeCommand)
 
       // "tearing off" padding
       if (newPaddingEdge.renderedValuePx < PaddingTearThreshold) {

--- a/editor/src/components/canvas/commands/adjust-css-length-command.ts
+++ b/editor/src/components/canvas/commands/adjust-css-length-command.ts
@@ -79,7 +79,7 @@ interface UpdatedPropsAndCommandDescription {
   commandDescription: string
 }
 
-export const runAdjustCssLengthProperty: CommandFunction<AdjustCssLengthProperties> = (
+export const runAdjustCssLengthProperties: CommandFunction<AdjustCssLengthProperties> = (
   editorState: EditorState,
   command: AdjustCssLengthProperties,
 ) => {

--- a/editor/src/components/canvas/commands/adjust-css-length-command.ts
+++ b/editor/src/components/canvas/commands/adjust-css-length-command.ts
@@ -1,20 +1,24 @@
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { isLeft, isRight, left } from '../../../core/shared/either'
+import { Either, foldEither, isLeft, isRight, left, mapEither } from '../../../core/shared/either'
 import * as EP from '../../../core/shared/element-path'
 import {
   emptyComments,
   isJSXElement,
   jsExpressionValue,
+  JSXAttributes,
+  JSXElement,
+  JSXElementChild,
 } from '../../../core/shared/element-template'
 import {
-  GetModifiableAttributeResult,
   getModifiableJSXAttributeAtPath,
   jsxSimpleAttributeToValue,
+  setJSXValuesAtPaths,
+  unsetJSXValuesAtPaths,
   ValueAtPath,
 } from '../../../core/shared/jsx-attributes'
 import { ElementPath, PropertyPath } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
-import { EditorState, withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
+import { EditorState, modifyUnderlyingForOpenFile } from '../../editor/store/editor-state'
 import {
   CSSNumber,
   FlexDirection,
@@ -22,153 +26,242 @@ import {
   parseCSSPx,
   printCSSNumber,
 } from '../../inspector/common/css-utils'
-import { applyValuesAtPath } from './adjust-number-command'
-import { BaseCommand, CommandFunction, CommandFunctionResult, WhenToRun } from './commands'
+import { BaseCommand, CommandFunction, WhenToRun } from './commands'
 import { deleteValuesAtPath } from './delete-properties-command'
+import { patchParseSuccessAtElementPath } from './patch-utils'
 
 export type CreateIfNotExistant = 'create-if-not-existing' | 'do-not-create-if-doesnt-exist'
 
-export interface AdjustCssLengthProperty extends BaseCommand {
-  type: 'ADJUST_CSS_LENGTH_PROPERTY'
-  target: ElementPath
+export interface LengthPropertyToAdjust {
   property: PropertyPath
   valuePx: number
   parentDimensionPx: number | undefined
-  parentFlexDirection: FlexDirection | null
   createIfNonExistant: CreateIfNotExistant
 }
 
-export function adjustCssLengthProperty(
-  whenToRun: WhenToRun,
-  target: ElementPath,
+export function lengthPropertyToAdjust(
   property: PropertyPath,
   valuePx: number,
   parentDimensionPx: number | undefined,
-  parentFlexDirection: FlexDirection | null,
   createIfNonExistant: CreateIfNotExistant,
-): AdjustCssLengthProperty {
+): LengthPropertyToAdjust {
   return {
-    type: 'ADJUST_CSS_LENGTH_PROPERTY',
-    whenToRun: whenToRun,
-    target: target,
     property: property,
     valuePx: valuePx,
     parentDimensionPx: parentDimensionPx,
-    parentFlexDirection: parentFlexDirection,
     createIfNonExistant: createIfNonExistant,
   }
 }
 
-export const runAdjustCssLengthProperty: CommandFunction<AdjustCssLengthProperty> = (
-  editorState: EditorState,
-  command: AdjustCssLengthProperty,
-) => {
-  // in case of width or height change, delete min, max and flex props
-  const editorStateWithPropsDeleted = deleteConflictingPropsForWidthHeight(
-    editorState,
-    command.target,
-    command.property,
-    command.parentFlexDirection,
-  )
+export interface AdjustCssLengthProperties extends BaseCommand {
+  type: 'ADJUST_CSS_LENGTH_PROPERTY'
+  target: ElementPath
+  parentFlexDirection: FlexDirection | null
+  properties: Array<LengthPropertyToAdjust>
+}
 
-  // Identify the current value, whatever that may be.
-  const currentValue: GetModifiableAttributeResult = withUnderlyingTargetFromEditorState(
+export function adjustCssLengthProperties(
+  whenToRun: WhenToRun,
+  target: ElementPath,
+  parentFlexDirection: FlexDirection | null,
+  properties: Array<LengthPropertyToAdjust>,
+): AdjustCssLengthProperties {
+  return {
+    type: 'ADJUST_CSS_LENGTH_PROPERTY',
+    whenToRun: whenToRun,
+    target: target,
+    parentFlexDirection: parentFlexDirection,
+    properties: properties,
+  }
+}
+
+interface UpdatedPropsAndCommandDescription {
+  updatedProps: JSXAttributes
+  commandDescription: string
+}
+
+export const runAdjustCssLengthProperty: CommandFunction<AdjustCssLengthProperties> = (
+  editorState: EditorState,
+  command: AdjustCssLengthProperties,
+) => {
+  let commandDescriptions: Array<string> = []
+  const updatedEditorState: EditorState = modifyUnderlyingForOpenFile(
     command.target,
-    editorStateWithPropsDeleted,
-    left(`no target element was found at path ${EP.toString(command.target)}`),
-    (_, element) => {
+    editorState,
+    (element) => {
       if (isJSXElement(element)) {
-        return getModifiableJSXAttributeAtPath(element.props, command.property)
-      } else {
-        return left(`No JSXElement was found at path ${EP.toString(command.target)}`)
+        const originalElement: JSXElement = element
+        let workingElement: JSXElement = element
+        for (const property of command.properties) {
+          const attributesWithConflictingPropsDeleted =
+            deleteConflictingPropsForWidthHeightFromAttributes(
+              workingElement.props,
+              property.property,
+              command.parentFlexDirection,
+            )
+          if (isLeft(attributesWithConflictingPropsDeleted)) {
+            commandDescriptions.push(attributesWithConflictingPropsDeleted.value)
+            return element
+          }
+          const currentValue = getModifiableJSXAttributeAtPath(
+            attributesWithConflictingPropsDeleted.value,
+            property.property,
+          )
+
+          if (isLeft(currentValue)) {
+            commandDescriptions.push(
+              `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
+                property.property,
+              )} not applied as value is not writeable.`,
+            )
+            return element
+          }
+          const currentModifiableValue = currentValue.value
+          const simpleValueResult = jsxSimpleAttributeToValue(currentModifiableValue)
+          const valueProbablyExpression = isLeft(simpleValueResult)
+          const targetPropertyNonExistant: boolean =
+            currentModifiableValue.type === 'ATTRIBUTE_NOT_FOUND'
+
+          if (
+            targetPropertyNonExistant &&
+            property.createIfNonExistant === 'do-not-create-if-doesnt-exist'
+          ) {
+            commandDescriptions.push(
+              `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
+                property.property,
+              )} not applied as the property does not exist.`,
+            )
+            return element
+          }
+
+          if (valueProbablyExpression) {
+            // TODO add option to override expressions!!!
+            commandDescriptions.push(
+              `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
+                property.property,
+              )} not applied as the property is an expression we did not want to override.`,
+            )
+            return element
+          }
+
+          const parsePxResult = parseCSSPx(simpleValueResult.value) // TODO make type contain px
+
+          function handleUpdateResult(
+            result: Either<string, UpdatedPropsAndCommandDescription>,
+          ): void {
+            foldEither(
+              (error) => {
+                commandDescriptions.push(error)
+                workingElement = originalElement
+              },
+              (updatedProps) => {
+                commandDescriptions.push(updatedProps.commandDescription)
+                workingElement = {
+                  ...workingElement,
+                  props: updatedProps.updatedProps,
+                }
+              },
+              result,
+            )
+          }
+
+          if (isRight(parsePxResult)) {
+            handleUpdateResult(
+              updatePixelValueByPixel(
+                attributesWithConflictingPropsDeleted.value,
+                command.target,
+                property.property,
+                parsePxResult.value,
+                property.valuePx,
+              ),
+            )
+            continue
+          }
+
+          const parsePercentResult = parseCSSPercent(simpleValueResult.value) // TODO make type contain %
+          if (isRight(parsePercentResult)) {
+            handleUpdateResult(
+              updatePercentageValueByPixel(
+                attributesWithConflictingPropsDeleted.value,
+                command.target,
+                property.property,
+                property.parentDimensionPx,
+                parsePercentResult.value,
+                property.valuePx,
+              ),
+            )
+            continue
+          }
+
+          if (property.createIfNonExistant === 'create-if-not-existing') {
+            handleUpdateResult(
+              setPixelValue(
+                attributesWithConflictingPropsDeleted.value,
+                command.target,
+                property.property,
+                property.valuePx,
+              ),
+            )
+            continue
+          }
+
+          // Updating the props fallback.
+          commandDescriptions.push(
+            `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
+              property.property,
+            )} not applied as the property is in a CSS unit we do not support. (${
+              simpleValueResult.value
+            })`,
+          )
+          return element
+        }
+        return workingElement
       }
+
+      // Final fallback.
+      return element
     },
   )
-  if (isLeft(currentValue)) {
+  if (commandDescriptions == null) {
     return {
       editorStatePatches: [],
-      commandDescription: `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
-        command.property,
-      )} not applied as value is not writeable.`,
+      commandDescription: `No JSXElement was found at path ${EP.toString(command.target)}.`,
     }
-  }
-  const currentModifiableValue = currentValue.value
-  const simpleValueResult = jsxSimpleAttributeToValue(currentModifiableValue)
-  const valueProbablyExpression = isLeft(simpleValueResult)
-  const targetPropertyNonExistant: boolean = currentModifiableValue.type === 'ATTRIBUTE_NOT_FOUND'
-
-  if (
-    targetPropertyNonExistant &&
-    command.createIfNonExistant === 'do-not-create-if-doesnt-exist'
-  ) {
-    return {
-      editorStatePatches: [],
-      commandDescription: `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
-        command.property,
-      )} not applied as the property does not exist.`,
+  } else {
+    if (updatedEditorState === editorState) {
+      return {
+        editorStatePatches: [],
+        commandDescription: commandDescriptions.join('\n'),
+      }
+    } else {
+      const editorStatePatch = patchParseSuccessAtElementPath(
+        command.target,
+        updatedEditorState,
+        (success) => {
+          return {
+            topLevelElements: {
+              $set: success.topLevelElements,
+            },
+            imports: {
+              $set: success.imports,
+            },
+          }
+        },
+      )
+      return {
+        editorStatePatches: [editorStatePatch],
+        commandDescription: commandDescriptions.join('\n'),
+      }
     }
-  }
-
-  if (valueProbablyExpression) {
-    // TODO add option to override expressions!!!
-    return {
-      editorStatePatches: [],
-      commandDescription: `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
-        command.property,
-      )} not applied as the property is an expression we did not want to override.`,
-    }
-  }
-
-  const parsePxResult = parseCSSPx(simpleValueResult.value) // TODO make type contain px
-
-  if (isRight(parsePxResult)) {
-    return updatePixelValueByPixel(
-      editorStateWithPropsDeleted,
-      command.target,
-      command.property,
-      parsePxResult.value,
-      command.valuePx,
-    )
-  }
-
-  const parsePercentResult = parseCSSPercent(simpleValueResult.value) // TODO make type contain %
-  if (isRight(parsePercentResult)) {
-    return updatePercentageValueByPixel(
-      editorStateWithPropsDeleted,
-      command.target,
-      command.property,
-      command.parentDimensionPx,
-      parsePercentResult.value,
-      command.valuePx,
-    )
-  }
-
-  if (command.createIfNonExistant === 'create-if-not-existing') {
-    return setPixelValue(
-      editorStateWithPropsDeleted,
-      command.target,
-      command.property,
-      command.valuePx,
-    )
-  }
-
-  // fallback return
-  return {
-    editorStatePatches: [],
-    commandDescription: `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
-      command.property,
-    )} not applied as the property is in a CSS unit we do not support. (${
-      simpleValueResult.value
-    })`,
   }
 }
 
 function setPixelValue(
-  editorState: EditorState,
+  properties: JSXAttributes,
   targetElement: ElementPath,
   targetProperty: PropertyPath,
   value: number,
-) {
+): Either<string, UpdatedPropsAndCommandDescription> {
   const newValueCssNumber: CSSNumber = {
     value: value,
     unit: null,
@@ -182,28 +275,25 @@ function setPixelValue(
     },
   ]
 
-  // Apply the update to the properties.
-  const { editorStatePatch: propertyUpdatePatch } = applyValuesAtPath(
-    editorState,
-    targetElement,
-    propsToUpdate,
-  )
+  const updatePropsResult = setJSXValuesAtPaths(properties, propsToUpdate)
 
-  return {
-    editorStatePatches: [propertyUpdatePatch],
-    commandDescription: `Set css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
-      targetProperty,
-    )} by ${value}`,
-  }
+  return mapEither((updatedProps) => {
+    return {
+      updatedProps: updatedProps,
+      commandDescription: `Set css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
+        targetProperty,
+      )} to ${value}.`,
+    }
+  }, updatePropsResult)
 }
 
 function updatePixelValueByPixel(
-  editorState: EditorState,
+  properties: JSXAttributes,
   targetElement: ElementPath,
   targetProperty: PropertyPath,
   currentValue: CSSNumber,
   byValue: number,
-): CommandFunctionResult {
+): Either<string, UpdatedPropsAndCommandDescription> {
   if (currentValue.unit != null && currentValue.unit !== 'px') {
     throw new Error('updatePixelValueByPixel called with a non-pixel cssnumber')
   }
@@ -220,48 +310,42 @@ function updatePixelValueByPixel(
       value: jsExpressionValue(newValue, emptyComments),
     },
   ]
+  const updatePropsResult = setJSXValuesAtPaths(properties, propsToUpdate)
 
-  // Apply the update to the properties.
-  const { editorStatePatch: propertyUpdatePatch } = applyValuesAtPath(
-    editorState,
-    targetElement,
-    propsToUpdate,
-  )
-
-  return {
-    editorStatePatches: [propertyUpdatePatch],
-    commandDescription: `Adjust Css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
-      targetProperty,
-    )} by ${byValue}`,
-  }
+  return mapEither((updatedProps) => {
+    return {
+      updatedProps: updatedProps,
+      commandDescription: `Adjust Css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
+        targetProperty,
+      )} by ${byValue}`,
+    }
+  }, updatePropsResult)
 }
 
 function updatePercentageValueByPixel(
-  editorState: EditorState,
+  properties: JSXAttributes,
   targetElement: ElementPath,
   targetProperty: PropertyPath,
   parentDimensionPx: number | undefined,
   currentValue: CSSNumber, // TODO restrict to percentage numbers
   byValue: number,
-): CommandFunctionResult {
+): Either<string, UpdatedPropsAndCommandDescription> {
   if (currentValue.unit == null || currentValue.unit !== '%') {
     throw new Error('updatePercentageValueByPixel called with a non-percentage cssnumber')
   }
   if (parentDimensionPx == null) {
-    return {
-      editorStatePatches: [],
-      commandDescription: `Adjust Css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
+    return left(
+      `Adjust Css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
         targetProperty,
       )} not applied because the parent dimensions are unknown for some reason.`,
-    }
+    )
   }
   if (parentDimensionPx === 0) {
-    return {
-      editorStatePatches: [],
-      commandDescription: `Adjust Css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
+    return left(
+      `Adjust Css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
         targetProperty,
       )} not applied because the parent dimension is 0.`,
-    }
+    )
   }
   const currentValuePercent = currentValue.value
   const offsetInPercent = (byValue / parentDimensionPx) * 100
@@ -278,19 +362,16 @@ function updatePercentageValueByPixel(
     },
   ]
 
-  // Apply the update to the properties.
-  const { editorStatePatch: propertyUpdatePatch } = applyValuesAtPath(
-    editorState,
-    targetElement,
-    propsToUpdate,
-  )
+  const updatePropsResult = setJSXValuesAtPaths(properties, propsToUpdate)
 
-  return {
-    editorStatePatches: [propertyUpdatePatch],
-    commandDescription: `Adjust Css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
-      targetProperty,
-    )} by ${byValue}`,
-  }
+  return mapEither((updatedProps) => {
+    return {
+      updatedProps: updatedProps,
+      commandDescription: `Adjust Css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
+        targetProperty,
+      )} by ${byValue}`,
+    }
+  }, updatePropsResult)
 }
 
 const FlexSizeProperties: Array<PropertyPath> = [
@@ -300,12 +381,10 @@ const FlexSizeProperties: Array<PropertyPath> = [
   PP.create('style', 'flexBasis'),
 ]
 
-export function deleteConflictingPropsForWidthHeight(
-  editorState: EditorState,
-  target: ElementPath,
-  propertyPath: PropertyPath,
+function getConflictingPropertiesToDelete(
   parentFlexDirection: FlexDirection | null,
-): EditorState {
+  propertyPath: PropertyPath,
+) {
   let propertiesToDelete: Array<PropertyPath> = []
 
   const parentFlexDimension =
@@ -327,6 +406,31 @@ export function deleteConflictingPropsForWidthHeight(
       }
       break
   }
+  return propertiesToDelete
+}
+
+export function deleteConflictingPropsForWidthHeightFromAttributes(
+  attributes: JSXAttributes,
+  propertyPath: PropertyPath,
+  parentFlexDirection: FlexDirection | null,
+): Either<string, JSXAttributes> {
+  const propertiesToDelete: Array<PropertyPath> = getConflictingPropertiesToDelete(
+    parentFlexDirection,
+    propertyPath,
+  )
+  return unsetJSXValuesAtPaths(attributes, propertiesToDelete)
+}
+
+export function deleteConflictingPropsForWidthHeight(
+  editorState: EditorState,
+  target: ElementPath,
+  propertyPath: PropertyPath,
+  parentFlexDirection: FlexDirection | null,
+): EditorState {
+  const propertiesToDelete: Array<PropertyPath> = getConflictingPropertiesToDelete(
+    parentFlexDirection,
+    propertyPath,
+  )
 
   const { editorStateWithChanges: editorStateWithPropsDeleted } = deleteValuesAtPath(
     editorState,

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -12,7 +12,10 @@ import {
 } from '../../assets'
 import { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import { CommandDescription } from '../canvas-strategies/interaction-state'
-import { AdjustCssLengthProperties, runAdjustCssLengthProperty } from './adjust-css-length-command'
+import {
+  AdjustCssLengthProperties,
+  runAdjustCssLengthProperties,
+} from './adjust-css-length-command'
 import { AdjustNumberProperty, runAdjustNumberProperty } from './adjust-number-command'
 import { ConvertToAbsolute, runConvertToAbsolute } from './convert-to-absolute-command'
 import { ReorderElement, runReorderElement } from './reorder-element-command'
@@ -136,7 +139,7 @@ export function runCanvasCommand(
     case 'ADJUST_NUMBER_PROPERTY':
       return runAdjustNumberProperty(editorState, command)
     case 'ADJUST_CSS_LENGTH_PROPERTY':
-      return runAdjustCssLengthProperty(editorState, command)
+      return runAdjustCssLengthProperties(editorState, command)
     case 'REPARENT_ELEMENT':
       return runReparentElement(editorState, command)
     case 'DUPLICATE_ELEMENT':

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -12,7 +12,7 @@ import {
 } from '../../assets'
 import { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import { CommandDescription } from '../canvas-strategies/interaction-state'
-import { AdjustCssLengthProperty, runAdjustCssLengthProperty } from './adjust-css-length-command'
+import { AdjustCssLengthProperties, runAdjustCssLengthProperty } from './adjust-css-length-command'
 import { AdjustNumberProperty, runAdjustNumberProperty } from './adjust-number-command'
 import { ConvertToAbsolute, runConvertToAbsolute } from './convert-to-absolute-command'
 import { ReorderElement, runReorderElement } from './reorder-element-command'
@@ -90,7 +90,7 @@ export type CanvasCommand =
   | UpdateFunctionCommand
   | StrategySwitched
   | AdjustNumberProperty
-  | AdjustCssLengthProperty
+  | AdjustCssLengthProperties
   | ReparentElement
   | DuplicateElement
   | UpdateSelectedViews

--- a/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
+++ b/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
@@ -41,7 +41,7 @@ import { replaceFragmentLikePathsWithTheirChildrenRecursive } from '../canvas-st
 import { treatElementAsGroupLike } from '../canvas-strategies/strategies/group-helpers'
 import { resizeBoundingBoxFromCorner } from '../canvas-strategies/strategies/resize-helpers'
 import { CanvasFrameAndTarget, EdgePositionBottomRight, FrameAndTarget } from '../canvas-types'
-import { adjustCssLengthProperty } from './adjust-css-length-command'
+import { adjustCssLengthProperties, lengthPropertyToAdjust } from './adjust-css-length-command'
 import {
   BaseCommand,
   CanvasCommand,
@@ -395,43 +395,38 @@ function setGroupPins(
 ): Array<CanvasCommand> {
   // TODO retarget Fragments
   const result = [
-    adjustCssLengthProperty(
+    adjustCssLengthProperties(
       'always',
       instance.elementPath,
-      PP.create('style', 'top'),
-      updatedGlobalFrame.y - currentGlobalFrame.y,
-      instance.specialSizeMeasurements.coordinateSystemBounds?.height,
       instance.specialSizeMeasurements.parentFlexDirection,
-      'do-not-create-if-doesnt-exist',
-    ),
-    adjustCssLengthProperty(
-      'always',
-      instance.elementPath,
-      PP.create('style', 'left'),
-      updatedGlobalFrame.x - currentGlobalFrame.x,
-      instance.specialSizeMeasurements.coordinateSystemBounds?.width,
-      instance.specialSizeMeasurements.parentFlexDirection,
-      'do-not-create-if-doesnt-exist',
-    ),
-    adjustCssLengthProperty(
-      'always',
-      instance.elementPath,
-      PP.create('style', 'right'),
-      // prettier-ignore
-      (currentGlobalFrame.x + currentGlobalFrame.width) - (updatedGlobalFrame.x + updatedGlobalFrame.width),
-      instance.specialSizeMeasurements.coordinateSystemBounds?.width,
-      instance.specialSizeMeasurements.parentFlexDirection,
-      'do-not-create-if-doesnt-exist',
-    ),
-    adjustCssLengthProperty(
-      'always',
-      instance.elementPath,
-      PP.create('style', 'bottom'),
-      // prettier-ignore
-      (currentGlobalFrame.y + currentGlobalFrame.height) - (updatedGlobalFrame.y + updatedGlobalFrame.height),
-      instance.specialSizeMeasurements.coordinateSystemBounds?.height,
-      instance.specialSizeMeasurements.parentFlexDirection,
-      'do-not-create-if-doesnt-exist',
+      [
+        lengthPropertyToAdjust(
+          PP.create('style', 'top'),
+          updatedGlobalFrame.y - currentGlobalFrame.y,
+          instance.specialSizeMeasurements.coordinateSystemBounds?.height,
+          'do-not-create-if-doesnt-exist',
+        ),
+        lengthPropertyToAdjust(
+          PP.create('style', 'left'),
+          updatedGlobalFrame.x - currentGlobalFrame.x,
+          instance.specialSizeMeasurements.coordinateSystemBounds?.width,
+          'do-not-create-if-doesnt-exist',
+        ),
+        lengthPropertyToAdjust(
+          PP.create('style', 'right'),
+          // prettier-ignore
+          (currentGlobalFrame.x + currentGlobalFrame.width) - (updatedGlobalFrame.x + updatedGlobalFrame.width),
+          instance.specialSizeMeasurements.coordinateSystemBounds?.width,
+          'do-not-create-if-doesnt-exist',
+        ),
+        lengthPropertyToAdjust(
+          PP.create('style', 'bottom'),
+          // prettier-ignore
+          (currentGlobalFrame.y + currentGlobalFrame.height) - (updatedGlobalFrame.y + updatedGlobalFrame.height),
+          instance.specialSizeMeasurements.coordinateSystemBounds?.height,
+          'do-not-create-if-doesnt-exist',
+        ),
+      ],
     ),
     setCssLengthProperty(
       'always',
@@ -477,43 +472,38 @@ function keepElementPutInParent(
       MetadataUtils.findElementByElementPath(metadata, target),
     )
     return [
-      adjustCssLengthProperty(
+      adjustCssLengthProperties(
         'always',
         target,
-        PP.create('style', 'top'),
-        currentGlobalFrame.y - updatedGlobalFrame.y,
-        instance.specialSizeMeasurements.coordinateSystemBounds?.height,
         instance.specialSizeMeasurements.parentFlexDirection,
-        'do-not-create-if-doesnt-exist',
-      ),
-      adjustCssLengthProperty(
-        'always',
-        instance.elementPath,
-        PP.create('style', 'left'),
-        currentGlobalFrame.x - updatedGlobalFrame.x,
-        instance.specialSizeMeasurements.coordinateSystemBounds?.width,
-        instance.specialSizeMeasurements.parentFlexDirection,
-        'do-not-create-if-doesnt-exist',
-      ),
-      adjustCssLengthProperty(
-        'always',
-        instance.elementPath,
-        PP.create('style', 'right'),
-        // prettier-ignore
-        (updatedGlobalFrame.x + updatedGlobalFrame.width) - (currentGlobalFrame.x + currentGlobalFrame.width),
-        instance.specialSizeMeasurements.coordinateSystemBounds?.width,
-        instance.specialSizeMeasurements.parentFlexDirection,
-        'do-not-create-if-doesnt-exist',
-      ),
-      adjustCssLengthProperty(
-        'always',
-        instance.elementPath,
-        PP.create('style', 'bottom'),
-        // prettier-ignore
-        (updatedGlobalFrame.y + updatedGlobalFrame.height) - (currentGlobalFrame.y + currentGlobalFrame.height),
-        instance.specialSizeMeasurements.coordinateSystemBounds?.height,
-        instance.specialSizeMeasurements.parentFlexDirection,
-        'do-not-create-if-doesnt-exist',
+        [
+          lengthPropertyToAdjust(
+            PP.create('style', 'top'),
+            currentGlobalFrame.y - updatedGlobalFrame.y,
+            instance.specialSizeMeasurements.coordinateSystemBounds?.height,
+            'do-not-create-if-doesnt-exist',
+          ),
+          lengthPropertyToAdjust(
+            PP.create('style', 'left'),
+            currentGlobalFrame.x - updatedGlobalFrame.x,
+            instance.specialSizeMeasurements.coordinateSystemBounds?.width,
+            'do-not-create-if-doesnt-exist',
+          ),
+          lengthPropertyToAdjust(
+            PP.create('style', 'right'),
+            // prettier-ignore
+            (updatedGlobalFrame.x + updatedGlobalFrame.width) - (currentGlobalFrame.x + currentGlobalFrame.width),
+            instance.specialSizeMeasurements.coordinateSystemBounds?.width,
+            'do-not-create-if-doesnt-exist',
+          ),
+          lengthPropertyToAdjust(
+            PP.create('style', 'bottom'),
+            // prettier-ignore
+            (updatedGlobalFrame.y + updatedGlobalFrame.height) - (currentGlobalFrame.y + currentGlobalFrame.height),
+            instance.specialSizeMeasurements.coordinateSystemBounds?.height,
+            'do-not-create-if-doesnt-exist',
+          ),
+        ],
       ),
     ]
   })

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -357,7 +357,7 @@ export const PaddingControl = React.memo(() => {
           ? null
           : pixelPaddingTop + pixelPaddingBottom
 
-      const adjustSizeCommands = getSizeUpdateCommandsForNewPadding(
+      const adjustSizeCommand = getSizeUpdateCommandsForNewPadding(
         combinedXPadding,
         combinedYPadding,
         startingFrame,
@@ -366,7 +366,9 @@ export const PaddingControl = React.memo(() => {
         pathTreesRef.current,
       )
 
-      return adjustSizeCommands.length > 0 ? [applyCommandsAction(adjustSizeCommands)] : []
+      return adjustSizeCommand.properties.length > 0
+        ? [applyCommandsAction([adjustSizeCommand])]
+        : []
     },
     [metadataRef, pathTreesRef, selectedViewsRef, startingFrame],
   )


### PR DESCRIPTION
**Problem:**
Currently the `AdjustCssLengthProperty` command used by the canvas strategies does up to 4 traversals of `EditorState`:
- Delete any conflicting properties.
- Get the current value.
- Update the value with the adjustment.
- Build the `EditorState` patch.

In most places where it is used it is also created for 4 properties, which means that in the maximal case will perform 16 traversals of `EditorState`.

**Fix:**
The fix falls into two main parts:
- For the changes to the element, only perform that traversal a single time. Which means that the deletion of conflicting properties, getting and updating the current value only incur that one walk down and update of `EditorState`.
- Support updating multiple properties at the same time. Now rather than creating 4 instances of `AdjustCssLengthProperty`, we create a single one that includes 4 instances of `LengthPropertyToAdjust`, each one relating to a single property.

This takes the maximal case of 16 traversals down to just 2, the first for all the updates and the second for the patch.

**Results:**
An example of how long this took before:
![image](https://github.com/concrete-utopia/utopia/assets/217400/f1a54942-3127-4168-b7dc-f864fda60f78)

After:
![image](https://github.com/concrete-utopia/utopia/assets/217400/632b7ec5-07c0-4e72-a070-091a41e13e79)

This should cause some improvements across the board of various strategies that move/resize/reparent.

**Commit Details:**
- Added `LengthPropertyToAdjust` type and factory function for it.
- Renamed `AdjustCssLengthProperty` to `AdjustCssLengthProperties`.
- Moved the property specific properties from `AdjustCssLengthProperties` to `LengthPropertyToAdjust`.
- `runAdjustCssLengthProperties` now reduces over the properties to update and performs the combined update pass per property on an instance of `JSXElement`.
- `setPixelValue`, `updatePixelValueByPixel` and `updatePercentageValueByPixel` now all operate on instances of `JSXAttributes` instead of on `EditorState`.
- Added `deleteConflictingPropsForWidthHeightFromAttributes` to handle updating an instance of `JSXAttributes`.
- Updated the old call sites of `adjustCssLengthProperty` to cater for the changes to the type.