### PR TITLE
Remove the parsed model from project contents in persistentModelForProjectContents

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -2867,7 +2867,7 @@ export function persistentModelForProjectContents(
     forkedFromProjectId: null,
     projectVersion: CURRENT_PROJECT_VERSION,
     projectDescription: '',
-    projectContents: projectContents,
+    projectContents: removeParsedModelsFromProjectContents(projectContents),
     exportsInfo: [],
     codeEditorErrors: {
       buildErrors: {},


### PR DESCRIPTION
**Problem:**
Github commits were huge because we were including the parsed model for all files in the server request

**Fix:**
We already strip the parsed model in `persistentModelFromEditorModel`, so we should do the same thing with `persistentModelForProjectContents`

**Note:**
This PR comes without a test, because there is no satisfactory way to cover the problem (accidentally including the parsed models in server requests) via tests. Instead, my proposal is to alter `PersistentModel`, replacing the `projectContents` there with a new type that does not include parsed models, since we don't want them in the `PersistentModel`.