### PR TITLE
Remove `getRoutesFromRouteManifest`

### DIFF
--- a/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
@@ -5,7 +5,7 @@ import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
 import {
   DefaultFutureConfig,
   createRouteManifestFromProjectContents,
-  getRoutesFromRouteManifest,
+  getRoutesAndModulesFromManifest,
 } from './remix-utils'
 
 const storyboardFileContent = `
@@ -271,24 +271,34 @@ describe('Routes', () => {
       renderResult.getEditorState().editor.projectContents,
     )
     expect(remixManifest).not.toBeNull()
-    const remixRoutes = getRoutesFromRouteManifest(remixManifest!, DefaultFutureConfig)
+
+    let routeModuleCache = { current: {} }
+    const remixRoutes = getRoutesAndModulesFromManifest(
+      remixManifest!,
+      DefaultFutureConfig,
+      renderResult.getEditorState().editor.codeResultCache.curriedRequireFn,
+      renderResult.getEditorState().editor.codeResultCache.curriedResolveFn,
+      renderResult.getEditorState().editor.projectContents,
+      routeModuleCache.current,
+    )?.routes
+    expect(remixRoutes).toBeDefined()
 
     expect(remixRoutes).toHaveLength(1)
-    expect(remixRoutes[0]).toEqual(
+    expect(remixRoutes![0]).toEqual(
       expect.objectContaining({ id: 'root', path: '', index: undefined }),
     )
-    expect(remixRoutes[0].children).toHaveLength(3)
-    expect(remixRoutes[0]!.children![0]).toEqual(
+    expect(remixRoutes![0].children).toHaveLength(3)
+    expect(remixRoutes![0]!.children![0]).toEqual(
       expect.objectContaining({
         id: 'routes/posts.$postId',
         path: 'posts/:postId',
         index: undefined,
       }),
     )
-    expect(remixRoutes[0]!.children![1]).toEqual(
+    expect(remixRoutes![0]!.children![1]).toEqual(
       expect.objectContaining({ id: 'routes/posts._index', path: 'posts', index: true }),
     )
-    expect(remixRoutes[0]!.children![2]).toEqual(
+    expect(remixRoutes![0]!.children![2]).toEqual(
       expect.objectContaining({ id: 'routes/_index', path: undefined, index: true }),
     )
   })
@@ -311,43 +321,52 @@ describe('Routes', () => {
       renderResult.getEditorState().editor.projectContents,
     )
 
+    let routeModuleCache = { current: {} }
     expect(remixManifest).not.toBeNull()
-    const remixRoutes = getRoutesFromRouteManifest(remixManifest!, DefaultFutureConfig)
+    const remixRoutes = getRoutesAndModulesFromManifest(
+      remixManifest!,
+      DefaultFutureConfig,
+      renderResult.getEditorState().editor.codeResultCache.curriedRequireFn,
+      renderResult.getEditorState().editor.codeResultCache.curriedResolveFn,
+      renderResult.getEditorState().editor.projectContents,
+      routeModuleCache.current,
+    )?.routes
+    expect(remixRoutes).toBeDefined()
 
     expect(remixRoutes).toHaveLength(1)
-    expect(remixRoutes[0]).toEqual(
+    expect(remixRoutes![0]).toEqual(
       expect.objectContaining({ id: 'root', path: '', index: undefined }),
     )
 
-    expect(remixRoutes[0].children).toHaveLength(5)
-    expect(remixRoutes[0]!.children![0]).toEqual(
+    expect(remixRoutes![0].children).toHaveLength(5)
+    expect(remixRoutes![0]!.children![0]).toEqual(
       expect.objectContaining({
         id: 'routes/healthcheck',
         path: 'healthcheck',
         index: undefined,
       }),
     )
-    expect(remixRoutes[0]!.children![1]).toEqual(
+    expect(remixRoutes![0]!.children![1]).toEqual(
       expect.objectContaining({ id: 'routes/_index', path: undefined, index: true }),
     )
-    expect(remixRoutes[0]!.children![2]).toEqual(
+    expect(remixRoutes![0]!.children![2]).toEqual(
       expect.objectContaining({ id: 'routes/logout', path: 'logout', index: undefined }),
     )
-    expect(remixRoutes[0]!.children![3]).toEqual(
+    expect(remixRoutes![0]!.children![3]).toEqual(
       expect.objectContaining({ id: 'routes/notes', path: 'notes', index: undefined }),
     )
-    expect(remixRoutes[0]!.children![4]).toEqual(
+    expect(remixRoutes![0]!.children![4]).toEqual(
       expect.objectContaining({ id: 'routes/join', path: 'join', index: undefined }),
     )
 
-    expect(remixRoutes[0]!.children![3].children).toHaveLength(3)
-    expect(remixRoutes[0]!.children![3].children![0]).toEqual(
+    expect(remixRoutes![0]!.children![3].children).toHaveLength(3)
+    expect(remixRoutes![0]!.children![3].children![0]).toEqual(
       expect.objectContaining({ id: 'routes/notes.$noteId', path: ':noteId', index: undefined }),
     )
-    expect(remixRoutes[0]!.children![3].children![1]).toEqual(
+    expect(remixRoutes![0]!.children![3].children![1]).toEqual(
       expect.objectContaining({ id: 'routes/notes._index', path: undefined, index: true }),
     )
-    expect(remixRoutes[0]!.children![3].children![2]).toEqual(
+    expect(remixRoutes![0]!.children![3].children![2]).toEqual(
       expect.objectContaining({ id: 'routes/notes.new', path: 'new', index: undefined }),
     )
   })

--- a/editor/src/components/canvas/remix/remix-utils.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.tsx
@@ -59,7 +59,7 @@ export const DefaultFutureConfig: FutureConfig = {
 
 // This is necessary to create a simple node.fs-like implementation for Utopia projectContents, which
 // can be used by the Remix functions to parse the routes
-export function projectContentsToFileOps(projectContents: ProjectContentTreeRoot): FileOps {
+function projectContentsToFileOps(projectContents: ProjectContentTreeRoot): FileOps {
   return {
     existsSync: (file: string): boolean => getContentsTreeFromPath(projectContents, file) != null,
     readdirSync: (dir: string): Array<string> => {
@@ -130,7 +130,7 @@ export function createAssetsManifest(routes: RouteManifest<EntryRoute>): AssetsM
   }
 }
 
-export interface RouteModuleCreator {
+interface RouteModuleCreator {
   filePath: string
   executionScopeCreator: ExecutionScopeCreator
 }
@@ -146,7 +146,7 @@ export interface RouteModulesWithRelativePaths {
   }
 }
 
-export interface GetRoutesAndModulesFromManifestResult {
+interface GetRoutesAndModulesFromManifestResult {
   routeModuleCreators: RouteIdsToModuleCreators
   routes: Array<DataRouteObject>
   routeModulesToRelativePaths: RouteModulesWithRelativePaths


### PR DESCRIPTION
## Description
`getRoutesFromRouteManifest` ended up only used by the test testing it. This PR removes it and replaces it with `getRoutesAndModulesFromManifest` in the tests.