### PR TITLE
Hide constraints section if empty

### DIFF
--- a/editor/src/components/inspector/constraints-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/constraints-section.spec.browser2.tsx
@@ -211,9 +211,10 @@ describe('Constraints Section', () => {
     )
   })
 
-  it('is hidden when the selection does not contain elements for which pins are applicable', async () => {
-    const renderResult = await renderTestEditorWithCode(
-      formatTestProjectCode(`
+  describe('hidden behaviour', () => {
+    it('is hidden when the selection is made of groups', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        formatTestProjectCode(`
 		  import * as React from 'react'
 		  import { Group, Storyboard } from 'utopia-api'
 
@@ -228,12 +229,72 @@ describe('Constraints Section', () => {
 			)
 		  }
 	  `),
-      'await-first-dom-report',
-    )
+        'await-first-dom-report',
+      )
 
-    await renderResult.dispatch([selectComponents([EP.fromString('sb/group')], true)], true)
+      await renderResult.dispatch([selectComponents([EP.fromString('sb/group')], true)], true)
 
-    const section = screen.queryByTestId(InspectorSectionConstraintsTestId)
-    expect(section).toBeNull()
+      const section = screen.queryByTestId(InspectorSectionConstraintsTestId)
+      expect(section).toBeNull()
+    })
+
+    it('is hidden when the selection contains groups', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        formatTestProjectCode(`
+		  import * as React from 'react'
+		  import { Group, Storyboard } from 'utopia-api'
+
+		  var storyboard = () => {
+			return (
+				<Storyboard data-uid='sb'>
+					<Group data-uid='group' style={{ position: 'absolute', left: 0, top: 0, width: 164, height: 129 }}>
+      					<div style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 0, top: 0, width: 70, height: 70 }} />
+      					<div style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 84, top: 49, width: 80, height: 80 }} />
+    				</Group>
+					<div data-uid='foo' style={{ position: 'absolute', left: 200, top: 200, width: 50, height: 50, background: 'red' }} />
+				</Storyboard>
+			)
+		  }
+	  `),
+        'await-first-dom-report',
+      )
+
+      await renderResult.dispatch(
+        [selectComponents([EP.fromString('sb/group'), EP.fromString('sb/foo')], true)],
+        true,
+      )
+
+      const section = screen.queryByTestId(InspectorSectionConstraintsTestId)
+      expect(section).toBeNull()
+    })
+    it('is hidden when the selection contains group children and non-group-children', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        formatTestProjectCode(`
+		  import * as React from 'react'
+		  import { Group, Storyboard } from 'utopia-api'
+
+		  var storyboard = () => {
+			return (
+				<Storyboard data-uid='sb'>
+					<Group data-uid='group' style={{ position: 'absolute', left: 0, top: 0, width: 164, height: 129 }}>
+      					<div data-uid='child1' style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 0, top: 0, width: 70, height: 70 }} />
+      					<div data-uid='child2' style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 84, top: 49, width: 80, height: 80 }} />
+    				</Group>
+					<div data-uid='foo' style={{ position: 'absolute', left: 200, top: 200, width: 50, height: 50, background: 'red' }} />
+				</Storyboard>
+			)
+		  }
+	  `),
+        'await-first-dom-report',
+      )
+
+      await renderResult.dispatch(
+        [selectComponents([EP.fromString('sb/group/child1'), EP.fromString('sb/foo')], true)],
+        true,
+      )
+
+      const section = screen.queryByTestId(InspectorSectionConstraintsTestId)
+      expect(section).toBeNull()
+    })
   })
 })

--- a/editor/src/components/inspector/constraints-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/constraints-section.spec.browser2.tsx
@@ -211,7 +211,7 @@ describe('Constraints Section', () => {
     )
   })
 
-  it('is hidden when there are no contents', async () => {
+  it('is hidden when the selection does not contain elements for which pins are applicable', async () => {
     const renderResult = await renderTestEditorWithCode(
       formatTestProjectCode(`
 		  import * as React from 'react'

