### PR TITLE
Don't push intended bounds for group children with hug sides

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -221,6 +221,7 @@ export function absoluteResizeBoundingBoxStrategy(
                 pushIntendedBoundsAndUpdateGroups(
                   [{ target: selectedElement, frame: newFrame }],
                   'starting-metadata',
+                  'resize',
                 ),
               ]
             })

--- a/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
@@ -222,6 +222,7 @@ export function basicResizeStrategy(
             pushIntendedBoundsAndUpdateGroups(
               [{ target: selectedElement, frame: resizedBounds }],
               'starting-metadata',
+              'resize',
             ),
             ...groupChildren.map((c) => queueGroupTrueUp([trueUpElementChanged(c.elementPath)])),
           ])

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
@@ -221,6 +221,7 @@ export function flexResizeBasicStrategy(
             pushIntendedBoundsAndUpdateGroups(
               [{ target: selectedElement, frame: resizedBounds }],
               'starting-metadata',
+              'resize',
             ),
             ...groupChildren.map((c) => queueGroupTrueUp([trueUpElementChanged(c.elementPath)])),
           ])

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-strategy.tsx
@@ -352,6 +352,7 @@ export function flexResizeStrategy(
             pushIntendedBoundsAndUpdateGroups(
               [{ target: selectedElement, frame: newFrame }],
               'starting-metadata',
+              'resize',
             ),
             ...groupChildren.map((c) => queueGroupTrueUp([trueUpElementChanged(c.elementPath)])),
           ])

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
@@ -91,7 +91,9 @@ export function keyboardAbsoluteMoveStrategy(
         const guidelines = getKeyboardStrategyGuidelines(canvasState, interactionSession, newFrame)
 
         commands.push(setSnappingGuidelines('mid-interaction', guidelines))
-        commands.push(pushIntendedBoundsAndUpdateGroups(intendedBounds, 'starting-metadata'))
+        commands.push(
+          pushIntendedBoundsAndUpdateGroups(intendedBounds, 'starting-metadata', 'move'),
+        )
         commands.push(setElementsToRerenderCommand(selectedElements))
         return strategyApplicationResult(commands)
       } else {

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
@@ -201,7 +201,9 @@ export function keyboardAbsoluteResizeStrategy(
         })
         const guidelines = getKeyboardStrategyGuidelines(canvasState, interactionSession, newFrame)
         commands.push(setSnappingGuidelines('mid-interaction', guidelines))
-        commands.push(pushIntendedBoundsAndUpdateGroups(intendedBounds, 'starting-metadata'))
+        commands.push(
+          pushIntendedBoundsAndUpdateGroups(intendedBounds, 'starting-metadata', 'resize'),
+        )
         commands.push(setElementsToRerenderCommand(selectedElements))
         return strategyApplicationResult(commands)
       } else {

--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
@@ -125,6 +125,7 @@ export function applyMoveCommon(
         pushIntendedBoundsAndUpdateGroups(
           commandsForSelectedElements.intendedBounds,
           'starting-metadata',
+          'move',
         ),
         updateHighlightedViews('mid-interaction', []),
         setElementsToRerenderCommand(targets),
@@ -160,6 +161,7 @@ export function applyMoveCommon(
         pushIntendedBoundsAndUpdateGroups(
           commandsForSelectedElements.intendedBounds,
           'starting-metadata',
+          'move',
         ),
         setElementsToRerenderCommand([...targets, ...targetsForSnapping]),
         setCursorCommand(CSSCursor.Select),

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3984,7 +3984,7 @@ export const UPDATE_FNS = {
       }
     }, targetsToTrueUp)
     const editorWithGroupsTruedUp = foldAndApplyCommandsSimple(editor, [
-      pushIntendedBoundsAndUpdateGroups(canvasFrameAndTargets, 'live-metadata'),
+      pushIntendedBoundsAndUpdateGroups(canvasFrameAndTargets, 'live-metadata', 'resize'),
     ])
     return { ...editorWithGroupsTruedUp, trueUpGroupsForElementAfterDomWalkerRuns: [] }
   },

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -675,6 +675,17 @@ export function isFixedHugFillModeApplied(
   )
 }
 
+export function isFixedHugFillModeAppliedOnAnySide(
+  metadata: ElementInstanceMetadataMap,
+  element: ElementPath,
+  mode: FixedHugFillMode,
+): boolean {
+  return (
+    detectFillHugFixedState('horizontal', metadata, element).fixedHugFill?.type === mode ||
+    detectFillHugFixedState('vertical', metadata, element).fixedHugFill?.type === mode
+  )
+}
+
 export function setToFixedSizeCommands(
   metadata: ElementInstanceMetadataMap,
   elementPathTree: ElementPathTrees,


### PR DESCRIPTION
Fixes #4058

**Problem:**

If a group child has `Hug x Hug` text children, when moving the group around the children points will be converted to fixed.

https://github.com/concrete-utopia/utopia/assets/1081051/afe8e7c1-7c0f-49a8-901e-80a05c820c9e

**Fix:**

The reality is that this happen for all `Hug x [anything]` children - so this PR branches the logic of the `getUpdateResizedGroupChildrenCommands` function so that it can discriminate between `moving` and `resizing` something, and skip hugging elements if in the `moving` situation.

The outcome is that if you move something its w/h frame points won't be touched but they will if you resize (which makes the most sense?).

https://github.com/concrete-utopia/utopia/assets/1081051/a26fe167-4098-4736-80ec-6134b5bcb9b5

Note: I've not added specific tests to this one because I think the behavior itself can be up for interpretation anyways and it would make sense to play around with it before deciding it's the right choice.