### PR TITLE
More sophisticated flex conversion for containers with a single text child

### DIFF
--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
@@ -1632,8 +1632,8 @@ describe('Smart convert to flex centered layout', () => {
         style={{
           wordBreak: 'break-word',
           fontSize: 15,
-          width: 126,
-          height: 17,
+          width: 'max-content',
+          height: 'max-content',
         }}
         data-testid='text'
         data-uid='text'

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
@@ -1570,6 +1570,80 @@ describe('Smart Convert To Flex if Fragment Children', () => {
   })
 })
 
+describe('Smart convert to flex centered layout', () => {
+  it('adds centered layout to a single span child', async () => {
+    const editor = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 334,
+          top: -215,
+          width: 165,
+          height: 122,
+        }}
+        data-uid='a'
+      >
+        <span
+          style={{
+            position: 'absolute',
+            wordBreak: 'break-word',
+            left: 51,
+            top: 73,
+            width: 'max-content',
+            height: 'max-content',
+          }}
+          data-testid='text'
+          data-uid='text'
+        >
+          This will be centered
+        </span>
+      </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    const targetPath = EP.appendNewElementPath(TestScenePath, ['a'])
+    await editor.dispatch([selectComponents([targetPath], false)], true)
+
+    await expectSingleUndo2Saves(editor, () => pressShiftA(editor))
+
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+    <div
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        left: 334,
+        top: -215,
+        width: 'max-content',
+        height: 'max-content',
+        display: 'flex',
+        flexDirection: 'row',
+        padding: '30.5px 0',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+      data-uid='a'
+    >
+      <span
+        style={{
+          wordBreak: 'break-word',
+          width: 135,
+          height: 18.5,
+        }}
+        data-testid='text'
+        data-uid='text'
+      >
+        This will be centered
+      </span>
+    </div>
+    `),
+    )
+  })
+})
+
 function renderProjectWith(input: { parent: LTWH; children: Array<LTWH> }) {
   const [parentL, parentT, parentW, parentH] = input.parent
   return renderTestEditorWithCode(

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
@@ -1591,6 +1591,7 @@ describe('Smart convert to flex centered layout', () => {
             wordBreak: 'break-word',
             left: 51,
             top: 73,
+            fontSize: 15,
             width: 'max-content',
             height: 'max-content',
           }}
@@ -1621,7 +1622,7 @@ describe('Smart convert to flex centered layout', () => {
         height: 'max-content',
         display: 'flex',
         flexDirection: 'row',
-        padding: '30.5px 0',
+        padding: '32px 0',
         alignItems: 'center',
         justifyContent: 'center',
       }}
@@ -1630,8 +1631,9 @@ describe('Smart convert to flex centered layout', () => {
       <span
         style={{
           wordBreak: 'break-word',
-          width: 135,
-          height: 18.5,
+          fontSize: 15,
+          width: 126,
+          height: 17,
         }}
         data-testid='text'
         data-uid='text'

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
@@ -98,6 +98,8 @@ export function convertLayoutToFlexCommands(
       ? [
           setProperty('always', path, PP.create('style', 'alignItems'), 'center'),
           setProperty('always', path, PP.create('style', 'justifyContent'), 'center'),
+          setHugContentForAxis('horizontal', childrenPaths[0], parentFlexDirection),
+          setHugContentForAxis('vertical', childrenPaths[0], parentFlexDirection),
         ]
       : []
 

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
@@ -97,7 +97,7 @@ export function convertLayoutToFlexCommands(
     const optionalCenterAlignCommands = onlyChildIsSpan(metadata, childrenPaths)
       ? [
           setProperty('always', path, PP.create('style', 'alignItems'), 'center'),
-          setProperty('always', path, PP.create('style', 'justifyContents'), 'center'),
+          setProperty('always', path, PP.create('style', 'justifyContent'), 'center'),
         ]
       : []
 

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -322,11 +322,26 @@ export function widthHeightFromAxis(axis: Axis): 'width' | 'height' {
 export function childIs100PercentSizedInEitherDirection(
   metadataMap: ElementInstanceMetadataMap,
   elementPath: ElementPath,
-): [childHorizontal100: boolean, childVertical100: boolean] {
-  return [
-    childIs100PercentSizedInDirection(metadataMap, elementPath, 'row'),
-    childIs100PercentSizedInDirection(metadataMap, elementPath, 'column'),
-  ]
+): { childWidth100Percent: boolean; childHeight100Percent: boolean } {
+  return {
+    childWidth100Percent: childIs100PercentSizedInDirection(metadataMap, elementPath, 'row'),
+    childHeight100Percent: childIs100PercentSizedInDirection(metadataMap, elementPath, 'column'),
+  }
+}
+
+export function onlyChildIsSpan(
+  metadataMap: ElementInstanceMetadataMap,
+  childrenPaths: ElementPath[],
+): boolean {
+  if (childrenPaths.length !== 0) {
+    return false
+  }
+  return (
+    optionalMap(
+      (i) => MetadataUtils.isSpan(i),
+      MetadataUtils.findElementByElementPath(metadataMap, childrenPaths[0]),
+    ) ?? false
+  )
 }
 
 function childIs100PercentSizedInDirection(

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -333,7 +333,7 @@ export function onlyChildIsSpan(
   metadataMap: ElementInstanceMetadataMap,
   childrenPaths: ElementPath[],
 ): boolean {
-  if (childrenPaths.length !== 0) {
+  if (childrenPaths.length !== 1) {
     return false
   }
   return (


### PR DESCRIPTION
https://screenshot.click/17-43-rylpy-esrzl.mp4

## Problem
When flex layout is added to a container, and the container only has a single text child, we should center align that text so that it stays centered when the container is resized.

## Fix
Add the behaviour described above to the convert to flex strategy