### PR TITLE
Handle elements that subsequently become expressions.

### DIFF
--- a/editor/src/core/workers/parser-printer/uid-fix.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.ts
@@ -65,7 +65,7 @@ const expressionOtherJavaScriptUIDOptic: Optic<JSExpressionOtherJavaScript, stri
 
 const jsExpressionUIDOptic: Optic<JSExpression, string> = fromField('uid')
 
-interface FixUIDsState {
+export interface FixUIDsState {
   mutableAllNewUIDs: Set<string>
   uidsExpectedToBeSeen: Set<string>
   mappings: UIDMappings
@@ -561,21 +561,7 @@ export function fixJSXElementChildUIDs(
     case 'ATTRIBUTE_NESTED_OBJECT':
     case 'ATTRIBUTE_FUNCTION_CALL':
     case 'ATTRIBUTE_OTHER_JAVASCRIPT': {
-      switch (oldElement?.type) {
-        case 'ATTRIBUTE_VALUE':
-        case 'ATTRIBUTE_NESTED_ARRAY':
-        case 'ATTRIBUTE_NESTED_OBJECT':
-        case 'ATTRIBUTE_FUNCTION_CALL':
-        case 'ATTRIBUTE_OTHER_JAVASCRIPT':
-          return fixExpressionUIDs(oldElement, newElement, fixUIDsState)
-        default:
-          return updateUID(
-            jsExpressionUIDOptic,
-            oldElement?.uid ?? newElement.uid,
-            fixUIDsState,
-            newElement,
-          )
-      }
+      return fixExpressionUIDs(oldElement, newElement, fixUIDsState)
     }
     default:
       assertNever(newElement)
@@ -642,7 +628,7 @@ export function fixJSXElementUIDs(
 }
 
 export function fixExpressionUIDs(
-  oldExpression: JSExpression | null | undefined,
+  oldExpression: JSXElementChild | null | undefined,
   newExpression: JSExpression,
   fixUIDsState: FixUIDsState,
 ): JSExpression {


### PR DESCRIPTION
**Problem:**
If an element with a given `data-uid` was wrapped in the code editor with an expression, then a duplicate UIDs error would trigger.

**Cause:**
In `fixJSXElementChildUIDs` if the new element was an attribute like value and the old element is not, then the new element is not walked and only its UID is updated. In the case above, this meant that `elementsWithin` would not be walked, but the UID would be copied over but would already exist in the unchanged `elementsWithin`.

**Fix:**
`fixJSXElementChildUIDs` has now been changed to always walk the attribute like values, regardless of the type.

**Commit Details:**
- `fixJSXElementChildUIDs` now calls `fixExpressionUIDs` for every possible case of `oldElement`.
- `fixExpressionUIDs` now supports a wider type for `oldExpression`.