### PR TITLE
design changes for special code navigator items

### DIFF
--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -1626,14 +1626,14 @@ describe('conditionals in the navigator', () => {
       {
         await renderResult.dispatch([setConditionalOverriddenCondition(target, false)], true)
         expect(await getLabelColor('false-case')).not.toEqual(defaultLabelColor)
-        expect(await getLabelColor('true-case')).toEqual(defaultLabelColor)
+        expect(await getLabelColor('true-case')).not.toEqual(await getLabelColor('false-case'))
       }
 
       // try the other way around
       {
         await renderResult.dispatch([setConditionalOverriddenCondition(target, true)], true)
         expect(await getLabelColor('true-case')).not.toEqual(defaultLabelColor)
-        expect(await getLabelColor('false-case')).toEqual(defaultLabelColor)
+        expect(await getLabelColor('false-case')).not.toEqual(await getLabelColor('true-case'))
       }
     })
   })

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -1616,25 +1616,22 @@ describe('conditionals in the navigator', () => {
 
       const target = EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:aaa/conditional')
       const defaultLabelColor = await getLabelColor('true-case')
-      const otherLabelColor = await getLabelColor('false-case')
 
-      // with no overrides, both labels are the same
+      // even without overrides, labels are never the same
       {
-        expect(await getLabelColor('false-case')).toEqual(otherLabelColor)
+        expect(await getLabelColor('false-case')).not.toEqual(await getLabelColor('true-case'))
       }
 
       // override a branch, its color changes
       {
         await renderResult.dispatch([setConditionalOverriddenCondition(target, false)], true)
         expect(await getLabelColor('false-case')).not.toEqual(defaultLabelColor)
-        expect(await getLabelColor('true-case')).toEqual(defaultLabelColor)
       }
 
       // try the other way around
       {
         await renderResult.dispatch([setConditionalOverriddenCondition(target, true)], true)
-        expect(await getLabelColor('true-case')).not.toEqual(otherLabelColor)
-        expect(await getLabelColor('false-case')).toEqual(otherLabelColor)
+        expect(await getLabelColor('true-case')).not.toEqual(defaultLabelColor)
       }
     })
   })

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -1626,12 +1626,14 @@ describe('conditionals in the navigator', () => {
       {
         await renderResult.dispatch([setConditionalOverriddenCondition(target, false)], true)
         expect(await getLabelColor('false-case')).not.toEqual(defaultLabelColor)
+        expect(await getLabelColor('true-case')).toEqual(defaultLabelColor)
       }
 
       // try the other way around
       {
         await renderResult.dispatch([setConditionalOverriddenCondition(target, true)], true)
         expect(await getLabelColor('true-case')).not.toEqual(defaultLabelColor)
+        expect(await getLabelColor('false-case')).toEqual(defaultLabelColor)
       }
     })
   })

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -1616,10 +1616,11 @@ describe('conditionals in the navigator', () => {
 
       const target = EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:aaa/conditional')
       const defaultLabelColor = await getLabelColor('true-case')
+      const otherLabelColor = await getLabelColor('false-case')
 
       // with no overrides, both labels are the same
       {
-        expect(await getLabelColor('false-case')).toEqual(defaultLabelColor)
+        expect(await getLabelColor('false-case')).toEqual(otherLabelColor)
       }
 
       // override a branch, its color changes
@@ -1632,8 +1633,8 @@ describe('conditionals in the navigator', () => {
       // try the other way around
       {
         await renderResult.dispatch([setConditionalOverriddenCondition(target, true)], true)
-        expect(await getLabelColor('true-case')).not.toEqual(defaultLabelColor)
-        expect(await getLabelColor('false-case')).toEqual(defaultLabelColor)
+        expect(await getLabelColor('true-case')).not.toEqual(otherLabelColor)
+        expect(await getLabelColor('false-case')).toEqual(otherLabelColor)
       }
     })
   })

