### PR TITLE
Resize near the size label

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -46,6 +46,7 @@ import {
   mouseClickAtPoint,
   mouseDoubleClickAtPoint,
   mouseDownAtPoint,
+  mouseDragFromPointToPoint,
   mouseDragFromPointWithDelta,
   mouseMoveToPoint,
 } from '../../event-helpers.test-utils'
@@ -2942,6 +2943,58 @@ describe('Absolute Resize Strategy Canvas Controls', () => {
 
     expect(renderResult.renderedDOM.getByTestId('guideline-0').style.display).toEqual('block')
     expect(renderResult.renderedDOM.getByTestId('guideline-1').style.display).toEqual('block')
+  })
+
+  it('can resize from near the size label', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+            style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 40, top: 50, width: 200, height: 120 }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    const target = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
+    const dragDelta = windowPoint({ x: 40, y: -25 })
+
+    await renderResult.dispatch([selectComponents([target], false)], true)
+
+    const canvasControl = getResizeControl(renderResult, EdgePositionBottom)
+    if (canvasControl == null) {
+      throw new Error(`Could not find canvas control.`)
+    }
+
+    const resizeCornerBounds = canvasControl.getBoundingClientRect()
+    const startPoint = windowPoint({
+      x: resizeCornerBounds.x + resizeCornerBounds.width / 2,
+      y: resizeCornerBounds.y + resizeCornerBounds.height - 1,
+    })
+
+    const endPoint = {
+      x: startPoint.x + dragDelta.x,
+      y: startPoint.y + dragDelta.y,
+    }
+
+    await mouseDragFromPointToPoint(canvasControl, startPoint, endPoint, { realMouseDown: true })
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+          style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 40, top: 50, width: 200, height: 95 }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+    )
   })
 })
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -43,6 +43,7 @@ import {
   BakedInStoryboardUID,
 } from '../../../../core/model/scene-utils'
 import {
+  dispatchMouseEnterEventAtPoint,
   mouseClickAtPoint,
   mouseDoubleClickAtPoint,
   mouseDownAtPoint,
@@ -75,6 +76,7 @@ import {
   SafeGapSmallElementSize,
   SmallElementSize,
 } from '../../controls/bounding-box-hooks'
+import { act } from 'react-dom/test-utils'
 
 // no mouseup here! it starts the interaction and resizes with drag delta
 async function startDragUsingActions(
@@ -3403,5 +3405,31 @@ describe('Absolute Resize Control', () => {
     expect(resizeControlLeft.style.left).toEqual('')
     expect(resizeControlLeft.style.width).toEqual('10px')
     expect(resizeControlLeft.style.height).toEqual(`${height}px`)
+  })
+  it('dims the size label on hover', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+            style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 40, top: 50, width: 200, height: 120 }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    const target = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
+
+    await renderResult.dispatch([selectComponents([target], false)], true)
+    const sizeLabel = renderResult.renderedDOM.getByTestId(SizeLabelTestId)
+    const sizeLabelBounds = sizeLabel.getBoundingClientRect()
+    act(() => {
+      dispatchMouseEnterEventAtPoint({ x: sizeLabelBounds.x + 2, y: sizeLabelBounds.y + 2 })
+    })
+
+    const { opacity } = sizeLabel.style
+    expect(opacity).toEqual('0.075')
   })
 })

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -584,6 +584,7 @@ const SizeLabel = React.memo(
               height: ExplicitHeightHacked / scale,
               opacity: dimmed ? 0.075 : 1,
               transition: '0.1s',
+              pointerEvents: 'initial',
             }}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -563,6 +563,7 @@ const SizeLabel = React.memo(
           position: 'absolute',
           display: 'flex',
           justifyContent: 'center',
+          pointerEvents: 'none',
         }}
         data-testid='parent-resize-label'
       >

--- a/editor/src/components/canvas/event-helpers.test-utils.tsx
+++ b/editor/src/components/canvas/event-helpers.test-utils.tsx
@@ -459,6 +459,54 @@ export function dispatchMouseDownEventAtPoint(
   )
 }
 
