### PR TITLE
Renamed feature switch function and fixed usages

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.spec.browser2.tsx
@@ -17,7 +17,6 @@ import { mouseClickAtPoint, mouseDragFromPointToPoint } from '../../event-helper
 import {
   expectElementWithTestIdNotToBeRendered,
   selectComponentsForTest,
-  setFeatureForBrowserTests,
 } from '../../../../utils/utils.test-utils'
 import * as EP from '../../../../core/shared/element-path'
 import { ImmediateParentOutlinesTestId } from '../../controls/parent-outlines'

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
@@ -31,7 +31,6 @@ import { ImmediateParentOutlinesTestId } from '../../controls/parent-outlines'
 import {
   expectElementWithTestIdNotToBeRendered,
   expectElementWithTestIdToBeRendered,
-  setFeatureForBrowserTests,
   selectComponentsForTest,
 } from '../../../../utils/utils.test-utils'
 import { ImmediateParentBoundsTestId } from '../../controls/parent-bounds'

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
@@ -27,7 +27,7 @@ import * as EP from '../../../../core/shared/element-path'
 import { ExtraPadding } from './reparent-helpers/reparent-strategy-sibling-position-helpers'
 import { navigatorEntryToKey } from '../../../../components/editor/store/editor-state'
 import { selectComponents } from '../../../editor/actions/action-creators'
