### PR TITLE
Scroll to element and bring it to the center of the canvas

### DIFF
--- a/editor/src/components/canvas/controls/elements-outside-visible-area.tsx
+++ b/editor/src/components/canvas/controls/elements-outside-visible-area.tsx
@@ -29,7 +29,7 @@ export const ElementsOutsideVisibleAreaIndicators = React.memo(
 
     const scrollTo = React.useCallback(
       (path: ElementPath) => () => {
-        dispatch([scrollToElement(path, false)])
+        dispatch([scrollToElement(path, 'to-center')])
       },
       [dispatch],
     )

--- a/editor/src/components/canvas/controls/elements-outside-visible.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/elements-outside-visible.spec.browser2.tsx
@@ -385,14 +385,10 @@ describe('elements outside visible area', () => {
         throw new Error('element frame not found')
       }
 
-      const bodyRect = document.body.getBoundingClientRect()
-      const pointOnWindow = offsetPoint(
-        canvasPointToWindowPoint(
-          elementFrame,
-          renderResult.getEditorState().editor.canvas.scale,
-          renderResult.getEditorState().editor.canvas.roundedCanvasOffset,
-        ),
-        windowPoint({ x: 0, y: -(bodyRect.y + canvasRect.y + 20) }), // accommodate for Karma runner vertical skew
+      const pointOnWindow = canvasPointToWindowPoint(
+        elementFrame,
+        renderResult.getEditorState().editor.canvas.scale,
+        renderResult.getEditorState().editor.canvas.roundedCanvasOffset,
       )
 
       const canvasCenter = getRectCenter(

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -212,7 +212,7 @@ export const setAsFocusedElement: ContextMenuItem<CanvasData> = {
       const sv = data.selectedViews[0]
       requireDispatch(dispatch)([
         EditorActions.setFocusedElement(sv),
-        EditorActions.scrollToElement(sv, true),
+        EditorActions.scrollToElement(sv, 'keep-scroll-position-if-visible'),
       ])
     }
   },
@@ -242,7 +242,7 @@ export const scrollToElement: ContextMenuItem<CanvasData> = {
   action: (data, dispatch?: EditorDispatch) => {
     if (data.selectedViews.length > 0) {
       const sv = data.selectedViews[0]
-      requireDispatch(dispatch)([EditorActions.scrollToElement(sv, false)])
+      requireDispatch(dispatch)([EditorActions.scrollToElement(sv, 'to-origin')])
     }
   },
 }

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -921,10 +921,12 @@ export interface SetFocusedElement {
   focusedElementPath: ElementPath | null
 }
 
+export type ScrollToElementBehaviour = 'keep-scroll-position-if-visible' | 'to-center' | 'to-origin'
+
 export interface ScrollToElement {
   action: 'SCROLL_TO_ELEMENT'
   target: ElementPath
-  keepScrollPositionIfVisible: boolean
+  behaviour: ScrollToElementBehaviour
 }
 
 export interface SetScrollAnimation {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -224,6 +224,7 @@ import type {
   UpdateConditionalExpression,
   PasteToReplace,
   CutSelectionToClipboard,
+  ScrollToElementBehaviour,
 } from '../action-types'
 import { EditorModes, insertionSubject, InsertionSubjectWrapper, Mode } from '../editor-modes'
 import type {
@@ -1481,12 +1482,12 @@ export function setFocusedElement(
 
 export function scrollToElement(
   focusedElementElementPath: ElementPath,
-  keepScrollPositionIfVisible: boolean,
+  behaviour: ScrollToElementBehaviour,
 ): ScrollToElement {
   return {
     action: 'SCROLL_TO_ELEMENT',
     target: focusedElementElementPath,
-    keepScrollPositionIfVisible: keepScrollPositionIfVisible,
+    behaviour: behaviour,
   }
 }
 

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -424,6 +424,7 @@ import {
   reparentTargetFromNavigatorEntry,
   modifyOpenJsxChildAtPath,
   isConditionalClauseNavigatorEntry,
+  DefaultNavigatorWidth,
 } from '../store/editor-state'
 import { loadStoredState } from '../stored-state'
 import { applyMigrations } from './migrations/migrations'
@@ -4875,7 +4876,7 @@ export const UPDATE_FNS = {
     if (targetElementCoords != null && isFiniteRectangle(targetElementCoords)) {
       const isNavigatorOnTop = !editor.navigator.minimised
       const containerRootDiv = document.getElementById('canvas-root')
-      const navigatorOffset = isNavigatorOnTop ? LeftPaneDefaultWidth : 0
+      const navigatorOffset = isNavigatorOnTop ? DefaultNavigatorWidth : 0
 
       // This returns the offset for 'to-origin' scroll behaviours, or used as the default
       // for the other behaviours.
@@ -4901,7 +4902,7 @@ export const UPDATE_FNS = {
           }),
         )
         const topLeftTarget = canvasPoint({
-          x: canvasCenter.x - frame.width / 2 - bounds.x + (navigatorOffset / 2 + 10) * scale,
+          x: canvasCenter.x - frame.width / 2 - bounds.x + (navigatorOffset / 2) * scale,
           y: canvasCenter.y - frame.height / 2 - bounds.y,
         })
         return Utils.pointDifference(frame, topLeftTarget)

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4896,7 +4896,7 @@ export const UPDATE_FNS = {
         }
         const xOffset = navigatorOffset > 0 ? navigatorOffset + 20 : 0
         return canvasPoint({
-          x: xOffset + (bounds.width - xOffset - frame.width) / 2,
+          x: xOffset + (bounds.width - xOffset - frame.width) / 2 - frame.x,
           y: (bounds.height - frame.height) / 2,
         })
       }

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -121,6 +121,7 @@ import {
   boundingRectangleArray,
   offsetPoint,
   CanvasVector,
+  getRectCenter,
 } from '../../../core/shared/math-utils'
 import {
   PackageStatusMap,
@@ -4894,11 +4895,20 @@ export const UPDATE_FNS = {
         if (bounds == null) {
           return canvasOffsetToOrigin(frame) // fallback default
         }
-        const xOffset = navigatorOffset > 0 ? navigatorOffset + 20 : 0
-        return canvasPoint({
-          x: xOffset + (bounds.width - xOffset - frame.width) / 2 - frame.x,
-          y: (bounds.height - frame.height) / 2,
+        const scale = 1 / editor.canvas.scale
+        const canvasCenter = getRectCenter(
+          canvasRectangle({
+            x: bounds.x,
+            y: bounds.y,
+            width: bounds.width * scale,
+            height: bounds.height * scale,
+          }),
+        )
+        const topLeftTarget = canvasPoint({
+          x: canvasCenter.x - frame.width / 2 - bounds.x + (navigatorOffset / 2 + 10) * scale,
+          y: canvasCenter.y - frame.height / 2 - bounds.y,
         })
+        return Utils.pointDifference(frame, topLeftTarget)
       }
 
       function canvasOffsetKeepScrollPositionIfVisible(


### PR DESCRIPTION
Fixes #3869 

**Problem:**

The `SCROLL_TO_ELEMENT` function does not support scrolling so that the target element ends up in the center of the canvas. This came up clearly in #3842, and this PR is a follow up to that.

**Fix:**

https://github.com/concrete-utopia/utopia/assets/1081051/1fc9944b-8f31-4648-a36a-ae96c368240d

Extend the "behaviour" of the `SCROLL_TO_ELEMENT` action so that it can do three things depending on its invocation:
1. scroll to origin (top left) of the canvas
2. scroll to the center of the canvas **`(← added in this PR)`**
3. do nothing if the element is already visible

The new scroll-to-center behaviour is used only in the arrow indicators, as I kept the other two for compatibility; they can be swapped out though by changing the behaviour parameter.