### PR TITLE
Add computed case to fill-hug-fix-control.

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -376,6 +376,8 @@ const sizeLabel = (state: FixedHugFill['type'], actualSize: number): string => {
       return `${actualSize}`
     case 'hug':
       return 'Hug'
+    case 'computed':
+      return `${actualSize}`
   }
 }
 

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -1208,13 +1208,13 @@ describe('inspector tests with real metadata', () => {
     matchInlineSnapshotBrowser(widthControl.value, `"150"`)
     matchInlineSnapshotBrowser(
       widthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"controlled"`,
+      `"disabled"`,
     )
 
     matchInlineSnapshotBrowser(heightControl.value, `"130"`)
     matchInlineSnapshotBrowser(
       heightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"controlled"`,
+      `"disabled"`,
     )
 
     matchInlineSnapshotBrowser(topControl.value, `"33"`)
@@ -2166,7 +2166,7 @@ describe('inspector tests with real metadata', () => {
     matchInlineSnapshotBrowser(heightControl.value, `"130"`)
     matchInlineSnapshotBrowser(
       heightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"controlled"`,
+      `"disabled"`,
     )
   })
   it('Shows multifile selected element properties', async () => {

--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -41,6 +41,7 @@ export const FillFixedHugControlId = (segment: 'width' | 'height'): string =>
 export const FillContainerLabel = 'Fill container' as const
 export const FixedLabel = 'Fixed' as const
 export const HugContentsLabel = 'Hug contents' as const
+export const ComputedLabel = 'Computed' as const
 
 export function selectOptionLabel(mode: FixedHugFillMode): string {
   switch (mode) {
@@ -50,6 +51,8 @@ export function selectOptionLabel(mode: FixedHugFillMode): string {
       return FixedLabel
     case 'hug':
       return HugContentsLabel
+    case 'computed':
+      return ComputedLabel
     default:
       assertNever(mode)
   }
@@ -211,7 +214,10 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
           setPropFillStrategies('vertical', value.value, false),
         )
       }
-      if (heightCurrentValue.fixedHugFill?.type === 'fixed') {
+      if (
+        heightCurrentValue.fixedHugFill?.type === 'fixed' ||
+        heightCurrentValue.fixedHugFill?.type === 'computed'
+      ) {
         executeFirstApplicableStrategy(
           dispatch,
           metadataRef.current,
@@ -254,7 +260,10 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
           setPropFillStrategies('horizontal', value.value, false),
         )
       }
-      if (widthCurrentValue.fixedHugFill?.type === 'fixed') {
+      if (
+        widthCurrentValue.fixedHugFill?.type === 'fixed' ||
+        widthCurrentValue.fixedHugFill?.type === 'computed'
+      ) {
         executeFirstApplicableStrategy(
           dispatch,
           metadataRef.current,
@@ -401,6 +410,7 @@ function strategyForMode(
     case 'hug':
       return setPropHugStrategies(axis)
     case 'fixed':
+    case 'computed':
       return setPropFixedStrategies('always', axis, cssNumber(fixedValue, null))
     default:
       assertNever(mode)
@@ -408,13 +418,16 @@ function strategyForMode(
 }
 
 function pickFixedValue(value: FixedHugFill): CSSNumber | undefined {
-  if (value.type === 'fixed') {
-    return value.value
+  switch (value.type) {
+    case 'computed':
+    case 'fixed':
+    case 'fill':
+      return value.value
+    case 'hug':
+      return undefined
+    default:
+      assertNever(value)
   }
-  if (value.type === 'fill') {
-    return value.value
-  }
-  return undefined
 }
 
 function pickNumberType(value: FixedHugFill | null): CSSNumberType {

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -535,6 +535,7 @@ export type FixedHugFill =
   | { type: 'fixed'; value: CSSNumber }
   | { type: 'fill'; value: CSSNumber }
   | { type: 'hug' }
+  | { type: 'computed'; value: CSSNumber }
 
 export type FixedHugFillMode = FixedHugFill['type']
 
@@ -631,7 +632,6 @@ export function detectFillHugFixedState(
   const frame = element.globalFrame
   if (frame != null && isFiniteRectangle(frame)) {
     const dimension = widthHeightFromAxis(axis)
-    const valueWithType = { type: 'fixed' as const, value: cssNumber(frame[dimension]) }
 
     const controlStatus = getFallbackControlStatusForProperty(
       property,
@@ -639,6 +639,10 @@ export function detectFillHugFixedState(
       element.attributeMetadatada,
     )
 
+    const valueWithType: FixedHugFill = {
+      type: controlStatus === 'controlled' ? 'computed' : 'fixed',
+      value: cssNumber(frame[dimension]),
+    }
     return { fixedHugFill: valueWithType, controlStatus: controlStatus }
   }
 
@@ -950,6 +954,7 @@ export function isFixedHugFillEqual(
       return b.fixedHugFill.type === 'hug'
     case 'fill':
     case 'fixed':
+    case 'computed':
       return (
         a.fixedHugFill.type === b.fixedHugFill.type &&
         a.fixedHugFill.value.value === b.fixedHugFill.value.value &&

--- a/editor/src/components/inspector/sections/style-section/text-subsection/text-auto-sizing-control.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/text-auto-sizing-control.tsx
@@ -26,7 +26,10 @@ import { commandsForFirstApplicableStrategy } from '../../../inspector-strategie
 
 export const TextAutoSizingTestId = 'textAutoSizing'
 
-function useAutoSizingTypeAndStatus(): { status: ControlStatus; type: 'fixed' | 'hug' | null } {
+function useAutoSizingTypeAndStatus(): {
+  status: ControlStatus
+  type: 'fixed' | 'hug' | 'computed' | null
+} {
   const isEditableText = useEditorState(
     Substores.metadata,
     (store) => {


### PR DESCRIPTION
**Change:**
When the control status is `controlled` (which means the value is defined by an expression) for the width and height controls in `FillHugFixedControl`, mark them as "Computed" instead of "Fixed" as they currently are.

**Notes:**
When the value is defined by an expression the input field for the size becomes disabled. If we want to have it so that it overwrites the expression with a value if you punch one in then there's some refactoring that will be necessary as the strategy commands do not currently support that.

**Commit Details:**
- Added `computed` case to `FixedHugFill` type.
- `detectFillHugFixedState` now caters for the `computed` case.
- `FillHugFixedControl` treats `computed` mostly similarly to `fixed`, with the exception being that it is disabled.