### PR TITLE
Fix/static reparent absolute

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
@@ -39,7 +39,10 @@ export function reparentStrategyForPaste(
 ): ReparentStrategy {
   const parentIsFlexLayout =
     MetadataUtils.findLayoutSystemForChildren(currentMetadata, pathTrees, parent) === 'flex'
-  return parentIsFlexLayout ? 'REPARENT_AS_STATIC' : 'REPARENT_AS_ABSOLUTE'
+  const isTextFromMetadata = MetadataUtils.isTextFromMetadata(
+    MetadataUtils.findElementByElementPath(currentMetadata, parent),
+  )
+  return parentIsFlexLayout || isTextFromMetadata ? 'REPARENT_AS_STATIC' : 'REPARENT_AS_ABSOLUTE'
 }
 
 export function findReparentStrategies(

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
@@ -7,7 +7,6 @@ import { getTargetPathsFromInteractionTarget } from '../../canvas-strategy-types
 import type { AllowSmallerParent } from '../../interaction-state'
 import {
   autoLayoutParentAbsoluteOrStatic,
-  flowParentAbsoluteOrStatic,
   getReparentTargetUnified,
 } from './reparent-strategy-parent-lookup'
 import { flattenSelection } from '../shared-move-strategies-helpers'

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
@@ -5,10 +5,7 @@ import type { ElementPath } from '../../../../../core/shared/project-file-types'
 import type { InteractionCanvasState, InteractionTarget } from '../../canvas-strategy-types'
 import { getTargetPathsFromInteractionTarget } from '../../canvas-strategy-types'
 import type { AllowSmallerParent } from '../../interaction-state'
-import {
-  autoLayoutParentAbsoluteOrStatic,
-  getReparentTargetUnified,
-} from './reparent-strategy-parent-lookup'
+import { getReparentTargetUnified } from './reparent-strategy-parent-lookup'
 import { flattenSelection } from '../shared-move-strategies-helpers'
 import type { Direction } from '../../../../inspector/common/css-utils'
 import type { ElementSupportsChildren } from '../../../../../core/model/element-template-utils'
@@ -40,7 +37,12 @@ export function reparentStrategyForPaste(
   pathTrees: ElementPathTrees,
   parent: ElementPath,
 ): ReparentStrategy {
-  return autoLayoutParentAbsoluteOrStatic(currentMetadata, allElementProps, pathTrees, parent)
+  const parentIsFlexLayout =
+    MetadataUtils.findLayoutSystemForChildren(currentMetadata, pathTrees, parent) === 'flex'
+  const isTextFromMetadata = MetadataUtils.isTextFromMetadata(
+    MetadataUtils.findElementByElementPath(currentMetadata, parent),
+  )
+  return parentIsFlexLayout || isTextFromMetadata ? 'REPARENT_AS_STATIC' : 'REPARENT_AS_ABSOLUTE'
 }
 
 export function findReparentStrategies(

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
@@ -5,7 +5,10 @@ import type { ElementPath } from '../../../../../core/shared/project-file-types'
 import type { InteractionCanvasState, InteractionTarget } from '../../canvas-strategy-types'
 import { getTargetPathsFromInteractionTarget } from '../../canvas-strategy-types'
 import type { AllowSmallerParent } from '../../interaction-state'
-import { getReparentTargetUnified } from './reparent-strategy-parent-lookup'
+import {
+  autoLayoutParentAbsoluteOrStatic,
+  getReparentTargetUnified,
+} from './reparent-strategy-parent-lookup'
 import { flattenSelection } from '../shared-move-strategies-helpers'
 import type { Direction } from '../../../../inspector/common/css-utils'
 import type { ElementSupportsChildren } from '../../../../../core/model/element-template-utils'
@@ -37,12 +40,7 @@ export function reparentStrategyForPaste(
   pathTrees: ElementPathTrees,
   parent: ElementPath,
 ): ReparentStrategy {
-  const parentIsFlexLayout =
-    MetadataUtils.findLayoutSystemForChildren(currentMetadata, pathTrees, parent) === 'flex'
-  const isTextFromMetadata = MetadataUtils.isTextFromMetadata(
-    MetadataUtils.findElementByElementPath(currentMetadata, parent),
-  )
-  return parentIsFlexLayout || isTextFromMetadata ? 'REPARENT_AS_STATIC' : 'REPARENT_AS_ABSOLUTE'
+  return autoLayoutParentAbsoluteOrStatic(currentMetadata, allElementProps, pathTrees, parent)
 }
 
 export function findReparentStrategies(

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
@@ -5,7 +5,11 @@ import type { ElementPath } from '../../../../../core/shared/project-file-types'
 import type { InteractionCanvasState, InteractionTarget } from '../../canvas-strategy-types'
 import { getTargetPathsFromInteractionTarget } from '../../canvas-strategy-types'
 import type { AllowSmallerParent } from '../../interaction-state'
-import { getReparentTargetUnified } from './reparent-strategy-parent-lookup'
+import {
+  autoLayoutParentAbsoluteOrStatic,
+  flowParentAbsoluteOrStatic,
+  getReparentTargetUnified,
+} from './reparent-strategy-parent-lookup'
 import { flattenSelection } from '../shared-move-strategies-helpers'
 import type { Direction } from '../../../../inspector/common/css-utils'
 import type { ElementSupportsChildren } from '../../../../../core/model/element-template-utils'
@@ -37,12 +41,13 @@ export function reparentStrategyForPaste(
   pathTrees: ElementPathTrees,
   parent: ElementPath,
 ): ReparentStrategy {
-  const parentIsFlexLayout =
-    MetadataUtils.findLayoutSystemForChildren(currentMetadata, pathTrees, parent) === 'flex'
-  const isTextFromMetadata = MetadataUtils.isTextFromMetadata(
-    MetadataUtils.findElementByElementPath(currentMetadata, parent),
+  return autoLayoutParentAbsoluteOrStatic(
+    currentMetadata,
+    allElementProps,
+    pathTrees,
+    parent,
+    'prefer-absolute',
   )
-  return parentIsFlexLayout || isTextFromMetadata ? 'REPARENT_AS_STATIC' : 'REPARENT_AS_ABSOLUTE'
 }
 
 export function findReparentStrategies(

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
@@ -5,10 +5,7 @@ import type { ElementPath } from '../../../../../core/shared/project-file-types'
 import type { InteractionCanvasState, InteractionTarget } from '../../canvas-strategy-types'
 import { getTargetPathsFromInteractionTarget } from '../../canvas-strategy-types'
 import type { AllowSmallerParent } from '../../interaction-state'
-import {
-  flowParentAbsoluteOrStatic,
-  getReparentTargetUnified,
-} from './reparent-strategy-parent-lookup'
+import { getReparentTargetUnified } from './reparent-strategy-parent-lookup'
 import { flattenSelection } from '../shared-move-strategies-helpers'
 import type { Direction } from '../../../../inspector/common/css-utils'
 import type { ElementSupportsChildren } from '../../../../../core/model/element-template-utils'
@@ -42,15 +39,7 @@ export function reparentStrategyForPaste(
 ): ReparentStrategy {
   const parentIsFlexLayout =
     MetadataUtils.findLayoutSystemForChildren(currentMetadata, pathTrees, parent) === 'flex'
-
-  const flowParentReparentType = flowParentAbsoluteOrStatic(
-    currentMetadata,
-    allElementProps,
-    pathTrees,
-    parent,
-  )
-  const reparentAsStatic = parentIsFlexLayout || flowParentReparentType === 'REPARENT_AS_STATIC'
-  return reparentAsStatic ? 'REPARENT_AS_STATIC' : 'REPARENT_AS_ABSOLUTE'
+  return parentIsFlexLayout ? 'REPARENT_AS_STATIC' : 'REPARENT_AS_ABSOLUTE'
 }
 
 export function findReparentStrategies(

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -546,27 +546,12 @@ function findIndexForSingleAxisAutolayoutParent(
   return { targetUnderMouseIndex, shouldConvertToInline }
 }
 
-function autoLayoutParentAbsoluteOrStatic(
+export function autoLayoutParentAbsoluteOrStatic(
   metadata: ElementInstanceMetadataMap,
   allElementProps: AllElementProps,
   pathTrees: ElementPathTrees,
   parent: ElementPath,
-): ReparentStrategy {
-  const newParentMetadata = MetadataUtils.findElementByElementPath(metadata, parent)
-  const parentIsFlexLayout = MetadataUtils.isFlexLayoutedContainer(newParentMetadata)
-
-  if (parentIsFlexLayout) {
-    return 'REPARENT_AS_STATIC'
-  }
-
-  return flowParentAbsoluteOrStatic(metadata, allElementProps, pathTrees, parent)
-}
-
-export function flowParentAbsoluteOrStatic(
-  metadata: ElementInstanceMetadataMap,
-  allElementProps: AllElementProps,
-  pathTrees: ElementPathTrees,
-  parent: ElementPath,
+  preferAbsolute: 'prefer-absolute' | null = null,
 ): ReparentStrategy {
   const parentMetadata = MetadataUtils.findElementByElementPath(metadata, parent)
   const children = MetadataUtils.getChildrenOrdered(metadata, pathTrees, parent)
@@ -577,8 +562,25 @@ export function flowParentAbsoluteOrStatic(
     return 'REPARENT_AS_ABSOLUTE'
   }
 
+  const parentIsFlexLayout =
+    MetadataUtils.findLayoutSystemForChildren(metadata, pathTrees, parent) === 'flex'
+  if (parentIsFlexLayout) {
+    return 'REPARENT_AS_STATIC'
+  }
+
+  const isTextFromMetadata = MetadataUtils.isTextFromMetadata(
+    MetadataUtils.findElementByElementPath(metadata, parent),
+  )
+  if (isTextFromMetadata) {
+    return 'REPARENT_AS_STATIC'
+  }
+
   const isFragmentLike = treatElementAsFragmentLike(metadata, allElementProps, pathTrees, parent)
   if (isFragmentLike) {
+    return 'REPARENT_AS_ABSOLUTE'
+  }
+
+  if (preferAbsolute === 'prefer-absolute') {
     return 'REPARENT_AS_ABSOLUTE'
   }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -546,7 +546,7 @@ function findIndexForSingleAxisAutolayoutParent(
   return { targetUnderMouseIndex, shouldConvertToInline }
 }
 
-function autoLayoutParentAbsoluteOrStatic(
+export function autoLayoutParentAbsoluteOrStatic(
   metadata: ElementInstanceMetadataMap,
   allElementProps: AllElementProps,
   pathTrees: ElementPathTrees,
@@ -554,73 +554,14 @@ function autoLayoutParentAbsoluteOrStatic(
 ): ReparentStrategy {
   const newParentMetadata = MetadataUtils.findElementByElementPath(metadata, parent)
   const parentIsFlexLayout = MetadataUtils.isFlexLayoutedContainer(newParentMetadata)
-
-  if (parentIsFlexLayout) {
+  const isTextFromMetadata = MetadataUtils.isTextFromMetadata(
+    MetadataUtils.findElementByElementPath(metadata, parent),
+  )
+  if (parentIsFlexLayout || isTextFromMetadata) {
     return 'REPARENT_AS_STATIC'
   }
 
-  return flowParentAbsoluteOrStatic(metadata, allElementProps, pathTrees, parent)
-}
-
-export function flowParentAbsoluteOrStatic(
-  metadata: ElementInstanceMetadataMap,
-  allElementProps: AllElementProps,
-  pathTrees: ElementPathTrees,
-  parent: ElementPath,
-): ReparentStrategy {
-  const parentMetadata = MetadataUtils.findElementByElementPath(metadata, parent)
-  const children = MetadataUtils.getChildrenOrdered(metadata, pathTrees, parent)
-
-  const storyboardRoot = EP.isStoryboardPath(parent)
-  if (storyboardRoot) {
-    // always reparent as absolute to the Storyboard
-    return 'REPARENT_AS_ABSOLUTE'
-  }
-
-  const isFragmentLike = treatElementAsFragmentLike(metadata, allElementProps, pathTrees, parent)
-  if (isFragmentLike) {
-    return 'REPARENT_AS_ABSOLUTE'
-  }
-
-  const parentIsContainingBlock =
-    parentMetadata?.specialSizeMeasurements.providesBoundsForAbsoluteChildren ?? false
-  if (!parentIsContainingBlock) {
-    return 'REPARENT_AS_STATIC'
-  }
-
-  const allChildrenFlow =
-    children.length > 0 &&
-    children.every((child) => child.specialSizeMeasurements.position === 'static')
-
-  if (allChildrenFlow) {
-    return 'REPARENT_AS_STATIC'
-  }
-
-  const parentFrame = parentMetadata?.globalFrame ?? null
-  const parentWidth =
-    parentFrame == null ? 0 : isInfinityRectangle(parentFrame) ? Infinity : parentFrame.width
-  const parentHeight =
-    parentFrame == null ? 0 : isInfinityRectangle(parentFrame) ? Infinity : parentFrame.height
-
-  const emptyParentWithDimensionsGreaterThanZero =
-    children.length === 0 && parentWidth > 0 && parentHeight > 0
-  if (emptyParentWithDimensionsGreaterThanZero) {
-    return 'REPARENT_AS_ABSOLUTE'
-  }
-
-  // TODO ABSOLUTE drag onto the padded area of flow layout target parent
-
-  // TODO is this needed?
-  const emptyParentWithAnyDimensionZero =
-    children.length === 0 && (parentWidth === 0 || parentHeight === 0)
-  if (emptyParentWithAnyDimensionZero) {
-    return 'REPARENT_AS_STATIC'
-  }
-
-  // the fallback is reparent as absolute
   return 'REPARENT_AS_ABSOLUTE'
-
-  // should there be a DO_NOT_REPARENT return type here?
 }
 
 function isSingleAxisAutoLayoutCompatibleWithReorder(

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -389,7 +389,7 @@ describe('actions', () => {
         <div data-uid='aaa'>
             <div data-uid='bbb'>foo</div>
             <div data-uid='ccc'>bar</div>
-            <div data-uid='aad'>foo</div>
+            <div data-uid='aad' style={{ top: 0, left: 0, position: 'absolute' }}>foo</div>
         </div>
 		`,
       },
@@ -424,8 +424,8 @@ describe('actions', () => {
             <div data-uid='bbb'>foo</div>
             <div data-uid='ccc'>bar</div>
             <div data-uid='ddd'>baz</div>
-            <div data-uid='aad'>foo</div>
-            <div data-uid='aah'>bar</div>
+            <div data-uid='aad' style={{ top: 0, left: 0, position: 'absolute' }}>foo</div>
+            <div data-uid='aah' style={{ top: 19, left: 0, position: 'absolute' }}>bar</div>
         </div>
 		`,
       },
@@ -1066,7 +1066,7 @@ describe('actions', () => {
           // @utopia/uid=conditional
           true ? <div data-uid='aaa'>foo</div> : null
         }
-        <div data-uid='aad'>foo</div>
+        <div data-uid='aad' style={{ top: 0, left: 0, position: 'absolute' }}>foo</div>
       </div>
 		`,
       },
@@ -1426,7 +1426,7 @@ describe('actions', () => {
                 style={{ width: 60, height: 60 }}
               />
             </div>
-            <div data-uid='aar'>
+            <div data-uid='aar' style={{ top: 0, left: 0, position: 'absolute' }}>
               <div
                 data-uid='aai'
                 style={{
@@ -2562,7 +2562,7 @@ export var storyboard = (props) => {
                     true ? <div data-uid='aaa' /> : null
                   }
                   <div data-uid='bbb'>foo</div>
-                  <div data-uid='aad'>foo</div>
+                  <div data-uid='aad' style={{ top: 0, left: 0, position: 'absolute' }}>foo</div>
                 </div>
               `),
           )
@@ -2606,7 +2606,7 @@ export var storyboard = (props) => {
                     // @utopia/uid=conditional
                     true ? (
                       <div data-uid='aaa'>
-                        <div data-uid='aad'>foo</div>
+                        <div data-uid='aad' style={{top: 0, left: 0, position: 'absolute'}}>foo</div>
                       </div>
                     ) : null
                   }
@@ -2832,7 +2832,7 @@ export var storyboard = (props) => {
                 </div>
               </div>
               <div data-uid='ccc' style={{contain: 'layout'}}>
-                <div data-uid='aak' style={{ height: 20 }}>
+                <div data-uid='aak' style={{ height: 20, top: -10, left: 15, position: 'absolute' }}>
                   <div data-uid='aae' style={{ width: 20, height: 20 }}/>
                 </div>
               </div>
@@ -3035,7 +3035,7 @@ export var storyboard = (props) => {
             result: `<div data-uid='root'>
                 <span data-uid='ccc'>hi</span>
                 <div data-uid='bbb' style={{ width: 50, height: 50, contain: 'layout' }} />
-                <div data-uid='aaf' style={{ width: 50, height: 50, contain: 'layout' }} />
+                <div data-uid='aaf' style={{ width: 50, height: 50, contain: 'layout', top: 19, left: 0, position: 'absolute' }} />
               </div>`,
           },
           {

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -396,7 +396,7 @@ describe('actions', () => {
       {
         name: 'multiple elements',
         startingCode: `
-        <div data-uid='aaa'>
+        <div data-uid='aaa' style={{ lineHeight: '20px' }}>
             <div data-uid='bbb'>foo</div>
             <div data-uid='ccc'>bar</div>
             <div data-uid='ddd'>baz</div>
@@ -420,12 +420,12 @@ describe('actions', () => {
         },
         pasteInto: childInsertionPath(EP.appendNewElementPath(TestScenePath, ['aaa'])),
         want: `
-        <div data-uid='aaa'>
+        <div data-uid='aaa' style={{ lineHeight: '20px' }}>
             <div data-uid='bbb'>foo</div>
             <div data-uid='ccc'>bar</div>
             <div data-uid='ddd'>baz</div>
             <div data-uid='aad' style={{ top: 0, left: 0, position: 'absolute' }}>foo</div>
-            <div data-uid='aah' style={{ top: 19, left: 0, position: 'absolute' }}>bar</div>
+            <div data-uid='aah' style={{ top: 20, left: 0, position: 'absolute' }}>bar</div>
         </div>
 		`,
       },
@@ -3027,15 +3027,15 @@ export var storyboard = (props) => {
           },
           {
             name: 'trying to paste a div into a span is not allowed',
-            input: `<div data-uid='root'>
+            input: `<div data-uid='root' style={{ lineHeight: '20px' }}>
                 <span data-uid='ccc'>hi</span>
                 <div data-uid='bbb' style={{ width: 50, height: 50, contain: 'layout' }} />
               </div>`,
             targets: [makeTargetPath('root/bbb')],
-            result: `<div data-uid='root'>
+            result: `<div data-uid='root' style={{ lineHeight: '20px' }}>
                 <span data-uid='ccc'>hi</span>
                 <div data-uid='bbb' style={{ width: 50, height: 50, contain: 'layout' }} />
-                <div data-uid='aaf' style={{ width: 50, height: 50, contain: 'layout', top: 19, left: 0, position: 'absolute' }} />
+                <div data-uid='aaf' style={{ width: 50, height: 50, contain: 'layout', top: 20, left: 0, position: 'absolute' }} />
               </div>`,
           },
           {

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -933,7 +933,7 @@ describe('conditionals', () => {
                   true ? (
                     <div data-uid='eee'>
                       insert into this
-                      <div data-uid='aad'>copy me</div>
+                      <div data-uid='aad' style={{top: 19, left: 0, position: 'absolute'}}>copy me</div>
                     </div>
                   ) : null
                 }
@@ -1092,7 +1092,7 @@ describe('conditionals', () => {
                   true ? null : (
                     <div data-uid='eee'>
                       insert into this
-                      <div data-uid='aad'>copy me</div>
+                      <div data-uid='aad' style={{top: 0, left: 0, position: 'absolute'}} >copy me</div>
                     </div>
                   )
                 }

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -906,7 +906,7 @@ describe('conditionals', () => {
         })
         it('can paste to children supporting element in branch', async () => {
           const startSnippet = `
-            <div data-uid='aaa'>
+            <div data-uid='aaa' style={{ lineHeight: '20px' }}>
               {
                 // @utopia/uid=cond
                 true ? <div data-uid='eee'>insert into this</div> : null
@@ -927,13 +927,13 @@ describe('conditionals', () => {
 
           expect(got).toEqual(
             makeTestProjectCodeWithSnippet(`
-              <div data-uid='aaa'>
+              <div data-uid='aaa' style={{ lineHeight: '20px' }}>
                 {
                   // @utopia/uid=cond
                   true ? (
                     <div data-uid='eee'>
                       insert into this
-                      <div data-uid='aad' style={{top: 19, left: 0, position: 'absolute'}}>copy me</div>
+                      <div data-uid='aad' style={{top: 20, left: 0, position: 'absolute'}}>copy me</div>
                     </div>
                   ) : null
                 }


### PR DESCRIPTION
**Problem:**
Pasted/reparented elements easily end up as flow elements even in non-flex containers.

**Fix:**
Only paste/reparent as flow when the parent is a flex container or a text element.

**Commit Details:**
- update tests
- change `reparentStrategyForPaste`
