### PR TITLE
Fix/inspector size section group true up

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -218,7 +218,10 @@ export function absoluteResizeBoundingBoxStrategy(
                     ? 'only-offset-pins-are-needed'
                     : 'ensure-two-pins-per-dimension-exists',
                 ),
-                pushIntendedBoundsAndUpdateGroups([{ target: selectedElement, frame: newFrame }]),
+                pushIntendedBoundsAndUpdateGroups(
+                  [{ target: selectedElement, frame: newFrame }],
+                  'metadata-is-stale',
+                ),
               ]
             })
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -220,7 +220,7 @@ export function absoluteResizeBoundingBoxStrategy(
                 ),
                 pushIntendedBoundsAndUpdateGroups(
                   [{ target: selectedElement, frame: newFrame }],
-                  'metadata-is-stale',
+                  'starting-metadata',
                 ),
               ]
             })

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
@@ -91,7 +91,7 @@ export function keyboardAbsoluteMoveStrategy(
         const guidelines = getKeyboardStrategyGuidelines(canvasState, interactionSession, newFrame)
 
         commands.push(setSnappingGuidelines('mid-interaction', guidelines))
-        commands.push(pushIntendedBoundsAndUpdateGroups(intendedBounds, 'metadata-is-stale'))
+        commands.push(pushIntendedBoundsAndUpdateGroups(intendedBounds, 'starting-metadata'))
         commands.push(setElementsToRerenderCommand(selectedElements))
         return strategyApplicationResult(commands)
       } else {

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
@@ -91,7 +91,7 @@ export function keyboardAbsoluteMoveStrategy(
         const guidelines = getKeyboardStrategyGuidelines(canvasState, interactionSession, newFrame)
 
         commands.push(setSnappingGuidelines('mid-interaction', guidelines))
-        commands.push(pushIntendedBoundsAndUpdateGroups(intendedBounds))
+        commands.push(pushIntendedBoundsAndUpdateGroups(intendedBounds, 'metadata-is-stale'))
         commands.push(setElementsToRerenderCommand(selectedElements))
         return strategyApplicationResult(commands)
       } else {

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
@@ -201,7 +201,7 @@ export function keyboardAbsoluteResizeStrategy(
         })
         const guidelines = getKeyboardStrategyGuidelines(canvasState, interactionSession, newFrame)
         commands.push(setSnappingGuidelines('mid-interaction', guidelines))
-        commands.push(pushIntendedBoundsAndUpdateGroups(intendedBounds))
+        commands.push(pushIntendedBoundsAndUpdateGroups(intendedBounds, 'metadata-is-stale'))
         commands.push(setElementsToRerenderCommand(selectedElements))
         return strategyApplicationResult(commands)
       } else {

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
@@ -201,7 +201,7 @@ export function keyboardAbsoluteResizeStrategy(
         })
         const guidelines = getKeyboardStrategyGuidelines(canvasState, interactionSession, newFrame)
         commands.push(setSnappingGuidelines('mid-interaction', guidelines))
