### PR TITLE
Unify offsets calculations and fix offsets for scroll-to and arrows

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2216,3 +2216,16 @@ export function shouldShowErrorOverlay(
 ): boolean {
   return errorRecords.length > 0 || overlayErrors.length > 0
 }
+
+export function canvasPanelOffsets(): {
+  left: number
+  right: number
+} {
+  const inspector = document.getElementById('inspector-root')
+  const codeEditor = document.getElementById('vscode-editor')
+  const leftPane = document.getElementById('left-pane')
+  return {
+    left: (codeEditor?.clientWidth ?? 0) + (leftPane?.clientWidth ?? 0),
+    right: inspector?.clientWidth ?? 0,
+  }
+}

--- a/editor/src/components/canvas/controls/elements-outside-visible-area-hooks.tsx
+++ b/editor/src/components/canvas/controls/elements-outside-visible-area-hooks.tsx
@@ -20,6 +20,7 @@ import { canvasPointToWindowPoint } from '../dom-lookup'
 import { useAtom } from 'jotai'
 import { InspectorWidthAtom } from '../../inspector/common/inspector-atoms'
 import { UtopiaTheme } from '../../../uuiui'
+import { canvasPanelOffsets } from '../canvas-utils'
 
 export const ElementOutisdeVisibleAreaIndicatorSize = 22 // px
 const minClusterDistance = 17 // px
@@ -64,17 +65,8 @@ export function useElementsOutsideVisibleArea(
     (store) => store.editor.canvas.roundedCanvasOffset,
     'useElementsOutsideVisibleArea canvasOffset',
   )
-  const leftMenuWidth = useEditorState(
-    Substores.restOfEditor,
-    (store) => (store.editor.leftMenu.expanded ? store.editor.leftMenu.paneWidth : 0),
-    'useElementsOutsideVisibleArea leftMenuWidth',
-  )
-  const [atomInspectorWidth] = useAtom(InspectorWidthAtom)
-  const inspectorWidth = React.useMemo(() => {
-    return atomInspectorWidth === 'regular'
-      ? UtopiaTheme.layout.inspectorSmallWidth
-      : UtopiaTheme.layout.inspectorLargeWidth
-  }, [atomInspectorWidth])
+
+  const panelOffsets = canvasPanelOffsets()
 
   const elements = React.useMemo(() => {
     return uniqBy([...localSelectedViews, ...localHighlightedViews], EP.pathsEqual)
@@ -103,10 +95,10 @@ export function useElementsOutsideVisibleArea(
     return windowRectangle({
       x: bounds.x * scaleRatio,
       y: bounds.y * scaleRatio,
-      width: bounds.width * scaleRatio - leftMenuWidth - (inspectorWidth + 20),
+      width: bounds.width * scaleRatio - panelOffsets.left - (panelOffsets.right + 20),
       height: bounds.height * scaleRatio,
     })
-  }, [bounds, leftMenuWidth, canvasScale, inspectorWidth])
+  }, [bounds, panelOffsets, canvasScale])
 
   const scaledCanvasAreaCenter = React.useMemo(() => {
     if (scaledCanvasArea == null) {
@@ -125,7 +117,7 @@ export function useElementsOutsideVisibleArea(
         return null
       }
 
-      const topLeftSkew = windowPoint({ x: -leftMenuWidth, y: 0 })
+      const topLeftSkew = windowPoint({ x: -panelOffsets.left, y: 0 })
       const topLeftPoint = offsetPoint(
         canvasPointToWindowPoint(frame, canvasScale, canvasOffset),
         topLeftSkew,
@@ -148,7 +140,7 @@ export function useElementsOutsideVisibleArea(
         directions: directions,
       }
     }, elements)
-  }, [elements, canvasOffset, canvasScale, scaledCanvasArea, framesByPathString, leftMenuWidth])
+  }, [elements, canvasOffset, canvasScale, scaledCanvasArea, framesByPathString, panelOffsets])
 
   return React.useMemo((): ElementOutsideVisibleAreaIndicator[] => {
     if (
@@ -178,7 +170,7 @@ export function useElementsOutsideVisibleArea(
           ),
           directions,
           scaledCanvasArea,
-          leftMenuWidth,
+          panelOffsets.left,
           windowRectangle(canvasToolbar),
         ),
       }
@@ -199,7 +191,7 @@ export function useElementsOutsideVisibleArea(
     elementsOutsideVisibleArea,
     scaledCanvasArea,
     scaledCanvasAreaCenter,
-    leftMenuWidth,
+    panelOffsets,
     bounds,
     canvasToolbar,
   ])

