### PR TITLE
Only unique elements in selected views

### DIFF
--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -4297,4 +4297,19 @@ export var storyboard = (
       )
     })
   })
+  describe('SELECT_COMPONENTS', () => {
+    it('Can not select the same element path twice', async () => {
+      const testCode = `<div data-uid='aaa'/>`
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(testCode),
+        'await-first-dom-report',
+      )
+      await renderResult.dispatch(
+        [selectComponents([makeTargetPath('aaa'), makeTargetPath('aaa')], false)],
+        true,
+      )
+      await renderResult.getDispatchFollowUpActionsFinished()
+      expect(renderResult.getEditorState().editor.selectedViews).toEqual([makeTargetPath('aaa')])
+    })
+  })
 })

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -420,6 +420,7 @@ import {
   ConditionalClauseNavigatorEntry,
   reparentTargetFromNavigatorEntry,
   modifyOpenJsxChildAtPath,
+  isConditionalClauseNavigatorEntry,
 } from '../store/editor-state'
 import { loadStoredState } from '../stored-state'
 import { applyMigrations } from './migrations/migrations'
@@ -1577,7 +1578,10 @@ function updateSelectedComponentsFromEditorPosition(
     const newlySelectedElements = getElementPathsInBounds(
       line,
       highlightBoundsForUids,
-      toArrayOf(allElementPathsOptic, derived.navigatorTargets),
+      toArrayOf(
+        allElementPathsOptic,
+        derived.navigatorTargets.filter((t) => !isConditionalClauseNavigatorEntry(t)),
+      ),
     )
     return UPDATE_FNS.SELECT_COMPONENTS(
       selectComponents(newlySelectedElements, false),
@@ -2048,7 +2052,7 @@ export const UPDATE_FNS = {
         return EP.addPathIfMissing(path, working)
       }, editor.selectedViews)
     } else {
-      newlySelectedPaths = action.target
+      newlySelectedPaths = EP.uniqueElementPaths(action.target)
     }
     const newHighlightedViews = editor.highlightedViews.filter(
       (path) => !EP.containsPath(path, newlySelectedPaths),


### PR DESCRIPTION
**Problem:**
When you select a conditional in the code editor, the conditional inspector section is not shown.

**Root cause:**
In `updateSelectedComponentsFromEditorPosition` we iterate through all navigator entries and get their element paths, and select the ones which fit the target element. But conditional element paths are included in three navigator items: in the conditional item itself and in the two conditional clause items (the "TRUE"/"FALSE" labels). This results in a fake multiselection (with the conditional path 3 times in the selection array).
The action implementation itself does not filter for unique element paths, and the inspector section does not allow multiselection.

**Fix:**
1. Filter out `conditionalClauseNavigatorItem`-s when searching for selectable element paths.
2. Do not allow non-unique selection paths in the `selectComponents` action.