### PR TITLE
Improve the UID arbitrary handling.

### DIFF
--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -79,7 +79,7 @@ export function generateMockNextGeneratedUID(): string | null {
 
 export const UtopiaIDPropertyPath = PP.create('data-uid')
 
-const atoz = [
+export const atoz = [
   'a',
   'b',
   'c',

--- a/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
@@ -98,7 +98,7 @@ import {
   exportVariables,
 } from '../../shared/project-file-types'
 import { lintAndParse, printCode, printCodeOptions } from './parser-printer'
-import { getUtopiaID, getUtopiaIDFromJSXElement } from '../../shared/uid-utils'
+import { atoz, getUtopiaID, getUtopiaIDFromJSXElement } from '../../shared/uid-utils'
 import { assertNever, fastForEach } from '../../shared/utils'
 import { addUniquely, flatMapArray } from '../../shared/array-utils'
 import { optionalMap } from '../../shared/optional-utils'
@@ -501,13 +501,13 @@ export function lowercaseStringArbitrary(): Arbitrary<string> {
   })
 }
 
-// Engineered to cause some number of collisions.
 export function uidArbitrary(): Arbitrary<string> {
   return FastCheck.tuple(
-    FastCheck.constantFrom('a', 'b', 'c'),
-    FastCheck.constantFrom('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'),
-  ).map(([second, third]) => {
-    return `a${second}${third}`
+    FastCheck.constantFrom(...atoz.slice(0, 10)),
+    FastCheck.constantFrom(...atoz.slice(0, 10)),
+    FastCheck.constantFrom(...atoz.slice(0, 10)),
+  ).map(([first, second, third]) => {
+    return `${first}${second}${third}`
   })
 }
 

--- a/editor/src/core/workers/parser-printer/uid-fix.spec.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.spec.ts
@@ -24,7 +24,8 @@ import {
   textFile,
   textFileContents,
 } from '../../shared/project-file-types'
-import { emptySet } from '../../shared/set-utils'
+import { emptySet, intersection } from '../../shared/set-utils'
+import { isEmptyObject } from '../../shared/object-utils'
 import { lintAndParse } from './parser-printer'
 import {
   elementsStructure,
@@ -518,19 +519,17 @@ describe('fixParseSuccessUIDs', () => {
   })
 })
 
-function hasNoDuplicateUIDs(expression: JSXElementChild): boolean {
-  const uniqueIDsResult = getAllUniqueUIdsFromElementChild(expression)
-  return Object.keys(uniqueIDsResult.duplicateIDs).length === 0
-}
-
 function checkUIDValues([first, second]: [JSXElementChild, JSXElementChild]): boolean {
-  const uidsOfSecond = getAllUniqueUIdsFromElementChild(second).allIDs
+  const firstUIDsResult = getAllUniqueUIdsFromElementChild(first)
+  const secondUIDsResult = getAllUniqueUIdsFromElementChild(second)
   // Check:
   // - first has no internal duplicates.
   // - second has no internal duplicates.
   // - first doesn't have a uid which is within the second value.
   return (
-    hasNoDuplicateUIDs(first) && hasNoDuplicateUIDs(second) && !uidsOfSecond.includes(first.uid)
+    isEmptyObject(firstUIDsResult.duplicateIDs) &&
+    isEmptyObject(secondUIDsResult.duplicateIDs) &&
+    intersection([new Set(firstUIDsResult.allIDs), new Set(secondUIDsResult.allIDs)]).size === 0
   )
 }
 


### PR DESCRIPTION
**Problem:**
Seemingly randomly a test in `uid-fix.spec.ts` will fail.

**Cause:**
`checkUIDValues` was not checking for collisions between the two entries generated, which meant that the element UID could be utilised by a descendant resulting in a change in the UID.

On top of this the UID arbitrary generator was causing collisions too often which then means that `checkUIDValues` would filter vast numbers of test cases out, causing the test to take a long time.

**Fix:**
`checkUIDValues` was reworked a little to make it more effectively do the checks it's supposed to make.

The UID arbitrary generator now generates a much wider range of values, but still limited so that collisions can happen.

**Commit Details:**
- `uidArbitrary` now likely to generate a much wider range of values.
- `checkUIDValues` now ensures there's no crossover between the two values supplied.