--- a/editor/src/components/inspector/constraints-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/constraints-section.spec.browser2.tsx
@@ -1,12 +1,15 @@
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "testGroupChild", "testFrameChild"] }] */
 
+import { screen } from '@testing-library/react'
 import * as EP from '../../core/shared/element-path'
 import type { ElementPath } from '../../core/shared/project-file-types'
 import {
+  formatTestProjectCode,
   makeTestProjectCodeWithSnippet,
   renderTestEditorWithCode,
 } from '../canvas/ui-jsx.test-utils'
 import { selectComponents } from '../editor/actions/action-creators'
+import { InspectorSectionConstraintsTestId } from './constraints-section'
 
 const testChild = (params: {
   snippet: string
@@ -206,5 +209,31 @@ describe('Constraints Section', () => {
         expectedHeightConstraintDropdownOption: 'Bottom',
       }),
     )
+  })
+
+  it('is hidden when there are no contents', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      formatTestProjectCode(`
+		  import * as React from 'react'
+		  import { Group, Storyboard } from 'utopia-api'
+
+		  var storyboard = () => {
+			return (
+				<Storyboard data-uid='sb'>
+					<Group data-uid='group' style={{ position: 'absolute', left: 0, top: 0, width: 164, height: 129 }}>
+      					<div style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 0, top: 0, width: 70, height: 70 }} />
+      					<div style={{ backgroundColor: '#aaaaaa33', position: 'absolute', left: 84, top: 49, width: 80, height: 80 }} />
+    				</Group>
+				</Storyboard>
+			)
+		  }
+	  `),
+      'await-first-dom-report',
+    )
+
+    await renderResult.dispatch([selectComponents([EP.fromString('sb/group')], true)], true)
+
+    const section = screen.queryByTestId(InspectorSectionConstraintsTestId)
+    expect(section).toBeNull()
   })
 })

--- a/editor/src/components/inspector/constraints-section.tsx
+++ b/editor/src/components/inspector/constraints-section.tsx
@@ -38,6 +38,8 @@ import {
 import { UIGridRow } from './widgets/ui-grid-row'
 import { NO_OP } from '../../core/shared/utils'
 
+export const InspectorSectionConstraintsTestId = 'inspector-section-constraints'
+
 export const ConstraintsSection = React.memo(() => {
   const noGroupOrGroupChildrenSelected = !useEditorState(
     Substores.metadata,
@@ -62,6 +64,7 @@ export const ConstraintsSection = React.memo(() => {
     <React.Fragment>
       <InspectorSubsectionHeader>
         <FlexRow
+          data-testId={InspectorSectionConstraintsTestId}
           style={{
             flexGrow: 1,
             height: 42,

--- a/editor/src/components/inspector/constraints-section.tsx
+++ b/editor/src/components/inspector/constraints-section.tsx
@@ -35,7 +35,6 @@ import {
   getFrameChangeActionsForFrameChild,
   useDetectedConstraints,
 } from './simplified-pinning-helpers'
-import { PinHeightSVG, PinWidthSVG } from './utility-controls/pin-control'
 import { UIGridRow } from './widgets/ui-grid-row'
 import { NO_OP } from '../../core/shared/utils'
 
@@ -50,6 +49,14 @@ export const ConstraintsSection = React.memo(() => {
     allElementsAreGroupChildren,
     'ConstraintsSection onlyGroupChildrenSelected',
   )
+
+  const showSection = React.useMemo(() => {
+    return noGroupOrGroupChildrenSelected || onlyGroupChildrenSelected
+  }, [noGroupOrGroupChildrenSelected, onlyGroupChildrenSelected])
+
+  if (!showSection) {
+    return null
+  }
 
   return (
     <React.Fragment>


### PR DESCRIPTION
Fixes #4418 

**Problem:**

The `Constraints` section is shown in the inspector even when it's effectively empty.

<img width="270" alt="Screenshot 2023-10-24 at 4 08 25 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/371e83cf-d3d9-43b2-bfb2-6d59194374a8">

**Fix:**

Don't show it if that's the case.