### PR TITLE
Catch errors from Remix flatRoutes

### DIFF
--- a/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
@@ -25,7 +25,7 @@ export var storyboard = (
 );
 `
 
-describe('Remix utils', () => {
+describe('Route manifest', () => {
   setFeatureForBrowserTestsUseInDescribeBlockOnly('Remix support', true)
   it('Parses the route manifest from a simple project', async () => {
     const project = createModifiedProject({
@@ -80,6 +80,18 @@ describe('Remix utils', () => {
         filePath: '/src/root.js',
       },
     })
+  })
+  it('Returns null to a non-remix project', async () => {
+    const project = createModifiedProject({
+      [StoryboardFilePath]: storyboardFileContent,
+    })
+    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+
+    const remixManifest = createRouteManifestFromProjectContents(
+      renderResult.getEditorState().editor.projectContents,
+    )
+
+    expect(remixManifest).toBeNull()
   })
   it('Parses the route manifest from the Remix Blog Tutorial project files', async () => {
     const project = createModifiedProject({

--- a/editor/src/components/canvas/remix/remix-utils.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.tsx
@@ -53,7 +53,13 @@ export function projectContentsToFileOps(projectContents: ProjectContentTreeRoot
 export function createRouteManifestFromProjectContents(
   projectContents: ProjectContentTreeRoot,
 ): RouteManifest<EntryRouteWithFilePath> | null {
-  const routesFromRemix = flatRoutes(ROOT_DIR, projectContentsToFileOps(projectContents))
+  const routesFromRemix = (() => {
+    try {
+      return flatRoutes(ROOT_DIR, projectContentsToFileOps(projectContents))
+    } catch (e) {
+      return null
+    }
+  })()
 
   if (routesFromRemix == null) {
     return null


### PR DESCRIPTION
**Description:**
We create the Remix route manifest using a function from the Remix project called `flatRoutes`. This function throws an exception when the Remix root file is missing.
We never want Remix route parsing to throw an error, so I call `flatRoutes` from a try catch block and just return null in this case.
