### PR TITLE
Fix/inspector offsets for scroll-to and indicator arrows

### DIFF
--- a/editor/src/components/canvas/controls/elements-outside-visible-area-hooks.tsx
+++ b/editor/src/components/canvas/controls/elements-outside-visible-area-hooks.tsx
@@ -17,6 +17,9 @@ import { CanvasToolbarId } from '../../editor/canvas-toolbar'
 import { LeftPaneDefaultWidth } from '../../editor/store/editor-state'
 import { Substores, useEditorState, useRefEditorState } from '../../editor/store/store-hook'
 import { canvasPointToWindowPoint } from '../dom-lookup'
+import { useAtom } from 'jotai'
+import { InspectorWidthAtom } from '../../inspector/common/inspector-atoms'
+import { UtopiaTheme } from '../../../uuiui'
 
 export const ElementOutisdeVisibleAreaIndicatorSize = 22 // px
 const minClusterDistance = 17 // px
@@ -66,6 +69,12 @@ export function useElementsOutsideVisibleArea(
     (store) => (store.editor.leftMenu.expanded ? store.editor.leftMenu.paneWidth : 0),
     'useElementsOutsideVisibleArea leftMenuWidth',
   )
+  const [atomInspectorWidth] = useAtom(InspectorWidthAtom)
+  const inspectorWidth = React.useMemo(() => {
+    return atomInspectorWidth === 'regular'
+      ? UtopiaTheme.layout.inspectorSmallWidth
+      : UtopiaTheme.layout.inspectorLargeWidth
+  }, [atomInspectorWidth])
 
   const elements = React.useMemo(() => {
     return uniqBy([...localSelectedViews, ...localHighlightedViews], EP.pathsEqual)
@@ -94,10 +103,10 @@ export function useElementsOutsideVisibleArea(
     return windowRectangle({
       x: bounds.x * scaleRatio,
       y: bounds.y * scaleRatio,
-      width: bounds.width * scaleRatio - leftMenuWidth,
+      width: bounds.width * scaleRatio - leftMenuWidth - (inspectorWidth + 20),
       height: bounds.height * scaleRatio,
     })
-  }, [bounds, leftMenuWidth, canvasScale])
+  }, [bounds, leftMenuWidth, canvasScale, inspectorWidth])
 
   const scaledCanvasAreaCenter = React.useMemo(() => {
     if (scaledCanvasArea == null) {

--- a/editor/src/components/canvas/controls/elements-outside-visible.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/elements-outside-visible.spec.browser2.tsx
@@ -106,7 +106,7 @@ describe('elements outside visible area', () => {
       const indicator = screen.queryByTestId(getIndicatorId(targetPath, ['right']))
       expect(indicator).not.toBeNull()
       expect(indicator?.style.top).toBe('182px')
-      expect(indicator?.style.left).toBe('2175px')
+      expect(indicator?.style.left).toBe('1900px')
     })
     it('shows the indicator on the top side', async () => {
       const renderResult = await renderTestEditorWithCode(
@@ -206,7 +206,7 @@ describe('elements outside visible area', () => {
       const indicator = screen.queryByTestId(getIndicatorId(targetPath, ['top', 'right']))
       expect(indicator).not.toBeNull()
       expect(indicator?.style.top).toBe('0px')
-      expect(indicator?.style.left).toMatch('2175px')
+      expect(indicator?.style.left).toMatch('1900px')
     })
     it('shows the indicator on the bottom-left side', async () => {
       const renderResult = await renderTestEditorWithCode(
@@ -256,7 +256,7 @@ describe('elements outside visible area', () => {
       const indicator = screen.queryByTestId(getIndicatorId(targetPath, ['bottom', 'right']))
       expect(indicator).not.toBeNull()
       expect(indicator?.style.top).toBe('936px')
-      expect(indicator?.style.left).toMatch('2175px')
+      expect(indicator?.style.left).toMatch('1900px')
     })
   })
   describe('multiple elements', () => {
@@ -392,7 +392,7 @@ describe('elements outside visible area', () => {
         windowRectangle({
           x: canvasRect.x + DefaultNavigatorWidth,
           y: canvasRect.y,
-          width: canvasRect.width - DefaultNavigatorWidth,
+          width: canvasRect.width - DefaultNavigatorWidth - 255, // 255 being the default inspector width (inspectorSmallWidth)
           height: canvasRect.height,
         }),
       )

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -343,6 +343,7 @@ const ResizableInspectorPane = React.memo<ResizableInspectorPaneProps>((props) =
 
   return (
     <div
+      id='inspector-root'
       style={{
         height: 'calc(100% - 20px)',
         position: 'absolute',

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4575,7 +4575,9 @@ export const UPDATE_FNS = {
     if (targetElementCoords != null && isFiniteRectangle(targetElementCoords)) {
       const isNavigatorOnTop = !editor.navigator.minimised
       const containerRootDiv = document.getElementById('canvas-root')
+      const inspector = document.getElementById('inspector-root')
       const navigatorOffset = isNavigatorOnTop ? DefaultNavigatorWidth : 0
+      const inspectorOffset = editor.inspector.visible ? inspector?.clientWidth ?? 0 : 0
       const scale = 1 / editor.canvas.scale
 
       // This returns the offset used as the fallback for the other behaviours when the container bounds are not defined.
@@ -4606,7 +4608,12 @@ export const UPDATE_FNS = {
           }),
         )
         const topLeftTarget = canvasPoint({
-          x: canvasCenter.x - frame.width / 2 - bounds.x + (navigatorOffset / 2) * scale,
+          x:
+            canvasCenter.x -
+            frame.width / 2 -
+            bounds.x +
+            (navigatorOffset / 2) * scale -
+            (inspectorOffset / 2) * scale,
           y: canvasCenter.y - frame.height / 2 - bounds.y,
         })
         return Utils.pointDifference(frame, topLeftTarget)


### PR DESCRIPTION
**Problem:**

With the recent changes to the UI two things diverged:
- `scroll to` does not calculate the center of the viewport correctly (or, well, it does but it is not good given the floating inspector)
- the indicator arrows are unusable when overflowing on the right side of the canvas

**Fix:**

Take the inspector into the account and:
- adjust the scroll-to target `x`
- adjust the rightmost limit of the indicator arrows


https://github.com/concrete-utopia/utopia/assets/1081051/8089691f-2048-4376-9cfc-63f3a9b816e6

