### PR TITLE
add detected state to width/height control

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -10,7 +10,7 @@ import {
   windowPoint,
 } from '../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
-import { NO_OP } from '../../../../core/shared/utils'
+import { assertNever, NO_OP } from '../../../../core/shared/utils'
 import { Modifier } from '../../../../utils/modifiers'
 import { when } from '../../../../utils/react-conditionals'
 import { useColorTheme } from '../../../../uuiui'
@@ -372,12 +372,14 @@ const sizeLabel = (state: FixedHugFill['type'], actualSize: number): string => {
   switch (state) {
     case 'fill':
       return 'Fill'
-    case 'fixed':
-      return `${actualSize}`
     case 'hug':
       return 'Hug'
+    case 'fixed':
+    case 'detected':
     case 'computed':
       return `${actualSize}`
+    default:
+      assertNever(state)
   }
 }
 

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -448,13 +448,13 @@ describe('inspector tests with real metadata', () => {
     matchInlineSnapshotBrowser(widthControl.value, `"335"`)
     matchInlineSnapshotBrowser(
       widthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"detected"`,
+      `"disabled"`,
     )
 
     matchInlineSnapshotBrowser(heightControl.value, `"102"`)
     matchInlineSnapshotBrowser(
       heightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"detected"`,
+      `"disabled"`,
     )
 
     matchInlineSnapshotBrowser(metadata.computedStyle?.['top'], `"98px"`)
@@ -797,13 +797,13 @@ describe('inspector tests with real metadata', () => {
     matchInlineSnapshotBrowser(widthControl.value, `"0"`)
     matchInlineSnapshotBrowser(
       widthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"simple-unknown-css"`,
+      `"disabled"`,
     )
 
     matchInlineSnapshotBrowser(heightControl.value, `"0"`)
     matchInlineSnapshotBrowser(
       heightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"simple-unknown-css"`,
+      `"disabled"`,
     )
 
     matchInlineSnapshotBrowser(topControl.value, `"0"`)
@@ -1109,13 +1109,13 @@ describe('inspector tests with real metadata', () => {
     matchInlineSnapshotBrowser(widthControl.value, `"150"`)
     matchInlineSnapshotBrowser(
       widthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"simple-unknown-css"`,
+      `"disabled"`,
     )
 
     matchInlineSnapshotBrowser(heightControl.value, `"88"`)
     matchInlineSnapshotBrowser(
       heightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"simple-unknown-css"`,
+      `"disabled"`,
     )
 
     matchInlineSnapshotBrowser(topControl.value, `"220"`)
@@ -1443,14 +1443,14 @@ describe('inspector tests with real metadata', () => {
     matchInlineSnapshotBrowser(earlyWidthControl.value, `"203"`)
     matchInlineSnapshotBrowser(
       earlyWidthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"detected-fromcss"`,
+      `"disabled"`,
     )
 
     matchInlineSnapshotBrowser(earlyMetadata.computedStyle?.['height'], `"102px"`)
     matchInlineSnapshotBrowser(earlyHeightControl.value, `"102"`)
     matchInlineSnapshotBrowser(
       earlyHeightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"detected-fromcss"`,
+      `"disabled"`,
     )
 
     matchInlineSnapshotBrowser(earlyPaddingLeftControl.value, `"16"`)
@@ -1501,14 +1501,14 @@ describe('inspector tests with real metadata', () => {
     matchInlineSnapshotBrowser(laterWidthControl.value, `"203"`)
     matchInlineSnapshotBrowser(
       laterWidthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"detected-fromcss"`,
+      `"disabled"`,
     )
 
     matchInlineSnapshotBrowser(laterMetadata.computedStyle?.['height'], `"102px"`)
     matchInlineSnapshotBrowser(laterHeightControl.value, `"102"`)
     matchInlineSnapshotBrowser(
       laterHeightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"detected-fromcss"`,
+      `"disabled"`,
     )
 
     matchInlineSnapshotBrowser(laterPaddingLeftControl.value, `"16"`)
@@ -1592,13 +1592,13 @@ describe('inspector tests with real metadata', () => {
     matchInlineSnapshotBrowser(widthControl.value, `"0"`)
     matchInlineSnapshotBrowser(
       widthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"detected-fromcss"`,
+      `"disabled"`,
     )
 
     matchInlineSnapshotBrowser(heightControl.value, `"0"`)
     matchInlineSnapshotBrowser(
       heightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"detected-fromcss"`,
+      `"disabled"`,
     )
 
     matchInlineSnapshotBrowser(paddingControl.value, `"0"`)
@@ -1760,14 +1760,14 @@ describe('inspector tests with real metadata', () => {
     matchInlineSnapshotBrowser(widthControl.value, `"250"`)
     matchInlineSnapshotBrowser(
       widthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"detected-fromcss"`,
+      `"disabled"`,
     )
 
     matchInlineSnapshotBrowser(metadata.computedStyle?.['height'], `"250px"`)
     matchInlineSnapshotBrowser(heightControl.value, `"250"`)
     matchInlineSnapshotBrowser(
       heightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-      `"detected-fromcss"`,
+      `"disabled"`,
     )
 
     matchInlineSnapshotBrowser(metadata.computedStyle?.['paddingLeft'], `"14px"`)

--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -46,6 +46,7 @@ export const FillContainerLabel = 'Fill container' as const
 export const FixedLabel = 'Fixed' as const
 export const HugContentsLabel = 'Hug contents' as const
 export const ComputedLabel = 'Computed' as const
+export const DetectedLabel = 'Detected' as const
 
 export function selectOptionLabel(mode: FixedHugFillMode): string {
   switch (mode) {
@@ -57,6 +58,8 @@ export function selectOptionLabel(mode: FixedHugFillMode): string {
       return HugContentsLabel
     case 'computed':
       return ComputedLabel
+    case 'detected':
+      return DetectedLabel
     default:
       assertNever(mode)
   }
@@ -448,6 +451,7 @@ function strategyForMode(
     case 'hug':
       return setPropHugStrategies(axis)
     case 'fixed':
+    case 'detected':
     case 'computed':
       return setPropFixedStrategies('always', axis, cssNumber(fixedValue, null))
     default:
@@ -458,6 +462,7 @@ function strategyForMode(
 function pickFixedValue(value: FixedHugFill): CSSNumber | undefined {
   switch (value.type) {
     case 'computed':
+    case 'detected':
     case 'fixed':
     case 'fill':
       return value.value

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -543,6 +543,7 @@ export type FixedHugFill =
   | { type: 'fill'; value: CSSNumber }
   | { type: 'hug' }
   | { type: 'computed'; value: CSSNumber }
+  | { type: 'detected'; value: CSSNumber }
 
 export type FixedHugFillMode = FixedHugFill['type']
 
@@ -647,7 +648,7 @@ export function detectFillHugFixedState(
     )
 
     const valueWithType: FixedHugFill = {
-      type: controlStatus === 'controlled' ? 'computed' : 'fixed',
+      type: controlStatus === 'controlled' ? 'computed' : 'detected',
       value: cssNumber(frame[dimension]),
     }
     return { fixedHugFill: valueWithType, controlStatus: controlStatus }
@@ -962,6 +963,7 @@ export function isFixedHugFillEqual(
     case 'fill':
     case 'fixed':
     case 'computed':
+    case 'detected':
       return (
         a.fixedHugFill.type === b.fixedHugFill.type &&
         a.fixedHugFill.value.value === b.fixedHugFill.value.value &&

--- a/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
@@ -568,7 +568,7 @@ describe('Fixed / Fill / Hug control', () => {
       const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
       await editor.dispatch(selectComponents([targetPath], false), true)
 
-      const fixedControls = await editor.renderedDOM.findAllByText(FixedLabel)
+      const fixedControls = await editor.renderedDOM.findAllByText(DetectedLabel)
       const horizontalControl = fixedControls[0]
       await mouseClickAtPoint(horizontalControl, { x: 5, y: 5 })
 

--- a/editor/src/components/inspector/sections/style-section/text-subsection/text-auto-sizing-control.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/text-auto-sizing-control.tsx
@@ -28,7 +28,7 @@ export const TextAutoSizingTestId = 'textAutoSizing'
 
 function useAutoSizingTypeAndStatus(): {
   status: ControlStatus
-  type: 'fixed' | 'hug' | 'computed' | null
+  type: 'fixed' | 'hug' | 'computed' | 'detected' | null
 } {
   const isEditableText = useEditorState(
     Substores.metadata,


### PR DESCRIPTION
<img width="1234" alt="image" src="https://github.com/concrete-utopia/utopia/assets/16385508/1602f935-c24b-4965-974e-96587c001ff3">

## Problem
When an element has no explicit width/height prop set, we still show the width/height from its `globalFrame`, but the label reads `Fixed.` This is bad phrasing at best and misleading at worst since `Fixed` is used for width/height that is explicitly set in props.

## Fix 
Introduce a new state in the width/height control, `Detected`, used when no explicit size is set, and `globalFrame`  is used to get the width/height.