### PR TITLE
Support grouping conditionals

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
@@ -685,12 +685,17 @@ export function convertGroupToFrameCommands(
 
 export type GroupChildElement = JSXElementLike | JSXConditionalExpression
 
-function elementCanBeAGroupChild(element: JSXElementChild): element is GroupChildElement {
+export function elementCanBeAGroupChild(
+  element: JSXElementChild | null,
+): element is GroupChildElement {
+  if (element == null) {
+    return false
+  }
   return (
     isJSXElementLike(element) ||
     (isJSXConditionalExpression(element) &&
-      !isNullJSXAttributeValue(element.whenTrue) && // do not allow grouping zero-sized conditionals
-      !isNullJSXAttributeValue(element.whenFalse))
+      // do not allow grouping zero-sized conditionals
+      !(isNullJSXAttributeValue(element.whenTrue) && isNullJSXAttributeValue(element.whenFalse)))
   )
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/group-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-helpers.ts
@@ -15,6 +15,7 @@ import type {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
   JSXElement,
+  JSXElementChild,
   JSXElementChildren,
   JSXElementWithoutUID,
 } from '../../../../core/shared/element-template'
@@ -348,6 +349,20 @@ export function getGroupChildStateWithGroupMetadata(
     projectContents,
     elementMetadata,
     checkGroupHasExplicitSize(groupElement),
+  )
+}
+
+export function isMaybeGroupForWrapping(element: JSXElementChild, imports: Imports): boolean {
+  const group = groupJSXElement([])
+  const groupImports = groupJSXElementImportsToAdd()
+  return (
+    element.type === group.type &&
+    element.name.baseVariable === group.name.baseVariable &&
+    imports['utopia-api'] != null &&
+    imports['utopia-api'].importedFromWithin[0].name ===
+      groupImports['utopia-api'].importedFromWithin[0].name &&
+    imports['utopia-api'].importedFromWithin[0].alias ===
+      groupImports['utopia-api'].importedFromWithin[0].alias
   )
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/groups.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/groups.spec.browser2.tsx
@@ -782,6 +782,32 @@ describe('Groups behaviors', () => {
         expect(groupDiv.style.width).toBe('100px')
         expect(groupDiv.style.height).toBe('100px')
       })
+
+      it('group with conditionals', async () => {
+        const editor = await renderProjectWithGroup(`
+          <Group data-testid='group' style={{position: 'absolute', left: 50, top: 50}}>
+            <div
+              style={{
+                backgroundColor: 'red',
+                position: 'absolute',
+                bottom: 100,
+                right: 100,
+                width: 100,
+                height: 100,
+              }}
+            />
+            {
+              true ? (
+                <div style={{ position: 'absolute', left: 0, top: 0, width: 300, height: 300, background: 'blue' }} />
+              ) : null
+            }
+          </Group>
+        `)
+        const groupDiv = editor.renderedDOM.getByTestId('group')
+
+        expect(groupDiv.style.width).toBe('300px')
+        expect(groupDiv.style.height).toBe('300px')
+      })
     })
 
     describe('Group Resize', () => {

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -6740,37 +6740,127 @@ export var storyboard = (
         ),
       )
     })
