### PR TITLE
Inspector Label Colors

### DIFF
--- a/editor/src/components/inspector/common/control-styles.ts
+++ b/editor/src/components/inspector/common/control-styles.ts
@@ -84,6 +84,11 @@ const controlStylesByStatus: { [key: string]: ControlStyles } = mapArrayToDictio
       case 'detected':
       case 'multiselect-detected':
       case 'unset':
+        set = false
+        unsettable = false
+        mainColor = 'var(--control-styles-interactive-unset-secondary-color)'
+        secondaryColor = 'var(--control-styles-interactive-unset-secondary-color)'
+        break
       case 'multiselect-identical-unset':
         set = false
         unsettable = false

--- a/editor/src/components/inspector/widgets/property-label.tsx
+++ b/editor/src/components/inspector/widgets/property-label.tsx
@@ -7,6 +7,7 @@ import * as PP from '../../../core/shared/property-path'
 import { optionalAddOnUnsetValues } from '../common/context-menu-items'
 import { useInspectorInfoSimpleUntyped } from '../common/property-path-hooks'
 import type { ControlStyles } from '../common/control-styles'
+import { useColorTheme } from '../../../uuiui'
 
 type PropertyLabelProps = {
   target: ReadonlyArray<PropertyPath>
@@ -25,6 +26,7 @@ function useMetadataInfoForDomain(target: ReadonlyArray<PropertyPath>) {
 }
 
 export const PropertyLabel = React.memo((props: PropertyLabelProps) => {
+  const colorTheme = useColorTheme()
   const metadata = useMetadataInfoForDomain(props.target)
   const propsToUnset = props.propNamesToUnset ?? props.target.map(PP.lastPart)
   const contextMenuItems = optionalAddOnUnsetValues(
@@ -44,7 +46,7 @@ export const PropertyLabel = React.memo((props: PropertyLabelProps) => {
         overflowX: 'scroll',
         whiteSpace: 'nowrap',
         textOverflow: 'ellipsis',
-        color: controlStyles.mainColor,
+        color: colorTheme.fg1.value,
       }}
     >
       {props.children}

--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -715,7 +715,7 @@ export const NumberInput = React.memo<NumberInputProps>(
                   fontSize: '9px',
                   width: '100%',
                   height: '100%',
-                  color: controlStyles.secondaryColor,
+                  color: colorTheme.fg7.value,
                 }}
               >
                 {typeof labelInner === 'object' && 'type' in labelInner ? (


### PR DESCRIPTION
### Problem
The inspector property labels were hard to read if they were unset. Which makes it less enticing _to_ set them!
Also, there are too many different grays in the inspector in general.

Before:
<img width="262" alt="Screenshot 2023-10-11 at 11 47 33 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/5531359b-9b14-4ed5-a629-8e47cf1a3c0d">

### Solution
LABELS for not-yet-applied fields now _always_ use the regular text color, not the unset one. 
(With the exception of innerLabels, which are now _always_ grey)

The VALUE of the property is what changes depending on if it is set or not. 
It will be the main color if it is, greyed out if it is not. 

After:
<img width="269" alt="Screenshot 2023-10-11 at 11 45 47 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/664835fc-7b45-4059-b083-8b14c0e951a3">



