### PR TITLE
Fix and tweak locked overlay

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -540,6 +540,8 @@ function handleEventNoop(e: React.MouseEvent | React.KeyboardEvent) {
 }
 
 const LockedOverlay = React.memo(() => {
+  const colorTheme = useColorTheme()
+
   const githubOperations = useEditorState(
     Substores.github,
     (store) => store.editor.githubOperations.filter((op) => githubOperationLocksEditor(op)),
@@ -594,7 +596,7 @@ const LockedOverlay = React.memo(() => {
         left: 0,
         right: 0,
         bottom: 0,
-        backgroundColor: '#00000016',
+        backgroundColor: '#00000033',
         zIndex: 30,
         transition: 'all .1s ease-in-out',
         display: 'flex',
@@ -614,7 +616,8 @@ const LockedOverlay = React.memo(() => {
             opacity: 1,
             fontSize: 12,
             fontWeight: 500,
-            background: '#fff',
+            background: colorTheme.contextMenuBackground.value,
+            border: `1px solid ${colorTheme.neutralBorder.value}`,
             padding: 30,
             borderRadius: 2,
             boxShadow: `3px 4px 10px 0px ${UtopiaTheme.panelStyles.panelShadowColor}`,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -311,22 +311,21 @@ export type GithubOperation =
 export function githubOperationPrettyName(op: GithubOperation): string {
   switch (op.name) {
     case 'commitAndPush':
-      return 'Saving to Github'
+      return 'Saving to GitHub'
     case 'listBranches':
-      return 'Listing branches'
+      return 'Listing branches from GitHub'
     case 'loadBranch':
-      return 'Loading branch'
+      return 'Loading branch from GitHub'
     case 'loadRepositories':
       return 'Loading Repositories'
     case 'updateAgainstBranch':
-      return 'Updating'
+      return 'Updating against branch from GitHub'
     case 'listPullRequestsForBranch':
-      return 'Listing pull requests'
+      return 'Listing GitHub pull requests'
     case 'saveAsset':
-      return 'Saving asset to Github'
+      return 'Saving asset to GitHub'
     default:
-      const _exhaustiveCheck: never = op
-      return 'Unknown operation' // this should never happen
+      assertNever(op)
   }
 }
 


### PR DESCRIPTION
Fixes #4152 

**Problem:**

1. With the new UI panels the locked overlay is not shown in the right position anymore
![overlay](https://github.com/concrete-utopia/utopia/assets/1081051/9e4adf4d-8b6c-4f58-a8cb-92e7a16d6994)
2. While there is a dialog when dependencies are refreshed, there is no indication of the GitHub operation in the overlay

**Fix:**

The PR fixes the overlay positioning and consolidates the dialog behavior, so that a message is shown for those locking operations that can show meaningful information.

![overlay-fix](https://github.com/concrete-utopia/utopia/assets/1081051/8bcbaede-8b82-4469-8775-b68a46530a1f)
