### PR TITLE
Unwrap multiple targets

### DIFF
--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -402,9 +402,7 @@ export const unwrap: ContextMenuItem<CanvasData> = {
     )
   },
   action: (data, dispatch?: EditorDispatch) => {
-    if (data.selectedViews.length > 0) {
-      requireDispatch(dispatch)([EditorActions.unwrapElement(data.selectedViews[0])], 'everyone')
-    }
+    requireDispatch(dispatch)([EditorActions.unwrapElements(data.selectedViews)], 'everyone')
   },
 }
 

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -492,9 +492,9 @@ export interface CloseFloatingInsertMenu {
   action: 'CLOSE_FLOATING_INSERT_MENU'
 }
 
-export interface UnwrapElement {
-  action: 'UNWRAP_ELEMENT'
-  target: ElementPath
+export interface UnwrapElements {
+  action: 'UNWRAP_ELEMENTS'
+  targets: ElementPath[]
 }
 
 export interface UpdateFrameDimensions {
@@ -1094,7 +1094,7 @@ export type EditorAction =
   | WrapInElement
   | OpenFloatingInsertMenu
   | CloseFloatingInsertMenu
-  | UnwrapElement
+  | UnwrapElements
   | SetNavigatorRenamingTarget
   | RedrawOldCanvasControls
   | UpdateFrameDimensions

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -140,7 +140,7 @@ import type {
   TransientActions,
   Undo,
   UnsetProperty,
-  UnwrapElement,
+  UnwrapElements,
   UpdateText,
   UpdateCodeResultCache,
   UpdateDuplicationState,
@@ -717,10 +717,10 @@ export function resetPins(target: ElementPath): ResetPins {
   }
 }
 
-export function unwrapElement(target: ElementPath): UnwrapElement {
+export function unwrapElements(targets: ElementPath[]): UnwrapElements {
   return {
-    action: 'UNWRAP_ELEMENT',
-    target: target,
+    action: 'UNWRAP_ELEMENTS',
+    targets: targets,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -153,7 +153,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'deprecated_TOGGLE_ENABLED_PROPERTY':
     case 'RESET_PINS':
     case 'WRAP_IN_ELEMENT':
-    case 'UNWRAP_ELEMENT':
+    case 'UNWRAP_ELEMENTS':
     case 'SET_CANVAS_FRAMES':
     case 'SET_PROJECT_NAME':
     case 'SET_PROJECT_DESCRIPTION':

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -15,7 +15,7 @@ import {
   TestScenePath,
   TestSceneUID,
 } from '../../../components/canvas/ui-jsx.test-utils'
-import { deleteSelected, selectComponents, unwrapElement, wrapInElement } from './action-creators'
+import { deleteSelected, selectComponents, unwrapElements, wrapInElement } from './action-creators'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import type { ElementPaste } from '../action-types'
 import type { InsertionPath } from '../store/insertion-path'
@@ -5265,7 +5265,7 @@ export var storyboard = (
       })
     })
   })
