### PR TITLE
explicitly await loading of feature switches before loading the Editor

### DIFF
--- a/editor/src/templates/editor-entry-point.tsx
+++ b/editor/src/templates/editor-entry-point.tsx
@@ -7,7 +7,8 @@
 import '../vite-shims'
 
 // import feature switches so they are loaded before anything else can read them
-import '../utils/feature-switches'
+import { loadFeatureSwitches } from '../utils/feature-switches'
+await loadFeatureSwitches()
 
 // Fire off server requests that later block, to improve initial load on slower connections. These will still block,
 // but this gives us a chance to cache the result first

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -47,6 +47,8 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Debug - Print UIDs': false,
 }
 
+let FeatureSwitchLoaded: { [feature in FeatureName]?: boolean } = {}
+
 function settingKeyForName(featureName: FeatureName): string {
   return `Feature-Switch-${featureName}`
 }
@@ -54,18 +56,36 @@ function settingKeyForName(featureName: FeatureName): string {
 async function loadStoredValue(featureName: FeatureName) {
   if (isBrowserEnvironment && !IS_TEST_ENVIRONMENT) {
     const existing = await localforage.getItem<boolean | null>(settingKeyForName(featureName))
+    FeatureSwitchLoaded[featureName] = true
     if (existing != null) {
       FeatureSwitches[featureName] = existing
     }
+    return true
+  } else {
+    return true
   }
 }
 
 // Load stored settings
-fastForEach(AllFeatureNames, (name) => {
-  void loadStoredValue(name)
-})
+export async function loadFeatureSwitches(): Promise<void> {
+  if (IS_TEST_ENVIRONMENT) {
+    // in test environments, we actually don't want to load from localforage, ever
+    return
+  }
+  await Promise.all(
+    AllFeatureNames.map((name) => {
+      return loadStoredValue(name)
+    }),
+  )
+}
 
 export function isFeatureEnabled(featureName: FeatureName): boolean {
+  if (FeatureSwitchLoaded[featureName] !== true) {
+    if (!IS_TEST_ENVIRONMENT) {
+      // in test environments, we actually don't want to load from localforage, ever
+      throw new Error(`Reading FS before it was loaded! ${featureName}`)
+    }
+  }
   return FeatureSwitches[featureName] ?? false
 }
 


### PR DESCRIPTION
**Problem:**
We would load the editor before LocalForage had a chance to load the feature switch configuration. This would lead to a race condition between the first reads of the feature flags vs actually loading what the user picked. 

This issue was mostly masked by the fact that _most_ feature switches are re-read every time we execute code, ie for each dispatch we check if we should run debug logging.

But _some_ feature switches would be read only once at startup, and then never again, or not for a while. For example, the old panel layout vs the floating panels feature switch would evaluate once and not re-eval until the user actually interacted with the panels code.

**Fix:**
Await loading the feature switches before we load the editor

**Commit Details:**
- New async function `loadFeatureSwitches`
- editor entry point awaits `loadFeatureSwitches`
- For tests, we _never_ read from localforage, we use the default values, or the values set by the test environment
- For the actual non-test editor, we throw a new Error if we try to read a feature switch value that hasn't been initialized yet
