### PR TITLE
merge SET_PROPERTY into SET_PROP

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -192,13 +192,6 @@ export type UnsetProperty = {
   property: PropertyPath
 }
 
-export type SetProperty = {
-  action: 'SET_PROPERTY'
-  element: ElementPath
-  property: PropertyPath
-  value: JSExpression
-}
-
 export type SetCanvasFrames = {
   action: 'SET_CANVAS_FRAMES'
   framesAndTargets: Array<PinOrFlexFrameChange>
@@ -1057,7 +1050,6 @@ export type EditorAction =
   | SwitchEditorMode
   | SelectComponents
   | UnsetProperty
-  | SetProperty
   | Canvas
   | DuplicateSelected
   | MoveSelectedToBack

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -190,7 +190,6 @@ import type {
   ToggleSelectionLock,
   ElementPaste,
   SetGithubState,
-  SetProperty,
   UpdateProjectContents,
   UpdateGithubSettings,
   SetImageDragSessionState as SetDragSessionState,
@@ -282,19 +281,6 @@ export function unsetProperty(element: ElementPath, property: PropertyPath): Uns
     action: 'UNSET_PROPERTY',
     element: element,
     property: property,
-  }
-}
-
-export function setProperty(
-  element: ElementPath,
-  property: PropertyPath,
-  value: JSExpression,
-): SetProperty {
-  return {
-    action: 'SET_PROPERTY',
-    element: element,
-    property: property,
-    value: value,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -135,7 +135,6 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'DELETE_SELECTED':
     case 'DELETE_VIEW':
     case 'UNSET_PROPERTY':
-    case 'SET_PROPERTY':
     case 'INSERT_JSX_ELEMENT':
     case 'MOVE_SELECTED_TO_BACK':
     case 'MOVE_SELECTED_TO_FRONT':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -275,7 +275,6 @@ import {
   SetProjectID,
   SetProjectName,
   SetProp,
-  SetProperty,
   SetPropTransient,
   SetResizeOptionsTargetOptions,
   SetRightMenuExpanded,
@@ -1544,17 +1543,13 @@ export const UPDATE_FNS = {
       return updatedEditor
     }
   },
-  SET_PROPERTY: (
-    action: SetProperty,
-    editor: EditorModel,
-    dispatch: EditorDispatch,
-  ): EditorModel => {
+  SET_PROP: (action: SetProp, editor: EditorModel): EditorModel => {
     let setPropFailedMessage: string | null = null
     const updatedEditor = modifyUnderlyingElementForOpenFile(
-      action.element,
+      action.target,
       editor,
       (element) => {
-        const updatedProps = setJSXValueAtPath(element.props, action.property, action.value)
+        const updatedProps = setJSXValueAtPath(element.props, action.propertyPath, action.value)
         return foldEither(
           (failureMessage) => {
             setPropFailedMessage = failureMessage
@@ -1562,7 +1557,8 @@ export const UPDATE_FNS = {
           },
           (updatedAttributes) => ({
             ...element,
-            props: updatedAttributes,
+            // we round style.left/top/right/bottom/width/height pins for the modified element
+            props: roundAttributeLayoutValues(styleStringInArray, updatedAttributes),
           }),
           updatedProps,
         )
@@ -4063,14 +4059,6 @@ export const UPDATE_FNS = {
         },
       }
     }
-  },
-  SET_PROP: (action: SetProp, editor: EditorModel): EditorModel => {
-    return setPropertyOnTarget(editor, action.target, (props) => {
-      return mapEither(
-        (attrs) => roundAttributeLayoutValues(styleStringInArray, attrs),
-        setJSXValueAtPath(props, action.propertyPath, action.value),
-      )
-    })
   },
   // NB: this can only update attribute values and part of attribute value,
   // If you want other types of JSXAttributes, that needs to be added

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -778,7 +778,7 @@ export function handleKeyDown(
           .then(({ sRGBHex }) =>
             dispatch(
               selectedViews.map((view) =>
-                EditorActions.setProperty(
+                EditorActions.setProp_UNSAFE(
                   view,
                   PP.create('style', 'backgroundColor'),
                   jsExpressionValue(sRGBHex, emptyComments),

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -80,8 +80,6 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.NAVIGATOR_REORDER(action, state, derivedState, builtInDependencies)
     case 'UNSET_PROPERTY':
       return UPDATE_FNS.UNSET_PROPERTY(action, state, dispatch)
-    case 'SET_PROPERTY':
-      return UPDATE_FNS.SET_PROPERTY(action, state, dispatch)
     case 'UNDO':
       return UPDATE_FNS.UNDO(state, stateHistory)
     case 'REDO':

--- a/editor/src/components/inspector/sections/style-section/background-subsection/background-picker.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/background-picker.tsx
@@ -14,7 +14,6 @@ import {
   Icons,
 } from '../../../../../uuiui'
 import { pickColorWithEyeDropper } from '../../../../canvas/canvas-utils'
-import { setProperty } from '../../../../editor/actions/action-creators'
 import { useDispatch } from '../../../../editor/store/dispatch-context'
 import { Substores, useEditorState } from '../../../../editor/store/store-hook'
 import { ControlStatus } from '../../../common/control-status'
@@ -71,6 +70,7 @@ import {
 import { GradientStopsEditor } from './gradient-stop-editor'
 import { getIndexedUpdateCSSBackgroundLayerLinearGradientAngle } from './linear-gradient-layer'
 import { PickerImagePreview } from './picker-image-preview'
+import { setProp_UNSAFE } from '../../../../editor/actions/action-creators'
 
 const backgroundLayerOptionsByValue: {
   [key in CSSBackgroundLayerType]: CSSBackgroundLayerTypeSelectOption
@@ -489,7 +489,7 @@ export const BackgroundPicker: React.FunctionComponent<
       .then(({ sRGBHex }) => {
         dispatch(
           selectedViews.map((view) =>
-            setProperty(
+            setProp_UNSAFE(
               view,
               create('style', 'backgroundColor'),
               jsExpressionValue(sRGBHex, emptyComments),

--- a/editor/src/components/text-editor/text-editor-shortcut-helpers.ts
+++ b/editor/src/components/text-editor/text-editor-shortcut-helpers.ts
@@ -148,7 +148,7 @@ const toggleStyleProp = (
 ): void => {
   const newValue = currentValue === toggledValue ? defaultValue : toggledValue
 
-  const setAction = EditorActions.setProperty(
+  const setAction = EditorActions.setProp_UNSAFE(
     elementPath,
     PP.create('style', prop),
     jsExpressionValue(newValue, emptyComments),

--- a/editor/src/templates/image-dnd.spec.browser2.tsx
+++ b/editor/src/templates/image-dnd.spec.browser2.tsx
@@ -535,7 +535,7 @@ export var storyboard = (
           position: 'absolute',
           width: 1,
           height: 1,
-          top: 379.5,
+          top: 380,
           left: 350,
         }}
         data-uid='dragged-image'
@@ -611,7 +611,7 @@ export var storyboard = (
           position: 'absolute',
           width: 1,
           height: 1,
-          top: 379.5,
+          top: 380,
           left: 350,
         }}
         data-uid='dragged-image'
@@ -683,7 +683,7 @@ export var storyboard = (
           position: 'absolute',
           width: 1,
           height: 1,
-          top: 379.5,
+          top: 380,
           left: 350,
         }}
         data-uid='dragged-image'
@@ -747,10 +747,10 @@ export var storyboard = (
         src='./assets/multiplied_2@2x.png'
         style={{
           position: 'absolute',
-          width: 0.5,
-          height: 0.5,
-          top: 379.75,
-          left: 90.75,
+          width: 1,
+          height: 1,
+          top: 380,
+          left: 91,
         }}
         data-uid='dragged-image'
       />
@@ -818,7 +818,7 @@ export var storyboard = (
           position: 'absolute',
           width: 1,
           height: 1,
-          top: 379.5,
+          top: 380,
           left: 350,
         }}
         data-uid='dragged-image1'
@@ -830,7 +830,7 @@ export var storyboard = (
           position: 'absolute',
           width: 1,
           height: 1,
-          top: 379.5,
+          top: 380,
           left: 350,
         }}
         data-uid='dragged-image2'
@@ -842,7 +842,7 @@ export var storyboard = (
           position: 'absolute',
           width: 1,
           height: 1,
-          top: 379.5,
+          top: 380,
           left: 350,
         }}
         data-uid='dragged-image3'
@@ -917,7 +917,7 @@ export var storyboard = (
           position: 'absolute',
           width: 1,
           height: 1,
-          top: 379.5,
+          top: 380,
           left: 350,
         }}
         data-uid='dragged-image1'
@@ -929,7 +929,7 @@ export var storyboard = (
           position: 'absolute',
           width: 1,
           height: 1,
-          top: 379.5,
+          top: 380,
           left: 350,
         }}
         data-uid='dragged-image2'
@@ -941,7 +941,7 @@ export var storyboard = (
           position: 'absolute',
           width: 1,
           height: 1,
-          top: 379.5,
+          top: 380,
           left: 350,
         }}
         data-uid='dragged-image3'

--- a/editor/src/templates/image-dnd.spec.browser2.tsx
+++ b/editor/src/templates/image-dnd.spec.browser2.tsx
@@ -535,7 +535,7 @@ export var storyboard = (
           position: 'absolute',
           width: 1,
           height: 1,
-          top: 380,
+          top: 379.5,
           left: 350,
         }}
         data-uid='dragged-image'
@@ -611,7 +611,7 @@ export var storyboard = (
           position: 'absolute',
           width: 1,
           height: 1,
-          top: 380,
+          top: 379.5,
           left: 350,
         }}
         data-uid='dragged-image'

--- a/editor/src/templates/image-dnd.spec.browser2.tsx
+++ b/editor/src/templates/image-dnd.spec.browser2.tsx
@@ -818,7 +818,7 @@ export var storyboard = (
           position: 'absolute',
           width: 1,
           height: 1,
-          top: 380,
+          top: 379.5,
           left: 350,
         }}
         data-uid='dragged-image1'
@@ -830,7 +830,7 @@ export var storyboard = (
           position: 'absolute',
           width: 1,
           height: 1,
-          top: 380,
+          top: 379.5,
           left: 350,
         }}
         data-uid='dragged-image2'
@@ -842,7 +842,7 @@ export var storyboard = (
           position: 'absolute',
           width: 1,
           height: 1,
-          top: 380,
+          top: 379.5,
           left: 350,
         }}
         data-uid='dragged-image3'

--- a/editor/src/templates/image-drop.tsx
+++ b/editor/src/templates/image-drop.tsx
@@ -317,7 +317,7 @@ function updateImageSrcsActions(
     const maybeImageUpdateData = srcsIndex[props['data-uid']]
     return maybeImageUpdateData == null
       ? null
-      : EditorActions.setProperty(
+      : EditorActions.setProp_UNSAFE(
           fromString(path),
           PP.create('src'),
           jsExpressionValue(maybeImageUpdateData.path, emptyComments),


### PR DESCRIPTION
I was about to modify SET_PROP when I realized we also have SET_PROPERTY.

SET_PROP rounds the pin layout values if they are numbers.
SET_PROPERTY can show a toast if the property setting fails.

After a quick chat with Berci we decided to unify it into SET_PROP which shall 
- round pin layout values
- show a toast if the setting fails

And delete SET_PROPERTY. The practical reason is that dozens of places used SET_PROP and only a handful used SET_PROPERTY, so this made for a smaller diff.