### PR TITLE
Allow max-content w/h for all group children (not just text elements)

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/group-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-helpers.ts
@@ -187,7 +187,7 @@ function getLayoutPropVerbatim(props: PropsOrJSXAttributes, pin: AbsolutePin): E
 }
 
 function elementHasValidPins(jsxElement: JSXElement): boolean {
-  function isHugPinForTextElement(pin: AbsolutePin): boolean {
+  function isMaxContentWidthOrHeight(pin: AbsolutePin): boolean {
     if (pin !== 'width' && pin !== 'height') {
       return false
     }
@@ -201,7 +201,7 @@ function elementHasValidPins(jsxElement: JSXElement): boolean {
     const prop = getLayoutProperty(pin, right(jsxElement.props), styleStringInArray)
     const isNumericPin = isRight(prop) && prop.value != null
 
-    return isNumericPin || isHugPinForTextElement(pin)
+    return isNumericPin || isMaxContentWidthOrHeight(pin)
   }
 
   return (

--- a/editor/src/components/canvas/canvas-strategies/strategies/group-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-helpers.ts
@@ -191,12 +191,8 @@ function elementHasValidPins(jsxElement: JSXElement): boolean {
     if (pin !== 'width' && pin !== 'height') {
       return false
     }
-    const isTextElement =
-      jsxElement.children.length > 0 &&
-      jsxElement.children.every((child) => child.type === 'JSX_TEXT_BLOCK')
-    if (!isTextElement) {
-      return false
-    }
+
+    // max-content (hug) is fine
     const verbatimProp = getLayoutPropVerbatim(right(jsxElement.props), pin)
     return isRight(verbatimProp) && verbatimProp.value === MaxContent
   }


### PR DESCRIPTION
Fixes #4087 

This PR extends the validity of max-content for width/height of group children to all elements, not just text elements.