### PR TITLE
Remix navigator design

### DIFF
--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -215,11 +215,40 @@ export function createElementIconPropsFromMetadata(
     }
   }
 
-  if (MetadataUtils.isProbablyScene(metadata, elementPath)) {
+  if (
+    MetadataUtils.isProbablyScene(metadata, elementPath) ||
+    MetadataUtils.isProbablyRemixScene(metadata, elementPath)
+  ) {
     return {
       iconProps: {
         category: 'component',
         type: 'scene',
+        width: 18,
+        height: 18,
+      },
+
+      isPositionAbsolute: false,
+    }
+  }
+
+  if (MetadataUtils.isProbablyRemixOutletFromMetadata(element)) {
+    return {
+      iconProps: {
+        category: 'component',
+        type: 'remix-outlet',
+        width: 18,
+        height: 18,
+      },
+
+      isPositionAbsolute: false,
+    }
+  }
+
+  if (MetadataUtils.isProbablyRemixLinkFromMetadata(element)) {
+    return {
+      iconProps: {
+        category: 'component',
+        type: 'remix-link',
         width: 18,
         height: 18,
       },
@@ -377,6 +406,17 @@ function createComponentIconProps(
     return {
       category: 'component',
       type: 'animated',
+      width: 18,
+      height: 18,
+    }
+  }
+  const isRemixComponent =
+    MetadataUtils.isImportedComponentFromMetadata(element, '@remix-run/react', null) ||
+    MetadataUtils.isProbablyRemixSceneFromMetadata(element)
+  if (isRemixComponent) {
+    return {
+      category: 'component',
+      type: 'remix',
       width: 18,
       height: 18,
     }

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -391,7 +391,7 @@ const elementWarningsSelector = createCachedSelector(
   },
 )((_, navigatorEntry) => navigatorEntryToKey(navigatorEntry))
 
-type CodeItemType = 'conditional' | 'map' | 'code' | 'none'
+type CodeItemType = 'conditional' | 'map' | 'code' | 'none' | 'remix'
 
 export interface NavigatorItemInnerProps {
   navigatorEntry: NavigatorEntry
@@ -548,6 +548,11 @@ export const NavigatorItem: React.FunctionComponent<
       }
       if (MetadataUtils.isExpressionOtherJavascriptFromMetadata(elementMetadata)) {
         return 'code'
+      }
+      if (
+        MetadataUtils.isImportedComponentFromMetadata(elementMetadata, '@remix-run/react', null)
+      ) {
+        return 'remix'
       }
       return 'none'
     },
@@ -829,7 +834,8 @@ interface NavigatorRowLabelProps {
 export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
   const colorTheme = useColorTheme()
 
-  const isCodeItem = props.codeItemType !== 'none'
+  const isCodeItem = props.codeItemType !== 'none' && props.codeItemType !== 'remix'
+  const isRemixItem = props.codeItemType === 'remix'
 
   return (
     <div
@@ -845,7 +851,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
         paddingRight: props.codeItemType === 'map' ? 0 : 10,
         backgroundColor:
           isCodeItem && !props.selected ? colorTheme.dynamicBlue10.value : 'transparent',
-        color: isCodeItem ? colorTheme.dynamicBlue.value : undefined,
+        color: isCodeItem || isRemixItem ? colorTheme.dynamicBlue.value : undefined,
         textTransform: isCodeItem ? 'uppercase' : undefined,
       }}
     >

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -197,31 +197,42 @@ export const MetadataUtils = {
   ): Array<ElementInstanceMetadata> {
     return stripNulls(paths.map((path) => MetadataUtils.findElementByElementPath(elementMap, path)))
   },
-  isProbablySceneFromMetadata(element: ElementInstanceMetadata | null): boolean {
+  isImportedComponentFromMetadata(
+    element: ElementInstanceMetadata | null,
+    importedFrom: string,
+    componentName: string | null,
+  ): boolean {
     return (
       element != null &&
       element.importInfo != null &&
       isImportedOrigin(element.importInfo) &&
-      element.importInfo.filePath === 'utopia-api' &&
-      element.importInfo.exportedName === 'Scene'
+      element.importInfo.filePath === importedFrom &&
+      (componentName == null || element.importInfo.exportedName === componentName)
     )
+  },
+  isProbablySceneFromMetadata(element: ElementInstanceMetadata | null): boolean {
+    return MetadataUtils.isImportedComponentFromMetadata(element, 'utopia-api', 'Scene')
   },
   isProbablyRemixSceneFromMetadata(element: ElementInstanceMetadata | null): boolean {
-    return (
-      element != null &&
-      element.importInfo != null &&
-      isImportedOrigin(element.importInfo) &&
-      element.importInfo.filePath === 'utopia-api' &&
-      element.importInfo.exportedName === 'RemixScene'
-    )
+    return MetadataUtils.isImportedComponentFromMetadata(element, 'utopia-api', 'RemixScene')
   },
   isProbablyRemixOutletFromMetadata(element: ElementInstanceMetadata | null): boolean {
-    return (
-      element != null &&
-      element.importInfo != null &&
-      isImportedOrigin(element.importInfo) &&
-      element.importInfo.filePath === '@remix-run/react' &&
-      element.importInfo.exportedName === 'Outlet'
+    return MetadataUtils.isImportedComponentFromMetadata(element, '@remix-run/react', 'Outlet')
+  },
+  isProbablyRemixLinkFromMetadata(element: ElementInstanceMetadata | null): boolean {
+    return MetadataUtils.isImportedComponentFromMetadata(element, '@remix-run/react', 'Link')
+  },
+  isImportedComponent(
+    jsxMetadata: ElementInstanceMetadataMap,
+    path: ElementPath,
+    importedFrom: string,
+    componentName: string,
+  ): boolean {
+    const elementMetadata = MetadataUtils.findElementByElementPath(jsxMetadata, path)
+    return MetadataUtils.isImportedComponentFromMetadata(
+      elementMetadata,
+      componentName,
+      importedFrom,
     )
   },
   isProbablyScene(jsxMetadata: ElementInstanceMetadataMap, path: ElementPath): boolean {


### PR DESCRIPTION
**Description:**
A starting point to implement special navigator design for Remix components

<img width="275" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/bf27043e-adc3-4b36-8eea-0c730397d6d8">

- Replaced the `npm` icon to Remix icon when the component is imported from the Remix library (or a RemixScene from utopia-api)
- Added new icons for Outlet and Link
- Remix items are blue
- Added a MetadataUtils helper to check if an element is an imported component with a specific name from a specific lib.