### PR TITLE
canvas loading full screen

### DIFF
--- a/editor/src/components/canvas/canvas-loading-screen.tsx
+++ b/editor/src/components/canvas/canvas-loading-screen.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Global, css } from '@emotion/react'
-import { BaseCanvasOffsetLeftPane } from '../editor/store/editor-state'
 import { useColorTheme } from '../../uuiui'
 
 export const CanvasLoadingScreen = React.memo(() => {
@@ -11,17 +10,17 @@ export const CanvasLoadingScreen = React.memo(() => {
         styles={css`
           @keyframes placeholderShimmer {
             0% {
-              background-position: -468px 0;
+              background-position: -1468px 0;
             }
             100% {
-              background-position: 468px 0;
+              background-position: 1468px 0;
             }
           }
 
           .shimmer {
             color: transparent;
             animation-name: placeholderShimmer;
-            animation-duration: 1.25s;
+            animation-duration: 4.25s;
             animation-fill-mode: forwards;
             animation-iteration-count: infinite;
             animation-timing-function: linear;
@@ -32,7 +31,7 @@ export const CanvasLoadingScreen = React.memo(() => {
               ${colorTheme.codeEditorShimmerSecondary.value} 18%,
               ${colorTheme.codeEditorShimmerPrimary.value} 33%
             );
-            background-size: 800px 104px;
+            background-size: 1468px 104px;
             position: relative;
           }
         `}

--- a/editor/src/components/canvas/canvas-loading-screen.tsx
+++ b/editor/src/components/canvas/canvas-loading-screen.tsx
@@ -45,10 +45,10 @@ export const CanvasLoadingScreen = React.memo(() => {
           className='shimmer'
           style={{
             position: 'absolute',
-            left: BaseCanvasOffsetLeftPane.x,
-            top: BaseCanvasOffsetLeftPane.y,
-            width: 375,
-            height: 812,
+            left: 0,
+            top: 0,
+            width: '100vw',
+            height: '100vh',
           }}
         ></div>
       </div>

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -210,14 +210,14 @@ export const light = {
   githubMUDDefault: createUtopiColor('#ccc'),
 
   // Code editor loading screen
-  codeEditorShimmerPrimary: createUtopiColor('#f6f6f6'),
-  codeEditorShimmerSecondary: createUtopiColor('#f0f0f0'),
-  codeEditorTabRowBg: createUtopiColor('#f3f3f3'),
-  codeEditorTabSelectedBG: createUtopiColor('#fafafa'),
-  codeEditorTabSelectedFG: lightBase.fg2,
-  codeEditorTabSelectedBorder: createUtopiColor('rgb(243,243,243)'),
+  codeEditorShimmerPrimary: lightBase.bg4,
+  codeEditorShimmerSecondary: createUtopiColor('#D6D6D6'),
+  codeEditorTabRowBg: lightBase.bg2,
+  codeEditorTabSelectedBG: lightBase.bg1,
+  codeEditorTabSelectedFG: lightBase.fg0,
+  codeEditorTabSelectedBorder: lightBase.bg2,
   codeEditorBreadcrumbs: lightBase.fg5,
-  codeEditorTabRowFg: createUtopiColor('rgba(97, 97, 97, 0.8)'),
+  codeEditorTabRowFg: lightBase.fg5,
   codeEditorGrid: createUtopiColor('#6d705b'),
 
   // Gap controls


### PR DESCRIPTION
With the newly floating inspector and navigator panels, the loading canvas animation wasn't properly aligned to fill the space. Now it is :)

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/concrete-utopia/utopia/assets/47405698/719bbc71-cf0d-47c2-ba4a-1a48b24e8402)  | ![loading-screen](https://github.com/concrete-utopia/utopia/assets/47405698/861c094e-302d-482f-8b66-1807573c72a3) |
