### PR TITLE
fix(code-editor) add background color to container div

### DIFF
--- a/editor/src/components/code-editor/vscode-editor-loading-screen.tsx
+++ b/editor/src/components/code-editor/vscode-editor-loading-screen.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Global, css } from '@emotion/react'
 import { Substores, useEditorState } from '../editor/store/store-hook'
-import { colorTheme } from '../../uuiui'
+import { useColorTheme } from '../../uuiui'
 
 const SampleCode = [
   {
@@ -91,6 +91,7 @@ export const VSCodeLoadingScreen = React.memo((): React.ReactElement | null => {
     (store) => store.editor.vscodeLoadingScreenVisible,
     'VSCodeIframeContainer',
   )
+  const colorTheme = useColorTheme()
   if (!vscodeLoadingScreenVisible) {
     return null
   }
@@ -103,6 +104,7 @@ export const VSCodeLoadingScreen = React.memo((): React.ReactElement | null => {
         display: 'flex',
         flexDirection: 'column',
         fontFamily: '-apple-system, system-ui, sans-serif',
+        backgroundColor: colorTheme.inspectorBackground.value,
       }}
       id={VSCodeLoadingScreenID}
     >


### PR DESCRIPTION
**Problem:**
The code editor loading screen has a transparent background, the canvas elements are visible while the code editor loads.

**Fix:**
Add background color to loading screen container div

**Commit Details:**
- set backgroundColor to the usual floating panel color 
