### PR TITLE
Prevent clicks from passing through the toolbar buttons.

### DIFF
--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -518,6 +518,13 @@ const InsertModeButton = React.memo((props: InsertModeButtonProps) => {
     'CanvasToolbar canvasInLiveMode',
   )
   const iconCategory = props.iconCategory ?? 'element'
+  const onClickHandler = React.useCallback(
+    (event: React.MouseEvent<Element>) => {
+      event.stopPropagation()
+      props.onClick(event)
+    },
+    [props],
+  )
 
   return (
     <SquareButton
@@ -525,7 +532,7 @@ const InsertModeButton = React.memo((props: InsertModeButtonProps) => {
       style={{ ...props.style, height: 32, width: 32 }}
       primary={primary}
       highlight
-      onClick={props.onClick}
+      onClick={onClickHandler}
       disabled={canvasInLiveMode && !keepActiveInLiveMode}
     >
       <Icn


### PR DESCRIPTION
**Problem:**
Clicking on a canvas toolbar twice can result in the selected item being inserted underneath the toolbar.

**Fix:**
Prevent clicks from passing through the toolbar to the canvas.

**Commit Details:**
- Wrapped around the `onClick` handler passed to the button with one that calls `event.stopPropagation`.