### PR TITLE
Update vscode-overrides.css

### DIFF
--- a/editor/resources/editor/css/vscode-overrides.css
+++ b/editor/resources/editor/css/vscode-overrides.css
@@ -1,3 +1,74 @@
+.monaco-workbench .part.editor > .content .editor-group-container > .title {
+  background-color: transparent !important;
+}
+
+/* literally the container containing the tabs */
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container {
-  gap: 4px;
+  background: transparent;
+  gap: 8px;
+  height: 34px;
+}
+
+/* Tab styles */
+.tab {
+  font-weight: 500;
+  font-family: 'Inter';
+  border-right: none !important;
+}
+
+.monaco-workbench
+  .part.editor
+  > .content
+  .editor-group-container
+  > .title
+  .tabs-container
+  > .tab
+  .tab-label
+  a,
+.monaco-workbench .part.editor > .content .editor-group-container > .title .title-label a {
+  font-size: 11px;
+}
+
+.tab[aria-selected='true'] {
+  /* !important is required because vscode styles these at via inline styles */
+  background-color: transparent !important;
+  font-weight: 500;
+}
+
+.tab[aria-selected='false'] {
+  /* important is important because vscode styles these via inline styles */
+  font-weight: 500;
+  font-style: normal !important;
+  background-color: transparent !important;
+  /* VSCode sets a color with alpha value for the label for inactive tabs. 
+  We can't only adjust the alpha value of the color with CSS (yet), so this opacity
+  matches our Utopia tabs reasonably  */
+  opacity: 0.7;
+}
+
+.tab[aria-selected='false']:hover {
+  opacity: 1;
+}
+
+/* Tab bar heights */
+.monaco-workbench
+  .part.editor
+  > .content
+  .editor-group-container
+  > .title
+  .tabs-container
+  > .tab
+  .tab-label {
+  line-height: 34px;
+}
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab {
+  height: 34px;
+}
+
+.monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions {
+  height: 34px;
+}
+
+.monaco-action-bar .actions-container {
+  transform: scale(0.7);
 }

--- a/editor/resources/editor/css/vscode-overrides.css
+++ b/editor/resources/editor/css/vscode-overrides.css
@@ -1,12 +1,17 @@
+/* Notes: 
+  1) this file gets loaded after VSCode's CSS. If you use the same specificity in your 
+    selectors, you'll be able to override them
+  2) Beware that VSCode also sets a number of styles are set inline - 
+     typically anything coming from a color theme, and anything dynamic. 
+     If you want to override those, use !important
+  3) Because of the theme, avoid defining colors here unless your goal is to remove them
+     with transparent !important.
+  4) Don't forget to update the loading screen placeholder where needed 
+     (vscode-editor-loading-screen.tsx)
+*/
+
 .monaco-workbench .part.editor > .content .editor-group-container > .title {
   background-color: transparent !important;
-}
-
-/* literally the container containing the tabs */
-.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container {
-  background: transparent;
-  gap: 8px;
-  height: 34px;
 }
 
 /* Tab styles */
@@ -14,6 +19,19 @@
   font-weight: 500;
   font-family: 'Inter';
   border-right: none !important;
+  background-color: transparent !important;
+}
+
+.tab[aria-selected='true'] {
+  background-color: transparent !important;
+}
+
+.tab[aria-selected='false'] {
+  opacity: 0.7;
+}
+
+.tab[aria-selected='false']:hover {
+  opacity: 1;
 }
 
 .monaco-workbench
@@ -27,27 +45,12 @@
   a,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .title-label a {
   font-size: 11px;
-}
-
-.tab[aria-selected='true'] {
-  /* !important is required because vscode styles these at via inline styles */
-  background-color: transparent !important;
   font-weight: 500;
 }
 
-.tab[aria-selected='false'] {
-  /* important is important because vscode styles these via inline styles */
-  font-weight: 500;
-  font-style: normal !important;
-  background-color: transparent !important;
-  /* VSCode sets a color with alpha value for the label for inactive tabs. 
-  We can't only adjust the alpha value of the color with CSS (yet), so this opacity
-  matches our Utopia tabs reasonably  */
-  opacity: 0.7;
-}
-
-.tab[aria-selected='false']:hover {
-  opacity: 1;
+/* smaller 'edited / close'  marker, to match Utopia house style */
+.monaco-action-bar .actions-container {
+  transform: scale(0.7);
 }
 
 /* Tab bar heights */
@@ -68,7 +71,8 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions {
   height: 34px;
 }
-
-.monaco-action-bar .actions-container {
-  transform: scale(0.7);
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container {
+  background: transparent;
+  gap: 8px;
+  height: 34px;
 }

--- a/editor/src/components/code-editor/vscode-editor-loading-screen.tsx
+++ b/editor/src/components/code-editor/vscode-editor-loading-screen.tsx
@@ -100,7 +100,7 @@ export const VSCodeLoadingScreen = React.memo((): React.ReactElement | null => {
       style={{
         width: '100%',
         height: '100%',
-        fontSize: 13,
+        fontSize: 11,
         display: 'flex',
         flexDirection: 'column',
         fontFamily: '-apple-system, system-ui, sans-serif',
@@ -143,7 +143,7 @@ export const VSCodeLoadingScreen = React.memo((): React.ReactElement | null => {
         style={{
           display: 'flex',
           alignItems: 'flex-end',
-          height: 35,
+          height: 34,
           background: colorTheme.codeEditorTabRowBg.value,
         }}
       >
@@ -152,12 +152,12 @@ export const VSCodeLoadingScreen = React.memo((): React.ReactElement | null => {
           style={{
             background: colorTheme.codeEditorTabSelectedBG.value,
             color: colorTheme.codeEditorTabSelectedFG.value,
-            borderRight: `1px solid ${colorTheme.codeEditorTabSelectedBorder.value}`,
-            height: 35,
+            height: 34,
             display: 'flex',
             alignItems: 'center',
             paddingLeft: 12,
             paddingRight: 12,
+            fontWeight: 500,
             width: 140,
           }}
         >


### PR DESCRIPTION
**Problem:**
VSCode looks... particular. We'd rather it looked a bit more like Utopia, especially on first sight

**Fix:**
Used the VSCode CSS overrides to make the tab bar vaguely match the Utopia one.

<img width="775" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2945037/5b1f381c-68aa-457c-bfa3-96cd18056eb8">



**Notes**
- This doesn't touch anything else that could also be aligned (context menu, warning overlay)
- It's not a perfect match visually because VSCode sets a few things (colors, notably) based on theme _and does so dynamically at runtime_ - notably the inactive / active tab text color. 
- I've left comments in the code since we'll probably touch this very infrequently

