### PR TITLE
lock and eye icons fixed to the right

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -268,6 +268,7 @@ interface NavigatorItemActionSheetProps {
   instanceOriginalComponentName: string | null
   isSlot: boolean
   iconColor: IcnProps['color']
+  background?: string | any
   dispatch: EditorDispatch
 }
 
@@ -334,7 +335,15 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
   const isConditionalClauseTitle = isConditionalClauseNavigatorEntry(props.navigatorEntry)
 
   return (
-    <FlexRow style={{ marginRight: 5, gap: 1 }}>
+    <FlexRow
+      style={{
+        padding: '0 5px',
+        gap: 1,
+        position: 'fixed',
+        right: 0,
+        background: props.background,
+      }}
+    >
       <OriginalComponentNameLabel
         selected={props.selected}
         instanceOriginalComponentName={props.instanceOriginalComponentName}

--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -213,6 +213,7 @@ export const SelectionLockedIndicator: React.FunctionComponent<
         height: 18,
         width: 18,
         display: shouldShow ? 'block' : 'none',
+        paddingRight: 1,
       }}
     >
       {when(
@@ -338,10 +339,17 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
     <FlexRow
       style={{
         padding: '0 5px',
-        gap: 1,
         position: 'fixed',
         right: 0,
-        background: props.background,
+        background:
+          props.highlighted ||
+          props.selected ||
+          !props.isVisibleOnCanvas ||
+          isLockedElement ||
+          isLockedHierarchy ||
+          isDescendantOfLocked
+            ? props.background
+            : 'transparent',
       }}
     >
       <OriginalComponentNameLabel

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -186,7 +186,7 @@ const styleTypeColors: Record<StyleType, { color: keyof ThemeObject; iconColor: 
 }
 
 const selectedTypeBackground: Record<SelectedType, keyof ThemeObject> = {
-  unselected: 'transparent',
+  unselected: 'bg1',
   selected: 'denimBlue',
   descendantOfSelected: 'lightDenimBlue',
 }
@@ -819,6 +819,7 @@ export const NavigatorItem: React.FunctionComponent<
                 dispatch={dispatch}
                 isSlot={isSlot}
                 iconColor={iconColor}
+                background={rowStyle.background}
               />,
             )}
           </FlexRow>


### PR DESCRIPTION
**Problem:**
The lock and hide buttons in the navigator rows weren't visible because they were getting pushed out of the bounds of the navigator when the label was long.

**Fix:**
Now the buttons are fixed to the right edge of the navigator row, and they have the same background color as the row itself, so it covers any continuation of the label beneath it. The icons will stay fixed to the right even if the navigator is wider than the default.

![exhibit-A](https://github.com/concrete-utopia/utopia/assets/47405698/01b9162a-3b60-4fb9-868a-274a496a9fd7)
<img width="894" alt="Screenshot 2023-09-26 at 5 21 15 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/0a4a9316-99f0-4110-a2e1-103b77e1f464">

(*Note: For presentation purposes in the above gif, I made the left pane 268px wide. Today it is 260px and everything gets slightly cut off on the right in _all_ tabs of the left pane )