--- a/editor/src/components/navigator/navigator-item/item-label.tsx
+++ b/editor/src/components/navigator/navigator-item/item-label.tsx
@@ -203,7 +203,7 @@ export const ItemLabel = React.memo((props: ItemLabelProps) => {
             backgroundColor: 'transparent',
             paddingTop: 3,
             paddingBottom: 3,
-            marginLeft: isConditionalClause ? 2 : 6,
+            marginLeft: isConditionalClause ? 4 : 0,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',

--- a/editor/src/components/navigator/navigator-item/item-label.tsx
+++ b/editor/src/components/navigator/navigator-item/item-label.tsx
@@ -175,7 +175,7 @@ export const ItemLabel = React.memo((props: ItemLabelProps) => {
             opacity: isActiveConditionalClause ? 1 : 0,
             color: isActiveBranchOfOverriddenConditional
               ? colorTheme.brandNeonPink.value
-              : colorTheme.fg7.value,
+              : colorTheme.dynamicBlue.value,
           }}
         >
           ✓
@@ -214,6 +214,8 @@ export const ItemLabel = React.memo((props: ItemLabelProps) => {
             fontWeight: isConditionalClause ? 600 : undefined,
             color: isActiveBranchOfOverriddenConditional
               ? colorTheme.brandNeonPink.value
+              : isConditionalClause && isActiveConditionalClause
+              ? colorTheme.dynamicBlue.value
               : isConditionalClause
               ? colorTheme.fg7.value
               : undefined,

--- a/editor/src/components/navigator/navigator-item/item-label.tsx
+++ b/editor/src/components/navigator/navigator-item/item-label.tsx
@@ -214,7 +214,7 @@ export const ItemLabel = React.memo((props: ItemLabelProps) => {
             fontWeight: isConditionalClause ? 600 : undefined,
             color: isActiveBranchOfOverriddenConditional
               ? colorTheme.brandNeonPink.value
-              : isConditionalClause && isActiveConditionalClause
+              : isActiveConditionalClause
               ? colorTheme.dynamicBlue.value
               : isConditionalClause
               ? colorTheme.fg7.value

--- a/editor/src/components/navigator/navigator-item/layout-icon.tsx
+++ b/editor/src/components/navigator/navigator-item/layout-icon.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import type { ElementWarnings, NavigatorEntry } from '../../../components/editor/store/editor-state'
 import type { IcnProps } from '../../../uuiui'
+import { colorTheme } from '../../../uuiui'
 import { Icn, Icons } from '../../../uuiui'
 import { WarningIcon } from '../../../uuiui/warning-icon'
 import { invalidGroupStateToString } from '../../canvas/canvas-strategies/strategies/group-helpers'
@@ -79,7 +80,7 @@ export const LayoutIcon: React.FunctionComponent<React.PropsWithChildren<LayoutI
         return (
           <div
             style={{
-              color: '#ff00ff',
+              color: colorTheme.brandNeonPink.value,
               fontSize: 11,
               fontWeight: 600,
               paddingTop: 3,

--- a/editor/src/components/navigator/navigator-item/layout-icon.tsx
+++ b/editor/src/components/navigator/navigator-item/layout-icon.tsx
@@ -102,7 +102,6 @@ export const LayoutIcon: React.FunctionComponent<React.PropsWithChildren<LayoutI
           alignItems: 'center',
           justifyItems: 'center',
           position: 'relative',
-          marginLeft: 8,
           transform: 'scale(.8)',
         }}
       >

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -765,38 +765,19 @@ export const NavigatorItem: React.FunctionComponent<
             style={{ transform: 'scale(0.6)', opacity: 'var(--paneHoverOpacity)' }}
             testId={`navigator-item-collapse-${navigatorEntryToKey(props.navigatorEntry)}`}
             iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
-            //iconColor={resultingStyle.iconColor}
           />
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'row',
-              alignItems: 'center',
-              justifyContent: 'flex-start',
-              gap: 10,
-              borderRadius: 20,
-              height: 22,
-              padding: '0 15px 0 10px',
-              backgroundColor:
-                isConditional && !selected ? colorTheme.dynamicBlue10.value : 'transparent',
-              color: isConditional ? colorTheme.dynamicBlue.value : undefined,
-              textTransform: isConditional ? 'uppercase' : undefined,
-            }}
-          >
-            <NavigatorRowLabel
-              shouldShowParentOutline={props.parentOutline === 'child'}
-              navigatorEntry={navigatorEntry}
-              label={props.label}
-              renamingTarget={props.renamingTarget}
-              selected={props.selected}
-              dispatch={props.dispatch}
-              isDynamic={isDynamic}
-              iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
-              //iconColor={resultingStyle.iconColor}
-              elementWarnings={!isConditional ? elementWarnings : null}
-              isSlot={isSlot}
-            />
-          </div>
+          <NavigatorRowLabel
+            shouldShowParentOutline={props.parentOutline === 'child'}
+            navigatorEntry={navigatorEntry}
+            label={props.label}
+            renamingTarget={props.renamingTarget}
+            selected={props.selected}
+            dispatch={props.dispatch}
+            isDynamic={isDynamic}
+            iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
+            elementWarnings={!isConditional ? elementWarnings : null}
+            isSlot={isSlot}
+          />
         </FlexRow>
         <NavigatorItemActionSheet
           navigatorEntry={navigatorEntry}
@@ -807,7 +788,6 @@ export const NavigatorItem: React.FunctionComponent<
           dispatch={dispatch}
           isSlot={isSlot}
           iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
-          //iconColor={resultingStyle.iconColor}
         />
       </FlexRow>
     </div>
@@ -849,60 +829,77 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
 
   return (
     <React.Fragment>
-      {when(
-        props.isSlot,
-        <div
-          key={`label-${props.label}-slot`}
-          style={{
-            width: '100%',
-            height: 19,
-            borderRadius: 20,
-            padding: '0 40px',
-            textAlign: 'center',
-            backgroundColor: colorTheme.unavailable.value,
-            color: props.shouldShowParentOutline
-              ? colorTheme.navigatorResizeHintBorder.value
-              : colorTheme.unavailableGrey10.value,
-            border: `1px solid ${
-              props.shouldShowParentOutline
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'flex-start',
+          gap: 10,
+          borderRadius: 20,
+          height: 22,
+          padding: '0 15px 0 10px',
+          backgroundColor:
+            isConditionalLabel && !props.selected ? colorTheme.dynamicBlue10.value : 'transparent',
+          color: isConditionalLabel ? colorTheme.dynamicBlue.value : undefined,
+          textTransform: isConditionalLabel ? 'uppercase' : undefined,
+        }}
+      >
+        {when(
+          props.isSlot,
+          <div
+            key={`label-${props.label}-slot`}
+            style={{
+              width: '100%',
+              height: 19,
+              borderRadius: 20,
+              padding: '0 40px',
+              textAlign: 'center',
+              backgroundColor: colorTheme.unavailable.value,
+              color: props.shouldShowParentOutline
                 ? colorTheme.navigatorResizeHintBorder.value
-                : colorTheme.unavailableGrey10.value
-            }`,
-          }}
-        >
-          empty
-        </div>,
-      )}
-      {unless(
-        props.isSlot,
-        <React.Fragment>
-          {unless(
-            props.navigatorEntry.type === 'CONDITIONAL_CLAUSE',
-            <LayoutIcon
-              key={`layout-type-${props.label}`}
-              navigatorEntry={props.navigatorEntry}
-              color={props.iconColor}
-              elementWarnings={props.elementWarnings}
-            />,
-          )}
+                : colorTheme.unavailableGrey10.value,
+              border: `1px solid ${
+                props.shouldShowParentOutline
+                  ? colorTheme.navigatorResizeHintBorder.value
+                  : colorTheme.unavailableGrey10.value
+              }`,
+            }}
+          >
+            empty
+          </div>,
+        )}
+        {unless(
+          props.isSlot,
+          <React.Fragment>
+            {unless(
+              props.navigatorEntry.type === 'CONDITIONAL_CLAUSE',
+              <LayoutIcon
+                key={`layout-type-${props.label}`}
+                navigatorEntry={props.navigatorEntry}
+                color={props.iconColor}
+                elementWarnings={props.elementWarnings}
+              />,
+            )}
 
-          <ItemLabel
-            key={`label-${props.label}`}
-            testId={`navigator-item-label-${props.label}`}
-            name={props.label}
-            isDynamic={props.isDynamic}
-            target={props.navigatorEntry}
-            selected={props.selected}
-            dispatch={props.dispatch}
-            inputVisible={EP.pathsEqual(props.renamingTarget, props.navigatorEntry.elementPath)}
-          />
-        </React.Fragment>,
-      )}
-      <ComponentPreview
-        key={`preview-${props.label}`}
-        navigatorEntry={props.navigatorEntry}
-        color={props.iconColor}
-      />
+            <ItemLabel
+              key={`label-${props.label}`}
+              testId={`navigator-item-label-${props.label}`}
+              name={props.label}
+              isDynamic={props.isDynamic}
+              target={props.navigatorEntry}
+              selected={props.selected}
+              dispatch={props.dispatch}
+              inputVisible={EP.pathsEqual(props.renamingTarget, props.navigatorEntry.elementPath)}
+            />
+          </React.Fragment>,
+        )}
+        <ComponentPreview
+          key={`preview-${props.label}`}
+          navigatorEntry={props.navigatorEntry}
+          color={props.iconColor}
+        />
+      </div>
     </React.Fragment>
   )
 })

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -764,10 +764,10 @@ export const NavigatorItem: React.FunctionComponent<
             onMouseDown={collapse}
             style={{ transform: 'scale(0.6)', opacity: 'var(--paneHoverOpacity)' }}
             testId={`navigator-item-collapse-${navigatorEntryToKey(props.navigatorEntry)}`}
