### PR TITLE
Add a button to remove a dependency

### DIFF
--- a/editor/src/components/navigator/dependency-list-item.tsx
+++ b/editor/src/components/navigator/dependency-list-item.tsx
@@ -16,6 +16,7 @@ import {
 import { MenuProvider, MomentumContextMenu } from '../../uuiui-deps'
 import { handleKeyDown } from '../editor/global-shortcuts'
 import type { DependencyPackageDetails } from '../editor/store/editor-state'
+import { unless } from '../../utils/react-conditionals'
 
 interface DependencyListItemProps {
   packageDetails: DependencyPackageDetails
@@ -213,8 +214,6 @@ export const DependencyListItem: React.FunctionComponent<
               '.dependency-item:hover &': {
                 display: 'block',
               },
-              marginLeft: 4,
-              marginTop: 4,
             }}
           >
             <Icons.ExternalLinkSmaller />
@@ -226,6 +225,22 @@ export const DependencyListItem: React.FunctionComponent<
             flexShrink: 0,
           }}
         >
+          {unless(
+            isDefault,
+            <FlexRow
+              css={{
+                display: 'none',
+                '.dependency-item:hover &': {
+                  display: 'block',
+                },
+                cursor: 'pointer',
+              }}
+              // eslint-disable-next-line react/jsx-no-bind
+              onClick={() => removeDependency(name)}
+            >
+              <Icons.Cross tooltipText={`Remove ${name}`} />
+            </FlexRow>,
+          )}
           {versionFieldNode}
         </FlexRow>
       </FlexRow>


### PR DESCRIPTION
## Problem
Dependencies can only be removed via a context menu item, which is hard to discover.

## Fix
<img width="299" alt="image" src="https://github.com/concrete-utopia/utopia/assets/16385508/3229a248-5e21-43de-8c14-7323f1503a3a">

Create a button that appears on hover, and does the same thing as the corresponding context menu item. 

Dependencies that are required for Utopia projects cannot be removed. 