### PR TITLE
Font popup shouldn't crash the editor

### DIFF
--- a/editor/src/components/inspector/sections/style-section/text-subsection/font-family-select-popup.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/font-family-select-popup.tsx
@@ -434,7 +434,7 @@ export const FontFamilySelectPopup = React.memo(
       )
 
       const getItemSize = React.useCallback(
-        (index: number) => filteredData[index].height,
+        (index: number) => filteredData.at(index)?.height ?? 0,
         [filteredData],
       )
 


### PR DESCRIPTION
## Problem
Searching for a font with no results in the font popup crashes the editor

## Cause & fix
An unsafe indexing call, this PR makes it safe