### PR TITLE
Flexible type for what is being trued up.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
@@ -32,6 +32,7 @@ import type {
   PastePostActionMenuData,
   PasteToReplacePostActionMenuData,
 } from '../../../editor/store/editor-state'
+import { trueUpElementChanged } from '../../../editor/store/editor-state'
 import {
   childInsertionPath,
   replaceWithElementsWrappedInFragmentBehaviour,
@@ -281,7 +282,7 @@ export function staticReparentAndUpdatePosition(
         },
       },
     }),
-    ...groupTrueUpPaths.map((path) => queueGroupTrueUp(path)),
+    ...groupTrueUpPaths.map((path) => queueGroupTrueUp(trueUpElementChanged(path))),
   ])
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
@@ -56,6 +56,7 @@ import { notice } from '../../../common/notice'
 import type { AddToast, ApplyCommandsAction } from '../../../editor/action-types'
 import { applyCommandsAction, showToast } from '../../../editor/actions/action-creators'
 import type { AllElementProps, NavigatorEntry } from '../../../editor/store/editor-state'
+import { trueUpElementChanged } from '../../../editor/store/editor-state'
 import {
   childInsertionPath,
   commonInsertionPathFromArray,
@@ -573,7 +574,7 @@ export function convertFrameToGroup(
       indexPosition: absolute(MetadataUtils.getIndexInParent(metadata, pathTrees, elementPath)),
       importsToAdd: GroupImport,
     }),
-    queueGroupTrueUp(childInstances[0].elementPath), // let the editor know that the children are positioned correctly and the Group needs to be shifted/resized
+    queueGroupTrueUp(trueUpElementChanged(childInstances[0].elementPath)), // let the editor know that the children are positioned correctly and the Group needs to be shifted/resized
   ]
 }
 
@@ -834,7 +835,7 @@ export function createWrapInGroupActions(
     insertGroupCommand,
     ...pinChangeCommands,
     selectNewGroup,
-    queueGroupTrueUp(groupPath),
+    queueGroupTrueUp(trueUpElementChanged(groupPath)),
   ])
 }
 

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1326,6 +1326,34 @@ export interface PostActionMenuSession {
   postActionMenuData: PostActionMenuData
 }
 
