### PR TITLE
Drop pink inspector constrained w/h color

### DIFF
--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -609,7 +609,7 @@ const GroupConstraintSelect = React.memo(
     const mainColor = React.useMemo(() => {
       switch (type) {
         case 'constrained':
-          return colorTheme.brandNeonPink.value
+          return colorTheme.fg0.value
         case 'mixed':
           return colorTheme.fg6Opacity50.value
         case 'not-constrained':


### PR DESCRIPTION
Fixes #4263 

**Problem:**

The color for the `Constrained` w/h value in the inspector, when set, is unnecessarily pink.

<img width="293" alt="Screenshot 2023-09-28 at 6 23 39 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/d37ee6bc-b74d-48b7-ad03-37d37c152075">

**Fix:**

Make it `fg0`.

<img width="284" alt="Screenshot 2023-09-28 at 6 23 44 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/36cb401e-5106-41de-be11-3f03f61fae81">
