### PR TITLE
Fix text editing exception on conditionals with null branches

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -580,7 +580,7 @@ function jsxElementChildToText(
           return 'undefined'
         }
       }
-      return element.value.toString()
+      return element.value != null ? element.value.toString() : '{null}'
     case 'JSX_FRAGMENT':
     case 'ATTRIBUTE_NESTED_ARRAY':
     case 'ATTRIBUTE_NESTED_OBJECT':

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -858,6 +858,14 @@ describe('Use the text editor', () => {
         codeResult: 'The username is {1 >= 1 ? `${"Bob"}` : "Sam"}',
         renderedText: 'The username is Bob',
       },
+      {
+        label: 'handles nulls',
+        // eslint-disable-next-line no-template-curly-in-string
+        writtenText: 'The username is {1 >= 1 ? null : null}',
+        // eslint-disable-next-line no-template-curly-in-string
+        codeResult: 'The username is {1 >= 1 ? null : null}',
+        renderedText: 'The username is',
+      },
     ]
     tests.forEach((t) => {
       it(`${t.label}`, async () => {
@@ -933,6 +941,33 @@ describe('Use the text editor', () => {
         projectWithSnippet(`{
           // @utopia/uid=cond
           true ? 'hello' : <div data-uid='33d' />
+        }`),
+        'await-first-dom-report',
+      )
+
+      await editor.dispatch([selectComponents([EP.fromString('sb/39e/cond')], false)], true)
+      await pressKey('enter')
+      await editor.getDispatchFollowUpActionsFinished()
+
+      typeText('hi')
+      await closeTextEditor()
+
+      await editor.getDispatchFollowUpActionsFinished()
+      await wait(50)
+
+      expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          true ? 'hi' : <div data-uid='33d' />
+        }`),
+      )
+      expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('hi')
+    })
+    it('editing the active true clause with null inside from the selected conditional', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectWithSnippet(`{
+          // @utopia/uid=cond
+          true ? null : <div data-uid='33d' />
         }`),
         'await-first-dom-report',
       )


### PR DESCRIPTION
**Problem:**
I caused a regression in https://github.com/concrete-utopia/utopia/pull/3844
Text editing a null branch of a conditional throws an exception.

**Fix:**
Make sure to handle the null case separately in `renderCoreElement`