### PR TITLE
fix(cut) change CutSelectionToClipboard to non transient action

### DIFF
--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -32,7 +32,6 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'TOGGLE_FOCUSED_OMNIBOX_TAB':
     case 'TOGGLE_PANE':
     case 'COPY_SELECTION_TO_CLIPBOARD':
-    case 'CUT_SELECTION_TO_CLIPBOARD':
     case 'COPY_PROPERTIES':
     case 'OPEN_TEXT_EDITOR':
     case 'CLOSE_TEXT_EDITOR':
@@ -193,6 +192,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SET_CONDITIONAL_OVERRIDDEN_CONDITION':
     case 'SWITCH_CONDITIONAL_BRANCHES':
     case 'UPDATE_CONIDTIONAL_EXPRESSION':
+    case 'CUT_SELECTION_TO_CLIPBOARD':
       return false
     case 'SAVE_ASSET':
       return (


### PR DESCRIPTION
**Problem:**
Pressing UNDO after a cut interaction jumps 2 steps back in history.

**Fix:**
The issue is that `CUT_SELECTION_TO_CLIPBOARD` is a transient action.

**Commit Details:**
- move `CUT_SELECTION_TO_CLIPBOARD` to the list of non transient actions.
