### PR TITLE
Customary design tweaks

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.tsx
@@ -95,7 +95,7 @@ export const CanvasStrategyPicker = React.memo(() => {
               gap: 4,
               background: colorTheme.bg0.value,
               borderRadius: UtopiaTheme.panelStyles.panelBorderRadius,
-              boxShadow: `3px 4px 10px 0px ${UtopiaTheme.panelStyles.panelShadowColor}`,
+              boxShadow: UtopiaTheme.panelStyles.shadows.medium,
             }}
           >
             {allApplicableStrategies?.map(({ strategy, name }, index) => {

--- a/editor/src/components/canvas/controls/select-mode/post-action-menu.tsx
+++ b/editor/src/components/canvas/controls/select-mode/post-action-menu.tsx
@@ -388,7 +388,7 @@ export const FloatingPostActionMenu = React.memo(
               padding: 4,
               background: colorTheme.bg0.value,
               borderRadius: UtopiaTheme.panelStyles.panelBorderRadius,
-              boxShadow: `3px 4px 10px 0px ${UtopiaTheme.panelStyles.panelShadowColor}`,
+              boxShadow: UtopiaTheme.panelStyles.shadows.medium,
               cursor: open ? undefined : 'pointer',
               fontSize: 10,
             }}

--- a/editor/src/components/canvas/controls/select-mode/scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/scene-label.tsx
@@ -220,14 +220,12 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
             width: frame.width,
             paddingLeft: offsetX,
             paddingBottom: paddingY,
-            fontFamily:
-              '-apple-system, BlinkMacSystemFont, Helvetica, "Segoe UI", Roboto,  Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
+            fontFamily: 'Utopian-Inter',
             fontSize: scaledFontSize,
             lineHeight: `${scaledLineHeight}px`,
             whiteSpace: 'nowrap',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
-            boxShadow: boxShadow,
             borderRadius: borderRadius,
             backgroundColor: backgroundColor,
           }}

