### PR TITLE
Show toast when at end of history

### DIFF
--- a/editor/src/components/editor/history.spec.browser2.tsx
+++ b/editor/src/components/editor/history.spec.browser2.tsx
@@ -1,0 +1,56 @@
+import {
+  makeTestProjectCodeWithSnippet,
+  renderTestEditorWithCode,
+} from '../canvas/ui-jsx.test-utils'
+import { selectComponents } from './actions/meta-actions'
+import * as EP from '../../core/shared/element-path'
+import { deleteSelected, redo, undo } from './actions/action-creators'
+
+describe('history', () => {
+  describe('undo', () => {
+    it('shows a toast when trying to undo at the beginning of history', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(
+          "<div data-uid='foo' style={{ position:'absolute', top: 100, left: 100, backgroundColor: 'red', width: 100, height: 100 }} />",
+        ),
+        'await-first-dom-report',
+      )
+      await renderResult.dispatch(
+        selectComponents([EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity')], false),
+        true,
+      )
+      await renderResult.dispatch([deleteSelected()], true)
+      await renderResult.dispatch([undo()], true)
+      expect(renderResult.getEditorState().editor.toasts.length).toBe(0)
+      await renderResult.dispatch([undo()], true)
+      expect(renderResult.getEditorState().editor.toasts.length).toBe(1)
+      expect(renderResult.getEditorState().editor.toasts[0].message).toBe(
+        `Can't undo, reached the end of the undo history.`,
+      )
+    })
+  })
+  describe('redo', () => {
+    it('shows a toast when trying to redo at the end of history', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(
+          "<div data-uid='foo' style={{ position:'absolute', top: 100, left: 100, backgroundColor: 'red', width: 100, height: 100 }} />",
+        ),
+        'await-first-dom-report',
+      )
+      await renderResult.dispatch(
+        selectComponents([EP.fromString('utopia-storyboard-uid/scene-aaa/app-entity')], false),
+        true,
+      )
+      await renderResult.dispatch([deleteSelected()], true)
+      await renderResult.dispatch([undo()], true)
+      expect(renderResult.getEditorState().editor.toasts.length).toBe(0)
+      await renderResult.dispatch([redo()], true)
+      expect(renderResult.getEditorState().editor.toasts.length).toBe(0)
+      await renderResult.dispatch([redo()], true)
+      expect(renderResult.getEditorState().editor.toasts.length).toBe(1)
+      expect(renderResult.getEditorState().editor.toasts[0].message).toBe(
+        `Can't redo, reached the end of the undo history.`,
+      )
+    })
+  })
+})

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -95,6 +95,8 @@ type DispatchResultFields = {
 
 export type DispatchResult = EditorStoreFull & DispatchResultFields
 
+const cannotUndoRedoToastId = 'cannot-undo-or-redo'
+
 function processAction(
   dispatchEvent: EditorDispatch,
   editorStoreUnpatched: EditorStoreUnpatched,
@@ -111,10 +113,38 @@ function processAction(
     return processActions(dispatchEvent, working, action.actions, spyCollector)
   } else if (action.action === 'UNDO' && !History.canUndo(working.history)) {
     // Bail early and make no changes.
-    return working
+    return processActions(
+      dispatchEvent,
+      working,
+      [
+        EditorActions.addToast(
+          notice(
+            `Can't undo, reached the end of the undo history.`,
+            'NOTICE',
+            false,
+            cannotUndoRedoToastId,
+          ),
+        ),
+      ],
+      spyCollector,
+    )
   } else if (action.action === 'REDO' && !History.canRedo(working.history)) {
     // Bail early and make no changes.
-    return working
+    return processActions(
+      dispatchEvent,
+      working,
+      [
+        EditorActions.addToast(
+          notice(
+            `Can't redo, reached the end of the undo history.`,
+            'NOTICE',
+            false,
+            cannotUndoRedoToastId,
+          ),
+        ),
+      ],
+      spyCollector,
+    )
   } else if (action.action === 'SET_SHORTCUT') {
     return {
       ...working,

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -116,7 +116,8 @@ function cursorForKeysPressed(
   keysPressed: KeysPressed,
   mouseButtonsPressed: MouseButtonsPressed,
 ): CSSCursor | null {
-  if (keysPressed['z']) {
+  if (keysPressed['z'] && !keysPressed['cmd']) {
+    // must omit `cmd` to avoid triggering on undo/redo
     return keysPressed['alt'] ? CSSCursor.ZoomOut : CSSCursor.ZoomIn
   }
   if (keysPressed['space']) {


### PR DESCRIPTION
Fixes #4431

**Problem:**

Trying to undo/redo at the end of history does nothing, but there's no hint about that being the case.

**Fix:**

When trying to `undo` at the beginning of the undo history, or `redo` at the end of it, show a toast.

https://github.com/concrete-utopia/utopia/assets/1081051/7282b22b-2a3a-4f5c-b3bb-57f9c1178579

**Bonus point!** fixed the cursor transitioning to `ZoomIn` when undo'ing.

