### PR TITLE
True up groups on paste

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
@@ -31,6 +31,7 @@ import type {
 import { childInsertionPath } from '../../../editor/store/insertion-path'
 import type { CanvasCommand } from '../../commands/commands'
 import { foldAndApplyCommandsInner } from '../../commands/commands'
+import { queueGroupTrueUp } from '../../commands/queue-group-true-up-command'
 import { showToastCommand } from '../../commands/show-toast-command'
 import { updateFunctionCommand } from '../../commands/update-function-command'
 import { updateSelectedViews } from '../../commands/update-selected-views-command'
@@ -249,11 +250,7 @@ function pasteChoiceCommon(
         },
       },
     }),
-    wildcardPatch('on-complete', {
-      trueUpGroupsForElementAfterDomWalkerRuns: {
-        $set: groupTrueUpPaths,
-      },
-    }),
+    ...groupTrueUpPaths.map((path) => queueGroupTrueUp(path)),
   ]
 }
 

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -335,7 +335,7 @@ describe('actions', () => {
       elements: (renderResult: EditorRenderResult) => Array<ElementPaste>
       pasteInto: InsertionPath
       want: string
-      generatesUndoSteps?: number
+      generatesSaveCount?: number
     }
     const tests: Array<PasteTest> = [
       {
@@ -1282,7 +1282,7 @@ describe('actions', () => {
             },
           ]
         },
-        generatesUndoSteps: 4,
+        generatesSaveCount: 4,
         pasteInto: childInsertionPath(EP.appendNewElementPath(TestScenePath, ['root', 'group'])),
         want: `
             <div data-uid='root'>
@@ -1333,7 +1333,7 @@ describe('actions', () => {
 
         const canvasRoot = renderResult.renderedDOM.getByTestId('canvas-root')
 
-        await expectSingleUndoNSaves(renderResult, test.generatesUndoSteps ?? 2, async () => {
+        await expectSingleUndoNSaves(renderResult, test.generatesSaveCount ?? 2, async () => {
           firePasteEvent(canvasRoot)
 
           // Wait for the next frame

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -335,7 +335,7 @@ describe('actions', () => {
       elements: (renderResult: EditorRenderResult) => Array<ElementPaste>
       pasteInto: InsertionPath
       want: string
-      generatesUndoStep?: number
+      generatesUndoSteps?: number
     }
     const tests: Array<PasteTest> = [
       {
@@ -1282,7 +1282,7 @@ describe('actions', () => {
             },
           ]
         },
-        generatesUndoStep: 4,
+        generatesUndoSteps: 4,
         pasteInto: childInsertionPath(EP.appendNewElementPath(TestScenePath, ['root', 'group'])),
         want: `
             <div data-uid='root'>
@@ -1333,7 +1333,7 @@ describe('actions', () => {
 
         const canvasRoot = renderResult.renderedDOM.getByTestId('canvas-root')
 
-        await expectSingleUndoNSaves(renderResult, test.generatesUndoStep ?? 2, async () => {
+        await expectSingleUndoNSaves(renderResult, test.generatesUndoSteps ?? 2, async () => {
           firePasteEvent(canvasRoot)
 
           // Wait for the next frame

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -25,7 +25,7 @@ import { jsxFragment } from '../../../core/shared/element-template'
 import { defaultDivElement } from '../defaults'
 import {
   expectNoAction,
-  expectSingleUndo2Saves,
+  expectSingleUndoNSaves,
   selectComponentsForTest,
 } from '../../../utils/utils.test-utils'
 import {
@@ -335,7 +335,7 @@ describe('actions', () => {
       elements: (renderResult: EditorRenderResult) => Array<ElementPaste>
       pasteInto: InsertionPath
       want: string
-      generatesUndoStep?: boolean
+      generatesUndoStep?: number
     }
     const tests: Array<PasteTest> = [
       {
@@ -1261,6 +1261,40 @@ describe('actions', () => {
       </div>
 		`,
       },
+      {
+        name: 'into a group',
+        startingCode: `
+            <div data-uid='root'>
+              <div data-uid='foo' style={{ width: 50, height: 50, background: 'blue', position: 'absolute', left: 200, top: 200 }} />
+              <Group data-uid='group' style={{ background: 'yellow' }}>
+                <div data-uid='bar' style={{ width: 10, height: 10, background: 'red', position: 'absolute', top: 0, left: 0 }} />
+                <div data-uid='baz' style={{ width: 10, height: 10, background: 'red', position: 'absolute', top: 100, left: 20 }} />
+              </Group>
+            </div>
+          `,
+        elements: (renderResult) => {
+          const path = EP.appendNewElementPath(TestScenePath, ['root', 'foo'])
+          return [
+            {
+              element: getElementFromRenderResult(renderResult, path),
+              originalElementPath: path,
+              importsToAdd: {},
+            },
+          ]
+        },
+        generatesUndoStep: 4,
+        pasteInto: childInsertionPath(EP.appendNewElementPath(TestScenePath, ['root', 'group'])),
+        want: `
+            <div data-uid='root'>
+              <div data-uid='foo' style={{ width: 50, height: 50, background: 'blue', position: 'absolute', left: 200, top: 200 }} />
+              <Group data-uid='group' style={{ background: 'yellow', width: 50, height: 110 }}>
+                <div data-uid='bar' style={{ width: 10, height: 10, background: 'red', position: 'absolute', top: 0, left: 10 }} />
+                <div data-uid='baz' style={{ width: 10, height: 10, background: 'red', position: 'absolute', top: 100, left: 30 }} />
+                <div data-uid='aai' style={{ width: 50, height: 50, background: 'blue', position: 'absolute', left: 0, top: 30 }} />
+              </Group>
+            </div>
+          `,
+      },
     ]
     tests.forEach((test, i) => {
       it(`${i + 1}/${tests.length} ${test.name}`, async () => {
@@ -1268,9 +1302,6 @@ describe('actions', () => {
           makeTestProjectCodeWithSnippet(test.startingCode),
           'await-first-dom-report',
         )
-
-        const undoCheckerFn =
-          test.generatesUndoStep === false ? expectNoAction : expectSingleUndo2Saves
 
         const copiedPaths = test.elements(renderResult).map((e) => e.originalElementPath)
         await selectComponentsForTest(renderResult, copiedPaths)
@@ -1302,7 +1333,7 @@ describe('actions', () => {
 
         const canvasRoot = renderResult.renderedDOM.getByTestId('canvas-root')
 
-        await undoCheckerFn(renderResult, async () => {
+        await expectSingleUndoNSaves(renderResult, test.generatesUndoStep ?? 2, async () => {
           firePasteEvent(canvasRoot)
 
           // Wait for the next frame


### PR DESCRIPTION
Fixes #3943 

**Problem:**

Groups are not being true'd up on post-action paste.

**Fix:**

Add the pasted paths to the ones to true up if the target element is a group.
Positioning does not need to be adjusted as it's already being forced to the center of the target element, and cut already also trues them up.

**Notes:**

I believe this should be in an incremental diff, but - paste will generate multiple undo steps due to the trueing up, which I don't think is correct/ideal.