### PR TITLE
Fix select mode tests with Code in navigator FS on

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
@@ -33,6 +33,7 @@ import type { Modifiers } from '../../../../utils/modifiers'
 import { cmdModifier, emptyModifiers, shiftCmdModifier } from '../../../../utils/modifiers'
 import { FOR_TESTS_setNextGeneratedUids } from '../../../../core/model/element-template-utils.test-utils'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
+import { setFeatureForBrowserTests } from '../../../../utils/utils.test-utils'
 
 async function fireSingleClickEvents(
   target: HTMLElement,
@@ -669,6 +670,120 @@ describe('Select Mode Double Clicking With Fragments', () => {
     checkSelectedPaths(renderResult, [desiredPaths[1]])
   })
 
+  describe('With Code in navigator FS on', () => {
+    setFeatureForBrowserTests('Code in navigator', true)
+    it('Single click and three double clicks will focus a generated Card', async () => {
+      // prettier-ignore
+      const desiredPaths = createConsecutivePaths(
+      'sb' +                 // Skipped as it's the storyboard
+      '/scene-CardList' +    // Skipped because we skip over Scenes
+      '/CardList-instance' + // Skipped because we skip component children of Scenes
+      ':CardList-Root' +     // Skipped because we skip over root elements
+      '/CardList-Col',      // <- Single click
+      '/6d6',               // <- First double click selects the expression item
+      '/CardList-Card~~~1', // <- Second *and* third double click, as the Second is required to focus it
+    )
+
+      const renderResult = await renderTestEditorWithCode(
+        TestProjectAlpineClimb,
+        'await-first-dom-report',
+      )
+
+      const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+      const cardSceneRoot = renderResult.renderedDOM.getByTestId('generated-card-1')
+      const cardSceneRootBounds = cardSceneRoot.getBoundingClientRect()
+
+      const doubleClick = createDoubleClicker(
+        canvasControlsLayer,
+        cardSceneRootBounds.left + 130,
+        cardSceneRootBounds.top + 220,
+      )
+
+      await fireSingleClickEvents(
+        canvasControlsLayer,
+        cardSceneRootBounds.left + 130,
+        cardSceneRootBounds.top + 220,
+      )
+
+      checkFocusedPath(renderResult, null)
+      checkSelectedPaths(renderResult, [desiredPaths[0]])
+
+      await doubleClick()
+      checkFocusedPath(renderResult, null)
+      checkSelectedPaths(renderResult, [desiredPaths[1]])
+
+      await doubleClick()
+      checkFocusedPath(renderResult, null)
+      checkSelectedPaths(renderResult, [desiredPaths[2]])
+
+      await doubleClick()
+      checkFocusedPath(renderResult, desiredPaths[2])
+      checkSelectedPaths(renderResult, [desiredPaths[2]])
+    })
+
+    it('Single click and five double clicks will focus a generated Card and select the Button inside', async () => {
+      // prettier-ignore
+      const desiredPaths = createConsecutivePaths(
+        'sb' +                 // Skipped as it's the storyboard
+        '/scene-CardList' +    // Skipped because we skip over Scenes
+        '/CardList-instance' + // Skipped because we skip component children of Scenes
+        ':CardList-Root' +     // Skipped because we skip over root elements
+        '/CardList-Col',       // <- Single click
+        '/6d6',               // <- First double click selects the expression item
+        '/CardList-Card~~~1',  // <- Second *and* third double click, as the Second is required to focus it
+        ':Card-Root' +         // Skipped because we skip over root elements
+        '/Card-Row-Buttons',   // <- Fourth double click
+        '/Card-Button-3',      // <- Fifth double click
+      )
+
+      const renderResult = await renderTestEditorWithCode(
+        TestProjectAlpineClimb,
+        'await-first-dom-report',
+      )
+
+      const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+      const cardSceneRoot = renderResult.renderedDOM.getByTestId('generated-card-1')
+      const cardSceneRootBounds = cardSceneRoot.getBoundingClientRect()
+
+      const doubleClick = createDoubleClicker(
+        canvasControlsLayer,
+        cardSceneRootBounds.left + 130,
+        cardSceneRootBounds.top + 220,
+      )
+
+      await fireSingleClickEvents(
+        canvasControlsLayer,
+        cardSceneRootBounds.left + 130,
+        cardSceneRootBounds.top + 220,
+      )
+
+      checkFocusedPath(renderResult, null)
+      checkSelectedPaths(renderResult, [desiredPaths[0]])
+
+      await doubleClick()
+      checkFocusedPath(renderResult, null)
+      checkSelectedPaths(renderResult, [desiredPaths[1]])
+
+      await doubleClick()
+      checkFocusedPath(renderResult, null)
+      checkSelectedPaths(renderResult, [desiredPaths[2]])
+
+      await doubleClick()
+      checkFocusedPath(renderResult, desiredPaths[2])
+      checkSelectedPaths(renderResult, [desiredPaths[2]])
+
+      await doubleClick()
+      checkFocusedPath(renderResult, desiredPaths[2])
+      checkSelectedPaths(renderResult, [desiredPaths[3]])
+
+      await doubleClick()
+      checkFocusedPath(renderResult, desiredPaths[2])
+      checkSelectedPaths(renderResult, [desiredPaths[4]])
+    })
+  })
+
   it('Single click and two double clicks will focus a generated Card', async () => {
     // prettier-ignore
     const desiredPaths = createConsecutivePaths(
@@ -1123,6 +1238,50 @@ describe('Storyboard auto-focusing', () => {
 
     checkFocusedPath(renderResult, null)
     checkSelectedPaths(renderResult, [desiredPaths[1]])
+  })
+
+  describe('With Code in navigator FS on', () => {
+    setFeatureForBrowserTests('Code in navigator', true)
+    it('Scene with multiple generated children will not auto-focus those children', async () => {
+      // We expect neither of the Card components to be focused, meaning we can only directly select the instances
+      const desiredPaths = [
+        EP.fromString('sb/sc-generated/888/generated~~~1'),
+        EP.fromString('sb/sc-generated/888/generated~~~2'),
+      ]
+
+      const renderResult = await renderTestEditorWithCode(
+        TestProjectScene2Children,
+        'await-first-dom-report',
+      )
+
+      const generatedSpan1 = renderResult.renderedDOM.getByTestId('generated-span-1')
+      const generatedSpan1Bounds = generatedSpan1.getBoundingClientRect()
+
+      const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+      await fireSingleClickEvents(
+        canvasControlsLayer,
+        generatedSpan1Bounds.left + 2,
+        generatedSpan1Bounds.top + 2,
+        cmdModifier,
+      )
+
+      checkFocusedPath(renderResult, null)
+      checkSelectedPaths(renderResult, [desiredPaths[0]])
+
+      const generatedSpan2 = renderResult.renderedDOM.getByTestId('generated-span-2')
+      const generatedSpan2Bounds = generatedSpan2.getBoundingClientRect()
+
+      await fireSingleClickEvents(
+        canvasControlsLayer,
+        generatedSpan2Bounds.left + 2,
+        generatedSpan2Bounds.top + 2,
+        cmdModifier,
+      )
+
+      checkFocusedPath(renderResult, null)
+      checkSelectedPaths(renderResult, [desiredPaths[1]])
+    })
   })
 
   it('A child of the storyboard is not auto-focused', async () => {


### PR DESCRIPTION
**Problem:**
Fix select mode tests with Code in navigator FS on.
The only difference is the extra level in the element path and navigator hierarchy for the expression.
