### PR TITLE
(perf) Remove unnecessary navigator items rerenders

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -548,6 +548,9 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
     return EP.pathsEqual(firstSibling.elementPath, props.elementPath)
   }, [editorStateRef, props.elementPath])
 
+  // Note for future selves: watch out! This works because changing siblings triggers a re-render of the navigator,
+  // but if that were not to happen anymore, the references used here by the editorStateRef would not guarantee
+  // updated hook values.
   const isLastSibling = React.useMemo(() => {
     const siblings = MetadataUtils.getSiblingsOrdered(
       editorStateRef.current.jsxMetadata,

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -522,18 +522,6 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
     [props, updateDragSessionInProgress],
   )
 
-  const metadata = useEditorState(
-    Substores.metadata,
-    metadataSelector,
-    'NavigatorItemContainer metadata',
-  )
-
-  const elementPathTree = useEditorState(
-    Substores.metadata,
-    (store) => store.editor.elementPathTree,
-    'NavigatorItemDndWrapper elementPathTree',
-  )
-
   const dropTargetHint = useEditorState(
     Substores.navigator,
     (store) => store.editor.navigator.dropTargetHint,
@@ -547,24 +535,32 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
   )
 
   const isFirstSibling = React.useMemo(() => {
-    const siblings = MetadataUtils.getSiblingsOrdered(metadata, elementPathTree, props.elementPath)
+    const siblings = MetadataUtils.getSiblingsOrdered(
+      editorStateRef.current.jsxMetadata,
+      editorStateRef.current.elementPathTree,
+      props.elementPath,
+    )
     const firstSibling = siblings.at(0)
     if (firstSibling == null) {
       return false
     }
 
     return EP.pathsEqual(firstSibling.elementPath, props.elementPath)
-  }, [metadata, elementPathTree, props.elementPath])
+  }, [editorStateRef, props.elementPath])
 
   const isLastSibling = React.useMemo(() => {
-    const siblings = MetadataUtils.getSiblingsOrdered(metadata, elementPathTree, props.elementPath)
+    const siblings = MetadataUtils.getSiblingsOrdered(
+      editorStateRef.current.jsxMetadata,
+      editorStateRef.current.elementPathTree,
+      props.elementPath,
+    )
     const lastSibling = siblings.at(-1)
     if (lastSibling == null) {
       return false
     }
 
     return EP.pathsEqual(lastSibling.elementPath, props.elementPath)
-  }, [metadata, elementPathTree, props.elementPath])
+  }, [editorStateRef, props.elementPath])
 
   const [{ isOver: isOverBottomHint, canDrop: canDropOnBottomHint }, bottomDropRef] = useDrop<
     NavigatorItemDragAndDropWrapperProps,
@@ -585,7 +581,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
           'after',
           editorStateRef.current.jsxMetadata,
           navigatorTargets,
-          elementPathTree,
+          editorStateRef.current.elementPathTree,
           isLastSibling,
         )
       },
@@ -595,7 +591,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
           dropTargetHint != null &&
           !isDroppingToOriginalPosition(
             editorStateRef.current.jsxMetadata,
-            elementPathTree,
+            editorStateRef.current.elementPathTree,
             dropTargetHint,
             props.elementPath,
             item.elementPath,
@@ -625,7 +621,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
         return canDropNextTo(editorStateRef.current, target)
       },
     }),
-    [props, elementPathTree, dropTargetHint, isLastSibling],
+    [props, editorStateRef, dropTargetHint, isLastSibling],
   )
 
   const [{ isOver: isOverTopHint, canDrop: canDropOnTopHint }, topDropRef] = useDrop<
@@ -647,7 +643,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
           'before',
           editorStateRef.current.jsxMetadata,
           navigatorTargets,
-          elementPathTree,
+          editorStateRef.current.elementPathTree,
           isLastSibling,
         )
       },
@@ -657,7 +653,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
           dropTargetHint != null &&
           !isDroppingToOriginalPosition(
             editorStateRef.current.jsxMetadata,
-            elementPathTree,
+            editorStateRef.current.elementPathTree,
             dropTargetHint,
             props.elementPath,
             item.elementPath,
@@ -687,7 +683,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
         return canDropNextTo(editorStateRef.current, target)
       },
     }),
