### PR TITLE
Add "group-like" case for navigator icons.

### DIFF
--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -17,6 +17,7 @@ import { isRegularNavigatorEntry, isSyntheticNavigatorEntry } from '../editor/st
 import { getElementFragmentLikeType } from '../canvas/canvas-strategies/strategies/fragment-like-helpers'
 import { findMaybeConditionalExpression } from '../../core/model/conditionals'
 import type { ElementPathTrees } from '../../core/shared/element-path-tree'
+import { treatElementAsGroupLike } from '../canvas/canvas-strategies/strategies/group-helpers'
 
 interface LayoutIconResult {
   iconProps: IcnPropsBase
@@ -89,6 +90,18 @@ export function createLayoutOrElementIconResult(
 
   if (element != null && elementProps != null && elementProps.style != null) {
     isPositionAbsolute = elementProps.style['position'] === 'absolute'
+  }
+
+  if (treatElementAsGroupLike(metadata, pathTrees, path)) {
+    return {
+      iconProps: {
+        category: 'element',
+        type: 'group-closed',
+        width: 18,
+        height: 18,
+      },
+      isPositionAbsolute: isPositionAbsolute,
+    }
   }
 
   if (MetadataUtils.isConditionalFromMetadata(element)) {


### PR DESCRIPTION
**Problem:**
Group-like elements are not specifically called out in the navigator, they're just defaulting to showing the component icon.

**Fix:**
Now ahead of all other cases, we check `treatElementAsGroupLike` and display a different icon if that returns true.

**Commit Details:**
- Added `treatElementAsGroupLike` check to `createLayoutOrElementIconResult`.