### PR TITLE
UPDATE_TEXT trues up groups

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4234,13 +4234,7 @@ export const UPDATE_FNS = {
         assertNever(textProp)
       }
     })()
-    const withGroupTrueUpQueued: EditorState = {
-      ...withUpdatedText,
-      trueUpGroupsForElementAfterDomWalkerRuns: [
-        ...withUpdatedText.trueUpGroupsForElementAfterDomWalkerRuns,
-        action.target,
-      ],
-    }
+    const withGroupTrueUpQueued: EditorState = addToTrueUpGroups(withUpdatedText, action.target)
 
     const withCollapsedElements = collapseTextElements(action.target, withGroupTrueUpQueued)
 

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4158,7 +4158,7 @@ export const UPDATE_FNS = {
       action.text[0] === '{' &&
       action.text[action.text.length - 1] === '}'
 
-    const withUpdatedText = (() => {
+    const withUpdatedText = ((): EditorState => {
       if (textProp === 'child') {
         return modifyOpenJsxElementOrConditionalAtPath(
           action.target,
@@ -4234,12 +4234,20 @@ export const UPDATE_FNS = {
         assertNever(textProp)
       }
     })()
-    const withCollapsedElements = collapseTextElements(action.target, withUpdatedText)
+    const withGroupTrueUpQueued: EditorState = {
+      ...withUpdatedText,
+      trueUpGroupsForElementAfterDomWalkerRuns: [
+        ...withUpdatedText.trueUpGroupsForElementAfterDomWalkerRuns,
+        action.target,
+      ],
+    }
 
-    if (withUpdatedText === withCollapsedElements) {
+    const withCollapsedElements = collapseTextElements(action.target, withGroupTrueUpQueued)
+
+    if (withGroupTrueUpQueued === withCollapsedElements) {
       return {
         ...editorStore,
-        unpatchedEditor: withUpdatedText,
+        unpatchedEditor: withGroupTrueUpQueued,
       }
     } else {
       return {
@@ -4247,7 +4255,7 @@ export const UPDATE_FNS = {
         unpatchedEditor: withCollapsedElements,
         history: History.add(
           editorStore.history,
-          withUpdatedText,
+          withGroupTrueUpQueued,
           editorStore.unpatchedDerived,
           [],
         ),


### PR DESCRIPTION
**Problem:**
The UPDATE_TEXT action doesn't use the `trueUpGroupsForElementAfterDomWalkerRuns` mechanism, meaning that changing the text in a group child doesn't queue a group true-up.

**Fix:**
Now it does!