### PR TITLE
Enable `Editor` buttons even if live mode is active

### DIFF
--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -320,6 +320,7 @@ export const CanvasToolbar = React.memo(() => {
               iconType='refresh'
               iconCategory='semantic'
               onClick={resetCanvasCallback}
+              keepActiveInLiveMode
             />
           </Tooltip>
 
@@ -328,6 +329,7 @@ export const CanvasToolbar = React.memo(() => {
               iconType='navigator-larger'
               iconCategory='semantic'
               onClick={toggleNavigatorVisible}
+              keepActiveInLiveMode
             />
           </Tooltip>
           <Tooltip title='Toggle Inspector (⌘⌥2)' placement='bottom'>
@@ -335,6 +337,7 @@ export const CanvasToolbar = React.memo(() => {
               iconType='inspector-larger'
               iconCategory='semantic'
               onClick={toggleInspectorVisible}
+              keepActiveInLiveMode
             />
           </Tooltip>
           <Tooltip title='Toggle Code Editor (⌘.)' placement='bottom'>
@@ -342,6 +345,7 @@ export const CanvasToolbar = React.memo(() => {
               iconType='codymccodeface-larger'
               iconCategory='semantic'
               onClick={toggleCodeEditorVisible}
+              keepActiveInLiveMode
             />
           </Tooltip>
         </FlexRow>


### PR DESCRIPTION
## Problem
The buttons in the `Editor` section of the canvas toolbar are disabled in live mode, even though they would be useful in live mode too.

## Fix
Enable the Refresh, Toggle Navigator, Toggle Inspector and Toggle Code Editor buttons in live mode.