### PR TITLE
Add groups to Wrap In… menu, but not for insertion

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
@@ -12,6 +12,7 @@ import {
   jsExpressionValue,
   jsxAttributesFromMap,
   jsxElement,
+  jsxElementFromJSXElementWithoutUID,
   jsxElementName,
   jsxFragment,
 } from '../../../../core/shared/element-template'
@@ -21,8 +22,6 @@ import {
   isFiniteRectangle,
   isInfinityRectangle,
   zeroCanvasRect,
-  boundingRectangleArray,
-  nullIfInfinity,
 } from '../../../../core/shared/math-utils'
 import { optionalMap } from '../../../../core/shared/optional-utils'
 import type { ElementPath, Imports } from '../../../../core/shared/project-file-types'
@@ -50,14 +49,12 @@ import { addElement } from '../../commands/add-element-command'
 import { childInsertionPath } from '../../../editor/store/insertion-path'
 import type { ElementPathTrees } from '../../../../core/shared/element-path-tree'
 import { queueGroupTrueUp } from '../../commands/queue-group-true-up-command'
-import { pushIntendedBoundsAndUpdateGroups } from '../../commands/push-intended-bounds-and-update-groups-command'
-import { CanvasFrameAndTarget, EdgePositionBottomRight } from '../../canvas-types'
-import { createResizeCommandsFromFrame } from './resize-strategy-helpers'
 import type { AddToast, WrapInElement } from '../../../editor/action-types'
 import { showToast, wrapInElement } from '../../../editor/actions/action-creators'
 import type { ProjectContentTreeRoot } from '../../../assets'
 import { generateUidWithExistingComponents } from '../../../../core/model/element-template-utils'
 import { notice } from '../../../common/notice'
