### PR TITLE
merge namespaced imports and default imports

### DIFF
--- a/editor/src/core/workers/common/project-file-utils.spec.ts
+++ b/editor/src/core/workers/common/project-file-utils.spec.ts
@@ -164,13 +164,70 @@ describe('mergeImports', () => {
   })
 
   it('merges namespaced import and default import without named imports', () => {
-    const result = mergeImports(
-      '/src/code.js',
-      { '/src/fileA.js': importDetails('FileA', [], null) },
-      { '/src/fileA.js': importDetails(null, [], 'FileA') },
-    )
+    {
+      const result = mergeImports(
+        '/src/code.js',
+        { library: importDetails('Library', [], null) },
+        { library: importDetails(null, [], 'Library') },
+      )
 
-    expect(result).toEqual({ '/src/fileA.js': importDetails('FileA', [], null) })
+      /**
+       * import Library from 'library'
+       * import * as Library from 'library'
+       */
+      expect(result).toEqual({ library: importDetails('Library', [], null) })
+    }
+    {
+      const result = mergeImports(
+        '/src/code.js',
+        { LibraryToo: importDetails(null, [], 'library-too') },
+        { LibraryToo: importDetails('library-too', [], null) },
+      )
+
+      /**
+       * import * as Library from 'library'
+       * import Library from 'library'
+       * (same as the previous test but the other way around)
+       */
+      expect(result).toEqual({ LibraryToo: importDetails('library-too', [], null) })
+    }
+    {
+      const result = mergeImports(
+        '/src/code.js',
+        {
+          'death-star': importDetails(
+            'DeathStar',
+            [importAlias('hello', 'helloFn'), importAlias('General', 'GeneralComponent')],
+            null,
+          ),
+        },
+        {
+          'death-star': importDetails(
+            null,
+            [importAlias('there', 'thereFn'), importAlias('Kenobi', 'KenobiComponent')],
+            'DeathStar',
+          ),
+        },
+      )
+
+      /**
+       * import DeathStar, { hello as helloFn, General as GeneralComponent } from 'death-star'
+       * import * as DeathStar, { there as thereFn, Kenobi as KenobiComponent } from 'death-star'
+       */
+
+      expect(result).toEqual({
+        'death-star': importDetails(
+          'DeathStar',
+          [
+            importAlias('hello', 'helloFn'),
+            importAlias('General', 'GeneralComponent'),
+            importAlias('there', 'thereFn'),
+            importAlias('Kenobi', 'KenobiComponent'),
+          ],
+          null,
+        ),
+      })
+    }
   })
 })
 

--- a/editor/src/core/workers/common/project-file-utils.spec.ts
+++ b/editor/src/core/workers/common/project-file-utils.spec.ts
@@ -162,6 +162,16 @@ describe('mergeImports', () => {
       '/src/fileA': importDetails(null, [importAlias('Card'), importAlias('OtherCard')], null),
     })
   })
+
+  it('merges namespaced import and default import without named imports', () => {
+    const result = mergeImports(
+      '/src/code.js',
+      { '/src/fileA.js': importDetails('FileA', [], null) },
+      { '/src/fileA.js': importDetails(null, [], 'FileA') },
+    )
+
+    expect(result).toEqual({ '/src/fileA.js': importDetails('FileA', [], null) })
+  })
 })
 
 describe('addImport', () => {

--- a/editor/src/core/workers/common/project-file-utils.spec.ts
+++ b/editor/src/core/workers/common/project-file-utils.spec.ts
@@ -174,6 +174,10 @@ describe('mergeImports', () => {
       /**
        * import Library from 'library'
        * import * as Library from 'library'
+       *
+       * becomes
+       *
+       * import Library from 'library'
        */
       expect(result).toEqual({ library: importDetails('Library', [], null) })
     }
@@ -213,6 +217,10 @@ describe('mergeImports', () => {
       /**
        * import DeathStar, { hello as helloFn, General as GeneralComponent } from 'death-star'
        * import * as DeathStar, { there as thereFn, Kenobi as KenobiComponent } from 'death-star'
+       *
+       * becomes
+       *
+       * import DeathStar, { hello as helloFn, General as GeneralComponent, there as thereFn, Kenobi as KenobiComponent } from 'death-star'
        */
 
       expect(result).toEqual({


### PR DESCRIPTION
## Problem
Even though
```typescript
import * as Name from 'somewhere'
```
and 
```typescript
import Name from 'somewhere'
``` 

mean the same, we still don't merge them, which can lead to duplicate import statements such as 
```typescript
import Name from 'somewhere`
import * as Name from 'somewhere'
``` 

## Fix
Special case this situation when merging imports. The implementation on this PR merges the imports into a default import (e.g. `import Name from 'somewhere'`).
