### PR TITLE
Invalid groups warnings

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/group-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-helpers.ts
@@ -1,7 +1,15 @@
 import type { ElementPathTrees } from '../../../../core/shared/element-path-tree'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
-import type { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
+import type {
+  ElementInstanceMetadataMap,
+  JSXElement,
+} from '../../../../core/shared/element-template'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
+import { getLayoutProperty } from '../../../../core/layout/getLayoutProperty'
+import { styleStringInArray } from '../../../../utils/common-constants'
+import { isLeft, isRight, right } from '../../../../core/shared/either'
+import { isCSSNumber } from '../../../inspector/common/css-utils'
+import { assertNever } from '../../../../core/shared/utils'
 
 export function treatElementAsGroupLike(
   metadata: ElementInstanceMetadataMap,
@@ -14,5 +22,86 @@ export function treatElementAsGroupLike(
   return (
     allChildrenAreAbsolute &&
     MetadataUtils.isGroupAgainstImports(MetadataUtils.findElementByElementPath(metadata, path))
+  )
+}
+
+export type GroupChildState = 'valid' | InvalidGroupChildState
+
+export type InvalidGroupChildState =
+  | 'not-position-absolute'
+  | 'percentage-pins-without-group-size'
+  | 'missing-props'
+
+export function isInvalidGroupChildState(s: GroupChildState | null): s is InvalidGroupChildState {
+  return s !== 'valid'
+}
+
+export function invalidGroupChildStateToString(s: InvalidGroupChildState): string {
+  switch (s) {
+    case 'not-position-absolute':
+      return 'Group children have non-absolute position'
+    case 'percentage-pins-without-group-size':
+      return 'Group children have % pins, but group has no size'
+    case 'missing-props':
+      return 'Missing props'
+    default:
+      assertNever(s)
+  }
+}
+
+export function checkGroupHasExplicitSize(group: JSXElement): boolean {
+  const groupDimensions = [
+    getLayoutProperty('width', right(group.props), styleStringInArray),
+    getLayoutProperty('height', right(group.props), styleStringInArray),
+  ]
+
+  return groupDimensions.every((dimension) => {
+    return isRight(dimension) && isCSSNumber(dimension.value)
+  })
+}
+
+export function getGroupChildState(
+  element: JSXElement | null,
+  groupHasExplicitSize: boolean,
+): GroupChildState {
+  if (element?.props == null) {
+    return 'missing-props'
+  }
+
+  const position = getLayoutProperty('position', right(element.props), styleStringInArray)
+  if (isLeft(position) || position.value !== 'absolute') {
+    return 'not-position-absolute'
+  }
+
+  const pins = [
+    getLayoutProperty('width', right(element.props), styleStringInArray),
+    getLayoutProperty('height', right(element.props), styleStringInArray),
+    getLayoutProperty('left', right(element.props), styleStringInArray),
+    getLayoutProperty('top', right(element.props), styleStringInArray),
+  ]
+  const elementHasPercentagePins = pins.some((pin) => {
+    return isRight(pin) && isCSSNumber(pin.value) && pin.value.unit === '%'
+  })
+  if (!groupHasExplicitSize && elementHasPercentagePins) {
+    return 'percentage-pins-without-group-size'
+  }
+
+  return 'valid'
+}
+
+export function getGroupState(
+  path: ElementPath,
+  metadata: ElementInstanceMetadataMap,
+): GroupChildState {
+  const group = MetadataUtils.getJSXElementFromMetadata(metadata, path)
+  if (group == null) {
+    return 'missing-props'
+  }
+  const groupHasExplicitSize = checkGroupHasExplicitSize(group)
+  return (
+    MetadataUtils.getChildrenUnordered(metadata, path)
+      .map((child) => MetadataUtils.getJSXElementFromMetadata(metadata, child.elementPath))
+      .map((child) => getGroupChildState(child, groupHasExplicitSize))
+      .find(isInvalidGroupChildState) ?? 'valid'
   )
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/group-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-helpers.ts
@@ -49,7 +49,7 @@ export function invalidGroupChildStateToString(s: InvalidGroupChildState): strin
   }
 }
 
-export function checkGroupHasExplicitSize(group: JSXElement): boolean {
+function checkGroupHasExplicitSize(group: JSXElement): boolean {
   const groupDimensions = [
     getLayoutProperty('width', right(group.props), styleStringInArray),
     getLayoutProperty('height', right(group.props), styleStringInArray),
@@ -60,7 +60,7 @@ export function checkGroupHasExplicitSize(group: JSXElement): boolean {
   })
 }
 
-export function getGroupChildState(
+function getGroupChildState(
   element: JSXElement | null,
   groupHasExplicitSize: boolean,
 ): GroupChildState {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -173,10 +173,10 @@ import type {
   ElementPasteWithMetadata,
   ReparentTargetForPaste,
 } from '../../../utils/clipboard'
-import type { InvalidGroupChildState } from '../../canvas/canvas-strategies/strategies/group-helpers'
+import type { InvalidGroupState } from '../../canvas/canvas-strategies/strategies/group-helpers'
 import {
   getGroupState,
-  isInvalidGroupChildState,
+  isInvalidGroupState,
 } from '../../canvas/canvas-strategies/strategies/group-helpers'
 
 const ObjectPathImmutable: any = OPI
@@ -1950,14 +1950,14 @@ export interface ElementWarnings {
   widthOrHeightZero: boolean
   absoluteWithUnpositionedParent: boolean
   dynamicSceneChildWidthHeightPercentage: boolean
-  invalidGroup: InvalidGroupChildState | null
+  invalidGroup: InvalidGroupState | null
 }
 
 export function elementWarnings(
   widthOrHeightZero: boolean,
   absoluteWithUnpositionedParent: boolean,
   dynamicSceneChildWidthHeightPercentage: boolean,
-  invalidGroup: InvalidGroupChildState | null,
+  invalidGroup: InvalidGroupState | null,
 ): ElementWarnings {
   return {
     widthOrHeightZero: widthOrHeightZero,
@@ -2492,7 +2492,7 @@ function getElementWarningsInner(
     const groupState = MetadataUtils.isGroupAgainstImports(elementMetadata)
       ? getGroupState(elementMetadata.elementPath, rootMetadata)
       : null
-    const invalidGroup = isInvalidGroupChildState(groupState) ? groupState : null
+    const invalidGroup = isInvalidGroupState(groupState) ? groupState : null
 
     const warnings: ElementWarnings = {
       widthOrHeightZero: widthOrHeightZero,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -173,6 +173,11 @@ import type {
   ElementPasteWithMetadata,
   ReparentTargetForPaste,
 } from '../../../utils/clipboard'
+import type { InvalidGroupChildState } from '../../canvas/canvas-strategies/strategies/group-helpers'
+import {
+  getGroupState,
+  isInvalidGroupChildState,
+} from '../../canvas/canvas-strategies/strategies/group-helpers'
 
 const ObjectPathImmutable: any = OPI
 
@@ -1945,17 +1950,20 @@ export interface ElementWarnings {
   widthOrHeightZero: boolean
   absoluteWithUnpositionedParent: boolean
   dynamicSceneChildWidthHeightPercentage: boolean
+  invalidGroup: InvalidGroupChildState | null
 }
 
 export function elementWarnings(
   widthOrHeightZero: boolean,
   absoluteWithUnpositionedParent: boolean,
   dynamicSceneChildWidthHeightPercentage: boolean,
+  invalidGroup: InvalidGroupChildState | null,
 ): ElementWarnings {
   return {
     widthOrHeightZero: widthOrHeightZero,
     absoluteWithUnpositionedParent: absoluteWithUnpositionedParent,
     dynamicSceneChildWidthHeightPercentage: dynamicSceneChildWidthHeightPercentage,
+    invalidGroup: invalidGroup,
   }
 }
 
@@ -1963,6 +1971,7 @@ export const defaultElementWarnings: ElementWarnings = {
   widthOrHeightZero: false,
   absoluteWithUnpositionedParent: false,
   dynamicSceneChildWidthHeightPercentage: false,
+  invalidGroup: null,
 }
 
 export interface RegularNavigatorEntry {
@@ -2480,10 +2489,16 @@ function getElementWarningsInner(
       !elementMetadata.specialSizeMeasurements.immediateParentProvidesLayout
     const absoluteWithUnpositionedParent = isParentNotConfiguredForPins && !isParentFragmentLike
 
+    const groupState = MetadataUtils.isGroupAgainstImports(elementMetadata)
+      ? getGroupState(elementMetadata.elementPath, rootMetadata)
+      : null
+    const invalidGroup = isInvalidGroupChildState(groupState) ? groupState : null
+
     const warnings: ElementWarnings = {
       widthOrHeightZero: widthOrHeightZero,
       absoluteWithUnpositionedParent: absoluteWithUnpositionedParent,
       dynamicSceneChildWidthHeightPercentage: false,
+      invalidGroup: invalidGroup,
     }
     result[EP.toString(elementMetadata.elementPath)] = warnings
   })

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -56,6 +56,7 @@ import { LayoutIcon } from './layout-icon'
 import { NavigatorItemActionSheet } from './navigator-item-components'
 import { assertNever } from '../../../core/shared/utils'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
+import { invalidGroupChildStateToString } from '../../canvas/canvas-strategies/strategies/group-helpers'
 
 export function getItemHeight(navigatorEntry: NavigatorEntry): number {
   if (isConditionalClauseNavigatorEntry(navigatorEntry)) {
@@ -651,6 +652,8 @@ export const NavigatorItem: React.FunctionComponent<
     } else if (elementWarnings.absoluteWithUnpositionedParent) {
       warningText =
         'Element is trying to be positioned absolutely with an unconfigured parent. Add absolute or relative position to the parent.'
+    } else if (elementWarnings.invalidGroup != null) {
+      warningText = invalidGroupChildStateToString(elementWarnings.invalidGroup)
     }
   }
 

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -56,7 +56,7 @@ import { LayoutIcon } from './layout-icon'
 import { NavigatorItemActionSheet } from './navigator-item-components'
 import { assertNever } from '../../../core/shared/utils'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
-import { invalidGroupChildStateToString } from '../../canvas/canvas-strategies/strategies/group-helpers'
+import { invalidGroupStateToString } from '../../canvas/canvas-strategies/strategies/group-helpers'
 
 export function getItemHeight(navigatorEntry: NavigatorEntry): number {
   if (isConditionalClauseNavigatorEntry(navigatorEntry)) {
@@ -653,7 +653,7 @@ export const NavigatorItem: React.FunctionComponent<
       warningText =
         'Element is trying to be positioned absolutely with an unconfigured parent. Add absolute or relative position to the parent.'
     } else if (elementWarnings.invalidGroup != null) {
-      warningText = invalidGroupChildStateToString(elementWarnings.invalidGroup)
+      warningText = invalidGroupStateToString(elementWarnings.invalidGroup)
     }
   }
 

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1516,16 +1516,21 @@ export const MetadataUtils = {
     metadata: ElementInstanceMetadataMap,
     path: ElementPath,
   ): JSXElement | null {
-    const element = MetadataUtils.findElementByElementPath(metadata, path)
+    return this.getJSXElementFromElementInstanceMetadata(
+      MetadataUtils.findElementByElementPath(metadata, path),
+    )
+  },
+  getJSXElementFromElementInstanceMetadata(
+    element: ElementInstanceMetadata | null,
+  ): JSXElement | null {
     if (element == null) {
       return null
-    } else {
-      return foldEither(
-        (_) => null,
-        (e) => (isJSXElement(e) ? e : null),
-        element.element,
-      )
     }
+    return foldEither(
+      (_) => null,
+      (e) => (isJSXElement(e) ? e : null),
+      element.element,
+    )
   },
   getJSXElementName(jsxElement: JSXElementChild | null): JSXElementName | null {
     if (jsxElement != null) {

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1516,7 +1516,7 @@ export const MetadataUtils = {
     metadata: ElementInstanceMetadataMap,
     path: ElementPath,
   ): JSXElement | null {
-    return this.getJSXElementFromElementInstanceMetadata(
+    return MetadataUtils.getJSXElementFromElementInstanceMetadata(
       MetadataUtils.findElementByElementPath(metadata, path),
     )
   },

--- a/editor/src/utils/deep-equality-instances.ts
+++ b/editor/src/utils/deep-equality-instances.ts
@@ -156,12 +156,14 @@ export const LayoutTargetablePropArrayKeepDeepEquality: KeepDeepEqualityCall<
 > = arrayDeepEquality(createCallWithTripleEquals())
 
 export const ElementWarningsKeepDeepEquality: KeepDeepEqualityCall<ElementWarnings> =
-  combine3EqualityCalls(
+  combine4EqualityCalls(
     (warnings) => warnings.widthOrHeightZero,
     createCallWithTripleEquals(),
     (warnings) => warnings.absoluteWithUnpositionedParent,
     createCallWithTripleEquals(),
     (warnings) => warnings.dynamicSceneChildWidthHeightPercentage,
+    createCallWithTripleEquals(),
+    (warnings) => warnings.invalidGroup,
     createCallWithTripleEquals(),
     elementWarnings,
   )


### PR DESCRIPTION
Fixes #3949 

**Problem:**

Groups with "invalid" children configurations are not highlighted as such in the navigator.

**Fix:**

Show a warning in the navigator for group entries if:
- any of its children is not `position: absolute`
- any of its children has percentage pins _and_ the group does not have explicit `width` and `height`

The `getGroupState` function returns a `GroupChildState` which refers to the first invalid child of the group (or `valid` if all are ok).