### PR TITLE
Hint towards usePropControlledStateV2

### DIFF
--- a/editor/src/components/inspector/common/inspector-utils.tsx
+++ b/editor/src/components/inspector/common/inspector-utils.tsx
@@ -46,7 +46,7 @@ export function getIndexedSpliceArrayItem<T extends CSSArrayItem>(index: number)
 const forceUpdateFunction = (value: number) => value + 1
 
 /**
- * Please use usePropControlledStateV2 instead.
+ * @deprecated Please use usePropControlledStateV2 instead.
  */
 export function usePropControlledState_DEPRECATED<T>(
   propValue: T,

--- a/editor/src/components/inspector/common/inspector-utils.tsx
+++ b/editor/src/components/inspector/common/inspector-utils.tsx
@@ -45,7 +45,10 @@ export function getIndexedSpliceArrayItem<T extends CSSArrayItem>(index: number)
 
 const forceUpdateFunction = (value: number) => value + 1
 
-export function usePropControlledState<T>(
+/**
+ * Please use usePropControlledStateV2 instead.
+ */
+export function usePropControlledState_DEPRECATED<T>(
   propValue: T,
 ): [T, React.Dispatch<T>, React.DispatchWithoutAction] {
   const [localState, setLocalState] = React.useState<T>(propValue)

--- a/editor/src/components/inspector/controls/keyword-control.tsx
+++ b/editor/src/components/inspector/controls/keyword-control.tsx
@@ -9,7 +9,7 @@ import { StringInput } from '../../../uuiui'
 import { getControlStyles } from '../../../uuiui-deps'
 import type { CSSKeyword } from '../common/css-utils'
 import { cssKeyword, emptyInputValue, unknownInputValue } from '../common/css-utils'
-import { usePropControlledState } from '../common/inspector-utils'
+import { usePropControlledState_DEPRECATED } from '../common/inspector-utils'
 import type { InspectorControlProps, OnSubmitValueOrUnknownOrEmpty } from './control'
 
 export type ValidKeywords = Array<string> | 'all'
@@ -48,8 +48,8 @@ export const KeywordControl = React.memo<KeywordControlProps>(
     DEPRECATED_labelBelow,
   }) => {
     const controlStyles = getControlStyles(controlStatus)
-    const [mixed, setMixed] = usePropControlledState<boolean>(controlStyles.mixed)
-    const [stateValue, setStateValue] = usePropControlledState<string>(value.value)
+    const [mixed, setMixed] = usePropControlledState_DEPRECATED<boolean>(controlStyles.mixed)
+    const [stateValue, setStateValue] = usePropControlledState_DEPRECATED<string>(value.value)
     const ref = React.useRef<HTMLInputElement>(null)
 
     const { showContent, mixed: controlStylesMixed } = controlStyles

--- a/editor/src/components/inspector/controls/string-control.tsx
+++ b/editor/src/components/inspector/controls/string-control.tsx
@@ -4,7 +4,7 @@ import { jsx } from '@emotion/react'
 import classNames from 'classnames'
 import React from 'react'
 import { StringInput } from '../../../uuiui'
-import { usePropControlledState } from '../common/inspector-utils'
+import { usePropControlledState_DEPRECATED } from '../common/inspector-utils'
 import type { DEPRECATEDControlProps } from './control'
 
 export interface StringControlOptions {
@@ -14,11 +14,11 @@ export interface StringControlOptions {
 export const StringControl = React.memo(
   React.forwardRef<HTMLInputElement, DEPRECATEDControlProps<string>>(
     ({ value: propsValue, controlStyles, onBlur, onSubmitValue, ...props }, ref) => {
-      const [mixed, setMixed] = usePropControlledState<boolean>(controlStyles.mixed)
-      const [editDisabled, setEditDisabled] = usePropControlledState<boolean>(
+      const [mixed, setMixed] = usePropControlledState_DEPRECATED<boolean>(controlStyles.mixed)
+      const [editDisabled, setEditDisabled] = usePropControlledState_DEPRECATED<boolean>(
         !controlStyles.interactive,
       )
-      const [stateValue, setStateValue] = usePropControlledState<string>(propsValue)
+      const [stateValue, setStateValue] = usePropControlledState_DEPRECATED<string>(propsValue)
 
       const { showContent, mixed: controlStylesMixed } = controlStyles
       const getDisplayValue = React.useCallback(() => {

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -12,7 +12,7 @@ import {
   Tooltip,
   useColorTheme,
 } from '../../../../../uuiui'
-import { usePropControlledState } from '../../../../../uuiui-deps'
+import { usePropControlledState_DEPRECATED } from '../../../../../uuiui-deps'
 import { InlineIndicator, InlineLink } from '../../../../../uuiui/inline-button'
 import { Substores, useEditorState, useRefEditorState } from '../../../../editor/store/store-hook'
 import { ExpandableIndicator } from '../../../../navigator/navigator-item/expandable-indicator'
@@ -57,7 +57,7 @@ function useActiveLayoutTab(
   } else {
     value = 'flow'
   }
-  return usePropControlledState(value)
+  return usePropControlledState_DEPRECATED(value)
 }
 
 interface SelfLayoutSubsectionProps {

--- a/editor/src/uuiui-deps/index.tsx
+++ b/editor/src/uuiui-deps/index.tsx
@@ -29,7 +29,7 @@ import type {
   OnSubmitValueOrEmpty,
   OnSubmitValueOrUnknownOrEmpty,
 } from '../components/inspector/controls/control'
-import { usePropControlledState } from '../components/inspector/common/inspector-utils'
+import { usePropControlledState_DEPRECATED } from '../components/inspector/common/inspector-utils'
 import * as InspectorHooks from '../components/inspector/common/property-path-hooks'
 import * as InspectorContextMenuItems from '../components/inspector/common/context-menu-items'
 
@@ -61,7 +61,7 @@ export {
   CSSUtils,
   EitherUtils,
   CSSCursor,
-  usePropControlledState,
+  usePropControlledState_DEPRECATED,
   InspectorHooks,
   InspectorContextMenuItems,
 }


### PR DESCRIPTION
Ref https://github.com/concrete-utopia/utopia/pull/3915#discussion_r1261179913

1. Rename `usePropControlledState` to `usePropControlledState_DEPRECATED`
2. Add a comment pointing to `usePropControlledStateV2`

Note: we can revisit this later on to get rid of the deprecated function, but I don't think it's particularly high prio to do it now and potentially break things.