-            // iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
-            iconColor={resultingStyle.iconColor}
+            iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
+            //iconColor={resultingStyle.iconColor}
           />
-          {/* <div
+          <div
             style={{
               display: 'flex',
               flexDirection: 'row',
@@ -782,21 +782,21 @@ export const NavigatorItem: React.FunctionComponent<
               color: isConditional ? colorTheme.dynamicBlue.value : undefined,
               textTransform: isConditional ? 'uppercase' : undefined,
             }}
-          > */}
-          <NavigatorRowLabel
-            shouldShowParentOutline={props.parentOutline === 'child'}
-            navigatorEntry={navigatorEntry}
-            label={props.label}
-            renamingTarget={props.renamingTarget}
-            selected={props.selected}
-            dispatch={props.dispatch}
-            isDynamic={isDynamic}
-            // iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
-            iconColor={resultingStyle.iconColor}
-            elementWarnings={!isConditional ? elementWarnings : null}
-            isSlot={isSlot}
-          />
-          {/* </div> */}
+          >
+            <NavigatorRowLabel
+              shouldShowParentOutline={props.parentOutline === 'child'}
+              navigatorEntry={navigatorEntry}
+              label={props.label}
+              renamingTarget={props.renamingTarget}
+              selected={props.selected}
+              dispatch={props.dispatch}
+              isDynamic={isDynamic}
+              iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
+              //iconColor={resultingStyle.iconColor}
+              elementWarnings={!isConditional ? elementWarnings : null}
+              isSlot={isSlot}
+            />
+          </div>
         </FlexRow>
         <NavigatorItemActionSheet
           navigatorEntry={navigatorEntry}
