### PR TITLE
update dependecy crusier rules

### DIFF
--- a/editor/.dependency-cruiser.js
+++ b/editor/.dependency-cruiser.js
@@ -186,7 +186,7 @@ module.exports = {
     },
     {
       name: 'not-from-ts-to-tsx',
-      comment: 'Prevent a .ts file from pointing to a .tsx file.',
+      comment: 'Prevent a .worker.ts file from pointing to a .tsx file.',
       severity: 'error',
       from: {
         path: '\\worker.ts$',

--- a/editor/.dependency-cruiser.js
+++ b/editor/.dependency-cruiser.js
@@ -189,10 +189,11 @@ module.exports = {
       comment: 'Prevent a .ts file from pointing to a .tsx file.',
       severity: 'error',
       from: {
-        path: '\\.ts$',
+        path: '\\worker.ts$',
         pathNot: ['built-in-dependencies-list.ts$'],
       },
       to: {
+        reachable: true,
         path: '\\.tsx$',
       },
     },


### PR DESCRIPTION
## Description
The `not-from-ts-to-tsx` rule proved to be too restrictive when adding library code to `.tsx` files. With the rule present, refactoring files to work around the rule proved to be very time-consuming, so this PR scopes the rule to `*.worker.ts` files, so that Vite doesn't attempt to hot-reload them.