### PR TITLE
Fix navigator regressions caused by the map counter

### DIFF
--- a/editor/src/components/navigator/navigator-item/map-counter.tsx
+++ b/editor/src/components/navigator/navigator-item/map-counter.tsx
@@ -21,11 +21,11 @@ export const MapCounter = React.memo((props: MapCounterProps) => {
   const { navigatorEntry } = props
   const { elementPath } = navigatorEntry
 
-  const counterValue = useEditorState(
+  const counterValue: number | null = useEditorState(
     Substores.metadata,
     (store) => {
       if (!isRegularNavigatorEntry(navigatorEntry)) {
-        return false
+        return null
       }
       const elementMetadata = MetadataUtils.findElementByElementPath(
         store.editor.jsxMetadata,

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -794,23 +794,29 @@ interface NavigatorRowLabelProps {
 export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
   const colorTheme = useColorTheme()
 
-  const isConditionalOrMapLabel = useEditorState(
+  const conditionalOrMapLabel: 'conditional' | 'map' | null = useEditorState(
     Substores.metadata,
     (store) => {
       if (!isRegularNavigatorEntry(props.navigatorEntry)) {
-        return false
+        return null
       }
       const elementMetadata = MetadataUtils.findElementByElementPath(
         store.editor.jsxMetadata,
         props.navigatorEntry.elementPath,
       )
-      return (
-        MetadataUtils.isConditionalFromMetadata(elementMetadata) ||
-        MetadataUtils.isJSXMapExpressionFromMetadata(elementMetadata)
-      )
+      if (MetadataUtils.isConditionalFromMetadata(elementMetadata)) {
+        return 'conditional'
+      }
+      if (MetadataUtils.isJSXMapExpressionFromMetadata(elementMetadata)) {
+        return 'map'
+      }
+      return null
     },
     'NavigatorRowLabel isConditionalLabel',
   )
+
+  const isConditionalOrMapLabel =
+    conditionalOrMapLabel === 'conditional' || conditionalOrMapLabel === 'map'
 
   return (
     <div
@@ -823,6 +829,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
         borderRadius: 20,
         height: 22,
         paddingLeft: 10,
+        paddingRight: conditionalOrMapLabel === 'map' ? 0 : 10,
         backgroundColor:
           isConditionalOrMapLabel && !props.selected
             ? colorTheme.dynamicBlue10.value


### PR DESCRIPTION
**Problem:**
- Map counter background was accidentally shown for non-regular navigator entries, because the selector returned false and not null..... I added type declaration to prevent another error like this.
- NavigatorRowLabel padding-right should have stayed 10 when it is not a map.
