### PR TITLE
absolute duplicate flex child

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.spec.browser2.tsx
@@ -81,7 +81,7 @@ describe('Absolute Duplicate Strategy', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-        <div style={{ width: '100%', height: '100%', position: 'relative' }} data-uid='aaa'>
+        <div style={{ width: '100%', height: '100%', position: 'relative', contain: 'layout' }} data-uid='aaa'>
           <div
             style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 40, top: 50, width: 200, height: 120 }}
             data-uid='hello'

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.tsx
@@ -1,8 +1,8 @@
-import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { generateUidWithExistingComponents } from '../../../../core/model/element-template-utils'
 import * as EP from '../../../../core/shared/element-path'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
 import type {
+  AllElementProps,
   DerivedState,
   EditorState,
   EditorStatePatch,
@@ -26,12 +26,17 @@ import type {
 } from '../canvas-strategy-types'
 import {
   controlWithProps,
+  defaultCustomStrategyState,
   getTargetPathsFromInteractionTarget,
   strategyApplicationResult,
 } from '../canvas-strategy-types'
 import type { InteractionSession } from '../interaction-state'
 import { flattenSelection } from './shared-move-strategies-helpers'
-import { replaceFragmentLikePathsWithTheirChildrenRecursive } from './fragment-like-helpers'
+import { getElementFragmentLikeType } from './fragment-like-helpers'
+import { setProperty } from '../../commands/set-property-command'
+import * as PP from '../../../../core/shared/property-path'
+import type { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
+import type { ElementPathTrees } from '../../../../core/shared/element-path-tree'
 
 export function absoluteDuplicateStrategy(
   canvasState: InteractionCanvasState,
@@ -52,7 +57,7 @@ export function absoluteDuplicateStrategy(
   const isDragging = interactionSession.interactionData.drag != null
   const flattenedSelectionForMultiSelect = flattenSelection(selectedElements)
 
-  if (!isApplicable(canvasState, flattenedSelectionForMultiSelect)) {
+  if (!isApplicable(flattenedSelectionForMultiSelect)) {
     return null
   }
 
@@ -98,6 +103,19 @@ export function absoluteDuplicateStrategy(
 
           newPaths.push(newPath)
           duplicateCommands.push(duplicateElement('always', selectedElement, newUid, 'before'))
+
+          if (
+            !isElementSizelessDiv(
+              canvasState.startingMetadata,
+              canvasState.startingAllElementProps,
+              canvasState.startingElementPathTree,
+              selectedElement,
+            )
+          ) {
+            duplicateCommands.push(
+              setProperty('always', selectedElement, PP.create('style', 'position'), 'absolute'),
+            )
+          }
         })
 
         return strategyApplicationResult(
@@ -138,17 +156,18 @@ function runMoveStrategy(
   strategyLifecycle: InteractionLifecycle,
 ): Array<EditorStatePatch> {
   const moveCommands =
-    absoluteMoveStrategy(canvasState, interactionSession)?.strategy.apply(strategyLifecycle)
-      .commands ?? []
+    absoluteMoveStrategy(
+      canvasState,
+      interactionSession,
+      defaultCustomStrategyState(),
+      'do-not-run-applicability-check',
+    )?.strategy.apply(strategyLifecycle).commands ?? []
 
   return foldAndApplyCommandsInner(editorState, derivedState, [], moveCommands, commandLifecycle)
     .statePatches
 }
 
-function isApplicable(
-  canvasState: InteractionCanvasState,
-  filteredSelectedElements: ElementPath[],
-) {
+function isApplicable(filteredSelectedElements: ElementPath[]) {
   return filteredSelectedElements.every((element) => {
     // for a multiselected elements, we only apply drag-to-duplicate if they are siblings
     // otherwise this would lead to an unpredictable behavior
@@ -158,23 +177,18 @@ function isApplicable(
       EP.parentPath(element),
     )
 
-    const unrolledChildren = replaceFragmentLikePathsWithTheirChildrenRecursive(
-      canvasState.startingMetadata,
-      canvasState.startingAllElementProps,
-      canvasState.startingElementPathTree,
-      [element],
-    )
-
-    const isElementAbsolute = unrolledChildren.every((path) =>
-      MetadataUtils.isPositionAbsolute(
-        MetadataUtils.findElementByElementPath(canvasState.startingMetadata, path),
-      ),
-    )
-
-    return (
-      !EP.isRootElementOfInstance(element) &&
-      allDraggedElementsHaveTheSameParent &&
-      isElementAbsolute
-    )
+    return !EP.isRootElementOfInstance(element) && allDraggedElementsHaveTheSameParent
   })
+}
+
+function isElementSizelessDiv(
+  metadata: ElementInstanceMetadataMap,
+  allElementProps: AllElementProps,
+  elementPathTrees: ElementPathTrees,
+  elementPath: ElementPath,
+): boolean {
+  return (
+    getElementFragmentLikeType(metadata, allElementProps, elementPathTrees, elementPath) ===
+    'sizeless-div'
+  )
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
@@ -2,7 +2,11 @@ import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { ImmediateParentBounds } from '../../controls/parent-bounds'
 import { ImmediateParentOutlines } from '../../controls/parent-outlines'
 import { ZeroSizedElementControls } from '../../controls/zero-sized-element-controls'
-import type { InteractionCanvasState, MoveStrategy } from '../canvas-strategy-types'
+import type {
+  CustomStrategyState,
+  InteractionCanvasState,
+  MoveStrategy,
+} from '../canvas-strategy-types'
 import {
   controlWithProps,
   emptyStrategyApplicationResult,
@@ -17,9 +21,15 @@ import {
   flattenSelection,
 } from './shared-move-strategies-helpers'
 
+export type ShouldRunApplicabilityCheck =
+  | 'run-applicability-check'
+  | 'do-not-run-applicability-check'
+
 export function absoluteMoveStrategy(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
+  _: CustomStrategyState,
+  runApplicabilityCheck: ShouldRunApplicabilityCheck = 'run-applicability-check',
 ): MoveStrategy | null {
   const originalTargets = flattenSelection(
     getTargetPathsFromInteractionTarget(canvasState.interactionTarget),
@@ -39,7 +49,7 @@ export function absoluteMoveStrategy(
       )
     })
 
-  if (!isApplicable) {
+  if (runApplicabilityCheck === 'run-applicability-check' && !isApplicable) {
     return null
   }
   return {

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-only-move.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-only-move.spec.tsx
@@ -110,6 +110,7 @@ function dragByPixels(
       startingAllElementProps,
     ),
     interactionSession,
+    defaultCustomStrategyState(),
   )!.strategy.apply('end-interaction')
 
   expect(strategyResult.customStatePatch).toEqual({})

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
@@ -17,6 +17,7 @@ import type {
 } from '../canvas-strategy-types'
 import {
   controlWithProps,
+  defaultCustomStrategyState,
   emptyStrategyApplicationResult,
   getTargetPathsFromInteractionTarget,
   strategyApplicationResult,
@@ -177,10 +178,14 @@ export function baseAbsoluteReparentStrategy(
               })
 
               const moveCommands =
-                absoluteMoveStrategy(canvasState, {
-                  ...interactionSession,
-                  updatedTargetPaths: updatedTargetPaths,
-                })?.strategy.apply(strategyLifecycle).commands ?? []
+                absoluteMoveStrategy(
+                  canvasState,
+                  {
+                    ...interactionSession,
+                    updatedTargetPaths: updatedTargetPaths,
+                  },
+                  defaultCustomStrategyState(),
+                )?.strategy.apply(strategyLifecycle).commands ?? []
 
               const elementsToRerender = EP.uniqueElementPaths([
                 ...customStrategyState.elementsToRerender,
@@ -202,9 +207,11 @@ export function baseAbsoluteReparentStrategy(
               )
             } else {
               const moveCommands =
-                absoluteMoveStrategy(canvasState, interactionSession)?.strategy.apply(
-                  strategyLifecycle,
-                ).commands ?? []
+                absoluteMoveStrategy(
+                  canvasState,
+                  interactionSession,
+                  defaultCustomStrategyState(),
+                )?.strategy.apply(strategyLifecycle).commands ?? []
               return strategyApplicationResult(moveCommands)
             }
           },


### PR DESCRIPTION
## Problem
The absolute duplicate strategy doesn't work with flex children


## Fix
Remove the absolute positioning requirement from `isApplicable`. Also, add `contain: layout` to the parent of the duplicated element so we don't generate a warning in the navigator