### PR TITLE
Show range correctly on selection change.

### DIFF
--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -484,9 +484,7 @@ function revealRangeIfPossibleInVisibleEditor(boundsInFile: BoundsInFile): void 
   )
   if (visibleEditor != null) {
     const rangeToReveal = getVSCodeRangeForScrolling(boundsInFile)
-    const alreadyVisible = visibleEditor.visibleRanges.some((r) =>
-      r.contains(visibleEditor.selection),
-    )
+    const alreadyVisible = visibleEditor.visibleRanges.some((r) => r.contains(rangeToReveal))
 
     const selectionRange = getVSCodeRange(boundsInFile)
     const newSelection = new vscode.Selection(selectionRange.start, selectionRange.start) // selectionRange.end?


### PR DESCRIPTION
**Problem:**
Sometimes VS Code wouldn't scroll to the right location on selection change.

**Cause:**
The range to reveal wasn't being used to check to see if it was visible.

**Fix:**
Use the range to reveal when checking to see if that range is visible.

**Commit Details:**
- When checking if the range is visible, use the range to reveal instead of the current editor selection.