-import { setFeatureForBrowserTests } from '../../../../utils/utils.test-utils'
+import { setFeatureForBrowserTestsUseInDescribeBlockOnly } from '../../../../utils/utils.test-utils'
 
 async function dragElement(
   renderResult: EditorRenderResult,
@@ -493,7 +493,7 @@ describe('Absolute Reparent To Flex Strategy', () => {
 })
 
 describe('With Code in navigator feature switch on', () => {
-  setFeatureForBrowserTests('Code in navigator', true)
+  setFeatureForBrowserTestsUseInDescribeBlockOnly('Code in navigator', true)
   it('cannot reparent a code element', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(defaultTestCode),

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flow-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-to-flow-strategy.spec.browser2.tsx
@@ -22,7 +22,7 @@ import {
   mouseDragFromPointWithDelta,
   pressKey,
 } from '../../event-helpers.test-utils'
-import { setFeatureForBrowserTests } from '../../../../utils/utils.test-utils'
+import { setFeatureForBrowserTestsUseInDescribeBlockOnly } from '../../../../utils/utils.test-utils'
 import { selectComponents } from '../../../editor/actions/action-creators'
 import * as EP from '../../../../core/shared/element-path'
 
@@ -87,7 +87,6 @@ ${snippet}
 
 describe('Absolute Reparent To Flow Strategy', () => {
   it('reparents to the end', async () => {
-    setFeatureForBrowserTests('Code in navigator', true)
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
       <div
@@ -870,7 +869,7 @@ describe('Absolute Reparent To Flow Strategy', () => {
 })
 
 describe('With Code in navigator feature switch on', () => {
-  setFeatureForBrowserTests('Code in navigator', true)
+  setFeatureForBrowserTestsUseInDescribeBlockOnly('Code in navigator', true)
   it('cannot reparent a code element', async () => {
     const testCode = `
       <div

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -39,7 +39,6 @@ import {
   expectElementWithTestIdToBeRendered,
   expectElementWithTestIdToBeRenderedWithDisplayNone,
   selectComponentsForTest,
-  setFeatureForBrowserTests,
   wait,
 } from '../../../../utils/utils.test-utils'
 import { ControlDelay } from '../canvas-strategy-types'

--- a/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.spec.browser2.tsx
@@ -3,7 +3,6 @@ import type { WindowPoint } from '../../../../core/shared/math-utils'
 import { windowPoint } from '../../../../core/shared/math-utils'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
 import { shiftModifier } from '../../../../utils/modifiers'
-import { setFeatureForBrowserTests, wait } from '../../../../utils/utils.test-utils'
 import { selectComponents } from '../../../editor/actions/meta-actions'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import {

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
@@ -53,11 +53,7 @@ import {
   getClosingFragmentLikeTag,
   getOpeningFragmentLikeTag,
 } from './fragment-like-helpers.test-utils'
-import {
-  selectComponentsForTest,
-  setFeatureForBrowserTests,
-  wait,
-} from '../../../../utils/utils.test-utils'
+import { selectComponentsForTest } from '../../../../utils/utils.test-utils'
 
 const complexProject = () => {
   const code = `

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reorder-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reorder-strategy.spec.browser2.tsx
@@ -12,7 +12,6 @@ import {
   pressKey,
 } from '../../event-helpers.test-utils'
 import { canvasPoint, windowPoint } from '../../../../core/shared/math-utils'
-import { setFeatureForBrowserTests, wait } from '../../../../utils/utils.test-utils'
 import {
   getClosingFragmentLikeTag,
   getOpeningFragmentLikeTag,
@@ -20,7 +19,6 @@ import {
 } from './fragment-like-helpers.test-utils'
 import type { FragmentLikeType } from './fragment-like-helpers'
 import { AllFragmentLikeNonDomElementTypes, AllFragmentLikeTypes } from './fragment-like-helpers'
-import { FOR_TESTS_setNextGeneratedUids } from '../../../../core/model/element-template-utils.test-utils'
 import { fromString } from '../../../../core/shared/element-path'
 
 const TestProject = (direction: string) => `

--- a/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-strategy.spec.browser2.tsx
@@ -24,7 +24,6 @@ import * as EP from '../../../../core/shared/element-path'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { assert } from 'chai'
 import { navigatorEntryToKey } from '../../../../components/editor/store/editor-state'
-import { setFeatureForBrowserTests } from '../../../../utils/utils.test-utils'
 
 const TestProjectBlockElements = (additionalContainerStyle: string = '') => `
 <div style={{ width: '100%', height: '100%', position: 'absolute', ${additionalContainerStyle} }} data-uid='container'>

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-resize.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-resize.spec.browser2.tsx
@@ -11,11 +11,7 @@ import {
   shiftCmdModifier,
   shiftModifier,
 } from '../../../../utils/modifiers'
-import {
-  selectComponentsForTest,
-  setFeatureForBrowserTests,
-  wait,
-} from '../../../../utils/utils.test-utils'
+import { selectComponentsForTest } from '../../../../utils/utils.test-utils'
 import { selectComponents, setHighlightedView } from '../../../editor/actions/action-creators'
 import { pressKey, keyDown, keyUp } from '../../event-helpers.test-utils'
 import type { GuidelineWithSnappingVectorAndPointsOfRelevance } from '../../guideline'

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-reorder-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-reorder-strategy.spec.browser2.tsx
@@ -1,5 +1,4 @@
 import * as EP from '../../../../core/shared/element-path'
-import { setFeatureForBrowserTests } from '../../../../utils/utils.test-utils'
 import { pressKey } from '../../event-helpers.test-utils'
 import type { EditorRenderResult } from '../../ui-jsx.test-utils'
 import { makeTestProjectCodeWithSnippet, renderTestEditorWithCode } from '../../ui-jsx.test-utils'
@@ -7,10 +6,7 @@ import { KeyboardInteractionTimeout } from '../interaction-state'
 import type { SinonFakeTimers } from 'sinon'
 import sinon from 'sinon'
 import { selectComponents } from '../../../editor/actions/action-creators'
-import {
-  NavigatorEntry,
-  navigatorEntryToKey,
-} from '../../../../components/editor/store/editor-state'
+import { navigatorEntryToKey } from '../../../../components/editor/store/editor-state'
 import {
   getClosingFragmentLikeTag,
   getOpeningFragmentLikeTag,
@@ -18,7 +14,6 @@ import {
 } from './fragment-like-helpers.test-utils'
 import type { FragmentLikeType } from './fragment-like-helpers'
 import { AllFragmentLikeTypes } from './fragment-like-helpers'
-import { assertNever } from '../../../../core/shared/utils'
 
 const TestProject = (
   display: 'block' | 'inline-block',

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size.spec.browser2.tsx
@@ -1,10 +1,7 @@
 import * as EP from '../../../../core/shared/element-path'
 import { assertNever } from '../../../../core/shared/utils'
 import { shiftCmdModifier } from '../../../../utils/modifiers'
-import {
-  selectComponentsForTest,
-  setFeatureForBrowserTests,
-} from '../../../../utils/utils.test-utils'
+import { selectComponentsForTest } from '../../../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import {
   mouseClickAtPoint,

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight.spec.browser2.tsx
@@ -1,8 +1,5 @@
 import { fromString } from '../../../../core/shared/element-path'
-import {
-  selectComponentsForTest,
-  setFeatureForBrowserTests,
-} from '../../../../utils/utils.test-utils'
+import { selectComponentsForTest } from '../../../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import { mouseClickAtPoint, pressKey } from '../../event-helpers.test-utils'
 import type { EditorRenderResult } from '../../ui-jsx.test-utils'

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.spec.browser2.tsx
@@ -1,8 +1,5 @@
 import * as EP from '../../../../core/shared/element-path'
-import {
-  selectComponentsForTest,
-  setFeatureForBrowserTests,
-} from '../../../../utils/utils.test-utils'
+import { selectComponentsForTest } from '../../../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import { mouseClickAtPoint, pressKey } from '../../event-helpers.test-utils'
 import type { EditorRenderResult } from '../../ui-jsx.test-utils'

--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
@@ -33,7 +33,7 @@ import type { Modifiers } from '../../../../utils/modifiers'
 import { cmdModifier, emptyModifiers, shiftCmdModifier } from '../../../../utils/modifiers'
 import { FOR_TESTS_setNextGeneratedUids } from '../../../../core/model/element-template-utils.test-utils'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
-import { setFeatureForBrowserTests } from '../../../../utils/utils.test-utils'
+import { setFeatureForBrowserTestsUseInDescribeBlockOnly } from '../../../../utils/utils.test-utils'
 
 async function fireSingleClickEvents(
   target: HTMLElement,
@@ -671,7 +671,7 @@ describe('Select Mode Double Clicking With Fragments', () => {
   })
 
   describe('With Code in navigator FS on', () => {
-    setFeatureForBrowserTests('Code in navigator', true)
+    setFeatureForBrowserTestsUseInDescribeBlockOnly('Code in navigator', true)
     it('Single click and three double clicks will focus a generated Card', async () => {
       // prettier-ignore
       const desiredPaths = createConsecutivePaths(
@@ -1241,7 +1241,7 @@ describe('Storyboard auto-focusing', () => {
   })
 
   describe('With Code in navigator FS on', () => {
-    setFeatureForBrowserTests('Code in navigator', true)
+    setFeatureForBrowserTestsUseInDescribeBlockOnly('Code in navigator', true)
     it('Scene with multiple generated children will not auto-focus those children', async () => {
       // We expect neither of the Card components to be focused, meaning we can only directly select the instances
       const desiredPaths = [

--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
@@ -389,7 +389,7 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.mode.type).toEqual('select')
       expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
       expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual(
-        'sb/39e/cond/33d~~~1',
+        'sb/39e/cond/ff4',
       )
     })
   })

--- a/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/text-edit-mode/text-edit-mode.spec.browser2.tsx
@@ -2,7 +2,7 @@ import * as EP from '../../../../core/shared/element-path'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
 import {
   selectComponentsForTest,
-  setFeatureForBrowserTests,
+  setFeatureForBrowserTestsUseInDescribeBlockOnly,
   wait,
 } from '../../../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../../../canvas/controls/new-canvas-controls'
@@ -85,49 +85,7 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
       expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e/cond')
     })
-    it('Entering text edit mode with double click on conditional with expression in active branch with Code in navigator FS on', async () => {
-      setFeatureForBrowserTests('Code in navigator', true)
-      const editor = await renderTestEditorWithCode(
-        project(`{
-        // @utopia/uid=cond
-        true ? 'Hello' : <div />
-      }`),
-        'await-first-dom-report',
-      )
-      await selectElement(editor, EP.fromString('sb/39e/cond'))
-      await clickOnElement(editor, 'div', 'double-click')
-      // wait for the next frame
-      await wait(1)
-
-      expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
-      expect(
-        EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
-      ).toEqual('sb/39e/cond')
-      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
-      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e/cond')
-    })
     it('Entering text edit mode with double click on conditional with expression in both branches', async () => {
-      const editor = await renderTestEditorWithCode(
-        project(`{
-        // @utopia/uid=cond
-        true ? 'Hello' : Utopia
-      }`),
-        'await-first-dom-report',
-      )
-      await selectElement(editor, EP.fromString('sb/39e/cond'))
-      await clickOnElement(editor, 'div', 'double-click')
-      // wait for the next frame
-      await wait(1)
-
-      expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
-      expect(
-        EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
-      ).toEqual('sb/39e/cond')
-      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
-      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e/cond')
-    })
-    it('Entering text edit mode with double click on conditional with expression in both branches with Code in navigator FS on', async () => {
-      setFeatureForBrowserTests('Code in navigator', true)
       const editor = await renderTestEditorWithCode(
         project(`{
         // @utopia/uid=cond
@@ -165,25 +123,6 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
       expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
     })
-    it('Can not entering text edit mode with double click on conditional with expression in active branch when there is sibling with Code in navigator FS on', async () => {
-      setFeatureForBrowserTests('Code in navigator', true)
-      const editor = await renderTestEditorWithCode(
-        project(`{
-          // @utopia/uid=cond
-          true ? 'Hello' : <div />
-        }
-        <div />`),
-        'await-first-dom-report',
-      )
-      await selectElement(editor, EP.fromString('sb/39e/cond'))
-      await clickOnElement(editor, 'div', 'double-click')
-      // wait for the next frame
-      await wait(1)
-
-      expect(editor.getEditorState().editor.mode.type).toEqual('select')
-      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
-      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
-    })
     it('Can not enter text edit mode with double click on conditional with element in active branch', async () => {
       const editor = await renderTestEditorWithCode(
         project(`{
@@ -200,26 +139,6 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.mode.type).toEqual('select')
     })
     it('Can not enter text edit mode with double click on conditional with expression in active branch which returns an element', async () => {
-      const editor = await renderTestEditorWithCode(
-        project(`{
-          // @utopia/uid=cond
-          true ? (() => <div>hello</div>)() : <div />
-        }`),
-        'await-first-dom-report',
-      )
-      await selectElement(editor, EP.fromString('sb/39e/cond'))
-      await clickOnElement(editor, 'div', 'double-click')
-      // wait for the next frame
-      await wait(1)
-
-      expect(editor.getEditorState().editor.mode.type).toEqual('select')
-      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
-      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual(
-        'sb/39e/cond/33d~~~1',
-      )
-    })
-    it('Can not enter text edit mode with double click on conditional with expression in active branch which returns an element with Code in navigator FS on', async () => {
-      setFeatureForBrowserTests('Code in navigator', true)
       const editor = await renderTestEditorWithCode(
         project(`{
           // @utopia/uid=cond
@@ -389,6 +308,88 @@ describe('Text edit mode', () => {
       expect(editor.getEditorState().editor.toasts.length).toEqual(1)
       expect(editor.getEditorState().editor.toasts[0].message).toEqual(
         "This element doesn't support children, so it cannot be text edited",
+      )
+    })
+  })
+
+  describe('Entering text edit mode with Code in navigator feature switch', () => {
+    setFeatureForBrowserTestsUseInDescribeBlockOnly('Code in navigator', true)
+
+    it('Entering text edit mode with double click on conditional with expression in active branch', async () => {
+      const editor = await renderTestEditorWithCode(
+        project(`{
+        // @utopia/uid=cond
+        true ? 'Hello' : <div />
+      }`),
+        'await-first-dom-report',
+      )
+      await selectElement(editor, EP.fromString('sb/39e/cond'))
+      await clickOnElement(editor, 'div', 'double-click')
+      // wait for the next frame
+      await wait(1)
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
+      expect(
+        EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
+      ).toEqual('sb/39e/cond')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e/cond')
+    })
+    it('Entering text edit mode with double click on conditional with expression in both branches', async () => {
+      const editor = await renderTestEditorWithCode(
+        project(`{
+        // @utopia/uid=cond
+        true ? 'Hello' : Utopia
+      }`),
+        'await-first-dom-report',
+      )
+      await selectElement(editor, EP.fromString('sb/39e/cond'))
+      await clickOnElement(editor, 'div', 'double-click')
+      // wait for the next frame
+      await wait(1)
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
+      expect(
+        EP.toString((editor.getEditorState().editor.mode as TextEditMode).editedText!),
+      ).toEqual('sb/39e/cond')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e/cond')
+    })
+    it('Can not entering text edit mode with double click on conditional with expression in active branch when there is sibling', async () => {
+      const editor = await renderTestEditorWithCode(
+        project(`{
+          // @utopia/uid=cond
+          true ? 'Hello' : <div />
+        }
+        <div />`),
+        'await-first-dom-report',
+      )
+      await selectElement(editor, EP.fromString('sb/39e/cond'))
+      await clickOnElement(editor, 'div', 'double-click')
+      // wait for the next frame
+      await wait(1)
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual('sb/39e')
+    })
+    it('Can not enter text edit mode with double click on conditional with expression in active branch which returns an element', async () => {
+      const editor = await renderTestEditorWithCode(
+        project(`{
+          // @utopia/uid=cond
+          true ? (() => <div>hello</div>)() : <div />
+        }`),
+        'await-first-dom-report',
+      )
+      await selectElement(editor, EP.fromString('sb/39e/cond'))
+      await clickOnElement(editor, 'div', 'double-click')
+      // wait for the next frame
+      await wait(1)
+
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
+      expect(editor.getEditorState().editor.selectedViews).toHaveLength(1)
+      expect(EP.toString(editor.getEditorState().editor.selectedViews[0])).toEqual(
+        'sb/39e/cond/33d~~~1',
       )
     })
   })

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -28,7 +28,7 @@ import {
 import { emptyComments, jsExpressionValue } from '../../core/shared/element-template'
 import { CanvasControlsContainerID } from './controls/new-canvas-controls'
 import {
-  setFeatureForBrowserTests,
+  setFeatureForBrowserTestsUseInDescribeBlockOnly,
   slightlyOffsetPointBecauseVeryWeirdIssue,
 } from '../../utils/utils.test-utils'
 import { mouseDownAtPoint, mouseMoveToPoint, mouseUpAtPoint } from './event-helpers.test-utils'
@@ -36,7 +36,7 @@ import { mouseDownAtPoint, mouseMoveToPoint, mouseUpAtPoint } from './event-help
 disableStoredStateforTests()
 
 describe('DOM Walker with Code in navigator FS on', () => {
-  setFeatureForBrowserTests('Code in navigator', true)
+  setFeatureForBrowserTestsUseInDescribeBlockOnly('Code in navigator', true)
   it('Test Project metadata contains entry for all elements', async () => {
     const renderResult = await renderTestEditorWithCode(TestProject, 'await-first-dom-report')
     const metadata = renderResult.getEditorState().editor.jsxMetadata

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-conditionals.spec.browser2.tsx
@@ -1,7 +1,6 @@
 import { createModifiedProject } from '../../../sample-projects/sample-project-utils.test-utils'
 import { navigatorEntryToKey, StoryboardFilePath } from '../../editor/store/editor-state'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
-import { setFeatureForBrowserTests } from '../../../utils/utils.test-utils'
 
 const appFilePath = '/src/app.js'
 const appFileContent = `

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser2.tsx
@@ -1,6 +1,9 @@
 import { canvasPoint, point } from '../../../core/shared/math-utils'
 import * as EP from '../../../core/shared/element-path'
-import { setFeatureForBrowserTests, simplifiedMetadataMap } from '../../../utils/utils.test-utils'
+import {
+  setFeatureForBrowserTestsUseInDescribeBlockOnly,
+  simplifiedMetadataMap,
+} from '../../../utils/utils.test-utils'
 import { setFocusedElement } from '../../editor/actions/action-creators'
 import { StoryboardFilePath } from '../../editor/store/editor-state'
 import CanvasActions from '../canvas-actions'
@@ -182,7 +185,7 @@ function createComponentWithConditionalProject() {
 }
 
 describe('Spy Wrapper Template Path Tests with Code in navigator FS on', () => {
-  setFeatureForBrowserTests('Code in navigator', true)
+  setFeatureForBrowserTestsUseInDescribeBlockOnly('Code in navigator', true)
   it('a simple component in a regular scene', async () => {
     const { getEditorState } = await createExampleProject()
 
@@ -896,7 +899,7 @@ describe('Spy Wrapper Template Path Tests with Code in navigator FS on', () => {
 })
 
 describe('Spy Wrapper Multifile Template Path Tests with Code in navigator FS on', () => {
-  setFeatureForBrowserTests('Code in navigator', true)
+  setFeatureForBrowserTestsUseInDescribeBlockOnly('Code in navigator', true)
   it('the Card instance is focused inside the main App component', async () => {
     const { dispatch, getEditorState } = await createExampleProject()
     await dispatch(
@@ -1727,7 +1730,7 @@ describe('Spy Wrapper Multifile Template Path Tests with Code in navigator FS on
 })
 
 describe('Spy Wrapper Multifile With Cyclic Dependencies with Code in navigator FS on', () => {
-  setFeatureForBrowserTests('Code in navigator', true)
+  setFeatureForBrowserTestsUseInDescribeBlockOnly('Code in navigator', true)
   it('a generated component instance is focused inside a component instance inside the main App component', async () => {
     const { dispatch, getEditorState } = await createAndRenderModifiedProject({
       [StoryboardFilePath]: exampleProject,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-warnings-errors.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-warnings-errors.spec.browser2.tsx
@@ -1,5 +1,4 @@
 import { getConsoleLogsForTests } from '../../../core/shared/runtime-report-logs'
-import { setFeatureForBrowserTests } from '../../../utils/utils.test-utils'
 import { makeTestProjectCodeWithSnippet, renderTestEditorWithCode } from '../ui-jsx.test-utils'
 
 describe('Canvas Renderer Warnings', () => {

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
@@ -2,13 +2,9 @@ import { navigatorEntryToKey } from '../../../components/editor/store/editor-sta
 import { BakedInStoryboardUID } from '../../../core/model/scene-utils'
 import * as EP from '../../../core/shared/element-path'
 import { shiftModifier } from '../../../utils/modifiers'
-import {
-  expectSingleUndo2Saves,
-  selectComponentsForTest,
-  setFeatureForBrowserTests,
-} from '../../../utils/utils.test-utils'
+import { expectSingleUndo2Saves, selectComponentsForTest } from '../../../utils/utils.test-utils'
 import { getRegularNavigatorTargets } from '../../canvas/canvas-strategies/strategies/fragment-like-helpers.test-utils'
-import { mouseClickAtPoint, pressKey } from '../../canvas/event-helpers.test-utils'
+import { pressKey } from '../../canvas/event-helpers.test-utils'
 import type { EditorRenderResult } from '../../canvas/ui-jsx.test-utils'
 import {
   getPrintedUiJsCode,
@@ -19,7 +15,6 @@ import {
   TestSceneUID,
 } from '../../canvas/ui-jsx.test-utils'
 import { selectComponents } from '../../editor/actions/action-creators'
-import { AddRemoveLayouSystemControlTestId } from '../../inspector/add-remove-layout-system-control'
 import type { FlexDirection } from '../../inspector/common/css-utils'
 import type { FlexAlignment, FlexJustifyContent } from '../../inspector/inspector-common'
 import { MaxContent } from '../../inspector/inspector-common'

--- a/editor/src/components/inspector/add-remove-layout-system-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.spec.browser2.tsx
@@ -1,5 +1,5 @@
 import { shiftModifier } from '../../utils/modifiers'
-import { expectSingleUndo2Saves, setFeatureForBrowserTests } from '../../utils/utils.test-utils'
+import { expectSingleUndo2Saves } from '../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
 import { mouseClickAtPoint, pressKey } from '../canvas/event-helpers.test-utils'
 import type { EditorRenderResult } from '../canvas/ui-jsx.test-utils'

--- a/editor/src/components/inspector/flex-direction-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/flex-direction-control.spec.browser2.tsx
@@ -3,7 +3,6 @@ import {
   expectSingleUndo2Saves,
   hoverControlWithCheck,
   selectComponentsForTest,
-  setFeatureForBrowserTests,
 } from '../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
 import { getSubduedPaddingControlTestID } from '../canvas/controls/select-mode/subdued-padding-control'

--- a/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.spec.browser2.tsx
@@ -1,4 +1,4 @@
-import { expectSingleUndo2Saves, setFeatureForBrowserTests } from '../../../utils/utils.test-utils'
+import { expectSingleUndo2Saves } from '../../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../../canvas/controls/new-canvas-controls'
 import { mouseClickAtPoint } from '../../canvas/event-helpers.test-utils'
 import type { EditorRenderResult } from '../../canvas/ui-jsx.test-utils'

--- a/editor/src/components/inspector/nine-block-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/nine-block-control.spec.browser2.tsx
@@ -3,7 +3,6 @@ import {
   expectSingleUndo2Saves,
   hoverControlWithCheck,
   selectComponentsForTest,
-  setFeatureForBrowserTests,
 } from '../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
 import { getSubduedPaddingControlTestID } from '../canvas/controls/select-mode/subdued-padding-control'

--- a/editor/src/components/inspector/resize-to-fit-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/resize-to-fit-control.spec.browser2.tsx
@@ -1,9 +1,5 @@
 import { cmdModifier } from '../../utils/modifiers'
-import {
-  expectSingleUndo2Saves,
-  setFeatureForBrowserTests,
-  wait,
-} from '../../utils/utils.test-utils'
+import { expectSingleUndo2Saves } from '../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-controls'
 import { mouseClickAtPoint, pressKey } from '../canvas/event-helpers.test-utils'
 import type { EditorRenderResult } from '../canvas/ui-jsx.test-utils'

--- a/editor/src/components/inspector/spaced-packed-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/spaced-packed-control.spec.browser2.tsx
@@ -3,7 +3,6 @@ import {
   expectSingleUndo2Saves,
   hoverControlWithCheck,
   selectComponentsForTest,
-  setFeatureForBrowserTests,
 } from '../../utils/utils.test-utils'
 import { getSubduedPaddingControlTestID } from '../canvas/controls/select-mode/subdued-padding-control'
 import { mouseClickAtPoint } from '../canvas/event-helpers.test-utils'

--- a/editor/src/components/inspector/three-bar-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/three-bar-control.spec.browser2.tsx
@@ -1,9 +1,5 @@
 import * as EP from '../../core/shared/element-path'
-import {
-  expectSingleUndo2Saves,
-  selectComponentsForTest,
-  setFeatureForBrowserTests,
-} from '../../utils/utils.test-utils'
+import { expectSingleUndo2Saves, selectComponentsForTest } from '../../utils/utils.test-utils'
 import { mouseClickAtPoint } from '../canvas/event-helpers.test-utils'
 import type { EditorRenderResult } from '../canvas/ui-jsx.test-utils'
 import { renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -32,7 +32,10 @@ import type { ElementPath } from '../../core/shared/project-file-types'
 import { getUtopiaID } from '../../core/shared/uid-utils'
 import { NO_OP } from '../../core/shared/utils'
 import { cmdModifier } from '../../utils/modifiers'
-import { selectComponentsForTest, setFeatureForBrowserTests } from '../../utils/utils.test-utils'
+import {
+  selectComponentsForTest,
+  setFeatureForBrowserTestsUseInDescribeBlockOnly,
+} from '../../utils/utils.test-utils'
 import {
   MockClipboardHandlers,
   firePasteEvent,
@@ -1636,7 +1639,7 @@ describe('conditionals in the navigator', () => {
   })
 
   describe('js expressions with Code in navigator FS on', () => {
-    setFeatureForBrowserTests('Code in navigator', true)
+    setFeatureForBrowserTestsUseInDescribeBlockOnly('Code in navigator', true)
     it('shows the right label for branches with js expressions with Code navigator FS on', async () => {
       await renderTestEditorWithCode(
         makeTestProjectCodeWithSnippet(`

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -33,7 +33,7 @@ import { NavigatorItemTestId } from './navigator-item/navigator-item'
 import {
   expectNoAction,
   selectComponentsForTest,
-  setFeatureForBrowserTests,
+  setFeatureForBrowserTestsUseInDescribeBlockOnly,
   wait,
 } from '../../utils/utils.test-utils'
 import {
@@ -900,7 +900,7 @@ describe('Navigator', () => {
     })
 
     describe('Code in navigator FS on', () => {
-      setFeatureForBrowserTests('Code in navigator', true)
+      setFeatureForBrowserTestsUseInDescribeBlockOnly('Code in navigator', true)
       it('by clicking the center of the item which is an expression', async () => {
         const renderResult = await renderTestEditorWithCode(
           projectWithExpressionMultipleValues,
@@ -3747,7 +3747,7 @@ describe('Navigator row order', () => {
   })
 
   describe('Code in navigator FS on', () => {
-    setFeatureForBrowserTests('Code in navigator', true)
+    setFeatureForBrowserTestsUseInDescribeBlockOnly('Code in navigator', true)
     it('is correct for js expressions with multiple values with "code in navigator" FS on', async () => {
       const renderResult = await renderTestEditorWithCode(
         projectWithExpressionMultipleValues,
@@ -3849,8 +3849,11 @@ describe('Navigator labels', () => {
     )
     expect(navigatorItem.textContent).toEqual('2')
   })
-  it('Labels are correct for text coming from expressions with code item FS on', async () => {
-    setFeatureForBrowserTests('Code in navigator', true)
+})
+
+describe('Navigator labels with Code in navigator feature switch on', () => {
+  setFeatureForBrowserTestsUseInDescribeBlockOnly('Code in navigator', true)
+  it('Labels are correct for text coming from expressions', async () => {
     const renderResult = await renderTestEditorWithCode(
       projectWithTextFromExpression,
       'await-first-dom-report',

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -2,7 +2,7 @@ import * as EP from '../../core/shared/element-path'
 import {
   expectSingleUndo2Saves,
   expectSingleUndoNSaves,
-  setFeatureForBrowserTests,
+  setFeatureForBrowserTestsUseInDescribeBlockOnly,
   wait,
 } from '../../utils/utils.test-utils'
 import type { Modifiers } from '../../utils/modifiers'
@@ -915,7 +915,7 @@ describe('Use the text editor', () => {
     })
   })
   describe('inline expressions with code in navigator feature switch on', () => {
-    setFeatureForBrowserTests('Code in navigator', true)
+    setFeatureForBrowserTestsUseInDescribeBlockOnly('Code in navigator', true)
     const tests = [
       {
         label: 'handles expressions',

--- a/editor/src/core/shared/element-path-tree.spec.browser2.tsx
+++ b/editor/src/core/shared/element-path-tree.spec.browser2.tsx
@@ -3,7 +3,7 @@ import { setFocusedElement } from '../../components/editor/actions/action-creato
 import { printTree } from './element-path-tree'
 import * as EP from './element-path'
 import { MetadataUtils } from '../model/element-metadata-utils'
-import { setFeatureForBrowserTests } from '../../utils/utils.test-utils'
+import { setFeatureForBrowserTestsUseInDescribeBlockOnly } from '../../utils/utils.test-utils'
 
 const TestCode = `
 import * as React from 'react'
@@ -158,7 +158,7 @@ describe('getChildrenOrdered', () => {
   })
 
   describe('With Code in navigator FS on', () => {
-    setFeatureForBrowserTests('Code in navigator', true)
+    setFeatureForBrowserTestsUseInDescribeBlockOnly('Code in navigator', true)
     it('Returns expression child of conditional', async () => {
       const renderResult = await renderTestEditorWithCode(TestCode, 'await-first-dom-report')
 

--- a/editor/src/core/workers/parser-printer/parser-printer-conditionals.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-conditionals.spec.ts
@@ -9,6 +9,7 @@ import {
 } from './parser-printer-conditionals.test-utils'
 import { printCode, printCodeOptions } from './parser-printer'
 import type { JSXElementChild } from '../../shared/element-template'
+import { isJSXElement } from '../../shared/element-template'
 import { findJSXElementChildAtPath } from '../../model/element-template-utils'
 import { getComponentsFromTopLevelElements } from '../../model/project-file-utils'
 import { fromStringStatic } from '../../shared/element-path'

--- a/editor/src/core/workers/parser-printer/parser-printer-conditionals.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-conditionals.spec.ts
@@ -2,18 +2,14 @@
 import { applyPrettier } from 'utopia-vscode-common'
 import { testParseCode, elementsStructure } from './parser-printer.test-utils'
 import type { ParsedTextFile } from '../../shared/project-file-types'
-import { ParseSuccess, isParseSuccess } from '../../shared/project-file-types'
+import { isParseSuccess } from '../../shared/project-file-types'
 import {
   NestedTernariesExample,
   SimpleConditionalsExample,
 } from './parser-printer-conditionals.test-utils'
-import { setFeatureForUnitTests } from '../../../utils/utils.test-utils'
-import { FOR_TESTS_setNextGeneratedUids } from '../../../core/model/element-template-utils.test-utils'
 import { printCode, printCodeOptions } from './parser-printer'
 import type { JSXElementChild } from '../../shared/element-template'
-import { TopLevelElement, isJSXElement } from '../../shared/element-template'
 import { findJSXElementChildAtPath } from '../../model/element-template-utils'
-import { staticElementPath } from '../../shared/element-path'
 import { getComponentsFromTopLevelElements } from '../../model/project-file-utils'
 import { fromStringStatic } from '../../shared/element-path'
 

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -494,7 +494,10 @@ export async function hoverControlWithCheck(
   await check()
 }
 
-export function setFeatureForBrowserTests(featureName: FeatureName, newValue: boolean): void {
+export function setFeatureForBrowserTestsUseInDescribeBlockOnly(
+  featureName: FeatureName,
+  newValue: boolean,
+): void {
   let originalFSValue: boolean = false
   before(() => {
     originalFSValue = isFeatureEnabled(featureName)
@@ -506,7 +509,10 @@ export function setFeatureForBrowserTests(featureName: FeatureName, newValue: bo
   })
 }
 
-export function setFeatureForUnitTests(featureName: FeatureName, newValue: boolean): void {
+export function setFeatureForUnitTestsUseInDescribeBlockOnly(
+  featureName: FeatureName,
+  newValue: boolean,
+): void {
   let originalFSValue: boolean = false
   beforeEach(() => {
     originalFSValue = isFeatureEnabled(featureName)


### PR DESCRIPTION
**Problem:**
`setFeatureForBrowserTests` and `setFeatureForUnitTests` can only be used inside `describe` blocks, but this is a hidden implementation detail

**Fix:**
Ranamed both functions to the ridiculously verbose `setFeatureForBrowserTestsUseInDescribeBlockOnly` and `setFeatureForUnitTestsUseInDescribeBlockOnly` respectively. I also checked the usages of both, and fixed them where I found them being used incorrectly.