### PR TITLE
Group size label

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -1497,6 +1497,32 @@ export var storyboard = (
     })
   })
   describe('groups', () => {
+    it('has a "Group" size label', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        formatTestProjectCode(`
+          import * as React from 'react'
+          import { Storyboard, Group } from 'utopia-api'
+
+          export var storyboard = (
+            <Storyboard data-uid='storyboard'>
+              <Group data-uid='group' style={{ position: 'absolute', width: 150, height: 150, background: 'black' }}>
+                <div data-uid='foo' style={{ position:'absolute', width: 50, height: 50, background: 'red', top: 0, left: 0 }} />
+                <div data-uid='bar' style={{ position:'absolute', width: 50, height: 50, background: 'blue', top: 100, left: 100 }} />
+              </Group>
+            </Storyboard>
+          )
+        `),
+        'await-first-dom-report',
+      )
+
+      await renderResult.dispatch(
+        [selectComponents([EP.fromString('storyboard/group')], false)],
+        true,
+      )
+
+      const label = await renderResult.renderedDOM.findByTestId(SizeLabelTestId)
+      expect(label.textContent).toEqual('Group')
+    })
     it('resizes groups correctly when dragging from top/left without existing left/top props (left)', async () => {
       const renderResult = await renderTestEditorWithCode(
         formatTestProjectCode(`


### PR DESCRIPTION
Fixes #4256

**Problem:**

Groups show the `Hug x Hug` size label, even though it makes little sense as it's the only possible configuration.

<img width="1004" alt="Screenshot 2023-09-28 at 2 49 52 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/b7e19789-0352-4d29-a6d2-405856de4c4c">

**Fix:**

Use `Group` as a size label for group elements.

<img width="1003" alt="Screenshot 2023-09-28 at 2 49 56 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/372d3192-a046-4afe-835f-78174e77ba6d">
