### PR TITLE
Flatten unwrap selection

### DIFF
--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -5525,7 +5525,7 @@ export var storyboard = (
         `),
       )
     })
-    it('can do multiselect unwrap under the same subtree', async () => {
+    it('can do multiselect unwrap under the same subtree predictably', async () => {
       const testCode = `
         <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
           <Group style={{ position: 'absolute' }} data-uid='group1'>
@@ -5585,18 +5585,113 @@ export var storyboard = (
               backgroundColor: 'blue',
             }}
             data-uid='div'
-          >
-            <View
+            >
+            <Group
               style={{
-                backgroundColor: 'red',
                 position: 'absolute',
                 width: 50,
                 height: 50,
-                left: 0,
-                top: 0,
               }}
-              data-uid='view'
-            />
+              data-uid='group2'
+            >
+              <View
+                style={{
+                  backgroundColor: 'red',
+                  position: 'absolute',
+                  width: 50,
+                  height: 50,
+                  left: 0,
+                  top: 0,
+                }}
+                data-uid='view'
+              />
+            </Group>
+          </div>
+        </div>
+      `),
+      )
+    })
+    it('can do multiselect unwrap under the same subtree predictably for immediate child', async () => {
+      const testCode = `
+        <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+          <Group style={{ position: 'absolute' }} data-uid='group1'>
+            <div
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: 100,
+                height: 100,
+                backgroundColor: 'blue',
+              }}
+              data-uid='div'
+            >
+              <Group
+                style={{
+                  position: 'absolute',
+                  width: 50,
+                  height: 50,
+                }}
+                data-uid='group2'
+              >
+                <View
+                  style={{
+                    backgroundColor: 'red',
+                    position: 'absolute',
+                    width: 50,
+                    height: 50,
+                    left: 0,
+                    top: 0,
+                  }}
+                  data-uid='view'
+                />
+              </Group>
+            </div>
+          </Group>
+        </div>
+      `
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(testCode),
+        'await-first-dom-report',
+      )
+      await renderResult.dispatch(
+        [unwrapElements([makeTargetPath('aaa/group1'), makeTargetPath('aaa/group1/div')])],
+        true,
+      )
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        makeTestProjectCodeWithSnippet(`
+        <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+          <div
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: 100,
+              height: 100,
+              backgroundColor: 'blue',
+            }}
+            data-uid='div'
+            >
+            <Group
+              style={{
+                position: 'absolute',
+                width: 50,
+                height: 50,
+              }}
+              data-uid='group2'
+            >
+              <View
+                style={{
+                  backgroundColor: 'red',
+                  position: 'absolute',
+                  width: 50,
+                  height: 50,
+                  left: 0,
+                  top: 0,
+                }}
+                data-uid='view'
+              />
+            </Group>
           </div>
         </div>
       `),

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -5525,7 +5525,7 @@ export var storyboard = (
         `),
       )
     })
-    it('can do multiselect unwrap under the same subtree predictably', async () => {
+    it('when doing multiselect unwrap for a subtree, predictably limit to the topmost ancestor', async () => {
       const testCode = `
         <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
           <Group style={{ position: 'absolute' }} data-uid='group1'>
@@ -5611,7 +5611,7 @@ export var storyboard = (
       `),
       )
     })
-    it('can do multiselect unwrap under the same subtree predictably for immediate child', async () => {
+    it('when doing multiselect unwrap for a subtree, predictably limit to the topmost ancestor (immediate child)', async () => {
       const testCode = `
         <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
           <Group style={{ position: 'absolute' }} data-uid='group1'>
@@ -5692,6 +5692,108 @@ export var storyboard = (
                 data-uid='view'
               />
             </Group>
+          </div>
+        </div>
+      `),
+      )
+    })
+    it('can do multiselect unwrap with subtrees and isolate elements', async () => {
+      const testCode = `
+        <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+          <Group style={{ position: 'absolute' }} data-uid='group1'>
+            <div
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: 100,
+                height: 100,
+                backgroundColor: 'blue',
+              }}
+              data-uid='div'
+            >
+              <Group
+                style={{
+                  position: 'absolute',
+                  width: 50,
+                  height: 50,
+                }}
+                data-uid='group2'
+              >
+                <View
+                  style={{
+                    backgroundColor: 'red',
+                    position: 'absolute',
+                    width: 50,
+                    height: 50,
+                    left: 0,
+                    top: 0,
+                  }}
+                  data-uid='view'
+                />
+              </Group>
+            </div>
+          </Group>
+          <div data-uid='another-div'>
+            <div data-uid='unwrap-this'>
+              <div data-uid='foo' />
+              <img data-uid='cat' src='https://placekitten.com/100/100' />
+            </div>
+          </div>
+        </div>
+      `
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(testCode),
+        'await-first-dom-report',
+      )
+      await renderResult.dispatch(
+        [
+          unwrapElements([
+            makeTargetPath('aaa/group1'),
+            makeTargetPath('aaa/group1/div'),
+            makeTargetPath('aaa/another-div/unwrap-this'),
+          ]),
+        ],
+        true,
+      )
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        makeTestProjectCodeWithSnippet(`
+        <div data-uid='aaa' style={{contain: 'layout', width: 300, height: 300}}>
+          <div
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: 100,
+              height: 100,
+              backgroundColor: 'blue',
+            }}
+            data-uid='div'
+          >
+            <Group
+              style={{
+                position: 'absolute',
+                width: 50,
+                height: 50,
+              }}
+              data-uid='group2'
+            >
+              <View
+                style={{
+                  backgroundColor: 'red',
+                  position: 'absolute',
+                  width: 50,
+                  height: 50,
+                  left: 0,
+                  top: 0,
+                }}
+                data-uid='view'
+              />
+            </Group>
+          </div>
+          <div data-uid='another-div'>
+            <div data-uid='foo' />
+            <img data-uid='cat' src='https://placekitten.com/100/100' />
           </div>
         </div>
       `),


### PR DESCRIPTION
Fixes #4033 

**Problem:**

This is a followup to https://github.com/concrete-utopia/utopia/pull/4019 which fixes an existing bug that would delete an entire subtree if an unwrap was triggered on multiple elements of the same subtree.

**Fix:**

Make sure to flatten the unwrap targets so that the unwrap only triggers the topmost ancestor and ignores the other elements.

- Adjusted the existing tests
- Added a test to make sure multiselect unwrap still works fine when both a subtree cluster and other elements in a different subtree are targeted.