### PR TITLE
Always show maps in the navigator

### DIFF
--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1309,7 +1309,7 @@ export const MetadataUtils = {
             return VoidElementsToFilter.includes(r.name.baseVariable)
           }
           if (
-            isJSExpressionMapOrOtherJavaScript(r) &&
+            isJSExpressionOtherJavaScript(r) &&
             !MetadataUtils.isElementPathConditionalFromMetadata(metadata, EP.parentPath(path))
           ) {
             const children = MetadataUtils.getChildrenOrdered(metadata, pathTree, path)


### PR DESCRIPTION
**Problem:**
After #4036 we were still filtering empty maps from the Navigator if the parent had text, but we always want to show the maps.

**Fix:**
Change the filtering here to only apply to `JSExpressionOtherJavaScript`, so that maps will always show in the Navigator.

I haven't added a test to this because tbh it seems a bit pointless in this case.