### PR TITLE
Use forked console-feed whilst it is missing from npm

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -128,7 +128,7 @@
     "chroma-js": "2.1.0",
     "classnames": "2.2.6",
     "clipboard-polyfill": "2.4.6",
-    "console-feed": "2.8.8",
+    "console-feed": "git://github.com/concrete-utopia/console-feed.git#v2.8.11",
     "create-react-class": "15.6.3",
     "css-tree": "1.1.3",
     "eslint-plugin-import": "2.25.3",

--- a/editor/package.json
+++ b/editor/package.json
@@ -128,7 +128,7 @@
     "chroma-js": "2.1.0",
     "classnames": "2.2.6",
     "clipboard-polyfill": "2.4.6",
-    "console-feed": "git://github.com/concrete-utopia/console-feed.git#v2.8.11",
+    "console-feed": "git://github.com/concrete-utopia/console-feed.git#13e2c367adedb732cf1e9937574a3324e1f8580f",
     "create-react-class": "15.6.3",
     "css-tree": "1.1.3",
     "eslint-plugin-import": "2.25.3",

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -150,7 +150,7 @@ specifiers:
   clean-webpack-plugin: 3.0.0
   clipboard-polyfill: 2.4.6
   concurrently: 3.5.1
-  console-feed: 2.8.8
+  console-feed: git://github.com/concrete-utopia/console-feed.git#v2.8.11
   create-react-class: 15.6.3
   css-loader: 0.28.4
   css-tree: 1.1.3
@@ -349,7 +349,7 @@ dependencies:
   chroma-js: 2.1.0
   classnames: 2.2.6
   clipboard-polyfill: 2.4.6
-  console-feed: 2.8.8_ceyt5bfod5miybgg2gmf5ylbc4
+  console-feed: github.com/concrete-utopia/console-feed/b580f39dfa84985417edcd669c66de41b198e93d_ceyt5bfod5miybgg2gmf5ylbc4
   create-react-class: 15.6.3
   css-tree: 1.1.3
   eslint-plugin-import: 2.25.3_o5qc6eitjww7eqrkfjp7lje6uq
@@ -6078,7 +6078,7 @@ packages:
     dev: true
 
   /component-indexof/0.0.3:
-    resolution: {integrity: sha1-EdCRMSI5648yyPJa6csAL/6NPCQ=}
+    resolution: {integrity: sha512-puDQKvx/64HZXb4hBwIcvQLaLgux8o1CbWl39s41hrIIZDl1lJiD5jc22gj3RBeGK0ovxALDYpIbyjqDUUl0rw==}
     dev: false
 
   /compressible/2.0.18:
@@ -6164,23 +6164,6 @@ packages:
   /console-browserify/1.2.0:
     resolution: {integrity: sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==}
     dev: true
-
-  /console-feed/2.8.8_ceyt5bfod5miybgg2gmf5ylbc4:
-    resolution: {integrity: sha512-tqONbPYrolH9Gn8yMc+7sBZG9F9FkNJM68ziG5dInznBOHbHNua+Mq0S70EgvkhEpE9AifvV9d7EX2Jm5yDw2w==}
-    peerDependencies:
-      react: ^15.x || ^16.x
-    dependencies:
-      emotion: 9.2.12
-      emotion-theming: 9.2.9_md2woffurl5yt3dayrtnpfbjvy
-      linkifyjs: 2.1.9_ef5jwxihqo6n7gxfmzogljlgcm
-      react: 18.1.0_47cciibm4ysmleigs33s763fqu
-      react-emotion: 9.2.12_beus4p4qy2l5kloq3acohbokce
-      react-inspector: 2.3.1_react@18.1.0
-    transitivePeerDependencies:
-      - jquery
-      - prop-types
-      - react-dom
-    dev: false
 
   /constants-browserify/1.0.0:
     resolution: {integrity: sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=}
@@ -9841,7 +9824,7 @@ packages:
       call-bind: 1.0.2
 
   /is-window/1.0.2:
