### PR TITLE
Fix missing group trueups when changing directions during keyboard move

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
@@ -31,6 +31,7 @@ import { createResizeCommands } from './shared-absolute-resize-strategy-helpers'
 import type { AccumulatedPresses } from './shared-keyboard-strategy-helpers'
 import {
   accumulatePresses,
+  addOrMergeIntendedBounds,
   getKeyboardStrategyGuidelines,
   getLastKeyPressState,
   getMovementDeltaFromKey,
@@ -194,7 +195,11 @@ export function keyboardAbsoluteResizeStrategy(
               )
               commands.push(...elementResult.commands)
               if (elementResult.intendedBounds != null) {
-                intendedBounds.push(elementResult.intendedBounds)
+                intendedBounds = addOrMergeIntendedBounds(
+                  intendedBounds,
+                  originalFrame,
+                  elementResult.intendedBounds,
+                )
               }
             }
           })


### PR DESCRIPTION
Fixes #4073

**Problem:**

Changing directions during the _same_ keyboard group move interaction session causes the group to lose its trueuing up.

![Kapture 2023-08-10 at 11 37 20](https://github.com/concrete-utopia/utopia/assets/1081051/cf865c3e-99fb-4d7f-833b-ec0b35ffefa9)

**Fix:**

The reason is that incremental accumulated presses with different keys inherit the not-changed portion of the frame from the _original_ frame. This PR changes this by merging incremental intended bounds based on their target element, so that changes on multiple points of the frame end up in the final intended bounds push.

![Kapture 2023-08-10 at 11 38 20](https://github.com/concrete-utopia/utopia/assets/1081051/d0f21074-855f-4600-b701-2238234c6023)