### PR TITLE
Hide width/height row pin toggle for groups

### DIFF
--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -22,19 +22,18 @@ import type { SelfLayoutTab } from './self-layout-subsection'
 import {
   useWrappedEmptyOrUnknownOnSubmitValue,
   NumberInput,
-  Icons,
   FlexColumn,
   SimpleNumberInput,
-  useColorTheme,
 } from '../../../../../uuiui'
 import { useInspectorInfoLonghandShorthand } from '../../../common/longhand-shorthand-hooks'
 import { isNotUnsetOrDefault } from '../../../common/control-status'
 import { usePropControlledStateV2 } from '../../../common/inspector-utils'
 import { useContextSelector } from 'use-context-selector'
-import { isFeatureEnabled } from '../../../../../utils/feature-switches'
 import { unless } from '../../../../../utils/react-conditionals'
 import type { OnSubmitValueOrUnknownOrEmpty } from '../../../controls/control'
-import { FlexCol, FlexRow } from 'utopia-api'
+import { FlexCol } from 'utopia-api'
+import { treatElementAsGroupLike } from '../../../../canvas/canvas-strategies/strategies/group-helpers'
+import { useEditorState, Substores } from '../../../../editor/store/store-hook'
 
 interface PinsLayoutNumberControlProps {
   label: string
@@ -454,10 +453,30 @@ const OtherPinsRow = React.memo((props: PinControlsProps) => {
   const firstYAxisControl: React.ReactElement = pinsLayoutNumberControl('left')
   const secondYAxisControl: React.ReactElement = pinsLayoutNumberControl('right')
 
+  const selectionContainsGroups = useEditorState(
+    Substores.metadata,
+    (store) =>
+      store.editor.selectedViews.some((path) =>
+        treatElementAsGroupLike(store.editor.jsxMetadata, path),
+      ),
+    'OtherPinsRow selectionContainsGroups',
+  )
+
   return (
-    <UIGridRow alignItems='start' padded={true} variant='<-auto->|20px|<----------1fr--------->'>
+    <UIGridRow
+      alignItems='start'
+      padded={true}
+      variant={
+        selectionContainsGroups
+          ? '<-auto-><----------1fr--------->'
+          : '<-auto->|20px|<----------1fr--------->'
+      }
+    >
       <PinControls resetPins={resetPinsFn} framePins={framePins} togglePin={togglePin} />
-      <WidthHeightRow togglePin={togglePin} framePins={framePins} />
+      {unless(
+        selectionContainsGroups,
+        <WidthHeightRow togglePin={togglePin} framePins={framePins} />,
+      )}
       <FlexColumn style={{ gap: 8 }}>
         <UIGridRow
           padded={false}


### PR DESCRIPTION
Fixes #4129 

**Problem:**

The w/h pin toggles are shown for groups even if they are not applicable.

<img width="264" alt="Screenshot 2023-08-30 at 1 16 42 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/a1afcea2-830a-4100-80f2-8e2004891fbe">


**Fix:**

Hide those buttons if the selection contains groups.