### PR TITLE
Fit and fill mandate a single selected element.

### DIFF
--- a/editor/src/components/inspector/resize-to-fit-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/resize-to-fit-control.spec.browser2.tsx
@@ -166,6 +166,28 @@ describe('Resize to fit control', () => {
     expect(view.style.flexBasis).toEqual('')
   })
   describe('for groups', () => {
+    describe('targeting multiple elements', () => {
+      it('resize to fit is disabled', async () => {
+        const editor = await renderTestEditorWithCode(projectWithGroup, 'await-first-dom-report')
+        await selectComponentsForTest(editor, [
+          EP.fromString(`storyboard/scene/group/child-1`),
+          EP.fromString(`storyboard/scene/group/child-2`),
+        ])
+        await expectNoAction(editor, async () => {
+          await clickResizeTo(editor, ResizeToFitControlTestId)
+        })
+      })
+      it('resize to fill is disabled', async () => {
+        const editor = await renderTestEditorWithCode(projectWithGroup, 'await-first-dom-report')
+        await selectComponentsForTest(editor, [
+          EP.fromString(`storyboard/scene/group/child-1`),
+          EP.fromString(`storyboard/scene/group/child-2`),
+        ])
+        await expectNoAction(editor, async () => {
+          await clickResizeTo(editor, ResizeToFillControlTestId)
+        })
+      })
+    })
     describe('targeting children of groups that are not groups themselves', () => {
       it('resize to fit works as usual', async () => {
         const editor = await renderTestEditorWithCode(projectWithGroup, 'await-first-dom-report')

--- a/editor/src/components/inspector/resize-to-fit-control.tsx
+++ b/editor/src/components/inspector/resize-to-fit-control.tsx
@@ -82,15 +82,21 @@ export const ResizeToFitControl = React.memo<ResizeToFitControlProps>(() => {
   const allElementPropsRef = useRefEditorState((store) => store.editor.allElementProps)
   const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
 
+  const onlyOneElementSelected = useEditorState(
+    Substores.selectedViews,
+    (store) => store.editor.selectedViews.length === 1,
+    'ResizeToFitControl onlyOneElementSelected',
+  )
+
   const isHugApplicable = useEditorState(
     Substores.metadata,
-    (store) => isApplicableSelector(store, 'hug'),
+    (store) => onlyOneElementSelected && isApplicableSelector(store, 'hug'),
     'ResizeToFitControl isHugApplicable',
   )
 
   const isFillApplicable = useEditorState(
     Substores.metadata,
-    (store) => isApplicableSelector(store, 'fill'),
+    (store) => onlyOneElementSelected && isApplicableSelector(store, 'fill'),
     'ResizeToFitControl isHugApplicable',
   )
 


### PR DESCRIPTION
**Problem:**
The fit and fill buttons in the inspector only check the first element for validity but apply their changes to everything.

**Fix:**
Disable fit and fill if anything other than one item is selected.

**Commit Details:**
- Added `onlyOneElementSelected` value to `ResizeToFitControl`.
- `isHugApplicable` and `isFillApplicable` now depend on `onlyOneElementSelected`.
