### PR TITLE
Only auto-focus single children of a scene

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -3038,6 +3038,9 @@ export function getValidElementPathsFromElement(
     // }
     let paths: Array<ElementPath> = []
     fastForEach(Object.values(element.elementsWithin), (e) =>
+      // We explicitly prevent auto-focusing generated elements here, because to support it would
+      // require using the elementPathTree to determine how many children of a scene were actually
+      // generated, creating a chicken and egg situation.
       paths.push(
         ...getValidElementPathsFromElement(
           focusedElementPath,
@@ -3046,7 +3049,7 @@ export function getValidElementPathsFromElement(
           projectContents,
           filePath,
           uiFilePath,
-          isOnlyChildOfScene,
+          false,
           parentIsInstance,
           transientFilesState,
           resolve,

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2967,13 +2967,14 @@ export function getValidElementPathsFromElement(
   projectContents: ProjectContentTreeRoot,
   filePath: string,
   uiFilePath: string,
-  parentIsScene: boolean,
+  isOnlyChildOfScene: boolean,
   parentIsInstance: boolean,
   transientFilesState: TransientFilesState | null,
   resolve: (importOrigin: string, toImport: string) => Either<string, string>,
 ): Array<ElementPath> {
   if (isJSXElementLike(element)) {
     const isScene = isSceneElement(element, filePath, projectContents)
+    const isSceneWithOneChild = isScene && element.children.length === 1
     const uid = getUtopiaID(element)
     const path = parentIsInstance
       ? EP.appendNewElementPath(parentPath, uid)
@@ -2988,7 +2989,7 @@ export function getValidElementPathsFromElement(
           projectContents,
           filePath,
           uiFilePath,
-          isScene,
+          isSceneWithOneChild,
           false,
           transientFilesState,
           resolve,
@@ -3003,7 +3004,7 @@ export function getValidElementPathsFromElement(
         ? null
         : EP.pathUpToElementPath(focusedElementPath, lastElementPathPart, 'static-path')
 
-    const isFocused = parentIsScene || matchingFocusedPathPart != null
+    const isFocused = isOnlyChildOfScene || matchingFocusedPathPart != null
     if (isFocused) {
       paths.push(
         ...getValidElementPaths(
@@ -3045,7 +3046,7 @@ export function getValidElementPathsFromElement(
           projectContents,
           filePath,
           uiFilePath,
-          parentIsScene,
+          isOnlyChildOfScene,
           parentIsInstance,
           transientFilesState,
           resolve,

--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
@@ -1010,28 +1010,69 @@ describe('Storyboard auto-focusing', () => {
       'await-first-dom-report',
     )
 
-    const card1Span = renderResult.renderedDOM.getByTestId('card1-span')
-    const card1SpanBounds = card1Span.getBoundingClientRect()
+    const cardSpan1 = renderResult.renderedDOM.getByTestId('card-span-1')
+    const cardSpan1Bounds = cardSpan1.getBoundingClientRect()
 
     const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
 
     await fireSingleClickEvents(
       canvasControlsLayer,
-      card1SpanBounds.left + 2,
-      card1SpanBounds.top + 2,
+      cardSpan1Bounds.left + 2,
+      cardSpan1Bounds.top + 2,
       cmdModifier,
     )
 
     checkFocusedPath(renderResult, null)
     checkSelectedPaths(renderResult, [desiredPaths[0]])
 
-    const card2Span = renderResult.renderedDOM.getByTestId('card2-span')
-    const card2SpanBounds = card2Span.getBoundingClientRect()
+    const cardSpan2 = renderResult.renderedDOM.getByTestId('card-span-2')
+    const cardSpan2Bounds = cardSpan2.getBoundingClientRect()
 
     await fireSingleClickEvents(
       canvasControlsLayer,
-      card2SpanBounds.left + 2,
-      card2SpanBounds.top + 2,
+      cardSpan2Bounds.left + 2,
+      cardSpan2Bounds.top + 2,
+      cmdModifier,
+    )
+
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPaths[1]])
+  })
+
+  it('Scene with multiple generated children will not auto-focus those children', async () => {
+    // We expect neither of the Card components to be focused, meaning we can only directly select the instances
+    const desiredPaths = [
+      EP.fromString('sb/sc-generated/generated~~~1'),
+      EP.fromString('sb/sc-generated/generated~~~2'),
+    ]
+
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectScene2Children,
+      'await-first-dom-report',
+    )
+
+    const generatedSpan1 = renderResult.renderedDOM.getByTestId('generated-span-1')
+    const generatedSpan1Bounds = generatedSpan1.getBoundingClientRect()
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    await fireSingleClickEvents(
+      canvasControlsLayer,
+      generatedSpan1Bounds.left + 2,
+      generatedSpan1Bounds.top + 2,
+      cmdModifier,
+    )
+
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [desiredPaths[0]])
+
+    const generatedSpan2 = renderResult.renderedDOM.getByTestId('generated-span-2')
+    const generatedSpan2Bounds = generatedSpan2.getBoundingClientRect()
+
+    await fireSingleClickEvents(
+      canvasControlsLayer,
+      generatedSpan2Bounds.left + 2,
+      generatedSpan2Bounds.top + 2,
       cmdModifier,
     )
 
@@ -2564,8 +2605,8 @@ const Card1 = (props) => {
     <div style={props.style} data-uid='card1-root'>
       <div data-uid='card1-div'>
         <span
-          data-uid='card1-span'
-          data-testid='card1-span'
+          data-uid='card-span-1'
+          data-testid='card-span-1'
         >
           Card1
         </span>
@@ -2579,8 +2620,8 @@ const Card2 = (props) => {
     <div style={props.style} data-uid='card2-root'>
       <div data-uid='card2-div'>
         <span
-          data-uid='card2-span'
-          data-testid='card2-span'
+          data-uid='card-span-2'
+          data-testid='card-span-2'
         >
           Card2
         </span>
@@ -2598,6 +2639,21 @@ const SBChild = (props) => {
           data-testid='sbchild-span'
         >
           Storyboard Child
+        </span>
+      </div>
+    </div>
+  )
+}
+
+const GeneratedComponent = (props) => {
+  return (
+    <div style={props.style} data-uid='generated-root'>
+      <div data-uid='generated-div'>
+        <span
+          data-uid='generated-span'
+          data-testid={props.testid}
+        >
+          Generated
         </span>
       </div>
     </div>
@@ -2661,10 +2717,35 @@ export var storyboard = (
         data-uid='app'
       />
     </Scene>
+    <Scene
+      style={{
+        width: 300,
+        height: 300,
+        position: 'absolute',
+        left: 10,
+        top: 350,
+      }}
+      data-uid='sc-generated'
+    >
+      {[1, 2, 3].map((i) => (
+        <GeneratedComponent
+          style={{
+            backgroundColor: '#aaaaaa33',
+            position: 'absolute',
+            left: 10 + (i - 1) * 85,
+            top: 10 + (i - 1) * 85,
+            width: 80,
+            height: 80,
+          }}
+          data-uid='generated'
+          testid={'generated-span-' + i}
+        />
+      ))}
+    </Scene>
     <SBChild
       style={{
         position: 'absolute',
-        left: 10,
+        left: 350,
         top: 350,
         width: 100,
         height: 100,

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -2231,28 +2231,33 @@ describe('Navigator', () => {
       export var storyboard = (
         <Storyboard data-uid='sb'>
           <Scene
-            data-uid='scene'
-            style={{ width: 432, height: 356, left: 98, top: 36 }}
+            data-uid='scene-1'
+            style={{ width: 300, height: 300, left: 10, top: 10 }}
           >
             <App
               style={{
                 backgroundColor: '#aaaaaa33',
                 position: 'absolute',
-                left: 34,
-                top: 31,
-                width: 346,
-                height: 223,
+                left: 10,
+                top: 10,
+                width: 280,
+                height: 280,
               }}
               data-uid='app'
             />
+          </Scene>
+          <Scene
+            data-uid='scene-2'
+            style={{ width: 300, height: 300, left: 320, top: 10 }}
+          >
             <App
               style={{
                 backgroundColor: '#aaaaaa33',
                 position: 'absolute',
-                left: 34,
-                top: 31,
-                width: 346,
-                height: 223,
+                left: 10,
+                top: 10,
+                width: 280,
+                height: 280,
               }}
               data-uid='app-2'
             />
@@ -2273,25 +2278,26 @@ describe('Navigator', () => {
           .derived.visibleNavigatorTargets.map(navigatorEntryToKey)
 
         expect(startingVisibleNavigatorEntries).toEqual([
-          'regular-sb/scene',
-          'regular-sb/scene/app',
-          'regular-sb/scene/app:app-root',
-          'regular-sb/scene/app:app-root/component-1',
-          'regular-sb/scene/app:app-root/component-1:custom-root',
-          'regular-sb/scene/app:app-root/component-1:custom-root/hello-1',
-          'regular-sb/scene/app:app-root/component-1:custom-root/aap',
-          'regular-sb/scene/app:app-root/component-1:custom-root/aat',
-          'regular-sb/scene/app:app-root/component-2',
-          'regular-sb/scene/app-2',
-          'regular-sb/scene/app-2:app-root',
-          'regular-sb/scene/app-2:app-root/component-1',
-          'regular-sb/scene/app-2:app-root/component-2',
+          'regular-sb/scene-1',
+          'regular-sb/scene-1/app',
+          'regular-sb/scene-1/app:app-root',
+          'regular-sb/scene-1/app:app-root/component-1',
+          'regular-sb/scene-1/app:app-root/component-1:custom-root',
+          'regular-sb/scene-1/app:app-root/component-1:custom-root/hello-1',
+          'regular-sb/scene-1/app:app-root/component-1:custom-root/aap',
+          'regular-sb/scene-1/app:app-root/component-1:custom-root/aat',
+          'regular-sb/scene-1/app:app-root/component-2',
+          'regular-sb/scene-2',
+          'regular-sb/scene-2/app-2',
+          'regular-sb/scene-2/app-2:app-root',
+          'regular-sb/scene-2/app-2:app-root/component-1',
+          'regular-sb/scene-2/app-2:app-root/component-2',
         ])
 
         await doBasicDrag(
           editor,
-          EP.fromString('sb/scene/app-2'),
-          EP.fromString('sb/scene/app:app-root/component-1:custom-root/hello-1'),
+          EP.fromString('sb/scene-2/app-2'),
+          EP.fromString('sb/scene-1/app:app-root/component-1:custom-root/hello-1'),
         )
         await editor.getDispatchFollowUpActionsFinished()
 


### PR DESCRIPTION
**Problem:**
Scenes are only meant to automatically focus a child component when it is the only child of the scene, but we are instead auto focusing all children of scenes.

**Fix:**
Include a check that the child of a scene is the only child inside the logic for determining the `validPaths` (which is in turn used to determine which elements are selectable and should have metadata recorded).

I've added some tests to ensure that we're not incorrectly auto-focusing multiple children of a scene or children of the storyboard by checking which element is selected when holding `cmd` whilst clicking.