### PR TITLE
Do not autolock root element when it is a leaf

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -757,7 +757,12 @@ function editorDispatchInner(
       const priorSimpleLocks = storedState.unpatchedEditor.lockedElements.simpleLock
       const updatedSimpleLocks = doNotUpdateLocks
         ? priorSimpleLocks
-        : updateSimpleLocks(storedState.unpatchedEditor.jsxMetadata, metadata, priorSimpleLocks)
+        : updateSimpleLocks(
+            storedState.unpatchedEditor.jsxMetadata,
+            metadata,
+            elementPathTree,
+            priorSimpleLocks,
+          )
       if (result.unpatchedEditor.canvas.interactionSession != null) {
         result = {
           ...result,

--- a/editor/src/core/shared/element-locking.spec.browser2.tsx
+++ b/editor/src/core/shared/element-locking.spec.browser2.tsx
@@ -1,0 +1,65 @@
+import { renderTestEditorWithCode } from '../../components/canvas/ui-jsx.test-utils'
+import * as EP from './element-path'
+
+function testCode(snippet: string) {
+  return `
+import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <Scene
+      style={{
+        width: 700,
+        height: 759,
+        position: 'absolute',
+        left: 10,
+        top: 10,
+      }}
+      data-uid='sc'
+    >
+      <App data-uid='app' />
+    </Scene>
+    {
+      // @utopia/uid=1e7
+      null
+    }
+  </Storyboard>
+)
+
+export var App = (props) => {
+  return (
+    <div
+      style={{
+        height: '100%',
+        width: '100%',
+        contain: 'layout',
+      }}
+      data-uid='app-root'
+    >
+     ${snippet}
+    </div>
+  )
+}`
+}
+
+describe('Auto-locking elements', () => {
+  it('Root element of component locked when it is not a leaf element', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      testCode('<div>Hello</div>'),
+      'await-first-dom-report',
+    )
+
+    expect(renderResult.getEditorState().editor.lockedElements.simpleLock.map(EP.toString)).toEqual(
+      ['sb/sc/app:app-root'],
+    )
+  })
+
+  it('Root element of component is not locked when it is a leaf element', async () => {
+    const renderResult = await renderTestEditorWithCode(testCode('Hello'), 'await-first-dom-report')
+
+    expect(renderResult.getEditorState().editor.lockedElements.simpleLock.map(EP.toString)).toEqual(
+      [],
+    )
+  })
+})

--- a/editor/src/core/shared/element-locking.spec.browser2.tsx
+++ b/editor/src/core/shared/element-locking.spec.browser2.tsx
@@ -20,10 +20,6 @@ export var storyboard = (
     >
       <App data-uid='app' />
     </Scene>
-    {
-      // @utopia/uid=1e7
-      null
-    }
   </Storyboard>
 )
 

--- a/editor/src/core/shared/element-locking.ts
+++ b/editor/src/core/shared/element-locking.ts
@@ -8,6 +8,7 @@ import { MetadataUtils } from '../model/element-metadata-utils'
 export function updateSimpleLocks(
   priorMetadata: ElementInstanceMetadataMap,
   newMetadata: ElementInstanceMetadataMap,
+  pathTree: ElementPathTrees,
   currentSimpleLockedItems: Array<ElementPath>,
 ): Array<ElementPath> {
   let result: Array<ElementPath> = [...currentSimpleLockedItems]
@@ -15,9 +16,11 @@ export function updateSimpleLocks(
     // This entry is the root element of an instance or a remix Outlet, and it isn't present in the previous metadata,
     // which implies that it has been newly added.
     if (
-      (EP.isRootElementOfInstance(value.elementPath) ||
-        MetadataUtils.isProbablyRemixOutlet(newMetadata, value.elementPath)) &&
-      !(key in priorMetadata)
+      !(key in priorMetadata) &&
+      ((EP.isRootElementOfInstance(value.elementPath) &&
+        MetadataUtils.getChildrenPathsOrdered(newMetadata, pathTree, value.elementPath).length >
+          0) ||
+        MetadataUtils.isProbablyRemixOutlet(newMetadata, value.elementPath))
     ) {
       result.push(value.elementPath)
     }

--- a/editor/src/core/shared/element-locking.ts
+++ b/editor/src/core/shared/element-locking.ts
@@ -13,15 +13,19 @@ export function updateSimpleLocks(
 ): Array<ElementPath> {
   let result: Array<ElementPath> = [...currentSimpleLockedItems]
   for (const [key, value] of Object.entries(newMetadata)) {
-    // This entry is the root element of an instance or a remix Outlet, and it isn't present in the previous metadata,
-    // which implies that it has been newly added.
-    if (
-      !(key in priorMetadata) &&
-      ((EP.isRootElementOfInstance(value.elementPath) &&
-        MetadataUtils.getChildrenPathsOrdered(newMetadata, pathTree, value.elementPath).length >
-          0) ||
-        MetadataUtils.isProbablyRemixOutlet(newMetadata, value.elementPath))
-    ) {
+    // The entry isn't present in the previous metadata, which implies that it has been newly added.
+    const isNewlyAdded = !(key in priorMetadata)
+
+    // You rarely want to select a root element of a component instance, except when it is a leaf element
+    const isNonLeafRootElement =
+      EP.isRootElementOfInstance(value.elementPath) &&
+      MetadataUtils.getChildrenPathsOrdered(newMetadata, pathTree, value.elementPath).length > 0
+
+    // Remix Outlet are rarely needed to be selected
+    const isRemixOutlet = MetadataUtils.isProbablyRemixOutlet(newMetadata, value.elementPath)
+
+    // This entry is a newly added non-leaf root element or a remix Outlet, it should be autolocked
+    if (isNewlyAdded && (isNonLeafRootElement || isRemixOutlet)) {
       result.push(value.elementPath)
     }
   }


### PR DESCRIPTION
**Problem:**
We automatically lock the root element of components since https://github.com/concrete-utopia/utopia/pull/3901
However, there is a case when this doesn't feel good: When the root element is a leaf element (so it doesn't have children), then it is not possible to select the contents of this component at all.

**Fix:**
Only autolock root elements when they don't have children