### PR TITLE
Handle carrying over UID for a commented out expression.

### DIFF
--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -1928,7 +1928,7 @@ function buildHighlightBoundsForExpressionsAndText(
     let highestEnd: number | null = null
     for (const expression of expressions) {
       lowestStart = Math.min(lowestStart ?? expression.startPos, expression.startPos)
-      highestEnd = Math.min(highestEnd ?? expression.endPos, expression.endPos)
+      highestEnd = Math.max(highestEnd ?? expression.endPos, expression.endPos)
     }
     if (lowestStart == null || highestEnd == null) {
       // In this case fail outright as the bounds cannot be produced from an empty array.

--- a/editor/src/core/workers/parser-printer/uid-fix.spec.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.spec.ts
@@ -489,6 +489,33 @@ describe('fixParseSuccessUIDs', () => {
           component"
     `)
   })
+  it(`handles an entirely commented out JSX expression which was not previously commented out`, () => {
+    const firstResult = lintAndParseAndValidateResult(
+      'test.js',
+      uncommentedJSXExpression,
+      null,
+      emptySet(),
+      'trim-bounds',
+    )
+    expect(getUidTree(firstResult)).toMatchInlineSnapshot(`
+      "e81
+        678
+          104
+          6b0"
+    `)
+    const secondResult = lintAndParseAndValidateResult(
+      'test.js',
+      commentedOutJSXExpression,
+      asParseSuccessOrNull(firstResult),
+      emptySet(),
+      'trim-bounds',
+    )
+    expect(getUidTree(secondResult)).toMatchInlineSnapshot(`
+      "e81
+        678
+          104"
+    `)
+  })
 })
 
 function hasNoDuplicateUIDs(expression: JSXElementChild): boolean {
@@ -600,6 +627,89 @@ export var SameFileApp = (props) => {
   )
 }
 `)
+
+const uncommentedJSXExpression = `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+import { App } from '/src/app.js'
+import { Playground } from '/src/playground.js'
+
+export var storyboard = (
+  <Storyboard>
+    <div
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        left: 209,
+        top: 99,
+        width: 340,
+        height: 338,
+      }}
+    >
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 80,
+          top: 60,
+          width: 104,
+          height: 95,
+        }}
+      />
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 128,
+          top: 205,
+          width: 96,
+          height: 80,
+        }}
+      />
+    </div>
+  </Storyboard>
+)
+`
+const commentedOutJSXExpression = `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+import { App } from '/src/app.js'
+import { Playground } from '/src/playground.js'
+
+export var storyboard = (
+  <Storyboard>
+    <div
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        left: 209,
+        top: 99,
+        width: 340,
+        height: 338,
+      }}
+    >
+      {/* <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 80,
+          top: 60,
+          width: 104,
+          height: 95,
+        }}
+      />
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 128,
+          top: 205,
+          width: 96,
+          height: 80,
+        }}
+      /> */}
+    </div>
+  </Storyboard>
+)
+`
 
 const duplicateDataUIDPropUIDBaseTestCase = `import * as React from 'react'
 import { Scene, Storyboard } from 'utopia-api'


### PR DESCRIPTION
**Problem:**
If an entire expression is commented out in the code, an error is raised about an invalid mapping coming from the parse.

**Cause:**
When attempting to carry over the UID from the element to the expression that represents the commented out block, the logic that updates the highlight bounds discovers that there's no highlight bounds for that expression. This is as a result of the construction of the highlight bounds for that expression returning a `null` and not adding one, which is itself a result of an array of expressions that are all null.

**Fix:**
For these, a fallback case has been added as `ExpressionAndText` itself does contain some bounds, so that if the nodes do not provide a useful bounds we construct it from those bounds instead.

**Commit Details:**
- Implemented `buildHighlightBoundsForExpressionsAndText` which caters for `ExpressionAndText` values using those to build bounds as a fallback.