### PR TITLE
Dim overlapping labels

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -582,6 +582,7 @@ const SizeLabel = React.memo(
               fontSize: FontSize / scale,
               height: ExplicitHeightHacked / scale,
               opacity: dimmed ? 0.075 : 1,
+              transition: '0.1s',
             }}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}


### PR DESCRIPTION
Fixes #4271 

**Problem:**

When there close elements, the size labels can get in the way of selecting neighbors.

![Kapture 2023-09-29 at 13 03 34](https://github.com/concrete-utopia/utopia/assets/1081051/4af8e861-b1e4-49de-a6f7-77042a502510)

**Fix:**

When the mouse is over the label, if the label is covering other elements, dim the label to almost-invisible.

![Kapture 2023-09-29 at 13 04 31](https://github.com/concrete-utopia/utopia/assets/1081051/e437758d-df55-4f39-a2af-a3901e9e428e)
