### PR TITLE
Play mode can be turned off with any top level toolbar button.

### DIFF
--- a/editor/src/components/editor/canvas-toolbar.spec.browser2.tsx
+++ b/editor/src/components/editor/canvas-toolbar.spec.browser2.tsx
@@ -31,9 +31,11 @@ import {
   renderTestEditorWithModel,
 } from '../canvas/ui-jsx.test-utils'
 import {
+  CanvasToolbarEditButtonID,
   CanvasToolbarSearchTestID,
   InsertConditionalButtonTestId,
   InsertMenuButtonTestId,
+  PlayModeButtonTestId,
 } from './canvas-toolbar'
 import { StoryboardFilePath, PlaygroundFilePath, navigatorEntryToKey } from './store/editor-state'
 
@@ -44,6 +46,36 @@ function slightlyOffsetWindowPointBecauseVeryWeirdIssue(point: { x: number; y: n
 }
 
 describe('canvas toolbar', () => {
+  it('can toggle play mode off by pressing edit button', async () => {
+    const editor = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`<div
+    style={{
+      backgroundColor: '#aaaaaa33',
+      position: 'absolute',
+      left: 57,
+      top: 168,
+      width: 247,
+      height: 402,
+    }}
+    data-uid='container'
+  >
+    <div data-uid='a3d' />
+  </div>`),
+      'await-first-dom-report',
+    )
+    expect(editor.getEditorState().editor.mode.type).toEqual('select')
+
+    const playButton = editor.renderedDOM.getByTestId(PlayModeButtonTestId)
+    const playButtonCenter = getDomRectCenter(playButton.getBoundingClientRect())
+    await mouseClickAtPoint(playButton, playButtonCenter)
+    expect(editor.getEditorState().editor.mode.type).toEqual('live')
+
+    const editButton = editor.renderedDOM.getByTestId(CanvasToolbarEditButtonID)
+    const editButtonCenter = getDomRectCenter(editButton.getBoundingClientRect())
+    await mouseClickAtPoint(editButton, editButtonCenter)
+    expect(editor.getEditorState().editor.mode.type).toEqual('select')
+  })
+
   it('can insert conditionals via the canvas toolbar', async () => {
     const editor = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -69,6 +69,7 @@ import {
 } from '../canvas/ui/floating-insert-menu'
 
 export const InsertMenuButtonTestId = 'insert-menu-button'
+export const PlayModeButtonTestId = 'canvas-toolbar-play-mode'
 export const InsertConditionalButtonTestId = 'insert-mode-conditional'
 export const CanvasToolbarId = 'canvas-toolbar'
 
@@ -520,6 +521,7 @@ export const CanvasToolbar = React.memo(() => {
               iconCategory={editButtonIcon.category}
               primary={canvasToolbarMode.primary === 'edit'}
               onClick={dispatchSwitchToSelectModeCloseMenus}
+              keepActiveInLiveMode
               testid={CanvasToolbarEditButtonID}
               style={{ width: 36 }}
             />
@@ -530,6 +532,7 @@ export const CanvasToolbar = React.memo(() => {
               iconCategory='tools'
               primary={canvasToolbarMode.primary === 'text'}
               onClick={insertTextCallback}
+              keepActiveInLiveMode
               style={{ width: 36 }}
             />
           </Tooltip>
@@ -540,13 +543,15 @@ export const CanvasToolbar = React.memo(() => {
               iconCategory='tools'
               primary={canvasToolbarMode.primary === 'insert'}
               onClick={toggleInsertButtonClicked}
+              keepActiveInLiveMode
               style={{ width: 36 }}
             />
           </Tooltip>
           <Tooltip title='Live Mode' placement='bottom'>
             <InsertModeButton
-              iconType='play'
-              iconCategory='tools'
+              testid={PlayModeButtonTestId}
+              iconType={isLiveMode ? 'icon-semantic-stop' : 'play'}
+              iconCategory={isLiveMode ? 'semantic' : 'tools'}
               primary={canvasToolbarMode.primary === 'play'}
               onClick={toggleLiveMode}
               keepActiveInLiveMode


### PR DESCRIPTION
**Problem:**
Play mode can be a bit of a pain to escape.

**Fix:**
Every other top level canvas toolbar button is now enabled during play mode and will switch to their relevant mode when clicked.

The play mode button switches to a visual "stop" button when play mode is engaged.

**Commit Details:**
- Added `keepActiveInLiveMode` to the other top level toolbar buttons.
- Play mode button changes icon to a stop icon if in play mode.