### PR TITLE
Make sure to apply group child pins on unwrap

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
@@ -787,39 +787,6 @@ export function createWrapInGroupActions(
 
   const groupPath = EP.appendToPath(parentPath.intendedParentPath, group.uid) // TODO does this work if the parentPath is a ConditionalClauseInsertionPath?
 
-  function createPinChangeCommandsForElement(
-    elementMetadata: ElementInstanceMetadata | null,
-    expectedPath: ElementPath,
-  ): Array<CanvasCommand> {
-    if (
-      elementMetadata == null ||
-      isLeft(elementMetadata.element) ||
-      !isJSXElement(elementMetadata.element.value)
-    ) {
-      throw new Error(
-        `Invariant violation: ElementInstanceMetadata.element found for ${EP.toString(
-          expectedPath,
-        )} was null or Left or not JSXElement`,
-      )
-    }
-    const childLocalRect: LocalRectangle = canvasRectangleToLocalRectangle(
-      forceFiniteRectangle(elementMetadata.globalFrame),
-      globalBoundingBoxOfAllElementsToBeWrapped,
-    )
-    return [
-      // make the child `position: absolute`
-      setProperty('always', expectedPath, PP.create('style', 'position'), 'absolute'),
-      // set child pins to match their intended new local rectangle
-      ...setElementPinsForLocalRectangleEnsureTwoPinsPerDimension(
-        expectedPath,
-        elementMetadata.element.value.props,
-        childLocalRect,
-        sizeFromRectangle(newLocalRectangleForGroup),
-        null,
-      ),
-    ]
-  }
-
   const pinChangeCommands: ReadonlyArray<CanvasCommand> = arrayAccumulate((acc) => {
     orderedActionTargets.forEach((maybeTarget) => {
       return replaceFragmentLikePathsWithTheirChildrenRecursive(
@@ -835,12 +802,54 @@ export function createWrapInGroupActions(
 
         const foundMetadata = MetadataUtils.findElementByElementPath(metadata, target)
 
-        acc.push(...createPinChangeCommandsForElement(foundMetadata, expectedPathInsideGroup))
+        acc.push(
+          ...createPinChangeCommandsForElement(
+            foundMetadata,
+            expectedPathInsideGroup,
+            globalBoundingBoxOfAllElementsToBeWrapped,
+            newLocalRectangleForGroup,
+          ),
+        )
       })
     })
   })
 
   return applyCommandsAction([...deleteCommands, insertGroupCommand, ...pinChangeCommands])
+}
+
+export function createPinChangeCommandsForElement(
+  elementMetadata: ElementInstanceMetadata | null,
+  expectedPath: ElementPath,
+  globalBoundingBoxOfAllElementsToBeWrapped: CanvasRectangle,
+  newLocalRectangleForGroup: LocalRectangle,
+): Array<CanvasCommand> {
+  if (
+    elementMetadata == null ||
+    isLeft(elementMetadata.element) ||
+    !isJSXElement(elementMetadata.element.value)
+  ) {
+    throw new Error(
+      `Invariant violation: ElementInstanceMetadata.element found for ${EP.toString(
+        expectedPath,
+      )} was null or Left or not JSXElement`,
+    )
+  }
+  const childLocalRect: LocalRectangle = canvasRectangleToLocalRectangle(
+    forceFiniteRectangle(elementMetadata.globalFrame),
+    globalBoundingBoxOfAllElementsToBeWrapped,
+  )
+  return [
+    // make the child `position: absolute`
+    setProperty('always', expectedPath, PP.create('style', 'position'), 'absolute'),
+    // set child pins to match their intended new local rectangle
+    ...setElementPinsForLocalRectangleEnsureTwoPinsPerDimension(
+      expectedPath,
+      elementMetadata.element.value.props,
+      childLocalRect,
+      sizeFromRectangle(newLocalRectangleForGroup),
+      null,
+    ),
+  ]
 }
 
 function setElementPinsForLocalRectangleEnsureTwoPinsPerDimension(

--- a/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
@@ -803,7 +803,7 @@ export function createWrapInGroupActions(
         const foundMetadata = MetadataUtils.findElementByElementPath(metadata, target)
 
         acc.push(
-          ...createPinChangeCommandsForElement(
+          ...createPinChangeCommandsForElementBecomingGroupChild(
             foundMetadata,
             expectedPathInsideGroup,
             globalBoundingBoxOfAllElementsToBeWrapped,
@@ -817,7 +817,7 @@ export function createWrapInGroupActions(
   return applyCommandsAction([...deleteCommands, insertGroupCommand, ...pinChangeCommands])
 }
 
-export function createPinChangeCommandsForElement(
+export function createPinChangeCommandsForElementBecomingGroupChild(
   elementMetadata: ElementInstanceMetadata | null,
   expectedPath: ElementPath,
   globalBoundingBoxOfAllElementsToBeWrapped: CanvasRectangle,

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -5445,6 +5445,109 @@ export var storyboard = (
         )
       })
     })
+    describe('groups', () => {
+      it('makes sure unwrapped children have pins and keep their frame intact', async () => {
+        const testCode = `
+          <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+            <Group data-uid='group'>
+              <div
+                data-uid='unwrap-me'
+                style={{
+                  position: 'absolute',
+                  left: 20,
+                  top: 50,
+                  width: 100,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 2,
+                }}>
+                  <div
+                    style={{
+                      backgroundColor: 'orange',
+                      width: 50,
+                      height: 50,
+                    }}
+                    data-uid='foo'
+                  />
+                  <div
+                    style={{
+                      backgroundColor: 'orange',
+                      width: 30,
+                      height: 30,
+                    }}
+                    data-uid='bar'
+                  />
+                  <div
+                    style={{
+                      backgroundColor: 'orange',
+                      height: 60,
+                    }}
+                    data-uid='baz'
+                  />
+              </div>
+              <div data-uid='ccc' style={{
+                width: 100,
+                height: 50,
+                left: 200,
+                top: 200,
+              }} />
+            </Group>
+          </div>
+        `
+        const renderResult = await renderTestEditorWithCode(
+          makeTestProjectCodeWithSnippet(testCode),
+          'await-first-dom-report',
+        )
+        await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/group/unwrap-me'))], true)
+        expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+          makeTestProjectCodeWithSnippet(`
+          <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+            <Group data-uid='group'>
+              <div
+                style={{
+                  backgroundColor: 'orange',
+                  width: 50,
+                  height: 50,
+                  left: 20,
+                  top: 50,
+                  position: 'absolute',
+                }}
+                data-uid='foo'
+              />
+              <div
+                style={{
+                  backgroundColor: 'orange',
+                  width: 30,
+                  height: 30,
+                  left: 20,
+                  top: 102,
+                  position: 'absolute',
+                }}
+                data-uid='bar'
+              />
+              <div
+                style={{
+                  backgroundColor: 'orange',
+                  height: 60,
+                  left: 20,
+                  top: 134,
+                  width: 100,
+                  position: 'absolute',
+                }}
+                data-uid='baz'
+              />
+              <div data-uid='ccc' style={{
+                width: 100,
+                height: 50,
+                left: 200,
+                top: 200,
+              }} />
+            </Group>
+          </div>
+        `),
+        )
+      })
+    })
   })
 
   describe('WRAP_IN_ELEMENT', () => {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -585,7 +585,7 @@ import {
   isInvalidGroupState,
   treatElementAsGroupLike,
 } from '../../canvas/canvas-strategies/strategies/group-helpers'
-import { createPinChangeCommandsForElement } from '../../canvas/canvas-strategies/strategies/group-conversion-helpers'
+import { createPinChangeCommandsForElementBecomingGroupChild } from '../../canvas/canvas-strategies/strategies/group-conversion-helpers'
 
 export const MIN_CODE_PANE_REOPEN_WIDTH = 100
 
@@ -2258,7 +2258,7 @@ export const UPDATE_FNS = {
               if (isGroupChild) {
                 return foldAndApplyCommandsSimple(
                   result.editor,
-                  createPinChangeCommandsForElement(
+                  createPinChangeCommandsForElementBecomingGroupChild(
                     child,
                     result.newPath,
                     parentFrame,


### PR DESCRIPTION
Fixes #3992 

**Problem:**

When unwrapping group children, the inherited grandchildren may not have valid pins and/or jump around (e.g. unwrapping a flex container).

**Fix:**

Apply `createPinChangeCommandsForElement` commands in the `UNWRAP_ELEMENT` function for group children.