-    [props, elementPathTree, dropTargetHint, isLastSibling],
+    [props, editorStateRef, dropTargetHint, isLastSibling],
   )
 
   const [{ canDrop: canDropParentOutline }, reparentDropRef] = useDrop<
@@ -739,10 +735,13 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
   const shouldShowTopHint =
     isOverTopHint &&
     canDropOnTopHint &&
-    !isHintDisallowed(dropTargetHint?.displayAtEntry?.elementPath ?? null, metadata)
+    !isHintDisallowed(
+      dropTargetHint?.displayAtEntry?.elementPath ?? null,
+      editorStateRef.current.jsxMetadata,
+    )
 
   const isConditionalEntry = MetadataUtils.isConditionalFromMetadata(
-    MetadataUtils.findElementByElementPath(metadata, props.elementPath),
+    MetadataUtils.findElementByElementPath(editorStateRef.current.jsxMetadata, props.elementPath),
   )
 
   const isCollapsedCondtionalEntry = isConditionalEntry ? props.collapsed : true
@@ -750,7 +749,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
   const shouldShowBottomHint =
     isOverBottomHint &&
     canDropOnBottomHint &&
-    !isHintDisallowed(props.elementPath, metadata) &&
+    !isHintDisallowed(props.elementPath, editorStateRef.current.jsxMetadata) &&
     isCollapsedCondtionalEntry
 
   const margin = (() => {
@@ -758,7 +757,9 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
       return 0
     }
 
-    return getHintPaddingForDepth(navigatorDepth(dropTargetHint.targetParent, metadata))
+    return getHintPaddingForDepth(
+      navigatorDepth(dropTargetHint.targetParent, editorStateRef.current.jsxMetadata),
+    )
   })()
 
   const parentOutline = React.useMemo((): ParentOutline => {

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -550,7 +550,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
 
   // Note for future selves: watch out! This works because changing siblings triggers a re-render of the navigator,
   // but if that were not to happen anymore, the references used here by the editorStateRef would not guarantee
-  // updated hook values.
+  // updated hook values. (https://github.com/concrete-utopia/utopia/pull/4055#discussion_r1285777910)
   const isLastSibling = React.useMemo(() => {
     const siblings = MetadataUtils.getSiblingsOrdered(
       editorStateRef.current.jsxMetadata,

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -208,14 +208,16 @@ export const NavigatorItemWrapper: React.FunctionComponent<
     'NavigatorItemWrapper elementSupportsChildren',
   )
 
-  const parentElement = useEditorState(
+  const maybeParentConditional = useEditorState(
     Substores.metadata,
     (store) =>
-      MetadataUtils.findElementByElementPath(
-        store.editor.jsxMetadata,
-        EP.parentPath(props.navigatorEntry.elementPath),
+      maybeConditionalExpression(
+        MetadataUtils.findElementByElementPath(
+          store.editor.jsxMetadata,
+          EP.parentPath(props.navigatorEntry.elementPath),
+        ),
       ),
-    'NavigatorItemWrapper parentElement',
+    'NavigatorItemWrapper maybeParentConditional',
   )
 
   function isNullConditionalBranch(
@@ -238,7 +240,7 @@ export const NavigatorItemWrapper: React.FunctionComponent<
   const canReparentInto =
     elementSupportsChildren ||
     isConditionalClauseNavigatorEntry(props.navigatorEntry) ||
-    isNullConditionalBranch(props.navigatorEntry, maybeConditionalExpression(parentElement))
+    isNullConditionalBranch(props.navigatorEntry, maybeParentConditional)
 
   const labelForTheElement = useEditorState(
     Substores.metadata,


### PR DESCRIPTION
Fixes #4056 

**Problem:**
The editor is painfully slow when dragging stuff around (esp. groups) in the canvas.

**Fix:**
There are **multiple** reasons for this, but this PR addresses the navigator item rerenders, which should noticeably improve the situation.