### PR TITLE
Fix allow selecting zero-sized elements with area selection

### DIFF
--- a/editor/src/components/canvas/canvas.ts
+++ b/editor/src/components/canvas/canvas.ts
@@ -296,33 +296,6 @@ const Canvas = {
       height: 1,
     })
   },
-  getAllTargetsAtPoint(
-    componentMetadata: ElementInstanceMetadataMap,
-    selectedViews: Array<ElementPath>,
-    hiddenInstances: Array<ElementPath>,
-    canvasPosition: CanvasPoint,
-    searchTypes: Array<TargetSearchType>,
-    useBoundingFrames: boolean,
-    looseTargetingForZeroSizedElements: 'strict' | 'loose',
-    elementPathTree: ElementPathTrees,
-    allElementProps: AllElementProps,
-  ): Array<{ elementPath: ElementPath; canBeFilteredOut: boolean }> {
-    const area = this.getMousePositionCanvasArea(canvasPosition)
-    if (area == null) {
-      return []
-    }
-    return this.getAllTargetsUnderArea(
-      componentMetadata,
-      selectedViews,
-      hiddenInstances,
-      area,
-      searchTypes,
-      useBoundingFrames,
-      looseTargetingForZeroSizedElements,
-      elementPathTree,
-      allElementProps,
-    )
-  },
   getAllTargetsUnderArea(
     componentMetadata: ElementInstanceMetadataMap,
     selectedViews: Array<ElementPath>,

--- a/editor/src/components/canvas/controls/selection-area-helpers.ts
+++ b/editor/src/components/canvas/controls/selection-area-helpers.ts
@@ -75,20 +75,11 @@ export const filterUnderSelectionArea = (
 
   return elements
     .filter((element) => {
-      // no zero-sized elements
-      if (element.zeroSized) {
-        return false
-      }
-
       // only outermost children
       if (
         element.type === 'regular' &&
         elements.some((other) => {
-          return (
-            other.type !== 'scene' &&
-            !other.zeroSized &&
-            EP.isDescendantOf(element.path, other.path)
-          )
+          return other.type !== 'scene' && EP.isDescendantOf(element.path, other.path)
         })
       ) {
         return false

--- a/editor/src/components/canvas/controls/selection-area-hooks.tsx
+++ b/editor/src/components/canvas/controls/selection-area-hooks.tsx
@@ -78,16 +78,8 @@ export function useSelectionArea(
         storeRef.current.elementPathTree,
         storeRef.current.allElementProps,
         true,
-        [TargetSearchType.SelectedElements],
+        [TargetSearchType.TopLevelElements, TargetSearchType.SelectedElements],
       )
-
-      if (
-        allTargetsUnderArea.some((path) =>
-          localSelectedViews.some((other) => EP.isDescendantOfOrEqualTo(path, other)),
-        )
-      ) {
-        return allTargetsUnderArea
-      }
 
       // filter out the targets that are not selectable
       // and aren't Scenes (which can be selected if fully contained)

--- a/editor/src/components/canvas/controls/selection-area.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/selection-area.spec.browser2.tsx
@@ -58,6 +58,55 @@ export var ${BakedInStoryboardVariableName} = (props) => {
       'root/foo',
     ])
   })
+  it('can select zero-sized elements', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      `
+import * as React from 'react'
+
+export var ${BakedInStoryboardVariableName} = (props) => {
+    return (
+        <div data-uid='root'>
+            <div
+                data-uid='foo'
+                style={{
+                    background: "red",
+                    width: 50,
+                    height: 50,
+                    position: "absolute",
+                    top: 100,
+                    left: 100,
+                }}
+            />
+            <div
+                data-uid='bar'
+                style={{
+                    position: "absolute",
+                    top: 200,
+                    left: 120,
+                    width: 0,
+                    height: 0,
+                }}
+            />
+        </div>
+    )
+}
+`,
+      'await-first-dom-report',
+    )
+    const container = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+    const rect = container.getBoundingClientRect()
+
+    await mouseDragFromPointToPoint(
+      container,
+      { x: rect.x + DefaultNavigatorWidth + 150, y: rect.y + 230 },
+      { x: rect.x + DefaultNavigatorWidth + 300, y: rect.y + 350 },
+      { moveBeforeMouseDown: true, staggerMoveEvents: true },
+    )
+
+    expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
+      'root/bar',
+    ])
+  })
   it('can select multiple elements on the storyboard', async () => {
     const renderResult = await renderTestEditorWithCode(
       `
@@ -312,7 +361,6 @@ export var ${BakedInStoryboardVariableName} = (props) => {
       'scene/foo',
     ])
   })
-
   it('can select multiple children of a scene', async () => {
     const renderResult = await renderTestEditorWithCode(
       `


### PR DESCRIPTION
Fixes #3827 

**Problem:**

Zero-sized elements cannot be selected with area selection.

**Fix:**

Don't filter out zero-sized elements from the elements under area selection.