### PR TITLE
Allow highlighting elements on hover during a discrete reparent interaction

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -704,9 +704,14 @@ function useSelectOrLiveModeSelectAndHover(
       if (isDragIntention) {
         return
       }
-      if (editorStoreRef.current.editor.canvas.interactionSession == null) {
+      if (
+        editorStoreRef.current.editor.canvas.interactionSession == null ||
+        editorStoreRef.current.editor.canvas.interactionSession.interactionData.type ===
+          'DISCRETE_REPARENT'
+      ) {
         innerOnMouseMove(event)
       } else {
+        // here
         // An interaction session has happened, which is important to know on mouseup
         interactionSessionHappened.current = true
       }

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -47,6 +47,7 @@ import {
   mouseDownAtPoint,
   mouseDragFromPointToPoint,
   mouseDragFromPointWithDelta,
+  mouseMoveToPoint,
   pressKey,
 } from '../../canvas/event-helpers.test-utils'
 import { cmdModifier, shiftCmdModifier } from '../../../utils/modifiers'
@@ -3729,6 +3730,93 @@ export var storyboard = (
 
           expect(renderResult.getEditorState().editor.canvas.interactionSession).toBeNull()
           expectResultsToBeCommitted(renderResult)
+        })
+      })
+
+      describe('mouse events during paste session', () => {
+        setFeatureForBrowserTests('Paste strategies', true)
+
+        it('hover', async () => {
+          const editor = await renderTestEditorWithCode(
+            `import * as React from 'react'
+          import { Scene, Storyboard } from 'utopia-api'
+          
+          const App = () => (
+            <div
+              style={{
+                position: 'relative',
+                height: '100%',
+                width: '100%',
+              }}
+              data-uid='root'
+            >
+              <div
+                style={{
+                  backgroundColor: '#00FF26',
+                  width: 103,
+                  height: 90,
+                  contain: 'layout',
+                  position: 'absolute',
+                  left: 26,
+                  top: 31,
+                }}
+                data-testid='element-to-be-copied'
+                data-uid='div'
+              />
+            </div>
+          )
+          
+          export var storyboard = (
+            <Storyboard data-uid='sb'>
+              <Scene
+                style={{
+                  width: 419,
+                  height: 363,
+                  position: 'absolute',
+                  left: 212,
+                  top: 128,
+                }}
+                data-label='Playground'
+                data-uid='scene'
+              >
+                <App data-uid='app' />
+              </Scene>
+            </Storyboard>
+          )
+          `,
+            'await-first-dom-report',
+          )
+
+          await selectComponentsForTest(editor, [EP.fromString('sb/scene/app:root/div')])
+          await pressKey('c', { modifiers: cmdModifier })
+          await editor.getDispatchFollowUpActionsFinished()
+
+          const canvasRoot = editor.renderedDOM.getByTestId('canvas-root')
+
+          firePasteEvent(canvasRoot)
+
+          await clipboardMock.pasteDone
+          await editor.getDispatchFollowUpActionsFinished()
+
+          expect(
+            editor.getEditorState().editor.canvas.interactionSession?.interactionData.type,
+          ).toEqual('DISCRETE_REPARENT')
+
+          const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
+          const originalElementBounds = editor.renderedDOM
+            .getAllByTestId('element-to-be-copied')
+            .at(0)!
+            .getBoundingClientRect()
+          await mouseMoveToPoint(canvasControlsLayer, {
+            x: originalElementBounds.x + 1,
+            y: originalElementBounds.y + 1,
+          })
+
+          await editor.getDispatchFollowUpActionsFinished()
+
+          expect(editor.getEditorState().editor.highlightedViews.map(EP.toString)).toEqual([
+            'sb/scene/app:root/div',
+          ])
         })
       })
     })


### PR DESCRIPTION
## Problem
During a discrete reparent interaction, elements cannot be highlighted by hovering the cursor over them.

## Fix
Introduce a helper in `select-mode-hooks.tsx`, `isMouseInteractionSession`, which determines if we consider an interaction session to be using the mouse or not. In `useSelectOrLiveModeSelectAndHover`, we check if an interaction session uses the mouse. If it does, we disable highlighting elements on mousemove, otherwise we allow it.
