### PR TITLE
Fix font family selector woes

### DIFF
--- a/editor/assets/google-fonts-list.ts
+++ b/editor/assets/google-fonts-list.ts
@@ -1,4 +1,4 @@
-import { GoogleFontsTypeface } from '../src/components/navigator/external-resources/google-fonts-utils'
+import type { GoogleFontsTypeface } from '../src/components/navigator/external-resources/google-fonts-utils'
 
 /** This is auto-generated using this workflow action: https://github.com/concrete-utopia/get-google-fonts-list-file */
 export const googleFontsList: Array<GoogleFontsTypeface> = [

--- a/editor/src/components/inspector/sections/style-section/text-subsection/font-family-select-popup.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/font-family-select-popup.tsx
@@ -387,15 +387,7 @@ export const FontFamilySelectPopup = React.memo(
         [filteredData, selectedOption],
       )
 
-      const onStringInputKeyDown = React.useCallback((e: React.KeyboardEvent) => {
-        if (
-          !(e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Enter' || e.key === 'Escape')
-        ) {
-          e.stopPropagation()
-        }
-      }, [])
-
-      const onWrapperKeyDown = React.useCallback(
+      const onStringInputKeyDown = React.useCallback(
         (e: React.KeyboardEvent) => {
           e.stopPropagation()
           switch (e.key) {
@@ -408,7 +400,6 @@ export const FontFamilySelectPopup = React.memo(
               break
             }
             case 'Enter': {
-              closePopup()
               if (selectedOption != null) {
                 submitNewValue(
                   onSubmitFontVariant,
@@ -418,18 +409,17 @@ export const FontFamilySelectPopup = React.memo(
                   pushNewFontFamilyVariant,
                 )
               }
+              closePopup()
               break
             }
             case 'Escape': {
               closePopup()
               break
             }
-            default: {
-              if (stringInputRef.current != null) {
-                stringInputRef.current.focus()
-                onStringInputKeyDown(e)
+            default:
+              if (filteredData.length > 0 && isSelectableItemData(filteredData[0])) {
+                setSelectedOption(filteredData[0])
               }
-            }
           }
         },
         [
@@ -440,7 +430,6 @@ export const FontFamilySelectPopup = React.memo(
           onSubmitFontVariant,
           pushNewFontFamilyVariant,
           selectedOption,
-          onStringInputKeyDown,
         ],
       )
 
@@ -488,57 +477,71 @@ export const FontFamilySelectPopup = React.memo(
       }, [])
 
       React.useEffect(() => {
-        if (stringInputRef.current != null) {
-          stringInputRef.current.focus()
-        }
-      })
+        setTimeout(() => {
+          if (stringInputRef.current != null) {
+            stringInputRef.current.focus()
+          }
+        }, 0)
+      }, [stringInputRef])
 
       return (
-        <FlexColumn
-          ref={wrapperRef}
-          tabIndex={0}
+        <div
           style={{
-            ...style,
-            backgroundColor: colorTheme.inspectorBackground.value,
-            width: UtopiaTheme.layout.inspectorSmallPaddedWidth, // TODO should this be resize-aware
-            boxShadow: '#0002 0px 0px 0px 1px, #0002 0px 4px 11px',
+            background: 'transparent',
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
             zIndex: 1,
-            borderRadius: UtopiaTheme.inputBorderRadius,
           }}
-          onKeyDown={onWrapperKeyDown}
+          onClick={closePopup}
         >
-          <FlexRow style={{ padding: 12 }}>
-            <StringInput
-              testId='font-family-search'
-              ref={stringInputRef}
-              placeholder='Search for fonts…'
-              value={searchTerm}
-              onKeyDown={onStringInputKeyDown}
-              onChange={onChange}
-              style={{ flexGrow: 1 }}
-            />
-          </FlexRow>
-          <VariableSizeList
-            ref={variableSizeListRef}
-            itemSize={getItemSize}
-            itemData={{
-              onSubmitFontFamily: onSubmitFontVariant,
-              itemsArray: filteredData,
-              fontWeight,
-              fontStyle,
-              closePopup,
-              selectedIndex,
-              setSelectedOption,
-              pushNewFontFamilyVariant,
-              updateSizes,
+          <FlexColumn
+            ref={wrapperRef}
+            tabIndex={0}
+            style={{
+              ...style,
+              backgroundColor: colorTheme.inspectorBackground.value,
+              width: UtopiaTheme.layout.inspectorSmallPaddedWidth, // TODO should this be resize-aware
+              boxShadow: '#0002 0px 0px 0px 1px, #0002 0px 4px 11px',
+              zIndex: 1,
+              borderRadius: UtopiaTheme.inputBorderRadius,
             }}
-            width={'100%'}
-            height={270}
-            itemCount={filteredData.length}
           >
-            {FontFamilySelectPopupItem}
-          </VariableSizeList>
-        </FlexColumn>
+            <FlexRow style={{ padding: 12 }}>
+              <StringInput
+                testId='font-family-search'
+                ref={stringInputRef}
+                placeholder='Search for fonts…'
+                value={searchTerm}
+                onKeyDown={onStringInputKeyDown}
+                onChange={onChange}
+                style={{ flexGrow: 1 }}
+              />
+            </FlexRow>
+            <VariableSizeList
+              ref={variableSizeListRef}
+              itemSize={getItemSize}
+              itemData={{
+                onSubmitFontFamily: onSubmitFontVariant,
+                itemsArray: filteredData,
+                fontWeight,
+                fontStyle,
+                closePopup,
+                selectedIndex,
+                setSelectedOption,
+                pushNewFontFamilyVariant,
+                updateSizes,
+              }}
+              width={'100%'}
+              height={270}
+              itemCount={filteredData.length}
+            >
+              {FontFamilySelectPopupItem}
+            </VariableSizeList>
+          </FlexColumn>
+        </div>
       )
     },
   ),


### PR DESCRIPTION
Fixes #4304 

**Problem:**

The font family selector in the inspector has a bunch of issues:
1. it does not acquire focus on open
2. closing it by clicking somewhere else does not actually reset it
3. closing it by clicking on the canvas triggers a canvas selection
4. arrow navigation is broken unless the mouse hovers its react-window component

**Fix:**

Although I believe this component should be rewritten, this is a set of fixes for all of the above using the current implementation. The reason for no tests is also to avoid investing a lot of time on tests setup (especially WRT react-window events) for something that should be massively reworked.