### PR TITLE
Ensure we correctly capture definedWithin for conditionals

### DIFF
--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -1106,4 +1106,52 @@ describe('conditionals', () => {
       })
     })
   })
+
+  describe('canvas', () => {
+    it('renders fine with nested arbitrary blocks and variables coming from different scopes', async () => {
+      const editor = await renderTestEditorWithCode(
+        `
+        import * as React from 'react'
+        import { Scene, Storyboard } from 'utopia-api'
+
+        const a = 1
+
+        export var storyboard = (
+          <Storyboard data-uid='sb'>
+            {[1].map((i) => (
+              <div data-uid='cond'>
+                {i > 0
+                  ? [2].map((j) => (
+                      <div>
+                        {j > i ? (
+                          <div>
+                            {(() => {
+                              const b = 5
+                              return (
+                                <div>
+                                  {b + a > j + i ? (
+                                    <div data-testid='find-me'>
+                                      It works
+                                    </div>
+                                  ) : null}
+                                </div>
+                              )
+                            })()}
+                          </div>
+                        ) : null}
+                      </div>
+                    ))
+                  : null}
+              </div>
+            ))}
+          </Storyboard>
+        )
+      `,
+        'await-first-dom-report',
+      )
+
+      const innerMostDiv = editor.renderedDOM.getByTestId('find-me')
+      expect(innerMostDiv.textContent?.trim()).toEqual('It works')
+    })
+  })
 })


### PR DESCRIPTION
**Problem:**
When a conditional is nested within a map, the conditional won't have access to variables coming from the scope of the map.

**Fix:**
The problem here is that we have a transpile step that replaces elements in arbitrary blocks with a lookup function `utopiaCanvasJSXLookup`. That transpile step needs to know the `definedWithin` for any arbitrary blocks inside the element being replaced, which happens via `getDefinedElsewhereFromElement`, but `getDefinedElsewhereFromElement` wasn't checking each element type exhaustively, meaning we hadn't updated it since adding the new conditionals type.

I've now made that function exhaustive, and added a test to check that an element inside some nested monstrosity will still render.