### PR TITLE
Completely disallow percentage based group children.

### DIFF
--- a/editor/src/components/inspector/common/layout-property-path-hooks.ts
+++ b/editor/src/components/inspector/common/layout-property-path-hooks.ts
@@ -46,7 +46,6 @@ import { getFramePointsFromMetadata, MaxContent } from '../inspector-common'
 import { mapDropNulls } from '../../../core/shared/array-utils'
 import {
   maybeInvalidGroupState,
-  maybeGroupChildWithoutFixedSizeForFill,
   groupErrorToastAction,
 } from '../../canvas/canvas-strategies/strategies/group-helpers'
 
@@ -416,11 +415,7 @@ export function usePinToggling(): UsePinTogglingResult {
               : null
           },
           onGroupChild: (path) => {
-            const group = MetadataUtils.getJSXElementFromMetadata(
-              jsxMetadataRef.current,
-              EP.parentPath(path),
-            )
-            return maybeGroupChildWithoutFixedSizeForFill(group) ?? null
+            return 'child-has-percentage-pins'
           },
         },
       )

--- a/editor/src/components/inspector/inspector-strategies/fill-container-basic-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/fill-container-basic-strategy.ts
@@ -23,7 +23,6 @@ import {
 } from '../../canvas/commands/set-css-length-command'
 import {
   groupErrorToastCommand,
-  maybeGroupChildWithoutFixedSizeForFill,
   maybeInvalidGroupState,
 } from '../../canvas/canvas-strategies/strategies/group-helpers'
 
@@ -45,8 +44,7 @@ export const fillContainerStrategyFlow = (
     const invalidGroupState = maybeInvalidGroupState(elements, metadata, {
       onGroup: () => 'group-has-percentage-pins',
       onGroupChild: (path) => {
-        const group = MetadataUtils.getJSXElementFromMetadata(metadata, EP.parentPath(path))
-        return maybeGroupChildWithoutFixedSizeForFill(group) ?? null
+        return 'child-has-percentage-pins'
       },
     })
     if (invalidGroupState != null) {

--- a/editor/src/components/inspector/inspector-strategies/fixed-size-basic-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/fixed-size-basic-strategy.ts
@@ -13,7 +13,6 @@ import type { InspectorStrategy } from './inspector-strategy'
 import { queueGroupTrueUp } from '../../canvas/commands/queue-group-true-up-command'
 import {
   groupErrorToastCommand,
-  maybeGroupChildWithoutFixedSizeForFill,
   maybeInvalidGroupState,
 } from '../../canvas/canvas-strategies/strategies/group-helpers'
 import { trueUpElementChanged } from '../../../components/editor/store/editor-state'
@@ -32,8 +31,7 @@ export const fixedSizeBasicStrategy = (
     const invalidGroupState = maybeInvalidGroupState(elementPaths, metadata, {
       onGroup: () => (value.unit === '%' ? 'group-has-percentage-pins' : null),
       onGroupChild: (path) => {
-        const group = MetadataUtils.getJSXElementFromMetadata(metadata, EP.parentPath(path))
-        return value.unit === '%' ? maybeGroupChildWithoutFixedSizeForFill(group) : null
+        return value.unit === '%' ? 'child-has-percentage-pins' : null
       },
     })
     if (invalidGroupState != null) {


### PR DESCRIPTION
Partly Fixes #4299

**Problem:**
Group children with percentage pins are problematic regardless of if the group has an explicit size.

**Fix:**
Widen the threshold for the existing check for group children with percentage pins by removing the check for the explicit size of a group.

**Commit Details:**
- Change `InvalidGroupState` value `'child-has-percentage-pins-without-group-size'` to `'child-has-percentage-pins'`.
- Remove a handful of checks to see if the groups have an explicit size.
- Add a test that checks for a child with percentage pins but explicit dimensions.