--- a/editor/src/components/canvas/controls/select-mode/strategy-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/strategy-indicator.tsx
@@ -41,7 +41,7 @@ export const StrategyIndicator = React.memo(() => {
         gap: 8,
         backgroundColor: colorTheme.bg0.value,
         borderRadius: UtopiaTheme.panelStyles.panelBorderRadius,
-        boxShadow: `3px 4px 10px 0px ${UtopiaTheme.panelStyles.panelShadowColor}`,
+        boxShadow: UtopiaTheme.panelStyles.shadows.medium,
         opacity:
           indicatorFlagsInfo.dragStarted && indicatorFlagsInfo.indicatorFlags.showIndicator ? 1 : 0,
       }}

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -232,7 +232,7 @@ const ResizableRightPane = React.memo(() => {
           overflow: 'hidden',
           backgroundColor: colorTheme.inspectorBackground.value,
           borderRadius: UtopiaTheme.panelStyles.panelBorderRadius,
-          boxShadow: `3px 4px 10px 0px ${UtopiaTheme.panelStyles.panelShadowColor}`,
+          boxShadow: UtopiaTheme.panelStyles.shadows.medium,
         }}
         snap={{
           x: [UtopiaTheme.layout.inspectorSmallWidth, UtopiaTheme.layout.inspectorLargeWidth],
@@ -326,7 +326,7 @@ const CodeEditorPane = React.memo(() => {
           justifyContent: 'stretch',
           alignItems: 'stretch',
           borderRadius: UtopiaTheme.panelStyles.panelBorderRadius,
-          boxShadow: `3px 4px 10px 0px ${UtopiaTheme.panelStyles.panelShadowColor}`,
+          boxShadow: UtopiaTheme.panelStyles.shadows.medium,
         }}
       >
         {when(codeEditorEnabled, <CodeEditorWrapper />)}

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -671,7 +671,7 @@ export var FloatingMenu = React.memo(() => {
           width: 280,
           height: 280,
           overflow: 'hidden',
-          boxShadow: `3px 4px 10px 0px ${UtopiaTheme.panelStyles.panelShadowColor}`,
+          boxShadow: UtopiaTheme.panelStyles.shadows.medium,
         }}
       >
         <div

--- a/editor/src/components/code-editor/code-problems.tsx
+++ b/editor/src/components/code-editor/code-problems.tsx
@@ -323,7 +323,6 @@ export const CodeEditorTabPane = React.memo<CodeEditorTabPaneProps>(
       >
         <UIRow
           style={{
-            borderBottom: `1px solid ${colorTheme.subduedBorder.value}`,
             alignItems: 'stretch',
             height: 32,
           }}

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -178,7 +178,7 @@ export const CanvasToolbar = React.memo(() => {
         width: 64,
         backgroundColor: theme.inspectorBackground.value,
         borderRadius: UtopiaTheme.panelStyles.panelBorderRadius,
-        boxShadow: `3px 4px 10px 0px ${UtopiaTheme.panelStyles.panelShadowColor}`,
+        boxShadow: UtopiaTheme.panelStyles.shadows.medium,
         pointerEvents: 'initial',
       }}
       onMouseDown={stopPropagation}

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -620,7 +620,7 @@ const LockedOverlay = React.memo(() => {
             border: `1px solid ${colorTheme.neutralBorder.value}`,
             padding: 30,
             borderRadius: 2,
-            boxShadow: `3px 4px 10px 0px ${UtopiaTheme.panelStyles.panelShadowColor}`,
+            boxShadow: UtopiaTheme.panelStyles.shadows.medium,
           }}
         >
           {dialogContent}

--- a/editor/src/components/navigator/left-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/index.tsx
@@ -131,8 +131,8 @@ export const LeftPaneComponent = React.memo(() => {
             backgroundColor: colorTheme.inspectorBackground.value,
             borderRadius: UtopiaTheme.panelStyles.panelBorderRadius,
             overflow: 'scroll',
-            boxShadow: `3px 4px 10px 0px ${UtopiaTheme.panelStyles.panelShadowColor}`,
             height: '100%',
+            boxShadow: UtopiaTheme.panelStyles.shadows.medium,
           }}
         >
           <div

--- a/editor/src/uuiui/menu-tab.tsx
+++ b/editor/src/uuiui/menu-tab.tsx
@@ -34,21 +34,20 @@ export const MenuTab: React.FunctionComponent<React.PropsWithChildren<MenuTabPro
     const baseStyle = {
       padding: '4px 6px',
       transition: 'all .05s ease-in-out',
-      '&:hover': {
-        backgroundColor: colorTheme.tabHoveredBackground.value,
-        boxShadow: `inset 0px -2px 0px 0px ${colorTheme.dynamicBlue.value}`,
-      },
       cursor: 'pointer',
       flexGrow: 1,
       justifyContent: 'center',
+      fontWeight: 500,
+      '&:hover': {
+        opacity: 1,
+      },
     }
 
     const selectionHandlingStyle = {
-      boxShadow: selected ? `inset 0px -2px 0px 0px ${colorTheme.dynamicBlue.value}` : undefined,
       color: hasErrorMessages
         ? colorTheme.errorForeground.value
         : colorTheme.tabSelectedForeground.value,
-      fontWeight: selected ? 500 : undefined,
+      opacity: selected ? 1 : 0.4,
     }
 
     return (

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -33,7 +33,7 @@ const lightBase = {
 
   bg0: createUtopiColor('hsl(0,0%,100%)'),
   bg1: createUtopiColor('lch(99.5 0.01 0)'),
-  bg2: createUtopiColor('lch(97.0 0.01 0)'),
+  bg2: createUtopiColor('lch(98.0 0.01 0)'),
   bg3: createUtopiColor('hsl(0,0%,94%)'),
   bg4: createUtopiColor('hsl(0,0%,92%)'),
   bg5: createUtopiColor('hsl(0,0%,90%)'),

--- a/editor/src/uuiui/styles/theme/utopia-theme.ts
+++ b/editor/src/uuiui/styles/theme/utopia-theme.ts
@@ -57,7 +57,10 @@ export const UtopiaTheme = {
   },
   panelStyles: {
     panelBorderRadius: 10,
-    panelShadowColor: colorTheme.panelShadowColor.value,
+    shadows: {
+      // NB this uses black since shadows are always darker than the surrounding area, dark mode or not
+      medium: `rgba(0, 0, 0, 0.1) 0px 1px 3px 0px, rgba(0, 0, 0, 0.06) 0px 1px 2px 0px`,
+    },
   },
 } as const
 

--- a/editor/src/uuiui/tab.tsx
+++ b/editor/src/uuiui/tab.tsx
@@ -53,7 +53,6 @@ export const TabComponent: React.FunctionComponent<React.PropsWithChildren<TabCo
     }
 
     const selectionHandlingStyle = {
-      boxShadow: selected ? `inset 0px 2px 0px 0px ${colorTheme.dynamicBlue.value}` : undefined,
       color: hasErrorMessages
         ? colorTheme.errorForeground.value
         : colorTheme.tabSelectedForeground.value,


### PR DESCRIPTION
**Problem:**
Demo day compels me to do this

**Fix:**
- Standardised shadow (lower altitude for floating panels) and used it
- Brought tab design into the 2020s and readier for floating panels
- Canvas in light mode slightly brigher
- A few tweaks relating to panels

Tabs:
<img width="279" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2945037/e1d83815-b8f6-4bd6-a42e-ed0756a7179f">

Floating shadow less distracting:
<img width="491" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2945037/6873ce29-cb83-4088-9c84-4b87cfefd26c">

Bottom of code editor panel looks less messy:
<img width="516" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2945037/60f060c9-c31f-476b-b765-6477b3350605">

