### PR TITLE
Built-in controls for Remix components

### DIFF
--- a/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
@@ -17,6 +17,7 @@ import type { UtopiaTsWorkers } from '../../workers/common/worker-types'
 import { UtopiaApiGroup } from './group-component'
 import * as RemixRunReact from '@remix-run/react'
 import * as ReactRouter from 'react-router'
+import { SafeLink, SafeOutlet } from './canvas-safe-remix'
 
 applyUIDMonkeyPatch()
 
@@ -89,7 +90,11 @@ export function createBuiltInDependenciesList(
     ),
     builtInDependency(
       '@remix-run/react',
-      RemixRunReact,
+      {
+        ...RemixRunReact,
+        Link: SafeLink,
+        Outlet: SafeOutlet,
+      },
       editorPackageJSON.dependencies['@remix-run/react'],
     ),
     builtInDependency('react-router', ReactRouter, editorPackageJSON.dependencies['react-router']),

--- a/editor/src/core/es-modules/package-manager/canvas-safe-remix.tsx
+++ b/editor/src/core/es-modules/package-manager/canvas-safe-remix.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+import { Link, Outlet } from '@remix-run/react'
+import type { LinkProps } from '@remix-run/react'
+import { useInRouterContext, Router } from 'react-router'
+import type { Navigator } from 'react-router'
+
+const dummyNavigator: Navigator = {
+  createHref: () => '',
+  go: (n) => {
+    /* Do Nothing */
+  },
+  push: (to, state, opts) => {
+    /* Do Nothing */
+  },
+  replace: (to, state, opts) => {
+    /* Do Nothing */
+  },
+}
+
+export const SafeLink: typeof Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  (props, forwardRef) => {
+    const inRouterContext = useInRouterContext()
+
+    if (inRouterContext) {
+      return <Link {...props} />
+    } else {
+      return (
+        <Router location='/' navigator={dummyNavigator}>
+          <Link {...props} ref={forwardRef} />
+        </Router>
+      )
+    }
+  },
+)
+
+export const SafeOutlet: typeof Outlet = (props) => {
+  const inRouterContext = useInRouterContext()
+
+  if (inRouterContext) {
+    return <Outlet {...props} />
+  } else {
+    return (
+      <Router location='/' navigator={dummyNavigator}>
+        <Outlet {...props} />
+      </Router>
+    )
+  }
+}

--- a/editor/src/core/third-party/remix-controls.ts
+++ b/editor/src/core/third-party/remix-controls.ts
@@ -35,4 +35,25 @@ export const RemixRunReactComponents: ComponentDescriptorsForFile = {
       },
     ],
   },
+  Outlet: {
+    properties: {},
+    variants: [
+      {
+        insertMenuLabel: 'Outlet',
+        importsToAdd: {
+          '@remix-run/react': {
+            importedWithName: null,
+            importedFromWithin: [
+              {
+                name: 'Outlet',
+                alias: 'Outlet',
+              },
+            ],
+            importedAs: null,
+          },
+        },
+        elementToInsert: jsxElementWithoutUID('Outlet', [], []),
+      },
+    ],
+  },
 }

--- a/editor/src/core/third-party/remix-controls.ts
+++ b/editor/src/core/third-party/remix-controls.ts
@@ -1,0 +1,38 @@
+import type { ComponentDescriptorsForFile } from '../../components/custom-code/code-file'
+import {
+  emptyComments,
+  jsExpressionValue,
+  jsxAttributesEntry,
+  jsxElementWithoutUID,
+  jsxTextBlock,
+} from '../shared/element-template'
+
+export const RemixRunReactComponents: ComponentDescriptorsForFile = {
+  Link: {
+    properties: {
+      to: { control: 'string-input' },
+    },
+    variants: [
+      {
+        insertMenuLabel: 'Link',
+        importsToAdd: {
+          '@remix-run/react': {
+            importedWithName: null,
+            importedFromWithin: [
+              {
+                name: 'Link',
+                alias: 'Link',
+              },
+            ],
+            importedAs: null,
+          },
+        },
+        elementToInsert: jsxElementWithoutUID(
+          'Link',
+          [jsxAttributesEntry('to', jsExpressionValue('/', emptyComments), emptyComments)],
+          [jsxTextBlock('Link')],
+        ),
+      },
+    ],
+  },
+}

--- a/editor/src/core/third-party/third-party-controls.ts
+++ b/editor/src/core/third-party/third-party-controls.ts
@@ -1,10 +1,12 @@
 import type { PropertyControlsInfo } from '../../components/custom-code/code-file'
 import { AntdComponents } from './antd-components'
 import { ReactThreeFiberComponents } from './react-three-fiber-components'
+import { RemixRunReactComponents } from './remix-controls'
 import { UtopiaApiComponents } from './utopia-api-components'
 
 export const DefaultThirdPartyControlDefinitions: PropertyControlsInfo = {
   '@react-three/fiber': ReactThreeFiberComponents,
   antd: AntdComponents,
   'utopia-api': UtopiaApiComponents,
+  '@remix-run/react': RemixRunReactComponents,
 }


### PR DESCRIPTION
## Description 
This PR adds built-in controls for Links and Outlets, and also adds `SafeLink` and `SafeOutlet`, which are wrapped versions of `Link` and `Outlet`, that can be placed in the storyboard