### PR TITLE
Identify auto-focusable scenes.

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/scene-label.tsx
@@ -53,6 +53,20 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
   const colorTheme = useColorTheme()
   const dispatch = useDispatch()
 
+  const sceneHasSingleChild = useEditorState(
+    Substores.metadata,
+    (store) => {
+      return (
+        MetadataUtils.getChildrenOrdered(
+          store.editor.jsxMetadata,
+          store.editor.elementPathTree,
+          props.target,
+        ).length === 1
+      )
+    },
+    'SceneLabel sceneHasSingleChild',
+  )
+
   const labelSelectable = useEditorState(
     Substores.restOfEditor,
     (store) => !store.editor.keysPressed['z'],
@@ -196,7 +210,9 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
           className='roleComponentName'
           style={{
             pointerEvents: labelSelectable ? 'initial' : 'none',
-            color: colorTheme.subduedForeground.value,
+            color: sceneHasSingleChild
+              ? colorTheme.componentPurple.value
+              : colorTheme.subduedForeground.value,
             position: 'absolute',
             fontWeight: 600,
             left: frame.x,

--- a/editor/src/components/canvas/controls/select-mode/scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/scene-label.tsx
@@ -14,6 +14,7 @@ import { boundingArea, createInteractionViaMouse } from '../../canvas-strategies
 import { windowToCanvasCoordinates } from '../../dom-lookup'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 import { isSelectModeWithArea } from '../../../editor/editor-modes'
+import { getSubTree } from '../../../../core/shared/element-path-tree'
 
 interface SceneLabelControlProps {
   maybeHighlightOnHover: (target: ElementPath) => void
@@ -56,13 +57,12 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
   const sceneHasSingleChild = useEditorState(
     Substores.metadata,
     (store) => {
-      return (
-        MetadataUtils.getChildrenOrdered(
-          store.editor.jsxMetadata,
-          store.editor.elementPathTree,
-          props.target,
-        ).length === 1
-      )
+      const subTree = getSubTree(store.editor.elementPathTree, props.target)
+      if (subTree == null) {
+        return false
+      } else {
+        return subTree.children.length === 1
+      }
     },
     'SceneLabel sceneHasSingleChild',
   )


### PR DESCRIPTION
**Change:**
For those scenes which are auto-focusable (where they have a single component as a child), indicate they are such with a change in the colour of the label.

**Commit Details:**
- `SceneLabel` now changes the colour of the label dependent on how many children it has.