### PR TITLE
Fix `flushSync` warnings

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.tsx
@@ -117,7 +117,7 @@ export const CanvasStrategyPicker = React.memo(() => {
                 >
                   <KeyIndicator keyNumber={index + 1} />
                   <span
-                    data-testId={
+                    data-testid={
                       strategy.id === activeStrategy ? 'strategy-picker-active-row' : undefined
                     }
                   >

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -144,20 +144,22 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
 
   const mode = useEditorState(Substores.restOfEditor, (store) => store.editor.mode, 'mode')
   React.useEffect(() => {
-    if (mode.type === 'live') {
-      dispatch([
-        EditorActions.showToast(
-          notice(
-            'You are in Live mode. Use ⌘ to select and scroll.',
-            'NOTICE',
-            true,
-            liveModeToastId,
+    setTimeout(() => {
+      if (mode.type === 'live') {
+        dispatch([
+          EditorActions.showToast(
+            notice(
+              'You are in Live mode. Use ⌘ to select and scroll.',
+              'NOTICE',
+              true,
+              liveModeToastId,
+            ),
           ),
-        ),
-      ])
-    } else {
-      dispatch([EditorActions.removeToast(liveModeToastId)])
-    }
+        ])
+      } else {
+        dispatch([EditorActions.removeToast(liveModeToastId)])
+      }
+    }, 0)
   }, [mode.type, dispatch])
 
   const onWindowKeyDown = React.useCallback(

--- a/editor/src/components/inspector/controls/color-picker-swatches.tsx
+++ b/editor/src/components/inspector/controls/color-picker-swatches.tsx
@@ -44,7 +44,7 @@ export const ColorPickerSwatches = React.memo((props: ColorPickerSwatchesProps) 
   }, [currentColor, colorSwatches])
 
   React.useEffect(() => {
-    dispatch([updateColorSwatches(colorSwatches)], 'everyone')
+    setTimeout(() => dispatch([updateColorSwatches(colorSwatches)], 'everyone'), 0)
   }, [colorSwatches, dispatch])
 
   React.useEffect(() => {


### PR DESCRIPTION
## Problem
Lately we've been getting a lot more `flushSync` warnings

## Fix
Comb through the `React.useEffect` calls, and check if all `dispatch` calls are wrapped into a setTimeout.

Also, `data-testId` -> `data-testid` in the strategy picker