### PR TITLE
Prevent showing the parent outline and bounds for a group.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize.test-utils.tsx
@@ -10,6 +10,9 @@ export async function resizeElement(
   dragDelta: Delta,
   edgePosition: EdgePosition,
   modifiers: Modifiers,
+  options: {
+    midDragCallback?: () => Promise<void>
+  } = {},
 ): Promise<void> {
   const canvasControl = renderResult.renderedDOM.queryByTestId(
     `resize-control-${edgePosition.x}-${edgePosition.y}`,
@@ -24,5 +27,8 @@ export async function resizeElement(
     y: resizeCornerBounds.y + 2,
   })
 
-  await mouseDragFromPointWithDelta(canvasControl, startPoint, dragDelta, { modifiers: modifiers })
+  await mouseDragFromPointWithDelta(canvasControl, startPoint, dragDelta, {
+    modifiers: modifiers,
+    midDragCallback: options.midDragCallback,
+  })
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/groups.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/groups.spec.browser2.tsx
@@ -99,7 +99,7 @@ Received: ${JSON.stringify(actualValue)}`,
   }
 }
 
-function checkThatParentOutlineNotPresent(
+function checkThatParentOutlinesAndBoundsNotPresent(
   editorRenderResult: EditorRenderResult,
 ): () => Promise<void> {
   return async () => {
@@ -2134,7 +2134,7 @@ describe('Groups behaviors', () => {
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-2`)])
 
         await dragByPixels(editor, { x: 100, y: 100 }, 'child-2', {
-          midDragCallback: checkThatParentOutlineNotPresent(editor),
+          midDragCallback: checkThatParentOutlinesAndBoundsNotPresent(editor),
         })
 
         expect(groupDiv.style.width).toBe('300px')
@@ -2217,7 +2217,7 @@ describe('Groups behaviors', () => {
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-2`)])
 
         await dragByPixels(editor, { x: 100, y: 100 }, 'child-2', {
-          midDragCallback: checkThatParentOutlineNotPresent(editor),
+          midDragCallback: checkThatParentOutlinesAndBoundsNotPresent(editor),
         })
 
         expect(groupDiv.style.width).toBe('300px')
@@ -2300,7 +2300,7 @@ describe('Groups behaviors', () => {
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-2`)])
 
         await dragByPixels(editor, { x: 100, y: 100 }, 'child-2', {
-          midDragCallback: checkThatParentOutlineNotPresent(editor),
+          midDragCallback: checkThatParentOutlinesAndBoundsNotPresent(editor),
         })
 
         expect(groupDiv.style.width).toBe('300px')
@@ -2383,7 +2383,7 @@ describe('Groups behaviors', () => {
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-1`)])
 
         await dragByPixels(editor, { x: -100, y: -100 }, 'child-1', {
-          midDragCallback: checkThatParentOutlineNotPresent(editor),
+          midDragCallback: checkThatParentOutlinesAndBoundsNotPresent(editor),
         })
 
         expect(groupDiv.style.width).toBe('300px')
@@ -2466,7 +2466,7 @@ describe('Groups behaviors', () => {
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-1`)])
 
         await dragByPixels(editor, { x: -100, y: -100 }, 'child-1', {
-          midDragCallback: checkThatParentOutlineNotPresent(editor),
+          midDragCallback: checkThatParentOutlinesAndBoundsNotPresent(editor),
         })
 
         expect(groupDiv.style.width).toBe('300px')
@@ -2549,7 +2549,7 @@ describe('Groups behaviors', () => {
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-3`)])
 
         await dragByPixels(editor, { x: 100, y: -100 }, 'child-3', {
-          midDragCallback: checkThatParentOutlineNotPresent(editor),
+          midDragCallback: checkThatParentOutlinesAndBoundsNotPresent(editor),
         })
 
         expect(groupDiv.style.width).toBe('300px')
@@ -2641,7 +2641,7 @@ describe('Groups behaviors', () => {
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-2`)])
 
         await dragByPixels(editor, { x: 100, y: 100 }, 'child-2', {
-          midDragCallback: checkThatParentOutlineNotPresent(editor),
+          midDragCallback: checkThatParentOutlinesAndBoundsNotPresent(editor),
         })
 
         expect(groupDiv.style.width).toBe('300px')