-    resolution: {integrity: sha1-LIlspT25feRdPDMTOmXYyfVjSA0=}
+    resolution: {integrity: sha512-uj00kdXyZb9t9RcAUAwMZAnkBUwdYGhYlt7djMXhfyhUCzwNba50tIiBKR7q0l7tdoBtFVw/3JmLY6fI3rmZmg==}
     dev: false
 
   /is-windows/1.0.2:
@@ -16976,6 +16959,26 @@ packages:
     dependencies:
       localforage: 1.9.0
       prettier: 2.0.5
+    dev: false
+
+  github.com/concrete-utopia/console-feed/b580f39dfa84985417edcd669c66de41b198e93d_ceyt5bfod5miybgg2gmf5ylbc4:
+    resolution: {tarball: https://codeload.github.com/concrete-utopia/console-feed/tar.gz/b580f39dfa84985417edcd669c66de41b198e93d}
+    id: github.com/concrete-utopia/console-feed/b580f39dfa84985417edcd669c66de41b198e93d
+    name: console-feed
+    version: 2.8.11
+    peerDependencies:
+      react: ^15.x || ^16.x
+    dependencies:
+      emotion: 9.2.12
+      emotion-theming: 9.2.9_md2woffurl5yt3dayrtnpfbjvy
+      linkifyjs: 2.1.9_ef5jwxihqo6n7gxfmzogljlgcm
+      react: 18.1.0_47cciibm4ysmleigs33s763fqu
+      react-emotion: 9.2.12_beus4p4qy2l5kloq3acohbokce
+      react-inspector: 2.3.1_react@18.1.0
+    transitivePeerDependencies:
+      - jquery
+      - prop-types
+      - react-dom
     dev: false
 
   github.com/concrete-utopia/react-error-overlay/201980990d653e821f36ab4f921a4f83588a8a42:

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -150,7 +150,7 @@ specifiers:
   clean-webpack-plugin: 3.0.0
   clipboard-polyfill: 2.4.6
   concurrently: 3.5.1
-  console-feed: git://github.com/concrete-utopia/console-feed.git#v2.8.11
+  console-feed: git://github.com/concrete-utopia/console-feed.git#13e2c367adedb732cf1e9937574a3324e1f8580f
   create-react-class: 15.6.3
   css-loader: 0.28.4
   css-tree: 1.1.3
@@ -349,7 +349,7 @@ dependencies:
   chroma-js: 2.1.0
   classnames: 2.2.6
   clipboard-polyfill: 2.4.6
-  console-feed: github.com/concrete-utopia/console-feed/b580f39dfa84985417edcd669c66de41b198e93d_ceyt5bfod5miybgg2gmf5ylbc4
+  console-feed: github.com/concrete-utopia/console-feed/13e2c367adedb732cf1e9937574a3324e1f8580f_ceyt5bfod5miybgg2gmf5ylbc4
   create-react-class: 15.6.3
   css-tree: 1.1.3
   eslint-plugin-import: 2.25.3_o5qc6eitjww7eqrkfjp7lje6uq
@@ -16961,9 +16961,9 @@ packages:
       prettier: 2.0.5
     dev: false
 
-  github.com/concrete-utopia/console-feed/b580f39dfa84985417edcd669c66de41b198e93d_ceyt5bfod5miybgg2gmf5ylbc4:
-    resolution: {tarball: https://codeload.github.com/concrete-utopia/console-feed/tar.gz/b580f39dfa84985417edcd669c66de41b198e93d}
-    id: github.com/concrete-utopia/console-feed/b580f39dfa84985417edcd669c66de41b198e93d
+  github.com/concrete-utopia/console-feed/13e2c367adedb732cf1e9937574a3324e1f8580f_ceyt5bfod5miybgg2gmf5ylbc4:
+    resolution: {tarball: https://codeload.github.com/concrete-utopia/console-feed/tar.gz/13e2c367adedb732cf1e9937574a3324e1f8580f}
+    id: github.com/concrete-utopia/console-feed/13e2c367adedb732cf1e9937574a3324e1f8580f
     name: console-feed
     version: 2.8.11
     peerDependencies:


### PR DESCRIPTION
**Problem:**
The `console-feed` package has disappeared from the npm registry.

**Fix:**
Use a fork of the package until then. I've also gone with v2.8.11 due to an XSS issue in versions < 2.8.10
