### PR TITLE
Prevent group selection/highlight when child of group selected.

### DIFF
--- a/editor/mocha-setup-beforeall.js
+++ b/editor/mocha-setup-beforeall.js
@@ -1,3 +1,6 @@
 beforeEach(function () {
   viewport.set(2200, 1000)
+  if ('resetGlobalPositions' in globalThis) {
+    globalThis.resetGlobalPositions()
+  }
 })

--- a/editor/src/components/canvas/canvas-strategies/strategies/reorder-slider-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reorder-slider-strategy.spec.browser2.tsx
@@ -21,7 +21,6 @@ import {
   mouseDragFromPointWithDelta,
   mouseMoveToPoint,
 } from '../../event-helpers.test-utils'
-import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import { navigatorEntryToKey } from '../../../../components/editor/store/editor-state'
 

--- a/editor/src/components/canvas/controls/reorder-slider-control.tsx
+++ b/editor/src/components/canvas/controls/reorder-slider-control.tsx
@@ -57,7 +57,7 @@ export const ReorderSliderControl = controlForStrategyMemoized(
       Substores.highlightedHoveredViews,
       (store) => {
         const { hoveredViews } = store.editor
-        return target != null && hoveredViews.includes(target)
+        return target != null && EP.containsPath(target, hoveredViews)
       },
       'ReorderSliderControl isTargetElementHovered',
     )

--- a/editor/src/components/canvas/controls/selection-area-hooks.tsx
+++ b/editor/src/components/canvas/controls/selection-area-hooks.tsx
@@ -15,7 +15,7 @@ import { useDispatch } from '../../editor/store/dispatch-context'
 import { useRefEditorState } from '../../editor/store/store-hook'
 import Canvas, { TargetSearchType } from '../canvas'
 import { getAllTargetsUnderAreaAABB, windowToCanvasCoordinates } from '../dom-lookup'
-import { useGetSelectableViewsForSelectMode } from './select-mode/select-mode-hooks'
+import { useGetSelectableViewsForSelectModeFromSelectedViews } from './select-mode/select-mode-hooks'
 import {
   filterUnderSelectionArea,
   getSelectionAreaRenderedRect,
@@ -58,7 +58,7 @@ export function useSelectionArea(
     [storeRef],
   )
 
-  const getSelectableViews = useGetSelectableViewsForSelectMode()
+  const getSelectableViews = useGetSelectableViewsForSelectModeFromSelectedViews(localSelectedViews)
 
   const getValidElementsUnderArea = React.useCallback(
     (area: CanvasRectangle | null): ElementPath[] => {

--- a/editor/src/components/titlebar/test-menu.tsx
+++ b/editor/src/components/titlebar/test-menu.tsx
@@ -35,8 +35,6 @@ const Tile = styled.div<TileProps>((props) => ({
 export const TestMenu = React.memo(() => {
   const entireStateRef = useRefEditorState((store) => store)
 
-  const dispatch = useDispatch()
-
   const jsxMetadata = useRefEditorState((store) => {
     return store.editor.jsxMetadata
   })

--- a/editor/src/utils/global-positions.ts
+++ b/editor/src/utils/global-positions.ts
@@ -16,3 +16,14 @@ export function updateGlobalPositions(
   CanvasMousePositionRounded = canvasMousePositionRounded
   WindowMousePositionRaw = windowMousePositionRaw
 }
+
+export function resetGlobalPositions(): void {
+  CanvasMousePositionRaw = null
+  CanvasMousePositionRounded = null
+  WindowMousePositionRaw = null
+
+  CanvasScrollOffset = { x: 0, y: 0 } as CanvasPoint
+  CanvasScale = { current: 1 }
+}
+
+;(globalThis as any).resetGlobalPositions = resetGlobalPositions


### PR DESCRIPTION
**Problem:**
When the child of a group is selected, clicking on the group itself should deselect the child and not select the group.

**Fix:**
A change to `replaceNonSelectablePaths` was made which relies on the selected views, however this would result in the mouse down deselecting the child and then the mouse up would select the group because at that point there were no selected views. The fix for this was to keep the selected views stable across the entire click for the logic that handles the selection change, so that the mouse up could see the selected views as they were before the interaction had started. With `useGetSelectableViewsForSelectModeFromSelectedViews` being very similar to another function with relies on editor state refs, but in this case takes the selected views as a parameter.

The above work uncovered an issue with how browser tests rely on some globals for the mouse position. The globals would carry over from one test to the next, which meant that any change in test order or the removal of a test might result in an unrelated test then failing. Now before each test the globals are reset to how they were before the editor is loaded.

**Commit Details:**
- `replaceNonSelectablePaths` now also excludes group like ancestors of the currently selected element.
- Added `useGetSelectableViewsForSelectModeFromSelectedViews` as an alternative to `useGetSelectableViewsForSelectMode` when the selected views should stay constant from the start.
- `isTargetElementHovered` value in `ReorderSliderControl` uses `containsPath` for some extra safety.
- `useSelectionArea` now uses `useGetSelectableViewsForSelectModeFromSelectedViews`.
- Added `resetGlobalPositions` utility function.
- In `mocha-setup-beforeall.js` trigger `resetGlobalPositions` before each test run.