### PR TITLE
fix(canvas) when the panels are closed there should be no extra padding

### DIFF
--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -105,7 +105,7 @@ export const CanvasWrapperComponent = React.memo(() => {
 
   const leftPanelWidthAtom = usePubSubAtomReadOnly(LeftPanelWidthAtom, AlwaysTrue)
   const leftPanelWidth = React.useMemo(
-    () => (isNavigatorOverCanvas ? leftPanelWidthAtom : 0),
+    () => (isNavigatorOverCanvas ? leftPanelWidthAtom + 10 : 0),
     [leftPanelWidthAtom, isNavigatorOverCanvas],
   )
 
@@ -113,7 +113,7 @@ export const CanvasWrapperComponent = React.memo(() => {
     Substores.restOfEditor,
     (store) =>
       store.editor.interfaceDesigner.codePaneVisible
-        ? store.editor.interfaceDesigner.codePaneWidth
+        ? store.editor.interfaceDesigner.codePaneWidth + 10
         : 0,
     'CanvasWrapperComponent codeEditorWidth',
   )
@@ -165,7 +165,7 @@ export const CanvasWrapperComponent = React.memo(() => {
           height: '100%',
           transform: 'translateZ(0)', // to keep this from tarnishing canvas render performance, we force it to a new layer
           pointerEvents: 'none', // you need to re-enable pointerevents for the various overlays
-          left: leftPanelWidth + codeEditorWidth + 20, // padding
+          left: leftPanelWidth + codeEditorWidth,
         }}
       >
         <FlexRow

--- a/editor/src/components/navigator/left-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/index.tsx
@@ -92,7 +92,7 @@ export const LeftPaneComponent = React.memo(() => {
     Substores.restOfEditor,
     (store) =>
       store.editor.interfaceDesigner.codePaneVisible
-        ? store.editor.interfaceDesigner.codePaneWidth
+        ? store.editor.interfaceDesigner.codePaneWidth + 10
         : 0,
     'LeftPaneComponent interfaceDesigner',
   )
@@ -114,7 +114,7 @@ export const LeftPaneComponent = React.memo(() => {
           height: 'calc(100% - 20px)',
           position: 'absolute',
           top: 0,
-          left: codeEditorWidth + 10,
+          left: codeEditorWidth,
           zIndex: 1,
           margin: 10,
         }}


### PR DESCRIPTION
**Problem:**
When the code editor and left pane are closed there is an extra gap on the left side of the canvas-toolbar. Same problem when only the code editor is closed for the left pane.

**Fix:**
Only add extra paddings when the panels are open.

**Commit Details:**
- fix left pane
- fix canvas toolbar wrapper