@@ -2726,7 +2726,7 @@ describe('Groups behaviors', () => {
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-1`)])
 
         await dragByPixels(editor, { x: -100, y: -100 }, 'child-1', {
-          midDragCallback: checkThatParentOutlineNotPresent(editor),
+          midDragCallback: checkThatParentOutlinesAndBoundsNotPresent(editor),
         })
 
         expect(groupDiv.style.width).toBe('300px')
@@ -2903,7 +2903,7 @@ describe('Groups behaviors', () => {
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/inner-group/child-2`)])
 
         await dragByPixels(editor, { x: 100, y: 100 }, 'child-2', {
-          midDragCallback: checkThatParentOutlineNotPresent(editor),
+          midDragCallback: checkThatParentOutlinesAndBoundsNotPresent(editor),
         })
 
         expect(groupDiv.style.width).toBe('300px')
@@ -3004,7 +3004,7 @@ describe('Groups behaviors', () => {
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/inner-group/child-2`)])
 
         await dragByPixels(editor, { x: 100, y: 100 }, 'child-2', {
-          midDragCallback: checkThatParentOutlineNotPresent(editor),
+          midDragCallback: checkThatParentOutlinesAndBoundsNotPresent(editor),
         })
 
         expect(groupDiv.style.width).toBe('300px')
@@ -3115,7 +3115,7 @@ describe('Groups behaviors', () => {
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-1`)])
 
         await dragByPixels(editor, { x: -45, y: -45 }, 'child-1', {
-          midDragCallback: checkThatParentOutlineNotPresent(editor),
+          midDragCallback: checkThatParentOutlinesAndBoundsNotPresent(editor),
         })
 
         expect(groupDiv.style.width).toBe('200px')

--- a/editor/src/components/canvas/canvas-strategies/strategies/groups.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/groups.spec.browser2.tsx
@@ -24,6 +24,8 @@ import { TestSceneUID } from '../../ui-jsx.test-utils'
 import { makeTestProjectCodeWithSnippet, renderTestEditorWithCode } from '../../ui-jsx.test-utils'
 import { resizeElement } from './absolute-resize.test-utils'
 import { changeInspectorNumberControl } from '../../../inspector/common/inspector.test-utils'
+import { ParentOutlinesTestIdSuffix } from '../../controls/parent-outlines'
+import { ParentBoundsTestIdSuffix } from '../../controls/parent-bounds'
 
 const GroupPath = `${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:root-div/group`
 
@@ -48,19 +50,19 @@ async function dragByPixels(
   editor: EditorRenderResult,
   delta: { x: number; y: number },
   testid: string,
-  modifiers: Modifiers = emptyModifiers,
+  options: {
+    modifiers?: Modifiers
+    eventOptions?: MouseEventInit
+    staggerMoveEvents?: boolean
+    midDragCallback?: () => Promise<void>
+  } = {},
 ) {
   const targetElement = editor.renderedDOM.getByTestId(testid)
   const targetElementBounds = targetElement.getBoundingClientRect()
   const targetElementCenter = getDomRectCenter(targetElementBounds)
   const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
 
-  await mouseDragFromPointWithDelta(canvasControlsLayer, targetElementCenter, delta, {
-    modifiers,
-    midDragCallback: async () => {
-      NO_OP()
-    },
-  })
+  await mouseDragFromPointWithDelta(canvasControlsLayer, targetElementCenter, delta, options)
 }
 
 function assertStylePropsSet(
@@ -94,6 +96,23 @@ Received: ${JSON.stringify(actualValue)}`,
       )
     }
     expect(actualValue).toEqual(expectedValue)
+  }
+}
+
+function checkThatParentOutlineNotPresent(
+  editorRenderResult: EditorRenderResult,
+): () => Promise<void> {
+  return async () => {
+    // Check that there are no parent outlines.
+    const outlines = editorRenderResult.renderedDOM.queryAllByTestId((content) => {
+      return content.endsWith(ParentOutlinesTestIdSuffix)
+    })
+    expect(outlines).toHaveLength(0)
+    // Check that there are no parent bounds.
+    const bounds = editorRenderResult.renderedDOM.queryAllByTestId((content) => {
+      return content.endsWith(ParentBoundsTestIdSuffix)
+    })
+    expect(bounds).toHaveLength(0)
   }
 }
 
@@ -2114,7 +2133,9 @@ describe('Groups behaviors', () => {
 
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-2`)])
 
-        await dragByPixels(editor, { x: 100, y: 100 }, 'child-2')
+        await dragByPixels(editor, { x: 100, y: 100 }, 'child-2', {
+          midDragCallback: checkThatParentOutlineNotPresent(editor),
+        })
 
         expect(groupDiv.style.width).toBe('300px')
         expect(groupDiv.style.height).toBe('300px')
