### PR TITLE
Fixed component style prop usage detection

### DIFF
--- a/editor/src/core/model/element-template-utils.spec.tsx
+++ b/editor/src/core/model/element-template-utils.spec.tsx
@@ -525,12 +525,36 @@ export const TestComponent = (props) => {
     const result = componentHonoursPropsPosition(component)
     expect(result).toEqual(true)
   })
+  it('returns true for a component that assigns props.style to style directly', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = (props) => {
+  return <div style={props.style}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsPosition(component)
+    expect(result).toEqual(true)
+  })
   it('returns true for a component that spreads style into the props with destructuring', () => {
     const component = getComponentFromCode(
       'TestComponent',
       `
 export const TestComponent = ({style}) => {
   return <div style={{position: 'absolute', ...style}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsPosition(component)
+    expect(result).toEqual(true)
+  })
+  it('returns true for a component that assigns to style directly with destructuring', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = ({style}) => {
+  return <div style={style}>The Best Test Component</div>
 }
     `,
     )
@@ -612,12 +636,36 @@ export const TestComponent = (props) => {
     const result = componentHonoursPropsSize(component)
     expect(result).toEqual(true)
   })
+  it('returns true for a component that assigns props.style to style directly', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = (props) => {
+  return <div style={props.style}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsSize(component)
+    expect(result).toEqual(true)
+  })
   it('returns true for a component that spreads style into the props with destructuring', () => {
     const component = getComponentFromCode(
       'TestComponent',
       `
 export const TestComponent = ({style}) => {
   return <div style={{position: 'absolute', ...style}}>The Best Test Component</div>
+}
+    `,
+    )
+    const result = componentHonoursPropsSize(component)
+    expect(result).toEqual(true)
+  })
+  it('returns true for a component that assigns to style directly with destructuring', () => {
+    const component = getComponentFromCode(
+      'TestComponent',
+      `
+export const TestComponent = ({style}) => {
+  return <div style={style}>The Best Test Component</div>
 }
     `,
     )

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -24,6 +24,7 @@ import type {
   JSXProperty,
   JSXFragment,
   ElementInstanceMetadataMap,
+  JSExpressionOtherJavaScript,
 } from '../shared/element-template'
 import {
   isJSExpressionOtherJavaScript,
@@ -831,10 +832,23 @@ export function componentHonoursPropsSize(component: UtopiaJSXComponent): boolea
   }
 }
 
-export function propsStyleIsSpreadInto(propsParam: Param, attributes: JSXAttributes): boolean {
+function checkJSReferencesVariable(
+  jsExpression: JSExpressionOtherJavaScript,
+  variableName: string,
+  variableUseToCheck: string,
+): boolean {
+  return (
+    jsExpression.definedElsewhere.includes(variableName) &&
+    jsExpression.transpiledJavascript.includes(variableUseToCheck)
+  )
+}
+
+function propsStyleIsSpreadInto(propsParam: Param, attributes: JSXAttributes): boolean {
   const boundParam = propsParam.boundParam
   switch (boundParam.type) {
     case 'REGULAR_PARAM': {
+      const propsVariableName = boundParam.paramName
+      const stylePropPath = `${propsVariableName}.style`
       const styleProp = getJSXAttributesAtPath(attributes, PP.create('style'))
       const styleAttribute = styleProp.attribute
       switch (styleAttribute.type) {
@@ -843,7 +857,7 @@ export function propsStyleIsSpreadInto(propsParam: Param, attributes: JSXAttribu
         case 'ATTRIBUTE_VALUE':
           return false
         case 'ATTRIBUTE_OTHER_JAVASCRIPT':
-          return false
+          return checkJSReferencesVariable(styleAttribute, propsVariableName, stylePropPath)
         case 'ATTRIBUTE_NESTED_ARRAY':
           return false
         case 'ATTRIBUTE_NESTED_OBJECT':
@@ -851,10 +865,7 @@ export function propsStyleIsSpreadInto(propsParam: Param, attributes: JSXAttribu
             if (isSpreadAssignment(attributePart)) {
               const spreadPart = attributePart.value
               if (modifiableAttributeIsAttributeOtherJavaScript(spreadPart)) {
-                return (
-                  spreadPart.definedElsewhere.includes(boundParam.paramName) &&
-                  spreadPart.transpiledJavascript.includes(`${boundParam.paramName}.style`)
-                )
+                return checkJSReferencesVariable(spreadPart, propsVariableName, stylePropPath)
               }
             }
             return false
@@ -886,7 +897,11 @@ export function propsStyleIsSpreadInto(propsParam: Param, attributes: JSXAttribu
               case 'ATTRIBUTE_VALUE':
                 return false
               case 'ATTRIBUTE_OTHER_JAVASCRIPT':
-                return false
+                return checkJSReferencesVariable(
+                  styleAttribute,
+                  propertyToLookFor,
+                  propertyToLookFor,
+                )
               case 'ATTRIBUTE_NESTED_ARRAY':
                 return false
               case 'ATTRIBUTE_NESTED_OBJECT':
@@ -894,9 +909,10 @@ export function propsStyleIsSpreadInto(propsParam: Param, attributes: JSXAttribu
                   if (isSpreadAssignment(attributePart)) {
                     const spreadPart = attributePart.value
                     if (modifiableAttributeIsAttributeOtherJavaScript(spreadPart)) {
-                      return (
-                        spreadPart.definedElsewhere.includes(propertyToLookFor) &&
-                        spreadPart.transpiledJavascript.includes(propertyToLookFor)
+                      return checkJSReferencesVariable(
+                        spreadPart,
+                        propertyToLookFor,
+                        propertyToLookFor,
                       )
                     }
                   }


### PR DESCRIPTION
**Problem:**
When detecting if a component honours the style prop (for position or sizing) we were handling `style={{...props.style}}` but not `style={props.style}`

**Fix:**
For whatever reason we were only checking for a spread style prop, whereas we also needed to handle `ATTRIBUTE_OTHER_JAVASCRIPT`. Since the logic to handle the spread style prop was then resulting in a check of the spread part, which was also `ATTRIBUTE_OTHER_JAVASCRIPT`, it meant we could just reuse that logic.
