### PR TITLE
feature(floating-panels) code editor floats

### DIFF
--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -103,7 +103,21 @@ export const CanvasWrapperComponent = React.memo(() => {
 
   const scale = useEditorState(Substores.canvas, (store) => store.editor.canvas.scale, 'scale')
 
-  const leftPanelWidth = usePubSubAtomReadOnly(LeftPanelWidthAtom, AlwaysTrue)
+  const leftPanelWidthAtom = usePubSubAtomReadOnly(LeftPanelWidthAtom, AlwaysTrue)
+  const leftPanelWidth = React.useMemo(
+    () => (isNavigatorOverCanvas ? leftPanelWidthAtom : 0),
+    [leftPanelWidthAtom, isNavigatorOverCanvas],
+  )
+
+  const codeEditorWidth = useEditorState(
+    Substores.restOfEditor,
+    (store) =>
+      store.editor.interfaceDesigner.codePaneVisible
+        ? store.editor.interfaceDesigner.codePaneWidth
+        : 0,
+    'CanvasWrapperComponent codeEditorWidth',
+  )
+
   const updateCanvasSize = usePubSubAtomWriteOnly(CanvasSizeAtom)
 
   const postActionSessionInProgress = useEditorState(
@@ -141,7 +155,6 @@ export const CanvasWrapperComponent = React.memo(() => {
           model={createCanvasModelKILLME(editorState, derivedState)}
           builtinDependencies={builtinDependencies}
           updateCanvasSize={updateCanvasSize}
-          navigatorWidth={isNavigatorOverCanvas ? leftPanelWidth : 0}
           dispatch={dispatch}
         />
       ) : null}
@@ -152,7 +165,7 @@ export const CanvasWrapperComponent = React.memo(() => {
           height: '100%',
           transform: 'translateZ(0)', // to keep this from tarnishing canvas render performance, we force it to a new layer
           pointerEvents: 'none', // you need to re-enable pointerevents for the various overlays
-          left: isNavigatorOverCanvas ? leftPanelWidth + 10 : 0,
+          left: leftPanelWidth + codeEditorWidth + 20, // padding
         }}
       >
         <FlexRow

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -124,28 +124,6 @@ const NothingOpenCard = React.memo(() => {
 })
 
 const DesignPanelRootInner = React.memo(() => {
-  const dispatch = useDispatch()
-  const interfaceDesigner = useEditorState(
-    Substores.restOfEditor,
-    (store) => store.editor.interfaceDesigner,
-    'DesignPanelRoot interfaceDesigner',
-  )
-
-  const colorTheme = useColorTheme()
-
-  const codeEditorEnabled = isCodeEditorEnabled()
-  const onResizeStop = React.useCallback(
-    (
-      event: MouseEvent | TouchEvent,
-      direction: ResizeDirection,
-      elementRef: HTMLElement,
-      delta: NumberSize,
-    ) => {
-      dispatch([EditorActions.resizeInterfaceDesignerCodePane(delta.width)])
-    },
-    [dispatch],
-  )
-
   return (
     <>
       <SimpleFlexRow
@@ -159,44 +137,6 @@ const DesignPanelRootInner = React.memo(() => {
           flexShrink: 0,
         }}
       >
-        <SimpleFlexColumn>
-          <Resizable
-            defaultSize={{
-              width: interfaceDesigner.codePaneWidth,
-              height: '100%',
-            }}
-            size={{
-              width: interfaceDesigner.codePaneWidth,
-              height: '100%',
-            }}
-            onResizeStop={onResizeStop}
-            enable={{
-              top: false,
-              right: true,
-              bottom: false,
-              topRight: false,
-              bottomRight: false,
-              bottomLeft: false,
-              topLeft: false,
-            }}
-            className='resizableFlexColumnCanvasCode'
-            style={{
-              ...UtopiaStyles.flexColumn,
-              display: interfaceDesigner.codePaneVisible ? 'flex' : 'none',
-              width: interfaceDesigner.codePaneWidth,
-              height: '100%',
-              position: 'relative',
-              overflow: 'hidden',
-              justifyContent: 'stretch',
-              alignItems: 'stretch',
-              borderLeft: `1px solid ${colorTheme.subduedBorder.value}`,
-            }}
-          >
-            {when(codeEditorEnabled, <CodeEditorWrapper />)}
-            <ConsoleAndErrorsPane />
-          </Resizable>
-        </SimpleFlexColumn>
-
         {
           <SimpleFlexColumn
             style={{
@@ -205,6 +145,7 @@ const DesignPanelRootInner = React.memo(() => {
               position: 'relative',
             }}
           >
+            <CodeEditorPane />
             <LeftPaneComponent />
             <CanvasWrapperComponent />
             <FloatingInsertMenu />
@@ -319,6 +260,77 @@ const ResizableRightPane = React.memo(() => {
           {selectedTab === RightMenuTab.Inspector && <InspectorEntryPoint />}
         </SimpleFlexRow>
         <CanvasStrategyInspector />
+      </Resizable>
+    </div>
+  )
+})
+
+const CodeEditorPane = React.memo(() => {
+  const colorTheme = useColorTheme()
+  const dispatch = useDispatch()
+  const interfaceDesigner = useEditorState(
+    Substores.restOfEditor,
+    (store) => store.editor.interfaceDesigner,
+    'CodeEditorPane interfaceDesigner',
+  )
+
+  const codeEditorEnabled = isCodeEditorEnabled()
+  const onResizeStop = React.useCallback(
+    (
+      event: MouseEvent | TouchEvent,
+      direction: ResizeDirection,
+      elementRef: HTMLElement,
+      delta: NumberSize,
+    ) => {
+      dispatch([EditorActions.resizeInterfaceDesignerCodePane(delta.width)])
+    },
+    [dispatch],
+  )
+
+  return (
+    <div
+      style={{
+        height: 'calc(100% - 20px)',
+        position: 'absolute',
+        margin: 10,
+        zIndex: 1,
+      }}
+    >
+      <Resizable
+        defaultSize={{
+          width: interfaceDesigner.codePaneWidth,
+          height: '100%',
+        }}
+        size={{
+          width: interfaceDesigner.codePaneWidth,
+          height: '100%',
+        }}
+        onResizeStop={onResizeStop}
+        enable={{
+          top: false,
+          right: true,
+          bottom: false,
+          topRight: false,
+          bottomRight: false,
+          bottomLeft: false,
+          topLeft: false,
+        }}
+        className='resizableFlexColumnCanvasCode'
+        style={{
+          ...UtopiaStyles.flexColumn,
+          display: interfaceDesigner.codePaneVisible ? 'flex' : 'none',
+          width: interfaceDesigner.codePaneWidth,
+          height: '100%',
+          position: 'relative',
+          overflow: 'hidden',
+          justifyContent: 'stretch',
+          alignItems: 'stretch',
+          borderRadius: UtopiaTheme.panelStyles.panelBorderRadius,
+          boxShadow: `3px 4px 10px 0px ${UtopiaTheme.panelStyles.panelShadowColor}`,
+        }}
+      >
+        {when(codeEditorEnabled, <CodeEditorWrapper />)}
+        <ConsoleAndErrorsPane />
       </Resizable>
     </div>
   )

--- a/editor/src/components/navigator/left-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/index.tsx
@@ -88,10 +88,19 @@ export const LeftPaneComponent = React.memo(() => {
     [setLeftPanelWidth],
   )
 
+  const codeEditorWidth = useEditorState(
+    Substores.restOfEditor,
+    (store) =>
+      store.editor.interfaceDesigner.codePaneVisible
+        ? store.editor.interfaceDesigner.codePaneWidth
+        : 0,
+    'LeftPaneComponent interfaceDesigner',
+  )
+
   const leftMenuExpanded = useEditorState(
     Substores.restOfEditor,
     (store) => store.editor.leftMenu.expanded,
-    'EditorComponentInner leftMenuExpanded',
+    'LeftPaneComponent leftMenuExpanded',
   )
 
   if (!leftMenuExpanded) {
@@ -105,7 +114,7 @@ export const LeftPaneComponent = React.memo(() => {
           height: 'calc(100% - 20px)',
           position: 'absolute',
           top: 0,
-          left: 0,
+          left: codeEditorWidth + 10,
           zIndex: 1,
           margin: 10,
         }}

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -667,7 +667,6 @@ interface EditorCanvasProps {
   builtinDependencies: BuiltInDependencies
   dispatch: EditorDispatch
   updateCanvasSize: (newValueOrUpdater: Size | ((oldValue: Size) => Size)) => void
-  navigatorWidth: number
 }
 
 export class EditorCanvas extends React.Component<EditorCanvasProps> {


### PR DESCRIPTION
**Fix:**
Code editor is now in a floating panel too. This is needed before I start the draggable grid layout.

**Commit Details:**
- created a new component `CodeEditorPane`
- update canvas-toolbar and left pane position based on the code editor size
