### PR TITLE
fix insert menu item backgrounds

### DIFF
--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -365,7 +365,7 @@ const Option = React.memo((props: OptionProps<ComponentOptionItem, false>) => {
             : isSelected
             ? colorTheme.bg1.value
             : colorTheme.fg1.value,
-          background: isComponentCurrentlyInserted ? colorTheme.brandNeonPink.value : undefined,
+          background: isComponentCurrentlyInserted ? colorTheme.dynamicBlue.value : undefined,
           gap: 4,
           border: '1px solid transparent',
         }}

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -182,17 +182,9 @@ function elementBeingInserted(insertableComponent: InsertableComponent): Element
 }
 
 export function elementBeingInsertedEquals(
-  first: ElementBeingInserted | null,
-  second: ElementBeingInserted | null,
+  first: ElementBeingInserted,
+  second: ElementBeingInserted,
 ): boolean {
-  if (first == null) {
-    return second == null
-  }
-
-  if (second == null) {
-    return false
-  }
-
   if (first.type === 'component' && second.type === 'component') {
     return (
       importsEquals(first.importsToAdd, second.importsToAdd) &&
@@ -342,13 +334,15 @@ const Option = React.memo((props: OptionProps<ComponentOptionItem, false>) => {
     [dispatch],
   )
 
+  const isComponentCurrentlyInserted =
+    currentlyBeingInserted != null &&
+    elementBeingInsertedEquals(currentlyBeingInserted, elementBeingInserted(component))
+
   const isSelected = React.useMemo(() => {
-    const beingInserted = elementBeingInsertedEquals(
-      currentlyBeingInserted,
-      elementBeingInserted(component),
+    return (
+      isComponentCurrentlyInserted || (isActive && isFocused && currentlyBeingInserted !== null)
     )
-    return beingInserted || (isActive && isFocused && currentlyBeingInserted !== null)
-  }, [component, currentlyBeingInserted, isFocused, isActive])
+  }, [isComponentCurrentlyInserted, isActive, isFocused, currentlyBeingInserted])
 
   const [isHovered, setIsHovered] = useState(false)
   const setIsHoveredTrue = React.useCallback(() => {
@@ -371,7 +365,7 @@ const Option = React.memo((props: OptionProps<ComponentOptionItem, false>) => {
             : isSelected
             ? colorTheme.bg1.value
             : colorTheme.fg1.value,
-          background: currentlyBeingInserted !== null ? colorTheme.dynamicBlue.value : undefined,
+          background: isComponentCurrentlyInserted ? colorTheme.brandNeonPink.value : undefined,
           gap: 4,
           border: '1px solid transparent',
         }}


### PR DESCRIPTION
## Problem
When the insert text button is clicked in the canvas toolbar, all elements in the insert menu are marked as currently being inserted
<img width="838" alt="image" src="https://github.com/concrete-utopia/utopia/assets/16385508/d39eb7ef-a5a2-4a91-b24a-fddf4fae83dc">

## Fix
Fix the condition of the background color

<img width="929" alt="image" src="https://github.com/concrete-utopia/utopia/assets/16385508/98989715-8e78-4a1e-8b48-34ecf626c22a">