-  describe('UNWRAP_ELEMENT', () => {
+  describe('UNWRAP_ELEMENTS', () => {
     it(`Unwraps a fragment-like element`, async () => {
       const testCode = `
       <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
@@ -5279,7 +5279,7 @@ export var storyboard = (
         makeTestProjectCodeWithSnippet(testCode),
         'await-first-dom-report',
       )
-      await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/bbb'))], true)
+      await renderResult.dispatch([unwrapElements([makeTargetPath('aaa/bbb')])], true)
 
       expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
         makeTestProjectCodeWithSnippet(
@@ -5302,7 +5302,7 @@ export var storyboard = (
         makeTestProjectCodeWithSnippet(testCode),
         'await-first-dom-report',
       )
-      await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/bbb'))], true)
+      await renderResult.dispatch([unwrapElements([makeTargetPath('aaa/bbb')])], true)
 
       expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
         makeTestProjectCodeWithSnippet(
@@ -5335,7 +5335,7 @@ export var storyboard = (
         makeTestProjectCodeWithSnippet(testCode),
         'await-first-dom-report',
       )
-      await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/bbb'))], true)
+      await renderResult.dispatch([unwrapElements([makeTargetPath('aaa/bbb')])], true)
 
       expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
         makeTestProjectCodeWithSnippet(
@@ -5359,7 +5359,7 @@ export var storyboard = (
         makeTestProjectCodeWithSnippet(testCode),
         'await-first-dom-report',
       )
-      await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/bbb'))], true)
+      await renderResult.dispatch([unwrapElements([makeTargetPath('aaa/bbb')])], true)
 
       expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
         makeTestProjectCodeWithSnippet(
@@ -5383,12 +5383,137 @@ export var storyboard = (
         makeTestProjectCodeWithSnippet(testCode),
         'await-first-dom-report',
       )
-      await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/bbb'))], true)
+      await renderResult.dispatch([unwrapElements([makeTargetPath('aaa/bbb')])], true)
 
       expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
         makeTestProjectCodeWithSnippet(
           `<div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}} />`,
         ),
+      )
+    })
+    it('can do multiselect unwrap', async () => {
+      const testCode = `
+          <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+            <div data-uid='unwrap-div'>
+              <div
+                style={{
+                  backgroundColor: 'orange',
+                  width: 50,
+                  height: 50,
+                }}
+                data-uid='foo'
+              />
+              <div
+                style={{
+                  backgroundColor: 'orange',
+                  width: 30,
+                  height: 30,
+                }}
+                data-uid='bar'
+              />
+              <div
+                style={{
+                  backgroundColor: 'orange',
+                  height: 60,
+                }}
+                data-uid='baz'
+              />
+            </div>
+            <View data-uid='unwrap-view'>
+              <div
+                style={{
+                  backgroundColor: 'orange',
+                  width: 30,
+                  height: 30,
+                }}
+                data-uid='qux'
+              />
+              <div
+                style={{
+                  backgroundColor: 'orange',
+                  height: 60,
+                }}
+                data-uid='waldo'
+              />
+            </View>
+            <div data-uid='nested'>
+                <div data-uid='nested-div' />
+                <React.Fragment data-uid='fragment'>
+                  <div data-uid='fragment-child1' />
+                  <div data-uid='fragment-child2' />
+                  <div data-uid='fragment-child3' />
+                </React.Fragment>
+            </div>
+            {
+              // @utopia/uid=cond
+              true ? <div data-uid='true-branch' /> : <div data-uid='false-branch' />
+            }
+          </div>
+        `
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(testCode),
+        'await-first-dom-report',
+      )
+      await renderResult.dispatch(
+        [
+          unwrapElements([
+            makeTargetPath('aaa/unwrap-div'),
+            makeTargetPath('aaa/unwrap-view'),
+            makeTargetPath('aaa/nested/fragment'),
+            makeTargetPath('aaa/cond'),
+          ]),
+        ],
+        true,
+      )
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        makeTestProjectCodeWithSnippet(`
+          <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+            <div
+              style={{
+                backgroundColor: 'orange',
+                width: 50,
+                height: 50,
+              }}
+              data-uid='foo'
+            />
+            <div
+              style={{
+                backgroundColor: 'orange',
+                width: 30,
+                height: 30,
+              }}
+              data-uid='bar'
+            />
+            <div
+              style={{ backgroundColor: 'orange', height: 60 }}
+              data-uid='baz'
+            />
+            <div
+              style={{
+                backgroundColor: 'orange',
+                width: 30,
+                height: 30,
+                top: 140,
+              }}
+              data-uid='qux'
+            />
+            <div
+              style={{
+                backgroundColor: 'orange',
+                height: 60,
+                top: 170,
+              }}
+              data-uid='waldo'
+            />
+            <div data-uid='nested'>
+                <div data-uid='nested-div' />
+                <div data-uid='fragment-child1' />
+                <div data-uid='fragment-child2' />
+                <div data-uid='fragment-child3' />
+            </div>
+            <div data-uid='true-branch' />
+          </div>
+        `),
       )
     })
     it(`Unwraps a fragment`, async () => {
@@ -5404,7 +5529,7 @@ export var storyboard = (
         makeTestProjectCodeWithSnippet(testCode),
         'await-first-dom-report',
       )
-      await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/fragment'))], true)
+      await renderResult.dispatch([unwrapElements([makeTargetPath('aaa/fragment')])], true)
 
       expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
         makeTestProjectCodeWithSnippet(`
@@ -5429,7 +5554,7 @@ export var storyboard = (
           makeTestProjectCodeWithSnippet(testCode),
           'await-first-dom-report',
         )
-        await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/conditional'))], true)
+        await renderResult.dispatch([unwrapElements([makeTargetPath('aaa/conditional')])], true)
 
         expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
           makeTestProjectCodeWithSnippet(`
@@ -5452,7 +5577,7 @@ export var storyboard = (
           makeTestProjectCodeWithSnippet(testCode),
           'await-first-dom-report',
         )
-        await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/conditional'))], true)
+        await renderResult.dispatch([unwrapElements([makeTargetPath('aaa/conditional')])], true)
 
         expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
           makeTestProjectCodeWithSnippet(`
@@ -5476,7 +5601,7 @@ export var storyboard = (
           makeTestProjectCodeWithSnippet(testCode),
           'await-first-dom-report',
         )
-        await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/conditional'))], true)
+        await renderResult.dispatch([unwrapElements([makeTargetPath('aaa/conditional')])], true)
 
         expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
           makeTestProjectCodeWithSnippet(`
@@ -5499,7 +5624,7 @@ export var storyboard = (
           makeTestProjectCodeWithSnippet(testCode),
           'await-first-dom-report',
         )
-        await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/conditional'))], true)
+        await renderResult.dispatch([unwrapElements([makeTargetPath('aaa/conditional')])], true)
 
         expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
           makeTestProjectCodeWithSnippet(`
@@ -5522,7 +5647,7 @@ export var storyboard = (
           makeTestProjectCodeWithSnippet(testCode),
           'await-first-dom-report',
         )
-        await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/conditional'))], true)
+        await renderResult.dispatch([unwrapElements([makeTargetPath('aaa/conditional')])], true)
 
         expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
           makeTestProjectCodeWithSnippet(`
@@ -5554,7 +5679,7 @@ export var storyboard = (
           'await-first-dom-report',
         )
         await renderResult.dispatch(
-          [unwrapElement(makeTargetPath('aaa/conditional/conditional2'))],
+          [unwrapElements([makeTargetPath('aaa/conditional/conditional2')])],
           true,
         )
 
@@ -5589,7 +5714,7 @@ export var storyboard = (
           'await-first-dom-report',
         )
         await renderResult.dispatch(
-          [unwrapElement(makeTargetPath('aaa/conditional/conditional2'))],
+          [unwrapElements([makeTargetPath('aaa/conditional/conditional2')])],
           true,
         )
 
@@ -5662,7 +5787,7 @@ export var storyboard = (
           makeTestProjectCodeWithSnippet(testCode),
           'await-first-dom-report',
         )
-        await renderResult.dispatch([unwrapElement(makeTargetPath('aaa/group/unwrap-me'))], true)
+        await renderResult.dispatch([unwrapElements([makeTargetPath('aaa/group/unwrap-me')])], true)
         expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
           makeTestProjectCodeWithSnippet(`
           <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
@@ -5709,6 +5834,110 @@ export var storyboard = (
             </Group>
           </div>
         `),
+        )
+      })
+      it('selects all unwrapped children on multiselect unwrap', async () => {
+        const testCode = `
+          <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+            <Group data-uid='group1'>
+              <div
+                style={{
+                  backgroundColor: 'orange',
+                  width: 50,
+                  height: 50,
+                }}
+                data-uid='foo'
+              />
+              <div
+                style={{
+                  backgroundColor: 'orange',
+                  width: 30,
+                  height: 30,
+                }}
+                data-uid='bar'
+              />
+              <div
+                style={{
+                  backgroundColor: 'orange',
+                  height: 60,
+                }}
+                data-uid='baz'
+              />
+            </Group>
+            <Group data-uid='group2'>
+              <div
+                style={{
+                  backgroundColor: 'orange',
+                  width: 30,
+                  height: 30,
+                }}
+                data-uid='qux'
+              />
+              <div
+                style={{
+                  backgroundColor: 'orange',
+                  height: 60,
+                }}
+                data-uid='waldo'
+              />
+            </Group>
+          </div>
+        `
+        const renderResult = await renderTestEditorWithCode(
+          makeTestProjectCodeWithSnippet(testCode),
+          'await-first-dom-report',
+        )
+        await renderResult.dispatch(
+          [unwrapElements([makeTargetPath('aaa/group1'), makeTargetPath('aaa/group2')])],
+          true,
+        )
+        expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+          makeTestProjectCodeWithSnippet(`
+            <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+              <div
+                style={{
+                  backgroundColor: 'orange',
+                  width: 50,
+                  height: 50,
+                }}
+                data-uid='foo'
+              />
+              <div
+                style={{
+                  backgroundColor: 'orange',
+                  width: 30,
+                  height: 30,
+                }}
+                data-uid='bar'
+              />
+              <div
+                style={{ backgroundColor: 'orange', height: 60 }}
+                data-uid='baz'
+              />
+              <div
+                style={{
+                  backgroundColor: 'orange',
+                  width: 30,
+                  height: 30,
+                }}
+                data-uid='qux'
+              />
+              <div
+                style={{ backgroundColor: 'orange', height: 60 }}
+                data-uid='waldo'
+              />
+            </div>
+        `),
+        )
+        const selection = [...renderResult.getEditorState().editor.selectedViews].sort(comparePaths)
+        expect(selection).toEqual(
+          [
+            makeTargetPath('aaa/foo'),
+            makeTargetPath('aaa/bar'),
+            makeTargetPath('aaa/baz'),
+            makeTargetPath('aaa/qux'),
+            makeTargetPath('aaa/waldo'),
+          ].sort(comparePaths),
         )
       })
     })
@@ -5837,3 +6066,7 @@ export var storyboard = (
     })
   })
 })
+
+function comparePaths(a: ElementPath, b: ElementPath): number {
+  return EP.toString(a).localeCompare(EP.toString(b))
+}

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -305,7 +305,7 @@ import type {
   ToggleProperty,
   ToggleSelectionLock,
   UnsetProperty,
-  UnwrapElement,
+  UnwrapElements,
   UpdateText,
   UpdateCodeResultCache,
   UpdateDuplicationState,
@@ -2231,8 +2231,8 @@ export const UPDATE_FNS = {
       },
     }
   },
-  UNWRAP_ELEMENT: (
-    action: UnwrapElement,
+  UNWRAP_ELEMENTS: (
+    action: UnwrapElements,
     editorForAction: EditorModel,
     dispatch: EditorDispatch,
     builtInDependencies: BuiltInDependencies,
@@ -2241,136 +2241,143 @@ export const UPDATE_FNS = {
       `Cannot unwrap a generated element.`,
       editorForAction,
       false,
-      (editor) => {
-        const supportsChildren = MetadataUtils.targetSupportsChildren(
-          editor.projectContents,
-          editor.jsxMetadata,
-          editor.nodeModules.files,
-          editor.canvas.openFile?.filename,
-          action.target,
-          editor.elementPathTree,
-        )
+      (initialEditor) => {
+        let groupTrueUps: ElementPath[] = []
+        let viewsToDelete: ElementPath[] = []
+        let newSelection: ElementPath[] = []
 
-        const elementIsFragmentLike = treatElementAsFragmentLike(
-          editor.jsxMetadata,
-          editor.allElementProps,
-          editor.elementPathTree,
-          action.target,
-        )
-
-        if (!(supportsChildren || elementIsFragmentLike)) {
-          return editor
-        }
-
-        const parentPath = MetadataUtils.getReparentTargetOfTarget(
-          editorForAction.jsxMetadata,
-          action.target,
-        )
-
-        const indexPosition: IndexPosition = indexPositionForAdjustment(
-          action.target,
-          editor,
-          'forward',
-        )
-        const children = MetadataUtils.getChildrenOrdered(
-          editor.jsxMetadata,
-          editor.elementPathTree,
-          action.target,
-        ).reverse() // children are reversed so when they are readded one by one as 'forward' index they keep their original order
-
-        const isGroupChild = treatElementAsGroupLike(
-          editor.jsxMetadata,
-          EP.parentPath(action.target),
-        )
-
-        if (parentPath != null && isConditionalClauseInsertionPath(parentPath)) {
-          return unwrapConditionalClause(editor, action.target, parentPath)
-        }
-
-        if (elementIsFragmentLike) {
-          if (isTextContainingConditional(action.target, editor.jsxMetadata)) {
-            return unwrapTextContainingConditional(editor, action.target, dispatch)
-          }
-
-          const { editor: withChildrenMoved, newPaths } = editorMoveMultiSelectedTemplates(
-            builtInDependencies,
-            children.map((child) => child.elementPath),
-            indexPosition,
-            parentPath,
-            editor,
+        const withViewsUnwrapped: EditorState = action.targets.reduce((workingEditor, target) => {
+          const supportsChildren = MetadataUtils.targetSupportsChildren(
+            workingEditor.projectContents,
+            workingEditor.jsxMetadata,
+            workingEditor.nodeModules.files,
+            workingEditor.canvas.openFile?.filename,
+            target,
+            workingEditor.elementPathTree,
           )
-          const withViewDeleted = deleteElements([action.target], withChildrenMoved)
 
-          return {
-            ...withViewDeleted,
-            selectedViews: newPaths,
-            canvas: {
-              ...withViewDeleted.canvas,
-              domWalkerInvalidateCount: editor.canvas.domWalkerInvalidateCount + 1,
-            },
-          }
-        } else {
-          const parentFrame =
-            parentPath == null
-              ? (Utils.zeroRectangle as CanvasRectangle)
-              : MetadataUtils.getFrameOrZeroRectInCanvasCoords(
-                  parentPath.intendedParentPath,
-                  editor.jsxMetadata,
-                )
+          const elementIsFragmentLike = treatElementAsFragmentLike(
+            workingEditor.jsxMetadata,
+            workingEditor.allElementProps,
+            workingEditor.elementPathTree,
+            target,
+          )
 
-          let groupTrueUps: ElementPath[] = []
-          if (isGroupChild && parentPath != null) {
-            groupTrueUps.push(parentPath.intendedParentPath)
+          if (!(supportsChildren || elementIsFragmentLike)) {
+            return workingEditor
           }
 
-          let newSelection: ElementPath[] = []
-          const withChildrenMoved = children.reduce((working, child) => {
-            const childFrame = MetadataUtils.getFrameOrZeroRectInCanvasCoords(
-              child.elementPath,
-              editor.jsxMetadata,
-            )
-            const result = editorMoveTemplate(
-              child.elementPath,
-              child.elementPath,
-              childFrame,
-              indexPosition,
-              parentPath?.intendedParentPath ?? null,
-              parentFrame,
-              working,
-              null,
-              null,
-            )
-            if (result.newPath != null) {
-              newSelection.push(result.newPath)
-              if (isGroupChild) {
-                groupTrueUps.push(result.newPath)
-                return foldAndApplyCommandsSimple(
-                  result.editor,
-                  createPinChangeCommandsForElementBecomingGroupChild(
-                    child,
-                    result.newPath,
-                    parentFrame,
-                    localRectangle(parentFrame),
-                  ),
-                )
-              }
+          viewsToDelete.push(target)
+
+          const parentPath = MetadataUtils.getReparentTargetOfTarget(
+            editorForAction.jsxMetadata,
+            target,
+          )
+
+          const indexPosition: IndexPosition = indexPositionForAdjustment(
+            target,
+            workingEditor,
+            'forward',
+          )
+          const children = MetadataUtils.getChildrenOrdered(
+            workingEditor.jsxMetadata,
+            workingEditor.elementPathTree,
+            target,
+          ).reverse() // children are reversed so when they are readded one by one as 'forward' index they keep their original order
+          const isGroupChild = treatElementAsGroupLike(
+            workingEditor.jsxMetadata,
+            EP.parentPath(target),
+          )
+
+          if (parentPath != null && isConditionalClauseInsertionPath(parentPath)) {
+            return unwrapConditionalClause(workingEditor, target, parentPath)
+          }
+          if (elementIsFragmentLike) {
+            if (isTextContainingConditional(target, workingEditor.jsxMetadata)) {
+              return unwrapTextContainingConditional(workingEditor, target, dispatch)
             }
-            return result.editor
-          }, editor)
-          const withViewDeleted = deleteElements([action.target], withChildrenMoved)
 
-          return {
-            ...withViewDeleted,
-            selectedViews: newSelection,
-            canvas: {
-              ...withViewDeleted.canvas,
-              domWalkerInvalidateCount: editor.canvas.domWalkerInvalidateCount + 1,
-              trueUpGroupsForElementAfterDomWalkerRuns: [
-                ...withViewDeleted.trueUpGroupsForElementAfterDomWalkerRuns,
-                ...groupTrueUps,
-              ],
-            },
+            const { editor: withChildrenMoved, newPaths } = editorMoveMultiSelectedTemplates(
+              builtInDependencies,
+              children.map((child) => child.elementPath),
+              indexPosition,
+              parentPath,
+              workingEditor,
+            )
+
+            return {
+              ...withChildrenMoved,
+              selectedViews: newPaths,
+              canvas: {
+                ...withChildrenMoved.canvas,
+                domWalkerInvalidateCount: workingEditor.canvas.domWalkerInvalidateCount + 1,
+              },
+            }
+          } else {
+            const parentFrame =
+              parentPath == null
+                ? (Utils.zeroRectangle as CanvasRectangle)
+                : MetadataUtils.getFrameOrZeroRectInCanvasCoords(
+                    parentPath.intendedParentPath,
+                    workingEditor.jsxMetadata,
+                  )
+
+            if (isGroupChild && parentPath != null) {
+              groupTrueUps.push(parentPath.intendedParentPath)
+            }
+
+            const withChildrenMoved = children.reduce((working, child) => {
+              const childFrame = MetadataUtils.getFrameOrZeroRectInCanvasCoords(
+                child.elementPath,
+                workingEditor.jsxMetadata,
+              )
+              const result = editorMoveTemplate(
+                child.elementPath,
+                child.elementPath,
+                childFrame,
+                indexPosition,
+                parentPath?.intendedParentPath ?? null,
+                parentFrame,
+                working,
+                null,
+                null,
+              )
+              if (result.newPath != null) {
+                newSelection.push(result.newPath)
+                if (isGroupChild) {
+                  groupTrueUps.push(result.newPath)
+                  return foldAndApplyCommandsSimple(
+                    result.editor,
+                    createPinChangeCommandsForElementBecomingGroupChild(
+                      child,
+                      result.newPath,
+                      parentFrame,
+                      localRectangle(parentFrame),
+                    ),
+                  )
+                }
+              }
+              return result.editor
+            }, workingEditor)
+
+            return {
+              ...withChildrenMoved,
+              canvas: {
+                ...withChildrenMoved.canvas,
+                domWalkerInvalidateCount: workingEditor.canvas.domWalkerInvalidateCount + 1,
+              },
+            }
           }
+        }, initialEditor)
+
+        const withViewsDeleted = deleteElements(viewsToDelete, withViewsUnwrapped)
+        return {
+          ...withViewsDeleted,
+          selectedViews: newSelection,
+          trueUpGroupsForElementAfterDomWalkerRuns: [
+            ...withViewsDeleted.trueUpGroupsForElementAfterDomWalkerRuns,
+            ...groupTrueUps,
+          ],
         }
       },
       dispatch,

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -27,7 +27,7 @@ import {
 import {
   deleteSelected,
   selectComponents,
-  unwrapElement,
+  unwrapElements,
   wrapInElement,
 } from '../editor/actions/action-creators'
 import { ConditionalSectionTestId } from '../inspector/sections/layout-section/conditional-section'
@@ -549,7 +549,7 @@ describe('conditionals', () => {
       const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional'])
 
       await act(async () => {
-        await renderResult.dispatch([unwrapElement(targetPath)], true)
+        await renderResult.dispatch([unwrapElements([targetPath])], true)
       })
 
       expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
@@ -582,7 +582,7 @@ describe('conditionals', () => {
       const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional'])
 
       await act(async () => {
-        await renderResult.dispatch([unwrapElement(targetPath)], true)
+        await renderResult.dispatch([unwrapElements([targetPath])], true)
       })
 
       expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
@@ -610,7 +610,7 @@ describe('conditionals', () => {
       const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional'])
 
       await act(async () => {
-        await renderResult.dispatch([unwrapElement(targetPath)], true)
+        await renderResult.dispatch([unwrapElements([targetPath])], true)
       })
 
       expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
@@ -642,7 +642,7 @@ describe('conditionals', () => {
       const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional', 'bbb'])
 
       await act(async () => {
-        await renderResult.dispatch([unwrapElement(targetPath)], true)
+        await renderResult.dispatch([unwrapElements([targetPath])], true)
       })
 
       expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
@@ -677,7 +677,7 @@ describe('conditionals', () => {
       const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'conditional'])
 
       await act(async () => {
-        await renderResult.dispatch([unwrapElement(targetPath)], true)
+        await renderResult.dispatch([unwrapElements([targetPath])], true)
       })
 
       expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
@@ -712,7 +712,7 @@ describe('conditionals', () => {
       ])
 
       await act(async () => {
-        await renderResult.dispatch([unwrapElement(targetPath)], true)
+        await renderResult.dispatch([unwrapElements([targetPath])], true)
       })
 
       expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -575,9 +575,7 @@ export function handleKeyDown(
           : []
       },
       [UNWRAP_ELEMENT_SHORTCUT]: () => {
-        return isSelectMode(editor.mode)
-          ? editor.selectedViews.map((target) => EditorActions.unwrapElement(target))
-          : []
+        return isSelectMode(editor.mode) ? [EditorActions.unwrapElements(editor.selectedViews)] : []
       },
       [WRAP_ELEMENT_DEFAULT_SHORTCUT]: () => {
         return isSelectMode(editor.mode) && editor.selectedViews.length > 0

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -257,8 +257,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.WRAP_IN_ELEMENT(action, state, derivedState, dispatch, builtInDependencies)
     case 'OPEN_FLOATING_INSERT_MENU':
       return UPDATE_FNS.OPEN_FLOATING_INSERT_MENU(action, state)
-    case 'UNWRAP_ELEMENT':
-      return UPDATE_FNS.UNWRAP_ELEMENT(action, state, dispatch, builtInDependencies)
+    case 'UNWRAP_ELEMENTS':
+      return UPDATE_FNS.UNWRAP_ELEMENTS(action, state, dispatch, builtInDependencies)
     case 'INSERT_IMAGE_INTO_UI':
       return UPDATE_FNS.INSERT_IMAGE_INTO_UI(action, state, derivedState)
     case 'UPDATE_JSX_ELEMENT_NAME':


### PR DESCRIPTION
Fixes #4018 

**Problem:**

- Unwrapping multiple groups with CMD+G only selects the children of the first unwrapped group
- Unwrapping multiple groups with the context menu only unwraps one of the groups, as multiple unwrapping is not supported

![Kapture 2023-08-01 at 16 38 36](https://github.com/concrete-utopia/utopia/assets/1081051/f72b994f-dd7e-4a4c-9a26-a35b8094ead6)

This is because:
1. The unwrapping for multiple selected views works by enqueueing sequential unwraps, each of which resets the selection
2. The unwrapping for the context menu triggers the unwrap on the `0th` element of the selection

**Fix:**

- Rework the unwrapping logic so that it supports multiple targets, which solves both the above in one go
- Make sure the old tests pass
- Add specific tests

![Kapture 2023-08-01 at 16 39 41](https://github.com/concrete-utopia/utopia/assets/1081051/20e95336-3246-47d3-951e-668adc787ef6)

**Notes:**

I tried to touch the logic of the unwrapping as little as possible: there's quite a bit of room for improvement there, but imho this is already a relevant enough change that it should simply make sure the existing logic works fine as-is, with just the minimum set of additions to work with the multiple targets approach, without adding all the cognitive load of a larger rewrite.