### PR TITLE
Switch to the navigator pane on selection change

### DIFF
--- a/editor/src/components/canvas/commands/update-selected-views-command.ts
+++ b/editor/src/components/canvas/commands/update-selected-views-command.ts
@@ -1,6 +1,10 @@
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
-import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import {
+  LeftMenuTab,
+  type EditorState,
+  type EditorStatePatch,
+} from '../../editor/store/editor-state'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface UpdateSelectedViews extends BaseCommand {
@@ -26,6 +30,11 @@ export const runUpdateSelectedViews: CommandFunction<UpdateSelectedViews> = (
   const editorStatePatch: EditorStatePatch = {
     selectedViews: {
       $set: command.value,
+    },
+    leftMenu: {
+      selectedTab: {
+        $set: LeftMenuTab.Navigator,
+      },
     },
   }
   return {

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jest/expect-expect */
 import * as EP from '../../../core/shared/element-path'
 import {
   BakedInStoryboardUID,
@@ -16,9 +15,12 @@ import {
   TestSceneUID,
 } from '../../../components/canvas/ui-jsx.test-utils'
 import {
+  applyCommandsAction,
+  clearSelection,
   deleteSelected,
   deleteView,
   selectComponents,
+  setLeftMenuTab,
   truncateHistory,
   undo,
   unwrapElements,
@@ -54,7 +56,12 @@ import {
 import { cmdModifier, shiftCmdModifier } from '../../../utils/modifiers'
 import { FOR_TESTS_setNextGeneratedUids } from '../../../core/model/element-template-utils.test-utils'
 import { createTestProjectWithMultipleFiles } from '../../../sample-projects/sample-project-utils.test-utils'
-import { navigatorEntryToKey, PlaygroundFilePath, StoryboardFilePath } from '../store/editor-state'
+import {
+  LeftMenuTab,
+  navigatorEntryToKey,
+  PlaygroundFilePath,
+  StoryboardFilePath,
+} from '../store/editor-state'
 import { CanvasControlsContainerID } from '../../canvas/controls/new-canvas-controls'
 import { windowPoint } from '../../../core/shared/math-utils'
 import { assertNever } from '../../../core/shared/utils'
@@ -73,6 +80,7 @@ import {
   groupJSXElementImportsToAdd,
 } from '../../canvas/canvas-strategies/strategies/group-helpers'
 import { safeIndex } from '../../../core/shared/array-utils'
+import { updateSelectedViews } from '../../canvas/commands/update-selected-views-command'
 
 async function deleteFromScene(
   inputSnippet: string,
@@ -7145,6 +7153,75 @@ export var storyboard = (
       )
       await renderResult.getDispatchFollowUpActionsFinished()
       expect(renderResult.getEditorState().editor.selectedViews).toEqual([makeTargetPath('aaa')])
+    })
+    it('the navigator pane is shown when selection changes', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(`
+      <div data-uid='root'>
+        <div data-uid='child1' />
+        <div data-uid='child2' />
+      </div>`),
+        'await-first-dom-report',
+      )
+
+      {
+        // selectComponents
+        await renderResult.dispatch([setLeftMenuTab(LeftMenuTab.Github)], true)
+        expect(renderResult.getEditorState().editor.leftMenu.selectedTab).toEqual(
+          LeftMenuTab.Github,
+        )
+
+        await renderResult.dispatch(
+          [selectComponents([EP.appendNewElementPath(TestScenePath, ['root', 'child1'])], false)],
+          true,
+        )
+
+        expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
+          'utopia-storyboard-uid/scene-aaa/app-entity:root/child1',
+        ])
+        expect(renderResult.getEditorState().editor.leftMenu.selectedTab).toEqual(
+          LeftMenuTab.Navigator,
+        )
+      }
+
+      {
+        // setLeftMenuTab
+        await renderResult.dispatch([setLeftMenuTab(LeftMenuTab.Github)], true)
+        expect(renderResult.getEditorState().editor.leftMenu.selectedTab).toEqual(
+          LeftMenuTab.Github,
+        )
+
+        await renderResult.dispatch([clearSelection()], true)
+
+        expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([])
+        expect(renderResult.getEditorState().editor.leftMenu.selectedTab).toEqual(
+          LeftMenuTab.Navigator,
+        )
+      }
+
+      {
+        // updateSelectedViews command
+        await renderResult.dispatch([setLeftMenuTab(LeftMenuTab.Github)], true)
+        expect(renderResult.getEditorState().editor.leftMenu.selectedTab).toEqual(
+          LeftMenuTab.Github,
+        )
+
+        await renderResult.dispatch(
+          [
+            applyCommandsAction([
+              updateSelectedViews('always', [EP.appendNewElementPath(TestScenePath, ['root'])]),
+            ]),
+          ],
+          true,
+        )
+
+        expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
+          'utopia-storyboard-uid/scene-aaa/app-entity:root',
+        ])
+        expect(renderResult.getEditorState().editor.leftMenu.selectedTab).toEqual(
+          LeftMenuTab.Navigator,
+        )
+      }
     })
   })
 

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1805,6 +1805,7 @@ export const UPDATE_FNS = {
     const updatedEditor: EditorModel = {
       ...editor,
       selectedViews: newlySelectedPaths,
+      leftMenu: { visible: editor.leftMenu.visible, selectedTab: LeftMenuTab.Navigator },
       navigator:
         newlySelectedPaths === editor.selectedViews
           ? editor.navigator
@@ -1821,6 +1822,7 @@ export const UPDATE_FNS = {
 
     return {
       ...editor,
+      leftMenu: { visible: editor.leftMenu.visible, selectedTab: LeftMenuTab.Navigator },
       selectedViews: [],
       navigator: updateNavigatorCollapsedState([], editor.navigator),
       pasteTargetsToIgnore: [],
@@ -1851,6 +1853,7 @@ export const UPDATE_FNS = {
 
     return {
       ...editor,
+      leftMenu: { visible: editor.leftMenu.visible, selectedTab: LeftMenuTab.Navigator },
       selectedViews: [...editor.selectedViews, ...additionalTargets],
       pasteTargetsToIgnore: [],
     }

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2037,6 +2037,7 @@ export const UPDATE_FNS = {
     )
     return {
       ...withNewElement,
+      leftMenu: { visible: editor.leftMenu.visible, selectedTab: LeftMenuTab.Navigator },
       selectedViews: newSelectedViews,
     }
   },
@@ -2165,6 +2166,7 @@ export const UPDATE_FNS = {
         return {
           ...editorWithElementsInserted,
           selectedViews: [actualInsertionPath.intendedParentPath],
+          leftMenu: { visible: editor.leftMenu.visible, selectedTab: LeftMenuTab.Navigator },
           highlightedViews: [],
           trueUpGroupsForElementAfterDomWalkerRuns: [
             ...editorWithElementsInserted.trueUpGroupsForElementAfterDomWalkerRuns,
@@ -2352,6 +2354,10 @@ export const UPDATE_FNS = {
         return {
           ...withViewsDeleted,
           selectedViews: newSelection,
+          leftMenu: {
+            visible: withViewsDeleted.leftMenu.visible,
+            selectedTab: LeftMenuTab.Navigator,
+          },
           trueUpGroupsForElementAfterDomWalkerRuns: [
             ...withViewsDeleted.trueUpGroupsForElementAfterDomWalkerRuns,
             ...adjustedGroupTrueUps.map(trueUpElementChanged),
@@ -4821,6 +4827,7 @@ export const UPDATE_FNS = {
         {
           ...withNewElement,
           selectedViews: newSelectedViews,
+          leftMenu: { visible: editor.leftMenu.visible, selectedTab: LeftMenuTab.Navigator },
           trueUpGroupsForElementAfterDomWalkerRuns: [
             ...editor.trueUpGroupsForElementAfterDomWalkerRuns,
             trueUpElementChanged(newPath),

--- a/editor/src/templates/image-dnd.spec.browser2.tsx
+++ b/editor/src/templates/image-dnd.spec.browser2.tsx
@@ -392,7 +392,6 @@ describe('image drag and drop', () => {
 
       expect(editor.getEditorState().strategyState.currentStrategy).toEqual(null)
       expect(editor.getEditorState().editor.canvas.interactionSession).toEqual(null)
-      expect(editor.getEditorState().editor.fileBrowser.dropTarget).toEqual(fileItemTargetFolder)
 
       await dropElementAtPoint(targetFolder, endPoint, [])
 
@@ -428,12 +427,6 @@ describe('image drag and drop', () => {
         y: Math.floor(canvasSceneBounds.y + canvasSceneBounds.height / 2),
       }
 
-      await dragElementToPoint(null, canvasControlsLayer, { x: 5, y: 5 }, canvasPoint, [file])
-
-      await editor.getDispatchFollowUpActionsFinished()
-
-      expect(editor.getEditorState().strategyState.currentStrategy).toEqual('Drag to Insert (Abs)')
-
       const fileItemTargetFolder = '/public'
       const targetFolder = editor.renderedDOM.getByTestId(`fileitem-${fileItemTargetFolder}`)
       const targetFolderBounds = targetFolder.getBoundingClientRect()
@@ -441,6 +434,12 @@ describe('image drag and drop', () => {
         x: targetFolderBounds.x + targetFolderBounds.width / 2,
         y: targetFolderBounds.y + targetFolderBounds.height / 2,
       }
+
+      await dragElementToPoint(null, canvasControlsLayer, { x: 5, y: 5 }, canvasPoint, [file])
+
+      await editor.getDispatchFollowUpActionsFinished()
+
+      expect(editor.getEditorState().strategyState.currentStrategy).toEqual('Drag to Insert (Abs)')
 
       await switchDragAndDropElementTargets(
         canvasControlsLayer,


### PR DESCRIPTION
## Problem
If one switches away from the navigator pane, and then goes on to do something on the canvas, one needs to manually toggle back the navigator pane to to see the navigator again

## Fix
Switch back to the navigator on selection change. This PR covers the `selectComponents` and`clearSelection` actions, and the `updateSelectedViews` command