### PR TITLE
More understandable constrained labels

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -3957,7 +3957,7 @@ describe('inspector tests with real metadata', () => {
               throw new Error('cannot find select')
             }
 
-            await selectEvent.select(control, 'Constrained')
+            await selectEvent.select(control, 'Fixed')
           },
           want: `
             <div

--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -638,7 +638,10 @@ const GroupConstraintSelect = React.memo(
         onSubmitValue={onSubmitValue}
         value={listValue}
         options={groupChildConstraintOptions}
-        style={{ position: 'relative' }}
+        style={{
+          position: 'relative',
+          fontSize: listValue.value === 'not-constrained' ? 9 : 'inherit',
+        }}
         containerMode={type === 'constrained' ? 'default' : 'showBorderOnHover'}
         controlStyles={{
           ...getControlStyles('simple'),
@@ -766,9 +769,9 @@ type GroupChildConstraintOptionType = 'constrained' | 'not-constrained'
 function groupChildConstraintOption(type: GroupChildConstraintOptionType): SelectOption {
   switch (type) {
     case 'constrained':
-      return { value: 'constrained', label: 'Constrained' }
+      return { value: 'constrained', label: 'Fixed' }
     case 'not-constrained':
-      return { value: 'not-constrained', label: 'Unconstrained' }
+      return { value: 'not-constrained', label: 'Scale with parent' }
     default:
       assertNever(type)
   }


### PR DESCRIPTION
Fixes #4284

**Problem:**

The labels for the constrained/unconstrained dropdowns for group children are hard to understand.

![Kapture 2023-10-02 at 13 16 12](https://github.com/concrete-utopia/utopia/assets/1081051/7d6db95e-7f76-4dfd-9d4c-a7409a679952)

**Fix:**

- `Constrained` becomes `Fixed`
- `Unconstrained` becomes `Scale with parent`

![Kapture 2023-10-02 at 13 15 21](https://github.com/concrete-utopia/utopia/assets/1081051/5c08a949-8c1a-4064-b9a8-bd0d744cf304)
