### PR TITLE
VS Code CSS overrides.

### DIFF
--- a/editor/resources/editor/css/vscode-overrides.css
+++ b/editor/resources/editor/css/vscode-overrides.css
@@ -1,0 +1,3 @@
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container {
+  gap: 4px;
+}

--- a/editor/src/templates/vscode-editor-iframe/index.html
+++ b/editor/src/templates/vscode-editor-iframe/index.html
@@ -39,4 +39,5 @@
   <script src="<%- UTOPIA_DOMAIN %>/vscode/vscode/vs/workbench/workbench.web.api.nls.js?hash=<%- UTOPIA_SHA %>"></script>
   <script src="<%- UTOPIA_DOMAIN %>/vscode/vscode/vs/workbench/workbench.web.api.js?hash=<%- UTOPIA_SHA %>"></script>
   <script src="<%- UTOPIA_DOMAIN %>/vscode/vscode/vs/code/browser/workbench/workbench.js?hash=<%- UTOPIA_SHA %>"></script>
+  <link rel="stylesheet" href="<%- UTOPIA_DOMAIN %>/editor/css/vscode-overrides.css" />
 </html>


### PR DESCRIPTION
**Problem:**
We want to override parts of the design of the VS Code editor without mangling the original source.

**Change:**
The iframe HTML that loads VS Code now has some additional CSS included, which loads as late as it can be specified without using JS. Primarily this is so that it loads after `workbench.web.api.css` so that the "latest loaded" rule applies for anything that has identical selectors.

**Commit Details:**
- Add stylesheet link to `vscode-editor-iframe/index.html`.
- Added `editor/resources/editor/css/vscode-overrides.css`.