### PR TITLE
Update history with changes to selected views.

### DIFF
--- a/editor/src/components/editor/history.ts
+++ b/editor/src/components/editor/history.ts
@@ -164,6 +164,21 @@ export function replaceLast(
   return newHistory
 }
 
+export function replaceLastWithUpdate(
+  stateHistory: StateHistory,
+  updateEditor: (editorState: EditorState) => EditorState,
+): StateHistory {
+  const newHistory: StateHistory = {
+    previous: stateHistory.previous,
+    current: {
+      ...stateHistory.current,
+      editor: updateEditor(stateHistory.current.editor),
+    },
+    next: stateHistory.next,
+  }
+  return newHistory
+}
+
 export function init(editor: EditorState, derived: DerivedState): StateHistory {
   return {
     previous: [],

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -3550,12 +3550,6 @@ describe('Undo behavior in inspector', () => {
       fireEvent.keyUp(opacityControl, { key: 'z', keyCode: 90, metaKey: true })
     })
 
-    expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([]) // selection is reset to the previous selection (no elements selected)
-
-    await act(async () => {
-      await renderResult.dispatch([selectComponents([targetPath], false)], false)
-    })
-
     // the control's value should now be undone
     matchInlineSnapshotBrowser(
       ((await renderResult.renderedDOM.findByTestId('opacity-number-input')) as HTMLInputElement)


### PR DESCRIPTION
**Problem:**
Selection bug with undo. Start with one group child selected, then select the group, then change the size twice in the inspector. double undo after two group size changes also change the selection to what was previously selected.

**Cause:**
The selection does not trigger updates to the undo history unless accompanied with actions that do trigger updates to the undo history.

**Fix:**
Now changes that wouldn't otherwise update the history but do update selection, will update the selection into the history.

**Commit Details:**
- Added `replaceLastWithUpdate` utility function to permit general updates to the editor state that is "current" in the undo history.
- `editorDispatchClosingOut` now triggers an update to the selected views using `replaceLastWithUpdate` if the change would otherwise not update the history.