### PR TITLE
Truncate history after loading branch

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -858,6 +858,10 @@ export interface UpdateText {
   textProp: TextProp
 }
 
+export interface TruncateHistory {
+  action: 'TRUNCATE_HISTORY'
+}
+
 export interface SetFocusedElement {
   action: 'SET_FOCUSED_ELEMENT'
   focusedElementPath: ElementPath | null
@@ -1202,6 +1206,7 @@ export type EditorAction =
   | ClearPostActionSession
   | StartPostActionSession
   | FromVSCodeAction
+  | TruncateHistory
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -216,6 +216,7 @@ import type {
   ScrollToElementBehaviour,
   OpenCodeEditor,
   SetMapCountOverride,
+  TruncateHistory,
 } from '../action-types'
 import type { InsertionSubjectWrapper, Mode } from '../editor-modes'
 import { EditorModes, insertionSubject } from '../editor-modes'
@@ -1354,6 +1355,12 @@ export function updateText(target: ElementPath, text: string, textProp: TextProp
     target: target,
     text: text,
     textProp: textProp,
+  }
+}
+
+export function truncateHistory(): TruncateHistory {
+  return {
+    action: 'TRUNCATE_HISTORY',
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -128,6 +128,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'REMOVE_FILE_CONFLICT':
     case 'CLEAR_POST_ACTION_SESSION':
     case 'START_POST_ACTION_SESSION':
+    case 'TRUNCATE_HISTORY':
       return true
 
     case 'TRUE_UP_GROUPS':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4461,6 +4461,13 @@ export const UPDATE_FNS = {
       }
     }
   },
+  TRUNCATE_HISTORY: (editorStore: EditorStoreUnpatched): EditorStoreUnpatched => {
+    const newHistory = History.init(editorStore.unpatchedEditor, editorStore.unpatchedDerived)
+    return {
+      ...editorStore,
+      history: newHistory,
+    }
+  },
   MARK_VSCODE_BRIDGE_READY: (action: MarkVSCodeBridgeReady, editor: EditorModel): EditorModel => {
     return {
       ...editor,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4462,10 +4462,9 @@ export const UPDATE_FNS = {
     }
   },
   TRUNCATE_HISTORY: (editorStore: EditorStoreUnpatched): EditorStoreUnpatched => {
-    const newHistory = History.init(editorStore.unpatchedEditor, editorStore.unpatchedDerived)
     return {
       ...editorStore,
-      history: newHistory,
+      history: History.init(editorStore.unpatchedEditor, editorStore.unpatchedDerived),
     }
   },
   MARK_VSCODE_BRIDGE_READY: (action: MarkVSCodeBridgeReady, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -143,6 +143,10 @@ function processAction(
     working = UPDATE_FNS.UPDATE_TEXT(action, working)
   }
 
+  if (action.action === 'TRUNCATE_HISTORY') {
+    working = UPDATE_FNS.TRUNCATE_HISTORY(working)
+  }
+
   if (action.action === 'START_POST_ACTION_SESSION') {
     working = runExecuteStartPostActionMenuAction(action, working)
   }

--- a/editor/src/core/shared/github/operations/load-branch.ts
+++ b/editor/src/core/shared/github/operations/load-branch.ts
@@ -8,6 +8,7 @@ import { notice } from '../../../../components/common/notice'
 import type { EditorDispatch } from '../../../../components/editor/action-types'
 import {
   showToast,
+  truncateHistory,
   updateBranchContents,
   updateProjectContents,
 } from '../../../../components/editor/actions/action-creators'
@@ -134,6 +135,7 @@ export async function updateProjectWithBranchContent(
               ),
               updateProjectContents(parsedProjectContents),
               updateBranchContents(parsedProjectContents),
+              truncateHistory(),
               showToast(
                 notice(
                   `Github: Updated the project with the content from ${branchName}`,


### PR DESCRIPTION
Fixes #4154 

**Problem:**

It's possible to undo changes after loading a GH branch.

**Fix:**

Truncate history after loading a GH branch.