### PR TITLE
Kill gap slider

### DIFF
--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
@@ -5,8 +5,6 @@ import type { ControlStatus, ControlStyles } from '../../../common/control-statu
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import type { OptionChainOption } from '../../../controls/option-chain-control'
 import { OptionChainControl } from '../../../controls/option-chain-control'
-import type { DEPRECATEDSliderControlOptions } from '../../../controls/slider-control'
-import { SliderControl } from '../../../controls/slider-control'
 import {
   InspectorPropsContext,
   stylePropPathMappingFn,
@@ -17,17 +15,9 @@ import type { OptionsType } from 'react-select'
 import { unsetPropertyMenuItem } from '../../../common/context-menu-items'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import { PropertyLabel } from '../../../widgets/property-label'
-import {
-  PopupList,
-  useWrappedEmptyOrUnknownOnSubmitValue,
-  SimpleNumberInput,
-  NumberInput,
-} from '../../../../../uuiui'
-import { OnSubmitValueOrEmpty } from '../../../controls/control'
+import { PopupList, useWrappedEmptyOrUnknownOnSubmitValue, NumberInput } from '../../../../../uuiui'
 import { useContextSelector } from 'use-context-selector'
 import type { FlexDirection } from '../../../common/css-utils'
-import { CSSNumber, setCSSNumberValue } from '../../../common/css-utils'
-import { SliderNumberControl } from '../../../controls/slider-number-control'
 
 type uglyLabel =
   | 'left'
@@ -239,15 +229,8 @@ export const FlexJustifyContentControl = React.memo((props: FlexJustifyContentCo
 })
 
 export const FlexGapControl = React.memo(() => {
-  const {
-    value,
-    useSubmitValueFactory,
-    onSubmitValue,
-    onUnsetValues,
-    onTransientSubmitValue,
-    controlStatus,
-    controlStyles,
-  } = useInspectorLayoutInfo('gap')
+  const { value, onSubmitValue, onUnsetValues, onTransientSubmitValue, controlStatus } =
+    useInspectorLayoutInfo('gap')
   const menuItems = [unsetPropertyMenuItem('Flex Gap', onUnsetValues)]
 
   const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(onSubmitValue, onUnsetValues)
@@ -256,20 +239,13 @@ export const FlexGapControl = React.memo(() => {
     onUnsetValues,
   )
 
-  const transformNumberToCSSNumber = React.useCallback(
-    (newValue: number) => setCSSNumberValue(value, newValue),
-    [value],
-  )
-  const [sliderSubmitValue, sliderTransientSubmitValue] = useSubmitValueFactory(
-    transformNumberToCSSNumber,
-  )
-
   const targetPath = useContextSelector(InspectorPropsContext, (contextData) => {
     return contextData.targetPath
   })
   const flexGapProp = React.useMemo(() => {
     return [stylePropPathMappingFn('gap', targetPath)]
   }, [targetPath])
+
   return (
     <InspectorContextMenuWrapper id={`gap-context-menu`} items={menuItems} data={{}}>
       <UIGridRow padded={false} variant='<-auto-><----------1fr--------->'>

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
@@ -21,6 +21,7 @@ import {
   PopupList,
   useWrappedEmptyOrUnknownOnSubmitValue,
   SimpleNumberInput,
+  NumberInput,
 } from '../../../../../uuiui'
 import { OnSubmitValueOrEmpty } from '../../../controls/control'
 import { useContextSelector } from 'use-context-selector'
@@ -273,34 +274,17 @@ export const FlexGapControl = React.memo(() => {
     <InspectorContextMenuWrapper id={`gap-context-menu`} items={menuItems} data={{}}>
       <UIGridRow padded={false} variant='<-auto-><----------1fr--------->'>
         <PropertyLabel target={flexGapProp}>Gap</PropertyLabel>
-        <SliderNumberControl
+        <NumberInput
           id='flex.container.gap'
-          key='flex.container.gap'
           testId='flex.container.gap'
+          key='flex.container.gap'
           value={value}
-          DEPRECATED_controlOptions={
-            {
-              minimum: 0,
-              maximum: 50,
-              stepSize: 1,
-              origin: 0,
-              filled: true,
-              tooltip: 'Gap (sets margin on children)',
-            } as DEPRECATEDSliderControlOptions
-          }
-          controlStatus={controlStatus}
-          controlStyles={controlStyles}
-          minimum={0}
-          maximum={50}
-          stepSize={1}
-          defaultUnitToHide={'px'}
-          numberType='LengthPercent'
           onSubmitValue={wrappedOnSubmitValue}
           onTransientSubmitValue={wrappedOnTransientSubmitValue}
           onForcedSubmitValue={wrappedOnSubmitValue}
-          onSliderSubmitValue={sliderSubmitValue}
-          onSliderTransientSubmitValue={sliderTransientSubmitValue}
-          transformSliderValueToCSSNumber={transformNumberToCSSNumber}
+          controlStatus={controlStatus}
+          numberType='LengthPercent'
+          defaultUnitToHide={'px'}
         />
       </UIGridRow>
     </InspectorContextMenuWrapper>


### PR DESCRIPTION
Having a slider for the flex gap control meant we had to choose an arbitrary limit for its value, when it really is limitless. Now it is just a humble `<NumberInput/>` without any limit. The on-canvas gap slider is unchanged.

<img width="535" alt="Screenshot 2023-08-24 at 11 29 23 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/613bf58e-43ea-4e61-a395-100dadd95436">
