### PR TITLE
Add fixed resize option for Groups

### DIFF
--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -51,11 +51,22 @@ import { isLayoutPinnedProp, type LayoutPinnedProp } from '../../core/layout/lay
 import type { AllElementProps } from '../editor/store/editor-state'
 import { jsExpressionValue, emptyComments } from '../../core/shared/element-template'
 import type { EditorDispatch, EditorAction } from '../editor/action-types'
-import { unsetProperty, setProp_UNSAFE } from '../editor/actions/action-creators'
+import {
+  unsetProperty,
+  setProp_UNSAFE,
+  applyCommandsAction,
+  showToast,
+} from '../editor/actions/action-creators'
 import { FlexCol } from 'utopia-api'
 import { PinControl } from './controls/pin-control'
 import type { FramePinsInfo } from './common/layout-property-path-hooks'
 import { MixedPlaceholder } from '../../uuiui/inputs/base-input'
+import {
+  convertGroupToFrameCommands,
+  getInstanceForGroupToFrameConversion,
+  isConversionForbidden,
+} from '../canvas/canvas-strategies/strategies/group-conversion-helpers'
+import { notice } from '../common/notice'
 
 export const FillFixedHugControlId = (segment: 'width' | 'height'): string =>
   `hug-fixed-fill-${segment}`
@@ -398,6 +409,32 @@ function useOnSubmitFixedFillHugType(dimension: 'width' | 'height') {
 
       const firstSelectedView = safeIndex(selectedViewsRef.current, 0)
       if (firstSelectedView != null) {
+        // changing value for a group means converting its contract
+        if (treatElementAsGroupLike(metadataRef.current, firstSelectedView) && value === 'fixed') {
+          const conversion = getInstanceForGroupToFrameConversion(
+            metadataRef.current,
+            elementPathTreeRef.current,
+            allElementPropsRef.current,
+            firstSelectedView,
+          )
+          if (isConversionForbidden(conversion)) {
+            dispatch([showToast(notice(conversion.reason, 'ERROR'))])
+          } else {
+            dispatch([
+              applyCommandsAction(
+                convertGroupToFrameCommands(
+                  metadataRef.current,
+                  elementPathTreeRef.current,
+                  allElementPropsRef.current,
+                  firstSelectedView,
+                ),
+              ),
+              showToast(notice('Converted to frame')),
+            ])
+          }
+          return
+        }
+
         const valueToUse =
           dimension === 'width'
             ? fixedSizeDimensionHandlingText(

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -905,23 +905,18 @@ export function toggleResizeToFitSetToFixed(
     : resizeToFitCommands(metadata, elementPaths, elementPathTree, allElementProps)
 }
 
-function fixedOrHugForGroup(
-  metadata: ElementInstanceMetadataMap,
-  path: ElementPath,
-): 'fixed' | 'hug-group' {
-  return treatElementAsGroupLike(metadata, path) ? 'hug-group' : 'fixed'
-}
-
 export function getFixedFillHugOptionsForElement(
   metadata: ElementInstanceMetadataMap,
   pathTrees: ElementPathTrees,
   selectedView: ElementPath,
 ): Set<FixedHugFillMode> {
+  const isGroup = treatElementAsGroupLike(metadata, selectedView)
   return new Set(
     stripNulls([
-      fixedOrHugForGroup(metadata, selectedView),
+      isGroup ? 'hug-group' : null,
+      'fixed',
       hugContentsApplicableForText(metadata, selectedView) ||
-      hugContentsApplicableForContainer(metadata, pathTrees, selectedView)
+      (!isGroup && hugContentsApplicableForContainer(metadata, pathTrees, selectedView))
         ? 'hug'
         : null,
       fillContainerApplicable(metadata, selectedView) ? 'fill' : null,


### PR DESCRIPTION
Fixes #4324 

**Problem:**

The Groups resize dropdown only shows a single `Hug contents` option.

<img width="1000" alt="Screenshot 2023-10-05 at 11 35 43 AM" src="https://github.com/concrete-utopia/utopia/assets/1081051/044ddcd1-af5a-4532-b4ca-f42ee66fa21e">

**Fix:**

Add a `Fixed` option that will convert the Group to a Frame (and show a toast).

![Kapture 2023-10-05 at 11 36 57](https://github.com/concrete-utopia/utopia/assets/1081051/c5b2b190-f04d-479f-ba1b-c6a9a3f1e058)
