### PR TITLE
Provide descriptive labels and icons for canvas interactions.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -8,7 +8,6 @@ import type { ProjectContentTreeRoot } from '../../assets'
 import type { InsertionSubject } from '../../editor/editor-modes'
 import type { CanvasCommand } from '../commands/commands'
 import type { StrategyApplicationStatus } from './interaction-state'
-import { InteractionSession } from './interaction-state'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import type { RemixRoutingTable } from '../../editor/store/remix-derived-data'
 
@@ -155,6 +154,11 @@ export type CanvasStrategyId = string
 
 export type InteractionLifecycle = 'mid-interaction' | 'end-interaction'
 
+export interface CanvasStrategyIcon {
+  category: string
+  type: string
+}
+
 export interface CanvasStrategy {
   id: CanvasStrategyId // We'd need to do something to guarantee uniqueness here if using this for the commands' reason
   name: string
@@ -167,6 +171,12 @@ export interface CanvasStrategy {
 
   // Returns the commands that inform how the model and the editor should be updated
   apply: (strategyLifecycle: InteractionLifecycle) => StrategyApplicationResult
+
+  // Label to be shown to the user, not necessarily unique.
+  descriptiveLabel: string
+
+  // Icon to be shown in the UI when this strategy is active.
+  icon: CanvasStrategyIcon
 }
 
 export const ControlDelay = 600

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -20,7 +20,11 @@ import type { EdgePiece, EdgePosition } from '../canvas-types'
 import { MoveIntoDragThreshold } from '../canvas-utils'
 import type { CanvasCommand } from '../commands/commands'
 import type { ApplicableStrategy } from './canvas-strategies'
-import type { CanvasStrategyId, CustomStrategyState } from './canvas-strategy-types'
+import type {
+  CanvasStrategyIcon,
+  CanvasStrategyId,
+  CustomStrategyState,
+} from './canvas-strategy-types'
 import { defaultCustomStrategyState } from './canvas-strategy-types'
 import { ElementPasteWithMetadata } from '../../../utils/clipboard'
 
@@ -144,6 +148,8 @@ export interface StrategyState {
   // Need to track here which strategy is being applied.
   currentStrategy: CanvasStrategyId | null
   currentStrategyFitness: number
+  currentStrategyDescriptiveLabel: string | null
+  currentStrategyIcon: CanvasStrategyIcon | null
   currentStrategyCommands: Array<CanvasCommand>
   commandDescriptions: Array<CommandDescription>
   sortedApplicableStrategies: Array<ApplicableStrategy> | null
@@ -164,6 +170,8 @@ export function createEmptyStrategyState(
   return {
     currentStrategy: null,
     currentStrategyFitness: 0,
+    currentStrategyDescriptiveLabel: null,
+    currentStrategyIcon: null,
     currentStrategyCommands: [],
     commandDescriptions: [],
     sortedApplicableStrategies: null,

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.tsx
@@ -59,6 +59,11 @@ export function absoluteDuplicateStrategy(
   return {
     id: 'ABSOLUTE_DUPLICATE',
     name: 'Duplicate',
+    descriptiveLabel: 'Duplicating Elements',
+    icon: {
+      category: 'modalities',
+      type: 'replant-large',
+    },
     controlsToRender: [
       controlWithProps({
         control: ImmediateParentOutlines,

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
@@ -44,6 +44,8 @@ import {
 import { getDomRectCenter } from '../../../../core/shared/dom-utils'
 import { cartesianProduct } from '../../../../core/shared/array-utils'
 import { NO_OP } from '../../../../core/shared/utils'
+import { MoveReorderReparentIndicatorID } from '../../controls/select-mode/strategy-indicator'
+import { CanvasToolbarEditButtonID } from '../../../editor/canvas-toolbar'
 
 async function dragByPixels(
   editor: EditorRenderResult,
@@ -611,7 +613,18 @@ describe('Absolute Move Strategy', () => {
     const startPoint = windowPoint({ x: targetElementBounds.x + 5, y: targetElementBounds.y + 5 })
     const dragDelta = windowPoint({ x: 40, y: -25 })
 
-    await dragElement(canvasControlsLayer, startPoint, dragDelta, emptyModifiers)
+    await dragElement(canvasControlsLayer, startPoint, dragDelta, emptyModifiers, async () => {
+      const moveReorderReparentIndicator = renderResult.renderedDOM.getByTestId(
+        MoveReorderReparentIndicatorID,
+      )
+      expect(moveReorderReparentIndicator.innerText).toEqual('Moving Absolute Elements')
+      const toolbarEditButtonImage = renderResult.renderedDOM.getByTestId(
+        `${CanvasToolbarEditButtonID}-icon`,
+      )
+      expect(toolbarEditButtonImage.getAttribute('src')).toEqual(
+        'http://localhost:9876/editor/icons/light/modalities/moveabs-large-white-18x18@2x.png',
+      )
+    })
 
     await renderResult.getDispatchFollowUpActionsFinished()
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
@@ -46,6 +46,11 @@ export function absoluteMoveStrategy(
     strategy: {
       id: 'ABSOLUTE_MOVE',
       name: 'Move',
+      descriptiveLabel: 'Moving Absolute Elements',
+      icon: {
+        category: 'modalities',
+        type: 'moveabs-large',
+      },
       controlsToRender: [
         controlWithProps({
           control: ImmediateParentOutlines,

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
@@ -73,6 +73,11 @@ export function baseAbsoluteReparentStrategy(
     return {
       id: `ABSOLUTE_REPARENT`,
       name: `Reparent (Abs)`,
+      descriptiveLabel: 'Reparenting Absolute Elements',
+      icon: {
+        category: 'modalities',
+        type: 'reparent-large',
+      },
       controlsToRender: [
         controlWithProps({
           control: ParentOutlines,

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -74,6 +74,11 @@ export function absoluteResizeBoundingBoxStrategy(
   return {
     id: 'ABSOLUTE_RESIZE_BOUNDING_BOX',
     name: 'Resize',
+    descriptiveLabel: 'Resizing Elements',
+    icon: {
+      category: 'modalities',
+      type: 'moveabs-large',
+    },
     controlsToRender: [
       controlWithProps({
         control: AbsoluteResizeControl,

--- a/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
@@ -95,6 +95,11 @@ export function basicResizeStrategy(
   return {
     id: BASIC_RESIZE_STRATEGY_ID,
     name: 'Resize (Basic)',
+    descriptiveLabel: 'Resizing Elements',
+    icon: {
+      category: 'modalities',
+      type: 'moveabs-large',
+    },
     controlsToRender: [
       controlWithProps({
         control: AbsoluteResizeControl,

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -120,6 +120,11 @@ export function convertToAbsoluteAndMoveStrategy(
   return {
     id: ConvertToAbsoluteAndMoveStrategyID,
     name: 'Move (Abs)',
+    descriptiveLabel: 'Converting To Absolute And Moving',
+    icon: {
+      category: 'modalities',
+      type: 'moveabs-large',
+    },
     controlsToRender: [
       controlWithProps({
         control: ImmediateParentOutlines,

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
@@ -168,6 +168,8 @@ function dragToInsertStrategyFactory(
   return {
     id: name,
     name: name,
+    descriptiveLabel: 'Dragging To Insert',
+    icon: { category: 'tools', type: 'pointer' },
     controlsToRender: [
       controlWithProps({
         control: ParentOutlines,

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-move-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-move-metastrategy.tsx
@@ -130,6 +130,8 @@ export function doNothingStrategy(
   return {
     id: DoNothingStrategyID,
     name: 'No Default Available',
+    descriptiveLabel: 'Doing Nothing',
+    icon: { category: 'semantic', type: 'cross-medium' },
     controlsToRender: [
       controlWithProps({
         control: DragOutlineControl,

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -163,6 +163,8 @@ export function drawToInsertStrategyFactory(
   return {
     id: name,
     name: name,
+    descriptiveLabel: 'Drawing To Insert',
+    icon: { category: 'semantic', type: 'editpencil' },
     controlsToRender: [
       controlWithProps({
         control: ParentOutlines,

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
@@ -56,6 +56,8 @@ export const drawToInsertTextStrategy: MetaCanvasStrategy = (
     {
       id: DRAW_TO_INSERT_TEXT_STRATEGY_ID,
       name: name,
+      descriptiveLabel: 'Drawing To Insert Text',
+      icon: { category: 'semantic', type: 'editpencil' },
       controlsToRender: [],
       fitness: insertionSubject.textEdit && drawToInsertFitness(interactionSession) ? 1 : 0,
       apply: (s) => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reorder-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reorder-strategy.spec.browser2.tsx
@@ -20,6 +20,8 @@ import {
 import type { FragmentLikeType } from './fragment-like-helpers'
 import { AllFragmentLikeNonDomElementTypes, AllFragmentLikeTypes } from './fragment-like-helpers'
 import { fromString } from '../../../../core/shared/element-path'
+import { MoveReorderReparentIndicatorID } from '../../controls/select-mode/strategy-indicator'
+import { CanvasToolbarEditButtonID } from '../../../../components/editor/canvas-toolbar'
 
 const TestProject = (direction: string) => `
 <div
@@ -242,6 +244,16 @@ describe('Flex Reorder Strategy', () => {
         {
           modifiers: emptyModifiers,
           midDragCallback: async () => {
+            const moveReorderReparentIndicator = renderResult.renderedDOM.getByTestId(
+              MoveReorderReparentIndicatorID,
+            )
+            expect(moveReorderReparentIndicator.innerText).toEqual('Reordering Flex Elements')
+            const toolbarEditButtonImage = renderResult.renderedDOM.getByTestId(
+              `${CanvasToolbarEditButtonID}-icon`,
+            )
+            expect(toolbarEditButtonImage.getAttribute('src')).toEqual(
+              'http://localhost:9876/editor/icons/light/modalities/reorder-large-white-18x18@2x.png',
+            )
             expect(renderResult.getEditorState().strategyState.currentStrategy).toEqual(
               'FLEX_REORDER',
             )

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reorder-strategy.tsx
@@ -59,6 +59,11 @@ export function flexReorderStrategy(
     strategy: {
       id: 'FLEX_REORDER',
       name: 'Reorder (Flex)',
+      descriptiveLabel: 'Reordering Flex Elements',
+      icon: {
+        category: 'modalities',
+        type: 'reorder-large',
+      },
       controlsToRender: [
         controlWithProps({
           control: DragOutlineControl,

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
@@ -41,6 +41,11 @@ export function baseFlexReparentToAbsoluteStrategy(
     return {
       id: `FLEX_REPARENT_TO_ABSOLUTE`,
       name: `Reparent (Abs)`,
+      descriptiveLabel: 'Reparenting Flex Elements',
+      icon: {
+        category: 'modalities',
+        type: 'reparent-large',
+      },
       controlsToRender: [
         controlWithProps({
           control: ParentOutlines,

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-basic-strategy.tsx
@@ -94,6 +94,11 @@ export function flexResizeBasicStrategy(
   return {
     id: 'FLEX_RESIZE_BASIC',
     name: 'Flex Resize (Basic)',
+    descriptiveLabel: 'Resizing Flex Elements',
+    icon: {
+      category: 'modalities',
+      type: 'reorder-large',
+    },
     controlsToRender: [
       controlWithProps({
         control: AbsoluteResizeControl,

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-resize-strategy.tsx
@@ -112,6 +112,11 @@ export function flexResizeStrategy(
   return {
     id: FLEX_RESIZE_STRATEGY_ID,
     name: 'Flex Resize',
+    descriptiveLabel: 'Resizing Flex Elements',
+    icon: {
+      category: 'modalities',
+      type: 'reorder-large',
+    },
     controlsToRender: [
       controlWithProps({
         control: AbsoluteResizeControl,

--- a/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flow-reorder-strategy.tsx
@@ -58,6 +58,11 @@ export function flowReorderStrategy(
     strategy: {
       id: 'FLOW_REORDER',
       name: 'Reorder (Flow)',
+      descriptiveLabel: 'Reordering Elements',
+      icon: {
+        category: 'modalities',
+        type: 'reorder-large',
+      },
       controlsToRender: [
         controlWithProps({
           control: ImmediateParentOutlines,

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
@@ -52,6 +52,11 @@ export function keyboardAbsoluteMoveStrategy(
   return {
     id: 'KEYBOARD_ABSOLUTE_MOVE',
     name: 'Move',
+    descriptiveLabel: 'Moving Elements',
+    icon: {
+      category: 'modalities',
+      type: 'moveabs-large',
+    },
     controlsToRender: [], // Uses existing hooks in select-mode-hooks.tsx
     fitness: getFitness(interactionSession),
     apply: () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
@@ -128,6 +128,11 @@ export function keyboardAbsoluteResizeStrategy(
   return {
     id: 'KEYBOARD_ABSOLUTE_RESIZE',
     name: 'Resize',
+    descriptiveLabel: 'Resizing Elements',
+    icon: {
+      category: 'modalities',
+      type: 'moveabs-large',
+    },
     controlsToRender: [
       controlWithProps({
         control: AbsoluteResizeControl,

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-reorder-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-reorder-strategy.ts
@@ -58,6 +58,11 @@ export function keyboardReorderStrategy(
   return {
     id: 'KEYBOARD_REORDER',
     name: 'Reorder',
+    descriptiveLabel: 'Reordering Elements',
+    icon: {
+      category: 'modalities',
+      type: 'reorder-large',
+    },
     controlsToRender: [],
     fitness: fitness(interactionSession),
     apply: () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size-strategy.tsx
@@ -40,6 +40,11 @@ export function keyboardSetFontSizeStrategy(
   return {
     id: 'set-font-size',
     name: 'Set font size',
+    descriptiveLabel: 'Changing Font Size',
+    icon: {
+      category: 'element',
+      type: 'pure-text',
+    },
     controlsToRender: [],
     fitness: fitness(interactionSession),
     apply: () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight-strategy.tsx
@@ -35,6 +35,11 @@ export function keyboardSetFontWeightStrategy(
   return {
     id: 'set-font-weight',
     name: 'Set font weight',
+    descriptiveLabel: 'Changing Font Weight',
+    icon: {
+      category: 'element',
+      type: 'pure-text',
+    },
     controlsToRender: [],
     fitness: fitness(interactionSession),
     apply: () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
@@ -31,7 +31,7 @@ export function keyboardSetOpacityStrategy(
     descriptiveLabel: 'Changing Opacity',
     icon: {
       category: 'semantic',
-      type: 'twoghosts',
+      type: 'magnifyingglass',
     },
     controlsToRender: [],
     fitness: fitness(interactionSession),

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
@@ -28,6 +28,11 @@ export function keyboardSetOpacityStrategy(
   return {
     id: 'set-opacity',
     name: 'Set opacity',
+    descriptiveLabel: 'Changing Opacity',
+    icon: {
+      category: 'semantic',
+      type: 'twoghosts',
+    },
     controlsToRender: [],
     fitness: fitness(interactionSession),
     apply: () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/relative-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/relative-move-strategy.tsx
@@ -49,6 +49,11 @@ export function relativeMoveStrategy(
     strategy: {
       id: 'RELATIVE_MOVE',
       name: 'Move (Relative)',
+      descriptiveLabel: 'Moving Relative Elements',
+      icon: {
+        category: 'modalities',
+        type: 'moveabs-large',
+      },
       controlsToRender: [
         controlWithProps({
           control: ImmediateParentOutlines,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reorder-slider-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reorder-slider-strategy.tsx
@@ -55,6 +55,11 @@ export function reorderSliderStategy(
   return {
     id: 'REORDER_SLIDER',
     name: 'Reorder (Slider)',
+    descriptiveLabel: 'Reordering Elements',
+    icon: {
+      category: 'modalities',
+      type: 'reorder-large',
+    },
     controlsToRender: [
       controlWithProps({
         control: ReorderSliderControl,

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -57,7 +57,7 @@ export function baseReparentAsStaticStrategy(
     }
 
     return {
-      ...getIdAndNameOfReparentToStaticStrategy(targetLayout),
+      ...getDescriptivePropertiesOfReparentToStaticStrategy(targetLayout),
       controlsToRender: [
         controlWithProps({
           control: ParentOutlines,
@@ -103,20 +103,29 @@ export function baseReparentAsStaticStrategy(
   }
 }
 
-function getIdAndNameOfReparentToStaticStrategy(targetLayout: 'flex' | 'flow'): {
-  id: string
-  name: string
-} {
+function getDescriptivePropertiesOfReparentToStaticStrategy(
+  targetLayout: 'flex' | 'flow',
+): Pick<CanvasStrategy, 'id' | 'name' | 'descriptiveLabel' | 'icon'> {
   switch (targetLayout) {
     case 'flex':
       return {
         id: 'REPARENT_TO_FLEX',
         name: 'Reparent (Flex)',
+        descriptiveLabel: 'Reparenting Into A Flex Element',
+        icon: {
+          category: 'modalities',
+          type: 'reparent-large',
+        },
       }
     case 'flow':
       return {
         id: 'REPARENT_TO_FLOW',
         name: 'Reparent (Flow)',
+        descriptiveLabel: 'Reparenting Into A Flow Element',
+        icon: {
+          category: 'modalities',
+          type: 'reparent-large',
+        },
       }
     default:
       assertNever(targetLayout)

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -126,6 +126,11 @@ export const setBorderRadiusStrategy: CanvasStrategyFactory = (
   return {
     id: SetBorderRadiusStrategyId,
     name: 'Set border radius',
+    descriptiveLabel: 'Changing Border Radius',
+    icon: {
+      category: 'inspector',
+      type: 'border',
+    },
     fitness: onlyFitWhenDraggingThisControl(interactionSession, 'BORDER_RADIUS_RESIZE_HANDLE', 1),
     controlsToRender: [
       controlWithProps({

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
@@ -136,6 +136,11 @@ export const setFlexGapStrategy: CanvasStrategyFactory = (
   return {
     id: SetFlexGapStrategyId,
     name: 'Set flex gap',
+    descriptiveLabel: 'Changing Flex Gap',
+    icon: {
+      category: 'modalities',
+      type: 'reorder-large',
+    },
     controlsToRender: controlsToRender,
     fitness: onlyFitWhenDraggingThisControl(interactionSession, 'FLEX_GAP_HANDLE', 1),
     apply: () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -150,6 +150,8 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
     id: 'SET_PADDING_STRATEGY',
     name: SetPaddingStrategyName,
     controlsToRender: controlsToRender,
+    descriptiveLabel: 'Changing Padding',
+    icon: { category: 'semantic', type: 'canvas-larger' },
     fitness: onlyFitWhenDraggingThisControl(interactionSession, 'PADDING_RESIZE_HANDLE', 1),
     apply: () => {
       if (

--- a/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.spec.browser2.tsx
@@ -25,6 +25,8 @@ import { wait } from '../../../../utils/utils.test-utils'
 const BestStrategy: CanvasStrategy = {
   id: 'BEST_STRATEGY',
   name: 'Best Strategy',
+  descriptiveLabel: 'The Best Strategy',
+  icon: { category: 'semantic', type: 'editpencil' },
   controlsToRender: [],
   fitness: 10,
   apply: () => strategyApplicationResult([]),
@@ -33,6 +35,8 @@ const BestStrategy: CanvasStrategy = {
 const AverageStrategy: CanvasStrategy = {
   id: 'AVERAGE_STRATEGY',
   name: 'Average Strategy',
+  descriptiveLabel: 'A Very Average Strategy',
+  icon: { category: 'semantic', type: 'editpencil' },
   controlsToRender: [],
   fitness: 5,
   apply: () => strategyApplicationResult([]),
@@ -41,6 +45,8 @@ const AverageStrategy: CanvasStrategy = {
 const WorstStrategy: CanvasStrategy = {
   id: 'WORST_STRATEGY',
   name: 'Worst Strategy',
+  descriptiveLabel: 'The Worst Strategy',
+  icon: { category: 'semantic', type: 'editpencil' },
   controlsToRender: [],
   fitness: 1,
   apply: () => strategyApplicationResult([]),
@@ -49,6 +55,8 @@ const WorstStrategy: CanvasStrategy = {
 const UnfitStrategy: CanvasStrategy = {
   id: 'UNFIT_STRATEGY',
   name: 'Unfit Strategy',
+  descriptiveLabel: 'Terribly Unfit Strategy',
+  icon: { category: 'semantic', type: 'editpencil' },
   controlsToRender: [],
   fitness: 0,
   apply: () => strategyApplicationResult([]),

--- a/editor/src/components/canvas/controls/select-mode/strategy-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/strategy-indicator.tsx
@@ -56,21 +56,23 @@ export const StrategyIndicator = React.memo(() => {
       }}
       data-testid='drag-strategy-indicator'
     >
-      <MoveReorderReparentIndicator
-        dragType={indicatorFlagsInfo?.indicatorFlags.dragType ?? 'none'}
-        reparentStatus={indicatorFlagsInfo?.indicatorFlags.reparent ?? 'none'}
-      />
+      <MoveReorderReparentIndicator />
       <AncestorIndicatorItem enabled={indicatorFlagsInfo?.indicatorFlags.ancestor ?? false} />
     </FlexRow>
   )
 })
 
-interface MoveIndicatorItemProps {
-  dragType: DragToMoveIndicatorFlags['dragType']
-  reparentStatus: DragToMoveIndicatorFlags['reparent']
-}
+export const MoveReorderReparentIndicatorID = 'move-reorder-reparent-indicator'
 
-const MoveReorderReparentIndicator = React.memo<MoveIndicatorItemProps>((props) => {
+const MoveReorderReparentIndicator = React.memo(() => {
+  const currentStrategyState = useEditorState(
+    Substores.restOfStore,
+    (store) => store.strategyState,
+    'MoveReorderReparentIndicator currentStrategyState',
+  )
+  const indicatorText = React.useMemo(() => {
+    return currentStrategyState.currentStrategyDescriptiveLabel ?? 'Interaction'
+  }, [currentStrategyState.currentStrategyDescriptiveLabel])
   const colorTheme = useColorTheme()
   return (
     <FlexRow
@@ -79,24 +81,10 @@ const MoveReorderReparentIndicator = React.memo<MoveIndicatorItemProps>((props) 
         color: colorTheme.primary.value,
         minWidth: 110,
       }}
+      data-testid={MoveReorderReparentIndicatorID}
     >
       <Icons.Checkmark color='primary' />
-      {(() => {
-        if (props.reparentStatus !== 'none') {
-          if (props.dragType === 'absolute') {
-            return 'Absolute Reparent'
-          } else {
-            return 'Reparent'
-          }
-        }
-        if (props.dragType === 'absolute') {
-          return 'Absolute Move'
-        }
-        if (props.dragType === 'static') {
-          return 'Reorder'
-        }
-        return 'Interaction'
-      })()}
+      {indicatorText}
     </FlexRow>
   )
 })

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -183,7 +183,9 @@ describe('interactionStart', () => {
         "commandDescriptions": Array [],
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
+        "currentStrategyDescriptiveLabel": null,
         "currentStrategyFitness": 0,
+        "currentStrategyIcon": null,
         "customStrategyState": Object {
           "duplicatedElementNewUids": Object {},
           "elementsToRerender": Array [],
@@ -242,7 +244,9 @@ describe('interactionStart', () => {
         "commandDescriptions": Array [],
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
+        "currentStrategyDescriptiveLabel": null,
         "currentStrategyFitness": 0,
+        "currentStrategyIcon": null,
         "customStrategyState": Object {
           "duplicatedElementNewUids": Object {},
           "elementsToRerender": Array [],
@@ -318,7 +322,12 @@ describe('interactionUpdate', () => {
             "whenToRun": "always",
           },
         ],
+        "currentStrategyDescriptiveLabel": "A Test Strategy",
         "currentStrategyFitness": 10,
+        "currentStrategyIcon": Object {
+          "category": "modalities",
+          "type": "magic-large",
+        },
         "customStrategyState": Object {
           "duplicatedElementNewUids": Object {},
           "elementsToRerender": Array [],
@@ -332,7 +341,12 @@ describe('interactionUpdate', () => {
             "strategy": Object {
               "apply": [Function],
               "controlsToRender": Array [],
+              "descriptiveLabel": "A Test Strategy",
               "fitness": 10,
+              "icon": Object {
+                "category": "modalities",
+                "type": "magic-large",
+              },
               "id": "TEST_STRATEGY",
               "name": "Test Strategy",
             },
@@ -392,7 +406,9 @@ describe('interactionUpdate', () => {
         "commandDescriptions": Array [],
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
+        "currentStrategyDescriptiveLabel": null,
         "currentStrategyFitness": 0,
+        "currentStrategyIcon": null,
         "customStrategyState": Object {
           "duplicatedElementNewUids": Object {},
           "elementsToRerender": Array [],
@@ -462,7 +478,12 @@ describe('interactionHardReset', () => {
             "whenToRun": "always",
           },
         ],
+        "currentStrategyDescriptiveLabel": "A Test Strategy",
         "currentStrategyFitness": 10,
+        "currentStrategyIcon": Object {
+          "category": "modalities",
+          "type": "magic-large",
+        },
         "customStrategyState": Object {
           "duplicatedElementNewUids": Object {},
           "elementsToRerender": Array [],
@@ -476,7 +497,12 @@ describe('interactionHardReset', () => {
             "strategy": Object {
               "apply": [Function],
               "controlsToRender": Array [],
+              "descriptiveLabel": "A Test Strategy",
               "fitness": 10,
+              "icon": Object {
+                "category": "modalities",
+                "type": "magic-large",
+              },
               "id": "TEST_STRATEGY",
               "name": "Test Strategy",
             },
@@ -538,7 +564,9 @@ describe('interactionHardReset', () => {
         "commandDescriptions": Array [],
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
+        "currentStrategyDescriptiveLabel": null,
         "currentStrategyFitness": 0,
+        "currentStrategyIcon": null,
         "customStrategyState": Object {
           "duplicatedElementNewUids": Object {},
           "elementsToRerender": Array [],
@@ -622,7 +650,12 @@ describe('interactionUpdate with user changed strategy', () => {
             "whenToRun": "always",
           },
         ],
+        "currentStrategyDescriptiveLabel": "A Test Strategy",
         "currentStrategyFitness": 10,
+        "currentStrategyIcon": Object {
+          "category": "modalities",
+          "type": "magic-large",
+        },
         "customStrategyState": Object {
           "duplicatedElementNewUids": Object {},
           "elementsToRerender": Array [],
@@ -636,7 +669,12 @@ describe('interactionUpdate with user changed strategy', () => {
             "strategy": Object {
               "apply": [Function],
               "controlsToRender": Array [],
+              "descriptiveLabel": "A Test Strategy",
               "fitness": 10,
+              "icon": Object {
+                "category": "modalities",
+                "type": "magic-large",
+              },
               "id": "TEST_STRATEGY",
               "name": "Test Strategy",
             },
@@ -699,7 +737,9 @@ describe('interactionUpdate with user changed strategy', () => {
         "commandDescriptions": Array [],
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
+        "currentStrategyDescriptiveLabel": null,
         "currentStrategyFitness": 0,
+        "currentStrategyIcon": null,
         "customStrategyState": Object {
           "duplicatedElementNewUids": Object {},
           "elementsToRerender": Array [],

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -155,6 +155,11 @@ const testStrategy: MetaCanvasStrategy = (
         wildcardPatch('always', { canvas: { scale: { $set: 100 } } }),
       ])
     },
+    descriptiveLabel: 'A Test Strategy',
+    icon: {
+      category: 'modalities',
+      type: 'magic-large',
+    },
   },
 ]
 
@@ -868,6 +873,11 @@ describe('only update metadata on SAVE_DOM_REPORT', () => {
             name: 'Test Strategy',
             controlsToRender: [],
             fitness: 10,
+            descriptiveLabel: 'A Test Strategy',
+            icon: {
+              category: 'modalities',
+              type: 'magic-large',
+            },
             apply: function (): StrategyApplicationResult {
               if (interactionSession == null) {
                 return strategyApplicationResult([])

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -203,6 +203,8 @@ export function interactionHardReset(
       const newStrategyState: StrategyState = {
         currentStrategy: strategy.strategy.id,
         currentStrategyFitness: strategy.fitness,
+        currentStrategyDescriptiveLabel: strategy.strategy.descriptiveLabel,
+        currentStrategyIcon: strategy.strategy.icon,
         currentStrategyCommands: strategyResult.commands,
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
@@ -370,6 +372,8 @@ export function interactionStart(
       const newStrategyState: StrategyState = {
         currentStrategy: strategy.strategy.id,
         currentStrategyFitness: strategy.fitness,
+        currentStrategyDescriptiveLabel: strategy.strategy.descriptiveLabel,
+        currentStrategyIcon: strategy.strategy.icon,
         currentStrategyCommands: strategyResult.commands,
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
@@ -474,6 +478,8 @@ function handleUserChangedStrategy(
     const newStrategyState: StrategyState = {
       currentStrategy: strategy.strategy.id,
       currentStrategyFitness: strategy.fitness,
+      currentStrategyDescriptiveLabel: strategy.strategy.descriptiveLabel,
+      currentStrategyIcon: strategy.strategy.icon,
       currentStrategyCommands: strategyResult.commands,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
@@ -557,6 +563,8 @@ function handleAccumulatingKeypresses(
       const newStrategyState: StrategyState = {
         currentStrategy: strategy?.strategy.id ?? null,
         currentStrategyFitness: strategy?.fitness ?? 0,
+        currentStrategyDescriptiveLabel: strategy?.strategy.descriptiveLabel ?? null,
+        currentStrategyIcon: strategy?.strategy.icon ?? null,
         currentStrategyCommands: strategyResult.commands,
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
@@ -622,6 +630,8 @@ function handleUpdate(
     const newStrategyState: StrategyState = {
       currentStrategy: strategy?.strategy.id ?? null,
       currentStrategyFitness: strategy?.fitness ?? 0,
+      currentStrategyDescriptiveLabel: strategy?.strategy.descriptiveLabel ?? null,
+      currentStrategyIcon: strategy?.strategy.icon ?? null,
       currentStrategyCommands: strategyResult.commands,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,


### PR DESCRIPTION
**Desired Outcome:**
For the canvas toolbar we want more descriptive labels during interactions and for the edit button icon to represent the currently active interaction.

**Changes:**
All strategies now contain a new descriptive label field and one containing the details of the icon that should be shown when it is active. The toolbar has been updated to replace the general label during an interaction with that label and the edit button will display the icon for the interaction while it is active. Note that the labels and icons are not currently final, something approximating the most appropriate has been selected.

**Screenshot:**
![image](https://github.com/concrete-utopia/utopia/assets/217400/91f17209-eda4-4600-86dd-fdc4c2c9bd13)

**Commit Details:**
- Added `descriptiveLabel` and `icon` to `CanvasStrategy`.
- Added `currentStrategyDescriptiveLabel` and `currentStrategyIcon` to `StrategyState`.
- Updated `MoveReorderReparentIndicator` to use the descriptive label from the currently active strategy.
- Edit button on toolbar now gets the icon details via `currentStrategyIcon`.
- Various strategy functions updated to carry through the new fields.
- `InsertModeButton` now passes through the `testid` prop with a suffix to the `Icn` component.
- Added `descriptiveLabel` and `icon` values to all the existing strategies.