### PR TITLE
Explicitly prevent code editor actions from triggering code editor changes

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -26,7 +26,6 @@ import {
   NodeModules,
   Imports,
   ParsedTextFile,
-  HighlightBoundsForUids,
   ImageFile,
 } from '../../core/shared/project-file-types'
 import { CodeResultCache, PropertyControlsInfo } from '../custom-code/code-file'
@@ -47,7 +46,6 @@ import {
   ElementsToRerender,
   ErrorMessages,
   FloatingInsertMenuState,
-  GithubRepo,
   GithubState,
   LeftMenuTab,
   ModalDialog,
@@ -57,15 +55,12 @@ import {
   RightMenuTab,
   StoredEditorState,
   GithubOperation,
-  FileChecksums,
   GithubData,
   UserConfiguration,
   ThemeSetting,
   ColorSwatch,
-  NavigatorEntry,
 } from './store/editor-state'
 import { Notice } from '../common/notice'
-import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
 import type { LoginState } from '../../common/user'
 import { InsertableComponent, StylePropOption } from '../shared/project-components'
 import { LayoutTargetableProp } from '../../core/layout/layout-helpers-new'
@@ -76,6 +71,7 @@ import { CanvasCommand } from '../canvas/commands/commands'
 import { InsertionPath } from './store/insertion-path'
 import { TextProp } from '../text-editor/text-editor'
 import { ElementPathTrees } from '../../core/shared/element-path-tree'
+import { FromVSCodeAction } from './actions/actions-from-vscode'
 export { isLoggedIn, loggedInUser, notLoggedIn } from '../../common/user'
 export type { LoginState, UserDetails } from '../../common/user'
 
@@ -679,13 +675,6 @@ export interface UpdateFromWorker {
   updates: Array<WorkerParsedUpdate | WorkerCodeAndParsedUpdate>
 }
 
-export interface UpdateFromCodeEditor {
-  action: 'UPDATE_FROM_CODE_EDITOR'
-  filePath: string
-  savedContent: string
-  unsavedContent: string | null
-}
-
 export interface ClearParseOrPrintInFlight {
   action: 'CLEAR_PARSE_OR_PRINT_IN_FLIGHT'
 }
@@ -726,12 +715,6 @@ export interface SetCodeEditorBuildErrors {
 export interface SetCodeEditorLintErrors {
   action: 'SET_CODE_EDITOR_LINT_ERRORS'
   lintErrors: ErrorMessages
-}
-
-export interface SendLinterRequestMessage {
-  action: 'SEND_LINTER_REQUEST_MESSAGE'
-  filePath: string
-  content: string
 }
 
 export interface SaveDOMReport {
@@ -900,22 +883,6 @@ export interface UpdateText {
   textProp: TextProp
 }
 
-export interface MarkVSCodeBridgeReady {
-  action: 'MARK_VSCODE_BRIDGE_READY'
-  ready: boolean
-}
-
-export interface SelectFromFileAndPosition {
-  action: 'SELECT_FROM_FILE_AND_POSITION'
-  filePath: string
-  line: number
-  column: number
-}
-
-export interface SendCodeEditorInitialisation {
-  action: 'SEND_CODE_EDITOR_INITIALISATION'
-}
-
 export interface SetFocusedElement {
   action: 'SET_FOCUSED_ELEMENT'
   focusedElementPath: ElementPath | null
@@ -935,11 +902,6 @@ export interface SetScrollAnimation {
 export interface SetFollowSelectionEnabled {
   action: 'SET_FOLLOW_SELECTION_ENABLED'
   value: boolean
-}
-
-export interface UpdateConfigFromVSCode {
-  action: 'UPDATE_CONFIG_FROM_VSCODE'
-  config: UtopiaVSCodeConfig
 }
 
 export interface SetLoginState {
@@ -1030,15 +992,6 @@ export interface SetResizeOptionsTargetOptions {
   action: 'SET_RESIZE_OPTIONS_TARGET_OPTIONS'
   propertyTargetOptions: Array<LayoutTargetableProp>
   index: number | null
-}
-
-export interface HideVSCodeLoadingScreen {
-  action: 'HIDE_VSCODE_LOADING_SCREEN'
-}
-
-export interface SetIndexedDBFailed {
-  action: 'SET_INDEXED_DB_FAILED'
-  indexedDBFailed: boolean
 }
 
 export interface ForceParseFile {
@@ -1187,7 +1140,6 @@ export type EditorAction =
   | UpdateGithubData
   | RemoveFileConflict
   | UpdateFromWorker
-  | UpdateFromCodeEditor
   | ClearParseOrPrintInFlight
   | ClearImageFileBlob
   | AddFolder
@@ -1196,7 +1148,6 @@ export type EditorAction =
   | SetMainUIFile
   | SetCodeEditorBuildErrors
   | SetCodeEditorLintErrors
-  | SendLinterRequestMessage
   | SaveDOMReport
   | SetProp
   | SetPropWithElementPath
@@ -1226,14 +1177,10 @@ export type EditorAction =
   | UpdatePropertyControlsInfo
   | AddStoryboardFile
   | UpdateText
-  | MarkVSCodeBridgeReady
-  | SelectFromFileAndPosition
-  | SendCodeEditorInitialisation
   | SetFocusedElement
   | ScrollToElement
   | SetScrollAnimation
   | SetFollowSelectionEnabled
-  | UpdateConfigFromVSCode
   | SetLoginState
   | SetGithubState
   | SetUserConfiguration
@@ -1250,8 +1197,6 @@ export type EditorAction =
   | DecrementResizeOptionsSelectedIndex
   | IncrementResizeOptionsSelectedIndex
   | SetResizeOptionsTargetOptions
-  | HideVSCodeLoadingScreen
-  | SetIndexedDBFailed
   | ForceParseFile
   | RunEscapeHatch
   | SetElementsToRerender
@@ -1266,6 +1211,7 @@ export type EditorAction =
   | SetConditionalOverriddenCondition
   | SwitchConditionalBranches
   | UpdateConditionalExpression
+  | FromVSCodeAction
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -101,7 +101,6 @@ import type {
   SaveImageSwitchMode,
   SelectAllSiblings,
   SelectComponents,
-  SendLinterRequestMessage,
   SendPreviewModel,
   SetAspectRatioLock,
   SetCanvasFrames,
@@ -160,17 +159,12 @@ import type {
   UpdatePreviewConnected,
   UpdatePropertyControlsInfo,
   UpdateThumbnailGenerated,
-  UpdateFromCodeEditor,
-  MarkVSCodeBridgeReady,
-  SelectFromFileAndPosition,
-  SendCodeEditorInitialisation,
   CloseDesignerFile,
   SetFocusedElement,
   AddImports,
   ScrollToElement,
   WorkerParsedUpdate,
   SetScrollAnimation,
-  UpdateConfigFromVSCode,
   SetFollowSelectionEnabled,
   SetLoginState,
   ResetCanvas,
@@ -191,8 +185,6 @@ import type {
   DecrementResizeOptionsSelectedIndex,
   IncrementResizeOptionsSelectedIndex,
   SetResizeOptionsTargetOptions,
-  HideVSCodeLoadingScreen,
-  SetIndexedDBFailed,
   ForceParseFile,
   RemoveFromNodeModulesContents,
   RunEscapeHatch,
@@ -1116,19 +1108,6 @@ export function updateFromWorker(
   }
 }
 
-export function updateFromCodeEditor(
-  filePath: string,
-  savedContent: string,
-  unsavedContent: string | null,
-): UpdateFromCodeEditor {
-  return {
-    action: 'UPDATE_FROM_CODE_EDITOR',
-    filePath: filePath,
-    savedContent: savedContent,
-    unsavedContent: unsavedContent,
-  }
-}
-
 export function clearParseOrPrintInFlight(): ClearParseOrPrintInFlight {
   return {
     action: 'CLEAR_PARSE_OR_PRINT_IN_FLIGHT',
@@ -1424,49 +1403,12 @@ export function addStoryboardFile(): AddStoryboardFile {
   }
 }
 
-export function sendLinterRequestMessage(
-  filePath: string,
-  content: string,
-): SendLinterRequestMessage {
-  return {
-    action: 'SEND_LINTER_REQUEST_MESSAGE',
-    filePath: filePath,
-    content: content,
-  }
-}
-
 export function updateText(target: ElementPath, text: string, textProp: TextProp): UpdateText {
   return {
     action: 'UPDATE_TEXT',
     target: target,
     text: text,
     textProp: textProp,
-  }
-}
-
-export function markVSCodeBridgeReady(ready: boolean): MarkVSCodeBridgeReady {
-  return {
-    action: 'MARK_VSCODE_BRIDGE_READY',
-    ready: ready,
-  }
-}
-
-export function selectFromFileAndPosition(
-  filePath: string,
-  line: number,
-  column: number,
-): SelectFromFileAndPosition {
-  return {
-    action: 'SELECT_FROM_FILE_AND_POSITION',
-    filePath: filePath,
-    line: line,
-    column: column,
-  }
-}
-
-export function sendCodeEditorInitialisation(): SendCodeEditorInitialisation {
-  return {
-    action: 'SEND_CODE_EDITOR_INITIALISATION',
   }
 }
 
@@ -1501,13 +1443,6 @@ export function setFollowSelectionEnabled(value: boolean): SetFollowSelectionEna
   return {
     action: 'SET_FOLLOW_SELECTION_ENABLED',
     value: value,
-  }
-}
-
-export function updateConfigFromVSCode(config: UtopiaVSCodeConfig): UpdateConfigFromVSCode {
-  return {
-    action: 'UPDATE_CONFIG_FROM_VSCODE',
-    config: config,
   }
 }
 
@@ -1632,18 +1567,6 @@ export function setResizeOptionsTargetOptions(
     action: 'SET_RESIZE_OPTIONS_TARGET_OPTIONS',
     propertyTargetOptions: propertyTargetOptions,
     index: index,
-  }
-}
-export function hideVSCodeLoadingScreen(): HideVSCodeLoadingScreen {
-  return {
-    action: 'HIDE_VSCODE_LOADING_SCREEN',
-  }
-}
-
-export function setIndexedDBFailed(indexedDBFailed: boolean): SetIndexedDBFailed {
-  return {
-    action: 'SET_INDEXED_DB_FAILED',
-    indexedDBFailed: indexedDBFailed,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -1,4 +1,5 @@
 import { EditorAction } from '../action-types'
+import { isFromVSCodeAction } from './actions-from-vscode'
 
 export function isTransientAction(action: EditorAction): boolean {
   switch (action.action) {
@@ -163,6 +164,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_FILE_PATH':
     case 'ADD_FOLDER':
     case 'DELETE_FILE':
+    case 'DELETE_FILE_FROM_VSCODE':
     case 'ADD_TEXT_FILE':
     case 'UPDATE_FILE':
     case 'UPDATE_PROJECT_CONTENTS':
@@ -241,11 +243,8 @@ export function isFromVSCode(action: EditorAction): boolean {
     case 'ATOMIC':
     case 'MERGE_WITH_PREV_UNDO':
       return action.actions.some(isFromVSCode)
-    case 'UPDATE_FROM_CODE_EDITOR':
-    case 'SEND_LINTER_REQUEST_MESSAGE':
-      return true
     default:
-      return false
+      return isFromVSCodeAction(action)
   }
 }
 

--- a/editor/src/components/editor/actions/actions-from-vscode.ts
+++ b/editor/src/components/editor/actions/actions-from-vscode.ts
@@ -1,0 +1,157 @@
+import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
+
+export interface DeleteFileFromVSCode {
+  // Exactly the same as the regular DeleteFile action, but signifies this came from the code editor
+  action: 'DELETE_FILE_FROM_VSCODE'
+  filename: string
+}
+
+export function deleteFileFromVSCode(filename: string): DeleteFileFromVSCode {
+  return {
+    action: 'DELETE_FILE_FROM_VSCODE',
+    filename: filename,
+  }
+}
+
+export interface HideVSCodeLoadingScreen {
+  action: 'HIDE_VSCODE_LOADING_SCREEN'
+}
+
+export function hideVSCodeLoadingScreen(): HideVSCodeLoadingScreen {
+  return {
+    action: 'HIDE_VSCODE_LOADING_SCREEN',
+  }
+}
+
+export interface MarkVSCodeBridgeReady {
+  action: 'MARK_VSCODE_BRIDGE_READY'
+  ready: boolean
+}
+
+export function markVSCodeBridgeReady(ready: boolean): MarkVSCodeBridgeReady {
+  return {
+    action: 'MARK_VSCODE_BRIDGE_READY',
+    ready: ready,
+  }
+}
+
+export interface SelectFromFileAndPosition {
+  action: 'SELECT_FROM_FILE_AND_POSITION'
+  filePath: string
+  line: number
+  column: number
+}
+
+export function selectFromFileAndPosition(
+  filePath: string,
+  line: number,
+  column: number,
+): SelectFromFileAndPosition {
+  return {
+    action: 'SELECT_FROM_FILE_AND_POSITION',
+    filePath: filePath,
+    line: line,
+    column: column,
+  }
+}
+
+export interface SendCodeEditorInitialisation {
+  action: 'SEND_CODE_EDITOR_INITIALISATION'
+}
+
+export function sendCodeEditorInitialisation(): SendCodeEditorInitialisation {
+  return {
+    action: 'SEND_CODE_EDITOR_INITIALISATION',
+  }
+}
+
+export interface SendLinterRequestMessage {
+  action: 'SEND_LINTER_REQUEST_MESSAGE'
+  filePath: string
+  content: string
+}
+
+export function sendLinterRequestMessage(
+  filePath: string,
+  content: string,
+): SendLinterRequestMessage {
+  return {
+    action: 'SEND_LINTER_REQUEST_MESSAGE',
+    filePath: filePath,
+    content: content,
+  }
+}
+
+export interface SetIndexedDBFailed {
+  action: 'SET_INDEXED_DB_FAILED'
+  indexedDBFailed: boolean
+}
+
+export function setIndexedDBFailed(indexedDBFailed: boolean): SetIndexedDBFailed {
+  return {
+    action: 'SET_INDEXED_DB_FAILED',
+    indexedDBFailed: indexedDBFailed,
+  }
+}
+
+export interface UpdateConfigFromVSCode {
+  action: 'UPDATE_CONFIG_FROM_VSCODE'
+  config: UtopiaVSCodeConfig
+}
+
+export function updateConfigFromVSCode(config: UtopiaVSCodeConfig): UpdateConfigFromVSCode {
+  return {
+    action: 'UPDATE_CONFIG_FROM_VSCODE',
+    config: config,
+  }
+}
+
+export interface UpdateFromCodeEditor {
+  action: 'UPDATE_FROM_CODE_EDITOR'
+  filePath: string
+  savedContent: string
+  unsavedContent: string | null
+}
+
+export function updateFromCodeEditor(
+  filePath: string,
+  savedContent: string,
+  unsavedContent: string | null,
+): UpdateFromCodeEditor {
+  return {
+    action: 'UPDATE_FROM_CODE_EDITOR',
+    filePath: filePath,
+    savedContent: savedContent,
+    unsavedContent: unsavedContent,
+  }
+}
+
+export type FromVSCodeAction =
+  | DeleteFileFromVSCode
+  | HideVSCodeLoadingScreen
+  | MarkVSCodeBridgeReady
+  | SelectFromFileAndPosition
+  | SendCodeEditorInitialisation
+  | SendLinterRequestMessage
+  | SetIndexedDBFailed
+  | UpdateConfigFromVSCode
+  | UpdateFromCodeEditor
+
+export function isFromVSCodeAction(
+  action: { action: string } & unknown,
+): action is FromVSCodeAction {
+  switch (action.action) {
+    case 'DELETE_FILE_FROM_VSCODE':
+    case 'HIDE_VSCODE_LOADING_SCREEN':
+    case 'MARK_VSCODE_BRIDGE_READY':
+    case 'SELECT_FROM_FILE_AND_POSITION':
+    case 'SEND_CODE_EDITOR_INITIALISATION':
+    case 'SEND_LINTER_REQUEST_MESSAGE':
+    case 'SET_INDEXED_DB_FAILED':
+    case 'UPDATE_CONFIG_FROM_VSCODE':
+    case 'UPDATE_FROM_CODE_EDITOR':
+      return true
+    default:
+      return false
+  }
+}

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -220,14 +220,12 @@ import {
   FinishCheckpointTimer,
   ForceParseFile,
   HideModal,
-  HideVSCodeLoadingScreen,
   InsertDroppedImage,
   InsertImageIntoUI,
   InsertInsertable,
   InsertJSXElement,
   isLoggedIn,
   Load,
-  MarkVSCodeBridgeReady,
   NavigatorReorder,
   NewProject,
   OpenCodeEditorFile,
@@ -250,8 +248,6 @@ import {
   ScrollToElement,
   SelectAllSiblings,
   SelectComponents,
-  SelectFromFileAndPosition,
-  SendCodeEditorInitialisation,
   SendPreviewModel,
   SetAspectRatioLock,
   SetCanvasFrames,
@@ -269,7 +265,6 @@ import {
   SetGithubState,
   SetHighlightedViews,
   SetImageDragSessionState,
-  SetIndexedDBFailed,
   SetLeftMenuExpanded,
   SetLeftMenuTab,
   SetLoginState,
@@ -309,14 +304,12 @@ import {
   UnwrapElement,
   UpdateText,
   UpdateCodeResultCache,
-  UpdateConfigFromVSCode,
   UpdateDuplicationState,
   UpdateEditorMode,
   UpdateFile,
   UpdateFilePath,
   UpdateFormulaBarMode,
   UpdateFrameDimensions,
-  UpdateFromCodeEditor,
   UpdateFromWorker,
   UpdateGithubSettings,
   UpdateJSXElementName,
@@ -348,7 +341,6 @@ import {
   PasteToReplace,
   ElementPaste,
 } from '../action-types'
-import { defaultSceneElement, defaultTransparentViewElement } from '../defaults'
 import { EditorModes, isLiveMode, isSelectMode, Mode } from '../editor-modes'
 import * as History from '../history'
 import { StateHistory } from '../history'
@@ -564,6 +556,16 @@ import { MetadataSnapshots } from '../../canvas/canvas-strategies/strategies/rep
 import { getAllUniqueUids } from '../../../core/model/get-unique-ids'
 import { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import { addToReparentedToPaths } from '../../canvas/commands/add-to-reparented-to-paths-command'
+import {
+  DeleteFileFromVSCode,
+  HideVSCodeLoadingScreen,
+  MarkVSCodeBridgeReady,
+  SelectFromFileAndPosition,
+  SendCodeEditorInitialisation,
+  SetIndexedDBFailed,
+  UpdateConfigFromVSCode,
+  UpdateFromCodeEditor,
+} from './actions-from-vscode'
 
 export const MIN_CODE_PANE_REOPEN_WIDTH = 100
 
@@ -4124,7 +4126,7 @@ export const UPDATE_FNS = {
     return UPDATE_FNS.OPEN_CODE_EDITOR_FILE(openCodeEditorFile(newFileKey, false), updatedEditor)
   },
   DELETE_FILE: (
-    action: DeleteFile,
+    action: DeleteFile | DeleteFileFromVSCode,
     editor: EditorModel,
     derived: DerivedState,
     userState: UserState,

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -577,8 +577,12 @@ export function editorDispatch(
 
   if (!isLoadAction) {
     // If the action was a load action then we don't want to send across any changes
-    const projectChanges = getProjectChanges(storedState.unpatchedEditor, frozenEditorState)
-    applyProjectChanges(frozenEditorState, projectChanges, updatedFromVSCode)
+    const projectChanges = getProjectChanges(
+      storedState.unpatchedEditor,
+      frozenEditorState,
+      updatedFromVSCode,
+    )
+    applyProjectChanges(frozenEditorState, projectChanges)
   }
 
   const shouldUpdatePreview =
@@ -645,17 +649,8 @@ function cullElementPathCache() {
   removePathsWithDeadUIDs(new Set(allExistingUids))
 }
 
-function applyProjectChanges(
-  frozenEditorState: EditorState,
-  projectChanges: ProjectChanges,
-  updatedFromVSCode: boolean,
-) {
-  accumulatedProjectChanges = combineProjectChanges(
-    accumulatedProjectChanges,
-    updatedFromVSCode
-      ? { ...projectChanges, selectedChanged: null, fileChanges: [] }
-      : projectChanges,
-  )
+function applyProjectChanges(frozenEditorState: EditorState, projectChanges: ProjectChanges) {
+  accumulatedProjectChanges = combineProjectChanges(accumulatedProjectChanges, projectChanges)
 
   if (frozenEditorState.vscodeReady) {
     const changesToSend = accumulatedProjectChanges

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -575,12 +575,20 @@ export function editorDispatch(
     )
   }
 
+  // If the action was a load action then we don't want to send across any changes
   if (!isLoadAction) {
-    // If the action was a load action then we don't want to send across any changes
+    const parsedAfterCodeChanged =
+      dispatchedActions.length === 1 &&
+      dispatchedActions[0].action === 'UPDATE_FROM_WORKER' &&
+      dispatchedActions[0].updates.some((update) => update.type === 'WORKER_PARSED_UPDATE')
+
+    // We don't want to send selection changes coming from updates triggered by changes made in the code editor
+    const updatedFromVSCodeOrParsedAfterCodeChange = updatedFromVSCode || parsedAfterCodeChanged
+
     const projectChanges = getProjectChanges(
       storedState.unpatchedEditor,
       frozenEditorState,
-      updatedFromVSCode,
+      updatedFromVSCodeOrParsedAfterCodeChange,
     )
     applyProjectChanges(frozenEditorState, projectChanges)
   }

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -652,7 +652,9 @@ function applyProjectChanges(
 ) {
   accumulatedProjectChanges = combineProjectChanges(
     accumulatedProjectChanges,
-    updatedFromVSCode ? { ...projectChanges, fileChanges: [] } : projectChanges,
+    updatedFromVSCode
+      ? { ...projectChanges, selectedChanged: null, fileChanges: [] }
+      : projectChanges,
   )
 
   if (frozenEditorState.vscodeReady) {

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -225,6 +225,7 @@ export function runSimpleLocalEditorAction(
     case 'ADD_FOLDER':
       return UPDATE_FNS.ADD_FOLDER(action, state)
     case 'DELETE_FILE':
+    case 'DELETE_FILE_FROM_VSCODE':
       return UPDATE_FNS.DELETE_FILE(action, state, derivedState, userState)
     case 'ADD_TEXT_FILE':
       return UPDATE_FNS.ADD_TEXT_FILE(action, state)

--- a/editor/src/components/editor/store/vscode-changes.ts
+++ b/editor/src/components/editor/store/vscode-changes.ts
@@ -290,15 +290,17 @@ export function projectChangesToVSCodeMessages(local: ProjectChanges): Accumulat
 export function getProjectChanges(
   oldEditorState: EditorState,
   newEditorState: EditorState,
+  updatedFromVSCode: boolean,
 ): ProjectChanges {
   return {
-    fileChanges: getProjectContentsChanges(oldEditorState, newEditorState),
+    fileChanges: updatedFromVSCode ? [] : getProjectContentsChanges(oldEditorState, newEditorState),
     updateDecorations: shouldIncludeVSCodeDecorations(oldEditorState, newEditorState)
       ? getCodeEditorDecorations(newEditorState)
       : null,
-    selectedChanged: shouldIncludeSelectedElementChanges(oldEditorState, newEditorState)
-      ? getSelectedElementChangedMessage(newEditorState)
-      : null,
+    selectedChanged:
+      !updatedFromVSCode && shouldIncludeSelectedElementChanges(oldEditorState, newEditorState)
+        ? getSelectedElementChangedMessage(newEditorState)
+        : null,
   }
 }
 

--- a/editor/src/components/editor/store/vscode-changes.ts
+++ b/editor/src/components/editor/store/vscode-changes.ts
@@ -32,6 +32,7 @@ import {
   getUnderlyingVSCodeBridgeID,
 } from './editor-state'
 import { shallowEqual } from '../../../core/shared/equality-utils'
+import * as EP from '../../../core/shared/element-path'
 
 export interface WriteProjectFileChange {
   type: 'WRITE_PROJECT_FILE'
@@ -186,10 +187,10 @@ export function shouldIncludeVSCodeDecorations(
     [...newEditorState.highlightedViews, ...newEditorState.selectedViews],
     newEditorState,
   )
-  return (
-    oldEditorState.selectedViews !== newEditorState.selectedViews ||
-    oldEditorState.highlightedViews !== newEditorState.highlightedViews ||
-    !shallowEqual(oldHighlightBounds, newHighlightBounds)
+  return !(
+    EP.arrayOfPathsEqual(oldEditorState.selectedViews, newEditorState.selectedViews) &&
+    EP.arrayOfPathsEqual(oldEditorState.highlightedViews, newEditorState.highlightedViews) &&
+    shallowEqual(oldHighlightBounds, newHighlightBounds)
   )
 }
 
@@ -206,9 +207,10 @@ export function shouldIncludeSelectedElementChanges(
     newEditorState,
   )
   return (
-    (oldEditorState.selectedViews !== newEditorState.selectedViews ||
-      !shallowEqual(oldHighlightBounds, newHighlightBounds)) &&
-    newEditorState.selectedViews.length > 0
+    !(
+      EP.arrayOfPathsEqual(oldEditorState.selectedViews, newEditorState.selectedViews) &&
+      shallowEqual(oldHighlightBounds, newHighlightBounds)
+    ) && newEditorState.selectedViews.length > 0
   )
 }
 

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -17,7 +17,6 @@ import {
   textFileContents,
   unparsed,
 } from '../../../core/shared/project-file-types'
-import { setFeatureEnabled } from '../../../utils/feature-switches'
 import { expectSingleUndo2Saves, selectComponentsForTest } from '../../../utils/utils.test-utils'
 import { contentsToTree } from '../../assets'
 import { SubduedBorderRadiusControlTestId } from '../../canvas/controls/select-mode/subdued-border-radius-control'
@@ -34,11 +33,7 @@ import {
 } from '../../canvas/ui-jsx.test-utils'
 import { createCodeFile } from '../../custom-code/code-file.test-utils'
 import { EditorAction } from '../../editor/action-types'
-import {
-  selectComponents,
-  sendLinterRequestMessage,
-  updateFromCodeEditor,
-} from '../../editor/actions/action-creators'
+import { selectComponents } from '../../editor/actions/action-creators'
 import { DefaultPackageJson, StoryboardFilePath } from '../../editor/store/editor-state'
 import {
   ConditionalOverrideControlToggleTestId,
@@ -53,6 +48,10 @@ import {
   ConditionalsControlSwitchBranchesTestId,
 } from '../sections/layout-section/conditional-section'
 import { pressKey } from '../../canvas/event-helpers.test-utils'
+import {
+  sendLinterRequestMessage,
+  updateFromCodeEditor,
+} from '../../editor/actions/actions-from-vscode'
 
 async function getControl(
   controlTestId: string,

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -5,7 +5,13 @@ import {
   StaticElementPathPart,
   StaticElementPath,
 } from './project-file-types'
-import { arrayEqualsByReference, longestCommonArray, identity, fastForEach } from './utils'
+import {
+  arrayEqualsByReference,
+  longestCommonArray,
+  identity,
+  fastForEach,
+  arrayEqualsByValue,
+} from './utils'
 import { replaceAll } from './string-utils'
 import { last, dropLastN, drop, splitAt, flattenArray, dropLast } from './array-utils'
 import { forceNotNull } from './optional-utils'
@@ -548,6 +554,10 @@ export function pathsEqual(l: ElementPath | null, r: ElementPath | null): boolea
   } else {
     return stringifiedPathsEqual(l, r)
   }
+}
+
+export function arrayOfPathsEqual(l: Array<ElementPath>, r: Array<ElementPath>): boolean {
+  return arrayEqualsByValue(l, r, pathsEqual)
 }
 
 export function containsPath(path: ElementPath, paths: Array<ElementPath>): boolean {


### PR DESCRIPTION
**Problem:**
When the `selectedViews` are changed we check if the code editor pane is the `document.activeElement` before sending the updated selection to the code editor. There is a flaw with this however - if the code editor is focused, and the user clicks to select a new element (via the Navigator and in some cases via the Canvas) the code editor will still be the `activeElement` at the point where we attempt to send that selection change.

**Fix:**
Rather than trying to hack together a fix that works in this edge case, I've opted to explicitly type the actions that are dispatched by the code editor as `FromVSCodeAction`. These have all been moved to their own file, along with a function `isFromVSCodeAction`, and the `dispatch` provided to the VS Code Bridge has been restricted to only these actions. Now that this has been done, we can rely on a check that we already had which checks if the dispatched actions have come from VS Code, and if that is the case we won't send project changes or selection changes back to the code editor (rather than having to rely on the `activeElement`).

Along the way I also discovered that we were using reference equality when determining if the selected or highlighted elements had changed (so we'd know whether or not to update the code editor), so I've replaced that with regular `pathsEqual` check that we should have been using.