### PR TITLE
Keep currently selected view selectable

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -200,40 +200,46 @@ function replaceNonSelectablePaths(
   selectablePaths: Array<ElementPath>,
   componentMetadata: ElementInstanceMetadataMap,
   pathTrees: ElementPathTrees,
+  selectedViews: Array<ElementPath>,
   lockedElements: LockedElements,
 ): Array<ElementPath> {
   let updatedSelectablePaths: Array<ElementPath> = []
   Utils.fastForEach(selectablePaths, (selectablePath) => {
-    const isLocked = lockedElements.simpleLock.some((lockedPath) =>
-      EP.pathsEqual(lockedPath, selectablePath),
-    )
-    const isRootPath = EP.isRootElementOfInstance(selectablePath)
-
-    const mustReplaceWithChildren = isLocked
-    const shouldAttemptToReplaceWithChildren = isRootPath
-
-    // If this element is locked we want to recurse the children
-    if (mustReplaceWithChildren || shouldAttemptToReplaceWithChildren) {
-      const childrenPaths = MetadataUtils.getImmediateChildrenPathsOrdered(
-        componentMetadata,
-        pathTrees,
-        selectablePath,
+    if (selectedViews.some((selectedView) => EP.pathsEqual(selectablePath, selectedView))) {
+      updatedSelectablePaths.push(selectablePath)
+    } else {
+      const isLocked = lockedElements.simpleLock.some((lockedPath) =>
+        EP.pathsEqual(lockedPath, selectablePath),
       )
-      const childrenPathsWithLockedPathsReplaced = replaceNonSelectablePaths(
-        childrenPaths,
-        componentMetadata,
-        pathTrees,
-        lockedElements,
-      )
+      const isRootPath = EP.isRootElementOfInstance(selectablePath)
 
-      if (childrenPathsWithLockedPathsReplaced.length > 0) {
-        updatedSelectablePaths.push(...childrenPathsWithLockedPathsReplaced)
-      } else if (!mustReplaceWithChildren) {
-        // In certain cases we want to keep this path selectable if it has no children
+      const mustReplaceWithChildren = isLocked
+      const shouldAttemptToReplaceWithChildren = isRootPath
+
+      // If this element is locked we want to recurse the children
+      if (mustReplaceWithChildren || shouldAttemptToReplaceWithChildren) {
+        const childrenPaths = MetadataUtils.getImmediateChildrenPathsOrdered(
+          componentMetadata,
+          pathTrees,
+          selectablePath,
+        )
+        const childrenPathsWithLockedPathsReplaced = replaceNonSelectablePaths(
+          childrenPaths,
+          componentMetadata,
+          pathTrees,
+          selectedViews,
+          lockedElements,
+        )
+
+        if (childrenPathsWithLockedPathsReplaced.length > 0) {
+          updatedSelectablePaths.push(...childrenPathsWithLockedPathsReplaced)
+        } else if (!mustReplaceWithChildren) {
+          // In certain cases we want to keep this path selectable if it has no children
+          updatedSelectablePaths.push(selectablePath)
+        }
+      } else {
         updatedSelectablePaths.push(selectablePath)
       }
-    } else {
-      updatedSelectablePaths.push(selectablePath)
     }
   })
 
@@ -322,6 +328,7 @@ function getCandidateSelectableViews(
       allPotentiallySelectableViews,
       componentMetadata,
       elementPathTree,
+      selectedViews,
       lockedElements,
     )
     const uniqueSelectableViews = uniqBy<ElementPath>(selectableViews, EP.pathsEqual)


### PR DESCRIPTION
**Problem:**
If the root element is already selected, a second click will de-select it.

**Fix:**
The problem is that we deliberately exclude certain elements from single click selection (see #3420), but also deliberately keep all ancestors single click selectable, so in this case the root element is being skipped but the parent instance is selectable. The fix is simply to keep the currently selected elements selectable.

**Before:**
![root-div-select-before](https://github.com/concrete-utopia/utopia/assets/1044774/44e2e22f-2f5a-435c-a9c3-37d10497dd69)

**After:**
![root-div-select-after](https://github.com/concrete-utopia/utopia/assets/1044774/519d1b8e-c58b-4c11-9bb9-b59bf371398f)
