### PR TITLE
Give yarn a bit more memory as some packages require quite a lot to download.

### DIFF
--- a/server/src/Utopia/Web/Packager/NPM.hs
+++ b/server/src/Utopia/Web/Packager/NPM.hs
@@ -116,7 +116,7 @@ withInstalledProject logger NPMMetrics{..} semaphore versionedPackageName withIn
   bracketP createDir deleteDir $ \tempDir -> do
     -- Run `npm install "packageName@packageVersion"`.
     let baseProc = proc "yarn" ["add", "--silent", "--ignore-scripts", toS versionedPackageName]
-    let procWithCwd = baseProc { cwd = Just tempDir, env = Just [("NODE_OPTIONS", "--max_old_space_size=256")] }
+    let procWithCwd = baseProc { cwd = Just tempDir, env = Just [("NODE_OPTIONS", "--max_old_space_size=512")] }
     liftIO $ limitWithSemaphore semaphore $ do
       loggerLn logger ("Starting Yarn Add: " <> toLogStr versionedPackageName)
       _ <- invokeAndMeasure npmInstallMetric $


### PR DESCRIPTION
**Problem:**
Our 256MB limit on yarn appears to be too aggressive for some dependencies, as it causes yarn to run out of heap space.

**Fix:**
Bumped the limit instead to 512MB as testing packages that have failed with 256MB, they all appear to be fine with this limit.

**Commit Details:**
- Changed the `NODE_OPTIONS` value for `max_old_space_size` to 512 from 256.