@@ -2195,7 +2216,9 @@ describe('Groups behaviors', () => {
 
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-2`)])
 
-        await dragByPixels(editor, { x: 100, y: 100 }, 'child-2')
+        await dragByPixels(editor, { x: 100, y: 100 }, 'child-2', {
+          midDragCallback: checkThatParentOutlineNotPresent(editor),
+        })
 
         expect(groupDiv.style.width).toBe('300px')
         expect(groupDiv.style.height).toBe('300px')
@@ -2276,7 +2299,9 @@ describe('Groups behaviors', () => {
 
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-2`)])
 
-        await dragByPixels(editor, { x: 100, y: 100 }, 'child-2')
+        await dragByPixels(editor, { x: 100, y: 100 }, 'child-2', {
+          midDragCallback: checkThatParentOutlineNotPresent(editor),
+        })
 
         expect(groupDiv.style.width).toBe('300px')
         expect(groupDiv.style.height).toBe('300px')
@@ -2357,7 +2382,9 @@ describe('Groups behaviors', () => {
 
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-1`)])
 
-        await dragByPixels(editor, { x: -100, y: -100 }, 'child-1')
+        await dragByPixels(editor, { x: -100, y: -100 }, 'child-1', {
+          midDragCallback: checkThatParentOutlineNotPresent(editor),
+        })
 
         expect(groupDiv.style.width).toBe('300px')
         expect(groupDiv.style.height).toBe('300px')
@@ -2438,7 +2465,9 @@ describe('Groups behaviors', () => {
 
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-1`)])
 
-        await dragByPixels(editor, { x: -100, y: -100 }, 'child-1')
+        await dragByPixels(editor, { x: -100, y: -100 }, 'child-1', {
+          midDragCallback: checkThatParentOutlineNotPresent(editor),
+        })
 
         expect(groupDiv.style.width).toBe('300px')
         expect(groupDiv.style.height).toBe('300px')
@@ -2519,7 +2548,9 @@ describe('Groups behaviors', () => {
 
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-3`)])
 
-        await dragByPixels(editor, { x: 100, y: -100 }, 'child-3')
+        await dragByPixels(editor, { x: 100, y: -100 }, 'child-3', {
+          midDragCallback: checkThatParentOutlineNotPresent(editor),
+        })
 
         expect(groupDiv.style.width).toBe('300px')
         expect(groupDiv.style.height).toBe('300px')
@@ -2609,7 +2640,9 @@ describe('Groups behaviors', () => {
 
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-2`)])
 
-        await dragByPixels(editor, { x: 100, y: 100 }, 'child-2')
+        await dragByPixels(editor, { x: 100, y: 100 }, 'child-2', {
+          midDragCallback: checkThatParentOutlineNotPresent(editor),
+        })
 
         expect(groupDiv.style.width).toBe('300px')
         expect(groupDiv.style.height).toBe('300px')
@@ -2692,7 +2725,9 @@ describe('Groups behaviors', () => {
 
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-1`)])
 
-        await dragByPixels(editor, { x: -100, y: -100 }, 'child-1')
+        await dragByPixels(editor, { x: -100, y: -100 }, 'child-1', {
+          midDragCallback: checkThatParentOutlineNotPresent(editor),
+        })
 
         expect(groupDiv.style.width).toBe('300px')
         expect(groupDiv.style.height).toBe('300px')
@@ -2867,7 +2902,9 @@ describe('Groups behaviors', () => {
 
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/inner-group/child-2`)])
 
-        await dragByPixels(editor, { x: 100, y: 100 }, 'child-2')
+        await dragByPixels(editor, { x: 100, y: 100 }, 'child-2', {
+          midDragCallback: checkThatParentOutlineNotPresent(editor),
+        })
 
         expect(groupDiv.style.width).toBe('300px')
         expect(groupDiv.style.height).toBe('300px')
