### PR TITLE
Correct paths using tilde in workflows

### DIFF
--- a/.github/workflows/cache-pnpm-install.yml
+++ b/.github/workflows/cache-pnpm-install.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Cache pnpm store
         uses: actions/cache@v2
         with:
-          path: ${{ capture-pnpm-store-path.outputs.pnpm-store-path }}
+          path: ${{ steps.capture-pnpm-store-path.outputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
       - name: Run the install steps
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run install-website-editor-ci

--- a/.github/workflows/cache-pnpm-install.yml
+++ b/.github/workflows/cache-pnpm-install.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Cache pnpm store
         uses: actions/cache@v2
         with:
-          path: ${{ steps.capture-pnpm-store-path.outputs.pnpm-store-path }
+          path: ${{ steps.capture-pnpm-store-path.outputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
       - name: Run the install steps
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run install-website-editor-ci

--- a/.github/workflows/cache-pnpm-install.yml
+++ b/.github/workflows/cache-pnpm-install.yml
@@ -1,0 +1,37 @@
+name: Cache PNPM Install
+
+on:
+  workflow_call:
+    outputs:
+      pnpm-store-path:
+        value: ${{ jobs.cache-pnpm-store.outputs.pnpm-store-path }}
+
+jobs:
+  cache-pnpm-store:
+    name: Install everything PNPM and cache it
+    runs-on: ubuntu-latest
+    env:
+      UTOPIA_SHA: ${{ github.sha }}
+    outputs:
+      pnpm-store-path: ${{ steps.capture-pnpm-store-path.outputs.pnpm-store-path }}
+    steps:
+      - name: Cancel existing runs on this branch
+        uses: fauguste/auto-cancellation-running-action@0.1.4
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Install nix
+        uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
+      - name: Capture pnpm store path
+        id: capture-pnpm-store-path
+        run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run 'echo "pnpm-store-path=$(pnpm store path)" >> "$GITHUB_OUTPUT"'
+      - name: Cache pnpm store
+        uses: actions/cache@v2
+        with:
+          path: ${{ capture-pnpm-store-path.outputs.pnpm-store-path }}
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
+      - name: Run the install steps
+        run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run install-website-editor-ci

--- a/.github/workflows/cache-pnpm-install.yml
+++ b/.github/workflows/cache-pnpm-install.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Cache pnpm store
         uses: actions/cache@v2
         with:
-          path: ${{ steps.capture-pnpm-store-path.outputs.pnpm-store-path }}
+          path: ${{ steps.capture-pnpm-store-path.outputs.pnpm-store-path }
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
       - name: Run the install steps
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run install-website-editor-ci

--- a/.github/workflows/editor-sharded-tests.yml
+++ b/.github/workflows/editor-sharded-tests.yml
@@ -8,6 +8,9 @@ on:
       branch:
         required: true
         type: string
+      pnpm-store-path:
+        required: true
+        type: string
 
 jobs:
   test-editor-karma-shard:
@@ -32,8 +35,8 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: .pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ${{ inputs.pnpm-store-path }}
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
       - name: Install nix
         uses: cachix/install-nix-action@v12
         with:

--- a/.github/workflows/editor-sharded-tests.yml
+++ b/.github/workflows/editor-sharded-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: ~/.pnpm-store
+          path: .pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install nix
         uses: cachix/install-nix-action@v12

--- a/.github/workflows/master-pushes.yml
+++ b/.github/workflows/master-pushes.yml
@@ -4,9 +4,15 @@ on:
     branches: [master]
 
 jobs:
+  cache-pnpm-store:
+    name: Install everything PNPM and cache it
+    secrets: inherit
+    uses: ./.github/workflows/cache-pnpm-install.yml
+
   test-editor-code:
     name: Test Editor - TypeScript, ESLint, dependency-cruiser
     runs-on: ubuntu-latest
+    needs: [cache-pnpm-store]
     env:
       UTOPIA_SHA: ${{ github.sha }}
     steps:
@@ -26,8 +32,8 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: .pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
       - name: Install nix
         uses: cachix/install-nix-action@v12
         with:
@@ -47,6 +53,7 @@ jobs:
   test-editor-jest:
     name: Test Editor - Jest tests
     runs-on: ubuntu-latest
+    needs: [cache-pnpm-store]
     env:
       UTOPIA_SHA: ${{ github.sha }}
     steps:
@@ -66,8 +73,8 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: .pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
       - name: Install nix
         uses: cachix/install-nix-action@v12
         with:
@@ -86,19 +93,23 @@ jobs:
 
   call-test-editor-karma-shard-1:
     name: Test Editor Shard 1
+    needs: [cache-pnpm-store]
     uses: ./.github/workflows/editor-sharded-tests.yml
     secrets: inherit
     with:
       shard_number: 1
       branch: master
+      pnpm-store-path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
 
   call-test-editor-karma-shard-2:
     name: Test Editor Shard 2
+    needs: [cache-pnpm-store]
     uses: ./.github/workflows/editor-sharded-tests.yml
     secrets: inherit
     with:
       shard_number: 2
       branch: master
+      pnpm-store-path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
 
   test-server:
     name: Test Server

--- a/.github/workflows/master-pushes.yml
+++ b/.github/workflows/master-pushes.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: ~/.pnpm-store
+          path: .pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install nix
         uses: cachix/install-nix-action@v12
@@ -66,7 +66,7 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: ~/.pnpm-store
+          path: .pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install nix
         uses: cachix/install-nix-action@v12
@@ -108,15 +108,15 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-      - name: Cache ~/.cabal/packages
+      - name: Cache .cabal/packages
         uses: actions/cache@v2
         with:
-          path: ~/.cabal/packages
+          path: .cabal/packages
           key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-packages-2
-      - name: Cache ~/.cabal/store
+      - name: Cache .cabal/store
         uses: actions/cache@v2
         with:
-          path: ~/.cabal/store
+          path: .cabal/store
           key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-store-2
       - name: Cache dist-newstyle
         uses: actions/cache@v2

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -21,15 +21,18 @@ jobs:
           # For the tests it doesn't really matter what we cache
           path: editor/lib
           key: ${{ runner.os }}-editor-code-tests-PR-${{ hashFiles('editor/src/**') }}-${{ hashFiles('utopia-api/src/**') }}-${{ hashFiles('editor/package.json') }}-${{ hashFiles('utopia-api/package.json') }}
-      - name: Cache .pnpm-store
-        uses: actions/cache@v2
-        with:
-          path: .pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install nix
         uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
+      - name: Capture pnpm store location
+        id: capture-pnpm-store
+        run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run 'echo "##[set-output name=pnpm-store;]$(pnpm store path)"'
+      - name: Cache pnpm store
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.capture-pnpm-store.outputs.pnpm-store }}
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-test-capturing-location
       - name: Run tsc, eslint, depdendency-cruiser and the website tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-code-ci

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: ~/.pnpm-store
+          path: .pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install nix
         uses: cachix/install-nix-action@v12
@@ -55,7 +55,7 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: ~/.pnpm-store
+          path: .pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install nix
         uses: cachix/install-nix-action@v12
@@ -121,7 +121,7 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: ~/.pnpm-store
+          path: .pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install nix
         uses: cachix/install-nix-action@v12
@@ -219,7 +219,7 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: ~/.pnpm-store
+          path: .pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Build Performance Tests
         run: |
@@ -321,7 +321,7 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: ~/.pnpm-store
+          path: .pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install Puppeteer Libraries
         run: |

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -2,9 +2,15 @@ name: Pull Request
 on: [pull_request]
 
 jobs:
+  cache-pnpm-store:
+    name: Install everything PNPM and cache it
+    secrets: inherit
+    uses: ./.github/workflows/cache-pnpm-install.yml
+
   test-editor-code:
     name: Test Editor PR – TypeScript, ESLint, dependency-cruiser
     runs-on: ubuntu-latest
+    needs: [cache-pnpm-store]
     env:
       UTOPIA_SHA: ${{ github.sha }}
     steps:
@@ -21,23 +27,24 @@ jobs:
           # For the tests it doesn't really matter what we cache
           path: editor/lib
           key: ${{ runner.os }}-editor-code-tests-PR-${{ hashFiles('editor/src/**') }}-${{ hashFiles('utopia-api/src/**') }}-${{ hashFiles('editor/package.json') }}-${{ hashFiles('utopia-api/package.json') }}
+      - name: Cache pnpm store
+        uses: actions/cache@v2
+        with:
+          path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
       - name: Install nix
         uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
       - name: Capture pnpm store location
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run 'echo "pnpm-store-path=$(pnpm store path)" >> "$GITHUB_ENV"'
-      - name: Cache pnpm store
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.pnpm-store-path }}
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-test-capturing-location-3
       - name: Run tsc, eslint, depdendency-cruiser and the website tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-code-ci
   test-editor-jest:
     name: Test Editor PR – Jest tests
     runs-on: ubuntu-latest
+    needs: [cache-pnpm-store]
     env:
       UTOPIA_SHA: ${{ github.sha }}
     steps:
@@ -57,8 +64,8 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: .pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
       - name: Install nix
         uses: cachix/install-nix-action@v12
         with:
@@ -69,23 +76,28 @@ jobs:
 
   call-test-editor-karma-shard-1:
     name: Test Editor Shard 1
+    needs: [cache-pnpm-store]
     uses: ./.github/workflows/editor-sharded-tests.yml
     secrets: inherit
     with:
       shard_number: 1
       branch: PR
+      pnpm-store-path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
 
   call-test-editor-karma-shard-2:
     name: Test Editor Shard 2
+    needs: [cache-pnpm-store]
     uses: ./.github/workflows/editor-sharded-tests.yml
     secrets: inherit
     with:
       shard_number: 2
       branch: PR
+      pnpm-store-path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
 
   deploy-staging:
     name: Deploy Staging Editor
     runs-on: ubuntu-latest
+    needs: [cache-pnpm-store]
     env:
       UTOPIA_SHA: ${{ github.sha }}
       AUTH0_CLIENT_ID: KB7euFO46rVYeOaWmrEdktdhAFxEO266
@@ -123,8 +135,8 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: .pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
       - name: Install nix
         uses: cachix/install-nix-action@v12
         with:
@@ -201,7 +213,7 @@ jobs:
   performance-test:
     name: Run Performance Tests
     runs-on: self-hosted
-    needs: [deploy-staging]
+    needs: [deploy-staging, cache-pnpm-store]
     env:
       UTOPIA_SHA: ${{ github.sha }}
       AUTH0_CLIENT_ID: KB7euFO46rVYeOaWmrEdktdhAFxEO266
@@ -221,8 +233,8 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: .pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
       - name: Build Performance Tests
         run: |
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "build-puppeteer-tests"
@@ -306,7 +318,7 @@ jobs:
   system-test:
     name: Run System Tests
     runs-on: ubuntu-latest
-    needs: [deploy-staging]
+    needs: [deploy-staging, cache-pnpm-store]
     env:
       UTOPIA_SHA: ${{ github.sha }}
     steps:
@@ -323,8 +335,8 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: .pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
       - name: Install Puppeteer Libraries
         run: |
           sudo apt-get update

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pnpm-store-path }}
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-test-capturing-location
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-test-capturing-location-2
       - name: Run tsc, eslint, depdendency-cruiser and the website tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-code-ci

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pnpm-store-path }}
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-test-capturing-location-2
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-test-capturing-location-3
       - name: Run tsc, eslint, depdendency-cruiser and the website tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-code-ci

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -26,12 +26,11 @@ jobs:
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
       - name: Capture pnpm store location
