### PR TITLE
Support highlight bounds on code elements

### DIFF
--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-arbitrary-elements.spec.tsx.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-arbitrary-elements.spec.tsx.snap
@@ -324,6 +324,20 @@ return { a: a, b: b };",
     },
   },
   "highlightBounds": Object {
+    "492": Object {
+      "endCol": 10,
+      "endLine": 22,
+      "startCol": 6,
+      "startLine": 22,
+      "uid": "492",
+    },
+    "8b0": Object {
+      "endCol": 19,
+      "endLine": 22,
+      "startCol": 15,
+      "startLine": 22,
+      "uid": "8b0",
+    },
     "aaa": Object {
       "endCol": 26,
       "endLine": 22,

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -749,6 +749,20 @@ Object {
     },
   },
   "highlightBounds": Object {
+    "1ae": Object {
+      "endCol": 22,
+      "endLine": 6,
+      "startCol": 17,
+      "startLine": 6,
+      "uid": "1ae",
+    },
+    "3c4": Object {
+      "endCol": 22,
+      "endLine": 4,
+      "startCol": 17,
+      "startLine": 4,
+      "uid": "3c4",
+    },
     "4cf": Object {
       "endCol": 37,
       "endLine": 4,
@@ -763,6 +777,13 @@ Object {
       "startLine": 6,
       "uid": "5fd",
     },
+    "690": Object {
+      "endCol": 45,
+      "endLine": 6,
+      "startCol": 40,
+      "startLine": 6,
+      "uid": "690",
+    },
     "aaa": Object {
       "endCol": 56,
       "endLine": 5,
@@ -776,6 +797,13 @@ Object {
       "startCol": 25,
       "startLine": 6,
       "uid": "b93",
+    },
+    "c15": Object {
+      "endCol": 45,
+      "endLine": 4,
+      "startCol": 40,
+      "startLine": 4,
+      "uid": "c15",
     },
     "d03": Object {
       "endCol": 45,
@@ -1280,6 +1308,13 @@ return { a: a };",
       "startCol": 28,
       "startLine": 12,
       "uid": "bbb",
+    },
+    "bcf": Object {
+      "endCol": 9,
+      "endLine": 13,
+      "startCol": 3,
+      "startLine": 13,
+      "uid": "bcf",
     },
   },
   "imports": Object {

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -4846,18 +4846,28 @@ export var whatever2 = (props) => <View data-uid='aaa'>
               for (const topLevelElement of success.topLevelElements) {
                 switch (topLevelElement.type) {
                   case 'UTOPIA_JSX_COMPONENT':
-                    ensureElementsHaveUID(topLevelElement.rootElement, uids, isWantedElement, false)
+                    ensureElementsHaveUID(
+                      topLevelElement.rootElement,
+                      uids,
+                      isWantedElement,
+                      'do-not-walk-attributes',
+                    )
                     if (topLevelElement.arbitraryJSBlock != null) {
                       ensureArbitraryBlocksHaveUID(
                         topLevelElement.arbitraryJSBlock,
                         uids,
                         isWantedElement,
-                        false,
+                        'do-not-walk-attributes',
                       )
                     }
                     break
                   case 'ARBITRARY_JS_BLOCK':
-                    ensureArbitraryBlocksHaveUID(topLevelElement, uids, isWantedElement, false)
+                    ensureArbitraryBlocksHaveUID(
+                      topLevelElement,
+                      uids,
+                      isWantedElement,
+                      'do-not-walk-attributes',
+                    )
                     break
                   case 'IMPORT_STATEMENT':
                   case 'UNPARSED_CODE':

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -54,7 +54,6 @@ import {
 import { lintAndParse, parseCode, printCode, printCodeOptions } from './parser-printer'
 import { applyPrettier } from 'utopia-vscode-common'
 import { transpileJavascriptFromCode } from './parser-printer-transpiling'
-import type { PrintableProjectContent } from './parser-printer.test-utils'
 import {
   clearParseResultPassTimes,
   clearParseResultUniqueIDsAndEmptyBlocks,
@@ -62,11 +61,13 @@ import {
   elementsStructure,
   ensureArbitraryBlocksHaveUID,
   ensureElementsHaveUID,
+  isWantedElement,
   JustImportViewAndReact,
-  printableProjectContentArbitrary,
+  printedProjectContentArbitrary,
   simplifyParsedTextFileAttributes,
   testParseCode,
 } from './parser-printer.test-utils'
+import type { ArbitraryProject } from './parser-printer.test-utils'
 import { InfiniteLoopError, InfiniteLoopMaxIterations } from './transform-prevent-infinite-loops'
 import { BakedInStoryboardUID, BakedInStoryboardVariableName } from '../../model/scene-utils'
 import { optionalMap } from '../../shared/optional-utils'
@@ -4793,15 +4794,7 @@ export var whatever2 = (props) => <View data-uid='aaa'>
     )
   })
   it('inserts data-uid into elements as part of the parse', () => {
-    function checkDataUIDsPopulated(printableProjectContent: PrintableProjectContent): boolean {
-      const printedCode = printCode(
-        '/index.js',
-        printCodeOptions(false, true, false, false, true),
-        printableProjectContent.imports,
-        printableProjectContent.topLevelElements,
-        printableProjectContent.jsxFactoryFunction,
-        printableProjectContent.exportsDetail,
-      )
+    function checkDataUIDsPopulated({ code: printedCode }: ArbitraryProject): boolean {
       const parseResult = testParseCode(printedCode)
       return foldParsedTextFile(
         (failure) => {
@@ -4824,34 +4817,25 @@ export var whatever2 = (props) => <View data-uid='aaa'>
         parseResult,
       )
     }
-    const printableArbitrary = printableProjectContentArbitrary()
-    const dataUIDProperty = FastCheck.property(printableArbitrary, checkDataUIDsPopulated)
+    const printedArbitrary = printedProjectContentArbitrary(false)
+    const dataUIDProperty = FastCheck.property(printedArbitrary, checkDataUIDsPopulated)
     FastCheck.assert(dataUIDProperty, { verbose: true })
   })
   describe('check that the UIDs of everything in a file also align with the highlight bounds for that file', () => {
     function checkElementUIDs(stripUIDs: boolean): void {
       function checkElementUIDSMatchHighlightBounds(
-        printableProjectContent: [PrintableProjectContent, PrintableProjectContent],
+        printedArbitraryProjects: [ArbitraryProject, ArbitraryProject],
       ): boolean {
-        const [firstPrintableProjectContent, secondPrintableProjectContent] =
-          printableProjectContent
+        const [firstPrintedProjectContent, secondPrintedProjectContent] = printedArbitraryProjects
         const alreadyExistingUIDs: Set<string> = emptySet()
 
         let fileCounter: number = 100
         let projectContents: ProjectContents = {}
 
-        for (const printableContent of [
-          firstPrintableProjectContent,
-          secondPrintableProjectContent,
+        for (const { code: printedCode } of [
+          firstPrintedProjectContent,
+          secondPrintedProjectContent,
         ]) {
-          const printedCode = printCode(
-            '/index.js',
-            printCodeOptions(false, true, false, stripUIDs, true),
-            printableContent.imports,
-            printableContent.topLevelElements,
-            printableContent.jsxFactoryFunction,
-            printableContent.exportsDetail,
-          )
           const parseResult = testParseCode(printedCode, alreadyExistingUIDs)
           foldParsedTextFile(
             (failure) => {
@@ -4862,13 +4846,18 @@ export var whatever2 = (props) => <View data-uid='aaa'>
               for (const topLevelElement of success.topLevelElements) {
                 switch (topLevelElement.type) {
                   case 'UTOPIA_JSX_COMPONENT':
-                    ensureElementsHaveUID(topLevelElement.rootElement, uids)
+                    ensureElementsHaveUID(topLevelElement.rootElement, uids, isWantedElement, false)
                     if (topLevelElement.arbitraryJSBlock != null) {
-                      ensureArbitraryBlocksHaveUID(topLevelElement.arbitraryJSBlock, uids)
+                      ensureArbitraryBlocksHaveUID(
+                        topLevelElement.arbitraryJSBlock,
+                        uids,
+                        isWantedElement,
+                        false,
+                      )
                     }
                     break
                   case 'ARBITRARY_JS_BLOCK':
-                    ensureArbitraryBlocksHaveUID(topLevelElement, uids)
+                    ensureArbitraryBlocksHaveUID(topLevelElement, uids, isWantedElement, false)
                     break
                   case 'IMPORT_STATEMENT':
                   case 'UNPARSED_CODE':
@@ -4935,9 +4924,9 @@ export var whatever2 = (props) => <View data-uid='aaa'>
 
         return true
       }
-      const printableArbitrary = printableProjectContentArbitrary()
+      const printedArbitrary = printedProjectContentArbitrary(stripUIDs)
       const dataUIDProperty = FastCheck.property(
-        FastCheck.tuple(printableArbitrary, printableArbitrary),
+        FastCheck.tuple(printedArbitrary, printedArbitrary),
         checkElementUIDSMatchHighlightBounds,
       )
       FastCheck.assert(dataUIDProperty, { verbose: false, numRuns: 100 })

--- a/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
@@ -850,7 +850,7 @@ export function utopiaJSXComponentArbitrary(): Arbitrary<UtopiaJSXComponent> {
           }
         },
         () => true,
-        true,
+        'walk-attributes',
       )
       return !elementNames.some((elementName) => elementName === component.name)
     })
@@ -882,13 +882,14 @@ export function exportsDetailArbitrary(possibleNames: Array<string>): Arbitrary<
 }
 
 type IncludeDataUIDAttribute = 'include-data-uid-attribute' | 'do-not-include-data-uid-attribute'
+type ShouldWalkAttributes = 'walk-attributes' | 'do-not-walk-attributes'
 
 function walkElementsWithin(
   elementsWithin: ElementsWithin,
   includeDataUIDAttribute: IncludeDataUIDAttribute,
   walkWith: (elem: JSXElementChild) => void,
   shouldWalkElement: (elem: JSXElementChild) => boolean,
-  shouldWalkAttributes: boolean,
+  shouldWalkAttributes: ShouldWalkAttributes,
 ): void {
   fastForEach(Object.keys(elementsWithin), (elementWithinKey) => {
     const innerElement = elementsWithin[elementWithinKey]
@@ -907,7 +908,7 @@ function walkElements(
   includeDataUIDAttribute: IncludeDataUIDAttribute,
   walkWith: (elem: JSXElementChild) => void,
   shouldWalkElement: (elem: JSXElementChild) => boolean,
-  shouldWalkAttributes: boolean,
+  shouldWalkAttributes: ShouldWalkAttributes,
 ): void {
   if (!shouldWalkElement(jsxElementChild)) {
     return
@@ -916,7 +917,7 @@ function walkElements(
   walkWith(jsxElementChild)
   switch (jsxElementChild.type) {
     case 'JSX_ELEMENT':
-      if (shouldWalkAttributes) {
+      if (shouldWalkAttributes === 'walk-attributes') {
         walkJSXAttributes(
           jsxElementChild.props,
           includeDataUIDAttribute,
@@ -1036,7 +1037,7 @@ function walkJSXAttributes(
             includeDataUIDAttribute,
             walkWith,
             shouldWalkElement,
-            true,
+            'walk-attributes',
           )
         }
         break
@@ -1046,7 +1047,7 @@ function walkJSXAttributes(
           includeDataUIDAttribute,
           walkWith,
           shouldWalkElement,
-          true,
+          'walk-attributes',
         )
         break
       default:
@@ -1066,7 +1067,7 @@ function getAllBaseVariables(jsxElementChild: JSXElementChild): Array<string> {
       }
     },
     () => true,
-    true,
+    'walk-attributes',
   )
   return result
 }
@@ -1111,7 +1112,7 @@ export function ensureArbitraryBlocksHaveUID(
   arbitraryBlock: ArbitraryJSBlock,
   uids: Array<string>,
   shouldWalkElement: (element: JSXElementChild) => boolean,
-  shouldWalkAttributes: boolean,
+  shouldWalkAttributes: ShouldWalkAttributes,
 ): void {
   walkElementsWithin(
     arbitraryBlock.elementsWithin,
@@ -1128,7 +1129,7 @@ export function ensureElementsHaveUID(
   jsxElementChild: JSXElementChild,
   uids: Array<string>,
   shouldWalkElement: (element: JSXElementChild) => boolean = () => true,
-  shouldWalkAttributes: boolean = true,
+  shouldWalkAttributes: ShouldWalkAttributes = 'walk-attributes',
 ): void {
   walkElements(
     jsxElementChild,
@@ -1190,7 +1191,7 @@ export function ensureArbitraryJSXBlockCodeHasUIDs(jsxElementChild: JSXElementCh
       }
     },
     () => true,
-    true,
+    'walk-attributes',
   )
 }
 

--- a/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
@@ -210,7 +210,7 @@ export function testParseCode(
     let uids: Array<string> = []
     fastForEach(success.topLevelElements, (topLevelElement) => {
       if (isUtopiaJSXComponent(topLevelElement)) {
-        ensureElementsHaveUID(topLevelElement.rootElement, uids, () => true, true)
+        ensureElementsHaveUID(topLevelElement.rootElement, uids, () => true, 'walk-attributes')
         ensureArbitraryJSXBlockCodeHasUIDs(topLevelElement.rootElement)
       }
     })

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -1995,6 +1995,7 @@ export function trimHighlightBounds(success: ParseSuccess): ParseSuccess {
             break
           case 'JSX_CONDITIONAL_EXPRESSION':
             includeElement(element)
+            walkJSXElementChild(element.condition)
             walkJSXElementChild(element.whenTrue)
             walkJSXElementChild(element.whenFalse)
             break
@@ -2006,6 +2007,7 @@ export function trimHighlightBounds(success: ParseSuccess): ParseSuccess {
             // Don't walk any further down these.
             break
           case 'ATTRIBUTE_OTHER_JAVASCRIPT':
+            includeElement(element)
             walkElementsWithin(element.elementsWithin)
             break
           default:


### PR DESCRIPTION
**Problem:**
Now that we support code elements in the Navigator, we should also support highlight bounds for them

**Fix:**
The fix itself was a simple 1 liner, and that was to call `includeElement` for arbitrary JS expressions in `parser-printer.ts`. In doing so though I discovered some issues with our fast-check tests that are checking the highlight bounds contain all relevant UIDs (these are incidentally the tests that fail periodically on CI).

The problem with the fast-check tests is that, whilst we stop traversing the tree at certain types of elements when capturing the highlight bounds, we don't apply the same filter when running those tests (instead we just check at the point of testing if the element is one we are interested in, but continue walking the tree either way).

To fix the fast-check tests I've now added a filter function to decide if we want to continue walking or not, and a boolean flag to state whether we want to walk attributes of an element (which we also don't capture highlight bounds for right now). I've also removed a duplicate function here (it seems two different functions converged at some point).

Finally, since there was no reason not to (and we're checking it in the tests), I have included the highlight bounds for `element.condition` for conditional elements.