### PR TITLE
Ensure updating the remix router also updates the navigation data

### DIFF
--- a/editor/src/components/canvas/remix/remix-rendering.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-rendering.spec.browser2.tsx
@@ -45,6 +45,7 @@ import {
   RemixNavigationBarHomeLabel,
   RemixNavigationBarPathTestId,
 } from '../../editor/remix-navigation-bar'
+import { updateFromCodeEditor } from '../../editor/actions/actions-from-vscode'
 
 const DefaultRouteTextContent = 'Hello Remix!'
 const RootTextContent = 'This is root!'
@@ -348,6 +349,83 @@ describe('Remix content', () => {
     expect(
       renderResult.renderedDOM.queryAllByTestId(LocationDoesNotMatchRoutesTestId),
     ).toHaveLength(1) // location not matching warning is rendered
+  })
+
+  it("changing a route whilst 404 is shown doesn't break the navigation", async () => {
+    const project = createModifiedProject({
+      [StoryboardFilePath]: `import * as React from 'react'
+      import { RemixScene, Storyboard } from 'utopia-api'
+
+      export var storyboard = (
+        <Storyboard data-uid='sb'>
+          <RemixScene
+            style={{
+              width: 700,
+              height: 759,
+              position: 'absolute',
+              left: 212,
+              top: 128,
+            }}
+            data-label='Playground'
+            data-uid='remix-scene'
+          />
+        </Storyboard>
+      )
+      `,
+      ['/src/root.js']: `import React from 'react'
+      import { Outlet } from '@remix-run/react'
+
+      export default function Root() {
+        return (
+          <div data-uid='rootdiv'>
+            ${RootTextContent}
+            <Outlet data-uid='outlet'/>
+          </div>
+        )
+      }
+      `,
+      ['/src/routes/_index.js']: `import React from 'react'
+      import { Link } from '@remix-run/react'
+
+      export default function Index() {
+        return <Link to='/about' data-testid='remix-link' data-uid='remix-link'>${DefaultRouteTextContent}</Link>
+      }
+      `,
+    })
+
+    const renderResult = await renderRemixProject(project)
+
+    await switchToLiveMode(renderResult)
+
+    await clickRemixLink(renderResult)
+
+    expect(renderResult.renderedDOM.queryByText('404 Not Found')).not.toBeNull() // default 404 page is rendered
+
+    // Make a change to a route, which will in turn update the router
+    const newRouteTextContent = 'I have changed!'
+    await renderResult.dispatch(
+      [
+        updateFromCodeEditor(
+          '/src/routes/_index.js',
+          `import React from 'react'
+    import { Link } from '@remix-run/react'
+
+    export default function Index() {
+      return <Link to='/about' data-testid='remix-link' data-uid='remix-link'>${newRouteTextContent}</Link>
+    }
+    `,
+          null,
+        ),
+      ],
+      true,
+    )
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Ensure we can still hit the back button and navigate back to the previous route, with the new content
+    const pathToRemixScene = EP.fromString('sb/remix-scene')
+    await navigateWithRemixSceneLabelButton(renderResult, pathToRemixScene, 'back')
+    expect(renderResult.renderedDOM.queryByText(newRouteTextContent)).not.toBeNull()
+    expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene)).toEqual('(home)')
   })
 
   it('Two remix scenes, both have metadata', async () => {

--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -219,14 +219,14 @@ export const UtopiaRemixRootComponent = React.memo((props: UtopiaRemixRootCompon
     (
       innerRouter: RouterType,
       location: Location,
-      updateEntries: 'update-entries' | 'do-not-update-entries',
+      updateEntries: 'append-to-entries' | 'replace-entries',
     ) => {
       setNavigationData((current) => {
         const key = EP.toString(basePath)
         const existingEntries = current[key]?.entries ?? []
 
         const shouldUpdateEntries =
-          updateEntries === 'update-entries' &&
+          updateEntries === 'append-to-entries' &&
           existingEntries.at(-1)?.pathname !== location.pathname
 
         const updatedEntries = shouldUpdateEntries
@@ -250,14 +250,14 @@ export const UtopiaRemixRootComponent = React.memo((props: UtopiaRemixRootCompon
 
   const updateNavigationData = React.useCallback(
     (innerRouter: RouterType, location: Location) => {
-      setNavigationDataForRouter(innerRouter, location, 'update-entries')
+      setNavigationDataForRouter(innerRouter, location, 'append-to-entries')
     },
     [setNavigationDataForRouter],
   )
 
   const initialiseNavigationData = React.useCallback(
     (innerRouter: RouterType) => {
-      setNavigationDataForRouter(innerRouter, innerRouter.state.location, 'do-not-update-entries')
+      setNavigationDataForRouter(innerRouter, innerRouter.state.location, 'replace-entries')
     },
     [setNavigationDataForRouter],
   )


### PR DESCRIPTION
**Problem:**
When working on a Remix project, it is possible to get "stuck" on a 404 route (the navigation toolbars stop working) if a change is made to the project whilst one is showing

**Fix:**
The problem here is that a change to the project's routes will replace the `router` with a new one, but we weren't updating the `navigationData` when this happened, meaning the navigation functions would still be using the previous `router` until the new one had triggered any form of navigation. This meant that hitting the "back" button would still call the loader function for the correct route, but then that route would never be rendered since this was happening via a `router` that wasn't being used as the actual `RouterProvider` for the remix app.