### PR TITLE
correct label colors

### DIFF
--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -998,11 +998,7 @@ function severityFromErrors(errors: ErrorMessage[]): 'no-error' | 'warning' | 'e
     return 'warning'
   }
 
-  if (errors.some((e) => e.severity === 'fatal' || e.severity === 'error')) {
-    return 'error'
-  }
-
-  return 'no-error'
+  return 'error'
 }
 
 function getLabelColor(theme: ReturnType<typeof useColorTheme>, errors: ErrorMessage[]): string {


### PR DESCRIPTION
## Problem
File item labels and icons turn red if there are any linter messages present in the file
<img width="263" alt="image" src="https://github.com/concrete-utopia/utopia/assets/16385508/99294721-f516-45bc-840e-f5d4afb77440">


## Fix
Only turn them red if any of the linter messages are actual errors, not warnings
<img width="263" alt="image" src="https://github.com/concrete-utopia/utopia/assets/16385508/0f0e4c23-7996-479f-9adb-a934dd72b048">
