### PR TITLE
redirect performance tests to the regular github action runners

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -212,7 +212,7 @@ jobs:
 
   performance-test:
     name: Run Performance Tests
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [deploy-staging, cache-pnpm-store]
     env:
       UTOPIA_SHA: ${{ github.sha }}


### PR DESCRIPTION
**Problem:**
Our Linode is down for now

**Fix:**
Change the config so that `Run Performance Tests` runs on the regular github action runner
