### PR TITLE
Fix PopupList blocking undo-redo

### DIFF
--- a/editor/src/uuiui/widgets/popup-list/popup-list.tsx
+++ b/editor/src/uuiui/widgets/popup-list/popup-list.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 import * as ReactDOM from 'react-dom'
 import type {
   InputProps,
+  KeyboardEventHandler,
   MenuListComponentProps,
   OptionProps,
   OptionsType,
@@ -26,7 +27,6 @@ import type { ControlStyles, SelectOption } from '../../../uuiui-deps'
 import { CommonUtils, getControlStyles } from '../../../uuiui-deps'
 import { SmallerIcons } from '../../../uuiui/icons'
 import { Tooltip } from '../../tooltip'
-import { stopPropagation } from '../../../components/inspector/common/inspector-utils'
 
 type ContainerMode = 'default' | 'showBorderOnHover' | 'noBorder'
 
@@ -605,6 +605,13 @@ export const PopupList = React.memo<PopupListProps>(
       function isOptionDisabled(option: SelectOption) {
         return option.disabled === true
       }
+
+      const stopPropagation: KeyboardEventHandler = React.useCallback((event) => {
+        if (event.key.includes('Arrow')) {
+          // if the user is using the ArrowUp or ArrowDown to navigate the react select, don't trigger keyboard moves on the Canvas
+          event.stopPropagation()
+        }
+      }, [])
 
       return (
         <Select


### PR DESCRIPTION
**Problem:**
While the PopupList was in focus, no keyboard events propagated to the Editor. This was most noticable by Undo-redo not working. The real issue is that I added a stopPropagation to the keyDown to prevent elements from moving on the canvas while the user navigated the popupList using keyboard keys.

**Fix:**
Only call stopPropagation for arrowUp, arrowDown, arrowLeft, arrowRight, etc

