### PR TITLE
fix(paste) paste to storyboard center with floating menus

### DIFF
--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -3400,7 +3400,7 @@ export var storyboard = (props) => {
                 <div data-uid='bbb' style={{position: 'absolute', width: 50, height: 40, top: 30, left: 20}}>Hello!</div>
               </div>`,
             targets: [makeTargetPath('root/bbb')],
-            result: `<div data-uid='aai' style={{position: 'absolute', width: 50, height: 40, top: 400, left: 835}}>Hello!</div>`,
+            result: `<div data-uid='aai' style={{position: 'absolute', width: 50, height: 40, top: 400, left: 695}}>Hello!</div>`,
           },
           {
             name: `paste a flex child into the storyboard`,
@@ -3412,7 +3412,7 @@ export var storyboard = (props) => {
                 </div>
               </div>`,
             targets: [makeTargetPath('root/bbb/ddd')],
-            result: `<div data-uid='aak' style={{ height: 20, top: 410, left: 675, position: 'absolute' }}>
+            result: `<div data-uid='aak' style={{ height: 20, top: 410, left: 535, position: 'absolute' }}>
                 <div data-uid='aae' style={{ width: 20, height: 20 }}/>
               </div>`,
           },
@@ -3423,8 +3423,8 @@ export var storyboard = (props) => {
               <div data-uid='bello' style={{ position: 'absolute', top: 30, left: 30, contain: 'layout', height: 20 }}>bello</div>
             </div>`,
             targets: [makeTargetPath('root/hello'), makeTargetPath('root/bello')],
-            result: `<div data-uid='hel' style={{ position: 'absolute', top: 405, left: 854, contain: 'layout', height: 20 }}>hello</div>
-            <div data-uid='bel' style={{ position: 'absolute', top: 415, left: 834, contain: 'layout', height: 20 }}>bello</div>`,
+            result: `<div data-uid='hel' style={{ position: 'absolute', top: 405, left: 714, contain: 'layout', height: 20 }}>hello</div>
+            <div data-uid='bel' style={{ position: 'absolute', top: 415, left: 694, contain: 'layout', height: 20 }}>bello</div>`,
           },
         ]
 

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -2492,7 +2492,7 @@ export var storyboard = (props) => {
         style={{
           backgroundColor: '#da82c9',
           position: 'absolute',
-          left: 738,
+          left: 598,
           top: 316,
           width: 244,
           height: 208,
@@ -2503,7 +2503,7 @@ export var storyboard = (props) => {
         style={{
           backgroundColor: '#da82c9',
           position: 'absolute',
-          left: 992,
+          left: 852,
           top: 316,
           width: 244,
           height: 208,
@@ -2514,7 +2514,7 @@ export var storyboard = (props) => {
         style={{
           backgroundColor: '#da82c9',
           position: 'absolute',
-          left: 1246,
+          left: 1106,
           top: 316,
           width: 244,
           height: 208,
@@ -2525,7 +2525,7 @@ export var storyboard = (props) => {
         style={{
           backgroundColor: '#da82c9',
           position: 'absolute',
-          left: 1500,
+          left: 1360,
           top: 316,
           width: 244,
           height: 208,
@@ -4007,7 +4007,7 @@ export var storyboard = (
         width: 44,
         height: 33,
         top: 404,
-        left: 838,
+        left: 698,
         backgroundColor: '#cee5ff',
       }}
       onClick={undefined}
@@ -4135,7 +4135,7 @@ export var storyboard = (
     <div
       data-label='grandParent'
       data-uid='roo'
-      style={{ top: 420, left: 760, position: 'absolute' }}
+      style={{ top: 420, left: 620, position: 'absolute' }}
     >
       <div
         data-label='parent'
@@ -4716,7 +4716,7 @@ export var storyboard = (
     </Scene>
     <div
       data-uid='roo'
-      style={{ top: 420, left: 760, position: 'absolute' }}
+      style={{ top: 420, left: 620, position: 'absolute' }}
     >
       <div data-uid='par'>
         <div

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -1308,7 +1308,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
         const canvasViewportCenter = canvasPoint({
           x:
             -editor.canvas.roundedCanvasOffset.x +
-            (canvasWrapperRect.width + this.props.navigatorWidth) / editor.canvas.scale / 2,
+            canvasWrapperRect.width / editor.canvas.scale / 2,
           y:
             -editor.canvas.roundedCanvasOffset.y +
             canvasWrapperRect.height / editor.canvas.scale / 2,

--- a/editor/src/utils/clipboard.spec.browser2.tsx
+++ b/editor/src/utils/clipboard.spec.browser2.tsx
@@ -57,7 +57,7 @@ describe('Pasting an image onto the canvas', () => {
           src='./assets/clipboard/chucknorris.png'
           style={{
             position: 'absolute',
-            left: 859,
+            left: 719,
             top: 419.5,
             width: 1,
             height: 1,


### PR DESCRIPTION
**Problem:**
With the new floating menus (navigator, inspector) the pasted element didn't appear in the center of the storyboard.

**Fix:**
Center of the canvas now means the center, regardless of navigator/inspector visibility. Will revisit when more floating UI components are added and the center might be obscured.

**Commit Details:**
- update  `EditorCanvas`
- update tests
