### PR TITLE
Scroll Navigator to first element when selected

### DIFF
--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -176,7 +176,7 @@ export const NavigatorComponent = React.memo(() => {
   const itemListRef = React.createRef<VariableSizeList>()
 
   React.useEffect(() => {
-    if (selectionIndex > 0) {
+    if (selectionIndex >= 0) {
       itemListRef.current?.scrollToItem(selectionIndex)
     }
   }, [selectionIndex, itemListRef])


### PR DESCRIPTION
**Problem:**
The Navigator wouldn't scroll to the very first row if that element was selected

**Fix:**
This was a very simple `> 0` rather than `>= 0` check