### PR TITLE
Don't reparent out of groups (unless outside of a scene)

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
@@ -74,7 +74,7 @@ export function absoluteMoveStrategy(
       fitness:
         interactionSession?.interactionData.type === 'DRAG' &&
         interactionSession?.activeControl.type === 'BOUNDING_AREA'
-          ? 1
+          ? 2
           : 0,
       apply: () => {
         if (

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
@@ -74,7 +74,7 @@ export function absoluteMoveStrategy(
       fitness:
         interactionSession?.interactionData.type === 'DRAG' &&
         interactionSession?.activeControl.type === 'BOUNDING_AREA'
-          ? 2
+          ? 2 // NOTE: this is potentially a good candidate to look at in case some other strategies fail to trigger unexpectedly
           : 0,
       apply: () => {
         if (

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
@@ -1704,6 +1704,113 @@ export var ${BakedInStoryboardVariableName} = (props) => {
       )
     })
   })
+
+  describe('groups', () => {
+    it("does not reparent outside of a group (if it's not inside a scene)", async () => {
+      const renderResult = await renderTestEditorWithCode(
+        formatTestProjectCode(`
+          import * as React from 'react'
+          import { Storyboard, Group } from 'utopia-api'
+
+          export var storyboard = (
+            <Storyboard data-uid='sb'>
+              <div data-uid='div' style={{ backgroundColor: '#aaaaaa33', position: 'absolute', width: 300, height: 250 }}>
+                <Group data-uid='group' style={{ position: 'absolute', left: 25, top: 25, width: 175, height: 120, backgroundColor: 'white' }}>
+                  <div data-uid='child1' data-testid='child1' style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 0, top: 0, width: 50, height: 43 }} />
+                  <div data-uid='child2' style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 125, top: 77, width: 50, height: 43 }} />
+                </Group>
+              </div>
+            </Storyboard>
+          )
+        `),
+        'await-first-dom-report',
+      )
+      const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+      await renderResult.dispatch(
+        selectComponents([EP.fromString('sb/div/group/child1')], true),
+        true,
+      )
+
+      const dragme = (await renderResult.renderedDOM.findByTestId('child1')).getBoundingClientRect()
+
+      await mouseDragFromPointWithDelta(
+        canvasControlsLayer,
+        { x: dragme.x + 10, y: dragme.y + 10 },
+        { x: -100, y: 0 },
+      )
+
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        formatTestProjectCode(`
+          import * as React from 'react'
+          import { Storyboard, Group } from 'utopia-api'
+
+          export var storyboard = (
+            <Storyboard data-uid='sb'>
+              <div data-uid='div' style={{ backgroundColor: '#aaaaaa33', position: 'absolute', width: 300, height: 250 }}>
+                <Group data-uid='group' style={{ position: 'absolute', left: -75, top: 25, width: 275, height: 120, backgroundColor: 'white' }}>
+                  <div data-uid='child1' data-testid='child1' style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 0, top: 0, width: 50, height: 43 }} />
+                  <div data-uid='child2' style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 225, top: 77, width: 50, height: 43 }} />
+                </Group>
+              </div>
+            </Storyboard>
+          )
+        `),
+      )
+    })
+    it("does reparent outside of a group (if it's inside a scene)", async () => {
+      const renderResult = await renderTestEditorWithCode(
+        formatTestProjectCode(`
+          import * as React from 'react'
+          import { Storyboard, Scene, Group } from 'utopia-api'
+
+          export var storyboard = (
+            <Storyboard data-uid='sb'>
+              <Scene data-uid='scene' style={{ backgroundColor: '#aaaaaa33', position: 'absolute', width: 300, height: 250 }}>
+                <Group data-uid='group' style={{ position: 'absolute', left: 25, top: 25, width: 175, height: 120, backgroundColor: 'white' }}>
+                  <div data-uid='child1' data-testid='child1' style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 0, top: 0, width: 50, height: 43 }} />
+                  <div data-uid='child2' style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 125, top: 77, width: 50, height: 43 }} />
+                </Group>
+              </Scene>
+            </Storyboard>
+          )
+        `),
+        'await-first-dom-report',
+      )
+      const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+      await renderResult.dispatch(
+        selectComponents([EP.fromString('sb/scene/group/child1')], true),
+        true,
+      )
+
+      const dragme = (await renderResult.renderedDOM.findByTestId('child1')).getBoundingClientRect()
+
+      await mouseDragFromPointWithDelta(
+        canvasControlsLayer,
+        { x: dragme.x + 10, y: dragme.y + 10 },
+        { x: -100, y: 0 },
+      )
+
+      expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+        formatTestProjectCode(`
+          import * as React from 'react'
+          import { Storyboard, Scene, Group } from 'utopia-api'
+
+          export var storyboard = (
+            <Storyboard data-uid='sb'>
+              <Scene data-uid='scene' style={{ backgroundColor: '#aaaaaa33', position: 'absolute', width: 300, height: 250 }}>
+                <Group data-uid='group' style={{ position: 'absolute', left: 150, top: 102, width: 50, height: 43, backgroundColor: 'white' }}>
+                  <div data-uid='child2' style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 0, top: 0, width: 50, height: 43 }} />
+                </Group>
+              </Scene>
+              <div data-uid='child1' data-testid='child1' style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: -75, top: 25, width: 50, height: 43 }} />
+            </Storyboard>
+          )
+        `),
+      )
+    })
+  })
 })
 
 function testProjectWithUnstyledDivOrFragment(type: FragmentLikeType): string {

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
@@ -23,7 +23,7 @@ import {
 } from '../canvas-strategy-types'
 import type { InteractionSession, UpdatedPathMap } from '../interaction-state'
 import { absoluteMoveStrategy } from './absolute-move-strategy'
-import { honoursPropsPosition } from './absolute-utils'
+import { honoursPropsPosition, shouldKeepMovingDraggedGroupChildren } from './absolute-utils'
 import { replaceFragmentLikePathsWithTheirChildrenRecursive } from './fragment-like-helpers'
 import { ifAllowedToReparent, isAllowedToReparent } from './reparent-helpers/reparent-helpers'
 import { getAbsoluteReparentPropertyChanges } from './reparent-helpers/reparent-property-changes'
@@ -98,7 +98,13 @@ export function baseAbsoluteReparentStrategy(
           show: 'visible-only-while-active',
         }),
       ],
