### PR TITLE
Disable link following on click in the text editor

### DIFF
--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -1627,6 +1627,32 @@ describe('SWITCH_EDITOR_MODE', () => {
   })
 })
 
+describe('Mouse behavior during text editing', () => {
+  const beforeUnloadCallback = () => {
+    throw new Error('Should not navigate away on click')
+  }
+  before(() => window.addEventListener('beforeunload', beforeUnloadCallback))
+  after(() => window.removeEventListener('beforeunload', beforeUnloadCallback))
+  // eslint-disable-next-line jest/expect-expect
+  it('Clicking on link does not navigate away', async () => {
+    const editor = await renderTestEditorWithCode(
+      projectWithSnippet(`<a href='hello' data-uid='link' data-testid='link'>Hello link</a>`),
+      'await-first-dom-report',
+    )
+    await enterTextEditMode(editor)
+
+    const textEditor = editor.renderedDOM.getByTestId(TextEditorSpanId)
+    const textEditorBounds = textEditor.getBoundingClientRect()
+    const textEditorCorner = {
+      x: textEditorBounds.x + 20,
+      y: textEditorBounds.y + 10,
+    }
+
+    await mouseClickAtPoint(textEditor, textEditorCorner)
+    // no expectation, we just need to avoid the error in beforeUnloadCallback
+  })
+})
+
 function textSpan(text: string, extraStyleProps?: { [prop: string]: string }): string {
   const styleProps = {
     position: 'absolute',

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -467,7 +467,11 @@ const TextEditor = React.memo((props: TextEditorProps) => {
     onKeyDown: onKeyDown,
     onKeyUp: stopPropagation,
     onKeyPress: stopPropagation,
-    onClick: stopPropagation,
+    // preventDefault is necessary to make sure we don't navigate away when click on anchor elements
+    // It seems click events are not necessary for other built-in text editing functionality
+    // (e.g. setting cursor position, drag to select, etc.), if it turns out to be a problem later,
+    // we may revisit this decision
+    onClick: stopPropagationAndPreventDefault,
     onContextMenu: stopPropagation,
     onMouseDown: stopPropagation,
     onMouseEnter: stopPropagation,
@@ -483,7 +487,11 @@ const TextEditor = React.memo((props: TextEditorProps) => {
 
   const filteredPassthroughProps = filterEventHandlerProps(passthroughProps)
 
-  return React.createElement(component, filteredPassthroughProps, <span {...editorProps} />)
+  return React.createElement(
+    component,
+    filteredPassthroughProps,
+    <span data-testid={TextEditorSpanId} {...editorProps} />,
+  )
 })
 
 async function setSelectionToOffset(
@@ -549,6 +557,11 @@ async function setSelectionToOffset(
 }
 
 function stopPropagation(e: React.UIEvent | React.ClipboardEvent) {
+  e.stopPropagation()
+}
+
+function stopPropagationAndPreventDefault(e: React.UIEvent | React.ClipboardEvent) {
+  e.preventDefault()
   e.stopPropagation()
 }
 


### PR DESCRIPTION
**Problem:**
During text editing anchor elements are clickable, and on click the browser tries to navigate away to the target url.

**Fix:**
I applied a preventDefault to the click event in the text editor. This felt a little dangerous, because we heavily rely on the default browser behavior handling mouse events for text editing, e.g. clicking to set cursor position, drag to select a range, etc.
However, it seems the click event is not necessary for these, and the text editing features only rely on the more basic (mouseup, mousedown) etc mouse events.

