### PR TITLE
rename `getContentsTreeFileFromString` to `getProjectFileByFilePath`

### DIFF
--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -533,7 +533,7 @@ export function getContentsTreeFileFromElements(
   }
 }
 
-export function getContentsTreeFileFromString(
+export function getProjectFileByFilePath(
   tree: ProjectContentTreeRoot,
   path: string,
 ): ProjectFile | null {

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-multi-file.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-multi-file.spec.browser2.tsx
@@ -1,6 +1,6 @@
 import { act } from '@testing-library/react'
 import type { ProjectContentTreeRoot } from '../../../assets'
-import { contentsToTree, getContentsTreeFileFromString } from '../../../assets'
+import { contentsToTree, getProjectFileByFilePath } from '../../../assets'
 import * as EP from '../../../../core/shared/element-path'
 import { codeFile, isTextFile } from '../../../../core/shared/project-file-types'
 import { cmdModifier } from '../../../../utils/modifiers'
@@ -200,7 +200,7 @@ export var storyboard = (
 
 function getFileCode(renderResult: EditorRenderResult, filename: string): string {
   const projectContents = renderResult.getEditorState().editor.projectContents
-  const possibleFile = getContentsTreeFileFromString(projectContents, filename)
+  const possibleFile = getProjectFileByFilePath(projectContents, filename)
   if (possibleFile == null) {
     throw new Error(`Could not find file ${filename}.`)
   } else if (isTextFile(possibleFile)) {

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -154,7 +154,7 @@ import { getStoryboardElementPath, getStoryboardUID } from '../../core/model/sce
 import { forceNotNull, optionalMap } from '../../core/shared/optional-utils'
 import { assertNever, fastForEach } from '../../core/shared/utils'
 import type { ProjectContentTreeRoot } from '../assets'
-import { getContentsTreeFileFromString } from '../assets'
+import { getProjectFileByFilePath } from '../assets'
 import { getAllTargetsAtPointAABB } from './dom-lookup'
 import type { CSSNumber } from '../inspector/common/css-utils'
 import { parseCSSLengthPercent, printCSSNumber } from '../inspector/common/css-utils'
@@ -1914,7 +1914,7 @@ export function getParseSuccessForFilePath(
   filePath: string,
   projectContents: ProjectContentTreeRoot,
 ): GetParseSuccessResult {
-  const projectFile = getContentsTreeFileFromString(projectContents, filePath)
+  const projectFile = getProjectFileByFilePath(projectContents, filePath)
   if (
     projectFile != null &&
     isTextFile(projectFile) &&

--- a/editor/src/components/canvas/commands/delete-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/delete-element-command.spec.tsx
@@ -1,4 +1,4 @@
-import { getContentsTreeFileFromString } from '../../../components/assets'
+import { getProjectFileByFilePath } from '../../../components/assets'
 import { applyCommandsAction } from '../../../components/editor/actions/action-creators'
 import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
@@ -50,7 +50,7 @@ export var App = (props) => {
   return null
 }
 `)
-    const appFile = getContentsTreeFileFromString(
+    const appFile = getProjectFileByFilePath(
       renderResult.getEditorState().editor.projectContents,
       '/src/app.js',
     )

--- a/editor/src/components/canvas/commands/patch-utils.ts
+++ b/editor/src/components/canvas/commands/patch-utils.ts
@@ -2,7 +2,7 @@ import type { Spec } from 'immutability-helper'
 import { drop } from '../../../core/shared/array-utils'
 import type { ProjectContentsTree, ProjectContentTreeRoot } from '../../../components/assets'
 import {
-  getContentsTreeFileFromString,
+  getProjectFileByFilePath,
   getProjectContentKeyPathElements,
   ProjectContentFile,
 } from '../../../components/assets'
@@ -97,7 +97,7 @@ export function patchParseSuccessAtFilePath(
   editorState: EditorState,
   patchParseSuccess: (success: ParseSuccess) => Spec<ParsedTextFile> | null,
 ): Spec<EditorState> {
-  const projectFile = getContentsTreeFileFromString(editorState.projectContents, filePath)
+  const projectFile = getProjectFileByFilePath(editorState.projectContents, filePath)
   if (projectFile == null) {
     return {}
   } else {

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-code-execution.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-code-execution.spec.browser2.tsx
@@ -9,7 +9,7 @@ import {
 import { emptySet } from '../../../core/shared/set-utils'
 import { lintAndParse } from '../../../core/workers/parser-printer/parser-printer'
 import { createModifiedProject } from '../../../sample-projects/sample-project-utils.test-utils'
-import { getContentsTreeFileFromString } from '../../assets'
+import { getProjectFileByFilePath } from '../../assets'
 import { updateFile } from '../../editor/actions/action-creators'
 import { StoryboardFilePath } from '../../editor/store/editor-state'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
@@ -101,7 +101,7 @@ describe('Updating a transitive dependency', () => {
 
     const oldFile = forceNotNull(
       'Unexpectedly null.',
-      getContentsTreeFileFromString(getEditorState().editor.projectContents, indirectFilePath),
+      getProjectFileByFilePath(getEditorState().editor.projectContents, indirectFilePath),
     )
 
     const updatedIndirectFile = textFile(

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope.tsx
@@ -4,7 +4,7 @@ import type { UtopiaJSXComponent } from '../../../core/shared/element-template'
 import { ArbitraryJSBlock, isUtopiaJSXComponent } from '../../../core/shared/element-template'
 import { fastForEach } from '../../../core/shared/utils'
 import type { ProjectContentTreeRoot } from '../../assets'
-import { getContentsTreeFileFromString, ProjectContentsTree } from '../../assets'
+import { getProjectFileByFilePath, ProjectContentsTree } from '../../assets'
 import { importResultFromImports } from '../../editor/npm-dependency/npm-dependency'
 import type { CanvasBase64Blobs, UIFileBase64Blobs } from '../../editor/store/editor-state'
 import { TransientFilesState, TransientFileState } from '../../editor/store/editor-state'
@@ -187,7 +187,7 @@ export function getCodeAndHighlightBoundsForFile(
   code: string
   highlightBounds: HighlightBoundsForUids | null
 } {
-  const file = getContentsTreeFileFromString(projectContents, filePath)
+  const file = getProjectFileByFilePath(projectContents, filePath)
   if (file != null && isTextFile(file) && isParseSuccess(file.fileContents.parsed)) {
     return {
       code: file.fileContents.code,

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -68,7 +68,7 @@ import {
 import { unimportAllButTheseCSSFiles } from '../../core/webpack-loaders/css-loader'
 import { UTOPIA_INSTANCE_PATH } from '../../core/model/utopia-constants'
 import type { ProjectContentTreeRoot } from '../assets'
-import { getContentsTreeFileFromString } from '../assets'
+import { getProjectFileByFilePath } from '../assets'
 import { createExecutionScope } from './ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope'
 import { applyUIDMonkeyPatch } from '../../utils/canvas-react-utils'
 import { getParseSuccessForFilePath, getValidElementPaths } from './canvas-utils'
@@ -570,7 +570,7 @@ function attemptToResolveParsedComponents(
 ): Either<string, MapLike<any>> {
   return flatMapEither((resolvedFilePath) => {
     resolvedFromThisOrigin.push(toImport)
-    const projectFile = getContentsTreeFileFromString(projectContents, resolvedFilePath)
+    const projectFile = getProjectFileByFilePath(projectContents, resolvedFilePath)
     if (
       projectFile != null &&
       isTextFile(projectFile) &&

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -100,7 +100,7 @@ import type { PathAndFileEntry, ProjectContentTreeRoot } from '../assets'
 import {
   contentsToTree,
   contentsTreeOptic,
-  getContentsTreeFileFromString,
+  getProjectFileByFilePath,
   treeToContents,
 } from '../assets'
 import { testStaticElementPath } from '../../core/shared/element-path.test-utils'
@@ -663,7 +663,7 @@ export function getPrintedUiJsCode(
   store: EditorStorePatched,
   filePath: string = StoryboardFilePath,
 ): string {
-  const file = getContentsTreeFileFromString(store.editor.projectContents, filePath)
+  const file = getProjectFileByFilePath(store.editor.projectContents, filePath)
   if (file != null && isTextFile(file)) {
     return file.fileContents.code
   } else {
@@ -675,7 +675,7 @@ export function getPrintedUiJsCodeWithoutUIDs(
   store: EditorStorePatched,
   filePath: string = StoryboardFilePath,
 ): string {
-  const file = getContentsTreeFileFromString(store.editor.projectContents, filePath)
+  const file = getProjectFileByFilePath(store.editor.projectContents, filePath)
   if (file != null && isTextFile(file) && isParseSuccess(file.fileContents.parsed)) {
     return printCode(
       StoryboardFilePath,
@@ -847,7 +847,7 @@ export function editorStateToParseSuccess(
   editorState: EditorState,
   filePath: string = StoryboardFilePath,
 ): ParseSuccess {
-  const file = getContentsTreeFileFromString(editorState.projectContents, filePath)
+  const file = getProjectFileByFilePath(editorState.projectContents, filePath)
   if (file == null) {
     throw new Error(`Cannot find storyboard file.`)
   } else if (isTextFile(file)) {

--- a/editor/src/components/custom-code/code-file.test-utils.ts
+++ b/editor/src/components/custom-code/code-file.test-utils.ts
@@ -8,7 +8,7 @@ import {
 } from '../../core/shared/project-file-types'
 import { lintAndParse } from '../../core/workers/parser-printer/parser-printer'
 import type { ProjectContentTreeRoot } from '../assets'
-import { contentsToTree, getContentsTreeFileFromString, treeToContents } from '../assets'
+import { contentsToTree, getProjectFileByFilePath, treeToContents } from '../assets'
 import { StoryboardFilePath } from '../editor/store/editor-state'
 import { createComplexDefaultProjectContents } from '../../sample-projects/sample-project-utils'
 import { replaceAll } from '../../core/shared/string-utils'
@@ -66,7 +66,7 @@ export function defaultProjectContentsForNormalising(): ProjectContentTreeRoot {
 }
 
 export function getTextFileByPath(projectContents: ProjectContentTreeRoot, path: string): TextFile {
-  const possibleResult = getContentsTreeFileFromString(projectContents, path)
+  const possibleResult = getProjectFileByFilePath(projectContents, path)
   if (possibleResult != null && isTextFile(possibleResult)) {
     return possibleResult
   } else {

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -26,7 +26,7 @@ import { assertNever, fastForEach } from '../../core/shared/utils'
 import { arrayToObject } from '../../core/shared/array-utils'
 import { objectMap } from '../../core/shared/object-utils'
 import type { ProjectContentTreeRoot } from '../assets'
-import { getContentsTreeFileFromString, treeToContents } from '../assets'
+import { getProjectFileByFilePath, treeToContents } from '../assets'
 import type { Either } from '../../core/shared/either'
 import { isRight, left, right } from '../../core/shared/either'
 import * as EP from '../../core/shared/element-path'
@@ -213,7 +213,7 @@ export function incorporateBuildResult(
     if (modulesFile.transpiledCode == null) {
       delete nodeModules[moduleKey]
     } else {
-      const projectContentsFile = getContentsTreeFileFromString(projectContents, moduleKey)
+      const projectContentsFile = getProjectFileByFilePath(projectContents, moduleKey)
       const origin = projectContentsFile == null ? 'NODE_MODULES' : 'PROJECT_CONTENTS'
       nodeModules[moduleKey] = esCodeFile(modulesFile.transpiledCode, origin, moduleKey)
     }
@@ -223,7 +223,7 @@ export function incorporateBuildResult(
     const modulesFile = nodeModules[moduleKey]
     if (isEsCodeFile(modulesFile)) {
       if (modulesFile.origin === 'PROJECT_CONTENTS') {
-        const projectContentsFile = getContentsTreeFileFromString(projectContents, moduleKey)
+        const projectContentsFile = getProjectFileByFilePath(projectContents, moduleKey)
         if (projectContentsFile == null) {
           delete nodeModules[moduleKey]
         }
@@ -431,7 +431,7 @@ export function normalisePathToUnderlyingTarget(
   currentFilePath: string,
   elementPath: ElementPath | null,
 ): NormalisePathResult {
-  const currentFile = getContentsTreeFileFromString(projectContents, currentFilePath)
+  const currentFile = getProjectFileByFilePath(projectContents, currentFilePath)
   if (currentFile != null && isTextFile(currentFile)) {
     if (isParseSuccess(currentFile.fileContents.parsed)) {
       const staticPath = elementPath == null ? null : EP.dynamicPathToStaticPath(elementPath)
@@ -612,7 +612,7 @@ export function findUnderlyingTargetComponentImplementationFromImportInfo(
     importInfo.type === 'SAME_FILE_ORIGIN' ? importInfo.variableName : importInfo.exportedName
 
   // we have to find the element based on the top level name
-  const file = getContentsTreeFileFromString(projectContents, importInfo.filePath)
+  const file = getProjectFileByFilePath(projectContents, importInfo.filePath)
   const parsedContents = getParsedContentsFromTextFile(file)
   if (parsedContents == null) {
     return null

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -117,7 +117,7 @@ import { CURRENT_PROJECT_VERSION } from './migrations/migrations'
 import { generateCodeResultCache } from '../../custom-code/code-file'
 import {
   contentsToTree,
-  getContentsTreeFileFromString,
+  getProjectFileByFilePath,
   treeToContents,
   walkContentsTreeForParseSuccess,
 } from '../../assets'
@@ -276,7 +276,7 @@ describe('SET_PROP', () => {
       jsExpressionValue(100, emptyComments),
     )
     const newEditor = UPDATE_FNS.SET_PROP(action, testEditor)
-    const newUiJsFile = getContentsTreeFileFromString(
+    const newUiJsFile = getProjectFileByFilePath(
       newEditor.projectContents,
       StoryboardFilePath,
     ) as TextFile
@@ -315,7 +315,7 @@ describe('SET_CANVAS_FRAMES', () => {
       false,
     )
     const newEditor = UPDATE_FNS.SET_CANVAS_FRAMES(action, testEditor, derivedState)
-    const newUiJsFile = getContentsTreeFileFromString(
+    const newUiJsFile = getProjectFileByFilePath(
       newEditor.projectContents,
       StoryboardFilePath,
     ) as TextFile
@@ -451,7 +451,7 @@ xdescribe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = getContentsTreeFileFromString(
+    const newUiJsFile = getProjectFileByFilePath(
       newEditor.projectContents,
       StoryboardFilePath,
     ) as TextFile
@@ -496,7 +496,7 @@ xdescribe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = getContentsTreeFileFromString(newEditor.projectContents, StoryboardFilePath)
+    const newUiJsFile = getProjectFileByFilePath(newEditor.projectContents, StoryboardFilePath)
     if (newUiJsFile != null && isTextFile(newUiJsFile)) {
       if (isParseSuccess(newUiJsFile.fileContents.parsed)) {
         const newTopLevelElements = newUiJsFile.fileContents.parsed.topLevelElements
@@ -545,7 +545,7 @@ xdescribe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = getContentsTreeFileFromString(
+    const newUiJsFile = getProjectFileByFilePath(
       newEditor.projectContents,
       StoryboardFilePath,
     ) as TextFile
@@ -580,7 +580,7 @@ xdescribe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = getContentsTreeFileFromString(
+    const newUiJsFile = getProjectFileByFilePath(
       newEditor.projectContents,
       StoryboardFilePath,
     ) as TextFile
@@ -614,7 +614,7 @@ xdescribe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = getContentsTreeFileFromString(
+    const newUiJsFile = getProjectFileByFilePath(
       newEditor.projectContents,
       StoryboardFilePath,
     ) as TextFile
@@ -649,7 +649,7 @@ xdescribe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = getContentsTreeFileFromString(
+    const newUiJsFile = getProjectFileByFilePath(
       newEditor.projectContents,
       StoryboardFilePath,
     ) as TextFile
@@ -683,7 +683,7 @@ xdescribe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = getContentsTreeFileFromString(
+    const newUiJsFile = getProjectFileByFilePath(
       newEditor.projectContents,
       StoryboardFilePath,
     ) as TextFile
@@ -737,7 +737,7 @@ xdescribe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = getContentsTreeFileFromString(
+    const newUiJsFile = getProjectFileByFilePath(
       newEditor.projectContents,
       StoryboardFilePath,
     ) as TextFile
@@ -846,12 +846,12 @@ describe('LOAD', () => {
     const startingState = deepFreeze(createEditorState(NO_OP))
     const result = UPDATE_FNS.LOAD(action, startingState, NO_OP)
     const newFirstFileContents = (
-      getContentsTreeFileFromString(result.projectContents, firstUIJSFile) as TextFile
+      getProjectFileByFilePath(result.projectContents, firstUIJSFile) as TextFile
     ).fileContents
     expect(isUnparsed(newFirstFileContents.parsed)).toBeTruthy()
     expect(newFirstFileContents.code).toEqual(initialFileContents.code)
     const newSecondFileContents = (
-      getContentsTreeFileFromString(result.projectContents, secondUIJSFile) as TextFile
+      getProjectFileByFilePath(result.projectContents, secondUIJSFile) as TextFile
     ).fileContents
     expect(isUnparsed(newSecondFileContents.parsed)).toBeTruthy()
     expect(newSecondFileContents.code).toEqual(initialFileContents.code)
@@ -938,7 +938,7 @@ describe('INSERT_INSERTABLE', () => {
     )
 
     const actualResult = UPDATE_FNS.INSERT_INSERTABLE(action, editorState)
-    const cardFile = getContentsTreeFileFromString(actualResult.projectContents, '/src/card.js')
+    const cardFile = getProjectFileByFilePath(actualResult.projectContents, '/src/card.js')
     if (cardFile != null && isTextFile(cardFile)) {
       const parsed = cardFile.fileContents.parsed
       if (isParseSuccess(parsed)) {
@@ -1045,7 +1045,7 @@ describe('INSERT_INSERTABLE', () => {
     )
 
     const actualResult = UPDATE_FNS.INSERT_INSERTABLE(action, editorState)
-    const cardFile = getContentsTreeFileFromString(actualResult.projectContents, '/src/card.js')
+    const cardFile = getProjectFileByFilePath(actualResult.projectContents, '/src/card.js')
     if (cardFile != null && isTextFile(cardFile)) {
       const parsed = cardFile.fileContents.parsed
       if (isParseSuccess(parsed)) {
@@ -1146,7 +1146,7 @@ describe('INSERT_INSERTABLE', () => {
     const action = insertInsertable(childInsertionPath(targetPath), imgInsertable, 'add-size', null)
 
     const actualResult = UPDATE_FNS.INSERT_INSERTABLE(action, editorState)
-    const cardFile = getContentsTreeFileFromString(actualResult.projectContents, '/src/card.js')
+    const cardFile = getProjectFileByFilePath(actualResult.projectContents, '/src/card.js')
     if (cardFile != null && isTextFile(cardFile)) {
       const parsed = cardFile.fileContents.parsed
       if (isParseSuccess(parsed)) {
@@ -1243,7 +1243,7 @@ describe('INSERT_INSERTABLE', () => {
     })
 
     const actualResult = UPDATE_FNS.INSERT_INSERTABLE(action, editorState)
-    const cardFile = getContentsTreeFileFromString(actualResult.projectContents, '/src/card.js')
+    const cardFile = getProjectFileByFilePath(actualResult.projectContents, '/src/card.js')
     if (cardFile != null && isTextFile(cardFile)) {
       const parsed = cardFile.fileContents.parsed
       if (isParseSuccess(parsed)) {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -179,7 +179,7 @@ import type { ProjectContentTreeRoot } from '../../assets'
 import {
   addFileToProjectContents,
   contentsToTree,
-  getContentsTreeFileFromString,
+  getProjectFileByFilePath,
   removeFromProjectContents,
   treeToContents,
   walkContentsTreeForParseSuccess,
@@ -1492,7 +1492,7 @@ export const UPDATE_FNS = {
         )
       },
     )
-    const storyboardFile = getContentsTreeFileFromString(parsedProjectFiles, StoryboardFilePath)
+    const storyboardFile = getProjectFileByFilePath(parsedProjectFiles, StoryboardFilePath)
     const openFilePath = storyboardFile != null ? StoryboardFilePath : null
     initVSCodeBridge(parsedProjectFiles, dispatch, openFilePath)
 
@@ -3242,7 +3242,7 @@ export const UPDATE_FNS = {
     editor: EditorModel,
     derived: DerivedState,
   ): EditorModel => {
-    const possiblyAnImage = getContentsTreeFileFromString(editor.projectContents, action.imagePath)
+    const possiblyAnImage = getProjectFileByFilePath(editor.projectContents, action.imagePath)
     if (possiblyAnImage != null && isImageFile(possiblyAnImage)) {
       const newUID = generateUidWithExistingComponents(editor.projectContents)
       const imageURL = imagePathURL(action.imagePath)
@@ -3418,7 +3418,7 @@ export const UPDATE_FNS = {
             filename: newPath,
           }
         }
-        const oldContent = getContentsTreeFileFromString(editor.projectContents, oldPath)
+        const oldContent = getProjectFileByFilePath(editor.projectContents, oldPath)
         if (oldContent != null && (isImageFile(oldContent) || isAssetFile(oldContent))) {
           // Update assets.
           if (isLoggedIn(userState.loginState) && editor.id != null) {
@@ -3475,14 +3475,14 @@ export const UPDATE_FNS = {
   ): EditorModel => {
     if (
       !action.addIfNotInFiles &&
-      getContentsTreeFileFromString(editor.projectContents, action.filePath) == null
+      getProjectFileByFilePath(editor.projectContents, action.filePath) == null
     ) {
       return editor
     }
 
     const { file } = action
 
-    const existing = getContentsTreeFileFromString(editor.projectContents, action.filePath)
+    const existing = getProjectFileByFilePath(editor.projectContents, action.filePath)
     const updatedFile = updateFileIfPossible(file, existing)
 
     if (updatedFile === 'cant-update') {
@@ -3595,7 +3595,7 @@ export const UPDATE_FNS = {
     // files ends up stale only the model in one of them gets updated which clashes with the UIDs in
     // the old version of the other.
     for (const fileUpdate of action.updates) {
-      const existing = getContentsTreeFileFromString(editor.projectContents, fileUpdate.filePath)
+      const existing = getProjectFileByFilePath(editor.projectContents, fileUpdate.filePath)
       if (existing != null && isTextFile(existing)) {
         anyParsedUpdates = true
         const updateIsStale = fileUpdate.versionNumber < existing.versionNumber
@@ -3606,7 +3606,7 @@ export const UPDATE_FNS = {
     }
 
     for (const fileUpdate of action.updates) {
-      const existing = getContentsTreeFileFromString(editor.projectContents, fileUpdate.filePath)
+      const existing = getProjectFileByFilePath(editor.projectContents, fileUpdate.filePath)
       if (existing != null && isTextFile(existing)) {
         anyParsedUpdates = true
         let updatedFile: TextFile
@@ -3692,7 +3692,7 @@ export const UPDATE_FNS = {
     dispatch: EditorDispatch,
     builtInDependencies: BuiltInDependencies,
   ): EditorModel => {
-    const existing = getContentsTreeFileFromString(editor.projectContents, action.filePath)
+    const existing = getProjectFileByFilePath(editor.projectContents, action.filePath)
 
     const manualSave = action.unsavedContent == null
     const code = action.unsavedContent ?? action.savedContent
@@ -3777,7 +3777,7 @@ export const UPDATE_FNS = {
     derived: DerivedState,
     userState: UserState,
   ): EditorModel => {
-    const file = getContentsTreeFileFromString(editor.projectContents, action.filename)
+    const file = getProjectFileByFilePath(editor.projectContents, action.filename)
 
     // Don't delete package.json, otherwise it will bring about the end of days.
     if (file == null || action.filename === 'package.json') {
@@ -5041,7 +5041,7 @@ export const UPDATE_FNS = {
     dispatch: EditorDispatch,
     builtInDependencies: BuiltInDependencies,
   ): EditorModel => {
-    const packageJsonFile = getContentsTreeFileFromString(editor.projectContents, '/package.json')
+    const packageJsonFile = getProjectFileByFilePath(editor.projectContents, '/package.json')
     const currentNpmDeps = dependenciesFromPackageJson(packageJsonFile, 'regular-only')
 
     void findLatestVersion('tailwindcss').then((tailwindResult) => {
@@ -5082,7 +5082,7 @@ export const UPDATE_FNS = {
     })
 
     let updatedProjectContents = editor.projectContents
-    if (getContentsTreeFileFromString(editor.projectContents, TailwindConfigPath) == null) {
+    if (getProjectFileByFilePath(editor.projectContents, TailwindConfigPath) == null) {
       updatedProjectContents = addFileToProjectContents(
         editor.projectContents,
         TailwindConfigPath,
@@ -5090,7 +5090,7 @@ export const UPDATE_FNS = {
       )
     }
 
-    if (getContentsTreeFileFromString(editor.projectContents, PostCSSPath) == null) {
+    if (getProjectFileByFilePath(editor.projectContents, PostCSSPath) == null) {
       updatedProjectContents = addFileToProjectContents(
         updatedProjectContents,
         PostCSSPath,
@@ -5606,7 +5606,7 @@ function saveFileInProjectContents(
   projectContents: ProjectContentTreeRoot,
   filePath: string,
 ): ProjectContentTreeRoot {
-  const file = getContentsTreeFileFromString(projectContents, filePath)
+  const file = getProjectFileByFilePath(projectContents, filePath)
   if (file == null) {
     return projectContents
   } else {

--- a/editor/src/components/editor/actions/migrations/migrations.ts
+++ b/editor/src/components/editor/actions/migrations/migrations.ts
@@ -23,7 +23,7 @@ import type { ProjectContentFile, ProjectContentsTree } from '../../../assets'
 import {
   addFileToProjectContents,
   contentsToTree,
-  getContentsTreeFileFromString,
+  getProjectFileByFilePath,
   projectContentFile,
   removeFromProjectContents,
   transformContentsTree,
@@ -313,7 +313,7 @@ function migrateFromVersion6(
 
     let updatedProjectContents = persistentModel.projectContents
     if (storyboardTarget != null) {
-      const file = getContentsTreeFileFromString(updatedProjectContents, storyboardTarget)
+      const file = getProjectFileByFilePath(updatedProjectContents, storyboardTarget)
       if (file == null) {
         throw new Error(`Internal error in migration: Unable to find file ${storyboardTarget}.`)
       } else {

--- a/editor/src/components/editor/persistence/persistence.spec.ts
+++ b/editor/src/components/editor/persistence/persistence.spec.ts
@@ -9,7 +9,7 @@ import type { AssetToSave, SaveProjectResponse, LoadProjectResponse } from '../s
 import { localProjectKey } from '../../../common/persistence'
 import { MockUtopiaTsWorkers } from '../../../core/workers/workers'
 import type { AssetFileWithFileName } from '../../assets'
-import { addFileToProjectContents, getContentsTreeFileFromString } from '../../assets'
+import { addFileToProjectContents, getProjectFileByFilePath } from '../../assets'
 import { forceNotNull } from '../../../core/shared/optional-utils'
 import { assetFile } from '../../../core/model/project-file-utils'
 import type {
@@ -55,7 +55,7 @@ function mockRandomProjectID(): string {
 function updateModel(model: PersistentModel): PersistentModel {
   const oldFile = forceNotNull(
     'Unexpectedly null.',
-    getContentsTreeFileFromString(model.projectContents, StoryboardFilePath),
+    getProjectFileByFilePath(model.projectContents, StoryboardFilePath),
   )
   const updatedFile = {
     ...oldFile,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -81,7 +81,7 @@ import Utils from '../../../utils/utils'
 import type { ProjectContentTreeRoot } from '../../assets'
 import {
   addFileToProjectContents,
-  getContentsTreeFileFromString,
+  getProjectFileByFilePath,
   getProjectContentsChecksums,
 } from '../../assets'
 import type {
@@ -1626,12 +1626,12 @@ export function getOpenFile(model: EditorState): ProjectFile | null {
   if (openFile == null) {
     return null
   } else {
-    return getContentsTreeFileFromString(model.projectContents, openFile)
+    return getProjectFileByFilePath(model.projectContents, openFile)
   }
 }
 
 export function getFileForName(filePath: string, model: EditorState): ProjectFile | null {
-  return getContentsTreeFileFromString(model.projectContents, filePath)
+  return getProjectFileByFilePath(model.projectContents, filePath)
 }
 
 export function getOpenTextFileKey(model: EditorState): string | null {
@@ -1639,7 +1639,7 @@ export function getOpenTextFileKey(model: EditorState): string | null {
   if (openFilename == null) {
     return null
   } else {
-    const projectFile = getContentsTreeFileFromString(model.projectContents, openFilename)
+    const projectFile = getProjectFileByFilePath(model.projectContents, openFilename)
     if (projectFile != null && isTextFile(projectFile)) {
       return openFilename
     } else {
@@ -1666,7 +1666,7 @@ export function getOpenUIJSFileKey(model: EditorState): string | null {
   if (openFilename == null) {
     return null
   } else {
-    const projectFile = getContentsTreeFileFromString(model.projectContents, openFilename)
+    const projectFile = getProjectFileByFilePath(model.projectContents, openFilename)
     if (isParsedTextFile(projectFile)) {
       return openFilename
     } else {
@@ -1685,7 +1685,7 @@ export function getOpenUIJSFile(model: EditorState): TextFile | null {
   if (openFilename == null) {
     return null
   } else {
-    const projectFile = getContentsTreeFileFromString(model.projectContents, openFilename)
+    const projectFile = getProjectFileByFilePath(model.projectContents, openFilename)
     if (isParsedTextFile(projectFile)) {
       return projectFile
     } else {
@@ -1790,7 +1790,7 @@ function getImportedUtopiaJSXComponents(
   resolve: ResolveFn,
   pathsToFilter: string[],
 ): Array<UtopiaJSXComponent> {
-  const file = getContentsTreeFileFromString(projectContents, filePath)
+  const file = getProjectFileByFilePath(projectContents, filePath)
   if (file != null && isTextFile(file) && isParseSuccess(file.fileContents.parsed)) {
     let resolvedFilePaths: Array<string> = []
     for (const toImport of Object.keys(file.fileContents.parsed.imports)) {
@@ -2927,7 +2927,7 @@ export const DefaultPackageJson = {
 export function packageJsonFileFromProjectContents(
   projectContents: ProjectContentTreeRoot,
 ): ProjectFile | null {
-  return getContentsTreeFileFromString(projectContents, '/package.json')
+  return getProjectFileByFilePath(projectContents, '/package.json')
 }
 
 export function getPackageJsonFromEditorState(editor: EditorState): Either<string, any> {
@@ -2963,7 +2963,7 @@ export function getIndexHtmlFileFromEditorState(editor: EditorState): Either<str
     isRight(parsedFilePath) && typeof parsedFilePath.value === 'string'
       ? parsedFilePath.value
       : 'public/index.html'
-  const indexHtml = getContentsTreeFileFromString(editor.projectContents, `/${filePath}`)
+  const indexHtml = getProjectFileByFilePath(editor.projectContents, `/${filePath}`)
   if (indexHtml != null && isTextFile(indexHtml)) {
     return right(indexHtml)
   } else {
@@ -3177,7 +3177,7 @@ export function getHighlightBoundsForFile(
   editor: EditorState,
   fullPath: string,
 ): HighlightBoundsForUids | null {
-  const file = getContentsTreeFileFromString(editor.projectContents, fullPath)
+  const file = getProjectFileByFilePath(editor.projectContents, fullPath)
   if (file != null && isTextFile(file)) {
     if (isParseSuccess(file.fileContents.parsed)) {
       return getHighlightBoundsFromParseResult(file.fileContents.parsed)
@@ -3247,7 +3247,7 @@ export function modifyParseSuccessAtPath(
   editor: EditorState,
   modifyParseSuccess: (parseSuccess: ParseSuccess) => ParseSuccess,
 ): EditorState {
-  const projectFile = getContentsTreeFileFromString(editor.projectContents, filePath)
+  const projectFile = getProjectFileByFilePath(editor.projectContents, filePath)
   if (projectFile != null && isTextFile(projectFile)) {
     const parsedFileContents = projectFile.fileContents.parsed
     if (isParseSuccess(parsedFileContents)) {

--- a/editor/src/components/editor/store/editor-update.spec.tsx
+++ b/editor/src/components/editor/store/editor-update.spec.tsx
@@ -75,7 +75,7 @@ import {
 } from '../../../core/model/test-ui-js-file.test-utils'
 import { emptyUiJsxCanvasContextData } from '../../canvas/ui-jsx-canvas'
 import { requestedNpmDependency } from '../../../core/shared/npm-dependency-types'
-import { contentsToTree, getContentsTreeFileFromString } from '../../assets'
+import { contentsToTree, getProjectFileByFilePath } from '../../assets'
 import { forceParseSuccessFromFileOrFail } from '../../../core/workers/parser-printer/parser-printer.test-utils'
 import { notice } from '../../common/notice'
 import {
@@ -336,11 +336,8 @@ describe('action DUPLICATE_SPECIFIC_ELEMENTS', () => {
       emptyUiJsxCanvasContextData(),
       builtInDependencies,
     )
-    const mainUIJSFile = getContentsTreeFileFromString(
-      updatedEditor.projectContents,
-      StoryboardFilePath,
-    )
-    const oldUIJSFile = getContentsTreeFileFromString(editor.projectContents, StoryboardFilePath)
+    const mainUIJSFile = getProjectFileByFilePath(updatedEditor.projectContents, StoryboardFilePath)
+    const oldUIJSFile = getProjectFileByFilePath(editor.projectContents, StoryboardFilePath)
     if (
       oldUIJSFile != null &&
       isTextFile(oldUIJSFile) &&
@@ -380,11 +377,8 @@ describe('action DUPLICATE_SPECIFIC_ELEMENTS', () => {
       emptyUiJsxCanvasContextData(),
       builtInDependencies,
     )
-    const mainUIJSFile = getContentsTreeFileFromString(
-      updatedEditor.projectContents,
-      StoryboardFilePath,
-    )
-    const oldUIJSFile = getContentsTreeFileFromString(editor.projectContents, StoryboardFilePath)
+    const mainUIJSFile = getProjectFileByFilePath(updatedEditor.projectContents, StoryboardFilePath)
+    const oldUIJSFile = getProjectFileByFilePath(editor.projectContents, StoryboardFilePath)
     if (
       oldUIJSFile != null &&
       isTextFile(oldUIJSFile) &&
@@ -455,7 +449,7 @@ describe('action DELETE_SELECTED', () => {
     ])
 
     const parseSuccess = forceParseSuccessFromFileOrFail(
-      getContentsTreeFileFromString(editor.projectContents, StoryboardFilePath),
+      getProjectFileByFilePath(editor.projectContents, StoryboardFilePath),
     )
     const originalChildrenCount = Utils.pathOr(
       [],
@@ -475,10 +469,7 @@ describe('action DELETE_SELECTED', () => {
       emptyUiJsxCanvasContextData(),
       builtInDependencies,
     )
-    const mainUIJSFile = getContentsTreeFileFromString(
-      updatedEditor.projectContents,
-      StoryboardFilePath,
-    )
+    const mainUIJSFile = getProjectFileByFilePath(updatedEditor.projectContents, StoryboardFilePath)
     if (
       mainUIJSFile != null &&
       isTextFile(mainUIJSFile) &&
@@ -745,10 +736,7 @@ describe('action UPDATE_FRAME_DIMENSIONS', () => {
       emptyUiJsxCanvasContextData(),
       builtInDependencies,
     )
-    const mainUIJSFile = getContentsTreeFileFromString(
-      updatedEditor.projectContents,
-      StoryboardFilePath,
-    )
+    const mainUIJSFile = getProjectFileByFilePath(updatedEditor.projectContents, StoryboardFilePath)
     if (
       mainUIJSFile != null &&
       isTextFile(mainUIJSFile) &&
@@ -967,10 +955,7 @@ describe('updating package.json', () => {
       builtInDependencies,
     )
 
-    const packageJsonFile = getContentsTreeFileFromString(
-      updatedEditor.projectContents,
-      '/package.json',
-    )
+    const packageJsonFile = getProjectFileByFilePath(updatedEditor.projectContents, '/package.json')
     if (packageJsonFile == null || packageJsonFile.type != 'TEXT_FILE') {
       throw new Error('Package.json file should exist and should be a TextFile')
     } else {

--- a/editor/src/core/model/element-template-utils.spec.tsx
+++ b/editor/src/core/model/element-template-utils.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectElementAtPathHasMatchingUID*", "expectElementFoundNull"] }] */
 
-import { getContentsTreeFileFromString } from '../../components/assets'
+import { getProjectFileByFilePath } from '../../components/assets'
 import {
   makeTestProjectCodeWithSnippet,
   testPrintCodeFromParseSuccess,
@@ -1146,7 +1146,7 @@ describe('insertJSXElementChildren', () => {
       makeTestProjectCodeWithSnippet(snippet),
     ).projectContents
 
-    const file = getContentsTreeFileFromString(projectContents, StoryboardFilePath)
+    const file = getProjectFileByFilePath(projectContents, StoryboardFilePath)
 
     if (file?.type !== 'TEXT_FILE' || file.lastParseSuccess == null) {
       throw new Error('failed parsing the test project file')
@@ -1607,7 +1607,7 @@ describe('transformJSXComponentAtPath', () => {
 
     // console.log(JSON.stringify(projectContents))
 
-    const file = getContentsTreeFileFromString(projectContents, StoryboardFilePath)
+    const file = getProjectFileByFilePath(projectContents, StoryboardFilePath)
 
     if (file?.type !== 'TEXT_FILE' || file.lastParseSuccess == null) {
       throw new Error('failed parsing the test project file')

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -1,8 +1,5 @@
 import type { ProjectContentTreeRoot } from '../../components/assets'
-import {
-  getContentsTreeFileFromString,
-  walkContentsTreeForParseSuccess,
-} from '../../components/assets'
+import { getProjectFileByFilePath, walkContentsTreeForParseSuccess } from '../../components/assets'
 import type { IndexPosition } from '../../utils/utils'
 import Utils, {
   addElementsToArrayAtIndexPosition,
@@ -134,7 +131,7 @@ export function isSceneElement(
   filePath: string,
   projectContents: ProjectContentTreeRoot,
 ): boolean {
-  const file = getContentsTreeFileFromString(projectContents, filePath)
+  const file = getProjectFileByFilePath(projectContents, filePath)
   if (file != null && isTextFile(file) && isParseSuccess(file.fileContents.parsed)) {
     return isSceneAgainstImports(element, file.fileContents.parsed.imports)
   } else {

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -58,7 +58,7 @@ import { mapDropNulls, pluck } from '../shared/array-utils'
 import { forEachValue } from '../shared/object-utils'
 import type { ProjectContentsTree, ProjectContentTreeRoot } from '../../components/assets'
 import {
-  getContentsTreeFileFromString,
+  getProjectFileByFilePath,
   projectContentFile,
   transformContentsTree,
   walkContentsTree,
@@ -659,7 +659,7 @@ export function uniqueProjectContentID(
 ): string {
   const startingIDCorrected = correctProjectContentsPath(filename)
   const fileWithSameNameExistsAlready =
-    getContentsTreeFileFromString(projectContents, startingIDCorrected) != null
+    getProjectFileByFilePath(projectContents, startingIDCorrected) != null
 
   if (!fileWithSameNameExistsAlready) {
     return startingIDCorrected
@@ -676,7 +676,7 @@ export function uniqueProjectContentID(
   // eslint-disable-next-line no-constant-condition
   while (true) {
     const possibleNewID = makeNameWithCounter(counter)
-    if (getContentsTreeFileFromString(projectContents, possibleNewID) != null) {
+    if (getProjectFileByFilePath(projectContents, possibleNewID) != null) {
       counter += 1
     } else {
       return correctProjectContentsPath(possibleNewID)
@@ -686,7 +686,7 @@ export function uniqueProjectContentID(
 
 export function fileExists(projectContents: ProjectContentTreeRoot, filename: string): boolean {
   const filenameCorrected = correctProjectContentsPath(filename)
-  return getContentsTreeFileFromString(projectContents, filenameCorrected) != null
+  return getProjectFileByFilePath(projectContents, filenameCorrected) != null
 }
 
 export function saveTextFileContents(

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -41,7 +41,7 @@ import {
 import { stripNulls } from '../shared/array-utils'
 import { UTOPIA_UID_KEY } from './utopia-constants'
 import type { ProjectContentTreeRoot } from '../../components/assets'
-import { getContentsTreeFileFromString } from '../../components/assets'
+import { getProjectFileByFilePath } from '../../components/assets'
 import { getUtopiaJSXComponentsFromSuccess } from './project-file-utils'
 import { generateConsistentUID, generateUID, getUtopiaID } from '../shared/uid-utils'
 import { emptySet } from '../shared/set-utils'
@@ -285,7 +285,7 @@ export function getStoryboardElementPath(
   openFile: string | null | undefined,
 ): StaticElementPath | null {
   if (openFile != null) {
-    const file = getContentsTreeFileFromString(projectContents, openFile)
+    const file = getProjectFileByFilePath(projectContents, openFile)
     if (file != null && isTextFile(file) && isParseSuccess(file.fileContents.parsed)) {
       const possiblyStoryboard = getUtopiaJSXComponentsFromSuccess(file.fileContents.parsed).find(
         (component) => component.name === BakedInStoryboardVariableName,

--- a/editor/src/core/model/storyboard-utils.spec.ts
+++ b/editor/src/core/model/storyboard-utils.spec.ts
@@ -1,6 +1,6 @@
 import {
   addFileToProjectContents,
-  getContentsTreeFileFromString,
+  getProjectFileByFilePath,
   removeFromProjectContents,
 } from '../../components/assets'
 import type { EditorState } from '../../components/editor/store/editor-state'
@@ -72,7 +72,7 @@ describe('addStoryboardFileToProject', () => {
     if (actualResult == null) {
       throw new Error('Editor state was not updated.')
     } else {
-      const storyboardFile = getContentsTreeFileFromString(
+      const storyboardFile = getProjectFileByFilePath(
         actualResult.projectContents,
         StoryboardFilePath,
       )

--- a/editor/src/core/model/storyboard-utils.ts
+++ b/editor/src/core/model/storyboard-utils.ts
@@ -1,7 +1,7 @@
 import type { ProjectContentTreeRoot } from '../../components/assets'
 import {
   addFileToProjectContents,
-  getContentsTreeFileFromString,
+  getProjectFileByFilePath,
   walkContentsTree,
 } from '../../components/assets'
 import type { EditorModel } from '../../components/editor/action-types'
@@ -159,10 +159,7 @@ const compareComponentToImport: Compare<ComponentToImport> = compareCompose(
 )
 
 export function addStoryboardFileToProject(editorModel: EditorModel): EditorModel | null {
-  const storyboardFile = getContentsTreeFileFromString(
-    editorModel.projectContents,
-    StoryboardFilePath,
-  )
+  const storyboardFile = getProjectFileByFilePath(editorModel.projectContents, StoryboardFilePath)
   if (storyboardFile == null) {
     let currentImportCandidate: ComponentToImport | null = null
     function updateCandidate(importCandidate: ComponentToImport): void {
@@ -335,7 +332,7 @@ function addStoryboardFileForComponent(
       // Modify the targeted file to export the component we're interested in.
       const fileToModify = forceNotNull(
         `Unable to find file at ${createFileWithComponent.path}`,
-        getContentsTreeFileFromString(updatedProjectContents, createFileWithComponent.path),
+        getProjectFileByFilePath(updatedProjectContents, createFileWithComponent.path),
       )
       if (isTextFile(fileToModify)) {
         if (isParseSuccess(fileToModify.fileContents.parsed)) {

--- a/editor/src/core/shared/github/helpers.ts
+++ b/editor/src/core/shared/github/helpers.ts
@@ -7,7 +7,7 @@ import type { ProjectContentsTree, ProjectContentTreeRoot } from '../../../compo
 import {
   addFileToProjectContents,
   deriveGithubFileChanges,
-  getContentsTreeFileFromString,
+  getProjectFileByFilePath,
   getProjectContentsChecksums,
   getProjectFileFromContents,
   isProjectContentDirectory,
@@ -462,7 +462,7 @@ export function revertGithubFile(
         break
       case 'deleted':
       case 'modified':
-        const previousFile = getContentsTreeFileFromString(branchContents, filename)
+        const previousFile = getProjectFileByFilePath(branchContents, filename)
         if (previousFile != null) {
           const newTree = addFileToProjectContents(projectContents, filename, previousFile)
           actions.push(updateProjectContents(newTree))

--- a/editor/src/core/shared/project-contents-dependencies.ts
+++ b/editor/src/core/shared/project-contents-dependencies.ts
@@ -1,7 +1,7 @@
 import type { MapLike } from 'typescript'
 import type { ProjectContentsTree, ProjectContentTreeRoot } from '../../components/assets'
 import {
-  getContentsTreeFileFromString,
+  getProjectFileByFilePath,
   isProjectContentFile,
   walkContentsTree,
   zipContentsTree,
@@ -30,7 +30,7 @@ export function getDirectReverseDependencies(
               switch (successResult.file.type) {
                 case 'ES_CODE_FILE':
                   // Check if the file is part of the project.
-                  if (getContentsTreeFileFromString(projectContents, successResult.path) != null) {
+                  if (getProjectFileByFilePath(projectContents, successResult.path) != null) {
                     // Dependency, so record the connection.
                     result = addToMapOfArraysUnique(result, successResult.path, fullPath)
                   }

--- a/editor/src/core/shared/project-contents-utils.ts
+++ b/editor/src/core/shared/project-contents-utils.ts
@@ -1,5 +1,5 @@
 import type { ProjectContentTreeRoot } from '../../components/assets'
-import { getContentsTreeFileFromString } from '../../components/assets'
+import { getProjectFileByFilePath } from '../../components/assets'
 import { objectKeyParser, parseString } from '../../utils/value-parser-utils'
 import { defaultEither, eitherToMaybe, isLeft } from './either'
 import { is } from './equality-utils'
@@ -39,7 +39,7 @@ function packageJsonEquals(l: ProjectFile | undefined, r: ProjectFile | undefine
 const parsePackageJson = memoize(parsePackageJsonInner, { maxSize: 1, equals: packageJsonEquals })
 
 function getParsedPackageJson(projectContents: ProjectContentTreeRoot): Record<string, any> | null {
-  return parsePackageJson(getContentsTreeFileFromString(projectContents, '/package.json'))
+  return parsePackageJson(getProjectFileByFilePath(projectContents, '/package.json'))
 }
 
 function getUtopiaSpecificStringSetting(

--- a/editor/src/core/tailwind/tailwind-options.tsx
+++ b/editor/src/core/tailwind/tailwind-options.tsx
@@ -18,7 +18,7 @@ import {
 import { getOpenUIJSFileKey } from '../../components/editor/store/editor-state'
 import { normalisePathToUnderlyingTarget } from '../../components/custom-code/code-file'
 import type { ProjectContentTreeRoot } from '../../components/assets'
-import { getContentsTreeFileFromString } from '../../components/assets'
+import { getProjectFileByFilePath } from '../../components/assets'
 import type { JSXElementChild } from '../shared/element-template'
 import {
   modifiableAttributeIsAttributeNotFound,
@@ -243,7 +243,7 @@ function getJSXElementForTarget(
   )
   const underlyingPath =
     underlyingTarget.type === 'NORMALISE_PATH_SUCCESS' ? underlyingTarget.filePath : openUIJSFileKey
-  const projectFile = getContentsTreeFileFromString(projectContents, underlyingPath)
+  const projectFile = getProjectFileByFilePath(projectContents, underlyingPath)
   if (
     projectFile != null &&
     isTextFile(projectFile) &&

--- a/editor/src/core/tailwind/tailwind.ts
+++ b/editor/src/core/tailwind/tailwind.ts
@@ -1,5 +1,5 @@
 import type { ProjectContentTreeRoot } from '../../components/assets'
-import { getContentsTreeFileFromString } from '../../components/assets'
+import { getProjectFileByFilePath } from '../../components/assets'
 import type { Either } from '../shared/either'
 import { isRight, left, right } from '../shared/either'
 import type { RequireFn } from '../shared/npm-dependency-types'
@@ -53,7 +53,7 @@ function postCSSIncludesTailwindPlugin(postCSSFile: ProjectFile, requireFn: Requ
 
 function useGetPostCSSConfigFile(projectContents: ProjectContentTreeRoot): ProjectFile | null {
   return React.useMemo(
-    () => getContentsTreeFileFromString(projectContents, PostCSSPath),
+    () => getProjectFileByFilePath(projectContents, PostCSSPath),
     [projectContents],
   )
 }
@@ -119,7 +119,7 @@ function getTailwindConfig(
 
 function useGetTailwindConfigFile(projectContents: ProjectContentTreeRoot): ProjectFile | null {
   return React.useMemo(
-    () => getContentsTreeFileFromString(projectContents, TailwindConfigPath),
+    () => getProjectFileByFilePath(projectContents, TailwindConfigPath),
     [projectContents],
   )
 }
@@ -246,11 +246,11 @@ export function injectTwind(
   const packageJsonFile = packageJsonFileFromProjectContents(projectContents)
   const hasDependencies =
     packageJsonFile != null && hasRequiredDependenciesForTailwind(packageJsonFile)
-  const postCSSFile = getContentsTreeFileFromString(projectContents, PostCSSPath)
+  const postCSSFile = getProjectFileByFilePath(projectContents, PostCSSPath)
   const hasPostCSSPlugin =
     postCSSFile != null && postCSSIncludesTailwindPlugin(postCSSFile, requireFn)
   const shouldUseTwind = hasDependencies && hasPostCSSPlugin
-  const tailwindConfigFile = getContentsTreeFileFromString(projectContents, TailwindConfigPath)
+  const tailwindConfigFile = getProjectFileByFilePath(projectContents, TailwindConfigPath)
   const maybeTailwindConfig = getTailwindConfig(tailwindConfigFile, requireFn)
   const tailwindConfig = isRight(maybeTailwindConfig) ? maybeTailwindConfig.value : {}
   if (shouldUseTwind) {

--- a/editor/src/printer-parsers/html/external-resources-parser.tsx
+++ b/editor/src/printer-parsers/html/external-resources-parser.tsx
@@ -1,7 +1,7 @@
 import * as json5 from 'json5'
 import * as NodeHTMLParser from 'node-html-parser'
 import type { ProjectContentTreeRoot } from '../../components/assets'
-import { getContentsTreeFileFromString } from '../../components/assets'
+import { getProjectFileByFilePath } from '../../components/assets'
 import { notice } from '../../components/common/notice'
 import type { EditorDispatch } from '../../components/editor/action-types'
 import { addToast, updateFile } from '../../components/editor/actions/action-creators'
@@ -105,7 +105,7 @@ export function getGeneratedExternalLinkText(
 function getPreviewHTMLFilePath(
   projectContents: ProjectContentTreeRoot,
 ): Either<DescriptionParseError, string> {
-  const packageJson = getContentsTreeFileFromString(projectContents, '/package.json')
+  const packageJson = getProjectFileByFilePath(projectContents, '/package.json')
   if (packageJson != null && isTextFile(packageJson)) {
     try {
       const parsedJSON = json5.parse(packageJson.fileContents.code)
@@ -133,7 +133,7 @@ function getTextFileContentsFromPath(
   filePath: string,
   projectContents: ProjectContentTreeRoot,
 ): Either<DescriptionParseError, TextFile> {
-  const fileContents = getContentsTreeFileFromString(projectContents, filePath)
+  const fileContents = getProjectFileByFilePath(projectContents, filePath)
   if (fileContents != null && isTextFile(fileContents)) {
     return right(fileContents)
   } else {

--- a/editor/src/templates/image-dnd.spec.browser2.tsx
+++ b/editor/src/templates/image-dnd.spec.browser2.tsx
@@ -1,7 +1,7 @@
 import Sinon from 'sinon'
 import { loggedInUser } from '../common/user'
 import type { ProjectContentTreeRoot } from '../components/assets'
-import { getContentsTreeFileFromString } from '../components/assets'
+import { getProjectFileByFilePath } from '../components/assets'
 import { RegisteredCanvasStrategies } from '../components/canvas/canvas-strategies/canvas-strategies'
 import { CanvasControlsContainerID } from '../components/canvas/controls/new-canvas-controls'
 import {
@@ -401,7 +401,7 @@ describe('image drag and drop', () => {
       const expectedFileName = `${fileItemTargetFolder}/stuff.png`
 
       const filenameCorrected = correctProjectContentsPath(expectedFileName)
-      const fileContent = getContentsTreeFileFromString(
+      const fileContent = getProjectFileByFilePath(
         editor.getEditorState().editor.projectContents,
         filenameCorrected,
       )
@@ -462,7 +462,7 @@ describe('image drag and drop', () => {
       const expectedFileName = `${fileItemTargetFolder}/hello.png`
 
       const filenameCorrected = correctProjectContentsPath(expectedFileName)
-      const fileContent = getContentsTreeFileFromString(
+      const fileContent = getProjectFileByFilePath(
         editor.getEditorState().editor.projectContents,
         filenameCorrected,
       )

--- a/editor/src/templates/preview/preview.tsx
+++ b/editor/src/templates/preview/preview.tsx
@@ -4,7 +4,7 @@ import * as ReactErrorOverlay from 'react-error-overlay'
 import { BASE_URL, getProjectID, getQueryParam, PREVIEW_IS_EMBEDDED } from '../../common/env-vars'
 import { fetchLocalProject } from '../../common/persistence'
 import type { ProjectContentTreeRoot } from '../../components/assets'
-import { getContentsTreeFileFromString } from '../../components/assets'
+import { getProjectFileByFilePath } from '../../components/assets'
 import { incorporateBuildResult } from '../../components/custom-code/code-file'
 import { sendPreviewModel } from '../../components/editor/actions/action-creators'
 import { dependenciesWithEditorRequirements } from '../../components/editor/npm-dependency/npm-dependency'
@@ -261,10 +261,7 @@ const initPreview = () => {
 
     // replacing the document body first
     const previewHTMLFileName = getMainHTMLFilename(projectContents)
-    const previewHTMLFile = getContentsTreeFileFromString(
-      projectContents,
-      `/${previewHTMLFileName}`,
-    )
+    const previewHTMLFile = getProjectFileByFilePath(projectContents, `/${previewHTMLFileName}`)
     if (previewHTMLFile != null && isTextFile(previewHTMLFile)) {
       try {
         try {
@@ -287,7 +284,7 @@ const initPreview = () => {
 
     const previewJSFileName = getMainJSFilename(projectContents)
     const previewJSFilePath = `/${previewJSFileName}`
-    const previewJSFile = getContentsTreeFileFromString(projectContents, previewJSFilePath)
+    const previewJSFile = getProjectFileByFilePath(projectContents, previewJSFilePath)
     if (previewJSFile != null && isTextFile(previewJSFile)) {
       if (bundledProjectFiles[previewJSFilePath] == null) {
         throw new Error(

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -32,7 +32,7 @@ import * as json5 from 'json5'
 import { fastForEach } from '../core/shared/utils'
 import urljoin from 'url-join'
 import type { ProjectContentTreeRoot } from '../components/assets'
-import { getContentsTreeFileFromString } from '../components/assets'
+import { getProjectFileByFilePath } from '../components/assets'
 import {
   normalisePathSuccessOrThrowError,
   normalisePathToUnderlyingTarget,
@@ -337,10 +337,7 @@ export function createClipboardDataFromSelection(
       target,
     )
     const targetPathSuccess = normalisePathSuccessOrThrowError(underlyingTarget)
-    const projectFile = getContentsTreeFileFromString(
-      editor.projectContents,
-      targetPathSuccess.filePath,
-    )
+    const projectFile = getProjectFileByFilePath(editor.projectContents, targetPathSuccess.filePath)
     if (
       projectFile != null &&
       isTextFile(projectFile) &&


### PR DESCRIPTION
**Problem:**
`getContentsTreeFileFromString` needs a better name

**Fix:**
Rename it to `getProjectFileByFilePath`
