### PR TITLE
Map counter override styling

### DIFF
--- a/editor/src/components/navigator/navigator-item/map-counter.tsx
+++ b/editor/src/components/navigator/navigator-item/map-counter.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import type { CSSProperties } from 'react'
 import type { NavigatorEntry } from '../../../components/editor/store/editor-state'
 import { isRegularNavigatorEntry } from '../../../components/editor/store/editor-state'
 import { Substores, useEditorState } from '../../editor/store/store-hook'
@@ -6,12 +7,21 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { colorTheme } from '../../../uuiui'
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
+import {
+  findUtopiaCommentFlag,
+  isUtopiaCommentFlagMapCount,
+} from '../../../core/shared/comment-flags'
+import { isRight } from '../../../core/shared/either'
+import { isJSXMapExpression } from '../../../core/shared/element-template'
+import { assertNever } from '../../../core/shared/utils'
 
 export const MapCounterTestIdPrefix = 'map-counter-'
 
 export function getMapCounterTestId(path: ElementPath): string {
   return `${MapCounterTestIdPrefix}${EP.toString(path)}`
 }
+
+type OverrideStatus = 'no-override' | 'overridden' | 'override-failed'
 
 interface MapCounterProps {
   navigatorEntry: NavigatorEntry
@@ -21,48 +31,104 @@ export const MapCounter = React.memo((props: MapCounterProps) => {
   const { navigatorEntry } = props
   const { elementPath } = navigatorEntry
 
-  const counterValue: number | null = useEditorState(
+  const { nrChildren, countOverride } = useEditorState(
     Substores.metadata,
     (store) => {
       if (!isRegularNavigatorEntry(navigatorEntry)) {
-        return null
+        return {
+          nrChildren: null,
+          countOverride: null,
+        }
       }
       const elementMetadata = MetadataUtils.findElementByElementPath(
         store.editor.jsxMetadata,
         elementPath,
       )
-      if (MetadataUtils.isJSXMapExpressionFromMetadata(elementMetadata)) {
-        return MetadataUtils.getChildrenOrdered(
+
+      const element =
+        elementMetadata != null && isRight(elementMetadata.element)
+          ? elementMetadata.element.value
+          : null
+      if (element == null || !isJSXMapExpression(element)) {
+        return {
+          nrChildren: null,
+          countOverride: null,
+        }
+      }
+      const commentFlag = findUtopiaCommentFlag(element.comments, 'map-count')
+      const mapCountOverride = isUtopiaCommentFlagMapCount(commentFlag) ? commentFlag.value : null
+      return {
+        nrChildren: MetadataUtils.getChildrenOrdered(
           store.editor.jsxMetadata,
           store.editor.elementPathTree,
           elementPath,
-        ).length
+        ).length,
+        countOverride: mapCountOverride,
       }
-      return null
     },
     'MapCounter counterValue',
   )
 
-  if (counterValue == null) {
+  if (nrChildren == null) {
     return null
   }
+
+  const isOverridden = countOverride != null
+  const shownCounterValue = countOverride ?? nrChildren
+  const overrideFailed = isOverridden && countOverride > nrChildren
+  const overrideStatus: OverrideStatus = (() => {
+    if (isOverridden) {
+      if (overrideFailed) {
+        return 'override-failed'
+      }
+      return 'overridden'
+    }
+    return 'no-override'
+  })()
 
   return (
     <div
       data-testid={getMapCounterTestId(elementPath)}
-      style={{
-        display: 'flex',
-        justifyContent: 'center',
-        height: 22,
-        minWidth: 22,
-        width: 'max-content',
-        padding: 5,
-        alignItems: 'center',
-        borderRadius: 11,
-        backgroundColor: colorTheme.dynamicBlue10.value,
-      }}
+      style={getMapCounterStyleProps(overrideStatus)}
     >
-      {counterValue}
+      {shownCounterValue}
     </div>
   )
 })
+
+function getMapCounterStyleProps(overrideStatus: OverrideStatus): CSSProperties {
+  const stylePropsBase: CSSProperties = {
+    display: 'flex',
+    justifyContent: 'center',
+    height: 22,
+    minWidth: 22,
+    width: 'max-content',
+    padding: 5,
+    alignItems: 'center',
+    borderRadius: 11,
+  }
+
+  switch (overrideStatus) {
+    case 'no-override':
+      return {
+        ...stylePropsBase,
+        backgroundColor: colorTheme.dynamicBlue10.value,
+      }
+    case 'overridden':
+      return {
+        ...stylePropsBase,
+        color: colorTheme.brandNeonPink.value,
+        backgroundColor: colorTheme.pinkSubdued.value,
+      }
+    case 'override-failed':
+      return {
+        ...stylePropsBase,
+        color: colorTheme.brandNeonPink.value,
+        background: `linear-gradient(to left bottom, ${colorTheme.pinkSubdued.value} 48%, ${colorTheme.brandNeonPink.value} 48%, ${colorTheme.brandNeonPink.value} 52%, ${colorTheme.pinkSubdued.value} 52%)`,
+        boxSizing: 'border-box',
+        border: `1px solid ${colorTheme.brandNeonPink.value}`,
+      }
+    default:
+      assertNever(overrideStatus)
+  }
+}

--- a/editor/src/components/navigator/navigator-item/map-counter.tsx
+++ b/editor/src/components/navigator/navigator-item/map-counter.tsx
@@ -75,7 +75,7 @@ export const MapCounter = React.memo((props: MapCounterProps) => {
 
   const isOverridden = countOverride != null
   const shownCounterValue = countOverride ?? nrChildren
-  const overrideFailed = isOverridden && countOverride > nrChildren
+  const overrideFailed = isOverridden && countOverride !== nrChildren
   const overrideStatus: OverrideStatus = (() => {
     if (isOverridden) {
       if (overrideFailed) {

--- a/editor/src/components/navigator/navigator-item/map-counter.tsx
+++ b/editor/src/components/navigator/navigator-item/map-counter.tsx
@@ -124,7 +124,7 @@ function getMapCounterStyleProps(overrideStatus: OverrideStatus): CSSProperties 
       return {
         ...stylePropsBase,
         color: colorTheme.brandNeonPink.value,
-        background: `linear-gradient(to left bottom, ${colorTheme.pinkSubdued.value} 48%, ${colorTheme.brandNeonPink.value} 48%, ${colorTheme.brandNeonPink.value} 52%, ${colorTheme.pinkSubdued.value} 52%)`,
+        background: `linear-gradient(to left bottom, ${colorTheme.pinkSubdued.value} 47%, ${colorTheme.brandNeonPink.value} 48%, ${colorTheme.brandNeonPink.value} 52%, ${colorTheme.pinkSubdued.value} 53%)`,
         boxSizing: 'border-box',
         border: `1px solid ${colorTheme.brandNeonPink.value}`,
       }

--- a/editor/src/components/navigator/navigator-map.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-map.spec.browser2.tsx
@@ -6,6 +6,7 @@ import {
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { BakedInStoryboardUID, BakedInStoryboardVariableName } from '../../core/model/scene-utils'
 import * as EP from '../../core/shared/element-path'
+import { colorTheme } from '../../uuiui'
 import { getMapCounterTestId } from './navigator-item/map-counter'
 
 function getProjectCode<T>(arr: Array<T>, countOverride?: number): string {
@@ -86,52 +87,82 @@ describe('maps in the navigator', () => {
         const counter = await renderResult.renderedDOM.findByTestId(counterTestId)
 
         expect(counter.textContent).toEqual(arr.length.toString())
+        expect(counter.style.backgroundColor).toEqual('var(--utopitheme-dynamicBlue10)')
+        expect(counter.style.color).toEqual('')
       })
     })
+  })
 
-    describe('with overridden count value', () => {
-      const testData = [
-        {
-          arr: [0, 1, 2, 3],
-          overrideCount: 0,
-        },
-        {
-          arr: [0, 1, 2, 3],
-          overrideCount: 1,
-        },
-        {
-          arr: [0, 1, 2, 3],
-          overrideCount: 2,
-        },
-        {
-          arr: [0, 1, 2, 3],
-          overrideCount: 3,
-        },
-        {
-          arr: [0, 1, 2, 3],
-          overrideCount: 4,
-        },
-      ]
+  describe('with overridden count value', () => {
+    const testData = [
+      {
+        arr: [0, 1, 2, 3],
+        overrideCount: 0,
+        overrideSuccess: true,
+      },
+      {
+        arr: [0, 1, 2, 3],
+        overrideCount: 1,
+        overrideSuccess: true,
+      },
+      {
+        arr: [0, 1, 2, 3],
+        overrideCount: 2,
+        overrideSuccess: true,
+      },
+      {
+        arr: [0, 1, 2, 3],
+        overrideCount: 3,
+        overrideSuccess: true,
+      },
+      {
+        arr: [0, 1, 2, 3],
+        overrideCount: 4,
+        overrideSuccess: true,
+      },
+      {
+        arr: [0, 1, 2, 3],
+        overrideCount: 4,
+        overrideSuccess: true,
+      },
+      {
+        arr: [0, 1, 2, 3],
+        overrideCount: -1,
+        overrideSuccess: false,
+      },
+      {
+        arr: [0, 1, 2, 3],
+        overrideCount: 5,
+        overrideSuccess: false,
+      },
+    ]
 
-      testData.forEach(({ arr, overrideCount }) => {
-        it(`shows counter for map items with list length ${arr.length}`, async () => {
-          const renderResult = await renderTestEditorWithCode(
-            getProjectCode(arr, overrideCount),
-            'await-first-dom-report',
-          )
+    testData.forEach(({ arr, overrideCount, overrideSuccess }) => {
+      it(`shows overridden counter ${overrideCount} for map items with list length ${arr.length}`, async () => {
+        const renderResult = await renderTestEditorWithCode(
+          getProjectCode(arr, overrideCount),
+          'await-first-dom-report',
+        )
 
-          const mapParent = EP.fromString('utopia-storyboard-uid/scene-aaa/containing-div/')
-          const mapElement = MetadataUtils.getChildrenOrdered(
-            renderResult.getEditorState().editor.jsxMetadata,
-            renderResult.getEditorState().editor.elementPathTree,
-            mapParent,
-          )[0]
+        const mapParent = EP.fromString('utopia-storyboard-uid/scene-aaa/containing-div/')
+        const mapElement = MetadataUtils.getChildrenOrdered(
+          renderResult.getEditorState().editor.jsxMetadata,
+          renderResult.getEditorState().editor.elementPathTree,
+          mapParent,
+        )[0]
 
-          const counterTestId = getMapCounterTestId(mapElement.elementPath)
-          const counter = await renderResult.renderedDOM.findByTestId(counterTestId)
+        const counterTestId = getMapCounterTestId(mapElement.elementPath)
+        const counter = await renderResult.renderedDOM.findByTestId(counterTestId)
 
-          expect(counter.textContent).toEqual(overrideCount.toString())
-        })
+        expect(counter.textContent).toEqual(overrideCount.toString())
+        expect(counter.style.color).toEqual('var(--utopitheme-brandNeonPink)')
+        if (overrideSuccess) {
+          // successful override background color
+          expect(counter.style.backgroundColor).toEqual('var(--utopitheme-pinkSubdued)')
+        } else {
+          // failed override shows a diagonal strikethrough implemented with linear-gradient
+          expect(counter.style.background.slice(0, 15)).toEqual('linear-gradient')
+        }
       })
     })
   })

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -15,6 +15,7 @@ const darkBase = {
   brandNeonPink: createUtopiColor('oklch(78.64% 0.237 327.81)'),
   brandNeonPink10: createUtopiColor('oklch(78.64% 0.237 327.81 / 10%)'),
   brandNeonGreen: base.neongreen,
+  pinkSubdued: createUtopiColor('#FFCCE7 '), // TODO: review this color
   jsYellow: base.jsYellow,
   secondaryBlue: createUtopiColor('#679AD1'),
   secondaryOrange: createUtopiColor('#E89A74'),

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -15,6 +15,7 @@ const lightBase = {
   brandNeonPink: base.neonpink,
   brandNeonPink10: createUtopiColor('oklch(72.53% 0.353 331.69 / 10%)'),
   brandNeonGreen: base.neongreen,
+  pinkSubdued: createUtopiColor('#FFCCE7 '), // TODO: review this color
   jsYellow: base.jsYellow,
   secondaryBlue: createUtopiColor('#49B6FF'),
   secondaryOrange: createUtopiColor('#EEA544'),


### PR DESCRIPTION
**Description:**
Show whether the map count override is successful or not on the UI.

No override:
<img width="228" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/2fa75798-88fa-4742-ab9a-3a80fbd78d91">

Successful override:
<img width="126" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/c1bca542-dfb9-4dbd-90e5-580e5a037371">

Not enough children for the override:
<img width="158" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/dde90ebf-5d9f-43f6-9a3a-3e7e96c55daf">


