### PR TITLE
history.replaceLast does not clear history.next

### DIFF
--- a/editor/src/components/editor/history.ts
+++ b/editor/src/components/editor/history.ts
@@ -159,7 +159,7 @@ export function replaceLast(
       derived: derived,
       assetRenames: stateHistory.current.assetRenames.concat(assetRenames),
     },
-    next: [],
+    next: stateHistory.next,
   }
   return newHistory
 }


### PR DESCRIPTION
**Problem:**
As a result of #3959 we are now updating the last history item far more often than before, which is good _but_ in doing so we were clearing `history.next`, which prevents any redo actions

**Fix:**
Don't clear `history.next` when calling `history.replaceLast`