### PR TITLE
The 🤦‍♂️ Fix

### DIFF
--- a/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
+++ b/editor/src/components/canvas/commands/push-intended-bounds-and-update-groups-command.ts
@@ -222,7 +222,7 @@ function getUpdateResizedGroupChildrenCommands(
             editor.jsxMetadata,
             editor.allElementProps,
             child,
-            'only-explicit-constraints', // TODO make sure to match this in detectConstraintsSetForGroupChild
+            'include-max-content', // TODO make sure to keep this in sync with detectConstraintsSetForGroupChild
           )
 
           const elementMetadata = MetadataUtils.findElementByElementPath(editor.jsxMetadata, child)

--- a/editor/src/components/inspector/constraints-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/constraints-section.spec.browser2.tsx
@@ -175,7 +175,7 @@ describe('Constraints Section', () => {
       'Span with max-content width shows up as Width / Scale',
       testGroupChild({
         snippet: `<span data-uid='target' style={{ width: 'max-content' }}>An implicitly constrained span</span>`,
-        expectedWidthConstraintDropdownOption: 'Scale',
+        expectedWidthConstraintDropdownOption: 'Width',
         expectedHeightConstraintDropdownOption: 'Scale',
       }),
     )
@@ -184,8 +184,8 @@ describe('Constraints Section', () => {
       'Span with max-content width height shows up as Width / Height',
       testGroupChild({
         snippet: `<span data-uid='target' style={{ width: 'max-content', height: 'max-content' }}>An implicitly constrained span</span>`,
-        expectedWidthConstraintDropdownOption: 'Scale',
-        expectedHeightConstraintDropdownOption: 'Scale',
+        expectedWidthConstraintDropdownOption: 'Width',
+        expectedHeightConstraintDropdownOption: 'Height',
       }),
     )
 

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -1220,7 +1220,7 @@ export function getConstraintsIncludingImplicitForElement(
   metadata: ElementInstanceMetadataMap,
   allElementProps: AllElementProps,
   element: ElementPath,
-  includeImplicitConstraints: 'include-implicit-constraints' | 'only-explicit-constraints',
+  includeImplicitConstraints: 'include-max-content' | 'only-explicit-constraints',
 ) {
   let constraints: Set<LayoutPinnedProp> = new Set(
     getSafeGroupChildConstraintsArray(allElementProps, element),
@@ -1233,10 +1233,10 @@ export function getConstraintsIncludingImplicitForElement(
   // collect implicit constraints
   const jsxElement = MetadataUtils.getJSXElementFromMetadata(metadata, element)
   if (jsxElement != null) {
-    if (isHugFromStyleAttribute(jsxElement.props, 'width', 'include-all-hugs')) {
+    if (isHugFromStyleAttribute(jsxElement.props, 'width', 'only-max-content')) {
       constraints.add('width')
     }
-    if (isHugFromStyleAttribute(jsxElement.props, 'height', 'include-all-hugs')) {
+    if (isHugFromStyleAttribute(jsxElement.props, 'height', 'only-max-content')) {
       constraints.add('height')
     }
   }

--- a/editor/src/components/inspector/simplified-pinning-helpers.tsx
+++ b/editor/src/components/inspector/simplified-pinning-helpers.tsx
@@ -294,7 +294,7 @@ function detectConstraintsSetForGroupChild(
     metadata,
     allElementProps,
     target,
-    'only-explicit-constraints', // TODO make sure to match this in getUpdateResizedGroupChildrenCommands
+    'include-max-content', // TODO make sure to keep this in sync with getUpdateResizedGroupChildrenCommands
   )
 
   const element = MetadataUtils.findElementByElementPath(metadata, target)


### PR DESCRIPTION
**Problem:**
Yesterday at 2am I did a last minute tweak on my PR, completely killing the core functionality: text spans with Hug should show up as Fixed when they are group children, instead the PR started showing them as Scale. I even updated the tests to reflect the wrong outcome.

**Fix:**
Fix

**Commit Details:**
- include-implicit-constraints becomes include-max-content because nothing in the codebase works for implicit contraints yet (follow up task)
- using include-max-content in constraints detection for hug children instead of relying only on data-constraints
- fixing the test
