### PR TITLE
Setting hugging parent to fixed is optional when converting to absolute

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -32,7 +32,10 @@ import { isNotYetStartedDragInteraction } from './interaction-state'
 import { keyboardAbsoluteMoveStrategy } from './strategies/keyboard-absolute-move-strategy'
 import { absoluteResizeBoundingBoxStrategy } from './strategies/absolute-resize-bounding-box-strategy'
 import { keyboardAbsoluteResizeStrategy } from './strategies/keyboard-absolute-resize-strategy'
-import { convertToAbsoluteAndMoveStrategy } from './strategies/convert-to-absolute-and-move-strategy'
+import {
+  convertToAbsoluteAndMoveAndSetParentFixedStrategy,
+  convertToAbsoluteAndMoveStrategy,
+} from './strategies/convert-to-absolute-and-move-strategy'
 import { absoluteDuplicateStrategy } from './strategies/absolute-duplicate-strategy'
 import type { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import type { StateSelector } from 'zustand'
@@ -85,6 +88,7 @@ const moveOrReorderStrategies: MetaCanvasStrategy = (
       keyboardAbsoluteMoveStrategy,
       keyboardReorderStrategy,
       convertToAbsoluteAndMoveStrategy,
+      convertToAbsoluteAndMoveAndSetParentFixedStrategy,
       reorderSliderStategy,
     ],
   )

