### PR TITLE
Fix cross origin error when logging an event object

### DIFF
--- a/editor/src/components/canvas/console-proxy.ts
+++ b/editor/src/components/canvas/console-proxy.ts
@@ -1,6 +1,7 @@
 import React from 'react'
 import Utils from '../../utils/utils'
 import Parse from 'console-feed/lib/Hook/parse'
+import { Decode, Encode } from 'console-feed'
 import type { ConsoleLog } from '../editor/store/editor-state'
 
 const ConsoleMethodsToProxy: Array<string> = [
@@ -53,7 +54,7 @@ export function proxyConsole(
       // Invoke our dispatcher.
       const parsed = Parse(consoleMethodName, args)
       if (parsed != false) {
-        addToConsoleLogs(parsed)
+        addToConsoleLogs(Decode(Encode(parsed)))
       }
     }
   })


### PR DESCRIPTION
**Problem:**
When calling `console.log(event)` inside an event handler, we're hitting a cross origin error at the point where `console-feed` attempts to stringify that event.

**Important caveat:**
I didn't get to the bottom of why we're hitting this cross origin error. After much debugging and checking the code (and my sanity) I can't see any place where we're changing origins between evaluating the user's JS (which calls the `console.log`) and `console-feed` attempting to print the message. I don't think this is worth wasting any more time on though, since we have a solution that works fine any.

**Fix:**
We're not using the `Hook` directly, but instead calling an internal function `Parse` that the `Hook` uses. However, by default the `Hook` will call `Encode` (https://github.com/concrete-utopia/console-feed/blob/v2.8.11/src/Hook/index.ts#L52) because of precisely this cross origin issue (https://github.com/concrete-utopia/console-feed/tree/v2.8.11#serialization). But then after encoding, you then have to `Decode` the result before passing it to the `Console` component. The end result of both of these is that you create a replication of the original object (https://github.com/concrete-utopia/console-feed/blob/v2.8.11/src/Transform/index.ts#L19) that is safe to pass to the `Console`.