### PR TITLE
Convert flex layout special case 3 elements with constraints.

### DIFF
--- a/editor/src/components/canvas/remix/remix-rendering.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-rendering.spec.browser2.tsx
@@ -20,7 +20,7 @@ import {
 import { EditorModes } from '../../editor/editor-modes'
 import { StoryboardFilePath, navigatorEntryToKey } from '../../editor/store/editor-state'
 import type { PersistentModel } from '../../editor/store/editor-state'
-import { AddRemoveLayouSystemControlTestId } from '../../inspector/add-remove-layout-system-control'
+import { AddRemoveLayoutSystemControlTestId } from '../../inspector/add-remove-layout-system-control'
 import { CanvasControlsContainerID } from '../controls/new-canvas-controls'
 import type { RemixSceneLabelButtonType } from '../controls/select-mode/remix-scene-label'
 import {
@@ -1599,7 +1599,7 @@ export default function Index() {
 
     const absoluteDiv = await clickElementOnCanvasControlsLayer(renderResult, AbsoluteDivTestId)
 
-    const targetElement = renderResult.renderedDOM.getByTestId(AddRemoveLayouSystemControlTestId())
+    const targetElement = renderResult.renderedDOM.getByTestId(AddRemoveLayoutSystemControlTestId())
     await mouseClickAtPoint(targetElement, { x: 1, y: 1 }, { modifiers: cmdModifier })
 
     expect(absoluteDiv.style.display).toEqual('flex')

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
@@ -599,7 +599,7 @@ describe('Smart Convert To Flex', () => {
               top: 29,
               width: 'max-content',
             }}
-            data-constraints={['left']}
+            data-constraints={['left', 'right']}
           >
             Hello World
           </span>
@@ -642,7 +642,7 @@ describe('Smart Convert To Flex', () => {
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
 		<div style={{ ...props.style }} data-uid='a'>
-      <Group
+      <div
         data-uid='parent'
         style={{
           height: 204,
@@ -652,7 +652,7 @@ describe('Smart Convert To Flex', () => {
           width: 584,
           display: 'flex',
           flexDirection: 'row',
-          justifyContent: 'space-between',
+          gap: 32,
         }}
       >
         <div
@@ -664,7 +664,6 @@ describe('Smart Convert To Flex', () => {
             width: 59,
             flexGrow: 0,
           }}
-          data-constraints={['left', 'width']}
         />
         <span
           data-uid='second'
@@ -673,9 +672,8 @@ describe('Smart Convert To Flex', () => {
             fontSize: '31px',
             height: 119,
             width: 'max-content',
-            flexGrow: 0.75,
+            flexGrow: 1,
           }}
-          data-constraints={['left']}
         >
           Hello World
         </span>
@@ -688,9 +686,8 @@ describe('Smart Convert To Flex', () => {
             width: 119,
             flexGrow: 0,
           }}
-          data-constraints={['right', 'width']}
         />
-      </Group>
+      </div>
 		</div>
 	`),
     )

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
@@ -650,6 +650,8 @@ describe('Smart Convert To Flex', () => {
           left: 14,
           top: 343,
           width: 584,
+          alignItems: 'center',
+          justifyContent: 'flex-start',
           display: 'flex',
           flexDirection: 'row',
           gap: 32,

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.spec.browser2.tsx
@@ -572,6 +572,129 @@ describe('Smart Convert To Flex', () => {
 	`),
     )
   })
+
+  it('converts groups with constraints that imply a certain row-like layout', async () => {
+    const editor = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(
+        `
+			<div style={{ ...props.style }} data-uid='a'>
+        <Group
+          data-uid='parent'
+          style={{
+            height: 204,
+            position: 'absolute',
+            left: 14,
+            top: 343,
+            width: 584,
+          }}
+        >
+          <span
+            data-uid='second'
+            style={{
+              wordBreak: 'break-word',
+              fontSize: '31px',
+              height: 119,
+              position: 'absolute',
+              left: 91,
+              top: 29,
+              width: 'max-content',
+            }}
+            data-constraints={['left']}
+          >
+            Hello World
+          </span>
+          <div
+            data-uid='third'
+            style={{
+              backgroundColor: '#FF69B4AB',
+              height: 204,
+              contain: 'layout',
+              width: 119,
+              position: 'absolute',
+              left: 465,
+              top: 0,
+            }}
+            data-constraints={['right', 'width']}
+          />
+          <div
+            data-uid='first'
+            style={{
+              backgroundColor: '#FF69B4AB',
+              height: 204,
+              contain: 'layout',
+              width: 59,
+              position: 'absolute',
+              left: 0,
+              top: 0,
+            }}
+            data-constraints={['left', 'width']}
+          />
+        </Group>
+			</div>
+	  `,
+      ),
+
+      'await-first-dom-report',
+    )
+
+    await convertParentToFlex(editor)
+
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+		<div style={{ ...props.style }} data-uid='a'>
+      <Group
+        data-uid='parent'
+        style={{
+          height: 204,
+          position: 'absolute',
+          left: 14,
+          top: 343,
+          width: 584,
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+        }}
+      >
+        <div
+          data-uid='first'
+          style={{
+            backgroundColor: '#FF69B4AB',
+            height: 204,
+            contain: 'layout',
+            width: 59,
+            flexGrow: 0,
+          }}
+          data-constraints={['left', 'width']}
+        />
+        <span
+          data-uid='second'
+          style={{
+            wordBreak: 'break-word',
+            fontSize: '31px',
+            height: 119,
+            width: 'max-content',
+            flexGrow: 0.75,
+          }}
+          data-constraints={['left']}
+        >
+          Hello World
+        </span>
+        <div
+          data-uid='third'
+          style={{
+            backgroundColor: '#FF69B4AB',
+            height: 204,
+            contain: 'layout',
+            width: 119,
+            flexGrow: 0,
+          }}
+          data-constraints={['right', 'width']}
+        />
+      </Group>
+		</div>
+	`),
+    )
+  })
 })
 
 describe('Smart Convert to Flex Reordering Children if Needed', () => {

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
@@ -244,6 +244,13 @@ export function convertLayoutToFlexCommands(
                 'group',
                 'frame',
               ),
+              ...maybeAlignElementsToCenter(
+                metadata,
+                childrenPaths,
+                path,
+                direction,
+                parentFlexDirection,
+              ),
               setProperty('always', path, PP.create('style', 'display'), 'flex'),
               setProperty('always', path, PP.create('style', 'flexDirection'), 'row'),
               setProperty('always', path, PP.create('style', 'gap'), gapValue),

--- a/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
+++ b/editor/src/components/common/shared-strategies/convert-to-flex-strategy.ts
@@ -105,6 +105,146 @@ function laidOutAsRow(...elementMetadataEntries: Array<ElementInstanceMetadata>)
   }
 }
 
+type CommandsOrNotApplicable = Array<CanvasCommand> | 'not-applicable'
+
+function convertSingleChildWith100PercentSize(
+  metadata: ElementInstanceMetadataMap,
+  allElementProps: AllElementProps,
+  elementPathTree: ElementPathTrees,
+  parentFlexDirection: FlexDirection | null,
+  path: ElementPath,
+  childrenPaths: Array<ElementPath>,
+  direction: FlexDirectionRowColumn,
+): CommandsOrNotApplicable {
+  const firstChildPath = childrenPaths[0]
+
+  const { childWidth100Percent, childHeight100Percent } = childIs100PercentSizedInEitherDirection(
+    metadata,
+    firstChildPath,
+  )
+
+  const optionalCenterAlignCommands = onlyChildIsSpan(metadata, childrenPaths)
+    ? [
+        setProperty('always', path, PP.create('style', 'alignItems'), 'center'),
+        setProperty('always', path, PP.create('style', 'justifyContent'), 'center'),
+        setHugContentForAxis('horizontal', firstChildPath, parentFlexDirection),
+        setHugContentForAxis('vertical', firstChildPath, parentFlexDirection),
+      ]
+    : []
+
+  if (childrenPaths.length === 1 && (childWidth100Percent || childHeight100Percent)) {
+    return [
+      ...ifElementIsFragmentLikeFirstConvertItToFrame(
+        metadata,
+        allElementProps,
+        elementPathTree,
+        path,
+      ),
+      setProperty('always', path, PP.create('style', 'display'), 'flex'),
+      setProperty('always', path, PP.create('style', 'flexDirection'), direction),
+      ...(childWidth100Percent
+        ? []
+        : [setHugContentForAxis('horizontal', path, parentFlexDirection)]),
+      ...(childHeight100Percent
+        ? []
+        : [setHugContentForAxis('vertical', path, parentFlexDirection)]),
+      ...childrenPaths.flatMap((child) => [
+        ...nukeAllAbsolutePositioningPropsCommands(child),
+        ...convertWidthToFlexGrowOptionally(metadata, child, direction),
+      ]),
+      ...optionalCenterAlignCommands,
+    ]
+  }
+
+  return 'not-applicable'
+}
+
+function convertThreeElementGroupRow(
+  metadata: ElementInstanceMetadataMap,
+  allElementProps: AllElementProps,
+  elementPathTree: ElementPathTrees,
+  path: ElementPath,
+  childrenPaths: Array<ElementPath>,
+  parentFlexDirection: FlexDirection | null,
+  direction: FlexDirectionRowColumn,
+): CommandsOrNotApplicable {
+  if (childrenPaths.length === 3) {
+    const childrenMetadata = mapDropNulls(
+      (childPath) => MetadataUtils.findElementByElementPath(metadata, childPath),
+      childrenPaths,
+    )
+    if (childrenMetadata.length === 3) {
+      // This should make the logic independent of the ordering within the code,
+      // as their logical order does not necessarily relate to their visual position.
+      const childrenMetadataOrderedByHorizontalPosition = sortBy(
+        childrenMetadata,
+        (first, second) => {
+          return (
+            zeroRectIfNullOrInfinity(first.localFrame).x -
+            zeroRectIfNullOrInfinity(second.localFrame).x
+          )
+        },
+      )
+      // Get the reordered metadata and paths.
+      const [firstChildElement, secondChildElement, thirdChildElement] =
+        childrenMetadataOrderedByHorizontalPosition
+      const [firstChildPath, secondChildPath, thirdChildPath] =
+        childrenMetadataOrderedByHorizontalPosition.map((meta) => meta.elementPath)
+      if (laidOutAsRow(firstChildElement, secondChildElement, thirdChildElement)) {
+        if (
+          checkConstraintsForThreeElementRow(
+            allElementProps,
+            firstChildPath,
+            secondChildPath,
+            thirdChildPath,
+          )
+        ) {
+          const firstFrame = zeroRectIfNullOrInfinity(firstChildElement.localFrame)
+          const secondFrame = zeroRectIfNullOrInfinity(secondChildElement.localFrame)
+
+          const gapValue = roundTo(secondFrame.x - firstFrame.width, 2)
+
+          return [
+            // Configure the parent element.
+            ...getCommandsForConversionToDesiredType(
+              metadata,
+              elementPathTree,
+              allElementProps,
+              [path],
+              'group',
+              'frame',
+            ),
+            ...maybeAlignElementsToCenter(
+              metadata,
+              childrenPaths,
+              path,
+              direction,
+              parentFlexDirection,
+            ),
+            setProperty('always', path, PP.create('style', 'display'), 'flex'),
+            setProperty('always', path, PP.create('style', 'flexDirection'), 'row'),
+            setProperty('always', path, PP.create('style', 'gap'), gapValue),
+            // Configure and reorder the "first" element.
+            ...nukeAllAbsolutePositioningPropsCommands(firstChildPath),
+            setProperty('always', firstChildPath, PP.create('style', 'flexGrow'), 0),
+            reorderElement('always', firstChildPath, absolute(0)),
+            // Configure and reorder the "second" element.
+            ...nukeAllAbsolutePositioningPropsCommands(secondChildPath),
+            setProperty('always', secondChildPath, PP.create('style', 'flexGrow'), 1),
+            reorderElement('always', secondChildPath, absolute(1)),
+            // Configure and reorder the "third" element.
+            ...nukeAllAbsolutePositioningPropsCommands(thirdChildPath),
+            setProperty('always', thirdChildPath, PP.create('style', 'flexGrow'), 0),
+            reorderElement('always', thirdChildPath, absolute(2)),
+          ]
+        }
+      }
+    }
+  }
+
+  return 'not-applicable'
+}
+
 export function convertLayoutToFlexCommands(
   metadata: ElementInstanceMetadataMap,
   elementPathTree: ElementPathTrees,
@@ -152,124 +292,39 @@ export function convertLayoutToFlexCommands(
       return [setProperty('always', path, PP.create('style', 'display'), 'flex')]
     }
 
-    const { direction, sortedChildren, averageGap, padding, alignItems } = guessMatchingFlexSetup(
+    const { direction, averageGap, sortedChildren, padding, alignItems } = guessMatchingFlexSetup(
       metadata,
       path,
       childrenPaths,
     )
     const sortedChildrenPaths = sortedChildren.map((c) => EP.dynamicPathToStaticPath(c.target))
 
-    const { childWidth100Percent, childHeight100Percent } = childIs100PercentSizedInEitherDirection(
+    // Special case: We only have a single child which has a size of 100%.
+    const possibleSingleChildWith100PercentSize = convertSingleChildWith100PercentSize(
       metadata,
-      childrenPaths[0],
+      allElementProps,
+      elementPathTree,
+      parentFlexDirection,
+      path,
+      childrenPaths,
+      direction,
     )
-
-    const optionalCenterAlignCommands = onlyChildIsSpan(metadata, childrenPaths)
-      ? [
-          setProperty('always', path, PP.create('style', 'alignItems'), 'center'),
-          setProperty('always', path, PP.create('style', 'justifyContent'), 'center'),
-          setHugContentForAxis('horizontal', childrenPaths[0], parentFlexDirection),
-          setHugContentForAxis('vertical', childrenPaths[0], parentFlexDirection),
-        ]
-      : []
-
-    if (childrenPaths.length === 1 && (childWidth100Percent || childHeight100Percent)) {
-      // special case: we only have a single child which has a size of 100%.
-      return [
-        ...ifElementIsFragmentLikeFirstConvertItToFrame(
-          metadata,
-          allElementProps,
-          elementPathTree,
-          path,
-        ),
-        setProperty('always', path, PP.create('style', 'display'), 'flex'),
-        setProperty('always', path, PP.create('style', 'flexDirection'), direction),
-        ...(childWidth100Percent
-          ? []
-          : [setHugContentForAxis('horizontal', path, parentFlexDirection)]),
-        ...(childHeight100Percent
-          ? []
-          : [setHugContentForAxis('vertical', path, parentFlexDirection)]),
-        ...childrenPaths.flatMap((child) => [
-          ...nukeAllAbsolutePositioningPropsCommands(child),
-          ...convertWidthToFlexGrowOptionally(metadata, child, direction),
-        ]),
-        ...optionalCenterAlignCommands,
-      ]
+    if (possibleSingleChildWith100PercentSize !== 'not-applicable') {
+      return possibleSingleChildWith100PercentSize
     }
 
-    if (childrenPaths.length === 3) {
-      const childrenMetadata = mapDropNulls(
-        (childPath) => MetadataUtils.findElementByElementPath(metadata, childPath),
-        childrenPaths,
-      )
-      if (childrenMetadata.length === 3) {
-        // This should make the logic independent of the ordering within the code,
-        // as their logical order does not necessarily relate to their visual position.
-        const childrenMetadataOrderedByHorizontalPosition = sortBy(
-          childrenMetadata,
-          (first, second) => {
-            return (
-              zeroRectIfNullOrInfinity(first.localFrame).x -
-              zeroRectIfNullOrInfinity(second.localFrame).x
-            )
-          },
-        )
-        // Get the reordered metadata and paths.
-        const [firstChildElement, secondChildElement, thirdChildElement] =
-          childrenMetadataOrderedByHorizontalPosition
-        const [firstChildPath, secondChildPath, thirdChildPath] =
-          childrenMetadataOrderedByHorizontalPosition.map((meta) => meta.elementPath)
-        if (laidOutAsRow(firstChildElement, secondChildElement, thirdChildElement)) {
-          if (
-            checkConstraintsForThreeElementRow(
-              allElementProps,
-              firstChildPath,
-              secondChildPath,
-              thirdChildPath,
-            )
-          ) {
-            const firstFrame = zeroRectIfNullOrInfinity(firstChildElement.localFrame)
-            const secondFrame = zeroRectIfNullOrInfinity(secondChildElement.localFrame)
-
-            const gapValue = roundTo(secondFrame.x - firstFrame.width, 2)
-
-            return [
-              // Configure the parent element.
-              ...getCommandsForConversionToDesiredType(
-                metadata,
-                elementPathTree,
-                allElementProps,
-                [path],
-                'group',
-                'frame',
-              ),
-              ...maybeAlignElementsToCenter(
-                metadata,
-                childrenPaths,
-                path,
-                direction,
-                parentFlexDirection,
-              ),
-              setProperty('always', path, PP.create('style', 'display'), 'flex'),
-              setProperty('always', path, PP.create('style', 'flexDirection'), 'row'),
-              setProperty('always', path, PP.create('style', 'gap'), gapValue),
-              // Configure and reorder the "first" element.
-              ...nukeAllAbsolutePositioningPropsCommands(firstChildPath),
-              setProperty('always', firstChildPath, PP.create('style', 'flexGrow'), 0),
-              reorderElement('always', firstChildPath, absolute(0)),
-              // Configure and reorder the "second" element.
-              ...nukeAllAbsolutePositioningPropsCommands(secondChildPath),
-              setProperty('always', secondChildPath, PP.create('style', 'flexGrow'), 1),
-              reorderElement('always', secondChildPath, absolute(1)),
-              // Configure and reorder the "third" element.
-              ...nukeAllAbsolutePositioningPropsCommands(thirdChildPath),
-              setProperty('always', thirdChildPath, PP.create('style', 'flexGrow'), 0),
-              reorderElement('always', thirdChildPath, absolute(2)),
-            ]
-          }
-        }
-      }
+    // Special case: Group with 3 child elements in a row with some specific `data-constraints`.
+    const possibleThreeElementGroupRow = convertThreeElementGroupRow(
+      metadata,
+      allElementProps,
+      elementPathTree,
+      path,
+      childrenPaths,
+      parentFlexDirection,
+      direction,
+    )
+    if (possibleThreeElementGroupRow !== 'not-applicable') {
+      return possibleThreeElementGroupRow
     }
 
     const rearrangedChildrenPaths = rearrangedPathsWithFlexConversionMeasurementBoundariesIntact(

--- a/editor/src/components/inspector/add-remove-layout-system-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.spec.browser2.tsx
@@ -4,7 +4,7 @@ import { CanvasControlsContainerID } from '../canvas/controls/new-canvas-control
 import { mouseClickAtPoint, pressKey } from '../canvas/event-helpers.test-utils'
 import type { EditorRenderResult } from '../canvas/ui-jsx.test-utils'
 import { renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
-import { AddRemoveLayouSystemControlTestId } from './add-remove-layout-system-control'
+import { AddRemoveLayoutSystemControlTestId } from './add-remove-layout-system-control'
 
 describe('add layout system', () => {
   it('add and remove layout system via keyboard shortcut', async () => {
@@ -206,7 +206,7 @@ async function selectDiv(editor: EditorRenderResult): Promise<HTMLElement> {
 }
 
 async function clickOn(editor: EditorRenderResult) {
-  const flexDirectionToggle = editor.renderedDOM.getByTestId(AddRemoveLayouSystemControlTestId())
+  const flexDirectionToggle = editor.renderedDOM.getByTestId(AddRemoveLayoutSystemControlTestId())
 
   await mouseClickAtPoint(flexDirectionToggle, { x: 2, y: 2 })
 }

--- a/editor/src/components/inspector/add-remove-layout-system-control.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.tsx
@@ -20,16 +20,16 @@ import { detectAreElementsFlexContainers } from './inspector-common'
 import { executeFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
 import { useDispatch } from '../editor/store/dispatch-context'
 
-export const AddRemoveLayouSystemControlTestId = (): string => 'AddRemoveLayouSystemControlTestId'
+export const AddRemoveLayoutSystemControlTestId = (): string => 'AddRemoveLayoutSystemControlTestId'
 
 interface AddRemoveLayoutSystemControlProps {}
 
-export const AddRemoveLayouSystemControl = React.memo<AddRemoveLayoutSystemControlProps>(() => {
+export const AddRemoveLayoutSystemControl = React.memo<AddRemoveLayoutSystemControlProps>(() => {
   const isFlexLayoutedContainer = useEditorState(
     Substores.metadata,
     (store) =>
       detectAreElementsFlexContainers(metadataSelector(store), selectedViewsSelector(store)),
-    'AddRemoveLayouSystemControl, isFlexLayoutedContainer',
+    'AddRemoveLayoutSystemControl isFlexLayoutedContainer',
   )
 
   const dispatch = useDispatch()
@@ -89,7 +89,7 @@ export const AddRemoveLayouSystemControl = React.memo<AddRemoveLayoutSystemContr
       </FlexRow>
       {isFlexLayoutedContainer ? (
         <SquareButton
-          data-testid={AddRemoveLayouSystemControlTestId()}
+          data-testid={AddRemoveLayoutSystemControlTestId()}
           highlight
           onClick={removeLayoutSystem}
         >
@@ -97,7 +97,7 @@ export const AddRemoveLayouSystemControl = React.memo<AddRemoveLayoutSystemContr
         </SquareButton>
       ) : (
         <SquareButton
-          data-testid={AddRemoveLayouSystemControlTestId()}
+          data-testid={AddRemoveLayoutSystemControlTestId()}
           highlight
           onClick={addLayoutSystem}
         >

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { createSelector } from 'reselect'
 import { when } from '../../utils/react-conditionals'
 import { Substores, useEditorState } from '../editor/store/store-hook'
-import { AddRemoveLayouSystemControl } from './add-remove-layout-system-control'
+import { AddRemoveLayoutSystemControl } from './add-remove-layout-system-control'
 import { FlexDirectionToggle } from './flex-direction-control'
 import { selectedViewsSelector, metadataSelector } from './inpector-selectors'
 import { detectAreElementsFlexContainers } from './inspector-common'
@@ -33,7 +33,7 @@ export const FlexSection = React.memo(() => {
 
   return (
     <div>
-      <AddRemoveLayouSystemControl />
+      <AddRemoveLayoutSystemControl />
       {when(
         allElementsInFlexLayout,
         <FlexCol css={{ gap: 10 }}>

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -1278,7 +1278,7 @@ export function setFixedSizeCommands(
   return sizeToDimensionsFromFrame(metadata, pathTrees, elementPath, frame)
 }
 
-function getSafeGroupChildConstraintsArray(
+export function getSafeGroupChildConstraintsArray(
   allElementProps: AllElementProps,
   path: ElementPath,
 ): LayoutPinnedProp[] {

--- a/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.spec.browser2.tsx
@@ -3,7 +3,7 @@ import { CanvasControlsContainerID } from '../../canvas/controls/new-canvas-cont
 import { mouseClickAtPoint } from '../../canvas/event-helpers.test-utils'
 import type { EditorRenderResult } from '../../canvas/ui-jsx.test-utils'
 import { renderTestEditorWithCode } from '../../canvas/ui-jsx.test-utils'
-import { AddRemoveLayouSystemControlTestId } from '../add-remove-layout-system-control'
+import { AddRemoveLayoutSystemControlTestId } from '../add-remove-layout-system-control'
 
 describe('remove-flex-convert-to-absolute strategy', () => {
   it('remove flex layout', async () => {
@@ -54,7 +54,7 @@ async function selectDiv(editor: EditorRenderResult): Promise<HTMLElement> {
 }
 
 async function clickOn(editor: EditorRenderResult): Promise<void> {
-  const plusButton = editor.renderedDOM.getByTestId(AddRemoveLayouSystemControlTestId())
+  const plusButton = editor.renderedDOM.getByTestId(AddRemoveLayoutSystemControlTestId())
 
   await mouseClickAtPoint(plusButton, { x: 2, y: 2 })
 }

--- a/editor/src/core/shared/math-utils.spec.ts
+++ b/editor/src/core/shared/math-utils.spec.ts
@@ -1,4 +1,9 @@
-import { wrapValue } from './math-utils'
+import {
+  canvasRectangle,
+  doRectanglesIntersect,
+  infinityCanvasRectangle,
+  wrapValue,
+} from './math-utils'
 
 describe('math utils', () => {
   describe('wrapValue', () => {
@@ -19,6 +24,29 @@ describe('math utils', () => {
       expect(wrapValue(-4, -7, -3)).toEqual(-4)
       expect(wrapValue(-11, -7, -3)).toEqual(-6)
       expect(wrapValue(-2, -7, -3)).toEqual(-7)
+    })
+  })
+  describe('doRectanglesIntersect', () => {
+    it('when either value is an infinity rectangle returns true', () => {
+      const regularRectangle = canvasRectangle({ x: 10, y: 20, width: 100, height: 200 })
+      expect(doRectanglesIntersect(infinityCanvasRectangle, regularRectangle)).toEqual(true)
+      expect(doRectanglesIntersect(regularRectangle, infinityCanvasRectangle)).toEqual(true)
+      expect(doRectanglesIntersect(infinityCanvasRectangle, infinityCanvasRectangle)).toEqual(true)
+    })
+    it('when the rectangles are independent returns false', () => {
+      const regularRectangle1 = canvasRectangle({ x: 10, y: 20, width: 100, height: 200 })
+      const regularRectangle2 = canvasRectangle({ x: 400, y: 20, width: 100, height: 200 })
+      expect(doRectanglesIntersect(regularRectangle1, regularRectangle2)).toEqual(false)
+    })
+    it('when the rectangles intersect on a corner returns true', () => {
+      const regularRectangle1 = canvasRectangle({ x: 10, y: 20, width: 100, height: 200 })
+      const regularRectangle2 = canvasRectangle({ x: 40, y: 50, width: 100, height: 200 })
+      expect(doRectanglesIntersect(regularRectangle1, regularRectangle2)).toEqual(true)
+    })
+    it('when the rectangles fully overlap returns true', () => {
+      const regularRectangle1 = canvasRectangle({ x: 10, y: 20, width: 100, height: 200 })
+      const regularRectangle2 = canvasRectangle({ x: 5, y: 5, width: 400, height: 400 })
+      expect(doRectanglesIntersect(regularRectangle1, regularRectangle2)).toEqual(true)
     })
   })
 })

--- a/editor/src/core/shared/math-utils.ts
+++ b/editor/src/core/shared/math-utils.ts
@@ -533,6 +533,31 @@ export function rectangleIntersection<C extends CoordinateMarker>(
   }
 }
 
+export function doRectanglesIntersect<C extends CoordinateMarker>(
+  rect1: MaybeInfinityRectangle<C>,
+  rect2: MaybeInfinityRectangle<C>,
+): boolean {
+  if (isInfinityRectangle(rect1) || isInfinityRectangle(rect2)) {
+    // Infinity rectangles intersect with anything and everything.
+    return true
+  } else {
+    return rectangleIntersection(rect1, rect2) != null
+  }
+}
+
+export function anyRectanglesIntersect<C extends CoordinateMarker>(
+  rectangles: Array<MaybeInfinityRectangle<C>>,
+): boolean {
+  for (let firstIndex = 0; firstIndex < rectangles.length; firstIndex++) {
+    for (let secondIndex = firstIndex + 1; secondIndex < rectangles.length; secondIndex++) {
+      if (doRectanglesIntersect(rectangles[firstIndex], rectangles[secondIndex])) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
 export function pointDifference<C extends CoordinateMarker>(
   from: Point<C>,
   to: Point<C>,


### PR DESCRIPTION
**Problem:**
For a specific set of circumstances of 3 elements with the following sets of constraints from left to right:
- `[left, width]`
- `[left, right]`
- `[right, width]`

Which also do not overlap, we want to be preserve the layout as much as reasonably possible while still converting to a flex layout.

**Fix:**
In `convertLayoutToFlexCommands` an additional special case has been added which initially checks if there are 3 children of the selected element. Then because they're in a group and the visual positioning does not necessarily line up with the logical ordering, we sort them visually to determine the "first", "second" and "third" elements. The constraints are validated along with checking that there's no overlap.

Once the validation is all successful, then a `flexGrow` value is back-calculated for the "second" element so that it ends up horizontally positioned as close to the original starting position as possible. Along with values like the absolute positioning properties being expunged and the entries being reordered to make sense in a flex context.

**Commit Details:**
- Added `doRectanglesIntersect` and `anyRectanglesIntersect` utility functions.
- Renamed `AddRemoveLayouSystemControl` to `AddRemoveLayoutSystemControl`.
- Renamed `AddRemoveLayouSystemControlTestId` to `AddRemoveLayoutSystemControlTestId`.
- Added `checkConstraintsForThreeElementRow`, `anyOverlappingFrames` and `laidOutAsRow` utility functions to directly support the checks needed.
- Implemented special case to `convertLayoutToFlexCommands` for a group of 3 constrained elements laid out in a row.