@@ -806,8 +806,8 @@ export const NavigatorItem: React.FunctionComponent<
           instanceOriginalComponentName={null}
           dispatch={dispatch}
           isSlot={isSlot}
-          // iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
-          iconColor={resultingStyle.iconColor}
+          iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
+          //iconColor={resultingStyle.iconColor}
         />
       </FlexRow>
     </div>

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -855,6 +855,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
               borderRadius: 20,
               padding: '0 40px',
               textAlign: 'center',
+              textTransform: 'lowercase',
               backgroundColor: colorTheme.unavailable.value,
               color: props.shouldShowParentOutline
                 ? colorTheme.navigatorResizeHintBorder.value
@@ -866,7 +867,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
               }`,
             }}
           >
-            empty
+            Empty
           </div>,
         )}
         {unless(

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -817,22 +817,22 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
         <div
           key={`label-${props.label}-slot`}
           style={{
-            border: `1px solid ${
-              props.selected
-                ? colorTheme.bg0.value
-                : props.shouldShowParentOutline
-                ? colorTheme.navigatorResizeHintBorder.value
-                : colorTheme.fg7.value
-            }`,
-            opacity: props.selected ? 0.8 : 1,
             width: '100%',
-            padding: '2px 6px',
-            borderRadius: 2,
-            color: props.selected ? colorTheme.bg0.value : colorTheme.fg8.value,
-            textTransform: 'lowercase',
+            height: 19,
+            borderRadius: 20,
+            textAlign: 'center',
+            backgroundColor: colorTheme.unavailable.value,
+            color: props.shouldShowParentOutline
+              ? colorTheme.navigatorResizeHintBorder.value
+              : colorTheme.unavailableGrey10.value,
+            border: `1px solid ${
+              props.shouldShowParentOutline
+                ? colorTheme.navigatorResizeHintBorder.value
+                : colorTheme.unavailableGrey10.value
+            }`,
           }}
         >
-          Empty
+          empty
         </div>,
       )}
       {unless(

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -56,6 +56,7 @@ import { NavigatorItemActionSheet } from './navigator-item-components'
 import { assertNever } from '../../../core/shared/utils'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import { invalidGroupStateToString } from '../../canvas/canvas-strategies/strategies/group-helpers'
+// import { isConditional } from '@babel/types'
 
 export function getItemHeight(navigatorEntry: NavigatorEntry): number {
   if (isConditionalClauseNavigatorEntry(navigatorEntry)) {
@@ -763,8 +764,25 @@ export const NavigatorItem: React.FunctionComponent<
             onMouseDown={collapse}
             style={{ transform: 'scale(0.6)', opacity: 'var(--paneHoverOpacity)' }}
             testId={`navigator-item-collapse-${navigatorEntryToKey(props.navigatorEntry)}`}
+            // iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
             iconColor={resultingStyle.iconColor}
           />
+          {/* <div
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'flex-start',
+              gap: 10,
+              borderRadius: 20,
+              height: 22,
+              padding: '0 15px 0 10px',
+              backgroundColor:
+                isConditional && !selected ? colorTheme.dynamicBlue10.value : 'transparent',
+              color: isConditional ? colorTheme.dynamicBlue.value : undefined,
+              textTransform: isConditional ? 'uppercase' : undefined,
+            }}
+          > */}
           <NavigatorRowLabel
             shouldShowParentOutline={props.parentOutline === 'child'}
             navigatorEntry={navigatorEntry}
@@ -773,10 +791,12 @@ export const NavigatorItem: React.FunctionComponent<
             selected={props.selected}
             dispatch={props.dispatch}
             isDynamic={isDynamic}
+            // iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
             iconColor={resultingStyle.iconColor}
             elementWarnings={!isConditional ? elementWarnings : null}
             isSlot={isSlot}
           />
+          {/* </div> */}
         </FlexRow>
         <NavigatorItemActionSheet
           navigatorEntry={navigatorEntry}
@@ -786,6 +806,7 @@ export const NavigatorItem: React.FunctionComponent<
           instanceOriginalComponentName={null}
           dispatch={dispatch}
           isSlot={isSlot}
+          // iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
           iconColor={resultingStyle.iconColor}
         />
       </FlexRow>
@@ -820,6 +841,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
             width: '100%',
             height: 19,
             borderRadius: 20,
+            padding: '0 40px',
             textAlign: 'center',
             backgroundColor: colorTheme.unavailable.value,
             color: props.shouldShowParentOutline

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -56,7 +56,6 @@ import { NavigatorItemActionSheet } from './navigator-item-components'
 import { assertNever } from '../../../core/shared/utils'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import { invalidGroupStateToString } from '../../canvas/canvas-strategies/strategies/group-helpers'
-// import { isConditional } from '@babel/types'
 
 export function getItemHeight(navigatorEntry: NavigatorEntry): number {
   if (isConditionalClauseNavigatorEntry(navigatorEntry)) {

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -25,6 +25,9 @@ const darkBase = {
   componentPurple: createUtopiColor('oklch(76% 0.155 300)'),
   dynamicBlue: createUtopiColor('oklch(81% 0.11 241)'),
   dynamicBlue10: createUtopiColor('oklch(81% 0.11 241 / 10%)'),
+  unavailable: createUtopiColor('oklch(0% 0 0 / 5%)'),
+  unavailableGrey: createUtopiColor('oklch(100% 0 0 / 22%)'),
+  unavailableGrey10: createUtopiColor('oklch(100% 0 0 / 10%)'),
 
   bg0: createUtopiColor('#000000'),
   bg1: createUtopiColor('#181C20'),

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -24,6 +24,7 @@ const darkBase = {
   componentOrange: createUtopiColor('oklch(80.6% 0.15 50)'),
   componentPurple: createUtopiColor('oklch(76% 0.155 300)'),
   dynamicBlue: createUtopiColor('oklch(81% 0.11 241)'),
+  dynamicBlue10: createUtopiColor('oklch(81% 0.11 241 / 10%)'),
 
   bg0: createUtopiColor('#000000'),
   bg1: createUtopiColor('#181C20'),

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -12,7 +12,7 @@ const darkBase = {
   white: base.white,
   black: base.black,
   brandPurple: base.purple,
-  brandNeonPink: base.neonpink,
+  brandNeonPink: createUtopiColor('oklch(78.64% 0.237 327.81)'),
   brandNeonGreen: base.neongreen,
   jsYellow: base.jsYellow,
   secondaryBlue: createUtopiColor('#679AD1'),

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -24,6 +24,7 @@ const lightBase = {
   componentOrange: createUtopiColor('lch(61% 89 50)'),
   componentPurple: base.purple,
   dynamicBlue: base.blue,
+  dynamicBlue10: createUtopiColor('oklch(58.98% 0.246 254.39 / 10%)'),
 
   bg0: createUtopiColor('hsl(0,0%,100%)'),
   bg1: createUtopiColor('lch(99.5 0.01 0)'),

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -25,6 +25,9 @@ const lightBase = {
   componentPurple: base.purple,
   dynamicBlue: base.blue,
   dynamicBlue10: createUtopiColor('oklch(58.98% 0.246 254.39 / 10%)'),
+  unavailable: createUtopiColor('oklch(54.52% 0 0 / 5%)'),
+  unavailableGrey: createUtopiColor('oklch(0% 0 0 / 22%)'),
+  unavailableGrey10: createUtopiColor('oklch(0% 0 0 / 10%)'),
 
   bg0: createUtopiColor('hsl(0,0%,100%)'),
   bg1: createUtopiColor('lch(99.5 0.01 0)'),


### PR DESCRIPTION
Design updates for conditional navigator items, and for other kinds of special code navigator items in the future.

- created a new color variable `dynamicBlue10`
- gave the conditional navigator rows a lozenge background using `dynamicBlue10`, and `dynamicBlue` for the text and icon colors
- hide the lozenge background when the row is selected (because it gets too busy and its already emphasized enough)
- created new color variables for slots
- used the new color variables in slots, and updated their other styles
- updated the "TRUE" and "FALSE" rows to use the `dynamicBlue` when active as well
- changed the dark mode css variable for our magenta/brandNeonPink

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/concrete-utopia/utopia/assets/47405698/2f45100e-54a7-41f5-a3eb-15e063d8b3c9)  | ![image](https://github.com/concrete-utopia/utopia/assets/47405698/2a14ed02-c873-4ea3-af58-f26481e9772c)  |
| ![image](https://github.com/concrete-utopia/utopia/assets/47405698/7983a220-ba94-486d-8fad-d63ab66c1fff)  | ![image](https://github.com/concrete-utopia/utopia/assets/47405698/16da582d-c16e-4838-841b-ddaea95dfc45)  |
