### PR TITLE
Show notice when `contain: 'layout'` added.

### DIFF
--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -72,6 +72,7 @@ import {
   groupJSXElement,
   groupJSXElementImportsToAdd,
 } from '../../canvas/canvas-strategies/strategies/group-helpers'
+import { safeIndex } from '../../../core/shared/array-utils'
 
 async function deleteFromScene(
   inputSnippet: string,
@@ -6717,6 +6718,12 @@ export var storyboard = (
         </div>`,
         ),
       )
+      expect(renderResult.getEditorState().editor.toasts).toHaveLength(1)
+      const firstToast = safeIndex(renderResult.getEditorState().editor.toasts, 0)
+      expect(firstToast?.level).toEqual('INFO')
+      expect(firstToast?.message).toEqual(
+        "Added `contain: 'layout'` to the parent of the newly added element.",
+      )
     })
     it(`Wraps 2 elements with a fragment`, async () => {
       const testUID = 'zzz'
@@ -6826,6 +6833,13 @@ export var storyboard = (
               </div>
           `),
           ),
+        )
+
+        expect(renderResult.getEditorState().editor.toasts).toHaveLength(1)
+        const firstToast = safeIndex(renderResult.getEditorState().editor.toasts, 0)
+        expect(firstToast?.level).toEqual('INFO')
+        expect(firstToast?.message).toEqual(
+          "Added `contain: 'layout'` to the parent of the newly added element.",
         )
       })
 
@@ -6968,6 +6982,13 @@ export var storyboard = (
               </div>
           `),
           ),
+        )
+
+        expect(renderResult.getEditorState().editor.toasts).toHaveLength(1)
+        const firstToast = safeIndex(renderResult.getEditorState().editor.toasts, 0)
+        expect(firstToast?.level).toEqual('INFO')
+        expect(firstToast?.message).toEqual(
+          "Added `contain: 'layout'` to the parent of the newly added element.",
         )
       })
 

--- a/editor/src/components/editor/actions/wrap-unwrap-helpers.tsx
+++ b/editor/src/components/editor/actions/wrap-unwrap-helpers.tsx
@@ -67,6 +67,8 @@ import { foldEither, right } from '../../../core/shared/either'
 import { editorStateToElementChildOptic } from '../../../core/model/common-optics'
 import { fromField, fromTypeGuard } from '../../../core/shared/optics/optic-creators'
 import { setJSXValueAtPath } from '../../../core/shared/jsx-attributes'
+import { addToastToState } from './toast-helpers'
+import { notice } from '../../../components/common/notice'
 
 export function unwrapConditionalClause(
   editor: EditorState,
@@ -315,7 +317,12 @@ export function fixParentContainingBlockSettings(
       editorState,
     )
     if (attributesUpdated) {
-      return updatedEditorState
+      // Add a toast indicating that `contain: 'layout'` has been added.
+      const toast = notice(
+        "Added `contain: 'layout'` to the parent of the newly added element.",
+        'INFO',
+      )
+      return addToastToState(updatedEditorState, toast)
     }
   }
 


### PR DESCRIPTION
**Problem:**
A user may be caught unawares when we add `contain: 'layout'` to the parent of a newly added wrapper element, especially if it results in some changes to the layout of what is onscreen.

**Fix:**
When `contain: 'layout'` is added to a parent element, display a toast indicating what change was made.

**Commit Details:**
- Added a toast into `fixParentContainingBlockSettings`.