### PR TITLE
Text only conditionals parsed as conditionals

### DIFF
--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
@@ -84,6 +84,26 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
       expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e/cond')
     })
+    it('Entering text edit mode with double click on conditional with expression in both branches', async () => {
+      const editor = await renderTestEditorWithCode(
+        project(`{
+        // @utopia/uid=cond
+        true ? 'Hello' : Utopia
+      }`),
+        'await-first-dom-report',
+      )
+      await selectElement(editor, EP.fromString('sb/39e/cond'))
+      await clickOnElement(editor, 'div', 'double-click')
+      // wait for the next frame
+      await wait(1)
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
+      expect(
+        EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
+      ).toEqual('sb/39e/cond')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e/cond')
+    })
     it('Can not entering text edit mode with double click on conditional with expression in active branch when there is sibling', async () => {
       const editor = await renderTestEditorWithCode(
         project(`{

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4745,9 +4745,11 @@ export const UPDATE_FNS = {
     // if the edited element is a js expression AND the content is still between curly brackets after editing,
     // just save it as an expression, otherwise save it as text content
     const isActionTextExpression =
+      (textProp === 'itself' || textProp === 'whenTrue' || textProp === 'whenFalse') &&
       action.text.length > 1 &&
       action.text[0] === '{' &&
       action.text[action.text.length - 1] === '}'
+
     const withUpdatedText = (() => {
       if (textProp === 'child') {
         return modifyOpenJsxElementOrConditionalAtPath(
@@ -4784,6 +4786,15 @@ export const UPDATE_FNS = {
             } else {
               return jsExpressionValue(action.text, comments, element.uid)
             }
+          },
+          editorStore.unpatchedEditor,
+        )
+      } else if (textProp === 'fullConditional') {
+        return modifyOpenJsxChildAtPath(
+          action.target,
+          () => {
+            // the whole expression will be reparsed again so we can just save it as a text block
+            return jsxTextBlock(action.text)
           },
           editorStore.unpatchedEditor,
         )

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -1713,12 +1713,16 @@ describe('conditionals in the navigator', () => {
         ),
       ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
     regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/46a~~~1
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/46a~~~2
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/46a~~~3
-    regular-utopia-storyboard-uid/scene-aaa/a59~~~1
-    regular-utopia-storyboard-uid/scene-aaa/a59~~~2
-    regular-utopia-storyboard-uid/scene-aaa/a59~~~3
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional-true-case
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/33d~~~1
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/33d~~~2
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/33d~~~3
+        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional-false-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional/a25-attribute
+    regular-utopia-storyboard-uid/scene-aaa/46a~~~1
+    regular-utopia-storyboard-uid/scene-aaa/46a~~~2
+    regular-utopia-storyboard-uid/scene-aaa/46a~~~3
     regular-utopia-storyboard-uid/scene-aaa/hey`)
     })
     it('keeps the right order for inlined expressions with multiple values (not-null inactive branch)', async () => {

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -955,6 +955,58 @@ describe('Use the text editor', () => {
       )
       expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('hi')
     })
+    it('editing the full conditional from the selected conditional (to a non-conditional)', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          true ? 'hello' : 'utopia'
+        }`),
+        'await-first-dom-report',
+      )
+
+      await editor.dispatch([selectComponents([EP.fromString('sb/39e/cond')], false)], true)
+      await pressKey('enter')
+      await editor.getDispatchFollowUpActionsFinished()
+
+      typeText('hi')
+      await closeTextEditor()
+
+      await editor.getDispatchFollowUpActionsFinished()
+      await wait(50)
+
+      expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(projectWithSnippet('hi'))
+      expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('hi')
+    })
+    it('editing the full conditional from the selected conditional (keeping it a conditional)', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          true ? 'hello' : 'utopia'
+        }`),
+        'await-first-dom-report',
+      )
+
+      await editor.dispatch([selectComponents([EP.fromString('sb/39e/cond')], false)], true)
+      await pressKey('enter')
+      await editor.getDispatchFollowUpActionsFinished()
+
+      typeText(`{
+        // @utopia/uid=cond
+        true ? 'hi' : 'utopia'
+      }`)
+      await closeTextEditor()
+
+      await editor.getDispatchFollowUpActionsFinished()
+      await wait(50)
+
+      expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          true ? 'hi' : 'utopia'
+        }`),
+      )
+      expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('hi')
+    })
     it('editing is not allowed with siblings', async () => {
       const editor = await renderTestEditorWithCode(
         projectWithSnippet(`{

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -42,7 +42,7 @@ import { assertNever } from '../../core/shared/utils'
 
 export const TextEditorSpanId = 'text-editor'
 
-export type TextProp = 'itself' | 'child' | 'whenTrue' | 'whenFalse'
+export type TextProp = 'itself' | 'child' | 'whenTrue' | 'whenFalse' | 'fullConditional'
 
 export interface TextEditorProps {
   elementPath: ElementPath
@@ -74,6 +74,7 @@ export function escapeHTML(s: string, textProp: TextProp): string {
       // restore br tags
       return encoded.replace(/\n/g, '\n<br />')
     case 'itself':
+    case 'fullConditional':
     case 'whenTrue':
     case 'whenFalse':
       return encoded

--- a/editor/src/core/workers/parser-printer/parser-printer-conditionals.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-conditionals.spec.ts
@@ -171,7 +171,7 @@ describe('Conditonals JSX printer', () => {
   })
 })
 
-describe('Conditional elements either parse as conditional or ATTRIBUTE_OTHER_JAVASCRIPT', () => {
+describe('Conditional elements are parse as conditionals', () => {
   it('both branches are regular strings', () => {
     const code = createCode(`
       {
@@ -183,24 +183,10 @@ describe('Conditional elements either parse as conditional or ATTRIBUTE_OTHER_JA
     `)
     const parseResult = testParseCode(code)
 
-    expectOtherJavascriptAsChild(parseResult)
+    expectConditionalExpressionAsChild(parseResult)
   })
 
-  it('both branches are regular strings parse as text', () => {
-    const code = createCode(`
-      {
-        // @utopia/uid=conditional1
-        isTrue
-        ? 'The book is sealed'
-        : 'The book has been unsealed'
-      }
-    `)
-    const parseResult = testParseCode(code)
-
-    expectOtherJavascriptAsChild(parseResult)
-  })
-
-  it('one string, one null parses as text', () => {
+  it('one string, one null', () => {
     const code = createCode(`
       {
         // @utopia/uid=conditional1
@@ -211,10 +197,10 @@ describe('Conditional elements either parse as conditional or ATTRIBUTE_OTHER_JA
     `)
     const parseResult = testParseCode(code)
 
-    expectOtherJavascriptAsChild(parseResult)
+    expectConditionalExpressionAsChild(parseResult)
   })
 
-  it('one null, one string parses as text', () => {
+  it('one null, one string', () => {
     const code = createCode(`
       {
         // @utopia/uid=conditional1
@@ -225,7 +211,7 @@ describe('Conditional elements either parse as conditional or ATTRIBUTE_OTHER_JA
     `)
     const parseResult = testParseCode(code)
 
-    expectOtherJavascriptAsChild(parseResult)
+    expectConditionalExpressionAsChild(parseResult)
   })
 
   it('both null parses as a full conditional expression with slots', () => {
@@ -253,7 +239,7 @@ describe('Conditional elements either parse as conditional or ATTRIBUTE_OTHER_JA
     `)
     const parseResult = testParseCode(code)
 
-    expectOtherJavascriptAsChild(parseResult)
+    expectConditionalExpressionAsChild(parseResult)
   })
 
   it('one string, one template string literal parse as text', () => {
@@ -267,10 +253,10 @@ describe('Conditional elements either parse as conditional or ATTRIBUTE_OTHER_JA
     `)
     const parseResult = testParseCode(code)
 
-    expectOtherJavascriptAsChild(parseResult)
+    expectConditionalExpressionAsChild(parseResult)
   })
 
-  it('one template literal, one string parses as text', () => {
+  it('one template literal, one string', () => {
     const code = createCode(`
       {
         // @utopia/uid=conditional1
@@ -281,7 +267,7 @@ describe('Conditional elements either parse as conditional or ATTRIBUTE_OTHER_JA
     `)
     const parseResult = testParseCode(code)
 
-    expectOtherJavascriptAsChild(parseResult)
+    expectConditionalExpressionAsChild(parseResult)
   })
 
   it('two template literals, both use vars parse as text', () => {
@@ -295,7 +281,7 @@ describe('Conditional elements either parse as conditional or ATTRIBUTE_OTHER_JA
     `)
     const parseResult = testParseCode(code)
 
-    expectOtherJavascriptAsChild(parseResult)
+    expectConditionalExpressionAsChild(parseResult)
   })
 
   it('string and var parse as text', () => {
@@ -309,7 +295,7 @@ describe('Conditional elements either parse as conditional or ATTRIBUTE_OTHER_JA
     `)
     const parseResult = testParseCode(code)
 
-    expectOtherJavascriptAsChild(parseResult)
+    expectConditionalExpressionAsChild(parseResult)
   })
 
   it('string and span parse as full conditional', () => {
@@ -375,7 +361,7 @@ describe('Conditional elements either parse as conditional or ATTRIBUTE_OTHER_JA
     expectConditionalExpressionAsChild(parseResult)
   })
 
-  it('string and string-only nested conditional parses as text', () => {
+  it('string and string-only nested conditional', () => {
     const code = createCode(`
       {
         // @utopia/uid=conditional1
@@ -388,10 +374,10 @@ describe('Conditional elements either parse as conditional or ATTRIBUTE_OTHER_JA
     `)
     const parseResult = testParseCode(code)
 
-    expectOtherJavascriptAsChild(parseResult)
+    expectConditionalExpressionAsChild(parseResult)
   })
 
-  it('string and div-containing nested conditional parses as text', () => {
+  it('string and div-containing nested conditional', () => {
     const code = createCode(`
       {
         // @utopia/uid=conditional1
@@ -407,7 +393,7 @@ describe('Conditional elements either parse as conditional or ATTRIBUTE_OTHER_JA
     expectConditionalExpressionAsChild(parseResult)
   })
 
-  it('string and number parses as text', () => {
+  it('string and number', () => {
     const code = createCode(`
       {
         // @utopia/uid=conditional1
@@ -418,7 +404,7 @@ describe('Conditional elements either parse as conditional or ATTRIBUTE_OTHER_JA
     `)
     const parseResult = testParseCode(code)
 
-    expectOtherJavascriptAsChild(parseResult)
+    expectConditionalExpressionAsChild(parseResult)
   })
 })
 

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -2519,51 +2519,6 @@ export function parseOutJSXElements(
       : expression.whenFalse
     const whenFalseBlock = parseClause(innerWhenFalse)
 
-    const parseAsFullConditionalExpression = (() => {
-      const trueBlockJsxElementLike =
-        isRight(whenTrueBlock) && isJSXElementLike(whenTrueBlock.value.value)
-      const trueBlockConditionalExpression =
-        isRight(whenTrueBlock) && isJSXConditionalExpression(whenTrueBlock.value.value)
-      const falseBlockJsxElementLike =
-        isRight(whenFalseBlock) && isJSXElementLike(whenFalseBlock.value.value)
-      const falseBlockConditionalExpression =
-        isRight(whenFalseBlock) && isJSXConditionalExpression(whenFalseBlock.value.value)
-      const trueBlockNull =
-        isRight(whenTrueBlock) &&
-        isJSXAttributeValue(whenTrueBlock.value.value) &&
-        whenTrueBlock.value.value.value == null
-
-      const falseBlockNull =
-        isRight(whenFalseBlock) &&
-        isJSXAttributeValue(whenFalseBlock.value.value) &&
-        whenFalseBlock.value.value.value == null
-
-      if (
-        trueBlockJsxElementLike ||
-        trueBlockConditionalExpression ||
-        falseBlockJsxElementLike ||
-        falseBlockConditionalExpression
-      ) {
-        // if either branches are element-like or recursive conditional expression, let's show the full navigator
-        return true
-      }
-      if (trueBlockNull && falseBlockNull) {
-        // if both branches are null, let's show the full navigator so we expose slots
-        return true
-      }
-
-      // otherwise, parse as ATTRIBUTE_OTHER_JAVASCRIPT so we can show it as an inline expression in text content
-      return false
-    })()
-
-    if (!parseAsFullConditionalExpression) {
-      // instead of parsing as conditional, return the value as ATTRIBUTE_OTHER_JAVASCRIPT so we can show it as an inline expression in text content
-      return mapEither(
-        (e) => withParserMetadata(e, {}, [], []),
-        produceArbitraryBlockFromExpression(expression),
-      )
-    }
-
     return applicative3Either<
       string,
       WithParserMetadata<JSExpression>,


### PR DESCRIPTION
**Problem:**
We wanted text only conditionals to be fully text editable, so when you have a conditional like `{ true ? 'hello' : 'utopia }`, we wanted the text editor to show the full conditional code instead of just the active branch.
A solution for this was to not parse these text only conditionals as conditionals, but as ATTRIBUTE_OTHER_JAVASCRIPT expressions. These expressions are text editable anyway, so that solved the issue.

However, it became really clear that it is unpredictable for the users that some conditionals appear as conditionals in the navigator, others as expressions, and the whole thing is just really confusing.

**Fix:**
I wanted to keep the advantage that text only conditionals are text editable, but at the same time I wanted all conditionals to be parsed as conditionals, so you can see them in the navigator (and even text edit their branch separately).

The solution was to add a new kind of `textProp` to the text editor, the `fullConditional`. In this mode the text editor can edit the full conditional code and save back in the project. The element renderer decides whether this conditional should only provide text editing for its active branch (when the inactive branch is not just an expression, but e.g. a jsx element), or the full conditional code.

After save we reparse the full project, so it is not a problem if the user modified the conditional code in a way that it is not a conditional anymore.

For the note, we can also decide the provide full conditional text editing for all conditionals - I was just afraid of potentially huge jsx code inside the text editor, so I did not want to go this far. But later we can make this decision more explicit, we could even provide UI to the user to switch between the different text edit modes.