-    it('Cannot wrap an empty group', async () => {
-      const testCode = `
+    describe('groups', () => {
+      it('cannot wrap an empty group', async () => {
+        const testCode = `
         <div data-uid='aaa'>
           <Group data-uid='group' />
         </div>
       `
-      const renderResult = await renderTestEditorWithCode(
-        makeTestProjectCodeWithSnippet(testCode),
-        'await-first-dom-report',
-      )
-      await renderResult.dispatch(
-        [
-          wrapInElement([makeTargetPath('aaa/group')], {
-            element: { ...groupJSXElement([]), uid: 'foo' },
-            importsToAdd: groupJSXElementImportsToAdd(),
-          }),
-        ],
-        true,
-      )
+        const renderResult = await renderTestEditorWithCode(
+          makeTestProjectCodeWithSnippet(testCode),
+          'await-first-dom-report',
+        )
+        await renderResult.dispatch(
+          [
+            wrapInElement([makeTargetPath('aaa/group')], {
+              element: { ...groupJSXElement([]), uid: 'foo' },
+              importsToAdd: groupJSXElementImportsToAdd(),
+            }),
+          ],
+          true,
+        )
 
-      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
-        makeTestProjectCodeWithSnippet(`
+        expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+          makeTestProjectCodeWithSnippet(`
           <div data-uid='aaa'>
             <Group data-uid='group' />
           </div>
         `),
-      )
-      expect(renderResult.getEditorState().editor.toasts.length).toEqual(1)
-      expect(renderResult.getEditorState().editor.toasts[0].message).toEqual(
-        'Empty Groups cannot be wrapped',
-      )
+        )
+        expect(renderResult.getEditorState().editor.toasts.length).toEqual(1)
+        expect(renderResult.getEditorState().editor.toasts[0].message).toEqual(
+          'Empty Groups cannot be wrapped',
+        )
+      })
+
+      it('can group conditionals', async () => {
+        const testCode = `
+          <div data-uid='aaa'>
+            <div data-uid='foo' style={{ position: 'absolute', width: 50, height: 50, top: 0, left: 0, background: 'red' }} />
+            {
+              // @utopia/uid=cond
+              true ? <div data-uid='bar' style={{ position: 'absolute', width: 50, height: 50, top: 0, left: 0, background: 'blue' }} /> : null
+            }
+          </div>
+        `
+        const renderResult = await renderTestEditorWithCode(
+          formatTestProjectCode(makeTestProjectCodeWithSnippet(testCode)),
+          'await-first-dom-report',
+        )
+        await renderResult.dispatch(
+          [
+            wrapInElement([makeTargetPath('aaa/foo'), makeTargetPath('aaa/cond')], {
+              element: { ...groupJSXElement([]), uid: 'grp' },
+              importsToAdd: groupJSXElementImportsToAdd(),
+            }),
+          ],
+          true,
+        )
+
+        expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+          formatTestProjectCode(
+            makeTestProjectCodeWithSnippet(`
+              <div data-uid='aaa'>
+                <Group
+                  style={{ position: 'absolute', left: 0, top: 0 }}
+                  data-uid='grp'
+                >
+                  <div data-uid='foo' style={{ position: 'absolute', width: 50, height: 50, top: 0, left: 0, background: 'red' }} />
+                  {
+                    // @utopia/uid=cond
+                    true ? <div data-uid='bar' style={{ position: 'absolute', width: 50, height: 50, top: 0, left: 0, background: 'blue' }} /> : null
+                  }
+                </Group>
+              </div>
+          `),
+          ),
+        )
+      })
+
+      it('cannot group empty conditionals', async () => {
+        const testCode = `
+          <div data-uid='aaa'>
+            <div data-uid='foo' style={{ position: 'absolute', width: 50, height: 50, top: 0, left: 0, background: 'red' }} />
+            {
+              // @utopia/uid=cond
+              true ? null : null
+            }
+          </div>
+        `
+        const renderResult = await renderTestEditorWithCode(
+          formatTestProjectCode(makeTestProjectCodeWithSnippet(testCode)),
+          'await-first-dom-report',
+        )
+        await renderResult.dispatch(
+          [
+            wrapInElement([makeTargetPath('aaa/foo'), makeTargetPath('aaa/cond')], {
+              element: { ...groupJSXElement([]), uid: 'grp' },
+              importsToAdd: groupJSXElementImportsToAdd(),
+            }),
+          ],
+          true,
+        )
+
+        expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+          formatTestProjectCode(
+            makeTestProjectCodeWithSnippet(`
+              <div data-uid='aaa'>
+                <div data-uid='foo' style={{ position: 'absolute', width: 50, height: 50, top: 0, left: 0, background: 'red' }} />
+                {
+                  // @utopia/uid=cond
+                  true ? null : null
+                }
+              </div>
+          `),
+          ),
+        )
+
+        expect(renderResult.getEditorState().editor.toasts.length).toEqual(1)
+        expect(renderResult.getEditorState().editor.toasts[0].message).toEqual(
+          'Empty conditionals cannot be wrapped in a Group',
+        )
+      })
     })
   })
   describe('SELECT_COMPONENTS', () => {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2404,6 +2404,7 @@ export const UPDATE_FNS = {
                   return foldAndApplyCommandsSimple(
                     result.editor,
                     createPinChangeCommandsForElementBecomingGroupChild(
+                      workingEditor.jsxMetadata,
                       child,
                       result.newPath,
                       parentFrame,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -592,12 +592,14 @@ import {
   groupStateFromJSXElement,
   invalidGroupStateToString,
   isEmptyGroup,
+  isMaybeGroupForWrapping,
   isInvalidGroupState,
   treatElementAsGroupLike,
 } from '../../canvas/canvas-strategies/strategies/group-helpers'
 import {
   createPinChangeCommandsForElementInsertedIntoGroup,
   createPinChangeCommandsForElementBecomingGroupChild,
+  elementCanBeAGroupChild,
 } from '../../canvas/canvas-strategies/strategies/group-conversion-helpers'
 import { reparentElement } from '../../canvas/commands/reparent-element-command'
 import { addElements } from '../../canvas/commands/add-elements-command'
@@ -2202,6 +2204,23 @@ export const UPDATE_FNS = {
         if (anyTargetIsAnEmptyGroup) {
           return UPDATE_FNS.ADD_TOAST(
             showToast(notice('Empty Groups cannot be wrapped', 'ERROR')),
+            editor,
+          )
+        }
+
+        if (
+          isMaybeGroupForWrapping(
+            action.whatToWrapWith.element,
+            action.whatToWrapWith.importsToAdd,
+          ) &&
+          orderedActionTargets.some((path) => {
+            return !elementCanBeAGroupChild(
+              MetadataUtils.getJsxElementChildFromMetadata(editor.jsxMetadata, path),
+            )
+          })
+        ) {
+          return UPDATE_FNS.ADD_TOAST(
+            showToast(notice('Empty conditionals cannot be wrapped in a Group', 'ERROR')),
             editor,
           )
         }


### PR DESCRIPTION
Fixes #4108 

**Problem:**

Trying to group conditional elements is not currently allowed.

**Fix:**

- Support wrapping conditionals with groups
- Support grouping conditionals with CMD+G
- Trim margins when grouping conditionals
- Explicitly don't allow grouping null conditionals (we can change this later on, when tackling zero-sized elements more specifically)