### PR TITLE
Only show one set of padding controls.

### DIFF
--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -57,9 +57,6 @@ export const FlexSection = React.memo(() => {
           <UIGridRow padded={false} variant='<-------------1fr------------->'>
             <SpacedPackedControl />
           </UIGridRow>
-          <UIGridRow padded={false} variant='<-------------1fr------------->'>
-            <PaddingRow />
-          </UIGridRow>
         </FlexCol>,
       )}
     </div>

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -18,7 +18,7 @@ import { FlexGapControl } from './sections/layout-section/flex-container-subsect
 import { FlexContainerControls } from './sections/layout-section/flex-container-subsection/flex-container-subsection'
 import { FlexCol } from 'utopia-api'
 
-const areElementsFlexContainersSelector = createSelector(
+export const areElementsFlexContainersSelector = createSelector(
   metadataSelector,
   selectedViewsSelector,
   detectAreElementsFlexContainers,

--- a/editor/src/components/inspector/sections/style-section/container-subsection/container-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/container-subsection.tsx
@@ -5,9 +5,18 @@ import { PaddingRow } from '../../layout-section/layout-system-subsection/layout
 import { BlendModeRow } from './blendmode-row'
 import { OpacityRow } from './opacity-row'
 import { OverflowRow } from './overflow-row'
+import { Substores, useEditorState } from '../../../../editor/store/store-hook'
+import { areElementsFlexContainersSelector } from '../../../flex-section'
+import { unless } from '../../../../../utils/react-conditionals'
 
 export const ContainerSubsection = React.memo(() => {
   const [seeMoreVisible, toggleSeeMoreVisible] = useToggle(false)
+
+  const allElementsInFlexLayout = useEditorState(
+    Substores.metadata,
+    areElementsFlexContainersSelector,
+    'ContainerSection areAllElementsInFlexLayout',
+  )
 
   return (
     <>
@@ -28,7 +37,7 @@ export const ContainerSubsection = React.memo(() => {
       </InspectorSubsectionHeader>
       <OpacityRow />
       <OverflowRow />
-      <PaddingRow />
+      {unless(allElementsInFlexLayout, <PaddingRow />)}
       <SeeMoreHOC visible={seeMoreVisible}>
         <BlendModeRow />
       </SeeMoreHOC>

--- a/editor/src/components/inspector/sections/style-section/container-subsection/container-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/container-subsection.tsx
@@ -5,18 +5,9 @@ import { PaddingRow } from '../../layout-section/layout-system-subsection/layout
 import { BlendModeRow } from './blendmode-row'
 import { OpacityRow } from './opacity-row'
 import { OverflowRow } from './overflow-row'
-import { Substores, useEditorState } from '../../../../editor/store/store-hook'
-import { areElementsFlexContainersSelector } from '../../../flex-section'
-import { unless } from '../../../../../utils/react-conditionals'
 
 export const ContainerSubsection = React.memo(() => {
   const [seeMoreVisible, toggleSeeMoreVisible] = useToggle(false)
-
-  const allElementsInFlexLayout = useEditorState(
-    Substores.metadata,
-    areElementsFlexContainersSelector,
-    'ContainerSection areAllElementsInFlexLayout',
-  )
 
   return (
     <>
@@ -37,7 +28,7 @@ export const ContainerSubsection = React.memo(() => {
       </InspectorSubsectionHeader>
       <OpacityRow />
       <OverflowRow />
-      {unless(allElementsInFlexLayout, <PaddingRow />)}
+      <PaddingRow />
       <SeeMoreHOC visible={seeMoreVisible}>
         <BlendModeRow />
       </SeeMoreHOC>


### PR DESCRIPTION
**Problem:**
The padding control is rendered twice for containers with autolayout.

**Fix:**
When the flex layout section wants to show the padding section, do not display it in the container section by checking the same selector result.

**Commit Details:**
- Exported `areElementsFlexContainersSelector`.
- In `ContainerSubsection` don't show `PaddingRow` if `allElementsInFlexLayout` is true.