### PR TITLE
Group delete behaviours

### DIFF
--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -363,6 +363,79 @@ describe('actions', () => {
     `,
         wantSelection: [makeTargetPath('aaa')],
       },
+      {
+        name: 'delete group child selects next sibling',
+        input: `
+          <View data-uid='view'>
+            <Group data-uid='group'>
+              <div data-uid='child1' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 0, background: 'blue' }} />
+              <div data-uid='child2' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 40, background: 'blue' }} />
+              <div data-uid='child3' style={{ position: 'absolute', width: 10, height: 10, top: 40, left: 0, background: 'blue' }} />
+              <div data-uid='child4' style={{ position: 'absolute', width: 10, height: 10, top: 40, left: 40, background: 'blue' }} />
+            </Group>
+          </View>
+        `,
+        targets: [makeTargetPath('view/group/child3')],
+        wantCode: `
+          <View data-uid='view'>
+            <Group
+              data-uid='group'
+              style={{ width: 50, height: 50 }}
+            >
+              <div data-uid='child1' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 0, background: 'blue' }} />
+              <div data-uid='child2' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 40, background: 'blue' }} />
+              <div data-uid='child4' style={{ position: 'absolute', width: 10, height: 10, top: 40, left: 40, background: 'blue' }} />
+            </Group>
+          </View>
+        `,
+        wantSelection: [makeTargetPath('view/group/child1')],
+      },
+      {
+        name: 'delete group child selects next sibling (multiple selection)',
+        input: `
+          <View data-uid='view'>
+            <Group
+              data-uid='group'
+              style={{ width: 50, height: 50 }}
+            >
+              <div data-uid='child1' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 0, background: 'blue' }} />
+              <div data-uid='child2' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 40, background: 'blue' }} />
+              <div data-uid='child3' style={{ position: 'absolute', width: 10, height: 10, top: 40, left: 0, background: 'blue' }} />
+              <div data-uid='child4' style={{ position: 'absolute', width: 10, height: 10, top: 40, left: 40, background: 'blue' }} />
+            </Group>
+            <div data-uid='foo'>
+              <div data-uid='bar' />
+            </div>
+          </View>
+        `,
+        targets: [makeTargetPath('view/group/child3'), makeTargetPath('view/foo/bar')],
+        wantCode: `
+          <View data-uid='view'>
+            <Group data-uid='group'>
+              <div data-uid='child1' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 0, background: 'blue' }} />
+              <div data-uid='child2' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 40, background: 'blue' }} />
+              <div data-uid='child4' style={{ position: 'absolute', width: 10, height: 10, top: 40, left: 40, background: 'blue' }} />
+            </Group>
+            <div data-uid='foo' />
+          </View>
+        `,
+        wantSelection: [makeTargetPath('view/group/child1'), makeTargetPath('view/foo')],
+      },
+      {
+        name: 'delete last group child deletes the group',
+        input: `
+          <View data-uid='view'>
+            <Group data-uid='group'>
+              <div data-uid='child1' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 0, background: 'blue' }} />
+            </Group>
+          </View>
+        `,
+        targets: [makeTargetPath('view/group/child1')],
+        wantCode: `
+          <View data-uid='view' />
+        `,
+        wantSelection: [makeTargetPath('view')],
+      },
     ]
     tests.forEach((tt, idx) => {
       it(`(${idx + 1}) ${tt.name}`, async () => {

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -237,7 +237,7 @@ describe('actions', () => {
       />
     </View>
     `,
-        wantSelection: [makeTargetPath('aaa/000')],
+        wantSelection: [makeTargetPath('aaa/000/ccc')],
       },
       {
         name: 'delete empty fragments (multiple targets)',
@@ -305,7 +305,7 @@ describe('actions', () => {
       />
     </View>
     `,
-        wantSelection: [makeTargetPath('aaa/000'), makeTargetPath('aaa')],
+        wantSelection: [makeTargetPath('aaa/000/ccc'), makeTargetPath('aaa')],
       },
       {
         name: 'delete map expression',
@@ -394,10 +394,7 @@ describe('actions', () => {
         name: 'delete group child selects next sibling (multiple selection)',
         input: `
           <View data-uid='view'>
-            <Group
-              data-uid='group'
-              style={{ width: 50, height: 50 }}
-            >
+            <Group data-uid='group'>
               <div data-uid='child1' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 0, background: 'blue' }} />
               <div data-uid='child2' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 40, background: 'blue' }} />
               <div data-uid='child3' style={{ position: 'absolute', width: 10, height: 10, top: 40, left: 0, background: 'blue' }} />
