### PR TITLE
Reuse createClientRoutes from Remix

### DIFF
--- a/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
@@ -1,4 +1,3 @@
-import { DataRouteObject } from 'react-router'
 import { createModifiedProject } from '../../../sample-projects/sample-project-utils.test-utils'
 import { setFeatureForBrowserTestsUseInDescribeBlockOnly } from '../../../utils/utils.test-utils'
 import { StoryboardFilePath } from '../../editor/store/editor-state'

--- a/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
@@ -1,8 +1,13 @@
+import { DataRouteObject } from 'react-router'
 import { createModifiedProject } from '../../../sample-projects/sample-project-utils.test-utils'
 import { setFeatureForBrowserTestsUseInDescribeBlockOnly } from '../../../utils/utils.test-utils'
 import { StoryboardFilePath } from '../../editor/store/editor-state'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
-import { createRouteManifestFromProjectContents } from './remix-utils'
+import {
+  DefaultFutureConfig,
+  createRouteManifestFromProjectContents,
+  getRoutesFromRouteManifest,
+} from './remix-utils'
 
 const storyboardFileContent = `
 import * as React from 'react';
@@ -29,7 +34,7 @@ describe('Route manifest', () => {
     const project = createModifiedProject({
       [StoryboardFilePath]: storyboardFileContent,
       ['src/root.js']: '',
-      ['src/_index.js']: '',
+      ['src/routes/_index.js']: '',
       ['src/routes/posts.$postId.js']: '',
       ['src/routes/posts._index.js']: '',
     })
@@ -73,6 +78,18 @@ describe('Route manifest', () => {
         hasLoader: false,
         hasCatchBoundary: false,
         hasErrorBoundary: false,
+      },
+      'routes/_index': {
+        file: 'routes/_index.js',
+        hasAction: false,
+        hasCatchBoundary: false,
+        hasErrorBoundary: false,
+        hasLoader: false,
+        id: 'routes/_index',
+        index: true,
+        module: '/src/routes/_index.js',
+        parentId: 'root',
+        path: undefined,
       },
     })
   })
@@ -208,5 +225,103 @@ describe('Route manifest', () => {
         hasErrorBoundary: false,
       },
     })
+  })
+})
+
+describe('Routes', () => {
+  setFeatureForBrowserTestsUseInDescribeBlockOnly('Remix support', true)
+  it('Parses the routes from a simple project', async () => {
+    const project = createModifiedProject({
+      [StoryboardFilePath]: storyboardFileContent,
+      ['src/root.js']: '',
+      ['src/routes/_index.js']: '',
+      ['src/routes/posts.$postId.js']: '',
+      ['src/routes/posts._index.js']: '',
+    })
+    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+
+    const remixManifest = createRouteManifestFromProjectContents(
+      renderResult.getEditorState().editor.projectContents,
+    )
+    expect(remixManifest).not.toBeNull()
+    const remixRoutes = getRoutesFromRouteManifest(remixManifest!, DefaultFutureConfig)
+
+    expect(remixRoutes).toHaveLength(1)
+    expect(remixRoutes[0]).toEqual(
+      expect.objectContaining({ id: 'root', path: '', index: undefined }),
+    )
+    expect(remixRoutes[0].children).toHaveLength(3)
+    expect(remixRoutes[0]!.children![0]).toEqual(
+      expect.objectContaining({
+        id: 'routes/posts.$postId',
+        path: 'posts/:postId',
+        index: undefined,
+      }),
+    )
+    expect(remixRoutes[0]!.children![1]).toEqual(
+      expect.objectContaining({ id: 'routes/posts._index', path: 'posts', index: true }),
+    )
+    expect(remixRoutes[0]!.children![2]).toEqual(
+      expect.objectContaining({ id: 'routes/_index', path: undefined, index: true }),
+    )
+  })
+  it('Parses the routes from the Remix Blog Tutorial project files', async () => {
+    const project = createModifiedProject({
+      [StoryboardFilePath]: storyboardFileContent,
+      ['src/root.js']: '',
+      ['src/routes/_index.js']: '',
+      ['src/routes/healthcheck.js']: '',
+      ['src/routes/join.js']: '',
+      ['src/routes/logout.js']: '',
+      ['src/routes/notes._index.js']: '',
+      ['src/routes/notes.$noteId.js']: '',
+      ['src/routes/notes.new.js']: '',
+      ['src/routes/notes.js']: '',
+    })
+    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+
+    const remixManifest = createRouteManifestFromProjectContents(
+      renderResult.getEditorState().editor.projectContents,
+    )
+
+    expect(remixManifest).not.toBeNull()
+    const remixRoutes = getRoutesFromRouteManifest(remixManifest!, DefaultFutureConfig)
+
+    expect(remixRoutes).toHaveLength(1)
+    expect(remixRoutes[0]).toEqual(
+      expect.objectContaining({ id: 'root', path: '', index: undefined }),
+    )
+
+    expect(remixRoutes[0].children).toHaveLength(5)
+    expect(remixRoutes[0]!.children![0]).toEqual(
+      expect.objectContaining({
+        id: 'routes/healthcheck',
+        path: 'healthcheck',
+        index: undefined,
+      }),
+    )
+    expect(remixRoutes[0]!.children![1]).toEqual(
+      expect.objectContaining({ id: 'routes/_index', path: undefined, index: true }),
+    )
+    expect(remixRoutes[0]!.children![2]).toEqual(
+      expect.objectContaining({ id: 'routes/logout', path: 'logout', index: undefined }),
+    )
+    expect(remixRoutes[0]!.children![3]).toEqual(
+      expect.objectContaining({ id: 'routes/notes', path: 'notes', index: undefined }),
+    )
+    expect(remixRoutes[0]!.children![4]).toEqual(
+      expect.objectContaining({ id: 'routes/join', path: 'join', index: undefined }),
+    )
+
+    expect(remixRoutes[0]!.children![3].children).toHaveLength(3)
+    expect(remixRoutes[0]!.children![3].children![0]).toEqual(
+      expect.objectContaining({ id: 'routes/notes.$noteId', path: ':noteId', index: undefined }),
+    )
+    expect(remixRoutes[0]!.children![3].children![1]).toEqual(
+      expect.objectContaining({ id: 'routes/notes._index', path: undefined, index: true }),
+    )
+    expect(remixRoutes[0]!.children![3].children![2]).toEqual(
+      expect.objectContaining({ id: 'routes/notes.new', path: 'new', index: undefined }),
+    )
   })
 })

--- a/editor/src/components/canvas/remix/remix-utils.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.tsx
@@ -8,6 +8,8 @@ import { getContentsTreeFromPath } from '../../assets'
 import type { FileOps } from '../../../third-party/remix/flat-routes'
 import { flatRoutes } from '../../../third-party/remix/flat-routes'
 import type { ConfigRoute } from '../../../third-party/remix/routes'
+import type { DataRouteObject } from 'react-router'
+import { createClientRoutes, groupRoutesByParentId } from '../../../third-party/remix/client-routes'
 
 const ROOT_DIR = '/src'
 
@@ -84,4 +86,16 @@ function patchRemixRoutes(routesFromRemix: RouteManifest<ConfigRoute> | null) {
   }, {} as RouteManifest<EntryRoute>)
 
   return resultRoutes
+}
+
+export function getRoutesFromRouteManifest(
+  routeManifest: RouteManifest<EntryRoute>,
+  futureConfig: FutureConfig,
+): DataRouteObject[] {
+  const routesByParentId = groupRoutesByParentId(routeManifest)
+  try {
+    return createClientRoutes(routeManifest, {}, futureConfig, '', routesByParentId)
+  } catch (e) {
+    return []
+  }
 }

--- a/editor/src/third-party/remix/client-routes.tsx
+++ b/editor/src/third-party/remix/client-routes.tsx
@@ -1,0 +1,164 @@
+/* eslint-disable */
+import React from 'react'
+import { FutureConfig } from '@remix-run/react/dist/entry'
+import { RouteModules } from '@remix-run/react/dist/routeModules'
+import { DataRouteObject, ShouldRevalidateFunction } from 'react-router'
+import { RemixRoute, RemixRouteError } from '@remix-run/react/dist/components'
+import invariant from './invariant'
+
+export interface RouteManifest<Route> {
+  [routeId: string]: Route
+}
+
+// NOTE: make sure to change the Route in server-runtime if you change this
+interface Route {
+  index?: boolean
+  caseSensitive?: boolean
+  id: string
+  parentId?: string
+  path?: string
+}
+
+// NOTE: make sure to change the EntryRoute in server-runtime if you change this
+export interface EntryRoute extends Route {
+  hasAction: boolean
+  hasLoader: boolean
+  hasCatchBoundary: boolean
+  hasErrorBoundary: boolean
+  imports?: string[]
+  module: string
+  parentId?: string
+}
+
+// Create a map of routes by parentId to use recursively instead of
+// repeatedly filtering the manifest.
+export function groupRoutesByParentId(manifest: RouteManifest<EntryRoute>) {
+  let routes: Record<string, Omit<EntryRoute, 'children'>[]> = {}
+
+  Object.values(manifest).forEach((route) => {
+    let parentId = route.parentId || ''
+    if (!routes[parentId]) {
+      routes[parentId] = []
+    }
+    routes[parentId].push(route)
+  })
+
+  return routes
+}
+
+export function createServerRoutes(
+  manifest: RouteManifest<EntryRoute>,
+  routeModules: RouteModules,
+  future: FutureConfig,
+  parentId: string = '',
+  routesByParentId: Record<string, Omit<EntryRoute, 'children'>[]> = groupRoutesByParentId(
+    manifest,
+  ),
+): DataRouteObject[] {
+  return (routesByParentId[parentId] || []).map((route) => {
+    let hasErrorBoundary =
+      future.v2_errorBoundary === true
+        ? route.id === 'root' || route.hasErrorBoundary
+        : route.id === 'root' || route.hasCatchBoundary || route.hasErrorBoundary
+    let dataRoute: DataRouteObject = {
+      caseSensitive: route.caseSensitive,
+      element: <RemixRoute id={route.id} />,
+      errorElement: hasErrorBoundary ? <RemixRouteError id={route.id} /> : undefined,
+      id: route.id,
+      index: route.index,
+      path: route.path,
+      handle: routeModules[route.id].handle,
+      // Note: we don't need loader/action/shouldRevalidate on these routes
+      // since they're for a static render
+    }
+
+    let children = createServerRoutes(manifest, routeModules, future, route.id, routesByParentId)
+    if (children.length > 0) dataRoute.children = children
+    return dataRoute
+  })
+}
+
+export function createClientRoutesWithHMRRevalidationOptOut(
+  needsRevalidation: Set<string>,
+  manifest: RouteManifest<EntryRoute>,
+  routeModulesCache: RouteModules,
+  future: FutureConfig,
+) {
+  return createClientRoutes(
+    manifest,
+    routeModulesCache,
+    future,
+    '',
+    groupRoutesByParentId(manifest),
+    needsRevalidation,
+  )
+}
+
+export function createClientRoutes(
+  manifest: RouteManifest<EntryRoute>,
+  routeModulesCache: RouteModules,
+  future: FutureConfig,
+  parentId: string = '',
+  routesByParentId: Record<string, Omit<EntryRoute, 'children'>[]> = groupRoutesByParentId(
+    manifest,
+  ),
+  needsRevalidation?: Set<string>,
+): DataRouteObject[] {
+  return (routesByParentId[parentId] || []).map((route) => {
+    let hasErrorBoundary =
+      future.v2_errorBoundary === true
+        ? route.id === 'root' || route.hasErrorBoundary
+        : route.id === 'root' || route.hasCatchBoundary || route.hasErrorBoundary
+
+    let dataRoute: DataRouteObject = {
+      caseSensitive: route.caseSensitive,
+      element: <RemixRoute id={route.id} />,
+      errorElement: hasErrorBoundary ? <RemixRouteError id={route.id} /> : undefined,
+      id: route.id,
+      index: route.index,
+      path: route.path,
+      // handle gets added in via useMatches since we aren't guaranteed to
+      // have the route module available here
+      handle: undefined,
+      loader: undefined,
+      action: undefined,
+      shouldRevalidate: createShouldRevalidate(route, routeModulesCache, needsRevalidation),
+    }
+    let children = createClientRoutes(
+      manifest,
+      routeModulesCache,
+      future,
+      route.id,
+      routesByParentId,
+      needsRevalidation,
+    )
+    if (children.length > 0) dataRoute.children = children
+    return dataRoute
+  })
+}
+
+function createShouldRevalidate(
+  route: EntryRoute,
+  routeModules: RouteModules,
+  needsRevalidation?: Set<string>,
+): ShouldRevalidateFunction {
+  let handledRevalidation = false
+  return function (arg) {
+    let module = routeModules[route.id]
+    invariant(module, `Expected route module to be loaded for ${route.id}`)
+
+    // When an HMR / HDR update happens we opt out of all user-defined
+    // revalidation logic and the do as the dev server tells us the first
+    // time router.revalidate() is called.
+    if (needsRevalidation !== undefined && !handledRevalidation) {
+      handledRevalidation = true
+      return needsRevalidation.has(route.id)
+    }
+
+    if (module.shouldRevalidate) {
+      return module.shouldRevalidate(arg as any)
+    }
+
+    return arg.defaultShouldRevalidate
+  }
+}

--- a/editor/src/third-party/remix/invariant.ts
+++ b/editor/src/third-party/remix/invariant.ts
@@ -1,0 +1,10 @@
+export default function invariant(value: boolean, message?: string): asserts value
+export default function invariant<T>(
+  value: T | null | undefined,
+  message?: string,
+): asserts value is T
+export default function invariant(value: any, message?: string) {
+  if (value === false || value === null || typeof value === 'undefined') {
+    throw new Error(message)
+  }
+}


### PR DESCRIPTION
**Description:**
Another function borrowed from Remix: `createClientRoutes` uses the `RouteManifest` to generate the routes which can be provided to the `createMemoryRouter` function.

In Remix this function also loads the `loader` and `action` functions from the modules, we are going to do that separately (from projectContents), so I removed that part.

