### PR TITLE
clean up strategy interface

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-absolute-resize-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-absolute-resize-strategy-helpers.ts
@@ -356,6 +356,8 @@ export function changeBounds(
 }
 
 export function resizeInspectorStrategy(
+  metadata: ElementInstanceMetadataMap,
+  selectedElements: Array<ElementPath>,
   projectContents: ProjectContentTreeRoot,
   originalFrame: CanvasRectangle,
   edgePosition: EdgePosition,
@@ -363,12 +365,7 @@ export function resizeInspectorStrategy(
 ): InspectorStrategy {
   return {
     name: 'Resize by pixels',
-    strategy: (
-      metadata: ElementInstanceMetadataMap,
-      selectedElements: Array<ElementPath>,
-      _elementPathTree: ElementPathTrees,
-      _allElementProps: AllElementProps,
-    ): Array<CanvasCommand> | null => {
+    strategy: (): Array<CanvasCommand> | null => {
       let commands: Array<CanvasCommand> = []
       const changeBoundsResult = changeBounds(
         projectContents,
@@ -390,18 +387,15 @@ export function resizeInspectorStrategy(
 }
 
 export function directResizeInspectorStrategy(
+  metadata: ElementInstanceMetadataMap,
+  selectedElements: Array<ElementPath>,
   projectContents: ProjectContentTreeRoot,
   widthOrHeight: 'width' | 'height',
   newPixelValue: number,
 ): InspectorStrategy {
   return {
     name: 'Resize to pixel size',
-    strategy: (
-      metadata: ElementInstanceMetadataMap,
-      selectedElements: Array<ElementPath>,
-      _elementPathTree: ElementPathTrees,
-      _allElementProps: AllElementProps,
-    ): Array<CanvasCommand> | null => {
+    strategy: (): Array<CanvasCommand> | null => {
       let commands: Array<CanvasCommand> = []
       for (const selectedElement of selectedElements) {
         const edgePosition: EdgePosition =

--- a/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/shared-move-strategies-helpers.ts
@@ -279,12 +279,14 @@ export function getInteractionMoveCommandsForSelectedElement(
 }
 
 export function moveInspectorStrategy(
+  metadata: ElementInstanceMetadataMap,
+  selectedElementPaths: ElementPath[],
   projectContents: ProjectContentTreeRoot,
   movement: CanvasVector,
 ): InspectorStrategy {
   return {
     name: 'Move by pixels',
-    strategy: (metadata, selectedElementPaths, _elementPathTree, _allElementProps) => {
+    strategy: () => {
       let commands: Array<CanvasCommand> = []
       let intendedBounds: Array<CanvasFrameAndTarget> = []
       for (const selectedPath of selectedElementPaths) {
@@ -306,13 +308,15 @@ export function moveInspectorStrategy(
 }
 
 export function directMoveInspectorStrategy(
+  metadata: ElementInstanceMetadataMap,
+  selectedElementPaths: ElementPath[],
   projectContents: ProjectContentTreeRoot,
   leftOrTop: 'left' | 'top',
   newPixelValue: number,
 ): InspectorStrategy {
   return {
     name: 'Move to a pixel position',
-    strategy: (metadata, selectedElementPaths, _elementPathTree, _allElementProps) => {
+    strategy: () => {
       let commands: Array<CanvasCommand> = []
       let intendedBounds: Array<CanvasFrameAndTarget> = []
       for (const selectedPath of selectedElementPaths) {

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -333,7 +333,6 @@ const ResizeEdge = React.memo(
     const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
     const selectedElementsRef = useRefEditorState((store) => store.editor.selectedViews)
     const elementPathTreeRef = useRefEditorState((store) => store.editor.elementPathTree)
-    const allElementPropsRef = useRefEditorState((store) => store.editor.allElementProps)
 
     const { maybeClearHighlightsOnHoverEnd } = useMaybeHighlightElement()
 
@@ -355,20 +354,14 @@ const ResizeEdge = React.memo(
     const onEdgeDblClick = React.useCallback(() => {
       executeFirstApplicableStrategy(
         dispatch,
-        metadataRef.current,
-        selectedElementsRef.current,
-        elementPathTreeRef.current,
-        allElementPropsRef.current,
-        setPropHugStrategies(invert(props.direction)),
+        setPropHugStrategies(
+          metadataRef.current,
+          selectedElementsRef.current,
+          elementPathTreeRef.current,
+          invert(props.direction),
+        ),
       )
-    }, [
-      allElementPropsRef,
-      dispatch,
-      metadataRef,
-      props.direction,
-      elementPathTreeRef,
-      selectedElementsRef,
-    ])
+    }, [dispatch, metadataRef, props.direction, elementPathTreeRef, selectedElementsRef])
 
     return (
       <div

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -718,30 +718,30 @@ export function reparentElementToUnwrap(
   editor: EditorModel,
   builtInDependencies: BuiltInDependencies,
 ): { editor: EditorModel; newPath: ElementPath | null } {
-  const result = resultForFirstApplicableStrategy(
-    editor.jsxMetadata,
-    editor.selectedViews,
-    editor.elementPathTree,
-    editor.allElementProps,
-    [
-      reparentToUnwrapAsAbsoluteStrategy(
-        pathToReparent(target),
-        insertionPath,
-        indexPosition,
-        builtInDependencies,
-        editor.projectContents,
-        editor.nodeModules.files,
-      ),
-      convertToAbsoluteAndReparentToUnwrapStrategy(
-        pathToReparent(target),
-        insertionPath,
-        indexPosition,
-        builtInDependencies,
-        editor.projectContents,
-        editor.nodeModules.files,
-      ),
-    ],
-  )
+  const result = resultForFirstApplicableStrategy([
+    reparentToUnwrapAsAbsoluteStrategy(
+      pathToReparent(target),
+      editor.jsxMetadata,
+      editor.elementPathTree,
+      editor.allElementProps,
+      insertionPath,
+      indexPosition,
+      builtInDependencies,
+      editor.projectContents,
+      editor.nodeModules.files,
+    ),
+    convertToAbsoluteAndReparentToUnwrapStrategy(
+      pathToReparent(target),
+      editor.jsxMetadata,
+      editor.elementPathTree,
+      editor.allElementProps,
+      insertionPath,
+      indexPosition,
+      builtInDependencies,
+      editor.projectContents,
+      editor.nodeModules.files,
+    ),
+  ])
 
   if (result == null) {
     return { editor: editor, newPath: null }

--- a/editor/src/components/editor/convert-callbacks.ts
+++ b/editor/src/components/editor/convert-callbacks.ts
@@ -129,13 +129,15 @@ export function changeElement(
   switch (floatingMenuState.insertMenuMode) {
     case 'wrap':
       if (source?.type === 'HTML_DIV') {
-        const commands = commandsForFirstApplicableStrategy(
-          jsxMetadata,
-          selectedViews,
-          elementPathTree,
-          allElementProps,
-          [wrapInDivStrategy(projectContents)],
-        )
+        const commands = commandsForFirstApplicableStrategy([
+          wrapInDivStrategy(
+            jsxMetadata,
+            selectedViews,
+            elementPathTree,
+            allElementProps,
+            projectContents,
+          ),
+        ])
 
         if (commands != null) {
           actionsToDispatch = [applyCommandsAction(commands)]

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -874,11 +874,18 @@ export function handleKeyDown(
           elementsConsideredForFlexConversion,
         )
         const commands = commandsForFirstApplicableStrategy(
-          editor.jsxMetadata,
-          elementsConsideredForFlexConversion,
-          editor.elementPathTree,
-          editor.allElementProps,
-          selectedElementsFlexContainers ? removeFlexLayoutStrategies : addFlexLayoutStrategies,
+          selectedElementsFlexContainers
+            ? removeFlexLayoutStrategies(
+                editor.jsxMetadata,
+                elementsConsideredForFlexConversion,
+                editor.elementPathTree,
+              )
+            : addFlexLayoutStrategies(
+                editor.jsxMetadata,
+                elementsConsideredForFlexConversion,
+                editor.elementPathTree,
+                editor.allElementProps,
+              ),
         )
         if (commands == null) {
           return []
@@ -928,13 +935,15 @@ export function handleKeyDown(
         if (!isSelectMode(editor.mode)) {
           return []
         }
-        const commands = commandsForFirstApplicableStrategy(
-          editor.jsxMetadata,
-          editor.selectedViews,
-          editor.elementPathTree,
-          editor.allElementProps,
-          [wrapInDivStrategy(editor.projectContents)],
-        )
+        const commands = commandsForFirstApplicableStrategy([
+          wrapInDivStrategy(
+            editor.jsxMetadata,
+            editor.selectedViews,
+            editor.elementPathTree,
+            editor.allElementProps,
+            editor.projectContents,
+          ),
+        ])
         if (commands == null) {
           return []
         }

--- a/editor/src/components/editor/insert-callbacks.ts
+++ b/editor/src/components/editor/insert-callbacks.ts
@@ -215,29 +215,28 @@ export function useToInsert(): (elementToInsert: InsertMenuItem | null) => void 
         return
       }
 
-      executeFirstApplicableStrategy(
-        dispatch,
-        jsxMetadataRef.current,
-        selectedViewsRef.current,
-        elementPathTreeRef.current,
-        allElementPropsRef.current,
-        [
-          insertAsAbsoluteStrategy(
-            element,
-            targetParent.value.parentPath,
-            builtInDependenciesRef.current,
-            projectContentsRef.current,
-            nodeModulesRef.current.files,
-          ),
-          insertAsStaticStrategy(
-            element,
-            targetParent.value.parentPath,
-            builtInDependenciesRef.current,
-            projectContentsRef.current,
-            nodeModulesRef.current.files,
-          ),
-        ],
-      )
+      executeFirstApplicableStrategy(dispatch, [
+        insertAsAbsoluteStrategy(
+          element,
+          jsxMetadataRef.current,
+          elementPathTreeRef.current,
+          allElementPropsRef.current,
+          targetParent.value.parentPath,
+          builtInDependenciesRef.current,
+          projectContentsRef.current,
+          nodeModulesRef.current.files,
+        ),
+        insertAsStaticStrategy(
+          element,
+          jsxMetadataRef.current,
+          elementPathTreeRef.current,
+          allElementPropsRef.current,
+          targetParent.value.parentPath,
+          builtInDependenciesRef.current,
+          projectContentsRef.current,
+          nodeModulesRef.current.files,
+        ),
+      ])
     },
     [
       allElementPropsRef,

--- a/editor/src/components/editor/one-shot-insertion-strategies/insert-as-absolute-strategy.tsx
+++ b/editor/src/components/editor/one-shot-insertion-strategies/insert-as-absolute-strategy.tsx
@@ -2,7 +2,7 @@ import type { BuiltInDependencies } from '../../../core/es-modules/package-manag
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import type { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
-import type { NodeModules, ElementPath } from '../../../core/shared/project-file-types'
+import type { NodeModules } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
 import { front } from '../../../utils/utils'
 import type { ProjectContentTreeRoot } from '../../assets'
@@ -20,18 +20,16 @@ import type { InsertionPath } from '../store/insertion-path'
 
 export const insertAsAbsoluteStrategy = (
   element: ElementToReparent,
+  metadata: ElementInstanceMetadataMap,
+  elementPathTree: ElementPathTrees,
+  allElementProps: AllElementProps,
   parentInsertionPath: InsertionPath,
   builtInDependencies: BuiltInDependencies,
   projectContents: ProjectContentTreeRoot,
   nodeModules: NodeModules,
 ): InspectorStrategy => ({
   name: 'Insert as absolute',
-  strategy: (
-    metadata: ElementInstanceMetadataMap,
-    _: Array<ElementPath>,
-    elementPathTree: ElementPathTrees,
-    allElementProps: AllElementProps,
-  ) => {
+  strategy: () => {
     const shouldReparentAsAbsoluteOrStatic = autoLayoutParentAbsoluteOrStatic(
       metadata,
       allElementProps,

--- a/editor/src/components/editor/one-shot-insertion-strategies/insert-as-static-strategy.tsx
+++ b/editor/src/components/editor/one-shot-insertion-strategies/insert-as-static-strategy.tsx
@@ -1,7 +1,7 @@
 import type { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import type { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
-import type { NodeModules, ElementPath } from '../../../core/shared/project-file-types'
+import type { NodeModules } from '../../../core/shared/project-file-types'
 import { front } from '../../../utils/utils'
 import type { ProjectContentTreeRoot } from '../../assets'
 import { getStaticReparentPropertyChanges } from '../../canvas/canvas-strategies/strategies/reparent-helpers/reparent-property-changes'
@@ -17,18 +17,16 @@ import type { InsertionPath } from '../store/insertion-path'
 
 export const insertAsStaticStrategy = (
   element: ElementToReparent,
+  metadata: ElementInstanceMetadataMap,
+  elementPathTree: ElementPathTrees,
+  allElementProps: AllElementProps,
   parentInsertionPath: InsertionPath,
   builtInDependencies: BuiltInDependencies,
   projectContents: ProjectContentTreeRoot,
   nodeModules: NodeModules,
 ): InspectorStrategy => ({
   name: 'Insert as absolute',
-  strategy: (
-    metadata: ElementInstanceMetadataMap,
-    _: Array<ElementPath>,
-    elementPathTree: ElementPathTrees,
-    allElementProps: AllElementProps,
-  ) => {
+  strategy: () => {
     const shouldReparentAsAbsoluteOrStatic = autoLayoutParentAbsoluteOrStatic(
       metadata,
       allElementProps,

--- a/editor/src/components/editor/one-shot-unwrap-strategies/convert-to-absolute-and-reparent-to-unwrap.tsx
+++ b/editor/src/components/editor/one-shot-unwrap-strategies/convert-to-absolute-and-reparent-to-unwrap.tsx
@@ -7,7 +7,7 @@ import {
   getLocalRectangleInNewParentContext,
   isFiniteRectangle,
 } from '../../../core/shared/math-utils'
-import type { NodeModules, ElementPath } from '../../../core/shared/project-file-types'
+import type { NodeModules } from '../../../core/shared/project-file-types'
 import type { IndexPosition } from '../../../utils/utils'
 import { front } from '../../../utils/utils'
 import type { ProjectContentTreeRoot } from '../../assets'
@@ -22,6 +22,9 @@ import type { UnwrapInspectorStrategy } from './unwrap-strategies-common'
 
 export const convertToAbsoluteAndReparentToUnwrapStrategy = (
   element: PathToReparent,
+  metadata: ElementInstanceMetadataMap,
+  elementPathTree: ElementPathTrees,
+  allElementProps: AllElementProps,
   parentInsertionPath: InsertionPath,
   indexPosition: IndexPosition,
   builtInDependencies: BuiltInDependencies,
@@ -29,12 +32,7 @@ export const convertToAbsoluteAndReparentToUnwrapStrategy = (
   nodeModules: NodeModules,
 ): UnwrapInspectorStrategy => ({
   name: 'Convert to absolute and reparent to unwrap',
-  strategy: (
-    metadata: ElementInstanceMetadataMap,
-    _: Array<ElementPath>,
-    elementPathTree: ElementPathTrees,
-    allElementProps: AllElementProps,
-  ) => {
+  strategy: () => {
     const shouldReparentAsAbsoluteOrStatic = autoLayoutParentAbsoluteOrStatic(
       metadata,
       allElementProps,

--- a/editor/src/components/editor/one-shot-unwrap-strategies/reparent-to-unwrap-as-absolute-strategy.tsx
+++ b/editor/src/components/editor/one-shot-unwrap-strategies/reparent-to-unwrap-as-absolute-strategy.tsx
@@ -2,7 +2,7 @@ import type { BuiltInDependencies } from '../../../core/es-modules/package-manag
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import type { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
-import type { NodeModules, ElementPath } from '../../../core/shared/project-file-types'
+import type { NodeModules } from '../../../core/shared/project-file-types'
 import type { IndexPosition } from '../../../utils/utils'
 import type { ProjectContentTreeRoot } from '../../assets'
 import { autoLayoutParentAbsoluteOrStatic } from '../../canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup'
@@ -14,6 +14,9 @@ import type { UnwrapInspectorStrategy } from './unwrap-strategies-common'
 
 export const reparentToUnwrapAsAbsoluteStrategy = (
   element: PathToReparent,
+  metadata: ElementInstanceMetadataMap,
+  elementPathTree: ElementPathTrees,
+  allElementProps: AllElementProps,
   parentInsertionPath: InsertionPath,
   indexPosition: IndexPosition,
   builtInDependencies: BuiltInDependencies,
@@ -21,12 +24,7 @@ export const reparentToUnwrapAsAbsoluteStrategy = (
   nodeModules: NodeModules,
 ): UnwrapInspectorStrategy => ({
   name: 'Reparent to unwrap as absolute',
-  strategy: (
-    metadata: ElementInstanceMetadataMap,
-    _: Array<ElementPath>,
-    elementPathTree: ElementPathTrees,
-    allElementProps: AllElementProps,
-  ) => {
+  strategy: () => {
     const shouldReparentAsAbsoluteOrStatic = autoLayoutParentAbsoluteOrStatic(
       metadata,
       allElementProps,

--- a/editor/src/components/editor/wrap-in-callbacks.ts
+++ b/editor/src/components/editor/wrap-in-callbacks.ts
@@ -49,9 +49,15 @@ type WrapInDivError =
   | 'Cannot determine the bounding box of selected elements'
   | 'Cannot insert into parent of selected elements'
 
-export const wrapInDivStrategy = (projectContents: ProjectContentTreeRoot): InspectorStrategy => ({
+export const wrapInDivStrategy = (
+  metadata: ElementInstanceMetadataMap,
+  selectedViews: ElementPath[],
+  elementPathTrees: ElementPathTrees,
+  allElementProps: AllElementProps,
+  projectContents: ProjectContentTreeRoot,
+): InspectorStrategy => ({
   name: 'Wrap in div',
-  strategy: (metadata, selectedViews, elementPathTrees, allElementProps) => {
+  strategy: () => {
     const result = wrapInDivCommands(
       metadata,
       elementPathTrees,

--- a/editor/src/components/inspector/add-remove-layout-system-control.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.tsx
@@ -42,11 +42,12 @@ export const AddRemoveLayoutSystemControl = React.memo<AddRemoveLayoutSystemCont
     () =>
       executeFirstApplicableStrategy(
         dispatch,
-        elementMetadataRef.current,
-        selectedViewsRef.current,
-        elementPathTreeRef.current,
-        allElementPropsRef.current,
-        addFlexLayoutStrategies,
+        addFlexLayoutStrategies(
+          elementMetadataRef.current,
+          selectedViewsRef.current,
+          elementPathTreeRef.current,
+          allElementPropsRef.current,
+        ),
       ),
     [allElementPropsRef, dispatch, elementMetadataRef, elementPathTreeRef, selectedViewsRef],
   )
@@ -55,13 +56,13 @@ export const AddRemoveLayoutSystemControl = React.memo<AddRemoveLayoutSystemCont
     () =>
       executeFirstApplicableStrategy(
         dispatch,
-        elementMetadataRef.current,
-        selectedViewsRef.current,
-        elementPathTreeRef.current,
-        allElementPropsRef.current,
-        removeFlexLayoutStrategies,
+        removeFlexLayoutStrategies(
+          elementMetadataRef.current,
+          selectedViewsRef.current,
+          elementPathTreeRef.current,
+        ),
       ),
-    [allElementPropsRef, dispatch, elementMetadataRef, elementPathTreeRef, selectedViewsRef],
+    [dispatch, elementMetadataRef, elementPathTreeRef, selectedViewsRef],
   )
 
   const colorTheme = useColorTheme()

--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -66,6 +66,7 @@ import type { InspectorStrategy } from './inspector-strategies/inspector-strateg
 import { executeFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
 import type { GridRowVariant } from './widgets/ui-grid-row'
 import { UIGridRow } from './widgets/ui-grid-row'
+import type { ElementPathTrees } from '../../core/shared/element-path-tree'
 
 export const FillFixedHugControlId = (segment: 'width' | 'height'): string =>
   `hug-fixed-fill-${segment}`
@@ -349,11 +350,13 @@ const WidthHeightNumberControl = React.memo((props: { dimension: 'width' | 'heig
         }
         executeFirstApplicableStrategy(
           dispatch,
-          metadataRef.current,
-          selectedViewsRef.current,
-          elementPathTreeRef.current,
-          allElementPropsRef.current,
-          setPropFixedSizeStrategies('always', axis, value),
+          setPropFixedSizeStrategies(
+            'always',
+            metadataRef.current,
+            selectedViewsRef.current,
+            axis,
+            value,
+          ),
         )
         return
       }
@@ -364,11 +367,13 @@ const WidthHeightNumberControl = React.memo((props: { dimension: 'width' | 'heig
         }
         executeFirstApplicableStrategy(
           dispatch,
-          metadataRef.current,
-          selectedViewsRef.current,
-          elementPathTreeRef.current,
-          allElementPropsRef.current,
-          setPropFillStrategies(axis, value.value, false),
+          setPropFillStrategies(
+            metadataRef.current,
+            selectedViewsRef.current,
+            axis,
+            value.value,
+            false,
+          ),
         )
       }
       if (
@@ -377,11 +382,13 @@ const WidthHeightNumberControl = React.memo((props: { dimension: 'width' | 'heig
       ) {
         executeFirstApplicableStrategy(
           dispatch,
-          metadataRef.current,
-          selectedViewsRef.current,
-          elementPathTreeRef.current,
-          allElementPropsRef.current,
-          setPropFixedSizeStrategies('always', axis, value),
+          setPropFixedSizeStrategies(
+            'always',
+            metadataRef.current,
+            selectedViewsRef.current,
+            axis,
+            value,
+          ),
         )
       }
     },
@@ -390,8 +397,6 @@ const WidthHeightNumberControl = React.memo((props: { dimension: 'width' | 'heig
       axis,
       currentValue.fixedHugFill?.type,
       metadataRef,
-      allElementPropsRef,
-      elementPathTreeRef,
       selectedViewsRef,
       elementOrParentGroupRef,
     ],
@@ -485,6 +490,10 @@ function useOnSubmitFixedFillHugType(dimension: 'width' | 'height') {
               )
             : currentComputedValue
         const strategy = strategyForChangingFillFixedHugType(
+          metadataRef.current,
+          selectedViewsRef.current,
+          elementPathTreeRef.current,
+          allElementPropsRef.current,
           valueToUse,
           axis,
           value,
@@ -492,10 +501,7 @@ function useOnSubmitFixedFillHugType(dimension: 'width' | 'height') {
         )
         executeFirstApplicableStrategy(
           dispatch,
-          metadataRef.current,
-          selectedViewsRef.current,
-          elementPathTreeRef.current,
-          allElementPropsRef.current,
+
           strategy,
         )
       }
@@ -642,6 +648,10 @@ export const GroupConstraintSelect = React.memo(
 GroupConstraintSelect.displayName = 'GroupConstraintSelect'
 
 function strategyForChangingFillFixedHugType(
+  metadata: ElementInstanceMetadataMap,
+  selectedElements: ElementPath[],
+  elementPathTree: ElementPathTrees,
+  allElementProps: AllElementProps,
   fixedValue: number,
   axis: Axis,
   mode: FixedHugFillMode,
@@ -649,15 +659,21 @@ function strategyForChangingFillFixedHugType(
 ): Array<InspectorStrategy> {
   switch (mode) {
     case 'fill':
-      return setPropFillStrategies(axis, 'default', otherAxisSetToFill)
+      return setPropFillStrategies(metadata, selectedElements, axis, 'default', otherAxisSetToFill)
     case 'hug':
-      return setPropHugStrategies(axis)
+      return setPropHugStrategies(metadata, selectedElements, elementPathTree, axis)
     case 'fixed':
     case 'scaled':
     case 'detected':
     case 'computed':
     case 'hug-group':
-      return setPropFixedSizeStrategies('always', axis, cssNumber(fixedValue, null))
+      return setPropFixedSizeStrategies(
+        'always',
+        metadata,
+        selectedElements,
+        axis,
+        cssNumber(fixedValue, null),
+      )
     default:
       assertNever(mode)
   }

--- a/editor/src/components/inspector/flex-direction-control.tsx
+++ b/editor/src/components/inspector/flex-direction-control.tsx
@@ -168,14 +168,12 @@ function maybeSetFlexDirection(
 ) {
   const strategies =
     desiredFlexDirection == null
-      ? removeFlexDirectionStrategies()
-      : updateFlexDirectionStrategies(desiredFlexDirection)
-  executeFirstApplicableStrategy(
-    dispatch,
-    metadata,
-    selectedViews,
-    elementPathTree,
-    allElementProps,
-    strategies,
-  )
+      ? removeFlexDirectionStrategies(metadata, selectedViews)
+      : updateFlexDirectionStrategies(
+          metadata,
+          selectedViews,
+          elementPathTree,
+          desiredFlexDirection,
+        )
+  executeFirstApplicableStrategy(dispatch, strategies)
 }

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -848,18 +848,10 @@ export function resizeToFitCommands(
 ): Array<CanvasCommand> {
   const commands = [
     ...(commandsForFirstApplicableStrategy(
-      metadata,
-      selectedViews,
-      elementPathTree,
-      allElementProps,
-      setPropHugStrategies('horizontal'),
+      setPropHugStrategies(metadata, selectedViews, elementPathTree, 'horizontal'),
     ) ?? []),
     ...(commandsForFirstApplicableStrategy(
-      metadata,
-      selectedViews,
-      elementPathTree,
-      allElementProps,
-      setPropHugStrategies('vertical'),
+      setPropHugStrategies(metadata, selectedViews, elementPathTree, 'vertical'),
     ) ?? []),
   ]
   return commands
@@ -868,23 +860,13 @@ export function resizeToFitCommands(
 export function resizeToFillCommands(
   metadata: ElementInstanceMetadataMap,
   selectedViews: Array<ElementPath>,
-  elementPathTree: ElementPathTrees,
-  allElementProps: AllElementProps,
 ): Array<CanvasCommand> {
   const commands = [
     ...(commandsForFirstApplicableStrategy(
-      metadata,
-      selectedViews,
-      elementPathTree,
-      allElementProps,
-      setPropFillStrategies('horizontal', 'default', false),
+      setPropFillStrategies(metadata, selectedViews, 'horizontal', 'default', false),
     ) ?? []),
     ...(commandsForFirstApplicableStrategy(
-      metadata,
-      selectedViews,
-      elementPathTree,
-      allElementProps,
-      setPropFillStrategies('vertical', 'default', false),
+      setPropFillStrategies(metadata, selectedViews, 'vertical', 'default', false),
     ) ?? []),
   ]
   return commands

--- a/editor/src/components/inspector/inspector-strategies/fill-container-basic-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/fill-container-basic-strategy.ts
@@ -1,5 +1,4 @@
 import * as PP from '../../../core/shared/property-path'
-import * as EP from '../../../core/shared/element-path'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { clamp } from '../../../core/shared/math-utils'
 import { setProperty } from '../../canvas/commands/set-property-command'
@@ -25,14 +24,18 @@ import {
   groupErrorToastCommand,
   maybeInvalidGroupState,
 } from '../../canvas/canvas-strategies/strategies/group-helpers'
+import type { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
+import type { ElementPath } from '../../../core/shared/project-file-types'
 
 export const fillContainerStrategyFlow = (
+  metadata: ElementInstanceMetadataMap,
+  elementPaths: ElementPath[],
   axis: Axis,
   value: 'default' | number,
   otherAxisSetToFill: boolean,
 ): InspectorStrategy => ({
   name: 'Set to Fill Container',
-  strategy: (metadata, elementPaths) => {
+  strategy: () => {
     const elements = elementPaths.filter((elementPath) =>
       fillContainerApplicable(metadata, elementPath),
     )
@@ -78,12 +81,14 @@ export interface FillContainerStrategyFlexParentOverrides {
 }
 
 export const fillContainerStrategyFlexParent = (
+  metadata: ElementInstanceMetadataMap,
+  elementPaths: ElementPath[],
   axis: Axis,
   value: 'default' | number,
   overrides: Partial<FillContainerStrategyFlexParentOverrides> = {},
 ): InspectorStrategy => ({
   name: 'Set to Fill Container, in flex layout',
-  strategy: (metadata, elementPaths) => {
+  strategy: () => {
     const elements = elementPaths.filter(
       (path) =>
         fillContainerApplicable(metadata, path) &&

--- a/editor/src/components/inspector/inspector-strategies/fixed-edge-basic-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/fixed-edge-basic-strategy.ts
@@ -14,21 +14,25 @@ import {
 } from '../../canvas/canvas-strategies/strategies/group-helpers'
 import { trueUpGroupElementChanged } from '../../../components/editor/store/editor-state'
 import type { LayoutEdgeProp } from '../../../core/layout/layout-helpers-new'
+import type { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
+import type { ElementPath } from '../../../core/shared/project-file-types'
 
 export const fixedEdgeBasicStrategy = (
+  metadata: ElementInstanceMetadataMap,
+  elementPaths: ElementPath[],
   whenToRun: WhenToRun,
   edge: LayoutEdgeProp,
   value: CSSNumber,
 ): InspectorStrategy => ({
   name: 'Set edge to Fixed',
-  strategy: (metadata, elementPaths) => {
+  strategy: () => {
     if (elementPaths.length === 0) {
       return null
     }
 
     const invalidGroupState = maybeInvalidGroupState(elementPaths, metadata, {
       onGroup: () => (value.unit === '%' ? 'group-has-percentage-pins' : null),
-      onGroupChild: (path) => {
+      onGroupChild: () => {
         return value.unit === '%' ? 'child-has-percentage-pins' : null
       },
     })

--- a/editor/src/components/inspector/inspector-strategies/fixed-size-basic-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/fixed-size-basic-strategy.ts
@@ -1,4 +1,3 @@
-import * as EP from '../../../core/shared/element-path'
 import * as PP from '../../../core/shared/property-path'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import type { WhenToRun } from '../../canvas/commands/commands'
@@ -16,14 +15,18 @@ import {
   maybeInvalidGroupState,
 } from '../../canvas/canvas-strategies/strategies/group-helpers'
 import { trueUpGroupElementChanged } from '../../../components/editor/store/editor-state'
+import type { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
+import type { ElementPath } from '../../../core/shared/project-file-types'
 
 export const fixedSizeBasicStrategy = (
   whenToRun: WhenToRun,
+  metadata: ElementInstanceMetadataMap,
+  elementPaths: ElementPath[],
   axis: Axis,
   value: CSSNumber,
 ): InspectorStrategy => ({
   name: 'Set to Fixed',
-  strategy: (metadata, elementPaths) => {
+  strategy: () => {
     if (elementPaths.length === 0) {
       return null
     }

--- a/editor/src/components/inspector/inspector-strategies/hug-contents-basic-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/hug-contents-basic-strategy.ts
@@ -9,10 +9,9 @@ import {
   setCssLengthProperty,
   setExplicitCssValue,
 } from '../../canvas/commands/set-css-length-command'
-import { SetProperty, setProperty } from '../../canvas/commands/set-property-command'
 import { showToastCommand } from '../../canvas/commands/show-toast-command'
 import type { FlexDirection } from '../common/css-utils'
-import { cssKeyword, cssUnitlessLength } from '../common/css-utils'
+import { cssKeyword } from '../common/css-utils'
 import type { Axis } from '../inspector-common'
 import {
   detectFillHugFixedState,
@@ -81,9 +80,14 @@ function hugContentsSingleElement(
   ]
 }
 
-export const hugContentsBasicStrategy = (axis: Axis): InspectorStrategy => ({
+export const hugContentsBasicStrategy = (
+  metadata: ElementInstanceMetadataMap,
+  elementPaths: ElementPath[],
+  pathTrees: ElementPathTrees,
+  axis: Axis,
+): InspectorStrategy => ({
   name: 'Set to Hug',
-  strategy: (metadata, elementPaths, pathTrees) => {
+  strategy: () => {
     const elements = elementPaths.filter(
       (path) =>
         hugContentsApplicableForContainer(metadata, pathTrees, path) ||

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategy.ts
@@ -1,10 +1,6 @@
-import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
-import type { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
-import type { ElementPath } from '../../../core/shared/project-file-types'
 import type { CanvasCommand } from '../../canvas/commands/commands'
 import type { EditorDispatch } from '../../editor/action-types'
 import { applyCommandsAction } from '../../editor/actions/action-creators'
-import type { AllElementProps } from '../../editor/store/editor-state'
 
 interface CustomInspectorStrategyResultBase {
   commands: Array<CanvasCommand>
@@ -17,33 +13,19 @@ export type CustomInspectorStrategyResult<T extends undefined | Record<string, u
 
 export interface CustomInspectorStrategy<T extends undefined | Record<string, unknown>> {
   name: string
-  strategy: (
-    metadata: ElementInstanceMetadataMap,
-    selectedElementPaths: Array<ElementPath>,
-    elementPathTree: ElementPathTrees,
-    allElementProps: AllElementProps,
-  ) => CustomInspectorStrategyResult<T> | null
+  strategy: () => CustomInspectorStrategyResult<T> | null
 }
 
 export interface InspectorStrategy {
   name: string
-  strategy: (
-    metadata: ElementInstanceMetadataMap,
-    selectedElementPaths: Array<ElementPath>,
-    elementPathTree: ElementPathTrees,
-    allElementProps: AllElementProps,
-  ) => Array<CanvasCommand> | null
+  strategy: () => Array<CanvasCommand> | null
 }
 
 export function resultForFirstApplicableStrategy<T extends undefined | Record<string, unknown>>(
-  metadata: ElementInstanceMetadataMap,
-  selectedViews: Array<ElementPath>,
-  elementPathTree: ElementPathTrees,
-  allElementProps: AllElementProps,
   strategies: Array<CustomInspectorStrategy<T>>,
 ): CustomInspectorStrategyResult<T> | null {
   for (const strategy of strategies) {
-    const result = strategy.strategy(metadata, selectedViews, elementPathTree, allElementProps)
+    const result = strategy.strategy()
     if (result != null) {
       return result
     }
@@ -52,14 +34,10 @@ export function resultForFirstApplicableStrategy<T extends undefined | Record<st
 }
 
 export function commandsForFirstApplicableStrategy(
-  metadata: ElementInstanceMetadataMap,
-  selectedViews: Array<ElementPath>,
-  elementPathTree: ElementPathTrees,
-  allElementProps: AllElementProps,
   strategies: Array<InspectorStrategy>,
 ): Array<CanvasCommand> | null {
   for (const strategy of strategies) {
-    const commands = strategy.strategy(metadata, selectedViews, elementPathTree, allElementProps)
+    const commands = strategy.strategy()
     if (commands != null) {
       return commands
     }
@@ -69,19 +47,10 @@ export function commandsForFirstApplicableStrategy(
 
 export function executeFirstApplicableStrategy(
   dispatch: EditorDispatch,
-  metadata: ElementInstanceMetadataMap,
-  selectedViews: ElementPath[],
-  elementPathTree: ElementPathTrees,
-  allElementProps: AllElementProps,
+
   strategies: InspectorStrategy[],
 ): void {
-  const commands = commandsForFirstApplicableStrategy(
-    metadata,
-    selectedViews,
-    elementPathTree,
-    allElementProps,
-    strategies,
-  )
+  const commands = commandsForFirstApplicableStrategy(strategies)
   if (commands != null) {
     dispatch([applyCommandsAction(commands)])
   }

--- a/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.ts
@@ -28,12 +28,16 @@ function removeFlexConvertToAbsoluteOne(
   ]
 }
 
-export const removeFlexConvertToAbsolute: InspectorStrategy = {
+export const removeFlexConvertToAbsolute = (
+  metadata: ElementInstanceMetadataMap,
+  elementPaths: ElementPath[],
+  pathTrees: ElementPathTrees,
+): InspectorStrategy => ({
   name: 'Remove flex layout and convert children to absolute',
-  strategy: (metadata, elementPaths, pathTrees) => {
+  strategy: () => {
     const commands = filterKeepFlexContainers(metadata, elementPaths).flatMap((path) =>
       removeFlexConvertToAbsoluteOne(metadata, pathTrees, path),
     )
     return nullOrNonEmpty(commands)
   },
-}
+})

--- a/editor/src/components/inspector/inspector-strategies/spacing-mode-strategies.ts
+++ b/editor/src/components/inspector/inspector-strategies/spacing-mode-strategies.ts
@@ -14,8 +14,9 @@ type InnerStrategy = (
 ) => Array<CanvasCommand>
 
 const mapInspectorStrategy =
-  (innerStrategy: InnerStrategy): InspectorStrategy['strategy'] =>
-  (metadata, elementPaths) =>
+  (metadata: ElementInstanceMetadataMap, elementPaths: ElementPath[]) =>
+  (innerStrategy: InnerStrategy) =>
+  () =>
     nullOrNonEmpty(elementPaths.flatMap((elementPath) => innerStrategy(metadata, elementPath)))
 
 function setSpacingModePackedSingleElement(
@@ -33,10 +34,13 @@ function setSpacingModePackedSingleElement(
   return [setProperty('always', elementPath, PP.create('style', 'justifyContent'), 'flex-start')]
 }
 
-export const setSpacingModePacked: InspectorStrategy = {
+export const setSpacingModePacked = (
+  metadata: ElementInstanceMetadataMap,
+  elementPaths: ElementPath[],
+): InspectorStrategy => ({
   name: 'Set spacing mode to packed',
-  strategy: mapInspectorStrategy(setSpacingModePackedSingleElement),
-}
+  strategy: mapInspectorStrategy(metadata, elementPaths)(setSpacingModePackedSingleElement),
+})
 
 function setSpacingModeSpaceBetweenSingleElement(
   metadata: ElementInstanceMetadataMap,
@@ -56,7 +60,10 @@ function setSpacingModeSpaceBetweenSingleElement(
   ]
 }
 
-export const setSpacingModeSpaceBetween: InspectorStrategy = {
+export const setSpacingModeSpaceBetween = (
+  metadata: ElementInstanceMetadataMap,
+  elementPaths: ElementPath[],
+): InspectorStrategy => ({
   name: 'Set spacing mode to packed',
-  strategy: mapInspectorStrategy(setSpacingModeSpaceBetweenSingleElement),
-}
+  strategy: mapInspectorStrategy(metadata, elementPaths)(setSpacingModeSpaceBetweenSingleElement),
+})

--- a/editor/src/components/inspector/nine-block-controls.tsx
+++ b/editor/src/components/inspector/nine-block-controls.tsx
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect'
 import { cartesianProduct } from '../../core/shared/array-utils'
 import type { Size } from '../../core/shared/math-utils'
 import { size } from '../../core/shared/math-utils'
-import { UtopiaTheme, colorTheme, useColorTheme } from '../../uuiui'
+import { UtopiaTheme, colorTheme } from '../../uuiui'
 import { useDispatch } from '../editor/store/dispatch-context'
 import { Substores, useEditorState, useRefEditorState } from '../editor/store/store-hook'
 import type { FlexDirection } from './common/css-utils'
@@ -267,32 +267,26 @@ export const NineBlockControl = React.memo(() => {
 
   const metadataRef = useRefEditorState(metadataSelector)
   const selectedViewsRef = useRefEditorState(selectedViewsSelector)
-  const elementPathTreeRef = useRefEditorState((store) => store.editor.elementPathTree)
-  const allElementPropsRef = useRefEditorState((store) => store.editor.allElementProps)
   const flexDirectionRef = useRefEditorState(flexDirectionSelector)
 
   const setAlignItemsJustifyContent = React.useCallback(
     (intendedFlexAlignment: StartCenterEnd, intendedJustifyContent: StartCenterEnd) => {
       const strategies = isFlexColumn(flexDirectionRef.current ?? DefaultFlexDirection)
-        ? setFlexAlignJustifyContentStrategies(intendedJustifyContent, intendedFlexAlignment)
-        : setFlexAlignJustifyContentStrategies(intendedFlexAlignment, intendedJustifyContent)
-      executeFirstApplicableStrategy(
-        dispatch,
-        metadataRef.current,
-        selectedViewsRef.current,
-        elementPathTreeRef.current,
-        allElementPropsRef.current,
-        strategies,
-      )
+        ? setFlexAlignJustifyContentStrategies(
+            metadataRef.current,
+            selectedViewsRef.current,
+            intendedJustifyContent,
+            intendedFlexAlignment,
+          )
+        : setFlexAlignJustifyContentStrategies(
+            metadataRef.current,
+            selectedViewsRef.current,
+            intendedFlexAlignment,
+            intendedJustifyContent,
+          )
+      executeFirstApplicableStrategy(dispatch, strategies)
     },
-    [
-      allElementPropsRef,
-      dispatch,
-      flexDirectionRef,
-      metadataRef,
-      elementPathTreeRef,
-      selectedViewsRef,
-    ],
+    [dispatch, flexDirectionRef, metadataRef, selectedViewsRef],
   )
 
   const paddingControlsForHover: Array<CanvasControlWithProps<SubduedPaddingControlProps>> =

--- a/editor/src/components/inspector/resize-to-fit-control.tsx
+++ b/editor/src/components/inspector/resize-to-fit-control.tsx
@@ -3,7 +3,6 @@ import type { CSSProperties } from 'react'
 import React from 'react'
 import { safeIndex } from '../../core/shared/array-utils'
 import { FlexRow, Icn, Tooltip } from '../../uuiui'
-import { convertGroupToFrameCommands } from '../canvas/canvas-strategies/strategies/group-conversion-helpers'
 import { treatElementAsGroupLike } from '../canvas/canvas-strategies/strategies/group-helpers'
 import { applyCommandsAction } from '../editor/actions/action-creators'
 import { useDispatch } from '../editor/store/dispatch-context'
@@ -123,24 +122,12 @@ export const ResizeToFitControl = React.memo<ResizeToFitControlProps>(() => {
 
   const onResizeToFill = React.useCallback(() => {
     if (isFillApplicable) {
-      const commands = resizeToFillCommands(
-        metadataRef.current,
-        selectedViewsRef.current,
-        elementPathTreeRef.current,
-        allElementPropsRef.current,
-      )
+      const commands = resizeToFillCommands(metadataRef.current, selectedViewsRef.current)
       if (commands.length > 0) {
         dispatch([applyCommandsAction(commands)])
       }
     }
-  }, [
-    allElementPropsRef,
-    dispatch,
-    metadataRef,
-    elementPathTreeRef,
-    selectedViewsRef,
-    isFillApplicable,
-  ])
+  }, [dispatch, metadataRef, selectedViewsRef, isFillApplicable])
 
   const onSetToFixedSize = React.useCallback(() => {
     const commands = setToFixedSizeCommands(

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -320,11 +320,13 @@ const FlexWidthControls = React.memo(() => {
     (value: CSSNumber, transient: boolean) => {
       executeFirstApplicableStrategy(
         dispatch,
-        editorStateRef.current.metadata,
-        editorStateRef.current.selectedViews,
-        editorStateRef.current.elementPathTree,
-        editorStateRef.current.allElementProps,
-        setPropFixedSizeStrategies(transient ? 'mid-interaction' : 'always', 'horizontal', value),
+        setPropFixedSizeStrategies(
+          transient ? 'mid-interaction' : 'always',
+          editorStateRef.current.metadata,
+          editorStateRef.current.selectedViews,
+          'horizontal',
+          value,
+        ),
       )
     },
     [dispatch, editorStateRef],
@@ -355,11 +357,13 @@ const FlexHeightControls = React.memo(() => {
     (value: CSSNumber, transient: boolean) => {
       executeFirstApplicableStrategy(
         dispatch,
-        editorStateRef.current.metadata,
-        editorStateRef.current.selectedViews,
-        editorStateRef.current.elementPathTree,
-        editorStateRef.current.allElementProps,
-        setPropFixedSizeStrategies(transient ? 'mid-interaction' : 'always', 'vertical', value),
+        setPropFixedSizeStrategies(
+          transient ? 'mid-interaction' : 'always',
+          editorStateRef.current.metadata,
+          editorStateRef.current.selectedViews,
+          'vertical',
+          value,
+        ),
       )
     },
     [dispatch, editorStateRef],

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/frame-updating-layout-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/frame-updating-layout-section.tsx
@@ -84,8 +84,6 @@ export const FrameUpdatingLayoutSection = React.memo(() => {
   const dispatch = useDispatch()
   const metadataRef = useRefEditorState(metadataSelector)
   const selectedViewsRef = useRefEditorState(selectedViewsSelector)
-  const elementPathTreeRef = useRefEditorState((store) => store.editor.elementPathTree)
-  const allElementPropsRef = useRefEditorState((store) => store.editor.allElementProps)
   const projectContentsRef = useRefEditorState((store) => store.editor.projectContents)
   const originalGlobalFrame: CanvasRectangle = useEditorState(
     Substores.metadata,
@@ -153,30 +151,25 @@ export const FrameUpdatingLayoutSection = React.memo(() => {
             frameUpdate.edgePosition === EdgePositionTop ||
             frameUpdate.edgePosition === EdgePositionLeft
           ) {
-            executeFirstApplicableStrategy(
-              dispatch,
-              metadataRef.current,
-              selectedViewsRef.current,
-              elementPathTreeRef.current,
-              allElementPropsRef.current,
-              [moveInspectorStrategy(projectContentsRef.current, frameUpdate.edgeMovement)],
-            )
+            executeFirstApplicableStrategy(dispatch, [
+              moveInspectorStrategy(
+                metadataRef.current,
+                selectedViewsRef.current,
+                projectContentsRef.current,
+                frameUpdate.edgeMovement,
+              ),
+            ])
           } else {
-            executeFirstApplicableStrategy(
-              dispatch,
-              metadataRef.current,
-              selectedViewsRef.current,
-              elementPathTreeRef.current,
-              allElementPropsRef.current,
-              [
-                resizeInspectorStrategy(
-                  projectContentsRef.current,
-                  originalGlobalFrame,
-                  frameUpdate.edgePosition,
-                  frameUpdate.edgeMovement,
-                ),
-              ],
-            )
+            executeFirstApplicableStrategy(dispatch, [
+              resizeInspectorStrategy(
+                metadataRef.current,
+                selectedViewsRef.current,
+                projectContentsRef.current,
+                originalGlobalFrame,
+                frameUpdate.edgePosition,
+                frameUpdate.edgeMovement,
+              ),
+            ])
           }
           break
         case 'DIRECT_FRAME_UPDATE':
@@ -185,52 +178,34 @@ export const FrameUpdatingLayoutSection = React.memo(() => {
             frameUpdate.edgePosition === EdgePositionLeft
           ) {
             const leftOrTop = frameUpdate.edgePosition === EdgePositionLeft ? 'left' : 'top'
-            executeFirstApplicableStrategy(
-              dispatch,
-              metadataRef.current,
-              selectedViewsRef.current,
-              elementPathTreeRef.current,
-              allElementPropsRef.current,
-              [
-                directMoveInspectorStrategy(
-                  projectContentsRef.current,
-                  leftOrTop,
-                  frameUpdate.edgeValue,
-                ),
-              ],
-            )
+            executeFirstApplicableStrategy(dispatch, [
+              directMoveInspectorStrategy(
+                metadataRef.current,
+                selectedViewsRef.current,
+                projectContentsRef.current,
+                leftOrTop,
+                frameUpdate.edgeValue,
+              ),
+            ])
           } else {
             const widthOrHeight =
               frameUpdate.edgePosition === EdgePositionRight ? 'width' : 'height'
-            executeFirstApplicableStrategy(
-              dispatch,
-              metadataRef.current,
-              selectedViewsRef.current,
-              elementPathTreeRef.current,
-              allElementPropsRef.current,
-              [
-                directResizeInspectorStrategy(
-                  projectContentsRef.current,
-                  widthOrHeight,
-                  frameUpdate.edgeValue,
-                ),
-              ],
-            )
+            executeFirstApplicableStrategy(dispatch, [
+              directResizeInspectorStrategy(
+                metadataRef.current,
+                selectedViewsRef.current,
+                projectContentsRef.current,
+                widthOrHeight,
+                frameUpdate.edgeValue,
+              ),
+            ])
           }
           break
         default:
           assertNever(frameUpdate)
       }
     },
-    [
-      allElementPropsRef,
-      dispatch,
-      elementPathTreeRef,
-      metadataRef,
-      originalGlobalFrame,
-      projectContentsRef,
-      selectedViewsRef,
-    ],
+    [dispatch, metadataRef, originalGlobalFrame, projectContentsRef, selectedViewsRef],
   )
 
   return (

--- a/editor/src/components/inspector/spaced-packed-control.tsx
+++ b/editor/src/components/inspector/spaced-packed-control.tsx
@@ -49,12 +49,14 @@ const packedSpacedSelector = createSelector(
 export const SpacedPackedControl = React.memo(() => {
   const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
   const selectedViewsRef = useRefEditorState((store) => store.editor.selectedViews)
-  const elementPathTreeRef = useRefEditorState((store) => store.editor.elementPathTree)
-  const allElementPropsRef = useRefEditorState((store) => store.editor.allElementProps)
 
   const dispatch = useDispatch()
 
-  const spacedPackedSetting = useEditorState(Substores.metadata, packedSpacedSelector, '')
+  const spacedPackedSetting = useEditorState(
+    Substores.metadata,
+    packedSpacedSelector,
+    'SpacedPackedControl spacedPackedSetting',
+  )
 
   const onUpdate = React.useCallback(
     (value: PackedSpaced) => {
@@ -62,26 +64,18 @@ export const SpacedPackedControl = React.memo(() => {
         case 'packed':
           return executeFirstApplicableStrategy(
             dispatch,
-            metadataRef.current,
-            selectedViewsRef.current,
-            elementPathTreeRef.current,
-            allElementPropsRef.current,
-            setSpacingModePackedStrategies,
+            setSpacingModePackedStrategies(metadataRef.current, selectedViewsRef.current),
           )
         case 'spaced':
           return executeFirstApplicableStrategy(
             dispatch,
-            metadataRef.current,
-            selectedViewsRef.current,
-            elementPathTreeRef.current,
-            allElementPropsRef.current,
-            setSpacingModeSpaceBetweenStrategies,
+            setSpacingModeSpaceBetweenStrategies(metadataRef.current, selectedViewsRef.current),
           )
         default:
           assertNever(value)
       }
     },
-    [allElementPropsRef, dispatch, metadataRef, elementPathTreeRef, selectedViewsRef],
+    [dispatch, metadataRef, selectedViewsRef],
   )
 
   const paddingControlsForHover: Array<CanvasControlWithProps<SubduedPaddingControlProps>> =

--- a/editor/src/components/inspector/three-bar-control.tsx
+++ b/editor/src/components/inspector/three-bar-control.tsx
@@ -9,7 +9,7 @@ import {
   selectedViewsSelector,
 } from './inpector-selectors'
 import { Substores, useEditorState, useRefEditorState } from '../editor/store/store-hook'
-import { UtopiaTheme, colorTheme, useColorTheme } from '../../uuiui'
+import { UtopiaTheme, colorTheme } from '../../uuiui'
 import { useDispatch } from '../editor/store/dispatch-context'
 import { executeFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
 import { setFlexAlignStrategies } from './inspector-strategies/inspector-strategies'
@@ -246,8 +246,6 @@ export const ThreeBarControl = React.memo(() => {
 
   const metadataRef = useRefEditorState(metadataSelector)
   const selectedViewsRef = useRefEditorState(selectedViewsSelector)
-  const elementPathTreeRef = useRefEditorState((store) => store.editor.elementPathTree)
-  const allElementPropsRef = useRefEditorState((store) => store.editor.allElementProps)
 
   const dispatch = useDispatch()
 
@@ -268,39 +266,27 @@ export const ThreeBarControl = React.memo(() => {
     () =>
       executeFirstApplicableStrategy(
         dispatch,
-        metadataRef.current,
-        selectedViewsRef.current,
-        elementPathTreeRef.current,
-        allElementPropsRef.current,
-        setFlexAlignStrategies('flex-start'),
+        setFlexAlignStrategies(metadataRef.current, selectedViewsRef.current, 'flex-start'),
       ),
-    [allElementPropsRef, dispatch, metadataRef, elementPathTreeRef, selectedViewsRef],
+    [dispatch, metadataRef, selectedViewsRef],
   )
 
   const setAlignItemsCenter = React.useCallback(
     () =>
       executeFirstApplicableStrategy(
         dispatch,
-        metadataRef.current,
-        selectedViewsRef.current,
-        elementPathTreeRef.current,
-        allElementPropsRef.current,
-        setFlexAlignStrategies('center'),
+        setFlexAlignStrategies(metadataRef.current, selectedViewsRef.current, 'center'),
       ),
-    [allElementPropsRef, dispatch, metadataRef, elementPathTreeRef, selectedViewsRef],
+    [dispatch, metadataRef, selectedViewsRef],
   )
 
   const setAlignItemsEnd = React.useCallback(
     () =>
       executeFirstApplicableStrategy(
         dispatch,
-        metadataRef.current,
-        selectedViewsRef.current,
-        elementPathTreeRef.current,
-        allElementPropsRef.current,
-        setFlexAlignStrategies('flex-end'),
+        setFlexAlignStrategies(metadataRef.current, selectedViewsRef.current, 'flex-end'),
       ),
-    [allElementPropsRef, dispatch, metadataRef, elementPathTreeRef, selectedViewsRef],
+    [dispatch, metadataRef, selectedViewsRef],
   )
 
   const shouldShow = nFlexContainers > 0 && packedSpacedSetting === 'spaced'


### PR DESCRIPTION
## Description
This PR refactors the inspector strategy interface so that the `strategy` function doesn't expect any params, instead the necessary values are captured via the constructor function of the various strategies. This way, there's less boilerplate code needed when invoking strategies, and there's no arbitrary separation of the strategy's constructor function and the `strategy` function. 

Original PR comment that outlined this direction: https://github.com/concrete-utopia/utopia/pull/4427#discussion_r1372903615