### PR TITLE
Fix for `interactionFinished`.

### DIFF
--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -130,6 +130,7 @@ export function interactionFinished(
       domMetadata: storedState.patchedEditor.domMetadata,
       spyMetadata: storedState.patchedEditor.spyMetadata,
       jsxMetadata: storedState.patchedEditor.jsxMetadata,
+      elementPathTree: storedState.patchedEditor.elementPathTree,
     }
     return {
       unpatchedEditorState: newEditorState,

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -103,6 +103,7 @@ export const labelSelector = createCachedSelector(
   (store: MetadataSubstate) => store.editor.elementPathTree,
   (metadata, elementMetadata, allElementProps, pathTrees) => {
     if (elementMetadata == null) {
+      // "Element" with ghost emoji.
       return 'Element 👻'
     }
     return MetadataUtils.getElementLabelFromMetadata(


### PR DESCRIPTION
**Problem:**
In a case triggered by a different bug, when clicking into some overflowing text with an ancestor of that focused, the focusing is updated but the navigator updates to show ghosts for descendants of the prior focused item.

**Cause:**
The `interactionFinished` function was triggered to close off the canvas strategies, which updated the metadata but not the `elementPathTree` value. Which meant that the structure of the navigator was in effect the same, but the metadata for those elements does not exist any more.

**Fix:**
In `interactionFinished` the `elementPathTree` value is now updated with the various `*metadata` fields.

**Commit Details:**
- Updated `interactionFinished` to update `elementPathTree` as well as the various metadata fields.
- Added a comment to make it easier to find the ghost emoji.