### PR TITLE
Modified Github title to make it more readable.

### DIFF
--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -8,6 +8,7 @@ import {
   Avatar,
   Button,
   colorTheme,
+  FlexColumn,
   Icons,
   LargerIcons,
   SimpleFlexRow,
@@ -135,103 +136,101 @@ export const TitleBarProjectTitle = React.memo((props: { panelData: StoredPanel 
   }, [])
 
   return (
-    <div
-      ref={drag}
-      className='handle'
-      style={{
-        height: TitleHeight,
-        width: '100%',
-        backgroundColor: theme.inspectorBackground.value,
-        paddingLeft: 10,
-        display: 'flex',
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: 10,
-        flexShrink: 0,
-      }}
-    >
-      <FlexRow css={{ gap: 6 }}>
-        <div
-          style={{
-            width: 8,
-            height: 8,
-            borderRadius: 8,
-            backgroundColor: theme.unavailableGrey.value,
-          }}
-        />
-        <div
-          style={{
-            width: 8,
-            height: 8,
-            borderRadius: 8,
-            backgroundColor: theme.unavailableGrey.value,
-          }}
-        />
-      </FlexRow>
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
-        {currentBranch != null ? (
-          <>
-            <SimpleFlexRow style={{ fontWeight: 600 }}>{currentBranch}</SimpleFlexRow>
-            <SimpleFlexRow style={{ fontWeight: 500, fontSize: 10, color: colorTheme.fg4.value }}>
-              {repoName}
-            </SimpleFlexRow>
-          </>
-        ) : (
-          <ProjectTitle>{projectName}</ProjectTitle>
-        )}
-        {when(
-          loggedIn,
+    <FlexColumn>
+      <div
+        ref={drag}
+        className='handle'
+        style={{
+          height: TitleHeight,
+          width: '100%',
+          backgroundColor: theme.inspectorBackground.value,
+          paddingLeft: 10,
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: 10,
+          flexShrink: 0,
+        }}
+      >
+        <FlexRow css={{ gap: 6 }}>
           <div
             style={{
-              display: 'flex',
-              flexDirection: 'row',
-              gap: 6,
-              scale: '75%',
-              transformOrigin: 'left',
+              width: 8,
+              height: 8,
+              borderRadius: 8,
+              backgroundColor: theme.unavailableGrey.value,
             }}
-          >
-            {when(
-              hasUpstreamChanges,
-              <RoundButton
-                color={colorTheme.secondaryOrange.value}
-                onClick={openLeftPaneltoGithubTab}
-                onMouseDown={onMouseDown}
-              >
-                {<Icons.Download style={{ width: 19, height: 19 }} color={'on-light-main'} />}
-                <>Remote</>
-              </RoundButton>,
-            )}
-            {when(
-              hasMergeConflicts,
-              <RoundButton
-                color={colorTheme.error.value}
-                onClick={showMergeConflict}
-                onMouseDown={onMouseDown}
-              >
-                {
-                  <Icons.WarningTriangle
-                    style={{ width: 19, height: 19 }}
-                    color={'on-light-main'}
-                  />
-                }
-                <>Merge Conflicts</>
-              </RoundButton>,
-            )}
-            {when(
-              hasDownstreamChanges,
-              <RoundButton
-                color={colorTheme.secondaryBlue.value}
-                onClick={openLeftPaneltoGithubTab}
-                onMouseDown={onMouseDown}
-              >
-                {<Icons.Upload style={{ width: 19, height: 19 }} color={'on-light-main'} />}
-                <>Local</>
-              </RoundButton>,
-            )}
-          </div>,
-        )}
+          />
+          <div
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: 8,
+              backgroundColor: theme.unavailableGrey.value,
+            }}
+          />
+        </FlexRow>
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          {currentBranch != null ? (
+            <>
+              <SimpleFlexRow style={{ fontWeight: 600 }}>{currentBranch}</SimpleFlexRow>
+              <SimpleFlexRow style={{ fontWeight: 500, fontSize: 10, color: colorTheme.fg4.value }}>
+                {repoName}
+              </SimpleFlexRow>
+            </>
+          ) : (
+            <ProjectTitle>{projectName}</ProjectTitle>
+          )}
+        </div>
       </div>
-    </div>
+      {when(
+        loggedIn,
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            gap: 6,
+            scale: '75%',
+            transformOrigin: 'left',
+            paddingLeft: 10,
+          }}
+        >
+          {when(
+            hasUpstreamChanges,
+            <RoundButton
+              color={colorTheme.secondaryOrange.value}
+              onClick={openLeftPaneltoGithubTab}
+              onMouseDown={onMouseDown}
+            >
+              {<Icons.Download style={{ width: 19, height: 19 }} color={'on-light-main'} />}
+              <>Remote</>
+            </RoundButton>,
+          )}
+          {when(
+            hasMergeConflicts,
+            <RoundButton
+              color={colorTheme.error.value}
+              onClick={showMergeConflict}
+              onMouseDown={onMouseDown}
+            >
+              {<Icons.WarningTriangle style={{ width: 19, height: 19 }} color={'on-light-main'} />}
+              <>Merge Conflicts</>
+            </RoundButton>,
+          )}
+          {when(
+            hasDownstreamChanges,
+            <RoundButton
+              color={colorTheme.secondaryBlue.value}
+              onClick={openLeftPaneltoGithubTab}
+              onMouseDown={onMouseDown}
+            >
+              {<Icons.Upload style={{ width: 19, height: 19 }} color={'on-light-main'} />}
+              <>Local</>
+            </RoundButton>,
+          )}
+        </div>,
+      )}
+    </FlexColumn>
   )
 })
 

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -170,17 +170,12 @@ export const TitleBarProjectTitle = React.memo((props: { panelData: StoredPanel 
       </FlexRow>
       <div style={{ display: 'flex', flexDirection: 'column' }}>
         {currentBranch != null ? (
-          <SimpleFlexRow
-            style={{
-              gap: 5,
-              scale: hasUpstreamChanges || hasMergeConflicts || hasDownstreamChanges ? '75%' : 1,
-              transformOrigin: 'left',
-            }}
-          >
-            {repoName}
-            {<Icons.Branch style={{ width: 19, height: 19 }} />}
-            {currentBranch}
-          </SimpleFlexRow>
+          <>
+            <SimpleFlexRow style={{ fontWeight: 600 }}>{currentBranch}</SimpleFlexRow>
+            <SimpleFlexRow style={{ fontWeight: 500, fontSize: 10, color: colorTheme.fg4.value }}>
+              {repoName}
+            </SimpleFlexRow>
+          </>
         ) : (
           <ProjectTitle>{projectName}</ProjectTitle>
         )}


### PR DESCRIPTION
**Problem:**
The Github title looks like this:
![before](https://github.com/concrete-utopia/utopia/assets/217400/946f4c5e-78c2-4ecc-b9ef-0e9cdee5d45e)
Which results in the branch name being lost outside of the bounds of the pane.

**Fix:**
Put the branch name and the repo on two different lines:
![image](https://github.com/concrete-utopia/utopia/assets/217400/ecf57840-2fe2-4d93-9767-4e9bb39f5d88)

**Commit Details:**
- Changed the Github section of `TitleBarProjectTitle` to put the branch and repo on different lines primarily.