### PR TITLE
No overflow inspector row for imgs

### DIFF
--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -1161,6 +1161,7 @@ const StyleSubSectionForType: { [key: string]: SubSectionAvailable } = {
   background: subSectionAllowAll,
   img: subSectionPermitList(['img']),
   transform: subSectionAllowAll,
+  overflow: subSectionDenyList(['img', 'video']),
 }
 
 const PropsToDiscard = [...UtopiaKeys, 'skipDeepFreeze', 'data-utopia-instance-path']

--- a/editor/src/components/inspector/sections/style-section/container-subsection/overflow-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/overflow-row.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import * as PP from '../../../../../core/shared/property-path'
 import { PropertyLabel } from '../../../widgets/property-label'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
-import { useInspectorStyleInfo } from '../../../common/property-path-hooks'
+import { useInspectorStyleInfo, useIsSubSectionVisible } from '../../../common/property-path-hooks'
 import type { OptionChainOption } from '../../../controls/option-chain-control'
 import { OptionChainControl } from '../../../controls/option-chain-control'
 import { InspectorContextMenuItems, InspectorContextMenuWrapper } from '../../../../../uuiui-deps'
@@ -23,6 +23,8 @@ const OverflowControlOptions: Array<OptionChainOption<boolean>> = [
 ]
 
 export const OverflowRow = React.memo(() => {
+  const isVisible = useIsSubSectionVisible('overflow')
+
   const { value, controlStatus, controlStyles, onSubmitValue, onUnsetValues } =
     useInspectorStyleInfo('overflow')
 
@@ -31,6 +33,10 @@ export const OverflowRow = React.memo(() => {
     ['overflow'],
     onUnsetValues,
   )
+
+  if (!isVisible) {
+    return null
+  }
 
   return (
     <InspectorContextMenuWrapper


### PR DESCRIPTION
**Description:**
Overflow row in the inspector doesn't work really well for imgs, and not very useful neither

**Fix:**
Disable the overflow row for imgs