@@ -411,7 +408,10 @@ describe('actions', () => {
         targets: [makeTargetPath('view/group/child3'), makeTargetPath('view/foo/bar')],
         wantCode: `
           <View data-uid='view'>
-            <Group data-uid='group'>
+            <Group
+              data-uid='group'
+              style={{ width: 50, height: 50 }}
+            >
               <div data-uid='child1' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 0, background: 'blue' }} />
               <div data-uid='child2' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 40, background: 'blue' }} />
               <div data-uid='child4' style={{ position: 'absolute', width: 10, height: 10, top: 40, left: 40, background: 'blue' }} />

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -436,6 +436,69 @@ describe('actions', () => {
         `,
         wantSelection: [makeTargetPath('view')],
       },
+      {
+        name: 'recursively delete empty parents when groups or fragments',
+        input: `
+        <div data-uid='root'>
+          <Group data-uid='g1'>
+            <Group data-uid='g2'>
+              <React.Fragment data-uid='f1'>
+                <div data-uid='child' />
+              </React.Fragment>
+            </Group>
+          </Group>
+        </div>
+        `,
+        targets: [makeTargetPath(`root/g1/g2/f1/child`)],
+        wantCode: `
+          <div data-uid='root' />
+        `,
+        wantSelection: [makeTargetPath(`root`)],
+      },
+      {
+        name: 'recursively delete empty parents when groups or fragments and stops',
+        input: `
+        <div data-uid='root'>
+          <Group data-uid='g1'>
+            <div data-uid='stop-here' />
+            <Group data-uid='g2'>
+              <React.Fragment data-uid='f1'>
+                <div data-uid='child' />
+              </React.Fragment>
+            </Group>
+          </Group>
+        </div>
+        `,
+        targets: [makeTargetPath(`root/g1/g2/f1/child`)],
+        wantCode: `
+          <div data-uid='root'>
+            <Group data-uid='g1'>
+              <div data-uid='stop-here' />
+            </Group>
+          </div>
+        `,
+        wantSelection: [makeTargetPath(`root/g1/stop-here`)],
+      },
+      {
+        name: 'recursively delete empty parents when groups or fragments with multiselect',
+        input: `
+        <div data-uid='root'>
+          <Group data-uid='g1'>
+            <div data-uid='delete-me' />
+            <Group data-uid='g2'>
+              <React.Fragment data-uid='f1'>
+                <div data-uid='child' />
+              </React.Fragment>
+            </Group>
+          </Group>
+        </div>
+        `,
+        targets: [makeTargetPath(`root/g1/g2/f1/child`), makeTargetPath(`root/g1/delete-me`)],
+        wantCode: `
+          <div data-uid='root' />
+        `,
+        wantSelection: [makeTargetPath(`root`)],
+      },
     ]
     tests.forEach((tt, idx) => {
       it(`(${idx + 1}) ${tt.name}`, async () => {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1686,9 +1686,23 @@ export const UPDATE_FNS = {
           })
 
         const withElementDeleted = deleteElements(staticSelectedElements, editor)
-        const parentsToSelect = uniqBy(
+        const newSelectedViews = uniqBy(
           mapDropNulls((view) => {
             const parentPath = EP.parentPath(view)
+            if (treatElementAsGroupLike(editor.jsxMetadata, parentPath)) {
+              const siblings = MetadataUtils.getSiblingsOrdered(
+                editor.jsxMetadata,
+                editor.elementPathTree,
+                view,
+              )
+              const firstSibling = siblings.find(
+                (element) => !EP.pathsEqual(element.elementPath, view),
+              )
+              if (firstSibling != null) {
+                return firstSibling.elementPath
+              }
+            }
+
             const parent = MetadataUtils.findElementByElementPath(editor.jsxMetadata, parentPath)
             if (
               parent != null &&
@@ -1724,7 +1738,7 @@ export const UPDATE_FNS = {
 
         return {
           ...withElementDeleted,
-          selectedViews: parentsToSelect,
+          selectedViews: newSelectedViews,
         }
       },
       dispatch,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1695,14 +1695,11 @@ export const UPDATE_FNS = {
           mapDropNulls((view) => {
             const parentPath = EP.parentPath(view)
             if (treatElementAsGroupLike(editor.jsxMetadata, parentPath)) {
-              const siblings = MetadataUtils.getSiblingsOrdered(
+              const firstSibling = MetadataUtils.getSiblingsOrdered(
                 editor.jsxMetadata,
                 editor.elementPathTree,
                 view,
-              )
-              const firstSibling = siblings.find(
-                (element) => !EP.pathsEqual(element.elementPath, view),
-              )
+              ).find((element) => !EP.pathsEqual(element.elementPath, view))
               if (firstSibling != null) {
                 return firstSibling.elementPath
               }

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1669,16 +1669,21 @@ export const UPDATE_FNS = {
             )
 
             const parentPath = EP.parentPath(path)
-            const parentIsFragment = MetadataUtils.isFragmentFromMetadata(
-              editor.jsxMetadata[EP.toString(parentPath)],
-            )
+
+            const mustDeleteEmptyParent =
+              // fragments
+              MetadataUtils.isFragmentFromMetadata(editor.jsxMetadata[EP.toString(parentPath)]) ||
+              // groups
+              treatElementAsGroupLike(editor.jsxMetadata, parentPath)
+
             const parentWillBeEmpty =
               MetadataUtils.getChildrenOrdered(
                 editor.jsxMetadata,
                 editor.elementPathTree,
                 parentPath,
               ).length === selectedSiblings.length
-            if (parentIsFragment && parentWillBeEmpty) {
+
+            if (mustDeleteEmptyParent && parentWillBeEmpty) {
               return parentPath
             }
 

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1690,7 +1690,7 @@ export const UPDATE_FNS = {
       editorForAction,
       true,
       (editor) => {
-        let bubbledUpDeletions: ElementPath[] = []
+        let bubbledUpDeletions: Array<ElementPath> = []
 
         const staticSelectedElements = editor.selectedViews
           .filter((selectedView) => {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1726,7 +1726,7 @@ export const UPDATE_FNS = {
                 ...deletableParents(editor.jsxMetadata, parentPath, allSelectedPaths),
               ]
               bubbledUpDeletions.push(...bubbledUp)
-              return bubbledUp[bubbledUp.length - 1]
+              return EP.getCommonParent(bubbledUpDeletions, true) ?? parentPath
             }
 
             return path
@@ -1744,7 +1744,7 @@ export const UPDATE_FNS = {
                 view,
                 ...deletableParents(editor.jsxMetadata, parentPath, staticSelectedElements),
               ].map(EP.parentPath)
-              const actualParent = parentsBubbledUp[parentsBubbledUp.length - 1]
+              const actualParent = EP.getCommonParent(parentsBubbledUp, true) ?? parentPath
 
               if (
                 EP.pathsEqual(actualParent, parentPath) ||

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1652,10 +1652,10 @@ export const UPDATE_FNS = {
     ).editor
   },
   DELETE_SELECTED: (editorForAction: EditorModel, dispatch: EditorDispatch): EditorModel => {
-    // This function returns whether the given path will have the "group-like" deletion behavior:
+    // This function returns whether the given path will have the following deletion behavior:
     //  1. when deleting one of its children, the next sibling will be selected
     //  2. when deleting the last chilren, it is removed as well so as not to remain empty
-    function behavesLikeAGroupForDeletion(
+    function behavesLikeGroupOrFragmentForDeletion(
       metadata: ElementInstanceMetadataMap,
       path: ElementPath,
     ): boolean {
@@ -1686,7 +1686,7 @@ export const UPDATE_FNS = {
 
             const parentPath = EP.parentPath(path)
 
-            const mustDeleteEmptyParent = behavesLikeAGroupForDeletion(
+            const mustDeleteEmptyParent = behavesLikeGroupOrFragmentForDeletion(
               editor.jsxMetadata,
               parentPath,
             )
@@ -1709,7 +1709,7 @@ export const UPDATE_FNS = {
         const newSelectedViews = uniqBy(
           mapDropNulls((view) => {
             const parentPath = EP.parentPath(view)
-            if (behavesLikeAGroupForDeletion(editor.jsxMetadata, parentPath)) {
+            if (behavesLikeGroupOrFragmentForDeletion(editor.jsxMetadata, parentPath)) {
               const firstSibling = MetadataUtils.getSiblingsOrdered(
                 editor.jsxMetadata,
                 editor.elementPathTree,


### PR DESCRIPTION
Fixes #4009 

**Problem:**

1. Deleting a group child should select the next sibling instead of the group itself.
2. Deleting the last group child should delete the group itself (like a fragment).

**Fix:**

Implement both the above.

![Kapture 2023-07-31 at 14 40 02](https://github.com/concrete-utopia/utopia/assets/1081051/e7e8d2a7-462a-4a35-97a9-607c0a60addb)

