### PR TITLE
take original placeholder into account

### DIFF
--- a/editor/src/uuiui/inputs/base-input.tsx
+++ b/editor/src/uuiui/inputs/base-input.tsx
@@ -171,12 +171,12 @@ export const InspectorInput = React.memo(
 export const MixedPlaceholder = 'Mixed'
 export const UnknownPlaceholer = 'Unknown'
 
-export function getInputPlaceholder(controlStyles: ControlStyles): string {
+export function getConrolStylesAwarePlaceholder(controlStyles: ControlStyles): string | null {
   if (controlStyles.unknown) {
     return UnknownPlaceholer
-  } else if (controlStyles.mixed) {
-    return MixedPlaceholder
-  } else {
-    return ''
   }
+  if (controlStyles.mixed) {
+    return MixedPlaceholder
+  }
+  return null
 }

--- a/editor/src/uuiui/inputs/base-input.tsx
+++ b/editor/src/uuiui/inputs/base-input.tsx
@@ -171,12 +171,12 @@ export const InspectorInput = React.memo(
 export const MixedPlaceholder = 'Mixed'
 export const UnknownPlaceholer = 'Unknown'
 
-export function getConrolStylesAwarePlaceholder(controlStyles: ControlStyles): string | null {
+export function getControlStylesAwarePlaceholder(controlStyles: ControlStyles): string | undefined {
   if (controlStyles.unknown) {
     return UnknownPlaceholer
   }
   if (controlStyles.mixed) {
     return MixedPlaceholder
   }
-  return null
+  return undefined
 }

--- a/editor/src/uuiui/inputs/number-input.spec.browser2.tsx
+++ b/editor/src/uuiui/inputs/number-input.spec.browser2.tsx
@@ -1,0 +1,74 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "checkPlaceholder"] }] */
+import type { RenderResult } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import React from 'react'
+import {
+  getStoreHook,
+  TestInspectorContextProvider,
+} from '../../components/inspector/common/inspector.test-utils'
+import { NumberInput } from './number-input'
+
+describe('NumberInput', () => {
+  function checkPlaceholder(renderResult: RenderResult, expectedPlaceholder: string | null): void {
+    const inputElement = renderResult.queryByTestId('placeholdertest')
+    if (inputElement == null) {
+      throw new Error('Could not find input element.')
+    } else {
+      expect(inputElement.getAttribute('placeholder')).toEqual(expectedPlaceholder)
+    }
+  }
+  it('ensures that no placeholder property is in the input field by default', () => {
+    const storeHookForTest = getStoreHook()
+    const result = render(
+      <TestInspectorContextProvider
+        selectedViews={storeHookForTest.getState().editor.selectedViews}
+        editorStoreData={storeHookForTest}
+      >
+        <NumberInput
+          testId='placeholdertest'
+          controlStatus='simple'
+          value={null}
+          numberType={'AnyValid'}
+          defaultUnitToHide={null}
+        />
+      </TestInspectorContextProvider>,
+    )
+    checkPlaceholder(result, null)
+  })
+  it('ensures that the unknown control styles property shows in the input field', () => {
+    const storeHookForTest = getStoreHook()
+    const result = render(
+      <TestInspectorContextProvider
+        selectedViews={storeHookForTest.getState().editor.selectedViews}
+        editorStoreData={storeHookForTest}
+      >
+        <NumberInput
+          testId='placeholdertest'
+          controlStatus='multiselect-simple-unknown-css'
+          value={null}
+          numberType={'AnyValid'}
+          defaultUnitToHide={null}
+        />
+      </TestInspectorContextProvider>,
+    )
+    checkPlaceholder(result, 'Unknown')
+  })
+  it('ensures that the mixed control styles property shows in the input field', () => {
+    const storeHookForTest = getStoreHook()
+    const result = render(
+      <TestInspectorContextProvider
+        selectedViews={storeHookForTest.getState().editor.selectedViews}
+        editorStoreData={storeHookForTest}
+      >
+        <NumberInput
+          testId='placeholdertest'
+          controlStatus='multiselect-mixed-simple-or-unset'
+          value={null}
+          numberType={'AnyValid'}
+          defaultUnitToHide={null}
+        />
+      </TestInspectorContextProvider>,
+    )
+    checkPlaceholder(result, 'Mixed')
+  })
+})

--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -45,7 +45,7 @@ import { FlexRow } from '../widgets/layout/flex-row'
 import type { BaseInputProps, BoxCorners, ChainedType } from './base-input'
 import {
   getBorderRadiusStyles,
-  getConrolStylesAwarePlaceholder,
+  getControlStylesAwarePlaceholder,
   InspectorInput,
 } from './base-input'
 import { usePropControlledStateV2 } from '../../components/inspector/common/inspector-utils'
@@ -622,7 +622,7 @@ export const NumberInput = React.memo<NumberInputProps>(
       [scrubOnMouseMove, scrubOnMouseUp, setGlobalCursor, value],
     )
 
-    const placeholder = getConrolStylesAwarePlaceholder(controlStyles) ?? ''
+    const placeholder = getControlStylesAwarePlaceholder(controlStyles)
 
     const chainedStyles: Interpolation<any> | undefined =
       (chained === 'first' || chained === 'middle') && !isFocused

--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -43,7 +43,11 @@ import { Icn } from '../icn'
 import { useColorTheme, UtopiaTheme } from '../styles/theme'
 import { FlexRow } from '../widgets/layout/flex-row'
 import type { BaseInputProps, BoxCorners, ChainedType } from './base-input'
-import { getBorderRadiusStyles, getInputPlaceholder, InspectorInput } from './base-input'
+import {
+  getBorderRadiusStyles,
+  getConrolStylesAwarePlaceholder,
+  InspectorInput,
+} from './base-input'
 import { usePropControlledStateV2 } from '../../components/inspector/common/inspector-utils'
 
 export type LabelDragDirection = 'horizontal' | 'vertical'
@@ -618,7 +622,7 @@ export const NumberInput = React.memo<NumberInputProps>(
       [scrubOnMouseMove, scrubOnMouseUp, setGlobalCursor, value],
     )
 
-    const placeholder = getInputPlaceholder(controlStyles)
+    const placeholder = getConrolStylesAwarePlaceholder(controlStyles) ?? ''
 
     const chainedStyles: Interpolation<any> | undefined =
       (chained === 'first' || chained === 'middle') && !isFocused

--- a/editor/src/uuiui/inputs/string-input.spec.browser2.tsx
+++ b/editor/src/uuiui/inputs/string-input.spec.browser2.tsx
@@ -1,0 +1,50 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "checkPlaceholder"] }] */
+import type { RenderResult } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import React from 'react'
+import { StringInput } from './string-input'
+
+describe('StringInput', () => {
+  function checkPlaceholder(renderResult: RenderResult, expectedPlaceholder: string | null): void {
+    const inputElement = renderResult.queryByTestId('placeholdertest')
+    if (inputElement == null) {
+      throw new Error('Could not find input element.')
+    } else {
+      expect(inputElement.getAttribute('placeholder')).toEqual(expectedPlaceholder)
+    }
+  }
+  it('ensures that no placeholder property shows in the input field by default', () => {
+    const result = render(<StringInput testId='placeholdertest' controlStatus='simple' />)
+    checkPlaceholder(result, null)
+  })
+  it('ensures that the placeholder property shows in the input field', () => {
+    const result = render(
+      <StringInput
+        testId='placeholdertest'
+        placeholder='this is a placeholder'
+        controlStatus='simple'
+      />,
+    )
+    checkPlaceholder(result, 'this is a placeholder')
+  })
+  it('ensures that the unknown control styles property shows in the input field', () => {
+    const result = render(
+      <StringInput
+        testId='placeholdertest'
+        placeholder='this is a placeholder'
+        controlStatus='multiselect-simple-unknown-css'
+      />,
+    )
+    checkPlaceholder(result, 'Unknown')
+  })
+  it('ensures that the mixed control styles property shows in the input field', () => {
+    const result = render(
+      <StringInput
+        testId='placeholdertest'
+        placeholder='this is a placeholder'
+        controlStatus='multiselect-mixed-simple-or-unset'
+      />,
+    )
+    checkPlaceholder(result, 'Mixed')
+  })
+})

