### PR TITLE
Disable "Fill container" for group elements

### DIFF
--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -281,7 +281,9 @@ export const hugContentsApplicableForText = (
 export const fillContainerApplicable = (
   metadata: ElementInstanceMetadataMap,
   elementPath: ElementPath,
-): boolean => !EP.isStoryboardChild(elementPath)
+): boolean => {
+  return !EP.isStoryboardChild(elementPath) && !treatElementAsGroupLike(metadata, elementPath)
+}
 
 export function justifyContentAlignItemsEquals(
   flexDirection: FlexDirection,


### PR DESCRIPTION
Fixes #4102 

**Problem:**

`Fill container` is not applicable to groups, as they are always `Hug Contents`.

**Fix:**
Expand `fillContainerApplicable` so it interprets groups as non-applicable.