### PR TITLE
Add an option for full logging of browser tests.

### DIFF
--- a/editor/karma-base.conf.js
+++ b/editor/karma-base.conf.js
@@ -21,6 +21,13 @@ webpackConfig['plugins'].push(
 )
 
 module.exports = function (config) {
+  var reporters = ['mocha', 'short-console-messages']
+  if (config.debug) {
+    reporters = ['mocha']
+  }
+  if (config.fullOutput) {
+    reporters = ['mocha', 'full-console-messages']
+  }
   config.set({
     plugins: [
       require('karma-parallel'),
@@ -30,8 +37,9 @@ module.exports = function (config) {
       'karma-viewport',
       'karma-mocha-reporter',
       require('./test/karma-custom-reporter/short-console-messages'),
+      require('./test/karma-custom-reporter/full-console-messages'),
     ],
-    reporters: config.debug ? ['mocha'] : ['mocha', 'short-console-messages'],
+    reporters: reporters,
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: '',
 

--- a/editor/package.json
+++ b/editor/package.json
@@ -28,6 +28,7 @@
     "test-update-snapshot": "pnpm run test -- --updateSnapshot",
     "test-browser-base": "NODE_OPTIONS=$NODE_OPENSSL_OPTION REACT_APP_AUTH0_CLIENT_ID='test' REACT_APP_AUTH0_ENDPOINT='test' REACT_APP_AUTH0_REDIRECT_URI='test' REACT_APP_ENVIRONMENT_CONFIG=development karma start",
     "test-browser": "pnpm run test-browser-base karma-no-shard.conf.js --single-run",
+    "test-browser-full-output": "pnpm run test-browser-base karma-no-shard.conf.js --single-run --full-output",
     "test-browser-debug": "REACT_APP_BROWSER_TEST_DEBUG='true' pnpm run test-browser-base karma-no-shard.conf.js --debug",
     "test-browser-shard-1": "pnpm run test-browser-base karma-shard-1.conf.js --single-run",
     "test-browser-shard-2": "pnpm run test-browser-base karma-shard-2.conf.js --single-run",

--- a/editor/test/karma-custom-reporter/full-console-messages.js
+++ b/editor/test/karma-custom-reporter/full-console-messages.js
@@ -1,0 +1,49 @@
+/* eslint-disable */
+var Levels = ['error', 'warn', 'info', 'debug', 'log']
+var FullConsoleMessages = function (baseReporterDecorator, formatError, config) {
+  baseReporterDecorator(this)
+  var self = this
+  /**
+   * @type Array<{type: string, log: string }>
+   */
+  var consoleMessagesForSpec = []
+  /**
+   * @type Array<{ {type: string, log: string, specName: string}}>
+   */
+  var allConsoleMessages = []
+
+  function printCleanConsoleMessages(consoleMessages) {
+    var messagesFiltered = []
+    consoleMessages.forEach((message) => {
+      self.write(`${message.type.toUpperCase()} ${message.log}\n`)
+      self.write(`this console message is from: \n  ${message.specName}\n`)
+      self.write(`\n`)
+    })
+  }
+
+  self.onBrowserLog = function (browser, log, type) {
+    consoleMessagesForSpec.push({
+      type: type,
+      log: log,
+    })
+  }
+
+  self.onRunComplete = function (browsers, results) {
+    printCleanConsoleMessages(allConsoleMessages)
+  }
+
+  self.onSpecComplete = function (browsers, results) {
+    const withSpecName = consoleMessagesForSpec.map((messageForSpec) => ({
+      ...messageForSpec,
+      specName: `${results.suite} ${results.description}`,
+    }))
+    allConsoleMessages.push(...withSpecName)
+    consoleMessagesForSpec = []
+  }
+}
+
+FullConsoleMessages.$inject = ['baseReporterDecorator', 'formatError', 'config']
+
+module.exports = {
+  'reporter:full-console-messages': ['type', FullConsoleMessages],
+}


### PR DESCRIPTION
**Problem:**
When trying to diagnose an issue with a particular test our short console messages reporter for Karma makes life difficult because of the way it accumulates logging messages that are the same and orders them first by log level.

**Fix:**
Added an alternative reporter which logs the messages as they are in the order they have arrived.

**Commit Details:**
- Added `FullConsoleMessages` logging reporter.
- Added configuration to the Karma config handling to switch on `FullConsoleMessages` if `full-output` is passed to the runner.
- Added `test-browser-full-output` npm script.