### PR TITLE
Have selectComponentsForTest check to see if the target exists.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.spec.browser2.tsx
@@ -246,7 +246,7 @@ describe('Absolute Duplicate Strategy', () => {
 
         expect(getPrintedUiJsCodeWithoutUIDs(renderResult.getEditorState())).toEqual(
           formatTestProjectCode(
-            projectWithFragment(`
+            projectWithFragmentWithoutUID(`
               ${getOpeningFragmentLikeTag(type, { stripTestId: true, stripUids: true })}
         <div
           style={{
@@ -287,6 +287,17 @@ describe('Absolute Duplicate Strategy', () => {
 })
 
 const projectWithFragment = (innards: string) => `import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid={'sb'}>
+    ${innards}
+  </Storyboard>
+)
+
+`
+
+const projectWithFragmentWithoutUID = (innards: string) => `import * as React from 'react'
 import { Storyboard } from 'utopia-api'
 
 export var storyboard = (

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
@@ -1377,7 +1377,7 @@ describe('Absolute Move Strategy', () => {
               width: 36,
               height: 44,
             }}
-            data-uid='b44'
+            data-uid='drag-me'
             data-testid='drag-me'
           />
         ${getClosingFragmentLikeTag(type)}
@@ -1460,7 +1460,7 @@ describe('Absolute Move Strategy', () => {
             width: 36,
             height: 44,
           }}
-          data-uid='b44'
+          data-uid='drag-me'
           data-testid='drag-me'
         />
       ${getClosingFragmentLikeTag(type)}
@@ -1549,7 +1549,7 @@ describe('Absolute Move Strategy', () => {
                 width: 33,
                 height: 61,
               }}
-              data-uid='839'
+              data-uid='drag-me'
               data-testid='drag-me'
             />
             ${getClosingFragmentLikeTag(inner)}

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.browser2.tsx
@@ -2000,6 +2000,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
               height: 80,
               padding: '11px 12px',
             }}
+            data-uid='container'
           >
             <img
               src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
@@ -2011,6 +2012,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
                 left: 12,
                 top: 11,
               }}
+              data-uid='drag-me'
               data-testid='drag-me'
             />
           </div>

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -1824,7 +1824,13 @@ describe('actions', () => {
       await selectComponentsForTest(renderResult, [makeTargetPath('aaa/ddd')])
       await pressKey('c', { modifiers: cmdModifier })
 
-      await selectComponentsForTest(renderResult, [makeTargetPath('aaa/bbb/b0b')])
+      const childrenOfBBB = MetadataUtils.getChildrenOrdered(
+        renderResult.getEditorState().editor.jsxMetadata,
+        renderResult.getEditorState().editor.elementPathTree,
+        makeTargetPath('aaa/bbb'),
+      )
+
+      await selectComponentsForTest(renderResult, [childrenOfBBB[0].elementPath])
 
       const canvasRoot = renderResult.renderedDOM.getByTestId('canvas-root')
 

--- a/editor/src/core/model/element-metadata.spec.browser2.tsx
+++ b/editor/src/core/model/element-metadata.spec.browser2.tsx
@@ -295,7 +295,7 @@ describe('globalContentBoxForChildren calculation', () => {
         'await-first-dom-report',
       )
 
-      await selectComponentsForTest(editor, [elementPathInInnards('a7b/b15/b0e')])
+      await selectComponentsForTest(editor, [elementPathInInnards('a7b/b15')])
 
       const containerInstance = MetadataUtils.findElementByElementPath(
         editor.getEditorState().editor.jsxMetadata,


### PR DESCRIPTION
**Problem:**
It's possible to select elements that don't exist with `selectComponentsForTest`, which can result in false positive results in tests.

**Fix:**
Now `selectComponentsForTest` checks to see if the elements exist first and throws an exception if they don't.

**Commit Details:**
- `selectComponentsForTest` now checks the metadata and project contents to see if the target exists.
- Fixed a few tests that were targeting paths that did not exist.