### PR TITLE
Committing the paste session on keydown

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -47,7 +47,7 @@ import {
 } from '../../canvas-strategies/interaction-state'
 import { Modifier } from '../../../../utils/modifiers'
 import { pathsEqual } from '../../../../core/shared/element-path'
-import { EditorAction } from '../../../../components/editor/action-types'
+import { EditorAction, EditorDispatch } from '../../../../components/editor/action-types'
 import { EditorModes, isInsertMode, isSelectModeWithArea } from '../../../editor/editor-modes'
 import {
   scheduleTextEditForNextFrame,
@@ -957,64 +957,91 @@ export function useClearKeyboardInteraction(editorStoreRef: {
 type KeyboardEventListener = (e: KeyboardEvent) => void
 type UnloadEventListener = (e: BeforeUnloadEvent) => void
 
+class StaticReparentInterruptionHandlers {
+  private abortController: AbortController | null = null
+
+  constructor(
+    private editorStoreRef: { current: EditorStorePatched },
+    private dispatch: EditorDispatch,
+  ) {}
+
+  keydown: KeyboardEventListener = (e) => {
+    if (isDigit(e.key) || e.key === 'Tab') {
+      return
+    }
+
+    e.preventDefault()
+    e.stopPropagation()
+
+    this.removeEventListeners()
+
+    if (
+      this.editorStoreRef.current.editor.canvas.interactionSession?.interactionData.type ===
+      'DISCRETE_REPARENT'
+    ) {
+      this.dispatch([CanvasActions.clearInteractionSession(true)], 'everyone')
+    }
+  }
+
+  everythingElse: UnloadEventListener = (e) => {
+    this.removeEventListeners()
+
+    if (
+      this.editorStoreRef.current.editor.canvas.interactionSession?.interactionData.type ===
+      'DISCRETE_REPARENT'
+    ) {
+      this.dispatch([CanvasActions.clearInteractionSession(true)], 'everyone')
+      e.returnValue = 'Unsaved changes'
+      return 'Unsaved changes'
+    }
+    return undefined
+  }
+
+  addEventListeners = () => {
+    this.removeEventListeners()
+
+    this.abortController = new AbortController()
+    window.addEventListener('mousedown', this.everythingElse, {
+      once: true,
+      capture: true,
+    })
+
+    window.addEventListener('beforeunload', this.everythingElse, {
+      capture: true,
+      once: true,
+    })
+
+    window.addEventListener('keydown', this.keydown, {
+      signal: this.abortController.signal,
+      capture: true,
+    })
+  }
+
+  removeEventListeners = () => {
+    this.abortController?.abort()
+    this.abortController = null
+    window.removeEventListener('mousedown', this.everythingElse)
+    window.removeEventListener('beforeunload', this.everythingElse)
+    window.removeEventListener('keydown', this.keydown)
+  }
+}
+
 export function useClearDiscreteReparentInteraction(editorStoreRef: {
   readonly current: EditorStorePatched
 }): () => void {
   const dispatch = useDispatch()
-  const staticReparentSessionInterruptHandlerRef = React.useRef<UnloadEventListener>(NO_OP)
-  const keyDownHandlerRef = React.useRef<KeyboardEventListener>(NO_OP)
+  const handlers = React.useMemo(
+    () => new StaticReparentInterruptionHandlers(editorStoreRef, dispatch),
+    [dispatch, editorStoreRef],
+  )
 
-  const removeEventListeners = () => {
-    window.removeEventListener('mousedown', staticReparentSessionInterruptHandlerRef.current)
-    window.removeEventListener('beforeunload', staticReparentSessionInterruptHandlerRef.current)
-    window.removeEventListener('keydown', keyDownHandlerRef.current)
-  }
-
-  React.useEffect(() => removeEventListeners)
+  React.useEffect(() => {
+    return () => handlers.removeEventListeners()
+  }, [handlers])
 
   return React.useCallback(() => {
-    staticReparentSessionInterruptHandlerRef.current = (e) => {
-      removeEventListeners()
-      if (
-        editorStoreRef.current.editor.canvas.interactionSession?.interactionData.type ===
-        'DISCRETE_REPARENT'
-      ) {
-        dispatch([CanvasActions.clearInteractionSession(true)], 'everyone')
-        e.returnValue = 'Unsaved changes'
-        return 'Unsaved changes'
-      }
-      return undefined
-    }
-
-    window.addEventListener('mousedown', staticReparentSessionInterruptHandlerRef.current, {
-      once: true,
-      capture: true,
-    })
-
-    window.addEventListener('beforeunload', staticReparentSessionInterruptHandlerRef.current, {
-      capture: true,
-      once: true,
-    })
-
-    keyDownHandlerRef.current = (e: KeyboardEvent) => {
-      if (isDigit(e.key) || e.key === 'Tab') {
-        return
-      }
-
-      removeEventListeners()
-
-      if (
-        editorStoreRef.current.editor.canvas.interactionSession?.interactionData.type ===
-        'DISCRETE_REPARENT'
-      ) {
-        dispatch([CanvasActions.clearInteractionSession(true)], 'everyone')
-      }
-    }
-
-    window.addEventListener('keydown', keyDownHandlerRef.current, {
-      capture: true,
-    })
-  }, [dispatch, editorStoreRef])
+    handlers.addEventListeners()
+  }, [handlers])
 }
 
 export function useSetHoveredControlsHandlers<T>(): {

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -3724,11 +3724,14 @@ export var storyboard = (
             renderResult.getEditorState().editor.canvas.interactionSession?.interactionData.type,
           ).toEqual('DISCRETE_REPARENT')
 
-          await keyDown('o')
+          await keyDown('Esc')
           await renderResult.getDispatchFollowUpActionsFinished()
 
           expect(renderResult.getEditorState().editor.canvas.interactionSession).toBeNull()
           expectResultsToBeCommitted(renderResult)
+          expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
+            'utopia-storyboard-uid/scene-aaa/app-entity:aaa/aaf', // this is the element that just got pasted, the selection doesn't jump to the parent
+          ])
         })
       })
     })

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -3732,6 +3732,12 @@ export var storyboard = (
           expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
             'utopia-storyboard-uid/scene-aaa/app-entity:aaa/aaf', // this is the element that just got pasted, the selection doesn't jump to the parent
           ])
