### PR TITLE
Remove uses of dist directory of remix

### DIFF
--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -1,5 +1,5 @@
 import { UNSAFE_RemixContext as RemixContext } from '@remix-run/react'
-import type { RouteModules, RouteModule } from '@remix-run/react/dist/routeModules'
+import type { UNSAFE_RouteModules as RouteModules } from '@remix-run/react'
 import React from 'react'
 import type { DataRouteObject, Location } from 'react-router'
 import { createMemoryRouter, RouterProvider } from 'react-router'
@@ -17,6 +17,7 @@ import { forceNotNull } from '../../../core/shared/optional-utils'
 import { AlwaysFalse, usePubSubAtomReadOnly } from '../../../core/shared/atom-with-pub-sub'
 import { CreateRemixDerivedDataRefsGLOBAL } from '../../editor/store/remix-derived-data'
 
+type RouteModule = RouteModules[keyof RouteModules]
 type RouterType = ReturnType<typeof createMemoryRouter>
 
 interface RemixNavigationContext {

--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -1,4 +1,4 @@
-import { RemixContext } from '@remix-run/react/dist/components'
+import { UNSAFE_RemixContext as RemixContext } from '@remix-run/react'
 import type { RouteModules, RouteModule } from '@remix-run/react/dist/routeModules'
 import React from 'react'
 import type { DataRouteObject, Location } from 'react-router'

--- a/editor/src/third-party/remix/client-routes.tsx
+++ b/editor/src/third-party/remix/client-routes.tsx
@@ -3,8 +3,10 @@
 // Copy pasted and adapted from Remix: https://github.com/remix-run/remix/blob/8779b24d0e51cc49a887d16afab9789557b80124/packages/remix-react/routes.tsx
 
 import React from 'react'
-import { FutureConfig } from '@remix-run/react/dist/entry'
-import { RouteModules } from '@remix-run/react/dist/routeModules'
+import {
+  UNSAFE_FutureConfig as FutureConfig,
+  UNSAFE_RouteModules as RouteModules,
+} from '@remix-run/react'
 import { DataRouteObject, ShouldRevalidateFunction } from 'react-router'
 import invariant from './invariant'
 import { isRouteErrorResponse, useRouteError } from '@remix-run/react'

--- a/editor/src/third-party/remix/remix-route.tsx
+++ b/editor/src/third-party/remix/remix-route.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import invariant from './invariant'
-import { RemixContextObject } from '@remix-run/react/dist/entry'
+import {
+  UNSAFE_RemixContextObject as RemixContextObject,
+  UNSAFE_RemixContext as RemixContext,
+} from '@remix-run/react'
 import { RemixRootDefaultErrorBoundary } from '@remix-run/react/dist/errorBoundaries'
-import { RemixContext } from '@remix-run/react/dist/components'
 import { Outlet, useRouteError } from 'react-router'
 
 function useRemixContext(): RemixContextObject {

--- a/editor/src/third-party/remix/remix-route.tsx
+++ b/editor/src/third-party/remix/remix-route.tsx
@@ -4,7 +4,6 @@ import {
   UNSAFE_RemixContextObject as RemixContextObject,
   UNSAFE_RemixContext as RemixContext,
 } from '@remix-run/react'
-import { RemixRootDefaultErrorBoundary } from '@remix-run/react/dist/errorBoundaries'
 import { Outlet, useRouteError } from 'react-router'
 
 function useRemixContext(): RemixContextObject {
@@ -50,10 +49,9 @@ export function RemixRouteError({ id }: { id: string }) {
   let error = useRouteError()
   let { ErrorBoundary } = routeModules[id]
 
+  // This should always be the case, because we've already checked the ErrorBoundary exists, but just in case
   if (ErrorBoundary) {
     return <ErrorBoundary />
-  } else if (id === 'root') {
-    return <RemixRootDefaultErrorBoundary error={error} />
   }
 
   throw error


### PR DESCRIPTION
**Problem:**
We had been importing from the `/dist` directory of the remix package, which lead to discrepancies around which context object was being used inside remix code calling `useRemixContext()`. This results in the error "You must render this element inside a <Remix> element" being thrown

**Fix:**
Replace all uses with either `UNSAFE_` imports, or replace / remove the code that couldn't be imported like that.
