### PR TITLE
Switch back to the official console-feed

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -129,7 +129,7 @@
     "chroma-js": "2.1.0",
     "classnames": "2.2.6",
     "clipboard-polyfill": "2.4.6",
-    "console-feed": "git://github.com/concrete-utopia/console-feed.git#13e2c367adedb732cf1e9937574a3324e1f8580f",
+    "console-feed": "2.8.11",
     "create-react-class": "15.6.3",
     "css-tree": "1.1.3",
     "eslint-plugin-import": "2.25.3",

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -150,7 +150,7 @@ specifiers:
   clean-webpack-plugin: 3.0.0
   clipboard-polyfill: 2.4.6
   concurrently: 3.5.1
-  console-feed: git://github.com/concrete-utopia/console-feed.git#13e2c367adedb732cf1e9937574a3324e1f8580f
+  console-feed: 2.8.11
   create-react-class: 15.6.3
   css-loader: 0.28.4
   css-tree: 1.1.3
@@ -349,7 +349,7 @@ dependencies:
   chroma-js: 2.1.0
   classnames: 2.2.6
   clipboard-polyfill: 2.4.6
-  console-feed: github.com/concrete-utopia/console-feed/13e2c367adedb732cf1e9937574a3324e1f8580f_ceyt5bfod5miybgg2gmf5ylbc4
+  console-feed: 2.8.11_ceyt5bfod5miybgg2gmf5ylbc4
   create-react-class: 15.6.3
   css-tree: 1.1.3
   eslint-plugin-import: 2.25.3_o5qc6eitjww7eqrkfjp7lje6uq
@@ -6164,6 +6164,23 @@ packages:
   /console-browserify/1.2.0:
     resolution: {integrity: sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==}
     dev: true
+
+  /console-feed/2.8.11_ceyt5bfod5miybgg2gmf5ylbc4:
+    resolution: {integrity: sha512-XBAM6n08Ft6kofFX3VyMazE3e0R/G5ABvp4vbwinTR+2HTQ7ZJJXXKrK2VPDQm6rkCurRw9tUI4d/N80w5+ZXA==}
+    peerDependencies:
+      react: ^15.x || ^16.x
+    dependencies:
+      emotion: 9.2.12
+      emotion-theming: 9.2.9_md2woffurl5yt3dayrtnpfbjvy
+      linkifyjs: 2.1.9_ef5jwxihqo6n7gxfmzogljlgcm
+      react: 18.1.0_47cciibm4ysmleigs33s763fqu
+      react-emotion: 9.2.12_beus4p4qy2l5kloq3acohbokce
+      react-inspector: 2.3.1_react@18.1.0
+    transitivePeerDependencies:
+      - jquery
+      - prop-types
+      - react-dom
+    dev: false
 
   /constants-browserify/1.0.0:
     resolution: {integrity: sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=}
@@ -16959,26 +16976,6 @@ packages:
     dependencies:
       localforage: 1.9.0
       prettier: 2.0.5
-    dev: false
-
-  github.com/concrete-utopia/console-feed/13e2c367adedb732cf1e9937574a3324e1f8580f_ceyt5bfod5miybgg2gmf5ylbc4:
-    resolution: {tarball: https://codeload.github.com/concrete-utopia/console-feed/tar.gz/13e2c367adedb732cf1e9937574a3324e1f8580f}
-    id: github.com/concrete-utopia/console-feed/13e2c367adedb732cf1e9937574a3324e1f8580f
-    name: console-feed
-    version: 2.8.11
-    peerDependencies:
-      react: ^15.x || ^16.x
-    dependencies:
-      emotion: 9.2.12
-      emotion-theming: 9.2.9_md2woffurl5yt3dayrtnpfbjvy
-      linkifyjs: 2.1.9_ef5jwxihqo6n7gxfmzogljlgcm
-      react: 18.1.0_47cciibm4ysmleigs33s763fqu
-      react-emotion: 9.2.12_beus4p4qy2l5kloq3acohbokce
-      react-inspector: 2.3.1_react@18.1.0
-    transitivePeerDependencies:
-      - jquery
-      - prop-types
-      - react-dom
     dev: false
 
   github.com/concrete-utopia/react-error-overlay/201980990d653e821f36ab4f921a4f83588a8a42:


### PR DESCRIPTION
The `console-feed` package disappeared from the NPM registry (see https://github.com/samdenty/console-feed/issues/124), so we have been relying on our own fork temporarily until that was rectified. The package was restored at some point in the last 24 hours, so we can now switch back to using that.