### PR TITLE
Remove unused interaction timer.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -37,7 +37,6 @@ export interface DragInteractionData {
   prevDrag: CanvasVector | null
   originalDragStart: CanvasPoint
   modifiers: Modifiers
-  globalTime: number
   hasMouseMoved: boolean
   _accumulatedMovement: CanvasVector
   spacePressed: boolean
@@ -206,7 +205,6 @@ export function createInteractionViaMouse(
       prevDrag: null,
       originalDragStart: mouseDownPoint,
       modifiers: modifiers,
-      globalTime: Date.now(),
       hasMouseMoved: false,
       _accumulatedMovement: zeroCanvasPoint,
       spacePressed: false,
@@ -292,7 +290,6 @@ export function updateInteractionViaDragDelta(
         prevDrag: currentState.interactionData.drag,
         originalDragStart: currentState.interactionData.originalDragStart,
         modifiers: modifiers,
-        globalTime: Date.now(),
         hasMouseMoved: true,
         _accumulatedMovement: accumulatedMovement,
         spacePressed: currentState.interactionData.spacePressed,
@@ -366,7 +363,6 @@ function updateInteractionDataViaMouse(
             prevDrag: currentData.drag,
             originalDragStart: currentData.originalDragStart,
             modifiers: modifiers,
-            globalTime: Date.now(),
             hasMouseMoved: true,
             _accumulatedMovement: currentData._accumulatedMovement,
             spacePressed: currentData.spacePressed,
@@ -380,7 +376,6 @@ function updateInteractionDataViaMouse(
             prevDrag: null,
             originalDragStart: mousePoint,
             modifiers: modifiers,
-            globalTime: Date.now(),
             hasMouseMoved: false,
             _accumulatedMovement: zeroCanvasPoint,
             spacePressed: false,
@@ -472,7 +467,6 @@ export function updateInteractionViaKeyboard(
           prevDrag: currentState.interactionData.prevDrag,
           originalDragStart: currentState.interactionData.originalDragStart,
           modifiers: modifiers,
-          globalTime: Date.now(),
           hasMouseMoved: currentState.interactionData.hasMouseMoved,
           _accumulatedMovement: currentState.interactionData._accumulatedMovement,
           spacePressed: isSpacePressed,

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -187,7 +187,6 @@ describe('interactionStart', () => {
     expect(
       actualResult.patchedEditorState.canvas.interactionSession?.interactionData,
     ).toMatchInlineSnapshot(
-      { globalTime: expect.any(Number) },
       `
       Object {
         "_accumulatedMovement": Object {
@@ -199,7 +198,6 @@ describe('interactionStart', () => {
           "x": 100,
           "y": 200,
         },
-        "globalTime": Any<Number>,
         "hasMouseMoved": false,
         "modifiers": Object {
           "alt": false,
@@ -336,7 +334,6 @@ describe('interactionUpdate', () => {
     expect(
       actualResult.patchedEditorState.canvas.interactionSession?.interactionData,
     ).toMatchInlineSnapshot(
-      { globalTime: expect.any(Number) },
       `
       Object {
         "_accumulatedMovement": Object {
@@ -351,7 +348,6 @@ describe('interactionUpdate', () => {
           "x": 100,
           "y": 200,
         },
-        "globalTime": Any<Number>,
         "hasMouseMoved": true,
         "modifiers": Object {
           "alt": false,
@@ -483,7 +479,6 @@ describe('interactionHardReset', () => {
     expect(
       actualResult.patchedEditorState.canvas.interactionSession?.interactionData,
     ).toMatchInlineSnapshot(
-      { globalTime: expect.any(Number) },
       `
       Object {
         "_accumulatedMovement": Object {
@@ -498,7 +493,6 @@ describe('interactionHardReset', () => {
           "x": 110,
           "y": 210,
         },
-        "globalTime": Any<Number>,
         "hasMouseMoved": false,
         "modifiers": Object {
           "alt": false,
@@ -646,7 +640,6 @@ describe('interactionUpdate with user changed strategy', () => {
     expect(
       actualResult.patchedEditorState.canvas.interactionSession?.interactionData,
     ).toMatchInlineSnapshot(
-      { globalTime: expect.any(Number) },
       `
       Object {
         "_accumulatedMovement": Object {
@@ -661,7 +654,6 @@ describe('interactionUpdate with user changed strategy', () => {
           "x": 110,
           "y": 210,
         },
-        "globalTime": Any<Number>,
         "hasMouseMoved": false,
         "modifiers": Object {
           "alt": false,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1952,7 +1952,7 @@ export const ModifiersKeepDeepEquality: KeepDeepEqualityCall<Modifiers> = combin
 )
 
 export const DragInteractionDataKeepDeepEquality: KeepDeepEqualityCall<DragInteractionData> =
-  combine10EqualityCalls(
+  combine9EqualityCalls(
     (data) => data.dragStart,
     CanvasPointKeepDeepEquality,
     (data) => data.drag,
@@ -1963,8 +1963,6 @@ export const DragInteractionDataKeepDeepEquality: KeepDeepEqualityCall<DragInter
     CanvasPointKeepDeepEquality,
     (data) => data.modifiers,
     ModifiersKeepDeepEquality,
-    (data) => data.globalTime,
-    createCallWithTripleEquals(),
     (data) => data.hasMouseMoved,
     BooleanKeepDeepEquality,
     (data) => data._accumulatedMovement,
@@ -1979,7 +1977,6 @@ export const DragInteractionDataKeepDeepEquality: KeepDeepEqualityCall<DragInter
       prevDrag,
       originalDragStart,
       modifiers,
-      globalTime,
       hasMouseMoved,
       accumulatedMovement,
       spacePressed,
@@ -1992,7 +1989,6 @@ export const DragInteractionDataKeepDeepEquality: KeepDeepEqualityCall<DragInter
         prevDrag: prevDrag,
         originalDragStart: originalDragStart,
         modifiers: modifiers,
-        globalTime: globalTime,
         hasMouseMoved: hasMouseMoved,
         _accumulatedMovement: accumulatedMovement,
         spacePressed: spacePressed,

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -385,7 +385,6 @@ function on(
   return additionalEvents
 }
 
-let interactionSessionTimerHandle: any = undefined
 export function runLocalCanvasAction(
   dispatch: EditorDispatch,
   model: EditorState,
@@ -460,12 +459,6 @@ export function runLocalCanvasAction(
       }
     }
     case 'CREATE_INTERACTION_SESSION':
-      clearInterval(interactionSessionTimerHandle)
-      if (action.interactionSession.interactionData.type === 'DRAG') {
-        interactionSessionTimerHandle = setInterval(() => {
-          dispatch([CanvasActions.updateDragInteractionData({ globalTime: Date.now() })])
-        }, 200)
-      }
       const metadata = model.canvas.interactionSession?.latestMetadata ?? model.jsxMetadata
       const allElementProps =
         model.canvas.interactionSession?.latestAllElementProps ?? model.allElementProps
@@ -485,7 +478,6 @@ export function runLocalCanvasAction(
         },
       }
     case 'CLEAR_INTERACTION_SESSION':
-      clearInterval(interactionSessionTimerHandle)
       const interactionWasInProgress = interactionInProgress(model.canvas.interactionSession)
       return {
         ...model,


### PR DESCRIPTION
**Problem:**
We have a `setInterval` call which updates the drag interaction every 200ms which can be seen firing in this profile of canvas moving/reparenting marked with the arrows:
![Timer Fired](https://github.com/concrete-utopia/utopia/assets/217400/026556b8-85aa-44ee-931f-b8e75722b576)
The field which that updates is completely unused by the strategies but the firing means the drag is effectively constantly hitching, most of the time it only takes around 20ms, but it has been seen to take around 50ms at times.

**Fix:**
Remove the `setInterval` call and the field it updates.

**Commit Details:**
- Removed `DragInterationData.globalTime`.
- Removed `setInterval` call that fired every 200ms.