### PR TITLE
Remove constraints when converting from a group.

### DIFF
--- a/editor/src/components/inspector/editor-contract-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/editor-contract-section.spec.browser2.tsx
@@ -1000,6 +1000,7 @@ function nestedGroupsWithWrapperType(outerWrapperType: WrapperType, innerWrapper
               width: 157,
               height: 112,
             }}
+            ${innerWrapperType === 'group' ? `data-constraints={['left', 'width']}` : ``}
             data-uid='f64'
           />
           <div
@@ -1011,6 +1012,7 @@ function nestedGroupsWithWrapperType(outerWrapperType: WrapperType, innerWrapper
               width: 139,
               height: 138,
             }}
+            ${innerWrapperType === 'group' ? `data-constraints={['left', 'width']}` : ``}
             data-uid='978'
           />
         ${closingTag(innerWrapperType)}

--- a/editor/src/components/inspector/editor-contract-section.tsx
+++ b/editor/src/components/inspector/editor-contract-section.tsx
@@ -17,7 +17,7 @@ import { metadataSelector, selectedViewsSelector } from './inpector-selectors'
 import {
   convertFragmentToFrame,
   convertFragmentToGroup,
-  convertFrameToFragmentCommands,
+  convertGroupOrFrameToFragmentCommands,
   convertFrameToGroup,
   convertGroupToFrameCommands,
   getInstanceForFragmentToFrameConversion,
@@ -26,6 +26,7 @@ import {
   getInstanceForFrameToGroupConversion,
   getInstanceForGroupToFrameConversion,
   isConversionForbidden,
+  getCommandsForConversionToDesiredType,
 } from '../canvas/canvas-strategies/strategies/group-conversion-helpers'
 import type { CanvasCommand } from '../canvas/commands/commands'
 import type { EditorContract } from '../canvas/canvas-strategies/strategies/contracts/contract-helpers'
@@ -155,94 +156,14 @@ export const EditorContractDropdown = React.memo(() => {
 
       const desiredType = value as EditorContract
 
-      if (desiredType === 'not-quite-frame') {
-        throw new Error(
-          'Invariant violation: not-quite-frame should never be a selectable option in the dropdown',
-        )
-      }
-
-      const commands = selectedViews.flatMap((elementPath): CanvasCommand[] => {
-        if (currentType === 'fragment') {
-          if (desiredType === 'fragment') {
-            // NOOP
-            return []
-          }
-
-          if (desiredType === 'frame') {
-            return convertFragmentToFrame(
-              metadataRef.current,
-              elementPathTreeRef.current,
-              allElementPropsRef.current,
-              elementPath,
-              'do-not-convert-if-it-has-static-children',
-            )
-          }
-
-          if (desiredType === 'group') {
-            return convertFragmentToGroup(
-              metadataRef.current,
-              elementPathTreeRef.current,
-              allElementPropsRef.current,
-              elementPath,
-            )
-          }
-          assertNever(desiredType)
-        }
-
-        if (currentType === 'frame' || currentType === 'not-quite-frame') {
-          if (desiredType === 'frame') {
-            // NOOP
-            return []
-          }
-
-          if (desiredType === 'fragment') {
-            return convertFrameToFragmentCommands(
-              metadataRef.current,
-              elementPathTreeRef.current,
-              allElementPropsRef.current,
-              elementPath,
-            )
-          }
-
-          if (desiredType === 'group') {
-            return convertFrameToGroup(
-              metadataRef.current,
-              elementPathTreeRef.current,
-              allElementPropsRef.current,
-              elementPath,
-            )
-          }
-          assertNever(desiredType)
-        }
-
-        if (currentType === 'group') {
-          if (desiredType === 'group') {
-            // NOOP
-            return []
-          }
-
-          if (desiredType === 'fragment') {
-            return convertFrameToFragmentCommands(
-              metadataRef.current,
-              elementPathTreeRef.current,
-              allElementPropsRef.current,
-              elementPath,
-            )
-          }
-
-          if (desiredType === 'frame') {
-            return convertGroupToFrameCommands(
-              metadataRef.current,
-              elementPathTreeRef.current,
-              allElementPropsRef.current,
-              elementPath,
-            )
-          }
-          assertNever(desiredType)
-        }
-
-        assertNever(currentType)
-      })
+      const commands = getCommandsForConversionToDesiredType(
+        metadataRef.current,
+        elementPathTreeRef.current,
+        allElementPropsRef.current,
+        selectedViews,
+        currentType,
+        desiredType,
+      )
 
       if (commands.length > 0) {
         dispatch([applyCommandsAction(commands)])


### PR DESCRIPTION
**Problem:**
When using the contract dropdown, if constraints have been added to the children of a group, those end up left behind when the group is converted to something else. Which looks a little odd as the editor will in no way honour them.

**Fix:**
Now with a little introspection of the children involved the conversion logic removes the `data-constraints` property from the children.

There is also a light sprinkling of refactoring moving the logic that chooses what type of conversion is applied into a new function `getCommandsForConversionToDesiredType`.

**Commit Details:**
- Created `getCommandsForConversionToDesiredType` by extracting the original logic from `EditorContractDropdown`.
- Removed `convertGroupToFragment` as it was unused.
- Renamed `convertFrameToFragmentCommands` to `convertGroupOrFrameToFragmentCommands` to represent where it is used.
- Added `removeDataConstraintsFromChildren` to strip the `data-constraints` properties from the children of a given element where possible.
- `convertGroupOrFrameToFragmentCommands` and `convertGroupToFrameCommands` now call `removeDataConstraintsFromChildren` to remove the constraints when invoked.