### PR TITLE
Show guidelines for group children

### DIFF
--- a/editor/src/components/canvas/controls/guideline-controls.tsx
+++ b/editor/src/components/canvas/controls/guideline-controls.tsx
@@ -24,6 +24,7 @@ import { mapDropNulls } from '../../../core/shared/array-utils'
 import { assertNever } from '../../../core/shared/utils'
 import type { CanvasSubstate } from '../../editor/store/store-hook-substore-types'
 import { FLEX_RESIZE_STRATEGY_ID } from '../canvas-strategies/strategies/flex-resize-strategy'
+import { treatElementAsGroupLike } from '../canvas-strategies/strategies/group-helpers'
 
 // STRATEGY GUIDELINE CONTROLS
 export const GuidelineControls = React.memo(() => {
@@ -41,7 +42,10 @@ export const GuidelineControls = React.memo(() => {
           if (measuredFrame == null || isInfinityRectangle(measuredFrame)) {
             return false
           } else {
-            return rectanglesEqual(measuredFrame, frame)
+            return (
+              rectanglesEqual(measuredFrame, frame) ||
+              treatElementAsGroupLike(store.editor.jsxMetadata, target)
+            )
           }
         })
       )


### PR DESCRIPTION
Fixes #4076 

**Problem:**

Group children don't show snap guidelines reliably.

![Kapture 2023-08-10 at 13 12 20](https://github.com/concrete-utopia/utopia/assets/1081051/c5a05a42-c668-40cf-abc2-0ff15c53db9f)


**Fix:**

Make it so, by skipping groups from the move validity checks that ensure the move is successful (because their frame changes constantly due to the trueing up).

![Kapture 2023-08-10 at 13 12 46](https://github.com/concrete-utopia/utopia/assets/1081051/f3ba916a-50c0-4e3b-8ff5-0c0f6a56298f)
