### PR TITLE
Remove Remix feature switch

### DIFF
--- a/editor/src/components/canvas/remix/remix-error-handling-with-boundary.spec.tsx
+++ b/editor/src/components/canvas/remix/remix-error-handling-with-boundary.spec.tsx
@@ -5,8 +5,6 @@ import { runTestReturningErrorBoundaries } from './remix-error-handling.test-uti
 // as otherwise it causes issues with Jest for some reason
 
 describe('Remix error handling', () => {
-  setFeatureForUnitTestsUseInDescribeBlockOnly('Remix support', true)
-
   it('Supports a user-defined error boundary', async () => {
     const { customBoundary, canvasOverlay } = await runTestReturningErrorBoundaries(
       'with-custom-boundary',

--- a/editor/src/components/canvas/remix/remix-error-handling-without-boundary.spec.tsx
+++ b/editor/src/components/canvas/remix/remix-error-handling-without-boundary.spec.tsx
@@ -5,8 +5,6 @@ import { runTestReturningErrorBoundaries } from './remix-error-handling.test-uti
 // as otherwise it causes issues with Jest for some reason
 
 describe('Remix error handling', () => {
-  setFeatureForUnitTestsUseInDescribeBlockOnly('Remix support', true)
-
   it('Bubbles errors to the canvas if no error boundary exists', async () => {
     const { customBoundary, canvasOverlay } = await runTestReturningErrorBoundaries(
       'without-custom-boundary',

--- a/editor/src/components/canvas/remix/remix-navigator.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-navigator.spec.browser2.tsx
@@ -26,7 +26,6 @@ async function renderRemixProject(project: PersistentModel) {
 }
 
 describe('Remix navigator', () => {
-  setFeatureForBrowserTestsUseInDescribeBlockOnly('Remix support', true)
   it('Shows navigator for remix content', async () => {
     const project = createModifiedProject({
       [StoryboardFilePath]: `import * as React from 'react'
@@ -281,7 +280,6 @@ describe('Remix navigator', () => {
   })
 })
 describe('Reparenting in Remix projects in the navigator', () => {
-  setFeatureForBrowserTestsUseInDescribeBlockOnly('Remix support', true)
   it('Can reparent into element in Remix', async () => {
     const project = createModifiedProject({
       [StoryboardFilePath]: `import * as React from 'react'

--- a/editor/src/components/canvas/remix/remix-rendering.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-rendering.spec.browser2.tsx
@@ -90,7 +90,6 @@ async function renderRemixProject(project: PersistentModel) {
 }
 
 describe('Remix content', () => {
-  setFeatureForBrowserTestsUseInDescribeBlockOnly('Remix support', true)
   it('Renders the remix container with actual content', async () => {
     const project = createModifiedProject({
       [StoryboardFilePath]: `import * as React from 'react'
@@ -803,22 +802,7 @@ describe('Remix content', () => {
   })
 })
 
-describe('Remix content with feature switch off', () => {
-  setFeatureForBrowserTestsUseInDescribeBlockOnly('Remix support', false)
-  it('Doesnt render the remix container with feature switch off', async () => {
-    const project = createModifiedProject({
-      [StoryboardFilePath]: storyboardFileContent,
-    })
-    const renderResult = await renderRemixProject(project)
-    await expect(async () =>
-      renderResult.renderedDOM.findAllByTestId(REMIX_SCENE_TESTID),
-    ).rejects.toThrow()
-  })
-})
-
 describe('Remix navigation', () => {
-  setFeatureForBrowserTestsUseInDescribeBlockOnly('Remix support', true)
-
   const projectWithMultipleRoutes = () =>
     createModifiedProject({
       [StoryboardFilePath]: `import * as React from 'react'
@@ -1327,8 +1311,6 @@ describe('Remix navigation', () => {
 })
 
 describe('Editing Remix content', () => {
-  setFeatureForBrowserTestsUseInDescribeBlockOnly('Remix support', true)
-
   it('set opacity on remix element', async () => {
     const project = createModifiedProject({
       [StoryboardFilePath]: `import * as React from 'react'
@@ -1987,7 +1969,6 @@ export default function Index() {
 })
 
 describe('Canvas controls with Remix', () => {
-  setFeatureForBrowserTestsUseInDescribeBlockOnly('Remix support', true)
   it('Multiselect from the same element in different scenes does not render multiselect outline', async () => {
     const project = createModifiedProject({
       [StoryboardFilePath]: `import * as React from 'react'

--- a/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
@@ -56,7 +56,6 @@ export default function Index() {
 `
 
 describe('Route manifest', () => {
-  setFeatureForBrowserTestsUseInDescribeBlockOnly('Remix support', true)
   it('Parses the route manifest from a simple project', async () => {
     const project = createModifiedProject({
       [StoryboardFilePath]: storyboardFileContent,
@@ -243,7 +242,6 @@ describe('Route manifest', () => {
 })
 
 describe('Routes', () => {
-  setFeatureForBrowserTestsUseInDescribeBlockOnly('Remix support', true)
   it('Parses the routes from a simple project', async () => {
     const project = createModifiedProject({
       [StoryboardFilePath]: storyboardFileContent,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -740,7 +740,7 @@ function renderJSXElement(
     if (elementIsScene) {
       return SceneComponent
     }
-    if (isFeatureEnabled('Remix support') && elementIsRemixScene) {
+    if (elementIsRemixScene) {
       return RemixSceneComponent
     }
     return elementFromScopeOrImport

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -13,7 +13,6 @@ export type FeatureName =
   | 'Canvas Strategies Debug Panel'
   | 'Project Thumbnail Generation'
   | 'Draggable Floating Panels'
-  | 'Remix support'
   | 'Debug - Print UIDs'
 
 export const AllFeatureNames: FeatureName[] = [
@@ -28,7 +27,6 @@ export const AllFeatureNames: FeatureName[] = [
   'Canvas Strategies Debug Panel',
   'Project Thumbnail Generation',
   'Draggable Floating Panels',
-  'Remix support',
   'Debug - Print UIDs',
 ]
 
@@ -43,7 +41,6 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Canvas Strategies Debug Panel': false,
   'Project Thumbnail Generation': false,
   'Draggable Floating Panels': false,
-  'Remix support': false,
   'Debug - Print UIDs': false,
 }
 


### PR DESCRIPTION
**Problem:**
Remix feature switch can be removed, it does not affect non-remix projects, and it is easy to forget to turn it on.
