### PR TITLE
Fix/paste to replace on root divs

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
@@ -587,14 +587,14 @@ export const PasteToReplaceWithPropsReplacedPostActionChoice = (
 function pasteToReplaceCommands(
   editor: EditorState,
   builtInDependencies: BuiltInDependencies,
-  targets: Array<ElementPath>,
+  unfilteredTargets: Array<ElementPath>,
   elementToPaste: Array<ElementPaste>,
   originalMetadata: ElementInstanceMetadataMap,
   originalPathTree: ElementPathTrees,
 ): Array<CanvasCommand> {
-  const targetsWithoutRoot = targets.filter((target) => !EP.isRootElementOfInstance(target))
+  const targets = unfilteredTargets.filter((target) => !EP.isRootElementOfInstance(target))
 
-  const pasteCommands = targetsWithoutRoot.flatMap((target) => {
+  const pasteCommands = targets.flatMap((target) => {
     return [
       updateFunctionCommand('always', (updatedEditor, commandLifecycle) => {
         const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, target)
@@ -646,13 +646,13 @@ function pasteToReplaceCommands(
       }),
     ]
   }, [] as Array<CanvasCommand>)
-  const deleteCommands = targetsWithoutRoot.map((target) => deleteElement('always', target))
+  const deleteCommands = targets.map((target) => deleteElement('always', target))
 
   return stripNulls([
     updateSelectedViews('always', []),
     ...pasteCommands,
     ...deleteCommands,
-    targetsWithoutRoot.length !== targets.length
+    targets.length !== unfilteredTargets.length
       ? showToastCommand('Cannot replace root elements', 'WARNING', 'paste-to-replace-on-root')
       : null,
   ])

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -155,7 +155,9 @@ export const pasteLayout: ContextMenuItem<CanvasData> = {
 }
 export const pasteToReplace: ContextMenuItem<CanvasData> = {
   name: 'Paste to Replace',
-  enabled: (data) => data.internalClipboard.elements.length !== 0,
+  enabled: (data) =>
+    data.internalClipboard.elements.length !== 0 &&
+    data.selectedViews.some((target) => !EP.isRootElementOfInstance(target)),
   shortcut: '⇧⌘V',
   action: (data, dispatch?: EditorDispatch) => {
     const actions = createPasteToReplacePostActionActions(


### PR DESCRIPTION
**Problem:**
When Paste to Replace is called on a root element it is inserted directly as a Component child. Root element insertion is not supported yet.

**Fix:**
Disable contextmenu entry "paste as value" when a root div is selected. Show toast when "Paste to Replace" is fired on selection when there is at least one root element. Toast is shown when the shortcut is used on a root div.

**Commit Details:**
- paste strategy filters selection for root divs
- show toast if there are root divs
- contextmenu is disabled on roots
