### PR TITLE
Fix remix execution scope refs

### DIFF
--- a/editor/src/components/canvas/remix/remix-utils.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.tsx
@@ -235,6 +235,11 @@ function getRemixExportsOfModule(
   executionScopeCreator: ExecutionScopeCreator
   rootComponentUid: string
 } {
+  let mutableContextRef: { current: MutableUtopiaCtxRefData } = { current: {} }
+  let topLevelComponentRendererComponents: {
+    current: MapLike<MapLike<ComponentRendererComponent>>
+  } = { current: {} }
+
   const executionScopeCreator = (
     innerProjectContents: ProjectContentTreeRoot,
     fileBlobs: CanvasBase64Blobs,
@@ -247,11 +252,6 @@ function getRemixExportsOfModule(
 
     const requireFn = curriedRequireFn(innerProjectContents)
     const resolve = curriedResolveFn(innerProjectContents)
-
-    let mutableContextRef: { current: MutableUtopiaCtxRefData } = { current: {} }
-    let topLevelComponentRendererComponents: {
-      current: MapLike<MapLike<ComponentRendererComponent>>
-    } = { current: {} }
 
     const customRequire = (importOrigin: string, toImport: string) => {
       if (resolvedFiles[importOrigin] == null) {


### PR DESCRIPTION
**Problem:**
Rendering the default component for a remix Route re-creates the execution scope, which is very similar to how the canvas works, but since we're re-creating the `topLevelComponentRendererComponents` "ref" and `mutableContextRef` "ref" each time, the result is that all other components from that same file will be re-mounted

**Fix:**
The fix here was to create those "refs" outside of the `executionScopeCreator` function to prevent them from being wiped each time. Since this problem was such an absolute nightmare to trace, I've also added a couple of tests to ensure this doesn't regress in vanilla or remix projects