### PR TITLE
True up groups on reparent

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
@@ -117,6 +117,8 @@ export function baseAbsoluteReparentStrategy(
             if (reparentTarget.shouldReparent && allowedToReparent) {
               const commands = mapDropNulls((selectedElement) => {
                 const reparentResult = getReparentOutcome(
+                  canvasState.startingMetadata,
+                  canvasState.startingElementPathTree,
                   canvasState.builtInDependencies,
                   projectContents,
                   nodeModules,

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -394,6 +394,8 @@ function collectReparentCommands(
     return []
   }
   const outcomeResult = getReparentOutcome(
+    canvasState.startingMetadata,
+    canvasState.startingElementPathTree,
     canvasState.builtInDependencies,
     canvasState.projectContents,
     canvasState.nodeModules,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -160,6 +160,8 @@ function applyStaticReparent(
 
           // Reparent the element.
           const outcomeResult = getReparentOutcome(
+            canvasState.startingMetadata,
+            canvasState.startingElementPathTree,
             canvasState.builtInDependencies,
             canvasState.projectContents,
             canvasState.nodeModules,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
@@ -48,6 +48,8 @@ import { getUtopiaID } from '../../../../core/shared/uid-utils'
 import type { IndexPosition } from '../../../../utils/utils'
 import { fastForEach } from '../../../../core/shared/utils'
 import { addElements } from '../../commands/add-elements-command'
+import { addPossibleTrueUp } from '../../commands/queue-group-true-up-command'
+import type { ElementPathTrees } from '../../../../core/shared/element-path-tree'
 
 interface GetReparentOutcomeResult {
   commands: Array<CanvasCommand>
@@ -83,6 +85,8 @@ export function elementToReparent(element: JSXElementChild, imports: Imports): E
 export type ToReparent = PathToReparent | ElementToReparent
 
 export function getReparentOutcome(
+  metadata: ElementInstanceMetadataMap,
+  pathTrees: ElementPathTrees,
   builtInDependencies: BuiltInDependencies,
   projectContents: ProjectContentTreeRoot,
   nodeModules: NodeModules,
@@ -140,6 +144,7 @@ export function getReparentOutcome(
       )
       commands.push(addImportsToFile(whenToRun, newTargetFilePath, importsToAdd))
       commands.push(reparentElement(whenToRun, toReparent.target, newParent, indexPosition))
+      commands.push(...addPossibleTrueUp(metadata, pathTrees, toReparent.target))
       newPath = EP.appendToPath(newParentElementPath, EP.toUid(toReparent.target))
       break
     case 'ELEMENT_TO_REPARENT':

--- a/editor/src/components/canvas/commands/queue-group-true-up-command.ts
+++ b/editor/src/components/canvas/commands/queue-group-true-up-command.ts
@@ -35,7 +35,7 @@ export const runQueueGroupTrueUp: CommandFunction<QueueGroupTrueUp> = (
 }
 
 // If the target is in a group, then this will add a command for including the siblings in a trueing up.
-export function addPossibleTrueUp(
+export function getRequiredGroupTrueUps(
   metadata: ElementInstanceMetadataMap,
   pathTrees: ElementPathTrees,
   target: ElementPath,

--- a/editor/src/components/canvas/commands/queue-group-true-up-command.ts
+++ b/editor/src/components/canvas/commands/queue-group-true-up-command.ts
@@ -1,6 +1,10 @@
+import type { ElementPathTrees } from 'src/core/shared/element-path-tree'
+import type { ElementInstanceMetadataMap } from 'src/core/shared/element-template'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import type { EditorState } from '../../editor/store/editor-state'
+import { treatElementAsGroupLike } from '../canvas-strategies/strategies/group-helpers'
 import type { BaseCommand, CommandFunction } from './commands'
 
 export interface QueueGroupTrueUp extends BaseCommand {
@@ -27,5 +31,20 @@ export const runQueueGroupTrueUp: CommandFunction<QueueGroupTrueUp> = (
     editorStatePatches: [
       { trueUpGroupsForElementAfterDomWalkerRuns: { $push: [command.element] } },
     ],
+  }
+}
+
+// If the target is in a group, then this will add a command for including the siblings in a trueing up.
+export function addPossibleTrueUp(
+  metadata: ElementInstanceMetadataMap,
+  pathTrees: ElementPathTrees,
+  target: ElementPath,
+): Array<QueueGroupTrueUp> {
+  const parentPath = EP.parentPath(target)
+  if (treatElementAsGroupLike(metadata, pathTrees, parentPath)) {
+    const siblings = MetadataUtils.getSiblingsOrdered(metadata, pathTrees, target)
+    return siblings.map((sibling) => queueGroupTrueUp(sibling.elementPath))
+  } else {
+    return []
   }
 }

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -686,6 +686,8 @@ export function editorMoveMultiSelectedTemplates(
     let templateToMove = updatedTargets[i]
 
     const outcomeResult = getReparentOutcome(
+      editor.jsxMetadata,
+      editor.elementPathTree,
       builtInDependencies,
       editor.projectContents,
       editor.nodeModules.files,


### PR DESCRIPTION
**Problem:**
When reparenting an element that is part of a group on the canvas, the group containing the element isn't true'd up.

**Fix:**
When calling `reparentElement`, also invoke `getRequiredGroupTrueUps` which adds the necessary commands when needed.

**Commit Details:**
- Implemented `getRequiredGroupTrueUps` which adds `QueueGroupTrueUp` commands
  when an element being reparented is part of a group.
- `getReparentOutcome` now includes a call to `getRequiredGroupTrueUps`.