### PR TITLE
Easier un-focusing of focused components

### DIFF
--- a/editor/src/components/canvas/canvas.ts
+++ b/editor/src/components/canvas/canvas.ts
@@ -144,7 +144,7 @@ const Canvas = {
       case 1:
         // Only a single element is selected...
         const parentPath = EP.parentPath(selectedViews[0])
-        if (parentPath == null) {
+        if (EP.isEmptyPath(parentPath)) {
           // ...the selected element is a top level one, so deselect.
           return 'CLEAR'
         }

--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
@@ -1106,6 +1106,258 @@ describe('Storyboard auto-focusing', () => {
   })
 })
 
+describe('Select mode focusing and un-focusing', () => {
+  it('Double clicking an unselected component will focus it', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectScene2Children,
+      'await-first-dom-report',
+    )
+
+    const cardSpan1 = renderResult.renderedDOM.getByTestId('card-span-1')
+    const cardSpan1Bounds = cardSpan1.getBoundingClientRect()
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    await createDoubleClicker(
+      canvasControlsLayer,
+      cardSpan1Bounds.left + 2,
+      cardSpan1Bounds.top + 2,
+    )()
+
+    // Check that double clicking focused the element
+    checkFocusedPath(renderResult, EP.fromString('sb/sc-cards/card1'))
+    checkSelectedPaths(renderResult, [EP.fromString('sb/sc-cards/card1:card1-root/card1-div')])
+  })
+
+  it('Double clicking a selected component will focus it', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectScene2Children,
+      'await-first-dom-report',
+    )
+
+    const cardSpan1 = renderResult.renderedDOM.getByTestId('card-span-1')
+    const cardSpan1Bounds = cardSpan1.getBoundingClientRect()
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    await fireSingleClickEvents(
+      canvasControlsLayer,
+      cardSpan1Bounds.left + 2,
+      cardSpan1Bounds.top + 2,
+      cmdModifier,
+    )
+
+    // Ensure that the selected element is neither auto-focused nor explicitly focused (so we can only select the instance)
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [EP.fromString('sb/sc-cards/card1')])
+
+    await createDoubleClicker(
+      canvasControlsLayer,
+      cardSpan1Bounds.left + 2,
+      cardSpan1Bounds.top + 2,
+    )()
+
+    // Check that double clicking focused the element
+    checkFocusedPath(renderResult, EP.fromString('sb/sc-cards/card1'))
+    checkSelectedPaths(renderResult, [EP.fromString('sb/sc-cards/card1:card1-root/card1-div')])
+  })
+
+  it('Clearing the selection or selecting a different element will not clear the focused path', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectScene2Children,
+      'await-first-dom-report',
+    )
+
+    const cardSpan1 = renderResult.renderedDOM.getByTestId('card-span-1')
+    const cardSpan1Bounds = cardSpan1.getBoundingClientRect()
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    await createDoubleClicker(
+      canvasControlsLayer,
+      cardSpan1Bounds.left + 2,
+      cardSpan1Bounds.top + 2,
+    )()
+
+    // Ensure the component was selected and focused
+    checkFocusedPath(renderResult, EP.fromString('sb/sc-cards/card1'))
+    checkSelectedPaths(renderResult, [EP.fromString('sb/sc-cards/card1:card1-root/card1-div')])
+
+    // Select a different element
+    const cardSpan2 = renderResult.renderedDOM.getByTestId('card-span-2')
+    const cardSpan2Bounds = cardSpan2.getBoundingClientRect()
+
+    await fireSingleClickEvents(
+      canvasControlsLayer,
+      cardSpan2Bounds.left + 2,
+      cardSpan2Bounds.top + 2,
+      cmdModifier,
+    )
+
+    // Check that a different element was selected without clearing the focused path
+    checkFocusedPath(renderResult, EP.fromString('sb/sc-cards/card1'))
+    checkSelectedPaths(renderResult, [EP.fromString('sb/sc-cards/card2')])
+
+    // Click the empty space on the canvas
+    await fireSingleClickEvents(canvasControlsLayer, -10, -10)
+
+    // Check that the selection was cleared without clearing the focused path
+    checkFocusedPath(renderResult, EP.fromString('sb/sc-cards/card1'))
+    checkSelectedPaths(renderResult, [])
+  })
+
+  it('Clearing the selection and clicking the empty canvas space will clear the focused path', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectScene2Children,
+      'await-first-dom-report',
+    )
+
+    const cardSpan1 = renderResult.renderedDOM.getByTestId('card-span-1')
+    const cardSpan1Bounds = cardSpan1.getBoundingClientRect()
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    await createDoubleClicker(
+      canvasControlsLayer,
+      cardSpan1Bounds.left + 2,
+      cardSpan1Bounds.top + 2,
+    )()
+
+    // Ensure the component was selected and focused
+    checkFocusedPath(renderResult, EP.fromString('sb/sc-cards/card1'))
+    checkSelectedPaths(renderResult, [EP.fromString('sb/sc-cards/card1:card1-root/card1-div')])
+
+    // Click the empty space on the canvas
+    await fireSingleClickEvents(canvasControlsLayer, -10, -10)
+
+    // Check that the selection was cleared without clearing the focused path
+    checkFocusedPath(renderResult, EP.fromString('sb/sc-cards/card1'))
+    checkSelectedPaths(renderResult, [])
+
+    // Click the empty space on the canvas again
+    await fireSingleClickEvents(canvasControlsLayer, -10, -10)
+
+    // Check that the focused path has now been cleared
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [])
+  })
+
+  it('Pressing esc when nothing is selected will clear the focused path', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectScene2Children,
+      'await-first-dom-report',
+    )
+
+    const cardSpan1 = renderResult.renderedDOM.getByTestId('card-span-1')
+    const cardSpan1Bounds = cardSpan1.getBoundingClientRect()
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    await createDoubleClicker(
+      canvasControlsLayer,
+      cardSpan1Bounds.left + 2,
+      cardSpan1Bounds.top + 2,
+    )()
+
+    // Ensure the component was selected and focused
+    checkFocusedPath(renderResult, EP.fromString('sb/sc-cards/card1'))
+    checkSelectedPaths(renderResult, [EP.fromString('sb/sc-cards/card1:card1-root/card1-div')])
+
+    // Click the empty space on the canvas
+    await fireSingleClickEvents(canvasControlsLayer, -10, -10)
+
+    // Check that the selection was cleared without clearing the focused path
+    checkFocusedPath(renderResult, EP.fromString('sb/sc-cards/card1'))
+    checkSelectedPaths(renderResult, [])
+
+    // Press the escape key
+    await pressKey('Escape')
+
+    // Check that the focused path has now been cleared
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [])
+  })
+
+  it('Pressing esc when a different element is selected will not clear the focused path', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectScene2Children,
+      'await-first-dom-report',
+    )
+
+    const cardSpan1 = renderResult.renderedDOM.getByTestId('card-span-1')
+    const cardSpan1Bounds = cardSpan1.getBoundingClientRect()
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    await createDoubleClicker(
+      canvasControlsLayer,
+      cardSpan1Bounds.left + 2,
+      cardSpan1Bounds.top + 2,
+    )()
+
+    // Ensure the component was selected and focused
+    checkFocusedPath(renderResult, EP.fromString('sb/sc-cards/card1'))
+    checkSelectedPaths(renderResult, [EP.fromString('sb/sc-cards/card1:card1-root/card1-div')])
+
+    // Select a different element
+    const cardSpan2 = renderResult.renderedDOM.getByTestId('card-span-2')
+    const cardSpan2Bounds = cardSpan2.getBoundingClientRect()
+
+    await fireSingleClickEvents(
+      canvasControlsLayer,
+      cardSpan2Bounds.left + 2,
+      cardSpan2Bounds.top + 2,
+      cmdModifier,
+    )
+
+    // Check that a different element was selected without clearing the focused path
+    checkFocusedPath(renderResult, EP.fromString('sb/sc-cards/card1'))
+    checkSelectedPaths(renderResult, [EP.fromString('sb/sc-cards/card2')])
+
+    // Press the escape key
+    await pressKey('Escape')
+
+    // Check that the selection was updated without clearing the focused path
+    checkFocusedPath(renderResult, EP.fromString('sb/sc-cards/card1'))
+    checkSelectedPaths(renderResult, [EP.fromString('sb/sc-cards')])
+  })
+
+  it('Pressing esc when a focused element is selected will clear the focused path', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectScene2Children,
+      'await-first-dom-report',
+    )
+
+    const cardSpan1 = renderResult.renderedDOM.getByTestId('card-span-1')
+    const cardSpan1Bounds = cardSpan1.getBoundingClientRect()
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    await createDoubleClicker(
+      canvasControlsLayer,
+      cardSpan1Bounds.left + 2,
+      cardSpan1Bounds.top + 2,
+    )()
+
+    // Ensure the component was selected and focused
+    checkFocusedPath(renderResult, EP.fromString('sb/sc-cards/card1'))
+    checkSelectedPaths(renderResult, [EP.fromString('sb/sc-cards/card1:card1-root/card1-div')])
+
+    // Keep pressing the esc key until we have worked our way up the hierarchy to the focused path
+    await pressKey('Escape')
+    checkFocusedPath(renderResult, EP.fromString('sb/sc-cards/card1'))
+    checkSelectedPaths(renderResult, [EP.fromString('sb/sc-cards/card1:card1-root')])
+    await pressKey('Escape')
+    checkFocusedPath(renderResult, EP.fromString('sb/sc-cards/card1'))
+    checkSelectedPaths(renderResult, [EP.fromString('sb/sc-cards/card1')])
+
+    // Now pressing it again should clear the focused path without changing the selection
+    await pressKey('Escape')
+    checkFocusedPath(renderResult, null)
+    checkSelectedPaths(renderResult, [EP.fromString('sb/sc-cards/card1')])
+  })
+})
+
 describe('mouseup selection', () => {
   const MouseupTestProject = makeTestProjectCodeWithSnippet(`
       <div

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -500,6 +500,7 @@ import {
   openCodeEditorFile,
   removeToast,
   selectComponents,
+  setFocusedElement,
   setPackageStatus,
   setPropWithElementPath_UNSAFE,
   setScrollAnimation,
@@ -2076,7 +2077,7 @@ export const UPDATE_FNS = {
   },
   CLEAR_SELECTION: (editor: EditorModel): EditorModel => {
     if (editor.selectedViews.length === 0) {
-      return editor
+      return UPDATE_FNS.SET_FOCUSED_ELEMENT(setFocusedElement(null), editor)
     }
 
     return {
@@ -4883,7 +4884,7 @@ export const UPDATE_FNS = {
   SET_FOCUSED_ELEMENT: (action: SetFocusedElement, editor: EditorModel): EditorModel => {
     let shouldApplyChange: boolean = false
     if (action.focusedElementPath == null) {
-      shouldApplyChange = true
+      shouldApplyChange = editor.focusedElementPath != null
     } else if (MetadataUtils.isFocusableComponent(action.focusedElementPath, editor.jsxMetadata)) {
       shouldApplyChange = true
     }

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -161,7 +161,7 @@ import {
   zeroCanvasPoint,
   zeroCanvasRect,
 } from '../../core/shared/math-utils'
-import { parentPath } from '../../core/shared/element-path'
+import * as EP from '../../core/shared/element-path'
 import { mapDropNulls } from '../../core/shared/array-utils'
 import { optionalMap } from '../../core/shared/optional-utils'
 import { groupConversionCommands } from '../canvas/canvas-strategies/strategies/group-conversion-helpers'
@@ -485,7 +485,14 @@ export function handleKeyDown(
         } else if (editor.canvas.interactionSession != null) {
           return [CanvasActions.clearInteractionSession(false)]
         } else if (isSelectMode(editor.mode)) {
-          return jumpToParentActions(editor.selectedViews, editor.jsxMetadata)
+          const focusedElementSelected =
+            editor.selectedViews.length === 1 &&
+            EP.pathsEqual(editor.selectedViews[0], editor.focusedElementPath)
+          if (editor.selectedViews.length === 0 || focusedElementSelected) {
+            return [EditorActions.setFocusedElement(null)]
+          } else {
+            return jumpToParentActions(editor.selectedViews, editor.jsxMetadata)
+          }
         }
 
         // TODO: Move this around.


### PR DESCRIPTION
**Problem:**
When a component has been explicitly focused, the only way to un-focus it is via the "Exit editing component" in the Navigator's context menu.

**Fix:**
We used to un-focus a component when deselecting it, but that was far too eager, as often you'd want to keep the component focused whilst making other changes on the Canvas. There was also the idea to use the esc key to un-focus components, but that key is also used for jumping the current selection to the parent, which makes sense if the focused component isn't currently the selected element. So I've introduced 2 ways to un-focus a component:

1. If nothing is selected, clicking the empty canvas (which triggers a `CLEAR_SELECTION` action) will then clear the `focusedPath`. This means you can completely deselect the element without immediately un-focusing it.
2. If nothing is selected, hitting the esc key will clear the `focusedPath`.
3. If the focused element itself is selected, hitting the esc key will clear the `focusedPath`. This is so that we can still use esc to jump to the parent selection if any other element is selected. IMO this feels very intuitive, since if we always cleared the `focusedPath` when something else was selected the action would be invisible in a lot of cases (seeming like the editor was unresponsive), or jarring if it were noticed.

**Examples:**

1. Hitting esc repeatedly to move up through the hierarchy. Here the first `App` component has been focused, so as soon as we hit esc when it is selected we un-focus it:
![easier-unfocusing-1](https://github.com/concrete-utopia/utopia/assets/1044774/5e2c20f9-8f15-4018-be6d-a6343428605f)

2. Hitting esc when nothing has been selected. Again the `App` component has been focused, so hitting esc here will un-focus it:
![easier-unfocusing-2](https://github.com/concrete-utopia/utopia/assets/1044774/2409147e-3614-451e-948c-fcafe0baae75)

3. Selecting nothing, then clicking the empty canvas again. The first canvas click will just clear the selection, whereas the second will un-focus the `App` component (please ignore the styling of the `App` component in the Navigator - it should be styled to show that it is focused, but that is a separate known bug):
![easier-unfocusing-3](https://github.com/concrete-utopia/utopia/assets/1044774/52b4594e-e6e8-4907-b54d-6f546de60104)
