### PR TITLE
add a transparent background layer

### DIFF
--- a/editor/src/uuiui/widgets/popup-list/popup-list.tsx
+++ b/editor/src/uuiui/widgets/popup-list/popup-list.tsx
@@ -320,57 +320,69 @@ const MenuPortal = (props: MenuPortalProps<SelectOption>) => {
   if (props.selectProps.menuPortalTarget != null) {
     return ReactDOM.createPortal(
       <div
-        className='ignore-react-onclickoutside'
-        onMouseMove={onMouseMove}
-        onMouseUpCapture={onMouseUp}
-        id='menuPortal'
+        // transparent background div so clicks are intercepted and don't spill over
         style={{
-          minWidth: 150,
-          maxWidth: 250,
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
           zIndex: 999999,
-          boxSizing: 'border-box',
-          position: 'absolute',
-          height: popupHeight,
-          top: popupTop,
-          left: alignRight ? undefined : popupLeft - CheckboxInset + ValueContainerLeftPadding,
-          right: alignRight ? ValueContainerLeftPadding : undefined,
-          overflow: 'hidden',
-          ...UtopiaStyles.popup,
+          background: 'transparent',
         }}
       >
         <div
-          ref={ref}
+          className='ignore-react-onclickoutside'
+          onMouseMove={onMouseMove}
+          onMouseUpCapture={onMouseUp}
+          id='menuPortal'
           style={{
             minWidth: 150,
             maxWidth: 250,
+            boxSizing: 'border-box',
+            position: 'absolute',
             height: popupHeight,
+            top: popupTop,
+            left: alignRight ? undefined : popupLeft - CheckboxInset + ValueContainerLeftPadding,
+            right: alignRight ? ValueContainerLeftPadding : undefined,
             overflow: 'hidden',
+            ...UtopiaStyles.popup,
           }}
         >
-          {props.children}
+          <div
+            ref={ref}
+            style={{
+              minWidth: 150,
+              maxWidth: 250,
+              height: popupHeight,
+              overflow: 'hidden',
+            }}
+          >
+            {props.children}
+          </div>
+          {croppedTop ? (
+            <OverflowIndicator
+              style={{
+                top: 0,
+              }}
+              onMouseOver={onCroppedTopMouseOver}
+              onMouseOut={onCroppedTopMouseOut}
+            >
+              …
+            </OverflowIndicator>
+          ) : null}
+          {croppedBottom ? (
+            <OverflowIndicator
+              style={{
+                bottom: 0,
+              }}
+              onMouseOver={onCroppedBottomMouseOver}
+              onMouseOut={onCroppedBottomMouseOut}
+            >
+              …
+            </OverflowIndicator>
+          ) : null}
         </div>
-        {croppedTop ? (
-          <OverflowIndicator
-            style={{
-              top: 0,
-            }}
-            onMouseOver={onCroppedTopMouseOver}
-            onMouseOut={onCroppedTopMouseOut}
-          >
-            …
-          </OverflowIndicator>
-        ) : null}
-        {croppedBottom ? (
-          <OverflowIndicator
-            style={{
-              bottom: 0,
-            }}
-            onMouseOver={onCroppedBottomMouseOver}
-            onMouseOut={onCroppedBottomMouseOut}
-          >
-            …
-          </OverflowIndicator>
-        ) : null}
       </div>,
       props.selectProps.menuPortalTarget,
     )


### PR DESCRIPTION
Fixes #4112 

**Problem:**

When clicking outside an open dropdown, the click passes through to the underlying element, triggering undesired side-effects such as a select-none event on the canvas.

https://github.com/concrete-utopia/utopia/assets/1081051/469c3c1e-2d55-49a7-8e31-704b1dfc799b

**Fix:**

There are multiple possible solutions to this - the one on this PR is the one that feels the most "stateless" and maintenance-free to me (compared to e.g. storing a `popupOpen` flag in the editor state): in the portal created by the popup list there is now a `fixed` transparent div that spans the whole screen and intercepts any mouse events before they can reach the elements behind it.

https://github.com/concrete-utopia/utopia/assets/1081051/566de5ac-b9de-47fe-8486-1a7c48d142d6
