### PR TITLE
only round width/height when resizing

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -1338,6 +1338,39 @@ export var storyboard = (
     const resizeControl = getResizeControl(renderResult, EdgePositionBottomRight)
     expect(resizeControl).toBeNull()
   })
+  it('resize does not affect the top/left coordinates', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+            style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 40.5, top: 50.5, width: 200, height: 120 }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    const target = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
+    const dragDelta = windowPoint({ x: 40, y: -25 })
+
+    await renderResult.dispatch([selectComponents([target], false)], true)
+    await resizeElement(renderResult, dragDelta, EdgePositionBottomRight, emptyModifiers)
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+            style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 40.5, top: 50.5, width: 240, height: 95 }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+    )
+  })
   describe('snap lines', () => {
     it('horizontal snap lines are shown when resizing a multiselection', async () => {
       const editor = await renderTestEditorWithCode(

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -8,7 +8,7 @@ import {
   canvasRectangle,
   isFiniteRectangle,
   isInfinityRectangle,
-  roundRectangleToNearestWhole,
+  roundRectangleWidthHeightToNearestHalf,
   transformFrameUsingBoundingBox,
 } from '../../../../core/shared/math-utils'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
@@ -192,7 +192,7 @@ export function absoluteResizeBoundingBoxStrategy(
                 selectedElement,
                 originalFrame,
                 edgePosition,
-                roundRectangleToNearestWhole(
+                roundRectangleWidthHeightToNearestHalf(
                   transformFrameUsingBoundingBox(
                     snappedBoundingBox,
                     originalBoundingBox,

--- a/editor/src/core/shared/math-utils.ts
+++ b/editor/src/core/shared/math-utils.ts
@@ -802,14 +802,14 @@ export function rectSizeToVector<C extends CoordinateMarker>(sizeOfVector: Size)
 
 export const roundToNearestWhole = (x: number) => roundTo(x, 0)
 
-export function roundRectangleToNearestWhole<C extends CoordinateMarker>(
+export function roundRectangleWidthHeightToNearestHalf<C extends CoordinateMarker>(
   rectangle: Rectangle<C>,
 ): Rectangle<C> {
   return {
-    x: roundToNearestWhole(rectangle.x),
-    y: roundToNearestWhole(rectangle.y),
-    width: roundToNearestWhole(rectangle.width),
-    height: roundToNearestWhole(rectangle.height),
+    x: rectangle.x,
+    y: rectangle.y,
+    width: roundToNearestHalf(rectangle.width),
+    height: roundToNearestHalf(rectangle.height),
   } as Rectangle<C>
 }
 


### PR DESCRIPTION
## Problem
When resizing, the `top` or `left` prop might have changed as a result of the edit

## Fix
Remove the rounding call that rounded all of `top`/`left`/`width`/`height` of the new frame, and only round `width` and `height`

## TODO
- [ ] fix wobblyiness