### PR TITLE
Don't snap when beyond threshold

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -1342,6 +1342,20 @@ export var storyboard = (
         ).toEqual('YAxisGuideline')
       })
     })
+    it('snap lines are not shown when the bounding box size is below the snapping threshold', async () => {
+      const editor = await renderTestEditorWithCode(
+        projectForMultiSelectResize,
+        'await-first-dom-report',
+      )
+      await wait(1000)
+      await selectComponentsForTest(editor, [EP.fromString('sb/one'), EP.fromString('sb/two')])
+      await wait(1000)
+      await doSnapDrag(editor, { x: -305, y: -147 }, EdgePositionBottomRight, async () => {
+        // the snap drag along the x axis makes the contents smaller than the snap threshold, so no guidelines are shown
+        await wait(1000)
+        expect(editor.getEditorState().editor.canvas.controls.snappingGuidelines.length).toEqual(0)
+      })
+    })
 
     describe('groups', () => {
       AllFragmentLikeTypes.forEach((type) => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-absolute-resize-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-absolute-resize-strategy-helpers.ts
@@ -142,6 +142,7 @@ export function runLegacyAbsoluteResizeSnapping(
     allElementProps,
     pathTrees,
     resizedBounds,
+    centerBased,
   )
 
   const snapDelta = pointDifference(draggedPointMovedWithoutSnap, snappedPointOnCanvas)

--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-absolute-resize-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-absolute-resize-strategy-helpers.ts
@@ -141,6 +141,7 @@ export function runLegacyAbsoluteResizeSnapping(
     draggedCorner,
     allElementProps,
     pathTrees,
+    resizedBounds,
   )
 
   const snapDelta = pointDifference(draggedPointMovedWithoutSnap, snappedPointOnCanvas)

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -47,7 +47,6 @@ import {
   getIndexInParent,
   generateUidWithExistingComponents,
   insertJSXElementChildren,
-  findPathToJSXElementChild,
 } from '../../core/model/element-template-utils'
 import { getUtopiaID, setUtopiaID } from '../../core/shared/uid-utils'
 import type { ValueAtPath } from '../../core/shared/jsx-attributes'
@@ -68,7 +67,6 @@ import {
   applyUtopiaJSXComponentsChanges,
   getDefaultExportedTopLevelElement,
   getUtopiaJSXComponentsFromSuccess,
-  isRemixOutletElement,
   isRemixSceneElement,
 } from '../../core/model/project-file-utils'
 import type { Either } from '../../core/shared/either'
@@ -99,7 +97,6 @@ import type {
   AllElementProps,
   ElementProps,
   NavigatorEntry,
-  DerivedState,
 } from '../editor/store/editor-state'
 import {
   removeElementAtPath,
@@ -107,7 +104,6 @@ import {
   withUnderlyingTargetFromEditorState,
   modifyUnderlyingElementForOpenFile,
   isSyntheticNavigatorEntry,
-  deriveState,
 } from '../editor/store/editor-state'
 import * as Frame from '../frame'
 import { getImageSizeFromMetadata, MultipliersForImages, scaleImageDimensions } from '../images'
@@ -159,8 +155,8 @@ import type { ElementPathTrees } from '../../core/shared/element-path-tree'
 import { getAllUniqueUids } from '../../core/model/get-unique-ids'
 import type { ErrorMessage } from '../../core/shared/error-messages'
 import type { OverlayError } from '../../core/shared/runtime-report-logs'
-import { unpatchedCreateRemixDerivedDataMemo } from '../editor/store/remix-derived-data'
 import type { RouteModulesWithRelativePaths } from './remix/remix-utils'
+import type { IsCenterBased } from './canvas-strategies/strategies/resize-helpers'
 
 function dragDeltaScaleForProp(prop: LayoutTargetableProp): number {
   switch (prop) {
@@ -1217,6 +1213,7 @@ export function snapPoint(
   allElementProps: AllElementProps,
   pathTrees: ElementPathTrees,
   resizedBounds: CanvasRectangle,
+  centerBased: IsCenterBased,
 ): {
   snappedPointOnCanvas: CanvasPoint
   guidelinesWithSnappingVector: Array<GuidelineWithSnappingVectorAndPointsOfRelevance>
@@ -1227,14 +1224,19 @@ export function snapPoint(
     true,
     false,
   )
+
   const anythingPinnedAndNotAbsolutePositioned = elementsToTarget.some((elementToTarget) => {
     return MetadataUtils.isPinnedAndNotAbsolutePositioned(jsxMetadata, elementToTarget)
   })
+
   const anyElementFragmentLike = selectedViews.some((elementPath) =>
     treatElementAsFragmentLike(jsxMetadata, allElementProps, pathTrees, elementPath),
   )
+
+  const threshold = centerBased === 'center-based' ? SnappingThreshold * 2 : SnappingThreshold
   const resizedBoundsBelowThreshold =
-    resizedBounds.width < SnappingThreshold || resizedBounds.height < SnappingThreshold
+    resizedBounds.width < threshold || resizedBounds.height < threshold
+
   const shouldSnap =
     enableSnapping &&
     !resizedBoundsBelowThreshold &&

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1216,6 +1216,7 @@ export function snapPoint(
   resizingFromPosition: EdgePosition | null,
   allElementProps: AllElementProps,
   pathTrees: ElementPathTrees,
+  resizedBounds: CanvasRectangle,
 ): {
   snappedPointOnCanvas: CanvasPoint
   guidelinesWithSnappingVector: Array<GuidelineWithSnappingVectorAndPointsOfRelevance>
@@ -1232,8 +1233,12 @@ export function snapPoint(
   const anyElementFragmentLike = selectedViews.some((elementPath) =>
     treatElementAsFragmentLike(jsxMetadata, allElementProps, pathTrees, elementPath),
   )
+  const resizedBoundsBelowThreshold =
+    resizedBounds.width < SnappingThreshold || resizedBounds.height < SnappingThreshold
   const shouldSnap =
-    enableSnapping && (anyElementFragmentLike || !anythingPinnedAndNotAbsolutePositioned)
+    enableSnapping &&
+    !resizedBoundsBelowThreshold &&
+    (anyElementFragmentLike || !anythingPinnedAndNotAbsolutePositioned)
 
   if (keepAspectRatio) {
     const closestPointOnLine = Utils.closestPointOnLine(diagonalA, diagonalB, pointToSnap)


### PR DESCRIPTION
Fixes #4197 

**Problem:**

Snap guidelines are shown when an element's resized dimension goes to zero.

![Kapture 2023-09-15 at 16 50 35](https://github.com/concrete-utopia/utopia/assets/1081051/2b136928-492a-42c6-915a-55cda92eb892)

**Fix:**

Don't show the guidelines when/while the resized bounds are below the snapping threshold.

![Kapture 2023-09-15 at 16 51 22](https://github.com/concrete-utopia/utopia/assets/1081051/0629f06a-9887-4c5c-98e5-cccc4a15d2e2)
