### PR TITLE
Prevent text wrapping when setting pin to `Scale`

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -4098,6 +4098,64 @@ describe('inspector tests with real metadata', () => {
         `,
         }),
       )
+
+      it(
+        'set hugging text to scale',
+        runTest({
+          input: `<div
+        style={{
+          height: '100%',
+          width: '100%',
+          contain: 'layout',
+        }}
+        data-uid='root'
+      >
+        <span
+          style={{
+            position: 'absolute',
+            wordBreak: 'break-word',
+            left: 261,
+            top: 139,
+            height: 19,
+            width: 'max-content',
+          }}
+          data-uid='text'
+        >
+          span
+        </span>
+      </div>`,
+          selection: [EP.appendNewElementPath(TestScenePath, ['root', 'text'])],
+          logic: async (renderResult) =>
+            pickFromReactSelectPopupList(
+              renderResult,
+              'frame-child-constraint-width-popuplist',
+              'Left',
+              'Scale',
+            ),
+          want: `<div
+          style={{
+            height: '100%',
+            width: '100%',
+            contain: 'layout',
+          }}
+          data-uid='root'
+        >
+          <span
+            style={{
+              position: 'absolute',
+              wordBreak: 'break-word',
+              top: 139,
+              height: 19,
+              left: '65.3%',
+              width: '7.5%',
+            }}
+            data-uid='text'
+          >
+            span
+          </span>
+        </div>`,
+        }),
+      )
     })
   })
 })

--- a/editor/src/components/inspector/constraints-section.tsx
+++ b/editor/src/components/inspector/constraints-section.tsx
@@ -145,6 +145,7 @@ const ChildPinControl = React.memo(
     const selectedViewsRef = useRefEditorState(selectedViewsSelector)
     const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
     const allElementPropsRef = useRefEditorState((store) => store.editor.allElementProps)
+    const elementPathTreesRef = useRefEditorState((store) => store.editor.elementPathTree)
 
     const onPinControlMouseDown = React.useCallback(
       (
@@ -217,12 +218,14 @@ const ChildPinControl = React.memo(
             ? getConstraintAndFrameChangeActionsForGroupChild(
                 metadataRef.current,
                 allElementPropsRef.current,
+                elementPathTreesRef.current,
                 propertyTarget,
                 selectedViewsRef.current,
                 requestedPinChange,
               )
             : getFrameChangeActionsForFrameChild(
                 metadataRef.current,
+                elementPathTreesRef.current,
                 propertyTarget,
                 selectedViewsRef.current,
                 requestedPinChange,
@@ -231,12 +234,14 @@ const ChildPinControl = React.memo(
       },
       [
         dispatch,
+        isGroupChild,
         metadataRef,
         allElementPropsRef,
-        selectedViewsRef,
-        isGroupChild,
+        elementPathTreesRef,
         propertyTarget,
-        pins,
+        selectedViewsRef,
+        pins.horizontal,
+        pins.vertical,
       ],
     )
 
@@ -266,6 +271,7 @@ const ChildConstraintSelect = React.memo(
       selectedViews: store.editor.selectedViews,
       metadata: store.editor.jsxMetadata,
       allElementProps: store.editor.allElementProps,
+      elementPathTrees: store.editor.elementPathTree,
     }))
 
     const pins = useDetectedConstraints(isGroupChild)
@@ -310,12 +316,14 @@ const ChildConstraintSelect = React.memo(
             ? getConstraintAndFrameChangeActionsForGroupChild(
                 editorRef.current.metadata,
                 editorRef.current.allElementProps,
+                editorRef.current.elementPathTrees,
                 propertyTarget,
                 editorRef.current.selectedViews,
                 requestedPins,
               )
             : getFrameChangeActionsForFrameChild(
                 editorRef.current.metadata,
+                editorRef.current.elementPathTrees,
                 propertyTarget,
                 editorRef.current.selectedViews,
                 requestedPins,

--- a/editor/src/components/inspector/simplified-pinning-helpers.tsx
+++ b/editor/src/components/inspector/simplified-pinning-helpers.tsx
@@ -33,7 +33,7 @@ import {
   getFramePointsFromMetadataTypeFixed,
 } from './inspector-common'
 import type { ElementPathTrees } from '../../core/shared/element-path-tree'
-import { getNonRoundedLocalRectangle } from '../text-editor/text-handling'
+import { getLocalRectangleWithFixedWidthHandlingText } from '../text-editor/text-handling'
 
 type HorizontalPinRequests =
   | 'left-and-width'
@@ -610,7 +610,9 @@ const getPinChanges =
     )
 
     const setActions: Array<SetProp> = targets.flatMap((target) => {
-      const localFrame = nullIfInfinity(getNonRoundedLocalRectangle(metadata, pathTrees, target))
+      const localFrame = nullIfInfinity(
+        getLocalRectangleWithFixedWidthHandlingText(metadata, pathTrees, target),
+      )
 
       const coordinateSystemBounds = MetadataUtils.findElementByElementPath(metadata, target)
         ?.specialSizeMeasurements.coordinateSystemBounds

--- a/editor/src/components/inspector/simplified-pinning-helpers.tsx
+++ b/editor/src/components/inspector/simplified-pinning-helpers.tsx
@@ -33,6 +33,7 @@ import {
   getFramePointsFromMetadataTypeFixed,
 } from './inspector-common'
 import type { ElementPathTrees } from '../../core/shared/element-path-tree'
+import { roundUpToPreventTextWrapping } from '../text-editor/text-handling'
 
 type HorizontalPinRequests =
   | 'left-and-width'
@@ -615,7 +616,7 @@ const getPinChanges =
         MetadataUtils.targetTextEditableAndHasText(metadata, pathTrees, target) &&
         localFrame != null
       ) {
-        const nonRoundedWidth = Math.ceil(
+        const nonRoundedWidth = roundUpToPreventTextWrapping(
           nullIfInfinity(
             MetadataUtils.findElementByElementPath(metadata, target)?.nonRoundedGlobalFrame,
           )?.width ?? localFrame.width,

--- a/editor/src/components/inspector/simplified-pinning-helpers.tsx
+++ b/editor/src/components/inspector/simplified-pinning-helpers.tsx
@@ -33,7 +33,7 @@ import {
   getFramePointsFromMetadataTypeFixed,
 } from './inspector-common'
 import type { ElementPathTrees } from '../../core/shared/element-path-tree'
-import { roundUpToPreventTextWrapping } from '../text-editor/text-handling'
+import { getNonRoundedLocalRectangle } from '../text-editor/text-handling'
 
 type HorizontalPinRequests =
   | 'left-and-width'
@@ -610,25 +610,7 @@ const getPinChanges =
     )
 
     const setActions: Array<SetProp> = targets.flatMap((target) => {
-      const elementMetadata = MetadataUtils.findElementByElementPath(metadata, target)
-      let localFrame = nullIfInfinity(elementMetadata?.localFrame)
-      if (
-        MetadataUtils.targetTextEditableAndHasText(metadata, pathTrees, target) &&
-        localFrame != null
-      ) {
-        const nonRoundedWidth = roundUpToPreventTextWrapping(
-          nullIfInfinity(
-            MetadataUtils.findElementByElementPath(metadata, target)?.nonRoundedGlobalFrame,
-          )?.width ?? localFrame.width,
-        )
-
-        localFrame = localRectangle({
-          x: localFrame.x,
-          y: localFrame.y,
-          height: localFrame.height,
-          width: nonRoundedWidth,
-        })
-      }
+      const localFrame = nullIfInfinity(getNonRoundedLocalRectangle(metadata, pathTrees, target))
 
       const coordinateSystemBounds = MetadataUtils.findElementByElementPath(metadata, target)
         ?.specialSizeMeasurements.coordinateSystemBounds

--- a/editor/src/components/text-editor/text-handling.ts
+++ b/editor/src/components/text-editor/text-handling.ts
@@ -1,5 +1,5 @@
 import type { ElementPath } from '../../core/shared/project-file-types'
-import type { DerivedState, EditorState } from '../editor/store/editor-state'
+import type { EditorState } from '../editor/store/editor-state'
 import {
   getElementFromProjectContents,
   modifyUnderlyingTargetElement,
@@ -25,7 +25,8 @@ import fastDeepEquals from 'fast-deep-equal'
 import { getUtopiaID } from '../../core/shared/uid-utils'
 import type { ElementPathTrees } from '../../core/shared/element-path-tree'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
-import { nullIfInfinity, zeroCanvasRect } from '../../core/shared/math-utils'
+import type { MaybeInfinityLocalRectangle } from '../../core/shared/math-utils'
+import { isInfinityRectangle, localRectangle, nullIfInfinity } from '../../core/shared/math-utils'
 
 // Validate this by making the type `Set<keyof CSSProperties>`.
 export const stylePropertiesEligibleForMerge: Set<string> = new Set([
@@ -259,7 +260,7 @@ export function collapseTextElements(target: ElementPath, editor: EditorState): 
 }
 
 // extracted into a separate function so that the intention is clear
-export function roundUpToPreventTextWrapping(value: number): number {
+function roundUpToPreventTextWrapping(value: number): number {
   return Math.ceil(value)
 }
 
@@ -272,4 +273,34 @@ export function fixedSizeDimensionHandlingText(
   // Fixed dimensions for a text containing element need to be rounded up to prevent wrapping.
   const containsText = MetadataUtils.targetTextEditableAndHasText(metadata, pathTrees, elementPath)
   return containsText ? roundUpToPreventTextWrapping(dimensionValue) : dimensionValue
+}
+
+export function getNonRoundedLocalRectangle(
+  metadata: ElementInstanceMetadataMap,
+  pathTrees: ElementPathTrees,
+  elementPath: ElementPath,
+): MaybeInfinityLocalRectangle | null {
+  const elementMetadata = MetadataUtils.findElementByElementPath(metadata, elementPath)
+  let localFrame = elementMetadata?.localFrame ?? null
+
+  if (
+    localFrame == null ||
+    isInfinityRectangle(localFrame) ||
+    !MetadataUtils.targetTextEditableAndHasText(metadata, pathTrees, elementPath)
+  ) {
+    return localFrame
+  }
+
+  const nonRoundedWidth = roundUpToPreventTextWrapping(
+    nullIfInfinity(
+      MetadataUtils.findElementByElementPath(metadata, elementPath)?.nonRoundedGlobalFrame,
+    )?.width ?? localFrame.width,
+  )
+
+  return localRectangle({
+    x: localFrame.x,
+    y: localFrame.y,
+    height: localFrame.height,
+    width: nonRoundedWidth,
+  })
 }

--- a/editor/src/components/text-editor/text-handling.ts
+++ b/editor/src/components/text-editor/text-handling.ts
@@ -258,6 +258,11 @@ export function collapseTextElements(target: ElementPath, editor: EditorState): 
   return editor
 }
 
+// extracted into a separate function so that the intention is clear
+export function roundUpToPreventTextWrapping(value: number): number {
+  return Math.ceil(value)
+}
+
 export function fixedSizeDimensionHandlingText(
   metadata: ElementInstanceMetadataMap,
   pathTrees: ElementPathTrees,
@@ -266,5 +271,5 @@ export function fixedSizeDimensionHandlingText(
 ): number {
   // Fixed dimensions for a text containing element need to be rounded up to prevent wrapping.
   const containsText = MetadataUtils.targetTextEditableAndHasText(metadata, pathTrees, elementPath)
-  return containsText ? Math.ceil(dimensionValue) : dimensionValue
+  return containsText ? roundUpToPreventTextWrapping(dimensionValue) : dimensionValue
 }

--- a/editor/src/components/text-editor/text-handling.ts
+++ b/editor/src/components/text-editor/text-handling.ts
@@ -275,7 +275,7 @@ export function fixedSizeDimensionHandlingText(
   return containsText ? roundUpToPreventTextWrapping(dimensionValue) : dimensionValue
 }
 
-export function getNonRoundedLocalRectangle(
+export function getLocalRectangleWithFixedWidthHandlingText(
   metadata: ElementInstanceMetadataMap,
   pathTrees: ElementPathTrees,
   elementPath: ElementPath,


### PR DESCRIPTION
## Problem
Text might get wrapped when its pin setting is set to `Scale` (see https://screenshot.click/24-37-x5of6-ihp3w.gif)

## Fix
Use the non-rounded frame as a basis for the width value when calculating the pin value