### PR TITLE
Feature/paste to replace post action menu

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-options.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-options.ts
@@ -1,9 +1,17 @@
 import type { BuiltInDependencies } from '../../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { stripNulls } from '../../../../core/shared/array-utils'
+import type { ElementPath } from '../../../../core/shared/project-file-types'
 import { assertNever } from '../../../../core/shared/utils'
+import type { EditorAction } from '../../../editor/action-types'
+import {
+  executePostActionMenuChoice,
+  startPostActionSession,
+} from '../../../editor/actions/action-creators'
 import type {
   DerivedState,
   EditorState,
+  InternalClipboard,
+  PasteToReplacePostActionMenuData,
   PostActionMenuData,
 } from '../../../editor/store/editor-state'
 import type { CanvasCommand } from '../../commands/commands'
@@ -46,4 +54,28 @@ export function generatePostactionChoices(data: PostActionMenuData): PostActionC
     default:
       assertNever(data)
   }
+}
+
+export function createPasteToReplacePostActionActions(
+  selectedViews: Array<ElementPath>,
+  internalClipboard: InternalClipboard,
+): Array<EditorAction> | null {
+  const pasteToReplacePostActionMenuData: PasteToReplacePostActionMenuData = {
+    type: 'PASTE_TO_REPLACE',
+    targets: selectedViews,
+    internalClipboard: internalClipboard,
+  }
+
+  const defaultChoice = stripNulls([
+    PasteToReplaceWithPropsReplacedPostActionChoice(pasteToReplacePostActionMenuData),
+    PasteToReplaceWithPropsPreservedPostActionChoice(pasteToReplacePostActionMenuData),
+  ]).at(0)
+
+  if (defaultChoice != null) {
+    return [
+      startPostActionSession(pasteToReplacePostActionMenuData),
+      executePostActionMenuChoice(defaultChoice),
+    ]
+  }
+  return null
 }

