### PR TITLE
Chore/remove modify open parse success

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -734,13 +734,6 @@ export interface SetProp {
   value: JSExpression
 }
 
-export interface SetPropWithElementPath {
-  action: 'SET_PROP_WITH_ELEMENT_PATH'
-  target: StaticElementPathPart
-  propertyPath: PropertyPath
-  value: JSExpression
-}
-
 export interface SetFilebrowserRenamingTarget {
   action: 'SET_FILEBROWSER_RENAMING_TARGET'
   filename: string | null
@@ -1163,7 +1156,6 @@ export type EditorAction =
   | SetCodeEditorLintErrors
   | SaveDOMReport
   | SetProp
-  | SetPropWithElementPath
   | SetFilebrowserRenamingTarget
   | ToggleProperty
   | DEPRECATEDToggleEnabledProperty

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -120,7 +120,6 @@ import type {
   SetProjectName,
   SetProjectDescription,
   SetProp,
-  SetPropWithElementPath,
   SetRightMenuExpanded,
   SetRightMenuTab,
   SetSafeMode,
@@ -1163,20 +1162,6 @@ export function setProp_UNSAFE(
 ): SetProp {
   return {
     action: 'SET_PROP',
-    target: target,
-    propertyPath: propertyPath,
-    value: value,
-  }
-}
-
-/** WARNING: you probably don't want to use setProp, instead you should use a domain-specific action! */
-export function setPropWithElementPath_UNSAFE(
-  target: StaticElementPathPart,
-  propertyPath: PropertyPath,
-  value: JSExpression,
-): SetPropWithElementPath {
-  return {
-    action: 'SET_PROP_WITH_ELEMENT_PATH',
     target: target,
     propertyPath: propertyPath,
     value: value,

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -174,7 +174,6 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_FROM_CODE_EDITOR':
     case 'SET_MAIN_UI_FILE':
     case 'SET_PROP':
-    case 'SET_PROP_WITH_ELEMENT_PATH':
     case 'SAVE_CURRENT_FILE':
     case 'UPDATE_JSX_ELEMENT_NAME':
     case 'ADD_IMPORTS':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -382,7 +382,6 @@ import {
   LeftPaneMinimumWidth,
   mergeStoredEditorStateIntoEditorState,
   modifyOpenJsxElementAtPath,
-  modifyOpenJSXElementsAndMetadata,
   modifyParseSuccessAtPath,
   modifyParseSuccessWithSimple,
   modifyUnderlyingElementForOpenFile,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -393,7 +393,6 @@ import {
   RightMenuTab,
   SimpleParseSuccess,
   StoryboardFilePath,
-  transformElementAtPath,
   UIFileBase64Blobs,
   updateMainUIInEditorState,
   UserConfiguration,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -393,6 +393,7 @@ import {
   RightMenuTab,
   SimpleParseSuccess,
   StoryboardFilePath,
+  transformElementAtPath,
   UIFileBase64Blobs,
   updateMainUIInEditorState,
   UserConfiguration,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -277,7 +277,6 @@ import {
   SetProp,
   SetProperty,
   SetPropTransient,
-  SetPropWithElementPath,
   SetResizeOptionsTargetOptions,
   SetRightMenuExpanded,
   SetRightMenuTab,
@@ -498,7 +497,6 @@ import {
   selectComponents,
   setFocusedElement,
   setPackageStatus,
-  setPropWithElementPath_UNSAFE,
   setScrollAnimation,
   showToast,
   updateFile,
@@ -652,22 +650,6 @@ function setPropertyOnTarget(
     (e: JSXElement) => applyUpdateToJSXElement(e, updateFn),
     editor,
   )
-}
-
-function setPropertyOnTargetAtElementPath(
-  editor: EditorModel,
-  target: StaticElementPathPart,
-  updateFn: (props: JSXAttributes) => Either<any, JSXAttributes>,
-): EditorModel {
-  return modifyOpenJSXElements((components) => {
-    return transformJSXComponentAtElementPath(components, target, (e: JSXElementChild) => {
-      if (isJSXElement(e)) {
-        return applyUpdateToJSXElement(e, updateFn)
-      } else {
-        return e
-      }
-    })
-  }, editor)
 }
 
 function setSpecialSizeMeasurementParentLayoutSystemOnAllChildren(
@@ -3205,9 +3187,10 @@ export const UPDATE_FNS = {
                   typeof srcValue.value === 'string' &&
                   srcValue.value.startsWith(imageWithoutHashURL)
                 ) {
-                  actionsToRunAfterSave.push(
-                    setPropWithElementPath_UNSAFE(elementPath, propertyPath, imageAttribute),
-                  )
+                  // Balazs: I think this code was already dormant / broken, keeping it as a comment for reference
+                  // actionsToRunAfterSave.push(
+                  //   setPropWithElementPath_UNSAFE(elementPath, propertyPath, imageAttribute),
+                  // )
                 }
               }
             }
@@ -4083,14 +4066,6 @@ export const UPDATE_FNS = {
         (attrs) => roundAttributeLayoutValues(styleStringInArray, attrs),
         setJSXValueAtPath(props, action.propertyPath, action.value),
       )
-    })
-  },
-  SET_PROP_WITH_ELEMENT_PATH: (
-    action: SetPropWithElementPath,
-    editor: EditorModel,
-  ): EditorModel => {
-    return setPropertyOnTargetAtElementPath(editor, action.target, (props) => {
-      return setJSXValueAtPath(props, action.propertyPath, action.value)
     })
   },
   // NB: this can only update attribute values and part of attribute value,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -382,7 +382,6 @@ import {
   LeftPaneMinimumWidth,
   mergeStoredEditorStateIntoEditorState,
   modifyOpenJsxElementAtPath,
-  modifyOpenJSXElements,
   modifyOpenJSXElementsAndMetadata,
   modifyParseSuccessAtPath,
   modifyParseSuccessWithSimple,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2007,8 +2007,14 @@ export const UPDATE_FNS = {
   },
   INSERT_JSX_ELEMENT: (action: InsertJSXElement, editor: EditorModel): EditorModel => {
     let newSelectedViews: ElementPath[] = []
+    const parentPath =
+      action.parent ??
+      forceNotNull(
+        'found no element path for the storyboard root',
+        getStoryboardElementPath(editor.projectContents, editor.canvas.openFile?.filename),
+      )
     const withNewElement = modifyUnderlyingTargetElement(
-      action.parent,
+      parentPath,
       forceNotNull('Should originate from a designer', editor.canvas.openFile?.filename),
       editor,
       (element) => element,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -3324,7 +3324,7 @@ export function modifyUnderlyingTargetElement(
 }
 
 function modifyUnderlyingJsxElementChild(
-  target: ElementPath | null,
+  target: ElementPath,
   currentFilePath: string,
   editor: EditorState,
   modifyElement: (

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1843,6 +1843,19 @@ export function insertElementAtPath(
   )
 }
 
+export function transformElementAtPath(
+  components: Array<UtopiaJSXComponent>,
+  target: ElementPath,
+  transform: (elem: JSXElementChild) => JSXElementChild,
+): Array<UtopiaJSXComponent> {
+  const staticTarget = EP.dynamicPathToStaticPath(target)
+  if (staticTarget == null) {
+    return components
+  } else {
+    return transformJSXComponentAtPath(components, staticTarget, transform)
+  }
+}
+
 export function transformJSXElementAtPath(
   components: Array<UtopiaJSXComponent>,
   target: ElementPath,
@@ -3226,7 +3239,7 @@ export function modifyUnderlyingTarget(
         elementModified = updatedElement !== element
         return updatedElement
       }
-      updatedUtopiaJSXComponents = transformJSXComponentAtPath(
+      updatedUtopiaJSXComponents = transformElementAtPath(
         oldUtopiaJSXComponents,
         targetSuccess.normalisedPath,
         innerModifyElement,
@@ -3341,7 +3354,7 @@ function modifyUnderlyingJsxElementChild(
         elementModified = updatedElement !== element
         return updatedElement
       }
-      updatedUtopiaJSXComponents = transformJSXComponentAtPath(
+      updatedUtopiaJSXComponents = transformElementAtPath(
         oldUtopiaJSXComponents,
         targetSuccess.normalisedPath,
         innerModifyElement,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -3295,7 +3295,7 @@ export function modifyUnderlyingForOpenFile(
 }
 
 export function modifyUnderlyingTargetElement(
-  target: ElementPath | null,
+  target: ElementPath,
   currentFilePath: string,
   editor: EditorState,
   modifyElement: (
@@ -3393,7 +3393,7 @@ function modifyUnderlyingJsxElementChild(
 }
 
 export function modifyUnderlyingElementForOpenFile(
-  target: ElementPath | null,
+  target: ElementPath,
   editor: EditorState,
   modifyElement: (
     element: JSXElement,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1673,67 +1673,6 @@ export interface ParseSuccessAndEditorChanges<T> {
   additionalData: T
 }
 
-export function modifyOpenParseSuccess(
-  transform: (
-    parseSuccess: ParseSuccess,
-    underlying: StaticElementPath | null,
-    underlyingFilePath: string,
-  ) => ParseSuccess,
-  model: EditorState,
-): EditorState {
-  return modifyUnderlyingTargetElement(
-    null,
-    forceNotNull('No open designer file.', model.canvas.openFile?.filename),
-    model,
-    (elem) => elem,
-    transform,
-  )
-}
-
-export function modifyOpenScenesAndJSXElements(
-  transform: (utopiaComponents: Array<UtopiaJSXComponent>) => Array<UtopiaJSXComponent>,
-  model: EditorState,
-): EditorState {
-  const successTransform = (success: ParseSuccess) => {
-    const oldUtopiaJSXComponents = getUtopiaJSXComponentsFromSuccess(success)
-    // Apply the transformation.
-    const updatedResult = transform(oldUtopiaJSXComponents)
-
-    const newTopLevelElements = applyUtopiaJSXComponentsChanges(
-      success.topLevelElements,
-      updatedResult,
-    )
-
-    return {
-      ...success,
-      topLevelElements: newTopLevelElements,
-    }
-  }
-  return modifyOpenParseSuccess(successTransform, model)
-}
-
-export function modifyOpenJSXElements(
-  transform: (utopiaComponents: Array<UtopiaJSXComponent>) => Array<UtopiaJSXComponent>,
-  model: EditorState,
-): EditorState {
-  const successTransform = (success: ParseSuccess) => {
-    const oldUtopiaJSXComponents = getUtopiaJSXComponentsFromSuccess(success)
-    // Apply the transformation.
-    const updatedUtopiaJSXComponents = transform(oldUtopiaJSXComponents)
-
-    const newTopLevelElements = applyUtopiaJSXComponentsChanges(
-      success.topLevelElements,
-      updatedUtopiaJSXComponents,
-    )
-
-    return {
-      ...success,
-      topLevelElements: newTopLevelElements,
-    }
-  }
-  return modifyOpenParseSuccess(successTransform, model)
-}
-
 export function modifyOpenJSXElementsAndMetadata(
   transform: (
     utopiaComponents: Array<UtopiaJSXComponent>,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1673,43 +1673,6 @@ export interface ParseSuccessAndEditorChanges<T> {
   additionalData: T
 }
 
-export function modifyOpenJSXElementsAndMetadata(
-  transform: (
-    utopiaComponents: Array<UtopiaJSXComponent>,
-    componentMetadata: ElementInstanceMetadataMap,
-  ) => { components: Array<UtopiaJSXComponent>; componentMetadata: ElementInstanceMetadataMap },
-  target: ElementPath,
-  model: EditorState,
-): EditorState {
-  let workingMetadata: ElementInstanceMetadataMap = model.jsxMetadata
-  const successTransform = (success: ParseSuccess) => {
-    const oldUtopiaJSXComponents = getUtopiaJSXComponentsFromSuccess(success)
-    // Apply the transformation.
-    const transformResult = transform(oldUtopiaJSXComponents, model.jsxMetadata)
-    workingMetadata = transformResult.componentMetadata
-
-    const newTopLevelElements = applyUtopiaJSXComponentsChanges(
-      success.topLevelElements,
-      transformResult.components,
-    )
-
-    return {
-      ...success,
-      topLevelElements: newTopLevelElements,
-    }
-  }
-  const beforeUpdatingMetadata = modifyUnderlyingElementForOpenFile(
-    target,
-    model,
-    (elem) => elem,
-    successTransform,
-  )
-  return {
-    ...beforeUpdatingMetadata,
-    jsxMetadata: workingMetadata,
-  }
-}
-
 export function modifyOpenJsxElementAtPath(
   path: ElementPath,
   transform: (element: JSXElement) => JSXElement,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1718,19 +1718,6 @@ export function modifyOpenJsxChildAtPath(
   )
 }
 
-export function modifyOpenJsxElementAtStaticPath(
-  path: StaticElementPath,
-  transform: (element: JSXElement) => JSXElement,
-  model: EditorState,
-): EditorState {
-  return modifyUnderlyingTargetElement(
-    path,
-    forceNotNull('No open designer file.', model.canvas.openFile?.filename),
-    model,
-    (element) => (isJSXElement(element) ? transform(element) : element),
-  )
-}
-
 function getImportedUtopiaJSXComponents(
   filePath: string,
   projectContents: ProjectContentTreeRoot,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1843,19 +1843,6 @@ export function insertElementAtPath(
   )
 }
 
-export function transformElementAtPath(
-  components: Array<UtopiaJSXComponent>,
-  target: ElementPath,
-  transform: (elem: JSXElementChild) => JSXElementChild,
-): Array<UtopiaJSXComponent> {
-  const staticTarget = EP.dynamicPathToStaticPath(target)
-  if (staticTarget == null) {
-    return components
-  } else {
-    return transformJSXComponentAtPath(components, staticTarget, transform)
-  }
-}
-
 export function transformJSXElementAtPath(
   components: Array<UtopiaJSXComponent>,
   target: ElementPath,
@@ -3239,7 +3226,7 @@ export function modifyUnderlyingTarget(
         elementModified = updatedElement !== element
         return updatedElement
       }
-      updatedUtopiaJSXComponents = transformElementAtPath(
+      updatedUtopiaJSXComponents = transformJSXComponentAtPath(
         oldUtopiaJSXComponents,
         targetSuccess.normalisedPath,
         innerModifyElement,
@@ -3354,7 +3341,7 @@ function modifyUnderlyingJsxElementChild(
         elementModified = updatedElement !== element
         return updatedElement
       }
-      updatedUtopiaJSXComponents = transformElementAtPath(
+      updatedUtopiaJSXComponents = transformJSXComponentAtPath(
         oldUtopiaJSXComponents,
         targetSuccess.normalisedPath,
         innerModifyElement,

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -245,8 +245,6 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.SAVE_DOM_REPORT(action, state, spyCollector)
     case 'SET_PROP':
       return UPDATE_FNS.SET_PROP(action, state)
-    case 'SET_PROP_WITH_ELEMENT_PATH':
-      return UPDATE_FNS.SET_PROP_WITH_ELEMENT_PATH(action, state)
     case 'SET_FILEBROWSER_RENAMING_TARGET':
       return UPDATE_FNS.SET_FILEBROWSER_RENAMING_TARGET(action, state)
     case 'TOGGLE_PROPERTY':

--- a/editor/src/components/inspector/common/inspector.test-utils.tsx
+++ b/editor/src/components/inspector/common/inspector.test-utils.tsx
@@ -15,9 +15,9 @@ import utils from '../../../utils/utils'
 import { EditorDispatch } from '../../editor/action-types'
 import {
   EditorStorePatched,
-  modifyOpenJsxElementAtStaticPath,
   defaultUserState,
   StoryboardFilePath,
+  modifyUnderlyingElementForOpenFile,
 } from '../../editor/store/editor-state'
 import {
   createStoresAndState,
@@ -110,8 +110,9 @@ export function editPropOfSelectedView(
 ): EditorStorePatched {
   return {
     ...store,
-    editor: modifyOpenJsxElementAtStaticPath(
+    editor: modifyUnderlyingElementForOpenFile(
       store.editor.selectedViews[0] as StaticElementPath,
+      store.editor,
       (element): JSXElement => {
         const updatedAttributes = setJSXValueAtPath(
           element.props,
@@ -127,7 +128,6 @@ export function editPropOfSelectedView(
           throw new Error(`Couldn't set property in test`)
         }
       },
-      store.editor,
     ),
   }
 }

--- a/editor/src/core/layout/layout-utils.ts
+++ b/editor/src/core/layout/layout-utils.ts
@@ -1,7 +1,6 @@
 import { AllFramePoints, AllFramePointsExceptSize, LayoutSystem } from 'utopia-api/core'
 import {
   AllElementProps,
-  transformElementAtPath,
   transformJSXElementAtPath,
 } from '../../components/editor/store/editor-state'
 import * as EP from '../shared/element-path'

--- a/editor/src/core/layout/layout-utils.ts
+++ b/editor/src/core/layout/layout-utils.ts
@@ -1,6 +1,7 @@
 import { AllFramePoints, AllFramePointsExceptSize, LayoutSystem } from 'utopia-api/core'
 import {
   AllElementProps,
+  transformElementAtPath,
   transformJSXElementAtPath,
 } from '../../components/editor/store/editor-state'
 import * as EP from '../shared/element-path'


### PR DESCRIPTION
It was discovered that `modifyOpenParseSuccess` is dangerous and may not even work properly.

**Details:**
I removed the following dormant functions / actions:
- removed `SET_PROP_WITH_ELEMENT_PATH`
- removed `modifyOpenParseSuccess` / `modifyOpenJSXElements`
- removed unrelated but unused `modifyOpenJSXElementsAndMetadata`
- `modifyUnderlyingTargetElement` no longer accepts a null as target path for the element
- `modifyUnderlyingJsxElementChild` no longer accepts a null target path

The only place using `SET_PROP_WITH_ELEMENT_PATH` was `SAVE_ASSET` where I commented out the line and left a comment.

