### PR TITLE
Only capture text content for leaf nodes

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -673,7 +673,7 @@ function collectMetadataForElement(
     'no-rounding',
   )
 
-  const textContentsMaybe = element.textContent
+  const textContentsMaybe = element.children.length === 0 ? element.textContent : null
 
   const specialSizeMeasurementsObject = getSpecialMeasurements(
     element,


### PR DESCRIPTION
**Problem:**
When capturing text content for the metadata of an element, we're using the `textContent` value of the HTMLElement, which includes text content of all descendants. This was introduced in #3605, however we're only ever interested in this value for leaf nodes. This was reflected in the map override counter not showing up if the map is empty and a sibling has text content.

**Fix:**
Only capture the text content for leaf elements. I've added a test for this, which includes some cases of elements where we might later want to change the logic (e.g. if the element has a `<br />` or is made up of only text elements), just purely so that we can capture that if we unintentionally change it.