### PR TITLE
Gap controls positioned to be consistent with element positions.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.spec.browser2.tsx
@@ -1,3 +1,4 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "checkFlexGapHandlesPositionedCorrectly"] }] */
 import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import {
   FlexGapControlHandleTestId,
@@ -11,6 +12,10 @@ import { shiftModifier } from '../../../../utils/modifiers'
 import { FlexGapTearThreshold } from './set-flex-gap-strategy'
 import type { CanvasPoint } from '../../../../core/shared/math-utils'
 import { canvasPoint } from '../../../../core/shared/math-utils'
+import { checkFlexGapHandlesPositionedCorrectly } from '../../controls/select-mode/flex-gap-control.test-utils'
+import { BakedInStoryboardUID } from '../../../../core/model/scene-utils'
+import { selectComponentsForTest } from '../../../../utils/utils.test-utils'
+import * as EP from '../../../../core/shared/element-path'
 
 const DivTestId = 'mydiv'
 
@@ -52,7 +57,9 @@ export var storyboard = (
 
     const gapControls = [
       ...editor.renderedDOM.queryAllByTestId(FlexGapControlTestId),
-      ...editor.renderedDOM.queryAllByTestId(FlexGapControlHandleTestId),
+      ...editor.renderedDOM.queryAllByTestId((testId) =>
+        testId.startsWith(FlexGapControlHandleTestId),
+      ),
     ]
 
     expect(gapControls).toEqual([])
@@ -110,9 +117,13 @@ export var storyboard = (
       y: divBounds.y + 5,
     })
 
+    await checkFlexGapHandlesPositionedCorrectly(editor, DivTestId)
+
     const gapControls = [
       ...editor.renderedDOM.queryAllByTestId(FlexGapControlTestId),
-      ...editor.renderedDOM.queryAllByTestId(FlexGapControlHandleTestId),
+      ...editor.renderedDOM.queryAllByTestId((testId) =>
+        testId.startsWith(FlexGapControlHandleTestId),
+      ),
     ]
 
     expect(gapControls.length).toEqual(2)
@@ -162,7 +173,9 @@ export var storyboard = (
       y: divBounds.y + 5,
     })
 
-    const gapControlHandles = editor.renderedDOM.queryAllByTestId(FlexGapControlHandleTestId)
+    const gapControlHandles = editor.renderedDOM.queryAllByTestId((testId) =>
+      testId.startsWith(FlexGapControlHandleTestId),
+    )
 
     expect(gapControlHandles).toEqual([])
   })
@@ -183,7 +196,9 @@ export var storyboard = (
 
     const gapControls = [
       ...editor.renderedDOM.queryAllByTestId(FlexGapControlTestId),
-      ...editor.renderedDOM.queryAllByTestId(FlexGapControlHandleTestId),
+      ...editor.renderedDOM.queryAllByTestId((testId) =>
+        testId.startsWith(FlexGapControlHandleTestId),
+      ),
     ]
 
     expect(gapControls).toEqual([])
@@ -203,7 +218,11 @@ export var storyboard = (
       y: divBounds.y + 5,
     })
 
-    const gapControls = [...editor.renderedDOM.queryAllByTestId(FlexGapControlHandleTestId)]
+    await checkFlexGapHandlesPositionedCorrectly(editor, DivTestId)
+
+    const gapControls = editor.renderedDOM.queryAllByTestId((testId) =>
+      testId.startsWith(FlexGapControlHandleTestId),
+    )
 
     expect(gapControls.length).toEqual(3)
   })
@@ -226,7 +245,9 @@ export var storyboard = (
       y: divBounds.y + 5,
     })
 
