### PR TITLE
Make element path cull test more explicit.

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -620,8 +620,14 @@ function editorChangesShouldTriggerSave(oldState: EditorState, newState: EditorS
 let cullElementPathCacheTimeoutId: number | undefined = undefined
 const CullElementPathCacheTimeout = 1000
 let lastProjectContents: ProjectContentTreeRoot = {}
-export function setLastProjectContentsForTesting(projectContents: ProjectContentTreeRoot) {
+export function setLastProjectContentsForTesting(projectContents: ProjectContentTreeRoot): void {
   lastProjectContents = projectContents
+}
+
+export function killElementPathCacheCallback(): void {
+  if (cullElementPathCacheTimeoutId != null) {
+    window.cancelIdleCallback(cullElementPathCacheTimeoutId)
+  }
 }
 
 function maybeCullElementPathCache(
@@ -633,9 +639,7 @@ function maybeCullElementPathCache(
     // Updates from the worker indicate that paths might have changed, so schedule a
     // cache cull for the next time the browser is idle
     if (typeof window.requestIdleCallback !== 'undefined') {
-      if (cullElementPathCacheTimeoutId != null) {
-        window.cancelIdleCallback(cullElementPathCacheTimeoutId)
-      }
+      killElementPathCacheCallback()
 
       cullElementPathCacheTimeoutId = window.requestIdleCallback(cullElementPathCache)
     } else {
@@ -648,7 +652,7 @@ function maybeCullElementPathCache(
   }
 }
 
-function cullElementPathCache() {
+export function cullElementPathCache(): void {
   const allExistingUids = getAllUniqueUids(lastProjectContents).allIDs
   removePathsWithDeadUIDs(new Set(allExistingUids))
 }

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -89,7 +89,7 @@ function removePathsFromElementPathCacheWithDeadUIDs(existingUIDs: Set<string>):
   return removedPaths
 }
 
-export function removePathsWithDeadUIDs(existingUIDs: Set<string>) {
+export function removePathsWithDeadUIDs(existingUIDs: Set<string>): void {
   const removedPaths = removePathsFromElementPathCacheWithDeadUIDs(existingUIDs)
 
   fastForEach(Object.keys(globalPathStringToPathCache), (stringifiedPath) => {


### PR DESCRIPTION
**Problem:**
Locally I had the element path culling test fail because the idle callback triggered after the initial render.

**Fix:**
This change disables the idle callback during the test and invokes the path culling explicitly at a particular point that should demonstrate the desired behaviour.

**Commit Details:**
- Refactored out `killElementPathCacheCallback` so that it can be invoked explicitly.
- Export `cullElementPathCache`.
- Change `ElementPath Caching` test to stop the idle callback and cull the cache explicitly.