### PR TITLE
Generate new uid for each property set by the inspector

### DIFF
--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -139,6 +139,7 @@ import { modify } from '../../core/shared/optics/optic-utilities'
 import { Optic } from '../../core/shared/optics/optics'
 import { fromField } from '../../core/shared/optics/optic-creators'
 import { memoEqualityCheckAnalysis } from '../../utils/react-performance'
+import { DuplicateUIDsResult, getAllUniqueUids } from '../../core/model/get-unique-ids'
 
 // eslint-disable-next-line no-unused-expressions
 typeof process !== 'undefined' &&
@@ -172,6 +173,11 @@ const FailJestOnCanvasError = () => {
   return null
 }
 
+type ActionsCausingDuplicateUIDs = Array<{
+  actions: ReadonlyArray<EditorAction>
+  duplicateUIDs: DuplicateUIDsResult
+}>
+
 export interface EditorRenderResult {
   dispatch: (
     actions: ReadonlyArray<EditorAction>,
@@ -188,6 +194,7 @@ export interface EditorRenderResult {
   clearRecordedActions: () => void
   getRecordedActions: () => ReadonlyArray<EditorAction>
   getDomWalkerState: () => DomWalkerMutableStateData
+  getActionsCausingDuplicateUIDs: () => ActionsCausingDuplicateUIDs
 }
 
 function formatAllCodeInModel(model: PersistentModel): PersistentModel {
@@ -250,6 +257,7 @@ export async function renderTestEditorWithModel(
   const model = formatAllCodeInModel(rawModel)
   const renderCountBaseline = renderCount
   let recordedActions: Array<EditorAction> = []
+  let actionsCausingDuplicateUIDs: ActionsCausingDuplicateUIDs = []
 
   let emptyEditorState = createEditorState(NO_OP)
   const derivedState = deriveState(emptyEditorState, null)
@@ -284,6 +292,14 @@ export async function renderTestEditorWithModel(
       spyCollector,
       innerStrategiesToUse,
     )
+
+    const duplicateUIDs = getAllUniqueUids(result.patchedEditor.projectContents).duplicateIDs
+    if (Object.keys(duplicateUIDs).length > 0) {
+      actionsCausingDuplicateUIDs.push({
+        actions: actions,
+        duplicateUIDs: duplicateUIDs,
+      })
+    }
 
     const anyWorkerUpdates = actions.some((action) => action.action === 'UPDATE_FROM_WORKER')
     const anyUndoOrRedo = actions.some(
@@ -509,6 +525,7 @@ label {
     },
     getRecordedActions: () => recordedActions,
     getDomWalkerState: () => domWalkerMutableState,
+    getActionsCausingDuplicateUIDs: () => actionsCausingDuplicateUIDs,
   }
 }
 

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -52,6 +52,7 @@ import {
   ConditionalsControlSectionOpenTestId,
   ConditionalsControlSwitchBranchesTestId,
 } from '../sections/layout-section/conditional-section'
+import { getAllUniqueUids } from '../../../core/model/get-unique-ids'
 async function getControl(
   controlTestId: string,
   renderedDOM: RenderResult,
@@ -386,6 +387,11 @@ describe('inspector tests with real metadata', () => {
       rightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
       `"multiselect-identical-unset"`,
     )
+
+    // Ensure that changing a value during multiselect doesn't cause duplicate UIDs
+    await setControlValue('position-top-number-input', '10', renderResult.renderedDOM)
+    await renderResult.getDispatchFollowUpActionsFinished()
+    expect(renderResult.getActionsCausingDuplicateUIDs().length).toEqual(0)
   })
   it('TLBR layout controls', async () => {
     const renderResult = await renderTestEditorWithCode(

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -52,7 +52,7 @@ import {
   ConditionalsControlSectionOpenTestId,
   ConditionalsControlSwitchBranchesTestId,
 } from '../sections/layout-section/conditional-section'
-import { getAllUniqueUids } from '../../../core/model/get-unique-ids'
+
 async function getControl(
   controlTestId: string,
   renderedDOM: RenderResult,

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -125,9 +125,9 @@ export interface InspectorCallbackContextData {
   onSubmitValue: (newValue: any, propertyPath: PropertyPath, transient: boolean) => void
   onUnsetValue: (propertyPath: PropertyPath | Array<PropertyPath>, transient: boolean) => void
   collectActionsToSubmitValue: (
-    newValue: any,
     propertyPath: PropertyPath,
     transient: boolean,
+    newValuePrinter: () => any,
   ) => Array<EditorAction>
   collectActionsToUnsetValue: (
     propertyPath: PropertyPath | Array<PropertyPath>,
@@ -400,9 +400,9 @@ export function useInspectorContext(): {
     transient: boolean,
   ) => void
   collectActionsToSubmitValue: (
-    newValue: any,
     propertyPath: PropertyPath,
     transient: boolean,
+    newValuePrinter: () => any,
   ) => Array<EditorAction>
   collectActionsToUnsetValue: (
     propertyPath: PropertyPath | Array<PropertyPath>,
@@ -616,9 +616,9 @@ function useCreateOnSubmitValue<P extends ParsedPropertiesKeys, T = ParsedProper
   pathMappingFn: PathMappingFn<P>,
   target: readonly string[],
   collectActionsToSubmitValue: (
-    newValue: any,
     propertyPath: PropertyPath,
     transient: boolean,
+    newValuePrinter: () => any,
   ) => Array<EditorAction>,
   collectActionsToUnsetValue: (
     propertyPath: PropertyPath | Array<PropertyPath>,
@@ -634,8 +634,11 @@ function useCreateOnSubmitValue<P extends ParsedPropertiesKeys, T = ParsedProper
         const propertyPath = pathMappingFn(propKey, target)
         const valueToPrint = untransformedValue[propKey]
         if (valueToPrint != null) {
-          const printedProperty = printCSSValue(propKey, valueToPrint as ParsedProperties[P])
-          actions.push(...collectActionsToSubmitValue(printedProperty, propertyPath, transient))
+          actions.push(
+            ...collectActionsToSubmitValue(propertyPath, transient, () =>
+              printCSSValue(propKey, valueToPrint as ParsedProperties[P]),
+            ),
+          )
         } else {
           actions.push(...collectActionsToUnsetValue(propertyPath, transient))
         }

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -750,10 +750,10 @@ export const InspectorContextProvider = React.memo<{
   )
 
   const collectActionsToSubmitValue = React.useCallback(
-    (newValue: JSExpression, path: PropertyPath, transient: boolean): Array<EditorAction> => {
+    (path: PropertyPath, transient: boolean, newValuePrinter: () => any): Array<EditorAction> => {
       const actionsArray = [
         ...refElementsToTargetForUpdates.current.map((elem) => {
-          return setProp_UNSAFE(elem, path, newValue)
+          return setProp_UNSAFE(elem, path, newValuePrinter())
         }),
       ]
       return transient

--- a/editor/src/core/model/get-unique-ids.ts
+++ b/editor/src/core/model/get-unique-ids.ts
@@ -9,9 +9,11 @@ import { emptySet } from '../shared/set-utils'
 import { assertNever, fastForEach } from '../shared/utils'
 import Utils from '../../utils/utils'
 
+export type DuplicateUIDsResult = { [key: string]: Array<Array<string>> }
+
 interface GetAllUniqueUIDsResult {
   uniqueIDs: Array<string>
-  duplicateIDs: { [key: string]: Array<Array<string>> }
+  duplicateIDs: DuplicateUIDsResult
   allIDs: Array<string>
 }
 


### PR DESCRIPTION
**Problem:**
Since we have added UIDs to all attributes, along with a check for duplicate UIDs, we are now triggering a duplicate UIDs error when multiselecting elements and setting a value via the Inspector.

**Fix:**
The problem here is that we create a single `JSExpressionValue` upfront once (at which point we generate the random UID) via a printer function (printers are the internal term used in the Inspector code for constructing the parsed model value from a css value), and then use that to set the attribute on all of the selected elements. To fix this, I've changed the function `collectActionsToSubmitValue` used by the Inspector's property path hooks to take a value printer rather than the final value itself, meaning that each generated action will be creating a new `JSExpressionValue`, and therefore generating a new UID for each.