### PR TITLE
Handle moving a group child when another element is targeted at the start.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
@@ -15,6 +15,7 @@ import type { ElementSupportsChildren } from '../../../../../core/model/element-
 import type { AllElementProps } from '../../../../editor/store/editor-state'
 import type { InsertionPath } from '../../../../editor/store/insertion-path'
 import type { ElementPathTrees } from '../../../../../core/shared/element-path-tree'
+import { assertNever } from '../../../../../core/shared/utils'
 
 export type ReparentAsAbsolute = 'REPARENT_AS_ABSOLUTE'
 export type ReparentAsStatic = 'REPARENT_AS_STATIC'
@@ -129,6 +130,19 @@ export function existingReparentSubjects(elements: Array<ElementPath>): Existing
   return {
     type: 'EXISTING_ELEMENTS',
     elements: elements,
+  }
+}
+
+export function getExistingElementsFromReparentSubjects(
+  reparentSubjects: ReparentSubjects,
+): Array<ElementPath> {
+  switch (reparentSubjects.type) {
+    case 'EXISTING_ELEMENTS':
+      return reparentSubjects.elements
+    case 'NEW_ELEMENTS':
+      return []
+    default:
+      assertNever(reparentSubjects)
   }
 }
 


### PR DESCRIPTION
**Problem:**
In a situation that looks like this:
![image](https://github.com/concrete-utopia/utopia/assets/217400/ac84c840-35d0-4276-a476-2746f067e5e1)
When dragging the blue element, when it reaches the current bounds of the group the element is reparented into the parent of the group.

**Cause:**
We protect against reparenting into the topmost element which is under the mouse when dragging starts, which in regular cases is the group parent. But in the case shown above would be the large pink element. As a result when the element was dragged beyond the bounds of the group, the group parent would be identified as a reparent target and then the reparenting would trigger.

**Fix:**
For elements in a group, always ignore the group parent as a target for reparenting so that as the element exceeds the starting bounds the group can then be resized around it.

**Commit Details:**
- Added `getExistingElementsFromReparentSubjects` utility function.
- `getStartingTargetParentsToFilterOutInner` now returns an array of results.
- For an element in a group, `getStartingTargetParentsToFilterOutInner` filters out the parent of the group.