### PR TITLE
Remove unnecessary DerivedState from commands

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
@@ -175,7 +175,6 @@ describe('Strategy Fitness', () => {
       RegisteredCanvasStrategies,
       pickCanvasStateFromEditorState(
         renderResult.getEditorState().editor,
-        renderResult.getEditorState().derived,
         renderResult.getEditorState().builtInDependencies,
       ),
       interactionSession,
@@ -225,7 +224,6 @@ describe('Strategy Fitness', () => {
       RegisteredCanvasStrategies,
       pickCanvasStateFromEditorState(
         renderResult.getEditorState().editor,
-        renderResult.getEditorState().derived,
         renderResult.getEditorState().builtInDependencies,
       ),
       interactionSession,
@@ -316,7 +314,6 @@ describe('Strategy Fitness', () => {
       RegisteredCanvasStrategies,
       pickCanvasStateFromEditorState(
         renderResult.getEditorState().editor,
-        renderResult.getEditorState().derived,
         renderResult.getEditorState().builtInDependencies,
       ),
       interactionSession,
@@ -366,7 +363,6 @@ describe('Strategy Fitness', () => {
       RegisteredCanvasStrategies,
       pickCanvasStateFromEditorState(
         renderResult.getEditorState().editor,
-        renderResult.getEditorState().derived,
         renderResult.getEditorState().builtInDependencies,
       ),
       interactionSession,
@@ -416,7 +412,6 @@ describe('Strategy Fitness', () => {
       RegisteredCanvasStrategies,
       pickCanvasStateFromEditorState(
         renderResult.getEditorState().editor,
-        renderResult.getEditorState().derived,
         renderResult.getEditorState().builtInDependencies,
       ),
       interactionSession,

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -170,7 +170,6 @@ export const RegisteredCanvasStrategies: Array<MetaCanvasStrategy> = [
 
 export function pickCanvasStateFromEditorState(
   editorState: EditorState,
-  derivedState: DerivedState,
   builtInDependencies: BuiltInDependencies,
 ): InteractionCanvasState {
   return {
@@ -178,7 +177,6 @@ export function pickCanvasStateFromEditorState(
     interactionTarget: getInteractionTargetFromEditorState(editorState),
     projectContents: editorState.projectContents,
     nodeModules: editorState.nodeModules.files,
-    remixRoutingTable: derivedState.remixData?.routingTable ?? null,
     openFile: editorState.canvas.openFile?.filename,
     scale: editorState.canvas.scale,
     canvasOffset: editorState.canvas.roundedCanvasOffset,
@@ -190,7 +188,6 @@ export function pickCanvasStateFromEditorState(
 
 export function pickCanvasStateFromEditorStateWithMetadata(
   editorState: EditorState,
-  derivedState: DerivedState,
   builtInDependencies: BuiltInDependencies,
   metadata: ElementInstanceMetadataMap,
   allElementProps?: AllElementProps,
@@ -200,7 +197,6 @@ export function pickCanvasStateFromEditorStateWithMetadata(
     interactionTarget: getInteractionTargetFromEditorState(editorState),
     projectContents: editorState.projectContents,
     nodeModules: editorState.nodeModules.files,
-    remixRoutingTable: derivedState.remixData?.routingTable ?? null,
     openFile: editorState.canvas.openFile?.filename,
     scale: editorState.canvas.scale,
     canvasOffset: editorState.canvas.roundedCanvasOffset,
@@ -267,7 +263,7 @@ const getApplicableStrategiesSelector = createSelector(
       store.strategyState.sortedApplicableStrategies,
     ),
   (store: EditorStorePatched): InteractionCanvasState => {
-    return pickCanvasStateFromEditorState(store.editor, store.derived, store.builtInDependencies)
+    return pickCanvasStateFromEditorState(store.editor, store.builtInDependencies)
   },
   (store: EditorStorePatched) => store.editor.canvas.interactionSession,
   (store: EditorStorePatched) => store.strategyState.customStrategyState,

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -90,7 +90,6 @@ export interface InteractionCanvasState {
   interactionTarget: InteractionTarget
   projectContents: ProjectContentTreeRoot
   nodeModules: NodeModules
-  remixRoutingTable: RemixRoutingTable | null
   builtInDependencies: BuiltInDependencies
   openFile: string | null | undefined
   scale: number

--- a/editor/src/components/canvas/canvas-strategies/post-action-options/navigator-reparent.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/navigator-reparent.ts
@@ -43,7 +43,6 @@ import { staticReparentAndUpdatePosition } from './post-action-paste'
 function getNavigatorReparentCommands(
   data: NavigatorReparentPostActionMenuData,
   editor: EditorState,
-  derivedState: DerivedState,
   builtInDependencies: BuiltInDependencies,
 ): Array<CanvasCommand> | null {
   const wrapperUID = generateUidWithExistingComponents(editor.projectContents)
@@ -121,7 +120,6 @@ function getNavigatorReparentCommands(
       openFile: editor.canvas.openFile?.filename ?? null,
       pasteTargetsToIgnore: [],
       projectContents: editor.projectContents,
-      remixRoutingTable: derivedState.remixData?.routingTable ?? null,
       startingMetadata: editor.jsxMetadata,
       startingElementPathTrees: editor.elementPathTree,
       startingAllElementProps: editor.allElementProps,
@@ -153,7 +151,7 @@ export const PropsPreservedNavigatorReparentPostActionChoice = (
   name: 'Reparent with variables preserved',
   id: PropsPreservedNavigatorReparentPostActionChoiceId,
   run: (editor, derived, builtInDependencies) =>
-    getNavigatorReparentCommands(data, editor, derived, builtInDependencies),
+    getNavigatorReparentCommands(data, editor, builtInDependencies),
 })
 
 export const PropsReplacedNavigatorReparentPostActionChoiceId =
@@ -188,12 +186,7 @@ export const PropsReplacedNavigatorReparentPostActionChoice = (
     name: 'Reparent with variables replaced',
     id: PropsReplacedNavigatorReparentPostActionChoiceId,
     run: (editor, derived, builtInDependencies) => {
-      const reparentCommands = getNavigatorReparentCommands(
-        data,
-        editor,
-        derived,
-        builtInDependencies,
-      )
+      const reparentCommands = getNavigatorReparentCommands(data, editor, builtInDependencies)
       if (reparentCommands == null) {
         return null
       }

--- a/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
@@ -72,7 +72,6 @@ import type { PostActionChoice } from './post-action-options'
 interface EditorStateContext {
   projectContents: ProjectContentTreeRoot
   nodeModules: NodeModules
-  remixRoutingTable: RemixRoutingTable | null
   openFile: string | null
   pasteTargetsToIgnore: Array<ElementPath>
   builtInDependencies: BuiltInDependencies
@@ -267,7 +266,7 @@ export function staticReparentAndUpdatePosition(
 
   const commands = elementsToInsert.flatMap((elementToInsert) => {
     return [
-      updateFunctionCommand('always', (editor, derivedState, commandLifecycle) => {
+      updateFunctionCommand('always', (editor, commandLifecycle) => {
         const newPath = oldPathToNewPathMapping[EP.toString(elementToInsert.elementPath)]
 
         if (newPath == null) {
@@ -316,7 +315,6 @@ export function staticReparentAndUpdatePosition(
 
         return foldAndApplyCommandsInner(
           editor,
-          derivedState,
           [],
           [...propertyCommands, updateSelectedViews('always', [...editor.selectedViews, newPath])],
           commandLifecycle,
@@ -370,7 +368,6 @@ export const PropsPreservedPastePostActionChoice = (
         openFile: store.canvas.openFile?.filename ?? null,
         pasteTargetsToIgnore: postActionMenuData.pasteTargetsToIgnore,
         projectContents: store.projectContents,
-        remixRoutingTable: derived.remixData?.routingTable ?? null,
         startingMetadata: store.jsxMetadata,
         startingElementPathTrees: store.elementPathTree,
         startingAllElementProps: store.allElementProps,
@@ -411,7 +408,6 @@ export const PropsReplacedPastePostActionChoice = (
           openFile: store.canvas.openFile?.filename ?? null,
           pasteTargetsToIgnore: postActionMenuData.pasteTargetsToIgnore,
           projectContents: store.projectContents,
-          remixRoutingTable: derived.remixData?.routingTable ?? null,
           startingMetadata: store.jsxMetadata,
           startingElementPathTrees: store.elementPathTree,
           startingAllElementProps: store.allElementProps,
@@ -469,7 +465,6 @@ export const PropsPreservedPasteHerePostActionChoice = (
         openFile: editor.canvas.openFile?.filename ?? null,
         pasteTargetsToIgnore: [],
         projectContents: editor.projectContents,
-        remixRoutingTable: derived.remixData?.routingTable ?? null,
         startingMetadata: editor.jsxMetadata,
         startingElementPathTrees: editor.elementPathTree,
         startingAllElementProps: editor.allElementProps,
@@ -537,7 +532,6 @@ export const PropsReplacedPasteHerePostActionChoice = (
           openFile: editor.canvas.openFile?.filename ?? null,
           pasteTargetsToIgnore: [],
           projectContents: editor.projectContents,
-          remixRoutingTable: derived.remixData?.routingTable ?? null,
           startingMetadata: editor.jsxMetadata,
           startingElementPathTrees: editor.elementPathTree,
           startingAllElementProps: editor.allElementProps,
@@ -698,7 +692,7 @@ function pasteToReplaceCommands(
 
   const pasteCommands = targets.flatMap((target) => {
     return [
-      updateFunctionCommand('always', (updatedEditor, updatedDerivedState, commandLifecycle) => {
+      updateFunctionCommand('always', (updatedEditor, commandLifecycle) => {
         const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, target)
         const position = MetadataUtils.getFrameOrZeroRectInCanvasCoords(target, editor.jsxMetadata)
         const strategy = MetadataUtils.isPositionAbsolute(element)
@@ -735,7 +729,6 @@ function pasteToReplaceCommands(
             openFile: editor.canvas.openFile?.filename ?? null,
             pasteTargetsToIgnore: [],
             projectContents: updatedEditor.projectContents,
-            remixRoutingTable: updatedDerivedState.remixData?.routingTable ?? null,
             startingMetadata: editor.jsxMetadata,
             startingElementPathTrees: editor.elementPathTree,
             startingAllElementProps: editor.allElementProps,
@@ -757,13 +750,7 @@ function pasteToReplaceCommands(
         if (commands == null) {
           return []
         }
-        return foldAndApplyCommandsInner(
-          updatedEditor,
-          updatedDerivedState,
-          [],
-          commands,
-          commandLifecycle,
-        ).statePatches
+        return foldAndApplyCommandsInner(updatedEditor, [], commands, commandLifecycle).statePatches
       }),
     ]
   }, [] as Array<CanvasCommand>)

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.spec.tsx
@@ -1,5 +1,4 @@
 import type { EditorState } from '../../../editor/store/editor-state'
-import { emptyDerivedState } from '../../../editor/store/editor-state'
 import { elementPath } from '../../../../core/shared/element-path'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
 import { getEditorState, makeTestProjectCodeWithSnippet } from '../../ui-jsx.test-utils'
@@ -13,10 +12,7 @@ import type { CanvasVector } from '../../../../core/shared/math-utils'
 import { canvasPoint, canvasRectangle, localRectangle } from '../../../../core/shared/math-utils'
 import type { Modifiers } from '../../../../utils/modifiers'
 import { altModifier } from '../../../../utils/modifiers'
-import {
-  pickCanvasStateFromEditorState,
-  pickCanvasStateFromEditorStateWithMetadata,
-} from '../canvas-strategies'
+import { pickCanvasStateFromEditorStateWithMetadata } from '../canvas-strategies'
 import type { InteractionSession } from '../interaction-state'
 import { boundingArea } from '../interaction-state'
 import { createMouseInteractionForTests } from '../interaction-state.test-utils'
@@ -79,7 +75,6 @@ function dragByPixelsIsApplicable(
     absoluteDuplicateStrategy(
       pickCanvasStateFromEditorStateWithMetadata(
         editorState,
-        emptyDerivedState(editorState),
         createBuiltInDependenciesList(null),
         metadata,
       ),

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.tsx
@@ -129,11 +129,10 @@ export function absoluteDuplicateStrategy(
             ...maybeAddContainLayoutCommand(commonParentPath),
             setElementsToRerenderCommand([...selectedElements, ...newPaths]),
             updateSelectedViews('always', selectedElements),
-            updateFunctionCommand('always', (editorState, derivedState, commandLifecycle) =>
+            updateFunctionCommand('always', (editorState, commandLifecycle) =>
               runMoveStrategy(
                 canvasState,
                 editorState,
-                derivedState,
                 interactionSession,
                 commandLifecycle,
                 strategyLifecycle,
@@ -156,7 +155,6 @@ export function absoluteDuplicateStrategy(
 function runMoveStrategy(
   canvasState: InteractionCanvasState,
   editorState: EditorState,
-  derivedState: DerivedState,
   interactionSession: InteractionSession,
   commandLifecycle: InteractionLifecycle,
   strategyLifecycle: InteractionLifecycle,
@@ -169,8 +167,7 @@ function runMoveStrategy(
       'do-not-run-applicability-check',
     )?.strategy.apply(strategyLifecycle).commands ?? []
 
-  return foldAndApplyCommandsInner(editorState, derivedState, [], moveCommands, commandLifecycle)
-    .statePatches
+  return foldAndApplyCommandsInner(editorState, [], moveCommands, commandLifecycle).statePatches
 }
 
 type IsAbsoluteMoveApplicableResult =

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-canvas.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-canvas.spec.tsx
@@ -21,7 +21,6 @@ import {
 import type { CanvasPoint } from '../../../../core/shared/math-utils'
 import { canvasPoint, canvasRectangle } from '../../../../core/shared/math-utils'
 import type { EditorState } from '../../../editor/store/editor-state'
-import { emptyDerivedState } from '../../../editor/store/editor-state'
 import { foldAndApplyCommands } from '../../commands/commands'
 import {
   getEditorStateWithSelectedViews,
@@ -134,7 +133,6 @@ function reparentElement(
 
   const canvasState = pickCanvasStateFromEditorStateWithMetadata(
     editorState,
-    emptyDerivedState(editorState),
     createBuiltInDependenciesList(null),
     startingMetadata,
   )
@@ -164,7 +162,6 @@ function reparentElement(
 
   const finalEditor = foldAndApplyCommands(
     editorState,
-    emptyDerivedState(editorState),
     editorState,
     [],
     strategyResult.commands,

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-only-move.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-only-move.spec.tsx
@@ -5,12 +5,11 @@ import type {
   SpecialSizeMeasurements,
 } from '../../../../core/shared/element-template'
 import type { CanvasVector } from '../../../../core/shared/math-utils'
-import { CanvasPoint, canvasPoint, canvasRectangle } from '../../../../core/shared/math-utils'
+import { canvasPoint, canvasRectangle } from '../../../../core/shared/math-utils'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
 import type { Modifiers } from '../../../../utils/modifiers'
 import { cmdModifier } from '../../../../utils/modifiers'
 import type { AllElementProps, EditorState } from '../../../editor/store/editor-state'
-import { emptyDerivedState } from '../../../editor/store/editor-state'
 import { foldAndApplyCommands } from '../../commands/commands'
 import {
   getEditorState,
@@ -18,13 +17,10 @@ import {
   testPrintCodeFromEditorState,
 } from '../../ui-jsx.test-utils'
 import { absoluteMoveStrategy } from './absolute-move-strategy'
-import {
-  pickCanvasStateFromEditorState,
-  pickCanvasStateFromEditorStateWithMetadata,
-} from '../canvas-strategies'
+import { pickCanvasStateFromEditorStateWithMetadata } from '../canvas-strategies'
 import { defaultCustomStrategyState } from '../canvas-strategy-types'
 import type { InteractionSession } from '../interaction-state'
-import { boundingArea, StrategyState } from '../interaction-state'
+import { boundingArea } from '../interaction-state'
 import { createMouseInteractionForTests } from '../interaction-state.test-utils'
 
 jest.mock('../../canvas-utils', () => ({
@@ -104,7 +100,6 @@ function dragByPixels(
   const strategyResult = absoluteMoveStrategy(
     pickCanvasStateFromEditorStateWithMetadata(
       editorState,
-      emptyDerivedState(editorState),
       createBuiltInDependenciesList(null),
       startingMetadata,
       startingAllElementProps,
@@ -118,7 +113,6 @@ function dragByPixels(
 
   const finalEditor = foldAndApplyCommands(
     editorState,
-    emptyDerivedState(editorState),
     editorState,
     [],
     strategyResult.commands,

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.tsx
@@ -15,7 +15,7 @@ import {
 import type { CanvasPoint } from '../../../../core/shared/math-utils'
 import { canvasPoint, canvasRectangle } from '../../../../core/shared/math-utils'
 import type { EditorState } from '../../../editor/store/editor-state'
-import { deriveState, emptyDerivedState } from '../../../editor/store/editor-state'
+import { deriveState } from '../../../editor/store/editor-state'
 import { patchedCreateRemixDerivedDataMemo } from '../../../editor/store/remix-derived-data'
 import { foldAndApplyCommands } from '../../commands/commands'
 import {
@@ -202,7 +202,6 @@ function reparentElement(
 
   const canvasState = pickCanvasStateFromEditorStateWithMetadata(
     editorState,
-    deriveState(editorState, null, 'patched', patchedCreateRemixDerivedDataMemo),
     createBuiltInDependenciesList(null),
     startingMetadata,
   )
@@ -234,7 +233,6 @@ function reparentElement(
 
     return foldAndApplyCommands(
       editorState,
-      emptyDerivedState(editorState),
       editorState,
       [],
       strategyResult.commands,

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -17,7 +17,6 @@ import {
   shiftModifier,
 } from '../../../../utils/modifiers'
 import type { AllElementProps, EditorState } from '../../../editor/store/editor-state'
-import { emptyDerivedState } from '../../../editor/store/editor-state'
 import type { EdgePosition } from '../../canvas-types'
 import { foldAndApplyCommands } from '../../commands/commands'
 import {
@@ -25,14 +24,9 @@ import {
   makeTestProjectCodeWithSnippet,
   testPrintCodeFromEditorState,
 } from '../../ui-jsx.test-utils'
-import {
-  pickCanvasStateFromEditorState,
-  pickCanvasStateFromEditorStateWithMetadata,
-} from '../canvas-strategies'
-import { StrategyState } from '../interaction-state'
+import { pickCanvasStateFromEditorStateWithMetadata } from '../canvas-strategies'
 import { createMouseInteractionForTests } from '../interaction-state.test-utils'
 import { absoluteResizeBoundingBoxStrategy } from './absolute-resize-bounding-box-strategy'
-import { defaultCustomStrategyState } from '../canvas-strategy-types'
 import { createBuiltInDependenciesList } from '../../../../core/es-modules/package-manager/built-in-dependencies-list'
 
 function multiselectResizeElements(
@@ -59,7 +53,6 @@ function multiselectResizeElements(
   const strategyResult = absoluteResizeBoundingBoxStrategy(
     pickCanvasStateFromEditorStateWithMetadata(
       initialEditor,
-      emptyDerivedState(initialEditor),
       createBuiltInDependenciesList(null),
       metadata,
       allElementProps,
@@ -77,7 +70,6 @@ function multiselectResizeElements(
 
   return foldAndApplyCommands(
     initialEditor,
-    emptyDerivedState(initialEditor),
     initialEditor,
     [],
     strategyResult.commands,

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.tsx
@@ -10,21 +10,16 @@ import { canvasPoint, canvasRectangle } from '../../../../core/shared/math-utils
 import type { ElementPath } from '../../../../core/shared/project-file-types'
 import { emptyModifiers } from '../../../../utils/modifiers'
 import type { EditorState } from '../../../editor/store/editor-state'
-import { emptyDerivedState } from '../../../editor/store/editor-state'
 import { foldAndApplyCommands } from '../../commands/commands'
 import {
   getEditorState,
   makeTestProjectCodeWithSnippet,
   testPrintCodeFromEditorState,
 } from '../../ui-jsx.test-utils'
-import {
-  pickCanvasStateFromEditorState,
-  pickCanvasStateFromEditorStateWithMetadata,
-} from '../canvas-strategies'
-import { defaultCustomStrategyState } from '../canvas-strategy-types'
+import { pickCanvasStateFromEditorStateWithMetadata } from '../canvas-strategies'
 import { convertToAbsoluteAndMoveStrategy } from './convert-to-absolute-and-move-strategy'
 import type { InteractionSession } from '../interaction-state'
-import { boundingArea, StrategyState } from '../interaction-state'
+import { boundingArea } from '../interaction-state'
 import { createMouseInteractionForTests } from '../interaction-state.test-utils'
 
 function prepareEditorState(codeSnippet: string, selectedViews: Array<ElementPath>): EditorState {
@@ -190,7 +185,6 @@ function dragByPixels(
     convertToAbsoluteAndMoveStrategy(
       pickCanvasStateFromEditorStateWithMetadata(
         editorState,
-        emptyDerivedState(editorState),
         createBuiltInDependenciesList(null),
         metadata,
       ),
@@ -199,7 +193,6 @@ function dragByPixels(
 
   const finalEditor = foldAndApplyCommands(
     editorState,
-    emptyDerivedState(editorState),
     editorState,
     [],
     strategyResultCommands,

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
@@ -14,11 +14,7 @@ import { canvasRectangle, offsetPoint, zeroCanvasPoint } from '../../../../core/
 import type { ElementPath } from '../../../../core/shared/project-file-types'
 import { CSSCursor, Utils } from '../../../../uuiui-deps'
 import type { InsertionSubject } from '../../../editor/editor-modes'
-import type {
-  DerivedState,
-  EditorState,
-  EditorStatePatch,
-} from '../../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../../editor/store/editor-state'
 import { foldAndApplyCommandsInner } from '../../commands/commands'
 import type { InsertElementInsertionSubject } from '../../commands/insert-element-insertion-subject'
 import { insertElementInsertionSubject } from '../../commands/insert-element-insertion-subject'
@@ -229,12 +225,11 @@ function dragToInsertStrategyFactory(
 
           const reparentCommand = updateFunctionCommand(
             'always',
-            (editorState, derivedState, transient): Array<EditorStatePatch> => {
+            (editorState, transient): Array<EditorStatePatch> => {
               return runTargetStrategiesForFreshlyInsertedElement(
                 reparentStrategyToUse,
                 canvasState.builtInDependencies,
                 editorState,
-                derivedState,
                 customStrategyState,
                 interactionSession,
                 transient,
@@ -251,10 +246,9 @@ function dragToInsertStrategyFactory(
               ? [
                   updateFunctionCommand(
                     'always',
-                    (editorState, derivedState, lifecycle): Array<EditorStatePatch> =>
+                    (editorState, lifecycle): Array<EditorStatePatch> =>
                       foldAndApplyCommandsInner(
                         editorState,
-                        derivedState,
                         [],
                         [
                           wrapInContainerCommand(
@@ -343,7 +337,6 @@ function runTargetStrategiesForFreshlyInsertedElement(
   reparentStrategyToUse: CanvasStrategyFactory,
   builtInDependencies: BuiltInDependencies,
   editorState: EditorState,
-  derivedState: DerivedState,
   customStrategyState: CustomStrategyState,
   interactionSession: InteractionSession,
   commandLifecycle: InteractionLifecycle,
@@ -387,7 +380,6 @@ function runTargetStrategiesForFreshlyInsertedElement(
   // so its index amongst its starting siblings isn't relevant.
   const canvasState = pickCanvasStateFromEditorStateWithMetadata(
     editorState,
-    derivedState,
     builtInDependencies,
     patchedMetadata,
   )
@@ -410,12 +402,7 @@ function runTargetStrategiesForFreshlyInsertedElement(
   } else {
     const reparentCommands = strategy.apply(strategyLifeCycle).commands
 
-    return foldAndApplyCommandsInner(
-      editorState,
-      derivedState,
-      [],
-      reparentCommands,
-      commandLifecycle,
-    ).statePatches
+    return foldAndApplyCommandsInner(editorState, [], reparentCommands, commandLifecycle)
+      .statePatches
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
@@ -105,10 +105,9 @@ export function baseFlexReparentToAbsoluteStrategy(
                 ...escapeHatchCommands,
                 updateFunctionCommand(
                   'always',
-                  (editorState, derivedState, commandLifecycle): Array<EditorStatePatch> => {
+                  (editorState, commandLifecycle): Array<EditorStatePatch> => {
                     const updatedCanvasState = pickCanvasStateFromEditorState(
                       editorState,
-                      derivedState,
                       canvasState.builtInDependencies,
                     )
                     const absoluteReparentStrategyToUse = baseAbsoluteReparentStrategy(
@@ -125,7 +124,6 @@ export function baseFlexReparentToAbsoluteStrategy(
 
                     return foldAndApplyCommandsInner(
                       editorState,
-                      derivedState,
                       [],
                       reparentCommands,
                       commandLifecycle,

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-interaction.test-utils.tsx
@@ -11,13 +11,8 @@ import { canvasRectangle } from '../../../../core/shared/math-utils'
 import type { KeyCharacter } from '../../../../utils/keyboard'
 import type { Modifiers } from '../../../../utils/modifiers'
 import type { EditorState } from '../../../editor/store/editor-state'
-import { deriveState, emptyDerivedState } from '../../../editor/store/editor-state'
-import { patchedCreateRemixDerivedDataMemo } from '../../../editor/store/remix-derived-data'
 import { foldAndApplyCommands } from '../../commands/commands'
-import {
-  pickCanvasStateFromEditorState,
-  pickCanvasStateFromEditorStateWithMetadata,
-} from '../canvas-strategies'
+import { pickCanvasStateFromEditorStateWithMetadata } from '../canvas-strategies'
 import type {
   CanvasStrategy,
   CustomStrategyState,
@@ -66,7 +61,6 @@ export function pressKeys(
   const strategy = strategyFactoryFunction(
     pickCanvasStateFromEditorStateWithMetadata(
       editorState,
-      emptyDerivedState(editorState),
       createBuiltInDependenciesList(null),
       metadata,
     ),
@@ -83,11 +77,8 @@ export function pressKeys(
   expect(strategyResult.customStatePatch).toEqual({})
   expect(strategyResult.status).toEqual('success')
 
-  const derivedState = deriveState(editorState, null, 'patched', patchedCreateRemixDerivedDataMemo)
-
   const finalEditor = foldAndApplyCommands(
     editorState,
-    derivedState,
     editorState,
     [],
     strategyResult.commands,

--- a/editor/src/components/canvas/commands/add-contain-layout-if-needed-command.ts
+++ b/editor/src/components/canvas/commands/add-contain-layout-if-needed-command.ts
@@ -4,7 +4,7 @@ import { emptyComments, jsExpressionValue } from '../../../core/shared/element-t
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import { PropertyPath } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
-import type { DerivedState, EditorState } from '../../editor/store/editor-state'
+import type { EditorState } from '../../editor/store/editor-state'
 import { applyValuesAtPath } from './adjust-number-command'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
@@ -26,7 +26,6 @@ export function addContainLayoutIfNeeded(
 
 export const runAddContainLayoutIfNeeded: CommandFunction<AddContainLayoutIfNeeded> = (
   editorState: EditorState,
-  _derivedState: DerivedState,
   command: AddContainLayoutIfNeeded,
 ) => {
   const elementMetadata = MetadataUtils.findElementByElementPath(

--- a/editor/src/components/canvas/commands/add-element-command.ts
+++ b/editor/src/components/canvas/commands/add-element-command.ts
@@ -3,11 +3,7 @@ import {
   getElementPathFromInsertionPath,
   insertionPathToString,
 } from '../../editor/store/insertion-path'
-import type {
-  DerivedState,
-  EditorState,
-  EditorStatePatch,
-} from '../../../components/editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../../components/editor/store/editor-state'
 import { forUnderlyingTargetFromEditorState } from '../../../components/editor/store/editor-state'
 import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
 import type { JSXElementChild } from '../../../core/shared/element-template'
@@ -48,7 +44,6 @@ export function addElement(
 
 export const runAddElement: CommandFunction<AddElement> = (
   editorState: EditorState,
-  _derivedState: DerivedState,
   command: AddElement,
 ) => {
   let editorStatePatches: Array<EditorStatePatch> = []

--- a/editor/src/components/canvas/commands/add-elements-command.ts
+++ b/editor/src/components/canvas/commands/add-elements-command.ts
@@ -3,11 +3,7 @@ import {
   getElementPathFromInsertionPath,
   insertionPathToString,
 } from '../../editor/store/insertion-path'
-import type {
-  DerivedState,
-  EditorState,
-  EditorStatePatch,
-} from '../../../components/editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../../components/editor/store/editor-state'
 import { forUnderlyingTargetFromEditorState } from '../../../components/editor/store/editor-state'
 import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
 import type { JSXElementChild } from '../../../core/shared/element-template'
@@ -49,7 +45,6 @@ export function addElements(
 
 export const runAddElements: CommandFunction<AddElements> = (
   editorState: EditorState,
-  _derivedState: DerivedState,
   command: AddElements,
 ) => {
   let editorStatePatches: Array<EditorStatePatch> = []

--- a/editor/src/components/canvas/commands/add-imports-to-file-command.ts
+++ b/editor/src/components/canvas/commands/add-imports-to-file-command.ts
@@ -1,5 +1,5 @@
 import { mergeImports } from '../../../core/workers/common/project-file-utils'
-import type { DerivedState, EditorState } from '../../../components/editor/store/editor-state'
+import type { EditorState } from '../../../components/editor/store/editor-state'
 import type { Imports } from '../../../core/shared/project-file-types'
 import type { BaseCommand, WhenToRun, CommandFunction, CommandFunctionResult } from './commands'
 import { patchParseSuccessAtFilePath } from './patch-utils'
@@ -25,7 +25,6 @@ export function addImportsToFile(
 
 export const runAddImportsToFile: CommandFunction<AddImportsToFile> = (
   editorState: EditorState,
-  derivedState: DerivedState,
   command: AddImportsToFile,
 ): CommandFunctionResult => {
   const editorStatePatch = patchParseSuccessAtFilePath(

--- a/editor/src/components/canvas/commands/add-to-reparented-to-paths-command.ts
+++ b/editor/src/components/canvas/commands/add-to-reparented-to-paths-command.ts
@@ -1,5 +1,5 @@
 import type { Spec } from 'immutability-helper'
-import type { DerivedState, EditorState } from '../../editor/store/editor-state'
+import type { EditorState } from '../../editor/store/editor-state'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import type { BaseCommand, CommandFunction, CommandFunctionResult, WhenToRun } from './commands'
 
@@ -21,7 +21,6 @@ export function addToReparentedToPaths(
 
 export const runAddToReparentedToPaths: CommandFunction<AddToReparentedToPaths> = (
   editorState: EditorState,
-  __: DerivedState,
   command: AddToReparentedToPaths,
 ): CommandFunctionResult => {
   const editorStatePatch: Spec<EditorState> = {

--- a/editor/src/components/canvas/commands/adjust-css-length-command.ts
+++ b/editor/src/components/canvas/commands/adjust-css-length-command.ts
@@ -18,9 +18,8 @@ import {
 import { roundTo } from '../../../core/shared/math-utils'
 import type { ElementPath, PropertyPath } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
-import type { DerivedState, EditorState } from '../../editor/store/editor-state'
-import { deriveState, modifyUnderlyingForOpenFile } from '../../editor/store/editor-state'
-import { patchedCreateRemixDerivedDataMemo } from '../../editor/store/remix-derived-data'
+import type { EditorState } from '../../editor/store/editor-state'
+import { modifyUnderlyingForOpenFile } from '../../editor/store/editor-state'
 import type { CSSNumber, FlexDirection } from '../../inspector/common/css-utils'
 import { parseCSSPercent, parseCSSPx, printCSSNumber } from '../../inspector/common/css-utils'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
@@ -79,7 +78,6 @@ interface UpdatedPropsAndCommandDescription {
 
 export const runAdjustCssLengthProperties: CommandFunction<AdjustCssLengthProperties> = (
   editorState: EditorState,
-  _derivedState: DerivedState,
   command: AdjustCssLengthProperties,
 ) => {
   let commandDescriptions: Array<string> = []

--- a/editor/src/components/canvas/commands/adjust-number-command.spec.tsx
+++ b/editor/src/components/canvas/commands/adjust-number-command.spec.tsx
@@ -60,7 +60,6 @@ describe('adjustNumberProperty', () => {
 
     const result = runAdjustNumberProperty(
       renderResult.getEditorState().editor,
-      renderResult.getEditorState().derived,
       adjustNumberPropertyCommand,
     )
 
@@ -116,7 +115,6 @@ describe('adjustNumberProperty', () => {
 
     const result = runAdjustNumberProperty(
       renderResult.getEditorState().editor,
-      renderResult.getEditorState().derived,
       adjustNumberPropertyCommand,
     )
 

--- a/editor/src/components/canvas/commands/adjust-number-command.ts
+++ b/editor/src/components/canvas/commands/adjust-number-command.ts
@@ -13,15 +13,13 @@ import {
 } from '../../../core/shared/jsx-attributes'
 import type { ElementPath, PropertyPath } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import {
-  deriveState,
   modifyUnderlyingElementForOpenFile,
   withUnderlyingTargetFromEditorState,
 } from '../../editor/store/editor-state'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 import { patchParseSuccessAtElementPath } from './patch-utils'
-import { patchedCreateRemixDerivedDataMemo } from '../../editor/store/remix-derived-data'
 
 export interface AdjustNumberProperty extends BaseCommand {
   type: 'ADJUST_NUMBER_PROPERTY'
@@ -67,7 +65,6 @@ export function adjustNumberInequalityCondition(
 
 export const runAdjustNumberProperty: CommandFunction<AdjustNumberProperty> = (
   editorState: EditorState,
-  derivedState: DerivedState,
   command: AdjustNumberProperty,
 ) => {
   // Handle updating the existing value, treating a value that can't be parsed

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -2,8 +2,7 @@ import update from 'immutability-helper'
 import { applyUtopiaJSXComponentsChanges } from '../../../core/model/project-file-utils'
 import type { TopLevelElement, UtopiaJSXComponent } from '../../../core/shared/element-template'
 import type { Imports } from '../../../core/shared/project-file-types'
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
-import { deriveState } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import type { CommandDescription } from '../canvas-strategies/interaction-state'
 import type { AdjustCssLengthProperties } from './adjust-css-length-command'
 import { runAdjustCssLengthProperties } from './adjust-css-length-command'
@@ -84,18 +83,13 @@ import type { AddElements } from './add-elements-command'
 import { runAddElements } from './add-elements-command'
 import type { QueueGroupTrueUp } from './queue-group-true-up-command'
 import { runQueueGroupTrueUp } from './queue-group-true-up-command'
-import { patchedCreateRemixDerivedDataMemo } from '../../editor/store/remix-derived-data'
 
 export interface CommandFunctionResult {
   editorStatePatches: Array<EditorStatePatch>
   commandDescription: string
 }
 
-export type CommandFunction<T> = (
-  editorState: EditorState,
-  derivedState: DerivedState,
-  command: T,
-) => CommandFunctionResult
+export type CommandFunction<T> = (editorState: EditorState, command: T) => CommandFunctionResult
 
 export type WhenToRun = 'mid-interaction' | 'always' | 'on-complete'
 
@@ -143,88 +137,82 @@ export type CanvasCommand =
 
 export function runCanvasCommand(
   editorState: EditorState,
-  derivedState: DerivedState,
   command: CanvasCommand,
   commandLifecycle: InteractionLifecycle,
 ): CommandFunctionResult {
   switch (command.type) {
     case 'WILDCARD_PATCH':
-      return runWildcardPatch(editorState, derivedState, command)
+      return runWildcardPatch(editorState, command)
     case 'UPDATE_FUNCTION_COMMAND':
-      return runUpdateFunctionCommand(editorState, derivedState, command, commandLifecycle)
+      return runUpdateFunctionCommand(editorState, command, commandLifecycle)
     case 'STRATEGY_SWITCHED':
       return runStrategySwitchedCommand(command)
     case 'ADJUST_NUMBER_PROPERTY':
-      return runAdjustNumberProperty(editorState, derivedState, command)
+      return runAdjustNumberProperty(editorState, command)
     case 'ADJUST_CSS_LENGTH_PROPERTY':
-      return runAdjustCssLengthProperties(editorState, derivedState, command)
+      return runAdjustCssLengthProperties(editorState, command)
     case 'REPARENT_ELEMENT':
-      return runReparentElement(editorState, derivedState, command)
+      return runReparentElement(editorState, command)
     case 'DUPLICATE_ELEMENT':
-      return runDuplicateElement(editorState, derivedState, command)
+      return runDuplicateElement(editorState, command)
     case 'UPDATE_SELECTED_VIEWS':
-      return runUpdateSelectedViews(editorState, derivedState, command)
+      return runUpdateSelectedViews(editorState, command)
     case 'UPDATE_HIGHLIGHTED_VIEWS':
-      return runUpdateHighlightedViews(editorState, derivedState, command)
+      return runUpdateHighlightedViews(editorState, command)
     case 'SET_SNAPPING_GUIDELINES':
-      return runSetSnappingGuidelines(editorState, derivedState, command)
+      return runSetSnappingGuidelines(editorState, command)
     case 'CONVERT_TO_ABSOLUTE':
-      return runConvertToAbsolute(editorState, derivedState, command)
+      return runConvertToAbsolute(editorState, command)
     case 'SET_CSS_LENGTH_PROPERTY':
-      return runSetCssLengthProperty(editorState, derivedState, command)
+      return runSetCssLengthProperty(editorState, command)
     case 'REORDER_ELEMENT':
-      return runReorderElement(editorState, derivedState, command)
+      return runReorderElement(editorState, command)
     case 'SHOW_OUTLINE_HIGHLIGHT':
-      return runShowOutlineHighlight(editorState, derivedState, command)
+      return runShowOutlineHighlight(editorState, command)
     case 'SHOW_REORDER_INDICATOR':
-      return runShowReorderIndicator(editorState, derivedState, command)
+      return runShowReorderIndicator(editorState, command)
     case 'SET_CURSOR_COMMAND':
-      return runSetCursor(editorState, derivedState, command)
+      return runSetCursor(editorState, command)
     case 'SET_ELEMENTS_TO_RERENDER_COMMAND':
-      return runSetElementsToRerender(editorState, derivedState, command)
+      return runSetElementsToRerender(editorState, command)
     case 'APPEND_ELEMENTS_TO_RERENDER_COMMAND':
-      return runAppendElementsToRerender(editorState, derivedState, command)
+      return runAppendElementsToRerender(editorState, command)
     case 'PUSH_INTENDED_BOUNDS_AND_UPDATE_GROUPS':
-      return runPushIntendedBoundsAndUpdateGroups(
-        editorState,
-        derivedState,
-        command,
-        commandLifecycle,
-      )
+      return runPushIntendedBoundsAndUpdateGroups(editorState, command, commandLifecycle)
     case 'DELETE_PROPERTIES':
-      return runDeleteProperties(editorState, derivedState, command)
+      return runDeleteProperties(editorState, command)
     case 'SET_PROPERTY':
-      return runSetProperty(editorState, derivedState, command)
+      return runSetProperty(editorState, command)
     case 'UPDATE_PROP_IF_EXISTS':
-      return runUpdatePropIfExists(editorState, derivedState, command)
+      return runUpdatePropIfExists(editorState, command)
     case 'ADD_IMPORTS_TO_FILE':
-      return runAddImportsToFile(editorState, derivedState, command)
+      return runAddImportsToFile(editorState, command)
     case 'ADD_TO_REPARENTED_TO_PATHS':
-      return runAddToReparentedToPaths(editorState, derivedState, command)
+      return runAddToReparentedToPaths(editorState, command)
     case 'INSERT_ELEMENT_INSERTION_SUBJECT':
-      return runInsertElementInsertionSubject(editorState, derivedState, command)
+      return runInsertElementInsertionSubject(editorState, command)
     case 'ADD_ELEMENT':
-      return runAddElement(editorState, derivedState, command)
+      return runAddElement(editorState, command)
     case 'ADD_ELEMENTS':
-      return runAddElements(editorState, derivedState, command)
+      return runAddElements(editorState, command)
     case 'HIGHLIGHT_ELEMENTS_COMMAND':
-      return runHighlightElementsCommand(editorState, derivedState, command)
+      return runHighlightElementsCommand(editorState, command)
     case 'CONVERT_CSS_PERCENT_TO_PX':
-      return runConvertCssPercentToPx(editorState, derivedState, command)
+      return runConvertCssPercentToPx(editorState, command)
     case 'HIDE_IN_NAVIGATOR_COMMAND':
-      return runHideInNavigatorCommand(editorState, derivedState, command)
+      return runHideInNavigatorCommand(editorState, command)
     case 'SHOW_TOAST_COMMAND':
       return runShowToastCommand(editorState, command, commandLifecycle)
     case 'ADD_CONTAIN_LAYOUT_IF_NEEDED':
-      return runAddContainLayoutIfNeeded(editorState, derivedState, command)
+      return runAddContainLayoutIfNeeded(editorState, command)
     case 'REARRANGE_CHILDREN':
-      return runRearrangeChildren(editorState, derivedState, command)
+      return runRearrangeChildren(editorState, command)
     case 'DELETE_ELEMENT':
-      return runDeleteElement(editorState, derivedState, command)
+      return runDeleteElement(editorState, command)
     case 'WRAP_IN_CONTAINER':
-      return runWrapInContainerCommand(editorState, derivedState, command)
+      return runWrapInContainerCommand(editorState, command)
     case 'QUEUE_GROUP_TRUE_UP':
-      return runQueueGroupTrueUp(editorState, derivedState, command)
+      return runQueueGroupTrueUp(editorState, command)
     default:
       const _exhaustiveCheck: never = command
       throw new Error(`Unhandled canvas command ${JSON.stringify(command)}`)
@@ -233,13 +221,12 @@ export function runCanvasCommand(
 
 export function foldAndApplyCommandsSimple(
   editorState: EditorState,
-  derivedState: DerivedState,
   commands: Array<CanvasCommand>,
 ): EditorState {
   const updatedEditorState = commands
     .filter((c) => c.whenToRun === 'always' || c.whenToRun === 'on-complete')
     .reduce((workingEditorState, command) => {
-      const patches = runCanvasCommand(workingEditorState, derivedState, command, 'end-interaction')
+      const patches = runCanvasCommand(workingEditorState, command, 'end-interaction')
       return updateEditorStateWithPatches(workingEditorState, patches.editorStatePatches)
     }, editorState)
 
@@ -248,7 +235,6 @@ export function foldAndApplyCommandsSimple(
 
 export function foldAndApplyCommandsInner(
   editorState: EditorState,
-  derivedState: DerivedState,
   commandsToAccumulate: Array<CanvasCommand>,
   commands: Array<CanvasCommand>,
   commandLifecycle: InteractionLifecycle,
@@ -259,7 +245,6 @@ export function foldAndApplyCommandsInner(
 } {
   let statePatches: Array<EditorStatePatch> = []
   let workingEditorState: EditorState = editorState
-  let workingDerivedState: DerivedState = derivedState
   let workingCommandDescriptions: Array<CommandDescription> = []
 
   function runCommand(command: CanvasCommand, shouldAccumulatePatches: boolean): void {
@@ -272,12 +257,7 @@ export function foldAndApplyCommandsInner(
 
     if (shouldRunCommand) {
       // Run the command with our current states.
-      const commandResult = runCanvasCommand(
-        workingEditorState,
-        workingDerivedState,
-        command,
-        commandLifecycle,
-      )
+      const commandResult = runCanvasCommand(workingEditorState, command, commandLifecycle)
       // Capture values from the result.
       const statePatch = commandResult.editorStatePatches
       // Apply the update to the editor state.
@@ -288,12 +268,6 @@ export function foldAndApplyCommandsInner(
         description: commandResult.commandDescription,
         transient: command.whenToRun === 'mid-interaction',
       })
-      workingDerivedState = deriveState(
-        workingEditorState,
-        workingDerivedState,
-        'patched',
-        patchedCreateRemixDerivedDataMemo,
-      )
     }
   }
 
@@ -309,7 +283,6 @@ export function foldAndApplyCommandsInner(
 
 export function foldAndApplyCommands(
   editorState: EditorState,
-  derivedState: DerivedState,
   priorPatchedState: EditorState,
   commandsToAccumulate: Array<CanvasCommand>,
   commands: Array<CanvasCommand>,
@@ -320,7 +293,6 @@ export function foldAndApplyCommands(
 } {
   const { statePatches, updatedEditorState, commandDescriptions } = foldAndApplyCommandsInner(
     editorState,
-    derivedState,
     commandsToAccumulate,
     commands,
     commandLifecycle,

--- a/editor/src/components/canvas/commands/convert-css-percent-to-px-command.ts
+++ b/editor/src/components/canvas/commands/convert-css-percent-to-px-command.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../core/shared/jsx-attributes'
 import type { ElementPath, PropertyPath } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
-import type { DerivedState, EditorState } from '../../editor/store/editor-state'
+import type { EditorState } from '../../editor/store/editor-state'
 import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import type { CSSNumber } from '../../inspector/common/css-utils'
 import { parseCSSPercent, printCSSNumber } from '../../inspector/common/css-utils'
@@ -43,7 +43,6 @@ export function convertCssPercentToPx(
 
 export const runConvertCssPercentToPx: CommandFunction<ConvertCssPercentToPx> = (
   editorState: EditorState,
-  _derivedState: DerivedState,
   command: ConvertCssPercentToPx,
 ) => {
   // Identify the current value, whatever that may be.

--- a/editor/src/components/canvas/commands/convert-to-absolute-command.spec.tsx
+++ b/editor/src/components/canvas/commands/convert-to-absolute-command.spec.tsx
@@ -30,7 +30,6 @@ describe('convertToAbsolute', () => {
     const convertToAbsoluteCommand = convertToAbsolute('always', appInstancePath)
     const result = runConvertToAbsolute(
       renderResult.getEditorState().editor,
-      renderResult.getEditorState().derived,
       convertToAbsoluteCommand,
     )
 

--- a/editor/src/components/canvas/commands/convert-to-absolute-command.ts
+++ b/editor/src/components/canvas/commands/convert-to-absolute-command.ts
@@ -5,7 +5,7 @@ import type { ElementInstanceMetadataMap } from '../../../core/shared/element-te
 import { emptyComments, jsExpressionValue } from '../../../core/shared/element-template'
 import type { ValueAtPath } from '../../../core/shared/jsx-attributes'
 import type { ElementPath } from '../../../core/shared/project-file-types'
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 import { applyValuesAtPath } from './adjust-number-command'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
@@ -25,7 +25,6 @@ export function convertToAbsolute(transient: WhenToRun, target: ElementPath): Co
 
 export const runConvertToAbsolute: CommandFunction<ConvertToAbsolute> = (
   editorState: EditorState,
-  _derivedState: DerivedState,
   command: ConvertToAbsolute,
 ) => {
   const propsToUpdate: Array<ValueAtPath> = [

--- a/editor/src/components/canvas/commands/delete-element-command.ts
+++ b/editor/src/components/canvas/commands/delete-element-command.ts
@@ -1,7 +1,7 @@
 import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import {
   forUnderlyingTargetFromEditorState,
   removeElementAtPath,
@@ -25,7 +25,6 @@ export function deleteElement(whenToRun: WhenToRun, target: ElementPath): Delete
 
 export const runDeleteElement: CommandFunction<DeleteElement> = (
   editorState: EditorState,
-  _derivedState: DerivedState,
   command: DeleteElement,
 ) => {
   let editorStatePatches: Array<EditorStatePatch> = []

--- a/editor/src/components/canvas/commands/delete-properties-command.ts
+++ b/editor/src/components/canvas/commands/delete-properties-command.ts
@@ -1,9 +1,5 @@
 import type { JSXElement } from '../../../core/shared/element-template'
-import type {
-  DerivedState,
-  EditorState,
-  EditorStatePatch,
-} from '../../../components/editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../../components/editor/store/editor-state'
 import { modifyUnderlyingElementForOpenFile } from '../../../components/editor/store/editor-state'
 import { foldEither } from '../../../core/shared/either'
 import { unsetJSXValuesAtPaths } from '../../../core/shared/jsx-attributes'
@@ -34,7 +30,6 @@ export function deleteProperties(
 
 export const runDeleteProperties: CommandFunction<DeleteProperties> = (
   editorState: EditorState,
-  _derivedState: DerivedState,
   command: DeleteProperties,
 ) => {
   // Apply the update to the properties.

--- a/editor/src/components/canvas/commands/duplicate-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/duplicate-element-command.spec.tsx
@@ -1,10 +1,7 @@
 import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import * as EP from '../../../core/shared/element-path'
 import { complexDefaultProjectPreParsed } from '../../../sample-projects/sample-project-utils.test-utils'
-import {
-  emptyDerivedState,
-  withUnderlyingTargetFromEditorState,
-} from '../../editor/store/editor-state'
+import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import {
   DefaultStartingFeatureSwitches,
   makeTestProjectCodeWithSnippet,
@@ -36,11 +33,7 @@ describe('runDuplicateElement', () => {
 
     const duplicateCommand = duplicateElement('always', targetPath, newUid)
 
-    const result = runDuplicateElement(
-      originalEditorState,
-      emptyDerivedState(originalEditorState),
-      duplicateCommand,
-    )
+    const result = runDuplicateElement(originalEditorState, duplicateCommand)
 
     const patchedEditor = updateEditorStateWithPatches(
       originalEditorState,
@@ -77,11 +70,7 @@ describe('runDuplicateElement', () => {
 
     const duplicateCommand = duplicateElement('always', targetPath, newUid)
 
-    const result = runDuplicateElement(
-      originalEditorState,
-      emptyDerivedState(originalEditorState),
-      duplicateCommand,
-    )
+    const result = runDuplicateElement(originalEditorState, duplicateCommand)
 
     const patchedEditor = updateEditorStateWithPatches(
       originalEditorState,
@@ -150,11 +139,7 @@ describe('runDuplicateElement', () => {
 
     const duplicateCommand = duplicateElement('always', targetPath, newUid)
 
-    const result = runDuplicateElement(
-      originalEditorState,
-      emptyDerivedState(originalEditorState),
-      duplicateCommand,
-    )
+    const result = runDuplicateElement(originalEditorState, duplicateCommand)
 
     const patchedEditor = updateEditorStateWithPatches(
       originalEditorState,

--- a/editor/src/components/canvas/commands/duplicate-element-command.ts
+++ b/editor/src/components/canvas/commands/duplicate-element-command.ts
@@ -1,7 +1,7 @@
 import * as EP from '../../../core/shared/element-path'
 import { isUtopiaJSXComponent } from '../../../core/shared/element-template'
 import type { ElementPath } from '../../../core/shared/project-file-types'
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import { duplicate } from '../canvas-utils'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
@@ -33,7 +33,6 @@ export function duplicateElement(
 
 export const runDuplicateElement: CommandFunction<DuplicateElement> = (
   editorState: EditorState,
-  _derivedState: DerivedState,
   command: DuplicateElement,
 ) => {
   const targetParent = EP.parentPath(command.target)

--- a/editor/src/components/canvas/commands/hide-in-navigator-command.ts
+++ b/editor/src/components/canvas/commands/hide-in-navigator-command.ts
@@ -1,6 +1,6 @@
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import type { BaseCommand, CommandFunction } from './commands'
 
 export interface HideInNavigatorCommand extends BaseCommand {
@@ -17,8 +17,7 @@ export function hideInNavigatorCommand(elements: Array<ElementPath>): HideInNavi
 }
 
 export const runHideInNavigatorCommand: CommandFunction<HideInNavigatorCommand> = (
-  editor: EditorState,
-  __: DerivedState,
+  _editor: EditorState,
   command: HideInNavigatorCommand,
 ) => {
   const editorStatePatch: EditorStatePatch = {

--- a/editor/src/components/canvas/commands/highlight-element-command.ts
+++ b/editor/src/components/canvas/commands/highlight-element-command.ts
@@ -1,6 +1,6 @@
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import type { BaseCommand, CommandFunction } from './commands'
 
 export interface HighlightElementsCommand extends BaseCommand {
@@ -18,7 +18,6 @@ export function highlightElementsCommand(value: ElementPath[]): HighlightElement
 
 export const runHighlightElementsCommand: CommandFunction<HighlightElementsCommand> = (
   _: EditorState,
-  __: DerivedState,
   command: HighlightElementsCommand,
 ) => {
   const editorStatePatch: EditorStatePatch = {

--- a/editor/src/components/canvas/commands/insert-element-insertion-subject.ts
+++ b/editor/src/components/canvas/commands/insert-element-insertion-subject.ts
@@ -6,7 +6,7 @@ import { optionalMap } from '../../../core/shared/optional-utils'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import { mergeImports } from '../../../core/workers/common/project-file-utils'
 import type { InsertionSubject } from '../../editor/editor-modes'
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import { forUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import type { InsertionPath } from '../../editor/store/insertion-path'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
@@ -33,7 +33,6 @@ export function insertElementInsertionSubject(
 
 export const runInsertElementInsertionSubject: CommandFunction<InsertElementInsertionSubject> = (
   editor: EditorState,
-  _derivedState: DerivedState,
   command: InsertElementInsertionSubject,
 ) => {
   let editorStatePatches: Array<EditorStatePatch> = []

--- a/editor/src/components/canvas/commands/patch-utils.ts
+++ b/editor/src/components/canvas/commands/patch-utils.ts
@@ -4,9 +4,8 @@ import type { ProjectContentsTree, ProjectContentTreeRoot } from '../../../compo
 import {
   getProjectFileByFilePath,
   getProjectContentKeyPathElements,
-  ProjectContentFile,
 } from '../../../components/assets'
-import type { DerivedState, EditorState } from '../../editor/store/editor-state'
+import type { EditorState } from '../../editor/store/editor-state'
 import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import type {
   ElementPath,

--- a/editor/src/components/canvas/commands/queue-group-true-up-command.ts
+++ b/editor/src/components/canvas/commands/queue-group-true-up-command.ts
@@ -4,12 +4,7 @@ import type { ElementInstanceMetadataMap } from '../../../core/shared/element-te
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
-import type {
-  AllElementProps,
-  DerivedState,
-  EditorState,
-  TrueUpTarget,
-} from '../../editor/store/editor-state'
+import type { AllElementProps, EditorState, TrueUpTarget } from '../../editor/store/editor-state'
 import { trueUpElementChanged } from '../../editor/store/editor-state'
 import { allowGroupTrueUp } from '../canvas-strategies/strategies/group-helpers'
 import type { BaseCommand, CommandFunction } from './commands'
@@ -30,7 +25,6 @@ export function queueGroupTrueUp(targets: Array<TrueUpTarget>): QueueGroupTrueUp
 
 export const runQueueGroupTrueUp: CommandFunction<QueueGroupTrueUp> = (
   editorState: EditorState,
-  __: DerivedState,
   command: QueueGroupTrueUp,
 ) => {
   return {

--- a/editor/src/components/canvas/commands/rearrange-children-command.ts
+++ b/editor/src/components/canvas/commands/rearrange-children-command.ts
@@ -1,7 +1,7 @@
 import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath, StaticElementPath } from '../../../core/shared/project-file-types'
-import type { DerivedState, EditorState } from '../../editor/store/editor-state'
+import type { EditorState } from '../../editor/store/editor-state'
 import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 import { getPatchForComponentChange } from './commands'
@@ -28,7 +28,6 @@ export function rearrangeChildren(
 
 export const runRearrangeChildren: CommandFunction<RearrangeChildren> = (
   editorState: EditorState,
-  _derivedState: DerivedState,
   command: RearrangeChildren,
 ) => {
   const patch = withUnderlyingTargetFromEditorState(

--- a/editor/src/components/canvas/commands/reorder-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/reorder-element-command.spec.tsx
@@ -1,10 +1,7 @@
 import { absolute } from '../../../utils/utils'
 import * as EP from '../../../core/shared/element-path'
 import type { EditorState } from '../../editor/store/editor-state'
-import {
-  emptyDerivedState,
-  withUnderlyingTargetFromEditorState,
-} from '../../editor/store/editor-state'
+import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import { getEditorState, makeTestProjectCodeWithSnippet } from '../ui-jsx.test-utils'
 import { updateEditorStateWithPatches } from './commands'
 import { reorderElement, runReorderElement } from './reorder-element-command'
@@ -81,11 +78,7 @@ describe('runReorderElement', () => {
 
       const reorderCommand = reorderElement('always', target, absolute(newIdx))
 
-      const result = runReorderElement(
-        originalEditorState,
-        emptyDerivedState(originalEditorState),
-        reorderCommand,
-      )
+      const result = runReorderElement(originalEditorState, reorderCommand)
 
       const patchedEditor = updateEditorStateWithPatches(
         originalEditorState,

--- a/editor/src/components/canvas/commands/reorder-element-command.ts
+++ b/editor/src/components/canvas/commands/reorder-element-command.ts
@@ -2,7 +2,7 @@ import type { IndexPosition } from '../../../utils/utils'
 import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
-import type { DerivedState, EditorState } from '../../editor/store/editor-state'
+import type { EditorState } from '../../editor/store/editor-state'
 import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import { reorderComponent } from '../canvas-utils'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
@@ -29,7 +29,6 @@ export function reorderElement(
 
 export const runReorderElement: CommandFunction<ReorderElement> = (
   editorState: EditorState,
-  _derivedState: DerivedState,
   command: ReorderElement,
 ) => {
   const patch = withUnderlyingTargetFromEditorState(

--- a/editor/src/components/canvas/commands/reparent-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/reparent-element-command.spec.tsx
@@ -31,11 +31,7 @@ describe('runReparentElement', () => {
 
     const reparentCommand = reparentElement('always', targetPath, childInsertionPath(newParentPath))
 
-    const result = runReparentElement(
-      originalEditorState,
-      renderResult.getEditorState().derived,
-      reparentCommand,
-    )
+    const result = runReparentElement(originalEditorState, reparentCommand)
 
     const patchedEditor = updateEditorStateWithPatches(
       originalEditorState,
@@ -86,11 +82,7 @@ describe('runReparentElement', () => {
 
     const reparentCommand = reparentElement('always', targetPath, childInsertionPath(newParentPath))
 
-    const result = runReparentElement(
-      originalEditorState,
-      renderResult.getEditorState().derived,
-      reparentCommand,
-    )
+    const result = runReparentElement(originalEditorState, reparentCommand)
 
     const oldFile = withUnderlyingTargetFromEditorState(
       targetPath,

--- a/editor/src/components/canvas/commands/reparent-element-command.ts
+++ b/editor/src/components/canvas/commands/reparent-element-command.ts
@@ -8,7 +8,7 @@ import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-f
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import { mergeImports } from '../../../core/workers/common/project-file-utils'
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import {
   forUnderlyingTargetFromEditorState,
   removeElementAtPath,
@@ -42,7 +42,6 @@ export function reparentElement(
 
 export const runReparentElement: CommandFunction<ReparentElement> = (
   editorState: EditorState,
-  _derivedState: DerivedState,
   command: ReparentElement,
 ) => {
   let editorStatePatches: Array<EditorStatePatch> = []

--- a/editor/src/components/canvas/commands/set-css-length-command.spec.tsx
+++ b/editor/src/components/canvas/commands/set-css-length-command.spec.tsx
@@ -50,7 +50,6 @@ describe('setCssLengthProperty', () => {
 
     const result = runSetCssLengthProperty(
       renderResult.getEditorState().editor,
-      renderResult.getEditorState().derived,
       setCSSPropertyCommand,
     )
 
@@ -228,7 +227,7 @@ function runCommandUpdateEditor(
   store: EditorStorePatched,
   command: SetCssLengthProperty,
 ): EditorState {
-  const result = runSetCssLengthProperty(store.editor, store.derived, command)
+  const result = runSetCssLengthProperty(store.editor, command)
 
   return updateEditorStateWithPatches(store.editor, result.editorStatePatches)
 }

--- a/editor/src/components/canvas/commands/set-css-length-command.ts
+++ b/editor/src/components/canvas/commands/set-css-length-command.ts
@@ -13,9 +13,8 @@ import {
 } from '../../../core/shared/jsx-attributes'
 import type { ElementPath, PropertyPath } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
-import { deriveState, withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
-import { patchedCreateRemixDerivedDataMemo } from '../../editor/store/remix-derived-data'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import type { CSSKeyword, CSSNumber, FlexDirection } from '../../inspector/common/css-utils'
 import {
   cssPixelLength,
@@ -77,7 +76,6 @@ export function setCssLengthProperty(
 
 export const runSetCssLengthProperty: CommandFunction<SetCssLengthProperty> = (
   editorState: EditorState,
-  _derivedState: DerivedState,
   command: SetCssLengthProperty,
 ) => {
   // in case of width or height change, delete min, max and flex props

--- a/editor/src/components/canvas/commands/set-cursor-command.ts
+++ b/editor/src/components/canvas/commands/set-cursor-command.ts
@@ -1,7 +1,6 @@
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import type { CSSCursor } from '../canvas-types'
 import type { BaseCommand, CommandFunction } from './commands'
-import { WhenToRun } from './commands'
 
 export interface SetCursorCommand extends BaseCommand {
   type: 'SET_CURSOR_COMMAND'
@@ -18,7 +17,6 @@ export function setCursorCommand(value: CSSCursor | null): SetCursorCommand {
 
 export const runSetCursor: CommandFunction<SetCursorCommand> = (
   _: EditorState,
-  __: DerivedState,
   command: SetCursorCommand,
 ) => {
   const editorStatePatch: EditorStatePatch = {

--- a/editor/src/components/canvas/commands/set-elements-to-rerender-command.ts
+++ b/editor/src/components/canvas/commands/set-elements-to-rerender-command.ts
@@ -1,6 +1,5 @@
 import * as EP from '../../../core/shared/element-path'
 import type {
-  DerivedState,
   EditorState,
   EditorStatePatch,
   ElementsToRerender,
@@ -25,7 +24,6 @@ export function setElementsToRerenderCommand(
 
 export const runSetElementsToRerender: CommandFunction<SetElementsToRerenderCommand> = (
   e: EditorState,
-  __: DerivedState,
   command: SetElementsToRerenderCommand,
 ) => {
   const editorStatePatch: EditorStatePatch = {
@@ -69,7 +67,6 @@ function mergeElementsToRerender(l: ElementsToRerender, r: ElementsToRerender): 
 
 export const runAppendElementsToRerender: CommandFunction<AppendElementsToRerenderCommand> = (
   e: EditorState,
-  __: DerivedState,
   command: AppendElementsToRerenderCommand,
 ) => {
   const editorStatePatch: EditorStatePatch = {

--- a/editor/src/components/canvas/commands/set-property-command.ts
+++ b/editor/src/components/canvas/commands/set-property-command.ts
@@ -6,7 +6,7 @@ import type {
   PropertyPathPart,
 } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
-import type { DerivedState, EditorState } from '../../editor/store/editor-state'
+import type { EditorState } from '../../editor/store/editor-state'
 import { applyValuesAtPath } from './adjust-number-command'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
@@ -49,7 +49,6 @@ export function setPropertyOmitNullProp<T extends PropertyPathPart>(
 
 export const runSetProperty: CommandFunction<SetProperty> = (
   editorState: EditorState,
-  _derivedState: DerivedState,
   command: SetProperty,
 ) => {
   // Apply the update to the properties.

--- a/editor/src/components/canvas/commands/set-snapping-guidelines-command.ts
+++ b/editor/src/components/canvas/commands/set-snapping-guidelines-command.ts
@@ -1,4 +1,4 @@
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import type { GuidelineWithSnappingVectorAndPointsOfRelevance } from '../guideline'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
@@ -20,7 +20,6 @@ export function setSnappingGuidelines(
 
 export const runSetSnappingGuidelines: CommandFunction<SetSnappingGuidelines> = (
   _: EditorState,
-  __: DerivedState,
   command: SetSnappingGuidelines,
 ) => {
   const editorStatePatch: EditorStatePatch = {

--- a/editor/src/components/canvas/commands/show-outline-highlight-command.ts
+++ b/editor/src/components/canvas/commands/show-outline-highlight-command.ts
@@ -1,5 +1,5 @@
 import type { CanvasRectangle } from '../../../core/shared/math-utils'
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface ShowOutlineHighlight extends BaseCommand {
@@ -20,7 +20,6 @@ export function showOutlineHighlight(
 
 export const runShowOutlineHighlight: CommandFunction<ShowOutlineHighlight> = (
   _: EditorState,
-  __: DerivedState,
   command: ShowOutlineHighlight,
 ) => {
   const editorStatePatch: EditorStatePatch = {

--- a/editor/src/components/canvas/commands/show-reorder-indicator-command.ts
+++ b/editor/src/components/canvas/commands/show-reorder-indicator-command.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../core/shared/math-utils'
 import { forceNotNull } from '../../../core/shared/optional-utils'
 import type { ElementPath } from '../../../core/shared/project-file-types'
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import { singleAxisAutoLayoutContainerDirections } from '../canvas-strategies/strategies/flow-reorder-helpers'
 import type { SiblingPosition } from '../canvas-strategies/strategies/reparent-helpers/reparent-strategy-sibling-position-helpers'
 import {
@@ -34,7 +34,6 @@ export function showReorderIndicator(target: ElementPath, index: number): ShowRe
 
 export const runShowReorderIndicator: CommandFunction<ShowReorderIndicator> = (
   editor: EditorState,
-  __: DerivedState,
   command: ShowReorderIndicator,
 ) => {
   const targetParent = MetadataUtils.findElementByElementPath(editor.jsxMetadata, command.target)

--- a/editor/src/components/canvas/commands/update-function-command.ts
+++ b/editor/src/components/canvas/commands/update-function-command.ts
@@ -1,4 +1,4 @@
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import type { InteractionLifecycle } from '../canvas-strategies/canvas-strategy-types'
 import type { BaseCommand, CommandFunctionResult, WhenToRun } from './commands'
 
@@ -6,7 +6,6 @@ export interface UpdateFunctionCommand extends BaseCommand {
   type: 'UPDATE_FUNCTION_COMMAND'
   updateFunction: (
     editorState: EditorState,
-    derivedState: DerivedState,
     commandLifecycle: InteractionLifecycle,
   ) => Array<EditorStatePatch>
 }
@@ -15,7 +14,6 @@ export function updateFunctionCommand(
   whenToRun: WhenToRun,
   updateFunction: (
     editorState: EditorState,
-    derivedState: DerivedState,
     commandLifecycle: InteractionLifecycle,
   ) => Array<EditorStatePatch>,
 ): UpdateFunctionCommand {
@@ -28,12 +26,11 @@ export function updateFunctionCommand(
 
 export const runUpdateFunctionCommand = (
   editorState: EditorState,
-  derivedState: DerivedState,
   command: UpdateFunctionCommand,
   commandLifecycle: InteractionLifecycle,
 ): CommandFunctionResult => {
   return {
-    editorStatePatches: command.updateFunction(editorState, derivedState, commandLifecycle),
+    editorStatePatches: command.updateFunction(editorState, commandLifecycle),
     commandDescription: `Update Callback`,
   }
 }

--- a/editor/src/components/canvas/commands/update-highlighted-views-command.ts
+++ b/editor/src/components/canvas/commands/update-highlighted-views-command.ts
@@ -1,6 +1,6 @@
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface UpdateHighlightedViews extends BaseCommand {
@@ -21,7 +21,6 @@ export function updateHighlightedViews(
 
 export const runUpdateHighlightedViews: CommandFunction<UpdateHighlightedViews> = (
   _: EditorState,
-  __: DerivedState,
   command: UpdateHighlightedViews,
 ) => {
   const editorStatePatch = {

--- a/editor/src/components/canvas/commands/update-prop-if-exists-command.ts
+++ b/editor/src/components/canvas/commands/update-prop-if-exists-command.ts
@@ -9,7 +9,7 @@ import {
 import { getModifiableJSXAttributeAtPath } from '../../../core/shared/jsx-attributes'
 import type { ElementPath, PropertyPath } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
-import type { DerivedState, EditorState } from '../../editor/store/editor-state'
+import type { EditorState } from '../../editor/store/editor-state'
 import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import { applyValuesAtPath } from './adjust-number-command'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
@@ -38,7 +38,6 @@ export function updatePropIfExists(
 
 export const runUpdatePropIfExists: CommandFunction<UpdatePropIfExists> = (
   editorState: EditorState,
-  _derivedState: DerivedState,
   command: UpdatePropIfExists,
 ) => {
   // check if the prop exists

--- a/editor/src/components/canvas/commands/update-selected-views-command.spec.tsx
+++ b/editor/src/components/canvas/commands/update-selected-views-command.spec.tsx
@@ -5,7 +5,6 @@ import { complexDefaultProjectPreParsed } from '../../../sample-projects/sample-
 import { DefaultStartingFeatureSwitches, renderTestEditorWithModel } from '../ui-jsx.test-utils'
 import { updateEditorStateWithPatches } from './commands'
 import { runUpdateSelectedViews, updateSelectedViews } from './update-selected-views-command'
-import { emptyDerivedState } from '../../editor/store/editor-state'
 
 describe('updateSelectedViews', () => {
   it('updating selected views work', async () => {
@@ -26,11 +25,7 @@ describe('updateSelectedViews', () => {
 
     const updateSelectedViewsCommand = updateSelectedViews('always', [targetPath])
 
-    const result = runUpdateSelectedViews(
-      originalEditorState,
-      emptyDerivedState(originalEditorState),
-      updateSelectedViewsCommand,
-    )
+    const result = runUpdateSelectedViews(originalEditorState, updateSelectedViewsCommand)
 
     const patchedEditor = updateEditorStateWithPatches(
       originalEditorState,

--- a/editor/src/components/canvas/commands/update-selected-views-command.ts
+++ b/editor/src/components/canvas/commands/update-selected-views-command.ts
@@ -1,6 +1,6 @@
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface UpdateSelectedViews extends BaseCommand {
@@ -21,7 +21,6 @@ export function updateSelectedViews(
 
 export const runUpdateSelectedViews: CommandFunction<UpdateSelectedViews> = (
   _: EditorState,
-  __: DerivedState,
   command: UpdateSelectedViews,
 ) => {
   const editorStatePatch: EditorStatePatch = {

--- a/editor/src/components/canvas/commands/wildcard-patch-command.spec.tsx
+++ b/editor/src/components/canvas/commands/wildcard-patch-command.spec.tsx
@@ -28,11 +28,7 @@ describe('wildcardPatch', () => {
 
     const wildcardCommand = wildcardPatch('always', { selectedViews: { $set: [] } })
 
-    const result = runWildcardPatch(
-      renderResult.getEditorState().editor,
-      renderResult.getEditorState().derived,
-      wildcardCommand,
-    )
+    const result = runWildcardPatch(renderResult.getEditorState().editor, wildcardCommand)
 
     const patchedEditor = updateEditorStateWithPatches(
       renderResult.getEditorState().editor,

--- a/editor/src/components/canvas/commands/wildcard-patch-command.ts
+++ b/editor/src/components/canvas/commands/wildcard-patch-command.ts
@@ -1,4 +1,4 @@
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface WildcardPatch extends BaseCommand {
@@ -16,7 +16,6 @@ export function wildcardPatch(whenToRun: WhenToRun, patch: EditorStatePatch): Wi
 
 export const runWildcardPatch: CommandFunction<WildcardPatch> = (
   _: EditorState,
-  __: DerivedState,
   command: WildcardPatch,
 ) => {
   return {

--- a/editor/src/components/canvas/commands/wrap-in-container-command.spec.tsx
+++ b/editor/src/components/canvas/commands/wrap-in-container-command.spec.tsx
@@ -42,7 +42,7 @@ describe('wrapInContainerCommand', () => {
     expect(originalElement).not.toBeNull()
 
     const cmd = wrapInContainerCommand('always', targetPath, 'the-wrapper', 'fragment')
-    const result = runWrapInContainerCommand(editor, renderResult.getEditorState().derived, cmd)
+    const result = runWrapInContainerCommand(editor, cmd)
     const patchedEditor = updateEditorStateWithPatches(editor, result.editorStatePatches)
 
     const wrapperPath = EP.appendToPath(EP.parentPath(targetPath), 'the-wrapper')
@@ -83,7 +83,7 @@ describe('wrapInContainerCommand', () => {
     expect(originalElement).not.toBeNull()
 
     const cmd = wrapInContainerCommand('always', targetPath, 'the-wrapper', 'conditional')
-    const result = runWrapInContainerCommand(editor, renderResult.getEditorState().derived, cmd)
+    const result = runWrapInContainerCommand(editor, cmd)
     const patchedEditor = updateEditorStateWithPatches(editor, result.editorStatePatches)
 
     const wrapperPath = EP.appendToPath(EP.parentPath(targetPath), 'the-wrapper')
@@ -128,7 +128,7 @@ describe('wrapInContainerCommand', () => {
     expect(originalElement).toBeNull()
 
     const cmd = wrapInContainerCommand('always', targetPath, 'the-wrapper', 'fragment')
-    const result = runWrapInContainerCommand(editor, renderResult.getEditorState().derived, cmd)
+    const result = runWrapInContainerCommand(editor, cmd)
     const patchedEditor = updateEditorStateWithPatches(editor, result.editorStatePatches)
 
     const wrapperPath = EP.appendToPath(EP.parentPath(targetPath), 'the-wrapper')

--- a/editor/src/components/canvas/commands/wrap-in-container-command.ts
+++ b/editor/src/components/canvas/commands/wrap-in-container-command.ts
@@ -9,7 +9,7 @@ import {
   jsxFragment,
 } from '../../../core/shared/element-template'
 import type { ElementPath, Imports } from '../../../core/shared/project-file-types'
-import type { DerivedState, EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import {
   forUnderlyingTargetFromEditorState,
   removeElementAtPath,
@@ -65,7 +65,6 @@ export function wrapInContainerCommand(
 
 export const runWrapInContainerCommand: CommandFunction<WrapInContainerCommand> = (
   editor: EditorState,
-  _derivedState: DerivedState,
   command: WrapInContainerCommand,
 ) => {
   let editorStatePatches: Array<EditorStatePatch> = []

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -94,7 +94,6 @@ import {
   defaultUserState,
   deriveState,
   editorModelFromPersistentModel,
-  emptyDerivedState,
   getOpenUIJSFile,
   withUnderlyingTargetFromEditorState,
 } from '../store/editor-state'
@@ -907,7 +906,7 @@ describe('INSERT_INSERTABLE', () => {
       null,
     )
 
-    const actualResult = UPDATE_FNS.INSERT_INSERTABLE(action, editorState, derivedState)
+    const actualResult = UPDATE_FNS.INSERT_INSERTABLE(action, editorState)
     const cardFile = getProjectFileByFilePath(actualResult.projectContents, '/src/card.js')
     if (cardFile != null && isTextFile(cardFile)) {
       const parsed = cardFile.fileContents.parsed
@@ -1020,7 +1019,7 @@ describe('INSERT_INSERTABLE', () => {
       null,
     )
 
-    const actualResult = UPDATE_FNS.INSERT_INSERTABLE(action, editorState, derivedState)
+    const actualResult = UPDATE_FNS.INSERT_INSERTABLE(action, editorState)
     const cardFile = getProjectFileByFilePath(actualResult.projectContents, '/src/card.js')
     if (cardFile != null && isTextFile(cardFile)) {
       const parsed = cardFile.fileContents.parsed
@@ -1127,7 +1126,7 @@ describe('INSERT_INSERTABLE', () => {
 
     const action = insertInsertable(childInsertionPath(targetPath), imgInsertable, 'add-size', null)
 
-    const actualResult = UPDATE_FNS.INSERT_INSERTABLE(action, editorState, derivedState)
+    const actualResult = UPDATE_FNS.INSERT_INSERTABLE(action, editorState)
     const cardFile = getProjectFileByFilePath(actualResult.projectContents, '/src/card.js')
     if (cardFile != null && isTextFile(cardFile)) {
       const parsed = cardFile.fileContents.parsed
@@ -1230,7 +1229,7 @@ describe('INSERT_INSERTABLE', () => {
       type: 'back',
     })
 
-    const actualResult = UPDATE_FNS.INSERT_INSERTABLE(action, editorState, derivedState)
+    const actualResult = UPDATE_FNS.INSERT_INSERTABLE(action, editorState)
     const cardFile = getProjectFileByFilePath(actualResult.projectContents, '/src/card.js')
     if (cardFile != null && isTextFile(cardFile)) {
       const parsed = cardFile.fileContents.parsed

--- a/editor/src/components/editor/actions/wrap-unwrap-helpers.tsx
+++ b/editor/src/components/editor/actions/wrap-unwrap-helpers.tsx
@@ -331,7 +331,6 @@ export function fixParentContainingBlockSettings(
 
 export function wrapElementInsertions(
   editor: EditorState,
-  derivedState: DerivedState,
   targets: Array<ElementPath>,
   parentPath: InsertionPath,
   rawElementToInsert: JSXElement | JSXFragment | JSXConditionalExpression,
@@ -385,7 +384,7 @@ export function wrapElementInsertions(
       switch (staticTarget.type) {
         case 'CHILD_INSERTION':
           return {
-            updatedEditor: foldAndApplyCommandsSimple(editor, derivedState, [
+            updatedEditor: foldAndApplyCommandsSimple(editor, [
               addElement('always', staticTarget, elementToInsert, { importsToAdd, indexPosition }),
             ]),
             newPath: newPath,
@@ -407,7 +406,7 @@ export function wrapElementInsertions(
       switch (staticTarget.type) {
         case 'CHILD_INSERTION':
           return {
-            updatedEditor: foldAndApplyCommandsSimple(editor, derivedState, [
+            updatedEditor: foldAndApplyCommandsSimple(editor, [
               addElement('always', staticTarget, elementToInsert, { importsToAdd, indexPosition }),
             ]),
             newPath: newPath,
@@ -429,7 +428,7 @@ export function wrapElementInsertions(
       switch (staticTarget.type) {
         case 'CHILD_INSERTION':
           return {
-            updatedEditor: foldAndApplyCommandsSimple(editor, derivedState, [
+            updatedEditor: foldAndApplyCommandsSimple(editor, [
               addElement('always', staticTarget, elementToInsert, { importsToAdd, indexPosition }),
             ]),
             newPath: newPath,

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -77,7 +77,6 @@ export function interactionFinished(
   )
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
     newEditorState,
-    result.unpatchedDerived,
     result.builtInDependencies,
   )
   const interactionSession = storedState.unpatchedEditor.canvas.interactionSession
@@ -105,7 +104,6 @@ export function interactionFinished(
           }
     const commandResult = foldAndApplyCommands(
       newEditorState,
-      result.unpatchedDerived,
       storedState.patchedEditor,
       [],
       strategyResult.commands,
@@ -155,7 +153,6 @@ export function interactionHardReset(
   }
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
     newEditorState,
-    result.unpatchedDerived,
     result.builtInDependencies,
   )
   const interactionSession = newEditorState.canvas.interactionSession
@@ -194,7 +191,6 @@ export function interactionHardReset(
       )
       const commandResult = foldAndApplyCommands(
         newEditorState,
-        result.unpatchedDerived,
         storedState.patchedEditor,
         [],
         strategyResult.commands,
@@ -242,7 +238,6 @@ export function interactionUpdate(
   const newEditorState = result.unpatchedEditor
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
     newEditorState,
-    result.unpatchedDerived,
     result.builtInDependencies,
   )
   const interactionSession = newEditorState.canvas.interactionSession
@@ -274,7 +269,6 @@ export function interactionUpdate(
         return handleUserChangedStrategy(
           result.builtInDependencies,
           newEditorState,
-          result.unpatchedDerived,
           storedState.patchedEditor,
           result.strategyState,
           strategy,
@@ -292,7 +286,6 @@ export function interactionUpdate(
       return handleAccumulatingKeypresses(
         result.builtInDependencies,
         newEditorState,
-        result.unpatchedDerived,
         storedState.patchedEditor,
         result.strategyState,
         strategy,
@@ -303,7 +296,6 @@ export function interactionUpdate(
     return handleUpdate(
       result.builtInDependencies,
       newEditorState,
-      result.unpatchedDerived,
       storedState.patchedEditor,
       result.strategyState,
       strategy,
@@ -328,7 +320,6 @@ export function interactionStart(
   )
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
     newEditorState,
-    result.unpatchedDerived,
     result.builtInDependencies,
   )
   const interactionSession = newEditorState.canvas.interactionSession
@@ -362,7 +353,6 @@ export function interactionStart(
       )
       const commandResult = foldAndApplyCommands(
         newEditorState,
-        result.unpatchedDerived,
         storedState.patchedEditor,
         [],
         strategyResult.commands,
@@ -430,7 +420,6 @@ export function interactionCancel(
 function handleUserChangedStrategy(
   builtInDependencies: BuiltInDependencies,
   newEditorState: EditorState,
-  newDerivedState: DerivedState,
   storedEditorState: EditorState,
   strategyState: StrategyState,
   strategy: StrategyWithFitness | null,
@@ -439,7 +428,6 @@ function handleUserChangedStrategy(
 ): HandleStrategiesResult {
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
     newEditorState,
-    newDerivedState,
     builtInDependencies,
   )
 
@@ -469,7 +457,6 @@ function handleUserChangedStrategy(
     )
     const commandResult = foldAndApplyCommands(
       newEditorState,
-      newDerivedState,
       storedEditorState,
       strategyChangedLogCommands.flatMap((c) => c.commands),
       strategyResult.commands,
@@ -510,7 +497,6 @@ function handleUserChangedStrategy(
 function handleAccumulatingKeypresses(
   builtInDependencies: BuiltInDependencies,
   newEditorState: EditorState,
-  newDerivedState: DerivedState,
   storedEditorState: EditorState,
   strategyState: StrategyState,
   strategy: StrategyWithFitness | null,
@@ -519,7 +505,6 @@ function handleAccumulatingKeypresses(
 ): HandleStrategiesResult {
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
     newEditorState,
-    newDerivedState,
     builtInDependencies,
   )
   // If there is a current strategy, produce the commands from it.
@@ -554,7 +539,6 @@ function handleAccumulatingKeypresses(
           : strategyApplicationResult([])
       const commandResult = foldAndApplyCommands(
         updatedEditorState,
-        newDerivedState,
         storedEditorState,
         strategyState.currentStrategyCommands,
         strategyResult.commands,
@@ -595,7 +579,6 @@ function handleAccumulatingKeypresses(
 function handleUpdate(
   builtInDependencies: BuiltInDependencies,
   newEditorState: EditorState,
-  newDerivedState: DerivedState,
   storedEditorState: EditorState,
   strategyState: StrategyState,
   strategy: StrategyWithFitness | null,
@@ -604,7 +587,6 @@ function handleUpdate(
 ): HandleStrategiesResult {
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
     newEditorState,
-    newDerivedState,
     builtInDependencies,
   )
   // If there is a current strategy, produce the commands from it.
@@ -621,7 +603,6 @@ function handleUpdate(
         : strategyApplicationResult([])
     const commandResult = foldAndApplyCommands(
       newEditorState,
-      newDerivedState,
       storedEditorState,
       [],
       strategyResult.commands,

--- a/editor/src/components/editor/store/editor-state.spec.ts
+++ b/editor/src/components/editor/store/editor-state.spec.ts
@@ -2,7 +2,6 @@ import type { EditorState } from './editor-state'
 import {
   createEditorState,
   defaultModifyParseSuccess,
-  emptyDerivedState,
   modifyUnderlyingTargetElement,
   StoryboardFilePath,
 } from './editor-state'

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -2182,7 +2182,7 @@ export interface DerivedState {
   remixData: RemixDerivedData | null
 }
 
-export function emptyDerivedState(editor: EditorState): DerivedState {
+function emptyDerivedState(editor: EditorState): DerivedState {
   return {
     navigatorTargets: [],
     visibleNavigatorTargets: [],

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -1,5 +1,4 @@
 import type { EditorState, DerivedState, UserState, EditorStoreUnpatched } from './editor-state'
-import { deriveState } from './editor-state'
 import type {
   EditorAction,
   EditorDispatch,
@@ -14,7 +13,6 @@ import type { UtopiaTsWorkers } from '../../../core/workers/common/worker-types'
 import type { UiJsxCanvasContextData } from '../../canvas/ui-jsx-canvas'
 import type { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { foldAndApplyCommandsSimple } from '../../canvas/commands/commands'
-import { unpatchedCreateRemixDerivedDataMemo } from './remix-derived-data'
 
 export function runLocalEditorAction(
   state: EditorState,
@@ -162,7 +160,7 @@ export function runSimpleLocalEditorAction(
     case 'SHOW_MODAL':
       return UPDATE_FNS.SHOW_MODAL(action, state)
     case 'RESET_PINS':
-      return UPDATE_FNS.RESET_PINS(action, state, derivedState)
+      return UPDATE_FNS.RESET_PINS(action, state)
     case 'SET_CURSOR_OVERLAY':
       return UPDATE_FNS.SET_CURSOR_OVERLAY(action, state)
     case 'SET_Z_INDEX':
@@ -239,7 +237,7 @@ export function runSimpleLocalEditorAction(
     case 'SAVE_DOM_REPORT':
       return UPDATE_FNS.SAVE_DOM_REPORT(action, state, spyCollector)
     case 'TRUE_UP_GROUPS':
-      return UPDATE_FNS.TRUE_UP_GROUPS(state, derivedState)
+      return UPDATE_FNS.TRUE_UP_GROUPS(state)
     case 'SET_PROP':
       return UPDATE_FNS.SET_PROP(action, state)
     case 'SET_FILEBROWSER_RENAMING_TARGET':
@@ -259,7 +257,7 @@ export function runSimpleLocalEditorAction(
     case 'OPEN_FLOATING_INSERT_MENU':
       return UPDATE_FNS.OPEN_FLOATING_INSERT_MENU(action, state)
     case 'UNWRAP_ELEMENTS':
-      return UPDATE_FNS.UNWRAP_ELEMENTS(action, state, dispatch, builtInDependencies, derivedState)
+      return UPDATE_FNS.UNWRAP_ELEMENTS(action, state, dispatch, builtInDependencies)
     case 'INSERT_IMAGE_INTO_UI':
       return UPDATE_FNS.INSERT_IMAGE_INTO_UI(action, state, derivedState)
     case 'UPDATE_JSX_ELEMENT_NAME':
@@ -336,7 +334,7 @@ export function runSimpleLocalEditorAction(
     case 'CLOSE_FLOATING_INSERT_MENU':
       return UPDATE_FNS.CLOSE_FLOATING_INSERT_MENU(action, state)
     case 'INSERT_INSERTABLE':
-      return UPDATE_FNS.INSERT_INSERTABLE(action, state, derivedState)
+      return UPDATE_FNS.INSERT_INSERTABLE(action, state)
     case 'SET_PROP_TRANSIENT':
       return UPDATE_FNS.SET_PROP_TRANSIENT(action, state)
     case 'CLEAR_TRANSIENT_PROPS':
@@ -358,7 +356,7 @@ export function runSimpleLocalEditorAction(
     case 'FORCE_PARSE_FILE':
       return UPDATE_FNS.FORCE_PARSE_FILE(action, state)
     case 'RUN_ESCAPE_HATCH':
-      return UPDATE_FNS.RUN_ESCAPE_HATCH(action, state, derivedState, builtInDependencies)
+      return UPDATE_FNS.RUN_ESCAPE_HATCH(action, state, builtInDependencies)
     case 'TOGGLE_SELECTION_LOCK':
       return UPDATE_FNS.TOGGLE_SELECTION_LOCK(action, state)
     case 'UPDATE_AGAINST_GITHUB':
@@ -366,7 +364,7 @@ export function runSimpleLocalEditorAction(
     case 'SET_IMAGE_DRAG_SESSION_STATE':
       return UPDATE_FNS.SET_FILE_BROWSER_DRAG_STATE(action, state)
     case 'APPLY_COMMANDS':
-      return UPDATE_FNS.APPLY_COMMANDS(action, state, derivedState)
+      return UPDATE_FNS.APPLY_COMMANDS(action, state)
     case 'UPDATE_COLOR_SWATCHES':
       return UPDATE_FNS.UPDATE_COLOR_SWATCHES(action, state)
     case 'SET_CONDITIONAL_OVERRIDDEN_CONDITION':
@@ -395,13 +393,6 @@ export function runExecuteWithPostActionMenuAction(
     working.postActionInteractionSession.editorStateSnapshot,
   )
 
-  const derivedState = deriveState(
-    editorState,
-    null,
-    'unpatched',
-    unpatchedCreateRemixDerivedDataMemo,
-  )
-
   const commands = action.choice.run(
     editorState,
     working.postActionInteractionSession.derivedStateSnapshot,
@@ -412,7 +403,7 @@ export function runExecuteWithPostActionMenuAction(
     return working
   }
 
-  const newEditorState = foldAndApplyCommandsSimple(editorState, derivedState, commands)
+  const newEditorState = foldAndApplyCommandsSimple(editorState, commands)
   return {
     ...working,
     unpatchedEditor: newEditorState,

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -15,11 +15,7 @@ import type {
   EditorState,
   EditorStorePatched,
 } from '../../editor/store/editor-state'
-import {
-  editorModelFromPersistentModel,
-  emptyDerivedState,
-  StoryboardFilePath,
-} from '../../editor/store/editor-state'
+import { editorModelFromPersistentModel, StoryboardFilePath } from '../../editor/store/editor-state'
 import { NO_OP } from '../../../core/shared/utils'
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
@@ -204,7 +200,7 @@ function callPropertyControlsHook(
 
   const initialEditorStore: EditorStorePatched = {
     editor: editorState,
-    derived: emptyDerivedState(editorState),
+    derived: null as any,
     strategyState: null as any,
     history: null as any,
     userState: null as any,


### PR DESCRIPTION
**Problem:**
DerivedState was added to CanvasCommands as an input parameter, because for a while it was necessary to be able to access the remix routing table from commands. However, this is unused since the refactoring of `normalisePathToUnderlyingTarget` ( https://github.com/concrete-utopia/utopia/pull/4185 ), because we no longer need the remix routing table to find a file for a uid in the project.

**Fix:**
Remove all derivedState parameters from commands and handle the fallout from that.