### PR TITLE
Prevent switching to text edit mode when ineligible.

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -350,6 +350,7 @@ import type {
 } from '../action-types'
 import { DeleteSelected, isLoggedIn } from '../action-types'
 import type { Mode } from '../editor-modes'
+import { isTextEditMode } from '../editor-modes'
 import { EditorModes, isLiveMode, isSelectMode } from '../editor-modes'
 import * as History from '../history'
 import type { StateHistory } from '../history'
@@ -1978,6 +1979,19 @@ export const UPDATE_FNS = {
       // For now there's not much more that we can do since the action here can be (and is) evaluated also for transient states
       // (e.g. a `textEdit` mode after an `insertMode`) created with wildcard patches.
       return editor
+    }
+    if (isTextEditMode(action.mode)) {
+      if (
+        !MetadataUtils.targetTextEditable(
+          editor.jsxMetadata,
+          editor.elementPathTree,
+          action.mode.editedText,
+        )
+      ) {
+        // If the target of text edit mode isn't editable, then ignore the requested change.
+        console.error(`Invalid target for text edit mode: ${EP.toString(action.mode.editedText)}`)
+        return editor
+      }
     }
     return setModeState(action.mode, editor)
   },

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -22,7 +22,8 @@ import {
 } from '../canvas/ui-jsx.test-utils'
 import { TextEditorSpanId } from './text-editor'
 import { FOR_TESTS_setNextGeneratedUid } from '../../core/model/element-template-utils.test-utils'
-import { selectComponents } from '../editor/actions/action-creators'
+import { selectComponents, switchEditorMode } from '../editor/actions/action-creators'
+import { EditorModes } from '../editor/editor-modes'
 
 describe('Use the text editor', () => {
   it('Click to edit text', async () => {
@@ -1589,6 +1590,40 @@ describe('Use the text editor', () => {
       }`),
     )
     expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('this is just a string')
+  })
+})
+
+describe('SWITCH_EDITOR_MODE', () => {
+  describe('TextEditMode', () => {
+    it('should be permitted for something that is text editable', async () => {
+      const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
+      await editor.dispatch(
+        [
+          switchEditorMode(
+            EditorModes.textEditMode(
+              EP.fromString('sb/39e'),
+              null,
+              'existing',
+              'no-text-selection',
+            ),
+          ),
+        ],
+        true,
+      )
+      expect(editor.getEditorState().editor.mode.type).toEqual('textEdit')
+    })
+    it('should not be permitted for something that is not text editable', async () => {
+      const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
+      await editor.dispatch(
+        [
+          switchEditorMode(
+            EditorModes.textEditMode(EP.fromString('sb'), null, 'existing', 'no-text-selection'),
+          ),
+        ],
+        true,
+      )
+      expect(editor.getEditorState().editor.mode.type).toEqual('select')
+    })
   })
 })
 


### PR DESCRIPTION
**Problem:**
Somehow a group appears to have been marked as the currently edited text element, putting the outline for that around it.

**Possible Cause:**
There is no check when switching to text edit mode for the element targeted to be text editable. Conceivably it's possible for a change to the model to fire ahead of a switch editor mode, where the latter is now wrongly targeting something that isn't text editable.

**Fix:**
Add in a check when `SWITCH_EDITOR_MODE` is invoked that when switching to text edit mode it checks to see if the target is text editable.

**Commit Details:**
- Added a check to `SWITCH_EDITOR_MODE`, when switching to `TextEditMode` the target is checked to see if it is text editable.