### PR TITLE
Check whether any actions introduced duplicate uids in `asyncTestDisaptch`

### DIFF
--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -367,6 +367,8 @@ export async function renderTestEditorWithModel(
       )
     }
 
+    expectNoActionsCausedDuplicateUids(actionsCausingDuplicateUIDs)
+
     editorDispatchPromises.push(result.entireUpdateFinished)
     invalidateDomWalkerIfNecessary(
       domWalkerMutableState,
@@ -693,6 +695,12 @@ function expectUpdatedFilesUpdateTimestamp(
       }
     })
   }
+}
+
+function expectNoActionsCausedDuplicateUids(
+  actionsCausingDuplicateUIDs: ActionsCausingDuplicateUIDs,
+) {
+  expect(actionsCausingDuplicateUIDs).toHaveLength(0)
 }
 
 export function getPrintedUiJsCode(

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -953,6 +953,6 @@ describe('only update metadata on SAVE_DOM_REPORT', () => {
       ],
     )
 
-    expect.assertions(6) // this ensures that the test fails if the expects inside the apply function are not called
+    expect.assertions(16) // this ensures that the test fails if the expects inside the apply function are not called
   })
 })


### PR DESCRIPTION
## Description
This PR adds a check in `asyncTestDispatch` that makes sure that no action introduces duplicate uids into projectContents