### PR TITLE
uid duplication from props

### DIFF
--- a/editor/src/components/canvas/canvas-globals.spec.ts
+++ b/editor/src/components/canvas/canvas-globals.spec.ts
@@ -30,13 +30,20 @@ const cardComponentDescriptor: ComponentDescriptor = {
   variants: [
     {
       insertMenuLabel: 'Card Default',
-      elementToInsert: clearJSXElementWithoutUIDUniqueIDs(
-        jsxElementWithoutUID(
-          'Card',
-          [jsxAttributesEntry('title', jsExpressionValue('Default', emptyComments), emptyComments)],
-          [],
+      elementToInsert: () =>
+        clearJSXElementWithoutUIDUniqueIDs(
+          jsxElementWithoutUID(
+            'Card',
+            [
+              jsxAttributesEntry(
+                'title',
+                jsExpressionValue('Default', emptyComments),
+                emptyComments,
+              ),
+            ],
+            [],
+          ),
         ),
-      ),
       importsToAdd: {
         ['/src/card']: importDetails(null, [importAlias('Card')], null),
       },
@@ -73,16 +80,25 @@ const modifiedCardComponentDescriptor: ComponentDescriptor = {
   variants: [
     {
       insertMenuLabel: 'Card Default',
-      elementToInsert: clearJSXElementWithoutUIDUniqueIDs(
-        jsxElementWithoutUID(
-          'Card',
-          [
-            jsxAttributesEntry('title', jsExpressionValue('Default', emptyComments), emptyComments),
-            jsxAttributesEntry('border', jsExpressionValue('shiny', emptyComments), emptyComments),
-          ],
-          [],
+      elementToInsert: () =>
+        clearJSXElementWithoutUIDUniqueIDs(
+          jsxElementWithoutUID(
+            'Card',
+            [
+              jsxAttributesEntry(
+                'title',
+                jsExpressionValue('Default', emptyComments),
+                emptyComments,
+              ),
+              jsxAttributesEntry(
+                'border',
+                jsExpressionValue('shiny', emptyComments),
+                emptyComments,
+              ),
+            ],
+            [],
+          ),
         ),
-      ),
       importsToAdd: {
         ['/src/card']: importDetails(null, [importAlias('Card')], null),
       },
@@ -110,19 +126,20 @@ const selectorComponentDescriptor: ComponentDescriptor = {
   variants: [
     {
       insertMenuLabel: 'True False Selector',
-      elementToInsert: clearJSXElementWithoutUIDUniqueIDs(
-        jsxElementWithoutUID(
-          'Selector',
-          [
-            jsxAttributesEntry(
-              'value',
-              jsExpressionValue(`'FileNotFound'`, emptyComments),
-              emptyComments,
-            ),
-          ],
-          [],
+      elementToInsert: () =>
+        clearJSXElementWithoutUIDUniqueIDs(
+          jsxElementWithoutUID(
+            'Selector',
+            [
+              jsxAttributesEntry(
+                'value',
+                jsExpressionValue(`'FileNotFound'`, emptyComments),
+                emptyComments,
+              ),
+            ],
+            [],
+          ),
         ),
-      ),
       importsToAdd: {
         ['/src/selector']: importDetails(null, [importAlias('Selector')], null),
       },
@@ -198,35 +215,7 @@ describe('validateControlsToCheck', () => {
                 },
                 "variants": Array [
                   Object {
-                    "elementToInsert": Object {
-                      "children": Array [],
-                      "name": Object {
-                        "baseVariable": "Card",
-                        "propertyPath": Object {
-                          "propertyElements": Array [],
-                        },
-                      },
-                      "props": Array [
-                        Object {
-                          "comments": Object {
-                            "leadingComments": Array [],
-                            "trailingComments": Array [],
-                          },
-                          "key": "title",
-                          "type": "JSX_ATTRIBUTES_ENTRY",
-                          "value": Object {
-                            "comments": Object {
-                              "leadingComments": Array [],
-                              "trailingComments": Array [],
-                            },
-                            "type": "ATTRIBUTE_VALUE",
-                            "uid": "",
-                            "value": "Default",
-                          },
-                        },
-                      ],
-                      "type": "JSX_ELEMENT",
-                    },
+                    "elementToInsert": [Function],
                     "importsToAdd": Object {
                       "/src/card": Object {
                         "importedAs": null,
@@ -364,35 +353,7 @@ describe('validateControlsToCheck', () => {
                   },
                   "variants": Array [
                     Object {
-                      "elementToInsert": Object {
-                        "children": Array [],
-                        "name": Object {
-                          "baseVariable": "Card",
-                          "propertyPath": Object {
-                            "propertyElements": Array [],
-                          },
-                        },
-                        "props": Array [
-                          Object {
-                            "comments": Object {
-                              "leadingComments": Array [],
-                              "trailingComments": Array [],
-                            },
-                            "key": "title",
-                            "type": "JSX_ATTRIBUTES_ENTRY",
-                            "value": Object {
-                              "comments": Object {
-                                "leadingComments": Array [],
-                                "trailingComments": Array [],
-                              },
-                              "type": "ATTRIBUTE_VALUE",
-                              "uid": "",
-                              "value": "Default",
-                            },
-                          },
-                        ],
-                        "type": "JSX_ELEMENT",
-                      },
+                      "elementToInsert": [Function],
                       "importsToAdd": Object {
                         "/src/card": Object {
                           "importedAs": null,
@@ -447,35 +408,7 @@ describe('validateControlsToCheck', () => {
                 },
                 "variants": Array [
                   Object {
-                    "elementToInsert": Object {
-                      "children": Array [],
-                      "name": Object {
-                        "baseVariable": "Selector",
-                        "propertyPath": Object {
-                          "propertyElements": Array [],
-                        },
-                      },
-                      "props": Array [
-                        Object {
-                          "comments": Object {
-                            "leadingComments": Array [],
-                            "trailingComments": Array [],
-                          },
-                          "key": "value",
-                          "type": "JSX_ATTRIBUTES_ENTRY",
-                          "value": Object {
-                            "comments": Object {
-                              "leadingComments": Array [],
-                              "trailingComments": Array [],
-                            },
-                            "type": "ATTRIBUTE_VALUE",
-                            "uid": "",
-                            "value": "'FileNotFound'",
-                          },
-                        },
-                      ],
-                      "type": "JSX_ELEMENT",
-                    },
+                    "elementToInsert": [Function],
                     "importsToAdd": Object {
                       "/src/selector": Object {
                         "importedAs": null,
@@ -537,52 +470,7 @@ describe('validateControlsToCheck', () => {
                 },
                 "variants": Array [
                   Object {
-                    "elementToInsert": Object {
-                      "children": Array [],
-                      "name": Object {
-                        "baseVariable": "Card",
-                        "propertyPath": Object {
-                          "propertyElements": Array [],
-                        },
-                      },
-                      "props": Array [
-                        Object {
-                          "comments": Object {
-                            "leadingComments": Array [],
-                            "trailingComments": Array [],
-                          },
-                          "key": "title",
-                          "type": "JSX_ATTRIBUTES_ENTRY",
-                          "value": Object {
-                            "comments": Object {
-                              "leadingComments": Array [],
-                              "trailingComments": Array [],
-                            },
-                            "type": "ATTRIBUTE_VALUE",
-                            "uid": "",
-                            "value": "Default",
-                          },
-                        },
-                        Object {
-                          "comments": Object {
-                            "leadingComments": Array [],
-                            "trailingComments": Array [],
-                          },
-                          "key": "border",
-                          "type": "JSX_ATTRIBUTES_ENTRY",
-                          "value": Object {
-                            "comments": Object {
-                              "leadingComments": Array [],
-                              "trailingComments": Array [],
-                            },
-                            "type": "ATTRIBUTE_VALUE",
-                            "uid": "",
-                            "value": "shiny",
-                          },
-                        },
-                      ],
-                      "type": "JSX_ELEMENT",
-                    },
+                    "elementToInsert": [Function],
                     "importsToAdd": Object {
                       "/src/card": Object {
                         "importedAs": null,
@@ -632,35 +520,7 @@ describe('validateControlsToCheck', () => {
                 },
                 "variants": Array [
                   Object {
-                    "elementToInsert": Object {
-                      "children": Array [],
-                      "name": Object {
-                        "baseVariable": "Card",
-                        "propertyPath": Object {
-                          "propertyElements": Array [],
-                        },
-                      },
-                      "props": Array [
-                        Object {
-                          "comments": Object {
-                            "leadingComments": Array [],
-                            "trailingComments": Array [],
-                          },
-                          "key": "title",
-                          "type": "JSX_ATTRIBUTES_ENTRY",
-                          "value": Object {
-                            "comments": Object {
-                              "leadingComments": Array [],
-                              "trailingComments": Array [],
-                            },
-                            "type": "ATTRIBUTE_VALUE",
-                            "uid": "",
-                            "value": "Default",
-                          },
-                        },
-                      ],
-                      "type": "JSX_ELEMENT",
-                    },
+                    "elementToInsert": [Function],
                     "importsToAdd": Object {
                       "/src/card": Object {
                         "importedAs": null,
@@ -686,35 +546,7 @@ describe('validateControlsToCheck', () => {
                 },
                 "variants": Array [
                   Object {
-                    "elementToInsert": Object {
-                      "children": Array [],
-                      "name": Object {
-                        "baseVariable": "Card",
-                        "propertyPath": Object {
-                          "propertyElements": Array [],
-                        },
-                      },
-                      "props": Array [
-                        Object {
-                          "comments": Object {
-                            "leadingComments": Array [],
-                            "trailingComments": Array [],
-                          },
-                          "key": "title",
-                          "type": "JSX_ATTRIBUTES_ENTRY",
-                          "value": Object {
-                            "comments": Object {
-                              "leadingComments": Array [],
-                              "trailingComments": Array [],
-                            },
-                            "type": "ATTRIBUTE_VALUE",
-                            "uid": "",
-                            "value": "Default",
-                          },
-                        },
-                      ],
-                      "type": "JSX_ELEMENT",
-                    },
+                    "elementToInsert": [Function],
                     "importsToAdd": Object {
                       "/src/card": Object {
                         "importedAs": null,

--- a/editor/src/components/canvas/controls/render-as.tsx
+++ b/editor/src/components/canvas/controls/render-as.tsx
@@ -49,10 +49,11 @@ export const RenderAsRow = React.memo(() => {
   const onSelect = React.useCallback(
     (selectOption: SelectOption) => {
       const value: InsertableComponent = selectOption.value
-      if (value.element.type !== 'JSX_ELEMENT') {
+      const element = value.element()
+      if (element.type !== 'JSX_ELEMENT') {
         return
       }
-      onElementTypeChange(value.element.name, value.importsToAdd)
+      onElementTypeChange(element.name, value.importsToAdd)
     },
     [onElementTypeChange],
   )
@@ -103,8 +104,9 @@ export const RenderAsRow = React.memo(() => {
       for (const selectOptionGroup of insertableComponents) {
         for (const selectOption of selectOptionGroup.options ?? []) {
           const insertableComponent: InsertableComponent = selectOption.value
-          if (insertableComponent != null && insertableComponent.element.type === 'JSX_ELEMENT') {
-            if (jsxElementNameEquals(insertableComponent.element.name, nameToSearchFor)) {
+          const element = insertableComponent.element()
+          if (insertableComponent != null && element.type === 'JSX_ELEMENT') {
+            if (jsxElementNameEquals(element.name, nameToSearchFor)) {
               return selectOption
             }
           }

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -106,13 +106,13 @@ export function clearComponentElementToInsertUniqueIDs(
 
 export interface ComponentInfo {
   insertMenuLabel: string
-  elementToInsert: ComponentElementToInsert
+  elementToInsert: () => ComponentElementToInsert
   importsToAdd: Imports
 }
 
 export function componentInfo(
   insertMenuLabel: string,
-  elementToInsert: ComponentElementToInsert,
+  elementToInsert: () => ComponentElementToInsert,
   importsToAdd: Imports,
 ): ComponentInfo {
   return {

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -9,8 +9,6 @@ import {
   jsxElementName,
   jsxAttributesFromMap,
   emptyComments,
-  jsxTextBlock,
-  jsxAttributesEntry,
   simpleAttribute,
 } from '../../core/shared/element-template'
 import type { NormalisedFrame } from 'utopia-api/core'
@@ -173,7 +171,7 @@ export function defaultImgElement(uid: string): JSXElement {
   return jsxElement(
     jsxElementName('img', []),
     uid,
-    [...defaultImageAttributes, simpleAttribute('data-uid', uid)],
+    [...defaultImageAttributes(), simpleAttribute('data-uid', uid)],
     [],
   )
 }

--- a/editor/src/components/editor/insert-callbacks.ts
+++ b/editor/src/components/editor/insert-callbacks.ts
@@ -191,7 +191,7 @@ export function useToInsert(): (elementToInsert: InsertMenuItem | null) => void 
 
       const element = elementToReparent(
         fixUtopiaElement(
-          elementFromInsertMenuItem(elementToInsert.value.element, elementUid),
+          elementFromInsertMenuItem(elementToInsert.value.element(), elementUid),
           allElementUids,
         ).value,
         elementToInsert.value.importsToAdd,

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -165,19 +165,16 @@ function componentBeingInserted(
 }
 
 function elementBeingInserted(insertableComponent: InsertableComponent): ElementBeingInserted {
-  switch (insertableComponent.element.type) {
+  const element = insertableComponent.element()
+  switch (element.type) {
     case 'JSX_CONDITIONAL_EXPRESSION':
       return { type: 'conditional' }
     case 'JSX_FRAGMENT':
       return { type: 'fragment' }
     case 'JSX_ELEMENT':
-      return componentBeingInserted(
-        insertableComponent.importsToAdd,
-        insertableComponent.element.name,
-        insertableComponent.element.props,
-      )
+      return componentBeingInserted(insertableComponent.importsToAdd, element.name, element.props)
     default:
-      assertNever(insertableComponent.element)
+      assertNever(element)
   }
 }
 
@@ -201,17 +198,18 @@ const enableInsertMode = (
   createInteractionSessionCommand: CanvasAction,
   dispatch: EditorDispatch,
 ) => {
-  switch (component.element.type) {
+  const element = component.element()
+  switch (element.type) {
     case 'JSX_ELEMENT': {
       const newElement = jsxElement(
-        component.element.name,
+        element.name,
         newUID,
         setJSXAttributesAttribute(
-          addPositionAbsoluteToProps(component.element.props),
+          addPositionAbsoluteToProps(element.props),
           'data-uid',
           jsExpressionValue(newUID, emptyComments),
         ),
-        component.element.children,
+        element.children,
       )
 
       return dispatch(
@@ -257,7 +255,7 @@ const enableInsertMode = (
         'everyone',
       )
     default:
-      assertNever(component.element)
+      assertNever(element)
   }
 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -3054,7 +3054,7 @@ export const ComponentInfoKeepDeepEquality: KeepDeepEqualityCall<ComponentInfo> 
     (info) => info.insertMenuLabel,
     StringKeepDeepEquality,
     (info) => info.elementToInsert,
-    ComponentElementToInsertKeepDeepEquality,
+    createCallWithTripleEquals<() => ComponentElementToInsert>(),
     (info) => info.importsToAdd,
     objectDeepEquality(ImportDetailsKeepDeepEquality),
     componentInfo,

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -181,7 +181,7 @@ function callPropertyControlsHook(
             {
               insertMenuLabel: 'App',
               importsToAdd: {},
-              elementToInsert: jsxElementWithoutUID('App', [], []),
+              elementToInsert: () => jsxElementWithoutUID('App', [], []),
             },
           ],
         },
@@ -191,7 +191,7 @@ function callPropertyControlsHook(
             {
               insertMenuLabel: 'OtherComponent',
               importsToAdd: {},
-              elementToInsert: jsxElementWithoutUID('OtherComponent', [], []),
+              elementToInsert: () => jsxElementWithoutUID('OtherComponent', [], []),
             },
           ],
         },

--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -6,17 +6,7 @@ Array [
     "insertableComponents": Array [
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "App",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {},
         "name": "App",
         "stylePropOptions": Array [
@@ -47,38 +37,7 @@ Array [
     "insertableComponents": Array [
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "div",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": Object {
-                  "backgroundColor": "#aaaaaa33",
-                  "position": "absolute",
-                },
-              },
-            },
-          ],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -94,17 +53,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "span",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -120,17 +69,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "h1",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -146,17 +85,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "h2",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -172,17 +101,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "p",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -198,17 +117,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "button",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -224,17 +133,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "input",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -250,107 +149,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "video",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": Object {
-                  "height": "120px",
-                  "position": "absolute",
-                  "width": "250px",
-                },
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "controls",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": true,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "autoPlay",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": true,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "loop",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": true,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "src",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": "https://dl8.webmfiles.org/big-buck-bunny_trailer.webm",
-              },
-            },
-          ],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -366,56 +165,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "img",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": Object {
-                  "height": "64px",
-                  "position": "absolute",
-                  "width": "64px",
-                },
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "src",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": "/editor/utopia-logo-white-fill.png?hash=nocommit",
-              },
-            },
-          ],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -438,41 +188,7 @@ Array [
     "insertableComponents": Array [
       Object {
         "defaultSize": null,
-        "element": Object {
-          "comments": Object {
-            "leadingComments": Array [],
-            "trailingComments": Array [],
-          },
-          "condition": Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "type": "ATTRIBUTE_VALUE",
-            "uid": "",
-            "value": true,
-          },
-          "originalConditionString": "true",
-          "type": "JSX_CONDITIONAL_EXPRESSION",
-          "whenFalse": Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "type": "ATTRIBUTE_VALUE",
-            "uid": "",
-            "value": null,
-          },
-          "whenTrue": Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "type": "ATTRIBUTE_VALUE",
-            "uid": "",
-            "value": null,
-          },
-        },
+        "element": [Function],
         "importsToAdd": Object {},
         "name": "Conditional",
         "stylePropOptions": Array [
@@ -488,11 +204,7 @@ Array [
     "insertableComponents": Array [
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "longForm": true,
-          "type": "JSX_FRAGMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -514,23 +226,7 @@ Array [
     "insertableComponents": Array [
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [
-            Object {
-              "text": "Sample text",
-              "type": "JSX_TEXT_BLOCK",
-              "uid": "",
-            },
-          ],
-          "name": Object {
-            "baseVariable": "span",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {},
         "name": "Sample text",
         "stylePropOptions": Array [
@@ -559,17 +255,7 @@ Array [
     "insertableComponents": Array [
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "App",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {},
         "name": "App",
         "stylePropOptions": Array [
@@ -600,38 +286,7 @@ Array [
     "insertableComponents": Array [
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "div",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": Object {
-                  "backgroundColor": "#aaaaaa33",
-                  "position": "absolute",
-                },
-              },
-            },
-          ],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -647,17 +302,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "span",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -673,17 +318,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "h1",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -699,17 +334,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "h2",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -725,17 +350,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "p",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -751,17 +366,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "button",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -777,17 +382,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "input",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -803,107 +398,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "video",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": Object {
-                  "height": "120px",
-                  "position": "absolute",
-                  "width": "250px",
-                },
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "controls",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": true,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "autoPlay",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": true,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "loop",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": true,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "src",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": "https://dl8.webmfiles.org/big-buck-bunny_trailer.webm",
-              },
-            },
-          ],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -919,56 +414,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "img",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "style",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": Object {
-                  "height": "64px",
-                  "position": "absolute",
-                  "width": "64px",
-                },
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "src",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": "/editor/utopia-logo-white-fill.png?hash=nocommit",
-              },
-            },
-          ],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -991,41 +437,7 @@ Array [
     "insertableComponents": Array [
       Object {
         "defaultSize": null,
-        "element": Object {
-          "comments": Object {
-            "leadingComments": Array [],
-            "trailingComments": Array [],
-          },
-          "condition": Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "type": "ATTRIBUTE_VALUE",
-            "uid": "",
-            "value": true,
-          },
-          "originalConditionString": "true",
-          "type": "JSX_CONDITIONAL_EXPRESSION",
-          "whenFalse": Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "type": "ATTRIBUTE_VALUE",
-            "uid": "",
-            "value": null,
-          },
-          "whenTrue": Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "type": "ATTRIBUTE_VALUE",
-            "uid": "",
-            "value": null,
-          },
-        },
+        "element": [Function],
         "importsToAdd": Object {},
         "name": "Conditional",
         "stylePropOptions": Array [
@@ -1041,11 +453,7 @@ Array [
     "insertableComponents": Array [
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "longForm": true,
-          "type": "JSX_FRAGMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -1067,23 +475,7 @@ Array [
     "insertableComponents": Array [
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [
-            Object {
-              "text": "Sample text",
-              "type": "JSX_TEXT_BLOCK",
-              "uid": "",
-            },
-          ],
-          "name": Object {
-            "baseVariable": "span",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {},
         "name": "Sample text",
         "stylePropOptions": Array [
@@ -1099,17 +491,7 @@ Array [
     "insertableComponents": Array [
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "DatePicker",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "antd": Object {
             "importedAs": null,
@@ -1135,154 +517,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "Button",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "disabled",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "type",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": "default",
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "shape",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": "default",
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "ghost",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "block",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "danger",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "loading",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "target",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": "button",
-              },
-            },
-          ],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "antd": Object {
             "importedAs": null,
@@ -1308,17 +543,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "InputNumber",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "antd": Object {
             "importedAs": null,
@@ -1344,69 +569,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "Row",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "align",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": "top",
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "gutter",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": 0,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "justify",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": "center",
-              },
-            },
-          ],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "antd": Object {
             "importedAs": null,
@@ -1432,205 +595,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "Col",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "flex",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": 1,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "offset",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": 0,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "order",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": 0,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "pull",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": 0,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "push",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": 0,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "xs",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": 0,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "sm",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": 0,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "md",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": 0,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "lg",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": 0,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "xl",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": 0,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "xxl",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": 0,
-              },
-            },
-          ],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "antd": Object {
             "importedAs": null,
@@ -1656,69 +621,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "Space",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "align",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": "center",
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "direction",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": "vertical",
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "size",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": "middle",
-              },
-            },
-          ],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "antd": Object {
             "importedAs": null,
@@ -1744,171 +647,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "Menu",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "forceSubMenuRender",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "inlineCollapsed",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "inlineIndent",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": 24,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "mode",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": "inline",
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "multiple",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "selectable",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": true,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "subMenuCloseDelay",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": 0.1,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "subMenuOpenDelay",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": 0,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "theme",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": "light",
-              },
-            },
-          ],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "antd": Object {
             "importedAs": null,
@@ -1934,54 +673,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "Menu",
-            "propertyPath": Object {
-              "propertyElements": Array [
-                "Item",
-              ],
-            },
-          },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "disabled",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "danger",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-          ],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "antd": Object {
             "importedAs": null,
@@ -2007,37 +699,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "Menu",
-            "propertyPath": Object {
-              "propertyElements": Array [
-                "SubMenu",
-              ],
-            },
-          },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "disabled",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-          ],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "antd": Object {
             "importedAs": null,
@@ -2063,19 +725,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "Menu",
-            "propertyPath": Object {
-              "propertyElements": Array [
-                "ItemGroup",
-              ],
-            },
-          },
-          "props": Array [],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "antd": Object {
             "importedAs": null,
@@ -2101,190 +751,7 @@ Array [
       },
       Object {
         "defaultSize": null,
-        "element": Object {
-          "children": Array [],
-          "name": Object {
-            "baseVariable": "Typography",
-            "propertyPath": Object {
-              "propertyElements": Array [
-                "Text",
-              ],
-            },
-          },
-          "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "code",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "copyable",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "delete",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "disabled",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "editable",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "ellipsis",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "mark",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "keyboard",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "underline",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "strong",
-              "type": "JSX_ATTRIBUTES_ENTRY",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "uid": "",
-                "value": false,
-              },
-            },
-          ],
-          "type": "JSX_ELEMENT",
-        },
+        "element": [Function],
         "importsToAdd": Object {
           "antd": Object {
             "importedAs": null,

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -51,7 +51,7 @@ export type StylePropOption = 'do-not-add' | 'add-size'
 
 export interface InsertableComponent {
   importsToAdd: Imports
-  element: ComponentElementToInsert
+  element: () => ComponentElementToInsert
   name: string
   stylePropOptions: Array<StylePropOption>
   defaultSize: Size | null
@@ -59,7 +59,7 @@ export interface InsertableComponent {
 
 export function insertableComponent(
   importsToAdd: Imports,
-  element: ComponentElementToInsert,
+  element: () => ComponentElementToInsert,
   name: string,
   stylePropOptions: Array<StylePropOption>,
   defaultSize: Size | null,
@@ -77,12 +77,12 @@ export function clearInsertableComponentUniqueIDs(
   insertableComponentToFix: InsertableComponent,
 ): InsertableComponent {
   const updatedElement =
-    typeof insertableComponentToFix.element === 'string'
-      ? insertableComponentToFix.element
-      : clearComponentElementToInsertUniqueIDs(insertableComponentToFix.element)
+    typeof insertableComponentToFix.element() === 'string'
+      ? insertableComponentToFix.element()
+      : clearComponentElementToInsertUniqueIDs(insertableComponentToFix.element())
   return {
     ...insertableComponentToFix,
-    element: updatedElement,
+    element: () => updatedElement,
   }
 }
 
@@ -269,7 +269,7 @@ const stockHTMLPropertyControls: PropertyControls = {
 function makeHTMLDescriptor(
   tag: string,
   extraPropertyControls: PropertyControls,
-  attributes?: JSXAttributes,
+  attributes?: () => JSXAttributes,
 ): ComponentDescriptor {
   const propertyControls: PropertyControls = {
     ...stockHTMLPropertyControls,
@@ -287,13 +287,13 @@ function makeHTMLDescriptor(
             importedWithName: null,
           },
         },
-        elementToInsert: jsxElementWithoutUID(tag, attributes ?? [], []),
+        elementToInsert: () => jsxElementWithoutUID(tag, attributes?.() ?? [], []),
       },
     ],
   }
 }
 
-export const defaultImageAttributes: JSXAttributes = [
+export const defaultImageAttributes = (): JSXAttributes => [
   simpleAttribute('style', {
     width: '64px',
     height: '64px',
@@ -303,9 +303,7 @@ export const defaultImageAttributes: JSXAttributes = [
 ]
 
 const basicHTMLElementsDescriptors = {
-  div: makeHTMLDescriptor(
-    'div',
-    {},
+  div: makeHTMLDescriptor('div', {}, () =>
     jsxAttributesFromMap({
       style: defaultElementStyle(),
     }),
@@ -335,7 +333,7 @@ const basicHTMLElementsDescriptors = {
         control: 'style-controls',
       },
     },
-    [
+    () => [
       simpleAttribute('style', {
         width: '250px',
         height: '120px',
@@ -367,13 +365,14 @@ const conditionalElementsDescriptors: ComponentDescriptorsForFile = {
     variants: [
       {
         insertMenuLabel: 'Conditional',
-        elementToInsert: jsxConditionalExpressionWithoutUID(
-          jsExpressionValue(true, emptyComments),
-          'true',
-          jsExpressionValue(null, emptyComments),
-          jsExpressionValue(null, emptyComments),
-          emptyComments,
-        ),
+        elementToInsert: () =>
+          jsxConditionalExpressionWithoutUID(
+            jsExpressionValue(true, emptyComments),
+            'true',
+            jsExpressionValue(null, emptyComments),
+            jsExpressionValue(null, emptyComments),
+            emptyComments,
+          ),
         importsToAdd: {},
       },
     ],
@@ -386,7 +385,7 @@ const groupElementsDescriptors: ComponentDescriptorsForFile = {
     variants: [
       {
         insertMenuLabel: 'Group',
-        elementToInsert: groupJSXElement([]),
+        elementToInsert: () => groupJSXElement([]),
         importsToAdd: groupJSXElementImportsToAdd(),
       },
     ],
@@ -395,7 +394,7 @@ const groupElementsDescriptors: ComponentDescriptorsForFile = {
 
 export const fragmentComponentInfo: ComponentInfo = {
   insertMenuLabel: 'Fragment',
-  elementToInsert: jsxFragmentWithoutUID([], true),
+  elementToInsert: () => jsxFragmentWithoutUID([], true),
   importsToAdd: {
     react: {
       importedAs: 'React',
@@ -418,7 +417,7 @@ const samplesDescriptors: ComponentDescriptorsForFile = {
     variants: [
       {
         insertMenuLabel: 'Sample text',
-        elementToInsert: jsxElementWithoutUID('span', [], [jsxTextBlock('Sample text')]),
+        elementToInsert: () => jsxElementWithoutUID('span', [], [jsxTextBlock('Sample text')]),
         importsToAdd: {},
       },
     ],
@@ -552,7 +551,7 @@ export function getComponentGroups(
             insertableComponents.push(
               insertableComponent(
                 exportedComponent.importsToAdd,
-                jsxElementWithoutUID(exportedComponent.listingName, [], []),
+                () => jsxElementWithoutUID(exportedComponent.listingName, [], []),
                 exportedComponent.listingName,
                 stylePropOptions,
                 null,

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -84,36 +84,7 @@ describe('registered property controls', () => {
           },
           "variants": Array [
             Object {
-              "elementToInsert": Object {
-                "children": Array [],
-                "name": Object {
-                  "baseVariable": "Card",
-                  "propertyPath": Object {
-                    "propertyElements": Array [],
-                  },
-                },
-                "props": Array [
-                  Object {
-                    "comments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "key": "data-uid",
-                    "type": "JSX_ATTRIBUTES_ENTRY",
-                    "value": Object {
-                      "comments": Object {
-                        "leadingComments": Array [],
-                        "trailingComments": Array [],
-                      },
-                      "type": "ATTRIBUTE_VALUE",
-                      "uid": "",
-                      "value": "fb0",
-                    },
-                  },
-                ],
-                "type": "JSX_ELEMENT",
-                "uid": "",
-              },
+              "elementToInsert": [Function],
               "importsToAdd": Object {
                 "/src/card": Object {
                   "importedAs": null,
@@ -129,79 +100,7 @@ describe('registered property controls', () => {
               "insertMenuLabel": "Card",
             },
             Object {
-              "elementToInsert": Object {
-                "children": Array [],
-                "name": Object {
-                  "baseVariable": "Card",
-                  "propertyPath": Object {
-                    "propertyElements": Array [],
-                  },
-                },
-                "props": Array [
-                  Object {
-                    "comments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "key": "person",
-                    "type": "JSX_ATTRIBUTES_ENTRY",
-                    "value": Object {
-                      "comments": Object {
-                        "leadingComments": Array [],
-                        "trailingComments": Array [],
-                      },
-                      "definedElsewhere": Array [
-                        "DefaultPerson",
-                      ],
-                      "elementsWithin": Object {},
-                      "javascript": "DefaultPerson",
-                      "originalJavascript": "DefaultPerson",
-                      "sourceMap": Object {
-                        "file": "code.tsx",
-                        "mappings": "OAI2BA",
-                        "names": Array [
-                          "DefaultPerson",
-                        ],
-                        "sources": Array [
-                          "code.tsx",
-                        ],
-                        "sourcesContent": Array [
-                          "import { Card } from '/src/card'; import { DefaultPerson } from '/src/defaults';;
-
-             function Utopia$$$Component(props) {
-                return (
-                  <Card person={DefaultPerson} />
-                )
-               }",
-                        ],
-                        "version": 3,
-                      },
-                      "transpiledJavascript": "return DefaultPerson;",
-                      "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
-                      "uid": "",
-                    },
-                  },
-                  Object {
-                    "comments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "key": "data-uid",
-                    "type": "JSX_ATTRIBUTES_ENTRY",
-                    "value": Object {
-                      "comments": Object {
-                        "leadingComments": Array [],
-                        "trailingComments": Array [],
-                      },
-                      "type": "ATTRIBUTE_VALUE",
-                      "uid": "",
-                      "value": "627",
-                    },
-                  },
-                ],
-                "type": "JSX_ELEMENT",
-                "uid": "",
-              },
+              "elementToInsert": [Function],
               "importsToAdd": Object {
                 "/src/card": Object {
                   "importedAs": null,

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -30,7 +30,6 @@ import {
   applicative3Either,
   bimapEither,
   foldEither,
-  isLeft,
   mapEither,
   sequenceEither,
 } from '../shared/either'
@@ -61,7 +60,7 @@ async function parseInsertOption(
   return mapEither(({ importsToAdd, elementToInsert }) => {
     return {
       insertMenuLabel: insertOption.label ?? componentName,
-      elementToInsert: elementToInsert,
+      elementToInsert: () => elementToInsert,
       importsToAdd: importsToAdd,
     }
   }, parsedParams)

--- a/editor/src/core/third-party/antd-components.ts
+++ b/editor/src/core/third-party/antd-components.ts
@@ -5,15 +5,7 @@ import type {
   ComponentDescriptorsForFile,
 } from '../../components/custom-code/code-file'
 import type { JSXAttributes } from '../shared/element-template'
-import {
-  emptyComments,
-  JSXAttributesEntry,
-  jsxAttributesEntry,
-  jsExpressionValue,
-  jsxElementName,
-  jsxElementWithoutUID,
-  simpleAttribute,
-} from '../shared/element-template'
+import { jsxElementName, jsxElementWithoutUID, simpleAttribute } from '../shared/element-template'
 import type { PropertyPathPart } from '../shared/project-file-types'
 
 const StyleObjectProps: PropertyControls = {
@@ -26,7 +18,7 @@ function createBasicComponent(
   baseVariable: string,
   propertyPathParts: PropertyPathPart[],
   propertyControls: PropertyControls,
-  attributes?: JSXAttributes,
+  attributes?: () => JSXAttributes,
 ): ComponentDescriptor {
   return {
     properties: { ...StyleObjectProps, ...propertyControls },
@@ -50,11 +42,12 @@ function createBasicComponent(
             importedAs: null,
           },
         },
-        elementToInsert: jsxElementWithoutUID(
-          jsxElementName(baseVariable, propertyPathParts),
-          attributes ?? [],
-          [],
-        ),
+        elementToInsert: () =>
+          jsxElementWithoutUID(
+            jsxElementName(baseVariable, propertyPathParts),
+            attributes?.() ?? [],
+            [],
+          ),
       },
     ],
   }
@@ -62,7 +55,7 @@ function createBasicComponent(
 
 export const AntdComponents: ComponentDescriptorsForFile = {
   DatePicker: createBasicComponent('DatePicker', [], {}),
-  Button: createBasicComponent('Button', [], AntdControls.Button, [
+  Button: createBasicComponent('Button', [], AntdControls.Button, () => [
     simpleAttribute('disabled', false),
     simpleAttribute('type', 'default'),
     simpleAttribute('shape', 'default'),
@@ -73,12 +66,12 @@ export const AntdComponents: ComponentDescriptorsForFile = {
     simpleAttribute('target', 'button'),
   ]),
   InputNumber: createBasicComponent('InputNumber', [], {}),
-  Row: createBasicComponent('Row', [], AntdControls.Row, [
+  Row: createBasicComponent('Row', [], AntdControls.Row, () => [
     simpleAttribute('align', 'top'),
     simpleAttribute('gutter', 0),
     simpleAttribute('justify', 'center'),
   ]),
-  Col: createBasicComponent('Col', [], AntdControls.Col, [
+  Col: createBasicComponent('Col', [], AntdControls.Col, () => [
     simpleAttribute('flex', 1),
     simpleAttribute('offset', 0),
     simpleAttribute('order', 0),
@@ -91,12 +84,12 @@ export const AntdComponents: ComponentDescriptorsForFile = {
     simpleAttribute('xl', 0),
     simpleAttribute('xxl', 0),
   ]),
-  Space: createBasicComponent('Space', [], AntdControls.Space, [
+  Space: createBasicComponent('Space', [], AntdControls.Space, () => [
     simpleAttribute('align', 'center'),
     simpleAttribute('direction', 'vertical'),
     simpleAttribute('size', 'middle'),
   ]),
-  Menu: createBasicComponent('Menu', [], AntdControls.Menu, [
+  Menu: createBasicComponent('Menu', [], AntdControls.Menu, () => [
     simpleAttribute('forceSubMenuRender', false),
     simpleAttribute('inlineCollapsed', false),
     simpleAttribute('inlineIndent', 24),
@@ -107,24 +100,29 @@ export const AntdComponents: ComponentDescriptorsForFile = {
     simpleAttribute('subMenuOpenDelay', 0.0),
     simpleAttribute('theme', 'light'),
   ]),
-  'Menu.Item': createBasicComponent('Menu', ['Item'], AntdControls['Menu.Item'], [
+  'Menu.Item': createBasicComponent('Menu', ['Item'], AntdControls['Menu.Item'], () => [
     simpleAttribute('disabled', false),
     simpleAttribute('danger', false),
   ]),
-  'Menu.SubMenu': createBasicComponent('Menu', ['SubMenu'], AntdControls['Menu.SubMenu'], [
+  'Menu.SubMenu': createBasicComponent('Menu', ['SubMenu'], AntdControls['Menu.SubMenu'], () => [
     simpleAttribute('disabled', false),
   ]),
   'Menu.ItemGroup': createBasicComponent('Menu', ['ItemGroup'], AntdControls['Menu.ItemGroup']),
-  'Typography.Text': createBasicComponent('Typography', ['Text'], AntdControls['Typography.Text'], [
-    simpleAttribute('code', false),
-    simpleAttribute('copyable', false),
-    simpleAttribute('delete', false),
-    simpleAttribute('disabled', false),
-    simpleAttribute('editable', false),
-    simpleAttribute('ellipsis', false),
-    simpleAttribute('mark', false),
-    simpleAttribute('keyboard', false),
-    simpleAttribute('underline', false),
-    simpleAttribute('strong', false),
-  ]),
+  'Typography.Text': createBasicComponent(
+    'Typography',
+    ['Text'],
+    AntdControls['Typography.Text'],
+    () => [
+      simpleAttribute('code', false),
+      simpleAttribute('copyable', false),
+      simpleAttribute('delete', false),
+      simpleAttribute('disabled', false),
+      simpleAttribute('editable', false),
+      simpleAttribute('ellipsis', false),
+      simpleAttribute('mark', false),
+      simpleAttribute('keyboard', false),
+      simpleAttribute('underline', false),
+      simpleAttribute('strong', false),
+    ],
+  ),
 }

--- a/editor/src/core/third-party/react-three-fiber-components.ts
+++ b/editor/src/core/third-party/react-three-fiber-components.ts
@@ -9,12 +9,11 @@ import {
   emptyComments,
   jsExpressionOtherJavaScript,
   jsxAttributesEntry,
-  jsExpressionValue,
   jsxElementWithoutUID,
   simpleAttribute,
 } from '../shared/element-template'
 import type { Imports } from '../shared/project-file-types'
-import { importAlias, importDetails } from '../shared/project-file-types'
+import { importDetails } from '../shared/project-file-types'
 
 function threeAttribute(key: string, fromThree: string): JSXAttributesEntry {
   return jsxAttributesEntry(
@@ -35,7 +34,7 @@ function threeAttribute(key: string, fromThree: string): JSXAttributesEntry {
 function createBasicComponent(
   name: string,
   propertyControls: PropertyControls,
-  attributes?: JSXAttributes,
+  attributes?: () => JSXAttributes,
   importsToAdd?: Imports,
 ): ComponentDescriptor {
   return {
@@ -44,7 +43,7 @@ function createBasicComponent(
       {
         insertMenuLabel: name,
         importsToAdd: importsToAdd ?? {},
-        elementToInsert: jsxElementWithoutUID(name, attributes ?? [], []),
+        elementToInsert: () => jsxElementWithoutUID(name, attributes?.() ?? [], []),
       },
     ],
   }
@@ -90,28 +89,28 @@ const materialDefaultValues: JSXAttributes = [
 ]
 
 export const ReactThreeFiberComponents: ComponentDescriptorsForFile = {
-  color: createBasicComponent('color', ReactThreeFiberControls.color, [
+  color: createBasicComponent('color', ReactThreeFiberControls.color, () => [
     simpleAttribute('attach', 1),
   ]),
-  fog: createBasicComponent('fog', ReactThreeFiberControls.fog, [
+  fog: createBasicComponent('fog', ReactThreeFiberControls.fog, () => [
     simpleAttribute('near', 1),
     simpleAttribute('far', 1000),
   ]),
-  ambientLight: createBasicComponent('ambientLight', ReactThreeFiberControls.ambientLight, [
+  ambientLight: createBasicComponent('ambientLight', ReactThreeFiberControls.ambientLight, () => [
     simpleAttribute('intensity', 1),
   ]),
   directionalLight: createBasicComponent(
     'directionalLight',
     ReactThreeFiberControls.directionalLight,
-    [simpleAttribute('intensity', 1), simpleAttribute('castShadow', false)],
+    () => [simpleAttribute('intensity', 1), simpleAttribute('castShadow', false)],
   ),
-  pointLight: createBasicComponent('pointLight', ReactThreeFiberControls.pointLight, [
+  pointLight: createBasicComponent('pointLight', ReactThreeFiberControls.pointLight, () => [
     simpleAttribute('intensity', 1),
     simpleAttribute('decay', 1),
     simpleAttribute('distance', 0),
     simpleAttribute('power', 4 * Math.PI),
   ]),
-  spotLight: createBasicComponent('spotLight', ReactThreeFiberControls.spotLight, [
+  spotLight: createBasicComponent('spotLight', ReactThreeFiberControls.spotLight, () => [
     simpleAttribute('intensity', 1),
     simpleAttribute('angle', Math.PI / 3),
     simpleAttribute('castShadow', false),
@@ -120,20 +119,26 @@ export const ReactThreeFiberComponents: ComponentDescriptorsForFile = {
     simpleAttribute('penumbra', 0),
     simpleAttribute('power', 4 * Math.PI),
   ]),
-  boxGeometry: createBasicComponent('boxGeometry', ReactThreeFiberControls.boxGeometry, [
+  boxGeometry: createBasicComponent('boxGeometry', ReactThreeFiberControls.boxGeometry, () => [
     simpleAttribute('morphTargetsRelative', false),
   ]),
-  planeGeometry: createBasicComponent('planeGeometry', ReactThreeFiberControls.planeGeometry, [
-    simpleAttribute('morphTargetsRelative', false),
-  ]),
-  sphereGeometry: createBasicComponent('sphereGeometry', ReactThreeFiberControls.sphereGeometry, [
-    simpleAttribute('morphTargetsRelative', false),
-    simpleAttribute('args', [1, 32, 16, 0, 2 * Math.PI, 0, Math.PI]),
-  ]),
+  planeGeometry: createBasicComponent(
+    'planeGeometry',
+    ReactThreeFiberControls.planeGeometry,
+    () => [simpleAttribute('morphTargetsRelative', false)],
+  ),
+  sphereGeometry: createBasicComponent(
+    'sphereGeometry',
+    ReactThreeFiberControls.sphereGeometry,
+    () => [
+      simpleAttribute('morphTargetsRelative', false),
+      simpleAttribute('args', [1, 32, 16, 0, 2 * Math.PI, 0, Math.PI]),
+    ],
+  ),
   meshBasicMaterial: createBasicComponent(
     'meshBasicMaterial',
     ReactThreeFiberControls.meshBasicMaterial,
-    [
+    () => [
       ...materialDefaultValues,
       simpleAttribute('aoMapIntensity', 1),
       threeAttribute('combine', 'Multiply'),
@@ -150,7 +155,7 @@ export const ReactThreeFiberComponents: ComponentDescriptorsForFile = {
   meshStandardMaterial: createBasicComponent(
     'meshStandardMaterial',
     ReactThreeFiberControls.meshStandardMaterial,
-    [
+    () => [
       ...materialDefaultValues,
       simpleAttribute('aoMapIntensity', 1),
       simpleAttribute('bumpScale', 1),
@@ -172,7 +177,7 @@ export const ReactThreeFiberComponents: ComponentDescriptorsForFile = {
   shadowMaterial: createBasicComponent(
     'shadowMaterial',
     ReactThreeFiberControls.shadowMaterial,
-    [...materialDefaultValues, simpleAttribute('transparent', true)],
+    () => [...materialDefaultValues, simpleAttribute('transparent', true)],
     { three: importDetails(null, [], 'THREE') },
   ),
 }

--- a/editor/src/core/third-party/remix-controls.ts
+++ b/editor/src/core/third-party/remix-controls.ts
@@ -27,11 +27,12 @@ export const RemixRunReactComponents: ComponentDescriptorsForFile = {
             importedAs: null,
           },
         },
-        elementToInsert: jsxElementWithoutUID(
-          'Link',
-          [jsxAttributesEntry('to', jsExpressionValue('/', emptyComments), emptyComments)],
-          [jsxTextBlock('Link')],
-        ),
+        elementToInsert: () =>
+          jsxElementWithoutUID(
+            'Link',
+            [jsxAttributesEntry('to', jsExpressionValue('/', emptyComments), emptyComments)],
+            [jsxTextBlock('Link')],
+          ),
       },
     ],
   },
@@ -52,7 +53,7 @@ export const RemixRunReactComponents: ComponentDescriptorsForFile = {
             importedAs: null,
           },
         },
-        elementToInsert: jsxElementWithoutUID('Outlet', [], []),
+        elementToInsert: () => jsxElementWithoutUID('Outlet', [], []),
       },
     ],
   },

--- a/editor/src/core/third-party/utopia-api-components.ts
+++ b/editor/src/core/third-party/utopia-api-components.ts
@@ -14,7 +14,7 @@ import { emptyComments, jsxAttributesEntry, jsxElementWithoutUID } from '../shar
 
 const BasicUtopiaComponentDescriptor = (
   name: string,
-  styleProp: JSExpression,
+  styleProp: () => JSExpression,
 ): ComponentDescriptor => {
   return {
     properties: {
@@ -37,22 +37,19 @@ const BasicUtopiaComponentDescriptor = (
             importedAs: null,
           },
         },
-        elementToInsert: jsxElementWithoutUID(
-          name,
-          [jsxAttributesEntry('style', styleProp, emptyComments)],
-          [],
-        ),
+        elementToInsert: () =>
+          jsxElementWithoutUID(name, [jsxAttributesEntry('style', styleProp(), emptyComments)], []),
       },
     ],
   }
 }
 
 export const UtopiaApiComponents: ComponentDescriptorsForFile = {
-  Ellipse: BasicUtopiaComponentDescriptor('Ellipse', defaultElementStyle()),
-  Rectangle: BasicUtopiaComponentDescriptor('Rectangle', defaultRectangleElementStyle()),
-  View: BasicUtopiaComponentDescriptor('View', defaultElementStyle()),
-  FlexRow: BasicUtopiaComponentDescriptor('FlexRow', defaultFlexRowOrColStyle()),
-  FlexCol: BasicUtopiaComponentDescriptor('FlexCol', defaultFlexRowOrColStyle()),
-  Scene: BasicUtopiaComponentDescriptor('Scene', defaultSceneElementStyle(null)),
-  RemixScene: BasicUtopiaComponentDescriptor('RemixScene', defaultSceneElementStyle(null)),
+  Ellipse: BasicUtopiaComponentDescriptor('Ellipse', defaultElementStyle),
+  Rectangle: BasicUtopiaComponentDescriptor('Rectangle', defaultRectangleElementStyle),
+  View: BasicUtopiaComponentDescriptor('View', defaultElementStyle),
+  FlexRow: BasicUtopiaComponentDescriptor('FlexRow', defaultFlexRowOrColStyle),
+  FlexCol: BasicUtopiaComponentDescriptor('FlexCol', defaultFlexRowOrColStyle),
+  Scene: BasicUtopiaComponentDescriptor('Scene', () => defaultSceneElementStyle(null)),
+  RemixScene: BasicUtopiaComponentDescriptor('RemixScene', () => defaultSceneElementStyle(null)),
 }


### PR DESCRIPTION
## Problem
Inserting two images from the insert pane triggers an unrecoverable error

## Cause
Same as https://github.com/concrete-utopia/utopia/pull/4346

## Fix
This PR attacks the problem from a different angle: `ComponentInfo` and `InsertableComponent` are refactored so that the element wrap is made lazy (via a function call). This, coupled with passing the attributes to the element templates in a lazy manner, makes the `jsExpressionValue` calls lazy as well, so the same element template will get new uids for its props every time it's inserted