### PR TITLE
Better "Hug Contents" detection

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -821,13 +821,13 @@ describe('inspector tests with real metadata', () => {
       'position-maxWidth-number-input',
     )) as HTMLInputElement
 
-    matchInlineSnapshotBrowser(widthControl.value, `"0"`)
+    matchInlineSnapshotBrowser(widthControl.value, `""`)
     matchInlineSnapshotBrowser(
       widthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
       `"disabled"`,
     )
 
-    matchInlineSnapshotBrowser(heightControl.value, `"0"`)
+    matchInlineSnapshotBrowser(heightControl.value, `""`)
     matchInlineSnapshotBrowser(
       heightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
       `"disabled"`,

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -703,7 +703,7 @@ export function isHugFromStyleAttribute(
   )
 
   if (simpleAttribute == null || typeof simpleAttribute !== 'string') {
-    return true
+    return false
   }
 
   if (HugContentAttrValues.includes(simpleAttribute)) {

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -763,7 +763,7 @@ export function detectFillHugFixedStateMultiselect(
 }
 
 export const MaxContent = 'max-content' as const
-const HugContentAttrValues = [MaxContent, 'min-content', 'fit-content', 'auto']
+export const HugContentAttrValues = [MaxContent, 'min-content', 'fit-content', 'auto']
 const HugContentAttrFunctions = ['fit-content']
 
 export type PackedSpaced = 'packed' | 'spaced'

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -702,7 +702,15 @@ export function isHugFromStyleAttribute(
     getSimpleAttributeAtPath(right(props), PP.create('style', property)),
   )
 
-  return simpleAttribute === MaxContent
+  if (simpleAttribute == null || typeof simpleAttribute !== 'string') {
+    return true
+  }
+
+  if (HugContentAttrValues.includes(simpleAttribute)) {
+    return true
+  }
+
+  return HugContentAttrFunctions.some((f) => simpleAttribute.startsWith(`${f}(`))
 }
 
 export function isHugFromStyleAttributeOrNull(
@@ -755,6 +763,8 @@ export function detectFillHugFixedStateMultiselect(
 }
 
 export const MaxContent = 'max-content' as const
+const HugContentAttrValues = [MaxContent, 'min-content', 'fit-content', 'auto']
+const HugContentAttrFunctions = ['fit-content']
 
 export type PackedSpaced = 'packed' | 'spaced'
 

--- a/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
@@ -34,7 +34,7 @@ import {
   selectOptionLabel,
 } from '../fill-hug-fixed-control'
 import type { Axis, FixedHugFillMode } from '../inspector-common'
-import { MaxContent } from '../inspector-common'
+import { HugContentAttrValues, MaxContent } from '../inspector-common'
 import { TextAutoSizingTestId } from '../sections/style-section/text-subsection/text-auto-sizing-control'
 import { BakedInStoryboardUID } from '../../../core/model/scene-utils'
 
@@ -553,6 +553,54 @@ describe('Fixed / Fill / Hug control', () => {
       expect(heightNumberControl.getAttribute('data-controlstatus')).toEqual('detected')
     })
 
+    const NonHugContentAttrValues = [200, '100%', 'inherit', '200px']
+    describe('Detect Hug Contents state with different width/height values', () => {
+      HugContentAttrValues.forEach((width) =>
+        NonHugContentAttrValues.forEach((height) =>
+          it(`child has Hug Contents width (${width}) but not height (${height})`, async () => {
+            const editor = await renderTestEditorWithCode(
+              projectWithParentWidthHeight(width, height),
+              'await-first-dom-report',
+            )
+            await select(editor, 'parent')
+
+            const buttons = await editor.renderedDOM.findAllByText(HugContentsLabel)
+
+            expect(buttons).toHaveLength(1)
+          }),
+        ),
+      )
+      HugContentAttrValues.forEach((height) =>
+        NonHugContentAttrValues.forEach((width) =>
+          it(`child has Hug Contents height (${height}) but not width ${width}`, async () => {
+            const editor = await renderTestEditorWithCode(
+              projectWithParentWidthHeight(width, height),
+              'await-first-dom-report',
+            )
+            await select(editor, 'parent')
+
+            const buttons = await editor.renderedDOM.findAllByText(HugContentsLabel)
+
+            expect(buttons).toHaveLength(1)
+          }),
+        ),
+      )
+      HugContentAttrValues.forEach((width) =>
+        HugContentAttrValues.forEach((height) =>
+          it(`child has Hug Contents width (${width}) and height (${height})`, async () => {
+            const editor = await renderTestEditorWithCode(
+              projectWithParentWidthHeight(width, height),
+              'await-first-dom-report',
+            )
+            await select(editor, 'parent')
+
+            const buttons = await editor.renderedDOM.findAllByText(HugContentsLabel)
+
+            expect(buttons).toHaveLength(2)
+          }),
+        ),
+      )
+    })
     describe('Convert children to fixed size when setting to hug contents to avoid parent container collapsing', () => {
       it('child is set to fill container on the horizontal axis', async () => {
         const editor = await renderTestEditorWithCode(
@@ -1827,6 +1875,39 @@ export var storyboard = (
           width: 229,
           height: 149,
           contain: 'layout',
+        }}
+      />
+    </div>
+  </Storyboard>
+)
+`
+
+const projectWithParentWidthHeight = (
+  width: number | string | null,
+  height: number | string | null,
+) => `import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+import { App } from '/src/app.js'
+
+export var storyboard = (
+  <Storyboard data-uid='0cd'>
+    <div
+      data-testid='parent'
+      style={{
+        ${width != null ? `width: '${width}'` : ''},
+        ${height != null ? `height: '${height}'` : ''},
+        position: 'absolute',
+        left: 212,
+        top: 128,
+      }}
+      data-label='Playground'
+    >
+      <div
+        data-testid='child'
+        style={{
+          backgroundColor: '#aaaaaa33',
+          width: 149,
+          height: 149,
         }}
       />
     </div>

--- a/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
@@ -8,6 +8,7 @@ import {
   expectNoAction,
   expectSingleUndo2Saves,
   selectComponentsForTest,
+  wait,
 } from '../../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../../canvas/controls/new-canvas-controls'
 import { mouseClickAtPoint, mouseDoubleClickAtPoint } from '../../canvas/event-helpers.test-utils'
@@ -556,64 +557,64 @@ describe('Fixed / Fill / Hug control', () => {
     const NonHugContentAttrValues = [200, '100%', 'inherit', '200px']
     describe('Detect Hug Contents state with different width/height values', () => {
       HugContentAttrValues.forEach((width) =>
-        NonHugContentAttrValues.slice(2).forEach((height) =>
-          it(`child has Hug Contents width (${width}) but not height (${height})`, async () => {
-            const editor = await renderTestEditorWithCode(
-              projectWithParentWidthHeight(width, height),
-              'await-first-dom-report',
-            )
-            await select(editor, 'parent')
+        it(`child has Hug Contents width (${width}) but not height (200)`, async () => {
+          const editor = await renderTestEditorWithCode(
+            projectWithParentWidthHeight(width, 200),
+            'await-first-dom-report',
+          )
+          await select(editor, 'parent')
 
-            const buttons = await editor.renderedDOM.findAllByText(HugContentsLabel)
+          const hugButtons = await editor.renderedDOM.findAllByText(HugContentsLabel)
+          expect(hugButtons).toHaveLength(1)
 
-            expect(buttons).toHaveLength(1)
-          }),
-        ),
+          const fixedButtons = await editor.renderedDOM.findAllByText(FixedLabel)
+          expect(fixedButtons).toHaveLength(1)
+        }),
       )
       HugContentAttrValues.forEach((height) =>
-        NonHugContentAttrValues.slice(2).forEach((width) =>
-          it(`child has Hug Contents height (${height}) but not width ${width}`, async () => {
-            const editor = await renderTestEditorWithCode(
-              projectWithParentWidthHeight(width, height),
-              'await-first-dom-report',
-            )
-            await select(editor, 'parent')
+        it(`child has Hug Contents height (${height}) but not width (200)`, async () => {
+          const editor = await renderTestEditorWithCode(
+            projectWithParentWidthHeight(200, height),
+            'await-first-dom-report',
+          )
+          await select(editor, 'parent')
 
-            const buttons = await editor.renderedDOM.findAllByText(HugContentsLabel)
+          const hugButtons = await editor.renderedDOM.findAllByText(HugContentsLabel)
+          expect(hugButtons).toHaveLength(1)
 
-            expect(buttons).toHaveLength(1)
-          }),
-        ),
+          const fixedButtons = await editor.renderedDOM.findAllByText(FixedLabel)
+          expect(fixedButtons).toHaveLength(1)
+        }),
       )
       HugContentAttrValues.forEach((width) =>
-        HugContentAttrValues.slice(2).forEach((height) =>
-          it(`child has Hug Contents width (${width}) and height (${height})`, async () => {
-            const editor = await renderTestEditorWithCode(
-              projectWithParentWidthHeight(width, height),
-              'await-first-dom-report',
-            )
-            await select(editor, 'parent')
+        it(`child has Hug Contents width (${width}) and height (${MaxContent})`, async () => {
+          const editor = await renderTestEditorWithCode(
+            projectWithParentWidthHeight(width, MaxContent),
+            'await-first-dom-report',
+          )
+          await select(editor, 'parent')
 
-            const buttons = await editor.renderedDOM.findAllByText(HugContentsLabel)
-
-            expect(buttons).toHaveLength(2)
-          }),
-        ),
+          const hugButtons = await editor.renderedDOM.findAllByText(HugContentsLabel)
+          expect(hugButtons).toHaveLength(2)
+        }),
       )
       NonHugContentAttrValues.forEach((width) =>
-        NonHugContentAttrValues.slice(2).forEach((height) =>
-          it(`child doesn't have Hug Contents in width (${width}) or height (${height})`, async () => {
-            const editor = await renderTestEditorWithCode(
-              projectWithParentWidthHeight(width, height),
-              'await-first-dom-report',
-            )
-            await select(editor, 'parent')
+        it(`child doesn't have Hug Contents in width (${width}) or height (200)`, async () => {
+          const editor = await renderTestEditorWithCode(
+            projectWithParentWidthHeight('100%', 200),
+            'await-first-dom-report',
+          )
+          await select(editor, 'parent')
 
-            const buttons = await editor.renderedDOM.queryAllByText(HugContentsLabel)
+          const hugButtons = editor.renderedDOM.queryAllByText(HugContentsLabel)
+          expect(hugButtons).toHaveLength(0)
 
-            expect(buttons).toHaveLength(0)
-          }),
-        ),
+          const otherButtons = await editor.renderedDOM.queryAllByText(
+            (content) =>
+              content === DetectedLabel || content === FixedLabel || content === FillContainerLabel,
+          )
+          expect(otherButtons).toHaveLength(2)
+        }),
       )
     })
     describe('Convert children to fixed size when setting to hug contents to avoid parent container collapsing', () => {

--- a/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
@@ -8,7 +8,6 @@ import {
   expectNoAction,
   expectSingleUndo2Saves,
   selectComponentsForTest,
-  wait,
 } from '../../../utils/utils.test-utils'
 import { CanvasControlsContainerID } from '../../canvas/controls/new-canvas-controls'
 import { mouseClickAtPoint, mouseDoubleClickAtPoint } from '../../canvas/event-helpers.test-utils'

--- a/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/fixed-fill-hug.spec.browser2.tsx
@@ -556,7 +556,7 @@ describe('Fixed / Fill / Hug control', () => {
     const NonHugContentAttrValues = [200, '100%', 'inherit', '200px']
     describe('Detect Hug Contents state with different width/height values', () => {
       HugContentAttrValues.forEach((width) =>
-        NonHugContentAttrValues.forEach((height) =>
+        NonHugContentAttrValues.slice(2).forEach((height) =>
           it(`child has Hug Contents width (${width}) but not height (${height})`, async () => {
             const editor = await renderTestEditorWithCode(
               projectWithParentWidthHeight(width, height),
@@ -571,7 +571,7 @@ describe('Fixed / Fill / Hug control', () => {
         ),
       )
       HugContentAttrValues.forEach((height) =>
-        NonHugContentAttrValues.forEach((width) =>
+        NonHugContentAttrValues.slice(2).forEach((width) =>
           it(`child has Hug Contents height (${height}) but not width ${width}`, async () => {
             const editor = await renderTestEditorWithCode(
               projectWithParentWidthHeight(width, height),
@@ -586,7 +586,7 @@ describe('Fixed / Fill / Hug control', () => {
         ),
       )
       HugContentAttrValues.forEach((width) =>
-        HugContentAttrValues.forEach((height) =>
+        HugContentAttrValues.slice(2).forEach((height) =>
           it(`child has Hug Contents width (${width}) and height (${height})`, async () => {
             const editor = await renderTestEditorWithCode(
               projectWithParentWidthHeight(width, height),
@@ -597,6 +597,21 @@ describe('Fixed / Fill / Hug control', () => {
             const buttons = await editor.renderedDOM.findAllByText(HugContentsLabel)
 
             expect(buttons).toHaveLength(2)
+          }),
+        ),
+      )
+      NonHugContentAttrValues.forEach((width) =>
+        NonHugContentAttrValues.slice(2).forEach((height) =>
+          it(`child doesn't have Hug Contents in width (${width}) or height (${height})`, async () => {
+            const editor = await renderTestEditorWithCode(
+              projectWithParentWidthHeight(width, height),
+              'await-first-dom-report',
+            )
+            await select(editor, 'parent')
+
+            const buttons = await editor.renderedDOM.queryAllByText(HugContentsLabel)
+
+            expect(buttons).toHaveLength(0)
           }),
         ),
       )


### PR DESCRIPTION
**Problem:**
We only detect the "Hug Contents" property of an element's dimension (width/height) when width/height is `max-content`.
But there are other possible width/height values which result in hugging the parent, e.g. `min-content`.

**Fix:**
Include these other possibilities in the `isHugFromStyleAttribute` function.