### PR TITLE
Allow setting width/height to `Fixed` from `Computed`

### DIFF
--- a/editor/src/components/canvas/commands/set-css-length-command.ts
+++ b/editor/src/components/canvas/commands/set-css-length-command.ts
@@ -108,16 +108,6 @@ export const runSetCssLengthProperty: CommandFunction<SetCssLengthProperty> = (
   }
   const currentModifiableValue = currentValue.value
   const simpleValueResult = jsxSimpleAttributeToValue(currentModifiableValue)
-  const valueProbablyExpression = isLeft(simpleValueResult)
-  if (valueProbablyExpression) {
-    // TODO add option to override expressions!!!
-    return {
-      editorStatePatches: [],
-      commandDescription: `Set Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
-        command.property,
-      )} not applied as the property is an expression we did not want to override.`,
-    }
-  }
 
   const targetPropertyNonExistant: boolean = currentModifiableValue.type === 'ATTRIBUTE_NOT_FOUND'
   if (


### PR DESCRIPTION
## Problem
When an element's width or height is classified as `Computed`, it cannot be set to Fixed (it can be set to Hug contents or Fill container).

## Cause
`SetCssLengthProperty`, the command that is used to set the width/height of an element to a fixed size, has a guard in the command implementation which disallows setting the required prop when it is set to a variable (as opposed to a literal value). In the case of the width/height control, this manifests itself as a bug because
- it's clearly shown that the value is computed
- there's clear user intent to overwrite the computed value with a fixed one
- but the command doesn't work due to this built-in limitation.

## Fix
Remove the guard from the command implementation. This guard should be re-implemented on the feature level in the long term.