+
+          await keyDown('Esc')
+
+          expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
+            'utopia-storyboard-uid/scene-aaa/app-entity:aaa', // the pasted element's parent is selected, which means the shortcut is not prevented anymore
+          ])
         })
       })
     })

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -1470,7 +1470,7 @@ export var storyboard = (
             await clipboardMock.pasteDone
             await editor.getDispatchFollowUpActionsFinished()
 
-            await pressKey('l')
+            await pressKey('Esc')
             await editor.getDispatchFollowUpActionsFinished()
 
             clipboardMock.resetDoneSignal()


### PR DESCRIPTION
## Problem
Whan a paste session is in progress, and one wants to end it by pressing a key, if the key is bound to a shortcut, the shortcut is executed (such as Esc jumping to the parent, or Enter entering text edit mode)

## Fix
Call preventDefault and stopPropagation on the keydown event.

### Trivia
It turns out that the `removeEventListener` needs to be passed the same options object that the respective `addEventListener` received. The following example illustrated "correctly" removing an event listener registered with `capture: true`:

```typescript
window.addEventListener('mousedown', this.onMouseDown, {
  once: true,
  capture: true,
})

// ...
 
window.removeEventListener('mousedown', this.everythingElse, { capture: true })
```

Docs: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener

Also,I refactored `useClearDiscreteReparentInteraction` to use an old-school class, so that the memoization is handled in a centralised place, and we don't have to juggle refs throughout the whole function.