### PR TITLE
Fixes for control structures in the navigator

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -235,8 +235,10 @@ function codeElementsTargeted(canvasState: InteractionCanvasState): boolean {
     getTargetPathsFromInteractionTarget(canvasState.interactionTarget),
   )
   const retargetedTargets = retargetStrategyToChildrenOfFragmentLikeElements(canvasState)
-  return [...originalTargets, ...retargetedTargets].some((target) =>
-    MetadataUtils.isExpressionOtherJavascript(target, canvasState.startingMetadata),
+  return [...originalTargets, ...retargetedTargets].some(
+    (target) =>
+      MetadataUtils.isExpressionOtherJavascript(target, canvasState.startingMetadata) ||
+      MetadataUtils.isJSXMapExpression(target, canvasState.startingMetadata),
   )
 }
 

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -253,7 +253,8 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
       store.editor.selectedViews.every(
         (path) =>
           MetadataUtils.isConditional(path, store.editor.jsxMetadata) ||
-          MetadataUtils.isExpressionOtherJavascript(path, store.editor.jsxMetadata),
+          MetadataUtils.isExpressionOtherJavascript(path, store.editor.jsxMetadata) ||
+          MetadataUtils.isJSXMapExpression(path, store.editor.jsxMetadata),
       ),
     'Inspector hideAllSections',
   )

