### PR TITLE
NOOP when selecting a constraints option with the same label

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -3661,13 +3661,13 @@ describe('inspector tests with real metadata', () => {
                 data-uid='foo'
                 style={{
                   position: 'absolute',
+                  left: 0,
+                  width: 100,
                   backgroundColor: 'blue',
                   top: 0,
                   height: 100,
-                  left: 0,
-                  width: 100,
                 }}
-                data-constraints={['top', 'height', 'left', 'width']}
+                data-constraints={['left', 'width', 'top', 'height']}
               />
               <div
                 data-uid='bar'

--- a/editor/src/components/inspector/constraints-section.tsx
+++ b/editor/src/components/inspector/constraints-section.tsx
@@ -321,6 +321,10 @@ const ChildConstraintSelect = React.memo(
     const onSubmit = React.useCallback(
       (option: SelectOption) => {
         const requestedPins: RequestedPins = option.value
+        if (activeOption.label === option.label) {
+          // using the same *label* as a noop to ensure consistency between the different dispatches
+          return
+        }
         dispatch(
           isGroupChild === 'group-child'
             ? getConstraintAndFrameChangeActionsForGroupChild(
@@ -340,7 +344,7 @@ const ChildConstraintSelect = React.memo(
               ),
         )
       },
-      [dispatch, propertyTarget, editorRef, isGroupChild],
+      [dispatch, propertyTarget, editorRef, isGroupChild, activeOption],
     )
 
     return (


### PR DESCRIPTION
Fixes #4433 

This PR adds an early return to the `onSubmit` handler for the constraints section dropdown so that if the new selected option matches the same _label_ of the active one, nothing happens.

This indirectly fixes weird behaviors like group children transitioning from hug to fixed dimensions when selecting the dimension.