### PR TITLE
fix(paste) paste layout properties extended list

### DIFF
--- a/editor/src/components/canvas/canvas-context-menu.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-context-menu.spec.browser2.tsx
@@ -122,7 +122,7 @@ describe('canvas context menu', () => {
             data-uid='bbb'
           >paste</div>
           <div
-            style={{ position: 'absolute', top: 20, opacity: 0.2, width: 200, height: 150 }}
+            style={{ opacity: 0.2, width: 200, height: 150 }}
             data-uid='ccc'
             data-testid='ccc'
           >hello</div>

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -528,7 +528,7 @@ import {
 } from '../../canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes'
 import { styleStringInArray } from '../../../utils/common-constants'
 import { collapseTextElements } from '../../../components/text-editor/text-handling'
-import { LayoutPropsWithoutTLBR, StyleProperties } from '../../inspector/common/css-utils'
+import { LayoutPropertyList, StyleProperties } from '../../inspector/common/css-utils'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { isUtopiaCommentFlag, makeUtopiaFlagComment } from '../../../core/shared/comment-flags'
 import { modify, toArrayOf } from '../../../core/shared/optics/optic-utilities'
@@ -2553,7 +2553,7 @@ export const UPDATE_FNS = {
     }
     return editor.selectedViews.reduce((working, target) => {
       return setPropertyOnTarget(working, target, (attributes) => {
-        const filterForNames = action.type === 'layout' ? LayoutPropsWithoutTLBR : StyleProperties
+        const filterForNames = action.type === 'layout' ? LayoutPropertyList : StyleProperties
         const originalPropsToUnset = filterForNames.map((propName) => PP.create('style', propName))
         const withOriginalPropertiesCleared = unsetJSXValuesAtPaths(
           attributes,

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -5001,9 +5001,14 @@ export const StyleProperties = [
   'textShadow',
 ]
 
-export const LayoutPropsWithoutTLBR = [
+export const LayoutPropertyList = [
+  'left',
+  'right',
+  'top',
+  'bottom',
   'width',
   'height',
+  'position',
   'float',
   'min-width',
   'min-height',
@@ -5033,19 +5038,23 @@ export const LayoutPropsWithoutTLBR = [
   'overflow',
   'box-sizing',
   'display',
-  'flex',
-  'flex-direction',
-  'flex-wrap',
-  'flex-flow',
-  'justify-content',
-  'align-items',
-  'align-content',
   'order',
+  'flex',
   'flex-grow',
   'flex-shrink',
   'flex-basis',
-  'flex',
+  'flex-direction',
+  'flex-wrap',
+  'flex-flow',
+  'align-items',
+  'align-content',
   'align-self',
+  'justify-content',
+  'justify-items',
+  'justify-self',
+  'gap',
+  'row-gap',
+  'column-gap',
   'grid-template-rows',
   'grid-template-columns',
   'grid-template-areas',
@@ -5068,8 +5077,6 @@ export const LayoutPropsWithoutTLBR = [
   'grid-template-columns',
   'grid-template-rows',
 ]
-
-const LayoutPropertyList = ['left', 'right', 'top', 'bottom', ...LayoutPropsWithoutTLBR]
 
 export function isLayoutPropDetectedInCSS(cssProps: { [key: string]: any }): boolean {
   return LayoutPropertyList.findIndex((prop: string) => cssProps[prop] != null) > -1


### PR DESCRIPTION
**Problem:**
Paste layout misses to paste important layout properties.

**Fix:**
Changed the `LayoutPropertyList` used by the `PASTE_PROPERTIES` action
Added these properties to paste: `top, left, right, bottom, position, gap, row-gap, column-gap, justify-items`

**Commit Details:**
- remove `LayoutPropsWithoutTLBR` and use `LayoutPropertyList` that contain TLBR too
- added extra layout props
- update test
