### PR TITLE
Canvas Toolbar: Fixing the Toggle Absolute Positioning button

### DIFF
--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -140,6 +140,7 @@ import {
   isIntrinsicallyInlineElement,
   setElementTopLeft,
   nukeSizingPropsForAxisCommand,
+  toggleAbsolutePositioningCommands,
 } from '../inspector/inspector-common'
 import type { CSSProperties } from 'react'
 import { setProperty } from '../canvas/commands/set-property-command'
@@ -938,56 +939,12 @@ export function handleKeyDown(
           return []
         }
 
-        const commands = editor.selectedViews.flatMap((elementPath) => {
-          const maybeGroupConversionCommands = groupConversionCommands(
-            editor.jsxMetadata,
-            editor.allElementProps,
-            editor.elementPathTree,
-            elementPath,
-          )
-
-          if (maybeGroupConversionCommands != null) {
-            return maybeGroupConversionCommands
-          }
-
-          const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, elementPath)
-          if (element == null) {
-            return []
-          }
-
-          if (
-            MetadataUtils.isFragmentFromMetadata(element) ||
-            MetadataUtils.isConditionalFromMetadata(element)
-          ) {
-            return []
-          }
-
-          if (MetadataUtils.isPositionAbsolute(element)) {
-            return [
-              ...nukeAllAbsolutePositioningPropsCommands(elementPath),
-              ...(isIntrinsicallyInlineElement(element)
-                ? [
-                    ...sizeToVisualDimensions(
-                      editor.jsxMetadata,
-                      editor.elementPathTree,
-                      elementPath,
-                    ),
-                    setProperty(
-                      'always',
-                      elementPath,
-                      PP.create('style', 'display'),
-                      'inline-block',
-                    ),
-                  ]
-                : []),
-            ]
-          } else {
-            return [
-              ...sizeToVisualDimensions(editor.jsxMetadata, editor.elementPathTree, elementPath),
-              ...addPositionAbsoluteTopLeft(editor.jsxMetadata, elementPath),
-            ]
-          }
-        })
+        const commands = toggleAbsolutePositioningCommands(
+          editor.jsxMetadata,
+          editor.allElementProps,
+          editor.elementPathTree,
+          editor.selectedViews,
+        )
 
         if (commands.length === 0) {
           return []


### PR DESCRIPTION
**Problem:**
The button to toggle between removing and adding absolute positioning (same funcitonality as the keyboard shortcut 'X') was not working because I forgot to implement the click handler callback

**Fix:**
- move code from the keyboard shortcut to a shared function `toggleAbsolutePositioningCommands`
- use `toggleAbsolutePositioningCommands` in `toggleAbsolutePositioningCallback`
- add the icon back to the toolbar
