### PR TITLE
root.jsx

### DIFF
--- a/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
@@ -1,11 +1,11 @@
 import { createModifiedProject } from '../../../sample-projects/sample-project-utils.test-utils'
-import { setFeatureForBrowserTestsUseInDescribeBlockOnly } from '../../../utils/utils.test-utils'
 import { StoryboardFilePath } from '../../editor/store/editor-state'
 import { CreateRemixDerivedDataRefsGLOBAL } from '../../editor/store/remix-derived-data'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
 import {
   DefaultFutureConfig,
   createRouteManifestFromProjectContents,
+  getRootFile,
   getRoutesAndModulesFromManifest,
 } from './remix-utils'
 import { RouteExportsForRouteObject } from './utopia-remix-root-component'
@@ -110,6 +110,7 @@ describe('Route manifest', () => {
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
     const remixManifest = createRouteManifestFromProjectContents(
+      getRootFile(renderResult.getEditorState().editor.projectContents)!.path,
       renderResult.getEditorState().editor.projectContents,
     )
 
@@ -165,6 +166,7 @@ describe('Route manifest', () => {
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
     const remixManifest = createRouteManifestFromProjectContents(
+      getRootFile(renderResult.getEditorState().editor.projectContents)?.path ?? '',
       renderResult.getEditorState().editor.projectContents,
     )
 
@@ -186,6 +188,7 @@ describe('Route manifest', () => {
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
     const remixManifest = createRouteManifestFromProjectContents(
+      getRootFile(renderResult.getEditorState().editor.projectContents)!.path,
       renderResult.getEditorState().editor.projectContents,
     )
 
@@ -296,12 +299,14 @@ describe('Routes', () => {
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
     const remixManifest = createRouteManifestFromProjectContents(
+      getRootFile(renderResult.getEditorState().editor.projectContents)!.path,
       renderResult.getEditorState().editor.projectContents,
     )
     expect(remixManifest).not.toBeNull()
 
     let routeModuleCache = { current: {} }
     const remixRoutes = getRoutesAndModulesFromManifest(
+      getRootFile(renderResult.getEditorState().editor.projectContents)!.file,
       remixManifest!,
       DefaultFutureConfig,
       renderResult.getEditorState().editor.codeResultCache.curriedRequireFn,
@@ -365,6 +370,22 @@ describe('Routes', () => {
       },
     ])
   })
+  it('Parses root.jsx', async () => {
+    const project = createModifiedProject({
+      [StoryboardFilePath]: storyboardFileContent,
+      ['/src/root.jsx']: rootFileContentWithExportedStuff,
+      ['/src/routes/_index.js']: routeFileContent('Index route'),
+    })
+
+    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+
+    const remixRoutes = renderResult.getEditorState().derived.remixData?.routes
+    expect(remixRoutes).toBeDefined()
+
+    expect(remixRoutes).toHaveLength(1)
+    expect(remixRoutes![0].id).toEqual('root')
+    expect(remixRoutes![0].children).toHaveLength(1)
+  })
   it('Parses the routes from the Remix Blog Tutorial project files', async () => {
     const project = createModifiedProject({
       [StoryboardFilePath]: storyboardFileContent,
@@ -381,12 +402,14 @@ describe('Routes', () => {
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
     const remixManifest = createRouteManifestFromProjectContents(
+      getRootFile(renderResult.getEditorState().editor.projectContents)!.path,
       renderResult.getEditorState().editor.projectContents,
     )
 
     let routeModuleCache = { current: {} }
     expect(remixManifest).not.toBeNull()
     const remixRoutes = getRoutesAndModulesFromManifest(
+      getRootFile(renderResult.getEditorState().editor.projectContents)!.file,
       remixManifest!,
       DefaultFutureConfig,
       renderResult.getEditorState().editor.codeResultCache.curriedRequireFn,

--- a/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
@@ -121,9 +121,10 @@ describe('Route manifest', () => {
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
     const rootDir = getRemixRootDir(renderResult.getEditorState().editor.projectContents)
+    const rootFilePath =
+      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
     const remixManifest = createRouteManifestFromProjectContents(
-      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? '',
-      rootDir,
+      { rootDir, rootFilePath },
       renderResult.getEditorState().editor.projectContents,
     )
 
@@ -179,9 +180,10 @@ describe('Route manifest', () => {
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
     const rootDir = getRemixRootDir(renderResult.getEditorState().editor.projectContents)
+    const rootFilePath =
+      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
     const remixManifest = createRouteManifestFromProjectContents(
-      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? '',
-      rootDir,
+      { rootDir, rootFilePath },
       renderResult.getEditorState().editor.projectContents,
     )
 
@@ -203,9 +205,10 @@ describe('Route manifest', () => {
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
     const rootDir = getRemixRootDir(renderResult.getEditorState().editor.projectContents)
+    const rootFilePath =
+      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
     const remixManifest = createRouteManifestFromProjectContents(
-      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? '',
-      rootDir,
+      { rootDir, rootFilePath },
       renderResult.getEditorState().editor.projectContents,
     )
 
@@ -316,9 +319,10 @@ describe('Routes', () => {
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
     const rootDir = getRemixRootDir(renderResult.getEditorState().editor.projectContents)
+    const rootFilePath =
+      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
     const remixManifest = createRouteManifestFromProjectContents(
-      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? '',
-      rootDir,
+      { rootDir, rootFilePath },
       renderResult.getEditorState().editor.projectContents,
     )
     expect(remixManifest).not.toBeNull()
@@ -392,8 +396,8 @@ describe('Routes', () => {
   it('Parses root.jsx', async () => {
     const project = createModifiedProject({
       [StoryboardFilePath]: storyboardFileContent,
-      ['/src/root.jsx']: rootFileContentWithExportedStuff,
-      ['/src/routes/_index.js']: routeFileContent('Index route'),
+      ['/app/root.jsx']: rootFileContentWithExportedStuff,
+      ['/app/routes/_index.js']: routeFileContent('Index route'),
     })
 
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
@@ -437,9 +441,10 @@ describe('Routes', () => {
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
     const rootDir = getRemixRootDir(renderResult.getEditorState().editor.projectContents)
+    const rootFilePath =
+      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
     const remixManifest = createRouteManifestFromProjectContents(
-      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? '',
-      rootDir,
+      { rootDir, rootFilePath },
       renderResult.getEditorState().editor.projectContents,
     )
 

--- a/editor/src/components/canvas/remix/remix-utils.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.tsx
@@ -18,7 +18,7 @@ import type { UiJsxCanvasContextData } from '../ui-jsx-canvas'
 import { attemptToResolveParsedComponents } from '../ui-jsx-canvas'
 import type { ComponentRendererComponent } from '../ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer'
 import type { MutableUtopiaCtxRefData } from '../ui-jsx-canvas-renderer/ui-jsx-canvas-contexts'
-import type { ElementPath } from '../../../core/shared/project-file-types'
+import type { ElementPath, TextFile } from '../../../core/shared/project-file-types'
 import type { ExecutionScope } from '../ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope'
 import { createExecutionScope } from '../ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope'
 import type { RemixRoutingTable } from '../../editor/store/remix-derived-data'
@@ -40,6 +40,7 @@ import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import { getAllUniqueUids } from '../../../core/model/get-unique-ids'
 import { safeIndex } from '../../../core/shared/array-utils'
 import { createClientRoutes, groupRoutesByParentId } from '../../../third-party/remix/client-routes'
+import path from 'path'
 
 export const OutletPathContext = React.createContext<ElementPath | null>(null)
 
@@ -83,6 +84,7 @@ function projectContentsToFileOps(projectContents: ProjectContentTreeRoot): File
 }
 
 export function createRouteManifestFromProjectContents(
+  rootFilePath: string,
   projectContents: ProjectContentTreeRoot,
 ): RouteManifest<EntryRoute> | null {
   const routesFromRemix = (() => {
@@ -96,16 +98,17 @@ export function createRouteManifestFromProjectContents(
   if (routesFromRemix == null) {
     return null
   }
-  return patchRemixRoutes(routesFromRemix, projectContents)
+  return patchRemixRoutes(rootFilePath, routesFromRemix, projectContents)
 }
 
 function patchRemixRoutes(
+  rootFilePath: string,
   routesFromRemix: RouteManifest<ConfigRoute> | null,
   projectContents: ProjectContentTreeRoot,
 ) {
   const routesFromRemixWithRoot: RouteManifest<ConfigRoute> = {
     ...routesFromRemix,
-    root: { path: '', id: 'root', file: 'root.js', parentId: '' },
+    root: { path: '', id: 'root', file: path.basename(rootFilePath), parentId: '' },
   }
 
   const resultRoutes = Object.values(routesFromRemixWithRoot).reduce((acc, route) => {
@@ -248,7 +251,7 @@ function getRemixExportsOfModule(
     metadataContext: UiJsxCanvasContextData,
   ) => {
     let resolvedFiles: MapLike<Array<string>> = {}
-    let resolvedFileNames: Array<string> = ['/src/root.js']
+    let resolvedFileNames: Array<string> = [filename]
 
     const requireFn = curriedRequireFn(innerProjectContents)
     const resolve = curriedResolveFn(innerProjectContents)
@@ -272,7 +275,7 @@ function getRemixExportsOfModule(
         customRequire,
         mutableContextRef,
         topLevelComponentRendererComponents,
-        '/src/root.js',
+        filename,
         fileBlobs,
         hiddenInstances,
         displayNoneInstances,
@@ -333,7 +336,24 @@ function safeGetClientRoutes(
   }
 }
 
+export function getRootFile(
+  projectContents: ProjectContentTreeRoot,
+): { file: TextFile; path: string } | null {
+  function getTextFileAtPath(filePath: string) {
+    const maybeTextFile = getProjectFileByFilePath(projectContents, filePath)
+    if (maybeTextFile == null || maybeTextFile.type !== 'TEXT_FILE') {
+      return null
+    }
+    return { file: maybeTextFile, path: filePath }
+  }
+
+  return (
+    getTextFileAtPath(`${ROOT_DIR}/root.js`) ?? getTextFileAtPath(`${ROOT_DIR}/root.jsx`) ?? null
+  )
+}
+
 export function getRoutesAndModulesFromManifest(
+  rootJsFile: TextFile,
   routeManifest: RouteManifestWithContents,
   futureConfig: FutureConfig,
   curriedRequireFn: CurriedUtopiaRequireFn,
@@ -343,11 +363,6 @@ export function getRoutesAndModulesFromManifest(
 ): GetRoutesAndModulesFromManifestResult | null {
   const routeModuleCreators: RouteIdsToModuleCreators = {}
   const routingTable: RemixRoutingTable = {}
-
-  const rootJsFile = getProjectFileByFilePath(projectContents, `${ROOT_DIR}/root.js`)
-  if (rootJsFile == null || rootJsFile.type !== 'TEXT_FILE') {
-    return null
-  }
 
   const rootJSRootElement = getDefaultExportedTopLevelElement(rootJsFile)
   if (rootJSRootElement == null) {
@@ -396,16 +411,20 @@ export function getRoutesAndModulesFromManifest(
 }
 
 export function getRouteComponentNameForOutlet(
-  path: ElementPath,
+  elementPath: ElementPath,
   metadata: ElementInstanceMetadataMap,
   projectContents: ProjectContentTreeRoot,
   pathTrees: ElementPathTrees,
 ): string | null {
-  if (!MetadataUtils.isProbablyRemixOutlet(metadata, path)) {
+  if (!MetadataUtils.isProbablyRemixOutlet(metadata, elementPath)) {
     return null
   }
 
-  const outletChildren = MetadataUtils.getImmediateChildrenPathsOrdered(metadata, pathTrees, path)
+  const outletChildren = MetadataUtils.getImmediateChildrenPathsOrdered(
+    metadata,
+    pathTrees,
+    elementPath,
+  )
   const outletChild = safeIndex(outletChildren, 0)
   if (outletChild == null) {
     return null

--- a/editor/src/components/canvas/remix/remix-utils.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.tsx
@@ -82,8 +82,13 @@ function projectContentsToFileOps(projectContents: ProjectContentTreeRoot): File
 }
 
 export function createRouteManifestFromProjectContents(
-  rootFilePath: string,
-  rootDir: string,
+  {
+    rootFilePath,
+    rootDir,
+  }: {
+    rootFilePath: string
+    rootDir: string
+  },
   projectContents: ProjectContentTreeRoot,
 ): RouteManifest<EntryRoute> | null {
   const routesFromRemix = (() => {

--- a/editor/src/components/editor/store/remix-derived-data.tsx
+++ b/editor/src/components/editor/store/remix-derived-data.tsx
@@ -17,6 +17,7 @@ import {
   DefaultFutureConfig,
   createAssetsManifest,
   createRouteManifestFromProjectContents,
+  getRootFile,
   getRoutesAndModulesFromManifest,
 } from '../../canvas/remix/remix-utils'
 import type { CurriedUtopiaRequireFn, CurriedResolveFn } from '../../custom-code/code-file'
@@ -53,7 +54,12 @@ export function createRemixDerivedData(
   curriedRequireFn: CurriedUtopiaRequireFn,
   curriedResolveFn: CurriedResolveFn,
 ): RemixDerivedData | null {
-  const routeManifest = createRouteManifestFromProjectContents(projectContents)
+  const rootJsFile = getRootFile(projectContents)
+  if (rootJsFile == null) {
+    return null
+  }
+
+  const routeManifest = createRouteManifestFromProjectContents(rootJsFile.path, projectContents)
   if (routeManifest == null) {
     return null
   }
@@ -61,6 +67,7 @@ export function createRemixDerivedData(
   const assetsManifest = createAssetsManifest(routeManifest)
 
   const routesAndModulesFromManifestResult = getRoutesAndModulesFromManifest(
+    rootJsFile.file,
     routeManifest,
     DefaultFutureConfig,
     curriedRequireFn,

--- a/editor/src/components/editor/store/remix-derived-data.tsx
+++ b/editor/src/components/editor/store/remix-derived-data.tsx
@@ -57,14 +57,14 @@ export function getRemixRootDir(projectContents: ProjectContentTreeRoot): string
   const defaultRootDirName = 'app'
   const makeRootDirPath = (dir: string = defaultRootDirName) => `/${dir}`
 
-  const code = getProjectFileByFilePath(projectContents, REMIX_CONFIG_JS_PATH)
-  if (code == null || code.type !== 'TEXT_FILE') {
+  const remixConfigFile = getProjectFileByFilePath(projectContents, REMIX_CONFIG_JS_PATH)
+  if (remixConfigFile == null || remixConfigFile.type !== 'TEXT_FILE') {
     return makeRootDirPath()
   }
 
   const m = evaluator(
     REMIX_CONFIG_JS_PATH,
-    code.fileContents.code,
+    remixConfigFile.fileContents.code,
     {
       exports: {},
     },
@@ -89,8 +89,7 @@ export function createRemixDerivedData(
   }
 
   const routeManifest = createRouteManifestFromProjectContents(
-    rootDir,
-    rootJsFile.path,
+    { rootFilePath: rootJsFile.path, rootDir: rootDir },
     projectContents,
   )
   if (routeManifest == null) {


### PR DESCRIPTION
## Problem
`root.js` is hardcoded as the root file name for Remix projects, even though `root.jsx` is valid as well.

## Fix 
Add `root.jsx` as a valid root file too.

## Details
`flatRoutes` also looks for the root file, so this logic is somewhat duplicated. However, we need the path of the root file for `patchRemixRoutes`, so this PR keeps the duplication