-        commands.push(pushIntendedBoundsAndUpdateGroups(intendedBounds, 'metadata-is-stale'))
+        commands.push(pushIntendedBoundsAndUpdateGroups(intendedBounds, 'starting-metadata'))
         commands.push(setElementsToRerenderCommand(selectedElements))
         return strategyApplicationResult(commands)
       } else {

--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
@@ -124,7 +124,7 @@ export function applyMoveCommon(
         ...commandsForSelectedElements.commands,
         pushIntendedBoundsAndUpdateGroups(
           commandsForSelectedElements.intendedBounds,
-          'metadata-is-stale',
+          'starting-metadata',
         ),
         updateHighlightedViews('mid-interaction', []),
         setElementsToRerenderCommand(targets),
@@ -159,7 +159,7 @@ export function applyMoveCommon(
         setSnappingGuidelines('mid-interaction', guidelinesWithSnappingVector),
         pushIntendedBoundsAndUpdateGroups(
           commandsForSelectedElements.intendedBounds,
-          'metadata-is-stale',
+          'starting-metadata',
         ),
         setElementsToRerenderCommand([...targets, ...targetsForSnapping]),
         setCursorCommand(CSSCursor.Select),

--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
@@ -122,7 +122,10 @@ export function applyMoveCommon(
 
       return strategyApplicationResult([
         ...commandsForSelectedElements.commands,
-        pushIntendedBoundsAndUpdateGroups(commandsForSelectedElements.intendedBounds),
+        pushIntendedBoundsAndUpdateGroups(
+          commandsForSelectedElements.intendedBounds,
+          'metadata-is-stale',
+        ),
         updateHighlightedViews('mid-interaction', []),
         setElementsToRerenderCommand(targets),
         setCursorCommand(CSSCursor.Select),
@@ -154,7 +157,10 @@ export function applyMoveCommon(
         ...commandsForSelectedElements.commands,
         updateHighlightedViews('mid-interaction', []),
         setSnappingGuidelines('mid-interaction', guidelinesWithSnappingVector),
-        pushIntendedBoundsAndUpdateGroups(commandsForSelectedElements.intendedBounds),
+        pushIntendedBoundsAndUpdateGroups(
+          commandsForSelectedElements.intendedBounds,
+          'metadata-is-stale',
+        ),
         setElementsToRerenderCommand([...targets, ...targetsForSnapping]),
         setCursorCommand(CSSCursor.Select),
       ])

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -90,6 +90,8 @@ import { runWrapInContainerCommand } from './wrap-in-container-command'
 import { patchProjectContentsWithParsedFile } from './patch-utils'
 import type { AddElements } from './add-elements-command'
 import { runAddElements } from './add-elements-command'
+import type { QueueGroupTrueUp } from './queue-group-true-up-command'
+import { runQueueGroupTrueUp } from './queue-group-true-up-command'
 
 export interface CommandFunctionResult {
   editorStatePatches: Array<EditorStatePatch>
@@ -140,6 +142,7 @@ export type CanvasCommand =
   | RearrangeChildren
   | DeleteElement
   | WrapInContainerCommand
+  | QueueGroupTrueUp
 
 export function runCanvasCommand(
   editorState: EditorState,
@@ -217,6 +220,8 @@ export function runCanvasCommand(
       return runDeleteElement(editorState, command)
     case 'WRAP_IN_CONTAINER':
       return runWrapInContainerCommand(editorState, command)
+    case 'QUEUE_GROUP_TRUE_UP':
+      return runQueueGroupTrueUp(editorState, command)
     default:
       const _exhaustiveCheck: never = command
       throw new Error(`Unhandled canvas command ${JSON.stringify(command)}`)

--- a/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
+++ b/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
@@ -143,15 +143,19 @@ function getUpdateResizedGroupChildrenCommands(
         frameAndTarget.target,
       )
 
+      // the original size of the group before the interaction ran
       const originalSize: Size =
         command.isMetadataStale === 'metadata-is-stale'
-          ? sizeFromRectangle(
+          ? // if we have the starting metadata, we can simply get the original measured bounds of the element and we know it's the originalSize
+            sizeFromRectangle(
               MetadataUtils.getLocalFrameFromSpecialSizeMeasurements(
                 frameAndTarget.target,
                 editor.jsxMetadata,
               ),
             )
-          : sizeFromRectangle(
+          : // if the metadata is fresh, the group is already resized. so we need to query the size of its children AABB
+            //(which was not yet updated, since this function is updating the children sizes) to get the originalSize
+            sizeFromRectangle(
               boundingRectangleArray(
                 children.map((c) =>
                   nullIfInfinity(

--- a/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
+++ b/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
@@ -49,15 +49,18 @@ import { wildcardPatch } from './wildcard-patch-command'
 export interface PushIntendedBoundsAndUpdateGroups extends BaseCommand {
   type: 'PUSH_INTENDED_BOUNDS_AND_UPDATE_GROUPS'
   value: Array<CanvasFrameAndTarget>
+  isMetadataStale: 'metadata-is-stale' | 'metadata-is-fresh'
 }
 
 export function pushIntendedBoundsAndUpdateGroups(
   value: Array<CanvasFrameAndTarget>,
+  isMetadataStale: 'metadata-is-stale' | 'metadata-is-fresh',
 ): PushIntendedBoundsAndUpdateGroups {
   return {
     type: 'PUSH_INTENDED_BOUNDS_AND_UPDATE_GROUPS',
     whenToRun: 'always',
     value: value,
+    isMetadataStale: isMetadataStale,
   }
 }
 
@@ -140,15 +143,23 @@ function getUpdateResizedGroupChildrenCommands(
         frameAndTarget.target,
       )
 
-      const originalSize: Size = sizeFromRectangle(
-        boundingRectangleArray(
-          children.map((c) =>
-            nullIfInfinity(
-              MetadataUtils.findElementByElementPath(editor.jsxMetadata, c)?.globalFrame,
-            ),
-          ),
-        ),
-      )
+      const originalSize: Size =
+        command.isMetadataStale === 'metadata-is-stale'
+          ? sizeFromRectangle(
+              MetadataUtils.getLocalFrameFromSpecialSizeMeasurements(
+                frameAndTarget.target,
+                editor.jsxMetadata,
+              ),
+            )
+          : sizeFromRectangle(
+              boundingRectangleArray(
+                children.map((c) =>
+                  nullIfInfinity(
+                    MetadataUtils.findElementByElementPath(editor.jsxMetadata, c)?.globalFrame,
+                  ),
+                ),
+              ),
+            )
 
       const updatedSize: Size = frameAndTarget.size
 

--- a/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
+++ b/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
@@ -49,18 +49,18 @@ import { wildcardPatch } from './wildcard-patch-command'
 export interface PushIntendedBoundsAndUpdateGroups extends BaseCommand {
   type: 'PUSH_INTENDED_BOUNDS_AND_UPDATE_GROUPS'
   value: Array<CanvasFrameAndTarget>
-  isMetadataStale: 'metadata-is-stale' | 'metadata-is-fresh'
+  isStartingMetadata: 'starting-metadata' | 'live-metadata'
 }
 
 export function pushIntendedBoundsAndUpdateGroups(
   value: Array<CanvasFrameAndTarget>,
-  isMetadataStale: 'metadata-is-stale' | 'metadata-is-fresh',
+  isStartingMetadata: 'starting-metadata' | 'live-metadata',
 ): PushIntendedBoundsAndUpdateGroups {
   return {
     type: 'PUSH_INTENDED_BOUNDS_AND_UPDATE_GROUPS',
     whenToRun: 'always',
     value: value,
-    isMetadataStale: isMetadataStale,
+    isStartingMetadata: isStartingMetadata,
   }
 }
 
@@ -145,7 +145,7 @@ function getUpdateResizedGroupChildrenCommands(
 
       // the original size of the group before the interaction ran
       const originalSize: Size =
-        command.isMetadataStale === 'metadata-is-stale'
+        command.isStartingMetadata === 'starting-metadata'
           ? // if we have the starting metadata, we can simply get the original measured bounds of the element and we know it's the originalSize
             sizeFromRectangle(
               MetadataUtils.getLocalFrameFromSpecialSizeMeasurements(

--- a/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
+++ b/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
@@ -134,12 +134,22 @@ function getUpdateResizedGroupChildrenCommands(
       frameAndTarget.target,
     )
     if (targetIsGroup) {
+      const children = MetadataUtils.getChildrenPathsOrdered(
+        editor.jsxMetadata,
+        editor.elementPathTree,
+        frameAndTarget.target,
+      )
+
       const originalSize: Size = sizeFromRectangle(
-        MetadataUtils.getLocalFrameFromSpecialSizeMeasurements(
-          frameAndTarget.target,
-          editor.jsxMetadata,
+        boundingRectangleArray(
+          children.map((c) =>
+            nullIfInfinity(
+              MetadataUtils.findElementByElementPath(editor.jsxMetadata, c)?.globalFrame,
+            ),
+          ),
         ),
       )
+
       const updatedSize: Size = frameAndTarget.size
 
       // if the target is a group and the reason for resizing is _NOT_ child-changed, then resize all the children to fit the new AABB
@@ -147,11 +157,7 @@ function getUpdateResizedGroupChildrenCommands(
         editor.jsxMetadata,
         editor.allElementProps,
         editor.elementPathTree,
-        MetadataUtils.getChildrenPathsOrdered(
-          editor.jsxMetadata,
-          editor.elementPathTree,
-          frameAndTarget.target,
-        ),
+        children,
       )
       childrenWithFragmentsRetargeted.forEach((child) => {
         const currentLocalFrame = MetadataUtils.getLocalFrameFromSpecialSizeMeasurements(

--- a/editor/src/components/canvas/commands/queue-group-true-up-command.ts
+++ b/editor/src/components/canvas/commands/queue-group-true-up-command.ts
@@ -1,0 +1,31 @@
+import * as EP from '../../../core/shared/element-path'
+import type { ElementPath } from '../../../core/shared/project-file-types'
+import type { EditorState } from '../../editor/store/editor-state'
+import type { BaseCommand, CommandFunction } from './commands'
+
+export interface QueueGroupTrueUp extends BaseCommand {
+  type: 'QUEUE_GROUP_TRUE_UP'
+  element: ElementPath
+}
+
+export function queueGroupTrueUp(element: ElementPath): QueueGroupTrueUp {
+  return {
+    type: 'QUEUE_GROUP_TRUE_UP',
+    whenToRun: 'on-complete',
+    element: element,
+  }
+}
+
+export const runQueueGroupTrueUp: CommandFunction<QueueGroupTrueUp> = (
+  editorState: EditorState,
+  command: QueueGroupTrueUp,
+) => {
+  return {
+    commandDescription: `Queue element for group true-up once the intearction finished: ${EP.toString(
+      command.element,
+    )}`,
+    editorStatePatches: [
+      { trueUpGroupsForElementAfterDomWalkerRuns: { $push: [command.element] } },
+    ],
+  }
+}

--- a/editor/src/components/canvas/commands/queue-group-true-up-command.ts
+++ b/editor/src/components/canvas/commands/queue-group-true-up-command.ts
@@ -21,7 +21,7 @@ export const runQueueGroupTrueUp: CommandFunction<QueueGroupTrueUp> = (
   command: QueueGroupTrueUp,
 ) => {
   return {
-    commandDescription: `Queue element for group true-up once the intearction finished: ${EP.toString(
+    commandDescription: `Queue element for group true-up once the interaction has finished: ${EP.toString(
       command.element,
     )}`,
     editorStatePatches: [

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4091,7 +4091,7 @@ export const UPDATE_FNS = {
       }
     }, editor.trueUpGroupsForElementAfterDomWalkerRuns)
     const editorWithGroupsTruedUp = foldAndApplyCommandsSimple(editor, [
-      pushIntendedBoundsAndUpdateGroups(canvasFrameAndTargets),
+      pushIntendedBoundsAndUpdateGroups(canvasFrameAndTargets, 'metadata-is-fresh'),
     ])
     return { ...editorWithGroupsTruedUp, trueUpGroupsForElementAfterDomWalkerRuns: [] }
   },

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4091,7 +4091,7 @@ export const UPDATE_FNS = {
       }
     }, editor.trueUpGroupsForElementAfterDomWalkerRuns)
     const editorWithGroupsTruedUp = foldAndApplyCommandsSimple(editor, [
-      pushIntendedBoundsAndUpdateGroups(canvasFrameAndTargets, 'metadata-is-fresh'),
+      pushIntendedBoundsAndUpdateGroups(canvasFrameAndTargets, 'live-metadata'),
     ])
     return { ...editorWithGroupsTruedUp, trueUpGroupsForElementAfterDomWalkerRuns: [] }
   },

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -974,37 +974,3 @@ export function isFixedHugFillEqual(
       throw new Error(`Unknown type in FixedHugFill ${JSON.stringify(a.fixedHugFill)}`)
   }
 }
-
-export function predictElementSize(
-  metadata: ElementInstanceMetadataMap,
-  path: ElementPath,
-  changedProp: 'width' | 'height',
-  newValue: CSSNumber,
-): CanvasRectangle {
-  const elementMetadata = forceNotNull(
-    `found no metadata for element at path ${EP.toString(path)}`,
-    MetadataUtils.findElementByElementPath(metadata, path),
-  )
-  const boundingParentSizeForPercentCalc = forceNotNull(
-    'coordinateSystemBounds was null in metadata',
-    elementMetadata.specialSizeMeasurements.coordinateSystemBounds,
-  )
-
-  const currentBounds: CanvasRectangle = zeroRectIfNullOrInfinity(elementMetadata.globalFrame)
-
-  if (newValue.unit !== 'px' && newValue.unit !== '%' && newValue.unit != null) {
-    // TODO we should be able to calculate the unit into pixel and use that value for prediction
-    return currentBounds
-  }
-
-  const newSizePx =
-    newValue.unit === '%'
-      ? newValue.value * 0.01 * boundingParentSizeForPercentCalc[changedProp]
-      : newValue.value
-
-  const newBounds = canvasRectangle({
-    ...(currentBounds as SimpleRectangle), // this conversion to SimpleRectangle needed for TS to allow the spread
-    [changedProp]: newSizePx,
-  })
-  return newBounds
-}

--- a/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
@@ -7,7 +7,9 @@ import { assertNever } from '../../../core/shared/utils'
 import {
   expectNoAction,
   expectSingleUndo2Saves,
+  expectSingleUndoNSaves,
   selectComponentsForTest,
+  wait,
 } from '../../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../../canvas/controls/new-canvas-controls'
 import { mouseClickAtPoint, mouseDoubleClickAtPoint } from '../../canvas/event-helpers.test-utils'
@@ -805,7 +807,7 @@ describe('Fixed / Fill / Hug control', () => {
 
       const control = editor.renderedDOM.getByTestId(FillFixedHugControlId('width'))
       await mouseClickAtPoint(control, { x: 5, y: 5 })
-      await expectSingleUndo2Saves(editor, async () => {
+      await expectSingleUndoNSaves(editor, 3, async () => {
         act(() => {
           fireEvent.change(control, { target: { value: '300' } })
           fireEvent.blur(control)
@@ -894,7 +896,7 @@ describe('Fixed / Fill / Hug control', () => {
 
       const control = editor.renderedDOM.getByTestId(FillFixedHugControlId('height'))
       await mouseClickAtPoint(control, { x: 5, y: 5 })
-      await expectSingleUndo2Saves(editor, async () => {
+      await expectSingleUndoNSaves(editor, 3, async () => {
         act(() => {
           fireEvent.change(control, { target: { value: '150' } })
           fireEvent.blur(control)
@@ -983,7 +985,7 @@ describe('Fixed / Fill / Hug control', () => {
 
       const control = editor.renderedDOM.getByTestId(FillFixedHugControlId('width'))
       await mouseClickAtPoint(control, { x: 5, y: 5 })
-      await expectSingleUndo2Saves(editor, async () => {
+      await expectSingleUndoNSaves(editor, 3, async () => {
         act(() => {
           fireEvent.change(control, { target: { value: '200' } })
           fireEvent.blur(control)
@@ -1154,7 +1156,7 @@ describe('Fixed / Fill / Hug control', () => {
       const control = editor.renderedDOM.getByTestId(FillFixedHugControlId('width'))
       await mouseClickAtPoint(control, { x: 5, y: 5 })
 
-      await expectSingleUndo2Saves(editor, async () => {
+      await expectSingleUndoNSaves(editor, 3, async () => {
         act(() => {
           fireEvent.change(control, { target: { value: '100' } })
           fireEvent.blur(control)

--- a/editor/src/components/inspector/inspector-strategies/fixed-size-basic-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/fixed-size-basic-strategy.ts
@@ -7,13 +7,9 @@ import {
 } from '../../canvas/commands/set-css-length-command'
 import type { CSSNumber } from '../common/css-utils'
 import type { Axis } from '../inspector-common'
-import {
-  predictElementSize,
-  removeExtraPinsWhenSettingSize,
-  widthHeightFromAxis,
-} from '../inspector-common'
+import { removeExtraPinsWhenSettingSize, widthHeightFromAxis } from '../inspector-common'
 import type { InspectorStrategy } from './inspector-strategy'
-import { pushIntendedBoundsAndUpdateGroups } from '../../canvas/commands/push-intended-bounds-and-update-groups-command'
+import { queueGroupTrueUp } from '../../canvas/commands/queue-group-true-up-command'
 
 export const fixedSizeBasicStrategy = (
   whenToRun: WhenToRun,
@@ -31,9 +27,6 @@ export const fixedSizeBasicStrategy = (
       const parentFlexDirection =
         elementMetadata?.specialSizeMeasurements.parentFlexDirection ?? null
 
-      const propToChange = widthHeightFromAxis(axis)
-      const predictedElementSize = predictElementSize(metadata, path, propToChange, value)
-
       return [
         ...removeExtraPinsWhenSettingSize(axis, elementMetadata),
         setCssLengthProperty(
@@ -43,7 +36,7 @@ export const fixedSizeBasicStrategy = (
           setExplicitCssValue(value),
           parentFlexDirection,
         ),
-        pushIntendedBoundsAndUpdateGroups([{ target: path, frame: predictedElementSize }]),
+        queueGroupTrueUp(path),
       ]
     })
   },


### PR DESCRIPTION
**Problem:**
I found a bug
https://screenshot.click/07-04-gub1v-og4s8.mp4
When changing the width / height in the inspector section for an element that had a right / bottom pin, the `predictElementSize` function used in the `fixedSizeBasicStrategy` inspector strategy would predict a wrong frame, resulting in a wrong group.

**Fix:**
Actually just use the measurement based group true-up system for these controls too. 

**Commit Details:**
- Added `QueueGroupTrueUp` command which queues the target element in `trueUpGroupsForElementAfterDomWalkerRuns`
- Fixed a bug in `getUpdateResizedGroupChildrenCommands` that assumed we are working with stale metadata
- Use QueueGroupTrueUp in fixedSizeBasicStrategy
- New test case demonstrating a scenario that fails on master
