### PR TITLE
Ensure first interaction works correctly.

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts.tsx
@@ -64,7 +64,7 @@ export const UtopiaProjectCtxAtom = atomWithPubSub<UtopiaProjectCtxProps>({
 })
 
 interface SceneLevelContextProps {
-  validPaths: Set<ElementPath>
+  validPaths: Set<string>
 }
 
 export const SceneLevelUtopiaCtxAtom = atomWithPubSub<SceneLevelContextProps>({

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -73,7 +73,7 @@ export function createLookupRender(
   hiddenInstances: Array<ElementPath>,
   displayNoneInstances: Array<ElementPath>,
   fileBlobs: UIFileBase64Blobs,
-  validPaths: Set<ElementPath>,
+  validPaths: Set<string>,
   reactChildren: React.ReactNode | undefined,
   metadataContext: UiJsxCanvasContextData,
   updateInvalidatedPaths: DomWalkerInvalidatePathsCtxData,
@@ -161,7 +161,7 @@ export function renderCoreElement(
   hiddenInstances: Array<ElementPath>,
   displayNoneInstances: Array<ElementPath>,
   fileBlobs: UIFileBase64Blobs,
-  validPaths: Set<ElementPath>,
+  validPaths: Set<string>,
   uid: string | undefined,
   reactChildren: React.ReactNode | undefined,
   metadataContext: UiJsxCanvasContextData,
@@ -646,7 +646,7 @@ function renderJSXElement(
   hiddenInstances: Array<ElementPath>,
   displayNoneInstances: Array<ElementPath>,
   fileBlobs: UIFileBase64Blobs,
-  validPaths: Set<ElementPath>,
+  validPaths: Set<string>,
   passthroughProps: MapLike<any>,
   metadataContext: UiJsxCanvasContextData,
   updateInvalidatedPaths: DomWalkerInvalidatePathsCtxData,
@@ -755,7 +755,10 @@ function renderJSXElement(
     throw canvasMissingJSXElementError(jsxFactoryFunctionName, code, jsx, filePath, highlightBounds)
   }
 
-  if (elementPath != null && validPaths.has(EP.makeLastPartOfPathStatic(elementPath))) {
+  if (
+    elementPath != null &&
+    validPaths.has(EP.toString(EP.makeLastPartOfPathStatic(elementPath)))
+  ) {
     if (elementIsTextEdited) {
       const textContent = trimJoinUnescapeTextFromJSXElements(childrenWithNewTextBlock)
       const textEditorProps: TextEditorProps = {

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
@@ -54,7 +54,7 @@ export function clearOpposingConditionalSpyValues(
 }
 
 export function addFakeSpyEntry(
-  validPaths: Set<ElementPath>,
+  validPaths: Set<string>,
   metadataContext: UiJsxCanvasContextData,
   elementPath: ElementPath,
   elementOrAttribute: JSXElementChild,
@@ -64,7 +64,7 @@ export function addFakeSpyEntry(
 ): void {
   // Ensure that entries are not created which aren't included in `validPaths`,
   // so that ghost like entries are not created.
-  if (validPaths.has(EP.makeLastPartOfPathStatic(elementPath))) {
+  if (validPaths.has(EP.toString(EP.makeLastPartOfPathStatic(elementPath)))) {
     const element: Either<string, JSXElementChild> = right(elementOrAttribute)
     const instanceMetadata: ElementInstanceMetadata = {
       element: element,

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -262,7 +262,7 @@ function useClearSpyMetadataOnRemount(
 }
 
 function clearSpyCollectorInvalidPaths(
-  validPaths: Set<ElementPath>,
+  validPaths: Set<string>,
   spyCollectorContextRef: UiJsxCanvasContextData,
 ): void {
   const spyKeys = Object.keys(spyCollectorContextRef.current.spyValues.metadata)
@@ -270,7 +270,7 @@ function clearSpyCollectorInvalidPaths(
     const elementPath =
       spyCollectorContextRef.current.spyValues.metadata[elementPathString].elementPath
     const staticElementPath = EP.makeLastPartOfPathStatic(elementPath)
-    if (!validPaths.has(staticElementPath)) {
+    if (!validPaths.has(EP.toString(staticElementPath))) {
       // we found a path that is no longer valid. let's delete it from the spy accumulator!
       delete spyCollectorContextRef.current.spyValues.metadata[elementPathString]
     }
@@ -736,7 +736,7 @@ function useGetStoryboardRoot(
 ): {
   StoryboardRootComponent: ComponentRendererComponent | undefined
   storyboardRootElementPath: ElementPath
-  rootValidPathsSet: Set<ElementPath>
+  rootValidPathsSet: Set<string>
   rootValidPathsArray: Array<ElementPath>
   rootInstancePath: ElementPath
 } {
@@ -761,7 +761,7 @@ function useGetStoryboardRoot(
   )
 
   const rootValidPathsArray = validPaths.map(EP.makeLastPartOfPathStatic)
-  const rootValidPathsSet = new Set(rootValidPathsArray)
+  const rootValidPathsSet = new Set(rootValidPathsArray.map(EP.toString))
 
   return {
     StoryboardRootComponent: StoryboardRootComponent,


### PR DESCRIPTION
**Problem:**
During the first interaction (dragging an element for example), several of the navigator elements turn orange erroneously. But only during that interaction, subsequent ones work completely fine.

**Cause:** 
`clearSpyCollectorInvalidPaths` wasn't working correctly because the entries in the `validPaths` set weren't referentially equal, when they were deeply equal. Likely this is due to the entries being removed from the path cache, resulting in new instances being created.

**Fix:**
Switching from `Set<ElementPath>` to `Set<string>` for the `validPaths` value, to make it completely independent of the particular instance of `ElementPath`, as `string` values are compared by value not by reference.

**Commit Details:**
- Use `Set<string>` instead of `Set<ElementPath>` for valid paths as the latter can fail because of reference equality checks that `Set` assumes.