--- a/editor/src/components/inspector/sections/code-element-section.tsx
+++ b/editor/src/components/inspector/sections/code-element-section.tsx
@@ -24,7 +24,10 @@ export const CodeElementSection = React.memo(({ paths }: { paths: ElementPath[] 
     Substores.metadata,
     (store) => {
       return paths.every((path) => {
-        return MetadataUtils.isExpressionOtherJavascript(path, store.editor.jsxMetadata)
+        return (
+          MetadataUtils.isExpressionOtherJavascript(path, store.editor.jsxMetadata) ||
+          MetadataUtils.isJSXMapExpression(path, store.editor.jsxMetadata)
+        )
       })
     },
     'CodeElementSection isCodeElement',

--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -158,11 +158,10 @@ export function createElementIconPropsFromMetadata(
 
   const isExpressionOtherJavascript = MetadataUtils.isExpressionOtherJavascriptFromMetadata(element)
   if (isExpressionOtherJavascript) {
-    // TODO: needs a real icon
     return {
       iconProps: {
         category: 'element',
-        type: 'lists',
+        type: 'genericcode',
         width: 18,
         height: 18,
       },
@@ -172,7 +171,6 @@ export function createElementIconPropsFromMetadata(
 
   const isJSXMapExpression = MetadataUtils.isJSXMapExpressionFromMetadata(element)
   if (isJSXMapExpression) {
-    // TODO: needs a real icon
     return {
       iconProps: {
         category: 'element',

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -1653,7 +1653,7 @@ describe('conditionals in the navigator', () => {
         `NavigatorItemTestId-regular_utopia_storyboard_uid/scene_aaa/app_entity:aaa/conditional/ba9-label`,
       )
 
-      expect(exprLabel.innerText).toEqual('(() => <div>HELLO!</div>)()')
+      expect(exprLabel.innerText).toEqual('CODE')
 
       const generatedElementLabel = await screen.findByTestId(
         `NavigatorItemTestId-regular_utopia_storyboard_uid/scene_aaa/app_entity:aaa/conditional/ba9/33d~~~1-label`,

--- a/editor/src/components/navigator/navigator-item/item-label.tsx
+++ b/editor/src/components/navigator/navigator-item/item-label.tsx
@@ -18,6 +18,10 @@ import { Substores, useEditorState } from '../../editor/store/store-hook'
 import { renameComponent } from '../actions'
 import { NavigatorItemTestId } from './navigator-item'
 
+export function itemLabelTestIdForEntry(navigatorEntry: NavigatorEntry): string {
+  return `${NavigatorItemTestId(varSafeNavigatorEntryToKey(navigatorEntry))}-label`
+}
+
 interface ItemLabelProps {
   testId: string
   dispatch: EditorDispatch
@@ -200,7 +204,7 @@ export const ItemLabel = React.memo((props: ItemLabelProps) => {
       ) : (
         <div
           key='item-label'
-          data-testid={`${NavigatorItemTestId(varSafeNavigatorEntryToKey(target))}-label`}
+          data-testid={itemLabelTestIdForEntry(target)}
           style={{
             backgroundColor: 'transparent',
             paddingTop: 3,

--- a/editor/src/components/navigator/navigator-item/navigator-item.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.spec.browser2.tsx
@@ -280,7 +280,7 @@ describe('Navigator item row icons', () => {
     await checkNavigatorIcon('Empty Slot', 'no-icon', visibleNavigatorTargets[11])
     await checkNavigatorIcon(
       'Code element',
-      { category: 'element', type: 'lists' },
+      { category: 'element', type: 'genericcode' },
       visibleNavigatorTargets[12],
     )
     await checkNavigatorIcon(

--- a/editor/src/components/navigator/navigator-item/navigator-item.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.spec.browser2.tsx
@@ -1,6 +1,8 @@
+import { wait } from '../../../utils/utils.test-utils'
 import { renderTestEditorWithCode } from '../../canvas/ui-jsx.test-utils'
 import type { NavigatorEntry } from '../../editor/store/editor-state'
 import { createElementIconPropsFromMetadata } from '../layout-element-icons'
+import { itemLabelTestIdForEntry } from './item-label'
 import { layoutIconTestIdForEntry } from './layout-icon'
 
 describe('Navigator item row icons', () => {
@@ -325,5 +327,48 @@ describe('Navigator item row icons', () => {
       { category: 'element', type: 'image' },
       visibleNavigatorTargets[20],
     )
+  })
+
+  it('Should show the correct labels for each type of row', async () => {
+    const editor = await renderTestEditorWithCode(testProjectCode, 'await-first-dom-report')
+    const visibleNavigatorTargets = editor.getEditorState().derived.visibleNavigatorTargets
+
+    async function checkNavigatorLabel(
+      navigatorEntry: NavigatorEntry,
+      expectedLabel: string | null,
+    ) {
+      const testId = itemLabelTestIdForEntry(navigatorEntry)
+      if (expectedLabel != null) {
+        const labelElement = editor.renderedDOM.getByTestId(testId)
+
+        expect(labelElement.textContent?.trim()).toEqual(expectedLabel)
+      } else {
+        expect(() => editor.renderedDOM.getByTestId(testId)).toThrow()
+      }
+    }
+
+    expect(visibleNavigatorTargets.length).toEqual(21)
+
+    await checkNavigatorLabel(visibleNavigatorTargets[0], 'div')
+    await checkNavigatorLabel(visibleNavigatorTargets[1], 'div with text')
+    await checkNavigatorLabel(visibleNavigatorTargets[2], 'Display Inline')
+    await checkNavigatorLabel(visibleNavigatorTargets[3], 'Some text')
+    await checkNavigatorLabel(visibleNavigatorTargets[4], 'Group')
+    await checkNavigatorLabel(visibleNavigatorTargets[5], 'Card')
+    await checkNavigatorLabel(visibleNavigatorTargets[6], 'button')
+    await checkNavigatorLabel(visibleNavigatorTargets[7], 'Conditional')
+    await checkNavigatorLabel(visibleNavigatorTargets[8], 'TRUE')
+    await checkNavigatorLabel(visibleNavigatorTargets[9], 'div')
+    await checkNavigatorLabel(visibleNavigatorTargets[10], 'FALSE')
+    await checkNavigatorLabel(visibleNavigatorTargets[11], null)
+    await checkNavigatorLabel(visibleNavigatorTargets[12], 'Code')
+    await checkNavigatorLabel(visibleNavigatorTargets[13], 'div')
+    await checkNavigatorLabel(visibleNavigatorTargets[14], 'Map')
+    await checkNavigatorLabel(visibleNavigatorTargets[15], 'div')
+    await checkNavigatorLabel(visibleNavigatorTargets[16], 'Fragment')
+    await checkNavigatorLabel(visibleNavigatorTargets[17], 'div')
+    await checkNavigatorLabel(visibleNavigatorTargets[18], 'text')
+    await checkNavigatorLabel(visibleNavigatorTargets[19], 'Scene')
+    await checkNavigatorLabel(visibleNavigatorTargets[20], 'img') // TODO: this is eventually replace by Utopia logo
   })
 })

--- a/editor/src/components/navigator/navigator-item/navigator-item.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.spec.browser2.tsx
@@ -341,7 +341,7 @@ describe('Navigator item row icons', () => {
       if (expectedLabel != null) {
         const labelElement = editor.renderedDOM.getByTestId(testId)
 
-        expect(labelElement.textContent?.trim()).toEqual(expectedLabel)
+        expect(labelElement.innerText).toEqual(expectedLabel)
       } else {
         expect(() => editor.renderedDOM.getByTestId(testId)).toThrow()
       }
@@ -356,19 +356,19 @@ describe('Navigator item row icons', () => {
     await checkNavigatorLabel(visibleNavigatorTargets[4], 'Group')
     await checkNavigatorLabel(visibleNavigatorTargets[5], 'Card')
     await checkNavigatorLabel(visibleNavigatorTargets[6], 'button')
-    await checkNavigatorLabel(visibleNavigatorTargets[7], 'Conditional')
+    await checkNavigatorLabel(visibleNavigatorTargets[7], 'CONDITIONAL')
     await checkNavigatorLabel(visibleNavigatorTargets[8], 'TRUE')
     await checkNavigatorLabel(visibleNavigatorTargets[9], 'div')
     await checkNavigatorLabel(visibleNavigatorTargets[10], 'FALSE')
     await checkNavigatorLabel(visibleNavigatorTargets[11], null)
-    await checkNavigatorLabel(visibleNavigatorTargets[12], 'Code')
+    await checkNavigatorLabel(visibleNavigatorTargets[12], 'CODE')
     await checkNavigatorLabel(visibleNavigatorTargets[13], 'div')
-    await checkNavigatorLabel(visibleNavigatorTargets[14], 'Map')
+    await checkNavigatorLabel(visibleNavigatorTargets[14], 'MAP')
     await checkNavigatorLabel(visibleNavigatorTargets[15], 'div')
     await checkNavigatorLabel(visibleNavigatorTargets[16], 'Fragment')
     await checkNavigatorLabel(visibleNavigatorTargets[17], 'div')
     await checkNavigatorLabel(visibleNavigatorTargets[18], 'text')
     await checkNavigatorLabel(visibleNavigatorTargets[19], 'Scene')
-    await checkNavigatorLabel(visibleNavigatorTargets[20], 'img') // TODO: this is eventually replace by Utopia logo
+    await checkNavigatorLabel(visibleNavigatorTargets[20], 'img') // TODO: this is eventually replaced by Utopia logo
   })
 })

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -537,7 +537,7 @@ export const NavigatorItem: React.FunctionComponent<
       }
       return 'none'
     },
-    'NavigatorRowLabel codeItemType',
+    'NavigatorItem codeItemType',
   )
 
   const isConditional = codeItemType === 'conditional'

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -387,7 +387,7 @@ const elementWarningsSelector = createCachedSelector(
   },
 )((_, navigatorEntry) => navigatorEntryToKey(navigatorEntry))
 
-type ConditionalOrMap = 'conditional' | 'map' | 'none'
+type CodeItemType = 'conditional' | 'map' | 'code' | 'none'
 
 export interface NavigatorItemInnerProps {
   navigatorEntry: NavigatorEntry
@@ -516,7 +516,7 @@ export const NavigatorItem: React.FunctionComponent<
   const isGenerated = MetadataUtils.isElementGenerated(navigatorEntry.elementPath)
   const isDynamic = isGenerated || containsExpressions || isConditionalDynamicBranch
 
-  const conditionalOrMap: ConditionalOrMap = useEditorState(
+  const codeItemType: CodeItemType = useEditorState(
     Substores.metadata,
     (store) => {
       if (!isRegularNavigatorEntry(props.navigatorEntry)) {
@@ -532,14 +532,16 @@ export const NavigatorItem: React.FunctionComponent<
       if (MetadataUtils.isJSXMapExpressionFromMetadata(elementMetadata)) {
         return 'map'
       }
+      if (MetadataUtils.isExpressionOtherJavascriptFromMetadata(elementMetadata)) {
+        return 'code'
+      }
       return 'none'
     },
-    'NavigatorRowLabel conditionalOrMap',
+    'NavigatorRowLabel codeItemType',
   )
 
-  const isConditional = conditionalOrMap === 'conditional'
-  const isMap = conditionalOrMap === 'map'
-  const isMapOrConditional = isConditional || isMap
+  const isConditional = codeItemType === 'conditional'
+  const isCodeItem = codeItemType !== 'none'
 
   const conditionalOverrideUpdate = useEditorState(
     Substores.metadata,
@@ -701,7 +703,7 @@ export const NavigatorItem: React.FunctionComponent<
     )
   }, [childComponentCount, isFocusedComponent, isConditional])
 
-  const iconColor = isMapOrConditional ? 'dynamic' : resultingStyle.iconColor
+  const iconColor = isCodeItem ? 'dynamic' : resultingStyle.iconColor
 
   return (
     <div
@@ -767,7 +769,7 @@ export const NavigatorItem: React.FunctionComponent<
                 label={props.label}
                 renamingTarget={props.renamingTarget}
                 selected={props.selected}
-                conditionalOrMap={conditionalOrMap}
+                codeItemType={codeItemType}
                 dispatch={props.dispatch}
                 isDynamic={isDynamic}
                 iconColor={iconColor}
@@ -803,7 +805,7 @@ interface NavigatorRowLabelProps {
   isDynamic: boolean
   renamingTarget: ElementPath | null
   selected: boolean
-  conditionalOrMap: ConditionalOrMap
+  codeItemType: CodeItemType
   shouldShowParentOutline: boolean
   dispatch: EditorDispatch
 }
@@ -811,8 +813,7 @@ interface NavigatorRowLabelProps {
 export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
   const colorTheme = useColorTheme()
 
-  const isConditionalOrMap =
-    props.conditionalOrMap === 'conditional' || props.conditionalOrMap === 'map'
+  const isCodeItem = props.codeItemType !== 'none'
 
   return (
     <div
@@ -825,11 +826,11 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
         borderRadius: 20,
         height: 22,
         paddingLeft: 10,
-        paddingRight: props.conditionalOrMap === 'map' ? 0 : 10,
+        paddingRight: props.codeItemType === 'map' ? 0 : 10,
         backgroundColor:
-          isConditionalOrMap && !props.selected ? colorTheme.dynamicBlue10.value : 'transparent',
-        color: isConditionalOrMap ? colorTheme.dynamicBlue.value : undefined,
-        textTransform: isConditionalOrMap ? 'uppercase' : undefined,
+          isCodeItem && !props.selected ? colorTheme.dynamicBlue10.value : 'transparent',
+        color: isCodeItem ? colorTheme.dynamicBlue.value : undefined,
+        textTransform: isCodeItem ? 'uppercase' : undefined,
       }}
     >
       {unless(

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1480,7 +1480,7 @@ export const MetadataUtils = {
             case 'JSX_MAP_EXPRESSION':
               return 'Map'
             case 'ATTRIBUTE_OTHER_JAVASCRIPT':
-              return jsxElement.originalJavascript
+              return 'Code'
             case 'JSX_FRAGMENT':
               return 'Fragment'
             case 'JSX_CONDITIONAL_EXPRESSION':

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -2018,7 +2018,7 @@ export const MetadataUtils = {
     return (
       element?.element != null &&
       isRight(element.element) &&
-      isJSExpressionMapOrOtherJavaScript(element.element.value)
+      isJSExpressionOtherJavaScript(element.element.value)
     )
   },
   isExpressionOtherJavascript(target: ElementPath, metadata: ElementInstanceMetadataMap): boolean {

--- a/editor/src/core/shared/element-path-tree.ts
+++ b/editor/src/core/shared/element-path-tree.ts
@@ -5,6 +5,7 @@ import * as EP from './element-path'
 import type { ElementInstanceMetadataMap } from './element-template'
 import {
   isJSExpressionMapOrOtherJavaScript,
+  isJSExpressionOtherJavaScript,
   isJSXConditionalExpression,
   isJSXElement,
   isJSXFragment,
@@ -94,7 +95,7 @@ function getChildrenPaths(
     element.element.value.children.length > 0
   ) {
     childrenFromElement = element.element.value.children
-      .filter((child) => !isJSXTextBlock(child))
+      .filter((child) => !isJSXTextBlock(child) && !isJSExpressionOtherJavaScript(child))
       .map((child) => EP.appendToPath(rootPath, child.uid))
   }
 

--- a/editor/src/core/shared/element-path-tree.ts
+++ b/editor/src/core/shared/element-path-tree.ts
@@ -94,7 +94,7 @@ function getChildrenPaths(
     element.element.value.children.length > 0
   ) {
     childrenFromElement = element.element.value.children
-      .filter((child) => !isJSXTextBlock(child) && !isJSExpressionMapOrOtherJavaScript(child))
+      .filter((child) => !isJSXTextBlock(child))
       .map((child) => EP.appendToPath(rootPath, child.uid))
   }
 

--- a/editor/src/core/shared/element-path-tree.ts
+++ b/editor/src/core/shared/element-path-tree.ts
@@ -95,7 +95,7 @@ function getChildrenPaths(
     element.element.value.children.length > 0
   ) {
     childrenFromElement = element.element.value.children
-      .filter((child) => !isJSXTextBlock(child) && !isJSExpressionOtherJavaScript(child))
+      .filter((child) => !isJSXTextBlock(child) && !isJSExpressionMapOrOtherJavaScript(child))
       .map((child) => EP.appendToPath(rootPath, child.uid))
   }
 
@@ -149,7 +149,8 @@ function getReorderedPaths(
     }
     return (
       MetadataUtils.isConditionalFromMetadata(element) ||
-      MetadataUtils.isExpressionOtherJavascriptFromMetadata(element)
+      MetadataUtils.isExpressionOtherJavascriptFromMetadata(element) ||
+      MetadataUtils.isJSXMapExpressionFromMetadata(element)
     )
   })
   const pathsToBeReordered = original.filter(

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1356,7 +1356,7 @@ export function isJSExpressionOtherJavaScript(
   return element.type === 'ATTRIBUTE_OTHER_JAVASCRIPT'
 }
 
-export function isJSXMapExpression(element: JSXElementChild) {
+export function isJSXMapExpression(element: JSXElementChild): element is JSXMapExpression {
   return element.type === 'JSX_MAP_EXPRESSION'
 }
 


### PR DESCRIPTION
**Description:**
This PR was started as a simple fix to the navigator.
For conditionals blue colors were already used for the layout icon, and I extended that to code and map items too.
I also changed the code icon to be different from the map icon.

However, when working on the tests for this, I realized that `MetadataUtils.isExpressionOtherJavascriptFromMetadata` returns true not just for otherjs expressions but for maps too!

I fixed that, and then a bunch of tests broke, because it turned out we have a few features which depended on this bug, because they need the same behavior for maps as for expressions.

I also modified the label for genericcode items to `CODE` and added new tests for all kinds navigator labels.

So after this PR the three kinds of control structure navigator items (conditional, map and code) use the same unified design with different icons:

![image](https://github.com/concrete-utopia/utopia/assets/127662/4803bf03-f8e9-48da-89ec-7199a4f99b42)


