### PR TITLE
Conditional can be added to a group with the add element shortcut.

### DIFF
--- a/editor/src/components/canvas/ui/floating-insert-menu.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.spec.browser2.tsx
@@ -64,6 +64,49 @@ describe('Floating insert menu', () => {
     )
   })
 
+  it('can insert a conditional into a group via the floating insert menu', async () => {
+    const editor = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`<Group
+    style={{
+      backgroundColor: '#aaaaaa33',
+      position: 'absolute',
+      left: 57,
+      top: 168,
+      width: 247,
+      height: 402,
+    }}
+    data-uid='container'
+  >
+    <div data-uid='a3d' />
+  </Group>`),
+      'await-first-dom-report',
+    )
+
+    await expectSingleUndo2Saves(editor, async () => {
+      await selectComponentsForTest(editor, [
+        EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:container`),
+      ])
+      await insertViaAddElementPopup(editor, 'conditional')
+    })
+
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`<Group
+    style={{
+      backgroundColor: '#aaaaaa33',
+      position: 'absolute',
+      left: 57,
+      top: 168,
+      width: 247,
+      height: 402,
+    }}
+    data-uid='container'
+  >
+    <div data-uid='a3d' />
+    {true ? null : null}
+  </Group>`),
+    )
+  })
+
   it('can insert a div via the floating insert menu', async () => {
     const editor = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`<div

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -381,6 +381,7 @@ import type {
   NavigatorEntry,
   TrueUpTarget,
 } from '../store/editor-state'
+import { trueUpChildrenOfElementChanged } from '../store/editor-state'
 import { AllElementProps, trueUpElementChanged } from '../store/editor-state'
 import {
   areGeneratedElementsTargeted,
@@ -598,6 +599,7 @@ import {
 import { reparentElement } from '../../canvas/commands/reparent-element-command'
 import { addElements } from '../../canvas/commands/add-elements-command'
 import { deleteElement } from '../../canvas/commands/delete-element-command'
+import { queueGroupTrueUp } from '../../canvas/commands/queue-group-true-up-command'
 
 export const MIN_CODE_PANE_REOPEN_WIDTH = 100
 
@@ -4965,8 +4967,11 @@ export const UPDATE_FNS = {
                 action.toInsert.element.whenTrue != null ||
                 action.toInsert.element.whenFalse != null
               ) {
-                // this needs updating when we support inserting conditionals with non-empty clause
-                throw new Error('unhandled conditional insert into group')
+                groupCommands.push(
+                  queueGroupTrueUp(
+                    trueUpChildrenOfElementChanged(action.insertionPath.intendedParentPath),
+                  ),
+                )
               }
               break
             case 'JSX_FRAGMENT':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4967,6 +4967,8 @@ export const UPDATE_FNS = {
                 action.toInsert.element.whenTrue != null ||
                 action.toInsert.element.whenFalse != null
               ) {
+                // FIXME: This is a mid-step, as the conditional being inserted currently
+                // has nulls in both clauses, resulting in a zero-sized element.
                 groupCommands.push(
                   queueGroupTrueUp(
                     trueUpChildrenOfElementChanged(action.insertionPath.intendedParentPath),


### PR DESCRIPTION
**Problem:**
If the add element shortcut is triggered and "Conditional" is then selected from the floating menu, an error would be logged to the console and the user would find themselves back at the menu.

**Fix:**
For this specific case, the exception throwing has been has been removed and replaced with a trigger to true up the children of the intended parent. 

**Notes:**
Currently this results in what gets marked as an "invalid group" in the navigator, which seems more preferable than breaking.

It was also tested in the browser using a modified version of the conditional that is added in, which had a `div` with the pre-requisite style properties and after adding it in the group expanded as expected.

**Commit Details:**
- In `INSERT_INSERTABLE` action handler, remove exception thrown when adding conditional to group, replaced with a queued group true up.
- Added test case for inserting into the group.