+import { groupJSXElement, groupJSXElementImportsToAdd } from './group-helpers'
 
 const GroupImport: Imports = {
   'utopia-api': {
@@ -624,24 +621,10 @@ export function createWrapInGroupAction(
     )
   }
   return wrapInElement(selectedViews, {
-    element: jsxElement(
-      'Group',
+    element: jsxElementFromJSXElementWithoutUID(
+      groupJSXElement([]),
       generateUidWithExistingComponents(projectContents),
-      jsxAttributesFromMap({
-        style: jsExpressionValue(
-          // we need to add position: absolute and top, left so that the TRUE_UP_GROUPS action can correct these values later
-          { position: 'absolute', left: 0, top: 0 },
-          emptyComments,
-        ),
-      }),
-      [],
     ),
-    importsToAdd: {
-      'utopia-api': {
-        importedAs: null,
-        importedFromWithin: [importAlias('Group')],
-        importedWithName: null,
-      },
-    },
+    importsToAdd: groupJSXElementImportsToAdd(),
   })
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/group-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-helpers.ts
@@ -7,8 +7,17 @@ import type {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
   JSXElement,
+  JSXElementChildren,
+  JSXElementWithoutUID,
 } from '../../../../core/shared/element-template'
-import type { ElementPath } from '../../../../core/shared/project-file-types'
+import {
+  jsxAttributesFromMap,
+  jsxElementWithoutUID,
+  emptyComments,
+  jsExpressionValue,
+} from '../../../../core/shared/element-template'
+import type { ElementPath, Imports } from '../../../../core/shared/project-file-types'
+import { importAlias } from '../../../../core/shared/project-file-types'
 import { assertNever } from '../../../../core/shared/utils'
 import { styleStringInArray } from '../../../../utils/common-constants'
 import { isCSSNumber } from '../../../inspector/common/css-utils'
@@ -154,4 +163,28 @@ export function getGroupChildStateWithGroupMetadata(
   }
 
   return getGroupChildState(elementMetadata, checkGroupHasExplicitSize(groupElement))
+}
+
+export function groupJSXElement(children: JSXElementChildren): JSXElementWithoutUID {
+  return jsxElementWithoutUID(
+    'Group',
+    jsxAttributesFromMap({
+      style: jsExpressionValue(
+        // we need to add position: absolute and top, left so that the TRUE_UP_GROUPS action can correct these values later
+        { position: 'absolute', left: 0, top: 0 },
+        emptyComments,
+      ),
+    }),
+    children,
+  )
+}
+
+export function groupJSXElementImportsToAdd(): Imports {
+  return {
+    'utopia-api': {
+      importedAs: null,
+      importedFromWithin: [importAlias('Group')],
+      importedWithName: null,
+    },
+  }
 }

--- a/editor/src/components/canvas/controls/render-as.tsx
+++ b/editor/src/components/canvas/controls/render-as.tsx
@@ -1,9 +1,6 @@
 import React from 'react'
 import { Substores, useEditorState, useRefEditorState } from '../../editor/store/store-hook'
-import { usePropControlledRef_DANGEROUS } from '../../inspector/common/inspector-utils'
 import type { SelectOption } from '../../../uuiui-deps'
-import { getControlStyles, Utils } from '../../../uuiui-deps'
-import * as EP from '../../../core/shared/element-path'
 import * as EditorActions from '../../editor/actions/action-creators'
 import { UIGridRow } from '../../inspector/widgets/ui-grid-row'
 import { PopupList } from '../../../uuiui'
@@ -90,6 +87,7 @@ export const RenderAsRow = React.memo(() => {
       return []
     } else {
       return getComponentGroupsAsSelectOptions(
+        'insert',
         packageStatus,
         propertyControlsInfo,
         projectContents,

--- a/editor/src/components/canvas/ui/floating-insert-menu-helpers.ts
+++ b/editor/src/components/canvas/ui/floating-insert-menu-helpers.ts
@@ -1,0 +1,15 @@
+export type InsertMenuMode = 'closed' | 'insert' | 'convert' | 'wrap'
+
+export const insertMenuModes: {
+  all: InsertMenuMode[]
+  onlyClosed: InsertMenuMode[]
+  onlyInsert: InsertMenuMode[]
+  onlyConvert: InsertMenuMode[]
+  onlyWrap: InsertMenuMode[]
+} = {
+  all: ['closed', 'insert', 'convert', 'wrap'],
+  onlyClosed: ['closed'],
+  onlyInsert: ['insert'],
+  onlyConvert: ['convert'],
+  onlyWrap: ['wrap'],
+}

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { jsx } from '@emotion/react'
 import type { CSSObject } from '@emotion/serialize'
 import type { InputActionMeta, OptionProps, StylesConfig } from 'react-windowed-select'
-import WindowedSelect, { ValueType } from 'react-windowed-select'
+import WindowedSelect from 'react-windowed-select'
 
 import { getControlStyles } from '../../../uuiui-deps'
 import { Substores, useEditorState, useRefEditorState } from '../../editor/store/store-hook'
@@ -34,10 +34,7 @@ import {
   updateJSXElementName,
   wrapInElement,
 } from '../../editor/actions/action-creators'
-import {
-  elementOnlyHasSingleTextChild,
-  generateUidWithExistingComponents,
-} from '../../../core/model/element-template-utils'
+import { generateUidWithExistingComponents } from '../../../core/model/element-template-utils'
 import type {
   JSXConditionalExpressionWithoutUID,
   JSXFragmentWithoutUID,
@@ -57,7 +54,6 @@ import type { EditorAction } from '../../editor/action-types'
 import { InspectorInputEmotionStyle } from '../../../uuiui/inputs/base-input'
 import type { ElementPath, Imports } from '../../../core/shared/project-file-types'
 import { safeIndex } from '../../../core/shared/array-utils'
-import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { optionalMap } from '../../../core/shared/optional-utils'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { assertNever } from '../../../core/shared/utils'
@@ -111,7 +107,7 @@ function convertInsertableComponentsToFlatList(
   })
 }
 
-function useGetInsertableComponents(): InsertableComponentFlatList {
+function useGetInsertableComponents(insertMenuMode: InsertMenuMode): InsertableComponentFlatList {
   const dependencies = usePossiblyResolvedPackageDependencies()
 
   const { packageStatus, propertyControlsInfo } = useEditorState(
@@ -143,6 +139,7 @@ function useGetInsertableComponents(): InsertableComponentFlatList {
     } else {
       return convertInsertableComponentsToFlatList(
         getNonEmptyComponentGroups(
+          insertMenuMode,
           packageStatus,
           propertyControlsInfo,
           projectContents,
@@ -151,7 +148,7 @@ function useGetInsertableComponents(): InsertableComponentFlatList {
         ),
       )
     }
-  }, [packageStatus, propertyControlsInfo, projectContents, dependencies, fullPath])
+  }, [packageStatus, propertyControlsInfo, projectContents, dependencies, fullPath, insertMenuMode])
 
   return insertableComponents
 }
@@ -391,7 +388,23 @@ const CheckboxRow = React.memo<React.PropsWithChildren<CheckboxRowProps>>(
   },
 )
 
-function getMenuTitle(insertMenuMode: 'closed' | 'insert' | 'convert' | 'wrap'): string {
+export type InsertMenuMode = 'closed' | 'insert' | 'convert' | 'wrap'
+
+export const insertMenuModes: {
+  all: InsertMenuMode[]
+  onlyClosed: InsertMenuMode[]
+  onlyInsert: InsertMenuMode[]
+  onlyConvert: InsertMenuMode[]
+  onlyWrap: InsertMenuMode[]
+} = {
+  all: ['closed', 'insert', 'convert', 'wrap'],
+  onlyClosed: ['closed'],
+  onlyInsert: ['insert'],
+  onlyConvert: ['convert'],
+  onlyWrap: ['wrap'],
+}
+
+function getMenuTitle(insertMenuMode: InsertMenuMode): string {
   switch (insertMenuMode) {
     case 'closed':
       return ''
@@ -452,7 +465,7 @@ export var FloatingMenu = React.memo(() => {
     'FloatingMenu elementPathTree',
   )
 
-  const insertableComponents = useGetInsertableComponents()
+  const insertableComponents = useGetInsertableComponents(floatingMenuState.insertMenuMode)
 
   const [addContentForInsertion, setAddContentForInsertion] = React.useState(false)
   const [fixedSizeForInsertion, setFixedSizeForInsertion] = React.useState(false)

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -60,6 +60,7 @@ import { assertNever } from '../../../core/shared/utils'
 import { emptyImports } from '../../../core/workers/common/project-file-utils'
 import { emptyElementPath } from '../../../core/shared/element-path'
 import { getInsertionPathWithSlotBehavior } from '../../editor/store/insertion-path'
+import type { InsertMenuMode } from './floating-insert-menu-helpers'
 
 export const FloatingMenuTestId = 'floating-menu-test-id'
 
@@ -387,22 +388,6 @@ const CheckboxRow = React.memo<React.PropsWithChildren<CheckboxRowProps>>(
     )
   },
 )
-
-export type InsertMenuMode = 'closed' | 'insert' | 'convert' | 'wrap'
-
-export const insertMenuModes: {
-  all: InsertMenuMode[]
-  onlyClosed: InsertMenuMode[]
-  onlyInsert: InsertMenuMode[]
-  onlyConvert: InsertMenuMode[]
-  onlyWrap: InsertMenuMode[]
-} = {
-  all: ['closed', 'insert', 'convert', 'wrap'],
-  onlyClosed: ['closed'],
-  onlyInsert: ['insert'],
-  onlyConvert: ['convert'],
-  onlyWrap: ['wrap'],
-}
 
 function getMenuTitle(insertMenuMode: InsertMenuMode): string {
   switch (insertMenuMode) {

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -903,6 +903,7 @@ describe('INSERT_INSERTABLE', () => {
     const editorState = editorModelFromPersistentModel(project, NO_OP)
 
     const insertableGroups = getComponentGroups(
+      'insert',
       { antd: { status: 'loaded' } },
       { antd: DefaultThirdPartyControlDefinitions.antd },
       editorState.projectContents,
@@ -1009,6 +1010,7 @@ describe('INSERT_INSERTABLE', () => {
     const editorState = editorModelFromPersistentModel(project, NO_OP)
 
     const insertableGroups = getComponentGroups(
+      'insert',
       { antd: { status: 'loaded' } },
       { antd: DefaultThirdPartyControlDefinitions.antd },
       editorState.projectContents,
@@ -1116,6 +1118,7 @@ describe('INSERT_INSERTABLE', () => {
     const editorState = editorModelFromPersistentModel(project, NO_OP)
 
     const insertableGroups = getComponentGroups(
+      'insert',
       {},
       {},
       editorState.projectContents,
@@ -1210,6 +1213,7 @@ describe('INSERT_INSERTABLE', () => {
     const editorState = editorModelFromPersistentModel(project, NO_OP)
 
     const insertableGroups = getComponentGroups(
+      'insert',
       {},
       {},
       editorState.projectContents,

--- a/editor/src/components/editor/insertmenu.spec.browser2.tsx
+++ b/editor/src/components/editor/insertmenu.spec.browser2.tsx
@@ -82,6 +82,17 @@ describe('insert menu', () => {
         expect(getInsertItems().length).toEqual(allInsertItemsCount)
       })
     })
+    it('does not show insertables that cannot be inserted', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(`<div />`),
+        'await-first-dom-report',
+      )
+
+      await openInsertMenu(renderResult)
+
+      document.execCommand('insertText', false, 'group')
+      expect(getInsertItems().length).toEqual(allInsertItemsCount)
+    })
   })
 
   it('supports inserting via keyboard', async () => {

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -504,6 +504,7 @@ const InsertMenuInner = React.memo((props: InsertMenuProps) => {
     }
     return moveSceneToTheBeginningAndSetDefaultSize(
       getNonEmptyComponentGroups(
+        'insert',
         props.packageStatus,
         props.propertyControlsInfo,
         props.projectContents,

--- a/editor/src/components/shared/project-components.spec.ts
+++ b/editor/src/components/shared/project-components.spec.ts
@@ -25,6 +25,7 @@ describe('getComponentGroups', () => {
       antd: DefaultThirdPartyControlDefinitions.antd,
     }
     const actualResult = getComponentGroups(
+      'insert',
       packageStatus,
       propertyControlsInfo,
       simpleDefaultProjectPreParsed().projectContents,
@@ -51,6 +52,7 @@ describe('getComponentGroups', () => {
       },
     }
     const actualResult = getComponentGroups(
+      'insert',
       packageStatus,
       propertyControlsInfo,
       simpleDefaultProjectPreParsed().projectContents,

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -26,8 +26,7 @@ import type {
 import { isResolvedNpmDependency } from '../../core/shared/npm-dependency-types'
 import type { Imports, ProjectFile } from '../../core/shared/project-file-types'
 import { isTextFile } from '../../core/shared/project-file-types'
-import { fastForEach } from '../../core/shared/utils'
-import { addImport, emptyImports } from '../../core/workers/common/project-file-utils'
+import { assertNever, fastForEach } from '../../core/shared/utils'
 import type { SelectOption } from '../../uuiui-deps'
 import type { ProjectContentTreeRoot } from '../assets'
 import { walkContentsTree } from '../assets'
@@ -40,6 +39,12 @@ import type {
 import { clearComponentElementToInsertUniqueIDs } from '../custom-code/code-file'
 import { defaultViewElementStyle } from '../editor/defaults'
 import { getExportedComponentImports } from '../editor/export-utils'
+import {
+  groupJSXElement,
+  groupJSXElementImportsToAdd,
+} from '../canvas/canvas-strategies/strategies/group-helpers'
+import { insertMenuModes } from '../canvas/ui/floating-insert-menu'
+import type { InsertMenuMode } from '../canvas/ui/floating-insert-menu'
 
 export type StylePropOption = 'do-not-add' | 'add-size'
 
@@ -104,6 +109,16 @@ export function insertableComponentGroupConditionals(): InsertableComponentGroup
   }
 }
 
+export function insertableComponentGroupGroups(): InsertableComponentGroupGroups {
+  return {
+    type: 'GROUPS_GROUP',
+  }
+}
+
+export interface InsertableComponentGroupGroups {
+  type: 'GROUPS_GROUP'
+}
+
 export interface InsertableComponentGroupFragment {
   type: 'FRAGMENT_GROUP'
 }
@@ -152,6 +167,7 @@ export type InsertableComponentGroupType =
   | InsertableComponentGroupConditionals
   | InsertableComponentGroupFragment
   | InsertableComponentGroupSamples
+  | InsertableComponentGroupGroups
 
 export interface InsertableComponentGroup {
   source: InsertableComponentGroupType
@@ -193,9 +209,10 @@ export function getInsertableGroupLabel(insertableType: InsertableComponentGroup
       return 'Conditionals'
     case 'FRAGMENT_GROUP':
       return 'Fragment'
+    case 'GROUPS_GROUP':
+      return 'Group'
     default:
-      const _exhaustiveCheck: never = insertableType
-      throw new Error(`Unhandled insertable type ${JSON.stringify(insertableType)}`)
+      assertNever(insertableType)
   }
 }
 
@@ -208,12 +225,12 @@ export function getInsertableGroupPackageStatus(
     case 'PROJECT_COMPONENT_GROUP':
     case 'CONDITIONALS_GROUP':
     case 'FRAGMENT_GROUP':
+    case 'GROUPS_GROUP':
       return 'loaded'
     case 'PROJECT_DEPENDENCY_GROUP':
       return insertableType.dependencyStatus
     default:
-      const _exhaustiveCheck: never = insertableType
-      throw new Error(`Unhandled insertable type ${JSON.stringify(insertableType)}`)
+      assertNever(insertableType)
   }
 }
 
@@ -238,8 +255,6 @@ export function getDependencyStatus(
       return regularStatus
   }
 }
-
-const emptyImportsValue = emptyImports()
 
 const doNotAddStyleProp: Array<StylePropOption> = ['do-not-add']
 const addSizeAndNotStyleProp: Array<StylePropOption> = ['do-not-add', 'add-size']
@@ -364,6 +379,19 @@ const conditionalElementsDescriptors: ComponentDescriptorsForFile = {
   },
 }
 
+const groupElementsDescriptors: ComponentDescriptorsForFile = {
+  group: {
+    properties: {},
+    variants: [
+      {
+        insertMenuLabel: 'Group',
+        elementToInsert: groupJSXElement([]),
+        importsToAdd: groupJSXElementImportsToAdd(),
+      },
+    ],
+  },
+}
+
 const fragmentElementsDescriptors: ComponentDescriptorsForFile = {
   fragment: {
     properties: {},
@@ -407,6 +435,7 @@ export function stylePropOptionsForPropertyControls(
 }
 
 export function getNonEmptyComponentGroups(
+  insertMenuMode: InsertMenuMode,
   packageStatus: PackageStatusMap,
   propertyControlsInfo: PropertyControlsInfo,
   projectContents: ProjectContentTreeRoot,
@@ -414,6 +443,7 @@ export function getNonEmptyComponentGroups(
   originatingPath: string,
 ): Array<InsertableComponentGroup> {
   const groups = getComponentGroups(
+    insertMenuMode,
     packageStatus,
     propertyControlsInfo,
     projectContents,
@@ -468,6 +498,7 @@ export function moveSceneToTheBeginningAndSetDefaultSize(
 }
 
 export function getComponentGroups(
+  insertMenuMode: InsertMenuMode,
   packageStatus: PackageStatusMap,
   propertyControlsInfo: PropertyControlsInfo,
   projectContents: ProjectContentTreeRoot,
@@ -580,8 +611,11 @@ export function getComponentGroups(
   // Add fragment group.
   addDependencyDescriptor(null, insertableComponentGroupFragment(), fragmentElementsDescriptors)
 
-  // Add samples group
+  // Add samples group.
   addDependencyDescriptor(null, { type: 'SAMPLES_GROUP' }, samplesDescriptors)
+
+  // Add groups group.
+  addDependencyDescriptor(null, insertableComponentGroupGroups(), groupElementsDescriptors)
 
   // Add entries for dependencies of the project.
   for (const dependency of dependencies) {
@@ -605,10 +639,13 @@ export function getComponentGroups(
     }
   }
 
-  return result
+  return result.filter((group) =>
+    insertMenuModesForInsertableComponentGroupType(group.source).includes(insertMenuMode),
+  )
 }
 
 export function getComponentGroupsAsSelectOptions(
+  insertMenuMode: InsertMenuMode,
   packageStatus: PackageStatusMap,
   propertyControlsInfo: PropertyControlsInfo,
   projectContents: ProjectContentTreeRoot,
@@ -616,6 +653,7 @@ export function getComponentGroupsAsSelectOptions(
   originatingPath: string,
 ): Array<SelectOption> {
   const insertableGroups = getComponentGroups(
+    insertMenuMode,
     packageStatus,
     propertyControlsInfo,
     projectContents,
@@ -643,4 +681,22 @@ export function getComponentGroupsAsSelectOptions(
     }
   }
   return result
+}
+
+export function insertMenuModesForInsertableComponentGroupType(
+  groupType: InsertableComponentGroupType,
+): InsertMenuMode[] {
+  switch (groupType.type) {
+    case 'CONDITIONALS_GROUP':
+    case 'FRAGMENT_GROUP':
+    case 'HTML_GROUP':
+    case 'PROJECT_COMPONENT_GROUP':
+    case 'PROJECT_DEPENDENCY_GROUP':
+    case 'SAMPLES_GROUP':
+      return insertMenuModes.all
+    case 'GROUPS_GROUP':
+      return insertMenuModes.onlyWrap
+    default:
+      assertNever(groupType)
+  }
 }

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -43,8 +43,8 @@ import {
   groupJSXElement,
   groupJSXElementImportsToAdd,
 } from '../canvas/canvas-strategies/strategies/group-helpers'
-import { insertMenuModes } from '../canvas/ui/floating-insert-menu'
-import type { InsertMenuMode } from '../canvas/ui/floating-insert-menu'
+import type { InsertMenuMode } from '../canvas/ui/floating-insert-menu-helpers'
+import { insertMenuModes } from '../canvas/ui/floating-insert-menu-helpers'
 
 export type StylePropOption = 'do-not-add' | 'add-size'
 

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1412,6 +1412,16 @@ export function jsxElement(
   }
 }
 
+export function jsxElementFromJSXElementWithoutUID(
+  element: JSXElementWithoutUID,
+  uid: string,
+): JSXElement {
+  return {
+    ...element,
+    uid: uid,
+  }
+}
+
 export function jsxTestElement(
   name: JSXElementName | string,
   props: JSXAttributes,


### PR DESCRIPTION
Fixes #3962

**Problem:**

`Cmd+G` already wraps elements in a group, but the same is currently not present in the Wrap In floating menu.

**Fix:**

1. Add a new entry for Groups in the insertable components
2. Add a filter for insertable components that checks suitability with the current insert mode (`insert`, `wrap`, ...), with the new `GROUPS_GROUP` matching only the `wrap` mode.