### PR TITLE
Fix some issues with the zero sized controls.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -66,6 +66,7 @@ export function absoluteResizeBoundingBoxStrategy(
   const originalTargets = flattenSelection(
     getTargetPathsFromInteractionTarget(canvasState.interactionTarget),
   )
+
   const retargetedTargets = flattenSelection(
     retargetStrategyToChildrenOfFragmentLikeElements(canvasState),
   )

--- a/editor/src/components/canvas/controls/highlight-control.tsx
+++ b/editor/src/components/canvas/controls/highlight-control.tsx
@@ -9,6 +9,7 @@ interface HighlightControlProps {
   canvasOffset: CanvasPoint
   scale: number
   color?: string
+  displayZeroSized: 'display-zero-sized' | 'do-not-display-zero-sized'
 }
 
 export const HighlightControl = React.memo((props: HighlightControlProps) => {
@@ -18,14 +19,19 @@ export const HighlightControl = React.memo((props: HighlightControlProps) => {
     props.color === null ? colorTheme.canvasSelectionPrimaryOutline.value : props.color
 
   if (isZeroSizedElement(props.frame)) {
-    return (
-      <ZeroSizeHighlightControl
-        frame={props.frame}
-        canvasOffset={props.canvasOffset}
-        scale={props.scale}
-        color={outlineColor}
-      />
-    )
+    // Only display the zero size higlight if it should be displayed.
+    if (props.displayZeroSized === 'display-zero-sized') {
+      return (
+        <ZeroSizeHighlightControl
+          frame={props.frame}
+          canvasOffset={props.canvasOffset}
+          scale={props.scale}
+          color={outlineColor}
+        />
+      )
+    } else {
+      return null
+    }
   } else {
     return (
       <div

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -447,6 +447,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
               frame={frame}
               scale={scale}
               canvasOffset={canvasOffset}
+              displayZeroSized={'display-zero-sized'}
             />
           )
         })

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -63,15 +63,15 @@ export const AbsoluteResizeControl = controlForStrategyMemoized(
       'AbsoluteResizeControl scale',
     )
 
-    const controlRef = useBoundingBox(targets, (ref, boundingBox) => {
-      if (isZeroSizedElement(boundingBox)) {
+    const controlRef = useBoundingBox(targets, (ref, safeGappedBoundingBox, realBoundingBox) => {
+      if (isZeroSizedElement(realBoundingBox)) {
         ref.current.style.display = 'none'
       } else {
         ref.current.style.display = 'block'
-        ref.current.style.left = boundingBox.x + 'px'
-        ref.current.style.top = boundingBox.y + 'px'
-        ref.current.style.width = boundingBox.width + 'px'
-        ref.current.style.height = boundingBox.height + 'px'
+        ref.current.style.left = safeGappedBoundingBox.x + 'px'
+        ref.current.style.top = safeGappedBoundingBox.y + 'px'
+        ref.current.style.width = safeGappedBoundingBox.width + 'px'
+        ref.current.style.height = safeGappedBoundingBox.height + 'px'
       }
     })
 

--- a/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
@@ -101,17 +101,20 @@ export const BorderRadiusControl = controlForStrategyMemoized<BorderRadiusContro
 
   const backgroundShown = hoveredViews.some((p) => EP.pathsEqual(p, selectedElement))
 
-  const controlRef = useBoundingBox([selectedElement], (ref, boundingBox) => {
-    if (isZeroSizedElement(boundingBox)) {
-      ref.current.style.display = 'none'
-    } else {
-      ref.current.style.display = 'block'
-      ref.current.style.left = boundingBox.x + 'px'
-      ref.current.style.top = boundingBox.y + 'px'
-      ref.current.style.width = boundingBox.width + 'px'
-      ref.current.style.height = boundingBox.height + 'px'
-    }
-  })
+  const controlRef = useBoundingBox(
+    [selectedElement],
+    (ref, safeGappedBoundingBox, realBoundingBox) => {
+      if (isZeroSizedElement(realBoundingBox)) {
+        ref.current.style.display = 'none'
+      } else {
+        ref.current.style.display = 'block'
+        ref.current.style.left = safeGappedBoundingBox.x + 'px'
+        ref.current.style.top = safeGappedBoundingBox.y + 'px'
+        ref.current.style.width = safeGappedBoundingBox.width + 'px'
+        ref.current.style.height = safeGappedBoundingBox.height + 'px'
+      }
+    },
+  )
 
   const borderRadius = useEditorState(
     Substores.metadata,

--- a/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
@@ -284,17 +284,20 @@ export const PaddingResizeControl = controlForStrategyMemoized((props: PaddingCo
 
   const numberToPxValue = (n: number) => n + 'px'
 
-  const controlRef = useBoundingBox(selectedElements, (ref, boundingBox) => {
-    if (isZeroSizedElement(boundingBox)) {
-      ref.current.style.display = 'none'
-    } else {
-      ref.current.style.display = 'block'
-      ref.current.style.left = boundingBox.x + 'px'
-      ref.current.style.top = boundingBox.y + 'px'
-      ref.current.style.width = boundingBox.width + 'px'
-      ref.current.style.height = boundingBox.height + 'px'
-    }
-  })
+  const controlRef = useBoundingBox(
+    selectedElements,
+    (ref, safeGappedBoundingBox, realBoundingBox) => {
+      if (isZeroSizedElement(realBoundingBox)) {
+        ref.current.style.display = 'none'
+      } else {
+        ref.current.style.display = 'block'
+        ref.current.style.left = safeGappedBoundingBox.x + 'px'
+        ref.current.style.top = safeGappedBoundingBox.y + 'px'
+        ref.current.style.width = safeGappedBoundingBox.width + 'px'
+        ref.current.style.height = safeGappedBoundingBox.height + 'px'
+      }
+    },
+  )
 
   const timeoutRef = React.useRef<NodeJS.Timeout | null>(null)
 

--- a/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
@@ -83,17 +83,20 @@ export const OutlineControl = React.memo<OutlineControlProps>((props) => {
     'OutlineControl scale',
   )
 
-  const outlineRef = useBoundingBox(targets, (ref, boundingBox, canvasScale) => {
-    if (isZeroSizedElement(boundingBox)) {
-      ref.current.style.display = 'none'
-    } else {
-      ref.current.style.display = 'block'
-      ref.current.style.left = `${boundingBox.x - 0.5 / canvasScale}px`
-      ref.current.style.top = `${boundingBox.y - 0.5 / canvasScale}px`
-      ref.current.style.width = `${boundingBox.width + 1 / canvasScale}px`
-      ref.current.style.height = `${boundingBox.height + 1 / canvasScale}px`
-    }
-  })
+  const outlineRef = useBoundingBox(
+    targets,
+    (ref, safeGappedBoundingBox, realBoundingBox, canvasScale) => {
+      if (isZeroSizedElement(realBoundingBox)) {
+        ref.current.style.display = 'none'
+      } else {
+        ref.current.style.display = 'block'
+        ref.current.style.left = `${safeGappedBoundingBox.x - 0.5 / canvasScale}px`
+        ref.current.style.top = `${safeGappedBoundingBox.y - 0.5 / canvasScale}px`
+        ref.current.style.width = `${safeGappedBoundingBox.width + 1 / canvasScale}px`
+        ref.current.style.height = `${safeGappedBoundingBox.height + 1 / canvasScale}px`
+      }
+    },
+  )
 
   if (targets.length > 0) {
     return (

--- a/editor/src/components/canvas/controls/select-mode/static-reparent-target-outline.tsx
+++ b/editor/src/components/canvas/controls/select-mode/static-reparent-target-outline.tsx
@@ -38,6 +38,7 @@ export const StaticReparentTargetOutlineIndicator = controlForStrategyMemoized((
         scale={scale}
         color={colorTheme.canvasSelectionPrimaryOutline.value}
         frame={parentFrame}
+        displayZeroSized={'do-not-display-zero-sized'}
       />
     )
   } else {

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.spec.browser2.tsx
@@ -10,25 +10,27 @@ import { mouseDoubleClickAtPoint } from '../event-helpers.test-utils'
 import * as EP from '../../../core/shared/element-path'
 import { BakedInStoryboardUID } from '../../../core/model/scene-utils'
 import { selectComponents } from '../../editor/actions/meta-actions'
-import { ZeroSizedControlTestID } from './zero-sized-element-controls'
 import type { ElementPath } from '../../../core/shared/project-file-types'
+import { ZeroSizedEventsControlTestID } from './zero-sized-element-controls'
 
 async function selectTargetAndDoubleClickOnZeroSizeControl(
   renderResult: EditorRenderResult,
   target: ElementPath,
   testID: string,
+  shiftX: number = 0,
+  shiftY: number = 0,
 ) {
   await renderResult.dispatch(selectComponents([target], false), true)
 
-  const zeroSizeControl = renderResult.renderedDOM.getByTestId(ZeroSizedControlTestID)
+  const zeroSizeControl = renderResult.renderedDOM.getByTestId(ZeroSizedEventsControlTestID)
   const element = renderResult.renderedDOM.getByTestId(testID)
   const elementBounds = element.getBoundingClientRect()
 
-  const topLeftCorner = {
-    x: elementBounds.x,
-    y: elementBounds.y,
+  const targetPoint = {
+    x: elementBounds.x + shiftX,
+    y: elementBounds.y + shiftY,
   }
-  await mouseDoubleClickAtPoint(zeroSizeControl, topLeftCorner)
+  await mouseDoubleClickAtPoint(zeroSizeControl, targetPoint)
 
   await renderResult.getDispatchFollowUpActionsFinished()
 }
@@ -69,6 +71,27 @@ describe('Zero sized element controls', () => {
 
     const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/bbb`)
     await selectTargetAndDoubleClickOnZeroSizeControl(renderResult, target, 'bbb')
+
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<div style={{ ...props.style }} data-uid='aaa'>
+          <div style={{ position: 'absolute', top: 20, left: 20, width: 100, height: 100 }} data-uid='bbb' data-testid='bbb' />
+        </div>`,
+      ),
+    )
+  })
+  it('double click slightly outside a div element (where the zero sized border is visually) adds size', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(
+        `<div style={{ ...props.style }} data-uid='aaa'>
+          <div style={{ position: 'absolute', top: 20, left: 20 }} data-uid='bbb' data-testid='bbb' />
+        </div>`,
+      ),
+      'await-first-dom-report',
+    )
+
+    const target = EP.fromString(`${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:aaa/bbb`)
+    await selectTargetAndDoubleClickOnZeroSizeControl(renderResult, target, 'bbb', -2, -2)
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -41,6 +41,7 @@ import { useWindowToCanvasCoordinates } from '../dom-lookup-hooks'
 import { boundingArea, createInteractionViaMouse } from '../canvas-strategies/interaction-state'
 
 export const ZeroSizedControlTestID = 'zero-sized-control'
+export const ZeroSizedEventsControlTestID = `${ZeroSizedControlTestID}-events`
 interface ZeroSizedElementControlProps {
   showAllPossibleElements: boolean
 }
@@ -422,7 +423,7 @@ export const ZeroSizeResizeControl = React.memo((props: ZeroSizeResizeControlPro
         onMouseDown={onControlMouseDown}
         onMouseUp={onControlMouseUp}
         onDoubleClick={onControlDoubleClick}
-        data-testid={`${ZeroSizedControlTestID}-events`}
+        data-testid={ZeroSizedEventsControlTestID}
         style={{
           position: 'absolute',
           ...zeroSizedEventControlDimensions(props.frame, props.scale),
@@ -488,8 +489,8 @@ function zeroSizedControlDimensions(
 } {
   const ratio = getScaleRatio(scale)
   return {
-    left: rect.x - ZeroControlSize / 2,
-    top: rect.y - ZeroControlSize / 2,
+    left: rect.x - (ZeroControlSize / 2) * ratio,
+    top: rect.y - (ZeroControlSize / 2) * ratio,
     width: rect.width + ZeroControlSize * ratio,
     height: rect.height + ZeroControlSize * ratio,
     borderRadius: borderRadius ? (ZeroControlSize / 2) * ratio : undefined,
@@ -510,12 +511,13 @@ function zeroSizedEventControlDimensions(
 } {
   const ratio = getScaleRatio(scale)
   const borderAdjustment = ZeroControlSize / 2
-  return {
-    left: rect.x - ZeroControlSize / 2 - borderAdjustment,
-    top: rect.y - ZeroControlSize / 2 - borderAdjustment,
-    width: rect.width + ZeroControlSize * ratio + borderAdjustment * 2,
-    height: rect.height + ZeroControlSize * ratio + borderAdjustment * 2,
+  const result = {
+    left: rect.x - (ZeroControlSize / 2) * ratio - borderAdjustment * ratio,
+    top: rect.y - (ZeroControlSize / 2) * ratio - borderAdjustment * ratio,
+    width: rect.width + (ZeroControlSize + borderAdjustment * 2) * ratio,
+    height: rect.height + (ZeroControlSize + borderAdjustment * 2) * ratio,
   }
+  return result
 }
 
 function zeroSizedControlBoxShadow(

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -1,5 +1,6 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
+/** @jsxFrag React.Fragment */
 import React from 'react'
 import { jsx } from '@emotion/react'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
@@ -178,21 +179,29 @@ const ZeroSizeSelectControl = React.memo((props: ZeroSizeSelectControlProps) => 
   } else {
     const frame = element.globalFrame
     return (
-      <div
-        onMouseDown={onControlMouseDown}
-        onMouseOver={onControlMouseOver}
-        onMouseOut={onControlMouseOut}
-        style={{
-          position: 'absolute',
-          ...zeroSizedControlDimensions(offsetRect(frame, canvasOffset), scale, true),
-        }}
-        css={{
-          boxShadow: zeroSizedControlBoxShadow(scale, colorTheme.primary.value, 'thin'),
-          '&:hover': {
-            boxShadow: zeroSizedControlBoxShadow(scale, colorTheme.primary.value, 'thick'),
-          },
-        }}
-      />
+      <>
+        <div
+          style={{
+            position: 'absolute',
+            ...zeroSizedControlDimensions(offsetRect(frame, canvasOffset), scale, true),
+          }}
+          css={{
+            boxShadow: zeroSizedControlBoxShadow(scale, colorTheme.primary.value, 'thin'),
+            '&:hover': {
+              boxShadow: zeroSizedControlBoxShadow(scale, colorTheme.primary.value, 'thick'),
+            },
+          }}
+        />
+        <div
+          onMouseDown={onControlMouseDown}
+          onMouseOver={onControlMouseOver}
+          onMouseOut={onControlMouseOut}
+          style={{
+            position: 'absolute',
+            ...zeroSizedEventControlDimensions(offsetRect(frame, canvasOffset), scale),
+          }}
+        />
+      </>
     )
   }
 })
@@ -401,15 +410,22 @@ export const ZeroSizeResizeControl = React.memo((props: ZeroSizeResizeControlPro
   return (
     <CanvasOffsetWrapper>
       <div
-        onMouseMove={onControlMouseMove}
-        onMouseDown={onControlMouseDown}
-        onMouseUp={onControlMouseUp}
-        onDoubleClick={onControlDoubleClick}
         className='role-resize-no-size'
         data-testid={ZeroSizedControlTestID}
         style={{
           position: 'absolute',
           ...zeroSizedControlDimensions(props.frame, props.scale),
+        }}
+      />
+      <div
+        onMouseMove={onControlMouseMove}
+        onMouseDown={onControlMouseDown}
+        onMouseUp={onControlMouseUp}
+        onDoubleClick={onControlDoubleClick}
+        data-testid={`${ZeroSizedControlTestID}-events`}
+        style={{
+          position: 'absolute',
+          ...zeroSizedEventControlDimensions(props.frame, props.scale),
         }}
       />
     </CanvasOffsetWrapper>
@@ -477,6 +493,28 @@ function zeroSizedControlDimensions(
     width: rect.width + ZeroControlSize * ratio,
     height: rect.height + ZeroControlSize * ratio,
     borderRadius: borderRadius ? (ZeroControlSize / 2) * ratio : undefined,
+  }
+}
+
+// So that we can capture events on what looks like the border
+// we need some bounds that overlap around the dimensions of the
+// control.
+function zeroSizedEventControlDimensions(
+  rect: CanvasRectangle,
+  scale: number,
+): {
+  left: number
+  top: number
+  width: number
+  height: number
+} {
+  const ratio = getScaleRatio(scale)
+  const borderAdjustment = ZeroControlSize / 2
+  return {
+    left: rect.x - ZeroControlSize / 2 - borderAdjustment,
+    top: rect.y - ZeroControlSize / 2 - borderAdjustment,
+    width: rect.width + ZeroControlSize * ratio + borderAdjustment * 2,
+    height: rect.height + ZeroControlSize * ratio + borderAdjustment * 2,
   }
 }
 


### PR DESCRIPTION
Fixes #4283 

**Problem:**
There are a couple of issues with the zero sized controls:
- The parent highlight looks a little strange when the parent is zero sized and visually the control appears in what a user might think is an odd place.
- The resize handles show along with the zero sized controls, which is visually noisy.
- Trying to trigger the zero sized control when the mouse is over the border/shadow of the control just deselects the element.
- Zoom scale wasn't taken account of correctly for the position of the zero sized controls.

**Fix:**
The fixes for the above issues are respectively:
- Prevent the parent highlight control from displaying its zero sized variant by supplying a property specifically to check that.
- Distinguish between the bounding box for the user controls and the real bounding box, as the gapped one will likely never be zero sized or at the very least will not be zero sized when the element itself is.
- The mouse events are now attached to an element which sits on top of the control and covers the zero sized control including the visual elements which sit outside of its bounds (browser element bounds in this case).
- Adjust the position and size of the zero sized control correctly taking account of the scale ratio.

**Commit Details:**
- Fixed `useBoundingBox` hook to support both a gapped bounding box and a real bounding box.
- `useBoundingBoxFromMetadataRef` now produces a gapped bounding box as well as the real bounding box.
- Controls using `useBoundingBox` now use the real bounding box when calling `isZeroSizedElement`.
- `HighlightControl` has a `displayZeroSized` property which gates the display of zero sized highlights.
- `ZeroSizeSelectControl` and `ZeroSizeResizeControl` now have their events attached to an element which covers the entire control so that border radius and box shadows will "trigger" the events when the mouse is over them.
- Fix to position of zero sized controls to now take account of the scale.
- Added browser test that clicks just outside the zero bounds of the element.