### PR TITLE
Nav item indentation

### DIFF
--- a/editor/src/components/navigator/navigator-item/expandable-indicator.tsx
+++ b/editor/src/components/navigator/navigator-item/expandable-indicator.tsx
@@ -22,7 +22,17 @@ export const ExpandableIndicator: React.FunctionComponent<
   const color = props.iconColor
 
   return (
-    <div data-testid={props.testId} style={{ width: 16, height: 16, ...props.style }}>
+    <div
+      data-testid={props.testId}
+      style={{
+        ...props.style,
+        width: 18,
+        height: 18,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
       <Icn
         category='semantic'
         type={`expansionarrow-${props.collapsed ? 'right' : 'down'}`}

--- a/editor/src/components/navigator/navigator-item/item-label.tsx
+++ b/editor/src/components/navigator/navigator-item/item-label.tsx
@@ -166,8 +166,8 @@ export const ItemLabel = React.memo((props: ItemLabelProps) => {
       {isConditionalClause && (
         <div
           style={{
-            width: 16,
-            height: 16,
+            width: 18,
+            height: 18,
             display: 'flex',
             fontWeight: 'bold',
             alignItems: 'center',

--- a/editor/src/components/navigator/navigator-item/item-label.tsx
+++ b/editor/src/components/navigator/navigator-item/item-label.tsx
@@ -176,6 +176,7 @@ export const ItemLabel = React.memo((props: ItemLabelProps) => {
             color: isActiveBranchOfOverriddenConditional
               ? colorTheme.brandNeonPink.value
               : colorTheme.dynamicBlue.value,
+            marginLeft: 6,
           }}
         >
           ✓

--- a/editor/src/components/navigator/navigator-item/item-label.tsx
+++ b/editor/src/components/navigator/navigator-item/item-label.tsx
@@ -161,6 +161,7 @@ export const ItemLabel = React.memo((props: ItemLabelProps) => {
         ...flexRowStyle,
         fontSize: 11,
         fontStyle: isDynamic ? 'italic' : 'normal',
+        gap: isConditionalClause ? 10 : undefined,
       }}
     >
       {isConditionalClause && (
@@ -177,6 +178,7 @@ export const ItemLabel = React.memo((props: ItemLabelProps) => {
               ? colorTheme.brandNeonPink.value
               : colorTheme.dynamicBlue.value,
             marginLeft: 6,
+            // marginRight: 8,
           }}
         >
           ✓
@@ -204,7 +206,7 @@ export const ItemLabel = React.memo((props: ItemLabelProps) => {
             backgroundColor: 'transparent',
             paddingTop: 3,
             paddingBottom: 3,
-            marginLeft: isConditionalClause ? 4 : 0,
+            // marginLeft: isConditionalClause ? 4 : 0,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',

--- a/editor/src/components/navigator/navigator-item/item-label.tsx
+++ b/editor/src/components/navigator/navigator-item/item-label.tsx
@@ -178,7 +178,6 @@ export const ItemLabel = React.memo((props: ItemLabelProps) => {
               ? colorTheme.brandNeonPink.value
               : colorTheme.dynamicBlue.value,
             marginLeft: 6,
-            // marginRight: 8,
           }}
         >
           ✓
@@ -206,7 +205,6 @@ export const ItemLabel = React.memo((props: ItemLabelProps) => {
             backgroundColor: 'transparent',
             paddingTop: 3,
             paddingBottom: 3,
-            // marginLeft: isConditionalClause ? 4 : 0,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -56,6 +56,7 @@ import { NavigatorItemActionSheet } from './navigator-item-components'
 import { assertNever } from '../../../core/shared/utils'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import { invalidGroupStateToString } from '../../canvas/canvas-strategies/strategies/group-helpers'
+import { justifyAlignSelector } from 'src/components/inspector/inpector-selectors'
 
 export function getItemHeight(navigatorEntry: NavigatorEntry): number {
   if (isConditionalClauseNavigatorEntry(navigatorEntry)) {
@@ -753,14 +754,14 @@ export const NavigatorItem: React.FunctionComponent<
         outlineOffset: props.parentOutline === 'solid' ? '-1px' : 0,
       }}
     >
-      {isSlot ? (
-        <FlexRow
-          data-testid={NavigatorItemTestId(varSafeNavigatorEntryToKey(navigatorEntry))}
-          onMouseDown={select}
-          onMouseMove={highlight}
-          onDoubleClick={focusComponent}
-          style={{ ...rowStyle }}
-        >
+      <FlexRow
+        data-testid={NavigatorItemTestId(varSafeNavigatorEntryToKey(navigatorEntry))}
+        style={rowStyle}
+        onMouseDown={select}
+        onMouseMove={highlight}
+        onDoubleClick={focusComponent}
+      >
+        {isSlot ? (
           <div
             key={`label-${props.label}-slot`}
             style={{
@@ -784,56 +785,50 @@ export const NavigatorItem: React.FunctionComponent<
           >
             Empty
           </div>
-        </FlexRow>
-      ) : (
-        <FlexRow
-          data-testid={NavigatorItemTestId(varSafeNavigatorEntryToKey(navigatorEntry))}
-          style={rowStyle}
-          onMouseDown={select}
-          onMouseMove={highlight}
-          onDoubleClick={focusComponent}
-        >
-          <FlexRow style={containerStyle}>
+        ) : (
+          <FlexRow style={{ justifyContent: 'space-between', ...containerStyle }}>
+            <FlexRow>
+              {unless(
+                props.navigatorEntry.type === 'CONDITIONAL_CLAUSE',
+                <ExpandableIndicator
+                  key='expandable-indicator'
+                  visible={showExpandableIndicator}
+                  collapsed={collapsed}
+                  selected={selected && !isInsideComponent}
+                  onMouseDown={collapse}
+                  style={{ transform: 'scale(0.6)', opacity: 'var(--paneHoverOpacity)' }}
+                  testId={`navigator-item-collapse-${navigatorEntryToKey(props.navigatorEntry)}`}
+                  iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
+                />,
+              )}
+              <NavigatorRowLabel
+                shouldShowParentOutline={props.parentOutline === 'child'}
+                navigatorEntry={navigatorEntry}
+                label={props.label}
+                renamingTarget={props.renamingTarget}
+                selected={props.selected}
+                dispatch={props.dispatch}
+                isDynamic={isDynamic}
+                iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
+                elementWarnings={!isConditional ? elementWarnings : null}
+              />
+            </FlexRow>
             {unless(
               props.navigatorEntry.type === 'CONDITIONAL_CLAUSE',
-              <ExpandableIndicator
-                key='expandable-indicator'
-                visible={showExpandableIndicator}
-                collapsed={collapsed}
-                selected={selected && !isInsideComponent}
-                onMouseDown={collapse}
-                style={{ transform: 'scale(0.6)', opacity: 'var(--paneHoverOpacity)' }}
-                testId={`navigator-item-collapse-${navigatorEntryToKey(props.navigatorEntry)}`}
+              <NavigatorItemActionSheet
+                navigatorEntry={navigatorEntry}
+                selected={selected}
+                highlighted={isHighlighted}
+                isVisibleOnCanvas={isElementVisible}
+                instanceOriginalComponentName={null}
+                dispatch={dispatch}
+                isSlot={isSlot}
                 iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
               />,
             )}
-            <NavigatorRowLabel
-              shouldShowParentOutline={props.parentOutline === 'child'}
-              navigatorEntry={navigatorEntry}
-              label={props.label}
-              renamingTarget={props.renamingTarget}
-              selected={props.selected}
-              dispatch={props.dispatch}
-              isDynamic={isDynamic}
-              iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
-              elementWarnings={!isConditional ? elementWarnings : null}
-            />
           </FlexRow>
-          {unless(
-            props.navigatorEntry.type === 'CONDITIONAL_CLAUSE',
-            <NavigatorItemActionSheet
-              navigatorEntry={navigatorEntry}
-              selected={selected}
-              highlighted={isHighlighted}
-              isVisibleOnCanvas={isElementVisible}
-              instanceOriginalComponentName={null}
-              dispatch={dispatch}
-              isSlot={isSlot}
-              iconColor={isConditional ? 'dynamic' : resultingStyle.iconColor}
-            />,
-          )}
-        </FlexRow>
-      )}
+        )}
+      </FlexRow>
     </div>
   )
 })

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -74,7 +74,7 @@ interface ComputedLook {
   iconColor: IcnProps['color']
 }
 
-export const BasePaddingUnit = 20
+export const BasePaddingUnit = 15
 
 export function getElementPadding(withNavigatorDepth: number): number {
   const paddingOffset = withNavigatorDepth - 1

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -451,41 +451,6 @@ export interface NavigatorItemInnerProps {
   visibleNavigatorTargets: Array<NavigatorEntry>
 }
 
-export const Slot = (props: {
-  label: any
-  shouldShowParentOutline: any
-  style: React.CSSProperties | undefined
-}) => {
-  const colorTheme = useColorTheme()
-
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', ...props.style }}>
-      <div
-        key={`label-${props.label}-slot`}
-        style={{
-          width: 140,
-          height: 19,
-          borderRadius: 20,
-          textAlign: 'center',
-          textTransform: 'lowercase',
-          backgroundColor: colorTheme.unavailable.value,
-          color: props.shouldShowParentOutline
-            ? colorTheme.navigatorResizeHintBorder.value
-            : colorTheme.unavailableGrey10.value,
-          border: `1px solid ${
-            props.shouldShowParentOutline
-              ? colorTheme.navigatorResizeHintBorder.value
-              : colorTheme.unavailableGrey10.value
-          }`,
-          marginLeft: 28,
-        }}
-      >
-        Empty
-      </div>
-    </div>
-  )
-}
-
 export const SyntheticEntry = (props: { style: React.CSSProperties | undefined }) => {
   const colorTheme = useColorTheme()
 
@@ -789,11 +754,37 @@ export const NavigatorItem: React.FunctionComponent<
       }}
     >
       {isSlot ? (
-        <Slot
-          style={rowStyle}
-          shouldShowParentOutline={props.parentOutline === 'child'}
-          label={props.label}
-        />
+        <FlexRow
+          data-testid={NavigatorItemTestId(varSafeNavigatorEntryToKey(navigatorEntry))}
+          onMouseDown={select}
+          onMouseMove={highlight}
+          onDoubleClick={focusComponent}
+          style={{ ...rowStyle }}
+        >
+          <div
+            key={`label-${props.label}-slot`}
+            style={{
+              width: 140,
+              height: 19,
+              borderRadius: 20,
+              textAlign: 'center',
+              textTransform: 'lowercase',
+              backgroundColor: colorTheme.unavailable.value,
+              color:
+                props.parentOutline === 'child'
+                  ? colorTheme.navigatorResizeHintBorder.value
+                  : colorTheme.unavailableGrey10.value,
+              border: `1px solid ${
+                props.parentOutline === 'child'
+                  ? colorTheme.navigatorResizeHintBorder.value
+                  : colorTheme.unavailableGrey10.value
+              }`,
+              marginLeft: 28,
+            }}
+          >
+            Empty
+          </div>
+        </FlexRow>
       ) : (
         <FlexRow
           data-testid={NavigatorItemTestId(varSafeNavigatorEntryToKey(navigatorEntry))}

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -477,7 +477,7 @@ export const Slot = (props: {
               ? colorTheme.navigatorResizeHintBorder.value
               : colorTheme.unavailableGrey10.value
           }`,
-          marginLeft: 24,
+          marginLeft: 28,
         }}
       >
         Empty

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -55,8 +55,6 @@ import { LayoutIcon } from './layout-icon'
 import { NavigatorItemActionSheet } from './navigator-item-components'
 import { assertNever } from '../../../core/shared/utils'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
-import { invalidGroupStateToString } from '../../canvas/canvas-strategies/strategies/group-helpers'
-import { justifyAlignSelector } from 'src/components/inspector/inpector-selectors'
 
 export function getItemHeight(navigatorEntry: NavigatorEntry): number {
   if (isConditionalClauseNavigatorEntry(navigatorEntry)) {
@@ -450,12 +448,6 @@ export interface NavigatorItemInnerProps {
   selected: boolean
   parentOutline: ParentOutline
   visibleNavigatorTargets: Array<NavigatorEntry>
-}
-
-export const SyntheticEntry = (props: { style: React.CSSProperties | undefined }) => {
-  const colorTheme = useColorTheme()
-
-  return <div style={{ ...props.style }}></div>
 }
 
 export const NavigatorItem: React.FunctionComponent<


### PR DESCRIPTION
Adjusting and realigning the indentation of different navigator items through:
- many various changes to style props
- moving the slot out of the NavigatorRowLabel, into the NavigatorItem
- changing the indentation increment of `BasePaddingUnit` from 20px to 15px

| Before  | Now |
| ------------- | ------------- |
| ![image](https://github.com/concrete-utopia/utopia/assets/47405698/4a217802-68af-47e0-a86c-a15bb91c40d4) | ![image](https://github.com/concrete-utopia/utopia/assets/47405698/26651a63-83b0-4075-adbd-2bec5e5876ef) |
