### PR TITLE
Add helper function for WindowRectangle

### DIFF
--- a/editor/src/components/canvas/controls/elements-outside-visible-area-hooks.tsx
+++ b/editor/src/components/canvas/controls/elements-outside-visible-area-hooks.tsx
@@ -12,6 +12,7 @@ import {
   isFiniteRectangle,
   offsetPoint,
   windowPoint,
+  windowRectangle,
 } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { CanvasToolbarId } from '../../editor/canvas-toolbar'
@@ -92,12 +93,12 @@ export function useElementsOutsideVisibleArea(
       return null
     }
     const scaleRatio = canvasScale > 1 ? canvasScale : 1
-    return {
+    return windowRectangle({
       x: bounds.x * scaleRatio,
       y: bounds.y * scaleRatio,
       width: bounds.width * scaleRatio - navigatorWidth,
       height: bounds.height * scaleRatio,
-    } as WindowRectangle
+    })
   }, [bounds, navigatorWidth, canvasScale])
 
   const scaledCanvasAreaCenter = React.useMemo(() => {
@@ -122,12 +123,12 @@ export function useElementsOutsideVisibleArea(
         canvasPointToWindowPoint(frame, canvasScale, canvasOffset),
         topLeftSkew,
       )
-      const elementRect = {
+      const elementRect = windowRectangle({
         x: topLeftPoint.x,
         y: topLeftPoint.y,
         width: frame.width * canvasScale,
         height: frame.height * canvasScale,
-      } as WindowRectangle
+      })
 
       const directions = getOutsideDirections(scaledCanvasArea, elementRect)
       if (directions.length === 0) {
@@ -171,7 +172,7 @@ export function useElementsOutsideVisibleArea(
           directions,
           scaledCanvasArea,
           navigatorWidth,
-          windowRectangleFromDOMRect(canvasToolbar),
+          windowRectangle(canvasToolbar),
         ),
       }
 
@@ -288,15 +289,6 @@ function adjustPosition(
       },
     ),
   })
-}
-
-function windowRectangleFromDOMRect(rect: DOMRect): WindowRectangle {
-  return {
-    x: rect.x,
-    y: rect.y,
-    width: rect.width,
-    height: rect.height,
-  } as WindowRectangle
 }
 
 export function getIndicatorId(

--- a/editor/src/components/canvas/controls/selection-area-helpers.ts
+++ b/editor/src/components/canvas/controls/selection-area-helpers.ts
@@ -3,10 +3,10 @@ import * as EP from '../../../core/shared/element-path'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
 import {
   CanvasRectangle,
-  WindowPoint,
   WindowRectangle,
   isFiniteRectangle,
   rectangleContainsRectangle,
+  windowRectangle,
 } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { KeysPressed } from '../../../utils/keyboard'
@@ -113,12 +113,12 @@ export function getSelectionAreaRenderedRect(
     return null
   }
   const scaleFactor = scale > 1 ? scale : 1
-  return {
+  return windowRectangle({
     x: selectionArea.x - boundingRect.x * scaleFactor,
     y: selectionArea.y - boundingRect.y * scaleFactor,
     width: selectionArea.width,
     height: selectionArea.height,
-  } as WindowRectangle
+  })
 }
 
 export function isValidMouseEventForSelectionArea(

--- a/editor/src/core/shared/math-utils.ts
+++ b/editor/src/core/shared/math-utils.ts
@@ -146,6 +146,20 @@ export function localRectangle(
   return rectangle as LocalRectangle
 }
 
+export function windowRectangle(rectangle: null | undefined): null
+export function windowRectangle(rectangle: SimpleRectangle): WindowRectangle
+export function windowRectangle(
+  rectangle: SimpleRectangle | null | undefined,
+): WindowRectangle | null
+export function windowRectangle(
+  rectangle: SimpleRectangle | null | undefined,
+): WindowRectangle | null {
+  if (rectangle == null) {
+    return null
+  }
+  return rectangle as WindowRectangle
+}
+
 export function zeroRectIfNullOrInfinity<C extends CoordinateMarker>(
   r: MaybeInfinityRectangle<C> | null,
 ): Rectangle<C> {

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -83,6 +83,7 @@ import {
   RawPoint,
   Size,
   WindowPoint,
+  windowRectangle,
   WindowRectangle,
   zeroCanvasPoint,
   zeroCanvasRect,
@@ -844,12 +845,12 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
       canvasBounds = null
     } else {
       const canvasBoundingRect = this.canvasWrapperRef.getBoundingClientRect()
-      canvasBounds = {
+      canvasBounds = windowRectangle({
         x: canvasBoundingRect.left,
         y: canvasBoundingRect.top,
         width: canvasBoundingRect.width,
         height: canvasBoundingRect.height,
-      } as WindowRectangle
+      })
     }
 
     let actions: Array<EditorAction> = []


### PR DESCRIPTION
Fixes #3864 

This is a followup to https://github.com/concrete-utopia/utopia/pull/3842#discussion_r1243594926 that adds a helper function in `math-utils.ts` to construct `WindowRectangle`s out of `SimpleRectangle`s.