### PR TITLE
When a canvas interaction starts, jump the children bounds to that of the group.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/groups.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/groups.spec.browser2.tsx
@@ -559,29 +559,6 @@ describe('Groups behaviors', () => {
         expect(childDiv.getBoundingClientRect().height).toBe(0)
       })
 
-      it('child with top,left,bottom,right, width, height (!!!!!!) pins', async () => {
-        const editor = await renderProjectWithGroup(`
-          <Group data-testid='group' style={{position: 'absolute', left: 50, top: 50}}>
-            <div 
-              style={{
-                backgroundColor: 'red',
-                position: 'absolute',
-                top: 50,
-                left: 50,
-                right: 100,
-                bottom: 100,
-                width: 50,
-                height: 50,
-              }}
-            />
-          </Group>
-        `)
-        const groupDiv = editor.renderedDOM.getByTestId('group')
-
-        expect(groupDiv.style.width).toBe('200px')
-        expect(groupDiv.style.height).toBe('200px')
-      })
-
       it('children with nested Fragments', async () => {
         const editor = await renderProjectWithGroup(`
           <Group data-testid='group' style={{position: 'absolute', left: 50, top: 50}}>
@@ -1367,12 +1344,12 @@ describe('Groups behaviors', () => {
           await selectComponentsForTest(editor, [fromString(GroupPath)])
           await resizeElement(editor, { x: 50, y: 50 }, EdgePositionBottomRight, emptyModifiers)
 
-          expect(groupDiv.style.width).toBe('133px')
-          expect(groupDiv.style.height).toBe('133px')
+          expect(groupDiv.style.width).toBe('200px')
+          expect(groupDiv.style.height).toBe('200px')
 
           assertStylePropsSet(editor, `${GroupPath}`, {
-            left: 117,
-            top: 117,
+            left: 50,
+            top: 50,
             width: undefined,
             height: undefined,
             right: undefined,
@@ -1381,8 +1358,8 @@ describe('Groups behaviors', () => {
           assertStylePropsSet(editor, `${GroupPath}/child-1`, {
             left: 0,
             top: 0,
-            width: 133,
-            height: 133,
+            width: 200,
+            height: 200,
           })
         }
 
@@ -1391,12 +1368,12 @@ describe('Groups behaviors', () => {
           await selectComponentsForTest(editor, [fromString(GroupPath)])
           await resizeElement(editor, { x: -50, y: -50 }, EdgePositionTopLeft, emptyModifiers)
 
-          expect(groupDiv.style.width).toBe('183px')
-          expect(groupDiv.style.height).toBe('183px')
+          expect(groupDiv.style.width).toBe('250px')
+          expect(groupDiv.style.height).toBe('250px')
 
           assertStylePropsSet(editor, `${GroupPath}`, {
-            left: 67,
-            top: 67,
+            left: 0,
+            top: 0,
             width: undefined,
             height: undefined,
             right: undefined,
@@ -1405,8 +1382,8 @@ describe('Groups behaviors', () => {
           assertStylePropsSet(editor, `${GroupPath}/child-1`, {
             left: 0,
             top: 0,
-            width: 183,
-            height: 183,
+            width: 250,
+            height: 250,
             right: undefined,
             bottom: undefined,
           })
@@ -1549,8 +1526,8 @@ describe('Groups behaviors', () => {
           expect(groupDiv.style.height).toBe('0px')
 
           assertStylePropsSet(editor, `${GroupPath}`, {
-            left: 117,
-            top: 117,
+            left: 50,
+            top: 50,
             width: undefined,
             height: undefined,
             right: undefined,
@@ -1576,8 +1553,8 @@ describe('Groups behaviors', () => {
           expect(groupDiv.style.height).toBe('0px')
 
           assertStylePropsSet(editor, `${GroupPath}`, {
-            left: 67,
-            top: 67,
+            left: 0,
+            top: 0,
             width: undefined,
             height: undefined,
             right: undefined,
@@ -1620,19 +1597,14 @@ describe('Groups behaviors', () => {
         // Resizing bottom right
         {
           await selectComponentsForTest(editor, [fromString(GroupPath)])
-          await resizeElement(editor, { x: 100, y: 150 }, EdgePositionBottomRight, emptyModifiers, {
-            midDragCallback: async () => {
-              expect(groupDiv.style.width).toBe('300px')
-              expect(groupDiv.style.height).toBe('351px') // TODO for a later date: ideally this would be 350, but I think I am making a rounding error somewhere
-            },
-          })
+          await resizeElement(editor, { x: 100, y: 150 }, EdgePositionBottomRight, emptyModifiers)
 
-          expect(groupDiv.style.width).toBe('75px')
-          expect(groupDiv.style.height).toBe('88px')
+          expect(groupDiv.style.width).toBe('300px')
+          expect(groupDiv.style.height).toBe('350px')
 
           assertStylePropsSet(editor, `${GroupPath}`, {
-            left: 125,
-            top: 138,
+            left: 50,
+            top: 50,
             width: undefined,
             height: undefined,
             right: undefined,
@@ -1643,8 +1615,8 @@ describe('Groups behaviors', () => {
             top: 0,
             right: 0,
             bottom: 0,
-            width: 75,
-            height: 88,
+            width: 300,
+            height: 350,
           })
         }
 
@@ -1653,12 +1625,12 @@ describe('Groups behaviors', () => {
           await selectComponentsForTest(editor, [fromString(GroupPath)])
           await resizeElement(editor, { x: -50, y: -50 }, EdgePositionTopLeft, emptyModifiers)
 
-          expect(groupDiv.style.width).toBe('125px')
-          expect(groupDiv.style.height).toBe('138px')
+          expect(groupDiv.style.width).toBe('350px')
+          expect(groupDiv.style.height).toBe('400px')
 
           assertStylePropsSet(editor, `${GroupPath}`, {
-            left: 75,
-            top: 88,
+            left: 0,
+            top: 0,
             width: undefined,
             height: undefined,
             right: undefined,
@@ -1669,8 +1641,8 @@ describe('Groups behaviors', () => {
             top: 0,
             right: 0,
             bottom: 0,
-            width: 125,
-            height: 138,
+            width: 350,
+            height: 400,
           })
         }
       })
@@ -2067,8 +2039,8 @@ describe('Groups behaviors', () => {
           await selectComponentsForTest(editor, [fromString(GroupPath)])
           await resizeElement(editor, { x: 50, y: 100 }, EdgePositionBottomRight, emptyModifiers)
 
-          expect(groupDiv.style.width).toBe('240px')
-          expect(groupDiv.style.height).toBe('280px')
+          expect(groupDiv.style.width).toBe('300px')
+          expect(groupDiv.style.height).toBe('350px')
 
           assertStylePropsSet(editor, `${GroupPath}`, {
             left: 50,
@@ -2081,14 +2053,14 @@ describe('Groups behaviors', () => {
           assertStylePropsSet(editor, `${GroupPath}/child-1`, {
             left: 0,
             top: 0,
-            width: 120,
-            height: 140,
+            width: 150,
+            height: 175,
             right: undefined,
             bottom: undefined,
           })
           assertStylePropsSet(editor, `${GroupPath}/inner-group`, {
-            left: 120,
-            top: 140,
+            left: 150,
+            top: 175,
             width: undefined,
             height: undefined,
             right: 0,
@@ -2097,8 +2069,8 @@ describe('Groups behaviors', () => {
           assertStylePropsSet(editor, `${GroupPath}/inner-group/child-2`, {
             left: 0,
             top: 0,
-            width: 120,
-            height: 140,
+            width: 150,
+            height: 175,
             right: undefined,
             bottom: undefined,
           })
@@ -2109,8 +2081,8 @@ describe('Groups behaviors', () => {
           await selectComponentsForTest(editor, [fromString(GroupPath)])
           await resizeElement(editor, { x: -50, y: -50 }, EdgePositionTopLeft, emptyModifiers)
 
-          expect(groupDiv.style.width).toBe('290px')
-          expect(groupDiv.style.height).toBe('330px')
+          expect(groupDiv.style.width).toBe('350px')
+          expect(groupDiv.style.height).toBe('400px')
 
           assertStylePropsSet(editor, `${GroupPath}`, {
             left: 0,
@@ -2123,14 +2095,14 @@ describe('Groups behaviors', () => {
           assertStylePropsSet(editor, `${GroupPath}/child-1`, {
             left: 0,
             top: 0,
-            width: 145,
-            height: 165,
+            width: 175,
+            height: 200,
             right: undefined,
             bottom: undefined,
           })
           assertStylePropsSet(editor, `${GroupPath}/inner-group`, {
-            left: 145,
-            top: 165,
+            left: 175,
+            top: 200,
             width: undefined,
             height: undefined,
             right: 0,
@@ -2139,8 +2111,8 @@ describe('Groups behaviors', () => {
           assertStylePropsSet(editor, `${GroupPath}/inner-group/child-2`, {
             left: 0,
             top: 0,
-            width: 145,
-            height: 165,
+            width: 175,
+            height: 200,
             right: undefined,
             bottom: undefined,
           })
@@ -2876,8 +2848,8 @@ describe('Groups behaviors', () => {
             },
           })
 
-          expect(groupDiv.style.width).toBe('140px')
-          expect(groupDiv.style.height).toBe('140px')
+          expect(groupDiv.style.width).toBe('210px')
+          expect(groupDiv.style.height).toBe('210px')
 
           assertStylePropsSet(editor, `${GroupPath}`, {
             left: 50,
@@ -2890,8 +2862,8 @@ describe('Groups behaviors', () => {
           assertStylePropsSet(editor, `${GroupPath}/child-1`, {
             left: 0,
             top: 0,
-            width: 140, // so this is interesting here, the original constraints were 100 width, 50 right. resizing by 60 split the resize 40-20 towards the width
-            height: 140,
+            width: 210, // so this is interesting here, the original constraints were 100 width, 50 right. resizing by 60 split the resize 40-20 towards the width
+            height: 210,
           })
         }
       })
@@ -3035,14 +3007,14 @@ describe('Groups behaviors', () => {
             },
           })
 
-          expect(groupDiv.style.width).toBe('50px')
-          expect(groupDiv.style.height).toBe('50px')
+          expect(groupDiv.style.width).toBe('200px')
+          expect(groupDiv.style.height).toBe('200px')
 
           assertStylePropsSet(editor, `${GroupPath}`, {
             left: 100,
             top: 100,
-            width: 50,
-            height: 50,
+            width: 200,
+            height: 200,
             right: undefined,
             bottom: undefined,
           })
@@ -3062,19 +3034,19 @@ describe('Groups behaviors', () => {
           await selectComponentsForTest(editor, [fromString(GroupPath)])
           await resizeElement(editor, { x: -50, y: -50 }, EdgePositionTopLeft, emptyModifiers, {
             midDragCallback: async () => {
-              expect(groupDiv.style.width).toBe('100px')
-              expect(groupDiv.style.height).toBe('100px')
+              expect(groupDiv.style.width).toBe('250px')
+              expect(groupDiv.style.height).toBe('250px')
             },
           })
 
-          expect(groupDiv.style.width).toBe('100px')
-          expect(groupDiv.style.height).toBe('100px')
+          expect(groupDiv.style.width).toBe('250px')
+          expect(groupDiv.style.height).toBe('250px')
 
           assertStylePropsSet(editor, `${GroupPath}`, {
             left: 50,
             top: 50,
-            width: 100,
-            height: 100,
+            width: 250,
+            height: 250,
             right: undefined,
             bottom: undefined,
           })
@@ -3128,22 +3100,22 @@ describe('Groups behaviors', () => {
             },
           })
 
-          expect(groupDiv.style.width).toBe('50px')
-          expect(groupDiv.style.height).toBe('50px')
+          expect(groupDiv.style.width).toBe('200px')
+          expect(groupDiv.style.height).toBe('200px')
 
           assertStylePropsSet(editor, `${GroupPath}`, {
             left: 100,
             top: 100,
-            width: 50,
-            height: 50,
+            width: 200,
+            height: 200,
             right: undefined,
             bottom: undefined,
           })
           assertStylePropsSet(editor, `${GroupPath}/child-1`, {
             left: 0,
             top: 0,
-            width: 50,
-            height: 50,
+            width: 200,
+            height: 200,
             right: 0,
             bottom: 0,
           })
@@ -3155,27 +3127,27 @@ describe('Groups behaviors', () => {
           await selectComponentsForTest(editor, [fromString(GroupPath)])
           await resizeElement(editor, { x: -50, y: -50 }, EdgePositionTopLeft, emptyModifiers, {
             midDragCallback: async () => {
-              expect(groupDiv.style.width).toBe('100px')
-              expect(groupDiv.style.height).toBe('100px')
+              expect(groupDiv.style.width).toBe('250px')
+              expect(groupDiv.style.height).toBe('250px')
             },
           })
 
-          expect(groupDiv.style.width).toBe('100px')
-          expect(groupDiv.style.height).toBe('100px')
+          expect(groupDiv.style.width).toBe('250px')
+          expect(groupDiv.style.height).toBe('250px')
 
           assertStylePropsSet(editor, `${GroupPath}`, {
             left: 50,
             top: 50,
-            width: 100,
-            height: 100,
+            width: 250,
+            height: 250,
             right: undefined,
             bottom: undefined,
           })
           assertStylePropsSet(editor, `${GroupPath}/child-1`, {
             left: 0,
             top: 0,
-            width: 100,
-            height: 100,
+            width: 250,
+            height: 250,
             right: 0,
             bottom: 0,
           })

--- a/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
+++ b/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
@@ -185,17 +185,10 @@ function getUpdateResizedGroupChildrenCommands(
         )
       }
 
-      // the original size of the group before the interaction ran
-      let childrenBounds: CanvasRectangle | null
-      if (command.isStartingMetadata === 'starting-metadata') {
-        // if we have the starting metadata, we can simply get the original measured bounds of the element and we know it's the originalSize
-        childrenBounds = rectangleFromChildrenBounds(editor, children) //sizeFromMeasuredBounds()
-      } else {
-        // if the metadata is fresh, the group is already resized. so we need to query the size of its children AABB
-        //(which was not yet updated, since this function is updating the children sizes) to get the originalSize
-        childrenBounds = rectangleFromChildrenBounds(editor, children)
-      }
+      // The original size of the children before the interaction ran.
+      const childrenBounds: CanvasRectangle | null = rectangleFromChildrenBounds(editor, children)
 
+      // The original size of the group before the interaction ran.
       const groupOriginalBounds = frameFromMeasuredBounds()
 
       if (childrenBounds != null && groupOriginalBounds != null) {

--- a/editor/src/components/canvas/commands/utils/group-resize-utils.ts
+++ b/editor/src/components/canvas/commands/utils/group-resize-utils.ts
@@ -1,4 +1,10 @@
-import type { LocalRectangle, Size } from '../../../../core/shared/math-utils'
+import type {
+  CanvasRectangle,
+  LocalRectangle,
+  SimpleRectangle,
+  Size,
+} from '../../../../core/shared/math-utils'
+import { canvasRectangle } from '../../../../core/shared/math-utils'
 import { roundToNearestWhole } from '../../../../core/shared/math-utils'
 
 type FramePoint = keyof FrameWithAllPoints
@@ -23,18 +29,29 @@ export type FrameWithAllPoints = {
   height: number
 }
 
-export function localRectangleToSixFramePoints(
-  localRectangle: LocalRectangle,
+export function rectangleToSixFramePoints(
+  rectangle: SimpleRectangle,
   containerSize: Size,
 ): FrameWithAllPoints {
   return {
-    left: localRectangle.x,
-    right: containerSize.width - (localRectangle.x + localRectangle.width),
-    width: localRectangle.width,
-    top: localRectangle.y,
-    bottom: containerSize.height - (localRectangle.y + localRectangle.height),
-    height: localRectangle.height,
+    left: rectangle.x,
+    right: containerSize.width - (rectangle.x + rectangle.width),
+    width: rectangle.width,
+    top: rectangle.y,
+    bottom: containerSize.height - (rectangle.y + rectangle.height),
+    height: rectangle.height,
   }
+}
+
+export function sixFramePointsToCanvasRectangle(
+  frameWithAllPoints: FrameWithAllPoints,
+): CanvasRectangle {
+  return canvasRectangle({
+    x: frameWithAllPoints.left,
+    y: frameWithAllPoints.top,
+    width: frameWithAllPoints.width,
+    height: frameWithAllPoints.height,
+  })
 }
 
 export function roundSixPointFrameToNearestWhole(
@@ -51,8 +68,9 @@ export function roundSixPointFrameToNearestWhole(
 }
 
 export function transformConstrainedLocalFullFrameUsingBoundingBox(
-  newBoundingBox: Size,
-  currentBoundingBox: Size,
+  groupOriginalBoundingBox: CanvasRectangle,
+  groupNewBoundingBox: CanvasRectangle,
+  childrenBoundingBox: CanvasRectangle,
   currentFrame: FrameWithAllPoints,
   constrainedPoints: Array<FramePoint>,
 ): FrameWithAllPoints {
@@ -80,10 +98,12 @@ export function transformConstrainedLocalFullFrameUsingBoundingBox(
       const horizontal = isHorizontalPoint(framePoint)
 
       const currentSizeForDimension = horizontal
-        ? currentBoundingBox.width
-        : currentBoundingBox.height
+        ? childrenBoundingBox.width
+        : childrenBoundingBox.height
 
-      const newSizeForDimension = horizontal ? newBoundingBox.width : newBoundingBox.height
+      const newSizeForDimension = horizontal
+        ? groupNewBoundingBox.width
+        : groupNewBoundingBox.height
 
       const constrainedPointsForDimension = horizontal
         ? horizontalConstrainedPoints
@@ -115,9 +135,25 @@ export function transformConstrainedLocalFullFrameUsingBoundingBox(
       // for non-constrained Frame Points, we change them by calculating the ratio of the old bounding rectangle's non-constrained area vs the new bounding rectangle's non-constrained area
       // as you can see above, while I think the maths is right, zeros are creeping in causing edge cases I need to fix
       // I think this function could be rewritten into a much shorter, way more elegant piece of code
-      const updatedFramePointLength =
-        (currentFramePointLength * (newSizeForDimension - constrainedLengthForDimension)) /
-        (currentSizeForDimension - constrainedLengthForDimension)
+      const dimensionRatioDivisor = currentSizeForDimension - constrainedLengthForDimension
+      const dimensionRatio =
+        dimensionRatioDivisor === 0
+          ? 1
+          : (newSizeForDimension - constrainedLengthForDimension) / dimensionRatioDivisor
+      function getUpdatedFramePoint(): number {
+        switch (framePoint) {
+          case 'left':
+            const leftShift = groupOriginalBoundingBox.x - childrenBoundingBox.x
+            return (currentFramePointLength + leftShift) * dimensionRatio
+          case 'top':
+            const topShift = groupOriginalBoundingBox.y - childrenBoundingBox.y
+            return (currentFramePointLength + topShift) * dimensionRatio
+          default:
+            return currentFramePointLength * dimensionRatio
+        }
+      }
+
+      const updatedFramePointLength = getUpdatedFramePoint()
 
       newFullFrame[framePoint] = updatedFramePointLength
       return newFullFrame

--- a/editor/src/components/canvas/commands/utils/group-resize-utils.ts
+++ b/editor/src/components/canvas/commands/utils/group-resize-utils.ts
@@ -74,8 +74,6 @@ export function transformConstrainedLocalFullFrameUsingBoundingBox(
   currentFrame: FrameWithAllPoints,
   constrainedPoints: Array<FramePoint>,
 ): FrameWithAllPoints {
-  // TODO verify that currentBoundingBox and currentFrame's dimensions match up
-
   function sumConstrainedLengths(sum: number, framePoint: FramePoint) {
     return sum + currentFrame[framePoint]
   }
@@ -132,30 +130,30 @@ export function transformConstrainedLocalFullFrameUsingBoundingBox(
 
       const currentFramePointLength = currentFrame[framePoint]
 
-      // for non-constrained Frame Points, we change them by calculating the ratio of the old bounding rectangle's non-constrained area vs the new bounding rectangle's non-constrained area
-      // as you can see above, while I think the maths is right, zeros are creeping in causing edge cases I need to fix
-      // I think this function could be rewritten into a much shorter, way more elegant piece of code
+      // For non-constrained Frame Points, we change them by calculating the ratio of the
+      // old bounding rectangle's non-constrained area vs the new bounding rectangle's non-constrained area.
       const dimensionRatioDivisor = currentSizeForDimension - constrainedLengthForDimension
       const dimensionRatio =
         dimensionRatioDivisor === 0
           ? 1
           : (newSizeForDimension - constrainedLengthForDimension) / dimensionRatioDivisor
+
       function getUpdatedFramePoint(): number {
         switch (framePoint) {
           case 'left':
             const leftShift = groupOriginalBoundingBox.x - childrenBoundingBox.x
-            return (currentFramePointLength + leftShift) * dimensionRatio
+            return currentFramePointLength + leftShift
           case 'top':
             const topShift = groupOriginalBoundingBox.y - childrenBoundingBox.y
-            return (currentFramePointLength + topShift) * dimensionRatio
+            return currentFramePointLength + topShift
           default:
-            return currentFramePointLength * dimensionRatio
+            return currentFramePointLength
         }
       }
 
-      const updatedFramePointLength = getUpdatedFramePoint()
+      const updatedFramePointValue = getUpdatedFramePoint()
 
-      newFullFrame[framePoint] = updatedFramePointLength
+      newFullFrame[framePoint] = updatedFramePointValue * dimensionRatio
       return newFullFrame
     },
     {},


### PR DESCRIPTION
**Problem:**
When starting to move/resize children of a group, there might be a "jump" in the size of the containing group, if the group doesn't match up to the bounds of the children. Which happens by default because of the truing up.

However we do not have a similar change when resizing a group, which is desired, for the children to match up to the bounds of the group and then the resize operation to continue from there.

**Fix:**
Previously the logic for this effectively assumed that the children frames matched up to the group frame, so the main change was the introduction of different values for the bounds of the children, the original bounds of the group and the new bounds of the group.

With that the difference can be included in the change to the children along with a slightly specialised change for the top and left as resizing to those needs to change those slightly differently to the other 4 frame points. Related to that change, `*Rectangle` types were used in place of `Size` so that enough information was available to do the calculations.

**Commit Details:**
- Type of `localRectangleToSixFramePoints` widened and slightly renamed to represent that.
- Added `sixFramePointsToCanvasRectangle`.
- Renamed parameters of `transformConstrainedLocalFullFrameUsingBoundingBox` and added a new parameter containing the bounding box of the children.
- `transformConstrainedLocalFullFrameUsingBoundingBox` now caters for the bounding box of the children being different to the bounding box of the group before the interaction starts.
- `getUpdateResizedGroupChildrenCommands` now repositions for top and left and calculates the delta with frames not just the size and utilises the change from jumping the children to match the bounds.