### PR TITLE
remove most ad-hoc performance measurements from editor.tsx

### DIFF
--- a/editor/src/components/editor/store/editor-dispatch-performance-logging.tsx
+++ b/editor/src/components/editor/store/editor-dispatch-performance-logging.tsx
@@ -1,0 +1,63 @@
+import { PERFORMANCE_MARKS_ALLOWED } from '../../../common/env-vars'
+import { isFeatureEnabled } from '../../../utils/feature-switches'
+import { EditorAction } from '../action-types'
+import { simpleStringifyActions } from './dispatch'
+
+export function createPerformanceMeasure() {
+  const MeasureSelectorsEnabled = isFeatureEnabled('Debug – Measure Selectors')
+  const PerformanceMarks =
+    (isFeatureEnabled('Debug – Performance Marks (Slow)') ||
+      isFeatureEnabled('Debug – Performance Marks (Fast)')) &&
+    PERFORMANCE_MARKS_ALLOWED
+
+  let stringifiedActions = ''
+
+  let tasks: {
+    [name: string]: { timingInfo: string; startMarkName: string; endMarkName: string }
+  } = {}
+  return {
+    logActions(actions: ReadonlyArray<EditorAction>): void {
+      stringifiedActions = simpleStringifyActions(actions)
+    },
+    taskTime<T>(name: string, task: () => T): T {
+      const startMarkName = `${name}-start`
+      const endMarkName = `${name}-end`
+
+      const before = MeasureSelectorsEnabled ? performance.now() : 0
+      if (PerformanceMarks) {
+        performance.mark(startMarkName)
+      }
+
+      // run the actual task
+      const result = task()
+
+      const after = MeasureSelectorsEnabled ? performance.now() : 0
+      if (PerformanceMarks) {
+        performance.mark(endMarkName)
+      }
+
+      tasks[name] = {
+        timingInfo: `${after - before}ms`,
+        startMarkName: startMarkName,
+        endMarkName: endMarkName,
+      }
+      return result
+    },
+    printMeasurements() {
+      if (MeasureSelectorsEnabled) {
+        console.info('------------------')
+        console.info(`dispatched actions: ${stringifiedActions}`)
+        console.info(
+          Object.entries(tasks)
+            .map(([task, { timingInfo }]) => `${task}: ${timingInfo}`)
+            .join('\n'),
+        )
+      }
+      if (PerformanceMarks) {
+        Object.entries(tasks).forEach(([task, { startMarkName, endMarkName }]) => {
+          performance.measure(task, startMarkName, endMarkName)
+        })
+      }
+    },
+  }
+}

--- a/editor/src/components/editor/store/store-hook-performance-logging.ts
+++ b/editor/src/components/editor/store/store-hook-performance-logging.ts
@@ -3,6 +3,8 @@ import { PERFORMANCE_MARKS_ALLOWED } from '../../../common/env-vars'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { StateSelector } from './store-hook'
 import { StoreKey, Substates } from './store-hook-substore-types'
