### PR TITLE
Wrap dispatch call in `setTimeout`

### DIFF
--- a/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
@@ -245,7 +245,7 @@ export const RepositoryListing = React.memo(
     }, [dispatch])
 
     React.useEffect(() => {
-      refreshRepos()
+      setTimeout(() => refreshRepos(), 0)
     }, [refreshRepos])
 
     const clearRepository = React.useCallback(() => {


### PR DESCRIPTION
## Problem
When switching to the Github tab, a flushsync warning is shown in the console

## Cause
`dispatch` is called from a `useEffect`, via `refreshRepos`

## Fix
Wrap the offending `refreshRepos` call in a `setTimeout`