### PR TITLE
detect center alignment when converting to flex

### DIFF
--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
@@ -803,6 +803,8 @@ describe('Smart Convert To Flex if Fragment Children', () => {
         flexDirection: 'row',
         gap: 41,
         padding: '80px 52px',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
       }}
       data-uid='container'
     >
@@ -971,6 +973,8 @@ describe('Smart Convert To Flex if Fragment Children', () => {
         flexDirection: 'row',
         gap: 65.6,
         padding: '42px 61px',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
       }}
       data-uid='container'
     >
@@ -1165,6 +1169,8 @@ describe('Smart Convert To Flex if Fragment Children', () => {
         flexDirection: 'row',
         gap: 56.5,
         padding: '56px 24px',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
       }}
       data-uid='container'
     >

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
@@ -1258,7 +1258,7 @@ describe('Smart convert to flex centered layout', () => {
     )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['a'])
-    await editor.dispatch([selectComponents([targetPath], false)], true)
+    await selectComponentsForTest(editor, [targetPath])
 
     await expectSingleUndo2Saves(editor, () => pressShiftA(editor))
 
@@ -1294,6 +1294,236 @@ describe('Smart convert to flex centered layout', () => {
       </span>
     </div>
     `),
+    )
+  })
+  it('adds centered layout if children are clustered around the x axis', async () => {
+    const editor = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`<div style={{ ...props.style }} data-uid='root'>
+    <div
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        left: 52,
+        top: 61,
+        width: 557,
+        height: 155,
+      }}
+      data-testid='container'
+      data-uid='container'
+    >
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 17,
+          top: 67,
+          width: 50,
+          height: 50,
+        }}
+        data-uid='c32'
+      />
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 99,
+          top: 42,
+          width: 50,
+          height: 50,
+        }}
+        data-uid='aa1'
+      />
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 184,
+          top: 78,
+          width: 50,
+          height: 50,
+        }}
+        data-uid='4e1'
+      />
+    </div>
+  </div>`),
+      'await-first-dom-report',
+    )
+
+    const targetPath = EP.appendNewElementPath(TestScenePath, ['root', 'container'])
+    await selectComponentsForTest(editor, [targetPath])
+
+    await expectSingleUndo2Saves(editor, () => pressShiftA(editor))
+
+    const { alignItems, justifyContent, flexDirection } =
+      editor.renderedDOM.getByTestId('container').style
+    expect({ alignItems, justifyContent, flexDirection }).toEqual({
+      alignItems: 'center',
+      justifyContent: 'flex-start',
+      flexDirection: 'row',
+    })
+
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`<div style={{ ...props.style }} data-uid='root'>
+    <div
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        left: 52,
+        top: 61,
+        width: 'max-content',
+        height: 'max-content',
+        display: 'flex',
+        flexDirection: 'row',
+        gap: 33.5,
+        padding: '27px 17px',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+      }}
+      data-testid='container'
+      data-uid='container'
+    >
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          width: 50,
+          height: 50,
+          contain: 'layout',
+        }}
+        data-uid='c32'
+      />
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          width: 50,
+          height: 50,
+          contain: 'layout',
+        }}
+        data-uid='aa1'
+      />
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          width: 50,
+          height: 50,
+          contain: 'layout',
+        }}
+        data-uid='4e1'
+      />
+    </div>
+  </div>`),
+    )
+  })
+  it('adds centered layout if children are clustered around the y axis', async () => {
+    const editor = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`<div style={{ ...props.style }} data-uid='root'>
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 47,
+          top: 15,
+          width: 155,
+          height: 394,
+        }}
+        data-testid='container'
+        data-uid='container'
+      >
+        <div
+          style={{
+            backgroundColor: '#aaaaaa33',
+            position: 'absolute',
+            left: 33,
+            top: 28,
+            width: 50,
+            height: 50,
+          }}
+        />
+        <div
+          style={{
+            backgroundColor: '#aaaaaa33',
+            position: 'absolute',
+            left: 58,
+            top: 142,
+            width: 50,
+            height: 50,
+          }}
+        />
+        <div
+          style={{
+            backgroundColor: '#aaaaaa33',
+            position: 'absolute',
+            left: 28,
+            top: 223,
+            width: 50,
+            height: 50,
+          }}
+        />
+      </div>
+    </div>`),
+      'await-first-dom-report',
+    )
+
+    const targetPath = EP.appendNewElementPath(TestScenePath, ['root', 'container'])
+    await selectComponentsForTest(editor, [targetPath])
+
+    await expectSingleUndo2Saves(editor, () => pressShiftA(editor))
+
+    const { alignItems, justifyContent, flexDirection } =
+      editor.renderedDOM.getByTestId('container').style
+    expect({ alignItems, justifyContent, flexDirection }).toEqual({
+      alignItems: 'center',
+      justifyContent: 'flex-start',
+      flexDirection: 'column',
+    })
+
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`<div style={{ ...props.style }} data-uid='root'><div
+    style={{
+      backgroundColor: '#aaaaaa33',
+      position: 'absolute',
+      left: 47,
+      top: 15,
+      width: 'max-content',
+      height: 'max-content',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 47.5,
+      padding: '28px 33px',
+      alignItems: 'center',
+      justifyContent: 'flex-start',
+    }}
+    data-testid='container'
+    data-uid='container'
+  >
+    <div
+      style={{
+        backgroundColor: '#aaaaaa33',
+        width: 50,
+        height: 50,
+        contain: 'layout',
+      }}
+      data-uid='9bd'
+    />
+    <div
+      style={{
+        backgroundColor: '#aaaaaa33',
+        width: 50,
+        height: 50,
+        contain: 'layout',
+      }}
+      data-uid='1ff'
+    />
+    <div
+      style={{
+        backgroundColor: '#aaaaaa33',
+        width: 50,
+        height: 50,
+        contain: 'layout',
+      }}
+      data-uid='0f3'
+    />
+  </div>
+  </div>`),
     )
   })
 })

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
@@ -247,7 +247,7 @@ function ifElementIsFragmentLikeFirstConvertItToFrame(
   return []
 }
 
-const NEAR_CENTER_LINE_TOLERANCE = 0.2
+const NEAR_CENTER_LINE_TOLERANCE_MULTIPLIER = 0.2
 
 function isElementNearCenterLine(
   parentGlobalFrame: CanvasRectangle,
@@ -268,12 +268,12 @@ function isElementNearCenterLine(
     case 'column':
       return (
         Math.abs(childCenter.x - parentCenter.x) <
-        parentGlobalFrame.width * NEAR_CENTER_LINE_TOLERANCE
+        parentGlobalFrame.width * NEAR_CENTER_LINE_TOLERANCE_MULTIPLIER
       )
     case 'row':
       return (
         Math.abs(childCenter.y - parentCenter.y) <
-        parentGlobalFrame.height * NEAR_CENTER_LINE_TOLERANCE
+        parentGlobalFrame.height * NEAR_CENTER_LINE_TOLERANCE_MULTIPLIER
       )
     default:
       assertNever(parentFlexDirection)

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
@@ -40,9 +40,8 @@ import {
   sizeToVisualDimensions,
 } from '../../inspector/inspector-common'
 import { setHugContentForAxis } from '../../inspector/inspector-strategies/hug-contents-basic-strategy'
-import type { FlexDirection } from '../../inspector/common/css-utils'
 
-type FlexDirectionRowColumn = 'row' | 'column' // a limited subset as we won't never guess row-reverse or column-reverse
+type FlexDirection = 'row' | 'column' // a limited subset as we won't never guess row-reverse or column-reverse
 type FlexAlignItems = 'center' | 'flex-end'
 
 export function convertLayoutToFlexCommands(
@@ -249,7 +248,7 @@ function ifElementIsFragmentLikeFirstConvertItToFrame(
 
 function isElementNearCenterLine(
   parentGlobalFrame: CanvasRectangle,
-  parentFlexDirection: FlexDirectionRowColumn,
+  parentFlexDirection: FlexDirection,
   metadata: ElementInstanceMetadataMap,
   elementPath: ElementPath,
 ): boolean {
@@ -263,9 +262,9 @@ function isElementNearCenterLine(
   const parentCenter = getRectCenter(parentGlobalFrame)
   const childCenter = getRectCenter(childGlobalFrame)
   if (parentFlexDirection === 'column') {
-    return Math.abs(childCenter.x - parentCenter.x) < parentGlobalFrame.height * 0.2
+    return Math.abs(childCenter.x - parentCenter.x) < parentGlobalFrame.width * 0.2
   } else if (parentFlexDirection === 'row') {
-    return Math.abs(childCenter.y - parentCenter.y) < parentGlobalFrame.width * 0.2
+    return Math.abs(childCenter.y - parentCenter.y) < parentGlobalFrame.height * 0.2
   }
   assertNever(parentFlexDirection)
 }
@@ -274,7 +273,7 @@ function maybeAlignElementsToCenter(
   metadata: ElementInstanceMetadataMap,
   childrenPaths: ElementPath[],
   targetPath: ElementPath,
-  detectedDirection: FlexDirectionRowColumn,
+  detectedDirection: FlexDirection,
 ) {
   if (onlyChildIsSpan(metadata, childrenPaths)) {
     return [
@@ -308,7 +307,7 @@ function guessMatchingFlexSetup(
   target: ElementPath,
   children: Array<ElementPath>,
 ): {
-  direction: FlexDirectionRowColumn
+  direction: FlexDirection
   sortedChildren: Array<CanvasFrameAndTarget>
   averageGap: number | null
   padding: string | null
@@ -336,13 +335,13 @@ function guessLayoutDirection(
   target: ElementPath,
   children: Array<ElementPath>,
 ): {
-  direction: FlexDirectionRowColumn
+  direction: FlexDirection
   sortedChildren: Array<CanvasFrameAndTarget>
   parentRect: CanvasRectangle
   averageGap: number | null
 } {
   const parentRect = MetadataUtils.getFrameOrZeroRectInCanvasCoords(target, metadata)
-  const firstGuess: FlexDirectionRowColumn = parentRect.width > parentRect.height ? 'row' : 'column'
+  const firstGuess: FlexDirection = parentRect.width > parentRect.height ? 'row' : 'column'
   const firstGuessResult = detectConfigurationInDirection(
     metadata,
     children,
@@ -368,7 +367,7 @@ function guessLayoutDirection(
 }
 
 function guessPadding(
-  direction: FlexDirectionRowColumn,
+  direction: FlexDirection,
   parentRect: CanvasRectangle,
   sortedChildren: Array<CanvasFrameAndTarget>,
 ): string | null {
@@ -398,11 +397,11 @@ function appendPx(value: number): string {
 function detectConfigurationInDirection(
   metadata: ElementInstanceMetadataMap,
   children: Array<ElementPath>,
-  direction: FlexDirectionRowColumn,
+  direction: FlexDirection,
   parentRect: CanvasRectangle,
 ): {
   childrenDontOverlap: boolean
-  direction: FlexDirectionRowColumn
+  direction: FlexDirection
   sortedChildren: Array<CanvasFrameAndTarget>
   averageGap: number | null
   parentRect: CanvasRectangle
@@ -455,7 +454,7 @@ function detectConfigurationInDirection(
 }
 
 function guessAlignItems(
-  direction: FlexDirectionRowColumn,
+  direction: FlexDirection,
   children: Array<CanvasFrameAndTarget>,
 ): FlexAlignItems | null {
   if (children.length < 2) {

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
@@ -247,6 +247,8 @@ function ifElementIsFragmentLikeFirstConvertItToFrame(
   return []
 }
 
+const NEAR_CENTER_LINE_TOLERANCE = 0.2
+
 function isElementNearCenterLine(
   parentGlobalFrame: CanvasRectangle,
   parentFlexDirection: FlexDirectionRowColumn,
@@ -262,12 +264,20 @@ function isElementNearCenterLine(
 
   const parentCenter = getRectCenter(parentGlobalFrame)
   const childCenter = getRectCenter(childGlobalFrame)
-  if (parentFlexDirection === 'column') {
-    return Math.abs(childCenter.x - parentCenter.x) < parentGlobalFrame.width * 0.2
-  } else if (parentFlexDirection === 'row') {
-    return Math.abs(childCenter.y - parentCenter.y) < parentGlobalFrame.height * 0.2
+  switch (parentFlexDirection) {
+    case 'column':
+      return (
+        Math.abs(childCenter.x - parentCenter.x) <
+        parentGlobalFrame.width * NEAR_CENTER_LINE_TOLERANCE
+      )
+    case 'row':
+      return (
+        Math.abs(childCenter.y - parentCenter.y) <
+        parentGlobalFrame.height * NEAR_CENTER_LINE_TOLERANCE
+      )
+    default:
+      assertNever(parentFlexDirection)
   }
-  assertNever(parentFlexDirection)
 }
 
 function maybeAlignElementsToCenter(


### PR DESCRIPTION
![19-50-1tqhe-8k8uc](https://github.com/concrete-utopia/utopia/assets/16385508/4a70bcd9-5569-444e-9dff-e8c9a56321f0)

## Problem
When converting an absolute layout to flex, elements arranged roughly along the center line of the container aren't center-aligned in the resulting flex container.

## Fix
Add extra logic in the flex conversion strategy to cater for this