### PR TITLE
Allow export default identifier in remix route files

### DIFF
--- a/editor/src/components/canvas/remix/remix-rendering.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-rendering.spec.browser2.tsx
@@ -125,6 +125,49 @@ describe('Remix content', () => {
     await expectRemixSceneToBeRendered(renderResult)
   })
 
+  it('Renders the remix project with separate export default statement in route file', async () => {
+    const project = createModifiedProject({
+      [StoryboardFilePath]: `import * as React from 'react'
+      import { RemixScene, Storyboard } from 'utopia-api'
+      
+      export var storyboard = (
+        <Storyboard>
+          <RemixScene
+            style={{
+              width: 700,
+              height: 759,
+              position: 'absolute',
+              left: 212,
+              top: 128,
+            }}
+            data-label='Playground'
+          />
+        </Storyboard>
+      )
+      `,
+      ['/src/root.js']: `import React from 'react'
+      import { Outlet } from '@remix-run/react'
+      
+      export default function Root() {
+        return (
+          <div>
+            ${RootTextContent}
+            <Outlet />
+          </div>
+        )
+      }
+      `,
+      ['/src/routes/_index.js']: `import React from 'react'
+
+      const Index = () => (<h1>${DefaultRouteTextContent}</h1>)
+      export default Index
+      `,
+    })
+
+    const renderResult = await renderRemixProject(project)
+    await expectRemixSceneToBeRendered(renderResult)
+  })
+
   it('Remix content has metadata', async () => {
     const project = createModifiedProject({
       [StoryboardFilePath]: `import * as React from 'react'

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -659,7 +659,7 @@ export function attemptToResolveParsedComponents(
                 addToFilteredScope('default', exportDetail.name)
               }
               break
-            case 'EXPORT_IDENTIFIER':
+            case 'EXPORT_DEFAULT_IDENTIFIER':
               addToFilteredScope('default', exportDetail.name)
               break
             case 'EXPORT_CLASS':

--- a/editor/src/components/editor/export-utils.ts
+++ b/editor/src/components/editor/export-utils.ts
@@ -115,7 +115,7 @@ export function getExportedComponentImports(
               )
             }
             break
-          case 'EXPORT_IDENTIFIER':
+          case 'EXPORT_DEFAULT_IDENTIFIER':
             addToResult(
               exportDetail.name,
               exportDetail.name,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -17,7 +17,7 @@ import type {
   ExportDestructuredAssignment,
   ExportDetail,
   ExportFunction,
-  ExportIdentifier,
+  ExportDefaultIdentifier,
   ExportVariable,
   ExportVariables,
   ExportVariablesWithModifier,
@@ -48,7 +48,7 @@ import {
   exportDefaultFunctionOrClass,
   exportDestructuredAssignment,
   exportFunction,
-  exportIdentifier,
+  exportDefaultIdentifier,
   exportVariable,
   exportVariables,
   exportVariablesWithModifier,
@@ -2576,8 +2576,8 @@ export const ExportDefaultFunctionOrClassKeepDeepEquality: KeepDeepEqualityCall<
     exportDefaultFunctionOrClass,
   )
 
-export const ExportIdentifierKeepDeepEquality: KeepDeepEqualityCall<ExportIdentifier> =
-  combine1EqualityCall((expIdent) => expIdent.name, StringKeepDeepEquality, exportIdentifier)
+export const ExportIdentifierKeepDeepEquality: KeepDeepEqualityCall<ExportDefaultIdentifier> =
+  combine1EqualityCall((expIdent) => expIdent.name, StringKeepDeepEquality, exportDefaultIdentifier)
 
 export const ReexportWildcardKeepDeepEquality: KeepDeepEqualityCall<ReexportWildcard> =
   combine2EqualityCalls(
@@ -2632,7 +2632,7 @@ export const ExportDetailKeepDeepEquality: KeepDeepEqualityCall<ExportDetail> = 
         return ExportDefaultFunctionOrClassKeepDeepEquality(oldValue, newValue)
       }
       break
-    case 'EXPORT_IDENTIFIER':
+    case 'EXPORT_DEFAULT_IDENTIFIER':
       if (newValue.type === oldValue.type) {
         return ExportIdentifierKeepDeepEquality(oldValue, newValue)
       }

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -18,6 +18,8 @@ import type {
   TextFileContents,
   HighlightBoundsWithFileForUids,
   RevisionsStateType,
+  ExportDefaultIdentifier,
+  ExportDefaultFunctionOrClass,
 } from '../shared/project-file-types'
 import {
   RevisionsState,
@@ -28,6 +30,8 @@ import {
   forEachParseSuccess,
   isParseSuccess,
   isExportDefaultFunctionOrClass,
+  isExportDefaultIdentifier,
+  isExportDefault,
 } from '../shared/project-file-types'
 import type {
   JSXElementChild,
@@ -876,7 +880,7 @@ export function getDefaultExportNameAndUidFromFile(
   }
 
   const defaultExportName =
-    file.fileContents.parsed.exportsDetail.find(isExportDefaultFunctionOrClass)?.name ?? null
+    file.fileContents.parsed.exportsDetail.find(isExportDefault)?.name ?? null
 
   if (defaultExportName == null) {
     return null

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -18,8 +18,6 @@ import type {
   TextFileContents,
   HighlightBoundsWithFileForUids,
   RevisionsStateType,
-  ExportDefaultIdentifier,
-  ExportDefaultFunctionOrClass,
 } from '../shared/project-file-types'
 import {
   RevisionsState,
@@ -30,7 +28,6 @@ import {
   forEachParseSuccess,
   isParseSuccess,
   isExportDefaultFunctionOrClass,
-  isExportDefaultIdentifier,
   isExportDefault,
 } from '../shared/project-file-types'
 import type {

--- a/editor/src/core/model/storyboard-utils.ts
+++ b/editor/src/core/model/storyboard-utils.ts
@@ -226,7 +226,7 @@ export function addStoryboardFileToProject(editorModel: EditorModel): EditorMode
                   }
                 }
                 break
-              case 'EXPORT_IDENTIFIER':
+              case 'EXPORT_DEFAULT_IDENTIFIER':
                 {
                   const possibleMainComponentName = PossiblyMainComponentNames.includes(
                     exportDetail.name,

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -262,16 +262,26 @@ export function isExportDefaultFunctionOrClass(e: ExportDetail): e is ExportDefa
 
 // const App = (…) { … }
 // export default App;
-export interface ExportIdentifier {
-  type: 'EXPORT_IDENTIFIER'
+export interface ExportDefaultIdentifier {
+  type: 'EXPORT_DEFAULT_IDENTIFIER'
   name: string
 }
 
-export function exportIdentifier(name: string): ExportIdentifier {
+export function exportDefaultIdentifier(name: string): ExportDefaultIdentifier {
   return {
-    type: 'EXPORT_IDENTIFIER',
+    type: 'EXPORT_DEFAULT_IDENTIFIER',
     name: name,
   }
+}
+
+export function isExportDefaultIdentifier(e: ExportDetail): e is ExportDefaultIdentifier {
+  return e.type === 'EXPORT_DEFAULT_IDENTIFIER'
+}
+
+export function isExportDefault(
+  e: ExportDetail,
+): e is ExportDefaultIdentifier | ExportDefaultFunctionOrClass {
+  return isExportDefaultFunctionOrClass(e) || isExportDefaultIdentifier(e)
 }
 
 // export * from …; // does not set the default export
@@ -320,7 +330,7 @@ export type ExportDetail =
   | ExportVariables
   | ExportDestructuredAssignment
   | ExportDefaultFunctionOrClass
-  | ExportIdentifier
+  | ExportDefaultIdentifier
   | ReexportWildcard
   | ReexportVariables
 

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -100,7 +100,7 @@ import {
   exportVariablesWithModifier,
   parseFailure,
   parseSuccess,
-  exportIdentifier,
+  exportDefaultIdentifier,
   isImportSideEffects,
   isParseSuccess,
 } from '../../shared/project-file-types'
@@ -626,7 +626,7 @@ function getModifersForComponent(
         break
       case 'EXPORT_VARIABLES':
         break
-      case 'EXPORT_IDENTIFIER':
+      case 'EXPORT_DEFAULT_IDENTIFIER':
         break
       case 'EXPORT_DESTRUCTURED_ASSIGNMENT':
         break
@@ -1130,7 +1130,7 @@ function detailsFromExportAssignment(
   declaration: TS.ExportAssignment,
 ): Either<TS.ExportAssignment, ExportDetail> {
   if (TS.isIdentifier(declaration.expression)) {
-    return right(exportIdentifier(declaration.expression.getText(sourceFile)))
+    return right(exportDefaultIdentifier(declaration.expression.getText(sourceFile)))
   } else if (TS.isArrowFunction(declaration.expression)) {
     return right(exportDefaultFunctionOrClass(null))
   } else {
@@ -1365,7 +1365,7 @@ export function parseCode(
         forEachRight(fromAssignment, (toMerge) => {
           detailOfExports = detailOfExports.concat(toMerge)
 
-          if (toMerge.type === 'EXPORT_IDENTIFIER') {
+          if (toMerge.type === 'EXPORT_DEFAULT_IDENTIFIER') {
             pushUnparsedCode(topLevelElement.getText(sourceFile))
           } else {
             pushArbitraryNode(topLevelElement)


### PR DESCRIPTION
**Problem:**
Remix routes need to have a default export component (which is rendered in place of the Outlet).
Until now we did not accept the syntax to separately export the component in an `export default <identifer>` line.

**Fix:**
At first I thought we do not parse these exports because they were called `EXPORT_IDENTIFIER` which does not really express that these are always default exports.
So I also renamed these to `EXPORT_DEFAULT_IDENTIFIER` to make this more clear