### PR TITLE
Prevent highlight on selection

### DIFF
--- a/editor/src/components/canvas/controls/highlight-control.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/highlight-control.spec.browser2.tsx
@@ -1,0 +1,46 @@
+import { getDomRectCenter } from '../../../core/shared/dom-utils'
+import { mouseClickAtPoint, mouseMoveToPoint } from '../event-helpers.test-utils'
+import { makeTestProjectCodeWithSnippet, renderTestEditorWithCode } from '../ui-jsx.test-utils'
+import { CanvasControlsContainerID } from './new-canvas-controls'
+
+describe('HighlightControl', () => {
+  it('is shown when an element is hovered', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          style={{ backgroundColor: 'red', width: 250, height: 300 }}
+          data-uid='target-to-highlight'
+          data-testid='target-to-highlight'
+        />
+      `),
+      'await-first-dom-report',
+    )
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+    const toHighlight = renderResult.renderedDOM.getByTestId('target-to-highlight')
+    const toHighlightCenter = getDomRectCenter(toHighlight.getBoundingClientRect())
+    await mouseMoveToPoint(canvasControlsLayer, toHighlightCenter)
+    const highlightControls = renderResult.renderedDOM.queryAllByTestId('highlight-control')
+    expect(highlightControls).toHaveLength(1)
+  })
+  it('is not shown when an element is hovered and selected', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          style={{ backgroundColor: 'red', width: 250, height: 300 }}
+          data-uid='target-to-highlight'
+          data-testid='target-to-highlight'
+        />
+      `),
+      'await-first-dom-report',
+    )
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+    const toHighlight = renderResult.renderedDOM.getByTestId('target-to-highlight')
+    const toHighlightCenter = getDomRectCenter(toHighlight.getBoundingClientRect())
+    await mouseMoveToPoint(canvasControlsLayer, toHighlightCenter)
+    await mouseClickAtPoint(canvasControlsLayer, toHighlightCenter)
+    const highlightControls = renderResult.renderedDOM.queryAllByTestId('highlight-control')
+    expect(highlightControls).toHaveLength(0)
+  })
+})

--- a/editor/src/components/canvas/controls/highlight-control.tsx
+++ b/editor/src/components/canvas/controls/highlight-control.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { CanvasRectangle, CanvasPoint } from '../../../core/shared/math-utils'
 import { useColorTheme } from '../../../uuiui'
-import { isZeroSizedElement, ZeroControlSize } from './outline-utils'
+import { isZeroSizedElement } from './outline-utils'
 import { ZeroSizeHighlightControl } from './zero-sized-element-controls'
 
 interface HighlightControlProps {
@@ -30,6 +30,7 @@ export const HighlightControl = React.memo((props: HighlightControlProps) => {
     return (
       <div
         className='role-component-highlight-outline'
+        data-testid='highlight-control'
         style={{
           position: 'absolute',
           left: props.canvasOffset.x + props.frame.x,

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -401,6 +401,9 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
   const renderHighlightControls = () => {
     return selectionEnabled
       ? localHighlightedViews.map((path) => {
+          if (EP.containsPath(path, localSelectedViews)) {
+            return null
+          }
           const frame = MetadataUtils.getFrameInCanvasCoords(path, componentMetadata)
           if (frame == null || isInfinityRectangle(frame)) {
             return null

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -401,6 +401,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
   const renderHighlightControls = () => {
     return selectionEnabled
       ? localHighlightedViews.map((path) => {
+          // Do not display the highlight controls if this element is selected.
           if (EP.containsPath(path, localSelectedViews)) {
             return null
           }


### PR DESCRIPTION
**Problem:**
https://github.com/concrete-utopia/utopia/pull/3862 introduced a bug where the highlight control is shown when the element is hovered and selected.

**Fix:**
Now where the highlight controls are regularly shown, we first check if the elements are selected and do not display the highlight controls in that case.

**Commit Details:**
- Added `data-testid` attribute to `HighlightControl`.
- `renderHighlightControls` now excludes selected elements from displaying the highlight control
  even if the element is a member of `localHighlightedViews`.
- Added tests to check the two main cases for the highlight controls.