### PR TITLE
Delete existing empty spans when leaving text edit mode

### DIFF
--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -357,7 +357,7 @@ describe('Use the text editor', () => {
   })
   describe('blur', () => {
     describe('when the element is empty', () => {
-      it('keeps existing elements', async () => {
+      it('deletes existing elements', async () => {
         const editor = await renderTestEditorWithCode(projectWithText, 'await-first-dom-report')
 
         await enterTextEditMode(editor)
@@ -375,20 +375,7 @@ describe('Use the text editor', () => {
 
 
             export var storyboard = (
-              <Storyboard data-uid='sb'>
-                <div
-                  data-testid='div'
-                  style={{
-                    backgroundColor: '#0091FFAA',
-                    position: 'absolute',
-                    left: 0,
-                    top: 0,
-                    width: 288,
-                    height: 362,
-                  }}
-                  data-uid='39e'
-                />
-              </Storyboard>
+              <Storyboard data-uid='sb' />
             )`),
         )
       })

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -467,68 +467,6 @@ describe('Use the text editor', () => {
           `),
         )
       })
-      it('does not delete span elements with styling', async () => {
-        const editor = await renderTestEditorWithCode(
-          formatTestProjectCode(`
-            import * as React from 'react'
-            import { Storyboard } from 'utopia-api'
-
-            export var storyboard = (
-              <Storyboard data-uid='sb'>
-                <span
-                  data-uid='span'
-                  data-testid='span'
-                  style={{
-                    position: 'absolute',
-                    wordBreak: 'break-word',
-                    left: 0,
-                    top: 0,
-                    width: 'max-content',
-                    height: 'max-content',
-                    border: '1px solid red',
-                  }}
-                >
-                  Hello
-                </span>
-              </Storyboard>
-            )
-          `),
-          'await-first-dom-report',
-        )
-
-        await enterTextEditMode(editor, 'start', 'span')
-
-        deleteTypedText()
-
-        await closeTextEditor()
-        await editor.getDispatchFollowUpActionsFinished()
-
-        expect(editor.getEditorState().editor.mode.type).toEqual('select')
-        expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-          formatTestProjectCode(`
-            import * as React from 'react'
-            import { Storyboard } from 'utopia-api'
-
-            export var storyboard = (
-              <Storyboard data-uid='sb'>
-                <span
-                  data-uid='span'
-                  data-testid='span'
-                  style={{
-                    position: 'absolute',
-                    wordBreak: 'break-word',
-                    left: 0,
-                    top: 0,
-                    width: 'max-content',
-                    height: 'max-content',
-                    border: '1px solid red',
-                  }}
-                />
-              </Storyboard>
-            )
-          `),
-        )
-      })
       it('does not delete span elements with event handlers', async () => {
         const editor = await renderTestEditorWithCode(
           formatTestProjectCode(`

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -448,7 +448,7 @@ describe('Use the text editor', () => {
           'await-first-dom-report',
         )
 
-        await enterTextEditMode(editor, 'span')
+        await enterTextEditMode(editor, 'start', 'span')
 
         deleteTypedText()
 
@@ -496,7 +496,7 @@ describe('Use the text editor', () => {
           'await-first-dom-report',
         )
 
-        await enterTextEditMode(editor, 'span')
+        await enterTextEditMode(editor, 'start', 'span')
 
         deleteTypedText()
 
@@ -558,7 +558,7 @@ describe('Use the text editor', () => {
           'await-first-dom-report',
         )
 
-        await enterTextEditMode(editor, 'span')
+        await enterTextEditMode(editor, 'start', 'span')
 
         deleteTypedText()
 
@@ -1970,14 +1970,15 @@ async function testModifierExpectingWayTooManySavesTheFirstTime(
 
 async function enterTextEditMode(
   editor: EditorRenderResult,
+  where: 'start' | 'end' = 'end',
   testId: string = 'div',
 ): Promise<void> {
   const canvasControlsLayer = editor.renderedDOM.getByTestId(CanvasControlsContainerID)
   const element = editor.renderedDOM.getByTestId(testId)
   const bounds = element.getBoundingClientRect()
   const corner = {
-    x: bounds.x + 1,
-    y: bounds.y + 1,
+    x: bounds.x + (where === 'start' ? 1 : 50),
+    y: bounds.y + (where === 'start' ? 1 : 40),
   }
 
   FOR_TESTS_setNextGeneratedUid('text-span')
@@ -1987,7 +1988,6 @@ async function enterTextEditMode(
   await mouseClickAtPoint(canvasControlsLayer, corner)
   await editor.getDispatchFollowUpActionsFinished()
 }
-
 function typeText(text: string) {
   document.execCommand('insertText', false, text)
 }

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -357,11 +357,11 @@ const TextEditor = React.memo((props: TextEditorProps) => {
           if (elementState != null && savedContentRef.current !== content) {
             savedContentRef.current = content
             requestAnimationFrame(() => dispatch([getSaveAction(elementPath, content, textProp)]))
-          }
 
-          // remove dangling empty spans
-          if (content != null && content.replace(/^\n/, '').length === 0 && canDeleteWhenEmpty) {
-            requestAnimationFrame(() => dispatch([deleteView(elementPath)]))
+            // remove dangling empty spans
+            if (content != null && content.replace(/^\n/, '').length === 0 && canDeleteWhenEmpty) {
+              requestAnimationFrame(() => dispatch([deleteView(elementPath)]))
+            }
           }
         }
       }

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -342,7 +342,7 @@ const TextEditor = React.memo((props: TextEditorProps) => {
     return () => {
       const content = currentElement.textContent
       if (content != null) {
-        if (elementState === 'new' && content.replace(/\n/g, '') === '') {
+        if (content.replace(/\n/g, '') === '') {
           requestAnimationFrame(() => dispatch([deleteView(elementPath)]))
         } else {
           if (elementState != null && savedContentRef.current !== content) {

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -333,6 +333,7 @@ const TextEditor = React.memo((props: TextEditorProps) => {
 
     currentElement.focus()
     savedContentRef.current = currentElement.textContent
+    const initialText = currentElement.textContent
 
     const elementCanvasFrame = MetadataUtils.getFrameOrZeroRectInCanvasCoords(
       elementPath,
@@ -357,11 +358,15 @@ const TextEditor = React.memo((props: TextEditorProps) => {
           if (elementState != null && savedContentRef.current !== content) {
             savedContentRef.current = content
             requestAnimationFrame(() => dispatch([getSaveAction(elementPath, content, textProp)]))
-
-            // remove dangling empty spans
-            if (content != null && content.replace(/^\n/, '').length === 0 && canDeleteWhenEmpty) {
-              requestAnimationFrame(() => dispatch([deleteView(elementPath)]))
-            }
+          }
+          // remove dangling empty spans
+          if (
+            content != null &&
+            initialText !== content &&
+            content.replace(/^\n/, '').length === 0 &&
+            canDeleteWhenEmpty
+          ) {
+            requestAnimationFrame(() => dispatch([deleteView(elementPath)]))
           }
         }
       }
@@ -608,21 +613,6 @@ function getSaveAction(
   return updateText(elementPath, escapeHTML(content, textProp), textProp)
 }
 
-const allowedStyleKeysForDeletion: string[] = [
-  'position',
-  'top',
-  'left',
-  'bottom',
-  'right',
-  'width',
-  'height',
-  'wordBreak',
-  'fontSize',
-  'fontWeight',
-  'fontFamily',
-  'font',
-]
-
 function canDeleteElementWhenEmpty(
   jsxMetadata: ElementInstanceMetadataMap,
   path: ElementPath,
@@ -638,14 +628,6 @@ function canDeleteElementWhenEmpty(
 
   const elementProps = allElementProps[toString(path)]
   if (elementProps == null) {
-    return false
-  }
-
-  // it must not have defined styling
-  if (
-    elementProps.style != null &&
-    Object.keys(elementProps.style).some((key) => !allowedStyleKeysForDeletion.includes(key))
-  ) {
     return false
   }
 

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -442,9 +442,7 @@ const TextEditor = React.memo((props: TextEditorProps) => {
     if (
       content != null &&
       content.replace(/^\n/, '').length === 0 &&
-      MetadataUtils.isMaybeSpan(
-        MetadataUtils.findElementByElementPath(metadataRef.current, elementPath),
-      )
+      canDeleteWhenEmpty(metadataRef.current, elementPath)
     ) {
       requestAnimationFrame(() => dispatch([deleteView(elementPath)]))
     }
@@ -603,4 +601,15 @@ function getSaveAction(
   textProp: TextProp,
 ): EditorAction {
   return updateText(elementPath, escapeHTML(content, textProp), textProp)
+}
+
+function canDeleteWhenEmpty(jsxMetadata: ElementInstanceMetadataMap, path: ElementPath): boolean {
+  const element = MetadataUtils.findElementByElementPath(jsxMetadata, path)
+  if (element == null) {
+    return false
+  }
+  if (!MetadataUtils.isSpan(element)) {
+    return false
+  }
+  return true
 }

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -342,7 +342,7 @@ const TextEditor = React.memo((props: TextEditorProps) => {
     return () => {
       const content = currentElement.textContent
       if (content != null) {
-        if (content.replace(/\n/g, '') === '') {
+        if (elementState === 'new' && content.replace(/\n/g, '') === '') {
           requestAnimationFrame(() => dispatch([deleteView(elementPath)]))
         } else {
           if (elementState != null && savedContentRef.current !== content) {
@@ -437,7 +437,18 @@ const TextEditor = React.memo((props: TextEditorProps) => {
     } else {
       dispatch([updateEditorMode(EditorModes.selectMode(null, false, 'none'))])
     }
-  }, [dispatch, elementPath, elementState, textProp])
+
+    // remove dangling empty spans
+    if (
+      content != null &&
+      content.replace(/^\n/, '').length === 0 &&
+      MetadataUtils.isMaybeSpan(
+        MetadataUtils.findElementByElementPath(metadataRef.current, elementPath),
+      )
+    ) {
+      requestAnimationFrame(() => dispatch([deleteView(elementPath)]))
+    }
+  }, [dispatch, elementPath, elementState, textProp, metadataRef])
 
   const editorProps: React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLSpanElement>,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -903,6 +903,9 @@ export const MetadataUtils = {
   isSpan(instance: ElementInstanceMetadata): boolean {
     return this.isElementOfType(instance, 'span')
   },
+  isMaybeSpan(instance: ElementInstanceMetadata | null): boolean {
+    return instance != null && this.isElementOfType(instance, 'span')
+  },
   targetIsScene(metadata: ElementInstanceMetadataMap, path: ElementPath): boolean {
     const elementMetadata = MetadataUtils.findElementByElementPath(metadata, path)
     return elementMetadata != null && isSceneFromMetadata(elementMetadata)

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -903,9 +903,6 @@ export const MetadataUtils = {
   isSpan(instance: ElementInstanceMetadata): boolean {
     return this.isElementOfType(instance, 'span')
   },
-  isMaybeSpan(instance: ElementInstanceMetadata | null): boolean {
-    return instance != null && this.isElementOfType(instance, 'span')
-  },
   targetIsScene(metadata: ElementInstanceMetadataMap, path: ElementPath): boolean {
     const elementMetadata = MetadataUtils.findElementByElementPath(metadata, path)
     return elementMetadata != null && isSceneFromMetadata(elementMetadata)


### PR DESCRIPTION
Fixes #4265

**Problem:**

When leaving text edit mode, new elements are deleted, but existing ones are kept.

**Fix:**

Update the behavior so it also removes _existing_ empty elements if:
1. the element is a span
3. _and_ it does not have event handlers