--- a/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-options.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-options.ts
@@ -12,6 +12,8 @@ import {
   PasteWithPropsReplacedPostActionChoice,
   PasteHereWithPropsPreservedPostActionChoice,
   PasteHereWithPropsReplacedPostActionChoice,
+  PasteToReplaceWithPropsReplacedPostActionChoice,
+  PasteToReplaceWithPropsPreservedPostActionChoice,
 } from './post-action-paste'
 
 export interface PostActionChoice {
@@ -35,6 +37,11 @@ export function generatePostactionChoices(data: PostActionMenuData): PostActionC
       return stripNulls([
         PasteHereWithPropsReplacedPostActionChoice(data),
         PasteHereWithPropsPreservedPostActionChoice(data),
+      ])
+    case 'PASTE_TO_REPLACE':
+      return stripNulls([
+        PasteToReplaceWithPropsReplacedPostActionChoice(data),
+        PasteToReplaceWithPropsPreservedPostActionChoice(data),
       ])
     default:
       assertNever(data)

--- a/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
@@ -71,7 +71,7 @@ interface PasteContext {
   canvasViewportCenter: CanvasPoint
   reparentStrategy: ReparentStrategy | null
   insertionPosition: CanvasPoint | null
-  keepSelectedViews?: boolean // selected views are cleared outside of pasteChoiceCommon
+  keepSelectedViews?: boolean // optionally selected views can be cleared outside of pasteChoiceCommon
 }
 
 function pasteChoiceCommon(

--- a/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
@@ -27,10 +27,12 @@ import type {
   EditorState,
   PasteHerePostActionMenuData,
   PastePostActionMenuData,
+  PasteToReplacePostActionMenuData,
 } from '../../../editor/store/editor-state'
 import { childInsertionPath } from '../../../editor/store/insertion-path'
 import type { CanvasCommand } from '../../commands/commands'
 import { foldAndApplyCommandsInner } from '../../commands/commands'
+import { deleteElement } from '../../commands/delete-element-command'
 import { showToastCommand } from '../../commands/show-toast-command'
 import { updateFunctionCommand } from '../../commands/update-function-command'
 import { updateSelectedViews } from '../../commands/update-selected-views-command'
@@ -486,4 +488,131 @@ function getTargetParentForPasteHere(
   const targetParent = sceneComponentRoot ?? storyboardChild ?? storyboardPath
 
   return right({ type: 'parent', parentPath: childInsertionPath(targetParent) })
+}
+
+export const PasteToReplaceWithPropsPreservedPostActionChoiceId =
+  'post-to-replace-action-choice-props-preserved'
+
+export const PasteToReplaceWithPropsPreservedPostActionChoice = (
+  data: PasteToReplacePostActionMenuData,
+): PostActionChoice => ({
+  name: 'Paste to replace with variables preserved',
+  id: PasteToReplaceWithPropsPreservedPostActionChoiceId,
+  run: (editor, derived, builtInDependencies) => {
+    if (
+      editor.internalClipboard.elements.length !== 1 ||
+      editor.internalClipboard.elements[0].copyDataWithPropsPreserved == null
+    ) {
+      return []
+    }
+
+    const elementToPaste = editor.internalClipboard.elements[0].copyDataWithPropsPreserved.elements
+    const originalMetadata =
+      editor.internalClipboard.elements[0].copyDataWithPropsPreserved.targetOriginalContextMetadata
+    const originalPathTree =
+      editor.internalClipboard.elements[0].targetOriginalContextElementPathTrees
+
+    return pasteToReplaceCommands(
+      editor,
+      builtInDependencies,
+      data.targets,
+      elementToPaste,
+      originalMetadata,
+      originalPathTree,
+    )
+  },
+})
+
+export const PasteToReplaceWithPropsReplacedPostActionChoiceId =
+  'post-to-replace-action-choice-props-replaced'
+
+export const PasteToReplaceWithPropsReplacedPostActionChoice = (
+  data: PasteToReplacePostActionMenuData,
+): PostActionChoice | null => {
+  if (
+    data.internalClipboard.elements.length !== 1 ||
+    data.internalClipboard.elements[0].copyDataWithPropsReplaced == null
+  ) {
+    return null
+  }
+  return {
+    name: 'Paste to replace with variables replaced',
+    id: PasteToReplaceWithPropsReplacedPostActionChoiceId,
+    run: (editor, derived, builtInDependencies) => {
+      if (
+        editor.internalClipboard.elements.length !== 1 ||
+        editor.internalClipboard.elements[0].copyDataWithPropsReplaced == null
+      ) {
+        return []
+      }
+      const elementToPaste = editor.internalClipboard.elements[0].copyDataWithPropsReplaced.elements
+      const originalMetadata =
+        editor.internalClipboard.elements[0].copyDataWithPropsPreserved
+          .targetOriginalContextMetadata
+      const originalPathTree =
+        editor.internalClipboard.elements[0].targetOriginalContextElementPathTrees
+
+      return pasteToReplaceCommands(
+        editor,
+        builtInDependencies,
+        data.targets,
+        elementToPaste,
+        originalMetadata,
+        originalPathTree,
+      )
+    },
+  }
+}
+
+function pasteToReplaceCommands(
+  editor: EditorState,
+  builtInDependencies: BuiltInDependencies,
+  targets: Array<ElementPath>,
+  elementToPaste: Array<ElementPaste>,
+  originalMetadata: ElementInstanceMetadataMap,
+  originalPathTree: ElementPathTrees,
+): Array<CanvasCommand> {
+  const pasteCommands = targets.flatMap((target) => {
+    return [
+      updateFunctionCommand('always', (updatedEditor, commandLifecycle) => {
+        const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, target)
+        const position = MetadataUtils.getFrameOrZeroRectInCanvasCoords(target, editor.jsxMetadata)
+        const strategy = MetadataUtils.isPositionAbsolute(element)
+          ? 'REPARENT_AS_ABSOLUTE'
+          : 'REPARENT_AS_STATIC'
+
+        const commands = pasteChoiceCommon(
+          { type: 'parent', parentPath: childInsertionPath(EP.parentPath(target)) },
+          {
+            builtInDependencies: builtInDependencies,
+            nodeModules: editor.nodeModules.files,
+            openFile: editor.canvas.openFile?.filename ?? null,
+            pasteTargetsToIgnore: [],
+            projectContents: updatedEditor.projectContents,
+            startingMetadata: editor.jsxMetadata,
+            startingElementPathTrees: editor.elementPathTree,
+            startingAllElementProps: editor.allElementProps,
+          },
+          {
+            selectedViews: editor.selectedViews,
+            elementPasteWithMetadata: {
+              elements: elementToPaste,
+              targetOriginalContextMetadata: originalMetadata,
+            },
+            targetOriginalPathTrees: originalPathTree,
+            canvasViewportCenter: zeroCanvasPoint,
+            reparentStrategy: strategy,
+            insertionPosition: position,
+          },
+        )
+        if (commands == null) {
+          return []
+        }
+        return foldAndApplyCommandsInner(updatedEditor, [], commands, commandLifecycle).statePatches
+      }),
+    ]
+  }, [] as Array<CanvasCommand>)
+  const deleteCommands = targets.map((target) => deleteElement('always', target))
+
+  return [...pasteCommands, ...deleteCommands]
 }

--- a/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
@@ -581,8 +581,19 @@ function pasteToReplaceCommands(
           ? 'REPARENT_AS_ABSOLUTE'
           : 'REPARENT_AS_STATIC'
 
+        const parentInsertionPath = MetadataUtils.getReparentTargetOfTarget(
+          updatedEditor.jsxMetadata,
+          target,
+        )
+        if (parentInsertionPath == null) {
+          return []
+        }
         const commands = pasteChoiceCommon(
-          { type: 'parent', parentPath: childInsertionPath(EP.parentPath(target)) },
+          {
+            type: 'sibling',
+            siblingPath: target,
+            parentPath: parentInsertionPath,
+          },
           {
             builtInDependencies: builtInDependencies,
             nodeModules: editor.nodeModules.files,

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -161,11 +161,11 @@ export const pasteToReplace: ContextMenuItem<CanvasData> = {
   enabled: (data) => data.internalClipboard.elements.length !== 0,
   shortcut: '⇧⌘V',
   action: (data, dispatch?: EditorDispatch) => {
-    const pasteToReplacePostActionMenuData = {
+    const pasteToReplacePostActionMenuData: PasteToReplacePostActionMenuData = {
       type: 'PASTE_TO_REPLACE',
       targets: data.selectedViews,
       internalClipboard: data.internalClipboard,
-    } as PasteToReplacePostActionMenuData
+    }
 
     const defaultChoice = stripNulls([
       PasteToReplaceWithPropsReplacedPostActionChoice(pasteToReplacePostActionMenuData),

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -19,7 +19,6 @@ import type { EditorDispatch } from './editor/action-types'
 import * as EditorActions from './editor/actions/action-creators'
 import {
   copySelectionToClipboard,
-  deleteView,
   duplicateSelected,
   toggleHidden,
 } from './editor/actions/action-creators'
@@ -27,7 +26,6 @@ import type {
   AllElementProps,
   InternalClipboard,
   PasteHerePostActionMenuData,
-  PasteToReplacePostActionMenuData,
 } from './editor/store/editor-state'
 import {
   toggleBackgroundLayers,
@@ -47,11 +45,10 @@ import type { ElementContextMenuInstance } from './element-context-menu'
 import {
   PasteHereWithPropsPreservedPostActionChoice,
   PasteHereWithPropsReplacedPostActionChoice,
-  PasteToReplaceWithPropsPreservedPostActionChoice,
-  PasteToReplaceWithPropsReplacedPostActionChoice,
 } from './canvas/canvas-strategies/post-action-options/post-action-paste'
 import { stripNulls } from '../core/shared/array-utils'
 import { createWrapInGroupAction } from './canvas/canvas-strategies/strategies/group-conversion-helpers'
+import { createPasteToReplacePostActionActions } from './canvas/canvas-strategies/post-action-options/post-action-options'
 
 export interface ContextMenuItem<T> {
   name: string | React.ReactNode
@@ -161,25 +158,12 @@ export const pasteToReplace: ContextMenuItem<CanvasData> = {
   enabled: (data) => data.internalClipboard.elements.length !== 0,
   shortcut: '⇧⌘V',
   action: (data, dispatch?: EditorDispatch) => {
-    const pasteToReplacePostActionMenuData: PasteToReplacePostActionMenuData = {
-      type: 'PASTE_TO_REPLACE',
-      targets: data.selectedViews,
-      internalClipboard: data.internalClipboard,
-    }
-
-    const defaultChoice = stripNulls([
-      PasteToReplaceWithPropsReplacedPostActionChoice(pasteToReplacePostActionMenuData),
-      PasteToReplaceWithPropsPreservedPostActionChoice(pasteToReplacePostActionMenuData),
-    ]).at(0)
-
-    if (defaultChoice != null) {
-      requireDispatch(dispatch)(
-        [
-          EditorActions.startPostActionSession(pasteToReplacePostActionMenuData),
-          EditorActions.executePostActionMenuChoice(defaultChoice),
-        ],
-        'noone',
-      )
+    const actions = createPasteToReplacePostActionActions(
+      data.selectedViews,
+      data.internalClipboard,
+    )
+    if (actions != null) {
+      requireDispatch(dispatch)(actions, 'noone')
     }
   },
 }

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -27,6 +27,7 @@ import type {
   AllElementProps,
   InternalClipboard,
   PasteHerePostActionMenuData,
+  PasteToReplacePostActionMenuData,
 } from './editor/store/editor-state'
 import {
   toggleBackgroundLayers,
@@ -46,6 +47,8 @@ import type { ElementContextMenuInstance } from './element-context-menu'
 import {
   PasteHereWithPropsPreservedPostActionChoice,
   PasteHereWithPropsReplacedPostActionChoice,
+  PasteToReplaceWithPropsPreservedPostActionChoice,
+  PasteToReplaceWithPropsReplacedPostActionChoice,
 } from './canvas/canvas-strategies/post-action-options/post-action-paste'
 import { stripNulls } from '../core/shared/array-utils'
 import { createWrapInGroupAction } from './canvas/canvas-strategies/strategies/group-conversion-helpers'
@@ -158,7 +161,26 @@ export const pasteToReplace: ContextMenuItem<CanvasData> = {
   enabled: (data) => data.internalClipboard.elements.length !== 0,
   shortcut: '⇧⌘V',
   action: (data, dispatch?: EditorDispatch) => {
-    requireDispatch(dispatch)([EditorActions.pasteToReplace()], 'noone')
+    const pasteToReplacePostActionMenuData = {
+      type: 'PASTE_TO_REPLACE',
+      targets: data.selectedViews,
+      internalClipboard: data.internalClipboard,
+    } as PasteToReplacePostActionMenuData
+
+    const defaultChoice = stripNulls([
+      PasteToReplaceWithPropsReplacedPostActionChoice(pasteToReplacePostActionMenuData),
+      PasteToReplaceWithPropsPreservedPostActionChoice(pasteToReplacePostActionMenuData),
+    ]).at(0)
+
+    if (defaultChoice != null) {
+      requireDispatch(dispatch)(
+        [
+          EditorActions.startPostActionSession(pasteToReplacePostActionMenuData),
+          EditorActions.executePostActionMenuChoice(defaultChoice),
+        ],
+        'noone',
+      )
+    }
   },
 }
 

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -347,9 +347,6 @@ export interface PasteProperties {
   action: 'PASTE_PROPERTIES'
   type: 'style' | 'layout'
 }
-export interface PasteToReplace {
-  action: 'PASTE_TO_REPLACE'
-}
 export interface SetProjectID {
   action: 'SET_PROJECT_ID'
   id: string
@@ -1074,7 +1071,6 @@ export type EditorAction =
   | CutSelectionToClipboard
   | CopyProperties
   | PasteProperties
-  | PasteToReplace
   | SetProjectID
   | SetForkedFromProjectID
   | OpenTextEditor

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -210,7 +210,6 @@ import type {
   SetConditionalOverriddenCondition,
   SwitchConditionalBranches,
   UpdateConditionalExpression,
-  PasteToReplace,
   CutSelectionToClipboard,
   ExecutePostActionMenuChoice,
   StartPostActionSession,
@@ -444,11 +443,6 @@ export function pasteProperties(type: 'style' | 'layout'): PasteProperties {
   return {
     action: 'PASTE_PROPERTIES',
     type: type,
-  }
-}
-export function pasteToReplace(): PasteToReplace {
-  return {
-    action: 'PASTE_TO_REPLACE',
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -147,7 +147,6 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'NAVIGATOR_REORDER':
     case 'RENAME_COMPONENT':
     case 'PASTE_PROPERTIES':
-    case 'PASTE_TO_REPLACE':
     case 'TOGGLE_PROPERTY':
     case 'deprecated_TOGGLE_ENABLED_PROPERTY':
     case 'RESET_PINS':

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -3282,6 +3282,7 @@ export var storyboard = (props) => {
         input: string
         copyTargets: Array<ElementPath>
         pasteTargets: Array<ElementPath>
+        expectedSelectedViews: Array<ElementPath> | null
         result: string
       }> = [
         {
@@ -3296,6 +3297,7 @@ export var storyboard = (props) => {
             </div>`,
           copyTargets: [makeTargetPath('root/bbb')],
           pasteTargets: [makeTargetPath('root/ddd')],
+          expectedSelectedViews: [makeTargetPath('root/aai')],
           result: `<div data-uid='root'>
               <div data-uid='bbb' style={{backgroundColor: 'lavender', outline: '1px solid black'}}>
                 <span data-uid='ccc'>Hello!</span>
@@ -3321,6 +3323,7 @@ export var storyboard = (props) => {
             </div>`,
           copyTargets: [makeTargetPath('root/bbb')],
           pasteTargets: [makeTargetPath('root/ddd/fff')],
+          expectedSelectedViews: [makeTargetPath('root/ddd/aak')],
           result: `<div data-uid='root'>
               <div data-uid='bbb' style={{backgroundColor: 'lavender', outline: '1px solid black', width: 50, height: 20}}>
                 <span data-uid='ccc'>Hello!</span>
@@ -3351,6 +3354,7 @@ export var storyboard = (props) => {
             </div>`,
           copyTargets: [makeTargetPath('root/bbb'), makeTargetPath('root/fff/ggg')],
           pasteTargets: [makeTargetPath('root/ddd')],
+          expectedSelectedViews: [makeTargetPath('root/aak'), makeTargetPath('root/aaz')],
           result: `<div data-uid='root'>
               <div data-uid='bbb' style={{backgroundColor: 'lavender', outline: '1px solid black', width: 40, height: 40}}>
                 <span data-uid='ccc'>Hello!</span>
@@ -3366,6 +3370,51 @@ export var storyboard = (props) => {
                   <span data-uid='hhh' style={{color: 'white'}}>second element</span>
                 </div>
               </div>
+            </div>`,
+        },
+        {
+          name: `paste to replace multiselected absolute elements with multiselected absolute elements`,
+          input: `<div data-uid='root'>
+            <div data-uid='bbb' style={{backgroundColor: 'lavender', outline: '1px solid black', width: 40, height: 40}}>
+              <span data-uid='ccc'>Hello!</span>
+            </div>
+            <div data-uid='ddd' style={{position: 'absolute', width: 50, height: 40, top: 100, left: 100}}>
+              <div data-uid='eee'>Hi!</div>
+            </div>
+            <div data-uid='fff' style={{position: 'absolute', top: 40, left: 40, backgroundColor: 'plum', outline: '1px solid white'}}>
+              <span data-uid='ggg' style={{color: 'white'}}>second element</span>
+            </div>
+            <div data-uid='jjj' style={{position: 'absolute', width: 50, height: 40, top: 200, left: 200}}>
+              <div data-uid='kkk'>Hi!</div>
+            </div>
+          </div>`,
+          copyTargets: [makeTargetPath('root/bbb'), makeTargetPath('root/fff')],
+          pasteTargets: [makeTargetPath('root/jjj'), makeTargetPath('root/ddd')],
+          expectedSelectedViews: [
+            makeTargetPath('root/aak'),
+            makeTargetPath('root/aaz'),
+            makeTargetPath('root/aau'),
+            makeTargetPath('root/abl'),
+          ],
+          result: `<div data-uid='root'>
+              <div data-uid='bbb' style={{backgroundColor: 'lavender', outline: '1px solid black', width: 40, height: 40}}>
+                <span data-uid='ccc'>Hello!</span>
+              </div>
+              <div data-uid='aau' style={{backgroundColor: 'lavender', outline: '1px solid black', width: 40, height: 40, top: 100, left: 100, position: 'absolute' }}>
+                <span data-uid='aaf'>Hello!</span>
+              </div>
+              <div data-uid='abl' style={{position: 'absolute', top: 140, left: 140, backgroundColor: 'plum', outline: '1px solid white'}}>
+                <span data-uid='abc' style={{color: 'white'}}>second element</span>
+              </div>
+              <div data-uid='fff' style={{position: 'absolute', top: 40, left: 40, backgroundColor: 'plum', outline: '1px solid white'}}>
+                <span data-uid='ggg' style={{color: 'white'}}>second element</span>
+              </div>
+              <div data-uid='aak' style={{backgroundColor: 'lavender', outline: '1px solid black', width: 40, height: 40, top: 200, left: 200, position: 'absolute' }}>
+                <span data-uid='aac'>Hello!</span>
+              </div>
+              <div data-uid='aaz' style={{position: 'absolute', top: 240, left: 240, backgroundColor: 'plum', outline: '1px solid white'}}>
+                  <span data-uid='aaq' style={{color: 'white'}}>second element</span>
+                </div>
             </div>`,
         },
         {
@@ -3387,6 +3436,7 @@ export var storyboard = (props) => {
           </div>`,
           copyTargets: [makeTargetPath('root/bbb')],
           pasteTargets: [makeTargetPath('root/cond/ddd')],
+          expectedSelectedViews: [makeTargetPath('root/cond/aai')],
           result: `<div data-uid='root'>
             <div data-uid='bbb' style={{backgroundColor: 'lavender', outline: '1px solid black'}}>
               <span data-uid='ccc'>Hello!</span>
@@ -3427,6 +3477,7 @@ export var storyboard = (props) => {
           </div>`,
           copyTargets: [makeTargetPath('root/bbb'), makeTargetPath('root/fff/ggg')],
           pasteTargets: [makeTargetPath('root/cond/ddd')],
+          expectedSelectedViews: null,
           result: `<div data-uid='root'>
             <div data-uid='bbb' style={{backgroundColor: 'lavender', outline: '1px solid black', width: 40, height: 40}}>
               <span data-uid='ccc'>Hello!</span>
@@ -3467,14 +3518,17 @@ export var storyboard = (props) => {
           await selectComponentsForTest(renderResult, tt.pasteTargets)
           await pressKey('v', { modifiers: shiftCmdModifier })
 
-          await pressKey('Esc')
-
           // Wait for the next frame
           await renderResult.getDispatchFollowUpActionsFinished()
 
           expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
             makeTestProjectCodeWithSnippet(tt.result),
           )
+          if (tt.expectedSelectedViews != null) {
+            expect(renderResult.getEditorState().editor.selectedViews).toEqual(
+              tt.expectedSelectedViews,
+            )
+          }
         })
       })
     })

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -103,11 +103,7 @@ import {
   OPEN_INSERT_MENU,
   PASTE_TO_REPLACE,
 } from './shortcut-definitions'
-import type {
-  EditorState,
-  LockedElements,
-  PasteToReplacePostActionMenuData,
-} from './store/editor-state'
+import type { EditorState, LockedElements } from './store/editor-state'
 import { DerivedState, getOpenFile, RightMenuTab } from './store/editor-state'
 import { CanvasMousePositionRaw, WindowMousePositionRaw } from '../../utils/global-positions'
 import { pickColorWithEyeDropper } from '../canvas/canvas-utils'
@@ -167,10 +163,7 @@ import {
 } from '../canvas/canvas-strategies/strategies/group-conversion-helpers'
 import { isRight } from '../../core/shared/either'
 import type { ElementPathTrees } from '../../core/shared/element-path-tree'
-import {
-  PasteToReplaceWithPropsPreservedPostActionChoice,
-  PasteToReplaceWithPropsReplacedPostActionChoice,
-} from '../canvas/canvas-strategies/post-action-options/post-action-paste'
+import { createPasteToReplacePostActionActions } from '../canvas/canvas-strategies/post-action-options/post-action-options'
 
 function updateKeysPressed(
   keysPressed: KeysPressed,
@@ -894,22 +887,12 @@ export function handleKeyDown(
       },
       [PASTE_TO_REPLACE]: () => {
         if (isSelectMode(editor.mode)) {
-          const pasteToReplacePostActionMenuData: PasteToReplacePostActionMenuData = {
-            type: 'PASTE_TO_REPLACE',
-            targets: editor.selectedViews,
-            internalClipboard: editor.internalClipboard,
-          }
-
-          const defaultChoice = stripNulls([
-            PasteToReplaceWithPropsReplacedPostActionChoice(pasteToReplacePostActionMenuData),
-            PasteToReplaceWithPropsPreservedPostActionChoice(pasteToReplacePostActionMenuData),
-          ]).at(0)
-
-          if (defaultChoice != null) {
-            return [
-              EditorActions.startPostActionSession(pasteToReplacePostActionMenuData),
-              EditorActions.executePostActionMenuChoice(defaultChoice),
-            ]
+          const actions = createPasteToReplacePostActionActions(
+            editor.selectedViews,
+            editor.internalClipboard,
+          )
+          if (actions != null) {
+            return actions
           }
         }
         return []

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1293,7 +1293,16 @@ export interface PasteHerePostActionMenuData {
   internalClipboard: InternalClipboard
 }
 
-export type PostActionMenuData = PastePostActionMenuData | PasteHerePostActionMenuData
+export interface PasteToReplacePostActionMenuData {
+  type: 'PASTE_TO_REPLACE'
+  targets: Array<ElementPath>
+  internalClipboard: InternalClipboard
+}
+
+export type PostActionMenuData =
+  | PastePostActionMenuData
+  | PasteHerePostActionMenuData
+  | PasteToReplacePostActionMenuData
 
 export interface PostActionMenuSession {
   activeChoiceId: string | null

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -118,8 +118,6 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.CLOSE_POPUP(action, state)
     case 'PASTE_PROPERTIES':
       return UPDATE_FNS.PASTE_PROPERTIES(action, state)
-    case 'PASTE_TO_REPLACE':
-      return UPDATE_FNS.PASTE_TO_REPLACE(action, state, dispatch, builtInDependencies)
     case 'COPY_SELECTION_TO_CLIPBOARD':
       return UPDATE_FNS.COPY_SELECTION_TO_CLIPBOARD(action, state, dispatch, builtInDependencies)
     case 'CUT_SELECTION_TO_CLIPBOARD':

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -315,6 +315,7 @@ import type {
   PostActionMenuData,
   PastePostActionMenuData,
   PasteHerePostActionMenuData,
+  PasteToReplacePostActionMenuData,
 } from './editor-state'
 import {
   TransientCanvasState,
@@ -3874,6 +3875,18 @@ export const PasteHerePostActionMenuDataKeepDeepEquality: KeepDeepEqualityCall<P
       internalClipboard: clipboard,
     }),
   )
+export const PasteToReplacePostActionMenuDataKeepDeepEquality: KeepDeepEqualityCall<PasteToReplacePostActionMenuData> =
+  combine2EqualityCalls(
+    (menudata) => menudata.targets,
+    ElementPathArrayKeepDeepEquality,
+    (menudata) => menudata.internalClipboard,
+    InternalClipboardKeepDeepEquality,
+    (targets, clipboard) => ({
+      type: 'PASTE_TO_REPLACE',
+      targets: targets,
+      internalClipboard: clipboard,
+    }),
+  )
 
 export const PostActionMenuDataKeepDeepEquality: KeepDeepEqualityCall<PostActionMenuData> = (
   oldValue,
@@ -3888,6 +3901,11 @@ export const PostActionMenuDataKeepDeepEquality: KeepDeepEqualityCall<PostAction
     case 'PASTE_HERE':
       if (newValue.type === oldValue.type) {
         return PasteHerePostActionMenuDataKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'PASTE_TO_REPLACE':
+      if (newValue.type === oldValue.type) {
+        return PasteToReplacePostActionMenuDataKeepDeepEquality(oldValue, newValue)
       }
       break
     default:

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -190,7 +190,7 @@ const SelectableElementItem = (props: SelectableElementItemProps) => {
 
   return (
     <FlexRow ref={rawRef}>
-      <Icn {...iconProps} color={isHighlighted ? 'on-highlight-main' : 'secondary'} />
+      <Icn {...iconProps} color={isHighlighted ? 'on-highlight-main' : 'main'} />
       <span style={{ paddingLeft: 6 }}>{label}</span>
     </FlexRow>
   )


### PR DESCRIPTION
https://utopia.pizza/p/30fc3aa5-charmed-foe/?branch_name=feature/paste-to-replace-post-action

**Problem:**
Paste to Replace feature is not using the Post Action menu yet.

**Fix:**
Remove "Paste to Replace" action and add it to the paste strategies.

**Commit Details:**
- added Paste To Replace options to the post action menu and paste strategies
- update context menu and global shortcuts to create post action session
- extended tests to check selected views after paste, except where a new fragment is inserted into a conditional because here the uid-s are inconsistent between test runs
- added one more test to paste to replace where multiselected elements are replaced
- minor fix in context menu for missing icon warnings for elements
