### PR TITLE
Fix text expressions in conditionals

### DIFF
--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -598,6 +598,15 @@ export var storyboard = (
       {[0, 1, 2].map((i) => (
         <div>fifth {i}</div>
       ))}
+
+      <div data-uid='text-expr-cond-wrapper'>{
+        // @utopia/uid=text-expr-cond
+        true ? (
+          [0, 1, 2].map(() => 'fourth')
+        ) : (
+          <div />
+        )
+      }</div>
     </div>
   </Storyboard>
 )
@@ -4400,6 +4409,12 @@ describe('Navigator row order', () => {
         'regular-sb/group/53a/3bc~~~2/ad3',
         'regular-sb/group/53a/3bc~~~3',
         'regular-sb/group/53a/3bc~~~3/ad3',
+        'regular-sb/group/text-expr-cond-wrapper',
+        'regular-sb/group/text-expr-cond-wrapper/text-expr-cond',
+        'conditional-clause-sb/group/text-expr-cond-wrapper/text-expr-cond-true-case',
+        'regular-sb/group/text-expr-cond-wrapper/text-expr-cond/508',
+        'conditional-clause-sb/group/text-expr-cond-wrapper/text-expr-cond-false-case',
+        'synthetic-sb/group/text-expr-cond-wrapper/text-expr-cond/2f3-element-2f3',
       ],
     )
     expect(
@@ -4431,6 +4446,12 @@ describe('Navigator row order', () => {
       'regular-sb/group/53a/3bc~~~1',
       'regular-sb/group/53a/3bc~~~2',
       'regular-sb/group/53a/3bc~~~3',
+      'regular-sb/group/text-expr-cond-wrapper',
+      'regular-sb/group/text-expr-cond-wrapper/text-expr-cond',
+      'conditional-clause-sb/group/text-expr-cond-wrapper/text-expr-cond-true-case',
+      'regular-sb/group/text-expr-cond-wrapper/text-expr-cond/508',
+      'conditional-clause-sb/group/text-expr-cond-wrapper/text-expr-cond-false-case',
+      'synthetic-sb/group/text-expr-cond-wrapper/text-expr-cond/2f3-element-2f3',
     ])
   })
 })

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -5038,7 +5038,7 @@ describe('Navigator row order', () => {
         'regular-sb/group/text-expr-cond-wrapper',
         'regular-sb/group/text-expr-cond-wrapper/text-expr-cond',
         'conditional-clause-sb/group/text-expr-cond-wrapper/text-expr-cond-true-case',
-        'regular-sb/group/text-expr-cond-wrapper/text-expr-cond/508',
+        'regular-sb/group/text-expr-cond-wrapper/text-expr-cond/619',
         'conditional-clause-sb/group/text-expr-cond-wrapper/text-expr-cond-false-case',
         'synthetic-sb/group/text-expr-cond-wrapper/text-expr-cond/2f3-element-2f3',
       ],
@@ -5075,7 +5075,7 @@ describe('Navigator row order', () => {
       'regular-sb/group/text-expr-cond-wrapper',
       'regular-sb/group/text-expr-cond-wrapper/text-expr-cond',
       'conditional-clause-sb/group/text-expr-cond-wrapper/text-expr-cond-true-case',
-      'regular-sb/group/text-expr-cond-wrapper/text-expr-cond/508',
+      'regular-sb/group/text-expr-cond-wrapper/text-expr-cond/619',
       'conditional-clause-sb/group/text-expr-cond-wrapper/text-expr-cond-false-case',
       'synthetic-sb/group/text-expr-cond-wrapper/text-expr-cond/2f3-element-2f3',
     ])

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -5122,6 +5122,7 @@ describe('Navigator row order', () => {
       'regular-sb/group/cond',
       'conditional-clause-sb/group/cond-true-case',
       'regular-sb/group/cond/4ce',
+      'regular-sb/group/cond/4ce/f23~~~1',
       'conditional-clause-sb/group/cond-false-case',
       'synthetic-sb/group/cond/15e-element-15e',
       'regular-sb/group/bar',

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1255,7 +1255,10 @@ export const MetadataUtils = {
           if (isJSXElement(r)) {
             return VoidElementsToFilter.includes(r.name.baseVariable)
           }
-          if (isJSExpressionOtherJavaScript(r)) {
+          if (
+            isJSExpressionOtherJavaScript(r) &&
+            !MetadataUtils.isElementPathConditionalFromMetadata(metadata, EP.parentPath(path))
+          ) {
             const children = MetadataUtils.getChildrenOrdered(metadata, pathTree, path)
             return children.length == 0
           }


### PR DESCRIPTION
**Problem:**
Normally we hide expression elements from the navigator when they only return text, e.g.

```<div>{1+1}</div>```

is shown as:

<img width="162" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/a2af704f-04c2-424a-a1d8-f8e237ade318">

The reason is that the expression results in text content, and normally we don't treat text content as elefants. 

However, when text content is in a conditional branch, we show a navigator line for that text content (otherwise it the conditional branch would be empty).

The bug was that the conditional branch in the navigator was really empty when there was an expression which returned text content:
```{true ? 1 + 1 : null}```
resulted in 
![image](https://github.com/concrete-utopia/utopia/assets/127662/ce379e21-e6e8-4f81-b3a3-d8b67ac17982)

**Fix:**
I made sure we don't filter out text only expressions when their parent is a conditional.

