### PR TITLE
Absolute reparent snapping

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
@@ -1221,62 +1221,6 @@ export var ${BakedInStoryboardVariableName} = (props) => {
       )
     })
   })
-  // TODO reenable this after conditionals work well with reparent
-  xit('renders correctly with ChildrenHider set to hide children', async () => {
-    const renderResult = await renderTestEditorWithCode(
-      getChildrenHiderProjectCode(true),
-      'await-first-dom-report',
-    )
-
-    const dragDelta = windowPoint({ x: 0, y: -150 })
-    await dragElement(
-      renderResult,
-      'child-to-reparent',
-      dragDelta,
-      cmdModifier,
-      {
-        cursor: CSSCursor.NotPermitted,
-      },
-      null,
-    )
-
-    await renderResult.getDispatchFollowUpActionsFinished()
-
-    expect(Object.keys(renderResult.getEditorState().editor.spyMetadata)).toEqual([
-      'utopia-storyboard-uid',
-      'utopia-storyboard-uid/scene-aaa',
-      'utopia-storyboard-uid/scene-aaa/outer-div',
-      'utopia-storyboard-uid/scene-aaa/outer-div/children-hider',
-    ])
-  })
-  xit('renders correctly with ChildrenHider set to show children', async () => {
-    const renderResult = await renderTestEditorWithCode(
-      getChildrenHiderProjectCode(false),
-      'await-first-dom-report',
-    )
-
-    const dragDelta = windowPoint({ x: 0, y: -150 })
-    await dragElement(
-      renderResult,
-      'child-to-reparent',
-      dragDelta,
-      cmdModifier,
-      {
-        cursor: CSSCursor.Move,
-      },
-      null,
-    )
-
-    await renderResult.getDispatchFollowUpActionsFinished()
-
-    expect(Object.keys(renderResult.getEditorState().editor.spyMetadata)).toEqual([
-      'utopia-storyboard-uid',
-      'utopia-storyboard-uid/scene-aaa',
-      'utopia-storyboard-uid/scene-aaa/outer-div',
-      'utopia-storyboard-uid/scene-aaa/outer-div/children-hider',
-      'utopia-storyboard-uid/scene-aaa/outer-div/children-hider/child-to-reparent',
-    ])
-  })
 
   describe('fragment-like reparent tests', () => {
     AllFragmentLikeTypes.forEach((type) => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
@@ -129,15 +129,14 @@ export function applyMoveCommon(
     } else {
       const constrainedDragAxis =
         shiftKeyPressed && drag != null ? determineConstrainedDragAxis(drag) : null
-
-      const targetsForSnapping = targets.map(
+      const targetsForSnapping = originalTargets.map(
         (path) => interactionSession.updatedTargetPaths[EP.toString(path)] ?? path,
       )
       const snapTargets: ElementPath[] = gatherParentAndSiblingTargets(
         canvasState.startingMetadata,
         canvasState.startingAllElementProps,
         canvasState.startingElementPathTree,
-        originalTargets,
+        targetsForSnapping,
       )
       const moveGuidelines = collectParentAndSiblingGuidelines(
         snapTargets,


### PR DESCRIPTION
## Problem
When reparenting an element into an absolute container, the element doesn't snap to its new parent or siblings.

## FIx
Re-apply the fix implemented in https://github.com/concrete-utopia/utopia/pull/2512, and add tests