### PR TITLE
Move dependencies from createRemixDerivedData into useGetRoutes hook

### DIFF
--- a/editor/src/components/canvas/remix/remix-navigator.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-navigator.spec.browser2.tsx
@@ -1,17 +1,25 @@
 import * as EP from '../../../core/shared/element-path'
 import { createModifiedProject } from '../../../sample-projects/sample-project-utils.test-utils'
 import { setFeatureForBrowserTestsUseInDescribeBlockOnly } from '../../../utils/utils.test-utils'
+import { runDOMWalker } from '../../editor/actions/action-creators'
 import {
   StoryboardFilePath,
   navigatorEntryToKey,
   regularNavigatorEntry,
   varSafeNavigatorEntryToKey,
 } from '../../editor/store/editor-state'
+import type { PersistentModel } from '../../editor/store/editor-state'
 import { NavigatorItemTestId } from '../../navigator/navigator-item/navigator-item'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
 
 const DefaultRouteTextContent = 'Hello Remix!'
 const RootTextContent = 'This is root!'
+
+async function renderRemixProject(project: PersistentModel) {
+  const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+  await renderResult.dispatch([runDOMWalker()], true)
+  return renderResult
+}
 
 describe('Remix navigator', () => {
   setFeatureForBrowserTestsUseInDescribeBlockOnly('Remix support', true)
@@ -67,7 +75,7 @@ describe('Remix navigator', () => {
       `,
     })
 
-    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+    const renderResult = await renderRemixProject(project)
     expect(renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey)).toEqual(
       [
         'regular-storyboard/remix-scene',
@@ -130,7 +138,7 @@ describe('Remix navigator', () => {
       `,
     })
 
-    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+    const renderResult = await renderRemixProject(project)
     expect(renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey)).toEqual(
       [
         'regular-storyboard/remix-scene',
@@ -194,7 +202,7 @@ describe('Remix navigator', () => {
       `,
     })
 
-    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+    const renderResult = await renderRemixProject(project)
     const navigatorItemElement = renderResult.renderedDOM.getByTestId(
       NavigatorItemTestId(
         varSafeNavigatorEntryToKey(

--- a/editor/src/components/canvas/remix/remix-rendering.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-rendering.spec.browser2.tsx
@@ -9,9 +9,10 @@ import {
   selectComponentsForTest,
   setFeatureForBrowserTestsUseInDescribeBlockOnly,
 } from '../../../utils/utils.test-utils'
-import { switchEditorMode } from '../../editor/actions/action-creators'
+import { runDOMWalker, switchEditorMode } from '../../editor/actions/action-creators'
 import { EditorModes } from '../../editor/editor-modes'
 import { StoryboardFilePath, navigatorEntryToKey } from '../../editor/store/editor-state'
+import type { PersistentModel } from '../../editor/store/editor-state'
 import { AddRemoveLayouSystemControlTestId } from '../../inspector/add-remove-layout-system-control'
 import { CanvasControlsContainerID } from '../controls/new-canvas-controls'
 import {
@@ -56,6 +57,12 @@ export var storyboard = (
 
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectRemixSceneToBeRendered"] }] */
 
+async function renderRemixProject(project: PersistentModel) {
+  const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+  await renderResult.dispatch([runDOMWalker()], true)
+  return renderResult
+}
+
 describe('Remix content', () => {
   setFeatureForBrowserTestsUseInDescribeBlockOnly('Remix support', true)
   it('Renders the remix container with actual content', async () => {
@@ -98,7 +105,7 @@ describe('Remix content', () => {
       `,
     })
 
-    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+    const renderResult = await renderRemixProject(project)
     await expectRemixSceneToBeRendered(renderResult)
   })
 
@@ -154,7 +161,7 @@ describe('Remix content', () => {
       `,
     })
 
-    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+    const renderResult = await renderRemixProject(project)
 
     const remixDivMetadata =
       renderResult.getEditorState().editor.jsxMetadata[
@@ -234,7 +241,7 @@ describe('Remix content', () => {
       `,
     })
 
-    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+    const renderResult = await renderRemixProject(project)
 
     const remixDivMetadata =
       renderResult.getEditorState().editor.jsxMetadata[
@@ -318,7 +325,7 @@ describe('Remix content', () => {
       `,
     })
 
-    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+    const renderResult = await renderRemixProject(project)
 
     const remixDivMetadata =
       renderResult.getEditorState().editor.jsxMetadata[
@@ -392,7 +399,7 @@ describe('Remix content', () => {
       `,
     })
 
-    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+    const renderResult = await renderRemixProject(project)
 
     const targetElement = renderResult.renderedDOM.getByTestId('remix-div')
     const targetElementBounds = targetElement.getBoundingClientRect()
@@ -452,7 +459,7 @@ describe('Remix content', () => {
       `,
     })
 
-    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+    const renderResult = await renderRemixProject(project)
 
     const targetElement = renderResult.renderedDOM.getAllByTestId('remix-div')[1]
     const targetElementBounds = targetElement.getBoundingClientRect()
@@ -521,7 +528,7 @@ describe('Remix content', () => {
       `,
     })
 
-    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+    const renderResult = await renderRemixProject(project)
 
     const targetElement = renderResult.renderedDOM.getByTestId(DraggedElementId)
     const targetElementBounds = targetElement.getBoundingClientRect()
@@ -543,7 +550,7 @@ describe('Remix content with feature switch off', () => {
     const project = createModifiedProject({
       [StoryboardFilePath]: storyboardFileContent,
     })
-    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+    const renderResult = await renderRemixProject(project)
     await expect(async () =>
       renderResult.renderedDOM.findAllByTestId(REMIX_SCENE_TESTID),
     ).rejects.toThrow()
@@ -599,7 +606,7 @@ describe('Remix navigation', () => {
         `,
     })
 
-    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+    const renderResult = await renderRemixProject(project)
     await renderResult.dispatch([switchEditorMode(EditorModes.liveMode())], true)
 
     const targetElement = renderResult.renderedDOM.getByTestId('remix-link')
@@ -671,15 +678,14 @@ describe('Remix navigation', () => {
       `,
     })
 
-    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+    const renderResult = await renderRemixProject(project)
+    await renderResult.dispatch([switchEditorMode(EditorModes.liveMode())], true)
 
     const remixLinkMetadata =
       renderResult.getEditorState().editor.jsxMetadata[
         'storyboard/remix-scene:rootdiv/outlet:remixlink'
       ]
     expect(remixLinkMetadata).not.toBeUndefined()
-
-    await renderResult.dispatch([switchEditorMode(EditorModes.liveMode())], true)
 
     const targetElement = renderResult.renderedDOM.getByTestId('remix-link')
     const targetElementBounds = targetElement.getBoundingClientRect()
@@ -753,7 +759,7 @@ describe('Editing Remix content', () => {
       `,
     })
 
-    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+    const renderResult = await renderRemixProject(project)
 
     const pathString = 'sb/rs:root/outlet:title'
 
@@ -936,7 +942,7 @@ describe('Editing Remix content', () => {
       `,
     })
 
-    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+    const renderResult = await renderRemixProject(project)
 
     const pathString = 'sb/rs:root/outlet2:title'
 
@@ -949,10 +955,7 @@ describe('Editing Remix content', () => {
   })
 
   it('delete element from remix scene', async () => {
-    const renderResult = await renderTestEditorWithModel(
-      remixProjectForEditingTests,
-      'await-first-dom-report',
-    )
+    const renderResult = await renderRemixProject(remixProjectForEditingTests)
 
     expect(renderResult.renderedDOM.queryAllByTestId(FlexDivTestId)).toHaveLength(1)
 
@@ -999,10 +1002,7 @@ export default function Index() {
   })
 
   it('use the inspector to add a layout system', async () => {
-    const renderResult = await renderTestEditorWithModel(
-      remixProjectForEditingTests,
-      'await-first-dom-report',
-    )
+    const renderResult = await renderRemixProject(remixProjectForEditingTests)
 
     const absoluteDiv = await clickElementOnCanvas(renderResult, AbsoluteDivTestId)
 
@@ -1013,10 +1013,9 @@ export default function Index() {
   })
 
   it('flex reorder elements inside Remix', async () => {
-    const renderResult = await renderTestEditorWithModel(
-      remixProjectForEditingTests,
-      'await-first-dom-report',
-    )
+    const renderResult = await renderRemixProject(remixProjectForEditingTests)
+
+    await renderResult.dispatch([runDOMWalker()], true)
 
     expect(renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey)).toEqual(
       [
@@ -1056,10 +1055,7 @@ export default function Index() {
   })
 
   it('absolute move elements inside Remix', async () => {
-    const renderResult = await renderTestEditorWithModel(
-      remixProjectForEditingTests,
-      'await-first-dom-report',
-    )
+    const renderResult = await renderRemixProject(remixProjectForEditingTests)
 
     const absoluteDiv = await clickElementOnCanvas(renderResult, AbsoluteDivTestId)
     expect({ left: absoluteDiv.style.left, top: absoluteDiv.style.top }).toEqual({
@@ -1081,10 +1077,9 @@ export default function Index() {
   })
 
   it('draw to insert into Remix', async () => {
-    const renderResult = await renderTestEditorWithModel(
-      remixProjectForEditingTests,
-      'await-first-dom-report',
-    )
+    const renderResult = await renderRemixProject(remixProjectForEditingTests)
+
+    await renderResult.dispatch([runDOMWalker()], true)
 
     expect(renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey)).toEqual(
       [
@@ -1203,10 +1198,7 @@ export default function Index() {
   const clipboardMock = new MockClipboardHandlers().mock()
 
   it('copy-paste element inside Remix', async () => {
-    const renderResult = await renderTestEditorWithModel(
-      remixProjectForEditingTests,
-      'await-first-dom-report',
-    )
+    const renderResult = await renderRemixProject(remixProjectForEditingTests)
 
     await selectComponentsForTest(renderResult, [
       EP.fromString('sb/remix-scene:app/outlet:index/absolute-div'),
@@ -1310,10 +1302,7 @@ export default function Index() {
   })
 
   it('dragging elements between Remix and the storyboard', async () => {
-    const renderResult = await renderTestEditorWithModel(
-      remixProjectForEditingTests,
-      'await-first-dom-report',
-    )
+    const renderResult = await renderRemixProject(remixProjectForEditingTests)
     expect(renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey)).toEqual(
       [
         'regular-sb/remix-scene',

--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -1,7 +1,7 @@
 import { RemixContext } from '@remix-run/react/dist/components'
 import type { RouteModules } from '@remix-run/react/dist/routeModules'
 import React from 'react'
-import type { Location } from 'react-router'
+import type { DataRouteObject, Location } from 'react-router'
 import { createMemoryRouter, RouterProvider } from 'react-router'
 import { UTOPIA_PATH_KEY } from '../../../core/model/utopia-constants'
 import type { ElementPath } from '../../../core/shared/project-file-types'
@@ -11,6 +11,10 @@ import { PathPropHOC } from './path-props-hoc'
 import { atom, useAtom, useSetAtom } from 'jotai'
 import { getDefaultExportNameAndUidFromFile } from '../../../core/model/project-file-utils'
 import { OutletPathContext } from './remix-utils'
+import { UiJsxCanvasCtxAtom } from '../ui-jsx-canvas'
+import type { UiJsxCanvasContextData } from '../ui-jsx-canvas'
+import { forceNotNull } from '../../../core/shared/optional-utils'
+import { AlwaysFalse, usePubSubAtomReadOnly } from '../../../core/shared/atom-with-pub-sub'
 
 type RouterType = ReturnType<typeof createMemoryRouter>
 
@@ -32,6 +36,14 @@ export const RemixNavigationAtom = atom<RemixNavigationAtomData>({})
 function useGetRouteModules(basePath: ElementPath) {
   const remixDerivedDataRef = useRefEditorState((store) => store.derived.remixData)
   const projectContentsRef = useRefEditorState((store) => store.editor.projectContents)
+  const fileBlobsRef = useRefEditorState((store) => store.editor.canvas.base64Blobs)
+  const hiddenInstancesRef = useRefEditorState((store) => store.editor.hiddenInstances)
+  const displayNoneInstancesRef = useRefEditorState((store) => store.editor.displayNoneInstances)
+
+  let metadataContext: UiJsxCanvasContextData = forceNotNull(
+    `Missing UiJsxCanvasCtxAtom provider`,
+    usePubSubAtomReadOnly(UiJsxCanvasCtxAtom, AlwaysFalse),
+  )
 
   const defaultExports = useEditorState(
     Substores.derived,
@@ -65,7 +77,13 @@ function useGetRouteModules(basePath: ElementPath) {
 
       const defaultComponent = (componentProps: any) =>
         value
-          .executionScopeCreator(projectContentsRef.current)
+          .executionScopeCreator(
+            projectContentsRef.current,
+            fileBlobsRef.current,
+            hiddenInstancesRef.current,
+            displayNoneInstancesRef.current,
+            metadataContext,
+          )
           .scope[nameAndUid.name]?.(componentProps) ?? <React.Fragment />
 
       routeModulesResult[routeId] = {
@@ -75,7 +93,86 @@ function useGetRouteModules(basePath: ElementPath) {
     }
 
     return routeModulesResult
-  }, [defaultExports, remixDerivedDataRef, projectContentsRef])
+  }, [
+    defaultExports,
+    metadataContext,
+    remixDerivedDataRef,
+    projectContentsRef,
+    fileBlobsRef,
+    hiddenInstancesRef,
+    displayNoneInstancesRef,
+  ])
+}
+
+function useGetRoutes() {
+  const routes = useEditorState(
+    Substores.derived,
+    (store) => store.derived.remixData?.routes ?? [],
+    'UtopiaRemixRootComponent routes',
+  )
+
+  const remixDerivedDataRef = useRefEditorState((store) => store.derived.remixData)
+  const projectContentsRef = useRefEditorState((store) => store.editor.projectContents)
+  const fileBlobsRef = useRefEditorState((store) => store.editor.canvas.base64Blobs)
+  const hiddenInstancesRef = useRefEditorState((store) => store.editor.hiddenInstances)
+  const displayNoneInstancesRef = useRefEditorState((store) => store.editor.displayNoneInstances)
+
+  let metadataContext: UiJsxCanvasContextData = forceNotNull(
+    `Missing UiJsxCanvasCtxAtom provider`,
+    usePubSubAtomReadOnly(UiJsxCanvasCtxAtom, AlwaysFalse),
+  )
+
+  return React.useMemo(() => {
+    if (remixDerivedDataRef.current == null) {
+      return routes
+    }
+
+    const creators = remixDerivedDataRef.current.routeModuleCreators
+
+    function addLoaderAndActionToRoutes(innerRoutes: DataRouteObject[]) {
+      innerRoutes.forEach((route) => {
+        // FIXME Adding a loader function to the 'root' route causes the `createShouldRevalidate` to fail, because
+        // we only ever pass in an empty object for the `routeModules` and never mutate it
+        const creatorForRoute = route.id === 'root' ? null : creators[route.id]
+        if (creatorForRoute != null) {
+          route.action = (args: any) =>
+            creatorForRoute
+              .executionScopeCreator(
+                projectContentsRef.current,
+                fileBlobsRef.current,
+                hiddenInstancesRef.current,
+                displayNoneInstancesRef.current,
+                metadataContext,
+              )
+              .scope['action']?.(args) ?? null
+          route.loader = (args: any) =>
+            creatorForRoute
+              .executionScopeCreator(
+                projectContentsRef.current,
+                fileBlobsRef.current,
+                hiddenInstancesRef.current,
+                displayNoneInstancesRef.current,
+                metadataContext,
+              )
+              .scope['loader']?.(args) ?? null
+        }
+
+        addLoaderAndActionToRoutes(route.children ?? [])
+      })
+    }
+
+    addLoaderAndActionToRoutes(routes)
+
+    return routes
+  }, [
+    displayNoneInstancesRef,
+    metadataContext,
+    fileBlobsRef,
+    hiddenInstancesRef,
+    projectContentsRef,
+    remixDerivedDataRef,
+    routes,
+  ])
 }
 
 export interface UtopiaRemixRootComponentProps {
@@ -85,11 +182,7 @@ export interface UtopiaRemixRootComponentProps {
 export const UtopiaRemixRootComponent = React.memo((props: UtopiaRemixRootComponentProps) => {
   const remixDerivedDataRef = useRefEditorState((store) => store.derived.remixData)
 
-  const routes = useEditorState(
-    Substores.derived,
-    (store) => store.derived.remixData?.routes ?? [],
-    'UtopiaRemixRootComponent routes',
-  )
+  const routes = useGetRoutes()
 
   const basePath = props[UTOPIA_PATH_KEY]
 

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -2598,11 +2598,6 @@ export function deriveState(
 
   const remixDerivedData = createRemixDerivedDataMemo(
     editor.projectContents,
-    editor.spyMetadata,
-    editor.allElementProps,
-    editor.canvas.base64Blobs,
-    editor.hiddenInstances,
-    editor.displayNoneInstances,
     editor.codeResultCache.curriedRequireFn,
     editor.codeResultCache.curriedResolveFn,
   )


### PR DESCRIPTION
**Problem:**
The use of `createRemixDerivedData` was causing us to repeatedly create new `router`s when nothing relevant had changed, which would cause issues with navigation in a running remix app.

**Fix:**
The problem here was really that we were trying to derive too much data here, creating the routes themselves as part of the derived state. Rather than doing that, we now effectively create placeholders for the routes, and then craft the `loader` and `action` functions (via `createExecutionScope`) as and when we need them, following the pattern that was set out with the `routeModules`. To achieve this I had to pull out a load of the dependencies of `getRemixExportsOfModule` and shift them into `createExecutionScope`, which then requires providing them when resolving the route or module. Then the final part of the puzzle was to provide those values via refs inside the `useGetRoutes` and `useGetRouteModules` hooks so that we could ensure we'd always have the up to date data without causing excessive renders.

I've also updated an existing test to navigate deeper into an app, which would otherwise fail.

Note that the Remix tests now dispatch an extra `runDOMWalker()` at the start of each test. The previously excessive rendering meant that when running those tests we would have the correct metadata, which is no longer the case, and so that extra dispatch is required. This appears to be a difference between running the tests in the test runner vs in the real app.
