### PR TITLE
Slider control guards against additional onAfterChange triggers.

### DIFF
--- a/editor/src/components/inspector/controls/slider-control.tsx
+++ b/editor/src/components/inspector/controls/slider-control.tsx
@@ -28,7 +28,9 @@ export const SliderControl: React.FunctionComponent<React.PropsWithChildren<Slid
   const [isSliding, setIsSliding] = React.useState(false)
   const [slidingValue, setSlidingValue] = React.useState(0)
 
+  const withinChange = React.useRef(false)
   const handleBeforeChange = React.useCallback(() => {
+    withinChange.current = true
     setIsSliding(true)
     if (onDragStart != null) {
       onDragStart()
@@ -48,10 +50,15 @@ export const SliderControl: React.FunctionComponent<React.PropsWithChildren<Slid
   const onChangeFn = props.onForcedSubmitValue ?? props.onSubmitValue
   const handleOnAfterChange = React.useCallback(
     (n: number) => {
-      onChangeFn(n)
-      setIsSliding(false)
-      if (onDragEnd != null) {
-        onDragEnd()
+      // Prevents any additional triggered onAfterChange calls without a matching
+      // onBeforeChange from being actioned.
+      if (withinChange.current) {
+        withinChange.current = false
+        onChangeFn(n)
+        setIsSliding(false)
+        if (onDragEnd != null) {
+          onDragEnd()
+        }
       }
     },
     [onChangeFn, onDragEnd],


### PR DESCRIPTION
**Problem:**
After changing opacity for an element via the inspector, selecting another element causes another undo entry to be added to the history.

**Cause:**
After the selection changes, the underlying rc-slider control fires its `onBlur` event handler, which in turn fires the `onAfterChange` event handler in our wrapper. Which updates the newly selected element with its current opacity value via the `SET_PROP` action. That in turn necessitates an addition to the undo history.

The key problem here is that it seems that `onBlur` is firing with some unusual timing as everything has shifted underneath it.

**Fix:**
Now we only allow the `onAfterChange` event handler from being fired if a `onBeforeChange` handler has fired prior to it, otherwise it is ignored.

**Commit Details:**
- Added check to `handleOnAfterChange` so that if an additional `onAfterChange` is fired without a matching `onBeforeChange` happening prior to that it's ignored.
