### PR TITLE
Fix/post action menu more shortcuts

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/post-action-menu.tsx
+++ b/editor/src/components/canvas/controls/select-mode/post-action-menu.tsx
@@ -72,7 +72,11 @@ export const PostActionMenu = React.memo(
     React.useEffect(() => {
       function handleKeyDown(event: KeyboardEvent) {
         const keyIntValue = Number.parseInt(event.key)
-        const isStrategySwitchingKey = !isNaN(keyIntValue) || event.key === 'Tab'
+        const isStrategySwitchingKey =
+          !isNaN(keyIntValue) ||
+          event.key === 'Tab' ||
+          event.key === 'ArrowDown' ||
+          event.key === 'ArrowUp'
         const isDismissKey = event.key === 'Enter' || event.key === 'Escape'
 
         if (isStrategySwitchingKey && isPostActionMenuActive(postActionSessionChoices)) {
@@ -80,14 +84,20 @@ export const PostActionMenu = React.memo(
           event.stopPropagation()
           event.stopImmediatePropagation()
 
-          if (event.key === 'Tab') {
+          if (event.key === 'Tab' || event.key === 'ArrowDown' || event.key === 'ArrowUp') {
             const activeStrategyIndex = postActionSessionChoices.findIndex(
               (choice) => choice.id === activePostActionChoice,
             )
-
-            const newStrategyIndex = event.shiftKey
-              ? activeStrategyIndex - 1
-              : activeStrategyIndex + 1
+            let newStrategyIndex: number = activeStrategyIndex
+            if (event.key === 'Tab') {
+              newStrategyIndex = event.shiftKey ? activeStrategyIndex - 1 : activeStrategyIndex + 1
+            }
+            if (event.key === 'ArrowDown') {
+              newStrategyIndex = activeStrategyIndex - 1
+            }
+            if (event.key === 'ArrowUp') {
+              newStrategyIndex = activeStrategyIndex + 1
+            }
 
             onSetPostActionChoice(newStrategyIndex)
             return

--- a/editor/src/components/canvas/controls/select-mode/post-action-menu.tsx
+++ b/editor/src/components/canvas/controls/select-mode/post-action-menu.tsx
@@ -309,13 +309,20 @@ export const FloatingPostActionMenu = React.memo(
     React.useEffect(() => {
       function handleKeyDown(event: KeyboardEvent) {
         const isDismissKey = event.key === 'Enter' || event.key === 'Escape'
+        const isOpenkey = event.key === 'k'
 
-        if (isDismissKey && isPostActionMenuActive(postActionSessionChoices)) {
+        if ((isDismissKey || isOpenkey) && isPostActionMenuActive(postActionSessionChoices)) {
           event.preventDefault()
           event.stopPropagation()
           event.stopImmediatePropagation()
-
+        }
+        if (isDismissKey) {
           dispatch([clearPostActionData()])
+        }
+        if (isOpenkey) {
+          if (!open) {
+            setOpen(true)
+          }
         }
       }
 
@@ -326,7 +333,7 @@ export const FloatingPostActionMenu = React.memo(
       return function cleanup() {
         window.removeEventListener('keydown', handleKeyDown, true)
       }
-    }, [dispatch, postActionSessionChoices])
+    }, [dispatch, postActionSessionChoices, open])
 
     if (!isPostActionMenuActive(postActionSessionChoices)) {
       return null


### PR DESCRIPTION
**Problem:**
It's not possible to open the post action menu using the keyboard.

**Fix:**
Using button 'k' to open the post action menu and added arrow keys to select next/previous item.

**Commit Details:**
- extend `handleKeyDown` in `PostActionMenu` and `FloatingPostActionMenu` components
