### PR TITLE
Prevent wrapping/cutting empty groups

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
@@ -92,7 +92,7 @@ import { updateSelectedViews } from '../../commands/update-selected-views-comman
 import { getLayoutProperty } from '../../../../core/layout/getLayoutProperty'
 import { styleStringInArray } from '../../../../utils/common-constants'
 import type { StyleLayoutProp } from '../../../../core/layout/layout-helpers-new'
-import { treatElementAsGroupLike } from './group-helpers'
+import { isEmptyGroup, treatElementAsGroupLike } from './group-helpers'
 
 const GroupImport: Imports = {
   'utopia-api': {
@@ -687,11 +687,7 @@ export function createWrapInGroupActions(
     )
   }
 
-  const anyTargetIsAnEmptyGroup = orderedActionTargets.some(
-    (e) =>
-      treatElementAsGroupLike(metadata, e) &&
-      MetadataUtils.getChildrenUnordered(metadata, e).length === 0,
-  )
+  const anyTargetIsAnEmptyGroup = orderedActionTargets.some((e) => isEmptyGroup(metadata, e))
   if (anyTargetIsAnEmptyGroup) {
     return showToast(notice('Empty Groups cannot be wrapped into Groups', 'ERROR'))
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
@@ -92,6 +92,7 @@ import { updateSelectedViews } from '../../commands/update-selected-views-comman
 import { getLayoutProperty } from '../../../../core/layout/getLayoutProperty'
 import { styleStringInArray } from '../../../../utils/common-constants'
 import type { StyleLayoutProp } from '../../../../core/layout/layout-helpers-new'
+import { treatElementAsGroupLike } from './group-helpers'
 
 const GroupImport: Imports = {
   'utopia-api': {
@@ -684,6 +685,15 @@ export function createWrapInGroupActions(
     return showToast(
       notice('Only simple JSX Elements can be wrapped into Groups for now 🙇', 'ERROR'),
     )
+  }
+
+  const anyTargetIsAnEmptyGroup = orderedActionTargets.some(
+    (e) =>
+      treatElementAsGroupLike(metadata, e) &&
+      MetadataUtils.getChildrenUnordered(metadata, e).length === 0,
+  )
+  if (anyTargetIsAnEmptyGroup) {
+    return showToast(notice('Empty Groups cannot be wrapped into Groups', 'ERROR'))
   }
 
   // TODO if any target doesn't honour the size or offset prop, refuse wrapping and show toast!

--- a/editor/src/components/canvas/canvas-strategies/strategies/group-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-helpers.ts
@@ -469,3 +469,10 @@ export function groupStateFromJSXElement(
     return null
   }
 }
+
+export function isEmptyGroup(metadata: ElementInstanceMetadataMap, path: ElementPath): boolean {
+  return (
+    treatElementAsGroupLike(metadata, path) &&
+    MetadataUtils.getChildrenUnordered(metadata, path).length === 0
+  )
+}

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -55,6 +55,10 @@ import {
 } from '../../canvas/canvas-strategies/post-action-options/post-action-paste'
 import { getDomRectCenter } from '../../../core/shared/dom-utils'
 import { FloatingPostActionMenuTestId } from '../../canvas/controls/select-mode/post-action-menu'
+import {
+  groupJSXElement,
+  groupJSXElementImportsToAdd,
+} from '../../canvas/canvas-strategies/strategies/group-helpers'
 
 async function deleteFromScene(
   inputSnippet: string,
@@ -5818,6 +5822,38 @@ export var storyboard = (
             </React.Fragment>
           </div>`,
         ),
+      )
+    })
+    it('Cannot wrap an empty group', async () => {
+      const testCode = `
+        <div data-uid='aaa'>
+          <Group data-uid='group' />
+        </div>
+      `
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(testCode),
+        'await-first-dom-report',
+      )
+      await renderResult.dispatch(
+        [
+          wrapInElement([makeTargetPath('aaa/group')], {
+            element: { ...groupJSXElement([]), uid: 'foo' },
+            importsToAdd: groupJSXElementImportsToAdd(),
+          }),
+        ],
+        true,
+      )
+
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        makeTestProjectCodeWithSnippet(`
+          <div data-uid='aaa'>
+            <Group data-uid='group' />
+          </div>
+        `),
+      )
+      expect(renderResult.getEditorState().editor.toasts.length).toEqual(1)
+      expect(renderResult.getEditorState().editor.toasts[0].message).toEqual(
+        'Empty Groups cannot be wrapped',
       )
     })
   })

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2688,6 +2688,19 @@ export const UPDATE_FNS = {
       return UPDATE_FNS.ADD_TOAST(showToastAction, editor)
     }
 
+    const isEmptyGroupOnStoryboard = editor.selectedViews.some(
+      (path) =>
+        EP.isStoryboardChild(path) &&
+        treatElementAsGroupLike(editor.jsxMetadata, path) &&
+        MetadataUtils.getChildrenUnordered(editor.jsxMetadata, path).length === 0,
+    )
+    if (isEmptyGroupOnStoryboard) {
+      return UPDATE_FNS.ADD_TOAST(
+        showToast(notice('Empty Groups on the storyboard cannot be cut', 'ERROR')),
+        editor,
+      )
+    }
+
     const editorWithCopyData = copySelectionToClipboardMutating(editor, builtInDependencies)
 
     return UPDATE_FNS.DELETE_SELECTED(editorWithCopyData, dispatch)

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2158,6 +2158,16 @@ export const UPDATE_FNS = {
           return UPDATE_FNS.ADD_TOAST(showToastAction, editor)
         }
 
+        const anyTargetIsAnEmptyGroup = orderedActionTargets.some((path) =>
+          isEmptyGroup(editor.jsxMetadata, path),
+        )
+        if (anyTargetIsAnEmptyGroup) {
+          return UPDATE_FNS.ADD_TOAST(
+            showToast(notice('Empty Groups cannot be wrapped', 'ERROR')),
+            editor,
+          )
+        }
+
         const detailsOfUpdate = null
         const { updatedEditor, newPath } = wrapElementInsertions(
           editor,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -587,6 +587,7 @@ import { addToTrueUpGroups } from '../../../core/model/groups'
 import {
   groupStateFromJSXElement,
   invalidGroupStateToString,
+  isEmptyGroup,
   isInvalidGroupState,
   treatElementAsGroupLike,
 } from '../../canvas/canvas-strategies/strategies/group-helpers'
@@ -2689,10 +2690,7 @@ export const UPDATE_FNS = {
     }
 
     const isEmptyGroupOnStoryboard = editor.selectedViews.some(
-      (path) =>
-        EP.isStoryboardChild(path) &&
-        treatElementAsGroupLike(editor.jsxMetadata, path) &&
-        MetadataUtils.getChildrenUnordered(editor.jsxMetadata, path).length === 0,
+      (path) => EP.isStoryboardChild(path) && isEmptyGroup(editor.jsxMetadata, path),
     )
     if (isEmptyGroupOnStoryboard) {
       return UPDATE_FNS.ADD_TOAST(

--- a/editor/src/components/editor/shortcuts.spec.browser2.tsx
+++ b/editor/src/components/editor/shortcuts.spec.browser2.tsx
@@ -1309,6 +1309,36 @@ export var storyboard = (
 )
 `)
     })
+
+    it('cannot wrap empty groups', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(`
+          <div data-uid='aaa'>
+            <Group data-uid='group' />
+          </div>
+        `),
+        'await-first-dom-report',
+      )
+
+      await selectComponentsForTest(renderResult, [
+        EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/group`),
+      ])
+
+      await pressKey('g', { modifiers: cmdModifier })
+      await renderResult.getDispatchFollowUpActionsFinished()
+
+      expect(getPrintedUiJsCodeWithoutUIDs(renderResult.getEditorState())).toEqual(
+        makeTestProjectCodeWithSnippetWithoutUIDs(`
+          <div>
+            <Group />
+          </div>
+        `),
+      )
+      expect(renderResult.getEditorState().editor.toasts.length).toEqual(1)
+      expect(renderResult.getEditorState().editor.toasts[0].message).toEqual(
+        'Empty Groups cannot be wrapped into Groups',
+      )
+    })
   })
 })
 


### PR DESCRIPTION
Fixes #4015

**Problem:**

It's possible to wrap empty groups into groups, which is illegal. Likewise is cutting empty groups on the storyboard.

**Fix:**

- Show a toast and stop when trying to CMD+G an empty group
- Show a toast and stop when trying to CMD+X an empty group on the storyboard
- Show a toast and stop when trying to wrap via the insert menu an empty group*

(*) I deliberately extended this to all wrapping elements (not just group-into-groups) because trying to wrap an empty group with almost any other element (e.g. a `div`) would break the editor (and it does not feel conceptually correct either).