@@ -2966,7 +3003,9 @@ describe('Groups behaviors', () => {
 
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/inner-group/child-2`)])
 
-        await dragByPixels(editor, { x: 100, y: 100 }, 'child-2')
+        await dragByPixels(editor, { x: 100, y: 100 }, 'child-2', {
+          midDragCallback: checkThatParentOutlineNotPresent(editor),
+        })
 
         expect(groupDiv.style.width).toBe('300px')
         expect(groupDiv.style.height).toBe('300px')
@@ -3075,7 +3114,9 @@ describe('Groups behaviors', () => {
 
         await selectComponentsForTest(editor, [fromString(`${GroupPath}/child-1`)])
 
-        await dragByPixels(editor, { x: -45, y: -45 }, 'child-1')
+        await dragByPixels(editor, { x: -45, y: -45 }, 'child-1', {
+          midDragCallback: checkThatParentOutlineNotPresent(editor),
+        })
 
         expect(groupDiv.style.width).toBe('200px')
         expect(groupDiv.style.height).toBe('200px')

--- a/editor/src/components/canvas/controls/parent-outlines.tsx
+++ b/editor/src/components/canvas/controls/parent-outlines.tsx
@@ -15,12 +15,15 @@ import {
   findMaybeConditionalExpression,
   findFirstNonConditionalAncestor,
 } from '../../../core/model/conditionals'
+import { treatElementAsGroupLike } from '../canvas-strategies/strategies/group-helpers'
+
+export const ParentOutlinesTestIdSuffix = `-parent-outlines-control`
 
 export const ImmediateParentOutlinesTestId = (targetPaths: Array<ElementPath>): string =>
-  `${targetPaths.map(EP.toString).sort()}-immediate-parent-outlines-control`
+  `${targetPaths.map(EP.toString).sort()}-immediate${ParentOutlinesTestIdSuffix}`
 
 export const ParentOutlinesTestId = (targetPaths: Array<ElementPath>): string =>
-  `${targetPaths.map(EP.toString).sort()}-parent-outlines-control`
+  `${targetPaths.map(EP.toString).sort()}${ParentOutlinesTestIdSuffix}`
 
 interface ImmediateParentOutlinesProps {
   targets: Array<ElementPath>
@@ -37,8 +40,19 @@ export const ImmediateParentOutlines = controlForStrategyMemoized(
     const parentFrame = useEditorState(
       Substores.fullStore,
       (store) => {
+        // Prevent this from showing when manipulating the child of a group.
+        function anyGroups(paths: Array<ElementPath>): boolean {
+          return paths.some((path) => {
+            return treatElementAsGroupLike(store.editor.jsxMetadata, path)
+          })
+        }
+
         const parentHighlightPaths = store.editor.canvas.controls.parentHighlightPaths
-        if (parentHighlightPaths != null && parentHighlightPaths.length === 1) {
+        if (
+          parentHighlightPaths != null &&
+          parentHighlightPaths.length === 1 &&
+          !anyGroups(parentHighlightPaths)
+        ) {
           return MetadataUtils.getFrameInCanvasCoords(
             parentHighlightPaths[0],
             store.editor.jsxMetadata,
@@ -50,7 +64,11 @@ export const ImmediateParentOutlines = controlForStrategyMemoized(
             stripNulls(targets.map((view) => EP.parentPath(view))),
             EP.pathsEqual,
           )
-          if (targetParents.length === 1 && !EP.isStoryboardPath(targetParents[0])) {
+          if (
+            targetParents.length === 1 &&
+            !EP.isStoryboardPath(targetParents[0]) &&
+            !anyGroups(targetParents)
+          ) {
             return MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, targets[0])
               ?.specialSizeMeasurements.immediateParentBounds
           }
@@ -85,6 +103,12 @@ export const ParentOutlines = controlForStrategyMemoized(
         if (EP.isStoryboardPath(targetParent)) {
           return { parentFrame: null, isSlot: false }
         }
+
+        // Prevent this from showing when manipulating the child of a group.
+        if (treatElementAsGroupLike(store.editor.jsxMetadata, targetParent)) {
+          return { parentFrame: null, isSlot: false }
+        }
+
         const isSlotTarget =
           findMaybeConditionalExpression(targetParent, store.editor.jsxMetadata) != null
         const target = isSlotTarget


### PR DESCRIPTION
**Problem:**
We don't want to show the parent bounds and outlines when moving or resizing the child of a group.

**Fix:**
The bounds and outlines are now filtered out for the cases where `treatElementAsGroupLike` returns true.

**Commit Details:**
- Extracted out `ParentBoundsTestIdSuffix` from `ImmediateParentBoundsTestId` and `ParentBoundsTestId`.
- Extracted out `ParentOutlinesTestIdSuffix` from `ImmediateParentOutlinesTestId` and `ParentOutlinesTestId`.
- `ImmediateParentOutlines` now checks `treatElementAsGroupLike` and if that is true prevents the control from showing.
- `ParentOutlines` now checks `treatElementAsGroupLike` and if that is true prevents the control from showing.
- `ImmediateParentBounds` now checks `treatElementAsGroupLike` and if that is true prevents the control from showing.
- `ParentBounds` now checks `treatElementAsGroupLike` and if that is true prevents the control from showing.
- Added support for passing `midDragCallback` to `resizeElement`.
- Added support for passing options to `dragByPixels`.
- Added test function `checkThatParentOutlinesAndBoundsNotPresent`.
- Tests dragging children of groups now check that the outlines and bounds are not shown.
