### PR TITLE
Fixing the width of a text container, rounds up.

### DIFF
--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
@@ -151,7 +151,7 @@ export function convertLayoutToFlexCommands(
       ...setPropertyOmitNullProp('always', path, PP.create('style', 'alignItems'), alignItems),
       ...childrenPaths.flatMap((child) => [
         ...nukeAllAbsolutePositioningPropsCommands(child),
-        ...sizeToVisualDimensions(metadata, child),
+        ...sizeToVisualDimensions(metadata, elementPathTree, child),
       ]),
       ...rearrangeCommands,
     ]

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -967,7 +967,11 @@ export function handleKeyDown(
               ...nukeAllAbsolutePositioningPropsCommands(elementPath),
               ...(isIntrinsicallyInlineElement(element)
                 ? [
-                    ...sizeToVisualDimensions(editor.jsxMetadata, elementPath),
+                    ...sizeToVisualDimensions(
+                      editor.jsxMetadata,
+                      editor.elementPathTree,
+                      elementPath,
+                    ),
                     setProperty(
                       'always',
                       elementPath,
@@ -979,7 +983,7 @@ export function handleKeyDown(
             ]
           } else {
             return [
-              ...sizeToVisualDimensions(editor.jsxMetadata, elementPath),
+              ...sizeToVisualDimensions(editor.jsxMetadata, editor.elementPathTree, elementPath),
               ...addPositionAbsoluteTopLeft(editor.jsxMetadata, elementPath),
             ]
           }

--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -41,6 +41,8 @@ import { UIGridRow } from './widgets/ui-grid-row'
 import { PropertyLabel } from './widgets/property-label'
 import { useContextSelector } from 'use-context-selector'
 import { InspectorPropsContext, stylePropPathMappingFn } from './common/property-path-hooks'
+import { safeIndex } from '../../core/shared/array-utils'
+import { fixedSizeDimensionHandlingText } from '../text-editor/text-handling'
 
 export const FillFixedHugControlId = (segment: 'width' | 'height'): string =>
   `hug-fixed-fill-${segment}`
@@ -209,20 +211,32 @@ export const FillHugFixedControl = React.memo<FillHugFixedControlProps>((props) 
             ? fillsContainerVerticallyRef.current
             : fillsContainerHorizontallyRef.current
 
-        const strategy = strategyForChangingFillFixedHugType(
-          currentComputedValue,
-          axis,
-          value,
-          otherAxisSetToFill,
-        )
-        executeFirstApplicableStrategy(
-          dispatch,
-          metadataRef.current,
-          selectedViewsRef.current,
-          elementPathTreeRef.current,
-          allElementPropsRef.current,
-          strategy,
-        )
+        const firstSelectedView = safeIndex(selectedViewsRef.current, 0)
+        if (firstSelectedView != null) {
+          const valueToUse =
+            axis === 'horizontal'
+              ? fixedSizeDimensionHandlingText(
+                  metadataRef.current,
+                  elementPathTreeRef.current,
+                  firstSelectedView,
+                  currentComputedValue,
+                )
+              : currentComputedValue
+          const strategy = strategyForChangingFillFixedHugType(
+            valueToUse,
+            axis,
+            value,
+            otherAxisSetToFill,
+          )
+          executeFirstApplicableStrategy(
+            dispatch,
+            metadataRef.current,
+            selectedViewsRef.current,
+            elementPathTreeRef.current,
+            allElementPropsRef.current,
+            strategy,
+          )
+        }
       }
 
     return {

--- a/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
@@ -1501,7 +1501,7 @@ describe('Fixed / Fill / Hug control', () => {
 
         const text = editor.renderedDOM.getByTestId('text')
 
-        expect(text.style.width).toEqual('58.5px')
+        expect(text.style.width).toEqual('59px')
       }
 
       {

--- a/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
@@ -1501,7 +1501,7 @@ describe('Fixed / Fill / Hug control', () => {
 
         const text = editor.renderedDOM.getByTestId('text')
 
-        expect(text.style.width).toEqual('59px')
+        expect(text.style.width).toEqual('58.5px')
       }
 
       {

--- a/editor/src/components/inspector/inspector-strategies/hug-contents-basic-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/hug-contents-basic-strategy.ts
@@ -69,7 +69,7 @@ function hugContentsSingleElement(
       return []
     }
     return [
-      ...sizeToVisualDimensions(metadata, child),
+      ...sizeToVisualDimensions(metadata, pathTrees, child),
       showToastCommand('Children converted to fixed size', 'INFO', CHILDREN_CONVERTED_TOAST_ID),
     ]
   })

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.ts
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.ts
@@ -114,7 +114,7 @@ export const updateFlexDirectionStrategies = (
         setProperty('always', path, PP.create('style', 'flexDirection'), flexDirection),
         ...MetadataUtils.getChildrenPathsOrdered(metadata, pathTrees, path).flatMap((child) => [
           ...pruneFlexPropsCommands(flexChildProps, child),
-          ...sizeToVisualDimensions(metadata, child),
+          ...sizeToVisualDimensions(metadata, pathTrees, child),
         ]),
       ])
     },

--- a/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.ts
@@ -29,9 +29,9 @@ function removeFlexConvertToAbsoluteOne(
   return [
     ...pruneFlexPropsCommands(flexContainerProps, elementPath), // flex-related stuff is pruned
     ...children.flatMap((c) => addPositionAbsoluteTopLeft(metadata, c)), // all children are converted to absolute,
-    ...children.flatMap((c) => sizeToVisualDimensions(metadata, c)), // with width/height based on measured dimensions
+    ...children.flatMap((c) => sizeToVisualDimensions(metadata, pathTrees, c)), // with width/height based on measured dimensions
     ...children.flatMap((c) => pruneFlexPropsCommands(flexChildProps, c)),
-    ...sizeToVisualDimensions(metadata, elementPath), // container is sized to keep its visual dimensions
+    ...sizeToVisualDimensions(metadata, pathTrees, elementPath), // container is sized to keep its visual dimensions
   ]
 }
 

--- a/editor/src/components/text-editor/text-handling.ts
+++ b/editor/src/components/text-editor/text-handling.ts
@@ -6,6 +6,7 @@ import {
 } from '../editor/store/editor-state'
 import * as EP from '../../core/shared/element-path'
 import type {
+  ElementInstanceMetadataMap,
   JSExpression,
   JSXAttributes,
   JSXElementChild,
@@ -22,6 +23,9 @@ import { jsxSimpleAttributeToValue } from '../../core/shared/jsx-attributes'
 import { foldEither } from '../../core/shared/either'
 import fastDeepEquals from 'fast-deep-equal'
 import { getUtopiaID } from '../../core/shared/uid-utils'
+import type { ElementPathTrees } from '../../core/shared/element-path-tree'
+import { MetadataUtils } from '../../core/model/element-metadata-utils'
+import { roundUpToNearestHalf } from '../../core/shared/math-utils'
 
 // Validate this by making the type `Set<keyof CSSProperties>`.
 export const stylePropertiesEligibleForMerge: Set<string> = new Set([
@@ -257,4 +261,15 @@ export function collapseTextElements(target: ElementPath, editor: EditorState): 
 
   // Fallback case.
   return editor
+}
+
+export function fixedSizeDimensionHandlingText(
+  metadata: ElementInstanceMetadataMap,
+  pathTrees: ElementPathTrees,
+  elementPath: ElementPath,
+  dimensionValue: number,
+): number {
+  // Fixed dimensions for a text containing element need to be rounded up to prevent wrapping.
+  const containsText = MetadataUtils.targetTextEditableAndHasText(metadata, pathTrees, elementPath)
+  return containsText ? roundUpToNearestHalf(dimensionValue) : dimensionValue
 }

--- a/editor/src/core/shared/math-utils.spec.ts
+++ b/editor/src/core/shared/math-utils.spec.ts
@@ -1,4 +1,4 @@
-import { wrapValue } from './math-utils'
+import { roundUpToNearestHalf, wrapValue } from './math-utils'
 
 describe('math utils', () => {
   describe('wrapValue', () => {
@@ -20,5 +20,27 @@ describe('math utils', () => {
       expect(wrapValue(-11, -7, -3)).toEqual(-6)
       expect(wrapValue(-2, -7, -3)).toEqual(-7)
     })
+  })
+  describe('roundUpToNearestHalf', () => {
+    const testValues: Array<[number, number]> = [
+      [-1000, -1000],
+      [-1000.1, -1000],
+      [-999.9, -999.5],
+      [-1, -1],
+      [-1.4, -1],
+      [-0.9, -0.5],
+      [-0.1, -0],
+      [0.1, 0.5],
+      [0.4, 0.5],
+      [0.5, 0.5],
+      [0.999, 1],
+      [9.1, 9.5],
+      [9.9, 10],
+    ]
+    for (const [inputValue, expectedResult] of testValues) {
+      it(`With ${inputValue} as an input, should return ${expectedResult}`, () => {
+        expect(roundUpToNearestHalf(inputValue)).toEqual(expectedResult)
+      })
+    }
   })
 })

--- a/editor/src/core/shared/math-utils.ts
+++ b/editor/src/core/shared/math-utils.ts
@@ -893,6 +893,10 @@ export function roundTo(number: number, digits: number = 0): number {
   return Math.round(n) / multiplicator
 }
 
+export function roundUpToNearestHalf(numberToRound: number): number {
+  return Math.ceil(numberToRound * 2) / 2
+}
+
 export function roundToNearestHalf(n: number): number {
   return Math.round(n * 2) / 2
 }


### PR DESCRIPTION
**Problem:**
Fixing the width (only not the height it would appear) of an element containing text sometimes can cause the text to end up wrapping or being cut off by a tiny amount.

**Fix:**
Now the width is rounded up to the nearest half when setting the dimension to be fixed rather than hugging the contents.

**Commit Details:**
- Added `roundUpToNearestHalf` utility function.
- Implemented `fixedSizeDimensionHandlingText`, which rounds up the dimension size to the nearest half if the element contains text.
- `sizeToVisualDimensions` now uses `fixedSizeDimensionHandlingText` for the width.
- Deleted `sizeToVisualDimensionsAlongAxis` as it is unused.
- `FillHugFixedControl` uses `fixedSizeDimensionHandlingText` for the width of the target.