-        id: capture-pnpm-store
-        run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run 'echo "##[set-output name=pnpm-store;]$(pnpm store path)"'
+        run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run 'echo "pnpm-store-path=$(pnpm store path)" >> "$GITHUB_ENV"'
       - name: Cache pnpm store
         uses: actions/cache@v2
         with:
-          path: ${{ steps.capture-pnpm-store.outputs.pnpm-store }}
+          path: ${{ env.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-test-capturing-location
       - name: Run tsc, eslint, depdendency-cruiser and the website tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'

--- a/.github/workflows/screenshot-production.yml
+++ b/.github/workflows/screenshot-production.yml
@@ -5,9 +5,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  cache-pnpm-store:
+    name: Install everything PNPM and cache it
+    secrets: inherit
+    uses: ./.github/workflows/cache-pnpm-install.yml
+
   take-screenshot:
     name: Take Screenshot
     runs-on: ubuntu-latest
+    needs: [cache-pnpm-store]
     steps:
       - name: Cancel existing runs on this branch
         uses: fauguste/auto-cancellation-running-action@0.1.4
@@ -18,8 +24,8 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: .pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
       - name: Install Puppeteer Libraries
         run: |
           sudo apt-get update

--- a/.github/workflows/screenshot-production.yml
+++ b/.github/workflows/screenshot-production.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: ~/.pnpm-store
+          path: .pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install Puppeteer Libraries
         run: |

--- a/.github/workflows/screenshot-staging.yml
+++ b/.github/workflows/screenshot-staging.yml
@@ -5,9 +5,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  cache-pnpm-store:
+    name: Install everything PNPM and cache it
+    secrets: inherit
+    uses: ./.github/workflows/cache-pnpm-install.yml
+
   take-screenshot:
     name: Take Screenshot
     runs-on: ubuntu-latest
+    needs: [cache-pnpm-store]
     steps:
       - name: Cancel existing runs on this branch
         uses: fauguste/auto-cancellation-running-action@0.1.4
@@ -18,8 +24,8 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: .pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
       - name: Install Puppeteer Libraries
         run: |
           sudo apt-get update

--- a/.github/workflows/screenshot-staging.yml
+++ b/.github/workflows/screenshot-staging.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: ~/.pnpm-store
+          path: .pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install Puppeteer Libraries
         run: |

--- a/.github/workflows/tag-release-automated.yml
+++ b/.github/workflows/tag-release-automated.yml
@@ -3,10 +3,16 @@ on:
   schedule:
     - cron: '0 5 * * 1-5' # Run every weekday 5:00 UTC
 jobs:
+  cache-pnpm-store:
+    name: Install everything PNPM and cache it
+    secrets: inherit
+    uses: ./.github/workflows/cache-pnpm-install.yml
+
   system-test:
     # For automated releases we want to check it is safe first
     name: Run System Tests
     runs-on: ubuntu-latest
+    needs: [cache-pnpm-store]
     env:
       UTOPIA_SHA: ${{ github.sha }}
     steps:
@@ -15,8 +21,8 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: .pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
       - name: Install Puppeteer Libraries
         run: |
           sudo apt-get update

--- a/.github/workflows/tag-release-automated.yml
+++ b/.github/workflows/tag-release-automated.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
-          path: ~/.pnpm-store
+          path: .pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install Puppeteer Libraries
         run: |

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -130,6 +130,8 @@ import {
   resetSelectorTimings,
 } from '../components/editor/store/store-hook-performance-logging'
 
+// A non-change to force workflows to rebuild
+
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()
   webFrame.setVisualZoomLevelLimits(1, 1)

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -130,7 +130,7 @@ import {
   resetSelectorTimings,
 } from '../components/editor/store/store-hook-performance-logging'
 
-// A non-change to force workflows to rebuild
+// Another non-change to force workflows to rebuild
 
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -130,8 +130,6 @@ import {
   resetSelectorTimings,
 } from '../components/editor/store/store-hook-performance-logging'
 
-// Another non-change to force workflows to rebuild
-
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()
   webFrame.setVisualZoomLevelLimits(1, 1)

--- a/shell.nix
+++ b/shell.nix
@@ -61,6 +61,12 @@ let
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/website-next
       pnpm install
     '')
+    (pkgs.writeScriptBin "install-website-editor-ci" ''
+      #!/usr/bin/env bash
+      set -e
+      install-editor-ci
+      install-website
+    '')
     (pkgs.writeScriptBin "test-editor" ''
       #!/usr/bin/env bash
       set -e


### PR DESCRIPTION
**Problem:**
We are incorrectly caching the wrong path for the pnpm store. This meant we couldn't fall back to relying on the offline installed versions of packages when the `console-feed` package disappeared from the public npm registry.

**Fix:**
Introduce a shared workflow that sets up nix, captures the actual pnpm-store path, runs all of the pnpm install steps, caches the result, and then gives that store path to all other jobs so that they can use that cache