### PR TITLE
Testing: Try Magic Nix Cache.

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -30,6 +30,8 @@ jobs:
         uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
+      - name: Run the Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v1
       - name: Run tsc, eslint, depdendency-cruiser and the website tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-code-ci
@@ -61,6 +63,8 @@ jobs:
         uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
+      - name: Run the Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v1
       - name: Run the Jest tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-jest-ci
@@ -127,6 +131,8 @@ jobs:
         uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
+      - name: Run the Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v1
       - name: Build Editor
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: |
@@ -331,6 +337,8 @@ jobs:
         uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
+      - name: Run the Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v1
       - name: Run System Test
         id: run-system-test
         env:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -26,12 +26,10 @@ jobs:
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-      - name: Install nix
-        uses: cachix/install-nix-action@v12
-        with:
-          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v4
       - name: Run the Magic Nix Cache From Determinate Systems
-        uses: DeterminateSystems/magic-nix-cache-action@v1
+        uses: DeterminateSystems/magic-nix-cache-action@v2
       - name: Run tsc, eslint, depdendency-cruiser and the website tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-code-ci
@@ -59,12 +57,10 @@ jobs:
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-      - name: Install nix
-        uses: cachix/install-nix-action@v12
-        with:
-          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v4
       - name: Run the Magic Nix Cache From Determinate Systems
-        uses: DeterminateSystems/magic-nix-cache-action@v1
+        uses: DeterminateSystems/magic-nix-cache-action@v2
       - name: Run the Jest tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-jest-ci
@@ -127,12 +123,10 @@ jobs:
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-      - name: Install nix
-        uses: cachix/install-nix-action@v12
-        with:
-          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v4
       - name: Run the Magic Nix Cache From Determinate Systems
-        uses: DeterminateSystems/magic-nix-cache-action@v1
+        uses: DeterminateSystems/magic-nix-cache-action@v2
       - name: Build Editor
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: |
@@ -333,12 +327,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ca-certificates fonts-liberation libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils
-      - name: Install nix
-        uses: cachix/install-nix-action@v12
-        with:
-          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v4
       - name: Run the Magic Nix Cache From Determinate Systems
-        uses: DeterminateSystems/magic-nix-cache-action@v1
+        uses: DeterminateSystems/magic-nix-cache-action@v2
       - name: Run System Test
         id: run-system-test
         env:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -30,7 +30,7 @@ jobs:
         uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
-      - name: Run the Magic Nix Cache
+      - name: Run the Magic Nix Cache From Determinate Systems
         uses: DeterminateSystems/magic-nix-cache-action@v1
       - name: Run tsc, eslint, depdendency-cruiser and the website tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
@@ -63,7 +63,7 @@ jobs:
         uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
-      - name: Run the Magic Nix Cache
+      - name: Run the Magic Nix Cache From Determinate Systems
         uses: DeterminateSystems/magic-nix-cache-action@v1
       - name: Run the Jest tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
@@ -131,7 +131,7 @@ jobs:
         uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
-      - name: Run the Magic Nix Cache
+      - name: Run the Magic Nix Cache From Determinate Systems
         uses: DeterminateSystems/magic-nix-cache-action@v1
       - name: Build Editor
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
@@ -337,7 +337,7 @@ jobs:
         uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
-      - name: Run the Magic Nix Cache
+      - name: Run the Magic Nix Cache From Determinate Systems
         uses: DeterminateSystems/magic-nix-cache-action@v1
       - name: Run System Test
         id: run-system-test

--- a/editor/src/core/shared/set-utils.spec.ts
+++ b/editor/src/core/shared/set-utils.spec.ts
@@ -1,7 +1,7 @@
 import * as fc from 'fast-check'
 import { intersection } from './set-utils'
 
-describe('intersection - set', () => {
+describe('intersection', () => {
   it('intersection of overlapping sets', () => {
     const result = intersection([new Set([1, 2, 3, 4]), new Set([3, 4, 5, 6])])
     expect(result).toEqual(new Set([3, 4]))

--- a/editor/src/core/shared/set-utils.spec.ts
+++ b/editor/src/core/shared/set-utils.spec.ts
@@ -1,7 +1,7 @@
 import * as fc from 'fast-check'
 import { intersection } from './set-utils'
 
-describe('intersection', () => {
+describe('intersection - set', () => {
   it('intersection of overlapping sets', () => {
     const result = intersection([new Set([1, 2, 3, 4]), new Set([3, 4, 5, 6])])
     expect(result).toEqual(new Set([3, 4]))


### PR DESCRIPTION
**Problem:**
Nix can be quite slow to populate its cache.

**Fix:**
Use Determinate Systems "Magic Nix Cache" to cache the nix store values directly via an API.

**Commit Details:**
- Added Magic Nix Cache to the pull requests workflow.