### PR TITLE
Fix converting Groups to flex

### DIFF
--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
@@ -39,6 +39,7 @@ import {
   sizeToVisualDimensions,
 } from '../../inspector/inspector-common'
 import { setHugContentForAxis } from '../../inspector/inspector-strategies/hug-contents-basic-strategy'
+import { treatElementAsGroupLike } from '../../canvas/canvas-strategies/strategies/group-helpers'
 
 type FlexDirection = 'row' | 'column' // a limited subset as we won't never guess row-reverse or column-reverse
 type FlexAlignItems = 'center' | 'flex-end'
@@ -210,7 +211,7 @@ function ifElementIsFragmentLikeFirstConvertItToFrame(
     return []
   }
 
-  if (type == 'fragment' || type == 'sizeless-div') {
+  if (type == 'fragment' || type == 'sizeless-div' || treatElementAsGroupLike(metadata, target)) {
     const childInstances = mapDropNulls(
       (path) => MetadataUtils.findElementByElementPath(metadata, path),
       replaceFragmentLikePathsWithTheirChildrenRecursive(


### PR DESCRIPTION
Fixes #4405 

**Problem:**

Converting a Group into flex (`Shift+A`) doesn't actually convert the Group itself but only its children.

https://github.com/concrete-utopia/utopia/assets/1081051/59211c7a-d21b-41ab-9beb-57baf674635c

**Fix:**

https://github.com/concrete-utopia/utopia/assets/1081051/14b5febb-bd18-4235-aaf7-1de6c7fee309

