### PR TITLE
only send printed code to VSCode when "both match"

### DIFF
--- a/editor/src/components/editor/store/vscode-changes.ts
+++ b/editor/src/components/editor/store/vscode-changes.ts
@@ -109,11 +109,13 @@ export function collateProjectChanges(
           const fileMarkedDirtyButNoCodeChangeYet =
             firstUnsavedContent == null && secondUnsavedContent === firstSavedContent
 
-          // When a parsed model is updated but that change hasn't been reflected in the code yet, we end up with a file
-          // that has no code change, so we don't want to write that to the FS for VS Code to act on it until the new code
-          // has been generated
           const fileShouldBeWritten =
+            // This means that we'll only send the code across when it is in sync with the parsed model, rather
+            // than sending a stale version of the code across whilst waiting on the new version.
             secondContents.content.fileContents.revisionsState === 'BOTH_MATCH' &&
+            // When a parsed model is updated but that change hasn't been reflected in the code yet, we end up with a file
+            // that has no code change, so we don't want to write that to the FS for VS Code to act on it until the new code
+            // has been generated
             (savedContentChanged || (unsavedContentChanged && !fileMarkedDirtyButNoCodeChangeYet))
 
           if (fileShouldBeWritten) {

--- a/editor/src/components/editor/store/vscode-changes.ts
+++ b/editor/src/components/editor/store/vscode-changes.ts
@@ -113,7 +113,8 @@ export function collateProjectChanges(
           // that has no code change, so we don't want to write that to the FS for VS Code to act on it until the new code
           // has been generated
           const fileShouldBeWritten =
-            savedContentChanged || (unsavedContentChanged && !fileMarkedDirtyButNoCodeChangeYet)
+            secondContents.content.fileContents.revisionsState === 'BOTH_MATCH' &&
+            (savedContentChanged || (unsavedContentChanged && !fileMarkedDirtyButNoCodeChangeYet))
 
           if (fileShouldBeWritten) {
             changesToProcess.push(writeProjectFileChange(fullPath, secondContents.content))


### PR DESCRIPTION
## Description

(taken from a team discussion)

> When the post action menu switches the paste type, it reverts the model to the previous state (before the paste happened) and applies the new paste type as an atomic action. The problem here is that pasting updates the parsed model, so the code is only updated by the parser-printer worker afterwards. This means that although the reversion and updated paste are applied as a single atomic action, there is still a very brief period where the old version of the code is in the file contents, which causes the code editor to display that for a split second whilst the new code is being printed.

> This change means that we'll only send the code across when it is in sync with the parsed model, rather than sending a stale version of the code across whilst waiting on the new version.

> A real world example of where this would have changed: making a load of changes in the Inspector in quick succession. On master you'd see an intermediate version of the printed code that includes maybe the first change, followed shortly by a newer version of the printed code containing the rest of the changes, whereas with this change you wouldn't see that intermediate version. Having thought about it, that makes far more sense than showing the intermediate (and already stale) version of the code whilst printing the newer version.