### PR TITLE
create new storyboard file if none exists

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -851,10 +851,6 @@ export interface UpdatePropertyControlsInfo {
   moduleNamesOrPathsToDelete: Array<string>
 }
 
-export interface AddStoryboardFile {
-  action: 'ADD_STORYBOARD_FILE'
-}
-
 export interface UpdateText {
   action: 'UPDATE_TEXT'
   target: ElementPath
@@ -1180,7 +1176,6 @@ export type EditorAction =
   | SetPackageStatus
   | SetShortcut
   | UpdatePropertyControlsInfo
-  | AddStoryboardFile
   | UpdateText
   | SetFocusedElement
   | ScrollToElement

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -51,7 +51,6 @@ import type { InsertableComponent, StylePropOption } from '../../shared/project-
 import type {
   AddFolder,
   AddMissingDimensions,
-  AddStoryboardFile,
   AddTextFile,
   Alignment,
   AlignSelectedViews,
@@ -1341,12 +1340,6 @@ export function updatePropertyControlsInfo(
     action: 'UPDATE_PROPERTY_CONTROLS_INFO',
     propertyControlsInfo: propertyControlsInfo,
     moduleNamesOrPathsToDelete: moduleNamesOrPathsToDelete,
-  }
-}
-
-export function addStoryboardFile(): AddStoryboardFile {
-  return {
-    action: 'ADD_STORYBOARD_FILE',
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -183,7 +183,6 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_PACKAGE_JSON':
     case 'FINISH_CHECKPOINT_TIMER':
     case 'ADD_MISSING_DIMENSIONS':
-    case 'ADD_STORYBOARD_FILE':
     case 'UPDATE_TEXT':
     case 'INSERT_INSERTABLE':
     case 'ADD_TAILWIND_CONFIG':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -352,8 +352,7 @@ import {
   trueUpChildrenOfGroupChanged,
   trueUpHuggingElement,
   trueUpGroupElementChanged,
-  deriveState,
-  getPackageJsonFromEditorState,
+  getPackageJsonFromProjectContents,
 } from '../store/editor-state'
 import {
   areGeneratedElementsTargeted,
@@ -1467,7 +1466,10 @@ function updateCodeEditorVisibility(editor: EditorModel, codePaneVisible: boolea
 function createStoryboardFileIfRemixProject(
   projectContents: ProjectContentTreeRoot,
 ): ProjectContentTreeRoot | null {
-  const packageJsonContents = defaultEither(null, getPackageJsonFromEditorState(projectContents))
+  const packageJsonContents = defaultEither(
+    null,
+    getPackageJsonFromProjectContents(projectContents),
+  )
   if (packageJsonContents == null) {
     return null
   }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -2913,8 +2913,10 @@ export const DefaultPackageJson = {
   },
 }
 
-export function getPackageJsonFromEditorState(editor: EditorState): Either<string, any> {
-  const packageJsonFile = packageJsonFileFromProjectContents(editor.projectContents)
+export function getPackageJsonFromEditorState(
+  projectContents: ProjectContentTreeRoot,
+): Either<string, any> {
+  const packageJsonFile = packageJsonFileFromProjectContents(projectContents)
   if (packageJsonFile != null && isTextFile(packageJsonFile)) {
     const packageJsonContents = Utils.jsonParseOrNull(packageJsonFile.fileContents.code)
     return packageJsonContents != null
@@ -2926,7 +2928,7 @@ export function getPackageJsonFromEditorState(editor: EditorState): Either<strin
 }
 
 export function getMainUIFromModel(model: EditorState): string | null {
-  const packageJsonContents = getPackageJsonFromEditorState(model)
+  const packageJsonContents = getPackageJsonFromEditorState(model.projectContents)
   if (isRight(packageJsonContents)) {
     const mainUI = Utils.path(['utopia', 'main-ui'], packageJsonContents.value)
     // Make sure someone hasn't put something bizarro in there.
@@ -2940,7 +2942,7 @@ export function getMainUIFromModel(model: EditorState): string | null {
 export function getIndexHtmlFileFromEditorState(editor: EditorState): Either<string, TextFile> {
   const parsedFilePath = mapEither(
     (contents) => contents?.utopia?.html,
-    getPackageJsonFromEditorState(editor),
+    getPackageJsonFromEditorState(editor.projectContents),
   )
   const filePath =
     isRight(parsedFilePath) && typeof parsedFilePath.value === 'string'

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -2913,7 +2913,7 @@ export const DefaultPackageJson = {
   },
 }
 
-export function getPackageJsonFromEditorState(
+export function getPackageJsonFromProjectContents(
   projectContents: ProjectContentTreeRoot,
 ): Either<string, any> {
   const packageJsonFile = packageJsonFileFromProjectContents(projectContents)
@@ -2928,7 +2928,7 @@ export function getPackageJsonFromEditorState(
 }
 
 export function getMainUIFromModel(model: EditorState): string | null {
-  const packageJsonContents = getPackageJsonFromEditorState(model.projectContents)
+  const packageJsonContents = getPackageJsonFromProjectContents(model.projectContents)
   if (isRight(packageJsonContents)) {
     const mainUI = Utils.path(['utopia', 'main-ui'], packageJsonContents.value)
     // Make sure someone hasn't put something bizarro in there.
@@ -2942,7 +2942,7 @@ export function getMainUIFromModel(model: EditorState): string | null {
 export function getIndexHtmlFileFromEditorState(editor: EditorState): Either<string, TextFile> {
   const parsedFilePath = mapEither(
     (contents) => contents?.utopia?.html,
-    getPackageJsonFromEditorState(editor.projectContents),
+    getPackageJsonFromProjectContents(editor.projectContents),
   )
   const filePath =
     isRight(parsedFilePath) && typeof parsedFilePath.value === 'string'

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -293,8 +293,6 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.SET_PACKAGE_STATUS(action, state)
     case 'UPDATE_PROPERTY_CONTROLS_INFO':
       return UPDATE_FNS.UPDATE_PROPERTY_CONTROLS_INFO(action, state)
-    case 'ADD_STORYBOARD_FILE':
-      return UPDATE_FNS.ADD_STORYBOARD_FILE(action, state)
     case 'SELECT_FROM_FILE_AND_POSITION':
       return UPDATE_FNS.SELECT_FROM_FILE_AND_POSITION(action, state, derivedState, dispatch)
     case 'SEND_LINTER_REQUEST_MESSAGE':

--- a/editor/src/core/model/storyboard-utils.spec.browser2.tsx
+++ b/editor/src/core/model/storyboard-utils.spec.browser2.tsx
@@ -10,7 +10,7 @@ import { createModifiedProject } from '../../sample-projects/sample-project-util
 describe('Storyboard utils', () => {
   describe("Create a storyboard file if one doesn't exist in the project", () => {
     it('Remix project', async () => {
-      const RemixComponentText = 'Hello Remix!'
+      const RemixRootComponentTestId = 'remix-root-component'
       const renderResult = await renderTestEditorWithModel(
         createModifiedProject(
           {
@@ -36,8 +36,8 @@ describe('Storyboard utils', () => {
               
               export default function Root() {
                 return (
-                  <div>
-                    ${RemixComponentText}
+                  <div data-testid="${RemixRootComponentTestId}">
+                    "Hello Remix!"
                   </div>
                 )
               }
@@ -49,10 +49,10 @@ describe('Storyboard utils', () => {
       )
 
       expectStoryboardFileExists(renderResult)
-      expect(renderResult.renderedDOM.queryByText(RemixComponentText)).not.toBeNull()
+      expect(renderResult.renderedDOM.queryByTestId(RemixRootComponentTestId)).not.toBeNull()
     })
     it('project with an exported App component', async () => {
-      const AppComponentText = 'This is App'
+      const AppTestId = 'App'
       const renderResult = await renderTestEditorWithModel(
         createModifiedProject(
           {
@@ -60,8 +60,8 @@ describe('Storyboard utils', () => {
                   
                   export function App() {
                     return (
-                      <div>
-                      ${AppComponentText}
+                      <div data-testid="${AppTestId}">
+                        This is App
                       </div>
                     )
                   }
@@ -73,7 +73,7 @@ describe('Storyboard utils', () => {
       )
 
       expectStoryboardFileExists(renderResult)
-      expect(renderResult.renderedDOM.queryByText(AppComponentText)).not.toBeNull()
+      expect(renderResult.renderedDOM.queryAllByTestId(AppTestId)).not.toBeNull()
     })
     it('project with no main component', async () => {
       const renderResult = await renderTestEditorWithModel(

--- a/editor/src/core/model/storyboard-utils.spec.browser2.tsx
+++ b/editor/src/core/model/storyboard-utils.spec.browser2.tsx
@@ -1,9 +1,24 @@
 import { getProjectFileByFilePath } from '../../components/assets'
+import { mouseClickAtPoint } from '../../components/canvas/event-helpers.test-utils'
 import type { EditorRenderResult } from '../../components/canvas/ui-jsx.test-utils'
-import { renderTestEditorWithModel } from '../../components/canvas/ui-jsx.test-utils'
+import {
+  makeTestProjectCodeWithSnippet,
+  optOutFromCheckFileTimestamps,
+  renderTestEditorWithCode,
+  renderTestEditorWithModel,
+} from '../../components/canvas/ui-jsx.test-utils'
 import { StoryboardFilePath } from '../../components/editor/store/editor-state'
 import { emptyDefaultProject } from '../../sample-projects/sample-project-utils'
 import { createModifiedProject } from '../../sample-projects/sample-project-utils.test-utils'
+import { GithubEndpoints } from '../shared/github/endpoints'
+import type { GetGithubUserSuccess, GetBranchContentResponse } from '../shared/github/helpers'
+import {
+  MockGithubOperations,
+  fakeResponse,
+  loginUserToGithubForTests,
+} from '../shared/github/operations/github-operations.test-utils'
+import type { GetBranchesSuccess } from '../shared/github/operations/list-branches'
+import type { GetUsersPublicRepositoriesSuccess } from '../shared/github/operations/load-repositories'
 
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectStoryboardFileExists"] }] */
 
@@ -98,6 +113,106 @@ describe('Storyboard utils', () => {
       expectStoryboardFileExists(renderResult)
     })
   })
+  describe('Create storyboard file on github import', () => {
+    const RemixRootComponentTestId = 'remix-root-component'
+    const { projectContents } = createModifiedProject(
+      {
+        '/package.json': `{
+            "name": "Utopia Project",
+            "version": "0.1.0",
+            "utopia": {
+              "main-ui": "utopia/storyboard.js",
+              "html": "public/index.html",
+              "js": "src/index.js"
+            },
+            "dependencies": {
+              "react": "16.13.1",
+              "react-dom": "16.13.1",
+              "utopia-api": "0.4.1",
+              "react-spring": "8.0.27",
+              "@heroicons/react": "1.0.1",
+              "@emotion/react": "11.9.3",
+              "@remix-run/react": "1.19.3"
+            }
+          }`,
+        '/app/root.js': `import React from 'react'
+          
+          export default function Root() {
+            return (
+              <div data-testid="${RemixRootComponentTestId}">
+                "Hello Remix!"
+              </div>
+            )
+          }
+          `,
+      },
+      emptyDefaultProject(),
+    )
+    const mock = new MockGithubOperations().mock({
+      fakeResolvedProjectContents: projectContents,
+      apiConfig: {
+        [GithubEndpoints.userDetails()]: fakeResponse<GetGithubUserSuccess>({
+          type: 'SUCCESS',
+          user: { login: 'login', name: 'Bob', avatarURL: 'avatar', htmlURL: 'www.example.com' },
+        }),
+        [GithubEndpoints.repositories()]: fakeResponse<GetUsersPublicRepositoriesSuccess>({
+          type: 'SUCCESS',
+          repositories: [
+            {
+              fullName: 'bob/awesome-project',
+              name: 'Awesome Project',
+              avatarUrl: null,
+              isPrivate: false,
+              description: 'An Awesome Project',
+              updatedAt: '1',
+              defaultBranch: 'main',
+              permissions: { admin: true, push: true, pull: true },
+            },
+          ],
+        }),
+        [GithubEndpoints.getBranches({ owner: 'bob', repository: 'awesome-project' })]:
+          fakeResponse<GetBranchesSuccess>({
+            type: 'SUCCESS',
+            branches: [{ name: 'main' }, { name: 'dev' }],
+          }),
+        [GithubEndpoints.branchContents({ owner: 'bob', repository: 'awesome-project' }, 'main')]:
+          fakeResponse<GetBranchContentResponse>({
+            type: 'SUCCESS',
+            branch: {
+              originCommit: 'initial',
+              content: projectContents,
+            },
+          }),
+      },
+    })
+
+    optOutFromCheckFileTimestamps()
+
+    it('storyboard file is added after cloning a github project', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProjectCodeWithSnippet(`
+            <h1>Starting Editor</h1>
+            `),
+        'await-first-dom-report',
+      )
+
+      await loginUserToGithubForTests(renderResult.dispatch)
+
+      await clickTextOnScreen(renderResult, 'Github')
+      await mock.getUsersPublicGithubRepositories
+
+      await clickTextOnScreen(renderResult, 'bob/awesome-project')
+      await mock.getBranchesForGithubRepository
+
+      await clickTextOnScreen(renderResult, 'main')
+      await clickTextOnScreen(renderResult, 'Load from Branch')
+      await clickTextOnScreen(renderResult, 'Yes, Load from this Branch.')
+      await mock.updateProjectWithBranchContent
+
+      expectStoryboardFileExists(renderResult)
+      expect(renderResult.renderedDOM.queryByTestId(RemixRootComponentTestId)).not.toBeNull()
+    })
+  })
 })
 
 function expectStoryboardFileExists(renderResult: EditorRenderResult) {
@@ -106,4 +221,9 @@ function expectStoryboardFileExists(renderResult: EditorRenderResult) {
     StoryboardFilePath,
   )
   expect(storyboardFile).not.toBeNull()
+}
+
+async function clickTextOnScreen(renderResult: EditorRenderResult, text: string) {
+  const element = renderResult.renderedDOM.getByText(text)
+  await mouseClickAtPoint(element, { x: 2, y: 2 })
 }

--- a/editor/src/core/model/storyboard-utils.spec.browser2.tsx
+++ b/editor/src/core/model/storyboard-utils.spec.browser2.tsx
@@ -1,0 +1,109 @@
+import { getProjectFileByFilePath } from '../../components/assets'
+import type { EditorRenderResult } from '../../components/canvas/ui-jsx.test-utils'
+import { renderTestEditorWithModel } from '../../components/canvas/ui-jsx.test-utils'
+import { StoryboardFilePath } from '../../components/editor/store/editor-state'
+import { emptyDefaultProject } from '../../sample-projects/sample-project-utils'
+import { createModifiedProject } from '../../sample-projects/sample-project-utils.test-utils'
+
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectStoryboardFileExists"] }] */
+
+describe('Storyboard utils', () => {
+  describe("Create a storyboard file if one doesn't exist in the project", () => {
+    it('Remix project', async () => {
+      const RemixComponentText = 'Hello Remix!'
+      const renderResult = await renderTestEditorWithModel(
+        createModifiedProject(
+          {
+            '/package.json': `{
+                "name": "Utopia Project",
+                "version": "0.1.0",
+                "utopia": {
+                  "main-ui": "utopia/storyboard.js",
+                  "html": "public/index.html",
+                  "js": "src/index.js"
+                },
+                "dependencies": {
+                  "react": "16.13.1",
+                  "react-dom": "16.13.1",
+                  "utopia-api": "0.4.1",
+                  "react-spring": "8.0.27",
+                  "@heroicons/react": "1.0.1",
+                  "@emotion/react": "11.9.3",
+                  "@remix-run/react": "1.19.3"
+                }
+              }`,
+            '/app/root.js': `import React from 'react'
+              
+              export default function Root() {
+                return (
+                  <div>
+                    ${RemixComponentText}
+                  </div>
+                )
+              }
+              `,
+          },
+          emptyDefaultProject(),
+        ),
+        'await-first-dom-report',
+      )
+
+      expectStoryboardFileExists(renderResult)
+      expect(renderResult.renderedDOM.queryByText(RemixComponentText)).not.toBeNull()
+    })
+    it('project with an exported App component', async () => {
+      const AppComponentText = 'This is App'
+      const renderResult = await renderTestEditorWithModel(
+        createModifiedProject(
+          {
+            '/src/app.js': `import React from 'react'
+                  
+                  export function App() {
+                    return (
+                      <div>
+                      ${AppComponentText}
+                      </div>
+                    )
+                  }
+                  `,
+          },
+          emptyDefaultProject(),
+        ),
+        'await-first-dom-report',
+      )
+
+      expectStoryboardFileExists(renderResult)
+      expect(renderResult.renderedDOM.queryByText(AppComponentText)).not.toBeNull()
+    })
+    it('project with no main component', async () => {
+      const renderResult = await renderTestEditorWithModel(
+        createModifiedProject(
+          {
+            '/src/editor.js': `import React from 'react'
+                  
+                  export function Editor() {
+                    return (
+                      <div>
+                        This is the entry point, but Utopia doesn't know that
+                      </div>
+                    )
+                  }
+                  `,
+          },
+          emptyDefaultProject(),
+        ),
+        'await-first-dom-report',
+      )
+
+      expectStoryboardFileExists(renderResult)
+    })
+  })
+})
+
+function expectStoryboardFileExists(renderResult: EditorRenderResult) {
+  const storyboardFile = getProjectFileByFilePath(
+    renderResult.getEditorState().editor.projectContents,
+    StoryboardFilePath,
+  )
+  expect(storyboardFile).not.toBeNull()
+}

--- a/editor/src/core/model/storyboard-utils.spec.ts
+++ b/editor/src/core/model/storyboard-utils.spec.ts
@@ -68,14 +68,13 @@ export var App = (props) => {
 
 describe('addStoryboardFileToProject', () => {
   it('adds storyboard file to project that does not have one', () => {
-    const actualResult = addStoryboardFileToProject(createTestProjectLackingStoryboardFile())
+    const actualResult = addStoryboardFileToProject(
+      createTestProjectLackingStoryboardFile().projectContents,
+    )
     if (actualResult == null) {
       throw new Error('Editor state was not updated.')
     } else {
-      const storyboardFile = getProjectFileByFilePath(
-        actualResult.projectContents,
-        StoryboardFilePath,
-      )
+      const storyboardFile = getProjectFileByFilePath(actualResult, StoryboardFilePath)
       if (storyboardFile == null) {
         throw new Error('No storyboard file was created.')
       } else {
@@ -115,7 +114,7 @@ describe('addStoryboardFileToProject', () => {
         expectedFile,
       ),
     }
-    const actualResult = addStoryboardFileToProject(editorModel)
+    const actualResult = addStoryboardFileToProject(editorModel.projectContents)
     expect(actualResult).toBeNull()
   })
 })

--- a/editor/src/core/model/storyboard-utils.ts
+++ b/editor/src/core/model/storyboard-utils.ts
@@ -158,8 +158,10 @@ const compareComponentToImport: Compare<ComponentToImport> = compareCompose(
   ),
 )
 
-export function addStoryboardFileToProject(editorModel: EditorModel): EditorModel | null {
-  const storyboardFile = getProjectFileByFilePath(editorModel.projectContents, StoryboardFilePath)
+export function addStoryboardFileToProject(
+  projectContents: ProjectContentTreeRoot,
+): ProjectContentTreeRoot | null {
+  const storyboardFile = getProjectFileByFilePath(projectContents, StoryboardFilePath)
   if (storyboardFile == null) {
     let currentImportCandidate: ComponentToImport | null = null
     function updateCandidate(importCandidate: ComponentToImport): void {
@@ -171,7 +173,7 @@ export function addStoryboardFileToProject(editorModel: EditorModel): EditorMode
         }
       }
     }
-    walkContentsTree(editorModel.projectContents, (fullPath, file) => {
+    walkContentsTree(projectContents, (fullPath, file) => {
       if (isParsedTextFile(file)) {
         // For those successfully parsed files, we want to search all of the components.
         forEachParseSuccess((success) => {
@@ -264,7 +266,7 @@ export function addStoryboardFileToProject(editorModel: EditorModel): EditorMode
     if (currentImportCandidate == null) {
       return null
     } else {
-      return addStoryboardFileForComponent(currentImportCandidate, editorModel)
+      return addStoryboardFileForComponent(currentImportCandidate, projectContents)
     }
   } else {
     return null
@@ -273,8 +275,8 @@ export function addStoryboardFileToProject(editorModel: EditorModel): EditorMode
 
 function addStoryboardFileForComponent(
   createFileWithComponent: ComponentToImport,
-  editorModel: EditorState,
-): EditorState {
+  projectContents: ProjectContentTreeRoot,
+): ProjectContentTreeRoot {
   // Add import of storyboard and scene components.
   let imports = addImport(StoryboardFilePath, 'react', null, [], 'React', {})
   imports = addImport(
@@ -287,7 +289,7 @@ function addStoryboardFileForComponent(
   )
   // Create the storyboard variable.
   let sceneElement: JSXElement
-  let updatedProjectContents: ProjectContentTreeRoot = editorModel.projectContents
+  let updatedProjectContents: ProjectContentTreeRoot = projectContents
   switch (createFileWithComponent.type) {
     case 'NAMED_COMPONENT_TO_IMPORT':
       sceneElement = createSceneFromComponent(
@@ -413,8 +415,6 @@ function addStoryboardFileForComponent(
     StoryboardFilePath,
     storyboardFileContents,
   )
-  return {
-    ...editorModel,
-    projectContents: updatedProjectContents,
-  }
+
+  return updatedProjectContents
 }

--- a/editor/src/core/shared/github/operations/load-branch.ts
+++ b/editor/src/core/shared/github/operations/load-branch.ts
@@ -34,6 +34,7 @@ import {
 } from '../helpers'
 import { updateProjectContentsWithParseResults } from '../../parser-projectcontents-utils'
 import type { GithubOperationContext } from './github-operation-context'
+import { createStoryboardFileIfNecessary } from '../../../../components/editor/actions/actions'
 
 export const saveAssetsToProject =
   (operationContext: GithubOperationContext) =>
@@ -136,9 +137,8 @@ export const updateProjectWithBranchContent =
 
             // Push any code through the parser so that the representations we end up with are in a state of `BOTH_MATCH`.
             // So that it will override any existing files that might already exist in the project when sending them to VS Code.
-            const parsedProjectContents = await updateProjectContentsWithParseResults(
-              workers,
-              responseBody.branch.content,
+            const parsedProjectContents = createStoryboardFileIfNecessary(
+              await updateProjectContentsWithParseResults(workers, responseBody.branch.content),
             )
 
             // Save assets to the server from Github.

--- a/editor/src/sample-projects/sample-project-utils.ts
+++ b/editor/src/sample-projects/sample-project-utils.ts
@@ -131,9 +131,13 @@ export var Card = (props) => {
 }
 
 export function complexDefaultProject(): PersistentModel {
-  const projectContents = createComplexDefaultProjectContents()
+  const projectContents: ProjectContents = createComplexDefaultProjectContents()
   const persistentModel = persistentModelForProjectContents(contentsToTree(projectContents))
   return persistentModel
+}
+
+export function emptyDefaultProject(): PersistentModel {
+  return persistentModelForProjectContents(contentsToTree({}))
 }
 
 function createBeachesProjectContents(): ProjectContentTreeRoot {


### PR DESCRIPTION
## Problem
Without a storyboard file, the canvas-based features of Utopia don't work.

## Fix 
Add a storyboard file if we detect it doesn't exist. The missing storyboard is added in the `UPDATE_FROM_WORKER`  action and in `GithubOperations.updateProjectWithBranchContent` (called when cloning a project from Github).

The generated storyboard file is tailored to the project:
- if the project's package.json includes `"@remix-run/react": "..."` in `package.json`, we add a storyboard with a `RemixScene`
- If the project contains an exported component called `App`, `Application` or `Main`, we add a scene that renders that component
- Otherwise, we render a scene with some instructions related to adding components