### PR TITLE
Exit text edit mode if element does not support children

### DIFF
--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -433,17 +433,8 @@ export function handleKeyDown(
       },
       [FIRST_CHILD_OR_EDIT_TEXT_SHORTCUT]: () => {
         if (isSelectMode(editor.mode)) {
-          const firstTextEditableView = editor.selectedViews.find(
-            (v) =>
-              MetadataUtils.targetTextEditable(editor.jsxMetadata, editor.elementPathTree, v) &&
-              MetadataUtils.targetSupportsChildren(
-                editor.projectContents,
-                editor.jsxMetadata,
-                editor.nodeModules.files,
-                editor.canvas.openFile?.filename ?? null,
-                v,
-                editor.elementPathTree,
-              ),
+          const firstTextEditableView = editor.selectedViews.find((v) =>
+            MetadataUtils.targetTextEditable(editor.jsxMetadata, editor.elementPathTree, v),
           )
           if (firstTextEditableView != null) {
             return [

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -433,8 +433,17 @@ export function handleKeyDown(
       },
       [FIRST_CHILD_OR_EDIT_TEXT_SHORTCUT]: () => {
         if (isSelectMode(editor.mode)) {
-          const firstTextEditableView = editor.selectedViews.find((v) =>
-            MetadataUtils.targetTextEditable(editor.jsxMetadata, editor.elementPathTree, v),
+          const firstTextEditableView = editor.selectedViews.find(
+            (v) =>
+              MetadataUtils.targetTextEditable(editor.jsxMetadata, editor.elementPathTree, v) &&
+              MetadataUtils.targetSupportsChildren(
+                editor.projectContents,
+                editor.jsxMetadata,
+                editor.nodeModules.files,
+                editor.canvas.openFile?.filename ?? null,
+                v,
+                editor.elementPathTree,
+              ),
           )
           if (firstTextEditableView != null) {
             return [

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -375,7 +375,7 @@ const TextEditor = React.memo((props: TextEditorProps) => {
         ])
       }, 0)
     }
-  })
+  }, [dispatch])
 
   React.useEffect(() => {
     if (myElement.current == null) {

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -23,6 +23,7 @@ import {
   deleteView,
   updateText,
   updateEditorMode,
+  showToast,
 } from '../editor/actions/action-creators'
 import { Coordinates, EditorModes } from '../editor/editor-modes'
 import { useDispatch } from '../editor/store/dispatch-context'
@@ -39,6 +40,7 @@ import { useColorTheme } from '../../uuiui'
 import { mapArrayToDictionary } from '../../core/shared/array-utils'
 import { TextRelatedProperties } from '../../core/properties/css-properties'
 import { assertNever } from '../../core/shared/utils'
+import { notice } from '../common/notice'
 
 export const TextEditorSpanId = 'text-editor'
 
@@ -356,6 +358,24 @@ const TextEditor = React.memo((props: TextEditorProps) => {
     }
     myElement.current.textContent = firstTextProp
   }, [firstTextProp])
+
+  React.useEffect(() => {
+    if (myElement.current == null) {
+      setTimeout(() => {
+        dispatch([
+          updateEditorMode(EditorModes.selectMode()),
+          showToast(
+            notice(
+              "This element doesn't support children, so it cannot be text edited",
+              'WARNING',
+              false,
+              'text-editor-does-not-support-children',
+            ),
+          ),
+        ])
+      }, 0)
+    }
+  })
 
   React.useEffect(() => {
     if (myElement.current == null) {


### PR DESCRIPTION
## Problem
When text edit mode is enabled on a component that doesn't use the `children` prop, the editor will enter text edit mode, but the actual contenteditable span doesn't make its way into the DOM (because its parent element doesn't render it). As a consequence, the event handlers that switch back to select mode (added to the contenteditable span) cannot fire, which makes the editor get stuck in text editor mode without an actual text editor.

## Fix
Add a check in `TextEditor` that checks whether the span is actually rendered. If it isn't, it switches the editor back to select mode and shows a toast that explains the situation.
