### PR TITLE
Always use the component orange colour for all focused elements in the Navigator

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
@@ -68,6 +68,7 @@ export const OutlineControl = React.memo<OutlineControlProps>((props) => {
           path,
           store.editor.jsxMetadata,
           store.editor.focusedElementPath,
+          store.derived.autoFocusedPaths,
           colorTheme,
         ),
       )
@@ -112,9 +113,10 @@ export function getSelectionColor(
   path: ElementPath,
   metadata: ElementInstanceMetadataMap,
   focusedElementPath: ElementPath | null,
+  autoFocusedPaths: Array<ElementPath>,
   colorTheme: any,
 ): string {
-  if (EP.isInsideFocusedComponent(path)) {
+  if (EP.isInsideFocusedComponent(path, autoFocusedPaths)) {
     if (MetadataUtils.isFocusableComponent(path, metadata)) {
       return colorTheme.canvasSelectionFocusableChild.value
     } else {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1124,6 +1124,7 @@ export function restoreDerivedState(history: StateHistory): DerivedState {
   return {
     navigatorTargets: poppedDerived.navigatorTargets,
     visibleNavigatorTargets: poppedDerived.visibleNavigatorTargets,
+    autoFocusedPaths: poppedDerived.autoFocusedPaths,
     controls: [],
     transientState: produceCanvasTransientState(
       poppedDerived.transientState.selectedViews,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -2244,6 +2244,7 @@ export function reparentTargetFromNavigatorEntry(
 export interface DerivedState {
   navigatorTargets: Array<NavigatorEntry>
   visibleNavigatorTargets: Array<NavigatorEntry>
+  autoFocusedPaths: Array<ElementPath>
   controls: Array<HigherOrderControl>
   transientState: TransientCanvasState
   elementWarnings: { [key: string]: ElementWarnings }
@@ -2255,6 +2256,7 @@ function emptyDerivedState(editor: EditorState): DerivedState {
   return {
     navigatorTargets: [],
     visibleNavigatorTargets: [],
+    autoFocusedPaths: [],
     controls: [],
     transientState: produceCanvasTransientState(editor.selectedViews, editor, false),
     elementWarnings: {},
@@ -2578,6 +2580,7 @@ type CacheableDerivedState = {
   navigatorTargets: Array<NavigatorEntry>
   visibleNavigatorTargets: Array<NavigatorEntry>
   elementWarnings: { [key: string]: ElementWarnings }
+  autoFocusedPaths: Array<ElementPath>
 }
 
 function deriveCacheableStateInner(
@@ -2596,10 +2599,17 @@ function deriveCacheableStateInner(
 
   const warnings = getElementWarnings(jsxMetadata, allElementProps, elementPathTree)
 
+  const autoFocusedPaths = MetadataUtils.getAllPaths(jsxMetadata, elementPathTree).filter(
+    (path) =>
+      EP.isStoryboardDescendant(path) &&
+      MetadataUtils.parentIsSceneWithOneChild(jsxMetadata, elementPathTree, path),
+  )
+
   return {
     navigatorTargets: navigatorTargets,
     visibleNavigatorTargets: visibleNavigatorTargets,
     elementWarnings: warnings,
+    autoFocusedPaths: autoFocusedPaths,
   }
 }
 
@@ -2620,6 +2630,7 @@ export function deriveState(
     navigatorTargets,
     visibleNavigatorTargets,
     elementWarnings: warnings,
+    autoFocusedPaths,
   } = deriveCacheableState(
     editor.jsxMetadata,
     editor.elementPathTree,
@@ -2631,6 +2642,7 @@ export function deriveState(
   const derived: DerivedState = {
     navigatorTargets: navigatorTargets,
     visibleNavigatorTargets: visibleNavigatorTargets,
+    autoFocusedPaths: autoFocusedPaths,
     controls: derivedState.controls,
     transientState: produceCanvasTransientState(
       oldDerivedState?.transientState.selectedViews ?? editor.selectedViews,

--- a/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
@@ -163,6 +163,7 @@ describe('DerivedStateKeepDeepEquality', () => {
   const oldValue: DerivedState = {
     navigatorTargets: [regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']]))],
     visibleNavigatorTargets: [regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']]))],
+    autoFocusedPaths: [EP.elementPath([['scene'], ['aaa']])],
     controls: [],
     transientState: transientCanvasState(
       [EP.elementPath([['scene'], ['aaa', 'bbb']])],
@@ -218,6 +219,7 @@ describe('DerivedStateKeepDeepEquality', () => {
   const newSameValue: DerivedState = {
     navigatorTargets: [regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']]))],
     visibleNavigatorTargets: [regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']]))],
+    autoFocusedPaths: [EP.elementPath([['scene'], ['aaa']])],
     controls: [],
     transientState: transientCanvasState(
       [EP.elementPath([['scene'], ['aaa', 'bbb']])],
@@ -273,6 +275,7 @@ describe('DerivedStateKeepDeepEquality', () => {
   const newDifferentValue: DerivedState = {
     navigatorTargets: [regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'ddd']]))],
     visibleNavigatorTargets: [regularNavigatorEntry(EP.elementPath([['scene'], ['aaa', 'bbb']]))],
+    autoFocusedPaths: [EP.elementPath([['scene'], ['aaa']])],
     controls: [],
     transientState: transientCanvasState(
       [EP.elementPath([['scene'], ['aaa', 'bbb']])],
@@ -341,6 +344,7 @@ describe('DerivedStateKeepDeepEquality', () => {
       newDifferentValue.navigatorTargets[0].elementPath,
     )
     expect(result.value.visibleNavigatorTargets).toBe(oldValue.visibleNavigatorTargets)
+    expect(result.value.autoFocusedPaths).toBe(oldValue.autoFocusedPaths)
     expect(result.value.controls).toBe(oldValue.controls)
     expect(result.value.transientState).toBe(oldValue.transientState)
     expect(result.value.elementWarnings).toBe(oldValue.elementWarnings)

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -647,11 +647,13 @@ export const NavigatorStateKeepDeepEquality: KeepDeepEqualityCall<NavigatorState
   )
 
 export function DerivedStateKeepDeepEquality(): KeepDeepEqualityCall<DerivedState> {
-  return combine7EqualityCalls(
+  return combine8EqualityCalls(
     (state) => state.navigatorTargets,
     arrayDeepEquality(NavigatorEntryKeepDeepEquality),
     (state) => state.visibleNavigatorTargets,
     arrayDeepEquality(NavigatorEntryKeepDeepEquality),
+    (state) => state.autoFocusedPaths,
+    arrayDeepEquality(ElementPathKeepDeepEquality),
     (state) => state.controls,
     HigherOrderControlArrayKeepDeepEquality,
     (state) => state.transientState,
@@ -665,6 +667,7 @@ export function DerivedStateKeepDeepEquality(): KeepDeepEqualityCall<DerivedStat
     (
       navigatorTargets,
       visibleNavigatorTargets,
+      autoFocusedPaths,
       controls,
       transientState,
       elementWarnings,
@@ -674,6 +677,7 @@ export function DerivedStateKeepDeepEquality(): KeepDeepEqualityCall<DerivedStat
       return {
         navigatorTargets: navigatorTargets,
         visibleNavigatorTargets: visibleNavigatorTargets,
+        autoFocusedPaths: autoFocusedPaths,
         controls: controls,
         transientState: transientState,
         elementWarnings: elementWarnings,

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -1657,20 +1657,13 @@ describe('conditionals in the navigator', () => {
     })
     it('shows js expression values in blue', async () => {
       await renderTestEditorWithCode(
-        makeTestProjectCodeWithSnippet(`
-          <div data-uid='aaa'>
-          {
-            // @utopia/uid=conditional
-            true ? (()=> <div><div>hey</div><div>there</div></div>)() : <div />
-          }
-          </div>
-          `),
+        getProjectCodeExpressionWithMultipleValues(),
         'await-first-dom-report',
       )
 
       const labelColor = (
         await screen.findByTestId(
-          `NavigatorItemTestId-regular_utopia_storyboard_uid/scene_aaa/app_entity:aaa/conditional/a59~~~1`,
+          `NavigatorItemTestId-regular_utopia_storyboard_uid/scene_aaa/containing_div/conditional/46a~~~1`,
         )
       ).style.color
 

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -446,10 +446,15 @@ export const NavigatorItem: React.FunctionComponent<
 
   const colorTheme = useColorTheme()
   const isFocusedComponent = useEditorState(
-    Substores.focusedElement,
+    Substores.metadata,
     (store) =>
       isRegularNavigatorEntry(navigatorEntry) &&
-      EP.isFocused(store.editor.focusedElementPath, navigatorEntry.elementPath),
+      MetadataUtils.isFocused(
+        navigatorEntry.elementPath,
+        store.editor.focusedElementPath,
+        store.editor.jsxMetadata,
+        store.editor.elementPathTree,
+      ),
     'NavigatorItem isFocusedComponent',
   )
 

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -296,7 +296,10 @@ const computeResultingStyle = (
   return result
 }
 
-function useStyleFullyVisible(navigatorEntry: NavigatorEntry): boolean {
+function useStyleFullyVisible(
+  navigatorEntry: NavigatorEntry,
+  autoFocusedPaths: Array<ElementPath>,
+): boolean {
   return useEditorState(
     Substores.metadata,
     (store) => {
@@ -336,7 +339,8 @@ function useStyleFullyVisible(navigatorEntry: NavigatorEntry): boolean {
         })
 
         let isInsideFocusedComponent =
-          EP.isFocused(store.editor.focusedElementPath, path) || EP.isInsideFocusedComponent(path)
+          EP.isFocused(store.editor.focusedElementPath, path) ||
+          EP.isInsideFocusedComponent(path, autoFocusedPaths)
 
         return (
           isStoryboardChild ||
@@ -445,15 +449,21 @@ export const NavigatorItem: React.FunctionComponent<
   } = props
 
   const colorTheme = useColorTheme()
+
+  const autoFocusedPaths = useEditorState(
+    Substores.derived,
+    (store) => store.derived.autoFocusedPaths,
+    'NavigatorItem autoFocusedPaths',
+  )
+
   const isFocusedComponent = useEditorState(
-    Substores.metadata,
+    Substores.focusedElement,
     (store) =>
       isRegularNavigatorEntry(navigatorEntry) &&
-      MetadataUtils.isFocused(
-        navigatorEntry.elementPath,
+      EP.isExplicitlyFocused(
         store.editor.focusedElementPath,
-        store.editor.jsxMetadata,
-        store.editor.elementPathTree,
+        autoFocusedPaths,
+        navigatorEntry.elementPath,
       ),
     'NavigatorItem isFocusedComponent',
   )
@@ -585,8 +595,8 @@ export const NavigatorItem: React.FunctionComponent<
   )
 
   const isInsideComponent =
-    EP.isInsideFocusedComponent(navigatorEntry.elementPath) || isFocusedComponent
-  const fullyVisible = useStyleFullyVisible(navigatorEntry)
+    EP.isInsideFocusedComponent(navigatorEntry.elementPath, autoFocusedPaths) || isFocusedComponent
+  const fullyVisible = useStyleFullyVisible(navigatorEntry, autoFocusedPaths)
   const isProbablyScene = useIsProbablyScene(navigatorEntry)
 
   const isHighlightedForInteraction = useEditorState(

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -200,6 +200,28 @@ export const MetadataUtils = {
     const elementMetadata = MetadataUtils.findElementByElementPath(jsxMetadata, path)
     return MetadataUtils.isProbablySceneFromMetadata(elementMetadata)
   },
+  parentIsSceneWithOneChild(
+    jsxMetadata: ElementInstanceMetadataMap,
+    pathTree: ElementPathTrees,
+    path: ElementPath,
+  ): boolean {
+    const parentPath = EP.parentPath(path)
+    return (
+      MetadataUtils.isProbablyScene(jsxMetadata, parentPath) &&
+      MetadataUtils.getChildrenPathsOrdered(jsxMetadata, pathTree, parentPath).length === 1
+    )
+  },
+  isFocused(
+    path: ElementPath,
+    focusedElementPath: ElementPath | null,
+    metadata: ElementInstanceMetadataMap,
+    pathTree: ElementPathTrees,
+  ): boolean {
+    return (
+      EP.isFocused(focusedElementPath, path) ||
+      MetadataUtils.parentIsSceneWithOneChild(metadata, pathTree, path)
+    )
+  },
   getIndexInParent(
     metadata: ElementInstanceMetadataMap,
     pathTree: ElementPathTrees,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -200,27 +200,22 @@ export const MetadataUtils = {
     const elementMetadata = MetadataUtils.findElementByElementPath(jsxMetadata, path)
     return MetadataUtils.isProbablySceneFromMetadata(elementMetadata)
   },
+  isSceneWithOneChild(
+    jsxMetadata: ElementInstanceMetadataMap,
+    pathTree: ElementPathTrees,
+    path: ElementPath,
+  ): boolean {
+    return (
+      MetadataUtils.isProbablyScene(jsxMetadata, path) &&
+      MetadataUtils.getChildrenPathsOrdered(jsxMetadata, pathTree, path).length === 1
+    )
+  },
   parentIsSceneWithOneChild(
     jsxMetadata: ElementInstanceMetadataMap,
     pathTree: ElementPathTrees,
     path: ElementPath,
   ): boolean {
-    const parentPath = EP.parentPath(path)
-    return (
-      MetadataUtils.isProbablyScene(jsxMetadata, parentPath) &&
-      MetadataUtils.getChildrenPathsOrdered(jsxMetadata, pathTree, parentPath).length === 1
-    )
-  },
-  isFocused(
-    path: ElementPath,
-    focusedElementPath: ElementPath | null,
-    metadata: ElementInstanceMetadataMap,
-    pathTree: ElementPathTrees,
-  ): boolean {
-    return (
-      EP.isFocused(focusedElementPath, path) ||
-      MetadataUtils.parentIsSceneWithOneChild(metadata, pathTree, path)
-    )
+    return MetadataUtils.isSceneWithOneChild(jsxMetadata, pathTree, EP.parentPath(path))
   },
   getIndexInParent(
     metadata: ElementInstanceMetadataMap,

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -328,8 +328,15 @@ export function fullDepth(path: ElementPath): number {
   return path.parts.reduce((working, part) => working + part.length, 0)
 }
 
-export function isInsideFocusedComponent(path: ElementPath): boolean {
-  return path.parts.length > 1
+export function isInsideFocusedComponent(
+  path: ElementPath,
+  autoFocusedPaths: Array<ElementPath>,
+): boolean {
+  return (
+    path.parts.length > 2 ||
+    (path.parts.length > 1 &&
+      !autoFocusedPaths.some((autoFocusedPath) => isDescendantOf(path, autoFocusedPath)))
+  )
 }
 
 function fullElementPathParent(path: StaticElementPathPart[]): StaticElementPathPart[]
@@ -1044,8 +1051,24 @@ export function isFocused(focusedElementPath: ElementPath | null, path: ElementP
   if (focusedElementPath == null || lastPart == null) {
     return false
   } else {
+    // FIXME this is incorrect, as it will be marking other instances as focused
     return pathUpToElementPath(focusedElementPath, lastPart, 'dynamic-path') != null
   }
+}
+
+export function isExplicitlyFocused(
+  focusedElementPath: ElementPath | null,
+  autoFocusedPaths: Array<ElementPath>,
+  path: ElementPath,
+): boolean {
+  if (pathsEqual(focusedElementPath, path)) {
+    return true
+  }
+
+  const isNotAutoFocused =
+    path.parts.length > 1 ||
+    !autoFocusedPaths.some((autoFocusedPath) => isDescendantOfOrEqualTo(path, autoFocusedPath))
+  return isNotAutoFocused && isFocused(focusedElementPath, path)
 }
 
 export function getOrderedPathsByDepth(elementPaths: Array<ElementPath>): Array<ElementPath> {

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -329,7 +329,7 @@ export function fullDepth(path: ElementPath): number {
 }
 
 export function isInsideFocusedComponent(path: ElementPath): boolean {
-  return path.parts.length > 2
+  return path.parts.length > 1
 }
 
 function fullElementPathParent(path: StaticElementPathPart[]): StaticElementPathPart[]
@@ -1041,7 +1041,7 @@ export function createBackwardsCompatibleScenePath(path: ElementPath): ElementPa
 
 export function isFocused(focusedElementPath: ElementPath | null, path: ElementPath): boolean {
   const lastPart = lastElementPathForPath(path)
-  if (focusedElementPath == null || lastPart == null || isStoryboardDescendant(path)) {
+  if (focusedElementPath == null || lastPart == null) {
     return false
   } else {
     return pathUpToElementPath(focusedElementPath, lastPart, 'dynamic-path') != null


### PR DESCRIPTION
## [Try me](https://utopia.pizza/p/31541d66-rainbow-archaeology/?branch_name=fix-consistent-nav-focus-styling)

**Problem:**
The Navigator has inconsistent styling for focused elements, sometimes using orange, sometimes using whatever other default colour a row would have.

**Fix:**
Fix up the styling to keep it consistent in all cases where a component is focused. This includes automatically focused components, i.e. those that are a single child of a `Scene`.