--- a/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.spec.browser2.tsx
@@ -579,7 +579,7 @@ describe('finds an applicable strategy for the nearest ancestor', () => {
     runTest(codeElementWithSibling, pathForShallowNestedElement, (editor) => {
       const strategies = editor.getEditorState().strategyState.sortedApplicableStrategies
 
-      expect(strategies?.length).toEqual(2)
+      expect(strategies?.length).toEqual(3)
       if (strategies == null) {
         // here for type assertion
         throw new Error('`strategies` should not be null')

--- a/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.spec.browser2.tsx
@@ -579,7 +579,7 @@ describe('finds an applicable strategy for the nearest ancestor', () => {
     runTest(codeElementWithSibling, pathForShallowNestedElement, (editor) => {
       const strategies = editor.getEditorState().strategyState.sortedApplicableStrategies
 
-      expect(strategies?.length).toEqual(3)
+      expect(strategies?.length).toEqual(2)
       if (strategies == null) {
         // here for type assertion
         throw new Error('`strategies` should not be null')

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
@@ -53,7 +53,10 @@ import {
   getOpeningFragmentLikeTag,
 } from './fragment-like-helpers.test-utils'
 import { selectComponentsForTest } from '../../../../utils/utils.test-utils'
-import { ConvertToAbsoluteAndMoveStrategyID } from './convert-to-absolute-and-move-strategy'
+import {
+  ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID,
+  ConvertToAbsoluteAndMoveStrategyID,
+} from './convert-to-absolute-and-move-strategy'
 import CanvasActions from '../../canvas-actions'
 
 const complexProject = () => {
@@ -675,7 +678,7 @@ describe('Convert to absolute/escape hatch', () => {
     keyDown('Space')
 
     const currentStrategy = renderResult.getEditorState().strategyState.currentStrategy
-    expect(currentStrategy).toEqual(ConvertToAbsoluteAndMoveStrategyID)
+    expect(currentStrategy).toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
   })
 
   it('becomes the active strategy while space is pressed rather than ancestor metastrategy', async () => {
@@ -739,7 +742,7 @@ describe('Convert to absolute/escape hatch', () => {
     keyDown('Space')
 
     const currentStrategy = renderResult.getEditorState().strategyState.currentStrategy
-    expect(currentStrategy).toEqual(ConvertToAbsoluteAndMoveStrategyID)
+    expect(currentStrategy).toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
   })
   ;(['flex', 'flow'] as const).forEach((parentLayoutSystem) =>
     it(`DOES NOT BECOME the active strategy when dragging for multiselection across the hierarchy for ${parentLayoutSystem} parent`, async () => {
@@ -784,7 +787,7 @@ describe('Convert to absolute/escape hatch', () => {
 
       const midDragStrategy = renderResult.getEditorState().strategyState.currentStrategy
       expect(midDragStrategy).not.toBeNull()
-      expect(midDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveStrategyID)
+      expect(midDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
 
       // Now drag until we have passed the sibling bounds
       await mouseMoveToPoint(canvasControlsLayer, {
@@ -794,12 +797,12 @@ describe('Convert to absolute/escape hatch', () => {
 
       const endDragStrategy = renderResult.getEditorState().strategyState.currentStrategy
       expect(endDragStrategy).not.toBeNull()
-      expect(endDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveStrategyID)
+      expect(endDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
 
       // HOWEVER!!!! pressing space now makes the strategy active!!!!!!
       keyDown('Space')
       const keydownStrategy = renderResult.getEditorState().strategyState.currentStrategy
-      expect(keydownStrategy).toEqual(ConvertToAbsoluteAndMoveStrategyID)
+      expect(keydownStrategy).toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
     }),
   )
   ;(['flex', 'flow'] as const).forEach((parentLayoutSystem) =>
@@ -844,7 +847,7 @@ describe('Convert to absolute/escape hatch', () => {
 
       const midDragStrategy = renderResult.getEditorState().strategyState.currentStrategy
       expect(midDragStrategy).not.toBeNull()
-      expect(midDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveStrategyID)
+      expect(midDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
 
       // Now drag until we have passed the sibling bounds
       await mouseMoveToPoint(canvasControlsLayer, {
@@ -854,12 +857,12 @@ describe('Convert to absolute/escape hatch', () => {
 
       const endDragStrategy = renderResult.getEditorState().strategyState.currentStrategy
       expect(endDragStrategy).not.toBeNull()
-      expect(endDragStrategy).toEqual(ConvertToAbsoluteAndMoveStrategyID)
+      expect(endDragStrategy).toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
 
       // pressing space keeps the strategy active
       keyDown('Space')
       const keydownStrategy = renderResult.getEditorState().strategyState.currentStrategy
-      expect(keydownStrategy).toEqual(ConvertToAbsoluteAndMoveStrategyID)
+      expect(keydownStrategy).toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
     }),
   )
 
@@ -907,7 +910,7 @@ describe('Convert to absolute/escape hatch', () => {
 
         const midDragStrategy = renderResult.getEditorState().strategyState.currentStrategy
         expect(midDragStrategy).not.toBeNull()
-        expect(midDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveStrategyID)
+        expect(midDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
 
         // Now drag until we have passed the sibling bounds
         await mouseMoveToPoint(canvasControlsLayer, {
@@ -917,7 +920,7 @@ describe('Convert to absolute/escape hatch', () => {
 
         const endDragStrategy = renderResult.getEditorState().strategyState.currentStrategy
         expect(endDragStrategy).not.toBeNull()
-        expect(endDragStrategy).toEqual(ConvertToAbsoluteAndMoveStrategyID)
+        expect(endDragStrategy).toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
       })
     },
   )
@@ -969,7 +972,7 @@ describe('Convert to absolute/escape hatch', () => {
 
         const midDragStrategy = renderResult.getEditorState().strategyState.currentStrategy
         expect(midDragStrategy).not.toBeNull()
-        expect(midDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveStrategyID)
+        expect(midDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
 
         // Now drag until we have passed the sibling bounds
         await mouseMoveToPoint(canvasControlsLayer, {
@@ -979,7 +982,7 @@ describe('Convert to absolute/escape hatch', () => {
 
         const endDragStrategy = renderResult.getEditorState().strategyState.currentStrategy
         expect(endDragStrategy).not.toBeNull()
-        expect(endDragStrategy).toEqual(ConvertToAbsoluteAndMoveStrategyID)
+        expect(endDragStrategy).toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
 
         await mouseUpAtPoint(canvasControlsLayer, {
           x: elementBounds.x + 110,

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
@@ -1454,7 +1454,7 @@ describe('Convert to absolute/escape hatch', () => {
         makeTestProjectCodeWithSnippet(
           `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
         <View
-          style={{ backgroundColor: '#aaaaaa33', width: '50%', height: '20%', right: 185, bottom: 305, top: 15, left: 15, position: 'absolute', }}
+          style={{ backgroundColor: '#aaaaaa33', width: 200, height: 80, right: 185, bottom: 305, top: 15, left: 15, position: 'absolute', }}
           data-uid='bbb'
           data-testid='bbb'
         />
@@ -1515,7 +1515,7 @@ describe('Convert to absolute/escape hatch', () => {
         makeTestProjectCodeWithSnippet(
           `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
           <View
-            style={{ backgroundColor: '#aaaaaa33', width: '50%', height: '20%', right: 185, bottom: 305, top: 15, left: 15, position: 'absolute', }}
+            style={{ backgroundColor: '#aaaaaa33', width: 200, height: 80, right: 185, bottom: 305, top: 15, left: 15, position: 'absolute', }}
             data-uid='bbb'
             data-testid='bbb'
           />
@@ -1630,8 +1630,9 @@ describe('Escape hatch strategy on awkward project', () => {
                   style={{
                     display: 'flex',
                     flexDirection: 'row',
-                    width: '100%',
+                    width: 400,
                     justifyContent: 'space-between',
+                    height: 100,
                   }}
                   data-uid='container'
                 >

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
@@ -54,10 +54,7 @@ import {
   getOpeningFragmentLikeTag,
 } from './fragment-like-helpers.test-utils'
 import { selectComponentsForTest } from '../../../../utils/utils.test-utils'
-import {
-  ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID,
-  ConvertToAbsoluteAndMoveStrategyID,
-} from './convert-to-absolute-and-move-strategy'
+import { ConvertToAbsoluteAndMoveStrategyID } from './convert-to-absolute-and-move-strategy'
 import CanvasActions from '../../canvas-actions'
 
 const complexProject = () => {
@@ -679,7 +676,7 @@ describe('Convert to absolute/escape hatch', () => {
     keyDown('Space')
 
     const currentStrategy = renderResult.getEditorState().strategyState.currentStrategy
-    expect(currentStrategy).toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
+    expect(currentStrategy).toEqual(ConvertToAbsoluteAndMoveStrategyID)
   })
 
   it('becomes the active strategy while space is pressed rather than ancestor metastrategy', async () => {
@@ -743,7 +740,7 @@ describe('Convert to absolute/escape hatch', () => {
     keyDown('Space')
 
     const currentStrategy = renderResult.getEditorState().strategyState.currentStrategy
-    expect(currentStrategy).toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
+    expect(currentStrategy).toEqual(ConvertToAbsoluteAndMoveStrategyID)
   })
   ;(['flex', 'flow'] as const).forEach((parentLayoutSystem) =>
     it(`DOES NOT BECOME the active strategy when dragging for multiselection across the hierarchy for ${parentLayoutSystem} parent`, async () => {
@@ -788,7 +785,7 @@ describe('Convert to absolute/escape hatch', () => {
 
       const midDragStrategy = renderResult.getEditorState().strategyState.currentStrategy
       expect(midDragStrategy).not.toBeNull()
-      expect(midDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
+      expect(midDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveStrategyID)
 
       // Now drag until we have passed the sibling bounds
       await mouseMoveToPoint(canvasControlsLayer, {
@@ -798,12 +795,12 @@ describe('Convert to absolute/escape hatch', () => {
 
       const endDragStrategy = renderResult.getEditorState().strategyState.currentStrategy
       expect(endDragStrategy).not.toBeNull()
-      expect(endDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
+      expect(endDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveStrategyID)
 
       // HOWEVER!!!! pressing space now makes the strategy active!!!!!!
       keyDown('Space')
       const keydownStrategy = renderResult.getEditorState().strategyState.currentStrategy
-      expect(keydownStrategy).toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
+      expect(keydownStrategy).toEqual(ConvertToAbsoluteAndMoveStrategyID)
     }),
   )
   ;(['flex', 'flow'] as const).forEach((parentLayoutSystem) =>
@@ -848,7 +845,7 @@ describe('Convert to absolute/escape hatch', () => {
 
       const midDragStrategy = renderResult.getEditorState().strategyState.currentStrategy
       expect(midDragStrategy).not.toBeNull()
-      expect(midDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
+      expect(midDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveStrategyID)
 
       // Now drag until we have passed the sibling bounds
       await mouseMoveToPoint(canvasControlsLayer, {
@@ -858,12 +855,12 @@ describe('Convert to absolute/escape hatch', () => {
 
       const endDragStrategy = renderResult.getEditorState().strategyState.currentStrategy
       expect(endDragStrategy).not.toBeNull()
-      expect(endDragStrategy).toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
+      expect(endDragStrategy).toEqual(ConvertToAbsoluteAndMoveStrategyID)
 
       // pressing space keeps the strategy active
       keyDown('Space')
       const keydownStrategy = renderResult.getEditorState().strategyState.currentStrategy
-      expect(keydownStrategy).toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
+      expect(keydownStrategy).toEqual(ConvertToAbsoluteAndMoveStrategyID)
     }),
   )
 
@@ -911,7 +908,7 @@ describe('Convert to absolute/escape hatch', () => {
 
         const midDragStrategy = renderResult.getEditorState().strategyState.currentStrategy
         expect(midDragStrategy).not.toBeNull()
-        expect(midDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
+        expect(midDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveStrategyID)
 
         // Now drag until we have passed the sibling bounds
         await mouseMoveToPoint(canvasControlsLayer, {
@@ -921,7 +918,7 @@ describe('Convert to absolute/escape hatch', () => {
 
         const endDragStrategy = renderResult.getEditorState().strategyState.currentStrategy
         expect(endDragStrategy).not.toBeNull()
-        expect(endDragStrategy).toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
+        expect(endDragStrategy).toEqual(ConvertToAbsoluteAndMoveStrategyID)
       })
     },
   )
@@ -973,7 +970,7 @@ describe('Convert to absolute/escape hatch', () => {
 
         const midDragStrategy = renderResult.getEditorState().strategyState.currentStrategy
         expect(midDragStrategy).not.toBeNull()
-        expect(midDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
+        expect(midDragStrategy).not.toEqual(ConvertToAbsoluteAndMoveStrategyID)
 
         // Now drag until we have passed the sibling bounds
         await mouseMoveToPoint(canvasControlsLayer, {
@@ -983,7 +980,7 @@ describe('Convert to absolute/escape hatch', () => {
 
         const endDragStrategy = renderResult.getEditorState().strategyState.currentStrategy
         expect(endDragStrategy).not.toBeNull()
-        expect(endDragStrategy).toEqual(ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID)
+        expect(endDragStrategy).toEqual(ConvertToAbsoluteAndMoveStrategyID)
 
         await mouseUpAtPoint(canvasControlsLayer, {
           x: elementBounds.x + 110,

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
@@ -42,7 +42,6 @@ import {
   pressKey,
 } from '../../event-helpers.test-utils'
 import { cmdModifier } from '../../../../utils/modifiers'
-import { ConvertToAbsoluteAndMoveStrategyID } from './convert-to-absolute-and-move-strategy'
 import type { FragmentLikeType } from './fragment-like-helpers'
 import {
   AllFragmentLikeNonDomElementTypes,
@@ -54,6 +53,7 @@ import {
   getOpeningFragmentLikeTag,
 } from './fragment-like-helpers.test-utils'
 import { selectComponentsForTest } from '../../../../utils/utils.test-utils'
+import { ConvertToAbsoluteAndMoveStrategyID } from './convert-to-absolute-and-move-strategy'
 
 const complexProject = () => {
   const code = `

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -138,6 +138,7 @@ function convertToAbsoluteAndMoveStrategyFactory(setHuggingParentToFixed: SetHug
       return null
     }
 
+    // When the parent is not hugging, don't offer the strategy which sets it to fixed size
     if (setHuggingParentToFixed === 'set-hugging-parent-to-fixed') {
       const setParentToFixedSizeCommands = createSetParentsToFixedSizeCommands(
         retargetedTargets,

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -101,8 +101,8 @@ function getBasicStrategyProperties(setHuggingParentToFixed: SetHuggingParentToF
     case 'set-hugging-parent-to-fixed':
       return {
         id: ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID,
-        name: 'Move (Abs + Set Hugging Parent Fixed)',
-        descriptiveLabel: 'Converting To Absolute And Moving (setting hugging parent to fixed)',
+        name: 'Move (Abs + Set Parent Fixed)',
+        descriptiveLabel: 'Converting To Absolute And Moving (setting parent to fixed)',
       }
     case 'dont-set-hugging-parent-to-fixed':
       return {
@@ -136,6 +136,19 @@ function convertToAbsoluteAndMoveStrategyFactory(setHuggingParentToFixed: SetHug
       })
     ) {
       return null
+    }
+
+    if (setHuggingParentToFixed === 'set-hugging-parent-to-fixed') {
+      const setParentToFixedSizeCommands = createSetParentsToFixedSizeCommands(
+        retargetedTargets,
+        canvasState.startingMetadata,
+        canvasState.startingElementPathTree,
+        canvasState.projectContents,
+      )
+
+      if (setParentToFixedSizeCommands.length === 0) {
+        return null
+      }
     }
 
     const autoLayoutSiblings = getAutoLayoutSiblings(
@@ -190,7 +203,7 @@ function convertToAbsoluteAndMoveStrategyFactory(setHuggingParentToFixed: SetHug
         ...autoLayoutSiblingsControl,
       ], // Uses existing hooks in select-mode-hooks.tsx
       fitness:
-        setHuggingParentToFixed === 'set-hugging-parent-to-fixed' ? baseFitness : baseFitness - 0.1, // by default we set the parent to fixed size
+        setHuggingParentToFixed === 'set-hugging-parent-to-fixed' ? baseFitness + 0.1 : baseFitness, // by default we set the parent to fixed size
       apply: () => {
         if (
           interactionSession != null &&

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -84,7 +84,7 @@ export type SetHuggingParentToFixed =
   | 'set-hugging-parent-to-fixed'
   | 'dont-set-hugging-parent-to-fixed'
 
-export const ConvertToAbsoluteAndMoveAndSetHuggingParentFixedStrategyID =
+export const ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID =
   'CONVERT_TO_ABSOLUTE_AND_MOVE_AND_SET_PARENT_FIXED_STRATEGY'
 export const ConvertToAbsoluteAndMoveStrategyID = 'CONVERT_TO_ABSOLUTE_AND_MOVE_STRATEGY'
 
@@ -99,7 +99,7 @@ function getBasicStrategyProperties(setHuggingParentToFixed: SetHuggingParentToF
   switch (setHuggingParentToFixed) {
     case 'set-hugging-parent-to-fixed':
       return {
-        id: ConvertToAbsoluteAndMoveAndSetHuggingParentFixedStrategyID,
+        id: ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID,
         name: 'Move (Abs + Set Hugging Parent Fixed)',
         descriptiveLabel: 'Converting To Absolute And Moving (setting hugging parent to fixed)',
       }

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -80,39 +80,41 @@ import { cssPixelLength } from '../../../inspector/common/css-utils'
 import type { ProjectContentTreeRoot } from '../../../assets'
 import { showToastCommand } from '../../commands/show-toast-command'
 
-type SetParentToFixed = 'set-parent-to-fixed' | 'dont-set-parent-to-fixed'
+export type SetHuggingParentToFixed =
+  | 'set-hugging-parent-to-fixed'
+  | 'dont-set-hugging-parent-to-fixed'
 
-export const ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID =
+export const ConvertToAbsoluteAndMoveAndSetHuggingParentFixedStrategyID =
   'CONVERT_TO_ABSOLUTE_AND_MOVE_AND_SET_PARENT_FIXED_STRATEGY'
 export const ConvertToAbsoluteAndMoveStrategyID = 'CONVERT_TO_ABSOLUTE_AND_MOVE_STRATEGY'
 
 export const convertToAbsoluteAndMoveStrategy = convertToAbsoluteAndMoveStrategyFactory(
-  'dont-set-parent-to-fixed',
+  'dont-set-hugging-parent-to-fixed',
 )
 
 export const convertToAbsoluteAndMoveAndSetParentFixedStrategy =
-  convertToAbsoluteAndMoveStrategyFactory('set-parent-to-fixed')
+  convertToAbsoluteAndMoveStrategyFactory('set-hugging-parent-to-fixed')
 
-function getBasicStrategyProperties(setParentToFixed: SetParentToFixed) {
-  switch (setParentToFixed) {
-    case 'set-parent-to-fixed':
+function getBasicStrategyProperties(setHuggingParentToFixed: SetHuggingParentToFixed) {
+  switch (setHuggingParentToFixed) {
+    case 'set-hugging-parent-to-fixed':
       return {
-        id: ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID,
-        name: 'Move (Abs + Set Parent Fixed)',
-        descriptiveLabel: 'Converting To Absolute And Moving (setting parent to fixed)',
+        id: ConvertToAbsoluteAndMoveAndSetHuggingParentFixedStrategyID,
+        name: 'Move (Abs + Set Hugging Parent Fixed)',
+        descriptiveLabel: 'Converting To Absolute And Moving (setting hugging parent to fixed)',
       }
-    case 'dont-set-parent-to-fixed':
+    case 'dont-set-hugging-parent-to-fixed':
       return {
         id: ConvertToAbsoluteAndMoveStrategyID,
         name: 'Move (Abs)',
         descriptiveLabel: 'Converting To Absolute And Moving',
       }
     default:
-      assertNever(setParentToFixed)
+      assertNever(setHuggingParentToFixed)
   }
 }
 
-function convertToAbsoluteAndMoveStrategyFactory(setParentToFixed: SetParentToFixed) {
+function convertToAbsoluteAndMoveStrategyFactory(setHuggingParentToFixed: SetHuggingParentToFixed) {
   return (
     canvasState: InteractionCanvasState,
     interactionSession: InteractionSession | null,
@@ -166,7 +168,7 @@ function convertToAbsoluteAndMoveStrategyFactory(setParentToFixed: SetParentToFi
     )
 
     return {
-      ...getBasicStrategyProperties(setParentToFixed),
+      ...getBasicStrategyProperties(setHuggingParentToFixed),
       icon: {
         category: 'modalities',
         type: 'moveabs-large',
@@ -186,7 +188,8 @@ function convertToAbsoluteAndMoveStrategyFactory(setParentToFixed: SetParentToFi
         }),
         ...autoLayoutSiblingsControl,
       ], // Uses existing hooks in select-mode-hooks.tsx
-      fitness: setParentToFixed === 'set-parent-to-fixed' ? baseFitness : baseFitness - 0.1,
+      fitness:
+        setHuggingParentToFixed === 'set-hugging-parent-to-fixed' ? baseFitness : baseFitness - 0.1, // by default we set the parent to fixed size
       apply: () => {
         if (
           interactionSession != null &&
@@ -204,7 +207,7 @@ function convertToAbsoluteAndMoveStrategyFactory(setParentToFixed: SetParentToFi
               canvasState.startingMetadata,
               canvasState,
               snappedDragVector,
-              setParentToFixed,
+              setHuggingParentToFixed,
             )
           }
           const absoluteMoveApplyResult = applyMoveCommon(
@@ -322,7 +325,7 @@ export function getEscapeHatchCommands(
   metadata: ElementInstanceMetadataMap,
   canvasState: InteractionCanvasState,
   dragDelta: CanvasVector | null,
-  setParentToFixed: SetParentToFixed,
+  setHuggingParentToFixed: SetHuggingParentToFixed,
 ): {
   commands: Array<CanvasCommand>
   intendedBounds: Array<CanvasFrameAndTarget>
@@ -349,7 +352,7 @@ export function getEscapeHatchCommands(
   )
 
   const setParentsToFixedSizeCommands =
-    setParentToFixed === 'set-parent-to-fixed'
+    setHuggingParentToFixed === 'set-hugging-parent-to-fixed'
       ? createSetParentsToFixedSizeCommands(
           elementsToConvertToAbsolute,
           metadata,
@@ -706,7 +709,7 @@ function createSetParentsToFixedSizeCommands(
         return []
       }
 
-      const setWidthCommands = isCollapsingParent(parentElement, 'width')
+      const setWidthCommands = isHuggingParent(parentElement, 'width')
         ? [
             setCssLengthProperty(
               'always',
@@ -717,7 +720,7 @@ function createSetParentsToFixedSizeCommands(
             ),
           ]
         : []
-      const setHeightCommands = isCollapsingParent(parentElement, 'width')
+      const setHeightCommands = isHuggingParent(parentElement, 'width')
         ? [
             setCssLengthProperty(
               'always',
@@ -743,13 +746,13 @@ function createSetParentsToFixedSizeCommands(
   return []
 }
 
-const CollapsingWidthHeightValues = ['max-content', 'min-content', 'fit-content', 'auto']
+const HuggingWidthHeightValues = ['max-content', 'min-content', 'fit-content', 'auto']
 
-function isCollapsingParent(element: JSXElement, property: 'width' | 'height') {
+function isHuggingParent(element: JSXElement, property: 'width' | 'height') {
   const simpleAttribute = defaultEither(
     null,
     getSimpleAttributeAtPath(right(element.props), PP.create('style', property)),
   )
 
-  return simpleAttribute == null || CollapsingWidthHeightValues.includes(simpleAttribute)
+  return simpleAttribute == null || HuggingWidthHeightValues.includes(simpleAttribute)
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
@@ -97,6 +97,7 @@ export function baseFlexReparentToAbsoluteStrategy(
               canvasState.startingMetadata,
               canvasState,
               canvasPoint({ x: 0, y: 0 }),
+              'dont-set-parent-to-fixed',
             ).commands
 
             return strategyApplicationResult(

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
@@ -97,7 +97,7 @@ export function baseFlexReparentToAbsoluteStrategy(
               canvasState.startingMetadata,
               canvasState,
               canvasPoint({ x: 0, y: 0 }),
-              'dont-set-parent-to-fixed',
+              'dont-set-hugging-parent-to-fixed',
             ).commands
 
             return strategyApplicationResult(

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -472,7 +472,10 @@ export const escapeHatch: ContextMenuItem<CanvasData> = {
   },
   action: (data, dispatch?: EditorDispatch) => {
     if (data.selectedViews.length > 0) {
-      requireDispatch(dispatch)([EditorActions.runEscapeHatch(data.selectedViews)], 'everyone')
+      requireDispatch(dispatch)(
+        [EditorActions.runEscapeHatch(data.selectedViews, 'set-hugging-parent-to-fixed')],
+        'everyone',
+      )
     }
   },
 }

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -76,6 +76,7 @@ import { ElementPathTrees } from '../../core/shared/element-path-tree'
 import type { PostActionChoice } from '../canvas/canvas-strategies/post-action-options/post-action-options'
 import type { FromVSCodeAction } from './actions/actions-from-vscode'
 import type { ProjectServerState } from './store/project-server-state'
+import type { SetHuggingParentToFixed } from '../canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy'
 export { isLoggedIn, loggedInUser, notLoggedIn } from '../../common/user'
 export type { LoginState, UserDetails } from '../../common/user'
 
@@ -997,6 +998,7 @@ export interface ForceParseFile {
 export interface RunEscapeHatch {
   action: 'RUN_ESCAPE_HATCH'
   targets: Array<ElementPath>
+  setHuggingParentToFixed: SetHuggingParentToFixed
 }
 
 export interface SetElementsToRerender {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -249,6 +249,7 @@ import type { TextProp } from '../../text-editor/text-editor'
 import { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import type { PostActionChoice } from '../../canvas/canvas-strategies/post-action-options/post-action-options'
 import type { ProjectServerState } from '../store/project-server-state'
+import type { SetHuggingParentToFixed } from '../../canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy'
 
 export function clearSelection(): EditorAction {
   return {
@@ -1550,10 +1551,14 @@ export function forceParseFile(filePath: string): ForceParseFile {
   }
 }
 
-export function runEscapeHatch(targets: Array<ElementPath>): RunEscapeHatch {
+export function runEscapeHatch(
+  targets: Array<ElementPath>,
+  setHuggingParentToFixed: SetHuggingParentToFixed,
+): RunEscapeHatch {
   return {
     action: 'RUN_ESCAPE_HATCH',
     targets: targets,
+    setHuggingParentToFixed: setHuggingParentToFixed,
   }
 }
 

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -5057,6 +5057,7 @@ export const UPDATE_FNS = {
         editor.jsxMetadata,
         canvasState,
         null,
+        'set-parent-to-fixed',
       ).commands
       return foldAndApplyCommandsSimple(editor, commands)
     } else {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -5057,7 +5057,7 @@ export const UPDATE_FNS = {
         editor.jsxMetadata,
         canvasState,
         null,
-        'set-parent-to-fixed',
+        action.setHuggingParentToFixed,
       ).commands
       return foldAndApplyCommandsSimple(editor, commands)
     } else {

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -27,7 +27,7 @@ import {
   useInitialSizeSectionState,
 } from '../flex-element-subsection/flex-element-subsection'
 import { GiganticSizePinsSubsection } from './gigantic-size-pins-subsection'
-import { runEscapeHatch, selectComponents } from '../../../../editor/actions/action-creators'
+import { selectComponents } from '../../../../editor/actions/action-creators'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import { unless, when } from '../../../../../utils/react-conditionals'
 import {


### PR DESCRIPTION
**Problem:**
This is a followup PR to https://github.com/concrete-utopia/utopia/pull/4318/
The goal was to make it optional to set the size of a hugging parent to fixed.

**Fix:**
- I modified the convertToAbsoluteAndMove strategy, now it is a factory function of two different strategies: one which sets the hugging parent size to fixed and one which does not do that.
- I also added an extra parameter to the RUN_ESCAPE_HATCH strategy, so now there are two ways to invoke it.
- The fitness of the strategy which sets the hugging parent to fixed size is a little larger than the fitness of the other one, so setting the hugging parent to fixed size is still the default behavior. However, the user can manually choose the other strategy if necessary.
- As an extra I removed some redundant code and replaced the custom size fixing code with a call to `sizeToVisualDimensions`