### PR TITLE
Select wrapper after wrapping

### DIFF
--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -6675,6 +6675,9 @@ export var storyboard = (
         </div>`,
         ),
       )
+      expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
+        `utopia-storyboard-uid/scene-aaa/app-entity:aaa/${testUID}`,
+      ])
     })
     it(`Wraps 2 elements inside a flex layout`, async () => {
       const testUID = 'zzz'

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2164,16 +2164,18 @@ export const UPDATE_FNS = {
           return childInsertionPath(newPath)
         }
 
+        const actualInsertionPath = insertionPath()
+
         const { editor: editorWithElementsInserted, newPaths } = insertIntoWrapper(
           orderedActionTargets,
-          insertionPath(),
+          actualInsertionPath,
           includeToast(detailsOfUpdate, withWrapperViewAdded),
           derived,
         )
 
         return {
           ...editorWithElementsInserted,
-          selectedViews: newPaths,
+          selectedViews: [actualInsertionPath.intendedParentPath],
           highlightedViews: [],
           trueUpGroupsForElementAfterDomWalkerRuns: [
             ...editorWithElementsInserted.trueUpGroupsForElementAfterDomWalkerRuns,


### PR DESCRIPTION
## Problem
When wrapping elements, the wrapped elements stay selected. Instead, the new wrapped should be selected.

## Fix
Implement the above