### PR TITLE
do not snap to parent if the parent is a Group

### DIFF
--- a/editor/src/components/canvas/controls/guideline-helpers.ts
+++ b/editor/src/components/canvas/controls/guideline-helpers.ts
@@ -26,6 +26,7 @@ import {
 } from '../canvas-strategies/strategies/fragment-like-helpers'
 import { fastForEach } from '../../../core/shared/utils'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
+import { treatElementAsGroupLike } from '../canvas-strategies/strategies/group-helpers'
 
 export const SnappingThreshold = 5
 
@@ -48,6 +49,12 @@ function getSnapTargetsForElementPath(
     pathTrees,
     MetadataUtils.getChildrenPathsOrdered(componentMetadata, pathTrees, parent),
   ).filter((path) => !EP.isDescendantOfOrEqualTo(path, elementPath))
+
+  const parentIsGroup = treatElementAsGroupLike(componentMetadata, EP.parentPath(elementPath))
+  if (parentIsGroup) {
+    // if parent is Group, only include siblings in the snaplines
+    return siblings
+  }
 
   return [parent, ...siblings]
 }

--- a/editor/src/components/canvas/controls/guideline-helpers.ts
+++ b/editor/src/components/canvas/controls/guideline-helpers.ts
@@ -50,8 +50,8 @@ function getSnapTargetsForElementPath(
     MetadataUtils.getChildrenPathsOrdered(componentMetadata, pathTrees, parent),
   ).filter((path) => !EP.isDescendantOfOrEqualTo(path, elementPath))
 
-  const parentIsGroup = treatElementAsGroupLike(componentMetadata, EP.parentPath(elementPath))
-  if (parentIsGroup) {
+  const parentIsGroupLike = treatElementAsGroupLike(componentMetadata, EP.parentPath(elementPath))
+  if (parentIsGroupLike) {
     // if parent is Group, only include siblings in the snaplines
     return siblings
   }

--- a/editor/src/components/canvas/event-helpers.test-utils.tsx
+++ b/editor/src/components/canvas/event-helpers.test-utils.tsx
@@ -176,6 +176,7 @@ export async function mouseDragFromPointWithDelta(
     eventOptions?: MouseEventInit
     staggerMoveEvents?: boolean
     midDragCallback?: () => Promise<void>
+    skipMouseUp?: boolean
   } = {},
 ): Promise<void> {
   const endPoint: Point = {
@@ -195,6 +196,7 @@ export async function mouseDragFromPointToPoint(
     staggerMoveEvents?: boolean
     midDragCallback?: () => Promise<void>
     moveBeforeMouseDown?: boolean
+    skipMouseUp?: boolean
   } = {},
 ): Promise<void> {
   const { buttons, ...mouseUpOptions } = options.eventOptions ?? {}
@@ -258,10 +260,12 @@ export async function mouseDragFromPointToPoint(
     await options.midDragCallback()
   }
 
-  await mouseUpAtPoint(eventSourceElement, endPoint, {
-    ...options,
-    eventOptions: mouseUpOptions,
-  })
+  if (!options.skipMouseUp) {
+    await mouseUpAtPoint(eventSourceElement, endPoint, {
+      ...options,
+      eventOptions: mouseUpOptions,
+    })
+  }
 }
 
 export async function mouseDragFromPointToPointNoMouseDown(


### PR DESCRIPTION
**Problem:**
Regular dragged/resized elements are snapping to their parent's (starging) edges and center lines. For children of Groups, however, we do not want to snap to the group's edges because it is simply buggy, because the snap system uses the starting measurements, but groups dynamically resize with their children. The starting snaplines are simply broken and nonsensical. 
We _could_ snap to the first non-group ancestor of the dragged/resized element, however that also poses problems if said element is set to Hug the group, again, because of the starting positions may be not where the actual element is.

**Solution**
For now, simply disallow parent snapping for children of groups, and only allow sibling snapping.

**Note**
As a consequence of the above rule, if the Group only has a single child, dragging/resizing it will not snap to anything.