+export function dispatchMouseEnterEventAtPoint(
+  point: Point,
+  options: {
+    modifiers?: Modifiers
+    eventOptions?: MouseEventInit
+  } = {},
+) {
+  const modifiers = options.modifiers ?? emptyModifiers
+  const passedEventOptions = options.eventOptions ?? {}
+  const eventOptions = {
+    ctrlKey: modifiers.ctrl,
+    metaKey: modifiers.cmd,
+    altKey: modifiers.alt,
+    shiftKey: modifiers.shift,
+    ...passedEventOptions,
+  }
+  const { buttons, ...mouseUpOptions } = eventOptions ?? {}
+
+  const eventSourceElement = document.elementFromPoint(point.x, point.y)
+  if (eventSourceElement == null) {
+    throw new Error('No DOM element found at point')
+  }
+
+  eventSourceElement.dispatchEvent(
+    new MouseEvent('mouseover', {
+      detail: 1,
+      bubbles: true,
+      cancelable: true,
+      clientX: point.x,
+      clientY: point.y,
+      buttons: 1,
+      ...eventOptions,
+    }),
+  )
+
+  eventSourceElement.dispatchEvent(
+    new MouseEvent('mouseenter', {
+      detail: 1,
+      bubbles: true,
+      cancelable: true,
+      clientX: point.x,
+      clientY: point.y,
+      buttons: 1,
+      ...eventOptions,
+    }),
+  )
+}
+
 export function dispatchMouseClickEventAtPoint(
   point: Point,
   options: {

--- a/editor/src/components/canvas/event-helpers.test-utils.tsx
+++ b/editor/src/components/canvas/event-helpers.test-utils.tsx
@@ -200,6 +200,7 @@ export async function mouseDragFromPointToPoint(
     midDragCallback?: () => Promise<void>
     moveBeforeMouseDown?: boolean
     skipMouseUp?: boolean
+    realMouseDown?: boolean
   } = {},
 ): Promise<void> {
   const { buttons, ...mouseUpOptions } = options.eventOptions ?? {}
@@ -213,7 +214,11 @@ export async function mouseDragFromPointToPoint(
   if (options.moveBeforeMouseDown) {
     await mouseMoveToPoint(eventSourceElement, startPoint, options)
   }
-  await mouseDownAtPoint(eventSourceElement, startPoint, options)
+  if (options.realMouseDown) {
+    dispatchMouseDownEventAtPoint(startPoint)
+  } else {
+    await mouseDownAtPoint(eventSourceElement, startPoint, options)
+  }
 
   if (staggerMoveEvents) {
     const numberOfSteps = 5
@@ -416,6 +421,42 @@ export async function mouseClickAtPoint(
       }),
     )
   })
+}
+
+export function dispatchMouseDownEventAtPoint(
+  point: Point,
+  options: {
+    modifiers?: Modifiers
+    eventOptions?: MouseEventInit
+  } = {},
+) {
+  const modifiers = options.modifiers ?? emptyModifiers
+  const passedEventOptions = options.eventOptions ?? {}
+  const eventOptions = {
+    ctrlKey: modifiers.ctrl,
+    metaKey: modifiers.cmd,
+    altKey: modifiers.alt,
+    shiftKey: modifiers.shift,
+    ...passedEventOptions,
+  }
+  const { buttons, ...mouseUpOptions } = eventOptions ?? {}
+
+  const eventSourceElement = document.elementFromPoint(point.x, point.y)
+  if (eventSourceElement == null) {
+    throw new Error('No DOM element found at point')
+  }
+
+  eventSourceElement.dispatchEvent(
+    new MouseEvent('mousedown', {
+      detail: 1,
+      bubbles: true,
+      cancelable: true,
+      clientX: point.x,
+      clientY: point.y,
+      buttons: 1,
+      ...eventOptions,
+    }),
+  )
 }
 
 export function dispatchMouseClickEventAtPoint(


### PR DESCRIPTION
## Problem
Elements can only be resized from the bottom if the cursor is over the element (instead of slightly below it). Subjectively, it feels like the catchement area is clipped and harder to reach.

## Cause
The container of the size label seems to overlap the bottom resize control, and catch the mouse events.

## Fix
Add `pointer-events: none` to the container of the size label
