### PR TITLE
wrap in group: preserve Hug pins

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
@@ -60,6 +60,8 @@ import {
 import type { FlexDirection } from '../../../inspector/common/css-utils'
 import { cssPixelLength } from '../../../inspector/common/css-utils'
 import {
+  detectFillHugFixedState,
+  isHugFromStyleAttribute,
   nukeAllAbsolutePositioningPropsCommands,
   nukeSizingPropsForAxisCommand,
   setElementTopLeft,
@@ -823,14 +825,24 @@ function setElementPinsForLocalRectangleEnsureTwoPinsPerDimension(
     )
   }
 
+  function setPinPreserveHug(pin: 'width' | 'height', value: number): Array<SetCssLengthProperty> {
+    const pinIsAlreadyHug = isHugFromStyleAttribute(elementCurrentProps, pin)
+
+    if (pinIsAlreadyHug) {
+      // we don't need to convert a Hug pin, do nothing here
+      return []
+    }
+    return [setPin(pin, value)]
+  }
+
   // TODO retarget Fragments
   const result = [
     setPin('left', localFrame.x),
     setPin('top', localFrame.y),
     setPin('right', parentSize.width - (localFrame.x + localFrame.width)),
     setPin('bottom', parentSize.height - (localFrame.y + localFrame.height)),
-    setPin('width', localFrame.width),
-    setPin('height', localFrame.height),
+    ...setPinPreserveHug('width', localFrame.width),
+    ...setPinPreserveHug('height', localFrame.height),
   ]
   return result
 }

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -11,6 +11,7 @@ import {
 import type {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
+  JSXAttributes,
 } from '../../core/shared/element-template'
 import {
   isJSXElement,
@@ -621,7 +622,7 @@ export function detectFillHugFixedState(
     getSimpleAttributeAtPath(right(element.element.value.props), PP.create('style', property)),
   )
 
-  if (simpleAttribute === MaxContent) {
+  if (isHugFromStyleAttribute(element.element.value.props, property)) {
     const valueWithType = { type: 'hug' as const }
     return { fixedHugFill: valueWithType, controlStatus: 'simple' }
   }
@@ -655,6 +656,18 @@ export function detectFillHugFixedState(
   }
 
   return { fixedHugFill: null, controlStatus: 'unset' }
+}
+
+export function isHugFromStyleAttribute(
+  props: JSXAttributes,
+  property: 'width' | 'height',
+): boolean {
+  const simpleAttribute = defaultEither(
+    null,
+    getSimpleAttributeAtPath(right(props), PP.create('style', property)),
+  )
+
+  return simpleAttribute === MaxContent
 }
 
 export function detectFillHugFixedStateMultiselect(


### PR DESCRIPTION
**Problem:**
Wrapping in Group destroys Hug pins by replacing them with their fixed measured value

**Fix:**
For width and height if the pin is Hug, leave it as is