### PR TITLE
Exclusive/complementary constraint resolution for group children

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -1,3 +1,4 @@
+import type { LayoutPinnedProp } from '../../../../core/layout/layout-helpers-new'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
 import type { ElementPathTrees } from '../../../../core/shared/element-path-tree'
@@ -368,7 +369,7 @@ function getConstrainedFramesAdjustments(
 function isDimensionConstrained(
   jsxMetadata: ElementInstanceMetadataMap,
   path: ElementPath,
-  constraintsArray: any[],
+  constraintsArray: LayoutPinnedProp[],
   dimension: 'width' | 'height',
 ): boolean {
   return (

--- a/editor/src/components/inspector/fill-hug-fixed-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.spec.browser2.tsx
@@ -1,0 +1,125 @@
+import type { LayoutPinnedProp } from '../../core/layout/layout-helpers-new'
+import type { ConstraintsMode } from './fill-hug-fixed-control'
+import { makeUpdatedConstraintsPropArray } from './fill-hug-fixed-control'
+
+describe('makeUniqueConstrainedProps', () => {
+  const tests: {
+    name: string
+    input: any[]
+    mode: ConstraintsMode
+    dimension: LayoutPinnedProp
+    want: any[]
+  }[] = [
+    {
+      name: 'adds a new value (empty)',
+      input: [],
+      mode: 'add',
+      dimension: 'top',
+      want: ['top'],
+    },
+    {
+      name: 'adds a new value (non-empty)',
+      input: ['width'],
+      mode: 'add',
+      dimension: 'top',
+      want: ['width', 'top'],
+    },
+    {
+      name: 'removes a new value (empty)',
+      input: [],
+      mode: 'remove',
+      dimension: 'top',
+      want: [],
+    },
+    {
+      name: 'removes a new value (non-empty)',
+      input: ['width', 'top', 'left'],
+      mode: 'remove',
+      dimension: 'top',
+      want: ['width', 'left'],
+    },
+    {
+      name: 'trims existing duplicated constraints (add)',
+      input: ['top', 'left', 'left', 'left'],
+      mode: 'add',
+      dimension: 'width',
+      want: ['top', 'left', 'width'],
+    },
+    {
+      name: 'removes new duplicated constraints (add)',
+      input: ['top', 'left', 'left', 'width'],
+      mode: 'add',
+      dimension: 'width',
+      want: ['top', 'left', 'width'],
+    },
+    {
+      name: 'trims existing duplicated constraints (remove)',
+      input: ['top', 'left', 'left', 'left'],
+      mode: 'remove',
+      dimension: 'top',
+      want: ['left'],
+    },
+    {
+      name: 'removes new duplicated constraints (remove)',
+      input: ['top', 'left', 'left', 'width'],
+      mode: 'remove',
+      dimension: 'width',
+      want: ['top', 'left'],
+    },
+    {
+      name: 'removes all constraints when duplicated',
+      input: ['left', 'left', 'left'],
+      mode: 'remove',
+      dimension: 'left',
+      want: [],
+    },
+    {
+      name: 'when setting width, if there are already left and right, remove the oldest',
+      input: ['top', 'left', 'right'],
+      mode: 'add',
+      dimension: 'width',
+      want: ['top', 'right', 'width'],
+    },
+    {
+      name: 'when setting height, if there are already top and bottom, remove the oldest',
+      input: ['top', 'left', 'bottom'],
+      mode: 'add',
+      dimension: 'height',
+      want: ['left', 'bottom', 'height'],
+    },
+    {
+      name: 'when setting left, if there are already right/width, remove the width',
+      input: ['right', 'width'],
+      mode: 'add',
+      dimension: 'left',
+      want: ['right', 'left'],
+    },
+    {
+      name: 'when setting right, if there are already left/width, remove the width',
+      input: ['left', 'width'],
+      mode: 'add',
+      dimension: 'right',
+      want: ['left', 'right'],
+    },
+    {
+      name: 'when setting top, if there are already bottom/height, remove the height',
+      input: ['bottom', 'height'],
+      mode: 'add',
+      dimension: 'top',
+      want: ['bottom', 'top'],
+    },
+    {
+      name: 'when setting bottom, if there are already top/height, remove the height',
+      input: ['top', 'height'],
+      mode: 'add',
+      dimension: 'bottom',
+      want: ['top', 'bottom'],
+    },
+  ]
+  tests.forEach((test, index) => {
+    it(`(${index + 1}) ${test.name}`, async () => {
+      const got = makeUpdatedConstraintsPropArray(test.input, test.mode, test.dimension)
+      expect(got).toEqual(test.want)
+    })
+  })
+})

--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -47,7 +47,7 @@ import { UIGridRow } from './widgets/ui-grid-row'
 import { mapDropNulls, safeIndex, uniqBy } from '../../core/shared/array-utils'
 import { fixedSizeDimensionHandlingText } from '../text-editor/text-handling'
 import { when } from '../../utils/react-conditionals'
-import type { LayoutPinnedProp } from '../../core/layout/layout-helpers-new'
+import { isLayoutPinnedProp, type LayoutPinnedProp } from '../../core/layout/layout-helpers-new'
 import type { AllElementProps } from '../editor/store/editor-state'
 import { jsExpressionValue, emptyComments } from '../../core/shared/element-template'
 import type { EditorDispatch, EditorAction } from '../editor/action-types'
@@ -777,12 +777,12 @@ function groupChildConstraintOption(type: GroupChildConstraintOptionType): Selec
 export function getSafeGroupChildConstraintsArray(
   allElementProps: AllElementProps,
   path: ElementPath,
-): any[] {
+): LayoutPinnedProp[] {
   const value = allElementProps[EP.toString(path)]?.['data-constraints'] ?? []
   if (!Array.isArray(value)) {
     return []
   }
-  return value
+  return value.filter((v) => typeof v === 'string' && isLayoutPinnedProp(v))
 }
 
 export type ConstraintsMode = 'add' | 'remove'
@@ -819,10 +819,10 @@ function setGroupChildConstraint(
 }
 
 export function makeUpdatedConstraintsPropArray(
-  constraints: any[],
+  constraints: LayoutPinnedProp[],
   mode: ConstraintsMode,
   dimension: LayoutPinnedProp,
-): any[] {
+): LayoutPinnedProp[] {
   const newProps = new Set(constraints)
   switch (mode) {
     case 'add':
@@ -864,8 +864,8 @@ export function makeUpdatedConstraintsPropArray(
 }
 
 function maybeRemoveOldestComplement(
-  set: Set<any>,
-  constraints: any[],
+  set: Set<LayoutPinnedProp>,
+  constraints: LayoutPinnedProp[],
   complements: [LayoutPinnedProp, LayoutPinnedProp],
 ) {
   if (set.has(complements[0]) && set.has(complements[1])) {
@@ -878,7 +878,7 @@ function maybeRemoveOldestComplement(
 }
 
 function maybeRemoveComplementaryDimension(
-  set: Set<any>,
+  set: Set<LayoutPinnedProp>,
   complement: LayoutPinnedProp,
   dimensionToDelete: LayoutPinnedProp,
 ) {


### PR DESCRIPTION
Fixes #4281 

**Problem:**

It's possible to over-specify group child constraints, e.g. setting both `left`, `right`, and `width`.

![Kapture 2023-10-02 at 11 54 13](https://github.com/concrete-utopia/utopia/assets/1081051/58763216-9f37-4387-b213-8774fed283e2)


**Fix:**

1. When setting a dimension constraint (w/h), if both the side complements (tlbr) are set, remove the oldest constraint
2. When setting a side constraint (tlbr), if both the dimension complements (w/h) are set, remove the dimension complement (so side pins win)

![Kapture 2023-10-02 at 11 56 51](https://github.com/concrete-utopia/utopia/assets/1081051/ca3ca457-9d89-4989-b741-df0b15bbb639)
