### PR TITLE
Snap on convert to absolute

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
@@ -632,7 +632,7 @@ describe('Convert to Absolute', () => {
       getCodeForTestProject(childTagAfter),
     )
   })
-  it('snaps to parent after being converted', async () => {
+  it('snaps to parent and sibling after being converted', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`<div
     style={{

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
@@ -632,6 +632,59 @@ describe('Convert to Absolute', () => {
       getCodeForTestProject(childTagAfter),
     )
   })
+  it('snaps to parent after being converted', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`<div
+    style={{
+      backgroundColor: '#aaaaaa33',
+      position: 'absolute',
+      left: 20,
+      top: 26,
+      width: 150,
+      height: 150,
+    }}
+    data-uid='container'
+  >
+    <div
+      style={{
+        backgroundColor: '#0075ff',
+        width: 50,
+        height: 50,
+        contain: 'layout',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+      }}
+      data-uid='child'
+      data-testid='child'
+    />
+  </div>`),
+      'await-first-dom-report',
+    )
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+    const element = renderResult.renderedDOM.getByTestId('child')
+    const elementBounds = element.getBoundingClientRect()
+
+    await mouseDownAtPoint(
+      canvasControlsLayer,
+      {
+        x: elementBounds.x + elementBounds.width / 2,
+        y: elementBounds.y + elementBounds.width / 2,
+      },
+      { modifiers: cmdModifier },
+    )
+
+    await mouseMoveToPoint(canvasControlsLayer, {
+      x: elementBounds.x + elementBounds.width / 2 + 50,
+      y: elementBounds.y + elementBounds.width / 2 + 50,
+    })
+
+    const activeStrategy = renderResult.getEditorState().strategyState.currentStrategy
+    expect(activeStrategy).not.toBeNull()
+    expect(activeStrategy).not.toEqual(ConvertToAbsoluteAndMoveStrategyID)
+    expect(renderResult.getEditorState().editor.canvas.controls.snappingGuidelines).toHaveLength(2)
+  })
 })
 
 describe('Convert to absolute/escape hatch', () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.browser2.tsx
@@ -658,6 +658,17 @@ describe('Convert to Absolute', () => {
       data-uid='child'
       data-testid='child'
     />
+    <div
+      style={{
+        backgroundColor: '#0075ff',
+        width: 50,
+        height: 65,
+        contain: 'layout',
+        position: 'absolute',
+        left: 100,
+        top: 86,
+      }}
+    />
   </div>`),
       'await-first-dom-report',
     )
@@ -675,15 +686,35 @@ describe('Convert to Absolute', () => {
       { modifiers: cmdModifier },
     )
 
+    // move so that the bottom right corner snaps to the center of the parent
     await mouseMoveToPoint(canvasControlsLayer, {
-      x: elementBounds.x + elementBounds.width / 2 + 50,
-      y: elementBounds.y + elementBounds.width / 2 + 50,
+      x: elementBounds.x + elementBounds.width / 2 + 25,
+      y: elementBounds.y + elementBounds.width / 2 + 25,
     })
 
-    const activeStrategy = renderResult.getEditorState().strategyState.currentStrategy
-    expect(activeStrategy).not.toBeNull()
-    expect(activeStrategy).not.toEqual(ConvertToAbsoluteAndMoveStrategyID)
-    expect(renderResult.getEditorState().editor.canvas.controls.snappingGuidelines).toHaveLength(2)
+    {
+      const activeStrategy = renderResult.getEditorState().strategyState.currentStrategy
+      expect(activeStrategy).not.toBeNull()
+      expect(activeStrategy).not.toEqual(ConvertToAbsoluteAndMoveStrategyID)
+      expect(renderResult.getEditorState().editor.canvas.controls.snappingGuidelines).toHaveLength(
+        2,
+      )
+    }
+
+    // move so that the bottom edge snaps to the top edge of the sibling
+    await mouseMoveToPoint(canvasControlsLayer, {
+      x: elementBounds.x + elementBounds.width / 2 + 5,
+      y: elementBounds.y + elementBounds.width / 2 + 35,
+    })
+
+    {
+      const activeStrategy = renderResult.getEditorState().strategyState.currentStrategy
+      expect(activeStrategy).not.toBeNull()
+      expect(activeStrategy).not.toEqual(ConvertToAbsoluteAndMoveStrategyID)
+      expect(renderResult.getEditorState().editor.canvas.controls.snappingGuidelines).toHaveLength(
+        1,
+      )
+    }
   })
 })
 

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -903,9 +903,6 @@ export function collectGuidelines(
 
   // For any images create guidelines at the current multiplier setting.
   if (resizingFromPosition != null) {
-    // TODO: images?
-    // TODO: selected views?
-    // TODO: repeating the `isLayoutedByFlowAndNotAbsolutePositioned` check?
     Utils.fastForEach(selectedViews, (selectedView) => {
       if (MetadataUtils.isLayoutedByFlowAndNotAbsolutePositioned(metadata, selectedView)) {
         return

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -904,7 +904,7 @@ export function collectGuidelines(
   // For any images create guidelines at the current multiplier setting.
   if (resizingFromPosition != null) {
     Utils.fastForEach(selectedViews, (selectedView) => {
-      if (MetadataUtils.isPinnedAndNotAbsolutePositioned(metadata, selectedView)) {
+      if (MetadataUtils.isLayoutedByFlowAndNotAbsolutePositioned(metadata, selectedView)) {
         return
       }
 
@@ -1218,7 +1218,7 @@ export function snapPoint(
   guidelinesWithSnappingVector: Array<GuidelineWithSnappingVectorAndPointsOfRelevance>
 } {
   const anythingPinnedAndNotAbsolutePositioned = selectedViews.some((elementToTarget) => {
-    return MetadataUtils.isPinnedAndNotAbsolutePositioned(jsxMetadata, elementToTarget)
+    return MetadataUtils.isLayoutedByFlowAndNotAbsolutePositioned(jsxMetadata, elementToTarget)
   })
 
   const anyElementFragmentLike = selectedViews.some((elementPath) =>

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -903,6 +903,9 @@ export function collectGuidelines(
 
   // For any images create guidelines at the current multiplier setting.
   if (resizingFromPosition != null) {
+    // TODO: images?
+    // TODO: selected views?
+    // TODO: repeating the `isLayoutedByFlowAndNotAbsolutePositioned` check?
     Utils.fastForEach(selectedViews, (selectedView) => {
       if (MetadataUtils.isLayoutedByFlowAndNotAbsolutePositioned(metadata, selectedView)) {
         return

--- a/editor/src/components/canvas/controls/guideline-helpers.ts
+++ b/editor/src/components/canvas/controls/guideline-helpers.ts
@@ -67,29 +67,11 @@ export function gatherParentAndSiblingTargets(
   pathTrees: ElementPathTrees,
   targets: Array<ElementPath>,
 ) {
-  return targets.flatMap((target) => {
-    const pinnedAndNotAbsolutePositioned = MetadataUtils.isPinnedAndNotAbsolutePositioned(
-      componentMetadata,
-      target,
-    )
-
-    const isElementFragmentLike = treatElementAsFragmentLike(
-      componentMetadata,
-      allElementProps,
-      pathTrees,
-      target,
-    )
-
-    if (isElementFragmentLike || !pinnedAndNotAbsolutePositioned) {
-      return getSnapTargetsForElementPath(
-        componentMetadata,
-        allElementProps,
-        pathTrees,
-        target,
-      ).filter((snapTarget) => targets.every((t) => !EP.pathsEqual(snapTarget, t)))
-    }
-    return []
-  })
+  return targets.flatMap((target) =>
+    getSnapTargetsForElementPath(componentMetadata, allElementProps, pathTrees, target).filter(
+      (snapTarget) => targets.every((t) => !EP.pathsEqual(snapTarget, t)),
+    ),
+  )
 }
 
 export function collectParentAndSiblingGuidelines(

--- a/editor/src/core/model/element-metadata-utils.spec.tsx
+++ b/editor/src/core/model/element-metadata-utils.spec.tsx
@@ -801,7 +801,7 @@ describe('isPinnedAndNotAbsolutePositioned', () => {
       },
     }
     expect(
-      MetadataUtils.isPinnedAndNotAbsolutePositioned(
+      MetadataUtils.isLayoutedByFlowAndNotAbsolutePositioned(
         elementMapForTest,
         EP.elementPath([[BakedInStoryboardUID, TestScenePath], ['View']]),
       ),
@@ -819,7 +819,7 @@ describe('isPinnedAndNotAbsolutePositioned', () => {
       },
     }
     expect(
-      MetadataUtils.isPinnedAndNotAbsolutePositioned(
+      MetadataUtils.isLayoutedByFlowAndNotAbsolutePositioned(
         elementMapForTest,
         EP.elementPath([[BakedInStoryboardUID, TestScenePath], ['View']]),
       ),
@@ -837,7 +837,7 @@ describe('isPinnedAndNotAbsolutePositioned', () => {
       },
     }
     expect(
-      MetadataUtils.isPinnedAndNotAbsolutePositioned(
+      MetadataUtils.isLayoutedByFlowAndNotAbsolutePositioned(
         elementMapForTest,
         EP.elementPath([[BakedInStoryboardUID, TestScenePath], ['View']]),
       ),
@@ -855,7 +855,7 @@ describe('isPinnedAndNotAbsolutePositioned', () => {
       },
     }
     expect(
-      MetadataUtils.isPinnedAndNotAbsolutePositioned(
+      MetadataUtils.isLayoutedByFlowAndNotAbsolutePositioned(
         elementMapForTest,
         EP.elementPath([[BakedInStoryboardUID, TestScenePath], ['View']]),
       ),

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1830,11 +1830,10 @@ export const MetadataUtils = {
     const elementName = MetadataUtils.getStaticElementName(path, rootElements)
     return elementName != null && !isIntrinsicHTMLElement(elementName)
   },
-  isPinnedAndNotAbsolutePositioned(
+  isLayoutedByFlowAndNotAbsolutePositioned(
     metadata: ElementInstanceMetadataMap,
     view: ElementPath,
   ): boolean {
-    // Disable snapping and guidelines for pinned elements marked with relative positioning:
     const elementMetadata = MetadataUtils.findElementByElementPath(metadata, view)
     return (
       elementMetadata != null &&


### PR DESCRIPTION
## Problem
Elements that use the convert to absolute and move strategy don't snap to their parent or siblings.

## Fix
Remove the `isLayoutedByFlowAndNotAbsolutePositioned` from `gatherParentAndSiblingTargets`. Since `gatherParentAndSiblingTargets` is called from the strategy, we're already certain that we want to generate snap lines for those elements, so there's no need for `gatherParentAndSiblingTargets` to filter out some of them heuristically.