### PR TITLE
Fix Code Pane Header Shrinking

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -18,6 +18,7 @@ import {
   useColorTheme,
   LargerIcons,
   FlexColumn,
+  colorTheme,
 } from '../../uuiui'
 import { ConsoleAndErrorsPane } from '../code-editor/console-and-errors-pane'
 import { InspectorWidthAtom } from '../inspector/common/inspector-atoms'
@@ -58,7 +59,6 @@ const TopMenuHeight = 35
 // with the top border of the first inspector section
 
 const NothingOpenCard = React.memo(() => {
-  const colorTheme = useColorTheme()
   const dispatch = useDispatch()
   const handleOpenCanvasClick = React.useCallback(() => {
     dispatch([EditorActions.setPanelVisibility('canvas', true)])
@@ -182,8 +182,6 @@ interface ResizableRightPaneProps {
 }
 
 export const RightPane = React.memo<ResizableRightPaneProps>((props) => {
-  const colorTheme = useColorTheme()
-
   const selectedTab = useEditorState(
     Substores.restOfEditor,
     (store) => store.editor.rightMenu.selectedTab,
@@ -292,6 +290,7 @@ export const CodeEditorPane = React.memo<CodeEditorPaneProps>((props) => {
         overflow: 'hidden',
         borderRadius: UtopiaTheme.panelStyles.panelBorderRadius,
         boxShadow: UtopiaTheme.panelStyles.shadows.medium,
+        background: colorTheme.bg1.value,
       }}
     >
       <TitleBarCode panelData={props.panelData} />

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -403,6 +403,7 @@ export const TitleBarCode = React.memo((props: { panelData: StoredPanel }) => {
       className='handle'
       style={{
         height: 40,
+        flexShrink: 0,
         width: '100%',
         backgroundColor: theme.inspectorBackground.value,
         padding: '0 10px',


### PR DESCRIPTION
Preventing the Code Editor pane header from shrinking.

**Bonus Fix: adding a background to the Code Editor Pane so you can't see the canvas through the gap.


| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/concrete-utopia/utopia/assets/47405698/5f0c4c2f-f97b-48d0-9e80-8b511874b24b)  | ![image](https://github.com/concrete-utopia/utopia/assets/47405698/3cff3c40-07b0-444d-8b9f-c9fd5930b200)  |
