### PR TITLE
add support for special exported functions

### DIFF
--- a/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
@@ -1,6 +1,7 @@
 import { createModifiedProject } from '../../../sample-projects/sample-project-utils.test-utils'
 import { setFeatureForBrowserTestsUseInDescribeBlockOnly } from '../../../utils/utils.test-utils'
 import { StoryboardFilePath } from '../../editor/store/editor-state'
+import { CreateRemixDerivedDataRefsGLOBAL } from '../../editor/store/remix-derived-data'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
 import {
   DefaultFutureConfig,
@@ -42,15 +43,18 @@ export function loader() {
   })
 }
 
-export const handle = {
+export const handle = () => ({
   its: "all yours",
-};
+});
 
 export const shouldRevalidate = () => true;
 
-export const links = () => [];
+export const links = () => [{
+  rel: "stylesheet",
+  href: "https://example.com/some/styles.css",
+}];
 
-export const meta = () => [];
+export const meta = () => [{ title: "Very cool app | Remix" }];
 
 export function action() {
   return json({ message: "this is a dummy action function" })
@@ -343,8 +347,23 @@ describe('Routes', () => {
       expect(remixRoutes![0][routeExport]).toBeDefined()
     }
 
-    // TODO: meta
-    // TOOD: links
+    expect(remixRoutes![0].handle?.()).toEqual({
+      its: 'all yours',
+    })
+
+    expect(remixRoutes![0].shouldRevalidate?.({} as any)).toEqual(true)
+
+    const { meta, links } = CreateRemixDerivedDataRefsGLOBAL.routeModulesCache.current['root']
+    expect(meta).toBeDefined()
+    expect(links).toBeDefined()
+
+    expect(meta?.({} as any)).toEqual([{ title: 'Very cool app | Remix' }])
+    expect(links?.()).toEqual([
+      {
+        rel: 'stylesheet',
+        href: 'https://example.com/some/styles.css',
+      },
+    ])
   })
   it('Parses the routes from the Remix Blog Tutorial project files', async () => {
     const project = createModifiedProject({

--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -121,7 +121,7 @@ function useGetRouteModules(basePath: ElementPath) {
   ])
 }
 
-const RouteExportsForRouteObject: Array<keyof RouteObject> = [
+export const RouteExportsForRouteObject: Array<keyof RouteObject> = [
   'action',
   'loader',
   'handle',
@@ -157,7 +157,7 @@ function useGetRoutes() {
       innerRoutes.forEach((route) => {
         // FIXME Adding a loader function to the 'root' route causes the `createShouldRevalidate` to fail, because
         // we only ever pass in an empty object for the `routeModules` and never mutate it
-        const creatorForRoute = route.id === 'root' ? null : creators[route.id]
+        const creatorForRoute = creators[route.id] ?? null
         if (creatorForRoute != null) {
           for (const routeExport of RouteExportsForRouteObject) {
             route[routeExport] = (args: any) =>
@@ -171,17 +171,6 @@ function useGetRoutes() {
                 )
                 .scope[routeExport]?.(args) ?? null
           }
-
-          route.loader = (args: any) =>
-            creatorForRoute
-              .executionScopeCreator(
-                projectContentsRef.current,
-                fileBlobsRef.current,
-                hiddenInstancesRef.current,
-                displayNoneInstancesRef.current,
-                metadataContext,
-              )
-              .scope['loader']?.(args) ?? null
         }
 
         addExportsToRoutes(route.children ?? [])

--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -93,9 +93,8 @@ function useGetRouteModules(basePath: ElementPath) {
         ? (componentProps: any) => createExecutionScope()['ErrorBoundary']?.(componentProps) ?? null
         : undefined
 
-      const links: RouteModule['links'] = () => createExecutionScope()['links'] ?? null
-      const meta: RouteModule['meta'] = (args: any) =>
-        createExecutionScope()['meta']?.(args) ?? null
+      const links: RouteModule['links'] = () => createExecutionScope()['links']?.() ?? null
+      const meta: RouteModule['meta'] = (args) => createExecutionScope()['meta']?.(args) ?? null
 
       const routeModule: RouteModule = {
         ...value,


### PR DESCRIPTION
## Problem
We’re missing support for a number of key named exports in Remix:
- `handle`
- `headers`
- `links`
- `loader`
- `meta`
- `shouldRevalidate` 
Also, `loader` and `action` aren't parsed for `root`

## Solution
Parse all these function for all route modules