### PR TITLE
Fix resizing groups with no T/L/TL

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -16,13 +16,8 @@ import {
 import CanvasActions from '../../canvas-actions'
 import { createInteractionViaMouse, updateInteractionViaMouse } from '../interaction-state'
 import type { CanvasVector } from '../../../../core/shared/math-utils'
-import {
-  canvasPoint,
-  windowPoint,
-  WindowPoint,
-  zeroCanvasPoint,
-} from '../../../../core/shared/math-utils'
-import { emptyModifiers, Modifiers, shiftModifier } from '../../../../utils/modifiers'
+import { canvasPoint, windowPoint, zeroCanvasPoint } from '../../../../core/shared/math-utils'
+import { emptyModifiers, shiftModifier } from '../../../../utils/modifiers'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
 import type { EdgePosition } from '../../canvas-types'
 import {
@@ -1448,6 +1443,128 @@ export var storyboard = (
           })
         })
       })
+    })
+  })
+  describe('groups', () => {
+    it('resizes groups correctly when dragging from top/left without existing left/top props (left)', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        formatTestProjectCode(`
+          import * as React from 'react'
+          import { Storyboard, Group } from 'utopia-api'
+
+          export var storyboard = (
+            <Storyboard data-uid='storyboard'>
+              <Group data-uid='group' style={{ position: 'absolute', width: 150, height: 150, background: 'black' }}>
+                <div data-uid='foo' style={{ position:'absolute', width: 50, height: 50, background: 'red', top: 0, left: 0 }} />
+                <div data-uid='bar' style={{ position:'absolute', width: 50, height: 50, background: 'blue', top: 100, left: 100 }} />
+              </Group>
+            </Storyboard>
+          )
+        `),
+        'await-first-dom-report',
+      )
+
+      const target = EP.fromString('storyboard/group')
+
+      await renderResult.dispatch([selectComponents([target], false)], true)
+
+      await resizeElement(renderResult, { x: -200, y: 0 }, EdgePositionLeft, emptyModifiers)
+
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        formatTestProjectCode(`
+          import * as React from 'react'
+          import { Storyboard, Group } from 'utopia-api'
+
+          export var storyboard = (
+            <Storyboard data-uid='storyboard'>
+              <Group data-uid='group' style={{ position: 'absolute', width: 350, height: 150, background: 'black', left: -200 }}>
+                <div data-uid='foo' style={{ position:'absolute', width: 117, height: 50, background: 'red', top: 0, left: 0 }} />
+                <div data-uid='bar' style={{ position:'absolute', width: 117, height: 50, background: 'blue', top: 100, left: 233 }} />
+              </Group>
+            </Storyboard>
+          )
+        `),
+      )
+    })
+    it('resizes groups correctly when dragging from top/left without existing left/top props (top)', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        formatTestProjectCode(`
+          import * as React from 'react'
+          import { Storyboard, Group } from 'utopia-api'
+
+          export var storyboard = (
+            <Storyboard data-uid='storyboard'>
+              <Group data-uid='group' style={{ position: 'absolute', width: 150, height: 150, background: 'black' }}>
+                <div data-uid='foo' style={{ position:'absolute', width: 50, height: 50, background: 'red', top: 0, left: 0 }} />
+                <div data-uid='bar' style={{ position:'absolute', width: 50, height: 50, background: 'blue', top: 100, left: 100 }} />
+              </Group>
+            </Storyboard>
+          )
+        `),
+        'await-first-dom-report',
+      )
+
+      const target = EP.fromString('storyboard/group')
+
+      await renderResult.dispatch([selectComponents([target], false)], true)
+
+      await resizeElement(renderResult, { x: 0, y: -200 }, EdgePositionTop, emptyModifiers)
+
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        formatTestProjectCode(`
+          import * as React from 'react'
+          import { Storyboard, Group } from 'utopia-api'
+
+          export var storyboard = (
+            <Storyboard data-uid='storyboard'>
+              <Group data-uid='group' style={{ position: 'absolute', width: 150, height: 350, background: 'black', top: -200 }}>
+                <div data-uid='foo' style={{ position:'absolute', width: 50, height: 117, background: 'red', top: 0, left: 0 }} />
+                <div data-uid='bar' style={{ position:'absolute', width: 50, height: 117, background: 'blue', top: 233, left: 100 }} />
+              </Group>
+            </Storyboard>
+          )
+        `),
+      )
+    })
+    it('resizes groups correctly when dragging from top/left without existing left/top props (top-left)', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        formatTestProjectCode(`
+          import * as React from 'react'
+          import { Storyboard, Group } from 'utopia-api'
+
+          export var storyboard = (
+            <Storyboard data-uid='storyboard'>
+              <Group data-uid='group' style={{ position: 'absolute', width: 150, height: 150, background: 'black' }}>
+                <div data-uid='foo' style={{ position:'absolute', width: 50, height: 50, background: 'red', top: 0, left: 0 }} />
+                <div data-uid='bar' style={{ position:'absolute', width: 50, height: 50, background: 'blue', top: 100, left: 100 }} />
+              </Group>
+            </Storyboard>
+          )
+        `),
+        'await-first-dom-report',
+      )
+
+      const target = EP.fromString('storyboard/group')
+
+      await renderResult.dispatch([selectComponents([target], false)], true)
+
+      await resizeElement(renderResult, { x: -100, y: -200 }, EdgePositionTopLeft, emptyModifiers)
+
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        formatTestProjectCode(`
+          import * as React from 'react'
+          import { Storyboard, Group } from 'utopia-api'
+
+          export var storyboard = (
+            <Storyboard data-uid='storyboard'>
+              <Group data-uid='group' style={{ position: 'absolute', width: 250, height: 350, background: 'black', left: -100, top: -200 }}>
+                <div data-uid='foo' style={{ position:'absolute', width: 83, height: 117, background: 'red', top: 0, left: 0 }} />
+                <div data-uid='bar' style={{ position:'absolute', width: 83, height: 117, background: 'blue', top: 233, left: 167 }} />
+              </Group>
+            </Storyboard>
+          )
+        `),
+      )
     })
   })
 })

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -41,7 +41,7 @@ import { flattenSelection, getMultiselectBounds } from './shared-move-strategies
 import { retargetStrategyToChildrenOfFragmentLikeElements } from './fragment-like-helpers'
 import type { ElementPathTrees } from '../../../../core/shared/element-path-tree'
 import { treatElementAsGroupLike } from './group-helpers'
