### PR TITLE
Only use ancestor strategy when parent has the same size as child

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.spec.browser2.tsx
@@ -101,6 +101,50 @@ export var storyboard = (
 )
 `)
 
+const codeElementWithNoSiblingsAndMatchingOnlyWidth =
+  formatTestProjectCode(`import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+import { App } from '/src/app.js'
+import { View, Rectangle } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='0cd'>
+    <Scene
+      style={{
+        width: 700,
+        height: 759,
+        position: 'absolute',
+        left: 207,
+        top: 126,
+      }}
+      data-label='Playground'
+      data-uid='3fc'
+    >
+      <View
+        style={{
+          backgroundColor: '#B37DB7AB',
+          width: 100,
+          height: 100,
+        }}
+        data-uid='a50'
+      >
+        <div
+          data-testid='${DraggedDivId}'
+          data-uid='a75'
+          style={{
+            height: 50,
+            width: '100%',
+            backgroundColor: '#EB0A0A',
+            left: 245,
+            top: 196,
+          }}
+        />
+      </View>
+    </Scene>
+  </Storyboard>
+)
+`)
+
 const codeElementWithSibling = formatTestProjectCode(`import * as React from 'react'
 import { Scene, Storyboard } from 'utopia-api'
 import { App } from '/src/app.js'
@@ -231,7 +275,7 @@ export var storyboard = (
           style={{
             backgroundColor: '#B98731E8',
             width: '100%',
-            height: 114,
+            height: 104,
           }}
           data-uid='bb3'
         >
@@ -502,6 +546,22 @@ describe('finds an applicable strategy for the nearest ancestor', () => {
       }
       expect(strategies[0].strategy.id.endsWith('_ANCESTOR_1')).toBeTruthy()
     }))
+
+  it('element with no siblings but only one matching dimension does not find ancestor strategy', () =>
+    runTest(
+      codeElementWithNoSiblingsAndMatchingOnlyWidth,
+      pathForShallowNestedElement,
+      (editor) => {
+        const strategies = editor.getEditorState().strategyState.sortedApplicableStrategies
+
+        expect(strategies?.length).toBeGreaterThan(0)
+        if (strategies == null) {
+          // here for type assertion
+          throw new Error('`strategies` should not be null')
+        }
+        expect(strategies[0].strategy.id.includes('_ANCESTOR_')).toBeFalsy()
+      },
+    ))
 
   it('deeply nested element with no siblings', () =>
     runTest(codeDeeplyNestedElement, pathForDeeplyNestedElement, (editor) => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.tsx
@@ -89,8 +89,7 @@ export function ancestorMetaStrategy(
     const targetSmallerThatParent =
       targetFrame != null &&
       parentFrame != null &&
-      parentFrame.width > targetFrame.width &&
-      parentFrame.height > targetFrame.height
+      (parentFrame.width > targetFrame.width || parentFrame.height > targetFrame.height)
 
     if (targetSmallerThatParent) {
       return []


### PR DESCRIPTION
**Description:**
Until now we disallowed the ancestor strategy when the target was smaller than the parent in both dimensions.

However, we should also disallow the ancestor strategy when the target is smaller in only one of the dimensions. E.g. in the following case the target has smaller height than its parent, so the ancestor strategy doesn't feel right, we should be able to move the element in its parent, or reparent it out of it:

![05-50-0dwm6-kmbi4](https://github.com/concrete-utopia/utopia/assets/127662/529f0b1a-3df0-43fe-bb8e-7f859c31568a)

