### PR TITLE
Include worker update results in undo stack

### DIFF
--- a/editor/src/components/canvas/dom-walker-caching.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker-caching.spec.browser2.tsx
@@ -101,11 +101,11 @@ describe('Dom-walker Caching', () => {
     expect(renderResult.getRecordedActions().map((a) => a.action)).toEqual([
       'SET_ELEMENTS_TO_RERENDER',
       'SET_CANVAS_FRAMES',
-      'UPDATE_FROM_WORKER',
+      'MERGE_WITH_PREV_UNDO',
       'SAVE_DOM_REPORT',
       'SAVE_DOM_REPORT',
       'SET_CANVAS_FRAMES',
-      'UPDATE_FROM_WORKER',
+      'MERGE_WITH_PREV_UNDO',
       'SAVE_DOM_REPORT',
       'SAVE_DOM_REPORT',
     ])
@@ -194,11 +194,11 @@ describe('Dom-walker Caching', () => {
     expect(renderResult.getRecordedActions().map((a) => a.action)).toEqual([
       'SET_ELEMENTS_TO_RERENDER',
       'SET_CANVAS_FRAMES',
-      'UPDATE_FROM_WORKER',
+      'MERGE_WITH_PREV_UNDO',
       'SAVE_DOM_REPORT',
       'SAVE_DOM_REPORT',
       'SET_CANVAS_FRAMES',
-      'UPDATE_FROM_WORKER',
+      'MERGE_WITH_PREV_UNDO',
       'SAVE_DOM_REPORT',
       'SAVE_DOM_REPORT',
     ])

--- a/editor/src/components/canvas/dom-walker-caching.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker-caching.spec.browser2.tsx
@@ -9,6 +9,7 @@ import { pinFrameChange } from './canvas-types'
 import { renderTestEditorWithProjectContent } from './ui-jsx.test-utils'
 import { act } from '@testing-library/react'
 import { wait } from '../../utils/utils.test-utils'
+import { simpleStringifyActions } from '../editor/actions/action-utils'
 
 describe('Dom-walker Caching', () => {
   async function prepareTestProject() {
@@ -98,17 +99,21 @@ describe('Dom-walker Caching', () => {
       await dispatchDone
     })
 
-    expect(renderResult.getRecordedActions().map((a) => a.action)).toEqual([
-      'SET_ELEMENTS_TO_RERENDER',
-      'SET_CANVAS_FRAMES',
-      'MERGE_WITH_PREV_UNDO',
-      'SAVE_DOM_REPORT',
-      'SAVE_DOM_REPORT',
-      'SET_CANVAS_FRAMES',
-      'MERGE_WITH_PREV_UNDO',
-      'SAVE_DOM_REPORT',
-      'SAVE_DOM_REPORT',
-    ])
+    expect(simpleStringifyActions(renderResult.getRecordedActions())).toEqual(`[
+  SET_ELEMENTS_TO_RERENDER,
+  SET_CANVAS_FRAMES,
+  MERGE_WITH_PREV_UNDO: [
+    UPDATE_FROM_WORKER
+  ],
+  SAVE_DOM_REPORT,
+  SAVE_DOM_REPORT,
+  SET_CANVAS_FRAMES,
+  MERGE_WITH_PREV_UNDO: [
+    UPDATE_FROM_WORKER
+  ],
+  SAVE_DOM_REPORT,
+  SAVE_DOM_REPORT
+]`)
 
     const saveDomReportActions = renderResult
       .getRecordedActions()
@@ -191,17 +196,21 @@ describe('Dom-walker Caching', () => {
       .getRecordedActions()
       .filter((action): action is SaveDOMReport => action.action === 'SAVE_DOM_REPORT')
 
-    expect(renderResult.getRecordedActions().map((a) => a.action)).toEqual([
-      'SET_ELEMENTS_TO_RERENDER',
-      'SET_CANVAS_FRAMES',
-      'MERGE_WITH_PREV_UNDO',
-      'SAVE_DOM_REPORT',
-      'SAVE_DOM_REPORT',
-      'SET_CANVAS_FRAMES',
-      'MERGE_WITH_PREV_UNDO',
-      'SAVE_DOM_REPORT',
-      'SAVE_DOM_REPORT',
-    ])
+    expect(simpleStringifyActions(renderResult.getRecordedActions())).toEqual(`[
+  SET_ELEMENTS_TO_RERENDER,
+  SET_CANVAS_FRAMES,
+  MERGE_WITH_PREV_UNDO: [
+    UPDATE_FROM_WORKER
+  ],
+  SAVE_DOM_REPORT,
+  SAVE_DOM_REPORT,
+  SET_CANVAS_FRAMES,
+  MERGE_WITH_PREV_UNDO: [
+    UPDATE_FROM_WORKER
+  ],
+  SAVE_DOM_REPORT,
+  SAVE_DOM_REPORT
+]`)
 
     expect(saveDomReportActions.length).toBe(4)
 

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -36,8 +36,6 @@ try {
 import type { RenderResult } from '@testing-library/react'
 import { act, render } from '@testing-library/react'
 import * as Prettier from 'prettier/standalone'
-import create, { GetState, Mutate, SetState, StoreApi } from 'zustand'
-import { subscribeWithSelector } from 'zustand/middleware'
 import type {
   ElementPath,
   ParsedTextFile,
@@ -73,11 +71,7 @@ import type {
 import { notLoggedIn } from '../editor/action-types'
 import { load } from '../editor/actions/actions'
 import * as History from '../editor/history'
-import {
-  editorDispatch,
-  resetDispatchGlobals,
-  simpleStringifyActions,
-} from '../editor/store/dispatch'
+import { editorDispatch, resetDispatchGlobals } from '../editor/store/dispatch'
 import type {
   EditorState,
   EditorStoreFull,
@@ -105,7 +99,7 @@ import {
   treeToContents,
 } from '../assets'
 import { testStaticElementPath } from '../../core/shared/element-path.test-utils'
-import { createFakeMetadataForParseSuccess, wait } from '../../utils/utils.test-utils'
+import { createFakeMetadataForParseSuccess } from '../../utils/utils.test-utils'
 import {
   mergeWithPrevUndo,
   saveDOMReport,
@@ -132,16 +126,13 @@ import {
 import { flushSync } from 'react-dom'
 import { shouldInspectorUpdate } from '../inspector/inspector'
 import { SampleNodeModules } from '../custom-code/code-file.test-utils'
-import { CanvasStrategy } from './canvas-strategies/canvas-strategy-types'
 import type { MetaCanvasStrategy } from './canvas-strategies/canvas-strategies'
 import { RegisteredCanvasStrategies } from './canvas-strategies/canvas-strategies'
 import type { UtopiaStoreAPI } from '../editor/store/store-hook'
 import { createStoresAndState } from '../editor/store/store-hook'
-import { checkAnyWorkerUpdates, isTransientAction } from '../editor/actions/action-utils'
+import { checkAnyWorkerUpdates, simpleStringifyActions } from '../editor/actions/action-utils'
 import { modify } from '../../core/shared/optics/optic-utilities'
-import { Optic } from '../../core/shared/optics/optics'
 import { fromField } from '../../core/shared/optics/optic-creators'
-import { memoEqualityCheckAnalysis } from '../../utils/react-performance'
 import type { DuplicateUIDsResult } from '../../core/model/get-unique-ids'
 import { getAllUniqueUids } from '../../core/model/get-unique-ids'
 

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -137,7 +137,7 @@ import type { MetaCanvasStrategy } from './canvas-strategies/canvas-strategies'
 import { RegisteredCanvasStrategies } from './canvas-strategies/canvas-strategies'
 import type { UtopiaStoreAPI } from '../editor/store/store-hook'
 import { createStoresAndState } from '../editor/store/store-hook'
-import { isTransientAction } from '../editor/actions/action-utils'
+import { checkAnyWorkerUpdates, isTransientAction } from '../editor/actions/action-utils'
 import { modify } from '../../core/shared/optics/optic-utilities'
 import { Optic } from '../../core/shared/optics/optics'
 import { fromField } from '../../core/shared/optics/optic-creators'
@@ -305,7 +305,7 @@ export async function renderTestEditorWithModel(
       })
     }
 
-    const anyWorkerUpdates = actions.some((action) => action.action === 'UPDATE_FROM_WORKER')
+    const anyWorkerUpdates = checkAnyWorkerUpdates(actions)
     const anyUndoOrRedoOrPostAction = actions.some(
       (action) =>
         action.action === 'UNDO' ||

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -129,9 +129,9 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'REMOVE_FILE_CONFLICT':
     case 'CLEAR_POST_ACTION_SESSION':
     case 'START_POST_ACTION_SESSION':
-    case 'TRUE_UP_GROUPS':
       return true
 
+    case 'TRUE_UP_GROUPS':
     case 'EXECUTE_POST_ACTION_MENU_CHOICE':
     case 'NEW':
     case 'LOAD':

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -315,3 +315,30 @@ export function onlyActionIsWorkerParsedUpdate(actions: ReadonlyArray<EditorActi
     )
   }
 }
+
+function simpleStringifyAction(action: EditorAction, indentation: number): string {
+  switch (action.action) {
+    case 'TRANSIENT_ACTIONS':
+      return `TRANSIENT_ACTIONS: ${simpleStringifyActions(
+        action.transientActions,
+        indentation + 1,
+      )}`
+    case 'ATOMIC':
+      return `ATOMIC: ${simpleStringifyActions(action.actions, indentation + 1)}`
+    case 'MERGE_WITH_PREV_UNDO':
+      return `MERGE_WITH_PREV_UNDO: ${simpleStringifyActions(action.actions, indentation + 1)}`
+    default:
+      return action.action
+  }
+}
+
+export function simpleStringifyActions(
+  actions: ReadonlyArray<EditorAction>,
+  indentation: number = 1,
+): string {
+  const spacing = '  '.repeat(indentation)
+  const spacingBeforeClose = '  '.repeat(indentation - 1)
+  return `[\n${spacing}${actions
+    .map((a) => simpleStringifyAction(a, indentation))
+    .join(`,\n${spacing}`)}\n${spacingBeforeClose}]`
+}

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -23,7 +23,13 @@ import type { LocalNavigatorAction } from '../../navigator/actions'
 import { PreviewIframeId, projectContentsUpdateMessage } from '../../preview/preview-pane'
 import type { EditorAction, EditorDispatch } from '../action-types'
 import { isLoggedIn, LoginState } from '../action-types'
-import { isTransientAction, isUndoOrRedo, isFromVSCode } from '../actions/action-utils'
+import {
+  isTransientAction,
+  isUndoOrRedo,
+  isFromVSCode,
+  checkAnyWorkerUpdates,
+  onlyActionIsWorkerParsedUpdate,
+} from '../actions/action-utils'
 import * as EditorActions from '../actions/action-creators'
 import * as History from '../history'
 import type { StateHistory } from '../history'
@@ -328,7 +334,7 @@ function maybeRequestModelUpdate(
           }
         })
 
-        dispatch([EditorActions.updateFromWorker(updates)])
+        dispatch([EditorActions.mergeWithPrevUndo([EditorActions.updateFromWorker(updates)])])
         return true
       })
       .catch((e) => {
@@ -408,9 +414,7 @@ export function editorDispatch(
   const anyFinishCheckpointTimer = dispatchedActions.some((action) => {
     return action.action === 'FINISH_CHECKPOINT_TIMER'
   })
-  const anyWorkerUpdates = dispatchedActions.some(
-    (action) => action.action === 'UPDATE_FROM_WORKER',
-  )
+  const anyWorkerUpdates = checkAnyWorkerUpdates(dispatchedActions)
   const anyUndoOrRedo = dispatchedActions.some(isUndoOrRedo)
   const anySendPreviewModel = dispatchedActions.some(isSendPreviewModel)
 
@@ -463,9 +467,6 @@ export function editorDispatch(
   // as it's likely that action on it's own didn't change anything, but the actions that paired with
   // START_CHECKPOINT_TIMER likely did.
   const transientOrNoChange = (allTransient || result.nothingChanged) && !anyFinishCheckpointTimer
-  const workerUpdatedModel = dispatchedActions.some(
-    (action) => action.action === 'UPDATE_FROM_WORKER',
-  )
 
   const unpatchedEditorState = result.unpatchedEditor
   const patchedEditorState = result.patchedEditor
@@ -476,31 +477,8 @@ export function editorDispatch(
 
   const frozenDerivedState = result.unpatchedDerived
 
-  // NOTE:
-  // We add the current editor state to undo history synchronously, although the parsed state can be out of date, and
-  // will be only fixed after the next UPDATE_FROM_WORKER action (which is transient and will not modify the
-  // undo history).
-  // This causes two known bugs:
-  // 1. the first undo step after load is unparsed, so if you undo till the beginning, the canvas is unmounted,
-  //    only mounted back after the worker is ready with the parsing (which causes a blink)
-  // 2. If you modify the code in the code editor, the undo history is going to contain out of date parse results,
-  //    so if you undo back until a code change, the canvas content will briefly contain the position from one
-  //    step earlier. How to reproduce?
-  //    1 - left is initially set to 50
-  //    2 - Change left to 100 via code - undo history now stores CODE_AHEAD version of the model, with the parsed
-  //        model still containing 50 until the workers return the new value (at which point the canvas updates)
-  //    3 - Drag the element on the canvas to update left to 200
-  //    4 - Undo the drag. Canvas renders with left: 50 briefly whilst the worker re-parses, then updates to left: 100
-  //
-  // All these issues are eventually fixed after the worker reparses the code, but they cause visual glitches.
-  //
-  // Potential solution:
-  //    Adding something with CODE_AHEAD or PARSED_AHEAD to the undo stack triggers its own worker request, that then
-  //    only updates that undo stack entry (i.e. that doesn't feed into the rest of the editor at all)
-  //    This worker could get an undo stack item id and only update that item in the undo history after it is ready
-
   const editorWithModelChecked =
-    !anyUndoOrRedo && transientOrNoChange && !workerUpdatedModel
+    !anyUndoOrRedo && transientOrNoChange && !anyWorkerUpdates
       ? { editorState: unpatchedEditorState, modelUpdateFinished: Promise.resolve(true) }
       : maybeRequestModelUpdateOnEditor(unpatchedEditorState, storedState.workers, boundDispatch)
 
@@ -527,15 +505,15 @@ export function editorDispatch(
   }
 
   let newHistory: StateHistory
-  if (transientOrNoChange || !shouldSave) {
-    newHistory = result.history
-  } else if (allMergeWithPrevUndo) {
+  if (allMergeWithPrevUndo) {
     newHistory = History.replaceLast(
       result.history,
       editorFilteredForFiles,
       frozenDerivedState,
       assetRenames,
     )
+  } else if (transientOrNoChange || !shouldSave) {
+    newHistory = result.history
   } else {
     newHistory = History.add(
       result.history,
@@ -596,10 +574,7 @@ export function editorDispatch(
 
   // If the action was a load action then we don't want to send across any changes
   if (!isLoadAction) {
-    const parsedAfterCodeChanged =
-      dispatchedActions.length === 1 &&
-      dispatchedActions[0].action === 'UPDATE_FROM_WORKER' &&
-      dispatchedActions[0].updates.some((update) => update.type === 'WORKER_PARSED_UPDATE')
+    const parsedAfterCodeChanged = onlyActionIsWorkerParsedUpdate(dispatchedActions)
 
     // We don't want to send selection changes coming from updates triggered by changes made in the code editor
     const updatedFromVSCodeOrParsedAfterCodeChange = updatedFromVSCode || parsedAfterCodeChanged

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -1,8 +1,4 @@
-import {
-  IS_TEST_ENVIRONMENT,
-  PERFORMANCE_MARKS_ALLOWED,
-  PRODUCTION_ENV,
-} from '../../../common/env-vars'
+import { PERFORMANCE_MARKS_ALLOWED, PRODUCTION_ENV } from '../../../common/env-vars'
 import { isParseSuccess, isTextFile } from '../../../core/shared/project-file-types'
 import {
   codeNeedsParsing,
@@ -18,17 +14,17 @@ import { runLocalCanvasAction } from '../../../templates/editor-canvas'
 import { runLocalNavigatorAction } from '../../../templates/editor-navigator'
 import { optionalDeepFreeze } from '../../../utils/deep-freeze'
 import type { CanvasAction } from '../../canvas/canvas-types'
-import { EdgePositionBottom } from '../../canvas/canvas-types'
 import type { LocalNavigatorAction } from '../../navigator/actions'
 import { PreviewIframeId, projectContentsUpdateMessage } from '../../preview/preview-pane'
 import type { EditorAction, EditorDispatch } from '../action-types'
-import { isLoggedIn, LoginState } from '../action-types'
+import { isLoggedIn } from '../action-types'
 import {
   isTransientAction,
   isUndoOrRedo,
   isFromVSCode,
   checkAnyWorkerUpdates,
   onlyActionIsWorkerParsedUpdate,
+  simpleStringifyActions,
 } from '../actions/action-utils'
 import * as EditorActions from '../actions/action-creators'
 import * as History from '../history'
@@ -44,7 +40,6 @@ import {
   deriveState,
   persistentModelFromEditorModel,
   reconstructJSXMetadata,
-  StoredEditorState,
   storedEditorStateFromEditorState,
 } from './editor-state'
 import {
@@ -56,7 +51,7 @@ import {
 import { fastForEach, isBrowserEnvironment } from '../../../core/shared/utils'
 import type { UiJsxCanvasContextData } from '../../canvas/ui-jsx-canvas'
 import type { ProjectContentTreeRoot } from '../../assets'
-import { treeToContents, walkContentsTree, walkContentsTreeForParseSuccess } from '../../assets'
+import { treeToContents, walkContentsTree } from '../../assets'
 import { isSendPreviewModel, restoreDerivedState, UPDATE_FNS } from '../actions/actions'
 import { getTransitiveReverseDependencies } from '../../../core/shared/project-contents-dependencies'
 import {
@@ -89,23 +84,6 @@ type DispatchResultFields = {
 
 export type InnerDispatchResult = EditorStoreFull & DispatchResultFields // TODO delete me
 export type DispatchResult = EditorStoreFull & DispatchResultFields
-
-function simpleStringifyAction(action: EditorAction): string {
-  switch (action.action) {
-    case 'TRANSIENT_ACTIONS':
-      return `Transient: ${simpleStringifyActions(action.transientActions)}`
-    case 'ATOMIC':
-      return `Atomic: ${simpleStringifyActions(action.actions)}`
-    case 'MERGE_WITH_PREV_UNDO':
-      return `Merge with prev undo: ${simpleStringifyActions(action.actions)}`
-    default:
-      return action.action
-  }
-}
-
-export function simpleStringifyActions(actions: ReadonlyArray<EditorAction>): string {
-  return `[\n\t${actions.map(simpleStringifyAction).join(',\n')}\n]`
-}
 
 function processAction(
   dispatchEvent: EditorDispatch,

--- a/editor/src/components/editor/store/editor-dispatch-performance-logging.tsx
+++ b/editor/src/components/editor/store/editor-dispatch-performance-logging.tsx
@@ -1,7 +1,7 @@
 import { PERFORMANCE_MARKS_ALLOWED } from '../../../common/env-vars'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import type { EditorAction } from '../action-types'
-import { simpleStringifyActions } from './dispatch'
+import { simpleStringifyActions } from '../actions/action-utils'
 
 export function createPerformanceMeasure() {
   const MeasureSelectorsEnabled = isFeatureEnabled('Debug – Measure Selectors')

--- a/editor/src/core/shared/array-utils.ts
+++ b/editor/src/core/shared/array-utils.ts
@@ -327,7 +327,7 @@ export function immutablyUpdateArrayIndex<T>(
   return working
 }
 
-export function safeIndex<T>(array: Array<T>, index: number): T | undefined {
+export function safeIndex<T>(array: Array<T> | ReadonlyArray<T>, index: number): T | undefined {
   if (index in array) {
     return array[index]
   } else {

--- a/editor/src/core/shared/array-utils.ts
+++ b/editor/src/core/shared/array-utils.ts
@@ -327,7 +327,7 @@ export function immutablyUpdateArrayIndex<T>(
   return working
 }
 
-export function safeIndex<T>(array: Array<T> | ReadonlyArray<T>, index: number): T | undefined {
+export function safeIndex<T>(array: ReadonlyArray<T>, index: number): T | undefined {
   if (index in array) {
     return array[index]
   } else {

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -4,7 +4,6 @@ import '../utils/feature-switches'
 import React from 'react'
 import * as ReactDOM from 'react-dom'
 import { hot } from 'react-hot-loader/root'
-import { unstable_trace as trace } from 'scheduler/tracing'
 import { useAtomsDevtools } from 'jotai-devtools'
 import '../utils/vite-hmr-config'
 import {
@@ -37,11 +36,7 @@ import {
   isRequestFailure,
   startPollingLoginState,
 } from '../components/editor/server'
-import {
-  DispatchResult,
-  editorDispatch,
-  simpleStringifyActions,
-} from '../components/editor/store/dispatch'
+import { editorDispatch } from '../components/editor/store/dispatch'
 import type {
   EditorStoreFull,
   PersistentModel,
@@ -50,14 +45,9 @@ import type {
 import {
   createEditorState,
   deriveState,
-  getMainUIFromModel,
   defaultUserState,
-  EditorState,
-  DerivedState,
-  UserState,
   createNewProjectName,
   persistentModelForProjectContents,
-  EditorStorePatched,
   patchedStoreFromFullStore,
   getCurrentTheme,
 } from '../components/editor/store/editor-state'
@@ -68,9 +58,7 @@ import {
   EditorStateContext,
   LowPriorityStateContext,
   OriginalMainEditorStateContext,
-  UtopiaStores,
 } from '../components/editor/store/store-hook'
-import { RealBundlerWorker } from '../core/workers/bundler-bridge'
 import type { LinterResultMessage } from '../core/workers/linter/linter-worker'
 import {
   RealLinterWorker,
@@ -87,18 +75,16 @@ import {
   UiJsxCanvasCtxAtom,
   ElementsToRerenderGLOBAL,
 } from '../components/canvas/ui-jsx-canvas'
-import { foldEither, isLeft } from '../core/shared/either'
+import { foldEither } from '../core/shared/either'
 import {
   getURLImportDetails,
   importZippedGitProject,
   isProjectImportSuccess,
   reuploadAssets,
 } from '../core/model/project-import'
-import { OutgoingWorkerMessage, UtopiaTsWorkers } from '../core/workers/common/worker-types'
 import { isSendPreviewModel, load } from '../components/editor/actions/actions'
 import { UtopiaStyles } from '../uuiui'
 import { reduxDevtoolsSendInitialState } from '../core/shared/redux-devtools'
-import { notice } from '../components/common/notice'
 import type { LoginState } from '../common/user'
 import { isCookiesOrLocalForageUnavailable } from '../common/user'
 import { PersistenceMachine } from '../components/editor/persistence/persistence'
@@ -110,15 +96,12 @@ import type { DomWalkerMutableStateData } from '../components/canvas/dom-walker'
 import {
   DomWalkerMutableStateCtx,
   createDomWalkerMutableState,
-  initDomWalkerObservers,
   invalidateDomWalkerIfNecessary,
-  runDomWalker,
 } from '../components/canvas/dom-walker'
 import { isFeatureEnabled } from '../utils/feature-switches'
 import { shouldInspectorUpdate as shouldUpdateLowPriorityUI } from '../components/inspector/inspector'
 import * as EP from '../core/shared/element-path'
 import { isAuthenticatedWithGithub } from '../utils/github-auth'
-import { ProjectContentTreeRootKeepDeepEquality } from '../components/editor/store/store-deep-equality-instances'
 import { waitUntil } from '../core/shared/promise-utils'
 import { sendSetVSCodeTheme } from '../core/vscode/vscode-bridge'
 import type { ElementPath } from '../core/shared/project-file-types'
@@ -134,6 +117,7 @@ import {
 } from '../components/editor/store/store-hook-performance-logging'
 import { createPerformanceMeasure } from '../components/editor/store/editor-dispatch-performance-logging'
 import { runDomWalkerAndSaveResults } from '../components/canvas/editor-dispatch-flow'
+import { simpleStringifyActions } from '../components/editor/actions/action-utils'
 
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()


### PR DESCRIPTION
**Problem:**
Worker updates are treated as transient, and therefore are never included in the undo history, which can in turn result in the code editor falling out of sync with the canvas when undoing under certain conditions

**Fix:**
Since we want the worker updates to remain transient _but_ be included in the undo history, we now wrap them in a `mergeWithPrevUndo`. 

This in turn highlighted that we were incorrectly treating all `MERGE_WITH_PREV_UNDO` actions as non-transient, whereas we should be determining that based on their wrapped actions, so I have fixed that as part of this, and corrected the order of `if` `else` block used when pushing to the undo stack.

Some grouping tests were broken by this change, because the tests were expecting the `TRUE_UP_GROUP` to be treated as non-transient, even though the action itself was marked as transient. I've fixed this (by marking the action as non-transient), though it sounds like in an upcoming PR that will become irrelevant anyway.