### PR TITLE
Apply edits to the root element or instance appropriately.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -154,7 +154,7 @@ const keyboardShortcutStrategies: MetaCanvasStrategy = (
 
 export const RegisteredCanvasStrategies: Array<MetaCanvasStrategy> = [
   ...AncestorCompatibleStrategies,
-  preventOnRootElements(resizeStrategies),
+  resizeStrategies,
   propertyControlStrategies,
   drawToInsertMetaStrategy,
   dragToInsertMetaStrategy,


### PR DESCRIPTION
**Problem:**
There are a few cases around editing root elements or component instances where the changes should actually go to the component instance properties or the root element of the component directly, depending on a few circumstances:
- If the property is set in the component instance properties.
- If the property is set in the root element properties.
- If `props.style` are spread into the style prop of the root element of the component.

