### PR TITLE
Changes to the strategy indication in the toolbar.

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/strategy-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/strategy-indicator.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import {
   FlexColumn,
   FlexRow,
+  Icons,
   ModalityIcons,
   useColorTheme,
   UtopiaStyles,
@@ -65,57 +66,37 @@ export const StrategyIndicator = React.memo(() => {
 })
 
 interface MoveIndicatorItemProps {
-  dragType: 'absolute' | 'static' | 'none'
-  reparentStatus: 'same-component' | 'different-component' | 'none'
+  dragType: DragToMoveIndicatorFlags['dragType']
+  reparentStatus: DragToMoveIndicatorFlags['reparent']
 }
 
 const MoveReorderReparentIndicator = React.memo<MoveIndicatorItemProps>((props) => {
   const colorTheme = useColorTheme()
   return (
-    <FlexRow style={{ height: 32 }}>
-      <FlexRow style={{}}>
-        <div
-          style={{
-            padding: 7,
-          }}
-        >
-          {(() => {
-            if (props.reparentStatus !== 'none') {
-              return <ModalityIcons.Reparent color={'primary'} />
-            }
-            if (props.dragType === 'absolute') {
-              return <ModalityIcons.MoveAbsolute color={'primary'} />
-            }
-            if (props.dragType === 'static') {
-              return <ModalityIcons.Reorder color={'primary'} />
-            }
-            return <ModalityIcons.MoveAbsolute color={'subdued'} />
-          })()}
-        </div>
-      </FlexRow>
-      <div
-        style={{
-          color: props.dragType === 'none' ? colorTheme.fg8.value : colorTheme.primary.value,
-          minWidth: 110,
-        }}
-      >
-        {(() => {
-          if (props.reparentStatus !== 'none') {
-            if (props.dragType === 'absolute') {
-              return 'Absolute Reparent'
-            } else {
-              return 'Reparent'
-            }
-          }
+    <FlexRow
+      style={{
+        height: 32,
+        color: colorTheme.primary.value,
+        minWidth: 110,
+      }}
+    >
+      <Icons.Checkmark color='primary' />
+      {(() => {
+        if (props.reparentStatus !== 'none') {
           if (props.dragType === 'absolute') {
-            return 'Absolute Move'
+            return 'Absolute Reparent'
+          } else {
+            return 'Reparent'
           }
-          if (props.dragType === 'static') {
-            return 'Reorder'
-          }
-          return 'Interaction'
-        })()}
-      </div>
+        }
+        if (props.dragType === 'absolute') {
+          return 'Absolute Move'
+        }
+        if (props.dragType === 'static') {
+          return 'Reorder'
+        }
+        return 'Interaction'
+      })()}
     </FlexRow>
   )
 })
@@ -124,7 +105,6 @@ interface IndicatorItemProps {
   enabled: boolean
 }
 const AncestorIndicatorItem = React.memo<IndicatorItemProps>((props) => {
-  const colorTheme = useColorTheme()
   return (
     <FlexRow style={{ alignItems: 'center', paddingRight: 8 }}>
       <div
@@ -135,13 +115,6 @@ const AncestorIndicatorItem = React.memo<IndicatorItemProps>((props) => {
         <VisibilityWrapper visible={props.enabled}>
           <ModalityIcons.Magic color={'main'} />
         </VisibilityWrapper>
-      </div>
-      <div
-        style={{
-          color: colorTheme.fg1.value,
-        }}
-      >
-        {props.enabled ? 'Affects Ancestor' : 'Does not affect Ancestor'}
       </div>
     </FlexRow>
   )

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -39,6 +39,7 @@ import {
   useToInsert,
 } from './insert-callbacks'
 import { useDispatch } from './store/dispatch-context'
+import type { DragToMoveIndicatorFlags } from './store/editor-state'
 import { RightMenuTab } from './store/editor-state'
 import { Substores, useEditorState, useRefEditorState } from './store/store-hook'
 import { togglePanel } from './actions/action-creators'
@@ -46,7 +47,10 @@ import { defaultTransparentViewElement } from './defaults'
 import { generateUidWithExistingComponents } from '../../core/model/element-template-utils'
 import { useToolbarMode } from './canvas-toolbar-states'
 import { when } from '../../utils/react-conditionals'
-import { StrategyIndicator } from '../canvas/controls/select-mode/strategy-indicator'
+import {
+  StrategyIndicator,
+  useGetDragStrategyIndicatorFlags,
+} from '../canvas/controls/select-mode/strategy-indicator'
 import { toggleAbsolutePositioningCommands } from '../inspector/inspector-common'
 import { NO_OP } from '../../core/shared/utils'
 import type {
@@ -73,6 +77,7 @@ import {
   insertableComponentGroupFragment,
 } from '../shared/project-components'
 import { setFocus } from '../common/actions'
+import { replace } from 'tar'
 
 export const InsertMenuButtonTestId = 'insert-menu-button'
 export const InsertConditionalButtonTestId = 'insert-mode-conditional'
@@ -180,6 +185,38 @@ export const CanvasToolbarSearch = React.memo((props: CanvasToolbarSearchProps) 
   )
 })
 CanvasToolbarSearch.displayName = 'CanvasToolbarSearch'
+
+interface EditButtonIconDetails {
+  iconCategory: string
+  iconType: string
+}
+
+function editButtonIconDetails(iconCategory: string, iconType: string): EditButtonIconDetails {
+  return {
+    iconCategory: iconCategory,
+    iconType: iconType,
+  }
+}
+
+function getEditButtonIcon(
+  dragType: DragToMoveIndicatorFlags['dragType'],
+  reparentStatus: DragToMoveIndicatorFlags['reparent'],
+): EditButtonIconDetails {
+  if (dragType === 'none' && reparentStatus === 'none') {
+    return editButtonIconDetails('tools', 'pointer')
+  } else {
+    if (reparentStatus !== 'none') {
+      return editButtonIconDetails('modalities', 'reparent-large')
+    }
+    if (dragType === 'absolute') {
+      return editButtonIconDetails('modalities', 'moveabs-large')
+    }
+    if (dragType === 'static') {
+      return editButtonIconDetails('modalities', 'reorder-large')
+    }
+    return editButtonIconDetails('tools', 'pointer')
+  }
+}
 
 export const CanvasToolbar = React.memo(() => {
   const dispatch = useDispatch()
@@ -401,6 +438,14 @@ export const CanvasToolbar = React.memo(() => {
     }
   }, [canvasToolbarMode.primary, dispatch, switchToSelectModeCloseMenus])
 
+  const indicatorFlagsInfo = useGetDragStrategyIndicatorFlags()
+  const editButtonIcon = React.useMemo(() => {
+    return getEditButtonIcon(
+      indicatorFlagsInfo?.indicatorFlags.dragType ?? 'none',
+      indicatorFlagsInfo?.indicatorFlags.reparent ?? 'none',
+    )
+  }, [indicatorFlagsInfo?.indicatorFlags.dragType, indicatorFlagsInfo?.indicatorFlags.reparent])
+
   const wrapInSubmenu = React.useCallback((wrapped: React.ReactNode) => {
     return (
       <FlexRow
@@ -528,8 +573,8 @@ export const CanvasToolbar = React.memo(() => {
         >
           <Tooltip title='Edit' placement='bottom'>
             <InsertModeButton
-              iconType='pointer'
-              iconCategory='tools'
+              iconType={editButtonIcon.iconType}
+              iconCategory={editButtonIcon.iconCategory}
               primary={canvasToolbarMode.primary === 'edit'}
               onClick={switchToSelectModeCloseMenus}
             />

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -823,8 +823,8 @@ export function editorStateCanvasTransientProperty(
 
 export function dragToMoveIndicatorFlags(
   showIndicator: boolean,
-  dragType: 'absolute' | 'static' | 'none',
-  reparent: 'same-component' | 'different-component' | 'none',
+  dragType: DragToMoveIndicatorFlags['dragType'],
+  reparent: DragToMoveIndicatorFlags['reparent'],
   ancestor: boolean,
 ): DragToMoveIndicatorFlags {
   return {


### PR DESCRIPTION
**Change:**
Mostly this pulls the icon for the strategy up to the top toolbar to replace the arrow when a strategy is active. But there are also some smaller tweaks like removing the text relating to affecting ancestor and just keeping the icon for the indication.

**Screenshot:**
![image](https://github.com/concrete-utopia/utopia/assets/217400/940bb0fd-45ab-4707-9fa4-69d9e2e31f5f)

**Commit Details:**
- Shifted the icon for the strategy up to the primary row of the toolbar.
- Reused some types from `DragToMoveIndicatorFlags`.
- Implemented `getEditButtonIcon` as a way to get the icon details for that top toolbar button.