### PR TITLE
Don't show groups border radius control

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -69,6 +69,7 @@ import {
 import type { InteractionSession } from '../interaction-state'
 import { deleteProperties } from '../../commands/delete-properties-command'
 import { allElemsEqual } from '../../../../core/shared/array-utils'
+import { treatElementAsGroupLikeFromMetadata } from './group-helpers'
 
 export const SetBorderRadiusStrategyId = 'SET_BORDER_RADIUS_STRATEGY'
 
@@ -100,6 +101,13 @@ export const setBorderRadiusStrategy: CanvasStrategyFactory = (
     canvasState.startingElementPathTree,
   ).has('borderRadius')
   if (!canShowBorderRadiusControls) {
+    return null
+  }
+
+  const isGroup = treatElementAsGroupLikeFromMetadata(element)
+  const hasOverflowHidden =
+    element.computedStyle != null && element.computedStyle['overflow'] === 'hidden'
+  if (isGroup && !hasOverflowHidden) {
     return null
   }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -69,7 +69,6 @@ import {
 import type { InteractionSession } from '../interaction-state'
 import { deleteProperties } from '../../commands/delete-properties-command'
 import { allElemsEqual } from '../../../../core/shared/array-utils'
-import { treatElementAsGroupLikeFromMetadata } from './group-helpers'
 
 export const SetBorderRadiusStrategyId = 'SET_BORDER_RADIUS_STRATEGY'
 
@@ -101,13 +100,6 @@ export const setBorderRadiusStrategy: CanvasStrategyFactory = (
     canvasState.startingElementPathTree,
   ).has('borderRadius')
   if (!canShowBorderRadiusControls) {
-    return null
-  }
-
-  const isGroup = treatElementAsGroupLikeFromMetadata(element)
-  const hasOverflowHidden =
-    element.computedStyle != null && element.computedStyle['overflow'] === 'hidden'
-  if (isGroup && !hasOverflowHidden) {
     return null
   }
 


### PR DESCRIPTION
Fixes #4127 

**Problem:**

Border radius controls are shown on the canvas for groups.

**Fix:**

Don't show the border radius controls for groups, unless they have `overflow: hidden`.