### PR TITLE
Remix Outlet navigator item label

### DIFF
--- a/editor/src/components/canvas/remix/remix-navigator.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-navigator.spec.browser2.tsx
@@ -212,4 +212,67 @@ describe('Remix navigator', () => {
     )
     expect(navigatorItemElement.style.color).toEqual('var(--utopitheme-fg0)')
   })
+
+  it('Remix Outlet navigator item label contains route component name', async () => {
+    const project = createModifiedProject({
+      [StoryboardFilePath]: `import * as React from 'react'
+      import { RemixScene, Storyboard } from 'utopia-api'
+      
+      export var storyboard = (
+        <Storyboard data-uid='storyboard'>
+          <RemixScene
+            style={{
+              width: 700,
+              height: 759,
+              position: 'absolute',
+              left: 212,
+              top: 128,
+            }}
+            data-label='Playground'
+            data-uid='remix-scene'
+          />
+        </Storyboard>
+      )
+      `,
+      ['/src/root.js']: `import React from 'react'
+      import { Outlet } from '@remix-run/react'
+      
+      export default function Root() {
+        return (
+          <div data-uid='rootdiv'>
+            ${RootTextContent}
+            <Outlet data-uid='outlet'/>
+          </div>
+        )
+      }
+      `,
+      ['/src/routes/_index.js']: `import React from 'react'
+
+      export default function Index() {
+        return <div
+          style={{
+            width: 200,
+            height: 200,
+            position: 'absolute',
+            left: 0,
+            top: 0,
+          }}
+          data-uid='remix-div'
+        >
+          ${DefaultRouteTextContent}
+        </div>
+      }
+      `,
+    })
+
+    const renderResult = await renderRemixProject(project)
+    const outletItemElement = renderResult.renderedDOM.getByTestId(
+      NavigatorItemTestId(
+        varSafeNavigatorEntryToKey(
+          regularNavigatorEntry(EP.fromString('storyboard/remix-scene:rootdiv/outlet')),
+        ),
+      ),
+    )
+    expect(outletItemElement.textContent).toEqual('Outlet: Index')
+  })
 })

--- a/editor/src/components/canvas/remix/remix-utils.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.tsx
@@ -38,6 +38,7 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import type { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import { getAllUniqueUids } from '../../../core/model/get-unique-ids'
+import { safeIndex } from '../../../core/shared/array-utils'
 
 export const OutletPathContext = React.createContext<ElementPath | null>(null)
 
@@ -399,12 +400,13 @@ export function getRouteComponentNameForOutlet(
   }
 
   const outletChildren = MetadataUtils.getImmediateChildrenPathsOrdered(metadata, pathTrees, path)
-  if (outletChildren.length == 0) {
+  const outletChild = safeIndex(outletChildren, 0)
+  if (outletChild == null) {
     return null
   }
 
   const uidsToFilePath = getAllUniqueUids(projectContents).uidsToFilePaths
-  const filePath = uidsToFilePath[EP.toUid(outletChildren[0])]
+  const filePath = uidsToFilePath[EP.toUid(outletChild)]
   if (filePath == null) {
     return null
   }

--- a/editor/src/components/editor/store/store-hook-substore-types.ts
+++ b/editor/src/components/editor/store/store-hook-substore-types.ts
@@ -159,6 +159,8 @@ export type CanvasAndMetadataSubstate = {
   editor: Pick<EditorState, 'jsxMetadata'>
 } & CanvasSubstate
 
+export type ProjectContentAndMetadataSubstate = ProjectContentSubstate & MetadataSubstate
+
 export type NavigatorSubstate = {
   editor: Pick<EditorState, 'navigator'>
 }

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -23,6 +23,7 @@ import type {
   MetadataSubstate,
   NavigatorSubstate,
   PostActionInteractionSessionSubstate,
+  ProjectContentAndMetadataSubstate,
   ProjectContentSubstate,
   RestOfEditorState,
   SelectedViewsSubstate,
@@ -291,6 +292,12 @@ export const Substores = {
     b: PostActionInteractionSessionSubstate,
   ) => {
     return a.postActionInteractionSession === b.postActionInteractionSession
+  },
+  projectContentsAndMetadata: (
+    a: ProjectContentAndMetadataSubstate,
+    b: ProjectContentAndMetadataSubstate,
+  ) => {
+    return keysEquality([...projectContentsKeys, ...metadataSubstateKeys], a.editor, b.editor)
   },
 } as const
 

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -294,7 +294,7 @@ export const ConditionalSection = React.memo(({ paths }: { paths: ElementPath[] 
   )
 
   const branchLabels = useEditorState(
-    Substores.metadata,
+    Substores.projectContentsAndMetadata,
     (store) => {
       function getLabel(entry: NavigatorEntry | null) {
         if (entry == null) {

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -32,6 +32,7 @@ import { Substores, useEditorState } from '../../editor/store/store-hook'
 import type {
   DerivedSubstate,
   MetadataSubstate,
+  ProjectContentAndMetadataSubstate,
   ProjectContentSubstate,
 } from '../../editor/store/store-hook-substore-types'
 import type {
@@ -98,11 +99,11 @@ const elementSupportsChildrenSelector = createCachedSelector(
 )((_, navigatorEntry) => navigatorEntryToKey(navigatorEntry))
 
 export const labelSelector = createCachedSelector(
-  (store: MetadataSubstate & ProjectContentSubstate) => store.editor.jsxMetadata,
+  (store: ProjectContentAndMetadataSubstate) => store.editor.jsxMetadata,
   targetElementMetadataSelector,
-  (store: MetadataSubstate & ProjectContentSubstate) => store.editor.allElementProps,
-  (store: MetadataSubstate & ProjectContentSubstate) => store.editor.elementPathTree,
-  (store: MetadataSubstate & ProjectContentSubstate) => store.editor.projectContents,
+  (store: ProjectContentAndMetadataSubstate) => store.editor.allElementProps,
+  (store: ProjectContentAndMetadataSubstate) => store.editor.elementPathTree,
+  (store: ProjectContentAndMetadataSubstate) => store.editor.projectContents,
   (metadata, elementMetadata, allElementProps, pathTrees, projectContents) => {
     if (elementMetadata == null) {
       // "Element" with ghost emoji.


### PR DESCRIPTION
**Description:**
Remix Outlet is a component with special behavior: during render it is replaced by the default exported component of the actual Remix route file.
But that route component is invisible in the navigator and does not appear in our metadata hierarchy.
As a minimal way to show which route component is rendered, I added the component name to the Outlet navigator item's label, e.g.:

<img width="237" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/b16f9d9b-b2c1-4a2a-a066-7596be383db3">

