### PR TITLE
Remove all but one jest root so that it starts tests faster.

### DIFF
--- a/editor/jest.config.js
+++ b/editor/jest.config.js
@@ -115,7 +115,7 @@ module.exports = {
       transform: {
         '\\.[jt]sx?$': 'babel-jest',
       },
-      roots: ['src', 'node_modules', '<rootDir>/node_modules'],
+      roots: ['src'],
       transformIgnorePatterns: ['<rootDir>/node_modules/.pnpm/(?!file+..+)'],
       setupFiles: ['./jest-setup-beforeall.js'],
     },


### PR DESCRIPTION
**Problem:**
Jest can take a really long time to get started running tests.

**Cause:**
Jest runs `find` on the command line, supplying the various paths in `roots` to it to find all the possible test files. Currently this includes `node_modules`, which means it walks the bajillion folders in there looking for test files that we've written.

**Fix:**
Remove everything but `src` from `roots` as that's where all our tests actually live.

**Commit Details:**
- Change `roots` to just `['src']`.