### PR TITLE
Handle elements with text content coming from expressions

### DIFF
--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
@@ -3,6 +3,7 @@ import type { ElementPath } from '../../../../core/shared/project-file-types'
 import {
   selectComponentsForTest,
   setFeatureForBrowserTests,
+  wait,
 } from '../../../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../../../canvas/controls/new-canvas-controls'
 import {

--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
@@ -1,6 +1,9 @@
 import * as EP from '../../../../core/shared/element-path'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
-import { selectComponentsForTest, wait } from '../../../../utils/utils.test-utils'
+import {
+  selectComponentsForTest,
+  setFeatureForBrowserTests,
+} from '../../../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../../../canvas/controls/new-canvas-controls'
 import {
   mouseClickAtPoint,
@@ -81,7 +84,49 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
       expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e/cond')
     })
+    it('Entering text edit mode with double click on conditional with expression in active branch with Code in navigator FS on', async () => {
+      setFeatureForBrowserTests('Code in navigator', true)
+      const editor = await renderTestEditorWithCode(
+        project(`{
+        // @utopia/uid=cond
+        true ? 'Hello' : <div />
+      }`),
+        'await-first-dom-report',
+      )
+      await selectElement(editor, EP.fromString('sb/39e/cond'))
+      await clickOnElement(editor, 'div', 'double-click')
+      // wait for the next frame
+      await wait(1)
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
+      expect(
+        EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
+      ).toEqual('sb/39e/cond')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e/cond')
+    })
     it('Entering text edit mode with double click on conditional with expression in both branches', async () => {
+      const editor = await renderTestEditorWithCode(
+        project(`{
+        // @utopia/uid=cond
+        true ? 'Hello' : Utopia
+      }`),
+        'await-first-dom-report',
+      )
+      await selectElement(editor, EP.fromString('sb/39e/cond'))
+      await clickOnElement(editor, 'div', 'double-click')
+      // wait for the next frame
+      await wait(1)
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
+      expect(
+        EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
+      ).toEqual('sb/39e/cond')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e/cond')
+    })
+    it('Entering text edit mode with double click on conditional with expression in both branches with Code in navigator FS on', async () => {
+      setFeatureForBrowserTests('Code in navigator', true)
       const editor = await renderTestEditorWithCode(
         project(`{
         // @utopia/uid=cond
@@ -119,6 +164,25 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
       expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
     })
+    it('Can not entering text edit mode with double click on conditional with expression in active branch when there is sibling with Code in navigator FS on', async () => {
+      setFeatureForBrowserTests('Code in navigator', true)
+      const editor = await renderTestEditorWithCode(
+        project(`{
+          // @utopia/uid=cond
+          true ? 'Hello' : <div />
+        }
+        <div />`),
+        'await-first-dom-report',
+      )
+      await selectElement(editor, EP.fromString('sb/39e/cond'))
+      await clickOnElement(editor, 'div', 'double-click')
+      // wait for the next frame
+      await wait(1)
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
+    })
     it('Can not enter text edit mode with double click on conditional with element in active branch', async () => {
       const editor = await renderTestEditorWithCode(
         project(`{
@@ -135,6 +199,26 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.mode.type).toEqual('select')
     })
     it('Can not enter text edit mode with double click on conditional with expression in active branch which returns an element', async () => {
+      const editor = await renderTestEditorWithCode(
+        project(`{
+          // @utopia/uid=cond
+          true ? (() => <div>hello</div>)() : <div />
+        }`),
+        'await-first-dom-report',
+      )
+      await selectElement(editor, EP.fromString('sb/39e/cond'))
+      await clickOnElement(editor, 'div', 'double-click')
+      // wait for the next frame
+      await wait(1)
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual(
+        'sb/39e/cond/33d~~~1',
+      )
+    })
+    it('Can not enter text edit mode with double click on conditional with expression in active branch which returns an element with Code in navigator FS on', async () => {
+      setFeatureForBrowserTests('Code in navigator', true)
       const editor = await renderTestEditorWithCode(
         project(`{
           // @utopia/uid=cond

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -489,6 +489,15 @@ export var storyboard = (
 )
 `
 
+const projectWithTextFromExpression = `import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div data-uid='div'>{1+1}</div>
+  </Storyboard>
+)
+`
+
 const projectWithFlexContainerAndCanvas = `import * as React from 'react'
 import { Scene, Storyboard, View, Group } from 'utopia-api'
 
@@ -3727,6 +3736,7 @@ describe('Navigator row order', () => {
       ],
     )
   })
+
   describe('Code in navigator FS on', () => {
     setFeatureForBrowserTests('Code in navigator', true)
     it('is correct for js expressions with multiple values with "code in navigator" FS on', async () => {
@@ -3813,5 +3823,35 @@ describe('Navigator row order', () => {
         'regular-sb/group/53a/3bc~~~3',
       ])
     })
+  })
+})
+
+describe('Navigator labels', () => {
+  it('Labels are correct for text coming from expressions', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      projectWithTextFromExpression,
+      'await-first-dom-report',
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    const navigatorItem = await renderResult.renderedDOM.findByTestId(
+      'NavigatorItemTestId-regular_sb/div-label',
+    )
+    expect(navigatorItem.textContent).toEqual('2')
+  })
+  it('Labels are correct for text coming from expressions with code item FS on', async () => {
+    setFeatureForBrowserTests('Code in navigator', true)
+    const renderResult = await renderTestEditorWithCode(
+      projectWithTextFromExpression,
+      'await-first-dom-report',
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    const navigatorItem = await renderResult.renderedDOM.findByTestId(
+      'NavigatorItemTestId-regular_sb/div-label',
+    )
+    expect(navigatorItem.textContent).toEqual('2')
   })
 })

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -3,6 +3,7 @@ import {
   expectSingleUndo2Saves,
   expectSingleUndoNSaves,
   setFeatureForBrowserTests,
+  wait,
 } from '../../utils/utils.test-utils'
 import type { Modifiers } from '../../utils/modifiers'
 import { altCmdModifier, cmdModifier, shiftCmdModifier } from '../../utils/modifiers'

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -1,5 +1,9 @@
 import * as EP from '../../core/shared/element-path'
-import { expectSingleUndo2Saves, expectSingleUndoNSaves, wait } from '../../utils/utils.test-utils'
+import {
+  expectSingleUndo2Saves,
+  expectSingleUndoNSaves,
+  setFeatureForBrowserTests,
+} from '../../utils/utils.test-utils'
 import type { Modifiers } from '../../utils/modifiers'
 import { altCmdModifier, cmdModifier, shiftCmdModifier } from '../../utils/modifiers'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
@@ -806,6 +810,111 @@ describe('Use the text editor', () => {
     })
   })
   describe('inline expressions', () => {
+    const tests = [
+      {
+        label: 'handles expressions',
+        writtenText: 'the answer is {41 + 1}',
+        codeResult: 'the answer is {41 + 1}',
+        renderedText: 'the answer is 42',
+      },
+      {
+        label: 'handles conditionals',
+        writtenText: 'The user name is {1 === 1 ? "Bob" : "Sam"}',
+        codeResult: 'The user name is {1 === 1 ? "Bob" : "Sam"}',
+        renderedText: 'The user name is Bob',
+      },
+      {
+        label: 'htmlencodes angular brackets in text parts',
+        writtenText: 'The <username> is {1 === 1 ? "Bob" : "Sam"}',
+        codeResult: 'The &lt;username&gt; is {1 === 1 ? "Bob" : "Sam"}',
+        renderedText: 'The <username> is Bob',
+      },
+      {
+        label: 'does not htmlencode angular brackets in js parts',
+        writtenText: 'The username is {1 >= 1 ? "Bob" : "Sam"}',
+        codeResult: 'The username is {1 >= 1 ? "Bob" : "Sam"}',
+        renderedText: 'The username is Bob',
+      },
+      {
+        label: 'handles angular brackets in text and js parts both',
+        writtenText: 'The <username> is {1 >= 1 ? "Bob" : "Sam"}',
+        codeResult: 'The &lt;username&gt; is {1 >= 1 ? "Bob" : "Sam"}',
+        renderedText: 'The <username> is Bob',
+      },
+      {
+        label: 'handles angular brackets in multiple text and js parts',
+        writtenText:
+          'The <username> is {1 >= 1 ? "Bob" : "Sam"} The <username> is {1 < 1 ? "Bob" : "Sam"}',
+        codeResult:
+          'The &lt;username&gt; is {1 >= 1 ? "Bob" : "Sam"} The &lt;username&gt; is {1 < 1 ? "Bob" : "Sam"}',
+        renderedText: 'The <username> is Bob The <username> is Sam',
+      },
+      {
+        label: 'ignores closing curly bracket when inside quotation marks',
+        writtenText: 'The username is {1 >= 1 ? "Bob" : "Sam}" + ">"}',
+        codeResult: 'The username is {1 >= 1 ? "Bob" : "Sam}" + ">"}',
+        renderedText: 'The username is Bob',
+      },
+      {
+        label: 'handles expressions with formatted strings inside',
+        // eslint-disable-next-line no-template-curly-in-string
+        writtenText: 'The username is {1 >= 1 ? `${"Bob"}` : "Sam"}',
+        // eslint-disable-next-line no-template-curly-in-string
+        codeResult: 'The username is {1 >= 1 ? `${"Bob"}` : "Sam"}',
+        renderedText: 'The username is Bob',
+      },
+      {
+        label: 'handles nulls',
+        // eslint-disable-next-line no-template-curly-in-string
+        writtenText: 'The username is {1 >= 1 ? null : null}',
+        // eslint-disable-next-line no-template-curly-in-string
+        codeResult: 'The username is {1 >= 1 ? null : null}',
+        renderedText: 'The username is',
+      },
+    ]
+    tests.forEach((t) => {
+      it(`${t.label}`, async () => {
+        const editor = await renderTestEditorWithCode(projectWithoutText, 'await-first-dom-report')
+
+        await enterTextEditMode(editor)
+        typeText(t.writtenText)
+        await closeTextEditor()
+
+        await editor.getDispatchFollowUpActionsFinished()
+        await wait(50)
+
+        expect(editor.getEditorState().editor.mode.type).toEqual('select')
+        expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+          formatTestProjectCode(`
+              import * as React from 'react'
+              import { Storyboard } from 'utopia-api'
+
+
+              export var storyboard = (
+                <Storyboard data-uid='sb'>
+                  <div
+                    data-testid='div'
+                    style={{
+                      backgroundColor: '#0091FFAA',
+                      position: 'absolute',
+                      left: 0,
+                      top: 0,
+                      width: 288,
+                      height: 362,
+                    }}
+                    data-uid='39e'
+                  >
+                    ${textSpan(t.codeResult)}
+                  </div>
+                </Storyboard>
+              )`),
+        )
+        expect(editor.renderedDOM.getByTestId('div').innerText).toEqual(t.renderedText)
+      })
+    })
+  })
+  describe('inline expressions with code in navigator feature switch on', () => {
+    setFeatureForBrowserTests('Code in navigator', true)
     const tests = [
       {
         label: 'handles expressions',

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -345,7 +345,11 @@ export function isTextEditableConditional(
     return false
   }
 
-  const childrenInMetadata = MetadataUtils.getChildrenUnordered(metadata, path)
+  const childrenInMetadata = MetadataUtils.getNonExpressionDescendants(
+    metadata,
+    elementPathTree,
+    path,
+  )
   if (childrenInMetadata.length > 0) {
     // we don't allow text editing of conditional branches when the conditional have children in metadata
     // that would mean there are elefants in the active branch, which should not be text editable

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -2113,21 +2113,29 @@ export const MetadataUtils = {
     if (!isFeatureEnabled('Code in navigator')) {
       return childrenInMetadata
     }
-    return childrenInMetadata.flatMap((c) => {
-      if (isRight(c.element) && isJSExpression(c.element.value)) {
-        const expressionElementPath = EP.appendToPath(target, c.element.value.uid)
-        const expressionChildren = MetadataUtils.getChildrenOrdered(
-          metadata,
-          pathTree,
-          expressionElementPath,
-        )
-        return expressionChildren.flatMap((exprChild) =>
-          MetadataUtils.getNonExpressionDescendants(metadata, pathTree, exprChild.elementPath),
-        )
-      }
-      return [c]
-    })
+
+    return childrenInMetadata.flatMap((c) =>
+      getNonExpressionDescendantsInner(metadata, pathTree, c),
+    )
   },
+}
+
+function getNonExpressionDescendantsInner(
+  metadata: ElementInstanceMetadataMap,
+  pathTree: ElementPathTrees,
+  element: ElementInstanceMetadata,
+): Array<ElementInstanceMetadata> {
+  if (isRight(element.element) && isJSExpression(element.element.value)) {
+    const expressionChildren = MetadataUtils.getChildrenOrdered(
+      metadata,
+      pathTree,
+      element.elementPath,
+    )
+    return expressionChildren.flatMap((exprChild) =>
+      getNonExpressionDescendantsInner(metadata, pathTree, exprChild),
+    )
+  }
+  return [element]
 }
 
 function fillSpyOnlyMetadata(


### PR DESCRIPTION
[**Try me**](https://utopia.pizza/p/476cc863-sticky-bovid/?branch_name=fix-leaf-expression-handling)

**Problem:**
By adding code elements to the metadata, I introduced some regressions connected to identifying text-only elements. 

1. For text-only elements we show the text content as navigator label.  To test this we check if the element has children or not. However, when there is an expression in the element (e.g. `{1+1}`), the expression as a standalone code element is the child of the original element, so the original element has a child.
2. We do very similar check to decide whether something is text editable, so elements with expressions are not text editable anymore.

**Fix:**
Instead of checking if the element has children, I check if it has non-expression descendants. When there is an expression in an element I only want to treat it as a text editable element when the expression does not generate other children elements, only text.