### PR TITLE
Fix navigator ghosts during reparenting

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -16,6 +16,7 @@ export interface CustomStrategyState {
   lastReorderIdx: number | null
   duplicatedElementNewUids: { [elementPath: string]: string }
   strategyGeneratedUidsCache: { [elementPath: string]: string | undefined }
+  elementsToRerender: Array<ElementPath>
 }
 
 export type CustomStrategyStatePatch = Partial<CustomStrategyState>
@@ -26,6 +27,7 @@ export function defaultCustomStrategyState(): CustomStrategyState {
     lastReorderIdx: null,
     duplicatedElementNewUids: {},
     strategyGeneratedUidsCache: {},
+    elementsToRerender: [],
   }
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
@@ -378,7 +378,14 @@ describe('Absolute Reparent Strategy', () => {
     )
 
     const dragDelta = windowPoint({ x: -1000, y: -1000 })
-    await dragElement(renderResult, 'bbb', dragDelta, cmdModifier, null, null)
+    await dragElement(renderResult, 'bbb', dragDelta, cmdModifier, null, async () => {
+      expect(getRegularNavigatorTargets(renderResult)).toEqual([
+        'utopia-storyboard-uid/scene-aaa',
+        'utopia-storyboard-uid/scene-aaa/app-entity',
+        'utopia-storyboard-uid/scene-aaa/app-entity:aaa',
+        'utopia-storyboard-uid/bbb', // only appears in the new target even mid-drag, no ghost element
+      ])
+    })
 
     await renderResult.getDispatchFollowUpActionsFinished()
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
@@ -92,6 +92,7 @@ export const dragToInsertMetaStrategy: MetaCanvasStrategy = (
     interactionData.modifiers.cmd,
     true,
     'allow-smaller-parent',
+    customStrategyState,
   )
 
   return mapDropNulls((result): CanvasStrategy | null => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -99,6 +99,7 @@ export const drawToInsertMetaStrategy: MetaCanvasStrategy = (
     interactionSession.interactionData.modifiers.cmd,
     true,
     'allow-smaller-parent',
+    customStrategyState,
   )
 
   return mapDropNulls((result): CanvasStrategy | null => {
@@ -120,7 +121,7 @@ export const drawToInsertMetaStrategy: MetaCanvasStrategy = (
 export function getDrawToInsertStrategyName(
   strategyType: ReparentStrategy,
   parentDisplayType: 'flex' | 'flow',
-) {
+): string {
   switch (strategyType) {
     case 'REPARENT_AS_ABSOLUTE':
       return 'Draw to Insert (Abs)'

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
@@ -66,6 +66,7 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
           false,
           true,
           'allow-smaller-parent',
+          customStrategyState,
           ['hasOnlyTextChildren', 'supportsChildren'],
         )
         if (applicableReparentFactories.length < 1) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
@@ -105,6 +105,7 @@ export function baseFlexReparentToAbsoluteStrategy(
                     const absoluteReparentStrategyToUse = baseAbsoluteReparentStrategy(
                       reparentTarget,
                       0,
+                      customStrategyState,
                     )
                     const reparentCommands =
                       absoluteReparentStrategyToUse(

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -189,9 +189,16 @@ function applyStaticReparent(
               updateSelectedViews('always', [newPath]),
             ]
 
+            const elementsToRerender = EP.uniqueElementPaths([
+              ...customStrategyState.elementsToRerender,
+              target,
+              EP.parentPath(newPath),
+              EP.parentPath(target),
+            ])
+
             const commandsAfterReorder = [
               ...propertyChangeCommands,
-              setElementsToRerenderCommand([target, newPath]), // TODO THIS LIST IS INCOMPLETE, KEEPS GHOSTS IN THE NAVIGATOR
+              setElementsToRerenderCommand(elementsToRerender),
               updateHighlightedViews('mid-interaction', []),
               setCursorCommand(CSSCursor.Move),
             ]
@@ -265,7 +272,7 @@ function applyStaticReparent(
 
             return {
               commands: [...midInteractionCommands, ...interactionFinishCommands],
-              customStatePatch: { duplicatedElementNewUids: duplicatedElementNewUids },
+              customStatePatch: { duplicatedElementNewUids, elementsToRerender },
               status: 'success',
             }
           }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -51,6 +51,7 @@ export function getApplicableReparentFactories(
   cmdPressed: boolean,
   allDraggedElementsAbsolute: boolean,
   allowSmallerParent: AllowSmallerParent,
+  customStrategyState: CustomStrategyState,
   elementSupportsChildren: Array<ElementSupportsChildren> = ['supportsChildren'],
 ): Array<ReparentFactoryAndDetails> {
   const reparentStrategies = findReparentStrategies(
@@ -73,7 +74,7 @@ export function getApplicableReparentFactories(
             targetParentDisplayType: 'flow',
             fitness: fitness,
             dragType: 'absolute',
-            factory: baseAbsoluteReparentStrategy(result.target, fitness),
+            factory: baseAbsoluteReparentStrategy(result.target, fitness, customStrategyState),
           }
         } else {
           return {
@@ -242,6 +243,7 @@ export const reparentMetaStrategy: MetaCanvasStrategy = (
     cmdPressed,
     allDraggedElementsAbsolute,
     cmdPressed ? 'allow-smaller-parent' : 'disallow-smaller-parent',
+    customStrategyState,
   )
 
   const targetIsValid = (target: ElementPath): boolean => {

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -385,7 +385,10 @@ function runSelectiveDomWalker(
       }
     })
     const otherElementPaths = Object.keys(globalProps.rootMetadataInStateRef.current).filter(
-      (path) => !Object.keys(workingMetadata).includes(path),
+      (path) =>
+        Object.keys(workingMetadata).find((updatedPath) =>
+          EP.isDescendantOfOrEqualTo(EP.fromString(path), EP.fromString(updatedPath)),
+        ) == null,
     )
     const rootMetadataForOtherElements = pick(
       otherElementPaths,

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -171,6 +171,7 @@ describe('interactionStart', () => {
         "currentStrategyFitness": 0,
         "customStrategyState": Object {
           "duplicatedElementNewUids": Object {},
+          "elementsToRerender": Array [],
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
@@ -184,10 +185,8 @@ describe('interactionStart', () => {
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(1)
     expect(actualResult.unpatchedEditorState.canvas.scale).toEqual(1)
-    expect(
-      actualResult.patchedEditorState.canvas.interactionSession?.interactionData,
-    ).toMatchInlineSnapshot(
-      `
+    expect(actualResult.patchedEditorState.canvas.interactionSession?.interactionData)
+      .toMatchInlineSnapshot(`
       Object {
         "_accumulatedMovement": Object {
           "x": 0,
@@ -214,8 +213,7 @@ describe('interactionStart', () => {
         "type": "DRAG",
         "zeroDragPermitted": "zero-drag-not-permitted",
       }
-    `,
-    )
+    `)
   })
   it('potentially process a start with no interaction session', () => {
     const editorStore = createEditorStore(null)
@@ -232,6 +230,7 @@ describe('interactionStart', () => {
         "currentStrategyFitness": 0,
         "customStrategyState": Object {
           "duplicatedElementNewUids": Object {},
+          "elementsToRerender": Array [],
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
@@ -307,6 +306,7 @@ describe('interactionUpdate', () => {
         "currentStrategyFitness": 10,
         "customStrategyState": Object {
           "duplicatedElementNewUids": Object {},
+          "elementsToRerender": Array [],
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
@@ -331,10 +331,8 @@ describe('interactionUpdate', () => {
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)
     expect(actualResult.unpatchedEditorState.canvas.scale).toEqual(1)
-    expect(
-      actualResult.patchedEditorState.canvas.interactionSession?.interactionData,
-    ).toMatchInlineSnapshot(
-      `
+    expect(actualResult.patchedEditorState.canvas.interactionSession?.interactionData)
+      .toMatchInlineSnapshot(`
       Object {
         "_accumulatedMovement": Object {
           "x": 0,
@@ -364,8 +362,7 @@ describe('interactionUpdate', () => {
         "type": "DRAG",
         "zeroDragPermitted": "zero-drag-not-permitted",
       }
-    `,
-    )
+    `)
   })
   it('potentially process an update with no interaction session', () => {
     const editorStore = createEditorStore(null)
@@ -383,6 +380,7 @@ describe('interactionUpdate', () => {
         "currentStrategyFitness": 0,
         "customStrategyState": Object {
           "duplicatedElementNewUids": Object {},
+          "elementsToRerender": Array [],
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
@@ -452,6 +450,7 @@ describe('interactionHardReset', () => {
         "currentStrategyFitness": 10,
         "customStrategyState": Object {
           "duplicatedElementNewUids": Object {},
+          "elementsToRerender": Array [],
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
@@ -476,10 +475,8 @@ describe('interactionHardReset', () => {
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)
     expect(actualResult.unpatchedEditorState.canvas.scale).toEqual(1)
-    expect(
-      actualResult.patchedEditorState.canvas.interactionSession?.interactionData,
-    ).toMatchInlineSnapshot(
-      `
+    expect(actualResult.patchedEditorState.canvas.interactionSession?.interactionData)
+      .toMatchInlineSnapshot(`
       Object {
         "_accumulatedMovement": Object {
           "x": 0,
@@ -512,8 +509,7 @@ describe('interactionHardReset', () => {
         "type": "DRAG",
         "zeroDragPermitted": "zero-drag-not-permitted",
       }
-    `,
-    )
+    `)
   })
   it('potentially process an update with no interaction session', () => {
     const editorStore = createEditorStore(null)
@@ -530,6 +526,7 @@ describe('interactionHardReset', () => {
         "currentStrategyFitness": 0,
         "customStrategyState": Object {
           "duplicatedElementNewUids": Object {},
+          "elementsToRerender": Array [],
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
@@ -613,6 +610,7 @@ describe('interactionUpdate with user changed strategy', () => {
         "currentStrategyFitness": 10,
         "customStrategyState": Object {
           "duplicatedElementNewUids": Object {},
+          "elementsToRerender": Array [],
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
@@ -637,10 +635,8 @@ describe('interactionUpdate with user changed strategy', () => {
     `)
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)
     expect(actualResult.unpatchedEditorState.canvas.scale).toEqual(1)
-    expect(
-      actualResult.patchedEditorState.canvas.interactionSession?.interactionData,
-    ).toMatchInlineSnapshot(
-      `
+    expect(actualResult.patchedEditorState.canvas.interactionSession?.interactionData)
+      .toMatchInlineSnapshot(`
       Object {
         "_accumulatedMovement": Object {
           "x": 0,
@@ -673,8 +669,7 @@ describe('interactionUpdate with user changed strategy', () => {
         "type": "DRAG",
         "zeroDragPermitted": "zero-drag-not-permitted",
       }
-    `,
-    )
+    `)
   })
   it('potentially process an update with no interaction session', () => {
     const editorStore = createEditorStore(null)
@@ -692,6 +687,7 @@ describe('interactionUpdate with user changed strategy', () => {
         "currentStrategyFitness": 0,
         "customStrategyState": Object {
           "duplicatedElementNewUids": Object {},
+          "elementsToRerender": Array [],
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},


### PR DESCRIPTION
**Problem:**
When you are reparenting, during dragging the target element is shown both in the old and in the new position in the navigator.

**Root cause:**
During selective rerendering dom walker only updates the metadata of the rerendered elements. However, those elements which disappear, they just stay in the metadata.

**Fix:**
1. Make sure all rerendered elements and their descendants are removed from the metadata in the dom-walker
2. Add the original and the new parent to the elements to rerender array
3. When dragging over multiple parents, we have take extra measures. The strategies always calculate from scratch, but the metadata remembers everything. We have to remove the previous candidate parent from the metadata too, but the strategy itself does not know about that when we are not dragging over it anymore. So I decided to store the current elementsToRerender array in the strategy state, and always extend that array during reparenting.


