### PR TITLE
Simplified normalise path cleanup

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/post-action-options/navigator-reparent.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/navigator-reparent.ts
@@ -51,9 +51,6 @@ function getNavigatorReparentCommands(
   const newParentPath = getInsertionPath(
     data.targetParent,
     editor.projectContents,
-    editor.nodeModules.files,
-    derivedState.remixData?.routingTable ?? null,
-    editor.canvas.openFile?.filename,
     editor.jsxMetadata,
     editor.elementPathTree,
     wrapperUID,

--- a/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
@@ -12,10 +12,7 @@ import type { Either } from '../../../../core/shared/either'
 import { isLeft, left, right } from '../../../../core/shared/either'
 import * as EP from '../../../../core/shared/element-path'
 import type { ElementPathTrees } from '../../../../core/shared/element-path-tree'
-import type {
-  ElementInstanceMetadataMap,
-  JSXElementChild,
-} from '../../../../core/shared/element-template'
+import type { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
 import {
   zeroCanvasPoint,
   canvasRectangle,
@@ -29,7 +26,6 @@ import type {
   NodeModules,
 } from '../../../../core/shared/project-file-types'
 import { fixUtopiaElement } from '../../../../core/shared/uid-utils'
-import { assertNever } from '../../../../core/shared/utils'
 import { getTargetParentForPaste } from '../../../../utils/clipboard'
 import type { ElementPasteWithMetadata, ReparentTargetForPaste } from '../../../../utils/clipboard'
 import type { IndexPosition } from '../../../../utils/utils'
@@ -240,7 +236,6 @@ export function staticReparentAndUpdatePosition(
     editorStateContext.builtInDependencies,
     editorStateContext.projectContents,
     editorStateContext.nodeModules,
-    editorStateContext.remixRoutingTable,
     editorStateContext.openFile,
     elementsToInsert.map((e) => e.pathToReparent),
     target.parentPath,
@@ -286,8 +281,6 @@ export function staticReparentAndUpdatePosition(
           editor.jsxMetadata,
           editor.elementPathTree,
           editor.projectContents,
-          derivedState.remixData?.routingTable ?? null,
-          editor.canvas.openFile?.filename ?? null,
           pastedElementMetadata?.specialSizeMeasurements.position ?? null,
           pastedElementMetadata?.specialSizeMeasurements.display ?? null,
           pasteContext.originalAllElementProps,
@@ -571,7 +564,6 @@ function getTargetParentForPasteHere(
   const target = getTargetParentForPaste(
     editor.projectContents,
     editor.selectedViews,
-    editor.nodeModules.files,
     editor.canvas.openFile?.filename ?? null,
     editor.jsxMetadata,
     editor.pasteTargetsToIgnore,
@@ -581,7 +573,6 @@ function getTargetParentForPasteHere(
       originalContextElementPathTrees: originalPathTree,
     },
     editor.elementPathTree,
-    derived.remixData?.routingTable ?? null,
   )
 
   const storyboardPath = getStoryboardElementPath(

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
@@ -123,7 +123,6 @@ export function baseAbsoluteReparentStrategy(
                   canvasState.builtInDependencies,
                   projectContents,
                   nodeModules,
-                  canvasState.remixRoutingTable,
                   openFile,
                   pathToReparent(selectedElement),
                   newParent,
@@ -146,8 +145,6 @@ export function baseAbsoluteReparentStrategy(
                       canvasState.startingMetadata,
                       canvasState.startingMetadata,
                       canvasState.projectContents,
-                      canvasState.remixRoutingTable,
-                      canvasState.openFile,
                     )
                   })
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -143,8 +143,6 @@ export function absoluteResizeBoundingBoxStrategy(
               const element = getElementFromProjectContents(
                 selectedElement,
                 canvasState.projectContents,
-                canvasState.remixRoutingTable,
-                canvasState.openFile,
               )
               const originalFrame = MetadataUtils.getFrameInCanvasCoords(
                 selectedElement,

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -400,7 +400,6 @@ function collectReparentCommands(
     canvasState.builtInDependencies,
     canvasState.projectContents,
     canvasState.nodeModules,
-    canvasState.remixRoutingTable,
     canvasState.openFile,
     pathToReparent(path),
     childInsertionPath(targetParent),
@@ -417,12 +416,7 @@ function filterPinsToSet(
   path: ElementPath,
   canvasState: InteractionCanvasState,
 ): Array<LayoutPinnedProp> {
-  const element = getElementFromProjectContents(
-    path,
-    canvasState.projectContents,
-    canvasState.remixRoutingTable,
-    canvasState.openFile,
-  )
+  const element = getElementFromProjectContents(path, canvasState.projectContents)
   if (element == null) {
     return ['top', 'left', 'width', 'height']
   } else {

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
@@ -167,9 +167,6 @@ export function keyboardAbsoluteResizeStrategy(
             const element = withUnderlyingTarget(
               selectedElement,
               canvasState.projectContents,
-              canvasState.nodeModules,
-              canvasState.remixRoutingTable,
-              canvasState.openFile,
               null,
               (_, e) => e,
             )

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -166,7 +166,6 @@ function applyStaticReparent(
             canvasState.builtInDependencies,
             canvasState.projectContents,
             canvasState.nodeModules,
-            canvasState.remixRoutingTable,
             canvasState.openFile,
             pathToReparent(target),
             newParent,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes.ts
@@ -5,7 +5,7 @@ import type { LayoutPinnedProp } from '../../../../../core/layout/layout-helpers
 import { framePointForPinnedProp } from '../../../../../core/layout/layout-helpers-new'
 import { MetadataUtils } from '../../../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../../../core/shared/array-utils'
-import { eitherToMaybe, isRight, right } from '../../../../../core/shared/either'
+import { isRight, right } from '../../../../../core/shared/either'
 import * as EP from '../../../../../core/shared/element-path'
 import type {
   ElementInstanceMetadataMap,
@@ -14,7 +14,6 @@ import type {
 import type { CanvasPoint } from '../../../../../core/shared/math-utils'
 import {
   canvasPoint,
-  CanvasVector,
   isInfinityRectangle,
   nullIfInfinity,
   pointDifference,
@@ -34,7 +33,6 @@ import type {
 } from '../../../commands/adjust-css-length-command'
 import {
   adjustCssLengthProperties,
-  CreateIfNotExistant,
   lengthPropertyToAdjust,
 } from '../../../commands/adjust-css-length-command'
 import type { CanvasCommand } from '../../../commands/commands'
@@ -65,7 +63,6 @@ import {
   treatElementAsFragmentLike,
 } from '../fragment-like-helpers'
 import type { OldPathToNewPathMapping } from '../../post-action-options/post-action-paste'
-import type { RemixRoutingTable } from '../../../../editor/store/remix-derived-data'
 
 const propertiesToRemove: Array<PropertyPath> = [
   PP.create('style', 'left'),
@@ -80,15 +77,8 @@ export function getAbsoluteReparentPropertyChanges(
   targetStartingMetadata: ElementInstanceMetadataMap,
   newParentStartingMetadata: ElementInstanceMetadataMap,
   projectContents: ProjectContentTreeRoot,
-  remixRoutingTable: RemixRoutingTable | null,
-  openFile: string | null | undefined,
 ): Array<AdjustCssLengthProperties | ConvertCssPercentToPx> {
-  const element: JSXElement | null = getElementFromProjectContents(
-    target,
-    projectContents,
-    remixRoutingTable,
-    openFile,
-  )
+  const element: JSXElement | null = getElementFromProjectContents(target, projectContents)
 
   const originalParentInstance = MetadataUtils.findElementByElementPath(
     targetStartingMetadata,
@@ -322,8 +312,6 @@ export function getReparentPropertyChanges(
   currentMetadata: ElementInstanceMetadataMap,
   currentPathTrees: ElementPathTrees,
   projectContents: ProjectContentTreeRoot,
-  remixRoutingTable: RemixRoutingTable | null,
-  openFile: string | null | undefined,
   targetOriginalStylePosition: CSSPosition | null,
   targetOriginalDisplayProp: string | null,
   oldAllElementProps: AllElementProps,
@@ -347,8 +335,6 @@ export function getReparentPropertyChanges(
         originalContextMetadata,
         currentMetadata,
         projectContents,
-        remixRoutingTable,
-        openFile,
       )
 
       const strategyCommands = runReparentPropertyStrategies([
@@ -363,8 +349,6 @@ export function getReparentPropertyChanges(
           newParent,
           reparentStrategy,
           projectContents,
-          remixRoutingTable,
-          openFile,
           [stripPinsConvertToVisualSize, convertRelativeSizingToVisualSize],
         ),
       ])
@@ -406,8 +390,6 @@ export function getReparentPropertyChanges(
           newParent,
           reparentStrategy,
           projectContents,
-          remixRoutingTable,
-          openFile,
           [
             stripPinsConvertToVisualSize,
             convertRelativeSizingToVisualSize,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-strategies.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-strategies.ts
@@ -35,7 +35,6 @@ import type { ReparentStrategy } from './reparent-strategy-helpers'
 import type { ProjectContentTreeRoot } from '../../../../assets'
 import { singleAxisAutoLayoutContainerDirections } from '../flow-reorder-helpers'
 import type { OldPathToNewPathMapping } from '../../post-action-options/post-action-paste'
-import type { RemixRoutingTable } from '../../../../editor/store/remix-derived-data'
 
 type ReparentPropertyStrategyUnapplicableReason = string
 
@@ -270,8 +269,6 @@ export const convertFragmentLikeChildrenToVisualSize =
     newParent: ElementPath,
     reparentStrategy: ReparentStrategy,
     projectContents: ProjectContentTreeRoot,
-    remixRoutingTable: RemixRoutingTable | null,
-    openFile: string | null | undefined,
     propertyStrategies: Array<
       (
         elementToReparent: ElementPathSnapshots,
@@ -315,8 +312,6 @@ export const convertFragmentLikeChildrenToVisualSize =
           metadata.originalTargetMetadata,
           metadata.currentMetadata,
           projectContents,
-          remixRoutingTable,
-          openFile,
         )
       } else {
         const directions = singleAxisAutoLayoutContainerDirections(

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
@@ -65,7 +65,6 @@ export function findReparentStrategies(
     canvasState,
     metadata,
     canvasState.startingElementPathTree,
-    canvasState.nodeModules,
     canvasState.startingAllElementProps,
     allowSmallerParent,
     elementSupportsChildren,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -16,7 +16,7 @@ import {
   sizeFitsInTarget,
   zeroRectIfNullOrInfinity,
 } from '../../../../../core/shared/math-utils'
-import type { ElementPath, NodeModules } from '../../../../../core/shared/project-file-types'
+import type { ElementPath } from '../../../../../core/shared/project-file-types'
 import type { AllElementProps } from '../../../../editor/store/editor-state'
 import type { Direction } from '../../../../inspector/common/css-utils'
 import { getAllTargetsAtPointAABB } from '../../../dom-lookup'
@@ -24,7 +24,7 @@ import type { InteractionCanvasState } from '../../canvas-strategy-types'
 import type { AllowSmallerParent } from '../../interaction-state'
 import type { SingleAxisAutolayoutContainerDirections } from '../flow-reorder-helpers'
 import { singleAxisAutoLayoutContainerDirections } from '../flow-reorder-helpers'
-import { getElementFragmentLikeType, treatElementAsFragmentLike } from '../fragment-like-helpers'
+import { treatElementAsFragmentLike } from '../fragment-like-helpers'
 import type {
   ReparentStrategy,
   ReparentSubjects,
@@ -49,7 +49,6 @@ export function getReparentTargetUnified(
   canvasState: InteractionCanvasState,
   metadata: ElementInstanceMetadataMap,
   elementPathTree: ElementPathTrees,
-  nodeModules: NodeModules,
   allElementProps: AllElementProps,
   allowSmallerParent: AllowSmallerParent,
   elementSupportsChildren: Array<ElementSupportsChildren> = ['supportsChildren'],
@@ -62,7 +61,6 @@ export function getReparentTargetUnified(
     cmdPressed,
     canvasState,
     metadata,
-    nodeModules,
     elementPathTree,
     allElementProps,
     allowSmallerParent,
@@ -149,7 +147,6 @@ function findValidTargetsUnderPoint(
   cmdPressed: boolean, // TODO: this should be removed from here and replaced by meaningful flag(s) (similar to allowSmallerParent)
   canvasState: InteractionCanvasState,
   metadata: ElementInstanceMetadataMap,
-  nodeModules: NodeModules,
   elementPathTree: ElementPathTrees,
   allElementProps: AllElementProps,
   allowSmallerParent: AllowSmallerParent,
@@ -223,9 +220,6 @@ function findValidTargetsUnderPoint(
         MetadataUtils.targetSupportsChildrenAlsoText(
           projectContents,
           metadata,
-          nodeModules,
-          canvasState.remixRoutingTable,
-          openFile,
           target,
           elementPathTree,
         ),

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -155,7 +155,6 @@ function getStartingTargetParentsToFilterOutInner(
     canvasState,
     canvasState.startingMetadata,
     canvasState.startingElementPathTree,
-    canvasState.nodeModules,
     canvasState.startingAllElementProps,
     allowSmallerParent,
     elementSupportsChildren,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
@@ -93,7 +93,6 @@ export function getReparentOutcome(
   builtInDependencies: BuiltInDependencies,
   projectContents: ProjectContentTreeRoot,
   nodeModules: NodeModules,
-  remixRoutingTable: RemixRoutingTable | null,
   openFile: string | null | undefined,
   toReparent: ToReparent,
   targetParent: InsertionPath | null,
@@ -124,9 +123,6 @@ export function getReparentOutcome(
     withUnderlyingTarget(
       newParentElementPath,
       projectContents,
-      nodeModules,
-      remixRoutingTable,
-      openFile,
       null,
       (success, element, underlyingTarget, underlyingFilePath) => {
         return underlyingFilePath
@@ -143,8 +139,6 @@ export function getReparentOutcome(
         toReparent.target,
         projectContents,
         nodeModules,
-        remixRoutingTable,
-        openFile,
         newTargetFilePath,
         builtInDependencies,
       )
@@ -189,7 +183,6 @@ export function getReparentOutcomeMultiselect(
   builtInDependencies: BuiltInDependencies,
   projectContents: ProjectContentTreeRoot,
   nodeModules: NodeModules,
-  remixRoutingTable: RemixRoutingTable | null,
   openFile: string | null | undefined,
   toReparentMultiple: Array<ToReparent>,
   targetParent: InsertionPath | null,
@@ -220,11 +213,8 @@ export function getReparentOutcomeMultiselect(
     withUnderlyingTarget(
       newParentElementPath,
       projectContents,
-      nodeModules,
-      remixRoutingTable,
-      openFile,
       null,
-      (success, element, underlyingTarget, underlyingFilePath) => {
+      (_success, _element, _underlyingTarget, underlyingFilePath) => {
         return underlyingFilePath
       },
     ),
@@ -239,8 +229,6 @@ export function getReparentOutcomeMultiselect(
           toReparent.target,
           projectContents,
           nodeModules,
-          remixRoutingTable,
-          openFile,
           newTargetFilePath,
           builtInDependencies,
         )

--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
@@ -24,12 +24,8 @@ import {
   zeroCanvasPoint,
 } from '../../../../core/shared/math-utils'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
-import type { ProjectContentTreeRoot } from '../../../assets'
 
-import {
-  getElementFromProjectContents,
-  withUnderlyingTarget,
-} from '../../../editor/store/editor-state'
+import { getElementFromProjectContents } from '../../../editor/store/editor-state'
 import { stylePropPathMappingFn } from '../../../inspector/common/property-path-hooks'
 import { determineConstrainedDragAxis } from '../../canvas-controls-frame'
 import type { CanvasFrameAndTarget } from '../../canvas-types'
@@ -180,8 +176,6 @@ export function getMoveCommandsForSelectedElement(
   const element: JSXElement | null = getElementFromProjectContents(
     selectedElement,
     canvasState.projectContents,
-    canvasState.remixRoutingTable,
-    canvasState.openFile,
   )
 
   const elementMetadata = MetadataUtils.findElementByElementPath(

--- a/editor/src/components/canvas/canvas-utils-unit-tests.spec.tsx
+++ b/editor/src/components/canvas/canvas-utils-unit-tests.spec.tsx
@@ -11,7 +11,7 @@ import type { CanvasVector } from '../../core/shared/math-utils'
 import { canvasRectangle } from '../../core/shared/math-utils'
 import { updateFramesOfScenesAndComponents } from './canvas-utils'
 import { NO_OP } from '../../core/shared/utils'
-import { editorModelFromPersistentModel, emptyDerivedState } from '../editor/store/editor-state'
+import { editorModelFromPersistentModel } from '../editor/store/editor-state'
 import { complexDefaultProjectPreParsed } from '../../sample-projects/sample-project-utils.test-utils'
 
 describe('updateFramesOfScenesAndComponents - multi-file', () => {
@@ -29,12 +29,7 @@ describe('updateFramesOfScenesAndComponents - multi-file', () => {
       { x: 60, y: 40 } as CanvasVector,
     )
 
-    const updatedProject = updateFramesOfScenesAndComponents(
-      testProject,
-      emptyDerivedState(testProject),
-      [pinChange],
-      null,
-    )
+    const updatedProject = updateFramesOfScenesAndComponents(testProject, [pinChange], null)
 
     expect(testPrintCodeFromEditorState(updatedProject, '/src/card.js')).toMatchInlineSnapshot(`
       "import * as React from 'react'
@@ -86,12 +81,7 @@ describe('updateFramesOfScenesAndComponents - multi-file', () => {
 
     const pinChange = pinMoveChange(targetPath, { x: 60, y: 40 } as CanvasVector)
 
-    const updatedProject = updateFramesOfScenesAndComponents(
-      testProject,
-      emptyDerivedState(testProject),
-      [pinChange],
-      null,
-    )
+    const updatedProject = updateFramesOfScenesAndComponents(testProject, [pinChange], null)
 
     expect(testPrintCodeFromEditorState(updatedProject, '/src/card.js')).toMatchInlineSnapshot(`
       "import * as React from 'react'
@@ -155,7 +145,6 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     const updatedProject = updateFramesOfScenesAndComponents(
       testProject,
-      emptyDerivedState(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
@@ -191,7 +180,6 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     const updatedProject = updateFramesOfScenesAndComponents(
       testProject,
-      emptyDerivedState(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
@@ -227,7 +215,6 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     const updatedProject = updateFramesOfScenesAndComponents(
       testProject,
-      emptyDerivedState(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
@@ -273,7 +260,6 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     const updatedProject = updateFramesOfScenesAndComponents(
       testProject,
-      emptyDerivedState(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
@@ -309,7 +295,6 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     const updatedProject = updateFramesOfScenesAndComponents(
       testProject,
-      emptyDerivedState(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
@@ -345,7 +330,6 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     const updatedProject = updateFramesOfScenesAndComponents(
       testProject,
-      emptyDerivedState(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
@@ -381,7 +365,6 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     const updatedProject = updateFramesOfScenesAndComponents(
       testProject,
-      emptyDerivedState(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
@@ -417,7 +400,6 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     const updatedProject = updateFramesOfScenesAndComponents(
       testProject,
-      emptyDerivedState(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
@@ -453,7 +435,6 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     const updatedProject = updateFramesOfScenesAndComponents(
       testProject,
-      emptyDerivedState(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
@@ -492,7 +473,6 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
 
     const updatedProject = updateFramesOfScenesAndComponents(
       testProject,
-      emptyDerivedState(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -248,12 +248,10 @@ function valueToUseForPin(
 
 export function updateFramesOfScenesAndComponents(
   editorState: EditorState,
-  derivedState: DerivedState,
   framesAndTargets: Array<PinOrFlexFrameChange>,
   optionalParentFrame: CanvasRectangle | null,
 ): EditorState {
   let workingEditorState: EditorState = editorState
-  let workingDerivedState: DerivedState = derivedState
   let toastsToAdd: Array<Notice> = []
   Utils.fastForEach(framesAndTargets, (frameAndTarget) => {
     const target = frameAndTarget.target
@@ -267,7 +265,6 @@ export function updateFramesOfScenesAndComponents(
     const element = withUnderlyingTargetFromEditorState(
       staticTarget,
       workingEditorState,
-      workingDerivedState,
       null,
       (success, underlyingElement) => underlyingElement,
     )
@@ -281,7 +278,6 @@ export function updateFramesOfScenesAndComponents(
     const parentElement = withUnderlyingTargetFromEditorState(
       staticParentPath,
       workingEditorState,
-      workingDerivedState,
       null,
       (success, underlyingElement) => underlyingElement,
     )
@@ -306,7 +302,6 @@ export function updateFramesOfScenesAndComponents(
           workingEditorState = modifyUnderlyingElementForOpenFile(
             originalTarget,
             workingEditorState,
-            workingDerivedState,
             (elem) => elem,
             (success, underlyingTarget) => {
               const components = getUtopiaJSXComponentsFromSuccess(success)
@@ -602,7 +597,6 @@ export function updateFramesOfScenesAndComponents(
       workingEditorState = modifyUnderlyingElementForOpenFile(
         originalTarget,
         workingEditorState,
-        workingDerivedState,
         (elem) => {
           // Remove the pinning and flex props first...
           const propsToMaybeRemove: Array<LayoutPinnedProp | 'flexBasis'> =
@@ -654,14 +648,7 @@ export function updateFramesOfScenesAndComponents(
     workingEditorState = modifyUnderlyingElementForOpenFile(
       staticTarget,
       workingEditorState,
-      workingDerivedState,
       (attrs) => roundJSXElementLayoutValues(styleStringInArray, attrs),
-    )
-    workingDerivedState = deriveState(
-      workingEditorState,
-      workingDerivedState,
-      'unpatched',
-      unpatchedCreateRemixDerivedDataMemo,
     )
     // TODO originalFrames is never being set, so we have a regression here, meaning keepChildrenGlobalCoords
     // doesn't work. Once that is fixed we can re-implement keeping the children in place
@@ -1338,7 +1325,6 @@ export function moveTemplate(
   newParentPath: ElementPath | null,
   parentFrame: CanvasRectangle | null,
   editorState: EditorState,
-  derivedState: DerivedState,
   componentMetadata: ElementInstanceMetadataMap,
   selectedViews: Array<ElementPath>,
   highlightedViews: Array<ElementPath>,
@@ -1363,13 +1349,11 @@ export function moveTemplate(
     return withUnderlyingTargetFromEditorState(
       target,
       editorState,
-      derivedState,
       noChanges(),
       (underlyingElementSuccess, underlyingElement, underlyingTarget, underlyingFilePath) => {
         return withUnderlyingTargetFromEditorState(
           newParentPath,
           editorState,
-          derivedState,
           noChanges(),
           (
             newParentSuccess,
@@ -1429,9 +1413,6 @@ export function moveTemplate(
                   const insertionPath = getInsertionPath(
                     newParentPath,
                     workingEditorState.projectContents,
-                    workingEditorState.nodeModules.files,
-                    derivedState.remixData?.routingTable ?? null,
-                    workingEditorState.canvas.openFile?.filename ?? null,
                     workingEditorState.jsxMetadata,
                     workingEditorState.elementPathTree,
                     wrapperUID,
@@ -1534,7 +1515,6 @@ export function moveTemplate(
 
                 workingEditorState = updateFramesOfScenesAndComponents(
                   workingEditorState,
-                  derivedState,
                   frameChanges,
                   parentFrame,
                 )
@@ -1695,7 +1675,6 @@ export function duplicate(
   paths: Array<ElementPath>,
   newParentPath: ElementPath | null,
   editor: EditorState,
-  derivedState: DerivedState,
   duplicateNewUIDsInjected: ReadonlyArray<DuplicateNewUID> = [],
   anchor: 'before' | 'after' = 'after',
 ): DuplicateResult | null {
@@ -1704,7 +1683,6 @@ export function duplicate(
 
   let newSelectedViews: Array<ElementPath> = []
   let workingEditorState: EditorState = editor
-  let workingDerivedState: DerivedState = derivedState
 
   const existingIDsMutable = new Set(getAllUniqueUids(workingEditorState.projectContents).allIDs)
   for (const path of paths) {
@@ -1715,7 +1693,6 @@ export function duplicate(
     workingEditorState = modifyUnderlyingElementForOpenFile(
       path,
       workingEditorState,
-      workingDerivedState,
       (elem) => elem,
       (success, underlyingInstancePath, underlyingFilePath) => {
         let utopiaComponents = getUtopiaJSXComponentsFromSuccess(success)
@@ -1848,12 +1825,6 @@ export function duplicate(
       ...workingEditorState,
       jsxMetadata: metadataUpdate(workingEditorState.jsxMetadata),
     }
-    workingDerivedState = deriveState(
-      workingEditorState,
-      workingDerivedState,
-      'unpatched',
-      unpatchedCreateRemixDerivedDataMemo,
-    )
   }
 
   return {

--- a/editor/src/components/canvas/commands/add-contain-layout-if-needed-command.ts
+++ b/editor/src/components/canvas/commands/add-contain-layout-if-needed-command.ts
@@ -26,7 +26,7 @@ export function addContainLayoutIfNeeded(
 
 export const runAddContainLayoutIfNeeded: CommandFunction<AddContainLayoutIfNeeded> = (
   editorState: EditorState,
-  derivedState: DerivedState,
+  _derivedState: DerivedState,
   command: AddContainLayoutIfNeeded,
 ) => {
   const elementMetadata = MetadataUtils.findElementByElementPath(
@@ -42,7 +42,7 @@ export const runAddContainLayoutIfNeeded: CommandFunction<AddContainLayoutIfNeed
     }
   } else {
     // Apply the update to the properties.
-    const { editorStatePatch } = applyValuesAtPath(editorState, derivedState, command.element, [
+    const { editorStatePatch } = applyValuesAtPath(editorState, command.element, [
       { path: PP.create('style', 'contain'), value: jsExpressionValue('layout', emptyComments) },
     ])
 

--- a/editor/src/components/canvas/commands/add-element-command.ts
+++ b/editor/src/components/canvas/commands/add-element-command.ts
@@ -48,14 +48,13 @@ export function addElement(
 
 export const runAddElement: CommandFunction<AddElement> = (
   editorState: EditorState,
-  derivedState: DerivedState,
+  _derivedState: DerivedState,
   command: AddElement,
 ) => {
   let editorStatePatches: Array<EditorStatePatch> = []
   forUnderlyingTargetFromEditorState(
     getElementPathFromInsertionPath(command.parentPath),
     editorState,
-    derivedState,
     (
       parentSuccess,
       _underlyingElementNewParent,

--- a/editor/src/components/canvas/commands/add-elements-command.ts
+++ b/editor/src/components/canvas/commands/add-elements-command.ts
@@ -49,14 +49,13 @@ export function addElements(
 
 export const runAddElements: CommandFunction<AddElements> = (
   editorState: EditorState,
-  derivedState: DerivedState,
+  _derivedState: DerivedState,
   command: AddElements,
 ) => {
   let editorStatePatches: Array<EditorStatePatch> = []
   forUnderlyingTargetFromEditorState(
     getElementPathFromInsertionPath(command.parentPath),
     editorState,
-    derivedState,
     (
       parentSuccess,
       _underlyingElementNewParent,

--- a/editor/src/components/canvas/commands/add-imports-to-file-command.ts
+++ b/editor/src/components/canvas/commands/add-imports-to-file-command.ts
@@ -1,19 +1,7 @@
 import { mergeImports } from '../../../core/workers/common/project-file-utils'
 import type { DerivedState, EditorState } from '../../../components/editor/store/editor-state'
-import {
-  modifyParseSuccessAtPath,
-  modifyUnderlyingElementForOpenFile,
-} from '../../../components/editor/store/editor-state'
 import type { Imports } from '../../../core/shared/project-file-types'
-import {
-  isParseSuccess,
-  isTextFile,
-  RevisionsState,
-  TextFile,
-} from '../../../core/shared/project-file-types'
 import type { BaseCommand, WhenToRun, CommandFunction, CommandFunctionResult } from './commands'
-import { Spec } from 'immutability-helper'
-import { ProjectContentTreeRoot } from '../../../components/assets'
 import { patchParseSuccessAtFilePath } from './patch-utils'
 
 export interface AddImportsToFile extends BaseCommand {

--- a/editor/src/components/canvas/commands/adjust-css-length-command.ts
+++ b/editor/src/components/canvas/commands/adjust-css-length-command.ts
@@ -78,14 +78,13 @@ interface UpdatedPropsAndCommandDescription {
 
 export const runAdjustCssLengthProperties: CommandFunction<AdjustCssLengthProperties> = (
   editorState: EditorState,
-  derivedState: DerivedState,
+  _derivedState: DerivedState,
   command: AdjustCssLengthProperties,
 ) => {
   let commandDescriptions: Array<string> = []
   const updatedEditorState: EditorState = modifyUnderlyingForOpenFile(
     command.target,
     editorState,
-    derivedState,
     (element) => {
       if (isJSXElement(element)) {
         return command.properties.reduce((workingElement, property) => {
@@ -243,18 +242,10 @@ export const runAdjustCssLengthProperties: CommandFunction<AdjustCssLengthProper
         commandDescription: commandDescriptions.join('\n'),
       }
     } else {
-      const updatedDerivedState = deriveState(
-        updatedEditorState,
-        derivedState,
-        'patched',
-        patchedCreateRemixDerivedDataMemo,
-      )
-
       // Build the patch for the changes.
       const editorStatePatch = patchParseSuccessAtElementPath(
         command.target,
         updatedEditorState,
-        updatedDerivedState,
         (success) => {
           return {
             topLevelElements: {
@@ -441,7 +432,6 @@ export function deleteConflictingPropsForWidthHeightFromAttributes(
 
 export function deleteConflictingPropsForWidthHeight(
   editorState: EditorState,
-  derivedState: DerivedState,
   target: ElementPath,
   propertyPath: PropertyPath,
   parentFlexDirection: FlexDirection | null,
@@ -453,7 +443,6 @@ export function deleteConflictingPropsForWidthHeight(
 
   const { editorStateWithChanges: editorStateWithPropsDeleted } = deleteValuesAtPath(
     editorState,
-    derivedState,
     target,
     propertiesToDelete,
   )

--- a/editor/src/components/canvas/commands/adjust-number-command.spec.tsx
+++ b/editor/src/components/canvas/commands/adjust-number-command.spec.tsx
@@ -4,11 +4,7 @@ import { createBuiltInDependenciesList } from '../../../core/es-modules/package-
 import * as EP from '../../../core/shared/element-path'
 import { getNumberPropertyFromProps } from '../../../core/shared/jsx-attributes'
 import { complexDefaultProjectPreParsed } from '../../../sample-projects/sample-project-utils.test-utils'
-import {
-  deriveState,
-  emptyDerivedState,
-  withUnderlyingTargetFromEditorState,
-} from '../../editor/store/editor-state'
+import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 import {
   DefaultStartingFeatureSwitches,
@@ -39,7 +35,6 @@ describe('adjustNumberProperty', () => {
     const originalLeftStyleProp = withUnderlyingTargetFromEditorState(
       cardInstancePath,
       originalEditorState,
-      emptyDerivedState(originalEditorState),
       null,
       (success, element, underlyingTarget, underlyingFilePath) => {
         if (isJSXElement(element)) {
@@ -77,7 +72,6 @@ describe('adjustNumberProperty', () => {
     const updatedLeftStyleProp = withUnderlyingTargetFromEditorState(
       cardInstancePath,
       patchedEditor,
-      emptyDerivedState(patchedEditor),
       null,
       (success, element, underlyingTarget, underlyingFilePath) => {
         if (isJSXElement(element)) {
@@ -133,7 +127,6 @@ describe('adjustNumberProperty', () => {
     const updatedLeftStyleProp = withUnderlyingTargetFromEditorState(
       elementPath,
       patchedEditor,
-      emptyDerivedState(patchedEditor),
       null,
       (success, element, underlyingTarget, underlyingFilePath) => {
         if (isJSXElement(element)) {

--- a/editor/src/components/canvas/commands/convert-css-percent-to-px-command.ts
+++ b/editor/src/components/canvas/commands/convert-css-percent-to-px-command.ts
@@ -43,14 +43,13 @@ export function convertCssPercentToPx(
 
 export const runConvertCssPercentToPx: CommandFunction<ConvertCssPercentToPx> = (
   editorState: EditorState,
-  derivedState: DerivedState,
+  _derivedState: DerivedState,
   command: ConvertCssPercentToPx,
 ) => {
   // Identify the current value, whatever that may be.
   const currentValue: GetModifiableAttributeResult = withUnderlyingTargetFromEditorState(
     command.target,
     editorState,
-    derivedState,
     left(`no target element was found at path ${EP.toString(command.target)}`),
     (_, element) => {
       if (isJSXElement(element)) {
@@ -111,7 +110,6 @@ export const runConvertCssPercentToPx: CommandFunction<ConvertCssPercentToPx> = 
   // Apply the update to the properties.
   const { editorStatePatch: propertyUpdatePatch } = applyValuesAtPath(
     editorState,
-    derivedState,
     command.target,
     propsToUpdate,
   )

--- a/editor/src/components/canvas/commands/convert-to-absolute-command.spec.tsx
+++ b/editor/src/components/canvas/commands/convert-to-absolute-command.spec.tsx
@@ -7,11 +7,7 @@ import {
   jsxSimpleAttributeToValue,
 } from '../../../core/shared/jsx-attributes'
 import { complexDefaultProjectPreParsed } from '../../../sample-projects/sample-project-utils.test-utils'
-import {
-  deriveState,
-  emptyDerivedState,
-  withUnderlyingTargetFromEditorState,
-} from '../../editor/store/editor-state'
+import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 import { DefaultStartingFeatureSwitches, renderTestEditorWithModel } from '../ui-jsx.test-utils'
 import { updateEditorStateWithPatches } from './commands'
@@ -46,7 +42,6 @@ describe('convertToAbsolute', () => {
     const originalPositionProp = withUnderlyingTargetFromEditorState(
       appInstancePath,
       originalEditorState,
-      emptyDerivedState(originalEditorState),
       null,
       (success, element, underlyingTarget, underlyingFilePath) => {
         if (isJSXElement(element)) {
@@ -69,7 +64,6 @@ describe('convertToAbsolute', () => {
     const updatedPositionProp = withUnderlyingTargetFromEditorState(
       appInstancePath,
       patchedEditor,
-      emptyDerivedState(patchedEditor),
       null,
       (success, element, underlyingTarget, underlyingFilePath) => {
         if (isJSXElement(element)) {

--- a/editor/src/components/canvas/commands/convert-to-absolute-command.ts
+++ b/editor/src/components/canvas/commands/convert-to-absolute-command.ts
@@ -25,7 +25,7 @@ export function convertToAbsolute(transient: WhenToRun, target: ElementPath): Co
 
 export const runConvertToAbsolute: CommandFunction<ConvertToAbsolute> = (
   editorState: EditorState,
-  derivedState: DerivedState,
+  _derivedState: DerivedState,
   command: ConvertToAbsolute,
 ) => {
   const propsToUpdate: Array<ValueAtPath> = [
@@ -37,7 +37,6 @@ export const runConvertToAbsolute: CommandFunction<ConvertToAbsolute> = (
 
   const { editorStatePatch: propertyUpdatePatch } = applyValuesAtPath(
     editorState,
-    derivedState,
     command.target,
     propsToUpdate,
   )

--- a/editor/src/components/canvas/commands/delete-element-command.ts
+++ b/editor/src/components/canvas/commands/delete-element-command.ts
@@ -25,14 +25,13 @@ export function deleteElement(whenToRun: WhenToRun, target: ElementPath): Delete
 
 export const runDeleteElement: CommandFunction<DeleteElement> = (
   editorState: EditorState,
-  derivedState: DerivedState,
+  _derivedState: DerivedState,
   command: DeleteElement,
 ) => {
   let editorStatePatches: Array<EditorStatePatch> = []
   forUnderlyingTargetFromEditorState(
     command.target,
     editorState,
-    derivedState,
     (successTarget, _underlyingElementTarget, underlyingTarget, underlyingFilePathTarget) => {
       const components = getUtopiaJSXComponentsFromSuccess(successTarget)
       const withElementRemoved = removeElementAtPath(underlyingTarget, components)

--- a/editor/src/components/canvas/commands/duplicate-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/duplicate-element-command.spec.tsx
@@ -50,7 +50,6 @@ describe('runDuplicateElement', () => {
     const newElement = withUnderlyingTargetFromEditorState(
       newPath,
       patchedEditor,
-      emptyDerivedState(patchedEditor),
       null,
       (_, element) => element,
     )
@@ -92,7 +91,6 @@ describe('runDuplicateElement', () => {
     const newElement = withUnderlyingTargetFromEditorState(
       newPath,
       patchedEditor,
-      emptyDerivedState(patchedEditor),
       null,
       (_, element) => element,
     )
@@ -166,7 +164,6 @@ describe('runDuplicateElement', () => {
     const newElement = withUnderlyingTargetFromEditorState(
       newPath,
       patchedEditor,
-      emptyDerivedState(patchedEditor),
       null,
       (_, element) => element,
     )

--- a/editor/src/components/canvas/commands/duplicate-element-command.ts
+++ b/editor/src/components/canvas/commands/duplicate-element-command.ts
@@ -2,8 +2,7 @@ import * as EP from '../../../core/shared/element-path'
 import { isUtopiaJSXComponent } from '../../../core/shared/element-template'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
-import { deriveState, withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
-import { patchedCreateRemixDerivedDataMemo } from '../../editor/store/remix-derived-data'
+import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import { duplicate } from '../canvas-utils'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 import { getPatchForComponentChange } from './commands'
@@ -34,7 +33,7 @@ export function duplicateElement(
 
 export const runDuplicateElement: CommandFunction<DuplicateElement> = (
   editorState: EditorState,
-  derivedState: DerivedState,
+  _derivedState: DerivedState,
   command: DuplicateElement,
 ) => {
   const targetParent = EP.parentPath(command.target)
@@ -44,7 +43,6 @@ export const runDuplicateElement: CommandFunction<DuplicateElement> = (
     [command.target],
     targetParent,
     editorState,
-    derivedState,
     [{ originalPath: command.target, newUID: command.newUid }],
     command.anchor,
   )
@@ -52,7 +50,6 @@ export const runDuplicateElement: CommandFunction<DuplicateElement> = (
   const originalParsedFile = withUnderlyingTargetFromEditorState(
     command.target,
     editorState,
-    derivedState,
     null,
     (parseSuccess, _, __, filePath) => ({ parseSuccess, filePath }),
   )
@@ -64,12 +61,6 @@ export const runDuplicateElement: CommandFunction<DuplicateElement> = (
   const newUtopiaComponents = withUnderlyingTargetFromEditorState(
     newPath,
     duplicateResult.updatedEditorState,
-    deriveState(
-      duplicateResult.updatedEditorState,
-      derivedState,
-      'patched',
-      patchedCreateRemixDerivedDataMemo,
-    ),
     [],
     (parsedFile) => {
       return parsedFile.topLevelElements.filter(isUtopiaJSXComponent) // TODO why can't getPatchForComponentChange just take all top level elements?

--- a/editor/src/components/canvas/commands/insert-element-insertion-subject.ts
+++ b/editor/src/components/canvas/commands/insert-element-insertion-subject.ts
@@ -33,7 +33,7 @@ export function insertElementInsertionSubject(
 
 export const runInsertElementInsertionSubject: CommandFunction<InsertElementInsertionSubject> = (
   editor: EditorState,
-  derivedState: DerivedState,
+  _derivedState: DerivedState,
   command: InsertElementInsertionSubject,
 ) => {
   let editorStatePatches: Array<EditorStatePatch> = []
@@ -43,7 +43,6 @@ export const runInsertElementInsertionSubject: CommandFunction<InsertElementInse
   forUnderlyingTargetFromEditorState(
     insertionPath.intendedParentPath,
     editor,
-    derivedState,
     (success, _element, _underlyingTarget, underlyingFilePath) => {
       const utopiaComponents = getUtopiaJSXComponentsFromSuccess(success)
 

--- a/editor/src/components/canvas/commands/patch-utils.ts
+++ b/editor/src/components/canvas/commands/patch-utils.ts
@@ -65,7 +65,6 @@ export function patchProjectContentsWithParsedFile(
 export function patchParseSuccessAtElementPath(
   target: ElementPath,
   editorState: EditorState,
-  derivedState: DerivedState,
   patchParseSuccess: (
     success: ParseSuccess,
     element: JSXElementChild,
@@ -76,7 +75,6 @@ export function patchParseSuccessAtElementPath(
   return withUnderlyingTargetFromEditorState(
     target,
     editorState,
-    derivedState,
     {},
     (success, underlyingElement, underlyingTarget, underlyingFilePath) => {
       const filePatch = patchParseSuccess(

--- a/editor/src/components/canvas/commands/rearrange-children-command.ts
+++ b/editor/src/components/canvas/commands/rearrange-children-command.ts
@@ -28,13 +28,12 @@ export function rearrangeChildren(
 
 export const runRearrangeChildren: CommandFunction<RearrangeChildren> = (
   editorState: EditorState,
-  derivedState: DerivedState,
+  _derivedState: DerivedState,
   command: RearrangeChildren,
 ) => {
   const patch = withUnderlyingTargetFromEditorState(
     command.target,
     editorState,
-    derivedState,
     {},
     (success, underlyingElement, underlyingTarget, underlyingFilePath) => {
       const components = getUtopiaJSXComponentsFromSuccess(success)

--- a/editor/src/components/canvas/commands/reorder-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/reorder-element-command.spec.tsx
@@ -95,7 +95,6 @@ describe('runReorderElement', () => {
       const children = withUnderlyingTargetFromEditorState(
         parent,
         patchedEditor,
-        emptyDerivedState(patchedEditor),
         null,
         (_, element) => {
           if (isJSXElementLike(element)) {

--- a/editor/src/components/canvas/commands/reorder-element-command.ts
+++ b/editor/src/components/canvas/commands/reorder-element-command.ts
@@ -29,13 +29,12 @@ export function reorderElement(
 
 export const runReorderElement: CommandFunction<ReorderElement> = (
   editorState: EditorState,
-  derivedState: DerivedState,
+  _derivedState: DerivedState,
   command: ReorderElement,
 ) => {
   const patch = withUnderlyingTargetFromEditorState(
     command.target,
     editorState,
-    derivedState,
     {},
     (success, underlyingElement, underlyingTarget, underlyingFilePath) => {
       const components = getUtopiaJSXComponentsFromSuccess(success)

--- a/editor/src/components/canvas/commands/reparent-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/reparent-element-command.spec.tsx
@@ -46,7 +46,6 @@ describe('runReparentElement', () => {
     const newElement = withUnderlyingTargetFromEditorState(
       newPath,
       patchedEditor,
-      renderResult.getEditorState().derived,
       null,
       (success, element, underlyingTarget, underlyingFilePath) => {
         return element
@@ -56,7 +55,6 @@ describe('runReparentElement', () => {
     const oldElement = withUnderlyingTargetFromEditorState(
       targetPath,
       patchedEditor,
-      renderResult.getEditorState().derived,
       null,
       (success, element, underlyingTarget, underlyingFilePath) => {
         return element
@@ -97,7 +95,6 @@ describe('runReparentElement', () => {
     const oldFile = withUnderlyingTargetFromEditorState(
       targetPath,
       originalEditorState,
-      renderResult.getEditorState().derived,
       null,
       (success, element, underlyingTarget, underlyingFilePath) => {
         return underlyingFilePath
@@ -113,7 +110,6 @@ describe('runReparentElement', () => {
     const { newElement, newFile } = withUnderlyingTargetFromEditorState(
       newPath,
       patchedEditor,
-      renderResult.getEditorState().derived,
       null,
       (success, element, underlyingTarget, underlyingFilePath) => {
         return {
@@ -126,7 +122,6 @@ describe('runReparentElement', () => {
     const oldElement = withUnderlyingTargetFromEditorState(
       targetPath,
       patchedEditor,
-      renderResult.getEditorState().derived,
       null,
       (success, element, underlyingTarget, underlyingFilePath) => {
         return element

--- a/editor/src/components/canvas/commands/reparent-element-command.ts
+++ b/editor/src/components/canvas/commands/reparent-element-command.ts
@@ -42,19 +42,17 @@ export function reparentElement(
 
 export const runReparentElement: CommandFunction<ReparentElement> = (
   editorState: EditorState,
-  derivedState: DerivedState,
+  _derivedState: DerivedState,
   command: ReparentElement,
 ) => {
   let editorStatePatches: Array<EditorStatePatch> = []
   forUnderlyingTargetFromEditorState(
     command.target,
     editorState,
-    derivedState,
     (successTarget, underlyingElementTarget, _underlyingTarget, underlyingFilePathTarget) => {
       forUnderlyingTargetFromEditorState(
         getElementPathFromInsertionPath(command.newParent),
         editorState,
-        derivedState,
         (
           successNewParent,
           _underlyingElementNewParent,

--- a/editor/src/components/canvas/commands/set-css-length-command.spec.tsx
+++ b/editor/src/components/canvas/commands/set-css-length-command.spec.tsx
@@ -6,7 +6,7 @@ import { getNumberPropertyFromProps } from '../../../core/shared/jsx-attributes'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import { complexDefaultProjectPreParsed } from '../../../sample-projects/sample-project-utils.test-utils'
 import { styleStringInArray } from '../../../utils/common-constants'
-import type { DerivedState, EditorState, EditorStorePatched } from '../../editor/store/editor-state'
+import type { EditorState, EditorStorePatched } from '../../editor/store/editor-state'
 import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import type { ParsedCSSProperties } from '../../inspector/common/css-utils'
 import { cssPixelLength } from '../../inspector/common/css-utils'
@@ -61,7 +61,6 @@ describe('setCssLengthProperty', () => {
     const updatedHeightProp = withUnderlyingTargetFromEditorState(
       cardInstancePath,
       patchedEditor,
-      renderResult.getEditorState().derived,
       null,
       (success, element, underlyingTarget, underlyingFilePath) => {
         if (isJSXElement(element)) {
@@ -95,15 +94,9 @@ describe('setCssLengthProperty', () => {
     )
 
     const result = runCommandUpdateEditor(editor.getEditorState(), command)
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'width'),
-    ).toBe(400)
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'minWidth'),
-    ).toBeNull()
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'maxWidth'),
-    ).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'width')).toBe(400)
+    expect(getStylePropForElement(result, targetPath, 'minWidth')).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'maxWidth')).toBeNull()
   })
 
   it('Setting height does not remove min-width and max-width props', async () => {
@@ -123,15 +116,9 @@ describe('setCssLengthProperty', () => {
     )
 
     const result = runCommandUpdateEditor(editor.getEditorState(), command)
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'height'),
-    ).toBe(400)
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'minWidth'),
-    ).toBe(50)
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'maxWidth'),
-    ).toBe(150)
+    expect(getStylePropForElement(result, targetPath, 'height')).toBe(400)
+    expect(getStylePropForElement(result, targetPath, 'minWidth')).toBe(50)
+    expect(getStylePropForElement(result, targetPath, 'maxWidth')).toBe(150)
   })
 
   it('Setting width removes flex props if the parent is a horizontal flex', async () => {
@@ -160,27 +147,13 @@ describe('setCssLengthProperty', () => {
     )
 
     const result = runCommandUpdateEditor(editor.getEditorState(), command)
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'width'),
-    ).toBe(400)
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'minWidth'),
-    ).toBeNull()
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'maxWidth'),
-    ).toBeNull()
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'flex'),
-    ).toBeNull()
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'flexGrow'),
-    ).toBeNull()
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'flexShrink'),
-    ).toBeNull()
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'flexBasis'),
-    ).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'width')).toBe(400)
+    expect(getStylePropForElement(result, targetPath, 'minWidth')).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'maxWidth')).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'flex')).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'flexGrow')).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'flexShrink')).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'flexBasis')).toBeNull()
   })
 
   it('Setting width keeps flex props if the parent is a vertical flex', async () => {
@@ -209,27 +182,13 @@ describe('setCssLengthProperty', () => {
     )
 
     const result = runCommandUpdateEditor(editor.getEditorState(), command)
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'width'),
-    ).toBe(400)
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'minWidth'),
-    ).toBeNull()
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'maxWidth'),
-    ).toBeNull()
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'flex'),
-    ).not.toBeNull()
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'flexGrow'),
-    ).not.toBeNull()
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'flexShrink'),
-    ).not.toBeNull()
-    expect(
-      getStylePropForElement(result, editor.getEditorState().derived, targetPath, 'flexBasis'),
-    ).not.toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'width')).toBe(400)
+    expect(getStylePropForElement(result, targetPath, 'minWidth')).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'maxWidth')).toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'flex')).not.toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'flexGrow')).not.toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'flexShrink')).not.toBeNull()
+    expect(getStylePropForElement(result, targetPath, 'flexBasis')).not.toBeNull()
   })
 })
 
@@ -276,14 +235,12 @@ function runCommandUpdateEditor(
 
 function getStylePropForElement(
   editor: EditorState,
-  derived: DerivedState,
   elementPath: ElementPath,
   styleProp: keyof ParsedCSSProperties,
 ): number | null {
   return withUnderlyingTargetFromEditorState(
     elementPath,
     editor,
-    derived,
     null,
     (success, element, underlyingTarget, underlyingFilePath) => {
       if (isJSXElement(element)) {

--- a/editor/src/components/canvas/commands/set-css-length-command.ts
+++ b/editor/src/components/canvas/commands/set-css-length-command.ts
@@ -72,13 +72,12 @@ export function setCssLengthProperty(
 
 export const runSetCssLengthProperty: CommandFunction<SetCssLengthProperty> = (
   editorState: EditorState,
-  derivedState: DerivedState,
+  _derivedState: DerivedState,
   command: SetCssLengthProperty,
 ) => {
   // in case of width or height change, delete min, max and flex props
   const editorStateWithPropsDeleted = deleteConflictingPropsForWidthHeight(
     editorState,
-    derivedState,
     command.target,
     command.property,
     command.parentFlexDirection,
@@ -88,7 +87,6 @@ export const runSetCssLengthProperty: CommandFunction<SetCssLengthProperty> = (
   const currentValue: GetModifiableAttributeResult = withUnderlyingTargetFromEditorState(
     command.target,
     editorState,
-    derivedState,
     left(`no target element was found at path ${EP.toString(command.target)}`),
     (_, element) => {
       if (isJSXElement(element)) {
@@ -156,17 +154,9 @@ export const runSetCssLengthProperty: CommandFunction<SetCssLengthProperty> = (
     })
   }
 
-  const derivedStateWithPropsDeleted = deriveState(
-    editorStateWithPropsDeleted,
-    derivedState,
-    'patched',
-    patchedCreateRemixDerivedDataMemo,
-  )
-
   // Apply the update to the properties.
   const { editorStatePatch: propertyUpdatePatch } = applyValuesAtPath(
     editorStateWithPropsDeleted,
-    derivedStateWithPropsDeleted,
     command.target,
     propsToUpdate,
   )

--- a/editor/src/components/canvas/commands/set-property-command.ts
+++ b/editor/src/components/canvas/commands/set-property-command.ts
@@ -49,13 +49,12 @@ export function setPropertyOmitNullProp<T extends PropertyPathPart>(
 
 export const runSetProperty: CommandFunction<SetProperty> = (
   editorState: EditorState,
-  derivedState: DerivedState,
+  _derivedState: DerivedState,
   command: SetProperty,
 ) => {
   // Apply the update to the properties.
   const { editorStatePatch: propertyUpdatePatch } = applyValuesAtPath(
     editorState,
-    derivedState,
     command.element,
     [{ path: command.property, value: jsExpressionValue(command.value, emptyComments) }],
   )

--- a/editor/src/components/canvas/commands/update-function-command.ts
+++ b/editor/src/components/canvas/commands/update-function-command.ts
@@ -1,11 +1,6 @@
-import * as EP from '../../../core/shared/element-path'
-import { isUtopiaJSXComponent } from '../../../core/shared/element-template'
-import { ElementPath } from '../../../core/shared/project-file-types'
 import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
-import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import type { InteractionLifecycle } from '../canvas-strategies/canvas-strategy-types'
 import type { BaseCommand, CommandFunctionResult, WhenToRun } from './commands'
-import { CommandFunction, getPatchForComponentChange } from './commands'
 
 export interface UpdateFunctionCommand extends BaseCommand {
   type: 'UPDATE_FUNCTION_COMMAND'

--- a/editor/src/components/canvas/commands/update-prop-if-exists-command.ts
+++ b/editor/src/components/canvas/commands/update-prop-if-exists-command.ts
@@ -38,14 +38,13 @@ export function updatePropIfExists(
 
 export const runUpdatePropIfExists: CommandFunction<UpdatePropIfExists> = (
   editorState: EditorState,
-  derivedState: DerivedState,
+  _derivedState: DerivedState,
   command: UpdatePropIfExists,
 ) => {
   // check if the prop exists
   const propertyExists = withUnderlyingTargetFromEditorState(
     command.element,
     editorState,
-    derivedState,
     false,
     (_, element) => {
       if (isJSXElement(element)) {
@@ -64,7 +63,6 @@ export const runUpdatePropIfExists: CommandFunction<UpdatePropIfExists> = (
     // Apply the update to the properties.
     const { editorStatePatch: propertyUpdatePatch } = applyValuesAtPath(
       editorState,
-      derivedState,
       command.element,
       [{ path: command.property, value: jsExpressionValue(command.value, emptyComments) }],
     )

--- a/editor/src/components/canvas/commands/wrap-in-container-command.spec.tsx
+++ b/editor/src/components/canvas/commands/wrap-in-container-command.spec.tsx
@@ -8,7 +8,7 @@ import type {
 } from '../../../core/shared/element-template'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import { complexDefaultProjectPreParsed } from '../../../sample-projects/sample-project-utils.test-utils'
-import type { EditorState, EditorStorePatched } from '../../editor/store/editor-state'
+import type { EditorStorePatched } from '../../editor/store/editor-state'
 import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import { DefaultStartingFeatureSwitches, renderTestEditorWithModel } from '../ui-jsx.test-utils'
 import { updateEditorStateWithPatches } from './commands'
@@ -16,13 +16,7 @@ import { runWrapInContainerCommand, wrapInContainerCommand } from './wrap-in-con
 
 describe('wrapInContainerCommand', () => {
   function getElement(path: ElementPath, store: EditorStorePatched) {
-    return withUnderlyingTargetFromEditorState(
-      path,
-      store.editor,
-      store.derived,
-      null,
-      (_, element) => element,
-    )
+    return withUnderlyingTargetFromEditorState(path, store.editor, null, (_, element) => element)
   }
 
   function getPath(uid: string) {

--- a/editor/src/components/canvas/commands/wrap-in-container-command.ts
+++ b/editor/src/components/canvas/commands/wrap-in-container-command.ts
@@ -65,7 +65,7 @@ export function wrapInContainerCommand(
 
 export const runWrapInContainerCommand: CommandFunction<WrapInContainerCommand> = (
   editor: EditorState,
-  derivedState: DerivedState,
+  _derivedState: DerivedState,
   command: WrapInContainerCommand,
 ) => {
   let editorStatePatches: Array<EditorStatePatch> = []
@@ -73,7 +73,6 @@ export const runWrapInContainerCommand: CommandFunction<WrapInContainerCommand> 
   forUnderlyingTargetFromEditorState(
     command.target,
     editor,
-    derivedState,
     (success, elementToWrap, _underlyingTarget, underlyingFilePath) => {
       const components = getUtopiaJSXComponentsFromSuccess(success)
       const withElementRemoved = removeElementAtPath(command.target, components)
@@ -97,9 +96,6 @@ export const runWrapInContainerCommand: CommandFunction<WrapInContainerCommand> 
       const insertionPath = getInsertionPath(
         targetParent,
         editor.projectContents,
-        editor.nodeModules.files,
-        derivedState.remixData?.routingTable ?? null,
-        editor.canvas.openFile?.filename,
         editor.jsxMetadata,
         editor.elementPathTree,
         wrapperUID,

--- a/editor/src/components/canvas/controls/insert-mode/insert-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/insert-mode/insert-mode-hooks.tsx
@@ -22,24 +22,13 @@ function useGetHighlightableViewsForInsertMode() {
     }
   })
   return React.useCallback(() => {
-    const {
-      componentMetadata,
-      elementPathTree,
-      mode,
-      projectContents,
-      nodeModules,
-      openFile,
-      remixRoutingTable,
-    } = storeRef.current
+    const { componentMetadata, elementPathTree, mode, projectContents } = storeRef.current
     if (isInsertMode(mode)) {
       const allPaths = MetadataUtils.getAllPaths(componentMetadata, elementPathTree)
       const insertTargets = allPaths.filter((path) => {
         return MetadataUtils.targetSupportsChildren(
           projectContents,
           componentMetadata,
-          nodeModules,
-          remixRoutingTable,
-          openFile,
           path,
           elementPathTree,
         )

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -428,19 +428,6 @@ export var FloatingMenu = React.memo(() => {
 
   const projectContentsRef = useRefEditorState((store) => store.editor.projectContents)
   const selectedViewsRef = useRefEditorState((store) => store.editor.selectedViews)
-  const remixRoutingTableRef = useRefEditorState(
-    (store) => store.derived.remixData?.routingTable ?? null,
-  )
-  const nodeModules = useEditorState(
-    Substores.restOfEditor,
-    (store) => store.editor.nodeModules.files,
-    'FloatingMenu nodeModules',
-  )
-  const openFile = useEditorState(
-    Substores.canvas,
-    (store) => store.editor.canvas.openFile?.filename ?? null,
-    'FloatingMenu openFile',
-  )
   const jsxMetadata = useEditorState(
     Substores.metadata,
     (store) => store.editor.jsxMetadata,
@@ -464,24 +451,13 @@ export var FloatingMenu = React.memo(() => {
       return getInsertionPath(
         target,
         projectContentsRef.current,
-        nodeModules,
-        remixRoutingTableRef.current,
-        openFile,
         jsxMetadata,
         elementPathTree,
         wrapperUID,
         selectedViewsRef.current.length,
       )
     },
-    [
-      projectContentsRef,
-      nodeModules,
-      remixRoutingTableRef,
-      openFile,
-      jsxMetadata,
-      elementPathTree,
-      selectedViewsRef,
-    ],
+    [projectContentsRef, jsxMetadata, elementPathTree, selectedViewsRef],
   )
 
   const onChangeConditionalOrFragment = React.useCallback(

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -1,20 +1,26 @@
 import { MetadataUtils } from '../core/model/element-metadata-utils'
 import type { Either } from '../core/shared/either'
 import { isRight } from '../core/shared/either'
-import type { ElementInstanceMetadataMap } from '../core/shared/element-template'
-import {
-  isIntrinsicElement,
-  isJSXElement,
-  isJSXElementLike,
-  isJSXFragment,
-} from '../core/shared/element-template'
-import type { CanvasPoint } from '../core/shared/math-utils'
-import type { NodeModules, ElementPath } from '../core/shared/project-file-types'
 import * as EP from '../core/shared/element-path'
+import type { ElementPathTrees } from '../core/shared/element-path-tree'
+import type { ElementInstanceMetadataMap } from '../core/shared/element-template'
+import { isIntrinsicElement, isJSXElementLike } from '../core/shared/element-template'
+import type { CanvasPoint } from '../core/shared/math-utils'
+import type { ElementPath } from '../core/shared/project-file-types'
 import * as PP from '../core/shared/property-path'
+import { WindowMousePositionRaw } from '../utils/global-positions'
 import RU from '../utils/react-utils'
 import Utils from '../utils/utils'
 import type { ProjectContentTreeRoot } from './assets'
+import { createPasteToReplacePostActionActions } from './canvas/canvas-strategies/post-action-options/post-action-options'
+import {
+  PropsPreservedPasteHerePostActionChoice,
+  PropsReplacedPasteHerePostActionChoice,
+} from './canvas/canvas-strategies/post-action-options/post-action-paste'
+import { treatElementAsFragmentLike } from './canvas/canvas-strategies/strategies/fragment-like-helpers'
+import { createWrapInGroupActions } from './canvas/canvas-strategies/strategies/group-conversion-helpers'
+import { areAllSelectedElementsNonAbsolute } from './canvas/canvas-strategies/strategies/shared-move-strategies-helpers'
+import { windowToCanvasCoordinates } from './canvas/dom-lookup'
 import type { EditorDispatch } from './editor/action-types'
 import * as EditorActions from './editor/actions/action-creators'
 import {
@@ -28,6 +34,7 @@ import type {
   NavigatorEntry,
   PasteHerePostActionMenuData,
 } from './editor/store/editor-state'
+import type { ElementContextMenuInstance } from './element-context-menu'
 import {
   toggleBackgroundLayers,
   toggleBorder,
@@ -35,22 +42,6 @@ import {
   toggleStylePropPath,
   toggleStylePropPaths,
 } from './inspector/common/css-utils'
-import { areAllSelectedElementsNonAbsolute } from './canvas/canvas-strategies/strategies/shared-move-strategies-helpers'
-import { generateUidWithExistingComponents } from '../core/model/element-template-utils'
-import { defaultTransparentViewElement } from './editor/defaults'
-import { treatElementAsFragmentLike } from './canvas/canvas-strategies/strategies/fragment-like-helpers'
-import type { ElementPathTrees } from '../core/shared/element-path-tree'
-import { windowToCanvasCoordinates } from './canvas/dom-lookup'
-import { WindowMousePositionRaw } from '../utils/global-positions'
-import type { ElementContextMenuInstance } from './element-context-menu'
-import {
-  PropsPreservedPasteHerePostActionChoice,
-  PropsReplacedPasteHerePostActionChoice,
-} from './canvas/canvas-strategies/post-action-options/post-action-paste'
-import { stripNulls } from '../core/shared/array-utils'
-import { createWrapInGroupActions } from './canvas/canvas-strategies/strategies/group-conversion-helpers'
-import { createPasteToReplacePostActionActions } from './canvas/canvas-strategies/post-action-options/post-action-options'
-import type { RemixRoutingTable } from './editor/store/remix-derived-data'
 
 export interface ContextMenuItem<T> {
   name: string | React.ReactNode
@@ -67,15 +58,12 @@ export interface CanvasData {
   selectedViews: Array<ElementPath>
   jsxMetadata: ElementInstanceMetadataMap
   projectContents: ProjectContentTreeRoot
-  remixRoutingTable: RemixRoutingTable | null
-  nodeModules: NodeModules
   resolve: (importOrigin: string, toImport: string) => Either<string, string>
   hiddenInstances: ElementPath[]
   scale: number
   focusedElementPath: ElementPath | null
   allElementProps: AllElementProps
   pathTrees: ElementPathTrees
-  openFile: string | null
   internalClipboard: InternalClipboard
   contextMenuInstance: ElementContextMenuInstance
   autoFocusedPaths: Array<ElementPath>
@@ -395,9 +383,6 @@ export const unwrap: ContextMenuItem<CanvasData> = {
         MetadataUtils.targetSupportsChildren(
           data.projectContents,
           data.jsxMetadata,
-          data.nodeModules,
-          data.remixRoutingTable,
-          data.openFile,
           path,
           data.pathTrees,
         ) ||

--- a/editor/src/components/custom-code/code-file.spec.ts
+++ b/editor/src/components/custom-code/code-file.spec.ts
@@ -478,10 +478,7 @@ describe('normalisePathToUnderlyingTarget', () => {
   it('handles finding the target', () => {
     const actualResult = normalisePathToUnderlyingTarget(
       projectContents,
-      SampleNodeModules,
-      StoryboardFilePath,
       EP.fromString('storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div'),
-      null,
     )
     const expectedResult = normalisePathSuccess(
       EP.dynamicPathToStaticPath(EP.fromString('same-file-app-div')),
@@ -492,22 +489,13 @@ describe('normalisePathToUnderlyingTarget', () => {
     expect(actualResult).toEqual(expectedResult)
   })
   it('gives an error when the element path is empty', () => {
-    const actualResult = normalisePathToUnderlyingTarget(
-      projectContents,
-      SampleNodeModules,
-      '/src/nonexistant.js',
-      null,
-      null,
-    )
+    const actualResult = normalisePathToUnderlyingTarget(projectContents, null)
     expect(actualResult.type).toEqual('NORMALISE_PATH_ERROR')
   })
   it('flags elements that can not be found', () => {
     const actualResult = normalisePathToUnderlyingTarget(
       projectContents,
-      SampleNodeModules,
-      StoryboardFilePath,
       EP.fromString('storyboard-entity/scene-1-entity/app-entity:non-existent'),
-      null,
     )
     const expectedResult = normalisePathElementNotFound(
       'storyboard-entity/scene-1-entity/app-entity:non-existent',

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -362,10 +362,7 @@ export function normalisePathSuccessOrThrowError(
 
 export function normalisePathToUnderlyingTarget(
   projectContents: ProjectContentTreeRoot,
-  _nodeModules: NodeModules,
-  _currentFilePath: string,
   elementPath: ElementPath | null,
-  _remixRoutingTable: RemixRoutingTable | null,
 ): NormalisePathResult {
   if (elementPath == null || EP.isEmptyPath(elementPath)) {
     return normalisePathError('Empty element path')

--- a/editor/src/components/editor/actions/wrap-unwrap-helpers.tsx
+++ b/editor/src/components/editor/actions/wrap-unwrap-helpers.tsx
@@ -58,16 +58,13 @@ import { getAllUniqueUids } from '../../../core/model/get-unique-ids'
 
 export function unwrapConditionalClause(
   editor: EditorState,
-  derivedState: DerivedState,
   target: ElementPath,
   parentPath: ConditionalClauseInsertionPath,
 ): EditorState {
   let newSelection: Array<ElementPath> = []
   const withElementMoved = modifyUnderlyingTargetElement(
     parentPath.intendedParentPath,
-    forceNotNull('No storyboard file found', editor.canvas.openFile?.filename),
     editor,
-    derivedState,
     (element) => element,
     (success) => {
       const components = getUtopiaJSXComponentsFromSuccess(success)
@@ -132,7 +129,6 @@ export function unwrapConditionalClause(
 }
 export function unwrapTextContainingConditional(
   editor: EditorState,
-  derived: DerivedState,
   target: ElementPath,
   dispatch: EditorDispatch,
 ): EditorState {
@@ -157,9 +153,7 @@ export function unwrapTextContainingConditional(
 
   const withParentUpdated = modifyUnderlyingTargetElement(
     targetParent,
-    forceNotNull('No storyboard file found', editor.canvas.openFile?.filename),
     editor,
-    derived,
     (element) => element,
     (success) => {
       const components = getUtopiaJSXComponentsFromSuccess(success)
@@ -168,9 +162,6 @@ export function unwrapTextContainingConditional(
       const insertionPath = getInsertionPath(
         targetParent,
         editor.projectContents,
-        editor.nodeModules.files,
-        derived.remixData?.routingTable ?? null,
-        editor.canvas.openFile?.filename,
         editor.jsxMetadata,
         editor.elementPathTree,
         wrapperUID,
@@ -199,7 +190,7 @@ export function unwrapTextContainingConditional(
     },
   )
 
-  return UPDATE_FNS.DELETE_VIEW(deleteView(target), withParentUpdated, dispatch, derived)
+  return UPDATE_FNS.DELETE_VIEW(deleteView(target), withParentUpdated, dispatch)
 }
 
 export function isTextContainingConditional(
@@ -288,7 +279,6 @@ export function wrapElementInsertions(
         case 'CONDITIONAL_CLAUSE_INSERTION':
           const withTargetAdded = insertElementIntoJSXConditional(
             editor,
-            derivedState,
             staticTarget,
             elementToInsert,
             importsToAdd,
@@ -311,7 +301,6 @@ export function wrapElementInsertions(
         case 'CONDITIONAL_CLAUSE_INSERTION':
           const withTargetAdded = insertElementIntoJSXConditional(
             editor,
-            derivedState,
             staticTarget,
             elementToInsert,
             importsToAdd,
@@ -334,7 +323,6 @@ export function wrapElementInsertions(
         case 'CONDITIONAL_CLAUSE_INSERTION':
           const withTargetAdded = insertConditionalIntoConditionalClause(
             editor,
-            derivedState,
             staticTarget,
             elementToInsert,
             importsToAdd,
@@ -379,16 +367,13 @@ function findIndexPositionInParent(
 
 function insertElementIntoJSXConditional(
   editor: EditorState,
-  derivedState: DerivedState,
   staticTarget: ConditionalClauseInsertionPath,
   elementToInsert: JSXElement | JSXFragment,
   importsToAdd: Imports,
 ): EditorState {
   return modifyUnderlyingTargetElement(
     staticTarget.intendedParentPath,
-    forceNotNull('No storyboard file found', editor.canvas.openFile?.filename),
     editor,
-    derivedState,
     (element) => element,
     (success, _, underlyingFilePath) => {
       const components = getUtopiaJSXComponentsFromSuccess(success)
@@ -432,16 +417,13 @@ function insertElementIntoJSXConditional(
 }
 function insertConditionalIntoConditionalClause(
   editor: EditorState,
-  derivedState: DerivedState,
   staticTarget: ConditionalClauseInsertionPath,
   elementToInsert: JSXConditionalExpression,
   importsToAdd: Imports,
 ): EditorState {
   return modifyUnderlyingTargetElement(
     staticTarget.intendedParentPath,
-    forceNotNull('No storyboard file found', editor.canvas.openFile?.filename),
     editor,
-    derivedState,
     (element) => element,
     (success, _, underlyingFilePath) => {
       const components = getUtopiaJSXComponentsFromSuccess(success)

--- a/editor/src/components/editor/import-utils.ts
+++ b/editor/src/components/editor/import-utils.ts
@@ -11,33 +11,22 @@ import {
   walkElement,
 } from '../../core/shared/element-template'
 import type { ElementPath, Imports, NodeModules } from '../../core/shared/project-file-types'
-import {
-  importAlias,
-  importDetails,
-  isParseSuccess,
-  isTextFile,
-} from '../../core/shared/project-file-types'
+import { importAlias, importDetails } from '../../core/shared/project-file-types'
 import type { ProjectContentTreeRoot } from '../assets'
 import type { BuiltInDependencies } from '../../core/es-modules/package-manager/built-in-dependencies-list'
 import { withUnderlyingTarget } from './store/editor-state'
 import * as EP from '../../core/shared/element-path'
-import type { RemixRoutingTable } from './store/remix-derived-data'
 
 export function getRequiredImportsForElement(
   target: ElementPath,
   projectContents: ProjectContentTreeRoot,
   nodeModules: NodeModules,
-  remixRoutingTable: RemixRoutingTable | null,
-  openFile: string | null | undefined,
   targetFilePath: string,
   builtInDependencies: BuiltInDependencies,
 ): Imports {
   return withUnderlyingTarget<Imports>(
     target,
     projectContents,
-    nodeModules,
-    remixRoutingTable,
-    openFile,
     emptyImports(),
     (success, element, underlyingTarget, underlyingFilePath) => {
       const importsInOriginFile = success.imports

--- a/editor/src/components/editor/store/editor-state.spec.ts
+++ b/editor/src/components/editor/store/editor-state.spec.ts
@@ -57,9 +57,7 @@ describe('modifyUnderlyingTarget', () => {
     const pathToElement = EP.fromString('app-outer-div/card-instance')
     const actualResult = modifyUnderlyingTargetElement(
       pathToElement,
-      '/src/app.js',
       startingEditorModel,
-      emptyDerivedState(startingEditorModel),
       (element) => {
         if (isJSXConditionalExpression(element) || isJSXFragment(element)) {
           return element
@@ -106,9 +104,7 @@ describe('modifyUnderlyingTarget', () => {
     const pathToElement = EP.fromString('card-outer-div/card-inner-div')
     const actualResult = modifyUnderlyingTargetElement(
       pathToElement,
-      '/src/card.js',
       startingEditorModel,
-      emptyDerivedState(startingEditorModel),
       (element) => element,
       (success: ParseSuccess) => {
         return parseSuccess(
@@ -145,9 +141,7 @@ describe('modifyUnderlyingTarget', () => {
     )
     const actualResult = modifyUnderlyingTargetElement(
       pathToElement,
-      StoryboardFilePath,
       startingEditorModel,
-      emptyDerivedState(startingEditorModel),
       (element) => {
         if (isJSXConditionalExpression(element) || isJSXFragment(element)) {
           return element
@@ -199,23 +193,17 @@ describe('modifyUnderlyingTarget', () => {
   it('tries to change something with a nonsense element path', () => {
     const pathToElement = EP.fromString('moon-palace/living-room')
     const modifyCall = () =>
-      modifyUnderlyingTargetElement(
-        pathToElement,
-        '/src/app.js',
-        startingEditorModel,
-        emptyDerivedState(startingEditorModel),
-        (element) => {
-          if (isJSXConditionalExpression(element) || isJSXFragment(element)) {
-            return element
-          }
-          const updatedAttributes = setJSXAttributesAttribute(
-            element.props,
-            'data-thing',
-            jsExpressionValue('a thing', emptyComments),
-          )
-          return jsxElement(element.name, element.uid, updatedAttributes, element.children)
-        },
-      )
+      modifyUnderlyingTargetElement(pathToElement, startingEditorModel, (element) => {
+        if (isJSXConditionalExpression(element) || isJSXFragment(element)) {
+          return element
+        }
+        const updatedAttributes = setJSXAttributesAttribute(
+          element.props,
+          'data-thing',
+          jsExpressionValue('a thing', emptyComments),
+        )
+        return jsxElement(element.name, element.uid, updatedAttributes, element.children)
+      })
     expect(modifyCall).toThrowError(`Could not find element with path moon-palace/living-room`)
   })
 })
@@ -229,9 +217,7 @@ describe('Revision state management', () => {
     const pathToElement = EP.fromString('app-outer-div/card-instance')
     const actualResult = modifyUnderlyingTargetElement(
       pathToElement,
-      '/src/app.js',
       startingEditorModel,
-      emptyDerivedState(startingEditorModel),
       (element) => {
         if (isJSXConditionalExpression(element) || isJSXFragment(element)) {
           return element

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -113,7 +113,6 @@ import type { UtopiaVSCodeConfig } from 'utopia-vscode-common'
 import { ProjectIDPlaceholderPrefix, defaultConfig } from 'utopia-vscode-common'
 import { loginNotYetKnown } from '../../../common/user'
 import * as EP from '../../../core/shared/element-path'
-import { forceNotNull } from '../../../core/shared/optional-utils'
 import { assertNever } from '../../../core/shared/utils'
 import type { Notice } from '../../common/notice'
 import type { ShortcutConfiguration } from '../shortcut-definitions'
@@ -1739,13 +1738,11 @@ export function modifyOpenJsxElementAtPath(
   path: ElementPath,
   transform: (element: JSXElement) => JSXElement,
   model: EditorState,
-  derivedState: DerivedState,
 ): EditorState {
   return modifyOpenJsxElementOrConditionalAtPath(
     path,
     (element) => (isJSXElement(element) ? transform(element) : element),
     model,
-    derivedState,
   )
 }
 
@@ -1755,13 +1752,10 @@ export function modifyOpenJsxElementOrConditionalAtPath(
     element: JSXElement | JSXConditionalExpression | JSXFragment,
   ) => JSXElement | JSXConditionalExpression | JSXFragment,
   model: EditorState,
-  derivedState: DerivedState,
 ): EditorState {
   return modifyUnderlyingTargetElement(
     path,
-    forceNotNull('No open designer file.', model.canvas.openFile?.filename),
     model,
-    derivedState,
     (element) =>
       isJSXElement(element) || isJSXConditionalExpression(element) || isJSXFragment(element)
         ? transform(element)
@@ -1774,13 +1768,10 @@ export function modifyOpenJsxChildAtPath(
   path: ElementPath,
   transform: (element: JSXElementChild) => JSXElementChild,
   model: EditorState,
-  derivedState: DerivedState,
 ): EditorState {
   return modifyUnderlyingTarget(
     path,
-    forceNotNull('No open designer file.', model.canvas.openFile?.filename),
     model,
-    derivedState,
     (element) => transform(element),
     defaultModifyParseSuccess,
   )
@@ -1837,7 +1828,6 @@ export function getOpenUtopiaJSXComponentsFromStateMultifile(
 export function getJSXComponentsAndImportsForPathFromState(
   path: ElementPath,
   model: EditorState,
-  derived: DerivedState,
 ): {
   components: UtopiaJSXComponent[]
   imports: Imports
@@ -1849,33 +1839,19 @@ export function getJSXComponentsAndImportsForPathFromState(
       imports: {},
     }
   }
-  return getJSXComponentsAndImportsForPath(
-    path,
-    storyboardFilePath,
-    model.projectContents,
-    model.nodeModules.files,
-    derived,
-  )
+  return getJSXComponentsAndImportsForPath(path, storyboardFilePath, model.projectContents)
 }
 
-export function getJSXComponentsAndImportsForPath(
+function getJSXComponentsAndImportsForPath(
   path: ElementPath,
   currentFilePath: string,
   projectContents: ProjectContentTreeRoot,
-  nodeModules: NodeModules,
-  derived: DerivedState,
 ): {
   underlyingFilePath: string
   components: UtopiaJSXComponent[]
   imports: Imports
 } {
-  const underlying = normalisePathToUnderlyingTarget(
-    projectContents,
-    nodeModules,
-    currentFilePath,
-    path,
-    derived.remixData?.routingTable ?? null,
-  )
+  const underlying = normalisePathToUnderlyingTarget(projectContents, path)
   const elementFilePath =
     underlying.type === 'NORMALISE_PATH_SUCCESS' ? underlying.filePath : currentFilePath
   const result = getParseSuccessForFilePath(elementFilePath, projectContents)
@@ -3296,11 +3272,9 @@ export function defaultModifyParseSuccess(success: ParseSuccess): ParseSuccess {
   return success
 }
 
-export function modifyUnderlyingTarget(
+function modifyUnderlyingTarget(
   target: ElementPath | null,
-  currentFilePath: string,
   editor: EditorState,
-  derivedState: DerivedState,
   modifyElement: (
     element: JSXElementChild,
     underlying: ElementPath,
@@ -3312,13 +3286,7 @@ export function modifyUnderlyingTarget(
     underlyingFilePath: string,
   ) => ParseSuccess = defaultModifyParseSuccess,
 ): EditorState {
-  const underlyingTarget = normalisePathToUnderlyingTarget(
-    editor.projectContents,
-    editor.nodeModules.files,
-    currentFilePath,
-    target,
-    derivedState.remixData?.routingTable ?? null,
-  )
+  const underlyingTarget = normalisePathToUnderlyingTarget(editor.projectContents, target)
   const targetSuccess = normalisePathSuccessOrThrowError(underlyingTarget)
 
   function innerModifyParseSuccess(oldParseSuccess: ParseSuccess): ParseSuccess {
@@ -3370,27 +3338,18 @@ export function modifyUnderlyingTarget(
 export function modifyUnderlyingForOpenFile(
   target: ElementPath | null,
   editor: EditorState,
-  derivedState: DerivedState,
   modifyElement: (
     element: JSXElementChild,
     underlying: ElementPath,
     underlyingFilePath: string,
   ) => JSXElementChild,
 ): EditorState {
-  return modifyUnderlyingTarget(
-    target,
-    forceNotNull('Designer file should be open.', editor.canvas.openFile?.filename),
-    editor,
-    derivedState,
-    modifyElement,
-  )
+  return modifyUnderlyingTarget(target, editor, modifyElement)
 }
 
 export function modifyUnderlyingTargetElement(
   target: ElementPath,
-  currentFilePath: string,
   editor: EditorState,
-  derivedState: DerivedState,
   modifyElement: (
     element: JSXElement | JSXConditionalExpression | JSXFragment,
     underlying: ElementPath,
@@ -3404,9 +3363,7 @@ export function modifyUnderlyingTargetElement(
 ): EditorState {
   return modifyUnderlyingTarget(
     target,
-    currentFilePath,
     editor,
-    derivedState,
     (element, underlying, underlyingFilePath) => {
       if (isJSXElement(element) || isJSXConditionalExpression(element) || isJSXFragment(element)) {
         return modifyElement(element, underlying, underlyingFilePath)
@@ -3417,10 +3374,10 @@ export function modifyUnderlyingTargetElement(
   )
 }
 
+// FIXME Replace with modifyUnderlyingTargetElement?
 export function modifyUnderlyingElementForOpenFile(
   target: ElementPath,
   editor: EditorState,
-  derivedState: DerivedState,
   modifyElement: (
     element: JSXElement,
     underlying: ElementPath,
@@ -3434,9 +3391,7 @@ export function modifyUnderlyingElementForOpenFile(
 ): EditorState {
   return modifyUnderlyingTargetElement(
     target,
-    forceNotNull('Designer file should be open.', editor.canvas.openFile?.filename),
     editor,
-    derivedState,
     (element, underlying, underlyingFilePath) =>
       isJSXElement(element) ? modifyElement(element, underlying, underlyingFilePath) : element,
     modifyParseSuccess,
@@ -3446,9 +3401,6 @@ export function modifyUnderlyingElementForOpenFile(
 export function withUnderlyingTarget<T>(
   target: ElementPath | null | undefined,
   projectContents: ProjectContentTreeRoot,
-  nodeModules: NodeModules,
-  remixRoutingTable: RemixRoutingTable | null,
-  openFile: string | null | undefined,
   defaultValue: T,
   withTarget: (
     success: ParseSuccess,
@@ -3458,13 +3410,7 @@ export function withUnderlyingTarget<T>(
     underlyingDynamicTarget: ElementPath,
   ) => T,
 ): T {
-  const underlyingTarget = normalisePathToUnderlyingTarget(
-    projectContents,
-    nodeModules,
-    forceNotNull('Designer file should be open.', openFile),
-    target ?? null,
-    remixRoutingTable,
-  )
+  const underlyingTarget = normalisePathToUnderlyingTarget(projectContents, target ?? null)
 
   if (
     underlyingTarget.type === 'NORMALISE_PATH_SUCCESS' &&
@@ -3495,7 +3441,6 @@ export function withUnderlyingTarget<T>(
 export function withUnderlyingTargetFromEditorState<T>(
   target: ElementPath | null,
   editor: EditorState,
-  derivedState: DerivedState,
   defaultValue: T,
   withTarget: (
     success: ParseSuccess,
@@ -3504,21 +3449,12 @@ export function withUnderlyingTargetFromEditorState<T>(
     underlyingFilePath: string,
   ) => T,
 ): T {
-  return withUnderlyingTarget(
-    target,
-    editor.projectContents,
-    editor.nodeModules.files,
-    derivedState.remixData?.routingTable ?? null,
-    editor.canvas.openFile?.filename ?? null,
-    defaultValue,
-    withTarget,
-  )
+  return withUnderlyingTarget(target, editor.projectContents, defaultValue, withTarget)
 }
 
 export function forUnderlyingTargetFromEditorState(
   target: ElementPath | null,
   editor: EditorState,
-  derivedState: DerivedState,
   withTarget: (
     success: ParseSuccess,
     element: JSXElementChild,
@@ -3526,54 +3462,20 @@ export function forUnderlyingTargetFromEditorState(
     underlyingFilePath: string,
   ) => void,
 ): void {
-  withUnderlyingTargetFromEditorState<any>(target, editor, derivedState, {}, withTarget)
-}
-
-export function forUnderlyingTarget(
-  target: ElementPath | null,
-  projectContents: ProjectContentTreeRoot,
-  nodeModules: NodeModules,
-  remixRoutingTable: RemixRoutingTable | null,
-  openFile: string | null | undefined,
-  withTarget: (
-    success: ParseSuccess,
-    element: JSXElementChild,
-    underlyingTarget: StaticElementPath,
-    underlyingFilePath: string,
-  ) => void,
-): void {
-  withUnderlyingTarget<any>(
-    target,
-    projectContents,
-    nodeModules,
-    remixRoutingTable,
-    openFile,
-    {},
-    withTarget,
-  )
+  withUnderlyingTargetFromEditorState<any>(target, editor, {}, withTarget)
 }
 
 export function getElementFromProjectContents(
   target: ElementPath | null,
   projectContents: ProjectContentTreeRoot,
-  remixRoutingTable: RemixRoutingTable | null,
-  openFile: string | null | undefined,
 ): JSXElement | null {
-  return withUnderlyingTarget(
-    target,
-    projectContents,
-    {},
-    remixRoutingTable,
-    openFile,
-    null,
-    (_, element) => {
-      if (isJSXElement(element)) {
-        return element
-      } else {
-        return null
-      }
-    },
-  )
+  return withUnderlyingTarget(target, projectContents, null, (_, element) => {
+    if (isJSXElement(element)) {
+      return element
+    } else {
+      return null
+    }
+  })
 }
 
 export function getCurrentTheme(userConfiguration: ThemeSubstate['userState']): Theme {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -3374,7 +3374,6 @@ export function modifyUnderlyingTargetElement(
   )
 }
 
-// FIXME Replace with modifyUnderlyingTargetElement?
 export function modifyUnderlyingElementForOpenFile(
   target: ElementPath,
   editor: EditorState,

--- a/editor/src/components/editor/store/editor-update.spec.tsx
+++ b/editor/src/components/editor/store/editor-update.spec.tsx
@@ -593,7 +593,7 @@ describe('INSERT_JSX_ELEMENT', () => {
     const { editor, derivedState, dispatch } = createEditorStates()
 
     const parentBeforeInsert = findJSXElementChildAtPath(
-      getJSXComponentsAndImportsForPathFromState(parentPath, editor, derivedState).components,
+      getJSXComponentsAndImportsForPathFromState(parentPath, editor).components,
       parentPath,
     )
 
@@ -620,7 +620,6 @@ describe('INSERT_JSX_ELEMENT', () => {
     const updatedComponents = getJSXComponentsAndImportsForPathFromState(
       parentPath,
       updatedEditor,
-      derivedState,
     ).components
     const parentAfterInsert = findJSXElementChildAtPath(updatedComponents, parentPath)
     const insertedElement = findJSXElementChildAtPath(
@@ -675,7 +674,6 @@ describe('INSERT_JSX_ELEMENT', () => {
     const componentsBeforeInsert = getJSXComponentsAndImportsForPathFromState(
       ScenePathForTestUiJsFile,
       editor,
-      derivedState,
     ).components
 
     const elementToInsert = jsxElement(
@@ -701,7 +699,6 @@ describe('INSERT_JSX_ELEMENT', () => {
     const updatedComponents = getJSXComponentsAndImportsForPathFromState(
       ScenePathForTestUiJsFile,
       updatedEditor,
-      derivedState,
     ).components
 
     const insertedElement = findJSXElementChildAtPath(

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -28,11 +28,11 @@ export function runLocalEditorAction(
 ): EditorState {
   switch (action.action) {
     case 'SET_CANVAS_FRAMES':
-      return UPDATE_FNS.SET_CANVAS_FRAMES(action, state, derivedState)
+      return UPDATE_FNS.SET_CANVAS_FRAMES(action, state)
     case 'ALIGN_SELECTED_VIEWS':
-      return UPDATE_FNS.ALIGN_SELECTED_VIEWS(action, state, derivedState)
+      return UPDATE_FNS.ALIGN_SELECTED_VIEWS(action, state)
     case 'DISTRIBUTE_SELECTED_VIEWS':
-      return UPDATE_FNS.DISTRIBUTE_SELECTED_VIEWS(action, state, derivedState)
+      return UPDATE_FNS.DISTRIBUTE_SELECTED_VIEWS(action, state)
     case 'SAVE_ASSET':
       return UPDATE_FNS.SAVE_ASSET(action, state, derivedState, dispatch, userState)
     default:
@@ -67,19 +67,19 @@ export function runSimpleLocalEditorAction(
     case 'LOAD':
       return UPDATE_FNS.LOAD(action, state, dispatch)
     case 'DUPLICATE_SELECTED':
-      return UPDATE_FNS.DUPLICATE_SELECTED(state, dispatch, derivedState)
+      return UPDATE_FNS.DUPLICATE_SELECTED(state, dispatch)
     case 'UPDATE_DUPLICATION_STATE':
       return UPDATE_FNS.UPDATE_DUPLICATION_STATE(action, state)
     case 'MOVE_SELECTED_TO_BACK':
-      return UPDATE_FNS.MOVE_SELECTED_TO_BACK(state, derivedState)
+      return UPDATE_FNS.MOVE_SELECTED_TO_BACK(state)
     case 'MOVE_SELECTED_TO_FRONT':
-      return UPDATE_FNS.MOVE_SELECTED_TO_FRONT(state, derivedState)
+      return UPDATE_FNS.MOVE_SELECTED_TO_FRONT(state)
     case 'MOVE_SELECTED_BACKWARD':
-      return UPDATE_FNS.MOVE_SELECTED_BACKWARD(state, derivedState)
+      return UPDATE_FNS.MOVE_SELECTED_BACKWARD(state)
     case 'MOVE_SELECTED_FORWARD':
-      return UPDATE_FNS.MOVE_SELECTED_FORWARD(state, derivedState)
+      return UPDATE_FNS.MOVE_SELECTED_FORWARD(state)
     case 'UNSET_PROPERTY':
-      return UPDATE_FNS.UNSET_PROPERTY(action, state, derivedState, dispatch)
+      return UPDATE_FNS.UNSET_PROPERTY(action, state)
     case 'UNDO':
       return UPDATE_FNS.UNDO(state, stateHistory)
     case 'REDO':
@@ -97,9 +97,9 @@ export function runSimpleLocalEditorAction(
     case 'TOGGLE_HIDDEN':
       return UPDATE_FNS.TOGGLE_HIDDEN(action, state)
     case 'RENAME_COMPONENT':
-      return UPDATE_FNS.RENAME_COMPONENT(action, state, derivedState)
+      return UPDATE_FNS.RENAME_COMPONENT(action, state)
     case 'INSERT_JSX_ELEMENT':
-      return UPDATE_FNS.INSERT_JSX_ELEMENT(action, state, derivedState)
+      return UPDATE_FNS.INSERT_JSX_ELEMENT(action, state)
     case 'SET_PANEL_VISIBILITY':
       return UPDATE_FNS.SET_PANEL_VISIBILITY(action, state)
     case 'TOGGLE_FOCUSED_OMNIBOX_TAB':
@@ -115,16 +115,11 @@ export function runSimpleLocalEditorAction(
     case 'CLOSE_POPUP':
       return UPDATE_FNS.CLOSE_POPUP(action, state)
     case 'PASTE_PROPERTIES':
-      return UPDATE_FNS.PASTE_PROPERTIES(action, state, derivedState)
+      return UPDATE_FNS.PASTE_PROPERTIES(action, state)
     case 'COPY_SELECTION_TO_CLIPBOARD':
-      return UPDATE_FNS.COPY_SELECTION_TO_CLIPBOARD(state, builtInDependencies, derivedState)
+      return UPDATE_FNS.COPY_SELECTION_TO_CLIPBOARD(state, builtInDependencies)
     case 'CUT_SELECTION_TO_CLIPBOARD':
-      return UPDATE_FNS.CUT_SELECTION_TO_CLIPBOARD(
-        state,
-        dispatch,
-        builtInDependencies,
-        derivedState,
-      )
+      return UPDATE_FNS.CUT_SELECTION_TO_CLIPBOARD(state, dispatch, builtInDependencies)
     case 'COPY_PROPERTIES':
       return UPDATE_FNS.COPY_PROPERTIES(action, state)
     case 'OPEN_TEXT_EDITOR':
@@ -170,9 +165,9 @@ export function runSimpleLocalEditorAction(
     case 'SET_CURSOR_OVERLAY':
       return UPDATE_FNS.SET_CURSOR_OVERLAY(action, state)
     case 'SET_Z_INDEX':
-      return UPDATE_FNS.SET_Z_INDEX(action, state, derivedState)
+      return UPDATE_FNS.SET_Z_INDEX(action, state)
     case 'UPDATE_FRAME_DIMENSIONS':
-      return UPDATE_FNS.UPDATE_FRAME_DIMENSIONS(action, state, derivedState)
+      return UPDATE_FNS.UPDATE_FRAME_DIMENSIONS(action, state)
     case 'SET_NAVIGATOR_RENAMING_TARGET':
       return UPDATE_FNS.SET_NAVIGATOR_RENAMING_TARGET(action, state)
     case 'SET_STORED_FONT_SETTINGS':
@@ -198,7 +193,7 @@ export function runSimpleLocalEditorAction(
     case 'SHOW_CONTEXT_MENU':
       return UPDATE_FNS.SHOW_CONTEXT_MENU(action, state)
     case 'DUPLICATE_SPECIFIC_ELEMENTS':
-      return UPDATE_FNS.DUPLICATE_SPECIFIC_ELEMENTS(action, state, derivedState, dispatch)
+      return UPDATE_FNS.DUPLICATE_SPECIFIC_ELEMENTS(action, state, dispatch)
     case 'SEND_PREVIEW_MODEL':
       return UPDATE_FNS.SEND_PREVIEW_MODEL(action, state)
     case 'UPDATE_FILE_PATH':
@@ -245,21 +240,21 @@ export function runSimpleLocalEditorAction(
     case 'TRUE_UP_GROUPS':
       return UPDATE_FNS.TRUE_UP_GROUPS(state, derivedState)
     case 'SET_PROP':
-      return UPDATE_FNS.SET_PROP(action, state, derivedState)
+      return UPDATE_FNS.SET_PROP(action, state)
     case 'SET_FILEBROWSER_RENAMING_TARGET':
       return UPDATE_FNS.SET_FILEBROWSER_RENAMING_TARGET(action, state)
     case 'TOGGLE_PROPERTY':
-      return UPDATE_FNS.TOGGLE_PROPERTY(action, state, derivedState)
+      return UPDATE_FNS.TOGGLE_PROPERTY(action, state)
     case 'CLEAR_IMAGE_FILE_BLOB':
       return UPDATE_FNS.CLEAR_IMAGE_FILE_BLOB(action, state)
     case 'SAVE_CURRENT_FILE':
       return UPDATE_FNS.SAVE_CURRENT_FILE(action, state)
     case 'DELETE_VIEW':
-      return UPDATE_FNS.DELETE_VIEW(action, state, dispatch, derivedState)
+      return UPDATE_FNS.DELETE_VIEW(action, state, dispatch)
     case 'DELETE_SELECTED':
-      return UPDATE_FNS.DELETE_SELECTED(state, dispatch, derivedState)
+      return UPDATE_FNS.DELETE_SELECTED(state, dispatch)
     case 'WRAP_IN_ELEMENT':
-      return UPDATE_FNS.WRAP_IN_ELEMENT(action, state, derivedState, dispatch, builtInDependencies)
+      return UPDATE_FNS.WRAP_IN_ELEMENT(action, state, derivedState, dispatch)
     case 'OPEN_FLOATING_INSERT_MENU':
       return UPDATE_FNS.OPEN_FLOATING_INSERT_MENU(action, state)
     case 'UNWRAP_ELEMENTS':
@@ -267,21 +262,21 @@ export function runSimpleLocalEditorAction(
     case 'INSERT_IMAGE_INTO_UI':
       return UPDATE_FNS.INSERT_IMAGE_INTO_UI(action, state, derivedState)
     case 'UPDATE_JSX_ELEMENT_NAME':
-      return UPDATE_FNS.UPDATE_JSX_ELEMENT_NAME(action, state, derivedState)
+      return UPDATE_FNS.UPDATE_JSX_ELEMENT_NAME(action, state)
     case 'ADD_IMPORTS':
-      return UPDATE_FNS.ADD_IMPORTS(action, state, derivedState)
+      return UPDATE_FNS.ADD_IMPORTS(action, state)
     case 'SET_ASPECT_RATIO_LOCK':
-      return UPDATE_FNS.SET_ASPECT_RATIO_LOCK(action, state, derivedState)
+      return UPDATE_FNS.SET_ASPECT_RATIO_LOCK(action, state)
     case 'TOGGLE_CANVAS_IS_LIVE':
       return UPDATE_FNS.TOGGLE_CANVAS_IS_LIVE(state, derivedState)
     case 'RENAME_PROP_KEY':
-      return UPDATE_FNS.RENAME_PROP_KEY(action, state, derivedState)
+      return UPDATE_FNS.RENAME_PROP_KEY(action, state)
     case 'SET_SAFE_MODE':
       return UPDATE_FNS.SET_SAFE_MODE(action, state)
     case 'SET_SAVE_ERROR':
       return UPDATE_FNS.SET_SAVE_ERROR(action, state)
     case 'INSERT_DROPPED_IMAGE':
-      return UPDATE_FNS.INSERT_DROPPED_IMAGE(action, state, derivedState)
+      return UPDATE_FNS.INSERT_DROPPED_IMAGE(action, state)
     case 'REMOVE_FROM_NODE_MODULES_CONTENTS':
       return UPDATE_FNS.REMOVE_FROM_NODE_MODULES_CONTENTS(
         action,
@@ -298,7 +293,7 @@ export function runSimpleLocalEditorAction(
     case 'FINISH_CHECKPOINT_TIMER':
       return UPDATE_FNS.FINISH_CHECKPOINT_TIMER(action, state)
     case 'ADD_MISSING_DIMENSIONS':
-      return UPDATE_FNS.ADD_MISSING_DIMENSIONS(action, state, derivedState)
+      return UPDATE_FNS.ADD_MISSING_DIMENSIONS(action, state)
     case 'SET_PACKAGE_STATUS':
       return UPDATE_FNS.SET_PACKAGE_STATUS(action, state)
     case 'UPDATE_PROPERTY_CONTROLS_INFO':
@@ -372,13 +367,13 @@ export function runSimpleLocalEditorAction(
     case 'UPDATE_COLOR_SWATCHES':
       return UPDATE_FNS.UPDATE_COLOR_SWATCHES(action, state)
     case 'SET_CONDITIONAL_OVERRIDDEN_CONDITION':
-      return UPDATE_FNS.SET_CONDITIONAL_OVERRIDDEN_CONDITION(action, state, derivedState)
+      return UPDATE_FNS.SET_CONDITIONAL_OVERRIDDEN_CONDITION(action, state)
     case 'SET_MAP_COUNT_OVERRIDE':
-      return UPDATE_FNS.SET_MAP_COUNT_OVERRIDE(action, state, derivedState)
+      return UPDATE_FNS.SET_MAP_COUNT_OVERRIDE(action, state)
     case 'UPDATE_CONIDTIONAL_EXPRESSION':
-      return UPDATE_FNS.UPDATE_CONDITIONAL_EXPRESSION(action, state, derivedState)
+      return UPDATE_FNS.UPDATE_CONDITIONAL_EXPRESSION(action, state)
     case 'SWITCH_CONDITIONAL_BRANCHES':
-      return UPDATE_FNS.SWITCH_CONDITIONAL_BRANCHES(action, state, derivedState)
+      return UPDATE_FNS.SWITCH_CONDITIONAL_BRANCHES(action, state)
     default:
       return state
   }

--- a/editor/src/components/editor/store/insertion-path.ts
+++ b/editor/src/components/editor/store/insertion-path.ts
@@ -1,8 +1,4 @@
-import type {
-  ElementPath,
-  NodeModules,
-  StaticElementPath,
-} from '../../../core/shared/project-file-types'
+import type { ElementPath, StaticElementPath } from '../../../core/shared/project-file-types'
 import * as EP from '../../../core/shared/element-path'
 import type { ConditionalCase } from '../../../core/model/conditionals'
 import {
@@ -18,7 +14,6 @@ import { isJSXConditionalExpression } from '../../../core/shared/element-templat
 import { isRight } from '../../../core/shared/either'
 import type { ProjectContentTreeRoot } from '../../assets'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
-import type { RemixRoutingTable } from './remix-derived-data'
 
 export type InsertionPath = ChildInsertionPath | ConditionalClauseInsertionPath
 
@@ -188,9 +183,6 @@ export function commonInsertionPathFromArray(
 export function getInsertionPath(
   target: ElementPath,
   projectContents: ProjectContentTreeRoot,
-  nodeModules: NodeModules,
-  remixRoutingTable: RemixRoutingTable | null,
-  openFile: string | null | undefined,
   metadata: ElementInstanceMetadataMap,
   elementPathTree: ElementPathTrees,
   fragmentWrapperUID: string,
@@ -199,9 +191,6 @@ export function getInsertionPath(
   const targetSupportsChildren = MetadataUtils.targetSupportsChildren(
     projectContents,
     metadata,
-    nodeModules,
-    remixRoutingTable,
-    openFile,
     target,
     elementPathTree,
   )

--- a/editor/src/components/inspector/common/inspector.test-utils.tsx
+++ b/editor/src/components/inspector/common/inspector.test-utils.tsx
@@ -119,7 +119,6 @@ export function editPropOfSelectedView(
     editor: modifyUnderlyingElementForOpenFile(
       store.editor.selectedViews[0] as StaticElementPath,
       store.editor,
-      store.derived,
       (element): JSXElement => {
         const updatedAttributes = setJSXValueAtPath(
           element.props,

--- a/editor/src/components/inspector/common/layout-property-path-hooks.ts
+++ b/editor/src/components/inspector/common/layout-property-path-hooks.ts
@@ -1,7 +1,6 @@
 import fastDeepEqual from 'fast-deep-equal'
 import type { Frame, FramePin, FramePoint } from 'utopia-api/core'
 import {
-  AllFramePoints,
   HorizontalFramePoints,
   isHorizontalPoint,
   isPercentPin,
@@ -13,11 +12,9 @@ import {
   framePointForPinnedProp,
   HorizontalLayoutPinnedProps,
   LayoutPinnedProps,
-  pinnedPropForFramePoint,
   VerticalLayoutPinnedProps,
 } from '../../../core/layout/layout-helpers-new'
-import { findElementAtPath, MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { isLeft, right as eitherRight } from '../../../core/shared/either'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import {
   emptyComments,
   isJSXElement,
@@ -35,7 +32,6 @@ import { getFullFrame } from '../../frame'
 import type { InspectorInfo } from './property-path-hooks'
 import {
   useInspectorLayoutInfo,
-  useSelectedViews,
   useRefSelectedViews,
   InspectorPropsContext,
   stylePropPathMappingFn,
@@ -44,7 +40,6 @@ import {
 import React from 'react'
 import type { CSSNumber } from './css-utils'
 import { cssNumberToString } from './css-utils'
-import { getJSXComponentsAndImportsForPathFromState } from '../../editor/store/editor-state'
 import { useContextSelector } from 'use-context-selector'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { getFramePointsFromMetadata, MaxContent } from '../inspector-common'

--- a/editor/src/components/inspector/common/property-controls-hooks.ts
+++ b/editor/src/components/inspector/common/property-controls-hooks.ts
@@ -10,38 +10,20 @@ import {
   getPropertyControlNames,
 } from '../../../core/property-controls/property-control-values'
 import type { UnionControlDescription, RegularControlDescription } from 'utopia-api/core'
-import {
-  BaseControlDescription,
-  ControlDescription,
-  ArrayControlDescription,
-  HigherLevelControlDescription,
-} from 'utopia-api/core'
 import type { InspectorInfo } from './property-path-hooks'
 import {
   filterUtopiaSpecificProps,
   InspectorPropsContext,
   useCallbackFactory,
   useInspectorContext,
-  useRefSelectedViews,
 } from './property-path-hooks'
 import type { ModifiableAttribute } from '../../../core/shared/jsx-attributes'
-import {
-  getModifiableJSXAttributeAtPath,
-  jsxSimpleAttributeToValue,
-} from '../../../core/shared/jsx-attributes'
+import { getModifiableJSXAttributeAtPath } from '../../../core/shared/jsx-attributes'
 import * as PP from '../../../core/shared/property-path'
 import type { Either } from '../../../core/shared/either'
-import {
-  eitherToMaybe,
-  flatMapEither,
-  foldEither,
-  mapEither,
-  right,
-  unwrapEither,
-} from '../../../core/shared/either'
+import { eitherToMaybe } from '../../../core/shared/either'
 import {
   calculatePropertyStatusForSelection,
-  ControlStatus,
   getControlStatusFromPropertyStatus,
 } from './control-status'
 import { getControlStyles } from './control-styles'
@@ -50,12 +32,8 @@ import {
   useKeepReferenceEqualityIfPossible,
 } from '../../../utils/react-performance'
 import type { UtopiaJSXComponent } from '../../../core/shared/element-template'
-import {
-  ElementInstanceMetadata,
-  isJSXElement,
-  JSXAttributes,
-} from '../../../core/shared/element-template'
-import { addUniquely, mapArrayToDictionary, mapDropNulls } from '../../../core/shared/array-utils'
+import { isJSXElement } from '../../../core/shared/element-template'
+import { addUniquely, mapDropNulls } from '../../../core/shared/array-utils'
 import { Substores, useEditorState } from '../../editor/store/store-hook'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { getPropertyControlsForTargetFromEditor } from '../../../core/property-controls/property-controls-utils'
@@ -222,11 +200,7 @@ export function useGetPropertyControlsForSelectedComponents(): Array<FullPropert
     (store) => {
       let propertyControlsAndTargets: Array<PropertyControlsAndTargets> = []
       fastForEach(store.editor.selectedViews, (path) => {
-        const propertyControls = getPropertyControlsForTargetFromEditor(
-          path,
-          store.editor,
-          store.derived,
-        )
+        const propertyControls = getPropertyControlsForTargetFromEditor(path, store.editor)
         if (propertyControls == null) {
           propertyControlsAndTargets.push({
             controls: emptyControls,

--- a/editor/src/components/inspector/common/property-controls.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/property-controls.spec.browser2.tsx
@@ -168,7 +168,6 @@ describe('Automatically derived property controls', () => {
     const element = withUnderlyingTargetFromEditorState(
       EP.fromString('storyboard/scene/app'),
       renderResult.getEditorState().editor,
-      renderResult.getEditorState().derived,
       null,
       (_success, underlyingElement) => {
         return underlyingElement

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -1076,9 +1076,6 @@ export function useIsSubSectionVisible(sectionName: string): boolean {
         const selectedViewType = withUnderlyingTarget(
           view,
           store.editor.projectContents,
-          store.editor.nodeModules.files,
-          store.derived.remixData?.routingTable ?? null,
-          store.editor.canvas.openFile?.filename ?? null,
           null,
           (underlyingSuccess, underlyingElement) => {
             if (isJSXElement(underlyingElement)) {
@@ -1186,8 +1183,7 @@ export function useInspectorWarningStatus(): boolean {
         forUnderlyingTargetFromEditorState(
           view,
           store.editor,
-          store.derived,
-          (underlyingSuccess, underlyingElement) => {
+          (_underlyingSuccess, underlyingElement) => {
             if (isJSXElement(underlyingElement)) {
               const cssAttribute = getJSXAttribute(underlyingElement.props, 'css')
               if (cssAttribute != null) {

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -281,7 +281,6 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
           const { components: rootComponents } = getJSXComponentsAndImportsForPathFromState(
             view,
             store.editor,
-            store.derived,
           )
           anyComponentsInner =
             anyComponentsInner || MetadataUtils.isComponentInstance(view, rootComponents)

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -810,10 +810,7 @@ export const ComponentSectionInner = React.memo((props: ComponentSectionProps) =
       if (importResult == null) {
         const underlyingTarget = normalisePathToUnderlyingTarget(
           state.editor.projectContents,
-          state.editor.nodeModules.files,
-          state.editor.canvas.openFile?.filename ?? '',
           target,
-          state.derived.remixData?.routingTable ?? null,
         )
 
         return underlyingTarget.type === 'NORMALISE_PATH_SUCCESS' ? underlyingTarget.filePath : null

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -120,17 +120,10 @@ export const ExpressionInputPropertyControl = React.memo(
     const targetFilePaths = useEditorState(
       Substores.fullStore,
       (store) => {
-        const currentFilePath = forceNotNull(
-          'Missing open file',
-          store.editor.canvas.openFile?.filename,
-        )
         return store.editor.selectedViews.map((selectedView) => {
           const normalisedPath = normalisePathToUnderlyingTarget(
             store.editor.projectContents,
-            store.editor.nodeModules.files,
-            currentFilePath,
             selectedView,
-            store.derived.remixData?.routingTable ?? null,
           )
           return normalisePathSuccessOrThrowError(normalisedPath).filePath
         })
@@ -240,17 +233,10 @@ export const ExpressionPopUpListPropertyControl = React.memo(
       Substores.fullStore,
       (store) => {
         // TODO probably make a store with selected views, projectContents and nodeModules.files ?
-        const currentFilePath = forceNotNull(
-          'Missing open file',
-          store.editor.canvas.openFile?.filename,
-        )
         return selectedViews.map((selectedView) => {
           const normalisedPath = normalisePathToUnderlyingTarget(
             store.editor.projectContents,
-            store.editor.nodeModules.files,
-            currentFilePath,
             selectedView,
-            store.derived.remixData?.routingTable ?? null,
           )
           return normalisePathSuccessOrThrowError(normalisedPath).filePath
         })

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -240,11 +240,7 @@ function notDroppingIntoOwnDefinition(
   )
 }
 
-function canDropInto(
-  editorState: EditorState,
-  derivedState: DerivedState,
-  moveToEntry: ElementPath,
-): boolean {
+function canDropInto(editorState: EditorState, moveToEntry: ElementPath): boolean {
   const notSelectedItem = editorState.selectedViews.every((selection) => {
     return !EP.isDescendantOfOrEqualTo(moveToEntry, selection)
   })
@@ -252,9 +248,6 @@ function canDropInto(
   const targetSupportsChildren = MetadataUtils.targetSupportsChildren(
     editorState.projectContents,
     editorState.jsxMetadata,
-    editorState.nodeModules.files,
-    derivedState.remixData?.routingTable ?? null,
-    editorState.canvas.openFile?.filename,
     moveToEntry,
     editorState.elementPathTree,
   )
@@ -494,7 +487,6 @@ function isHintDisallowed(elementPath: ElementPath | null, metadata: ElementInst
 
 export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDropWrapperProps) => {
   const editorStateRef = useRefEditorState((store) => store.editor)
-  const derivedStateRef = useRefEditorState((store) => store.derived)
   const canvasSize = usePubSubAtomReadOnly(CanvasSizeAtom, AlwaysFalse)
   const canvasViewportCenterRef = useRefEditorState((store) =>
     canvasPoint({
@@ -735,7 +727,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
         props.editorDispatch(actions)
       },
       canDrop: (item: NavigatorItemDragAndDropWrapperProps) => {
-        return canDropInto(editorStateRef.current, derivedStateRef.current, props.elementPath)
+        return canDropInto(editorStateRef.current, props.elementPath)
       },
     }),
     [props, dropTargetHint],

--- a/editor/src/components/text-editor/text-handling.ts
+++ b/editor/src/components/text-editor/text-handling.ts
@@ -161,29 +161,15 @@ export function isEligibleForCollapse(
   )
 }
 
-export function collapseTextElements(
-  target: ElementPath,
-  editor: EditorState,
-  derivedState: DerivedState,
-): EditorState {
+export function collapseTextElements(target: ElementPath, editor: EditorState): EditorState {
   const targetParent = EP.parentPath(target)
   const targetDataUID = EP.toUid(target)
   const openFile = editor.canvas.openFile?.filename
 
   if (openFile != null) {
-    const targetElement = getElementFromProjectContents(
-      target,
-      editor.projectContents,
-      derivedState.remixData?.routingTable ?? null,
-      openFile,
-    )
+    const targetElement = getElementFromProjectContents(target, editor.projectContents)
     // Identify a run of eligible elements including the target.
-    const parentElement = getElementFromProjectContents(
-      targetParent,
-      editor.projectContents,
-      derivedState.remixData?.routingTable ?? null,
-      openFile,
-    )
+    const parentElement = getElementFromProjectContents(targetParent, editor.projectContents)
     if (targetElement != null && parentElement != null && isJSXElement(parentElement)) {
       let targetRun: Array<JSXElementChild> = []
       let currentRun: Array<JSXElementChild> = []
@@ -235,9 +221,7 @@ export function collapseTextElements(
         // Modify the editor state.
         return modifyUnderlyingTargetElement(
           targetParent,
-          openFile,
           editor,
-          derivedState,
           (element) => {
             if (isJSXConditionalExpression(element)) {
               return element

--- a/editor/src/core/layout/layout-helpers.ts
+++ b/editor/src/core/layout/layout-helpers.ts
@@ -1,17 +1,10 @@
 import type { FlexLength, FlexStretch } from 'utopia-api/core'
-import {
-  FlexAlignment,
-  FlexElementProps,
-  FramePoint,
-  getUnstretchedWidthHeight,
-  LayoutSystem,
-} from 'utopia-api/core'
+import { getUnstretchedWidthHeight } from 'utopia-api/core'
 import type { UtopiaComponentProps } from 'utopia-api'
 import type { FullFrame } from '../../components/frame'
 import type { Either } from '../shared/either'
 import {
   applicative2Either,
-  defaultEither,
   flatMapEither,
   foldEither,
   isRight,
@@ -24,21 +17,14 @@ import {
   eitherFromMaybe,
 } from '../shared/either'
 import type { ElementInstanceMetadata, JSXAttributes, JSXElement } from '../shared/element-template'
-import {
-  isJSXElement,
-  jsExpressionValue,
-  UtopiaJSXComponent,
-  ElementInstanceMetadataMap,
-  emptyComments,
-} from '../shared/element-template'
+import { isJSXElement, jsExpressionValue, emptyComments } from '../shared/element-template'
 import type { ValueAtPath } from '../shared/jsx-attributes'
 import {
   setJSXValueAtPath,
   setJSXValuesAtPaths,
   unsetJSXValuesAtPaths,
 } from '../shared/jsx-attributes'
-import type { NodeModules, PropertyPath, ElementPath } from '../shared/project-file-types'
-import { Imports } from '../shared/project-file-types'
+import type { PropertyPath, ElementPath } from '../shared/project-file-types'
 import { getLayoutProperty } from './getLayoutProperty'
 import type { PropsOrJSXAttributes } from '../model/element-metadata-utils'
 import { getSimpleAttributeAtPath } from '../model/element-metadata-utils'
@@ -49,25 +35,19 @@ import {
 } from '../property-controls/property-controls-utils'
 import type { PropertyControlsInfo } from '../../components/custom-code/code-file'
 import type { ProjectContentTreeRoot } from '../../components/assets'
-import { StyleLayoutProp } from './layout-helpers-new'
 import { stylePropPathMappingFn } from '../../components/inspector/common/property-path-hooks'
-import type { RemixRoutingTable } from '../../components/editor/store/remix-derived-data'
 
 export function targetRespectsLayout(
   target: ElementPath,
   propertyControlsInfo: PropertyControlsInfo,
   openFilePath: string | null,
   projectContents: ProjectContentTreeRoot,
-  nodeModules: NodeModules,
-  remixRoutingTable: RemixRoutingTable | null,
 ): boolean {
   const propControls = getPropertyControlsForTarget(
     target,
     propertyControlsInfo,
     openFilePath,
     projectContents,
-    nodeModules,
-    remixRoutingTable,
   )
 
   return propControls != null && hasStyleControls(propControls)

--- a/editor/src/core/model/common-optics.ts
+++ b/editor/src/core/model/common-optics.ts
@@ -1,8 +1,4 @@
-import type {
-  DerivedState,
-  EditorState,
-  EditorStorePatched,
-} from '../../components/editor/store/editor-state'
+import type { EditorStorePatched } from '../../components/editor/store/editor-state'
 import {
   modifyUnderlyingForOpenFile,
   withUnderlyingTargetFromEditorState,
@@ -14,15 +10,9 @@ import type { ElementPath } from '../shared/project-file-types'
 
 export function forElementOptic(target: ElementPath): Optic<EditorStorePatched, JSXElementChild> {
   function from(store: EditorStorePatched): Array<JSXElementChild> {
-    return withUnderlyingTargetFromEditorState(
-      target,
-      store.editor,
-      store.derived,
-      [],
-      (_, element) => {
-        return [element]
-      },
-    )
+    return withUnderlyingTargetFromEditorState(target, store.editor, [], (_, element) => {
+      return [element]
+    })
   }
   function update(
     store: EditorStorePatched,
@@ -30,7 +20,7 @@ export function forElementOptic(target: ElementPath): Optic<EditorStorePatched, 
   ): EditorStorePatched {
     return {
       ...store,
-      editor: modifyUnderlyingForOpenFile(target, store.editor, store.derived, modify),
+      editor: modifyUnderlyingForOpenFile(target, store.editor, modify),
     }
   }
   return traversal(from, update)

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -961,18 +961,12 @@ export const MetadataUtils = {
   targetSupportsChildren(
     projectContents: ProjectContentTreeRoot,
     metadata: ElementInstanceMetadataMap,
-    nodeModules: NodeModules,
-    remixRoutingTable: RemixRoutingTable | null,
-    openFile: string | null | undefined,
     target: ElementPath | null,
     pathTree: ElementPathTrees,
   ): boolean {
     const targetSupportsChildrenValue = this.targetSupportsChildrenAlsoText(
       projectContents,
       metadata,
-      nodeModules,
-      remixRoutingTable,
-      openFile,
       target,
       pathTree,
     )
@@ -984,9 +978,6 @@ export const MetadataUtils = {
   targetSupportsChildrenAlsoText(
     projectContents: ProjectContentTreeRoot,
     metadata: ElementInstanceMetadataMap,
-    nodeModules: NodeModules,
-    remixRoutingTable: RemixRoutingTable | null,
-    openFile: string | null | undefined,
     target: ElementPath | null,
     pathTree: ElementPathTrees,
   ): ElementSupportsChildren {
@@ -999,9 +990,6 @@ export const MetadataUtils = {
         return withUnderlyingTarget(
           target,
           projectContents,
-          nodeModules,
-          remixRoutingTable,
-          openFile,
           'doesNotSupportChildren',
           (_, element) => {
             return (

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -44,7 +44,6 @@ export function propertyControlsForComponentInFile(
 export function getPropertyControlsForTargetFromEditor(
   target: ElementPath,
   editor: EditorState,
-  derivedState: DerivedState,
 ): PropertyControls | null {
   const openFilePath = getOpenUIJSFileKey(editor)
   return getPropertyControlsForTarget(
@@ -52,8 +51,6 @@ export function getPropertyControlsForTargetFromEditor(
     editor.propertyControlsInfo,
     openFilePath,
     editor.projectContents,
-    editor.nodeModules.files,
-    derivedState.remixData?.routingTable ?? null,
   )
 }
 
@@ -62,15 +59,10 @@ export function getPropertyControlsForTarget(
   propertyControlsInfo: PropertyControlsInfo,
   openFilePath: string | null,
   projectContents: ProjectContentTreeRoot,
-  nodeModules: NodeModules,
-  remixRoutingTable: RemixRoutingTable | null,
 ): PropertyControls | null {
   return withUnderlyingTarget(
     target,
     projectContents,
-    nodeModules,
-    remixRoutingTable,
-    openFilePath,
     null,
     (
       success: ParseSuccess,

--- a/editor/src/core/tailwind/tailwind-options.tsx
+++ b/editor/src/core/tailwind/tailwind-options.tsx
@@ -8,14 +8,13 @@ import {
   ClassNameToAttributes,
 } from '../third-party/tailwind-defaults'
 import Highlighter from 'react-highlight-words'
-import type { ElementPath, NodeModules } from '../shared/project-file-types'
+import type { ElementPath } from '../shared/project-file-types'
 import { isParseSuccess, isTextFile } from '../shared/project-file-types'
 import {
   Substores,
   useEditorState,
   useRefEditorState,
 } from '../../components/editor/store/store-hook'
-import type { DerivedState } from '../../components/editor/store/editor-state'
 import { getOpenUIJSFileKey } from '../../components/editor/store/editor-state'
 import { normalisePathToUnderlyingTarget } from '../../components/custom-code/code-file'
 import type { ProjectContentTreeRoot } from '../../components/assets'
@@ -23,13 +22,12 @@ import { getProjectFileByFilePath } from '../../components/assets'
 import type { JSXElementChild } from '../shared/element-template'
 import {
   modifiableAttributeIsAttributeNotFound,
-  isJSXAttributeValue,
   isJSXElement,
   modifiableAttributeIsAttributeValue,
 } from '../shared/element-template'
 import { findElementAtPath, MetadataUtils } from '../model/element-metadata-utils'
 import { getUtopiaJSXComponentsFromSuccess } from '../model/project-file-utils'
-import { eitherToMaybe, flatMapEither, foldEither, mapEither } from '../shared/either'
+import { eitherToMaybe, flatMapEither, foldEither } from '../shared/either'
 import {
   getModifiableJSXAttributeAtPath,
   jsxSimpleAttributeToValue,
@@ -234,16 +232,8 @@ function getJSXElementForTarget(
   target: ElementPath,
   openUIJSFileKey: string,
   projectContents: ProjectContentTreeRoot,
-  nodeModules: NodeModules,
-  derived: DerivedState,
 ): JSXElementChild | null {
-  const underlyingTarget = normalisePathToUnderlyingTarget(
-    projectContents,
-    nodeModules,
-    openUIJSFileKey,
-    target,
-    derived.remixData?.routingTable ?? null,
-  )
+  const underlyingTarget = normalisePathToUnderlyingTarget(projectContents, target)
   const underlyingPath =
     underlyingTarget.type === 'NORMALISE_PATH_SUCCESS' ? underlyingTarget.filePath : openUIJSFileKey
   const projectFile = getProjectFileByFilePath(projectContents, underlyingPath)
@@ -301,13 +291,7 @@ export function useGetSelectedClasses(): {
         return []
       } else {
         return store.editor.selectedViews.map((elementPath) =>
-          getJSXElementForTarget(
-            elementPath,
-            openUIJSFileKey,
-            store.editor.projectContents,
-            store.editor.nodeModules.files,
-            store.derived,
-          ),
+          getJSXElementForTarget(elementPath, openUIJSFileKey, store.editor.projectContents),
         )
       }
     },

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -1316,7 +1316,6 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
         void Clipboard.parseClipboardData(event.clipboardData).then((result) => {
           const actions = getActionsForClipboardItems(
             editor,
-            this.props.derived,
             canvasViewportCenter,
             result.utopiaData,
             result.files,

--- a/editor/src/utils/clipboard.spec.tsx
+++ b/editor/src/utils/clipboard.spec.tsx
@@ -92,7 +92,6 @@ export var Card = (props) => {
     const clipboardData = createClipboardDataFromSelection(
       renderResult.getEditorState().editor,
       renderResult.getEditorState().builtInDependencies,
-      renderResult.getEditorState().derived,
     )
 
     expect(clipboardData?.data.length).toEqual(1)


### PR DESCRIPTION
This is the cleanup PR to https://github.com/concrete-utopia/utopia/pull/4185, which removes the now redundant params after the simplifying of `normalisePathToUnderlyingTarget`. No logic has been changed in this PR, it was just a case of removing the unwanted params and then following that change up the call stacks as far as possible.