### PR TITLE
Resize safe gaps

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -53,7 +53,6 @@ import {
   SizeLabelTestId,
   ResizePointTestId,
   AbsoluteResizeControlTestId,
-  SmallElementSize,
 } from '../../controls/select-mode/absolute-resize-control'
 import type { FragmentLikeType } from './fragment-like-helpers'
 import { AllFragmentLikeTypes } from './fragment-like-helpers'
@@ -67,7 +66,7 @@ import { isRight } from '../../../../core/shared/either'
 import { ImmediateParentOutlinesTestId } from '../../controls/parent-outlines'
 import { ImmediateParentBoundsTestId } from '../../controls/parent-bounds'
 import { getResizeControl, resizeElement } from './absolute-resize.test-utils'
-import { RESIZE_CONTROL_SAFE_GAP } from '../../controls/bounding-box-hooks'
+import { RESIZE_CONTROL_SAFE_GAP, SmallElementSize } from '../../controls/bounding-box-hooks'
 
 // no mouseup here! it starts the interaction and resizes with drag delta
 async function startDragUsingActions(

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -67,6 +67,7 @@ import { isRight } from '../../../../core/shared/either'
 import { ImmediateParentOutlinesTestId } from '../../controls/parent-outlines'
 import { ImmediateParentBoundsTestId } from '../../controls/parent-bounds'
 import { getResizeControl, resizeElement } from './absolute-resize.test-utils'
+import { RESIZE_CONTROL_SAFE_GAP } from '../../controls/bounding-box-hooks'
 
 // no mouseup here! it starts the interaction and resizes with drag delta
 async function startDragUsingActions(
@@ -1992,7 +1993,7 @@ describe('Absolute Resize Group-like behaviors', () => {
 })
 
 describe('Absolute Resize Control', () => {
-  it('Resize control is placed on small elements outside of the draggable frame area', async () => {
+  it('Resize control is placed on small elements outside of the draggable frame area, with a safe gap', async () => {
     const width = SmallElementSize
     const height = SmallElementSize
     const renderResult = await renderTestEditorWithCode(
@@ -2017,26 +2018,26 @@ describe('Absolute Resize Control', () => {
     expect(resizeControlTop.style.transform).toEqual('translate(0px, -5px)')
     expect(resizeControlTop.style.top).toEqual('')
     expect(resizeControlTop.style.left).toEqual('')
-    expect(resizeControlTop.style.width).toEqual(`${width}px`)
-    expect(resizeControlTop.style.height).toEqual('5px')
+    expect(resizeControlTop.style.width).toEqual(`${width + RESIZE_CONTROL_SAFE_GAP * 2}px`)
+    expect(resizeControlTop.style.height).toEqual('10px')
 
     const resizeControlRight = renderResult.renderedDOM.getByTestId(
       `resize-control-${EdgePositionRight.x}-${EdgePositionRight.y}`,
     )
-    expect(resizeControlRight.style.transform).toEqual('translate(0px, 0px)')
+    expect(resizeControlRight.style.transform).toEqual('translate(-5px, 0px)')
     expect(resizeControlRight.style.top).toEqual('')
-    expect(resizeControlRight.style.left).toEqual(`${width}px`)
-    expect(resizeControlRight.style.width).toEqual('5px')
-    expect(resizeControlRight.style.height).toEqual(`${height}px`)
+    expect(resizeControlRight.style.left).toEqual(`${width + RESIZE_CONTROL_SAFE_GAP * 2}px`)
+    expect(resizeControlRight.style.width).toEqual('10px')
+    expect(resizeControlRight.style.height).toEqual(`${height + RESIZE_CONTROL_SAFE_GAP * 2}px`)
 
     const resizeControlBottom = renderResult.renderedDOM.getByTestId(
       `resize-control-${EdgePositionBottom.x}-${EdgePositionBottom.y}`,
     )
-    expect(resizeControlBottom.style.transform).toEqual('translate(0px, 0px)')
-    expect(resizeControlBottom.style.top).toEqual(`${height}px`)
+    expect(resizeControlBottom.style.transform).toEqual('translate(0px, -5px)')
+    expect(resizeControlBottom.style.top).toEqual(`${height + RESIZE_CONTROL_SAFE_GAP * 2}px`)
     expect(resizeControlBottom.style.left).toEqual('')
-    expect(resizeControlBottom.style.width).toEqual(`${width}px`)
-    expect(resizeControlBottom.style.height).toEqual('5px')
+    expect(resizeControlBottom.style.width).toEqual(`${width + RESIZE_CONTROL_SAFE_GAP * 2}px`)
+    expect(resizeControlBottom.style.height).toEqual('10px')
 
     const resizeControlLeft = renderResult.renderedDOM.getByTestId(
       `resize-control-${EdgePositionLeft.x}-${EdgePositionLeft.y}`,
@@ -2044,8 +2045,8 @@ describe('Absolute Resize Control', () => {
     expect(resizeControlLeft.style.transform).toEqual('translate(-5px, 0px)')
     expect(resizeControlLeft.style.top).toEqual('')
     expect(resizeControlLeft.style.left).toEqual('')
-    expect(resizeControlLeft.style.width).toEqual('5px')
-    expect(resizeControlLeft.style.height).toEqual(`${height}px`)
+    expect(resizeControlLeft.style.width).toEqual('10px')
+    expect(resizeControlLeft.style.height).toEqual(`${height + RESIZE_CONTROL_SAFE_GAP * 2}px`)
   })
   it('Resize control on non-small elements extend into the draggable frame area', async () => {
     const width = SmallElementSize + 1

--- a/editor/src/components/canvas/controls/bounding-box-hooks.ts
+++ b/editor/src/components/canvas/controls/bounding-box-hooks.ts
@@ -49,6 +49,10 @@ function useBoundingBoxFromMetadataRef(
   const metadataRef = useRefEditorState((store) => getMetadata(store.editor))
   const scaleRef = useRefEditorState((store) => store.editor.canvas.scale)
 
+  const isMidInteraction = useRefEditorState(
+    (store) => store.editor.canvas.interactionSession?.startedAt != null,
+  )
+
   const boundingBoxCallbackRef = React.useRef(boundingBoxCallback)
   boundingBoxCallbackRef.current = boundingBoxCallback
 
@@ -64,6 +68,9 @@ function useBoundingBoxFromMetadataRef(
     function getAdjustedBoundingBox(boundingBox: CanvasRectangle | null) {
       if (boundingBox == null) {
         return null
+      }
+      if (isMidInteraction.current) {
+        return boundingBox
       }
       let adjustedBoundingBox = {
         x: boundingBox.x,
@@ -85,7 +92,7 @@ function useBoundingBoxFromMetadataRef(
     const boundingBox = getAdjustedBoundingBox(boundingRectangleArray(frames))
 
     boundingBoxCallbackRef.current(boundingBox, scaleRef.current)
-  }, [selectedElements, metadataRef, scaleRef])
+  }, [selectedElements, metadataRef, scaleRef, isMidInteraction])
 
   useSelectorWithCallback(
     Substores.metadata,

--- a/editor/src/components/canvas/controls/bounding-box-hooks.ts
+++ b/editor/src/components/canvas/controls/bounding-box-hooks.ts
@@ -15,7 +15,6 @@ import {
 } from '../../editor/store/store-hook'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { getMetadata } from '../../editor/store/editor-state'
-import { SmallElementSize } from './select-mode/absolute-resize-control'
 
 interface NotNullRefObject<T> {
   readonly current: T
@@ -40,6 +39,7 @@ export function useBoundingBox<T = HTMLDivElement>(
   return controlRef
 }
 
+export const SmallElementSize = 20
 export const RESIZE_CONTROL_SAFE_GAP = 6 // safe gap applied when the dimension of an element is smaller than SmallElementSize
 
 function useBoundingBoxFromMetadataRef(

--- a/editor/src/components/canvas/controls/bounding-box-hooks.ts
+++ b/editor/src/components/canvas/controls/bounding-box-hooks.ts
@@ -66,12 +66,10 @@ function useBoundingBoxFromMetadataRef(
     })
 
     function getAdjustedBoundingBox(boundingBox: CanvasRectangle | null) {
-      if (boundingBox == null) {
-        return null
-      }
-      if (isMidInteraction.current) {
+      if (boundingBox == null || isMidInteraction.current) {
         return boundingBox
       }
+
       let adjustedBoundingBox = {
         x: boundingBox.x,
         y: boundingBox.y,

--- a/editor/src/components/canvas/controls/bounding-box-hooks.ts
+++ b/editor/src/components/canvas/controls/bounding-box-hooks.ts
@@ -39,8 +39,8 @@ export function useBoundingBox<T = HTMLDivElement>(
   return controlRef
 }
 
-const MIN_RESIZE_BOX_SIZE = 25
-const SAFE_GAP = 6
+const MIN_RESIZE_CONTROL_BOX_SIZE = 25 // minimum dimension for w/h of a bounding box, if smaller the safe gaps will be applied
+const RESIZE_CONTROL_SAFE_GAP = 6 // safe gap applied when the dimension of an element is smaller than MIN_RESIZE_CONTROL_BOX_SIZE
 
 function useBoundingBoxFromMetadataRef(
   selectedElements: ReadonlyArray<ElementPath>,
@@ -78,12 +78,12 @@ function useBoundingBoxFromMetadataRef(
         width: boundingBox.width,
         height: boundingBox.height,
       }
-      const scaledSafeGap = SAFE_GAP / scaleRef.current
-      if (boundingBox.width < MIN_RESIZE_BOX_SIZE) {
+      const scaledSafeGap = RESIZE_CONTROL_SAFE_GAP / scaleRef.current
+      if (boundingBox.width < MIN_RESIZE_CONTROL_BOX_SIZE) {
         adjustedBoundingBox.x -= scaledSafeGap
         adjustedBoundingBox.width += scaledSafeGap * 2
       }
-      if (boundingBox.height < MIN_RESIZE_BOX_SIZE) {
+      if (boundingBox.height < MIN_RESIZE_CONTROL_BOX_SIZE) {
         adjustedBoundingBox.y -= scaledSafeGap
         adjustedBoundingBox.height += scaledSafeGap * 2
       }

--- a/editor/src/components/canvas/controls/bounding-box-hooks.ts
+++ b/editor/src/components/canvas/controls/bounding-box-hooks.ts
@@ -54,8 +54,8 @@ function useBoundingBoxFromMetadataRef(
   )
 
   const shouldApplySafeGap = React.useCallback(
-    (dimension: number): boolean => {
-      return !isMidInteraction.current && dimension <= SmallElementSize
+    (dimension: number, scale: number): boolean => {
+      return !isMidInteraction.current && dimension <= SmallElementSize / scale
     },
     [isMidInteraction],
   )
@@ -84,11 +84,11 @@ function useBoundingBoxFromMetadataRef(
         height: boundingBox.height,
       }
       const scaledSafeGap = RESIZE_CONTROL_SAFE_GAP / scaleRef.current
-      if (shouldApplySafeGap(boundingBox.width)) {
+      if (shouldApplySafeGap(boundingBox.width, scaleRef.current)) {
         adjustedBoundingBox.x -= scaledSafeGap
         adjustedBoundingBox.width += scaledSafeGap * 2
       }
-      if (shouldApplySafeGap(boundingBox.height)) {
+      if (shouldApplySafeGap(boundingBox.height, scaleRef.current)) {
         adjustedBoundingBox.y -= scaledSafeGap
         adjustedBoundingBox.height += scaledSafeGap * 2
       }

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -364,7 +364,7 @@ const ResizeEdge = React.memo(
         }}
         onMouseDown={onEdgeMouseDown}
         onMouseMove={onMouseMove}
-        data-testid={`resize-control-${props.position.x}-${props.position.y}`}
+        data-testid={ResizePointTestId(props.position)}
       />
     )
   }),

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -33,7 +33,7 @@ import { createInteractionViaMouse } from '../../canvas-strategies/interaction-s
 import type { EdgePosition } from '../../canvas-types'
 import { CSSCursor } from '../../canvas-types'
 import { windowToCanvasCoordinates } from '../../dom-lookup'
-import { useBoundingBox } from '../bounding-box-hooks'
+import { SmallElementSize, useBoundingBox } from '../bounding-box-hooks'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 import { isZeroSizedElement } from '../outline-utils'
 import { useMaybeHighlightElement } from './select-mode-hooks'
@@ -46,7 +46,6 @@ interface AbsoluteResizeControlProps {
 }
 
 export const SizeLabelTestId = 'SizeLabelTestId'
-export const SmallElementSize = 20
 
 function shouldUseSmallElementResizeControl(size: number, scale: number): boolean {
   return size <= SmallElementSize / scale


### PR DESCRIPTION
Fixes #4172 

**Problem:**

Tiny elements have overlapping resize controls.

**Fix:**

Apply some safe gaps for tiny elements (currently: a gap of 6px per side, for elements with w/h smaller than 20px (`SmallElementSize`).


https://github.com/concrete-utopia/utopia/assets/1081051/656e9686-a4fb-4d54-9851-4353cfead5a8

