### PR TITLE
Don't set absolute position when grouping elements with hug

### DIFF
--- a/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
+++ b/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
@@ -242,25 +242,19 @@ function getUpdateResizedGroupChildrenCommands(
   let commandsToRun: Array<CanvasCommand> = []
   let updatedElements: Array<ElementPath> = []
 
-  Object.entries(updatedLocalFrames)
-    .filter(([path]) => {
-      return canPushIntendedBoundsForElement(
-        EP.fromString(path),
-        editor.jsxMetadata,
-        command.mode,
-        ['resize'],
-      )
-    })
-    .forEach(([pathStr, frameAndTarget]) => {
-      const elementToUpdate = EP.fromString(pathStr)
-      const metadata = MetadataUtils.findElementByElementPath(editor.jsxMetadata, elementToUpdate)
+  Object.entries(updatedLocalFrames).forEach(([pathStr, frameAndTarget]) => {
+    const elementToUpdate = EP.fromString(pathStr)
+    const metadata = MetadataUtils.findElementByElementPath(editor.jsxMetadata, elementToUpdate)
 
-      if (frameAndTarget == null || metadata == null) {
-        return
-      }
+    if (frameAndTarget == null || metadata == null) {
+      return
+    }
 
-      updatedElements.push(elementToUpdate)
+    updatedElements.push(elementToUpdate)
 
+    if (
+      canPushIntendedBoundsForElement(elementToUpdate, editor.jsxMetadata, command.mode, ['resize'])
+    ) {
       commandsToRun.push(
         ...setElementPins(
           elementToUpdate,
@@ -269,7 +263,8 @@ function getUpdateResizedGroupChildrenCommands(
           metadata.specialSizeMeasurements.parentFlexDirection,
         ),
       )
-    })
+    }
+  })
 
   const updatedEditor = foldAndApplyCommandsSimple(editor, commandsToRun)
   return {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3939,7 +3939,7 @@ export const UPDATE_FNS = {
       }
     }, targetsToTrueUp)
     const editorWithGroupsTruedUp = foldAndApplyCommandsSimple(editor, [
-      pushIntendedBoundsAndUpdateGroups(canvasFrameAndTargets, 'live-metadata', 'resize'),
+      pushIntendedBoundsAndUpdateGroups(canvasFrameAndTargets, 'live-metadata', 'wrap'),
     ])
     return { ...editorWithGroupsTruedUp, trueUpGroupsForElementAfterDomWalkerRuns: [] }
   },


### PR DESCRIPTION
Fixes #4079 

**Problem:**

Grouping text elements with hug contents sets their w/h to a fixed number.

**Fix:**

Do the calculations for the group sizing during the true up for the new `wrap` mode, but skip them during the pin updates if having hug contents.