### PR TITLE
parse jsx attribute with object literal

### DIFF
--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -1294,12 +1294,12 @@ return { a: a };",
     },
   ],
   "fullHighlightBounds": Object {
-    "29f": Object {
+    "24a": Object {
       "endCol": 9,
       "endLine": 13,
       "startCol": 3,
       "startLine": 13,
-      "uid": "29f",
+      "uid": "24a",
     },
     "854": Object {
       "endCol": 48,
@@ -1324,12 +1324,12 @@ return { a: a };",
     },
   },
   "highlightBounds": Object {
-    "29f": Object {
+    "24a": Object {
       "endCol": 9,
       "endLine": 13,
       "startCol": 3,
       "startLine": 13,
-      "uid": "29f",
+      "uid": "24a",
     },
     "bbb": Object {
       "endCol": 7,
@@ -1508,7 +1508,9 @@ return { a: a };",
               "leadingComments": Array [],
               "trailingComments": Array [],
             },
-            "definedElsewhere": Array [],
+            "definedElsewhere": Array [
+              "a",
+            ],
             "elementsWithin": Object {},
             "javascript": "({ a: a });",
             "originalJavascript": "{a: a}",

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -615,9 +615,12 @@ function parseOtherJavaScript<E extends TS.Node, T extends { uid: string }>(
           return true
         }
       }
-      if (TS.isObjectLiteralElement(nodeToCheck)) {
-        const nameToAdd = nodeToCheck.getText(sourceFile)
-        pushToDefinedElsewhereIfNotThere(inScope, nameToAdd)
+      if (
+        TS.isObjectLiteralElement(nodeToCheck) &&
+        nodeToCheck.name != null &&
+        TS.isIdentifier(nodeToCheck.name)
+      ) {
+        pushToDefinedElsewhereIfNotThere(inScope, nodeToCheck.name.getText(sourceFile))
         return true
       }
 
@@ -864,7 +867,6 @@ function parseOtherJavaScript<E extends TS.Node, T extends { uid: string }>(
               addIfDefinedElsewhere(scope, node.expression, false)
             } else if (TS.isObjectLiteralExpression(node)) {
               fastForEach(node.properties, (p) => {
-                addIfDefinedElsewhere(scope, p, false)
                 if (TS.isPropertyAssignment(p)) {
                   addIfDefinedElsewhere(scope, p.initializer, false)
                 } else if (TS.isShorthandPropertyAssignment(p)) {

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -543,9 +543,6 @@ function parseOtherJavaScript<E extends TS.Node, T extends { uid: string }>(
     isList: boolean,
   ) => Either<string, T>,
 ): Either<string, WithParserMetadata<T>> {
-  // if (expressionsAndTexts.some((e) => e.text.includes('showMeWhatYouGot'))) {
-  //   console.log('parseOtherJavaScript expressionsAndTexts', expressionsAndTexts)
-  // }
   if (expressionsAndTexts.length === 0) {
     throw new Error('Unable to deal with a collection of zero expressions.')
   } else {
@@ -617,6 +614,11 @@ function parseOtherJavaScript<E extends TS.Node, T extends { uid: string }>(
           pushToDefinedElsewhereIfNotThere(inScope, nameToAdd)
           return true
         }
+      }
+      if (TS.isObjectLiteralElement(nodeToCheck)) {
+        const nameToAdd = nodeToCheck.getText(sourceFile)
+        pushToDefinedElsewhereIfNotThere(inScope, nameToAdd)
+        return true
       }
 
       return false
@@ -865,6 +867,8 @@ function parseOtherJavaScript<E extends TS.Node, T extends { uid: string }>(
                 addIfDefinedElsewhere(scope, p, false)
                 if (TS.isPropertyAssignment(p)) {
                   addIfDefinedElsewhere(scope, p.initializer, false)
+                } else if (TS.isShorthandPropertyAssignment(p)) {
+                  addIfDefinedElsewhere(scope, p, false)
                 }
               })
             } else if (TS.isParenthesizedExpression(node)) {

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -543,6 +543,9 @@ function parseOtherJavaScript<E extends TS.Node, T extends { uid: string }>(
     isList: boolean,
   ) => Either<string, T>,
 ): Either<string, WithParserMetadata<T>> {
+  // if (expressionsAndTexts.some((e) => e.text.includes('showMeWhatYouGot'))) {
+  //   console.log('parseOtherJavaScript expressionsAndTexts', expressionsAndTexts)
+  // }
   if (expressionsAndTexts.length === 0) {
     throw new Error('Unable to deal with a collection of zero expressions.')
   } else {
@@ -858,7 +861,12 @@ function parseOtherJavaScript<E extends TS.Node, T extends { uid: string }>(
             } else if (TS.isNonNullExpression(node)) {
               addIfDefinedElsewhere(scope, node.expression, false)
             } else if (TS.isObjectLiteralExpression(node)) {
-              fastForEach(node.properties, (p) => addIfDefinedElsewhere(scope, p, false))
+              fastForEach(node.properties, (p) => {
+                addIfDefinedElsewhere(scope, p, false)
+                if (TS.isPropertyAssignment(p)) {
+                  addIfDefinedElsewhere(scope, p.initializer, false)
+                }
+              })
             } else if (TS.isParenthesizedExpression(node)) {
               addIfDefinedElsewhere(scope, node.expression, false)
             } else if (TS.isPostfixUnaryExpression(node)) {


### PR DESCRIPTION
# [Try it here](https://utopia.pizza/p/697deae1-piquant-litter/?branch_name=fix-jsx-attribute-with-object-literal)

## Problem
When parsing JS code, we don't add object literal initializers to `definedElsewhere` (see the example project above for an illustration).

## Fix
Cater for this in the parser-printer code. This PR add support for "normal" object initialization (e.g., `{ t: text }`) and shorthand initializers, e.g.
```typescript
const t = "hello there"
return <span>{greeting({ t })</span>
```