### PR TITLE
disallow pasting a component into its own definition

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/paste-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/paste-metastrategy.tsx
@@ -32,6 +32,8 @@ import { updateFunctionCommand } from '../../commands/update-function-command'
 import { foldAndApplyCommandsInner } from '../../commands/commands'
 import { updateSelectedViews } from '../../commands/update-selected-views-command'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import { isLeft } from '../../../../core/shared/either'
+import { showToastCommand } from '../../commands/show-toast-command'
 
 const PasteModes = ['replace', 'preserve'] as const
 type PasteMode = typeof PasteModes[number]
@@ -78,13 +80,15 @@ export function pasteStrategy(
         },
         canvasState.startingElementPathTree,
       )
-      if (target == null) {
-        return emptyStrategyApplicationResult
+      if (isLeft(target)) {
+        return strategyApplicationResult([
+          showToastCommand(target.value, 'ERROR', `${strategyProps.id}-get-target-parent-failure`),
+        ])
       }
 
       const elements = getElementsFromPaste(
         elementPasteWithMetadata.elements,
-        target.parentPath,
+        target.value.parentPath,
         canvasState.projectContents,
       )
 
@@ -92,7 +96,7 @@ export function pasteStrategy(
         canvasState.startingMetadata,
         canvasState.startingAllElementProps,
         canvasState.startingElementPathTree,
-        target.parentPath.intendedParentPath,
+        target.value.parentPath.intendedParentPath,
       )
 
       const commands = elements.flatMap((currentValue) => {
@@ -113,9 +117,9 @@ export function pasteStrategy(
               strategy === 'REPARENT_AS_ABSOLUTE'
                 ? {
                     type: strategy,
-                    insertionPath: target.parentPath,
+                    insertionPath: target.value.parentPath,
                     intendedCoordinates: absolutePositionForPaste(
-                      target,
+                      target.value,
                       currentValue.originalElementPath,
                       {
                         originalTargetMetadata:
@@ -128,15 +132,15 @@ export function pasteStrategy(
                       interactionSession.interactionData.canvasViewportCenter,
                     ),
                   }
-                : { type: strategy, insertionPath: target.parentPath }
+                : { type: strategy, insertionPath: target.value.parentPath }
 
             const indexPosition =
-              target.type === 'sibling'
+              target.value.type === 'sibling'
                 ? absolute(
                     MetadataUtils.getIndexInParent(
                       editor.jsxMetadata,
                       editor.elementPathTree,
-                      target.siblingPath,
+                      target.value.siblingPath,
                     ) + 1,
                   )
                 : front()

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
@@ -240,7 +240,7 @@ export function getInsertionPathForReparentTarget(
   return conditionalClauseInsertionPath(newParent, clause, 'replace')
 }
 
-function instancesOfSameComponent(
+function areElementsInstancesOfTheSameComponent(
   firstInstance: ElementInstanceMetadata | null,
   secondInstance: ElementInstanceMetadata | null,
 ): boolean {
@@ -258,7 +258,7 @@ function instancesOfSameComponent(
   return jsxElementNameEquals(firstInstance.element.value.name, secondInstance.element.value.name)
 }
 
-export function instanceInSubtreeOfSameComponent(
+export function isElementRenderedBySameComponent(
   metadata: ElementInstanceMetadataMap,
   targetPath: ElementPath,
   instance: ElementInstanceMetadata | null,
@@ -273,7 +273,7 @@ export function instanceInSubtreeOfSameComponent(
   )
 
   return (
-    instancesOfSameComponent(currentInstance, instance) ||
-    instanceInSubtreeOfSameComponent(metadata, EP.renderedByParentPath(targetPath), instance)
+    areElementsInstancesOfTheSameComponent(currentInstance, instance) ||
+    isElementRenderedBySameComponent(metadata, EP.renderedByParentPath(targetPath), instance)
   )
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
@@ -240,7 +240,7 @@ export function getInsertionPathForReparentTarget(
   return conditionalClauseInsertionPath(newParent, clause, 'replace')
 }
 
-export function instancesOfSameComponent(
+function instancesOfSameComponent(
   firstInstance: ElementInstanceMetadata | null,
   secondInstance: ElementInstanceMetadata | null,
 ): boolean {
@@ -256,4 +256,24 @@ export function instancesOfSameComponent(
   }
 
   return jsxElementNameEquals(firstInstance.element.value.name, secondInstance.element.value.name)
+}
+
+export function instanceInSubtreeOfSameComponent(
+  metadata: ElementInstanceMetadataMap,
+  targetPath: ElementPath,
+  instance: ElementInstanceMetadata | null,
+): boolean {
+  if (EP.isEmptyPath(targetPath)) {
+    return false
+  }
+
+  const currentInstance = MetadataUtils.findElementByElementPath(
+    metadata,
+    EP.renderedByParentPath(targetPath),
+  )
+
+  return (
+    instancesOfSameComponent(currentInstance, instance) ||
+    instanceInSubtreeOfSameComponent(metadata, EP.renderedByParentPath(targetPath), instance)
+  )
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
@@ -249,8 +249,8 @@ function areElementsInstancesOfTheSameComponent(
     secondInstance == null ||
     isLeft(firstInstance.element) ||
     isLeft(secondInstance.element) ||
-    firstInstance.element.value.type !== 'JSX_ELEMENT' ||
-    secondInstance.element.value.type !== 'JSX_ELEMENT'
+    !isJSXElement(firstInstance.element.value) ||
+    !isJSXElement(secondInstance.element.value)
   ) {
     return false
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
@@ -7,7 +7,7 @@ import {
   MetadataUtils,
   getSimpleAttributeAtPath,
 } from '../../../../../core/model/element-metadata-utils'
-import { Either, foldEither, left, right } from '../../../../../core/shared/either'
+import { Either, foldEither, isLeft, left, right } from '../../../../../core/shared/either'
 import * as EP from '../../../../../core/shared/element-path'
 import {
   ElementInstanceMetadata,
@@ -20,6 +20,7 @@ import {
   emptyComments,
   isJSXElement,
   jsExpressionValue,
+  jsxElementNameEquals,
 } from '../../../../../core/shared/element-template'
 import { ElementPath } from '../../../../../core/shared/project-file-types'
 import { ProjectContentTreeRoot } from '../../../../assets'
@@ -237,4 +238,22 @@ export function getInsertionPathForReparentTarget(
     return childInsertionPath(newParent)
   }
   return conditionalClauseInsertionPath(newParent, clause, 'replace')
+}
+
+export function instancesOfSameComponent(
+  firstInstance: ElementInstanceMetadata | null,
+  secondInstance: ElementInstanceMetadata | null,
+): boolean {
+  if (
+    firstInstance == null ||
+    secondInstance == null ||
+    isLeft(firstInstance.element) ||
+    isLeft(secondInstance.element) ||
+    firstInstance.element.value.type !== 'JSX_ELEMENT' ||
+    secondInstance.element.value.type !== 'JSX_ELEMENT'
+  ) {
+    return false
+  }
+
+  return jsxElementNameEquals(firstInstance.element.value.name, secondInstance.element.value.name)
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
@@ -269,11 +269,11 @@ export function isElementRenderedBySameComponent(
 
   const currentInstance = MetadataUtils.findElementByElementPath(
     metadata,
-    EP.renderedByParentPath(targetPath),
+    EP.getContainingComponent(targetPath),
   )
 
   return (
     areElementsInstancesOfTheSameComponent(currentInstance, instance) ||
-    isElementRenderedBySameComponent(metadata, EP.renderedByParentPath(targetPath), instance)
+    isElementRenderedBySameComponent(metadata, EP.getContainingComponent(targetPath), instance)
   )
 }

--- a/editor/src/components/canvas/canvas.ts
+++ b/editor/src/components/canvas/canvas.ts
@@ -296,33 +296,6 @@ const Canvas = {
       height: 1,
     })
   },
-  getAllTargetsAtPoint(
-    componentMetadata: ElementInstanceMetadataMap,
-    selectedViews: Array<ElementPath>,
-    hiddenInstances: Array<ElementPath>,
-    canvasPosition: CanvasPoint,
-    searchTypes: Array<TargetSearchType>,
-    useBoundingFrames: boolean,
-    looseTargetingForZeroSizedElements: 'strict' | 'loose',
-    elementPathTree: ElementPathTrees,
-    allElementProps: AllElementProps,
-  ): Array<{ elementPath: ElementPath; canBeFilteredOut: boolean }> {
-    const area = this.getMousePositionCanvasArea(canvasPosition)
-    if (area == null) {
-      return []
-    }
-    return this.getAllTargetsUnderArea(
-      componentMetadata,
-      selectedViews,
-      hiddenInstances,
-      area,
-      searchTypes,
-      useBoundingFrames,
-      looseTargetingForZeroSizedElements,
-      elementPathTree,
-      allElementProps,
-    )
-  },
   getAllTargetsUnderArea(
     componentMetadata: ElementInstanceMetadataMap,
     selectedViews: Array<ElementPath>,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2795,20 +2795,15 @@ export const UPDATE_FNS = {
       },
       editor.elementPathTree,
     )
-    if (target == null) {
+    if (isLeft(target)) {
       return addToastToState(
         editor,
-        notice(
-          'Cannot find suitable parent for pasting',
-          'ERROR',
-          false,
-          'paste-jsx-elements-cannot-find-parent',
-        ),
+        notice(target.value, 'ERROR', false, 'paste-jsx-elements-cannot-find-parent'),
       )
     }
 
     // when targeting a conditional, wrap multiple elements into a fragment
-    if (action.elements.length > 1 && isConditionalClauseInsertionPath(target.parentPath)) {
+    if (action.elements.length > 1 && isConditionalClauseInsertionPath(target.value.parentPath)) {
       const fragmentUID = generateUidWithExistingComponents(editor.projectContents)
       const mergedImportsFromElements = elements
         .map((e) => e.importsToAdd)
@@ -2839,7 +2834,7 @@ export const UPDATE_FNS = {
       editor.jsxMetadata,
       editor.allElementProps,
       editor.elementPathTree,
-      target.parentPath.intendedParentPath,
+      target.value.parentPath.intendedParentPath,
     )
 
     let newPaths: Array<ElementPath> = []
@@ -2854,9 +2849,9 @@ export const UPDATE_FNS = {
         strategy === 'REPARENT_AS_ABSOLUTE'
           ? {
               type: strategy,
-              insertionPath: target.parentPath,
+              insertionPath: target.value.parentPath,
               intendedCoordinates: absolutePositionForPaste(
-                target,
+                target.value,
                 currentValue.originalElementPath,
                 {
                   originalTargetMetadata: action.targetOriginalContextMetadata,
@@ -2867,15 +2862,15 @@ export const UPDATE_FNS = {
                 action.canvasViewportCenter,
               ),
             }
-          : { type: strategy, insertionPath: target.parentPath }
+          : { type: strategy, insertionPath: target.value.parentPath }
 
       const indexPosition =
-        target.type === 'sibling'
+        target.value.type === 'sibling'
           ? absolute(
               MetadataUtils.getIndexInParent(
                 editor.jsxMetadata,
                 editor.elementPathTree,
-                target.siblingPath,
+                target.value.siblingPath,
               ) + 1,
             )
           : front()

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -36,7 +36,6 @@ import {
 } from '../../../components/editor/store/store-hook'
 import {
   isElementRenderedBySameComponent,
-  instancesOfSameComponent,
   isAllowedToReparent,
 } from '../../canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -35,7 +35,7 @@ import {
   useRefEditorState,
 } from '../../../components/editor/store/store-hook'
 import {
-  instanceInSubtreeOfSameComponent,
+  isElementRenderedBySameComponent,
   instancesOfSameComponent,
   isAllowedToReparent,
 } from '../../canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers'
@@ -220,7 +220,7 @@ function notDroppingIntoOwnDefinition(
 ) {
   return selectedViews.every(
     (selection) =>
-      !instanceInSubtreeOfSameComponent(
+      !isElementRenderedBySameComponent(
         metadata,
         targetParent,
         MetadataUtils.findElementByElementPath(metadata, selection),

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -35,6 +35,7 @@ import {
   useRefEditorState,
 } from '../../../components/editor/store/store-hook'
 import {
+  instanceInSubtreeOfSameComponent,
   instancesOfSameComponent,
   isAllowedToReparent,
 } from '../../canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers'
@@ -217,19 +218,14 @@ function notDroppingIntoOwnDefinition(
   targetParent: ElementPath,
   metadata: ElementInstanceMetadataMap,
 ) {
-  const parentInstance = MetadataUtils.findElementByElementPath(
-    metadata,
-    EP.renderedByParentPath(targetParent),
+  return selectedViews.every(
+    (selection) =>
+      !instanceInSubtreeOfSameComponent(
+        metadata,
+        targetParent,
+        MetadataUtils.findElementByElementPath(metadata, selection),
+      ),
   )
-  return parentInstance == null
-    ? true
-    : selectedViews.every(
-        (selection) =>
-          !instancesOfSameComponent(
-            parentInstance,
-            MetadataUtils.findElementByElementPath(metadata, selection),
-          ),
-      )
 }
 
 function canDropInto(editorState: EditorState, moveToEntry: ElementPath): boolean {

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -34,7 +34,10 @@ import {
   useEditorState,
   useRefEditorState,
 } from '../../../components/editor/store/store-hook'
-import { isAllowedToReparent } from '../../canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers'
+import {
+  instancesOfSameComponent,
+  isAllowedToReparent,
+} from '../../canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { getEmptyImage } from 'react-dnd-html5-backend'
 import { when } from '../../../utils/react-conditionals'
@@ -209,6 +212,26 @@ function depthOfCommonAncestor(
   return baseNavigatorDepth(closestSharedAncestor)
 }
 
+function notDroppingIntoOwnDefinition(
+  selectedViews: Array<ElementPath>,
+  targetParent: ElementPath,
+  metadata: ElementInstanceMetadataMap,
+) {
+  const parentInstance = MetadataUtils.findElementByElementPath(
+    metadata,
+    EP.renderedByParentPath(targetParent),
+  )
+  return parentInstance == null
+    ? true
+    : selectedViews.every(
+        (selection) =>
+          !instancesOfSameComponent(
+            parentInstance,
+            MetadataUtils.findElementByElementPath(metadata, selection),
+          ),
+      )
+}
+
 function canDropInto(editorState: EditorState, moveToEntry: ElementPath): boolean {
   const notSelectedItem = editorState.selectedViews.every((selection) => {
     return !EP.isDescendantOfOrEqualTo(moveToEntry, selection)
@@ -222,7 +245,12 @@ function canDropInto(editorState: EditorState, moveToEntry: ElementPath): boolea
     moveToEntry,
     editorState.elementPathTree,
   )
-  return targetSupportsChildren && notSelectedItem
+
+  return (
+    targetSupportsChildren &&
+    notSelectedItem &&
+    notDroppingIntoOwnDefinition(editorState.selectedViews, moveToEntry, editorState.jsxMetadata)
+  )
 }
 
 function canDropNextTo(editorState: EditorState, moveToEntry: ElementPath): boolean {
@@ -561,6 +589,11 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
             dropTargetHint,
             props.elementPath,
             item.elementPath,
+          ) &&
+          notDroppingIntoOwnDefinition(
+            editorStateRef.current.selectedViews,
+            dropTargetHint.targetParent.elementPath,
+            editorStateRef.current.jsxMetadata,
           )
         ) {
           actions.push(
@@ -616,6 +649,11 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
             dropTargetHint,
             props.elementPath,
             item.elementPath,
+          ) &&
+          notDroppingIntoOwnDefinition(
+            editorStateRef.current.selectedViews,
+            dropTargetHint.targetParent.elementPath,
+            editorStateRef.current.jsxMetadata,
           )
         ) {
           actions.push(

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -20,6 +20,7 @@ import * as EP from '../../core/shared/element-path'
 import {
   dispatchMouseClickEventAtPoint,
   mouseClickAtPoint,
+  mouseDoubleClickAtPoint,
 } from '../canvas/event-helpers.test-utils'
 import { NavigatorItemTestId } from './navigator-item/navigator-item'
 import { expectNoAction, selectComponentsForTest, wait } from '../../utils/utils.test-utils'
@@ -2086,6 +2087,89 @@ describe('Navigator', () => {
       expect(
         renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey),
       ).toEqual(initialOrder)
+    })
+
+    describe('reparenting component instances', () => {
+      const projectWithComponents = `import * as React from 'react'
+      import { Storyboard, Scene } from 'utopia-api'
+      
+      const App = (props) => (
+        <div style={{ ...props.style }} data-uid='app-root'>
+          <ThisComponent data-uid='component-1' />
+          <ThisComponent data-uid='component-2' />
+        </div>
+      )
+      
+      const ThisComponent = (props) => (
+        <div style={{ ...props.style }} data-uid='custom-root'>
+          <div data-uid='hello-1' data-testid='target'>
+            Hello there 1!
+          </div>
+          <div data-uid='aap'>Hello there 2!</div>
+          <div data-uid='aat'>Hello there 3!</div>
+        </div>
+      )
+      
+      export var storyboard = (
+        <Storyboard data-uid='sb'>
+          <Scene
+            data-uid='scene'
+            style={{ width: 432, height: 356, left: 98, top: 36 }}
+          >
+            <App
+              style={{
+                backgroundColor: '#aaaaaa33',
+                position: 'absolute',
+                left: 34,
+                top: 31,
+                width: 346,
+                height: 223,
+              }}
+              data-uid='app'
+            />
+          </Scene>
+        </Storyboard>
+      )
+      `
+
+      it('cannot reparent component instance into its own definition via moving it next to a child', async () => {
+        const editor = await renderTestEditorWithCode(
+          projectWithComponents,
+          'await-first-dom-report',
+        )
+
+        await mouseDoubleClickAtPoint(editor.renderedDOM.getAllByText('ThisComponent')[0], {
+          x: 2,
+          y: 2,
+        })
+
+        const startingVisibleNavigatorEntries = editor
+          .getEditorState()
+          .derived.visibleNavigatorTargets.map(navigatorEntryToKey)
+
+        expect(startingVisibleNavigatorEntries).toEqual([
+          'regular-sb/scene',
+          'regular-sb/scene/app',
+          'regular-sb/scene/app:app-root',
+          'regular-sb/scene/app:app-root/component-1',
+          'regular-sb/scene/app:app-root/component-1:custom-root',
+          'regular-sb/scene/app:app-root/component-1:custom-root/hello-1',
+          'regular-sb/scene/app:app-root/component-1:custom-root/aap',
+          'regular-sb/scene/app:app-root/component-1:custom-root/aat',
+          'regular-sb/scene/app:app-root/component-2',
+        ])
+
+        await doBasicDrag(
+          editor,
+          EP.fromString('sb/scene/app:app-root/component-2'),
+          EP.fromString('sb/scene/app:app-root/component-1:custom-root/hello-1'),
+        )
+        await editor.getDispatchFollowUpActionsFinished()
+
+        expect(
+          editor.getEditorState().derived.visibleNavigatorTargets.map(navigatorEntryToKey),
+        ).toEqual(startingVisibleNavigatorEntries)
+      })
     })
   })
 

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -2090,7 +2090,9 @@ describe('Navigator', () => {
     })
 
     describe('reparenting component instances', () => {
-      const projectWithComponents = `import * as React from 'react'
+      it('cannot reparent component instance into its own definition via moving it next to a child', async () => {
+        const editor = await renderTestEditorWithCode(
+          `import * as React from 'react'
       import { Storyboard, Scene } from 'utopia-api'
       
       const App = (props) => (
@@ -2130,11 +2132,7 @@ describe('Navigator', () => {
           </Scene>
         </Storyboard>
       )
-      `
-
-      it('cannot reparent component instance into its own definition via moving it next to a child', async () => {
-        const editor = await renderTestEditorWithCode(
-          projectWithComponents,
+      `,
           'await-first-dom-report',
         )
 
@@ -2162,6 +2160,100 @@ describe('Navigator', () => {
         await doBasicDrag(
           editor,
           EP.fromString('sb/scene/app:app-root/component-2'),
+          EP.fromString('sb/scene/app:app-root/component-1:custom-root/hello-1'),
+        )
+        await editor.getDispatchFollowUpActionsFinished()
+
+        expect(
+          editor.getEditorState().derived.visibleNavigatorTargets.map(navigatorEntryToKey),
+        ).toEqual(startingVisibleNavigatorEntries)
+      })
+
+      it('cannot reparent component instance into its own definition, transitively', async () => {
+        const editor = await renderTestEditorWithCode(
+          `import * as React from 'react'
+      import { Storyboard, Scene } from 'utopia-api'
+      
+      const App = (props) => (
+        <div style={{ ...props.style }} data-uid='app-root'>
+          <ThisComponent data-uid='component-1' />
+          <ThisComponent data-uid='component-2' />
+        </div>
+      )
+      
+      const ThisComponent = (props) => (
+        <div style={{ ...props.style }} data-uid='custom-root'>
+          <div data-uid='hello-1' data-testid='target'>
+            Hello there 1!
+          </div>
+          <div data-uid='aap'>Hello there 2!</div>
+          <div data-uid='aat'>Hello there 3!</div>
+        </div>
+      )
+      
+      export var storyboard = (
+        <Storyboard data-uid='sb'>
+          <Scene
+            data-uid='scene'
+            style={{ width: 432, height: 356, left: 98, top: 36 }}
+          >
+            <App
+              style={{
+                backgroundColor: '#aaaaaa33',
+                position: 'absolute',
+                left: 34,
+                top: 31,
+                width: 346,
+                height: 223,
+              }}
+              data-uid='app'
+            />
+            <App
+              style={{
+                backgroundColor: '#aaaaaa33',
+                position: 'absolute',
+                left: 34,
+                top: 31,
+                width: 346,
+                height: 223,
+              }}
+              data-uid='app-2'
+            />
+          </Scene>
+        </Storyboard>
+      )
+      `,
+          'await-first-dom-report',
+        )
+
+        await mouseDoubleClickAtPoint(editor.renderedDOM.getAllByText('ThisComponent')[0], {
+          x: 2,
+          y: 2,
+        })
+
+        const startingVisibleNavigatorEntries = editor
+          .getEditorState()
+          .derived.visibleNavigatorTargets.map(navigatorEntryToKey)
+
+        expect(startingVisibleNavigatorEntries).toEqual([
+          'regular-sb/scene',
+          'regular-sb/scene/app',
+          'regular-sb/scene/app:app-root',
+          'regular-sb/scene/app:app-root/component-1',
+          'regular-sb/scene/app:app-root/component-1:custom-root',
+          'regular-sb/scene/app:app-root/component-1:custom-root/hello-1',
+          'regular-sb/scene/app:app-root/component-1:custom-root/aap',
+          'regular-sb/scene/app:app-root/component-1:custom-root/aat',
+          'regular-sb/scene/app:app-root/component-2',
+          'regular-sb/scene/app-2',
+          'regular-sb/scene/app-2:app-root',
+          'regular-sb/scene/app-2:app-root/component-1',
+          'regular-sb/scene/app-2:app-root/component-2',
+        ])
+
+        await doBasicDrag(
+          editor,
+          EP.fromString('sb/scene/app-2'),
           EP.fromString('sb/scene/app:app-root/component-1:custom-root/hello-1'),
         )
         await editor.getDispatchFollowUpActionsFinished()

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -1086,3 +1086,10 @@ export function extractOriginalUidFromIndexedUid(uid: string): string {
     return uid
   }
 }
+
+export function renderedByParentPath(path: ElementPath): ElementPath {
+  return {
+    type: 'elementpath',
+    parts: path.parts.slice(0, -1),
+  }
+}

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -1087,13 +1087,6 @@ export function extractOriginalUidFromIndexedUid(uid: string): string {
   }
 }
 
-export function renderedByParentPath(path: ElementPath): ElementPath {
-  return {
-    type: 'elementpath',
-    parts: path.parts.slice(0, -1),
-  }
-}
-
 export function getStoryboardPathFromPath(path: ElementPath): ElementPath | null {
   if (isEmptyPath(path)) {
     return null

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -737,6 +737,7 @@ export function replaceOrDefault(
   return replaceIfAncestor(path, replaceSearch, replaceWith) ?? path
 }
 
+// TODO: remove null
 export function closestSharedAncestor(
   l: ElementPath | null,
   r: ElementPath | null,

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -60,7 +60,7 @@ import { optionalMap } from '../core/shared/optional-utils'
 import { isFeatureEnabled } from './feature-switches'
 import { ElementPathTrees } from '../core/shared/element-path-tree'
 import {
-  instanceInSubtreeOfSameComponent,
+  isElementRenderedBySameComponent,
   instancesOfSameComponent,
   replaceJSXElementCopyData,
 } from '../components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers'
@@ -543,7 +543,7 @@ export function getTargetParentForPaste(
 
   if (
     copyData.elementPaste.some((pastedElement) =>
-      instanceInSubtreeOfSameComponent(
+      isElementRenderedBySameComponent(
         metadata,
         parentTarget,
         MetadataUtils.findElementByElementPath(

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -60,6 +60,7 @@ import { optionalMap } from '../core/shared/optional-utils'
 import { isFeatureEnabled } from './feature-switches'
 import { ElementPathTrees } from '../core/shared/element-path-tree'
 import {
+  instanceInSubtreeOfSameComponent,
   instancesOfSameComponent,
   replaceJSXElementCopyData,
 } from '../components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers'
@@ -540,15 +541,11 @@ export function getTargetParentForPaste(
     return left('Cannot find a suitable parent')
   }
 
-  const parentInstance = MetadataUtils.findElementByElementPath(
-    metadata,
-    EP.renderedByParentPath(parentTarget),
-  )
-
   if (
     copyData.elementPaste.some((pastedElement) =>
-      instancesOfSameComponent(
-        parentInstance,
+      instanceInSubtreeOfSameComponent(
+        metadata,
+        parentTarget,
         MetadataUtils.findElementByElementPath(
           copyData.originalContextMetadata,
           pastedElement.originalElementPath,

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -61,7 +61,6 @@ import { isFeatureEnabled } from './feature-switches'
 import { ElementPathTrees } from '../core/shared/element-path-tree'
 import {
   isElementRenderedBySameComponent,
-  instancesOfSameComponent,
   replaceJSXElementCopyData,
 } from '../components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers'
 import CanvasActions from '../components/canvas/canvas-actions'


### PR DESCRIPTION
## Problem

Cosnider the following project:
```tsx
import * as React from 'react'
import { Storyboard, Scene } from 'utopia-api'

const App = (props) => (
  <div style={{ ...props.style }} data-uid='app-root'>
    <ThisComponent data-uid='component-1' />
    <ThisComponent data-uid='component-2' />
  </div>
)

const ThisComponent = (props) => (
  <div style={{ ...props.style }} data-uid='custom-root'>
    <div data-uid='hello-1' data-testid='target'>
      Hello there 1!
    </div>
    <div data-uid='aap'>Hello there 2!</div>
    <div data-uid='aat'>Hello there 3!</div>
  </div>
)

export var storyboard = (
  <Storyboard data-uid='0cd'>
    <Scene
      data-uid='b58'
      style={{ width: 432, height: 356, left: 98, top: 36 }}
    >
      <App
        style={{
          backgroundColor: '#aaaaaa33',
          position: 'absolute',
          left: 34,
          top: 31,
          width: 346,
          height: 223,
        }}
        data-uid='app'
      />
    </Scene>
  </Storyboard>
)
```

If I copy `component-1` and paste it inside `ThisComponent`, next to `hello-1`, `ThisComponent` would infinitely re-render itself, breaking the canvas. The same thing can happen if in the above project `app` is pasted into `custom-root`, since that way `App` and `ThisComponent` would be mutually recursive.

## Fix
Even though recursively rendering components can have legit use cases (such as a tree structure visualizer), for our tool, at this time, this is too advanced a use case (since it's non-trivial to decide whether a recursive function will stop recursing if called). In order to avoid crashing the canvas, reparenting a component instance into its own definition is disallowed in the navigator and via cut/copy/paste.

If we disallow pasting to prevent recursive rendering, we show a toast that tries to explain the situation.

Creating a recursive structure is still possible via the code editor.
