### PR TITLE
testing tools for the github integration

### DIFF
--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -15,7 +15,7 @@ import urljoin from 'url-join'
 import JSZip from 'jszip'
 import type { AssetFileWithFileName } from '../assets'
 import { gitBlobChecksumFromBuffer } from '../assets'
-import { isLoginLost, isNotLoggedIn } from '../../common/user'
+import { isLoginLost } from '../../common/user'
 import { notice } from '../common/notice'
 import type { EditorDispatch } from './action-types'
 import { isLoggedIn } from './action-types'
@@ -26,9 +26,8 @@ import {
   setUserConfiguration,
   setGithubState,
 } from './actions/action-creators'
-import { getFileExtension } from '../../core/shared/file-utils'
-import { isAuthenticatedWithGithub } from '../../utils/github-auth'
 import { updateUserDetailsWhenAuthenticated } from '../../core/shared/github/helpers'
+import { GithubAuth } from '../../utils/github-auth'
 
 export { fetchProjectList, fetchShowcaseProjects, getLoginState } from '../../common/server'
 
@@ -397,7 +396,7 @@ export function startPollingLoginState(
         // Fetch the github auth status
         void updateUserDetailsWhenAuthenticated(
           dispatch,
-          isAuthenticatedWithGithub(loginState),
+          GithubAuth.isAuthenticatedWithGithub(loginState),
         ).then((authenticatedWithGithub) =>
           dispatch([
             setGithubState({

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -292,8 +292,7 @@ const BranchBlock = () => {
             borderRadius: 2,
           }}
         >
-          {(branchesForRepository ?? []).map((branch, index) => {
-            // TODO
+          {filteredBranches.map((branch, index) => {
             function selectBranch() {
               if (isListingBranches) {
                 return
@@ -385,7 +384,7 @@ const BranchBlock = () => {
   }, [
     branchFilter,
     updateBranchFilter,
-    branchesForRepository,
+    filteredBranches,
     refreshBranches,
     isListingBranches,
     currentBranch,

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -12,10 +12,6 @@ import {
   githubFileChangesToList,
   useGithubFileChanges,
 } from '../../../../core/shared/github/helpers'
-import { saveProjectToGithub } from '../../../../core/shared/github/operations/commit-and-push'
-import { getBranchesForGithubRepository } from '../../../../core/shared/github/operations/list-branches'
-import { updateProjectWithBranchContent } from '../../../../core/shared/github/operations/load-branch'
-import { updateProjectAgainstGithub } from '../../../../core/shared/github/operations/update-against-branch'
 import { startGithubAuthentication } from '../../../../utils/github-auth'
 import { unless, when } from '../../../../utils/react-conditionals'
 import {
@@ -53,6 +49,7 @@ import { cleanupBranchName } from './helpers'
 import { PullRequestPane } from './pull-request-pane'
 import { RefreshIcon } from './refresh-icon'
 import { RepositoryListing } from './repository-listing'
+import { GithubOperations } from '../../../../core/shared/github/operations'
 
 const compactTimeagoFormatter = (value: number, unit: string) => {
   return `${value}${unit.charAt(0)}`
@@ -185,7 +182,7 @@ const BranchBlock = () => {
     if (targetRepository != null) {
       void dispatchPromiseActions(
         dispatch,
-        getBranchesForGithubRepository(dispatch, targetRepository),
+        GithubOperations.getBranchesForGithubRepository(dispatch, targetRepository),
       )
     }
   }, [dispatch, targetRepository])
@@ -493,7 +490,7 @@ const RemoteChangesBlock = () => {
   )
   const triggerUpdateAgainstGithub = React.useCallback(() => {
     if (repo != null && branch != null && commit != null) {
-      void updateProjectAgainstGithub(
+      void GithubOperations.updateProjectAgainstGithub(
         workersRef.current,
         dispatch,
         repo,
@@ -662,7 +659,7 @@ const LocalChangesBlock = () => {
       console.warn('project id is not set')
       return
     }
-    void saveProjectToGithub(
+    void GithubOperations.saveProjectToGithub(
       projectId,
       repo,
       persistentModelForProjectContents(projectContents),
@@ -871,7 +868,7 @@ const BranchNotLoadedBlock = () => {
 
   const loadFromBranch = React.useCallback(() => {
     if (githubRepo != null && branchName != null) {
-      void updateProjectWithBranchContent(
+      void GithubOperations.updateProjectWithBranchContent(
         workersRef.current,
         dispatch,
         forceNotNull('Should have a project ID by now.', projectID),
@@ -928,7 +925,7 @@ const BranchNotLoadedBlock = () => {
     if (githubRepo == null || branchName == null || projectId == null) {
       return
     }
-    void saveProjectToGithub(
+    void GithubOperations.saveProjectToGithub(
       projectId,
       githubRepo,
       persistentModelForProjectContents(projectContents),

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -12,7 +12,6 @@ import {
   githubFileChangesToList,
   useGithubFileChanges,
 } from '../../../../core/shared/github/helpers'
-import { startGithubAuthentication } from '../../../../utils/github-auth'
 import { unless, when } from '../../../../utils/react-conditionals'
 import {
   Button,
@@ -50,6 +49,7 @@ import { PullRequestPane } from './pull-request-pane'
 import { RefreshIcon } from './refresh-icon'
 import { RepositoryListing } from './repository-listing'
 import { GithubOperations } from '../../../../core/shared/github/operations'
+import { GithubAuth } from '../../../../utils/github-auth'
 
 const compactTimeagoFormatter = (value: number, unit: string) => {
   return `${value}${unit.charAt(0)}`
@@ -66,7 +66,7 @@ const AccountBlock = () => {
   const state = React.useMemo(() => (authenticated ? 'successful' : 'incomplete'), [authenticated])
   const dispatch = useDispatch()
   const triggerAuthentication = React.useCallback(() => {
-    void startGithubAuthentication(dispatch)
+    void GithubAuth.startGithubAuthentication(dispatch)
   }, [dispatch])
 
   if (authenticated) {

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -292,7 +292,8 @@ const BranchBlock = () => {
             borderRadius: 2,
           }}
         >
-          {filteredBranches.map((branch, index) => {
+          {(branchesForRepository ?? []).map((branch, index) => {
+            // TODO
             function selectBranch() {
               if (isListingBranches) {
                 return
@@ -382,17 +383,17 @@ const BranchBlock = () => {
       </UIGridRow>
     )
   }, [
-    targetRepository,
-    dispatch,
-    githubOperations,
-    currentBranch,
-    isListingBranches,
-    refreshBranches,
     branchFilter,
     updateBranchFilter,
-    filteredBranches,
+    branchesForRepository,
+    refreshBranches,
+    isListingBranches,
+    currentBranch,
     clearBranch,
-    repositoryData,
+    githubOperations,
+    targetRepository,
+    repositoryData?.defaultBranch,
+    dispatch,
   ])
 
   const githubAuthenticated = useEditorState(

--- a/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
@@ -28,6 +28,7 @@ import { Substores, useEditorState } from '../../../editor/store/store-hook'
 import { Ellipsis } from './github-file-changes-list'
 import { GithubSpinner } from './github-spinner'
 import { RefreshIcon } from './refresh-icon'
+import { GithubOperations } from '../../../../core/shared/github/operations'
 
 interface RepositoryRowProps extends RepositoryEntry {
   importPermitted: boolean
@@ -239,7 +240,7 @@ export const RepositoryListing = React.memo(
     const dispatch = useDispatch()
 
     const refreshRepos = React.useCallback(() => {
-      void getUsersPublicGithubRepositories(dispatch).then((actions) => {
+      void GithubOperations.getUsersPublicGithubRepositories(dispatch).then((actions) => {
         dispatch(actions, 'everyone')
       })
     }, [dispatch])

--- a/editor/src/core/shared/github-ui.tsx
+++ b/editor/src/core/shared/github-ui.tsx
@@ -3,6 +3,7 @@ import type { EditorDispatch } from '../../components/editor/action-types'
 import type { GithubRepo } from '../../components/editor/store/editor-state'
 import type { Conflict } from './github/helpers'
 import { resolveConflict } from './github/helpers'
+import { GithubOperations } from './github/operations'
 
 export function getConflictMenuItems(
   githubRepo: GithubRepo,
@@ -13,7 +14,14 @@ export function getConflictMenuItems(
   submenuName: string | undefined,
 ): Array<ContextMenuItem<unknown>> {
   function applyChange(whichChange: 'utopia' | 'branch'): void {
-    void resolveConflict(githubRepo, projectID, path, conflict, whichChange, dispatch)
+    void GithubOperations.resolveConflict(
+      githubRepo,
+      projectID,
+      path,
+      conflict,
+      whichChange,
+      dispatch,
+    )
   }
   switch (conflict.type) {
     case 'DIFFERING_TYPES':

--- a/editor/src/core/shared/github/endpoints.ts
+++ b/editor/src/core/shared/github/endpoints.ts
@@ -1,0 +1,44 @@
+import urljoin from 'url-join'
+import { UTOPIA_BACKEND } from '../../../common/env-vars'
+import type { GithubRepo } from '../../../components/editor/store/editor-state'
+
+export const GithubEndpoints = {
+  repositories: () => urljoin(UTOPIA_BACKEND, 'github', 'user', 'repositories'),
+  userDetails: () => urljoin(UTOPIA_BACKEND, 'github', 'user'),
+  save: (projectID: string) => urljoin(UTOPIA_BACKEND, 'github', 'save', projectID),
+  getBranches: ({ owner, repository }: GithubRepo) =>
+    urljoin(UTOPIA_BACKEND, 'github', 'branches', owner, repository),
+  branchContents: (githubRepo: GithubRepo, branchName: string) =>
+    urljoin(
+      UTOPIA_BACKEND,
+      'github',
+      'branches',
+      githubRepo.owner,
+      githubRepo.repository,
+      'branch',
+      branchName,
+    ),
+  asset: (githubRepo: GithubRepo, assetSha: string) =>
+    urljoin(
+      UTOPIA_BACKEND,
+      'github',
+      'branches',
+      githubRepo.owner,
+      githubRepo.repository,
+      'asset',
+      assetSha,
+    ),
+  updatePullRequests: (githubRepo: GithubRepo, branchName: string) =>
+    urljoin(
+      UTOPIA_BACKEND,
+      'github',
+      'branches',
+      githubRepo.owner,
+      githubRepo.repository,
+      'branch',
+      branchName,
+      'pullrequest',
+    ),
+  authenticationStatus: () => urljoin(UTOPIA_BACKEND, 'github', 'authentication', 'status'),
+  authenticationStart: () => urljoin(UTOPIA_BACKEND, 'github', 'authentication', 'start'),
+} as const

--- a/editor/src/core/shared/github/github.spec.browser2.ts
+++ b/editor/src/core/shared/github/github.spec.browser2.ts
@@ -6,6 +6,7 @@ import {
   renderTestEditorWithCode,
 } from '../../../components/canvas/ui-jsx.test-utils'
 import { createTestProjectWithCode } from '../../../sample-projects/sample-project-utils.test-utils'
+import { wait } from '../../model/performance-scripts'
 import { GithubEndpoints } from './endpoints'
 import type { GetBranchContentResponse, GetGithubUserSuccess } from './helpers'
 import {
@@ -33,7 +34,7 @@ describe('Github integration', () => {
         type: 'SUCCESS',
         repositories: [
           {
-            fullName: 'www.github.com/bob/awesome-project',
+            fullName: 'bob/awesome-project',
             name: 'Awesome Project',
             avatarUrl: null,
             isPrivate: false,
@@ -79,7 +80,7 @@ describe('Github integration', () => {
     await clickTextOnScreen(renderResult, 'Github')
     await mock.getUsersPublicGithubRepositories
 
-    await clickTextOnScreen(renderResult, 'www.github.com/bob/awesome-project')
+    await clickTextOnScreen(renderResult, 'bob/awesome-project')
     await mock.getBranchesForGithubRepository
 
     await clickTextOnScreen(renderResult, 'main')

--- a/editor/src/core/shared/github/github.spec.browser2.ts
+++ b/editor/src/core/shared/github/github.spec.browser2.ts
@@ -1,0 +1,99 @@
+import { mouseClickAtPoint } from '../../../components/canvas/event-helpers.test-utils'
+import type { EditorRenderResult } from '../../../components/canvas/ui-jsx.test-utils'
+import {
+  makeTestProjectCodeWithSnippet,
+  optOutFromCheckFileTimestamps,
+  renderTestEditorWithCode,
+} from '../../../components/canvas/ui-jsx.test-utils'
+import { createTestProjectWithCode } from '../../../sample-projects/sample-project-utils.test-utils'
+import { GithubEndpoints } from './endpoints'
+import type { GetBranchContentResponse, GetGithubUserSuccess } from './helpers'
+import {
+  MockGithubOperations,
+  fakeResponse,
+  loginUserToGithubForTests,
+} from './operations/github-operations.test-utils'
+import type { GetBranchesSuccess } from './operations/list-branches'
+import type { GetUsersPublicRepositoriesSuccess } from './operations/load-repositories'
+
+describe('Github integration', () => {
+  const mock = new MockGithubOperations().mock({
+    fakeResolvedProjectContents: createTestProjectWithCode(
+      makeTestProjectCodeWithSnippet(`
+    <h1>Editor from Github</h1>
+    `),
+    ).projectContents,
+
+    apiConfig: {
+      [GithubEndpoints.userDetails()]: fakeResponse<GetGithubUserSuccess>({
+        type: 'SUCCESS',
+        user: { login: 'login', name: 'Bob', avatarURL: 'avatar', htmlURL: 'www.example.com' },
+      }),
+      [GithubEndpoints.repositories()]: fakeResponse<GetUsersPublicRepositoriesSuccess>({
+        type: 'SUCCESS',
+        repositories: [
+          {
+            fullName: 'www.github.com/bob/awesome-project',
+            name: 'Awesome Project',
+            avatarUrl: null,
+            isPrivate: false,
+            description: 'An Awesome Project',
+            updatedAt: '1',
+            defaultBranch: 'main',
+            permissions: { admin: true, push: true, pull: true },
+          },
+        ],
+      }),
+      [GithubEndpoints.getBranches({ owner: 'bob', repository: 'awesome-project' })]:
+        fakeResponse<GetBranchesSuccess>({
+          type: 'SUCCESS',
+          branches: [{ name: 'main' }, { name: 'dev' }],
+        }),
+      [GithubEndpoints.branchContents({ owner: 'bob', repository: 'awesome-project' }, 'main')]:
+        fakeResponse<GetBranchContentResponse>({
+          type: 'SUCCESS',
+          branch: {
+            originCommit: 'initial',
+            content: createTestProjectWithCode(
+              makeTestProjectCodeWithSnippet(`
+            <h1>Editor from Github</h1>
+            `),
+            ).projectContents,
+          },
+        }),
+    },
+  })
+
+  optOutFromCheckFileTimestamps()
+
+  it('can clone a branch', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+          <h1>Starting Editor</h1>
+          `),
+      'await-first-dom-report',
+    )
+
+    await loginUserToGithubForTests(renderResult.dispatch)
+
+    await clickTextOnScreen(renderResult, 'Github')
+    await mock.getUsersPublicGithubRepositories
+
+    await clickTextOnScreen(renderResult, 'www.github.com/bob/awesome-project')
+    await mock.getBranchesForGithubRepository
+
+    await clickTextOnScreen(renderResult, 'main')
+    await clickTextOnScreen(renderResult, 'Load from Branch')
+    await clickTextOnScreen(renderResult, 'Yes, Load from this Branch.')
+    await mock.updateProjectWithBranchContent
+
+    expect(renderResult.renderedDOM.getByText('Editor from Github')).toBeDefined()
+
+    expect('it works so far').toBeDefined()
+  })
+})
+
+async function clickTextOnScreen(renderResult: EditorRenderResult, text: string) {
+  const element = renderResult.renderedDOM.getByText(text)
+  await mouseClickAtPoint(element, { x: 2, y: 2 })
+}

--- a/editor/src/core/shared/github/github.spec.browser2.ts
+++ b/editor/src/core/shared/github/github.spec.browser2.ts
@@ -88,8 +88,6 @@ describe('Github integration', () => {
     await mock.updateProjectWithBranchContent
 
     expect(renderResult.renderedDOM.getByText('Editor from Github')).toBeDefined()
-
-    expect('it works so far').toBeDefined()
   })
 })
 

--- a/editor/src/core/shared/github/helpers.ts
+++ b/editor/src/core/shared/github/helpers.ts
@@ -1,8 +1,6 @@
 import { mergeDiff3 } from 'node-diff3'
 import { createSelector } from 'reselect'
 import type { UtopiaTsWorkers } from '../../../core/workers/common/worker-types'
-import urljoin from 'url-join'
-import { UTOPIA_BACKEND } from '../../../common/env-vars'
 import { HEADERS, MODE } from '../../../common/server'
 import type { ProjectContentsTree, ProjectContentTreeRoot } from '../../../components/assets'
 import {
@@ -66,6 +64,7 @@ import { getUsersPublicGithubRepositories } from './operations/load-repositories
 import { set } from '../optics/optic-utilities'
 import { fromField } from '../optics/optic-creators'
 import type { GithubOperationContext } from './operations/github-operation-context'
+import { GithubEndpoints } from './endpoints'
 
 export function dispatchPromiseActions(
   dispatch: EditorDispatch,
@@ -262,15 +261,7 @@ export async function getBranchContentFromServer(
   previousCommitSha: string | null,
   operationContext: GithubOperationContext,
 ): Promise<Response> {
-  const url = urljoin(
-    UTOPIA_BACKEND,
-    'github',
-    'branches',
-    githubRepo.owner,
-    githubRepo.repository,
-    'branch',
-    branchName,
-  )
+  const url = GithubEndpoints.branchContents(githubRepo, branchName)
   let includeQueryParams: boolean = false
   let paramsRecord: Record<string, string> = {}
   if (commitSha != null) {
@@ -293,7 +284,7 @@ export async function getBranchContentFromServer(
 }
 
 export async function getUserDetailsFromServer(): Promise<Array<EditorAction>> {
-  const url = urljoin(UTOPIA_BACKEND, 'github', 'user')
+  const url = GithubEndpoints.userDetails()
 
   const response = await fetch(url, {
     method: 'GET',
@@ -984,15 +975,7 @@ export async function saveGithubAsset(
     { name: 'saveAsset', path: path },
     dispatch,
     async (operation: GithubOperation) => {
-      const url = urljoin(
-        UTOPIA_BACKEND,
-        'github',
-        'branches',
-        githubRepo.owner,
-        githubRepo.repository,
-        'asset',
-        assetSha,
-      )
+      const url = GithubEndpoints.asset(githubRepo, assetSha)
 
       const paramsRecord: Record<string, string> = {
         project_id: projectID,

--- a/editor/src/core/shared/github/operations/commit-and-push.ts
+++ b/editor/src/core/shared/github/operations/commit-and-push.ts
@@ -25,6 +25,7 @@ import {
   runGithubOperation,
 } from '../helpers'
 import { getBranchesForGithubRepository } from './list-branches'
+import type { GithubOperationContext } from './github-operation-context'
 
 export interface SaveProjectToGithubOptions {
   branchName: string | null
@@ -41,107 +42,114 @@ export interface SaveToGithubSuccess {
 
 export type SaveToGithubResponse = SaveToGithubSuccess | GithubFailure
 
-export async function saveProjectToGithub(
-  projectID: string,
-  targetRepository: GithubRepo,
-  persistentModel: PersistentModel,
-  dispatch: EditorDispatch,
-  options: SaveProjectToGithubOptions,
-): Promise<void> {
-  await runGithubOperation(
-    { name: 'commitAndPush' },
-    dispatch,
-    async (operation: GithubOperation) => {
-      const { branchName, commitMessage } = options
+export const saveProjectToGithub =
+  (operationContext: GithubOperationContext) =>
+  async (
+    projectID: string,
+    targetRepository: GithubRepo,
+    persistentModel: PersistentModel,
+    dispatch: EditorDispatch,
+    options: SaveProjectToGithubOptions,
+  ): Promise<void> => {
+    await runGithubOperation(
+      { name: 'commitAndPush' },
+      dispatch,
+      async (operation: GithubOperation) => {
+        const { branchName, commitMessage } = options
 
-      // If this is a straight push, load the repo before saving
-      // in order to retrieve the head origin commit hash
-      // and avoid a fast forward error.
-      let originCommit = persistentModel.githubSettings.originCommit
-      if (originCommit == null && targetRepository != null && branchName != null) {
-        const getBranchResponse = await getBranchContentFromServer(
-          targetRepository,
-          branchName,
-          null,
-          null,
-        )
-        if (getBranchResponse.ok) {
-          const content: GetBranchContentResponse = await getBranchResponse.json()
-          if (content.type === 'SUCCESS' && content.branch != null) {
-            originCommit = content.branch.originCommit
+        // If this is a straight push, load the repo before saving
+        // in order to retrieve the head origin commit hash
+        // and avoid a fast forward error.
+        let originCommit = persistentModel.githubSettings.originCommit
+        if (originCommit == null && targetRepository != null && branchName != null) {
+          const getBranchResponse = await getBranchContentFromServer(
+            targetRepository,
+            branchName,
+            null,
+            null,
+            operationContext,
+          )
+          if (getBranchResponse.ok) {
+            const content: GetBranchContentResponse = await getBranchResponse.json()
+            if (content.type === 'SUCCESS' && content.branch != null) {
+              originCommit = content.branch.originCommit
+            }
           }
         }
-      }
 
-      const patchedModel: PersistentModel = {
-        ...persistentModel,
-        githubSettings: {
-          ...persistentModel.githubSettings,
-          originCommit: originCommit,
-          targetRepository: targetRepository,
-        },
-      }
+        const patchedModel: PersistentModel = {
+          ...persistentModel,
+          githubSettings: {
+            ...persistentModel.githubSettings,
+            originCommit: originCommit,
+            targetRepository: targetRepository,
+          },
+        }
 
-      const url = urljoin(UTOPIA_BACKEND, 'github', 'save', projectID)
+        const url = urljoin(UTOPIA_BACKEND, 'github', 'save', projectID)
 
-      let includeQueryParams: boolean = false
-      let paramsRecord: Record<string, string> = {}
-      if (branchName != null) {
-        includeQueryParams = true
-        paramsRecord.branch_name = branchName
-      }
-      if (commitMessage != null) {
-        includeQueryParams = true
-        paramsRecord.commit_message = commitMessage
-      }
-      const searchParams = new URLSearchParams(paramsRecord)
-      const urlToUse = includeQueryParams ? `${url}?${searchParams}` : url
+        let includeQueryParams: boolean = false
+        let paramsRecord: Record<string, string> = {}
+        if (branchName != null) {
+          includeQueryParams = true
+          paramsRecord.branch_name = branchName
+        }
+        if (commitMessage != null) {
+          includeQueryParams = true
+          paramsRecord.commit_message = commitMessage
+        }
+        const searchParams = new URLSearchParams(paramsRecord)
+        const urlToUse = includeQueryParams ? `${url}?${searchParams}` : url
 
-      const postBody = JSON.stringify(patchedModel)
-      const response = await fetch(urlToUse, {
-        method: 'POST',
-        credentials: 'include',
-        headers: HEADERS,
-        mode: MODE,
-        body: postBody,
-      })
-      if (!response.ok) {
-        throw await githubAPIErrorFromResponse(operation, response)
-      }
+        const postBody = JSON.stringify(patchedModel)
+        const response = await operationContext.fetch(urlToUse, {
+          method: 'POST',
+          credentials: 'include',
+          headers: HEADERS,
+          mode: MODE,
+          body: postBody,
+        })
+        if (!response.ok) {
+          throw await githubAPIErrorFromResponse(operation, response)
+        }
 
-      const responseBody: SaveToGithubResponse = await response.json()
-      switch (responseBody.type) {
-        case 'FAILURE':
-          throw githubAPIError(operation, responseBody.failureReason)
-        case 'SUCCESS':
-          dispatch(
-            [
-              updateGithubSettings(
-                projectGithubSettings(
-                  targetRepository,
-                  responseBody.newCommit,
-                  responseBody.branchName,
-                  responseBody.newCommit,
-                  true,
+        const responseBody: SaveToGithubResponse = await response.json()
+        switch (responseBody.type) {
+          case 'FAILURE':
+            throw githubAPIError(operation, responseBody.failureReason)
+          case 'SUCCESS':
+            dispatch(
+              [
+                updateGithubSettings(
+                  projectGithubSettings(
+                    targetRepository,
+                    responseBody.newCommit,
+                    responseBody.branchName,
+                    responseBody.newCommit,
+                    true,
+                  ),
                 ),
-              ),
-              updateBranchContents(persistentModel.projectContents),
-              showToast(notice(`Saved to branch ${responseBody.branchName}.`, 'SUCCESS')),
-            ],
-            'everyone',
-          )
+                updateBranchContents(persistentModel.projectContents),
+                showToast(notice(`Saved to branch ${responseBody.branchName}.`, 'SUCCESS')),
+              ],
+              'everyone',
+            )
 
-          // refresh the branches after the content was saved
-          void dispatchPromiseActions(
-            dispatch,
-            getBranchesForGithubRepository(dispatch, targetRepository),
-          )
-          break
-        default:
-          const _exhaustiveCheck: never = responseBody
-          throw githubAPIError(operation, `Unhandled response body ${JSON.stringify(responseBody)}`)
-      }
-      return []
-    },
-  )
-}
+            // refresh the branches after the content was saved
+            // TODO why not an await?
+            void dispatchPromiseActions(
+              dispatch,
+              getBranchesForGithubRepository(dispatch, targetRepository, operationContext),
+            )
+            break
+          default:
+            const _exhaustiveCheck: never = responseBody
+            throw githubAPIError(
+              operation,
+              `Unhandled response body ${JSON.stringify(responseBody)}`,
+            )
+        }
+        return []
+      },
+    )
+  }

--- a/editor/src/core/shared/github/operations/commit-and-push.ts
+++ b/editor/src/core/shared/github/operations/commit-and-push.ts
@@ -1,7 +1,4 @@
-import urljoin from 'url-join'
-import { UTOPIA_BACKEND } from '../../../../common/env-vars'
 import { HEADERS, MODE } from '../../../../common/server'
-import { getProjectContentsChecksums } from '../../../../components/assets'
 import { notice } from '../../../../components/common/notice'
 import type { EditorDispatch } from '../../../../components/editor/action-types'
 import {
@@ -26,6 +23,7 @@ import {
 } from '../helpers'
 import { getBranchesForGithubRepository } from './list-branches'
 import type { GithubOperationContext } from './github-operation-context'
+import { GithubEndpoints } from '../endpoints'
 
 export interface SaveProjectToGithubOptions {
   branchName: string | null
@@ -86,7 +84,7 @@ export const saveProjectToGithub =
           },
         }
 
-        const url = urljoin(UTOPIA_BACKEND, 'github', 'save', projectID)
+        const url = GithubEndpoints.save(projectID)
 
         let includeQueryParams: boolean = false
         let paramsRecord: Record<string, string> = {}
@@ -136,10 +134,9 @@ export const saveProjectToGithub =
             )
 
             // refresh the branches after the content was saved
-            // TODO why not an await?
-            void dispatchPromiseActions(
+            await dispatchPromiseActions(
               dispatch,
-              getBranchesForGithubRepository(dispatch, targetRepository, operationContext),
+              getBranchesForGithubRepository(operationContext)(dispatch, targetRepository),
             )
             break
           default:

--- a/editor/src/core/shared/github/operations/get-branch-checksums.ts
+++ b/editor/src/core/shared/github/operations/get-branch-checksums.ts
@@ -3,23 +3,32 @@ import { updateBranchContents } from '../../../../components/editor/actions/acti
 import type { GithubRepo } from '../../../../components/editor/store/editor-state'
 import type { GetBranchContentResponse } from '../helpers'
 import { getBranchContentFromServer } from '../helpers'
+import type { GithubOperationContext } from './github-operation-context'
 
-export async function getBranchChecksums(
-  githubRepo: GithubRepo,
-  branchName: string,
-  commitSha: string,
-): Promise<Array<EditorAction>> {
-  const specificCommitRequest = getBranchContentFromServer(githubRepo, branchName, commitSha, null)
+export const getBranchChecksums =
+  (operationContext: GithubOperationContext) =>
+  async (
+    githubRepo: GithubRepo,
+    branchName: string,
+    commitSha: string,
+  ): Promise<Array<EditorAction>> => {
+    const specificCommitRequest = getBranchContentFromServer(
+      githubRepo,
+      branchName,
+      commitSha,
+      null,
+      operationContext,
+    )
 
-  const specificCommitResponse = await specificCommitRequest
+    const specificCommitResponse = await specificCommitRequest
 
-  if (specificCommitResponse.ok) {
-    const specificCommitContent: GetBranchContentResponse = await specificCommitResponse.json()
-    if (specificCommitContent.type === 'SUCCESS') {
-      if (specificCommitContent.branch != null) {
-        return [updateBranchContents(specificCommitContent.branch.content)]
+    if (specificCommitResponse.ok) {
+      const specificCommitContent: GetBranchContentResponse = await specificCommitResponse.json()
+      if (specificCommitContent.type === 'SUCCESS') {
+        if (specificCommitContent.branch != null) {
+          return [updateBranchContents(specificCommitContent.branch.content)]
+        }
       }
     }
+    return []
   }
-  return []
-}

--- a/editor/src/core/shared/github/operations/github-operation-context.ts
+++ b/editor/src/core/shared/github/operations/github-operation-context.ts
@@ -2,7 +2,7 @@ import type { ProjectContentTreeRoot } from '../../../../components/assets'
 import type { UtopiaTsWorkers } from '../../../workers/common/worker-types'
 
 export interface GithubOperationContext {
-  fetch: (url: string | URL, options: RequestInit) => Promise<Response>
+  fetch: (url: string, options: RequestInit) => Promise<Response>
   updateProjectContentsWithParseResults: (
     workers: UtopiaTsWorkers,
     projectContents: ProjectContentTreeRoot,

--- a/editor/src/core/shared/github/operations/github-operation-context.ts
+++ b/editor/src/core/shared/github/operations/github-operation-context.ts
@@ -1,0 +1,10 @@
+import type { ProjectContentTreeRoot } from '../../../../components/assets'
+import type { UtopiaTsWorkers } from '../../../workers/common/worker-types'
+
+export interface GithubOperationContext {
+  fetch: (url: string | URL, options: RequestInit) => Promise<Response>
+  updateProjectContentsWithParseResults: (
+    workers: UtopiaTsWorkers,
+    projectContents: ProjectContentTreeRoot,
+  ) => Promise<ProjectContentTreeRoot>
+}

--- a/editor/src/core/shared/github/operations/github-operations.test-utils.ts
+++ b/editor/src/core/shared/github/operations/github-operations.test-utils.ts
@@ -1,0 +1,185 @@
+import type { Defer } from '../../../../utils/utils'
+import { defer } from '../../../../utils/utils'
+import Sinon from 'sinon'
+import type { GithubOperationContext } from './github-operation-context'
+import { GithubOperations } from '.'
+import { saveProjectToGithub } from './commit-and-push'
+import { getBranchChecksums } from './get-branch-checksums'
+import type { ProjectContentTreeRoot } from '../../../../components/assets'
+import { getBranchesForGithubRepository } from './list-branches'
+import { updatePullRequestsForBranch } from './list-pull-requests-for-branch'
+import { saveAssetsToProject, updateProjectWithBranchContent } from './load-branch'
+import { GithubAuth } from '../../../../utils/github-auth'
+import type { EditorDispatch } from '../../../../components/editor/action-types'
+import { setGithubState } from '../../../../components/editor/actions/action-creators'
+import { getUsersPublicGithubRepositories } from './load-repositories'
+import { updateProjectAgainstGithub } from './update-against-branch'
+import { resolveConflict, startGithubPolling } from '../helpers'
+
+export function setGithubAuthenticatedForTests(dispatch: EditorDispatch) {
+  dispatch([setGithubState({ authenticated: true })], 'everyone')
+}
+
+interface FakeGithubApiConfig {
+  [url: string]: Response | undefined
+}
+
+interface MockOperationContextOptions {
+  apiConfig: FakeGithubApiConfig
+  fakeResolvedProjectContents: ProjectContentTreeRoot
+}
+
+const MockOperationContext = (options: MockOperationContextOptions): GithubOperationContext => ({
+  fetch: async (url) => {
+    const response = options.apiConfig[url]
+    if (response == null) {
+      throw new Error(`No response defined for URL ${url}`)
+    }
+    return response
+  },
+  updateProjectContentsWithParseResults: async () => options.fakeResolvedProjectContents,
+})
+
+function wrapWithDeferResolve<Args extends any[], Return>(
+  deferred: { current: Defer<void> },
+  operation: (...operationParameters: Args) => Promise<Return>,
+): (...parameters: Args) => Promise<Return> {
+  return (...args) => {
+    const result = operation(...args)
+    deferred.current.resolve()
+    deferred.current = defer()
+    return result
+  }
+}
+
+export class MockGithubOperations {
+  githubOperationDone: Defer<void> = defer()
+  sandbox: Sinon.SinonSandbox | null = null
+
+  mock(options: MockOperationContextOptions): MockGithubOperations {
+    beforeEach(() => {
+      this.sandbox = Sinon.createSandbox()
+      this.githubOperationDone = defer()
+
+      const startGithubAuthenticationStub = this.sandbox.stub(
+        GithubAuth,
+        'startGithubAuthentication',
+      )
+      startGithubAuthenticationStub.callsFake(async () => {})
+
+      const isAuthenticatedWithGithubStub = this.sandbox.stub(
+        GithubAuth,
+        'isAuthenticatedWithGithub',
+      )
+      isAuthenticatedWithGithubStub.callsFake(async () => true)
+
+      const operationContext = MockOperationContext(options)
+
+      const saveProjectToGithubStub = this.sandbox.stub(GithubOperations, 'saveProjectToGithub')
+      saveProjectToGithubStub.callsFake(
+        wrapWithDeferResolve(
+          { current: this.githubOperationDone },
+          saveProjectToGithub(operationContext),
+        ),
+      )
+
+      const getBranchCheckSumsStub = this.sandbox.stub(GithubOperations, 'getBranchCheckSums')
+      getBranchCheckSumsStub.callsFake(
+        wrapWithDeferResolve(
+          { current: this.githubOperationDone },
+          getBranchChecksums(operationContext),
+        ),
+      )
+
+      const getBranchesForGithubRepositoryStub = this.sandbox.stub(
+        GithubOperations,
+        'getBranchesForGithubRepository',
+      )
+      getBranchesForGithubRepositoryStub.callsFake(
+        wrapWithDeferResolve(
+          { current: this.githubOperationDone },
+          getBranchesForGithubRepository(operationContext),
+        ),
+      )
+
+      const updatePullRequestsForBranchStub = this.sandbox.stub(
+        GithubOperations,
+        'updatePullRequestsForBranch',
+      )
+      updatePullRequestsForBranchStub.callsFake(
+        wrapWithDeferResolve(
+          { current: this.githubOperationDone },
+          updatePullRequestsForBranch(operationContext),
+        ),
+      )
+
+      const saveAssetsToProjectStub = this.sandbox.stub(GithubOperations, 'saveAssetsToProject')
+      saveAssetsToProjectStub.callsFake(
+        wrapWithDeferResolve(
+          { current: this.githubOperationDone },
+          saveAssetsToProject(operationContext),
+        ),
+      )
+
+      const getUsersPublicGithubRepositoriesStub = this.sandbox.stub(
+        GithubOperations,
+        'getUsersPublicGithubRepositories',
+      )
+      getUsersPublicGithubRepositoriesStub.callsFake(
+        wrapWithDeferResolve(
+          { current: this.githubOperationDone },
+          getUsersPublicGithubRepositories(operationContext),
+        ),
+      )
+
+      const updateProjectAgainstGithubStub = this.sandbox.stub(
+        GithubOperations,
+        'updateProjectAgainstGithub',
+      )
+      updateProjectAgainstGithubStub.callsFake(
+        wrapWithDeferResolve(
+          { current: this.githubOperationDone },
+          updateProjectAgainstGithub(operationContext),
+        ),
+      )
+
+      const startGithubPollingStub = this.sandbox.stub(GithubOperations, 'startGithubPolling')
+      startGithubPollingStub.callsFake(
+        wrapWithDeferResolve(
+          { current: this.githubOperationDone },
+          startGithubPolling(operationContext),
+        ),
+      )
+
+      const resolveConflictStub = this.sandbox.stub(GithubOperations, 'resolveConflict')
+      resolveConflictStub.callsFake(
+        wrapWithDeferResolve(
+          { current: this.githubOperationDone },
+          resolveConflict(operationContext),
+        ),
+      )
+
+      const updateProjectWithBranchContentStub = this.sandbox.stub(
+        GithubOperations,
+        'updateProjectWithBranchContent',
+      )
+      updateProjectWithBranchContentStub.callsFake(
+        wrapWithDeferResolve(
+          { current: this.githubOperationDone },
+          updateProjectWithBranchContent(operationContext),
+        ),
+      )
+    })
+
+    afterEach(() => {
+      this.sandbox?.restore()
+      this.sandbox = null
+    })
+
+    return this
+  }
+
+  resetDoneSignal(): void {
+    this.githubOperationDone = defer()
+  }
+}

--- a/editor/src/core/shared/github/operations/github-operations.test-utils.ts
+++ b/editor/src/core/shared/github/operations/github-operations.test-utils.ts
@@ -72,7 +72,6 @@ function wrapWithDeferResolve<Args extends any[], Return>(
 
 export class MockGithubOperations {
   private sandbox: Sinon.SinonSandbox | null = null
-  private privatePromise: Defer<void> = defer()
   getUsersPublicGithubRepositories: Defer<void> = defer()
   getBranchesForGithubRepository: Defer<void> = defer()
   updateProjectWithBranchContent: Defer<void> = defer()
@@ -80,51 +79,26 @@ export class MockGithubOperations {
   mock(options: MockOperationContextOptions): MockGithubOperations {
     beforeEach(() => {
       this.sandbox = Sinon.createSandbox()
-      this.privatePromise = defer()
 
       const startGithubAuthenticationStub = this.sandbox.stub(
         GithubAuth,
         'startGithubAuthentication',
       )
-      startGithubAuthenticationStub.callsFake(
-        wrapWithDeferResolve(
-          { current: this.privatePromise },
-          'startGithubAuthentication',
-          async () => {},
-        ),
-      )
+      startGithubAuthenticationStub.callsFake(async () => {})
 
       const isAuthenticatedWithGithubStub = this.sandbox.stub(
         GithubAuth,
         'isAuthenticatedWithGithub',
       )
-      isAuthenticatedWithGithubStub.callsFake(
-        wrapWithDeferResolve(
-          { current: this.privatePromise },
-          'isAuthenticatedWithGithub',
-          async () => true,
-        ),
-      )
+      isAuthenticatedWithGithubStub.callsFake(async () => true)
 
       const operationContext = MockOperationContext(options)
 
       const saveProjectToGithubStub = this.sandbox.stub(GithubOperations, 'saveProjectToGithub')
-      saveProjectToGithubStub.callsFake(
-        wrapWithDeferResolve(
-          { current: this.privatePromise },
-          'saveProjectToGithub',
-          saveProjectToGithub(operationContext),
-        ),
-      )
+      saveProjectToGithubStub.callsFake(saveProjectToGithub(operationContext))
 
       const getBranchCheckSumsStub = this.sandbox.stub(GithubOperations, 'getBranchCheckSums')
-      getBranchCheckSumsStub.callsFake(
-        wrapWithDeferResolve(
-          { current: this.privatePromise },
-          'getBranchCheckSums',
-          getBranchChecksums(operationContext),
-        ),
-      )
+      getBranchCheckSumsStub.callsFake(getBranchChecksums(operationContext))
 
       const getBranchesForGithubRepositoryStub = this.sandbox.stub(
         GithubOperations,
@@ -142,22 +116,10 @@ export class MockGithubOperations {
         GithubOperations,
         'updatePullRequestsForBranch',
       )
-      updatePullRequestsForBranchStub.callsFake(
-        wrapWithDeferResolve(
-          { current: this.privatePromise },
-          'updatePullRequestsForBranch',
-          updatePullRequestsForBranch(operationContext),
-        ),
-      )
+      updatePullRequestsForBranchStub.callsFake(updatePullRequestsForBranch(operationContext))
 
       const saveAssetsToProjectStub = this.sandbox.stub(GithubOperations, 'saveAssetsToProject')
-      saveAssetsToProjectStub.callsFake(
-        wrapWithDeferResolve(
-          { current: this.privatePromise },
-          'saveAssetsToProject',
-          saveAssetsToProject(operationContext),
-        ),
-      )
+      saveAssetsToProjectStub.callsFake(saveAssetsToProject(operationContext))
 
       const getUsersPublicGithubRepositoriesStub = this.sandbox.stub(
         GithubOperations,
@@ -175,31 +137,13 @@ export class MockGithubOperations {
         GithubOperations,
         'updateProjectAgainstGithub',
       )
-      updateProjectAgainstGithubStub.callsFake(
-        wrapWithDeferResolve(
-          { current: this.privatePromise },
-          'updateProjectAgainstGithub',
-          updateProjectAgainstGithub(operationContext),
-        ),
-      )
+      updateProjectAgainstGithubStub.callsFake(updateProjectAgainstGithub(operationContext))
 
       const startGithubPollingStub = this.sandbox.stub(GithubOperations, 'startGithubPolling')
-      startGithubPollingStub.callsFake(
-        wrapWithDeferResolve(
-          { current: this.privatePromise },
-          'startGithubPolling',
-          startGithubPolling(operationContext),
-        ),
-      )
+      startGithubPollingStub.callsFake(startGithubPolling(operationContext))
 
       const resolveConflictStub = this.sandbox.stub(GithubOperations, 'resolveConflict')
-      resolveConflictStub.callsFake(
-        wrapWithDeferResolve(
-          { current: this.privatePromise },
-          'resolveConflict',
-          resolveConflict(operationContext),
-        ),
-      )
+      resolveConflictStub.callsFake(resolveConflict(operationContext))
 
       const updateProjectWithBranchContentStub = this.sandbox.stub(
         GithubOperations,
@@ -220,9 +164,5 @@ export class MockGithubOperations {
     })
 
     return this
-  }
-
-  resetDoneSignal(): void {
-    this.privatePromise = defer()
   }
 }

--- a/editor/src/core/shared/github/operations/index.ts
+++ b/editor/src/core/shared/github/operations/index.ts
@@ -1,0 +1,18 @@
+import { updateProjectContentsWithParseResults } from '../../parser-projectcontents-utils'
+import { saveProjectToGithub } from './commit-and-push'
+import { getBranchChecksums } from './get-branch-checksums'
+import type { GithubOperationContext } from './github-operation-context'
+import { getBranchesForGithubRepository } from './list-branches'
+import { updatePullRequestsForBranch } from './list-pull-requests-for-branch'
+
+const ProdOperationContext: GithubOperationContext = {
+  fetch: fetch,
+  updateProjectContentsWithParseResults: updateProjectContentsWithParseResults,
+}
+
+export const GithubOperations = {
+  saveProjectToGithub: saveProjectToGithub(ProdOperationContext),
+  getBranchCheckSums: getBranchChecksums(ProdOperationContext),
+  getBranchesForGithubRepository: getBranchesForGithubRepository(ProdOperationContext),
+  updatePullRequestsForBranch: updatePullRequestsForBranch(ProdOperationContext),
+} as const

--- a/editor/src/core/shared/github/operations/index.ts
+++ b/editor/src/core/shared/github/operations/index.ts
@@ -1,18 +1,28 @@
 import { updateProjectContentsWithParseResults } from '../../parser-projectcontents-utils'
+import { resolveConflict, startGithubPolling } from '../helpers'
 import { saveProjectToGithub } from './commit-and-push'
 import { getBranchChecksums } from './get-branch-checksums'
 import type { GithubOperationContext } from './github-operation-context'
 import { getBranchesForGithubRepository } from './list-branches'
 import { updatePullRequestsForBranch } from './list-pull-requests-for-branch'
+import { saveAssetsToProject, updateProjectWithBranchContent } from './load-branch'
+import { getUsersPublicGithubRepositories } from './load-repositories'
+import { updateProjectAgainstGithub } from './update-against-branch'
 
-const ProdOperationContext: GithubOperationContext = {
-  fetch: fetch,
+const OperationContext: GithubOperationContext = {
+  fetch: (...args) => window.fetch(...args),
   updateProjectContentsWithParseResults: updateProjectContentsWithParseResults,
 }
 
 export const GithubOperations = {
-  saveProjectToGithub: saveProjectToGithub(ProdOperationContext),
-  getBranchCheckSums: getBranchChecksums(ProdOperationContext),
-  getBranchesForGithubRepository: getBranchesForGithubRepository(ProdOperationContext),
-  updatePullRequestsForBranch: updatePullRequestsForBranch(ProdOperationContext),
+  saveProjectToGithub: saveProjectToGithub(OperationContext),
+  getBranchCheckSums: getBranchChecksums(OperationContext),
+  getBranchesForGithubRepository: getBranchesForGithubRepository(OperationContext),
+  updatePullRequestsForBranch: updatePullRequestsForBranch(OperationContext),
+  saveAssetsToProject: saveAssetsToProject(OperationContext),
+  getUsersPublicGithubRepositories: getUsersPublicGithubRepositories(OperationContext),
+  updateProjectAgainstGithub: updateProjectAgainstGithub(OperationContext),
+  startGithubPolling: startGithubPolling(OperationContext),
+  resolveConflict: resolveConflict(OperationContext),
+  updateProjectWithBranchContent: updateProjectWithBranchContent(OperationContext),
 } as const

--- a/editor/src/core/shared/github/operations/list-branches.ts
+++ b/editor/src/core/shared/github/operations/list-branches.ts
@@ -1,9 +1,8 @@
-import urljoin from 'url-join'
-import { UTOPIA_BACKEND } from '../../../../common/env-vars'
 import { HEADERS, MODE } from '../../../../common/server'
 import type { EditorAction, EditorDispatch } from '../../../../components/editor/action-types'
 import { updateGithubData } from '../../../../components/editor/actions/action-creators'
 import type { GithubOperation, GithubRepo } from '../../../../components/editor/store/editor-state'
+import { GithubEndpoints } from '../endpoints'
 import type { GithubBranch, GithubFailure } from '../helpers'
 import { githubAPIError, githubAPIErrorFromResponse, runGithubOperation } from '../helpers'
 import type { GithubOperationContext } from './github-operation-context'
@@ -24,13 +23,7 @@ export const getBranchesForGithubRepository =
       { name: 'listBranches' },
       dispatch,
       async (operation: GithubOperation) => {
-        const url = urljoin(
-          UTOPIA_BACKEND,
-          'github',
-          'branches',
-          githubRepo.owner,
-          githubRepo.repository,
-        )
+        const url = GithubEndpoints.getBranches(githubRepo)
 
         const response = await operationContext.fetch(url, {
           method: 'GET',

--- a/editor/src/core/shared/github/operations/list-pull-requests-for-branch.ts
+++ b/editor/src/core/shared/github/operations/list-pull-requests-for-branch.ts
@@ -1,5 +1,3 @@
-import urljoin from 'url-join'
-import { UTOPIA_BACKEND } from '../../../../common/env-vars'
 import { HEADERS, MODE } from '../../../../common/server'
 import type { EditorAction, EditorDispatch } from '../../../../components/editor/action-types'
 import { updateGithubData } from '../../../../components/editor/actions/action-creators'
@@ -8,6 +6,7 @@ import type {
   GithubRepo,
   PullRequest,
 } from '../../../../components/editor/store/editor-state'
+import { GithubEndpoints } from '../endpoints'
 import type { GithubFailure } from '../helpers'
 import { githubAPIError, githubAPIErrorFromResponse, runGithubOperation } from '../helpers'
 import type { GithubOperationContext } from './github-operation-context'
@@ -44,16 +43,7 @@ export const updatePullRequestsForBranch =
       },
       dispatch,
       async (operation: GithubOperation) => {
-        const url = urljoin(
-          UTOPIA_BACKEND,
-          'github',
-          'branches',
-          githubRepo.owner,
-          githubRepo.repository,
-          'branch',
-          branchName,
-          'pullrequest',
-        )
+        const url = GithubEndpoints.updatePullRequests(githubRepo, branchName)
 
         const response = await operationContext.fetch(url, {
           method: 'GET',

--- a/editor/src/core/shared/github/operations/load-branch.ts
+++ b/editor/src/core/shared/github/operations/load-branch.ts
@@ -2,7 +2,6 @@ import type { UtopiaTsWorkers } from '../../../../core/workers/common/worker-typ
 import type { ProjectContentTreeRoot } from '../../../../components/assets'
 import { getProjectFileByFilePath } from '../../../../components/assets'
 import {
-  getProjectContentsChecksums,
   packageJsonFileFromProjectContents,
   walkContentsTreeAsync,
 } from '../../../../components/assets'

--- a/editor/src/core/shared/github/operations/load-repositories.ts
+++ b/editor/src/core/shared/github/operations/load-repositories.ts
@@ -1,5 +1,3 @@
-import urljoin from 'url-join'
-import { UTOPIA_BACKEND } from '../../../../common/env-vars'
 import { HEADERS, MODE } from '../../../../common/server'
 import type { EditorAction, EditorDispatch } from '../../../../components/editor/action-types'
 import {
@@ -9,6 +7,7 @@ import {
 } from '../../../../components/editor/actions/action-creators'
 import type { GithubOperation } from '../../../../components/editor/store/editor-state'
 import { emptyGithubSettings } from '../../../../components/editor/store/editor-state'
+import { GithubEndpoints } from '../endpoints'
 import type { GithubFailure, RepositoryEntry } from '../helpers'
 import { githubAPIError, githubAPIErrorFromResponse, runGithubOperation } from '../helpers'
 import type { GithubOperationContext } from './github-operation-context'
@@ -27,7 +26,7 @@ export const getUsersPublicGithubRepositories =
       { name: 'loadRepositories' },
       dispatch,
       async (operation: GithubOperation) => {
-        const url = urljoin(UTOPIA_BACKEND, 'github', 'user', 'repositories')
+        const url = GithubEndpoints.repositories()
 
         const response = await operationContext.fetch(url, {
           method: 'GET',

--- a/editor/src/core/shared/github/operations/update-against-branch.ts
+++ b/editor/src/core/shared/github/operations/update-against-branch.ts
@@ -89,13 +89,12 @@ export const updateProjectAgainstGithub =
         )
 
         // Save assets to the server from Github.
-        await saveAssetsToProject(
+        await saveAssetsToProject(operationContext)(
           githubRepo,
           projectID,
           branchLatestContent.branch,
           dispatch,
           currentProjectContents,
-          operationContext,
         )
 
         dispatch(

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -128,6 +128,7 @@ import {
   ProjectServerState,
   ProjectServerStateUpdater,
 } from '../components/editor/store/project-server-state'
+import { GithubOperations } from '../core/shared/github/operations'
 
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()
@@ -291,7 +292,7 @@ export class Editor {
 
     void renderRootEditor()
 
-    startGithubPolling(this.utopiaStoreHook, this.boundDispatch)
+    void GithubOperations.startGithubPolling(this.utopiaStoreHook, this.boundDispatch)
 
     reduxDevtoolsSendInitialState(this.storedState)
 
@@ -450,7 +451,7 @@ export class Editor {
       )
       const anyLoadActions = dispatchedActions.some((action) => action.action === 'LOAD')
       if (anyLoadActions) {
-        startGithubPolling(this.utopiaStoreHook, this.boundDispatch)
+        void GithubOperations.startGithubPolling(this.utopiaStoreHook, this.boundDispatch)
       }
 
       invalidateDomWalkerIfNecessary(

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -105,7 +105,6 @@ import {
 import { isFeatureEnabled } from '../utils/feature-switches'
 import { shouldInspectorUpdate as shouldUpdateLowPriorityUI } from '../components/inspector/inspector'
 import * as EP from '../core/shared/element-path'
-import { isAuthenticatedWithGithub } from '../utils/github-auth'
 import { waitUntil } from '../core/shared/promise-utils'
 import { sendSetVSCodeTheme } from '../core/vscode/vscode-bridge'
 import type { ElementPath } from '../core/shared/project-file-types'
@@ -129,6 +128,7 @@ import {
   ProjectServerStateUpdater,
 } from '../components/editor/store/project-server-state'
 import { GithubOperations } from '../core/shared/github/operations'
+import { GithubAuth } from '../utils/github-auth'
 
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()
@@ -340,7 +340,7 @@ export class Editor {
 
         void updateUserDetailsWhenAuthenticated(
           this.boundDispatch,
-          isAuthenticatedWithGithub(loginState),
+          GithubAuth.isAuthenticatedWithGithub(loginState),
         ).then((authenticatedWithGithub) => {
           this.storedState.userState = {
             ...this.storedState.userState,

--- a/editor/src/utils/github-auth.ts
+++ b/editor/src/utils/github-auth.ts
@@ -19,7 +19,7 @@ async function checkIfAuthenticatedWithGithub(): Promise<boolean> {
   }
 }
 
-export async function isAuthenticatedWithGithub(loginState: LoginState): Promise<boolean> {
+async function isAuthenticatedWithGithub(loginState: LoginState): Promise<boolean> {
   if (loginState.type === 'LOGGED_IN') {
     return checkIfAuthenticatedWithGithub()
   } else {
@@ -29,7 +29,7 @@ export async function isAuthenticatedWithGithub(loginState: LoginState): Promise
 
 const timeToWait = 1000 * 5
 
-export async function startGithubAuthentication(dispatch: EditorDispatch): Promise<void> {
+async function startGithubAuthentication(dispatch: EditorDispatch): Promise<void> {
   // Open the window that starts the authentication flow.
   const url = GithubEndpoints.authenticationStart()
   window.open(url)

--- a/editor/src/utils/github-auth.ts
+++ b/editor/src/utils/github-auth.ts
@@ -60,3 +60,8 @@ export async function startGithubAuthentication(dispatch: EditorDispatch): Promi
   // Try this for a maximum of 5 minutes.
   await checkAuthenticatedPeriodically(1000 * 60 * 5)
 }
+
+export const GithubAuth = {
+  isAuthenticatedWithGithub: isAuthenticatedWithGithub,
+  startGithubAuthentication: startGithubAuthentication,
+} as const

--- a/editor/src/utils/github-auth.ts
+++ b/editor/src/utils/github-auth.ts
@@ -1,13 +1,12 @@
-import { UTOPIA_BACKEND } from '../common/env-vars'
 import { MODE } from '../common/server'
-import urljoin from 'url-join'
 import type { LoginState } from '../common/user'
 import type { EditorDispatch } from '../components/editor/action-types'
 import { setGithubState } from '../components/editor/actions/action-creators'
+import { GithubEndpoints } from '../core/shared/github/endpoints'
 import { updateUserDetailsWhenAuthenticated } from '../core/shared/github/helpers'
 
 async function checkIfAuthenticatedWithGithub(): Promise<boolean> {
-  const url = urljoin(UTOPIA_BACKEND, 'github', 'authentication', 'status')
+  const url = GithubEndpoints.authenticationStatus()
   const response = await fetch(url, {
     method: 'GET',
     credentials: 'include',
@@ -32,7 +31,7 @@ const timeToWait = 1000 * 5
 
 export async function startGithubAuthentication(dispatch: EditorDispatch): Promise<void> {
   // Open the window that starts the authentication flow.
-  const url = urljoin(UTOPIA_BACKEND, 'github', 'authentication', 'start')
+  const url = GithubEndpoints.authenticationStart()
   window.open(url)
 
   async function checkAuthenticatedPeriodically(timeLeftMS: number): Promise<void> {

--- a/editor/src/utils/utils.ts
+++ b/editor/src/utils/utils.ts
@@ -894,10 +894,12 @@ function update<T>(index: number, newValue: T, array: Array<T>): Array<T> {
   return result
 }
 
-export function defer<T>(): Promise<T> & {
+export type Defer<T> = Promise<T> & {
   resolve: (value?: T) => void
   reject: (reason?: any) => void
-} {
+}
+
+export function defer<T>(): Defer<T> {
   var res, rej
 
   var promise = new Promise<T>((resolve, reject) => {


### PR DESCRIPTION
## Description
This PR makes it possible to dependecy inject `fetch` and `updateProjectContentsWithParseResults` into the functions implementing the GitHub operations. This way `fetch` and `updateProjectContentsWithParseResults` can be swapped out for a mock implementation for testing.

### Details
- The functions implementing the GitHub operations are passed an object (`GithubOperationContext`) with the functions we want to inject dependency. These functions are curried so that the `GithubOperationContext` param can be passed independently.
- The functions in `github-auth.ts` are extracted into an object export, `GithubAuth`, so that they can be mocked as well.
- The GitHub URLs are extracted into a separate constructor object (`GithubEndpoints`)
- Mocking is done by `MockGithubOperations`. All the functions on `GithubOperations` are stubbed and replaced with a function that is the original one with a different `operationContext`. `fetch` is replaced with a function that returns a hardcoded response to a given URL, and `updateProjectContentsWithParseResults` returns a hardcoded `ProjectContentTreeRoot`. `MockGithubOperations` exposes defers for some GitHub operations that can be awaited during tests (these can be extended later).

## Out of scope
This PR only intends to add the tools for writing tests for the GitHub integration, not the full test coverage.