### PR TITLE
Strategy label should show when a retargeted element is transformed

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -621,12 +621,12 @@ export function getWrapperWithGeneratedUid(
   return { wrapper: insertionSubjectWrapper, uid: uid }
 }
 
-export function getStrategyLabelWithRetargetedPaths(
+export function getDescriptiveStrategyLabelWithRetargetedPaths(
   originalLabel: string,
   pathsWereReplaced: boolean,
 ): string {
   if (pathsWereReplaced) {
-    return `${originalLabel} (Sizeless container, transforming children)`
+    return `${originalLabel} (Children)`
   }
   return originalLabel
 }

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -239,7 +239,7 @@ function codeElementsTargeted(canvasState: InteractionCanvasState): boolean {
   const originalTargets = flattenSelection(
     getTargetPathsFromInteractionTarget(canvasState.interactionTarget),
   )
-  const retargetedTargets = retargetStrategyToChildrenOfFragmentLikeElements(canvasState)
+  const retargetedTargets = retargetStrategyToChildrenOfFragmentLikeElements(canvasState).paths
   return [...originalTargets, ...retargetedTargets].some(
     (target) =>
       MetadataUtils.isExpressionOtherJavascript(target, canvasState.startingMetadata) ||
@@ -619,4 +619,14 @@ export function getWrapperWithGeneratedUid(
     generateUidWithExistingComponents(canvasState.projectContents)
 
   return { wrapper: insertionSubjectWrapper, uid: uid }
+}
+
+export function getStrategyLabelWithRetargetedPaths(
+  originalLabel: string,
+  pathsWereReplaced: boolean,
+): string {
+  if (pathsWereReplaced) {
+    return `${originalLabel} (Sizeless container, transforming children)`
+  }
+  return originalLabel
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
@@ -2,7 +2,7 @@ import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { ImmediateParentBounds } from '../../controls/parent-bounds'
 import { ImmediateParentOutlines } from '../../controls/parent-outlines'
 import { ZeroSizedElementControls } from '../../controls/zero-sized-element-controls'
-import { getStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
+import { getDescriptiveStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
 import type {
   CustomStrategyState,
   InteractionCanvasState,
@@ -57,8 +57,11 @@ export function absoluteMoveStrategy(
   return {
     strategy: {
       id: 'ABSOLUTE_MOVE',
-      name: getStrategyLabelWithRetargetedPaths('Move', pathsWereReplaced),
-      descriptiveLabel: 'Moving Absolute Elements',
+      name: 'Move',
+      descriptiveLabel: getDescriptiveStrategyLabelWithRetargetedPaths(
+        'Moving Absolute Elements',
+        pathsWereReplaced,
+      ),
       icon: {
         category: 'modalities',
         type: 'moveabs-large',

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
@@ -2,6 +2,7 @@ import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { ImmediateParentBounds } from '../../controls/parent-bounds'
 import { ImmediateParentOutlines } from '../../controls/parent-outlines'
 import { ZeroSizedElementControls } from '../../controls/zero-sized-element-controls'
+import { getStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
 import type {
   CustomStrategyState,
   InteractionCanvasState,
@@ -34,7 +35,8 @@ export function absoluteMoveStrategy(
   const originalTargets = flattenSelection(
     getTargetPathsFromInteractionTarget(canvasState.interactionTarget),
   )
-  const retargetedTargets = retargetStrategyToChildrenOfFragmentLikeElements(canvasState)
+  const { pathsWereReplaced, paths: retargetedTargets } =
+    retargetStrategyToChildrenOfFragmentLikeElements(canvasState)
 
   const isApplicable =
     retargetedTargets.length > 0 &&
@@ -55,7 +57,7 @@ export function absoluteMoveStrategy(
   return {
     strategy: {
       id: 'ABSOLUTE_MOVE',
-      name: 'Move',
+      name: getStrategyLabelWithRetargetedPaths('Move', pathsWereReplaced),
       descriptiveLabel: 'Moving Absolute Elements',
       icon: {
         category: 'modalities',

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -35,7 +35,10 @@ import { ImmediateParentBounds } from '../../controls/parent-bounds'
 import { ImmediateParentOutlines } from '../../controls/parent-outlines'
 import { AbsoluteResizeControl } from '../../controls/select-mode/absolute-resize-control'
 import { ZeroSizeResizeControlWrapper } from '../../controls/zero-sized-element-controls'
-import { onlyFitWhenDraggingThisControl } from '../canvas-strategies'
+import {
+  getStrategyLabelWithRetargetedPaths,
+  onlyFitWhenDraggingThisControl,
+} from '../canvas-strategies'
 import type { CanvasStrategy, InteractionCanvasState } from '../canvas-strategy-types'
 import {
   controlWithProps,
@@ -70,9 +73,10 @@ export function absoluteResizeBoundingBoxStrategy(
     getTargetPathsFromInteractionTarget(canvasState.interactionTarget),
   )
 
-  const retargetedTargets = flattenSelection(
-    retargetStrategyToChildrenOfFragmentLikeElements(canvasState),
-  )
+  const { pathsWereReplaced, paths } = retargetStrategyToChildrenOfFragmentLikeElements(canvasState)
+
+  const retargetedTargets = flattenSelection(paths)
+
   if (
     retargetedTargets.length === 0 ||
     !retargetedTargets.every((element) => {
@@ -84,7 +88,7 @@ export function absoluteResizeBoundingBoxStrategy(
 
   return {
     id: 'ABSOLUTE_RESIZE_BOUNDING_BOX',
-    name: 'Resize',
+    name: getStrategyLabelWithRetargetedPaths('Resize', pathsWereReplaced),
     descriptiveLabel: 'Resizing Elements',
     icon: {
       category: 'modalities',

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.tsx
@@ -36,7 +36,7 @@ import { ImmediateParentOutlines } from '../../controls/parent-outlines'
 import { AbsoluteResizeControl } from '../../controls/select-mode/absolute-resize-control'
 import { ZeroSizeResizeControlWrapper } from '../../controls/zero-sized-element-controls'
 import {
-  getStrategyLabelWithRetargetedPaths,
+  getDescriptiveStrategyLabelWithRetargetedPaths,
   onlyFitWhenDraggingThisControl,
 } from '../canvas-strategies'
 import type { CanvasStrategy, InteractionCanvasState } from '../canvas-strategy-types'
@@ -88,8 +88,11 @@ export function absoluteResizeBoundingBoxStrategy(
 
   return {
     id: 'ABSOLUTE_RESIZE_BOUNDING_BOX',
-    name: getStrategyLabelWithRetargetedPaths('Resize', pathsWereReplaced),
-    descriptiveLabel: 'Resizing Elements',
+    name: 'Resize',
+    descriptiveLabel: getDescriptiveStrategyLabelWithRetargetedPaths(
+      'Resizing Elements',
+      pathsWereReplaced,
+    ),
     icon: {
       category: 'modalities',
       type: 'resize',

--- a/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.tsx
@@ -47,7 +47,7 @@ export function ancestorMetaStrategy(
       return []
     }
 
-    const unrolledChildren = retargetStrategyToChildrenOfFragmentLikeElements(canvasState)
+    const unrolledChildren = retargetStrategyToChildrenOfFragmentLikeElements(canvasState).paths
 
     if (unrolledChildren.length !== 1) {
       return []

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -84,6 +84,7 @@ import {
   isHugFromStyleAttribute,
   sizeToVisualDimensions,
 } from '../../../inspector/inspector-common'
+import { getStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
 
 export type SetHuggingParentToFixed =
   | 'set-hugging-parent-to-fixed'
@@ -100,18 +101,24 @@ export const convertToAbsoluteAndMoveStrategy = convertToAbsoluteAndMoveStrategy
 export const convertToAbsoluteAndMoveAndSetParentFixedStrategy =
   convertToAbsoluteAndMoveStrategyFactory('set-hugging-parent-to-fixed')
 
-function getBasicStrategyProperties(setHuggingParentToFixed: SetHuggingParentToFixed) {
+function getBasicStrategyProperties(
+  setHuggingParentToFixed: SetHuggingParentToFixed,
+  pathsWereReplaced: boolean,
+) {
   switch (setHuggingParentToFixed) {
     case 'set-hugging-parent-to-fixed':
       return {
         id: ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID,
-        name: 'Move (Abs + Set Parent Fixed)',
+        name: getStrategyLabelWithRetargetedPaths(
+          'Move (Abs + Set Parent Fixed)',
+          pathsWereReplaced,
+        ),
         descriptiveLabel: 'Converting To Absolute And Moving (setting parent to fixed)',
       }
     case 'dont-set-hugging-parent-to-fixed':
       return {
         id: ConvertToAbsoluteAndMoveStrategyID,
-        name: 'Move (Abs)',
+        name: getStrategyLabelWithRetargetedPaths('Move (Abs)', pathsWereReplaced),
         descriptiveLabel: 'Converting To Absolute And Moving',
       }
     default:
@@ -125,7 +132,8 @@ function convertToAbsoluteAndMoveStrategyFactory(setHuggingParentToFixed: SetHug
     interactionSession: InteractionSession | null,
   ): CanvasStrategy | null => {
     const originalTargets = retargetStrategyToTopMostFragmentLikeElement(canvasState) // this needs a better variable name
-    const retargetedTargets = retargetStrategyToChildrenOfFragmentLikeElements(canvasState)
+    const { pathsWereReplaced, paths: retargetedTargets } =
+      retargetStrategyToChildrenOfFragmentLikeElements(canvasState)
 
     if (
       !retargetedTargets.every((element) => {
@@ -196,7 +204,7 @@ function convertToAbsoluteAndMoveStrategyFactory(setHuggingParentToFixed: SetHug
     )
 
     return {
-      ...getBasicStrategyProperties(setHuggingParentToFixed),
+      ...getBasicStrategyProperties(setHuggingParentToFixed, pathsWereReplaced),
       icon: {
         category: 'modalities',
         type: 'moveabs-large',

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -84,7 +84,7 @@ import {
   isHugFromStyleAttribute,
   sizeToVisualDimensions,
 } from '../../../inspector/inspector-common'
-import { getStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
+import { getDescriptiveStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
 
 export type SetHuggingParentToFixed =
   | 'set-hugging-parent-to-fixed'
@@ -109,17 +109,20 @@ function getBasicStrategyProperties(
     case 'set-hugging-parent-to-fixed':
       return {
         id: ConvertToAbsoluteAndMoveAndSetParentFixedStrategyID,
-        name: getStrategyLabelWithRetargetedPaths(
-          'Move (Abs + Set Parent Fixed)',
+        name: 'Move (Abs + Set Parent Fixed)',
+        descriptiveLabel: getDescriptiveStrategyLabelWithRetargetedPaths(
+          'Converting To Absolute And Moving (setting parent to fixed)',
           pathsWereReplaced,
         ),
-        descriptiveLabel: 'Converting To Absolute And Moving (setting parent to fixed)',
       }
     case 'dont-set-hugging-parent-to-fixed':
       return {
         id: ConvertToAbsoluteAndMoveStrategyID,
-        name: getStrategyLabelWithRetargetedPaths('Move (Abs)', pathsWereReplaced),
-        descriptiveLabel: 'Converting To Absolute And Moving',
+        name: 'Move (Abs)',
+        descriptiveLabel: getDescriptiveStrategyLabelWithRetargetedPaths(
+          'Converting To Absolute And Moving',
+          pathsWereReplaced,
+        ),
       }
     default:
       assertNever(setHuggingParentToFixed)

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-resize.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-resize.spec.browser2.tsx
@@ -178,6 +178,11 @@ describe('Keyboard Absolute Move E2E', () => {
         await selectComponentsForTest(editor, [EP.fromString(`sb/${FragmentLikeElementUid}`)])
 
         await pressArrowRightHoldingShift3x()
+
+        const descriptiveLabel =
+          editor.getEditorState().strategyState.currentStrategyDescriptiveLabel
+        expect(descriptiveLabel).toEqual('Moving Elements (Children)')
+
         await editor.getDispatchFollowUpActionsFinished()
 
         const aaa = editor.renderedDOM.getByTestId('aaa')
@@ -418,6 +423,11 @@ describe('Keyboard switching back and forth between absolute move and absolute r
         await selectComponentsForTest(editor, [EP.fromString(`sb/${FragmentLikeElementUid}`)])
 
         await keyDownArrowRightHoldingCmd3x()
+
+        const descriptiveLabel =
+          editor.getEditorState().strategyState.currentStrategyDescriptiveLabel
+        expect(descriptiveLabel).toEqual('Resizing Elements (Children)')
+
         await editor.getDispatchFollowUpActionsFinished()
 
         const aaa = editor.renderedDOM.getByTestId('aaa')

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
@@ -36,7 +36,7 @@ import type { InteractionSession } from '../interaction-state'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
 import { retargetStrategyToChildrenOfFragmentLikeElements } from './fragment-like-helpers'
 import { gatherParentAndSiblingTargets } from '../../controls/guideline-helpers'
-import { getStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
+import { getDescriptiveStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
 
 export function keyboardAbsoluteMoveStrategy(
   canvasState: InteractionCanvasState,
@@ -53,8 +53,11 @@ export function keyboardAbsoluteMoveStrategy(
 
   return {
     id: 'KEYBOARD_ABSOLUTE_MOVE',
-    name: getStrategyLabelWithRetargetedPaths('Move', pathsWereReplaced),
-    descriptiveLabel: 'Moving Elements',
+    name: 'Move',
+    descriptiveLabel: getDescriptiveStrategyLabelWithRetargetedPaths(
+      'Moving Elements',
+      pathsWereReplaced,
+    ),
     icon: {
       category: 'modalities',
       type: 'moveabs-large',

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-move-strategy.ts
@@ -36,12 +36,14 @@ import type { InteractionSession } from '../interaction-state'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
 import { retargetStrategyToChildrenOfFragmentLikeElements } from './fragment-like-helpers'
 import { gatherParentAndSiblingTargets } from '../../controls/guideline-helpers'
+import { getStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
 
 export function keyboardAbsoluteMoveStrategy(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
 ): CanvasStrategy | null {
-  const selectedElements = retargetStrategyToChildrenOfFragmentLikeElements(canvasState)
+  const { pathsWereReplaced, paths: selectedElements } =
+    retargetStrategyToChildrenOfFragmentLikeElements(canvasState)
   if (selectedElements.length === 0) {
     return null
   }
@@ -51,7 +53,7 @@ export function keyboardAbsoluteMoveStrategy(
 
   return {
     id: 'KEYBOARD_ABSOLUTE_MOVE',
-    name: 'Move',
+    name: getStrategyLabelWithRetargetedPaths('Move', pathsWereReplaced),
     descriptiveLabel: 'Moving Elements',
     icon: {
       category: 'modalities',

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
@@ -42,7 +42,7 @@ import { uniqBy } from '../../../../core/shared/array-utils'
 import * as EP from '../../../../core/shared/element-path'
 import type { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
 import type { AllElementProps } from '../../../editor/store/editor-state'
-import { getStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
+import { getDescriptiveStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
 
 interface VectorAndEdge {
   movement: CanvasVector
@@ -134,8 +134,11 @@ export function keyboardAbsoluteResizeStrategy(
 
   return {
     id: 'KEYBOARD_ABSOLUTE_RESIZE',
-    name: getStrategyLabelWithRetargetedPaths('Resize', pathsWereReplaced),
-    descriptiveLabel: 'Resizing Elements',
+    name: 'Resize',
+    descriptiveLabel: getDescriptiveStrategyLabelWithRetargetedPaths(
+      'Resizing Elements',
+      pathsWereReplaced,
+    ),
     icon: {
       category: 'modalities',
       type: 'moveabs-large',

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-absolute-resize-strategy.tsx
@@ -42,6 +42,7 @@ import { uniqBy } from '../../../../core/shared/array-utils'
 import * as EP from '../../../../core/shared/element-path'
 import type { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
 import type { AllElementProps } from '../../../editor/store/editor-state'
+import { getStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
 
 interface VectorAndEdge {
   movement: CanvasVector
@@ -119,7 +120,9 @@ export function keyboardAbsoluteResizeStrategy(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
 ): CanvasStrategy | null {
-  const selectedElements = retargetStrategyToChildrenOfFragmentLikeElements(canvasState)
+  const { pathsWereReplaced, paths: selectedElements } =
+    retargetStrategyToChildrenOfFragmentLikeElements(canvasState)
+
   if (
     selectedElements.length === 0 ||
     !selectedElements.every((element) => {
@@ -131,7 +134,7 @@ export function keyboardAbsoluteResizeStrategy(
 
   return {
     id: 'KEYBOARD_ABSOLUTE_RESIZE',
-    name: 'Resize',
+    name: getStrategyLabelWithRetargetedPaths('Resize', pathsWereReplaced),
     descriptiveLabel: 'Resizing Elements',
     icon: {
       category: 'modalities',

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size-strategy.tsx
@@ -19,7 +19,7 @@ import {
   printCSSNumber,
 } from '../../../inspector/common/css-utils'
 import { setProperty } from '../../commands/set-property-command'
-import { getStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
+import { getDescriptiveStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
 import type { InteractionCanvasState, CanvasStrategy } from '../canvas-strategy-types'
 import { emptyStrategyApplicationResult, strategyApplicationResult } from '../canvas-strategy-types'
 import type { InteractionSession } from '../interaction-state'
@@ -39,8 +39,11 @@ export function keyboardSetFontSizeStrategy(
 
   return {
     id: 'set-font-size',
-    name: getStrategyLabelWithRetargetedPaths('Set font size', pathsWereReplaced),
-    descriptiveLabel: 'Changing Font Size',
+    name: 'Set font size',
+    descriptiveLabel: getDescriptiveStrategyLabelWithRetargetedPaths(
+      'Changing Font Size',
+      pathsWereReplaced,
+    ),
     icon: {
       category: 'tools',
       type: 'pointer',

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size-strategy.tsx
@@ -19,6 +19,7 @@ import {
   printCSSNumber,
 } from '../../../inspector/common/css-utils'
 import { setProperty } from '../../commands/set-property-command'
+import { getStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
 import type { InteractionCanvasState, CanvasStrategy } from '../canvas-strategy-types'
 import { emptyStrategyApplicationResult, strategyApplicationResult } from '../canvas-strategy-types'
 import type { InteractionSession } from '../interaction-state'
@@ -29,9 +30,8 @@ export function keyboardSetFontSizeStrategy(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
 ): CanvasStrategy | null {
-  const validTargets = retargetStrategyToChildrenOfFragmentLikeElements(canvasState).filter(
-    (path) => isValidTarget(canvasState.startingMetadata, path),
-  )
+  const { pathsWereReplaced, paths } = retargetStrategyToChildrenOfFragmentLikeElements(canvasState)
+  const validTargets = paths.filter((path) => isValidTarget(canvasState.startingMetadata, path))
 
   if (validTargets.length === 0) {
     return null
@@ -39,7 +39,7 @@ export function keyboardSetFontSizeStrategy(
 
   return {
     id: 'set-font-size',
-    name: 'Set font size',
+    name: getStrategyLabelWithRetargetedPaths('Set font size', pathsWereReplaced),
     descriptiveLabel: 'Changing Font Size',
     icon: {
       category: 'tools',

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size.spec.browser2.tsx
@@ -173,6 +173,11 @@ describe('adjust font size with the keyboard', () => {
         await selectComponentsForTest(editor, [EP.fromString(`sb/${FragmentLikeElementUid}`)])
 
         await doTestWithDelta(editor, { increaseBy: 1, decreaseBy: 0 })
+
+        const descriptiveLabel =
+          editor.getEditorState().strategyState.currentStrategyDescriptiveLabel
+        expect(descriptiveLabel).toEqual('Changing Font Size (Children)')
+
         await editor.getDispatchFollowUpActionsFinished()
 
         const aaa = editor.renderedDOM.getByTestId('aaa')

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight-strategy.tsx
@@ -12,6 +12,7 @@ import type { KeyCharacter } from '../../../../utils/keyboard'
 import Keyboard from '../../../../utils/keyboard'
 import type { Modifiers } from '../../../../utils/modifiers'
 import { setProperty } from '../../commands/set-property-command'
+import { getStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
 import type { InteractionCanvasState, CanvasStrategy } from '../canvas-strategy-types'
 import { emptyStrategyApplicationResult, strategyApplicationResult } from '../canvas-strategy-types'
 import type { InteractionSession } from '../interaction-state'
@@ -24,9 +25,8 @@ export function keyboardSetFontWeightStrategy(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
 ): CanvasStrategy | null {
-  const validTargets = retargetStrategyToChildrenOfFragmentLikeElements(canvasState).filter(
-    (path) => isValidTarget(canvasState.startingMetadata, path),
-  )
+  const { pathsWereReplaced, paths } = retargetStrategyToChildrenOfFragmentLikeElements(canvasState)
+  const validTargets = paths.filter((path) => isValidTarget(canvasState.startingMetadata, path))
 
   if (validTargets.length === 0) {
     return null
@@ -34,7 +34,7 @@ export function keyboardSetFontWeightStrategy(
 
   return {
     id: 'set-font-weight',
-    name: 'Set font weight',
+    name: getStrategyLabelWithRetargetedPaths('Set font weight', pathsWereReplaced),
     descriptiveLabel: 'Changing Font Weight',
     icon: {
       category: 'tools',

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight-strategy.tsx
@@ -12,7 +12,7 @@ import type { KeyCharacter } from '../../../../utils/keyboard'
 import Keyboard from '../../../../utils/keyboard'
 import type { Modifiers } from '../../../../utils/modifiers'
 import { setProperty } from '../../commands/set-property-command'
-import { getStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
+import { getDescriptiveStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
 import type { InteractionCanvasState, CanvasStrategy } from '../canvas-strategy-types'
 import { emptyStrategyApplicationResult, strategyApplicationResult } from '../canvas-strategy-types'
 import type { InteractionSession } from '../interaction-state'
@@ -34,8 +34,11 @@ export function keyboardSetFontWeightStrategy(
 
   return {
     id: 'set-font-weight',
-    name: getStrategyLabelWithRetargetedPaths('Set font weight', pathsWereReplaced),
-    descriptiveLabel: 'Changing Font Weight',
+    name: 'Set font weight',
+    descriptiveLabel: getDescriptiveStrategyLabelWithRetargetedPaths(
+      'Changing Font Weight',
+      pathsWereReplaced,
+    ),
     icon: {
       category: 'tools',
       type: 'pointer',

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight.spec.browser2.tsx
@@ -167,6 +167,11 @@ describe('adjust font weight with the keyboard', () => {
 
         await selectComponentsForTest(editor, [fromString(`sb/${FragmentLikeElementUid}`)])
         await doTestWithDelta(editor, { increaseBy: 1, decreaseBy: 0 })
+
+        const descriptiveLabel =
+          editor.getEditorState().strategyState.currentStrategyDescriptiveLabel
+        expect(descriptiveLabel).toEqual('Changing Font Weight (Children)')
+
         await editor.getDispatchFollowUpActionsFinished()
 
         const aaa = editor.renderedDOM.getByTestId('aaa')

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
@@ -5,7 +5,7 @@ import Keyboard, { isDigit } from '../../../../utils/keyboard'
 import type { Modifiers } from '../../../../utils/modifiers'
 import { emptyModifiers, Modifier } from '../../../../utils/modifiers'
 import { setProperty } from '../../commands/set-property-command'
-import { getStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
+import { getDescriptiveStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
 import type { InteractionCanvasState, CanvasStrategy } from '../canvas-strategy-types'
 import {
   getTargetPathsFromInteractionTarget,
@@ -29,8 +29,11 @@ export function keyboardSetOpacityStrategy(
 
   return {
     id: 'set-opacity',
-    name: getStrategyLabelWithRetargetedPaths('Set opacity', pathsWereReplaced),
-    descriptiveLabel: 'Changing Opacity',
+    name: 'Set opacity',
+    descriptiveLabel: getDescriptiveStrategyLabelWithRetargetedPaths(
+      'Changing Opacity',
+      pathsWereReplaced,
+    ),
     icon: {
       category: 'tools',
       type: 'pointer',

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
@@ -5,6 +5,7 @@ import Keyboard, { isDigit } from '../../../../utils/keyboard'
 import type { Modifiers } from '../../../../utils/modifiers'
 import { emptyModifiers, Modifier } from '../../../../utils/modifiers'
 import { setProperty } from '../../commands/set-property-command'
+import { getStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
 import type { InteractionCanvasState, CanvasStrategy } from '../canvas-strategy-types'
 import {
   getTargetPathsFromInteractionTarget,
@@ -19,7 +20,8 @@ export function keyboardSetOpacityStrategy(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
 ): CanvasStrategy | null {
-  const selectedElements = retargetStrategyToChildrenOfFragmentLikeElements(canvasState)
+  const { pathsWereReplaced, paths: selectedElements } =
+    retargetStrategyToChildrenOfFragmentLikeElements(canvasState)
 
   if (selectedElements.length === 0) {
     return null
@@ -27,7 +29,7 @@ export function keyboardSetOpacityStrategy(
 
   return {
     id: 'set-opacity',
-    name: 'Set opacity',
+    name: getStrategyLabelWithRetargetedPaths('Set opacity', pathsWereReplaced),
     descriptiveLabel: 'Changing Opacity',
     icon: {
       category: 'tools',


### PR DESCRIPTION
**Problem:**
When you select a sizeless div, and transform (e.g. move/resize) it with a canvas interaction, it is barely visible that you actually transform its child(ren).

**Fix:**
Add `(Children)` as a postfix to the descriptive label of the strategy.