### PR TITLE
Specify the API version when making calls to Github.

### DIFF
--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -135,6 +135,7 @@ callGithub githubSemaphore makeRequest queryParameters handleErrorCases accessTo
   let options = WR.defaults
               & WR.header "User-Agent" .~ ["concrete-utopia/utopia"]
               & WR.header "Accept" .~ ["application/vnd.github.v3+json"]
+              & WR.header "X-GitHub-Api-Version" .~ ["2022-11-28"]
               & WR.header "Authorization" .~ ["Bearer " <> (encodeUtf8 $ atoken accessToken)]
               & WR.checkResponse .~ (Just $ \_ _ -> return ())
               & WR.params .~ queryParameters


### PR DESCRIPTION
**Problem:**
Github support versions of their API, which is helpful if they want to change their API and keep old versions running. But is also helpful for us because by default without specifying the version we could end up using whatever version Github thinks is best. So the API might shift like sand underneath us randomly one day.

**Fix:**
This specifies the `X-GitHub-Api-Version` header when making calls to Github.

**Commit Details:**
- `callGithub` now includes the `X-GitHub-Api-Version` header.