-    const gapControlHandle = editor.renderedDOM.getByTestId(FlexGapControlHandleTestId)
+    const gapControlHandle = editor.renderedDOM.getByTestId((testId) =>
+      testId.startsWith(FlexGapControlHandleTestId),
+    )
     const gapControlBounds = gapControlHandle.getBoundingClientRect()
 
     const center = {
@@ -241,6 +262,8 @@ export var storyboard = (
 
     await mouseDragFromPointToPoint(gapControlHandle, center, endPoint)
     await editor.getDispatchFollowUpActionsFinished()
+
+    await checkFlexGapHandlesPositionedCorrectly(editor, DivTestId)
 
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
       testCodeWithGap({ gap: `gap: '${initialGap + dragDelta}px',`, flexDirection: 'row' }),
@@ -267,7 +290,9 @@ export var storyboard = (
       y: divBounds.y + 5,
     })
 
-    const gapControlHandle = editor.renderedDOM.getByTestId(FlexGapControlHandleTestId)
+    const gapControlHandle = editor.renderedDOM.getByTestId((testId) =>
+      testId.startsWith(FlexGapControlHandleTestId),
+    )
     const gapControlBounds = gapControlHandle.getBoundingClientRect()
 
     const center = {
@@ -284,6 +309,8 @@ export var storyboard = (
       modifiers: shiftModifier,
     })
     await editor.getDispatchFollowUpActionsFinished()
+
+    await checkFlexGapHandlesPositionedCorrectly(editor, DivTestId)
 
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
       testCodeWithGap({ gap: `gap: '${coarseValue}px',`, flexDirection: 'row' }),
@@ -305,7 +332,9 @@ export var storyboard = (
       y: divBounds.y + 5,
     })
 
