### PR TITLE
Fixed some lookups when reparenting into a generated element

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -255,7 +255,7 @@ export const reparentMetaStrategy: MetaCanvasStrategy = (
     return []
   }
 
-  const existingParents = reparentSubjects.map((p) => EP.makeLastPartOfPathStatic(EP.parentPath(p)))
+  const existingParents = reparentSubjects.map((p) => EP.dynamicPathToStaticPath(EP.parentPath(p)))
 
   const startingTargetsToFilter = getStartingTargetParentsToFilterOut(
     canvasState,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -255,7 +255,7 @@ export const reparentMetaStrategy: MetaCanvasStrategy = (
     return []
   }
 
-  const existingParents = reparentSubjects.map(EP.parentPath)
+  const existingParents = reparentSubjects.map((p) => EP.makeLastPartOfPathStatic(EP.parentPath(p)))
 
   const startingTargetsToFilter = getStartingTargetParentsToFilterOut(
     canvasState,

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -330,7 +330,11 @@ export function findJSXElementChildAtPath(
         // this is the element we want
         return element
       } else {
-        if (isJSXElementLike(element)) {
+        if (isJSExpressionOtherJavaScript(element)) {
+          // We've found the expression that this element lives inside, so on the next call we
+          // should find it in elementsWithin
+          return findAtPathInner(element, tailPath)
+        } else if (isJSXElementLike(element)) {
           // we will want to delve into the children
           const children = element.children
           for (const child of children) {


### PR DESCRIPTION
**Problem:**
With the "Code in Navigator" feature switch on, attempting to insert into a generated element would fail with an  `Unable to determine target path` error.

**Fix:**
The issue here happens during the reparenting part of the insertion, and is that when walking the element path `findJSXElementChildAtPath` assumes that if it hits a `JSExpressionOtherJavaScript` it will look at the `elementsWithin` to find the current UID that is being checked, but the new feature switch includes the UIDs of arbitrary expressions in the element path. The fix I've made is to move along the element path and recurse `findAtPathInner` again if the UID matches that of the arbitrary expression.

I also discovered that when reparenting we are supposed to filter the existing parent from the potential targets, but since reparenting uses [`childInsertionPath`](https://github.com/concrete-utopia/utopia/blob/3a52397aa11553a7dc08732668fb2eaf5ae52ffc/editor/src/components/editor/store/insertion-path.ts#L37), which converts the target to a `StaticElementPath`, we should also be converting the `existingParents` (to filter) to `StaticElementPath`s. Without that change, you could accidentally attempt to reparent the child of a generated element into the same parent (which just causes confusion since that strategy will also be disallowed)
