### PR TITLE
Repository and Branch Labels Wrap

### DIFF
--- a/editor/src/components/navigator/left-pane/github-pane/block.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/block.tsx
@@ -109,14 +109,24 @@ export const Block = React.memo((props: BlockProps) => {
         >
           <FlexRow
             style={{
-              height: UtopiaTheme.layout.rowHeight.normal,
+              minHeight: UtopiaTheme.layout.rowHeight.normal,
               display: 'flex',
-              alignItems: 'center',
+              alignItems: 'baseline',
               justifyContent: 'space-between',
+              padding: '8px 0',
             }}
           >
             <div style={{ fontWeight: 700, color: colorTheme.fg0.value }}>{props.title}</div>
-            <Ellipsis style={{ maxWidth: 120 }}>{props.subtitle}</Ellipsis>
+            <Ellipsis
+              style={{
+                maxWidth: 120,
+                textAlign: 'right',
+                overflowWrap: 'break-word',
+                whiteSpace: 'pre-wrap',
+              }}
+            >
+              {props.subtitle}
+            </Ellipsis>
           </FlexRow>
         </FlexColumn>
       </UIGridRow>

--- a/editor/src/components/navigator/left-pane/github-pane/block.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/block.tsx
@@ -6,7 +6,6 @@ import React from 'react'
 import { when } from '../../../../utils/react-conditionals'
 import { colorTheme, FlexColumn, FlexRow, UtopiaTheme } from '../../../../uuiui'
 import { UIGridRow } from '../../../inspector/widgets/ui-grid-row'
-import { Ellipsis } from './github-file-changes-list'
 
 export const IndicatorLight = React.memo((props: { status: BlockStatus }) => (
   <div
@@ -117,7 +116,7 @@ export const Block = React.memo((props: BlockProps) => {
             }}
           >
             <div style={{ fontWeight: 700, color: colorTheme.fg0.value }}>{props.title}</div>
-            <Ellipsis
+            <div
               style={{
                 maxWidth: 120,
                 textAlign: 'right',
@@ -126,7 +125,7 @@ export const Block = React.memo((props: BlockProps) => {
               }}
             >
               {props.subtitle}
-            </Ellipsis>
+            </div>
           </FlexRow>
         </FlexColumn>
       </UIGridRow>

--- a/editor/src/components/navigator/left-pane/github-pane/github-file-changes-list.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/github-file-changes-list.tsx
@@ -37,10 +37,10 @@ export const Ellipsis: React.FC<{
   return (
     <div
       style={{
-        ...style,
         whiteSpace: 'nowrap',
         overflow: 'hidden',
         textOverflow: 'ellipsis',
+        ...style,
       }}
       title={title}
     >


### PR DESCRIPTION
Before, we couldn't read the labels for the repository or branch name if they were too long. Now the wrap to the next line, forcing a word-break if necessary.

| Problem  | Fix |
| ------------- | ------------- |
| ![image](https://github.com/concrete-utopia/utopia/assets/47405698/d4ad104f-fec3-47e0-abbb-7ecf80881236)  | ![image](https://github.com/concrete-utopia/utopia/assets/47405698/252e6b8f-20d6-4678-a54e-d318a0029198)  |

