### PR TITLE
oopsie

### DIFF
--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -518,7 +518,7 @@ export const GiganticSizePinsSubsection = React.memo((props: GiganticSizePinsSub
   const { resetAllPins, framePins, togglePin } = usePinToggling()
 
   return (
-    <div style={{ height: 200 }}>
+    <div>
       <WidthHeightRow togglePin={togglePin} framePins={framePins} />
       {minMaxToggled ? (
         <>


### PR DESCRIPTION
deleting a 200px height I shouldn't have added, oops!

was causing this:
<img width="181" alt="Screenshot 2023-08-02 at 12 49 11 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/2d4a635b-b499-488d-bf83-15bbb4ae61b9">

but now we're good!
<img width="178" alt="Screenshot 2023-08-02 at 12 49 40 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/b2d74542-9dbd-4cfa-a482-2b706bb13604">

