### PR TITLE
floating navigator

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -300,26 +300,26 @@ const DesignPanelRootInner = React.memo(() => {
             {isCanvasVisible && navigatorVisible ? (
               <div
                 style={{
-                  height: '100%',
+                  height: 'calc(100% - 20px)',
                   position: 'absolute',
                   top: 0,
                   left: 0,
                   zIndex: 1,
+                  margin: 10,
                 }}
               >
                 <ResizableFlexColumn
-                  style={{
-                    overscrollBehavior: 'contain',
-                    backgroundColor: colorTheme.inspectorBackground.value,
-                    margin: 10,
-                    borderRadius: UtopiaTheme.panelStyles.panelBorderRadius,
-                    overflow: 'scroll',
-                    boxShadow: `3px 4px 10px 0px ${UtopiaTheme.panelStyles.panelShadowColor}`,
-                  }}
                   onResizeStop={onNavigatorResizeStop}
                   defaultSize={{
                     width: navigatorWidth,
                     height: '100%',
+                  }}
+                  style={{
+                    overscrollBehavior: 'contain',
+                    backgroundColor: colorTheme.inspectorBackground.value,
+                    borderRadius: UtopiaTheme.panelStyles.panelBorderRadius,
+                    overflow: 'scroll',
+                    boxShadow: `3px 4px 10px 0px ${UtopiaTheme.panelStyles.panelShadowColor}`,
                   }}
                 >
                   <NavigatorComponent />

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -312,14 +312,14 @@ const DesignPanelRootInner = React.memo(() => {
                     overscrollBehavior: 'contain',
                     backgroundColor: colorTheme.inspectorBackground.value,
                     margin: 10,
-                    borderRadius: 10,
+                    borderRadius: UtopiaTheme.panelStyles.panelBorderRadius,
                     overflow: 'scroll',
-                    boxShadow: '3px 4px 10px 0px rgba(0,0,0, .3)',
+                    boxShadow: `3px 4px 10px 0px ${UtopiaTheme.panelStyles.panelShadowColor}`,
                   }}
                   onResizeStop={onNavigatorResizeStop}
                   defaultSize={{
                     width: navigatorWidth,
-                    height: '90%',
+                    height: '100%',
                   }}
                 >
                   <NavigatorComponent />

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -300,7 +300,7 @@ const DesignPanelRootInner = React.memo(() => {
             {isCanvasVisible && navigatorVisible ? (
               <div
                 style={{
-                  height: '90%',
+                  height: '100%',
                   position: 'absolute',
                   top: 0,
                   left: 0,

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -311,7 +311,6 @@ const DesignPanelRootInner = React.memo(() => {
                   style={{
                     overscrollBehavior: 'contain',
                     backgroundColor: colorTheme.inspectorBackground.value,
-                    // height: '90%',
                     margin: 10,
                     borderRadius: 10,
                     overflow: 'scroll',

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -300,25 +300,27 @@ const DesignPanelRootInner = React.memo(() => {
             {isCanvasVisible && navigatorVisible ? (
               <div
                 style={{
-                  height: '100%',
+                  height: '90%',
                   position: 'absolute',
                   top: 0,
                   left: 0,
-                  zIndex: 20,
-                  overflow: 'hidden',
-                  borderLeft: `1px solid ${colorTheme.subduedBorder.value}`,
-                  borderRight: `1px solid ${colorTheme.subduedBorder.value}`,
+                  zIndex: 1,
                 }}
               >
                 <ResizableFlexColumn
                   style={{
                     overscrollBehavior: 'contain',
                     backgroundColor: colorTheme.inspectorBackground.value,
+                    // height: '90%',
+                    margin: 10,
+                    borderRadius: 10,
+                    overflow: 'scroll',
+                    boxShadow: '3px 4px 10px 0px rgba(0,0,0, .3)',
                   }}
                   onResizeStop={onNavigatorResizeStop}
                   defaultSize={{
                     width: navigatorWidth,
-                    height: '100%',
+                    height: '90%',
                   }}
                 >
                   <NavigatorComponent />

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import type { TooltipProps } from '../../uuiui'
+import { UtopiaTheme } from '../../uuiui'
 import {
   colorTheme,
   FlexColumn,
@@ -178,9 +179,9 @@ export const CanvasToolbar = React.memo(() => {
         gap: 6,
         alignItems: 'stretch',
         width: 64,
-        borderRadius: 10,
+        borderRadius: UtopiaTheme.panelStyles.panelBorderRadius,
         backgroundColor: theme.inspectorBackground.value,
-        boxShadow: '3px 4px 10px 0px rgba(0,0,0, .3)',
+        boxShadow: `3px 4px 10px 0px ${UtopiaTheme.panelStyles.panelShadowColor}`,
         pointerEvents: 'initial',
       }}
       onMouseDown={stopPropagation}

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -173,14 +173,14 @@ export const CanvasToolbar = React.memo(() => {
       id={CanvasToolbarId}
       style={{
         position: 'absolute',
-        top: 12,
-        left: 12,
+        top: 10,
+        left: 20,
         gap: 6,
         alignItems: 'stretch',
         width: 64,
-        borderRadius: 4,
+        borderRadius: 10,
         backgroundColor: theme.inspectorBackground.value,
-        boxShadow: UtopiaStyles.popup.boxShadow,
+        boxShadow: '3px 4px 10px 0px rgba(0,0,0, .3)',
         pointerEvents: 'initial',
       }}
       onMouseDown={stopPropagation}

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -108,6 +108,8 @@ export const dark: typeof light = {
 
   textColor: base.white,
 
+  panelShadowColor: createUtopiColor('rgba(0,0,0, .3)'),
+
   // big sections
   leftMenuBackground: darkPrimitives.neutralBackground,
   leftPaneBackground: darkPrimitives.neutralBackground,

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -109,6 +109,8 @@ export const light = {
 
   textColor: base.almostBlack,
 
+  panelShadowColor: createUtopiColor('rgba(0,0,0, .3)'),
+
   // big sections
   leftMenuBackground: lightPrimitives.neutralBackground,
   leftPaneBackground: lightPrimitives.neutralBackground,

--- a/editor/src/uuiui/styles/theme/utopia-theme.ts
+++ b/editor/src/uuiui/styles/theme/utopia-theme.ts
@@ -55,6 +55,10 @@ export const UtopiaTheme = {
     inspectorSetUnselectedOpacity: 0.5,
     inspectorUnsetUnselectedOpacity: 0.3,
   },
+  panelStyles: {
+    panelBorderRadius: 10,
+    panelShadowColor: colorTheme.panelShadowColor.value,
+  },
 } as const
 
 const flexRow: React.CSSProperties = {


### PR DESCRIPTION
Part 1 of making all the panels in the UI float:

The navigator floats, and I slightly nudged the toolbar over to give it some space. Also changed the borderRadius and boxShadow style of the toolbar to match the navigator. 

<img width="1512" alt="Screenshot 2023-07-10 at 12 14 39 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/8fd02580-e94f-46f7-b7fa-c9f3a325f42f">
