### PR TITLE
Fix inserting a default exported component

### DIFF
--- a/editor/src/components/editor/export-utils.ts
+++ b/editor/src/components/editor/export-utils.ts
@@ -82,7 +82,7 @@ export function getExportedComponentImports(
             addToResult(
               exportDetail.name,
               exportDetail.name ?? '(default)',
-              importDetails(pathLastPart, [], null),
+              importDetails(exportDetail.name ?? pathLastPart, [], null),
             )
             break
           case 'EXPORT_CLASS':

--- a/editor/src/components/editor/export-utils.ts
+++ b/editor/src/components/editor/export-utils.ts
@@ -79,7 +79,11 @@ export function getExportedComponentImports(
       for (const exportDetail of success.exportsDetail) {
         switch (exportDetail.type) {
           case 'EXPORT_DEFAULT_FUNCTION_OR_CLASS':
-            addToResult(exportDetail.name, '(default)', importDetails(pathLastPart, [], null))
+            addToResult(
+              exportDetail.name,
+              exportDetail.name ?? '(default)',
+              importDetails(pathLastPart, [], null),
+            )
             break
           case 'EXPORT_CLASS':
             addToResult(


### PR DESCRIPTION
## Problem
If a component is a default export of a module, it shows up in the insert menus as `(default)`, which in itself would be OK, but when this component is inserted, it's inserted as 
```tsx
<(default) style={{ ... }} data-uid={...} />
```
which triggers an error.

## Fix
When gathering exports from modules, try to used the original name of the exported class/function, and only use `(default)` as a fallback