### PR TITLE
Fix memoize equality function option

### DIFF
--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -52,7 +52,7 @@ function getSHA1ChecksumInner(contents: string | Buffer): string {
 // those cached checksum objects.
 export const getSHA1Checksum = memoize(getSHA1ChecksumInner, {
   maxSize: 10,
-  equals: (first, second) => first === second,
+  matchesArg: (first, second) => first === second,
 })
 
 export function gitBlobChecksumFromBase64(base64: string): string {

--- a/editor/src/components/canvas/canvas-strategies/strategies/fragment-like-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/fragment-like-helpers.ts
@@ -58,7 +58,7 @@ export function retargetStrategyToTopMostFragmentLikeElement(
 
 export const replaceFragmentLikePathsWithTheirChildrenRecursive = memoize(
   replaceFragmentLikePathsWithTheirChildrenRecursiveInner,
-  { maxSize: 1, equals: is },
+  { maxSize: 1, matchesArg: is },
 )
 
 function replaceFragmentLikePathsWithTheirChildrenRecursiveInner(
@@ -102,7 +102,7 @@ function replaceFragmentLikePathsWithTheirChildrenRecursiveInner(
 
 export const replaceNonDOMElementPathsWithTheirChildrenRecursive = memoize(
   replaceNonDOMElementPathsWithTheirChildrenRecursiveInner,
-  { maxSize: 1, equals: is },
+  { maxSize: 1, matchesArg: is },
 )
 
 function replaceNonDOMElementPathsWithTheirChildrenRecursiveInner(

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -191,7 +191,7 @@ function isCanvasState(
 
 const getStartingTargetParentsToFilterOut = memoize(getStartingTargetParentsToFilterOutInner, {
   maxSize: 10,
-  equals: (
+  matchesArg: (
     l: InteractionCanvasState | InteractionSession,
     r: InteractionCanvasState | InteractionSession,
   ) => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
@@ -288,7 +288,7 @@ export function getMultiselectBounds(
 
 export const flattenSelection = memoize(flattenSelectionInner, {
   maxSize: 1,
-  equals: is,
+  matchesArg: is,
 })
 
 // No need to include descendants in multiselection when dragging

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -73,6 +73,7 @@ import {
   printMarginAsAttributeValue,
 } from '../../../printer-parsers/css/css-parser-margin'
 import { parseFlex, printFlexAsAttributeValue } from '../../../printer-parsers/css/css-parser-flex'
+import { memoize } from '../../../core/shared/memoize'
 
 var combineRegExp = function (regexpList: Array<RegExp | string>, flags?: string) {
   let source: string = ''
@@ -4901,12 +4902,12 @@ function parseValueFactory<T, K extends keyof T>(parserMap: {
   }
 }
 
-const parseMetadataValue = Utils.memoize(parseValueFactory(elementPropertiesParsers), {
+const parseMetadataValue = memoize(parseValueFactory(elementPropertiesParsers), {
   maxSize: 1000,
 })
-const parseCSSValue = Utils.memoize(parseValueFactory(cssParsers), { maxSize: 1000 })
-const parseOldLayoutValue = Utils.memoize(parseValueFactory(layoutParsers), { maxSize: 1000 })
-const parseNewLayoutValue = Utils.memoize(parseValueFactory(layoutParsersNew), { maxSize: 1000 })
+const parseCSSValue = memoize(parseValueFactory(cssParsers), { maxSize: 1000 })
+const parseOldLayoutValue = memoize(parseValueFactory(layoutParsers), { maxSize: 1000 })
+const parseNewLayoutValue = memoize(parseValueFactory(layoutParsersNew), { maxSize: 1000 })
 
 function isMetadataProp(prop: unknown): prop is keyof ParsedElementProperties {
   return typeof prop === 'string' && prop in elementPropertiesEmptyValues

--- a/editor/src/core/es-modules/package-manager/package-manager.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.ts
@@ -209,6 +209,6 @@ export const getDependencyTypeDefinitions = memoize(
   },
   {
     maxSize: 1,
-    equals: Object.is, // for an object with thousands of entries, where the values are _large_ strings, even a shallow equals is expensive
+    matchesArg: Object.is, // for an object with thousands of entries, where the values are _large_ strings, even a shallow equals is expensive
   },
 )

--- a/editor/src/core/model/get-unique-ids.ts
+++ b/editor/src/core/model/get-unique-ids.ts
@@ -8,7 +8,7 @@ import type {
 } from '../shared/element-template'
 import { emptySet } from '../shared/set-utils'
 import { assertNever, fastForEach } from '../shared/utils'
-import Utils from '../../utils/utils'
+import { memoize } from '../shared/memoize'
 
 export type DuplicateUIDsResult = { [key: string]: Array<Array<string>> }
 
@@ -199,7 +199,7 @@ function getAllUniqueUidsInner(projectContents: ProjectContentTreeRoot): GetAllU
   return getAllUniqueUIDsResultFromWorkingResult(workingResult)
 }
 
-export const getAllUniqueUids = Utils.memoize(getAllUniqueUidsInner)
+export const getAllUniqueUids = memoize(getAllUniqueUidsInner)
 
 export function getAllUniqueUidsFromAttributes(attributes: JSXAttributes): GetAllUniqueUIDsResult {
   const workingResult = emptyGetAllUniqueUIDsWorkingResult()

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -400,9 +400,7 @@ function getUtopiaJSXComponentsFromSuccessInner(success: ParseSuccess): Array<Ut
   return getComponentsFromTopLevelElements(success.topLevelElements)
 }
 
-export const getUtopiaJSXComponentsFromSuccess = Utils.memoize(
-  getUtopiaJSXComponentsFromSuccessInner,
-)
+export const getUtopiaJSXComponentsFromSuccess = memoize(getUtopiaJSXComponentsFromSuccessInner)
 
 export function applyUtopiaJSXComponentsChanges(
   topLevelElements: Array<TopLevelElement>,
@@ -472,7 +470,7 @@ function getHighlightBoundsForProjectImpl(
 
 export const getHighlightBoundsForProject = memoize(getHighlightBoundsForProjectImpl, {
   maxSize: 2,
-  equals: (a, b) => a === b,
+  matchesArg: (a, b) => a === b,
 })
 
 export function updateParsedTextFileHighlightBounds(

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -202,7 +202,7 @@ const convertScenesAndTopLevelElementsToUtopiaCanvasComponentMemoized = memoize(
     ...topLevelElements,
     convertScenesToUtopiaCanvasComponent(scenes),
   ],
-  { equals: fastDeepEqual }, // delete me as soon as possible
+  { matchesArg: fastDeepEqual }, // delete me as soon as possible
 )
 
 export function convertScenesAndTopLevelElementsToUtopiaCanvasComponent(

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -241,7 +241,7 @@ export function createRegisterModuleFunction(
             parseAndPrepareComponentsFn = memoize(
               partiallyParseAndPrepareComponents(workers, moduleName),
               {
-                equals: fastDeepEqual,
+                matchesArg: fastDeepEqual,
                 maxSize: 5,
               },
             )

--- a/editor/src/core/shared/memoize.spec.ts
+++ b/editor/src/core/shared/memoize.spec.ts
@@ -1,0 +1,78 @@
+import { memoize } from './memoize'
+
+describe('memoize', () => {
+  type AandB = { a: number; b: number }
+  type CandD = { c: number; d: number }
+
+  function isAandB(v: AandB | CandD): v is AandB {
+    return v.hasOwnProperty('a')
+  }
+
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  const testFunctionCount = new Map<Function, number>()
+
+  function createTestFn() {
+    const testFn = (first: AandB, second: CandD): { e: number } => {
+      const callCount = testFunctionCount.get(testFn) ?? 0
+      testFunctionCount.set(testFn, callCount + 1)
+      return {
+        e: first.a + first.b,
+      }
+    }
+
+    return testFn
+  }
+
+  it('memoizes using shallow equality by default', () => {
+    const testFn = createTestFn()
+    const memoized = memoize(testFn)
+    const firstRun = memoized({ a: 1, b: 2 }, { c: 3, d: 4 })
+    const secondRun = memoized({ a: 1, b: 2 }, { c: 3, d: 4 })
+    const thirdRun = memoized({ a: 1, b: 2 }, { c: 4, d: 5 })
+
+    expect(firstRun).toBe(secondRun)
+    expect(firstRun).not.toBe(thirdRun)
+    expect(testFunctionCount.get(testFn)).toEqual(2)
+  })
+
+  it('supports a custom maxSize', () => {
+    const testFn = createTestFn()
+    const memoized = memoize(testFn, { maxSize: 1 })
+    const firstRun = memoized({ a: 1, b: 2 }, { c: 3, d: 4 })
+    const secondRun = memoized({ a: 1, b: 2 }, { c: 4, d: 5 })
+    const thirdRun = memoized({ a: 1, b: 2 }, { c: 3, d: 4 })
+
+    expect(firstRun).not.toBe(secondRun)
+    expect(firstRun).not.toBe(thirdRun)
+    expect(testFunctionCount.get(testFn)).toEqual(3)
+
+    const memoizedWithLargerMaxSize = memoize(testFn, { maxSize: 2 })
+    const fourthRun = memoizedWithLargerMaxSize({ a: 1, b: 2 }, { c: 3, d: 4 })
+    const fifthRun = memoizedWithLargerMaxSize({ a: 1, b: 2 }, { c: 4, d: 5 })
+    const sixthRun = memoizedWithLargerMaxSize({ a: 1, b: 2 }, { c: 3, d: 4 })
+
+    expect(fourthRun).not.toBe(fifthRun)
+    expect(fourthRun).toBe(sixthRun)
+    expect(testFunctionCount.get(testFn)).toEqual(5)
+  })
+
+  it('can use a custom equality function', () => {
+    const testFn = createTestFn()
+    const memoized = memoize(testFn, {
+      matchesArg: (l: AandB | CandD, r: AandB | CandD) => {
+        if (isAandB(l) && isAandB(r)) {
+          return l.a === r.a && l.b === r.b
+        } else {
+          return true
+        }
+      },
+    })
+    const firstRun = memoized({ a: 1, b: 2 }, { c: 3, d: 4 })
+    const secondRun = memoized({ a: 1, b: 2 }, { c: 3, d: 4 })
+    const thirdRun = memoized({ a: 1, b: 2 }, { c: 4, d: 5 })
+
+    expect(firstRun).toBe(secondRun)
+    expect(firstRun).toBe(thirdRun)
+    expect(testFunctionCount.get(testFn)).toEqual(1)
+  })
+})

--- a/editor/src/core/shared/memoize.ts
+++ b/editor/src/core/shared/memoize.ts
@@ -1,32 +1,25 @@
 import moize from 'moize'
+import type { Options, Moizeable } from 'moize'
 import { shallowEqual } from './equality-utils'
 
-export interface MemoizeOptions<T> {
-  maxSize: number
-  equals: (a: T, b: T) => boolean
-}
-
-function getMemoizeOptions<T>(options?: Partial<MemoizeOptions<T>>): MemoizeOptions<T> {
-  let equalsFunction = shallowEqual
+function getMemoizeOptions<T extends Moizeable>(options?: Partial<Options<T>>): Options<T> {
+  let matchesArg = shallowEqual
   let maxSize = 5
   if (options != null) {
-    if (options.equals != null) {
-      equalsFunction = options.equals
+    if (options.matchesArg != null) {
+      matchesArg = options.matchesArg
     }
     if (options.maxSize != null) {
       maxSize = options.maxSize
     }
   }
   return {
-    equals: equalsFunction,
+    matchesArg: matchesArg,
     maxSize: maxSize,
   }
 }
 
-export function memoize<F extends (...args: Array<any>) => any, T>(
-  func: F,
-  options?: Partial<MemoizeOptions<T>>,
-): F {
+export function memoize<T extends Moizeable>(func: T, options?: Partial<Options<T>>): T {
   const memoizeOptions = getMemoizeOptions(options)
   return moize(func, memoizeOptions)
 }

--- a/editor/src/core/shared/project-contents-utils.ts
+++ b/editor/src/core/shared/project-contents-utils.ts
@@ -36,7 +36,10 @@ function packageJsonEquals(l: ProjectFile | undefined, r: ProjectFile | undefine
   }
 }
 
-const parsePackageJson = memoize(parsePackageJsonInner, { maxSize: 1, equals: packageJsonEquals })
+const parsePackageJson = memoize(parsePackageJsonInner, {
+  maxSize: 1,
+  matchesArg: packageJsonEquals,
+})
 
 function getParsedPackageJson(projectContents: ProjectContentTreeRoot): Record<string, any> | null {
   return parsePackageJson(getProjectFileByFilePath(projectContents, '/package.json'))

--- a/editor/src/core/tailwind/tailwind.ts
+++ b/editor/src/core/tailwind/tailwind.ts
@@ -192,7 +192,10 @@ export function adjustRuleScopeImpl(rule: string, prefixSelector: string | null)
   }
 }
 
-const adjustRuleScope = memoize(adjustRuleScopeImpl, { maxSize: 100, equals: (a, b) => a === b })
+const adjustRuleScope = memoize(adjustRuleScopeImpl, {
+  maxSize: 100,
+  matchesArg: (a, b) => a === b,
+})
 
 function updateTwind(config: Configuration, prefixSelector: string | null) {
   const element = document.head.appendChild(document.createElement('style'))

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -828,7 +828,7 @@ function printArbitraryJSBlock(block: ArbitraryJSBlock): TS.Node {
 }
 
 export const printCode = memoize(printCodeImpl, {
-  equals: (a, b) => a === b,
+  matchesArg: (a, b) => a === b,
   maxSize: 1,
 })
 

--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -1,6 +1,4 @@
 import React from 'react'
-import Utils from './utils'
-import { keepDeepReferenceEqualityIfPossible } from './react-performance'
 import { omitWithPredicate } from '../core/shared/object-utils'
 import type { MapLike } from 'typescript'
 import { firstLetterIsLowerCase } from '../core/shared/string-utils'
@@ -9,6 +7,7 @@ import { UtopiaKeys, UTOPIA_UID_KEY, UTOPIA_PATH_KEY } from '../core/model/utopi
 import { v4 } from 'uuid'
 import { isFeatureEnabled } from './feature-switches'
 import { PERFORMANCE_MARKS_ALLOWED } from '../common/env-vars'
+import { memoize } from '../core/shared/memoize'
 
 const realCreateElement = React.createElement
 
@@ -119,7 +118,7 @@ function attachDataUidToRoot(
   }
 }
 
-const mangleFunctionType = Utils.memoize(
+const mangleFunctionType = memoize(
   (type: unknown): React.FunctionComponent<React.PropsWithChildren<unknown>> => {
     const mangledFunctionName = `UtopiaSpiedFunctionComponent(${getDisplayName(type)})`
 
@@ -161,7 +160,7 @@ const mangleFunctionType = Utils.memoize(
   },
 )
 
-const mangleClassType = Utils.memoize(
+const mangleClassType = memoize(
   (type: any) => {
     const originalRender = type.prototype.render
     // mutation
@@ -197,7 +196,7 @@ const mangleClassType = Utils.memoize(
   },
 )
 
-const mangleExoticType = Utils.memoize(
+const mangleExoticType = memoize(
   (
     type: React.ComponentType<React.PropsWithChildren<unknown>>,
   ): React.FunctionComponent<React.PropsWithChildren<unknown>> => {

--- a/editor/src/utils/utils.spec.ts
+++ b/editor/src/utils/utils.spec.ts
@@ -225,28 +225,6 @@ describe('Utils.proxyValue', () => {
   })
 })
 
-describe('Utils.memoize', () => {
-  it('memoizes', () => {
-    const functionToMemoize = (params: { a: number; b: number }) => {
-      return Math.sqrt(params.a * params.a + params.b * params.b)
-    }
-    const memoized = Utils.memoize(functionToMemoize)
-    const firstRun = memoized({ a: 4, b: 12 })
-    const secondRun = memoized({ a: 4, b: 12 })
-    expect(firstRun).to.equal(secondRun)
-  })
-
-  it('returns new stuff', () => {
-    const functionToMemoize = (params: { a: number; b: number }) => {
-      return Math.sqrt(params.a * params.a + params.b * params.b)
-    }
-    const memoized = Utils.memoize(functionToMemoize)
-    const firstRun = memoized({ a: 4, b: 12 })
-    const secondRun = memoized({ a: 2, b: 1 })
-    expect(firstRun).to.not.equal(secondRun)
-  })
-})
-
 describe('Utils.boundingRectangle', () => {
   it('encompasses two overlapping rectangles', () => {
     const first = { x: 10, y: 20, width: 100, height: 200 } as CanvasRectangle

--- a/editor/src/utils/utils.ts
+++ b/editor/src/utils/utils.ts
@@ -141,7 +141,6 @@ import {
   SafeFunctionCurriedErrorHandler,
   processErrorWithSourceMap,
 } from '../core/shared/code-exec-utils'
-import { memoize } from '../core/shared/memoize'
 import type { ValueType, OptionsType, OptionTypeBase } from 'react-select'
 import { emptySet } from '../core/shared/set-utils'
 import * as ObjectPath from 'object-path'
@@ -1055,7 +1054,6 @@ export default {
   shallowClone: shallowClone,
   proxyValue: proxyValue,
   createSimpleClock: createSimpleClock,
-  memoize: memoize,
   shallowEqual: shallowEqual,
   oneLevelNestedEquals: oneLevelNestedEquals,
   keepReferenceIfShallowEqual: keepReferenceIfShallowEqual,


### PR DESCRIPTION
**Problem:**
We updated the version of `moize` that we depend on, but due to a lack of type checking we didn't catch that the API had removed the `equals` option and replaced it with `matchesArg`.

**Fix:**
Replace `equals` with `matchesArg`, use the correct `Options` type, and introduce a test that actually checks whether or not the memoized function was called.