+export interface TrueUpElementChanged {
+  type: 'TRUE_UP_ELEMENT_CHANGED'
+  target: ElementPath
+}
+
+export function trueUpElementChanged(target: ElementPath): TrueUpElementChanged {
+  return {
+    type: 'TRUE_UP_ELEMENT_CHANGED',
+    target: target,
+  }
+}
+
+export interface TrueUpChildrenOfElementChanged {
+  type: 'TRUE_UP_CHILDREN_OF_ELEMENT_CHANGED'
+  targetParent: ElementPath
+}
+
+export function trueUpChildrenOfElementChanged(
+  targetParent: ElementPath,
+): TrueUpChildrenOfElementChanged {
+  return {
+    type: 'TRUE_UP_CHILDREN_OF_ELEMENT_CHANGED',
+    targetParent: targetParent,
+  }
+}
+
+export type TrueUpTarget = TrueUpElementChanged | TrueUpChildrenOfElementChanged
+
 // FIXME We need to pull out ProjectState from here
 export interface EditorState {
   id: string | null
@@ -1336,7 +1364,7 @@ export interface EditorState {
   projectDescription: string
   projectVersion: number
   isLoaded: boolean
-  trueUpGroupsForElementAfterDomWalkerRuns: Array<ElementPath>
+  trueUpGroupsForElementAfterDomWalkerRuns: Array<TrueUpTarget>
   spyMetadata: ElementInstanceMetadataMap // this is coming from the canvas spy report.
   domMetadata: ElementInstanceMetadataMap // this is coming from the dom walking report.
   jsxMetadata: ElementInstanceMetadataMap // this is a merged result of the two above.
@@ -1414,7 +1442,7 @@ export function editorState(
   projectDescription: string,
   projectVersion: number,
   isLoaded: boolean,
-  trueUpGroupsForElementAfterDomWalkerRuns: Array<ElementPath>,
+  trueUpGroupsForElementAfterDomWalkerRuns: Array<TrueUpTarget>,
   spyMetadata: ElementInstanceMetadataMap,
   domMetadata: ElementInstanceMetadataMap,
   jsxMetadata: ElementInstanceMetadataMap,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -319,7 +319,11 @@ import type {
   PasteHerePostActionMenuData,
   PasteToReplacePostActionMenuData,
   NavigatorReparentPostActionMenuData,
+  TrueUpElementChanged,
+  TrueUpChildrenOfElementChanged,
+  TrueUpTarget,
 } from './editor-state'
+import { trueUpElementChanged, trueUpChildrenOfElementChanged } from './editor-state'
 import {
   TransientCanvasState,
   transientCanvasState,
@@ -3996,6 +4000,37 @@ export const PostActionMenuDataKeepDeepEquality: KeepDeepEqualityCall<PostAction
   return keepDeepEqualityResult(newValue, false)
 }
 
+export const TrueUpElementChangedKeepDeepEquality: KeepDeepEqualityCall<TrueUpElementChanged> =
+  combine1EqualityCall((value) => value.target, ElementPathKeepDeepEquality, trueUpElementChanged)
+
+export const TrueUpChildrenOfElementChangedKeepDeepEquality: KeepDeepEqualityCall<TrueUpChildrenOfElementChanged> =
+  combine1EqualityCall(
+    (value) => value.targetParent,
+    ElementPathKeepDeepEquality,
+    trueUpChildrenOfElementChanged,
+  )
+
+export const TrueUpTargetKeepDeepEquality: KeepDeepEqualityCall<TrueUpTarget> = (
+  oldValue,
+  newValue,
+) => {
+  switch (oldValue.type) {
+    case 'TRUE_UP_ELEMENT_CHANGED':
+      if (oldValue.type === newValue.type) {
+        return TrueUpElementChangedKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'TRUE_UP_CHILDREN_OF_ELEMENT_CHANGED':
+      if (oldValue.type === newValue.type) {
+        return TrueUpChildrenOfElementChangedKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    default:
+      assertNever(oldValue)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
+
 export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
   oldValue,
   newValue,
@@ -4025,7 +4060,9 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
   )
   const isLoadedResult = BooleanKeepDeepEquality(oldValue.isLoaded, newValue.isLoaded)
 
-  const trueUpGroupsForElementAfterDomWalkerRunsResult = ElementPathArrayKeepDeepEquality(
+  const trueUpGroupsForElementAfterDomWalkerRunsResult = arrayDeepEquality(
+    TrueUpTargetKeepDeepEquality,
+  )(
     oldValue.trueUpGroupsForElementAfterDomWalkerRuns,
     newValue.trueUpGroupsForElementAfterDomWalkerRuns,
   )

--- a/editor/src/components/inspector/inspector-strategies/fixed-size-basic-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/fixed-size-basic-strategy.ts
@@ -16,6 +16,7 @@ import {
   maybeGroupChildWithoutFixedSizeForFill,
   maybeInvalidGroupState,
 } from '../../canvas/canvas-strategies/strategies/group-helpers'
+import { trueUpElementChanged } from '../../../components/editor/store/editor-state'
 
 export const fixedSizeBasicStrategy = (
   whenToRun: WhenToRun,
@@ -53,7 +54,7 @@ export const fixedSizeBasicStrategy = (
           setExplicitCssValue(value),
           parentFlexDirection,
         ),
-        queueGroupTrueUp(path),
+        queueGroupTrueUp(trueUpElementChanged(path)),
       ]
     })
   },

--- a/editor/src/components/inspector/inspector-strategies/hug-contents-basic-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/hug-contents-basic-strategy.ts
@@ -26,6 +26,7 @@ import {
 } from '../inspector-common'
 import type { InspectorStrategy } from './inspector-strategy'
 import { queueGroupTrueUp } from '../../canvas/commands/queue-group-true-up-command'
+import { trueUpElementChanged } from '../../../components/editor/store/editor-state'
 
 const CHILDREN_CONVERTED_TOAST_ID = 'CHILDREN_CONVERTED_TOAST_ID'
 
@@ -73,7 +74,11 @@ function hugContentsSingleElement(
     ]
   })
 
-  return [...basicCommands, ...transformChildrenToFixedCommands, queueGroupTrueUp(elementPath)]
+  return [
+    ...basicCommands,
+    ...transformChildrenToFixedCommands,
+    queueGroupTrueUp(trueUpElementChanged(elementPath)),
+  ]
 }
 
 export const hugContentsBasicStrategy = (axis: Axis): InspectorStrategy => ({

--- a/editor/src/core/model/groups.ts
+++ b/editor/src/core/model/groups.ts
@@ -1,9 +1,40 @@
-import type { EditorState } from '../../components/editor/store/editor-state'
+import type { EditorState, TrueUpTarget } from '../../components/editor/store/editor-state'
+import * as EP from '../../core/shared/element-path'
+import type { ElementPathTrees } from '../shared/element-path-tree'
+import type { ElementInstanceMetadataMap } from '../shared/element-template'
 import type { ElementPath } from '../shared/project-file-types'
+import { assertNever } from '../shared/utils'
+import { MetadataUtils } from './element-metadata-utils'
+
+export function trueUpTargetToDescription(trueUpTarget: TrueUpTarget): string {
+  switch (trueUpTarget.type) {
+    case 'TRUE_UP_ELEMENT_CHANGED':
+      return `True up element ${EP.toString(trueUpTarget.target)}`
+    case 'TRUE_UP_CHILDREN_OF_ELEMENT_CHANGED':
+      return `True up children of ${EP.toString(trueUpTarget.targetParent)}`
+    default:
+      assertNever(trueUpTarget)
+  }
+}
+
+export function trueUpTargetToTargets(
+  metadata: ElementInstanceMetadataMap,
+  pathTree: ElementPathTrees,
+  trueUpTarget: TrueUpTarget,
+): Array<ElementPath> {
+  switch (trueUpTarget.type) {
+    case 'TRUE_UP_ELEMENT_CHANGED':
+      return [trueUpTarget.target]
+    case 'TRUE_UP_CHILDREN_OF_ELEMENT_CHANGED':
+      return MetadataUtils.getChildrenPathsOrdered(metadata, pathTree, trueUpTarget.targetParent)
+    default:
+      assertNever(trueUpTarget)
+  }
+}
 
 export function addToTrueUpGroups(
   editor: EditorState,
-  ...targets: Array<ElementPath>
+  ...targets: Array<TrueUpTarget>
 ): EditorState {
   return {
     ...editor,


### PR DESCRIPTION
**Problem:**
When setting the property for trueing up groups currently we have to specify the individual children of an element in the command when we wish the group containing them to be trued up against those. This forces some of the design for that to be a particular way.

**Fix:**
With this we support trueing up specific paths, but now we also support trueing up the children of an element. With the latter identifying those children at the point of execution not at the point of creation.

**Commit Details:**
- Added `TrueUpTarget` type along with two different cases of it.
- Added `trueUpTargetToTargets` and `trueUpTargetToDescription` utility functions.
