### PR TITLE
Change text mode control colors

### DIFF
--- a/editor/src/components/canvas/controls/text-editable-control.tsx
+++ b/editor/src/components/canvas/controls/text-editable-control.tsx
@@ -13,7 +13,6 @@ export const TextEditableControl = React.memo((props: TextEditableControlProps) 
   const colorTheme = useColorTheme()
   const outlineWidth = 1.5 / props.scale
   const outlineColor = colorTheme.textEditableOutline.value
-  const backgroundColor = colorTheme.textEditableFill.value
 
   if (isZeroSizedElement(props.frame)) {
     return null
@@ -29,7 +28,6 @@ export const TextEditableControl = React.memo((props: TextEditableControlProps) 
         width: props.frame.width,
         height: props.frame.height,
         boxShadow: `0px 0px 0px ${outlineWidth}px ${outlineColor}`,
-        background: backgroundColor,
         pointerEvents: 'none',
       }}
     />

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -318,7 +318,7 @@ const TextEditor = React.memo((props: TextEditorProps) => {
   )
 
   const colorTheme = useColorTheme()
-  const outlineWidth = 1.5 / scale
+  const outlineWidth = 1 / scale
   const outlineColor = colorTheme.textEditableOutline.value
 
   const [firstTextProp] = React.useState(text)

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -175,8 +175,7 @@ const darkTheme: typeof light = {
   canvasComponentButtonFocused: createUtopiColor('rgba(255,239,230,1)'),
   inspectorControlledBackground: createUtopiColor('rgba(242,248,255,1)'),
 
-  textEditableFill: createUtopiColor('rgba(255,128,255,.07)'),
-  textEditableOutline: createUtopiColor('rgba(255,128,255,1)'),
+  textEditableOutline: darkBase.primary,
 
   // interface elements: buttons, segment controls, checkboxes etc
 

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -175,8 +175,7 @@ const lightTheme = {
   canvasComponentButtonFocused: createUtopiColor('rgba(255,239,230,1)'),
   inspectorControlledBackground: createUtopiColor('rgba(242,248,255,1)'),
 
-  textEditableFill: createUtopiColor('rgba(255,128,255,.07)'),
-  textEditableOutline: createUtopiColor('rgba(255,128,255,1)'),
+  textEditableOutline: lightBase.primary,
 
   // interface elements: buttons, segment controls, checkboxes etc
 


### PR DESCRIPTION
**Description:**
- Use primary blue instead of pink for text editing outline color.
- Make the outline thinner.
- Remove pink background from the text editable controller.
