### PR TITLE
Make sure INSERT_INSERTABLE adds missing pins when targeting a group

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
@@ -1,11 +1,12 @@
 import type { CSSProperties } from 'react'
+import type { PropsOrJSXAttributes } from '../../../../core/model/element-metadata-utils'
 import {
   MetadataUtils,
   getZIndexOrderedViewsWithoutDirectChildren,
 } from '../../../../core/model/element-metadata-utils'
 import { generateUidWithExistingComponents } from '../../../../core/model/element-template-utils'
 import { arrayAccumulate, mapDropNulls } from '../../../../core/shared/array-utils'
-import { isLeft, right } from '../../../../core/shared/either'
+import { isLeft, isRight, right } from '../../../../core/shared/either'
 import * as EP from '../../../../core/shared/element-path'
 import type { ElementPathTrees } from '../../../../core/shared/element-path-tree'
 import type {
@@ -39,6 +40,7 @@ import {
   forceFiniteRectangle,
   isFiniteRectangle,
   isInfinityRectangle,
+  localRectangle,
   sizeFromRectangle,
   zeroCanvasPoint,
   zeroCanvasRect,
@@ -59,7 +61,7 @@ import {
   commonInsertionPathFromArray,
 } from '../../../editor/store/insertion-path'
 import type { FlexDirection } from '../../../inspector/common/css-utils'
-import { cssPixelLength } from '../../../inspector/common/css-utils'
+import { cssPixelLength, isCSSNumber } from '../../../inspector/common/css-utils'
 import {
   detectFillHugFixedState,
   isHugFromStyleAttribute,
@@ -87,6 +89,9 @@ import {
 import type { AbsolutePin } from './resize-helpers'
 import { ensureAtLeastTwoPinsForEdgePosition, isHorizontalPin } from './resize-helpers'
 import { updateSelectedViews } from '../../commands/update-selected-views-command'
+import { getLayoutProperty } from '../../../../core/layout/getLayoutProperty'
+import { styleStringInArray } from '../../../../utils/common-constants'
+import type { StyleLayoutProp } from '../../../../core/layout/layout-helpers-new'
 
 const GroupImport: Imports = {
   'utopia-api': {
@@ -847,15 +852,59 @@ export function createPinChangeCommandsForElementBecomingGroupChild(
     forceFiniteRectangle(elementMetadata.globalFrame),
     globalBoundingBoxOfAllElementsToBeWrapped,
   )
+  return commandsForPinChangeCommandForElementBecomingGroup(
+    expectedPath,
+    elementMetadata.element.value.props,
+    childLocalRect,
+    newLocalRectangleForGroup,
+  )
+}
+
+/**
+ * This is an "optimistic" variant of createPinChangeCommandsForElementBecomingGroupChild
+ * that will create missing pins for a new group child when its metadata is not available.
+ * It will be using the existing pins of the element, if present, or default to either 0,0 for
+ * its position and the parent width/height for dimensions.
+ */
+export function createPinChangeCommandsForElementInsertedIntoGroup(
+  expectedPath: ElementPath,
+  props: PropsOrJSXAttributes,
+  groupRectangle: CanvasRectangle,
+  newLocalRectangleForGroup: LocalRectangle,
+): Array<CanvasCommand> {
+  function propOrDefault(prop: StyleLayoutProp, defaultValue: number): number {
+    const maybeProp = getLayoutProperty(prop, props, styleStringInArray)
+    return isRight(maybeProp) && isCSSNumber(maybeProp.value) ? maybeProp.value.value : defaultValue
+  }
+  const childLocalRect: LocalRectangle = localRectangle({
+    x: propOrDefault('left', 0),
+    y: propOrDefault('top', 0),
+    width: propOrDefault('width', groupRectangle.width),
+    height: propOrDefault('height', groupRectangle.height),
+  })
+  return commandsForPinChangeCommandForElementBecomingGroup(
+    expectedPath,
+    props.value,
+    childLocalRect,
+    newLocalRectangleForGroup,
+  )
+}
+
+function commandsForPinChangeCommandForElementBecomingGroup(
+  expectedPath: ElementPath,
+  elementProps: JSXAttributes,
+  childRect: LocalRectangle,
+  groupRect: LocalRectangle,
+): Array<CanvasCommand> {
   return [
     // make the child `position: absolute`
     setProperty('always', expectedPath, PP.create('style', 'position'), 'absolute'),
     // set child pins to match their intended new local rectangle
     ...setElementPinsForLocalRectangleEnsureTwoPinsPerDimension(
       expectedPath,
-      elementMetadata.element.value.props,
-      childLocalRect,
-      sizeFromRectangle(newLocalRectangleForGroup),
+      elementProps,
+      childRect,
+      sizeFromRectangle(groupRect),
       null,
     ),
   ]

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -134,6 +134,7 @@ import {
   nullIfInfinity,
   isNotNullFiniteRectangle,
   localRectangle,
+  zeroRectIfNullOrInfinity,
 } from '../../../core/shared/math-utils'
 import type {
   PackageStatusMap,
@@ -4777,19 +4778,18 @@ export const UPDATE_FNS = {
 
       let groupCommands: CanvasCommand[] = []
       if (treatElementAsGroupLike(editor.jsxMetadata, action.insertionPath.intendedParentPath)) {
-        const groupFrame = MetadataUtils.getFrameOrZeroRectInCanvasCoords(
+        const group = MetadataUtils.findElementByElementPath(
+          editor.jsxMetadata,
           action.insertionPath.intendedParentPath,
-          withNewElement.jsxMetadata,
         )
-
-        if (action.toInsert.element.type === 'JSX_ELEMENT') {
+        if (group != null && action.toInsert.element.type === 'JSX_ELEMENT') {
           // this condition would need updating when we can insert fragments or conditionals with children
           groupCommands.push(
             ...createPinChangeCommandsForElementInsertedIntoGroup(
               newPath,
               right(action.toInsert.element.props),
-              groupFrame,
-              localRectangle(groupFrame),
+              zeroRectIfNullOrInfinity(group.globalFrame),
+              zeroRectIfNullOrInfinity(group.localFrame),
             ),
           )
         }

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4782,18 +4782,36 @@ export const UPDATE_FNS = {
           editor.jsxMetadata,
           action.insertionPath.intendedParentPath,
         )
-        if (group != null && action.toInsert.element.type === 'JSX_ELEMENT') {
-          groupCommands.push(
-            ...createPinChangeCommandsForElementInsertedIntoGroup(
-              newPath,
-              right(action.toInsert.element.props),
-              zeroRectIfNullOrInfinity(group.globalFrame),
-              zeroRectIfNullOrInfinity(group.localFrame),
-            ),
-          )
-        } else {
-          // this condition would need updating when we can insert fragments or conditionals with children
-          throw new Error(`unsupported insert ${action.toInsert.element.type} into a group`)
+        if (group != null) {
+          switch (action.toInsert.element.type) {
+            case 'JSX_ELEMENT':
+              groupCommands.push(
+                ...createPinChangeCommandsForElementInsertedIntoGroup(
+                  newPath,
+                  right(action.toInsert.element.props),
+                  zeroRectIfNullOrInfinity(group.globalFrame),
+                  zeroRectIfNullOrInfinity(group.localFrame),
+                ),
+              )
+              break
+            case 'JSX_CONDITIONAL_EXPRESSION':
+              if (
+                action.toInsert.element.whenTrue != null ||
+                action.toInsert.element.whenFalse != null
+              ) {
+                // this needs updating when we support inserting conditionals with non-empty clause
+                throw new Error('unhandled conditional insert into group')
+              }
+              break
+            case 'JSX_FRAGMENT':
+              if (action.toInsert.element.children.length > 0) {
+                // this needs updating when we support inserting fragments with children
+                throw new Error('unhandled fragment insert into group')
+              }
+              break
+            default:
+              assertNever(action.toInsert.element as never)
+          }
         }
       }
 

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4783,7 +4783,6 @@ export const UPDATE_FNS = {
           action.insertionPath.intendedParentPath,
         )
         if (group != null && action.toInsert.element.type === 'JSX_ELEMENT') {
-          // this condition would need updating when we can insert fragments or conditionals with children
           groupCommands.push(
             ...createPinChangeCommandsForElementInsertedIntoGroup(
               newPath,
@@ -4792,6 +4791,9 @@ export const UPDATE_FNS = {
               zeroRectIfNullOrInfinity(group.localFrame),
             ),
           )
+        } else {
+          // this condition would need updating when we can insert fragments or conditionals with children
+          throw new Error(`unsupported insert ${action.toInsert.element.type} into a group`)
         }
       }
 


### PR DESCRIPTION
Fixes #4002 

**Problem:**

Inserting a `img` (or any other insertable with missing pins) into a group ends up with an invalid group because the `img` has no position pins.

https://github.com/concrete-utopia/utopia/assets/1081051/00d14798-3c09-435f-a0e5-9f1650abe1f5

**Fix:**

Make sure that `INSERT_INSERTABLE` adds the missing pins on the element. Since the metadata is not available, I added an optimistic variant of `createPinChangeCommandsForElementBecomingGroupChild` that will try to get the best pins possible from the combination of the element _and_ the target group.

- For the position pins it will try to put the element in the center of the group, or `0,0` as a fallback.
- For the dimension pins it will use the element ones, or default to the group ones as a fallback.

https://github.com/concrete-utopia/utopia/assets/1081051/3ac83e79-f3bb-4b77-8e94-78f6d2b7ba79

