### PR TITLE
Set collapsing parent size to fixed when converting to absolute

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
@@ -549,7 +549,7 @@ describe('Convert to Absolute/runEscapeHatch action', () => {
 
 describe('Convert to Absolute', () => {
   it('Correctly uses the captured closestOffsetParentPath to determine which elements to update', async () => {
-    function getCodeForTestProject(childTag: string): string {
+    function getCodeForTestProject(appWithChildTag: string): string {
       return formatTestProjectCode(`
         import * as React from 'react'
         import { Scene, Storyboard } from 'utopia-api'
@@ -579,41 +579,43 @@ describe('Convert to Absolute', () => {
                 height: 812,
               }}
             >
-              <App data-uid='app'>
-                ${childTag}
-              </App>
+            ${appWithChildTag}
             </Scene>
           </Storyboard>
         )
       `)
     }
 
-    const childTagBefore = `
-    <div
-      data-uid='child'
-      style={{
-        width: 200,
-        height: 200,
-        backgroundColor: '#d3d3d3',
-      }}
-    />
+    const appWithChildTagBefore = `
+    <App data-uid='app'>
+      <div
+        data-uid='child'
+        style={{
+          width: 200,
+          height: 200,
+          backgroundColor: '#d3d3d3',
+        }}
+      />
+    </App>
     `
-    const childTagAfter = `
-    <div
-      data-uid='child'
-      style={{
-        width: 200,
-        height: 200,
-        backgroundColor: '#d3d3d3',
-        position: 'absolute',
-        left: 0,
-        top: 100,
-      }}
-    />
+    const appWithChildTagAfter = `
+    <App data-uid='app' style={{ width: 375, height: 0 }}>
+      <div
+        data-uid='child'
+        style={{
+          width: 200,
+          height: 200,
+          backgroundColor: '#d3d3d3',
+          position: 'absolute',
+          left: 0,
+          top: 100,
+        }}
+      />
+    </App>
     `
 
     const renderResult = await renderTestEditorWithCode(
-      getCodeForTestProject(childTagBefore),
+      getCodeForTestProject(appWithChildTagBefore),
       'await-first-dom-report',
     )
 
@@ -621,7 +623,7 @@ describe('Convert to Absolute', () => {
     await renderResult.dispatch([runEscapeHatch([targetToConvert])], true)
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
-      getCodeForTestProject(childTagAfter),
+      getCodeForTestProject(appWithChildTagAfter),
     )
   })
 })
@@ -1098,7 +1100,14 @@ describe('Convert to absolute/escape hatch', () => {
 
       expect(getPrintedUiJsCode(initialEditor.getEditorState())).toEqual(
         makeTestProjectCodeWithSnippet(
-          `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+          `<View
+            style={{
+              ...(props.style || {}),
+              width: 400,
+              height: 400,
+            }}
+            data-uid='aaa'
+          >
           <View
             style={{ backgroundColor: '#aaaaaa33', width: 250, height: 300, position: 'absolute', left: 0, top: 0  }}
             data-uid='bbb'
@@ -1154,7 +1163,14 @@ describe('Convert to absolute/escape hatch', () => {
 
       expect(getPrintedUiJsCode(initialEditor.getEditorState())).toEqual(
         makeTestProjectCodeWithSnippet(
-          `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+          `<View
+            style={{
+              ...(props.style || {}),
+              width: 400,
+              height: 400,
+            }}
+            data-uid='aaa'
+          >
           <View
             style={{ backgroundColor: '#aaaaaa33', width: '50%', height: '20%', right: 185, bottom: 305, top: 15, left: 15, position: 'absolute', }}
             data-uid='bbb'
@@ -1203,7 +1219,14 @@ describe('Convert to absolute/escape hatch', () => {
 
       expect(getPrintedUiJsCode(initialEditor.getEditorState())).toEqual(
         makeTestProjectCodeWithSnippet(
-          `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+          `<View
+            style={{
+              ...(props.style || {}),
+              width: 400,
+              height: 400,
+            }}
+            data-uid='aaa'
+          >
           <View
             style={{ backgroundColor: '#aaaaaa33', width: 250, height: 300, position: 'absolute', left: 15, top: 15  }}
             data-uid='bbb'
@@ -1260,7 +1283,14 @@ describe('Convert to absolute/escape hatch', () => {
 
       expect(getPrintedUiJsCode(initialEditor.getEditorState())).toEqual(
         makeTestProjectCodeWithSnippet(
-          `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+          `<View
+            style={{
+              ...(props.style || {}),
+              width: 400,
+              height: 400,
+            }}
+            data-uid='aaa'
+          >
           <View
             style={{ backgroundColor: '#aaaaaa33', width: '50%', height: '20%', right: 185, bottom: 305, top: 15, left: 15, position: 'absolute', }}
             data-uid='bbb'

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
@@ -549,7 +549,7 @@ describe('Convert to Absolute/runEscapeHatch action', () => {
 
 describe('Convert to Absolute', () => {
   it('Correctly uses the captured closestOffsetParentPath to determine which elements to update', async () => {
-    function getCodeForTestProject(appWithChildTag: string): string {
+    function getCodeForTestProject(childTag: string): string {
       return formatTestProjectCode(`
         import * as React from 'react'
         import { Scene, Storyboard } from 'utopia-api'
@@ -579,43 +579,41 @@ describe('Convert to Absolute', () => {
                 height: 812,
               }}
             >
-            ${appWithChildTag}
+              <App data-uid='app'>
+                ${childTag}
+              </App>
             </Scene>
           </Storyboard>
         )
       `)
     }
 
-    const appWithChildTagBefore = `
-    <App data-uid='app'>
-      <div
-        data-uid='child'
-        style={{
-          width: 200,
-          height: 200,
-          backgroundColor: '#d3d3d3',
-        }}
-      />
-    </App>
+    const childTagBefore = `
+    <div
+      data-uid='child'
+      style={{
+        width: 200,
+        height: 200,
+        backgroundColor: '#d3d3d3',
+      }}
+    />
     `
-    const appWithChildTagAfter = `
-    <App data-uid='app' style={{ width: 375, height: 0 }}>
-      <div
-        data-uid='child'
-        style={{
-          width: 200,
-          height: 200,
-          backgroundColor: '#d3d3d3',
-          position: 'absolute',
-          left: 0,
-          top: 100,
-        }}
-      />
-    </App>
+    const childTagAfter = `
+    <div
+      data-uid='child'
+      style={{
+        width: 200,
+        height: 200,
+        backgroundColor: '#d3d3d3',
+        position: 'absolute',
+        left: 0,
+        top: 100,
+      }}
+    />
     `
 
     const renderResult = await renderTestEditorWithCode(
-      getCodeForTestProject(appWithChildTagBefore),
+      getCodeForTestProject(childTagBefore),
       'await-first-dom-report',
     )
 
@@ -623,7 +621,7 @@ describe('Convert to Absolute', () => {
     await renderResult.dispatch([runEscapeHatch([targetToConvert])], true)
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
-      getCodeForTestProject(appWithChildTagAfter),
+      getCodeForTestProject(childTagAfter),
     )
   })
 })

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -659,38 +659,40 @@ function createSetParentsToFixedSizeCommands(
     }
     return firstAncestorsHonoringPropsSize.flatMap((ancestor) => {
       const parentMetadata = MetadataUtils.findElementByElementPath(metadata, ancestor)
-      const parentElement = MetadataUtils.getJSXElementFromMetadata(metadata, ancestor)
       const parentLocalFrame = parentMetadata?.localFrame
-      if (
-        parentElement != null &&
-        parentLocalFrame != null &&
-        isFiniteRectangle(parentLocalFrame)
-      ) {
-        const setWidthCommands = isCollapsingParent(parentElement, 'width')
-          ? [
-              setCssLengthProperty(
-                'always',
-                ancestor,
-                PP.create('style', 'width'),
-                setExplicitCssValue(cssPixelLength(parentLocalFrame.width)),
-                null,
-              ),
-            ]
-          : []
-        const setHeightCommands = isCollapsingParent(parentElement, 'width')
-          ? [
-              setCssLengthProperty(
-                'always',
-                ancestor,
-                PP.create('style', 'height'),
-                setExplicitCssValue(cssPixelLength(parentLocalFrame.height)),
-                null,
-              ),
-            ]
-          : []
-        return [...setWidthCommands, ...setHeightCommands]
+      if (parentLocalFrame == null || !isFiniteRectangle(parentLocalFrame)) {
+        return []
       }
-      return []
+
+      const parentElement = MetadataUtils.getJSXElementFromMetadata(metadata, ancestor)
+      if (parentElement == null) {
+        return []
+      }
+
+      const setWidthCommands = isCollapsingParent(parentElement, 'width')
+        ? [
+            setCssLengthProperty(
+              'always',
+              ancestor,
+              PP.create('style', 'width'),
+              setExplicitCssValue(cssPixelLength(parentLocalFrame.width)),
+              null,
+            ),
+          ]
+        : []
+      const setHeightCommands = isCollapsingParent(parentElement, 'width')
+        ? [
+            setCssLengthProperty(
+              'always',
+              ancestor,
+              PP.create('style', 'height'),
+              setExplicitCssValue(cssPixelLength(parentLocalFrame.height)),
+              null,
+            ),
+          ]
+        : []
+
+      return [...setWidthCommands, ...setHeightCommands]
     })
   }
 


### PR DESCRIPTION
**Problem:**
An element's dimension can be defined by its children (similarly to the "Hug Contents" size property in the inspector). In this case converting a child to absolute can collapse the parent to smaller or even zero size.

Note: This can also happen if you delete/reparent the child from the parent, but that is not the scope of this PR.

**Fix:**
In the convert-to-absolute strategy check if the parent is a "collapsing" one, and set its size to fixed to make sure it doesn't collapse.

Note: we decide whether a parent is a collapsing one based on its style props. Later, we will need a smarter solution, which can recognize this property from CSS rules coming from anywhere.