### PR TITLE
Add flex layout to zero-sized div

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
@@ -220,7 +220,7 @@ type JSXElementLikeConversion = {
   childInstances: ElementInstanceMetadata[]
 }
 
-type JSXFragmentConversion = {
+export type JSXFragmentConversion = {
   element: JSXFragment
   childInstances: ElementInstanceMetadata[]
   childrenBoundingFrame: CanvasRectangle

--- a/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
@@ -277,26 +277,12 @@ export function getInstanceForFragmentToFrameConversion(
   }
 }
 
-export function convertFragmentToFrame(
+export function actuallyConvertFramentToFrame(
   metadata: ElementInstanceMetadataMap,
   pathTrees: ElementPathTrees,
-  allElementProps: AllElementProps,
+  instance: JSXFragmentConversion,
   elementPath: ElementPath,
-  convertIfStaticChildren:
-    | 'do-not-convert-if-it-has-static-children'
-    | 'convert-even-if-it-has-static-children',
 ): CanvasCommand[] {
-  const instance = getInstanceForFragmentToFrameConversion(
-    metadata,
-    pathTrees,
-    allElementProps,
-    elementPath,
-    convertIfStaticChildren,
-  )
-  if (isConversionForbidden(instance)) {
-    return []
-  }
-
   const { children, uid } = instance.element
 
   const parentBounds =
@@ -341,6 +327,29 @@ export function convertFragmentToFrame(
     ),
     ...offsetChildrenByDelta(instance.childInstances, instance.childrenBoundingFrame),
   ]
+}
+
+export function convertFragmentToFrame(
+  metadata: ElementInstanceMetadataMap,
+  pathTrees: ElementPathTrees,
+  allElementProps: AllElementProps,
+  elementPath: ElementPath,
+  convertIfStaticChildren:
+    | 'do-not-convert-if-it-has-static-children'
+    | 'convert-even-if-it-has-static-children',
+): CanvasCommand[] {
+  const instance = getInstanceForFragmentToFrameConversion(
+    metadata,
+    pathTrees,
+    allElementProps,
+    elementPath,
+    convertIfStaticChildren,
+  )
+  if (isConversionForbidden(instance)) {
+    return []
+  }
+
+  return actuallyConvertFramentToFrame(metadata, pathTrees, instance, elementPath)
 }
 
 export function getInstanceForFragmentToGroupConversion(

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
@@ -436,7 +436,6 @@ describe('Smart Convert To Flex', () => {
         position: 'absolute',
       }}
       data-uid='zero-sized'
-      data-testid='zero-sized'
     >
       <img
         src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
@@ -449,6 +448,7 @@ describe('Smart Convert To Flex', () => {
           top: 16,
         }}
         data-testid='first-child'
+        data-uid='first-child'
       />
       <img
         src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
@@ -460,7 +460,7 @@ describe('Smart Convert To Flex', () => {
           left: 79,
           top: 16,
         }}
-        data-testid='second-child'
+        data-uid='second-child'
       />
       <img
         src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
@@ -472,7 +472,7 @@ describe('Smart Convert To Flex', () => {
           left: 143,
           top: 16,
         }}
-        data-testid='third-child'
+        data-uid='third-child'
       />
     </div>
   </div>`),
@@ -482,27 +482,32 @@ describe('Smart Convert To Flex', () => {
     const { top: firstChildTopBeforeFlexConversion, left: firstChildLeftBeforeFlexConversion } =
       renderResult.renderedDOM.getByTestId('first-child').style
 
-    await selectComponentsForTest(renderResult, [
-      EP.appendNewElementPath(TestScenePath, ['root', 'zero-sized']),
-    ])
+    const containerPath = EP.appendNewElementPath(TestScenePath, ['root', 'zero-sized'])
+    await selectComponentsForTest(renderResult, [containerPath])
     await expectSingleUndo2Saves(renderResult, () => pressShiftA(renderResult))
 
-    const { top, left } = renderResult.renderedDOM.getByTestId('zero-sized').style
-    // the first child didn't move, and the top/left of the flex container is the same as the first child's top/left
-    expect({ top, left }).toEqual({
+    const { top: containerTop, left: containerLeft } =
+      renderResult.getEditorState().editor.allElementProps[EP.toString(containerPath)]['style']
+
+    expect({
       top: firstChildTopBeforeFlexConversion,
       left: firstChildLeftBeforeFlexConversion,
+    }).toEqual({
+      top: `${containerTop}px`,
+      left: `${containerLeft}px`,
     })
 
-    expect(getPrintedUiJsCodeWithoutUIDs(renderResult.getEditorState())).toEqual(
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`<div
     style={{
       height: '100%',
       width: '100%',
       contain: 'layout',
     }}
+    data-uid='root'
   >
     <div
+      data-uid='zero-sized'
       style={{
         position: 'absolute',
         top: 16,
@@ -513,23 +518,25 @@ describe('Smart Convert To Flex', () => {
         flexDirection: 'row',
         gap: 13,
       }}
-      data-testid='zero-sized'
     >
       <img
         src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
         alt='Utopia logo'
         style={{ width: 51, height: 65 }}
         data-testid='first-child'
+        data-uid='first-child'
       />
       <img
         src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
         alt='Utopia logo'
         style={{ width: 51, height: 65 }}
+        data-uid='second-child'
       />
       <img
         src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
         alt='Utopia logo'
         style={{ width: 51, height: 65 }}
+        data-uid='third-child'
       />
     </div>
   </div>

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
@@ -12,10 +12,15 @@ import type { CanvasRectangle } from '../../../core/shared/math-utils'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
 import { fastForEach } from '../../../core/shared/utils'
-import { convertFragmentToFrame } from '../../canvas/canvas-strategies/strategies/group-conversion-helpers'
 import {
+  actuallyConvertFramentToFrame,
+  convertFragmentToFrame,
+} from '../../canvas/canvas-strategies/strategies/group-conversion-helpers'
+import {
+  getElementFragmentLikeType,
   isElementNonDOMElement,
   replaceNonDOMElementPathsWithTheirChildrenRecursive,
+  treatElementAsFragmentLike,
 } from '../../canvas/canvas-strategies/strategies/fragment-like-helpers'
 import type { CanvasFrameAndTarget } from '../../canvas/canvas-types'
 import type { CanvasCommand } from '../../canvas/commands/commands'
@@ -172,16 +177,22 @@ export function convertLayoutToFlexCommands(
 
 function ifElementIsFragmentFirstConvertItToFrame(
   metadata: ElementInstanceMetadataMap,
+  allElementProps: AllElementProps,
   elementPathTree: ElementPathTrees,
   target: ElementPath,
 ): Array<CanvasCommand> {
-  return convertFragmentToFrame(
+  const type = getElementFragmentLikeType(
     metadata,
+    allElementProps,
     elementPathTree,
-    {},
     target,
-    'convert-even-if-it-has-static-children',
+    'sizeless-div-considered-fragment-like',
   )
+  if (type == 'fragment' || type == 'sizeless-div') {
+    return actuallyConvertFramentToFrame(metadata, elementPathTree, __, target)
+  }
+
+  return []
 }
 
 function guessMatchingFlexSetup(


### PR DESCRIPTION
## Problem
When converting a zero-sized div to a flex container, the children of the div jump to the coordinates of the zero-sized div

## Fix
Convert the zero-sized div into a full-fledged frame before adding the flex props (and the rest of the changes in `convertLayoutToFlexCommands`), as if it was a fragment