-import type { EnsurePinsExist } from './resize-strategy-helpers'
+import type { EnsureFramePointsExist } from './resize-strategy-helpers'
 import { createResizeCommandsFromFrame } from './resize-strategy-helpers'
 import { isEdgePositionEqualTo } from '../../canvas-utils'
 
@@ -178,14 +178,14 @@ export function absoluteResizeBoundingBoxStrategy(
               const elementParentFlexDirection =
                 metadata?.specialSizeMeasurements.parentFlexDirection ?? null
 
-              const ensurePinsExist: EnsurePinsExist =
+              const ensureFramePointsExist: EnsureFramePointsExist =
                 !elementIsGroup ||
                 (isEdgePositionEqualTo(edgePosition, EdgePositionLeft) && originalFrame.x === 0) ||
                 (isEdgePositionEqualTo(edgePosition, EdgePositionTop) && originalFrame.y === 0) ||
                 (isEdgePositionEqualTo(edgePosition, EdgePositionTopLeft) &&
                   (originalFrame.x === 0 || originalFrame.y === 0))
-                  ? 'ensure-two-pins-per-dimension-exists'
-                  : 'only-offset-pins-are-needed'
+                  ? 'ensure-two-frame-points-per-dimension-exists'
+                  : 'only-offset-frame-points-are-needed'
 
               return [
                 ...createResizeCommandsFromFrame(
@@ -196,7 +196,7 @@ export function absoluteResizeBoundingBoxStrategy(
                   elementParentBounds,
                   elementParentFlexDirection,
                   edgePosition,
-                  ensurePinsExist,
+                  ensureFramePointsExist,
                 ),
                 pushIntendedBoundsAndUpdateGroups(
                   [{ target: selectedElement, frame: newFrame }],

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -1,42 +1,17 @@
-import { styleStringInArray } from '../../../../utils/common-constants'
-import { isHorizontalPoint } from 'utopia-api/core'
-import { getLayoutProperty } from '../../../../core/layout/getLayoutProperty'
-import { framePointForPinnedProp } from '../../../../core/layout/layout-helpers-new'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
-import { mapDropNulls } from '../../../../core/shared/array-utils'
-import { isRight, right } from '../../../../core/shared/either'
-import type {
-  ElementInstanceMetadataMap,
-  JSXElement,
-} from '../../../../core/shared/element-template'
-import type { CanvasRectangle, SimpleRectangle } from '../../../../core/shared/math-utils'
+import type { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
+import type { CanvasRectangle } from '../../../../core/shared/math-utils'
 import {
-  canvasRectangleToLocalRectangle,
   isInfinityRectangle,
-  rectangleDifference,
   roundRectangleToNearestWhole,
-  roundTo,
   transformFrameUsingBoundingBox,
 } from '../../../../core/shared/math-utils'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
 import type { AllElementProps } from '../../../editor/store/editor-state'
 import { getElementFromProjectContents } from '../../../editor/store/editor-state'
-import { stylePropPathMappingFn } from '../../../inspector/common/property-path-hooks'
 import type { EdgePosition } from '../../canvas-types'
-import type {
-  AdjustCssLengthProperties,
-  LengthPropertyToAdjust,
-} from '../../commands/adjust-css-length-command'
-import {
-  adjustCssLengthProperties,
-  lengthPropertyToAdjust,
-} from '../../commands/adjust-css-length-command'
+import { EdgePositionTop, EdgePositionLeft, EdgePositionTopLeft } from '../../canvas-types'
 import { pushIntendedBoundsAndUpdateGroups } from '../../commands/push-intended-bounds-and-update-groups-command'
-import type { SetCssLengthProperty } from '../../commands/set-css-length-command'
-import {
-  setCssLengthProperty,
-  setValueKeepingOriginalUnit,
-} from '../../commands/set-css-length-command'
 import { setCursorCommand } from '../../commands/set-cursor-command'
 import { setElementsToRerenderCommand } from '../../commands/set-elements-to-rerender-command'
 import { setSnappingGuidelines } from '../../commands/set-snapping-guidelines-command'
@@ -54,23 +29,21 @@ import {
   strategyApplicationResult,
 } from '../canvas-strategy-types'
 import type { InteractionSession } from '../interaction-state'
-import type { AbsolutePin } from './resize-helpers'
 import {
   isAnySelectedElementAspectRatioLocked,
-  ensureAtLeastTwoPinsForEdgePosition,
   getLockedAspectRatio,
   pickCursorFromEdgePosition,
   resizeBoundingBox,
   supportsAbsoluteResize,
-  onlyEnsureOffsetPinsExist,
 } from './resize-helpers'
 import { runLegacyAbsoluteResizeSnapping } from './shared-absolute-resize-strategy-helpers'
 import { flattenSelection, getMultiselectBounds } from './shared-move-strategies-helpers'
-import type { FlexDirection } from '../../../inspector/common/css-utils'
 import { retargetStrategyToChildrenOfFragmentLikeElements } from './fragment-like-helpers'
 import type { ElementPathTrees } from '../../../../core/shared/element-path-tree'
-import { allowGroupTrueUp, treatElementAsGroupLike } from './group-helpers'
+import { treatElementAsGroupLike } from './group-helpers'
+import type { EnsurePinsExist } from './resize-strategy-helpers'
 import { createResizeCommandsFromFrame } from './resize-strategy-helpers'
+import { isEdgePositionEqualTo } from '../../canvas-utils'
 
 export function absoluteResizeBoundingBoxStrategy(
   canvasState: InteractionCanvasState,
@@ -205,6 +178,15 @@ export function absoluteResizeBoundingBoxStrategy(
               const elementParentFlexDirection =
                 metadata?.specialSizeMeasurements.parentFlexDirection ?? null
 
+              const ensurePinsExist: EnsurePinsExist =
+                !elementIsGroup ||
+                (isEdgePositionEqualTo(edgePosition, EdgePositionLeft) && originalFrame.x === 0) ||
+                (isEdgePositionEqualTo(edgePosition, EdgePositionTop) && originalFrame.y === 0) ||
+                (isEdgePositionEqualTo(edgePosition, EdgePositionTopLeft) &&
+                  (originalFrame.x === 0 || originalFrame.y === 0))
+                  ? 'ensure-two-pins-per-dimension-exists'
+                  : 'only-offset-pins-are-needed'
+
               return [
                 ...createResizeCommandsFromFrame(
                   element,
@@ -214,9 +196,7 @@ export function absoluteResizeBoundingBoxStrategy(
                   elementParentBounds,
                   elementParentFlexDirection,
                   edgePosition,
-                  elementIsGroup
-                    ? 'only-offset-pins-are-needed'
-                    : 'ensure-two-pins-per-dimension-exists',
+                  ensurePinsExist,
                 ),
                 pushIntendedBoundsAndUpdateGroups(
                   [{ target: selectedElement, frame: newFrame }],

--- a/editor/src/components/canvas/canvas-strategies/strategies/resize-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/resize-strategy-helpers.ts
@@ -30,7 +30,9 @@ import {
 import type { AbsolutePin } from './resize-helpers'
 import { ensureAtLeastTwoPinsForEdgePosition, onlyEnsureOffsetPinsExist } from './resize-helpers'
 
-export type EnsurePinsExist = 'ensure-two-pins-per-dimension-exists' | 'only-offset-pins-are-needed'
+export type EnsureFramePointsExist =
+  | 'ensure-two-frame-points-per-dimension-exists'
+  | 'only-offset-frame-points-are-needed'
 
 export function createResizeCommandsFromFrame(
   element: JSXElement,
@@ -40,10 +42,10 @@ export function createResizeCommandsFromFrame(
   elementParentBounds: CanvasRectangle | null,
   elementParentFlexDirection: FlexDirection | null,
   edgePosition: EdgePosition,
-  ensurePinsExist: EnsurePinsExist,
+  ensureFramePointsExist: EnsureFramePointsExist,
 ): (AdjustCssLengthProperties | SetCssLengthProperty)[] {
   const pins: Array<AbsolutePin> =
-    ensurePinsExist === 'ensure-two-pins-per-dimension-exists'
+    ensureFramePointsExist === 'ensure-two-frame-points-per-dimension-exists'
       ? ensureAtLeastTwoPinsForEdgePosition(right(element.props), edgePosition)
       : onlyEnsureOffsetPinsExist(right(element.props), edgePosition)
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/resize-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/resize-strategy-helpers.ts
@@ -30,6 +30,8 @@ import {
 import type { AbsolutePin } from './resize-helpers'
 import { ensureAtLeastTwoPinsForEdgePosition, onlyEnsureOffsetPinsExist } from './resize-helpers'
 
+export type EnsurePinsExist = 'ensure-two-pins-per-dimension-exists' | 'only-offset-pins-are-needed'
+
 export function createResizeCommandsFromFrame(
   element: JSXElement,
   selectedElement: ElementPath,
@@ -38,7 +40,7 @@ export function createResizeCommandsFromFrame(
   elementParentBounds: CanvasRectangle | null,
   elementParentFlexDirection: FlexDirection | null,
   edgePosition: EdgePosition,
-  ensurePinsExist: 'ensure-two-pins-per-dimension-exists' | 'only-offset-pins-are-needed',
+  ensurePinsExist: EnsurePinsExist,
 ): (AdjustCssLengthProperties | SetCssLengthProperty)[] {
   const pins: Array<AbsolutePin> =
     ensurePinsExist === 'ensure-two-pins-per-dimension-exists'

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -902,6 +902,10 @@ export function isEdgePositionOnSide(edgePosition: EdgePosition): boolean {
   return edgePosition.x === 0.5 || edgePosition.y === 0.5
 }
 
+export function isEdgePositionEqualTo(a: EdgePosition, b: EdgePosition): boolean {
+  return a.x === b.x && a.y === b.y
+}
+
 export const SnappingThreshold = 5
 
 export function collectGuidelines(


### PR DESCRIPTION
Fixes #4104 

**Problem:**

If a group has no left/top props and is resized from the left/top/top-left edge, it is expanded incorrectly.

https://github.com/concrete-utopia/utopia/assets/1081051/87b59474-39b6-4b8a-a18f-030d5e4f9e02

**Fix:**

Make sure to set missing pins if the target is either not a group _or_ it's a group, and the edge is T/L/TL _and_ the related prop is zero.

https://github.com/concrete-utopia/utopia/assets/1081051/70060324-234f-446b-94ee-012d02c66e20
