### PR TITLE
Fix: better  auto-exiting from canvas toolbar insert mode 

### DIFF
--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -60,7 +60,8 @@ export const CanvasToolbar = React.memo(() => {
 
   const [forcedInsertMode, setForceInsertMode] = React.useState(false)
 
-  const toggleInsertButtonClicked = React.useCallback(() => {
+  const toggleInsertButtonClicked = React.useCallback((e: React.MouseEvent<Element>) => {
+    e.stopPropagation()
     setForceInsertMode((value) => !value)
   }, [])
 
@@ -312,8 +313,6 @@ export const CanvasToolbar = React.memo(() => {
             flexDirection: 'row',
             padding: '0 8px',
           }}
-          onMouseDown={stopPropagation}
-          onClick={stopPropagation}
         >
           <Tooltip title='Edit' placement='bottom'>
             <InsertModeButton


### PR DESCRIPTION
<img width="326" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/d352a4f7-54b8-4152-b5de-27f00df5b841">


We want the following behavior:
1. Clicking on the insert button on the canvas enters the toolbar's insert submenu, letting you select an option.
2. if an option is selected, such as insert div, we want the choice reflected, and the menu to be shown until the actual editor Insert Mode is ended (or until the  insert popup / insert sidebar is dismissed):
<img width="543" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/66634e51-baa1-498f-8378-3bb9bbfc78b8">

3. however, if no option is selected, we want the sub-menu to behave sort of like a context menu: disappear as soon as you click away.
4. If the user enters Insert Mode from a keyboard shortcut, or opens the insert popup / insert sidebar via keyboard, we want to show the insert submenu with the proper selection.

**Specified behavior:**
1. if the editor's EditorMode is Insert Mode and/or the insert popup / insert sidebar is open, we show the Insertion Submenu. we keep showing it so long as an active InsertMode is running, or until the popups dismissed. This, however, does not cater to what happens if the user clicks on the + insert button in the canvas toolbar.
2. If the user clicks on the + insert button on the canvas toolbar, we set a local state temporarily overriding the active submenu. This temporal override behaves like a context menu / popup: clicking outside removes the override and lets us return to the other submenus. clicking outside means clicking / interacting on the canvas and on other menu items in the canvas toolbar as well.

**Implementation**
We attach a click event listener to window, essentially acting as a form of on-click-outside catcher. The event handler sets the insert submenu override to false. Why not a real OnClickOutside? Because that would divert mouse clicks on the canvas preventing them from interacting with the editor controls, meaning the first click would _just_ dismiss the submenu, and the second click would start interaction elsewhere. Instead we want the first click to dismiss the submenu _and_ start an interaction elsewhere.

**what changed?**
This was already mostly implemented on master, but annoyingly some event stopPropagations prevented it from working when clicking on other menu items in the canvas toolbar, which made for a very visible bug. The fix was pretty simple, just shuffling around some stopPropagations