### PR TITLE
Paste shortcut commits paste session and starts new one

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -961,6 +961,8 @@ export function useClearKeyboardInteraction(editorStoreRef: {
 type KeyboardEventListener = (e: KeyboardEvent) => void
 type UnloadEventListener = (e: BeforeUnloadEvent) => void
 
+const isPasteShortcut = (e: KeyboardEvent) => e.metaKey && e.key === 'v'
+
 class StaticReparentInterruptionHandlers {
   constructor(
     private editorStoreRef: { current: EditorStorePatched },
@@ -972,8 +974,10 @@ class StaticReparentInterruptionHandlers {
       return
     }
 
-    e.preventDefault()
-    e.stopPropagation()
+    if (!isPasteShortcut(e)) {
+      e.preventDefault()
+      e.stopPropagation()
+    }
 
     this.removeEventListeners()
 

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -3740,6 +3740,22 @@ export var storyboard = (
             'utopia-storyboard-uid/scene-aaa/app-entity:aaa', // the pasted element's parent is selected, which means the shortcut is not prevented anymore
           ])
         })
+
+        it('the paste session ends on a new paste event', async () => {
+          const renderResult = await setupPasteSession()
+          clipboardMock.resetDoneSignal()
+          const canvasRoot = renderResult.renderedDOM.getByTestId('canvas-root')
+
+          firePasteEvent(canvasRoot)
+
+          await clipboardMock.pasteDone
+          await renderResult.getDispatchFollowUpActionsFinished()
+
+          expectResultsToBeCommitted(renderResult)
+          expect(
+            renderResult.getEditorState().editor.canvas.interactionSession?.interactionData.type,
+          ).toEqual('DISCRETE_REPARENT')
+        })
       })
 
       describe('mouse events during paste session', () => {


### PR DESCRIPTION
## Problem
If the paste shortcut is pressed during a paste session, the paste session is committed but the shortcut is overridden, so it has to be pressed again to actually perform the paste (this is especially problematic when one wants to paste multiple times in quick succession).

## Fix
Blacklist the paste shortcut from the keyboard events that are overridden during a paste session.
