### PR TITLE
Group children validate the use of props position and size.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/post-action-options/navigator-reparent.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/navigator-reparent.ts
@@ -1,3 +1,4 @@
+import type { ProjectContentTreeRoot } from '../../../../components/assets'
 import type { BuiltInDependencies } from '../../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../../core/shared/array-utils'
@@ -195,6 +196,7 @@ function adjustIntendedCoordinatesForGroups(
 }
 
 export function collectGroupTrueUp(
+  projectContents: ProjectContentTreeRoot,
   jsxMetadata: ElementInstanceMetadataMap,
   pathTrees: ElementPathTrees,
   allElementProps: AllElementProps,
@@ -203,6 +205,7 @@ export function collectGroupTrueUp(
   oldPath: ElementPath,
 ): Array<ElementPath> {
   const reparentTargetParentIsGroup = allowGroupTrueUp(
+    projectContents,
     jsxMetadata,
     pathTrees,
     allElementProps,
@@ -217,7 +220,7 @@ export function collectGroupTrueUp(
 
   const maybeElementAncestorGroup =
     EP.getAncestors(oldPath).find((path) => {
-      return allowGroupTrueUp(jsxMetadata, pathTrees, allElementProps, path)
+      return allowGroupTrueUp(projectContents, jsxMetadata, pathTrees, allElementProps, path)
     }) ?? null
   if (maybeElementAncestorGroup != null) {
     // the reparented element comes out of a group, so true up the group by its elements

--- a/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
@@ -254,6 +254,7 @@ export function staticReparentAndUpdatePosition(
 
   const groupTrueUpPaths = elementsToInsert.flatMap((element) =>
     collectGroupTrueUp(
+      editorStateContext.projectContents,
       editorStateContext.startingMetadata,
       editorStateContext.startingElementPathTrees,
       editorStateContext.startingAllElementProps,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
@@ -147,7 +147,13 @@ export function getReparentOutcome(
       commands.push(addImportsToFile(whenToRun, newTargetFilePath, importsToAdd))
       commands.push(reparentElement(whenToRun, toReparent.target, newParent, indexPosition))
       commands.push(
-        ...getRequiredGroupTrueUps(metadata, pathTrees, allElementProps, toReparent.target),
+        ...getRequiredGroupTrueUps(
+          projectContents,
+          metadata,
+          pathTrees,
+          allElementProps,
+          toReparent.target,
+        ),
       )
       newPath = EP.appendToPath(newParentElementPath, EP.toUid(toReparent.target))
       break

--- a/editor/src/components/canvas/canvas-utils-unit-tests.spec.tsx
+++ b/editor/src/components/canvas/canvas-utils-unit-tests.spec.tsx
@@ -243,17 +243,17 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
   it('TLRB pin change works, dragged from topleft point', async () => {
     const testProject = getEditorState(
       makeTestProjectCodeWithSnippet(`
-    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+    <View style={{ ...(props.style || {}) }} data-uid='outer-view'>
       <View
         style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 52, top: 61, right: 50, bottom: 20 }}
-        data-uid='bbb'
+        data-uid='inner-view'
       />
     </View>
     `),
     )
 
     const pinChange = singleResizeChange(
-      EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb']),
+      EP.appendNewElementPath(TestScenePath, ['outer-view', 'inner-view']),
       { x: 0, y: 0 } as EdgePosition,
       { x: 50, y: 20 } as CanvasVector,
     )
@@ -266,10 +266,10 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     expect(testPrintCodeFromEditorState(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        `<View style={{ ...(props.style || {}) }} data-uid='outer-view'>
         <View
           style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 2, top: 41, right: 50, bottom: 20 }}
-          data-uid='bbb'
+          data-uid='inner-view'
         />
       </View>`,
       ),
@@ -278,17 +278,17 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
   it('TLRB pin change works, dragged from bottom right point', async () => {
     const testProject = getEditorState(
       makeTestProjectCodeWithSnippet(`
-    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+    <View style={{ ...(props.style || {}) }} data-uid='outer-view'>
       <View
         style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 52, top: 61, right: 50, bottom: 20 }}
-        data-uid='bbb'
+        data-uid='inner-view'
       />
     </View>
     `),
     )
 
     const pinChange = singleResizeChange(
-      EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb']),
+      EP.appendNewElementPath(TestScenePath, ['outer-view', 'inner-view']),
       { x: 1, y: 1 } as EdgePosition,
       { x: 80, y: -10 } as CanvasVector,
     )
@@ -301,10 +301,10 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     expect(testPrintCodeFromEditorState(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        `<View style={{ ...(props.style || {}) }} data-uid='outer-view'>
         <View
           style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 52, top: 61, right: -30, bottom: 30 }}
-          data-uid='bbb'
+          data-uid='inner-view'
         />
       </View>`,
       ),

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -289,7 +289,9 @@ export function updateFramesOfScenesAndComponents(
       (success, underlyingElement) => underlyingElement,
     )
     if (element == null || !(isJSXElement(element) || isJSXConditionalExpression(element))) {
-      throw new Error(`Unexpected result when looking for element: ${element}`)
+      throw new Error(
+        `Unexpected result when looking for (${EP.toString(staticTarget)}) element: ${element}`,
+      )
     }
 
     const staticParentPath = EP.parentPath(staticTarget)

--- a/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
+++ b/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
@@ -138,6 +138,7 @@ function getUpdateResizedGroupChildrenCommands(
 
   for (const frameAndTarget of targets) {
     const targetIsGroup = allowGroupTrueUp(
+      editor.projectContents,
       editor.jsxMetadata,
       editor.elementPathTree,
       editor.allElementProps,
@@ -260,6 +261,7 @@ function getResizeAncestorGroupsCommands(
       EP.parentPath(frameAndTarget.target),
     )
     const groupTrueUpPermitted = allowGroupTrueUp(
+      editor.projectContents,
       editor.jsxMetadata,
       editor.elementPathTree,
       editor.allElementProps,

--- a/editor/src/components/canvas/commands/queue-group-true-up-command.ts
+++ b/editor/src/components/canvas/commands/queue-group-true-up-command.ts
@@ -1,5 +1,6 @@
-import type { ElementPathTrees } from 'src/core/shared/element-path-tree'
-import type { ElementInstanceMetadataMap } from 'src/core/shared/element-template'
+import type { ProjectContentTreeRoot } from '../../../components/assets'
+import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
+import type { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
@@ -36,13 +37,14 @@ export const runQueueGroupTrueUp: CommandFunction<QueueGroupTrueUp> = (
 
 // If the target is in a group, then this will add a command for including the siblings in a trueing up.
 export function getRequiredGroupTrueUps(
+  projectContents: ProjectContentTreeRoot,
   metadata: ElementInstanceMetadataMap,
   pathTrees: ElementPathTrees,
   allElementProps: AllElementProps,
   target: ElementPath,
 ): Array<QueueGroupTrueUp> {
   const parentPath = EP.parentPath(target)
-  if (allowGroupTrueUp(metadata, pathTrees, allElementProps, parentPath)) {
+  if (allowGroupTrueUp(projectContents, metadata, pathTrees, allElementProps, parentPath)) {
     const siblings = MetadataUtils.getSiblingsOrdered(metadata, pathTrees, target)
     return siblings.map((sibling) => queueGroupTrueUp(sibling.elementPath))
   } else {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1591,6 +1591,7 @@ export const UPDATE_FNS = {
             editor.jsxMetadata,
             editor.elementPathTree,
             editor.allElementProps,
+            editor.projectContents,
           )
           if (isInvalidGroupState(maybeInvalidGroupState)) {
             setPropFailedMessage = invalidGroupStateToString(maybeInvalidGroupState)

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -2485,6 +2485,7 @@ export interface OriginalCanvasAndLocalFrame {
 }
 
 function getElementWarningsInner(
+  projectContents: ProjectContentTreeRoot,
   rootMetadata: ElementInstanceMetadataMap,
   allElementProps: AllElementProps,
   pathTrees: ElementPathTrees,
@@ -2517,13 +2518,19 @@ function getElementWarningsInner(
     const parentElement = MetadataUtils.findElementByElementPath(rootMetadata, parentPath)
 
     const groupState = treatElementAsGroupLikeFromMetadata(elementMetadata)
-      ? getGroupState(elementMetadata.elementPath, rootMetadata, pathTrees, allElementProps)
+      ? getGroupState(
+          elementMetadata.elementPath,
+          rootMetadata,
+          pathTrees,
+          allElementProps,
+          projectContents,
+        )
       : null
     const invalidGroup = isInvalidGroupState(groupState) ? groupState : null
 
     const groupChildState =
       parentElement != null && treatElementAsGroupLikeFromMetadata(parentElement)
-        ? getGroupChildStateWithGroupMetadata(elementMetadata, parentElement)
+        ? getGroupChildStateWithGroupMetadata(projectContents, elementMetadata, parentElement)
         : null
     const invalidGroupChild = isInvalidGroupState(groupChildState) ? groupChildState : null
 
@@ -2549,6 +2556,7 @@ type CacheableDerivedState = {
 }
 
 function deriveCacheableStateInner(
+  projectContents: ProjectContentTreeRoot,
   jsxMetadata: ElementInstanceMetadataMap,
   elementPathTree: ElementPathTrees,
   allElementProps: AllElementProps,
@@ -2562,7 +2570,12 @@ function deriveCacheableStateInner(
     hiddenInNavigator,
   )
 
-  const warnings = getElementWarnings(jsxMetadata, allElementProps, elementPathTree)
+  const warnings = getElementWarnings(
+    projectContents,
+    jsxMetadata,
+    allElementProps,
+    elementPathTree,
+  )
 
   const autoFocusedPaths = MetadataUtils.getAllPaths(jsxMetadata, elementPathTree).filter(
     (path) => {
@@ -2597,6 +2610,7 @@ export function deriveState(
     elementWarnings: warnings,
     autoFocusedPaths,
   } = deriveCacheableState(
+    editor.projectContents,
     editor.jsxMetadata,
     editor.elementPathTree,
     editor.allElementProps,


### PR DESCRIPTION
**Problem:**
When a group child is a component, we need to ensure that it correctly honours the position and size properties of the props parameter. So that when they are supplied to the instance, they will carry forward and be used, otherwise there's now point in applying those property changes.

**Fix:**
By extending `getGroupChildState` to include pre-existing checks for honouring the position and size properties any component that doesn't honour them will not participate in group truing up.

**Commit Details:**
- Added `'child-does-not-honour-props-position'` and `'child-does-not-honour-props-size'` to `InvalidGroupState`.
- `groupValidityFromInvalidGroupState` updated for change to `InvalidGroupState`.
- invalidGroupStateToString` updated for change to `InvalidGroupState`.
- `getGroupChildState` now validates that the child honours the style props for position and size.
- Lots of small changes to now pass `ProjectContentTreeRoot` to various functions.