-    const gapControlHandle = editor.renderedDOM.getByTestId(FlexGapControlHandleTestId)
+    const gapControlHandle = editor.renderedDOM.getByTestId((testId) =>
+      testId.startsWith(FlexGapControlHandleTestId),
+    )
     const gapControlBounds = gapControlHandle.getBoundingClientRect()
 
     const center = {
@@ -320,6 +349,8 @@ export var storyboard = (
 
     await mouseDragFromPointToPoint(gapControlHandle, center, endPoint)
     await editor.getDispatchFollowUpActionsFinished()
+
+    await checkFlexGapHandlesPositionedCorrectly(editor, DivTestId)
 
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
       testCodeWithGap({ gap: `gap: '3.4em',`, flexDirection: 'row' }),
@@ -344,7 +375,9 @@ export var storyboard = (
       y: divBounds.y + 5,
     })
 
-    const gapControlHandle = editor.renderedDOM.getByTestId(FlexGapControlHandleTestId)
+    const gapControlHandle = editor.renderedDOM.getByTestId((testId) =>
+      testId.startsWith(FlexGapControlHandleTestId),
+    )
     const gapControlBounds = gapControlHandle.getBoundingClientRect()
 
     const center = {
@@ -359,6 +392,8 @@ export var storyboard = (
 
     await mouseDragFromPointToPoint(gapControlHandle, center, endPoint)
     await editor.getDispatchFollowUpActionsFinished()
+
+    await checkFlexGapHandlesPositionedCorrectly(editor, DivTestId)
 
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
       testCodeWithGap({ gap: `gap: '${initialGap + dragDelta}px',`, flexDirection: 'column' }),
@@ -380,7 +415,9 @@ export var storyboard = (
       y: divBounds.y + 5,
     })
 
-    const gapControlHandle = editor.renderedDOM.getByTestId(FlexGapControlHandleTestId)
+    const gapControlHandle = editor.renderedDOM.getByTestId((testId) =>
+      testId.startsWith(FlexGapControlHandleTestId),
+    )
     const gapControlBounds = gapControlHandle.getBoundingClientRect()
 
     const center = {
@@ -396,6 +433,8 @@ export var storyboard = (
     await mouseDragFromPointToPoint(gapControlHandle, center, endPoint)
     await editor.getDispatchFollowUpActionsFinished()
 
+    await checkFlexGapHandlesPositionedCorrectly(editor, DivTestId)
+
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
       testCodeWithGap({ gap: `gap: '0px',`, flexDirection: 'row' }),
     )
@@ -408,6 +447,8 @@ export var storyboard = (
     )
 
     await doGapResize(editor, canvasPoint({ x: FlexGapTearThreshold - 12 - 1, y: 0 }))
+
+    await checkFlexGapHandlesPositionedCorrectly(editor, DivTestId)
 
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
       testCodeWithNoGap({ flexDirection: 'row' }),
@@ -422,6 +463,8 @@ export var storyboard = (
 
     await doGapResize(editor, canvasPoint({ x: 0, y: FlexGapTearThreshold - 12 - 1 }))
 
+    await checkFlexGapHandlesPositionedCorrectly(editor, DivTestId)
+
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
       testCodeWithNoGap({ flexDirection: 'column' }),
     )
@@ -434,6 +477,8 @@ export var storyboard = (
     )
 
     await doGapResize(editor, canvasPoint({ x: -(FlexGapTearThreshold - 12 - 1), y: 0 }))
+
+    await checkFlexGapHandlesPositionedCorrectly(editor, DivTestId)
 
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
       testCodeWithNoGap({ flexDirection: 'row-reverse' }),
@@ -448,15 +493,369 @@ export var storyboard = (
 
     await doGapResize(editor, canvasPoint({ x: 0, y: -(FlexGapTearThreshold - 12 - 1) }))
 
+    await checkFlexGapHandlesPositionedCorrectly(editor, DivTestId)
+
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
       testCodeWithNoGap({ flexDirection: 'column-reverse' }),
     )
+  })
+
+  it('the gap handles show up where expected in a series of cases', async () => {
+    const editor = await renderTestEditorWithCode(
+      testCodeWithGapExamples(),
+      'await-first-dom-report',
+    )
+
+    await selectComponentsForTest(editor, [EP.fromString(`${BakedInStoryboardUID}/example-1`)])
+    await checkFlexGapHandlesPositionedCorrectly(editor, 'example-1')
+
+    await selectComponentsForTest(editor, [EP.fromString(`${BakedInStoryboardUID}/example-2`)])
+    await checkFlexGapHandlesPositionedCorrectly(editor, 'example-2')
+
+    await selectComponentsForTest(editor, [EP.fromString(`${BakedInStoryboardUID}/example-3`)])
+    await checkFlexGapHandlesPositionedCorrectly(editor, 'example-3')
+
+    await selectComponentsForTest(editor, [EP.fromString(`${BakedInStoryboardUID}/example-4`)])
+    await checkFlexGapHandlesPositionedCorrectly(editor, 'example-4')
+
+    await selectComponentsForTest(editor, [EP.fromString(`${BakedInStoryboardUID}/example-5`)])
+    await checkFlexGapHandlesPositionedCorrectly(editor, 'example-5')
+
+    await selectComponentsForTest(editor, [EP.fromString(`${BakedInStoryboardUID}/example-6`)])
+    await checkFlexGapHandlesPositionedCorrectly(editor, 'example-6')
   })
 })
 
 interface GapTestCodeParams {
   flexDirection: string
   gap: string
+}
+
+function testCodeWithGapExamples(): string {
+  return `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='${BakedInStoryboardUID}'>
+    <div
+      data-uid={'example-1'}
+      data-testid={'example-1'}
+      style={{
+        height: 'max-content',
+        position: 'absolute',
+        left: 50,
+        top: 50,
+        display: 'flex',
+        flexDirection: 'column',
+        width: 263,
+        gap: 30,
+        padding: '30px 15px 34px 15px',
+        alignItems: 'flex-start',
+        justifyContent: 'flex-start',
+      }}
+    >
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+    </div>
+    <div
+      data-uid={'example-2'}    
+      data-testid={'example-2'}
+      style={{
+        height: 'max-content',
+        position: 'absolute',
+        left: 350,
+        top: 50,
+        display: 'flex',
+        flexDirection: 'column',
+        width: 263,
+        gap: 30,
+        alignItems: 'flex-start',
+        justifyContent: 'flex-start',
+      }}
+    >
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+    </div>
+    <div
+      data-uid={'example-3'}    
+      data-testid={'example-3'}
+      style={{
+        height: 'max-content',
+        position: 'absolute',
+        left: 50,
+        top: 305,
+        display: 'flex',
+        flexDirection: 'column',
+        width: 263,
+        gap: 30,
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+      }}
+    >
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+    </div>
+    <div
+      data-uid={'example-4'}    
+      data-testid={'example-4'}
+      style={{
+        height: 'max-content',
+        position: 'absolute',
+        left: 400,
+        top: 305,
+        display: 'flex',
+        flexDirection: 'column',
+        width: 263,
+        gap: 30,
+        justifyContent: 'flex-start',
+      }}
+    >
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+        }}
+      >
+        absolute this
+      </span>
+    </div>
+    <div
+      data-uid={'example-5'}    
+      data-testid={'example-5'}
+      style={{
+        height: 145,
+        position: 'absolute',
+        left: 50,
+        top: 550,
+        display: 'flex',
+        flexDirection: 'row',
+        width: 414,
+        gap: 30,
+        alignItems: 'flex-end',
+        justifyContent: 'flex-start',
+      }}
+    >
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+    </div>
+    <div
+      data-uid={'example-6'}    
+      data-testid={'example-6'}
+      style={{
+        height: 145,
+        position: 'absolute',
+        left: 500,
+        top: 550,
+        display: 'flex',
+        flexDirection: 'row-reverse',
+        width: 414,
+        gap: 30,
+        alignItems: 'flex-end',
+        justifyContent: 'flex-start',
+      }}
+    >
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+      <span
+        style={{
+          backgroundColor: 'magenta',
+          color: 'white',
+          width: 'max-content',
+        }}
+      >
+        absolute this
+      </span>
+    </div>
+  </Storyboard>
+)
+`
 }
 
 function testCodeWithGap(params: GapTestCodeParams): string {
@@ -560,7 +959,9 @@ async function doGapResize(editor: EditorRenderResult, delta: CanvasPoint) {
     y: divBounds.y + 5,
   })
 
