### PR TITLE
signal routes not matching location

### DIFF
--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -27,7 +27,7 @@ interface RemixNavigationContext {
 }
 
 interface RemixNavigationAtomData {
-  [pathString: string]: RemixNavigationContext
+  [pathString: string]: RemixNavigationContext | undefined
 }
 
 export const ActiveRemixSceneAtom = atom<ElementPath>(EP.emptyElementPath)


### PR DESCRIPTION
<img width="419" alt="image" src="https://github.com/concrete-utopia/utopia/assets/16385508/fb569ed0-0f0d-4421-99c0-30e901bfad50">

## Problem
We want to provide some extra support for the eventuality when a location doesn't match because there's no corresponding route module (and not because the loader function returns a 404). This can easily happen when a route module is deleted, but there's still a link pointing to that route in the project, and it gets clicked, thus navigating to the non-existent route.

## Fix
Add an indicator in the Remix Scene label that explains the situation.