### PR TITLE
Navigator drag preview + floating panels

### DIFF
--- a/editor/src/components/navigator/navigator-drag-layer.tsx
+++ b/editor/src/components/navigator/navigator-drag-layer.tsx
@@ -33,6 +33,8 @@ export const NavigatorDragLayer = React.memo(() => {
     difference: (monitor.getDifferenceFromInitialOffset() as WindowPoint) ?? zeroPoint,
   }))
 
+  const containerRef = React.useRef<HTMLDivElement | null>(null)
+
   const navigatorEntry = React.useMemo(
     () => regularNavigatorEntry(item?.elementPath ?? emptyElementPath),
     [item?.elementPath],
@@ -48,8 +50,8 @@ export const NavigatorDragLayer = React.memo(() => {
   )
 
   const offset = windowPoint({
-    x: initialOffset.x + difference.x,
-    y: initialOffset.y + difference.y,
+    x: initialOffset.x + difference.x - (containerRef.current?.getBoundingClientRect()?.x ?? 0),
+    y: initialOffset.y + difference.y - (containerRef.current?.getBoundingClientRect()?.y ?? 0),
   })
 
   const icon = useLayoutOrElementIcon(navigatorEntry)?.iconProps ?? {}
@@ -58,6 +60,7 @@ export const NavigatorDragLayer = React.memo(() => {
 
   return hidden ? null : (
     <div
+      ref={containerRef}
       style={{
         position: 'fixed',
         pointerEvents: 'none',


### PR DESCRIPTION
## Problem
When the navigator is not the leftmost panel, the drag preview doesn't show up in the right place

## Fix
Tweak the positioning logic in the navigator drag layer so the preview is positioned correctly (as expected)