### PR TITLE
Counter in map navigator item

### DIFF
--- a/editor/src/components/navigator/navigator-item/map-counter.tsx
+++ b/editor/src/components/navigator/navigator-item/map-counter.tsx
@@ -44,16 +44,15 @@ export const MapCounter = React.memo((props: MapCounterProps) => {
       data-testid={testId}
       style={{
         display: 'flex',
-        width: 22,
-        height: 22,
-        flexDirection: 'column',
         justifyContent: 'center',
+        height: 22,
+        width: 22,
         alignItems: 'center',
-        borderRadius: 44,
+        borderRadius: '50%',
         backgroundColor: colorTheme.dynamicBlue10.value,
       }}
     >
-      <span>{counterValue}</span>
+      {counterValue}
     </div>
   )
 })

--- a/editor/src/components/navigator/navigator-item/map-counter.tsx
+++ b/editor/src/components/navigator/navigator-item/map-counter.tsx
@@ -4,14 +4,22 @@ import { isRegularNavigatorEntry } from '../../../components/editor/store/editor
 import { Substores, useEditorState } from '../../editor/store/store-hook'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { colorTheme } from '../../../uuiui'
+import * as EP from '../../../core/shared/element-path'
+import type { ElementPath } from '../../../core/shared/project-file-types'
+
+export const MapCounterTestIdPrefix = 'map-counter-'
+
+export function getMapCounterTestId(path: ElementPath): string {
+  return `${MapCounterTestIdPrefix}${EP.toString(path)}`
+}
 
 interface MapCounterProps {
-  testId: string
   navigatorEntry: NavigatorEntry
 }
 
 export const MapCounter = React.memo((props: MapCounterProps) => {
-  const { testId, navigatorEntry } = props
+  const { navigatorEntry } = props
+  const { elementPath } = navigatorEntry
 
   const counterValue = useEditorState(
     Substores.metadata,
@@ -21,13 +29,13 @@ export const MapCounter = React.memo((props: MapCounterProps) => {
       }
       const elementMetadata = MetadataUtils.findElementByElementPath(
         store.editor.jsxMetadata,
-        navigatorEntry.elementPath,
+        elementPath,
       )
       if (MetadataUtils.isJSXMapExpressionFromMetadata(elementMetadata)) {
         return MetadataUtils.getChildrenOrdered(
           store.editor.jsxMetadata,
           store.editor.elementPathTree,
-          navigatorEntry.elementPath,
+          elementPath,
         ).length
       }
       return null
@@ -41,7 +49,7 @@ export const MapCounter = React.memo((props: MapCounterProps) => {
 
   return (
     <div
-      data-testid={testId}
+      data-testid={getMapCounterTestId(elementPath)}
       style={{
         display: 'flex',
         justifyContent: 'center',

--- a/editor/src/components/navigator/navigator-item/map-counter.tsx
+++ b/editor/src/components/navigator/navigator-item/map-counter.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import type { NavigatorEntry } from '../../../components/editor/store/editor-state'
+import { isRegularNavigatorEntry } from '../../../components/editor/store/editor-state'
+import { Substores, useEditorState } from '../../editor/store/store-hook'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { colorTheme } from '../../../uuiui'
+
+interface MapCounterProps {
+  testId: string
+  navigatorEntry: NavigatorEntry
+}
+
+export const MapCounter = React.memo((props: MapCounterProps) => {
+  const { testId, navigatorEntry } = props
+
+  const counterValue = useEditorState(
+    Substores.metadata,
+    (store) => {
+      if (!isRegularNavigatorEntry(navigatorEntry)) {
+        return false
+      }
+      const elementMetadata = MetadataUtils.findElementByElementPath(
+        store.editor.jsxMetadata,
+        navigatorEntry.elementPath,
+      )
+      if (MetadataUtils.isJSXMapExpressionFromMetadata(elementMetadata)) {
+        return MetadataUtils.getChildrenOrdered(
+          store.editor.jsxMetadata,
+          store.editor.elementPathTree,
+          navigatorEntry.elementPath,
+        ).length
+      }
+      return null
+    },
+    'MapCounter counterValue',
+  )
+
+  if (counterValue == null) {
+    return null
+  }
+
+  return (
+    <div
+      data-testid={testId}
+      style={{
+        display: 'flex',
+        width: 22,
+        height: 22,
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        borderRadius: 44,
+        backgroundColor: colorTheme.dynamicBlue10.value,
+      }}
+    >
+      <span>{counterValue}</span>
+    </div>
+  )
+})

--- a/editor/src/components/navigator/navigator-item/map-counter.tsx
+++ b/editor/src/components/navigator/navigator-item/map-counter.tsx
@@ -54,9 +54,11 @@ export const MapCounter = React.memo((props: MapCounterProps) => {
         display: 'flex',
         justifyContent: 'center',
         height: 22,
-        width: 22,
+        minWidth: 22,
+        width: 'max-content',
+        padding: 5,
         alignItems: 'center',
-        borderRadius: '50%',
+        borderRadius: 11,
         backgroundColor: colorTheme.dynamicBlue10.value,
       }}
     >

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -55,6 +55,7 @@ import { LayoutIcon } from './layout-icon'
 import { NavigatorItemActionSheet } from './navigator-item-components'
 import { assertNever } from '../../../core/shared/utils'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
+import { MapCounter } from './map-counter'
 
 export function getItemHeight(navigatorEntry: NavigatorEntry): number {
   if (isConditionalClauseNavigatorEntry(navigatorEntry)) {
@@ -852,6 +853,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
             dispatch={props.dispatch}
             inputVisible={EP.pathsEqual(props.renamingTarget, props.navigatorEntry.elementPath)}
           />
+          <MapCounter testId={`map-counter-${props.label}`} navigatorEntry={props.navigatorEntry} />
         </React.Fragment>
         <ComponentPreview
           key={`preview-${props.label}`}

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -813,55 +813,51 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
   )
 
   return (
-    <React.Fragment>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-          alignItems: 'center',
-          justifyContent: 'flex-start',
-          gap: 10,
-          borderRadius: 20,
-          height: 22,
-          padding: '0 10px',
-          backgroundColor:
-            isConditionalOrMapLabel && !props.selected
-              ? colorTheme.dynamicBlue10.value
-              : 'transparent',
-          color: isConditionalOrMapLabel ? colorTheme.dynamicBlue.value : undefined,
-          textTransform: isConditionalOrMapLabel ? 'uppercase' : undefined,
-        }}
-      >
-        <React.Fragment>
-          {unless(
-            props.navigatorEntry.type === 'CONDITIONAL_CLAUSE',
-            <LayoutIcon
-              key={`layout-type-${props.label}`}
-              navigatorEntry={props.navigatorEntry}
-              color={props.iconColor}
-              elementWarnings={props.elementWarnings}
-            />,
-          )}
-
-          <ItemLabel
-            key={`label-${props.label}`}
-            testId={`navigator-item-label-${props.label}`}
-            name={props.label}
-            isDynamic={props.isDynamic}
-            target={props.navigatorEntry}
-            selected={props.selected}
-            dispatch={props.dispatch}
-            inputVisible={EP.pathsEqual(props.renamingTarget, props.navigatorEntry.elementPath)}
-          />
-          <MapCounter testId={`map-counter-${props.label}`} navigatorEntry={props.navigatorEntry} />
-        </React.Fragment>
-        <ComponentPreview
-          key={`preview-${props.label}`}
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+        gap: 10,
+        borderRadius: 20,
+        height: 22,
+        paddingLeft: 10,
+        backgroundColor:
+          isConditionalOrMapLabel && !props.selected
+            ? colorTheme.dynamicBlue10.value
+            : 'transparent',
+        color: isConditionalOrMapLabel ? colorTheme.dynamicBlue.value : undefined,
+        textTransform: isConditionalOrMapLabel ? 'uppercase' : undefined,
+      }}
+    >
+      {unless(
+        props.navigatorEntry.type === 'CONDITIONAL_CLAUSE',
+        <LayoutIcon
+          key={`layout-type-${props.label}`}
           navigatorEntry={props.navigatorEntry}
           color={props.iconColor}
-        />
-      </div>
-    </React.Fragment>
+          elementWarnings={props.elementWarnings}
+        />,
+      )}
+
+      <ItemLabel
+        key={`label-${props.label}`}
+        testId={`navigator-item-label-${props.label}`}
+        name={props.label}
+        isDynamic={props.isDynamic}
+        target={props.navigatorEntry}
+        selected={props.selected}
+        dispatch={props.dispatch}
+        inputVisible={EP.pathsEqual(props.renamingTarget, props.navigatorEntry.elementPath)}
+      />
+      <MapCounter testId={`map-counter-${props.label}`} navigatorEntry={props.navigatorEntry} />
+      <ComponentPreview
+        key={`preview-${props.label}`}
+        navigatorEntry={props.navigatorEntry}
+        color={props.iconColor}
+      />
+    </div>
   )
 })
 

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -851,7 +851,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
         dispatch={props.dispatch}
         inputVisible={EP.pathsEqual(props.renamingTarget, props.navigatorEntry.elementPath)}
       />
-      <MapCounter testId={`map-counter-${props.label}`} navigatorEntry={props.navigatorEntry} />
+      <MapCounter navigatorEntry={props.navigatorEntry} />
       <ComponentPreview
         key={`preview-${props.label}`}
         navigatorEntry={props.navigatorEntry}

--- a/editor/src/components/navigator/navigator-map.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-map.spec.browser2.tsx
@@ -1,0 +1,94 @@
+import {
+  TestSceneUID,
+  formatTestProjectCode,
+  renderTestEditorWithCode,
+} from '../../components/canvas/ui-jsx.test-utils'
+import { MetadataUtils } from '../../core/model/element-metadata-utils'
+import { BakedInStoryboardUID, BakedInStoryboardVariableName } from '../../core/model/scene-utils'
+import * as EP from '../../core/shared/element-path'
+import { getMapCounterTestId } from './navigator-item/map-counter'
+
+function getProjectCode<T>(arr: Array<T>): string {
+  return formatTestProjectCode(`import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export var ${BakedInStoryboardVariableName} = (
+  <Storyboard data-uid='${BakedInStoryboardUID}'>
+    <Scene
+      style={{
+        backgroundColor: 'white',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 700,
+      }}
+      data-uid='${TestSceneUID}'
+      data-testid='${TestSceneUID}'
+    >
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          contain: 'layout',
+        }}
+        data-uid='containing-div'
+        data-testid='containing-div'
+      >
+        {${JSON.stringify(arr)}.map(() => (
+          <div
+            style={{
+              height: 150,
+              width: 150,
+              position: 'absolute',
+              left: 154,
+              top: 134,
+              backgroundColor: 'lightblue',
+            }}
+            data-uid='map-child-div'
+            data-testid='map-child-div'
+          />
+        ))}
+        <div
+          style={{
+            height: 150,
+            width: 150,
+            position: 'absolute',
+            left: 300,
+            top: 300,
+            backgroundColor: 'darkblue',
+          }}
+          data-uid='sibling-div'
+          data-testid='sibling-div'
+        />
+      </div>
+    </Scene>
+  </Storyboard>
+)
+`)
+}
+
+const testArrays = [[0], [0, 1], [0, 1, 2], [0, 1, 2, 3]]
+
+describe('maps in the navigator', () => {
+  testArrays.forEach((arr) => {
+    it(`shows counter for map items with list length ${arr.length}`, async () => {
+      const renderResult = await renderTestEditorWithCode(
+        getProjectCode(arr),
+        'await-first-dom-report',
+      )
+
+      const mapParent = EP.fromString('utopia-storyboard-uid/scene-aaa/containing-div/')
+      const mapElement = MetadataUtils.getChildrenOrdered(
+        renderResult.getEditorState().editor.jsxMetadata,
+        renderResult.getEditorState().editor.elementPathTree,
+        mapParent,
+      )[0]
+
+      const counterTestId = getMapCounterTestId(mapElement.elementPath)
+      const counter = await renderResult.renderedDOM.findByTestId(counterTestId)
+
+      expect(counter.textContent).toEqual(arr.length.toString())
+    })
+  })
+})


### PR DESCRIPTION
**Description:**
This PR implements a counter to show the number of generated items in a map element.

![image](https://github.com/concrete-utopia/utopia/assets/127662/13249116-7cf3-4131-86db-d5d74308ad35)

I also eliminated some unnecessary fragments in NavigatorRowLabel along the way.

Note: there is no interactivity yet
