### PR TITLE
Remove unnecessary ordering for conditional children

### DIFF
--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
@@ -149,7 +149,9 @@ describe('Text edit mode', () => {
 
       expect(editor.getEditorState().editor.mode.type).toEqual('select')
       expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
-      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e/cond')
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual(
+        'sb/39e/cond/33d~~~1',
+      )
     })
     it('Entering text edit mode with double click on selected multiline text editable element', async () => {
       const editor = await renderTestEditorWithCode(

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -345,7 +345,7 @@ export function isTextEditableConditional(
     return false
   }
 
-  const childrenInMetadata = MetadataUtils.getChildrenOrdered(metadata, elementPathTree, path)
+  const childrenInMetadata = MetadataUtils.getChildrenUnordered(metadata, path)
   if (childrenInMetadata.length > 0) {
     // we don't allow text editing of conditional branches when the conditional have children in metadata
     // that would mean there are elefants in the active branch, which should not be text editable

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -345,7 +345,7 @@ export function isTextEditableConditional(
     return false
   }
 
-  const childrenInMetadata = MetadataUtils.getChildrenUnordered(metadata, path)
+  const childrenInMetadata = MetadataUtils.getChildrenOrdered(metadata, elementPathTree, path)
   if (childrenInMetadata.length > 0) {
     // we don't allow text editing of conditional branches when the conditional have children in metadata
     // that would mean there are elefants in the active branch, which should not be text editable


### PR DESCRIPTION
**Problem:**
I realized that `MetadataUtils.getChildrenOrdered` does not return generated elements coming from an expression which is inside a conditional branch.
The reason for that is we have a function to order the conditional children called `reorderConditionalChildPathTrees`.
However, this function has two problems:
1. it is incorrect, because it assumes the child element has the same uid as the `whenTrue` property of the conditional metadata. But that is not true when the whenTrue refers to an expression, which generates an element, e.g. 
```
{
  true ? (
    (() => <div>hello</div>)()
  ) : null
}
```
This means the function actually filters out the absolutely valid generated child from the children array.
2. it is unnecessary, because the path tree contains element path from the metadata, but the metadata only contains the active branch of the conditional, so it is impossible for the children array to contain multiple elements.

**Fix:**
So I decided to remove the whole function, added a conditional with expression in its branch to the element-path-tree test case and also an extra test to check that getChildrenOrdered can return the generated child of the conditional.