### PR TITLE
Fix/paste multiselect insertchildren

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/paste-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/paste-metastrategy.tsx
@@ -121,6 +121,7 @@ export function pasteStrategy(
                     intendedCoordinates: absolutePositionForPaste(
                       target.value,
                       currentValue.originalElementPath,
+                      elements.map((element) => element.originalElementPath),
                       {
                         originalTargetMetadata:
                           elementPasteWithMetadata.targetOriginalContextMetadata,

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -2871,6 +2871,16 @@ export var storyboard = (props) => {
                 <div data-uid='aae' style={{ width: 20, height: 20 }}/>
               </div>`,
           },
+          {
+            name: 'paste 2 absolute elements to the storyboard - elements will keep their position to each other',
+            input: `<div data-uid='root' style={{ contain: 'layout', width: '100%', height: '100%'}}>
+              <div data-uid='hello' style={{ position: 'absolute', top: 20, left: 50, contain: 'layout' }}>hello</div>
+              <div data-uid='bello' style={{ position: 'absolute', top: 30, left: 30, contain: 'layout' }}>bello</div>
+            </div>`,
+            targets: [makeTargetPath('root/hello'), makeTargetPath('root/bello')],
+            result: `<div data-uid='hel' style={{ position: 'absolute', top: 405.75, left: 586, contain: 'layout' }}>hello</div>
+            <div data-uid='bel' style={{ position: 'absolute', top: 415.75, left: 566, contain: 'layout' }}>bello</div>`,
+          },
         ]
 
         copyPasteToStoryboardTestCases.forEach((tt, idx) => {

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -1059,6 +1059,56 @@ describe('actions', () => {
       </React.Fragment>
 		`,
       },
+      {
+        name: 'a conditional clause with an element that doesnt support children',
+        startingCode: `
+        <div data-uid='root'>
+          {
+            // @utopia/uid=conditional
+            true ? <img data-uid='aaa' /> : null
+          }
+          <div data-uid='bbb'>bar</div>
+          <div data-uid='ccc'>baz</div>
+        </div>
+        `,
+        elements: (renderResult) => {
+          const path1 = EP.appendNewElementPath(TestScenePath, ['root', 'bbb'])
+          const path2 = EP.appendNewElementPath(TestScenePath, ['root', 'ccc'])
+          return [
+            {
+              element: getElementFromRenderResult(renderResult, path1),
+              originalElementPath: path1,
+              importsToAdd: {},
+            },
+            {
+              element: getElementFromRenderResult(renderResult, path2),
+              originalElementPath: path2,
+              importsToAdd: {},
+            },
+          ]
+        },
+        pasteInto: conditionalClauseInsertionPath(
+          EP.appendNewElementPath(TestScenePath, ['root', 'conditional']),
+          'true-case',
+          'wrap-with-fragment',
+        ),
+        want: `
+      <div data-uid='root'>
+        {
+          // @utopia/uid=conditional
+          true ? (
+            <React.Fragment>
+              <div data-uid='aad'>bar</div>
+              <div data-uid='aah'>baz</div>
+              <img data-uid='aaa'/>
+            </React.Fragment>
+          ) : null
+        }
+        <div data-uid='bbb'>bar</div>
+        <div data-uid='ccc'>baz</div>
+      </div>
+		`,
+      },
     ]
     tests.forEach((test, i) => {
       it(`${i + 1}/${tests.length} ${test.name}`, async () => {

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -2671,6 +2671,26 @@ export var storyboard = (props) => {
                 <h1 data-uid='bbb'>hello</h1>
               </div>`,
           },
+          {
+            name: 'paste 2 absolute elements - elements will keep their position to each other',
+            input: `<div data-uid='root' style={{ contain: 'layout', width: '100%', height: '100%'}}>
+              <div data-uid='ccc' style={{ contain: 'layout', position: 'absolute', top: 100, left: 100, height: 100, width: 100 }}>
+                <div data-uid='ddd' style={{ position: 'absolute', top: 10, left: 10 }}>hi</div>
+              </div>
+              <div data-uid='bbb' style={{ position: 'absolute', top: 20, left: 50, contain: 'layout' }}>hello</div>
+              <div data-uid='fff' style={{ position: 'absolute', top: 30, left: 30, contain: 'layout' }}>bello</div>
+            </div>`,
+            targets: [makeTargetPath('root/bbb'), makeTargetPath('root/fff')],
+            result: `<div data-uid='root' style={{ contain: 'layout', width: '100%', height: '100%'}}>
+              <div data-uid='ccc' style={{ contain: 'layout', position: 'absolute', top: 100, left: 100, height: 100, width: 100 }}>
+                <div data-uid='ddd' style={{ position: 'absolute', top: 10, left: 10 }}>hi</div>
+                <div data-uid='bbb' style={{ position: 'absolute', top: 36, left: 43, contain: 'layout' }}>hello</div>
+                <div data-uid='fff' style={{ position: 'absolute', top: 46, left: 23, contain: 'layout' }}>bello</div>
+              </div>
+              <div data-uid='bbb' style={{ position: 'absolute', top: 20, left: 50, contain: 'layout' }}>hello</div>
+              <div data-uid='fff' style={{ position: 'absolute', top: 30, left: 30, contain: 'layout' }}>bello</div>
+            </div>`,
+          },
         ]
 
         copyPasteLayoutTestCases.forEach((tt, idx) => {

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -2172,7 +2172,6 @@ export var storyboard = (props) => {
     })
 
     describe('paste into a conditional', () => {
-      setFeatureForBrowserTests('Paste wraps into fragment', true)
       describe('root', () => {
         it('pastes the element below the conditional', async () => {
           const testCode = `

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -395,7 +395,7 @@ describe('actions', () => {
             <div data-uid='ccc'>bar</div>
             <div data-uid='ddd'>baz</div>
             <div data-uid='aad'>foo</div>
-            <div data-uid='aag'>bar</div>
+            <div data-uid='aah'>bar</div>
         </div>
 		`,
       },
@@ -591,8 +591,8 @@ describe('actions', () => {
         <div data-uid='root'>
             <>
             	<div data-uid='aaa'>foo</div>
-                <div data-uid='aad'>bar</div>
-                <div data-uid='aag'>baz</div>
+              <div data-uid='aad'>bar</div>
+              <div data-uid='aah'>baz</div>
             </>
             <div data-uid='bbb'>bar</div>
             <div data-uid='ccc'>baz</div>

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -2677,18 +2677,18 @@ export var storyboard = (props) => {
               <div data-uid='ccc' style={{ contain: 'layout', position: 'absolute', top: 100, left: 100, height: 100, width: 100 }}>
                 <div data-uid='ddd' style={{ position: 'absolute', top: 10, left: 10 }}>hi</div>
               </div>
-              <div data-uid='bbb' style={{ position: 'absolute', top: 20, left: 50, contain: 'layout' }}>hello</div>
-              <div data-uid='fff' style={{ position: 'absolute', top: 30, left: 30, contain: 'layout' }}>bello</div>
+              <div data-uid='hello' style={{ position: 'absolute', top: 20, left: 50, contain: 'layout' }}>hello</div>
+              <div data-uid='bello' style={{ position: 'absolute', top: 30, left: 30, contain: 'layout' }}>bello</div>
             </div>`,
-            targets: [makeTargetPath('root/bbb'), makeTargetPath('root/fff')],
+            targets: [makeTargetPath('root/hello'), makeTargetPath('root/bello')],
             result: `<div data-uid='root' style={{ contain: 'layout', width: '100%', height: '100%'}}>
               <div data-uid='ccc' style={{ contain: 'layout', position: 'absolute', top: 100, left: 100, height: 100, width: 100 }}>
                 <div data-uid='ddd' style={{ position: 'absolute', top: 10, left: 10 }}>hi</div>
-                <div data-uid='bbb' style={{ position: 'absolute', top: 36, left: 43, contain: 'layout' }}>hello</div>
-                <div data-uid='fff' style={{ position: 'absolute', top: 46, left: 23, contain: 'layout' }}>bello</div>
+                <div data-uid='hel' style={{ position: 'absolute', top: 36, left: 44, contain: 'layout' }}>hello</div>
+                <div data-uid='bel' style={{ position: 'absolute', top: 46, left: 24, contain: 'layout' }}>bello</div>
               </div>
-              <div data-uid='bbb' style={{ position: 'absolute', top: 20, left: 50, contain: 'layout' }}>hello</div>
-              <div data-uid='fff' style={{ position: 'absolute', top: 30, left: 30, contain: 'layout' }}>bello</div>
+              <div data-uid='hello' style={{ position: 'absolute', top: 20, left: 50, contain: 'layout' }}>hello</div>
+              <div data-uid='bello' style={{ position: 'absolute', top: 30, left: 30, contain: 'layout' }}>bello</div>
             </div>`,
           },
         ]

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -2874,12 +2874,12 @@ export var storyboard = (props) => {
           {
             name: 'paste 2 absolute elements to the storyboard - elements will keep their position to each other',
             input: `<div data-uid='root' style={{ contain: 'layout', width: '100%', height: '100%'}}>
-              <div data-uid='hello' style={{ position: 'absolute', top: 20, left: 50, contain: 'layout' }}>hello</div>
-              <div data-uid='bello' style={{ position: 'absolute', top: 30, left: 30, contain: 'layout' }}>bello</div>
+              <div data-uid='hello' style={{ position: 'absolute', top: 20, left: 50, contain: 'layout', height: 20 }}>hello</div>
+              <div data-uid='bello' style={{ position: 'absolute', top: 30, left: 30, contain: 'layout', height: 20 }}>bello</div>
             </div>`,
             targets: [makeTargetPath('root/hello'), makeTargetPath('root/bello')],
-            result: `<div data-uid='hel' style={{ position: 'absolute', top: 405.75, left: 586, contain: 'layout' }}>hello</div>
-            <div data-uid='bel' style={{ position: 'absolute', top: 415.75, left: 566, contain: 'layout' }}>bello</div>`,
+            result: `<div data-uid='hel' style={{ position: 'absolute', top: 405, left: 586, contain: 'layout', height: 20 }}>hello</div>
+            <div data-uid='bel' style={{ position: 'absolute', top: 415, left: 566, contain: 'layout', height: 20 }}>bello</div>`,
           },
         ]
 

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2816,9 +2816,7 @@ export const UPDATE_FNS = {
     )
 
     let fixedUIDMappingNewUIDS: Array<string> = []
-    const elementsWithFixedUIDsAndCoordinates: Array<
-      ElementPaste & { intendedCoordinates: CanvasPoint }
-    > = action.elements.map((elementPaste) => {
+    const elementsToInsert = action.elements.map((elementPaste) => {
       const existingIDs = [
         ...getAllUniqueUids(editor.projectContents).allIDs,
         ...fixedUIDMappingNewUIDS,
@@ -2840,9 +2838,10 @@ export const UPDATE_FNS = {
       )
 
       return {
-        ...elementPaste,
-        element: elementWithUID.value,
+        elementPath: elementPaste.originalElementPath,
+        pathToReparent: elementToReparent(elementWithUID.value, elementPaste.importsToAdd),
         intendedCoordinates: intendedCoordinates,
+        uid: elementWithUID.value.uid,
       }
     })
 
@@ -2871,12 +2870,7 @@ export const UPDATE_FNS = {
       action.targetOriginalContextMetadata,
       action.targetOriginalElementPathTree,
       reparentTarget,
-      elementsWithFixedUIDsAndCoordinates.map((element) => ({
-        elementPath: element.originalElementPath,
-        pathToReparent: elementToReparent(element.element, element.importsToAdd),
-        intendedCoordinates: element.intendedCoordinates,
-        uid: element.element.uid,
-      })),
+      elementsToInsert,
       indexPosition,
       builtInDependencies,
     )
@@ -5890,17 +5884,19 @@ export function offsetPositionInPasteBoundingBox(
     : zeroCanvasPoint
 }
 
+type ElementToInsert = {
+  elementPath: ElementPath
+  pathToReparent: ToReparent
+  intendedCoordinates: CanvasPoint
+  uid: id
+}
+
 export function insertWithReparentStrategiesMultiSelect(
   editor: EditorState,
   originalContextMetadata: ElementInstanceMetadataMap,
   originalPathTrees: ElementPathTrees,
   reparentTarget: StaticReparentTarget,
-  elementsToInsert: Array<{
-    elementPath: ElementPath
-    pathToReparent: ToReparent
-    intendedCoordinates: CanvasPoint
-    uid: id
-  }>,
+  elementsToInsert: Array<ElementToInsert>,
   indexPosition: IndexPosition,
   builtInDependencies: BuiltInDependencies,
 ): { editor: EditorState; newPaths: Array<ElementPath> } | null {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -5990,10 +5990,13 @@ function absolutePositionForReparent(
   }
 
   if (EP.isStoryboardPath(targetParent)) {
-    return canvasPoint({
-      x: canvasViewportCenter.x - boundingBox.width / 2,
-      y: canvasViewportCenter.y - boundingBox.height / 2,
-    })
+    return offsetPoint(
+      canvasPoint({
+        x: canvasViewportCenter.x - boundingBox.width / 2,
+        y: canvasViewportCenter.y - boundingBox.height / 2,
+      }),
+      multiselectOffset,
+    )
   }
 
   const targetParentBounds = MetadataUtils.getFrameInCanvasCoords(

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -459,23 +459,14 @@ export function getTargetParentForPaste(
       // if so replace the target parent instead of trying to insert into it.
       const conditionalCase = maybeBranchConditionalCase(parentPath, parentElement, targetPath)
       if (conditionalCase != null) {
-        const parentInsertionPath = isFeatureEnabled('Paste wraps into fragment')
-          ? getInsertionPathWithWrapWithFragmentBehavior(
-              targetPath,
-              projectContents,
-              nodeModules,
-              openFile,
-              metadata,
-              elementPathTree,
-            )
-          : getInsertionPathWithSlotBehavior(
-              targetPath,
-              projectContents,
-              nodeModules,
-              openFile,
-              metadata,
-              elementPathTree,
-            )
+        const parentInsertionPath = getInsertionPathWithWrapWithFragmentBehavior(
+          targetPath,
+          projectContents,
+          nodeModules,
+          openFile,
+          metadata,
+          elementPathTree,
+        )
 
         if (parentInsertionPath == null) {
           return left('Cannot find a suitable parent')

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -13,7 +13,6 @@ export type FeatureName =
   | 'Canvas Strategies Debug Panel'
   | 'Nine block control'
   | 'Project Thumbnail Generation'
-  | 'Paste wraps into fragment'
   | 'Paste strategies'
 
 export const AllFeatureNames: FeatureName[] = [
@@ -28,7 +27,6 @@ export const AllFeatureNames: FeatureName[] = [
   'Canvas Strategies Debug Panel',
   'Nine block control',
   'Project Thumbnail Generation',
-  'Paste wraps into fragment',
   'Paste strategies',
 ]
 
@@ -43,7 +41,6 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Canvas Strategies Debug Panel': false,
   'Nine block control': true,
   'Project Thumbnail Generation': false,
-  'Paste wraps into fragment': false,
   'Paste strategies': false,
 }
 


### PR DESCRIPTION
**Problem:**
There are 2 issues fixed in this PR. 
When pasting multiple absolute elements their position was not updated because the extra fragment wrapping didn't handle it in the `PASTE_JSX_ELEMENT`. When pasting multiple absolute elements they appear on top of each other, but should be positioned to their initial bounding box.

**Fix:**
Update `PASTE_JSX_ELEMENT` to use the new `insertJSXElementChildren` with `insertWithReparentStrategiesMultiSelect` which handles fragment wrapping internally and updates the layout properties correctly, introduced in #3836. `absolutePositionForReparent` centers the bounding box of the elements to paste instead of centering them each, also applies the bounding box offset for the elements.

**Commit Details:**
- update `PASTE_JSX_ELEMENT`
- created a common helper `offsetPositionInPasteBoundingBox` that is used in `PASTE_TO_REPLACE` too.
- removing "Paste wraps into fragment" feature flag
- added tests
