### PR TITLE
unify modifyUnderlyingJsxElementChild into modifyUnderlyingTarget

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -3232,7 +3232,7 @@ export function modifyUnderlyingTarget(
 
   function innerModifyParseSuccess(oldParseSuccess: ParseSuccess): ParseSuccess {
     // Apply the ParseSuccess level changes.
-    let updatedParseSuccess: ParseSuccess = modifyParseSuccess(
+    const updatedParseSuccess: ParseSuccess = modifyParseSuccess(
       oldParseSuccess,
       targetSuccess.normalisedPath,
       targetSuccess.filePath,


### PR DESCRIPTION
modifyUnderlyingJsxElementChild seems to overlap with modifyUnderlyingTarget, so let's unify the two!