-  const gapControlHandle = editor.renderedDOM.getByTestId(FlexGapControlHandleTestId)
+  const gapControlHandle = editor.renderedDOM.getByTestId((testId) =>
+    testId.startsWith(FlexGapControlHandleTestId),
+  )
   const gapControlBounds = gapControlHandle.getBoundingClientRect()
 
   const center = {

--- a/editor/src/components/canvas/controls/select-mode/flex-gap-control.test-utils.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-gap-control.test-utils.tsx
@@ -1,0 +1,126 @@
+import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import type { CanvasPoint } from '../../../../core/shared/math-utils'
+import {
+  boundingRectangleArray,
+  canvasPoint,
+  canvasRectangle,
+  getRectCenter,
+  zeroRectIfNullOrInfinity,
+} from '../../../../core/shared/math-utils'
+import { forceNotNull } from '../../../../core/shared/optional-utils'
+import { mouseMoveToPoint } from '../../event-helpers.test-utils'
+import type { EditorRenderResult } from '../../ui-jsx.test-utils'
+import { FlexGapControlHandleTestId, FlexGapControlTestId } from './flex-gap-control'
+import * as EP from '../../../../core/shared/element-path'
+import { getDomRectCenter } from '../../../../core/shared/dom-utils'
+import { isReversedFlexDirection } from '../../../../core/model/flex-utils'
+import { reverse } from '../../../../core/shared/array-utils'
+
+function mainAxisCenter(frontStart: number, frontSize: number, backStart: number): number {
+  // Dependent on the width of the front element.
+  const frontEnd = frontStart + frontSize
+  const actualGapSize = backStart - frontEnd
+  return frontEnd + actualGapSize / 2
+}
+
+export async function checkFlexGapHandlesPositionedCorrectly(
+  renderResult: EditorRenderResult,
+  targetTestId: string,
+): Promise<void> {
+  const editorState = renderResult.getEditorState().editor
+  // Currently the flex gap controls are only shown if a single element is selected.
+  if (editorState.selectedViews.length === 1) {
+    const targetPath = editorState.selectedViews[0]
+    const selectedElement = forceNotNull(
+      'Should be able to get metadata for selected element.',
+      MetadataUtils.findElementByElementPath(editorState.jsxMetadata, targetPath),
+    )
+    const selectedElementFrame = zeroRectIfNullOrInfinity(selectedElement.localFrame)
+    // If this is a flex element and it has a gap specified.
+    if (
+      selectedElement.specialSizeMeasurements.layoutSystemForChildren === 'flex' &&
+      selectedElement.specialSizeMeasurements.gap != null
+    ) {
+      const flexDirection = selectedElement.specialSizeMeasurements.flexDirection
+      const isHorizontal = flexDirection?.startsWith('row')
+      // Move the mouse pointer to the center of the flex element.
+      const flexGapControl = await renderResult.renderedDOM.findByTestId(FlexGapControlTestId)
+      const flexGapControlBounds = flexGapControl.getBoundingClientRect()
+      // Need to use the width and height from the selected element not the control...
+      const flexElementDomBounds = canvasRectangle({
+        x: flexGapControlBounds.x,
+        y: flexGapControlBounds.y,
+        width: selectedElementFrame.width,
+        height: selectedElementFrame.height,
+      })
+      // ...as the control has no size.
+      const flexGapControlCenter = getRectCenter(flexElementDomBounds)
+      await mouseMoveToPoint(flexGapControl, flexGapControlCenter)
+      await renderResult.getDispatchFollowUpActionsFinished()
+
+      // Find the element that we're targeting in the canvas.
+      const targetFlexContainer = await renderResult.renderedDOM.findByTestId(targetTestId)
+
+      // Get the children of the target element.
+      let children = MetadataUtils.getChildrenOrdered(
+        editorState.jsxMetadata,
+        editorState.elementPathTree,
+        targetPath,
+      )
+      // The children of the flex container on the canvas.
+      let childDOMElements = Array.from(targetFlexContainer.children)
+
+      // When the flex direction is reversed, the gap handling needs to be similarly
+      // reversed as the DOM entries are reversed visually but not in the DOM itself.
+      if (flexDirection != null && isReversedFlexDirection(flexDirection)) {
+        children = reverse(children)
+        childDOMElements = reverse(childDOMElements)
+      }
+
+      const totalChildElementBounds = zeroRectIfNullOrInfinity(
+        boundingRectangleArray(
+          childDOMElements.map((elem) => {
+            return canvasRectangle(elem.getBoundingClientRect())
+          }),
+        ),
+      )
+
+      // Check that we have the same number of children as child DOM elements.
+      expect(childDOMElements).toHaveLength(children.length)
+
+      // Check the various pairs of children...
+      for (
+        let frontChildIndex: number = 0;
+        frontChildIndex < childDOMElements.length - 1;
+        frontChildIndex++
+      ) {
+        const frontChild = childDOMElements[frontChildIndex]
+        const frontChildBounds = frontChild.getBoundingClientRect()
+        const backChild = childDOMElements[frontChildIndex + 1]
+        const backChildBounds = backChild.getBoundingClientRect()
+        const expectedHandleCenter: CanvasPoint = canvasPoint({
+          x: isHorizontal
+            ? mainAxisCenter(frontChildBounds.x, frontChildBounds.width, backChildBounds.x)
+            : totalChildElementBounds.x + totalChildElementBounds.width / 2,
+          y: isHorizontal
+            ? totalChildElementBounds.y + totalChildElementBounds.height / 2
+            : mainAxisCenter(frontChildBounds.y, frontChildBounds.height, backChildBounds.y),
+        })
+
+        const frontChildPath = children[frontChildIndex].elementPath
+
+        // eslint-disable-next-line no-await-in-loop
+        const handleElement = await renderResult.renderedDOM.findByTestId(
+          `${FlexGapControlHandleTestId}-${EP.toString(frontChildPath)}`,
+        )
+        const handleRect = handleElement.getBoundingClientRect()
+        const handleCenter = getDomRectCenter(handleRect)
+        // Check the handle center is close to the center of the child pair.
+        expect(handleCenter.x).toBeGreaterThanOrEqual(expectedHandleCenter.x - 1)
+        expect(handleCenter.x).toBeLessThanOrEqual(expectedHandleCenter.x + 1)
+        expect(handleCenter.y).toBeGreaterThanOrEqual(expectedHandleCenter.y - 1)
+        expect(handleCenter.y).toBeLessThanOrEqual(expectedHandleCenter.y + 1)
+      }
+    }
+  }
+}

--- a/editor/src/components/canvas/gap-utils.ts
+++ b/editor/src/components/canvas/gap-utils.ts
@@ -1,5 +1,5 @@
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
-import { stripNulls } from '../../core/shared/array-utils'
+import { reverse, stripNulls } from '../../core/shared/array-utils'
 import { getLayoutProperty } from '../../core/layout/getLayoutProperty'
 import { defaultEither, isLeft, right } from '../../core/shared/either'
 import type { ElementInstanceMetadataMap } from '../../core/shared/element-template'
@@ -126,8 +126,13 @@ export function gapControlBoundsFromMetadata(
     pathTrees,
     selectedElement,
   )
+
+  // Needs to handle reversed content as that will be flipped in the visual order, which changes
+  // what elements will be either side of the gaps.
+  const possiblyReversedChildren = flexDirection.endsWith('-reverse') ? reverse(children) : children
+
   const childCanvasBounds = stripNulls(
-    children
+    possiblyReversedChildren
       .map((childPath) => {
         const childFrame = MetadataUtils.getFrameInCanvasCoords(childPath, elementMetadata)
         if (childFrame == null || isInfinityRectangle(childFrame)) {

--- a/editor/src/components/canvas/gap-utils.ts
+++ b/editor/src/components/canvas/gap-utils.ts
@@ -6,7 +6,6 @@ import type { ElementInstanceMetadataMap } from '../../core/shared/element-templ
 import { isJSXElement } from '../../core/shared/element-template'
 import type { CanvasRectangle, CanvasVector } from '../../core/shared/math-utils'
 import { canvasRectangle, isInfinityRectangle } from '../../core/shared/math-utils'
-import { optionalMap } from '../../core/shared/optional-utils'
 import type { ElementPath } from '../../core/shared/project-file-types'
 import { assertNever } from '../../core/shared/utils'
 import { CSSCursor } from './canvas-types'
@@ -17,6 +16,7 @@ import type { Sides } from 'utopia-api/core'
 import { sides } from 'utopia-api/core'
 import { styleStringInArray } from '../../utils/common-constants'
 import type { ElementPathTrees } from '../../core/shared/element-path-tree'
+import { isReversedFlexDirection } from '../../core/model/flex-utils'
 
 export interface PathWithBounds {
   bounds: CanvasRectangle
@@ -129,7 +129,9 @@ export function gapControlBoundsFromMetadata(
 
   // Needs to handle reversed content as that will be flipped in the visual order, which changes
   // what elements will be either side of the gaps.
-  const possiblyReversedChildren = flexDirection.endsWith('-reverse') ? reverse(children) : children
+  const possiblyReversedChildren = isReversedFlexDirection(flexDirection)
+    ? reverse(children)
+    : children
 
   const childCanvasBounds = stripNulls(
     possiblyReversedChildren

--- a/editor/src/core/model/flex-utils.ts
+++ b/editor/src/core/model/flex-utils.ts
@@ -1,0 +1,77 @@
+import type { FlexDirection } from '../../components/inspector/common/css-utils'
+import type { FlexAlignment, FlexJustifyContent } from '../../components/inspector/inspector-common'
+import { assertNever } from '../shared/utils'
+
+export function isReversedFlexDirection(flexDirection: FlexDirection): boolean {
+  switch (flexDirection) {
+    case 'row':
+    case 'column':
+      return false
+    case 'row-reverse':
+    case 'column-reverse':
+      return true
+    default:
+      assertNever(flexDirection)
+  }
+}
+
+export function flipFlexDirection(flexDirection: FlexDirection): FlexDirection {
+  switch (flexDirection) {
+    case 'row':
+      return 'column'
+    case 'row-reverse':
+      return 'column-reverse'
+    case 'column':
+      return 'row'
+    case 'column-reverse':
+      return 'row-reverse'
+    default:
+      assertNever(flexDirection)
+  }
+}
+
+export function reverseFlexDirection(flexDirection: FlexDirection): FlexDirection {
+  switch (flexDirection) {
+    case 'row':
+      return 'row-reverse'
+    case 'row-reverse':
+      return 'row'
+    case 'column':
+      return 'column-reverse'
+    case 'column-reverse':
+      return 'column'
+    default:
+      assertNever(flexDirection)
+  }
+}
+
+export function reverseFlexAlignment(flexAlignment: FlexAlignment): FlexAlignment {
+  switch (flexAlignment) {
+    case 'auto':
+    case 'center':
+    case 'stretch':
+      return flexAlignment
+    case 'flex-start':
+      return 'flex-end'
+    case 'flex-end':
+      return 'flex-start'
+    default:
+      assertNever(flexAlignment)
+  }
+}
+
+export function reverseJustifyContent(justifyContent: FlexJustifyContent): FlexJustifyContent {
+  switch (justifyContent) {
+    case 'center':
+    case 'space-around':
+    case 'space-evenly':
+    case 'space-between':
+      return justifyContent
+    case 'flex-start':
+      return 'flex-end'
+    case 'flex-end':
+      return 'flex-start'
+    default:
+      assertNever(justifyContent)
+  }
+}


### PR DESCRIPTION
**Problem:**
With pretty much anything other than elements that are full width/height in a flex container, the gap controls are invariably in an odd place like over on the left hand side when the content is aligned to the centre:
![image](https://github.com/concrete-utopia/utopia/assets/217400/0407a615-a5e2-4bdc-a9fb-2da6ac797398)

**Cause:**
The handles were centred in a div which was only _sized_ to that of the bounds of the children, so in the case of centre aligned elements the handles would be centred inside the div that was positioned on left at position 0 (for instance).

**Fix:**
By positioning the containing div for the handles against the accumulated boundary of the children, the handles end up centred against those positions instead, which means they are now in the right place:
![image](https://github.com/concrete-utopia/utopia/assets/217400/249750b3-9992-4876-b087-62c954ecec74)

**Commit Details:**
- `contentArea` in `FlexGapControl` is now a `CanvasRectangle` so that the position of the children as a whole can be utilised.
- `GapControlSegment` now uses the newly provided fields in `contentArea` to position the containing div so that the handles centered within it are centered against the bounds of the content.