### PR TITLE
Add tests for static groups.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -66,7 +66,7 @@ import { FOR_TESTS_setNextGeneratedUids } from '../../../../core/model/element-t
 import { isRight } from '../../../../core/shared/either'
 import { ImmediateParentOutlinesTestId } from '../../controls/parent-outlines'
 import { ImmediateParentBoundsTestId } from '../../controls/parent-bounds'
-import { resizeElement } from './absolute-resize.test-utils'
+import { getResizeControl, resizeElement } from './absolute-resize.test-utils'
 
 // no mouseup here! it starts the interaction and resizes with drag delta
 async function startDragUsingActions(
@@ -629,15 +629,9 @@ describe('Absolute Resize Strategy', () => {
     )
 
     const target = EP.appendNewElementPath(TestScenePath, ['app2'])
-    const dragDelta = windowPoint({ x: 40, y: -25 })
 
     await renderResult.dispatch([selectComponents([target], false)], true)
-    await resizeElement(renderResult, dragDelta, EdgePositionBottomRight, emptyModifiers)
-
-    await renderResult.getDispatchFollowUpActionsFinished()
-    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
-      formatTestProjectCode(projectDoesNotHonourSizeProperties),
-    )
+    expect(getResizeControl(renderResult, EdgePositionBottomRight)).toBeNull()
   })
   it('resizes absolute positioned element from bottom right edge', async () => {
     const renderResult = await renderTestEditorWithCode(
@@ -1299,18 +1293,10 @@ export var storyboard = (
     )
 
     const target = EP.fromString('storyboard/scene/containing-div/does-not-support-style')
-    const dragDelta = windowPoint({ x: 25, y: 25 })
 
     await renderResult.dispatch([selectComponents([target], false)], true)
-    await resizeElement(renderResult, dragDelta, EdgePositionBottomRight, emptyModifiers)
-    await renderResult.getDispatchFollowUpActionsFinished()
-
-    const supportsStyleDiv = renderResult.renderedDOM.getByTestId(
-      'does-not-support-style-component',
-    )
-    const supportsStyleRect = supportsStyleDiv.getBoundingClientRect()
-    expect(supportsStyleRect.width).toEqual(100)
-    expect(supportsStyleRect.height).toEqual(100)
+    const resizeControl = getResizeControl(renderResult, EdgePositionBottomRight)
+    expect(resizeControl).toBeNull()
   })
   describe('snap lines', () => {
     it('horizontal snap lines are shown when resizing a multiselection', async () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize.test-utils.tsx
@@ -5,6 +5,14 @@ import type { EdgePosition } from '../../canvas-types'
 import { mouseDragFromPointWithDelta } from '../../event-helpers.test-utils'
 import type { EditorRenderResult } from '../../ui-jsx.test-utils'
 
+export function getResizeControl(
+  renderResult: EditorRenderResult,
+  edgePosition: EdgePosition,
+): HTMLElement | null {
+  const testIdOfControl = `resize-control-${edgePosition.x}-${edgePosition.y}`
+  return renderResult.renderedDOM.queryByTestId(testIdOfControl)
+}
+
 export async function resizeElement(
   renderResult: EditorRenderResult,
   dragDelta: Delta,
@@ -14,11 +22,9 @@ export async function resizeElement(
     midDragCallback?: () => Promise<void>
   } = {},
 ): Promise<void> {
-  const canvasControl = renderResult.renderedDOM.queryByTestId(
-    `resize-control-${edgePosition.x}-${edgePosition.y}`,
-  )
+  const canvasControl = getResizeControl(renderResult, edgePosition)
   if (canvasControl == null) {
-    return
+    throw new Error(`Could not find canvas control.`)
   }
 
   const resizeCornerBounds = canvasControl.getBoundingClientRect()


### PR DESCRIPTION
**Problem:**
Currently there are no/limited tests for static positioned groups.

**Fix:**
Add more tests for static positioned groups.

**Commit Details:**
- Added tests for not absolutely positioned groups and flex contained groups.
- Changed `resizeElement` to throw an exception if the control could not be found.
- Extracted out `getResizeControl` and used it in tests where the expectation is that controls will not be shown.