### PR TITLE
Fix incrementing NumberInput values with up/down arrows

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -1656,14 +1656,6 @@ describe('inspector tests with real metadata', () => {
       await dispatchDone
     })
 
-    await act(async () => {
-      await screen.findByTestId('target-selector-style')
-      fireEvent.click(screen.getByTestId('target-selector'))
-      await screen.findByTestId('target-list-item-css')
-      fireEvent.mouseDown(screen.getByTestId('target-list-item-css'))
-      await screen.findByTestId('target-selector-css')
-    })
-
     const widthControl = (await renderResult.renderedDOM.findByTestId(
       'hug-fixed-fill-width',
     )) as HTMLInputElement


### PR DESCRIPTION
Fixes #3851 

**Problem:**

When pressing the up/down arrows to increment/decrement numeric values via `NumberInput` components, it would effectively become stuck.

**Fix:**

The problem is that the current value used in the `incrementBy` function is not actually current, as it remains fixed to the original one. The fix moves it to a separate state variable, altering it upon increment.