### PR TITLE
Update groups on deletion

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -969,11 +969,7 @@ function deleteElements(targets: ElementPath[], editor: EditorModel): EditorMode
     }
     const siblings = targets
       .flatMap((target) => {
-        return MetadataUtils.getSiblingsOrdered(
-          updatedEditor.jsxMetadata,
-          updatedEditor.elementPathTree,
-          target,
-        )
+        return MetadataUtils.getSiblingsOrdered(editor.jsxMetadata, editor.elementPathTree, target)
       })
       .map((entry) => entry.elementPath)
     return addToTrueUpGroups(withUpdatedSelectedViews, ...siblings)

--- a/editor/src/core/model/groups.ts
+++ b/editor/src/core/model/groups.ts
@@ -1,0 +1,15 @@
+import type { EditorState } from '../../components/editor/store/editor-state'
+import type { ElementPath } from '../shared/project-file-types'
+
+export function addToTrueUpGroups(
+  editor: EditorState,
+  ...targets: Array<ElementPath>
+): EditorState {
+  return {
+    ...editor,
+    trueUpGroupsForElementAfterDomWalkerRuns: [
+      ...editor.trueUpGroupsForElementAfterDomWalkerRuns,
+      ...targets,
+    ],
+  }
+}


### PR DESCRIPTION
**Problem:**
Currently groups are not updated when their children are deleted.

**Fix:**
Now when elements are deleted their prior siblings are now applied to `trueUpGroupsForElementAfterDomWalkerRuns`, so that the groups are resized against the current size of those children.

**Commit Details:**
- Extracted out `addToTrueUpGroups` from `actions.tsx`.
- `deleteElements` now invokes `addToTrueUpGroups` against the siblings of what
  was deleted.