--- a/editor/src/components/canvas/controls/elements-outside-visible-area-hooks.tsx
+++ b/editor/src/components/canvas/controls/elements-outside-visible-area-hooks.tsx
@@ -27,7 +27,7 @@ const minClusterDistance = 17 // px
 const topBarHeight = 40 // px
 const canvasToolbarSkew = topBarHeight + ElementOutisdeVisibleAreaIndicatorSize
 
-type ElementOutsideVisibleAreaDirection = 'top' | 'left' | 'bottom' | 'right'
+export type ElementOutsideVisibleAreaDirection = 'top' | 'left' | 'bottom' | 'right'
 
 type ElementOutsideVisibleArea = {
   path: ElementPath

--- a/editor/src/components/canvas/controls/elements-outside-visible.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/elements-outside-visible.spec.browser2.tsx
@@ -5,18 +5,15 @@ import { keyDown, mouseClickAtPoint, mouseDragFromPointToPoint } from '../event-
 import type { EditorRenderResult } from '../ui-jsx.test-utils'
 import { makeTestProjectCodeWithSnippet, renderTestEditorWithCode } from '../ui-jsx.test-utils'
 import { CanvasControlsContainerID } from './new-canvas-controls'
+import type { ElementOutsideVisibleAreaDirection } from './elements-outside-visible-area-hooks'
 import { getIndicatorId } from './elements-outside-visible-area-hooks'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import {
-  getRectCenter,
-  isFiniteRectangle,
-  offsetPoint,
-  windowPoint,
-  windowRectangle,
-} from '../../../core/shared/math-utils'
+import { getRectCenter, isFiniteRectangle, windowRectangle } from '../../../core/shared/math-utils'
 import { canvasPointToWindowPoint } from '../dom-lookup'
 import { DefaultNavigatorWidth } from '../../editor/store/editor-state'
+import { parseCSSNumber } from '../../inspector/common/css-utils'
+import { isRight } from '../../../core/shared/either'
 
 async function panCanvas(
   x: number,
@@ -57,6 +54,20 @@ async function selectAndPan(
 const farAway = 99999999 // px
 
 describe('elements outside visible area', () => {
+  function indicatorPoints(targetPath: ElementPath, sides: ElementOutsideVisibleAreaDirection[]) {
+    const indicator = screen.queryByTestId(getIndicatorId(targetPath, sides))
+    if (indicator == null) {
+      return null
+    }
+    function cssValueOrNull(s: string) {
+      const got = parseCSSNumber(s, 'Px')
+      return isRight(got) ? got.value.value : null
+    }
+    return {
+      top: cssValueOrNull(indicator.style.top),
+      left: cssValueOrNull(indicator.style.left),
+    }
+  }
   describe('single element', () => {
     it('shows the indicator on the left side', async () => {
       const renderResult = await renderTestEditorWithCode(
@@ -78,10 +89,10 @@ describe('elements outside visible area', () => {
 
       await selectAndPan(renderResult, [targetPath], -farAway, 0)
 
-      const indicator = screen.queryByTestId(getIndicatorId(targetPath, ['left']))
-      expect(indicator).not.toBeNull()
-      expect(indicator?.style.top).toBe('182px')
-      expect(indicator?.style.left).toBe('363px')
+      const points = indicatorPoints(targetPath, ['left'])
+      expect(points).not.toBeNull()
+      expect(points?.top).toBeGreaterThan(180)
+      expect(points?.left).toBeGreaterThan(300)
     })
     it('shows the indicator on the right side', async () => {
       const renderResult = await renderTestEditorWithCode(
@@ -103,10 +114,10 @@ describe('elements outside visible area', () => {
 
       await selectAndPan(renderResult, [targetPath], farAway, 0)
 
-      const indicator = screen.queryByTestId(getIndicatorId(targetPath, ['right']))
-      expect(indicator).not.toBeNull()
-      expect(indicator?.style.top).toBe('182px')
-      expect(indicator?.style.left).toBe('1900px')
+      const points = indicatorPoints(targetPath, ['right'])
+      expect(points).not.toBeNull()
+      expect(points?.top).toBeGreaterThan(180)
+      expect(points?.left).toBeGreaterThan(1500)
     })
     it('shows the indicator on the top side', async () => {
       const renderResult = await renderTestEditorWithCode(
@@ -128,10 +139,10 @@ describe('elements outside visible area', () => {
 
       await selectAndPan(renderResult, [targetPath], 0, -farAway)
 
-      const indicator = screen.queryByTestId(getIndicatorId(targetPath, ['top']))
-      expect(indicator).not.toBeNull()
-      expect(indicator?.style.top).toBe('0px')
-      expect(indicator?.style.left).toMatch('493px')
+      const points = indicatorPoints(targetPath, ['top'])
+      expect(points).not.toBeNull()
+      expect(points?.top).toEqual(0)
+      expect(points?.left).toBeGreaterThan(400)
     })
     it('shows the indicator on the bottom side', async () => {
       const renderResult = await renderTestEditorWithCode(
@@ -153,10 +164,10 @@ describe('elements outside visible area', () => {
 
       await selectAndPan(renderResult, [targetPath], 0, farAway)
 
-      const indicator = screen.queryByTestId(getIndicatorId(targetPath, ['bottom']))
-      expect(indicator).not.toBeNull()
-      expect(indicator?.style.top).toBe('936px')
-      expect(indicator?.style.left).toMatch('493px')
+      const points = indicatorPoints(targetPath, ['bottom'])
+      expect(points).not.toBeNull()
+      expect(points?.top).toBeGreaterThan(900)
+      expect(points?.left).toBeGreaterThan(450)
     })
     it('shows the indicator on the top-left side', async () => {
       const renderResult = await renderTestEditorWithCode(
@@ -178,10 +189,10 @@ describe('elements outside visible area', () => {
 
       await selectAndPan(renderResult, [targetPath], -farAway, -farAway)
 
-      const indicator = screen.queryByTestId(getIndicatorId(targetPath, ['top', 'left']))
-      expect(indicator).not.toBeNull()
-      expect(indicator?.style.top).toBe('0px')
-      expect(indicator?.style.left).toMatch('363px')
+      const points = indicatorPoints(targetPath, ['top', 'left'])
+      expect(points).not.toBeNull()
+      expect(points?.top).toEqual(0)
+      expect(points?.left).toBeGreaterThan(300)
     })
     it('shows the indicator on the top-right side', async () => {
       const renderResult = await renderTestEditorWithCode(
@@ -202,11 +213,10 @@ describe('elements outside visible area', () => {
       expect(screen.queryByTestId(getIndicatorId(targetPath, ['top', 'right']))).toBeNull()
 
       await selectAndPan(renderResult, [targetPath], farAway, -farAway)
-
-      const indicator = screen.queryByTestId(getIndicatorId(targetPath, ['top', 'right']))
-      expect(indicator).not.toBeNull()
-      expect(indicator?.style.top).toBe('0px')
-      expect(indicator?.style.left).toMatch('1900px')
+      const points = indicatorPoints(targetPath, ['top', 'right'])
+      expect(points).not.toBeNull()
+      expect(points?.top).toEqual(0)
+      expect(points?.left).toBeGreaterThan(1500)
     })
     it('shows the indicator on the bottom-left side', async () => {
       const renderResult = await renderTestEditorWithCode(
@@ -228,10 +238,10 @@ describe('elements outside visible area', () => {
 
       await selectAndPan(renderResult, [targetPath], -farAway, farAway)
 
-      const indicator = screen.queryByTestId(getIndicatorId(targetPath, ['bottom', 'left']))
-      expect(indicator).not.toBeNull()
-      expect(indicator?.style.top).toBe('936px')
-      expect(indicator?.style.left).toMatch('282px')
+      const points = indicatorPoints(targetPath, ['bottom', 'left'])
+      expect(points).not.toBeNull()
+      expect(points?.top).toBeGreaterThan(900)
+      expect(points?.left).toBeGreaterThan(250)
     })
     it('shows the indicator on the bottom-right side', async () => {
       const renderResult = await renderTestEditorWithCode(
@@ -253,10 +263,10 @@ describe('elements outside visible area', () => {
 
       await selectAndPan(renderResult, [targetPath], farAway, farAway)
 
-      const indicator = screen.queryByTestId(getIndicatorId(targetPath, ['bottom', 'right']))
-      expect(indicator).not.toBeNull()
-      expect(indicator?.style.top).toBe('936px')
-      expect(indicator?.style.left).toMatch('1900px')
+      const points = indicatorPoints(targetPath, ['bottom', 'right'])
+      expect(points).not.toBeNull()
+      expect(points?.top).toBeGreaterThan(900)
+      expect(points?.left).toBeGreaterThan(1500)
     })
   })
   describe('multiple elements', () => {
@@ -287,20 +297,21 @@ describe('elements outside visible area', () => {
 
       const foo = EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:container/foo')
       const bar = EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:container/bar')
-      expect(screen.queryByTestId(getIndicatorId(foo, ['top']))).toBeNull()
-      expect(screen.queryByTestId(getIndicatorId(bar, ['left']))).toBeNull()
+
+      expect(indicatorPoints(foo, ['top'])).toBeNull()
+      expect(indicatorPoints(bar, ['left'])).toBeNull()
 
       await selectAndPan(renderResult, [foo, bar], -250, -300)
 
-      const indicatorFoo = screen.queryByTestId(getIndicatorId(foo, ['top']))
-      expect(indicatorFoo).not.toBeNull()
-      expect(indicatorFoo?.style.top).toBe('0px')
-      expect(indicatorFoo?.style.left).toMatch('443px')
+      const pointsFoo = indicatorPoints(foo, ['top'])
+      expect(pointsFoo).not.toBeNull()
+      expect(pointsFoo?.top).toEqual(0)
+      expect(pointsFoo?.left).toBeGreaterThan(400)
 
-      const indicatorBar = screen.queryByTestId(getIndicatorId(bar, ['left']))
-      expect(indicatorBar).not.toBeNull()
-      expect(indicatorBar?.style.top).toBe('82px')
-      expect(indicatorBar?.style.left).toMatch('363px')
+      const pointsBar = indicatorPoints(bar, ['left'])
+      expect(pointsBar).not.toBeNull()
+      expect(pointsBar?.top).toBeGreaterThan(50)
+      expect(pointsBar?.left).toBeGreaterThan(300)
     })
     it('shows a single indicator for clustered elements', async () => {
       const renderResult = await renderTestEditorWithCode(
@@ -329,14 +340,15 @@ describe('elements outside visible area', () => {
 
       const foo = EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:container/foo')
       const bar = EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:container/bar')
-      expect(screen.queryByTestId(getIndicatorId(foo, ['top']))).toBeNull()
-      expect(screen.queryByTestId(getIndicatorId(bar, ['left']))).toBeNull()
+
+      expect(indicatorPoints(foo, ['top'])).toBeNull()
+      expect(indicatorPoints(bar, ['left'])).toBeNull()
       expect(screen.queryByTestId(getIndicatorId(bar, ['top', 'left']) + '-cluster-2')).toBeNull()
 
       await selectAndPan(renderResult, [foo, bar], -farAway, -farAway)
 
-      expect(screen.queryByTestId(getIndicatorId(foo, ['top']))).toBeNull()
-      expect(screen.queryByTestId(getIndicatorId(bar, ['left']))).toBeNull()
+      expect(indicatorPoints(foo, ['top'])).toBeNull()
+      expect(indicatorPoints(bar, ['left'])).toBeNull()
 
       const indicator = screen.queryByTestId(getIndicatorId(foo, ['top', 'left']) + '-cluster-2')
       expect(indicator).not.toBeNull()
@@ -361,7 +373,7 @@ describe('elements outside visible area', () => {
       )
 
       const targetPath = EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity:foo')
-      expect(screen.queryByTestId(getIndicatorId(targetPath, ['left']))).toBeNull()
+      expect(indicatorPoints(targetPath, ['top'])).toBeNull()
 
       await selectAndPan(renderResult, [targetPath], -farAway, 0)
 

--- a/editor/src/components/canvas/controls/elements-outside-visible.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/elements-outside-visible.spec.browser2.tsx
@@ -54,8 +54,12 @@ async function selectAndPan(
 const farAway = 99999999 // px
 
 describe('elements outside visible area', () => {
-  function indicatorPoints(targetPath: ElementPath, sides: ElementOutsideVisibleAreaDirection[]) {
-    const indicator = screen.queryByTestId(getIndicatorId(targetPath, sides))
+  function indicatorPoints(
+    targetPath: ElementPath,
+    sides: ElementOutsideVisibleAreaDirection[],
+    suffix: string = '',
+  ) {
+    const indicator = screen.queryByTestId(getIndicatorId(targetPath, sides) + suffix)
     if (indicator == null) {
       return null
     }
@@ -350,10 +354,10 @@ describe('elements outside visible area', () => {
       expect(indicatorPoints(foo, ['top'])).toBeNull()
       expect(indicatorPoints(bar, ['left'])).toBeNull()
 
-      const indicator = screen.queryByTestId(getIndicatorId(foo, ['top', 'left']) + '-cluster-2')
-      expect(indicator).not.toBeNull()
-      expect(indicator?.style.top).toBe('0px')
-      expect(indicator?.style.left).toMatch('363px')
+      const points = indicatorPoints(foo, ['top', 'left'], '-cluster-2')
+      expect(points).not.toBeNull()
+      expect(points?.top).toEqual(0)
+      expect(points?.left).toBeGreaterThan(300)
     })
   })
   describe('scroll', () => {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -187,6 +187,7 @@ import {
 import type { CanvasFrameAndTarget, PinOrFlexFrameChange } from '../../canvas/canvas-types'
 import { pinSizeChange } from '../../canvas/canvas-types'
 import {
+  canvasPanelOffsets,
   duplicate,
   getFrameChange,
   moveTemplate,
@@ -4557,18 +4558,16 @@ export const UPDATE_FNS = {
       editor.jsxMetadata,
     )
     if (targetElementCoords != null && isFiniteRectangle(targetElementCoords)) {
-      const isNavigatorOnTop = !editor.navigator.minimised
+      const isLeftMenuOpen = editor.leftMenu.expanded
       const containerRootDiv = document.getElementById('canvas-root')
-      const inspector = document.getElementById('inspector-root')
-      const navigatorOffset = isNavigatorOnTop ? DefaultNavigatorWidth : 0
-      const inspectorOffset = editor.inspector.visible ? inspector?.clientWidth ?? 0 : 0
+      const panelOffsets = canvasPanelOffsets()
       const scale = 1 / editor.canvas.scale
 
       // This returns the offset used as the fallback for the other behaviours when the container bounds are not defined.
       // It will effectively scroll to the element by positioning it at the origin (TL) of the
       // canvas, based on the BaseCanvasOffset value(s).
       function canvasOffsetToOrigin(frame: CanvasRectangle): CanvasVector {
-        const baseCanvasOffset = isNavigatorOnTop ? BaseCanvasOffsetLeftPane : BaseCanvasOffset
+        const baseCanvasOffset = isLeftMenuOpen ? BaseCanvasOffsetLeftPane : BaseCanvasOffset
         const target = canvasPoint({
           x: baseCanvasOffset.x * scale,
           y: baseCanvasOffset.y * scale,
@@ -4596,8 +4595,8 @@ export const UPDATE_FNS = {
             canvasCenter.x -
             frame.width / 2 -
             bounds.x +
-            (navigatorOffset / 2) * scale -
-            (inspectorOffset / 2) * scale,
+            (panelOffsets.left / 2) * scale -
+            (panelOffsets.right / 2) * scale,
           y: canvasCenter.y - frame.height / 2 - bounds.y,
         })
         return Utils.pointDifference(frame, topLeftTarget)
@@ -4611,7 +4610,7 @@ export const UPDATE_FNS = {
           return canvasOffsetToOrigin(frame) // fallback default
         }
         const containerRectangle = {
-          x: navigatorOffset - editor.canvas.realCanvasOffset.x,
+          x: panelOffsets.left - editor.canvas.realCanvasOffset.x,
           y: -editor.canvas.realCanvasOffset.y,
           width: bounds.width,
           height: bounds.height,


### PR DESCRIPTION
Fixes #4085 

**Problem:**

The recent changes to the editor layouts broke the offset calculations used by the scroll-to action and the arrow indicators, which were done based on a mix of state and DOM queries.

**Fix:**

Use a unified helper function to calculate the panel offsets, so if we change something in the layouts we can automatically adjust those calculations in a single place instead of having to hunt for them.