### PR TITLE
LoggedOutPane has moved

### DIFF
--- a/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
+++ b/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
@@ -7,8 +7,9 @@ import * as EditorActions from '../../../editor/actions/action-creators'
 import styled from '@emotion/styled'
 import { Substores, useEditorState } from '../../../editor/store/store-hook'
 import { FlexRow, UtopiaTheme, H2, CheckboxInput, FlexColumn, Subdued } from '../../../../uuiui'
-
 import { useDispatch } from '../../../editor/store/dispatch-context'
+import { User } from '../../../../uuiui-deps'
+import { LoggedOutPane } from '../../../../components/navigator/left-pane/logged-out-pane'
 
 const StyledFlexRow = styled(FlexRow)({
   height: UtopiaTheme.layout.rowHeight.normal,
@@ -51,8 +52,15 @@ export const SettingsPanel = React.memo(() => {
     dispatch([EditorActions.toggleInterfaceDesignerAdditionalControls()])
   }, [dispatch])
 
+  const loggedIn = useEditorState(
+    Substores.restOfStore,
+    (store) => User.isLoggedIn(store.userState.loginState),
+    'LeftPaneComponent loggedIn',
+  )
+
   return (
     <FlexColumn>
+      {loggedIn ? null : <LoggedOutPane />}
       <FlexRow style={{ marginTop: 8, marginBottom: 12, paddingLeft: 8 }}>
         <H2>Interface</H2>
       </FlexRow>

--- a/editor/src/components/navigator/left-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/index.tsx
@@ -23,7 +23,6 @@ import { UIGridRow } from '../../inspector/widgets/ui-grid-row'
 import { ContentsPane } from './contents-pane'
 import { ForksGiven } from './forks-given'
 import { GithubPane } from './github-pane'
-import { LoggedOutPane } from './logged-out-pane'
 import { SettingsPane } from './settings-pane'
 import { NavigatorComponent } from '../navigator'
 import { usePubSubAtom } from '../../../core/shared/atom-with-pub-sub'
@@ -169,7 +168,6 @@ export const LeftPaneComponent = React.memo<LeftPaneComponentProps>((props) => {
           {selectedTab === LeftMenuTab.Navigator ? <NavigatorComponent /> : null}
           {selectedTab === LeftMenuTab.Project ? <ContentsPane /> : null}
           {selectedTab === LeftMenuTab.Github ? <GithubPane /> : null}
-          {loggedIn ? null : <LoggedOutPane />}
         </div>
       </ResizableFlexColumn>
     </LowPriorityStoreProvider>

--- a/editor/src/components/navigator/left-pane/logged-out-pane.tsx
+++ b/editor/src/components/navigator/left-pane/logged-out-pane.tsx
@@ -12,17 +12,14 @@ import {
   SectionTitleRow,
   Subdued,
   Title,
+  colorTheme,
 } from '../../../uuiui'
 import { UIGridRow } from '../../inspector/widgets/ui-grid-row'
+import { FlexCol } from 'utopia-api'
 
 export const LoggedOutPane = React.memo(() => {
   return (
     <Section data-name='Storyboards' tabIndex={-1}>
-      <SectionTitleRow minimised={false} hideButton>
-        <FlexRow flexGrow={1} style={{ position: 'relative' }}>
-          <Title>Sign in to</Title>
-        </FlexRow>
-      </SectionTitleRow>
       <SectionBodyArea minimised={false}>
         <UIGridRow
           padded
@@ -42,6 +39,7 @@ export const LoggedOutPane = React.memo(() => {
             fontSize: '11px',
           }}
         >
+          <Title>Sign In To:</Title>
           <ul style={{ paddingLeft: 16 }}>
             <li>Design and code from anywhere</li>
             <li>Save and preview your projects</li>
@@ -49,13 +47,19 @@ export const LoggedOutPane = React.memo(() => {
             <li>Load and save projects on Github</li>
           </ul>
         </UIGridRow>
-        <UIGridRow style={{ gap: 8 }} padded variant='<--1fr--><--1fr-->'>
-          <Button primary highlight>
+        <FlexCol css={{ padding: '0 8px', gap: 8, alignItems: 'center', justifyContent: 'center' }}>
+          <Button
+            style={{
+              background: colorTheme.dynamicBlue.value,
+              color: colorTheme.bg0.value,
+              width: 180,
+            }}
+          >
             <b>Sign In</b>&nbsp;
-            <Icons.ExternalLinkSmaller color='on-highlight-main' />
+            <Icons.ExternalLinkSmaller color='on-light-main' />
           </Button>
           <Subdued>Free and Open Source</Subdued>
-        </UIGridRow>
+        </FlexCol>
       </SectionBodyArea>
     </Section>
   )

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -278,6 +278,7 @@ export const TitleBarUserProfile = React.memo((props: { panelData: StoredPanel }
               paddingRight: 8,
               background: colorTheme.dynamicBlue.value,
               color: colorTheme.bg1.value,
+              fontWeight: 600,
             }}
             onClick={onClickLoginNewTab}
             onMouseDown={onMouseDown}
@@ -516,6 +517,7 @@ const TitleBar = React.memo(() => {
               paddingRight: 8,
               background: colorTheme.dynamicBlue.value,
               color: colorTheme.bg1.value,
+              fontWeight: 600,
             }}
             onClick={onClickLoginNewTab}
           >


### PR DESCRIPTION
Moving the not-so-frequently seen LoggedOutPane from the Project tab or the left menu into the inspector tab of the right menu (when no canvas elements are selected), and made the blue colors theme-aware.

| Before | After |
| ------------- | ------------- |
| <img width="1195" alt="Screenshot 2023-09-29 at 5 28 17 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/72201254-1bc7-47eb-8dab-7b44e22d0ba9">  | <img width="305" alt="Screenshot 2023-09-29 at 5 26 15 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/14c22999-556a-4fbc-bf0c-1f4a3d22f272">  |
| <img width="1197" alt="Screenshot 2023-09-29 at 5 27 53 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/06dc776a-8dbf-4b4b-9f7d-7d94f53d5c22"> | <img width="280" alt="Screenshot 2023-09-29 at 5 26 50 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/58a5f096-a386-43e2-bba9-f0a7ddaad168">  |