-      fitness: fitness,
+      fitness: shouldKeepMovingDraggedGroupChildren(
+        canvasState.startingMetadata,
+        selectedElements,
+        reparentTarget.newParent,
+      )
+        ? 1
+        : fitness,
       apply: (strategyLifecycle) => {
         const { projectContents, openFile, nodeModules } = canvasState
         return ifAllowedToReparent(

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-utils.ts
@@ -1,6 +1,11 @@
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import { uniqBy } from '../../../../core/shared/array-utils'
+import * as EP from '../../../../core/shared/element-path'
+import type { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
+import type { InsertionPath } from '../../../editor/store/insertion-path'
 import type { InteractionCanvasState } from '../canvas-strategy-types'
+import { treatElementAsGroupLike } from './group-helpers'
 
 export function supportsStyle(canvasState: InteractionCanvasState, element: ElementPath): boolean {
   return MetadataUtils.targetUsesProperty(
@@ -28,4 +33,40 @@ export function honoursPropsPosition(
     canvasState.projectContents,
     MetadataUtils.findElementByElementPath(canvasState.startingMetadata, element),
   )
+}
+
+export function shouldKeepMovingDraggedGroupChildren(
+  jsxMetadata: ElementInstanceMetadataMap,
+  paths: ElementPath[],
+  reparentTarget: InsertionPath,
+): boolean {
+  // all selected elements must be under the same non-root hierarchy
+  const commonParent = EP.getCommonParent(paths, true)
+  if (commonParent == null || EP.isStoryboardPath(commonParent)) {
+    return false
+  }
+  // all elements must be group children
+  if (!paths.every((path) => treatElementAsGroupLike(jsxMetadata, EP.parentPath(path)))) {
+    return false
+  }
+
+  // all elements must not be crossing scenes
+  const sceneAncestors = uniqBy(
+    paths.flatMap((path) => EP.getAncestors(path)),
+    EP.pathsEqual,
+  ).filter((path) => MetadataUtils.isProbablyScene(jsxMetadata, path))
+  if (sceneAncestors.length > 0) {
+    const commonSceneParent = EP.getCommonParent(
+      [...sceneAncestors, reparentTarget.intendedParentPath],
+      true,
+    )
+    if (
+      commonSceneParent == null ||
+      !MetadataUtils.isProbablyScene(jsxMetadata, commonSceneParent)
+    ) {
+      return false
+    }
+  }
+
+  return true
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-utils.ts
@@ -45,6 +45,7 @@ export function shouldKeepMovingDraggedGroupChildren(
   if (commonParent == null || EP.isStoryboardPath(commonParent)) {
     return false
   }
+
   // all elements must be group children
   if (!paths.every((path) => treatElementAsGroupLike(jsxMetadata, EP.parentPath(path)))) {
     return false

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -30,6 +30,7 @@ import {
   getTargetPathsFromInteractionTarget,
 } from '../canvas-strategy-types'
 import type { InteractionSession } from '../interaction-state'
+import { shouldKeepMovingDraggedGroupChildren } from './absolute-utils'
 import { ifAllowedToReparent } from './reparent-helpers/reparent-helpers'
 import { getStaticReparentPropertyChanges } from './reparent-helpers/reparent-property-changes'
 import type { ReparentTarget } from './reparent-helpers/reparent-strategy-helpers'
@@ -90,7 +91,13 @@ export function baseReparentAsStaticStrategy(
           show: 'visible-only-while-active',
         }),
       ],
-      fitness: fitness,
+      fitness: shouldKeepMovingDraggedGroupChildren(
+        canvasState.startingMetadata,
+        selectedElements,
+        reparentTarget.newParent,
+      )
+        ? 1
+        : fitness,
       apply: () => {
         return applyStaticReparent(
           canvasState,


### PR DESCRIPTION
Fixes #4297 

**Problem:**

Dragging a group child outside its parent element bounds triggers a reparent which can be super confusing.

![Kapture 2023-10-03 at 11 31 48](https://github.com/concrete-utopia/utopia/assets/1081051/8ac81e84-8638-4b62-9f3d-5ee9248d6cd8)

**Fix:**

- When moving a group child around, prefer the move strategy over the reparenting ones (which can still be triggered with `Tab`)…
- …unless the reparent would happen outside of a `Scene`, in which case the reparenting is preferred.

https://github.com/concrete-utopia/utopia/assets/1081051/974821b0-2bf7-4eb7-b628-b90bc272aca7