+import { simpleStringifyActions } from './dispatch'
+import { EditorAction } from '../action-types'
 
 export function resetSelectorTimings(): void {
   SelectorTimings.current = {}
@@ -179,4 +181,63 @@ export function logSelectorTimings(phase: string): void {
   console.log(`Pre-Selectors during ${phase}`)
   // eslint-disable-next-line no-console
   console.table(SubstoreTimings.current, ['accumulatedTime', 'calledNumberOfTimes'])
+}
+
+export function createPerformanceMeasure() {
+  const MeasureSelectorsEnabled = isFeatureEnabled('Debug – Measure Selectors')
+  const PerformanceMarks =
+    (isFeatureEnabled('Debug – Performance Marks (Slow)') ||
+      isFeatureEnabled('Debug – Performance Marks (Fast)')) &&
+    PERFORMANCE_MARKS_ALLOWED
+
+  let stringifiedActions = ''
+
+  let tasks: {
+    [name: string]: { timingInfo: string; startMarkName: string; endMarkName: string }
+  } = {}
+  return {
+    logActions(actions: ReadonlyArray<EditorAction>): void {
+      stringifiedActions = simpleStringifyActions(actions)
+    },
+    taskTime<T>(name: string, task: () => T): T {
+      const startMarkName = `${name}-start`
+      const endMarkName = `${name}-end`
+
+      const before = MeasureSelectorsEnabled ? performance.now() : 0
+      if (PerformanceMarks) {
+        performance.mark(startMarkName)
+      }
+
+      // run the actual task
+      const result = task()
+
+      const after = MeasureSelectorsEnabled ? performance.now() : 0
+      if (PerformanceMarks) {
+        performance.mark(endMarkName)
+      }
+
+      tasks[name] = {
+        timingInfo: `${after - before}ms`,
+        startMarkName: startMarkName,
+        endMarkName: endMarkName,
+      }
+      return result
+    },
+    printMeasurements() {
+      if (MeasureSelectorsEnabled) {
+        console.info('------------------')
+        console.info(`dispatched actions: ${stringifiedActions}`)
+        console.info(
+          Object.entries(tasks)
+            .map(([task, { timingInfo }]) => `${task}: ${timingInfo}`)
+            .join('\n'),
+        )
+      }
+      if (PerformanceMarks) {
+        Object.entries(tasks).forEach(([task, { startMarkName, endMarkName }]) => {
+          performance.measure(task, startMarkName, endMarkName)
+        })
+      }
+    },
+  }
 }

--- a/editor/src/components/editor/store/store-hook-performance-logging.ts
+++ b/editor/src/components/editor/store/store-hook-performance-logging.ts
@@ -3,8 +3,6 @@ import { PERFORMANCE_MARKS_ALLOWED } from '../../../common/env-vars'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { StateSelector } from './store-hook'
 import { StoreKey, Substates } from './store-hook-substore-types'
-import { simpleStringifyActions } from './dispatch'
-import { EditorAction } from '../action-types'
 
 export function resetSelectorTimings(): void {
   SelectorTimings.current = {}
@@ -181,63 +179,4 @@ export function logSelectorTimings(phase: string): void {
   console.log(`Pre-Selectors during ${phase}`)
   // eslint-disable-next-line no-console
   console.table(SubstoreTimings.current, ['accumulatedTime', 'calledNumberOfTimes'])
-}
-
-export function createPerformanceMeasure() {
-  const MeasureSelectorsEnabled = isFeatureEnabled('Debug – Measure Selectors')
-  const PerformanceMarks =
-    (isFeatureEnabled('Debug – Performance Marks (Slow)') ||
-      isFeatureEnabled('Debug – Performance Marks (Fast)')) &&
-    PERFORMANCE_MARKS_ALLOWED
-
-  let stringifiedActions = ''
-
-  let tasks: {
-    [name: string]: { timingInfo: string; startMarkName: string; endMarkName: string }
-  } = {}
-  return {
-    logActions(actions: ReadonlyArray<EditorAction>): void {
-      stringifiedActions = simpleStringifyActions(actions)
-    },
-    taskTime<T>(name: string, task: () => T): T {
-      const startMarkName = `${name}-start`
-      const endMarkName = `${name}-end`
-
-      const before = MeasureSelectorsEnabled ? performance.now() : 0
-      if (PerformanceMarks) {
-        performance.mark(startMarkName)
-      }
-
-      // run the actual task
-      const result = task()
-
-      const after = MeasureSelectorsEnabled ? performance.now() : 0
-      if (PerformanceMarks) {
-        performance.mark(endMarkName)
-      }
-
-      tasks[name] = {
-        timingInfo: `${after - before}ms`,
-        startMarkName: startMarkName,
-        endMarkName: endMarkName,
-      }
-      return result
-    },
-    printMeasurements() {
-      if (MeasureSelectorsEnabled) {
-        console.info('------------------')
-        console.info(`dispatched actions: ${stringifiedActions}`)
-        console.info(
-          Object.entries(tasks)
-            .map(([task, { timingInfo }]) => `${task}: ${timingInfo}`)
-            .join('\n'),
-        )
-      }
-      if (PerformanceMarks) {
-        Object.entries(tasks).forEach(([task, { startMarkName, endMarkName }]) => {
-          performance.measure(task, startMarkName, endMarkName)
-        })
-      }
-    },
-  }
 }

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -126,10 +126,10 @@ import {
 } from '../core/shared/github/helpers'
 import { DispatchContext } from '../components/editor/store/dispatch-context'
 import {
-  createPerformanceMeasure,
   logSelectorTimings,
   resetSelectorTimings,
 } from '../components/editor/store/store-hook-performance-logging'
+import { createPerformanceMeasure } from '../components/editor/store/editor-dispatch-performance-logging'
 
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -126,6 +126,7 @@ import {
 } from '../core/shared/github/helpers'
 import { DispatchContext } from '../components/editor/store/dispatch-context'
 import {
+  createPerformanceMeasure,
   logSelectorTimings,
   resetSelectorTimings,
 } from '../components/editor/store/store-hook-performance-logging'
@@ -422,11 +423,10 @@ export class Editor {
   ): {
     entireUpdateFinished: Promise<any>
   } => {
+    const Measure = createPerformanceMeasure()
+    Measure.logActions(dispatchedActions)
+
     const MeasureSelectors = isFeatureEnabled('Debug – Measure Selectors')
-    if (MeasureSelectors) {
-      // eslint-disable-next-line no-console
-      console.log('------------------')
-    }
     const PerformanceMarks =
       (isFeatureEnabled('Debug – Performance Marks (Slow)') ||
         isFeatureEnabled('Debug – Performance Marks (Fast)')) &&
@@ -457,39 +457,24 @@ export class Editor {
 
       if (!dispatchResult.nothingChanged) {
         const updateId = canvasUpdateId++
-        // we update the zustand store with the new editor state. this will trigger a re-render in the EditorComponent
-        if (PerformanceMarks) {
-          performance.mark(`update canvas ${updateId}`)
-        }
-        const currentElementsToRender = fixElementsToRerender(
-          this.storedState.patchedEditor.canvas.elementsToRerender,
-          dispatchedActions,
-        )
-        ElementsToRerenderGLOBAL.current = currentElementsToRender // Mutation!
-        const beforeCanvasStore = MeasureSelectors ? performance.now() : 0
-        ReactDOM.flushSync(() => {
-          ReactDOM.unstable_batchedUpdates(() => {
-            this.canvasStore.setState(patchedStoreFromFullStore(this.storedState, 'canvas-store'))
+        Measure.taskTime(`update canvas ${updateId}`, () => {
+          const currentElementsToRender = fixElementsToRerender(
+            this.storedState.patchedEditor.canvas.elementsToRerender,
+            dispatchedActions,
+          )
+          ElementsToRerenderGLOBAL.current = currentElementsToRender // Mutation!
+          // we update the zustand store with the new editor state. this will trigger a re-render in the EditorComponent
+          ReactDOM.flushSync(() => {
+            ReactDOM.unstable_batchedUpdates(() => {
+              this.canvasStore.setState(patchedStoreFromFullStore(this.storedState, 'canvas-store'))
+            })
           })
         })
-        const afterCanvasStore = MeasureSelectors ? performance.now() : 0
-        if (PerformanceMarks) {
-          performance.mark(`update canvas end ${updateId}`)
-          performance.measure(
-            `Update Canvas ${updateId} – [${
-              typeof ElementsToRerenderGLOBAL.current === 'string'
-                ? ElementsToRerenderGLOBAL.current
-                : ElementsToRerenderGLOBAL.current.map(EP.toString).join(', ')
-            }]`,
-            `update canvas ${updateId}`,
-            `update canvas end ${updateId}`,
-          )
-        }
 
         const domWalkerResult = runDomWalker({
           domWalkerMutableState: this.domWalkerMutableState,
           selectedViews: this.storedState.patchedEditor.selectedViews,
-          elementsToFocusOn: currentElementsToRender,
+          elementsToFocusOn: ElementsToRerenderGLOBAL.current,
           scale: this.storedState.patchedEditor.canvas.scale,
           additionalElementsToUpdate:
             this.storedState.patchedEditor.canvas.domWalkerAdditionalElementsToUpdate,
@@ -518,74 +503,43 @@ export class Editor {
           ])
         }
 
-        if (PerformanceMarks) {
-          performance.mark(`update editor ${updateId}`)
-        }
-        ReactDOM.flushSync(() => {
-          ReactDOM.unstable_batchedUpdates(() => {
-            if (PerformanceMarks) {
-              performance.mark(`update main store ${updateId}`)
-            }
-            const beforeMainStore = MeasureSelectors ? performance.now() : 0
-            this.utopiaStoreHook.setState(
-              patchedStoreFromFullStore(this.storedState, 'editor-store'),
-            )
-            const afterMainStore = MeasureSelectors ? performance.now() : 0
-
-            if (PerformanceMarks) {
-              performance.measure(`Update Main Store ${updateId}`, `update main store ${updateId}`)
-            }
-
-            if (
-              shouldUpdateLowPriorityUI(this.storedState.strategyState, currentElementsToRender)
-            ) {
-              if (PerformanceMarks) {
-                performance.mark(`update low priority store ${updateId}`)
-              }
-              this.lowPriorityStore.setState(
-                patchedStoreFromFullStore(this.storedState, 'low-priority-store'),
-              )
-              if (PerformanceMarks) {
-                performance.measure(
-                  `Update Low Prio Store ${updateId}`,
-                  `update low priority store ${updateId}`,
+        Measure.taskTime(`Update Editor ${updateId}`, () => {
+          ReactDOM.flushSync(() => {
+            ReactDOM.unstable_batchedUpdates(() => {
+              Measure.taskTime(`Update Main Store ${updateId}`, () => {
+                this.utopiaStoreHook.setState(
+                  patchedStoreFromFullStore(this.storedState, 'editor-store'),
                 )
-              }
-            }
-            const afterStoreUpdate = MeasureSelectors ? performance.now() : 0
-            if (MeasureSelectors) {
-              console.info(
-                'Dispatched actions:',
-                simpleStringifyActions(dispatchedActions),
-                'All stores',
-                afterStoreUpdate - beforeCanvasStore,
-                'Canvas store',
-                afterCanvasStore - beforeCanvasStore,
-                'main store',
-                afterMainStore - beforeMainStore,
-                'slow store',
-                afterStoreUpdate - afterMainStore,
-              )
-              logSelectorTimings('store update phase')
-            }
-            if (PerformanceMarks) {
-              performance.mark(`react wrap up ${updateId}`)
-            }
+              })
 
-            // reset selector timings right before the end of flushSync means we'll capture the re-render related selector data with a clean slate
-            resetSelectorTimings()
+              if (
+                shouldUpdateLowPriorityUI(
+                  this.storedState.strategyState,
+                  ElementsToRerenderGLOBAL.current,
+                )
+              ) {
+                Measure.taskTime(`Update Low Prio Store ${updateId}`, () => {
+                  this.lowPriorityStore.setState(
+                    patchedStoreFromFullStore(this.storedState, 'low-priority-store'),
+                  )
+                })
+              }
+              if (MeasureSelectors) {
+                logSelectorTimings('store update phase')
+              }
+              if (PerformanceMarks) {
+                performance.mark(`react wrap up ${updateId}`)
+              }
+
+              // reset selector timings right before the end of flushSync means we'll capture the re-render related selector data with a clean slate
+              resetSelectorTimings()
+            })
           })
         })
         if (PerformanceMarks) {
           performance.measure(
             `Our Components Rendering + React Doing Stuff`,
             `react wrap up ${updateId}`,
-          )
-          performance.mark(`update editor end ${updateId}`)
-          performance.measure(
-            `Update Editor ${updateId}`,
-            `update editor ${updateId}`,
-            `update editor end ${updateId}`,
           )
         }
       }
@@ -598,16 +552,16 @@ export class Editor {
     if (PerformanceMarks) {
       performance.mark('beforeFullDispatch')
     }
-    const result = runDispatch()
+    const result = Measure.taskTime(
+      `Editor Dispatch ${simpleStringifyActions(dispatchedActions)}`,
+      () => {
+        return runDispatch()
+      },
+    )
     if (MeasureSelectors) {
       logSelectorTimings('re-render phase')
     }
-    if (PerformanceMarks) {
-      performance.measure(
-        `Editor Dispatch ${simpleStringifyActions(dispatchedActions)}`,
-        'beforeFullDispatch',
-      )
-    }
+    Measure.printMeasurements()
     return result
   }
 


### PR DESCRIPTION
I have an upcoming PR #3894 that touches the editor dispatch function in editor.tsx. the current ad-hoc performance measurements make the code hard to read and unsafe to refactor. 

in this PR I aim to make the code a little bit more palatable by using a single helper function to measure performance instead of relying on ad-hoc function calls and variables