### PR TITLE
Persistent panel layout in preferences

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -29,9 +29,7 @@ import { unless, when } from '../../utils/react-conditionals'
 import { InsertMenuPane } from '../navigator/insert-menu-pane'
 import { useDispatch } from '../editor/store/dispatch-context'
 import { LeftPaneComponent } from '../navigator/left-pane'
-import { GridMenuWidth } from './grid-panels-state'
 import { GridPanelsContainer } from './grid-panels-container'
-import type { Menu, Pane, StoredPanel } from './grid-panels-state'
 import type { ResizableProps } from '../../uuiui-deps'
 import type { Direction } from 're-resizable/lib/resizer'
 import { isFeatureEnabled } from '../../utils/feature-switches'
@@ -40,6 +38,7 @@ import type { EditorAction } from '../editor/action-types'
 import { SettingsPane } from '../navigator/left-pane/settings-pane'
 import { MenuTab } from '../../uuiui/menu-tab'
 import { FlexRow } from 'utopia-api'
+import type { StoredPanel } from './stored-layout'
 
 interface NumberSize {
   width: number

--- a/editor/src/components/canvas/grid-panel.tsx
+++ b/editor/src/components/canvas/grid-panel.tsx
@@ -3,12 +3,12 @@ import { colorTheme } from '../../uuiui'
 import { LeftPaneComponent } from '../navigator/left-pane'
 import { CodeEditorPane, RightPane } from './design-panel-root'
 import { useGridPanelDragInfo, useGridPanelDropArea } from './grid-panels-dnd'
-import type { GridPanelData, LayoutUpdate, StoredPanel } from './grid-panels-state'
+import type { StoredPanel, LayoutUpdate, GridPanelData } from './stored-layout'
 import {
+  GridPanelsNumberOfRows,
   GridPanelHorizontalGapHalf,
   GridPanelVerticalGapHalf,
-  GridPanelsNumberOfRows,
-} from './grid-panels-state'
+} from './stored-layout'
 
 interface GridPanelProps {
   onDrop: (itemToMove: StoredPanel, newPosition: LayoutUpdate) => void

--- a/editor/src/components/canvas/grid-panels-container.tsx
+++ b/editor/src/components/canvas/grid-panels-container.tsx
@@ -6,17 +6,8 @@ import {
   ColumnDragTargets,
   GridColumnResizeHandle,
 } from './grid-panels-drag-targets'
-import type { LayoutUpdate, StoredPanel } from './grid-panels-state'
+import { CanvasFloatingToolbars } from './canvas-floating-toolbars'
 import {
-  GridHorizontalExtraPadding,
-  GridMenuDefaultPanels,
-  GridMenuWidth,
-  GridPaneWidth,
-  GridPanelHorizontalGapHalf,
-  GridPanelVerticalGapHalf,
-  GridPanelsStateAtom,
-  GridVerticalExtraPadding,
-  NumberOfColumns,
   normalizeColIndex,
   updateLayout,
   useColumnWidths,
@@ -24,12 +15,36 @@ import {
   useResolvedGridPanels,
   wrapAroundColIndex,
 } from './grid-panels-state'
-import { CanvasFloatingToolbars } from './canvas-floating-toolbars'
-import { usePropControlledStateV2 } from '../inspector/common/inspector-utils'
-import { useAtom } from 'jotai'
+import type { StoredPanel, LayoutUpdate } from './stored-layout'
+import {
+  NumberOfColumns,
+  GridPanelVerticalGapHalf,
+  GridVerticalExtraPadding,
+  GridPanelHorizontalGapHalf,
+  GridHorizontalExtraPadding,
+} from './stored-layout'
+import { loadUserPreferences, saveUserPreferences } from '../common/user-preferences'
 
 export const GridPanelsContainer = React.memo(() => {
+  const [loaded, setLoaded] = React.useState(false)
   const [panelState, setPanelState] = useGridPanelState()
+
+  React.useEffect(() => {
+    async function loadPrefs() {
+      const prefs = await loadUserPreferences()
+      setPanelState(prefs.storedLayout)
+    }
+    if (!loaded) {
+      setLoaded(true)
+      void loadPrefs()
+    }
+  }, [loaded, setPanelState])
+
+  React.useEffect(() => {
+    if (loaded) {
+      void saveUserPreferences({ storedLayout: panelState })
+    }
+  }, [loaded, panelState])
 
   const orderedPanels = useResolvedGridPanels()
 

--- a/editor/src/components/canvas/grid-panels-container.tsx
+++ b/editor/src/components/canvas/grid-panels-container.tsx
@@ -26,7 +26,7 @@ import {
 import { loadUserPreferences, saveUserPreferences } from '../common/user-preferences'
 
 export const GridPanelsContainer = React.memo(() => {
-  const [loaded, setLoaded] = React.useState(false)
+  const [panelStateLoaded, setPanelStateLoaded] = React.useState(false)
   const [panelState, setPanelState] = useGridPanelState()
 
   React.useEffect(() => {
@@ -34,17 +34,17 @@ export const GridPanelsContainer = React.memo(() => {
       const prefs = await loadUserPreferences()
       setPanelState(prefs.storedLayout)
     }
-    if (!loaded) {
-      setLoaded(true)
+    if (!panelStateLoaded) {
+      setPanelStateLoaded(true)
       void loadPrefs()
     }
-  }, [loaded, setPanelState])
+  }, [panelStateLoaded, setPanelState])
 
   React.useEffect(() => {
-    if (loaded) {
+    if (panelStateLoaded) {
       void saveUserPreferences({ storedLayout: panelState })
     }
-  }, [loaded, panelState])
+  }, [panelStateLoaded, panelState])
 
   const orderedPanels = useResolvedGridPanels()
 

--- a/editor/src/components/canvas/grid-panels-container.tsx
+++ b/editor/src/components/canvas/grid-panels-container.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import { accumulate } from '../../core/shared/array-utils'
+import { CanvasFloatingToolbars } from './canvas-floating-toolbars'
 import { GridPanel } from './grid-panel'
 import {
   CanvasPaneDragTargets,
   ColumnDragTargets,
   GridColumnResizeHandle,
 } from './grid-panels-drag-targets'
-import { CanvasFloatingToolbars } from './canvas-floating-toolbars'
 import {
   normalizeColIndex,
   updateLayout,
@@ -15,48 +15,17 @@ import {
   useResolvedGridPanels,
   wrapAroundColIndex,
 } from './grid-panels-state'
-import type { StoredPanel, LayoutUpdate } from './stored-layout'
+import type { LayoutUpdate, StoredPanel } from './stored-layout'
 import {
-  NumberOfColumns,
+  GridHorizontalExtraPadding,
+  GridPanelHorizontalGapHalf,
   GridPanelVerticalGapHalf,
   GridVerticalExtraPadding,
-  GridPanelHorizontalGapHalf,
-  GridHorizontalExtraPadding,
+  NumberOfColumns,
 } from './stored-layout'
-import {
-  getProjectStoredLayoutOrDefault,
-  loadUserPreferences,
-  saveUserPreferencesProjectLayout,
-} from '../common/user-preferences'
-import { Substores, useEditorState } from '../editor/store/store-hook'
 
 export const GridPanelsContainer = React.memo(() => {
-  const [panelStateLoaded, setPanelStateLoaded] = React.useState(false)
   const [panelState, setPanelState] = useGridPanelState()
-  const projectId = useEditorState(
-    Substores.restOfEditor,
-    (store) => store.editor.id,
-    'GridPanelsContainer projectId',
-  )
-
-  React.useEffect(() => {
-    if (projectId == null || panelStateLoaded) {
-      return
-    }
-    setPanelStateLoaded(true)
-    async function loadPrefs(id: string) {
-      const prefs = await loadUserPreferences()
-      setPanelState(getProjectStoredLayoutOrDefault(prefs.panelsLayout, id))
-    }
-    void loadPrefs(projectId)
-  }, [panelStateLoaded, setPanelState, projectId])
-
-  React.useEffect(() => {
-    if (projectId == null || !panelStateLoaded) {
-      return
-    }
-    void saveUserPreferencesProjectLayout(projectId, panelState)
-  }, [panelStateLoaded, panelState, projectId])
 
   const orderedPanels = useResolvedGridPanels()
 

--- a/editor/src/components/canvas/grid-panels-dnd.tsx
+++ b/editor/src/components/canvas/grid-panels-dnd.tsx
@@ -1,7 +1,7 @@
 import type { ConnectDragPreview, ConnectDragSource, ConnectDropTarget } from 'react-dnd'
 import { useDrag, useDragLayer, useDrop } from 'react-dnd'
 import { magnitude, windowPoint } from '../../core/shared/math-utils'
-import type { StoredPanel } from './grid-panels-state'
+import type { StoredPanel } from './stored-layout'
 
 const FloatingPanelTitleBarType = 'floating-panel-title-bar'
 

--- a/editor/src/components/canvas/grid-panels-drag-targets.tsx
+++ b/editor/src/components/canvas/grid-panels-drag-targets.tsx
@@ -4,14 +4,14 @@ import { colorTheme } from '../../uuiui'
 import { usePropControlledRef_DANGEROUS } from '../inspector/common/inspector-utils'
 import { CSSCursor } from './canvas-types'
 import { useGridPanelDragInfo, useGridPanelDropArea } from './grid-panels-dnd'
-import type { LayoutUpdate, StoredPanel } from './grid-panels-state'
+import { wrapAroundColIndex } from './grid-panels-state'
+import type { StoredPanel, LayoutUpdate } from './stored-layout'
 import {
   ExtraHorizontalDropTargetPadding,
   GridPanelHorizontalGapHalf,
   IndexOfCanvas,
   ResizeColumnWidth,
-  wrapAroundColIndex,
-} from './grid-panels-state'
+} from './stored-layout'
 
 export const ColumnDragTargets = React.memo(
   (props: {

--- a/editor/src/components/canvas/grid-panels-state.tsx
+++ b/editor/src/components/canvas/grid-panels-state.tsx
@@ -1,118 +1,30 @@
+import immutableUpdate from 'immutability-helper'
+import { atom, useAtom, useSetAtom } from 'jotai'
 import findLastIndex from 'lodash.findlastindex'
 import React from 'react'
-import { v4 as UUID } from 'uuid'
 import { accumulate, insert, removeAll, removeIndexFromArray } from '../../core/shared/array-utils'
 import { clamp, mod } from '../../core/shared/math-utils'
 import { assertNever } from '../../core/shared/utils'
-import {
-  usePropControlledRef_DANGEROUS,
-  usePropControlledStateV2,
-} from '../inspector/common/inspector-utils'
-import invariant from '../../third-party/remix/invariant'
-import { useKeepShallowReferenceEquality } from '../../utils/react-performance'
-import { atom, useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
-import immutableUpdate from 'immutability-helper'
 import { deepFreeze } from '../../utils/deep-freeze'
 import { Substores, useEditorState } from '../editor/store/store-hook'
-
-export const GridMenuWidth = 268
-export const GridMenuMinWidth = 200
-export const GridMenuMaxWidth = 500
-
-export const GridPaneWidth = 500
-
-export const NumberOfColumns = 4
-export const IndexOfCanvas = 2
-
-export const GridPanelVerticalGapHalf = 6
-export const GridVerticalExtraPadding = -4
-export const GridPanelHorizontalGapHalf = 6
-export const GridHorizontalExtraPadding = -4
-
-export const ExtraHorizontalDropTargetPadding = 45
-
-export const ResizeColumnWidth = 10
-
-export const GridPanelsNumberOfRows = 12
-
-export type Menu = 'inspector' | 'navigator'
-export type Pane = 'code-editor'
-
-export const allMenusAndPanels: Array<Menu | Pane> = [
-  'navigator',
-  'code-editor',
-  'inspector',
-  // 'preview', // Does this exist?
-]
-
-export interface GridPanelData {
-  panel: StoredPanel
-  span: number
-  index: number
-  order: number
-  visible: boolean
-}
-
-export type PanelName = Menu | Pane
-
-export interface StoredPanel {
-  name: PanelName
-  type: 'menu' | 'pane'
-  uid: string
-}
-
-function storedPanel({ name, type }: { name: PanelName; type: 'menu' | 'pane' }): StoredPanel {
-  return {
-    name: name,
-    type: type,
-    uid: UUID(),
-  }
-}
-
-interface StoredColumn {
-  panels: Array<StoredPanel>
-  paneWidth: number // the width to use if they only contain Panes
-  menuWidth: number // the width to use if they contain at least one Menu
-}
-
-function storedColumn(panels: Array<StoredPanel>): StoredColumn {
-  return { panels: panels, paneWidth: GridPaneWidth, menuWidth: GridMenuWidth }
-}
-
-type StoredLayout = Array<StoredColumn>
-
-type BeforeColumn = {
-  type: 'before-column'
-  columnIndex: number
-}
-type AfterColumn = {
-  type: 'after-column'
-  columnIndex: number
-}
-type ColumnUpdate = BeforeColumn | AfterColumn
-
-type BeforeIndex = {
-  type: 'before-index'
-  columnIndex: number
-  indexInColumn: number
-}
-type AfterIndex = {
-  type: 'after-index'
-  columnIndex: number
-  indexInColumn: number
-}
-type RowUpdate = BeforeIndex | AfterIndex
-export type LayoutUpdate = ColumnUpdate | RowUpdate
-
-export const GridMenuDefaultPanels: StoredLayout = [
-  storedColumn([
-    storedPanel({ name: 'navigator', type: 'menu' }),
-    storedPanel({ name: 'code-editor', type: 'pane' }),
-  ]),
-  storedColumn([]),
-  storedColumn([]),
-  storedColumn([storedPanel({ name: 'inspector', type: 'menu' })]),
-]
+import type {
+  GridPanelData,
+  LayoutUpdate,
+  PanelName,
+  StoredColumn,
+  StoredLayout,
+  StoredPanel,
+} from './stored-layout'
+import {
+  GridMenuDefaultPanels,
+  GridMenuMaxWidth,
+  GridMenuMinWidth,
+  GridPanelsNumberOfRows,
+  IndexOfCanvas,
+  NumberOfColumns,
+  storedColumn,
+  storedPanel,
+} from './stored-layout'
 
 export const GridPanelsStateAtom = atom(GridMenuDefaultPanels)
 

--- a/editor/src/components/canvas/grid-panels-state.tsx
+++ b/editor/src/components/canvas/grid-panels-state.tsx
@@ -16,17 +16,17 @@ import type {
   StoredPanel,
 } from './stored-layout'
 import {
-  GridMenuDefaultPanels,
   GridMenuMaxWidth,
   GridMenuMinWidth,
   GridPanelsNumberOfRows,
   IndexOfCanvas,
   NumberOfColumns,
+  gridMenuDefaultPanels,
   storedColumn,
   storedPanel,
 } from './stored-layout'
 
-export const GridPanelsStateAtom = atom(GridMenuDefaultPanels)
+export const GridPanelsStateAtom = atom(gridMenuDefaultPanels())
 
 export function useGridPanelState() {
   return useAtom(GridPanelsStateAtom)

--- a/editor/src/components/canvas/stored-layout.ts
+++ b/editor/src/components/canvas/stored-layout.ts
@@ -1,0 +1,106 @@
+import { v4 as UUID } from 'uuid'
+
+export const GridMenuWidth = 268
+export const GridMenuMinWidth = 200
+export const GridMenuMaxWidth = 500
+
+export const GridPaneWidth = 500
+
+export const NumberOfColumns = 4
+export const IndexOfCanvas = 2
+
+export const GridPanelVerticalGapHalf = 6
+export const GridVerticalExtraPadding = -4
+export const GridPanelHorizontalGapHalf = 6
+export const GridHorizontalExtraPadding = -4
+
+export const ExtraHorizontalDropTargetPadding = 45
+
+export const ResizeColumnWidth = 10
+
+export const GridPanelsNumberOfRows = 12
+
+export type Menu = 'inspector' | 'navigator'
+export type Pane = 'code-editor'
+
+export const allMenusAndPanels: Array<Menu | Pane> = [
+  'navigator',
+  'code-editor',
+  'inspector',
+  // 'preview', // Does this exist?
+]
+
+export interface GridPanelData {
+  panel: StoredPanel
+  span: number
+  index: number
+  order: number
+  visible: boolean
+}
+
+export type PanelName = Menu | Pane
+
+export interface StoredPanel {
+  name: PanelName
+  type: 'menu' | 'pane'
+  uid: string
+}
+
+export function storedPanel({
+  name,
+  type,
+}: {
+  name: PanelName
+  type: 'menu' | 'pane'
+}): StoredPanel {
+  return {
+    name: name,
+    type: type,
+    uid: UUID(),
+  }
+}
+
+export interface StoredColumn {
+  panels: Array<StoredPanel>
+  paneWidth: number // the width to use if they only contain Panes
+  menuWidth: number // the width to use if they contain at least one Menu
+}
+
+export function storedColumn(panels: Array<StoredPanel>): StoredColumn {
+  return { panels: panels, paneWidth: GridPaneWidth, menuWidth: GridMenuWidth }
+}
+
+export type StoredLayout = Array<StoredColumn>
+
+export type BeforeColumn = {
+  type: 'before-column'
+  columnIndex: number
+}
+export type AfterColumn = {
+  type: 'after-column'
+  columnIndex: number
+}
+export type ColumnUpdate = BeforeColumn | AfterColumn
+
+export type BeforeIndex = {
+  type: 'before-index'
+  columnIndex: number
+  indexInColumn: number
+}
+export type AfterIndex = {
+  type: 'after-index'
+  columnIndex: number
+  indexInColumn: number
+}
+export type RowUpdate = BeforeIndex | AfterIndex
+export type LayoutUpdate = ColumnUpdate | RowUpdate
+
+export const GridMenuDefaultPanels: StoredLayout = [
+  storedColumn([
+    storedPanel({ name: 'navigator', type: 'menu' }),
+    storedPanel({ name: 'code-editor', type: 'pane' }),
+  ]),
+  storedColumn([]),
+  storedColumn([]),
+  storedColumn([storedPanel({ name: 'inspector', type: 'menu' })]),
+]

--- a/editor/src/components/canvas/stored-layout.ts
+++ b/editor/src/components/canvas/stored-layout.ts
@@ -95,12 +95,14 @@ export type AfterIndex = {
 export type RowUpdate = BeforeIndex | AfterIndex
 export type LayoutUpdate = ColumnUpdate | RowUpdate
 
-export const GridMenuDefaultPanels: StoredLayout = [
-  storedColumn([
-    storedPanel({ name: 'navigator', type: 'menu' }),
-    storedPanel({ name: 'code-editor', type: 'pane' }),
-  ]),
-  storedColumn([]),
-  storedColumn([]),
-  storedColumn([storedPanel({ name: 'inspector', type: 'menu' })]),
-]
+export function gridMenuDefaultPanels(): StoredLayout {
+  return [
+    storedColumn([
+      storedPanel({ name: 'navigator', type: 'menu' }),
+      storedPanel({ name: 'code-editor', type: 'pane' }),
+    ]),
+    storedColumn([]),
+    storedColumn([]),
+    storedColumn([storedPanel({ name: 'inspector', type: 'menu' })]),
+  ]
+}

--- a/editor/src/components/common/user-preferences.ts
+++ b/editor/src/components/common/user-preferences.ts
@@ -3,14 +3,34 @@ import type { StoredLayout } from '../canvas/stored-layout'
 import { GridMenuDefaultPanels } from '../canvas/stored-layout'
 
 export type UserPreferences = {
-  storedLayout: StoredLayout
+  panelsLayout: PanelsLayout
+}
+
+type PanelsLayout = {
+  // the default layout for new projects
+  default: StoredLayout
+  // per-project layouts
+  project: {
+    [key: string]: StoredLayout
+  }
+}
+
+export function getProjectStoredLayoutOrDefault(
+  layout: PanelsLayout,
+  projectId: string,
+): StoredLayout {
+  const projectLayout = layout.project[projectId]
+  return projectLayout ?? layout.default
 }
 
 export const USER_PREFERENCES_KEY = 'utopia.userPreferences'
 
 export function defaultUserPreferences(): UserPreferences {
   return {
-    storedLayout: GridMenuDefaultPanels,
+    panelsLayout: {
+      default: GridMenuDefaultPanels,
+      project: {},
+    },
   }
 }
 
@@ -21,6 +41,21 @@ export async function saveUserPreferences(prefs: Partial<UserPreferences>): Prom
     ...prefs,
   }
   await localforage.setItem(USER_PREFERENCES_KEY, newPrefs)
+}
+
+export async function saveUserPreferencesDefaultLayout(layout: StoredLayout): Promise<void> {
+  const prefs = await loadUserPreferences()
+  prefs.panelsLayout.default = layout
+  await localforage.setItem(USER_PREFERENCES_KEY, prefs)
+}
+
+export async function saveUserPreferencesProjectLayout(
+  projectId: string,
+  layout: StoredLayout,
+): Promise<void> {
+  const prefs = await loadUserPreferences()
+  prefs.panelsLayout.project[projectId] = layout
+  return saveUserPreferences(prefs)
 }
 
 export async function loadUserPreferences(): Promise<UserPreferences> {

--- a/editor/src/components/common/user-preferences.ts
+++ b/editor/src/components/common/user-preferences.ts
@@ -1,6 +1,6 @@
 import localforage from 'localforage'
 import type { StoredLayout } from '../canvas/stored-layout'
-import { GridMenuDefaultPanels } from '../canvas/stored-layout'
+import { gridMenuDefaultPanels } from '../canvas/stored-layout'
 
 export type UserPreferences = {
   panelsLayout: PanelsLayout
@@ -28,7 +28,7 @@ export const USER_PREFERENCES_KEY = 'utopia.userPreferences'
 export function defaultUserPreferences(): UserPreferences {
   return {
     panelsLayout: {
-      default: GridMenuDefaultPanels,
+      default: gridMenuDefaultPanels(),
       project: {},
     },
   }

--- a/editor/src/components/common/user-preferences.ts
+++ b/editor/src/components/common/user-preferences.ts
@@ -1,0 +1,29 @@
+import localforage from 'localforage'
+import type { StoredLayout } from '../canvas/stored-layout'
+import { GridMenuDefaultPanels } from '../canvas/stored-layout'
+
+export type UserPreferences = {
+  storedLayout: StoredLayout
+}
+
+export const USER_PREFERENCES_KEY = 'utopia.userPreferences'
+
+export function defaultUserPreferences(): UserPreferences {
+  return {
+    storedLayout: GridMenuDefaultPanels,
+  }
+}
+
+export async function saveUserPreferences(prefs: Partial<UserPreferences>): Promise<void> {
+  const currentPrefs = await loadUserPreferences()
+  const newPrefs = {
+    ...currentPrefs,
+    ...prefs,
+  }
+  await localforage.setItem(USER_PREFERENCES_KEY, newPrefs)
+}
+
+export async function loadUserPreferences(): Promise<UserPreferences> {
+  const stored = await localforage.getItem<UserPreferences | null>(USER_PREFERENCES_KEY)
+  return stored ?? defaultUserPreferences()
+}

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -172,8 +172,8 @@ import {
 } from '../../canvas/canvas-strategies/strategies/group-helpers'
 import type { RemixDerivedData, RemixDerivedDataFactory } from './remix-derived-data'
 import type { ProjectServerState } from './project-server-state'
-import { GridMenuWidth } from '../../canvas/grid-panels-state'
 import type { ReparentTargetForPaste } from '../../canvas/canvas-strategies/strategies/reparent-utils'
+import { GridMenuWidth } from '../../canvas/stored-layout'
 
 const ObjectPathImmutable: any = OPI
 

--- a/editor/src/components/navigator/left-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/index.tsx
@@ -5,7 +5,6 @@ import { jsx } from '@emotion/react'
 import React from 'react'
 import { FlexColumn, FlexRow, UtopiaTheme, colorTheme } from '../../../uuiui'
 import { MenuTab } from '../../../uuiui/menu-tab'
-import type { StoredPanel } from '../../canvas/grid-panels-state'
 import type { EditorAction, EditorDispatch, LoginState } from '../../editor/action-types'
 import { setLeftMenuTab } from '../../editor/actions/action-creators'
 import { useDispatch } from '../../editor/store/dispatch-context'
@@ -17,6 +16,7 @@ import { TitleBarProjectTitle } from '../../titlebar/title-bar'
 import { NavigatorComponent } from '../navigator'
 import { ContentsPane } from './contents-pane'
 import { GithubPane } from './github-pane'
+import type { StoredPanel } from '../../canvas/stored-layout'
 
 export interface LeftPaneProps {
   editorState: EditorState

--- a/editor/src/components/navigator/left-pane/settings-pane.tsx
+++ b/editor/src/components/navigator/left-pane/settings-pane.tsx
@@ -38,6 +38,9 @@ import { load } from '../../../components/editor/actions/actions'
 import { when } from '../../../utils/react-conditionals'
 import { useTriggerForkProject } from '../../editor/persistence-hooks'
 import { SettingsPanel } from '../../inspector/sections/settings-panel/inspector-settingspanel'
+import { saveUserPreferencesDefaultLayout } from '../../common/user-preferences'
+import { useGridPanelState } from '../../canvas/grid-panels-state'
+import { notice } from '../../common/notice'
 
 const themeOptions = [
   {
@@ -208,6 +211,15 @@ export const SettingsPane = React.memo(() => {
 
   const onForkProjectClicked = useTriggerForkProject()
 
+  const [panelState] = useGridPanelState()
+
+  const onSavePanelsLayout = React.useCallback(() => {
+    void saveUserPreferencesDefaultLayout(panelState)
+    dispatch([
+      EditorActions.addToast(notice('Saved panels layout as default for new project.', 'SUCCESS')),
+    ])
+  }, [panelState, dispatch])
+
   return (
     <FlexColumn
       id='leftPaneSettings'
@@ -296,6 +308,23 @@ export const SettingsPane = React.memo(() => {
               onSubmitValue={handleSubmitValueTheme}
               style={{ width: 150 }}
             />
+          </UIGridRow>
+          <UIGridRow padded variant='<---1fr--->|------172px-------|'>
+            <span style={{ color: colorTheme.fg2.value }}>Panels </span>
+            <Button
+              outline={false}
+              highlight
+              onClick={onSavePanelsLayout}
+              style={{
+                width: '100%',
+                cursor: 'pointer',
+                height: UtopiaTheme.layout.inputHeight.default,
+                background: colorTheme.dynamicBlue.value,
+                color: colorTheme.bg1.value,
+              }}
+            >
+              Save panels as default
+            </Button>
           </UIGridRow>
           <UIGridRow padded variant='<-------------1fr------------->'>
             <br />

--- a/editor/src/components/navigator/left-pane/settings-pane.tsx
+++ b/editor/src/components/navigator/left-pane/settings-pane.tsx
@@ -37,10 +37,10 @@ import json5 from 'json5'
 import { load } from '../../../components/editor/actions/actions'
 import { when } from '../../../utils/react-conditionals'
 import { useTriggerForkProject } from '../../editor/persistence-hooks'
-import { SettingsPanel } from '../../inspector/sections/settings-panel/inspector-settingspanel'
 import { saveUserPreferencesDefaultLayout } from '../../common/user-preferences'
 import { useGridPanelState } from '../../canvas/grid-panels-state'
 import { notice } from '../../common/notice'
+import { gridMenuDefaultPanels } from '../../canvas/stored-layout'
 
 const themeOptions = [
   {
@@ -211,14 +211,27 @@ export const SettingsPane = React.memo(() => {
 
   const onForkProjectClicked = useTriggerForkProject()
 
-  const [panelState] = useGridPanelState()
+  const [panelState, setPanelState] = useGridPanelState()
 
-  const onSavePanelsLayout = React.useCallback(() => {
+  const onSavePanelsDefaultLayout = React.useCallback(() => {
     void saveUserPreferencesDefaultLayout(panelState)
     dispatch([
-      EditorActions.addToast(notice('Saved panels layout as default for new project.', 'SUCCESS')),
+      EditorActions.addToast(
+        notice('Saved current panels layout as default for new projects.', 'SUCCESS'),
+      ),
     ])
   }, [panelState, dispatch])
+
+  const onResetPanelsLayout = React.useCallback(() => {
+    setPanelState(gridMenuDefaultPanels())
+    dispatch([EditorActions.addToast(notice('Restored project panels layout.', 'SUCCESS'))])
+  }, [dispatch, setPanelState])
+
+  const onResetPanelsDefaultLayout = React.useCallback(async () => {
+    await saveUserPreferencesDefaultLayout(gridMenuDefaultPanels())
+    setPanelState(gridMenuDefaultPanels())
+    dispatch([EditorActions.addToast(notice('Restored default panels layout.', 'SUCCESS'))])
+  }, [dispatch, setPanelState])
 
   return (
     <FlexColumn
@@ -309,22 +322,32 @@ export const SettingsPane = React.memo(() => {
               style={{ width: 150 }}
             />
           </UIGridRow>
-          <UIGridRow padded variant='<---1fr--->|------172px-------|'>
+          <UIGridRow
+            padded
+            variant='<---1fr--->|------172px-------|'
+            style={{ alignItems: 'flex-start' }}
+          >
             <span style={{ color: colorTheme.fg2.value }}>Panels </span>
-            <Button
-              outline={false}
-              highlight
-              onClick={onSavePanelsLayout}
-              style={{
-                width: '100%',
-                cursor: 'pointer',
-                height: UtopiaTheme.layout.inputHeight.default,
-                background: colorTheme.dynamicBlue.value,
-                color: colorTheme.bg1.value,
-              }}
-            >
-              Save panels as default
-            </Button>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <Button
+                outline={false}
+                highlight
+                onClick={onSavePanelsDefaultLayout}
+                style={{
+                  cursor: 'pointer',
+                  background: colorTheme.dynamicBlue.value,
+                  color: colorTheme.bg1.value,
+                }}
+              >
+                Set as default
+              </Button>
+              <Button outline={false} highlight spotlight onClick={onResetPanelsLayout}>
+                Reset for this project
+              </Button>
+              <Button outline={false} highlight spotlight onClick={onResetPanelsDefaultLayout}>
+                Restore defaults
+              </Button>
+            </div>
           </UIGridRow>
           <UIGridRow padded variant='<-------------1fr------------->'>
             <br />

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -34,10 +34,10 @@ import { useGridPanelDraggable } from '../canvas/grid-panels-dnd'
 import { FlexRow } from 'utopia-api'
 import {
   useUpdateGridPanelLayout,
-  type StoredPanel,
   useUpdateGridPanelLayoutPutCodeEditorBelowNavigator,
 } from '../canvas/grid-panels-state'
 import { NO_OP } from '../../core/shared/utils'
+import type { StoredPanel } from '../canvas/stored-layout'
 
 interface ProjectTitleProps {}
 


### PR DESCRIPTION
Fixes #4442

**Problem:**

The new panel layout grid is great, but changes made to the layout are not kept after the editor is closed/reloaded/etc.

**Fix:**

Store the layout as user preferences and load it instead of the default placement (if available).

The layout is stored _per project_. It can be made the default for _new_ projects from the `Settings` menu, and reset similarly from there.