--- a/editor/src/uuiui/inputs/string-input.tsx
+++ b/editor/src/uuiui/inputs/string-input.tsx
@@ -9,7 +9,7 @@ import type { ControlStyles } from '../../components/inspector/common/control-st
 import { getControlStyles } from '../../components/inspector/common/control-styles'
 import { preventDefault, stopPropagation } from '../../components/inspector/common/inspector-utils'
 import { useColorTheme } from '../styles/theme'
-import { InspectorInputEmotionStyle, getInputPlaceholder } from './base-input'
+import { InspectorInputEmotionStyle, getConrolStylesAwarePlaceholder } from './base-input'
 
 interface StringInputOptions {
   focusOnMount?: boolean
@@ -73,7 +73,7 @@ export const StringInput = React.memo(
         [inputPropsKeyDown],
       )
 
-      const placeholder = getInputPlaceholder(controlStyles)
+      const placeholder = getConrolStylesAwarePlaceholder(controlStyles) ?? initialPlaceHolder
 
       return (
         <form

--- a/editor/src/uuiui/inputs/string-input.tsx
+++ b/editor/src/uuiui/inputs/string-input.tsx
@@ -9,7 +9,7 @@ import type { ControlStyles } from '../../components/inspector/common/control-st
 import { getControlStyles } from '../../components/inspector/common/control-styles'
 import { preventDefault, stopPropagation } from '../../components/inspector/common/inspector-utils'
 import { useColorTheme } from '../styles/theme'
-import { InspectorInputEmotionStyle, getConrolStylesAwarePlaceholder } from './base-input'
+import { InspectorInputEmotionStyle, getControlStylesAwarePlaceholder } from './base-input'
 
 interface StringInputOptions {
   focusOnMount?: boolean
@@ -73,7 +73,7 @@ export const StringInput = React.memo(
         [inputPropsKeyDown],
       )
 
-      const placeholder = getConrolStylesAwarePlaceholder(controlStyles) ?? initialPlaceHolder
+      const placeholder = getControlStylesAwarePlaceholder(controlStyles) ?? initialPlaceHolder
 
       return (
         <form


### PR DESCRIPTION
**Problem:**
The placeholder values weren't being properly applied in the Github pane for things like the branch name and commit message.

**Cause:**
The placeholder value passed into `StringInput` was being thrown away in preference to a default empty string returned from what is now called `getControlStylesAwarePlaceholder`.

**Fix:**
If nothing comes from the control styles for the placeholder then `StringInput` defaults to the `placeholder` property.

**Commit Details:**
- Renamed `getInputPlaceholder` to `getControlStylesAwarePlaceholder` to better represent what it's actually for.
- `getControlStylesAwarePlaceholder` now defaults to returning `undefined` instead of an empty string.
- `StringInput` now falls back on the `placeholder` property.
- Added browser tests for `StringInput` and `NumberInput`.