### PR TITLE
Minimal Liveblocks Authentication.

### DIFF
--- a/clientmodel/lib/src/Utopia/ClientModel.hs
+++ b/clientmodel/lib/src/Utopia/ClientModel.hs
@@ -66,10 +66,10 @@ instance Arbitrary RevisionsState where
   shrink = genericShrink
 
 data ParseFailure = ParseFailure
-                  { diagnostics         :: Maybe [Value]
-                  , parsedJSONFailure   :: Value
-                  , errorMessage        :: Maybe Text
-                  , errorMessages       :: [Value]
+                  { diagnostics       :: Maybe [Value]
+                  , parsedJSONFailure :: Value
+                  , errorMessage      :: Maybe Text
+                  , errorMessages     :: [Value]
                   }
                   deriving (Eq, Show, Generic, Data, Typeable)
 

--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -1,0 +1,140 @@
+import { createClient } from '@liveblocks/client'
+import { createRoomContext } from '@liveblocks/react'
+import type { CanvasVector } from './src/core/shared/math-utils'
+
+export const liveblocksThrottle = 100 // ms
+
+export const liveblocksClient = createClient({
+  throttle: liveblocksThrottle,
+  authEndpoint: '/v1/liveblocks/authentication',
+})
+
+// Presence represents the properties that exist on every user in the Room
+// and that will automatically be kept in sync. Accessible through the
+// `user.presence` property. Must be JSON-serializable.
+export type Presence = {
+  playerId: string | null
+  playerName: string | null
+  //color: { light: MultiplayerCursorColor; dark: MultiplayerCursorColor } | null
+  cursor: { x: number; y: number } | null
+  canvasScale: number | null
+  canvasOffset: CanvasVector | null
+}
+
+export function initialPresence(): Presence {
+  return {
+    cursor: null,
+    playerId: null,
+    playerName: null,
+    //color: null,
+    canvasScale: null,
+    canvasOffset: null,
+  }
+}
+
+// Optionally, Storage represents the shared document that persists in the
+// Room, even after all users leave. Fields under Storage typically are
+// LiveList, LiveMap, LiveObject instances, for which updates are
+// automatically persisted and synced to all connected clients.
+export type Storage = {
+  // author: LiveObject<{ firstName: string, lastName: string }>,
+  // ...
+}
+
+// Optionally, UserMeta represents static/readonly metadata on each user, as
+// provided by your own custom auth back end (if used). Useful for data that
+// will not change during a session, like a user's name or avatar.
+export type UserMeta = {
+  // id?: string,  // Accessible through `user.id`
+  // info?: Json,  // Accessible through `user.info`
+}
+
+// Optionally, the type of custom events broadcast and listened to in this
+// room. Use a union for multiple events. Must be JSON-serializable.
+export type RoomEvent = {
+  // type: "NOTIFICATION",
+  // ...
+}
+
+// Optionally, when using Comments, ThreadMetadata represents metadata on
+// each thread. Can only contain booleans, strings, and numbers.
+export type ThreadMetadata = {
+  // resolved: boolean;
+  // quote: string;
+  // time: number;
+}
+
+export const {
+  suspense: {
+    RoomProvider,
+    useRoom,
+    useMyPresence,
+    useUpdateMyPresence,
+    useSelf,
+    useOthers,
+    useOthersMapped,
+    useOthersConnectionIds,
+    useOther,
+    useBroadcastEvent,
+    useEventListener,
+    useErrorListener,
+    useStorage,
+    useObject,
+    useMap,
+    useList,
+    useBatch,
+    useHistory,
+    useUndo,
+    useRedo,
+    useCanUndo,
+    useCanRedo,
+    useMutation,
+    useStatus,
+    useLostConnectionListener,
+    useThreads,
+    useUser,
+    useCreateThread,
+    useEditThreadMetadata,
+    useCreateComment,
+    useEditComment,
+    useDeleteComment,
+    useAddReaction,
+  },
+} = createRoomContext<Presence, Storage, UserMeta, RoomEvent, ThreadMetadata>(liveblocksClient, {
+  async resolveUsers({ userIds }) {
+    // Used only for Comments. Return a list of user information retrieved
+    // from `userIds`. This info is used in comments, mentions etc.
+
+    // const usersData = await __fetchUsersFromDB__(userIds);
+    //
+    // return usersData.map((userData) => ({
+    //   name: userData.name,
+    //   avatar: userData.avatar.src,
+    // }));
+
+    return []
+  },
+  async resolveMentionSuggestions({ text, roomId }) {
+    // Used only for Comments. Return a list of userIds that match `text`.
+    // These userIds are used to create a mention list when typing in the
+    // composer.
+    //
+    // For example when you type "@jo", `text` will be `"jo"`, and
+    // you should to return an array with John and Joanna's userIds:
+    // ["john@example.com", "joanna@example.com"]
+
+    // const userIds = await __fetchAllUserIdsFromDB__(roomId);
+    //
+    // Return all userIds if no `text`
+    // if (!text) {
+    //   return userIds;
+    // }
+    //
+    // Otherwise, filter userIds for the search `text` and return
+    // return userIds.filter((userId) =>
+    //   userId.toLowerCase().includes(text.toLowerCase())
+    // );
+
+    return []
+  },
+})

--- a/editor/package.json
+++ b/editor/package.json
@@ -110,6 +110,8 @@
     "@emotion/serialize": "1.0.2",
     "@emotion/styled": "11.0.0",
     "@emotion/styled-base": "11.0.0",
+    "@liveblocks/client": "1.7.0",
+    "@liveblocks/react": "1.7.0",
     "@popperjs/core": "2.4.4",
     "@remix-run/react": "2.0.1",
     "@root/encoding": "1.0.1",

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -60,6 +60,8 @@ specifiers:
   '@emotion/styled': 11.0.0
   '@emotion/styled-base': 11.0.0
   '@hot-loader/react-dom': 16.13.0
+  '@liveblocks/client': 1.7.0
+  '@liveblocks/react': 1.7.0
   '@originjs/vite-plugin-commonjs': 1.0.3
   '@popperjs/core': 2.4.4
   '@react-three/fiber': 8.0.14
@@ -340,6 +342,8 @@ dependencies:
   '@emotion/serialize': 1.0.2
   '@emotion/styled': 11.0.0_kf2s5ttaepyzuejtstis4wzmwe
   '@emotion/styled-base': 11.0.0
+  '@liveblocks/client': 1.7.0
+  '@liveblocks/react': 1.7.0_react@18.1.0
   '@popperjs/core': 2.4.4
   '@remix-run/react': 2.0.1_njludxb6fcqnim6moy22jieofi
   '@root/encoding': 1.0.1
@@ -3377,6 +3381,28 @@ packages:
   /@leichtgewicht/ip-codec/2.0.4:
     resolution: {integrity: sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==}
     dev: true
+
+  /@liveblocks/client/1.7.0:
+    resolution: {integrity: sha512-BJnHDnp2GH+d7NuJJSRSZwSHLSd73BNS3ApiNInsatE56y5FSOx861kbbYKyD2Spv9vg3z9QZfBWMSrzTR5IeA==}
+    dependencies:
+      '@liveblocks/core': 1.7.0
+    dev: false
+
+  /@liveblocks/core/1.7.0:
+    resolution: {integrity: sha512-JSEvFr4iQYAKnE0dH36VWNFW6KmWStP8XJtb711bSXevRxx/4ODN88kQkTNNVuUjpgAOM+ekKjbqEdHmd8JhKw==}
+    dev: false
+
+  /@liveblocks/react/1.7.0_react@18.1.0:
+    resolution: {integrity: sha512-dXSfMNlqjtMVuy1qpQAdUYQ8jKWI7kHKJsXc12vDUzGybyil7JKMJgRKI9RTQgHWcfq1t2aPlL5rw7JmQa4qbA==}
+    peerDependencies:
+      react: ^16.14.0 || ^17 || ^18
+    dependencies:
+      '@liveblocks/client': 1.7.0
+      '@liveblocks/core': 1.7.0
+      nanoid: 3.3.6
+      react: 18.1.0_47cciibm4ysmleigs33s763fqu
+      use-sync-external-store: 1.2.0_react@18.1.0
+    dev: false
 
   /@mantine/core/6.0.21_2nlaf5wpdo4ci5lvq3grwyjxf4:
     resolution: {integrity: sha512-Kx4RrRfv0I+cOCIcsq/UA2aWcYLyXgW3aluAuW870OdXnbII6qg7RW28D+r9D76SHPxWFKwIKwmcucAG08Divg==}
@@ -7056,7 +7082,7 @@ packages:
     dev: true
 
   /component-indexof/0.0.3:
-    resolution: {integrity: sha512-puDQKvx/64HZXb4hBwIcvQLaLgux8o1CbWl39s41hrIIZDl1lJiD5jc22gj3RBeGK0ovxALDYpIbyjqDUUl0rw==}
+    resolution: {integrity: sha1-EdCRMSI5648yyPJa6csAL/6NPCQ=}
     dev: false
 
   /compressible/2.0.18:
@@ -13090,7 +13116,6 @@ packages:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: true
 
   /nanomatch/1.2.13:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -55,6 +55,8 @@ import { EditorCommon } from './editor-component-common'
 import { notice } from '../common/notice'
 import { isFeatureEnabled } from '../../utils/feature-switches'
 import { ProjectServerStateUpdater } from './store/project-server-state'
+import { useRoom, RoomProvider, initialPresence } from '../../../liveblocks.config'
+import { generateUUID } from '../../utils/utils'
 
 const liveModeToastId = 'play-mode-toast'
 
@@ -88,6 +90,8 @@ function useDelayedValueHook(inputValue: boolean, delayMs: number): boolean {
 }
 
 export const EditorComponentInner = React.memo((props: EditorProps) => {
+  const room = useRoom()
+  console.info('room', JSON.stringify(room.getStatus()))
   const dispatch = useDispatch()
   const editorStoreRef = useRefEditorState((store) => store)
   const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
@@ -504,18 +508,26 @@ export function EditorComponent(props: EditorProps) {
 
   const dispatch = useDispatch()
 
+  const roomId = useEditorState(
+    Substores.restOfEditor,
+    (store) => (projectId == null ? generateUUID() : `project-room-${projectId}`),
+    'EditorComponent roomId',
+  )
+
   return indexedDBFailed ? (
     <FatalIndexedDBErrorComponent />
   ) : (
-    <DndProvider backend={HTML5Backend} context={window}>
-      <ProjectServerStateUpdater
-        projectId={projectId}
-        forkedFromProjectId={forkedFromProjectId}
-        dispatch={dispatch}
-      >
-        <EditorComponentInner {...props} />
-      </ProjectServerStateUpdater>
-    </DndProvider>
+    <RoomProvider id={roomId} autoConnect={true} initialPresence={initialPresence()}>
+      <DndProvider backend={HTML5Backend} context={window}>
+        <ProjectServerStateUpdater
+          projectId={projectId}
+          forkedFromProjectId={forkedFromProjectId}
+          dispatch={dispatch}
+        >
+          <EditorComponentInner {...props} />
+        </ProjectServerStateUpdater>
+      </DndProvider>
+    </RoomProvider>
   )
 }
 

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -705,6 +705,12 @@ getGithubUserEndpoint :: Maybe Text -> ServerMonad GetGithubUserResponse
 getGithubUserEndpoint cookie = requireUser cookie $ \sessionUser -> do
   getGithubUserDetails (view (field @"_id") sessionUser)
 
+liveblocksAuthenticationEndpoint :: Maybe Text -> LiveblocksAuthenticationRequest -> ServerMonad LiveblocksAuthenticationResponse
+liveblocksAuthenticationEndpoint cookie authBody = requireUser cookie $ \sessionUser -> do
+  let roomID = view (field @"_room") authBody
+  token <- authLiveblocksUser (view (field @"_id") sessionUser) roomID
+  pure $ LiveblocksAuthenticationResponse { _token = token }
+
 {-|
   Compose together all the individual endpoints into a definition for the whole server.
 -}
@@ -734,6 +740,7 @@ protected authCookie = logoutPage authCookie
                   :<|> getGithubUsersRepositoriesEndpoint authCookie
                   :<|> saveGithubAssetEndpoint authCookie
                   :<|> getGithubUserEndpoint authCookie
+                  :<|> liveblocksAuthenticationEndpoint authCookie
 
 unprotected :: ServerT Unprotected ServerMonad
 unprotected = authenticate

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -372,8 +372,8 @@ useAccessToken githubResources logger metrics pool userID action = do
       let expired = (fmap (< now) $ expiresAt authDetails) == Just True
       accessTokenToUse <- if expired then refreshTheToken else (pure $ Just currentAccessToken)
       case accessTokenToUse of
-        Nothing    -> throwE "User not authenticated with Github."
-        Just token -> action token
+        Nothing      -> throwE "User not authenticated with Github."
+        Just ghToken -> action ghToken
 
 createInitialCommitIfNecessary :: (MonadBaseControl IO m, MonadIO m) => QSem -> AccessToken -> Text -> Text -> ExceptT Text m (Maybe Text)
 createInitialCommitIfNecessary githubSemaphore accessToken owner repository = do

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -36,6 +36,8 @@ import           Utopia.Web.Editor.Branches
 import           Utopia.Web.Endpoints
 import           Utopia.Web.Executors.Common
 import           Utopia.Web.Github
+import           Utopia.Web.Liveblocks
+import           Utopia.Web.Liveblocks.Types
 import           Utopia.Web.Logging
 import           Utopia.Web.Metrics
 import           Utopia.Web.Packager.Locking
@@ -69,6 +71,7 @@ data ProductionServerResources = ProductionServerResources
                                , _cdnHost                 :: Text
                                , _logger                  :: FastLogger
                                , _loggerShutdown          :: IO ()
+                               , _liveblocksResources     :: LiveblocksResources
                                }
 
 type ProductionProcessMonad a = ServerProcessMonad ProductionServerResources a
@@ -323,6 +326,14 @@ innerServerExecutor (GetGithubUserDetails user action) = do
   pool <- fmap _projectPool ask
   result <- getDetailsOfGithubUser githubSemaphore githubResources logger metrics pool user
   pure $ action result
+innerServerExecutor (AuthLiveblocksUser user roomID action) = do
+  liveblocksResources <- fmap _liveblocksResources ask
+  metrics <- fmap _databaseMetrics ask
+  pool <- fmap _projectPool ask
+  errorOrToken <- liftIO $ authorizeUserForLiveblocksProjectRoom liveblocksResources metrics pool user roomID
+  case errorOrToken of
+    Left errorMessage -> putStrLn errorMessage >> throwError err500
+    Right token       -> pure $ action token
 
 readEditorContentFromDisk :: Maybe BranchDownloads -> Maybe Text -> Text -> IO Text
 readEditorContentFromDisk (Just downloads) (Just branchName) fileName = do
@@ -379,6 +390,8 @@ initialiseResources = do
   _locksRef <- newIORef mempty
   _matchingVersionsCache <- newMatchingVersionsCache
   (_logger, _loggerShutdown) <- newFastLogger (LogStdout defaultBufSize)
+  maybeLiveblocksResources <- makeLiveblocksResources
+  _liveblocksResources <- maybe (panic "No Liveblocks environment configured.") pure maybeLiveblocksResources
   return $ ProductionServerResources{..}
 
 startup :: ProductionServerResources -> IO Stop

--- a/server/src/Utopia/Web/Liveblocks.hs
+++ b/server/src/Utopia/Web/Liveblocks.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE ApplicativeDo          #-}
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE DeriveGeneric          #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE OverloadedStrings      #-}
+{-# LANGUAGE RankNTypes             #-}
+{-# LANGUAGE RecordWildCards        #-}
+{-# LANGUAGE TemplateHaskell        #-}
+{-# LANGUAGE TypeApplications       #-}
+{-# LANGUAGE TypeOperators          #-}
+
+module Utopia.Web.Liveblocks where
+
+import           Control.Lens
+import           Control.Monad.Trans.Except
+import           Control.Monad.Trans.Maybe
+import           Data.Aeson
+import           Data.Aeson.TH
+import           Data.Generics.Product
+import           Data.Generics.Sum
+import qualified Data.HashMap.Strict         as M
+import qualified Data.Text                   as T
+import           Network.HTTP.Client         (Manager, newManager)
+import           Network.HTTP.Client.TLS
+import           Network.HTTP.Types.Status
+import           Protolude                   hiding (Handler, toUpper)
+import           Servant
+import           Servant.Client
+import           System.Environment
+import           Utopia.Web.Database
+import           Utopia.Web.Database.Types
+import           Utopia.Web.JSON
+import           Utopia.Web.Liveblocks.API
+import           Utopia.Web.Liveblocks.Types
+
+makeLiveblocksResources :: IO (Maybe LiveblocksResources)
+makeLiveblocksResources = runMaybeT $ do
+  let liveblocksHost = "api.liveblocks.io"
+  secretKey <- fmap toS $ MaybeT $ lookupEnv "LIVEBLOCKS_SECRET_KEY"
+  let liveblocksBaseUrl = BaseUrl Https liveblocksHost 443 ""
+  liveblocksManager <- lift $ newManager tlsManagerSettings
+  let liveblocksClientEnv = mkClientEnv liveblocksManager liveblocksBaseUrl
+  pure $ LiveblocksResources
+       { _clientEnv = liveblocksClientEnv
+       , _secretKey = secretKey
+       }
+
+-- Parse out a project ID given a room ID used in Liveblocks.
+projectIDFromRoomID :: Text -> Either Text Text
+projectIDFromRoomID roomID =
+  let expectedPrefix = "project-room-"
+      isProjectRoom = T.isPrefixOf expectedPrefix roomID
+  in  if isProjectRoom then Right (T.drop (T.length expectedPrefix) roomID) else Left ("No projectID found for " <> roomID)
+
+ignoreConflicts :: ClientError -> ExceptT ClientError IO ()
+ignoreConflicts error@(FailureResponse _ response) = if responseStatusCode response == conflict409 then pure () else throwE error
+ignoreConflicts otherErrors = throwE otherErrors
+
+authorizeUserForLiveblocksProjectRoom :: LiveblocksResources -> DatabaseMetrics -> DBPool -> Text -> Text -> IO (Either Text Text)
+authorizeUserForLiveblocksProjectRoom liveblocksResources metrics pool userID roomID = runExceptT $ do
+  -- Try to identify the project ID for this room.
+  projectID <- except $ projectIDFromRoomID roomID
+  -- Authorize the user with Liveblocks, so we can obtain the token that the front end will use to access Liveblocks services.
+  token <- withExceptT show
+            $ ExceptT
+            $ authorizeUserWithLiveblocks liveblocksResources userID
+  -- Check if this user is the owner of the project.
+  isOwner <- lift $ checkIfProjectOwner metrics pool userID projectID
+  -- Don't need this with later versions of transformers.
+  let handleE = flip catchE
+  -- If the user is the owner, create the room in Liveblocks, ignoring a 409 which indicates the room already exists.
+  when isOwner
+    $ withExceptT show
+    $ handleE ignoreConflicts
+    $ ExceptT
+    $ createLiveblocksRoom liveblocksResources roomID
+  pure token

--- a/server/src/Utopia/Web/Liveblocks/API.hs
+++ b/server/src/Utopia/Web/Liveblocks/API.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE DeriveGeneric          #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE OverloadedStrings      #-}
+{-# LANGUAGE RankNTypes             #-}
+{-# LANGUAGE RecordWildCards        #-}
+{-# LANGUAGE TemplateHaskell        #-}
+{-# LANGUAGE TypeApplications       #-}
+{-# LANGUAGE TypeOperators          #-}
+
+module Utopia.Web.Liveblocks.API where
+
+import           Control.Lens
+import           Control.Monad.Trans.Maybe
+import           Data.Aeson
+import           Data.Aeson.TH
+import           Data.Generics.Product
+import           Data.Generics.Sum
+import qualified Data.HashMap.Strict         as M
+import           Network.HTTP.Client         (Manager, newManager)
+import           Network.HTTP.Client.TLS
+import           Protolude                   hiding (Handler, toUpper)
+import           Servant
+import           Servant.Client
+import           System.Environment
+import           Utopia.Web.JSON
+import           Utopia.Web.Liveblocks.Types
+
+getBearer :: LiveblocksResources -> Text
+getBearer liveblocksResources =
+  let secretKey = view (field @"_secretKey") liveblocksResources
+  in  ("Bearer " <> secretKey)
+
+authorizeUserWithLiveblocks :: LiveblocksResources -> Text -> IO (Either ClientError Text)
+authorizeUserWithLiveblocks liveblocksResources userID = (flip runClientM) (_clientEnv liveblocksResources) $ do
+  let liveblocksRequest = LiveblocksAuthorizeUserRequest
+                        { _userId = userID
+                        , _permissions = M.singleton "project-room-*" ["room:write"]
+                        }
+  liveblocksResponse <- liveblocksAuthorizeUser (getBearer liveblocksResources) liveblocksRequest
+  pure $ view (field @"_token") liveblocksResponse
+
+createLiveblocksRoom :: LiveblocksResources -> Text -> IO (Either ClientError ())
+createLiveblocksRoom liveblocksResources roomID = (flip runClientM) (_clientEnv liveblocksResources) $ do
+  let liveblocksRequest = LiveblocksCreateRoomRequest
+                        { _id              = roomID
+                        , _defaultAccesses = ["room:write"]
+                        }
+  _ <- liveblocksCreateRoom (getBearer liveblocksResources) liveblocksRequest
+  pure ()
+
+updateLiveblocksRoom :: LiveblocksResources -> Text -> IO (Either ClientError ())
+updateLiveblocksRoom liveblocksResources roomID = (flip runClientM) (_clientEnv liveblocksResources) $ do
+  let liveblocksRequest = LiveblocksUpdateRoomRequest
+                        { _defaultAccesses    = ["room:write"]
+                        }
+  _ <- liveblocksUpdateRoom roomID (getBearer liveblocksResources) liveblocksRequest
+  pure ()
+

--- a/server/src/Utopia/Web/Liveblocks/Types.hs
+++ b/server/src/Utopia/Web/Liveblocks/Types.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE DeriveGeneric          #-}
+{-# LANGUAGE DuplicateRecordFields  #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE OverloadedStrings      #-}
+{-# LANGUAGE RankNTypes             #-}
+{-# LANGUAGE RecordWildCards        #-}
+{-# LANGUAGE TemplateHaskell        #-}
+{-# LANGUAGE TypeApplications       #-}
+{-# LANGUAGE TypeOperators          #-}
+
+module Utopia.Web.Liveblocks.Types where
+
+import           Control.Lens
+import           Control.Monad.Trans.Maybe
+import           Data.Aeson
+import           Data.Aeson.TH
+import           Data.Generics.Product
+import           Data.Generics.Sum
+import qualified Data.HashMap.Strict       as M
+import           Network.HTTP.Client       (Manager, newManager)
+import           Network.HTTP.Client.TLS
+import           Protolude                 hiding (Handler, toUpper)
+import           Servant
+import           Servant.Client
+import           System.Environment
+import           Utopia.Web.JSON
+
+data LiveblocksResources = LiveblocksResources
+                         { _clientEnv :: ClientEnv
+                         , _secretKey :: Text
+                         } deriving (Generic)
+
+data LiveblocksAuthorizeUserRequest = LiveblocksAuthorizeUserRequest
+                                    { _userId      :: Text
+                                    , _permissions :: M.HashMap Text [Text]
+                                    } deriving (Eq, Show, Generic)
+
+$(deriveJSON jsonOptions ''LiveblocksAuthorizeUserRequest)
+
+data LiveblocksAuthorizeUserResponse = LiveblocksAuthorizeUserResponse
+                                     { _token :: Text
+                                     } deriving (Eq, Show, Generic)
+
+$(deriveJSON jsonOptions ''LiveblocksAuthorizeUserResponse)
+
+data LiveblocksUpdateRoomRequest = LiveblocksUpdateRoomRequest
+                                 { _defaultAccesses   :: [Text]
+                                 } deriving (Eq, Show, Generic)
+
+$(deriveJSON jsonOptions ''LiveblocksUpdateRoomRequest)
+
+data LiveblocksUpdateRoomResponse = LiveblocksUpdateRoomResponse
+                                     {
+                                     } deriving (Eq, Show, Generic)
+
+$(deriveJSON jsonOptions ''LiveblocksUpdateRoomResponse)
+
+data LiveblocksCreateRoomRequest = LiveblocksCreateRoomRequest
+                                 { _id              :: Text
+                                 , _defaultAccesses :: [Text]
+                                 } deriving (Eq, Show, Generic)
+
+$(deriveJSON jsonOptions ''LiveblocksCreateRoomRequest)
+
+data LiveblocksCreateRoomResponse = LiveblocksCreateRoomResponse
+                                     {
+                                     } deriving (Eq, Show, Generic)
+
+$(deriveJSON jsonOptions ''LiveblocksCreateRoomResponse)
+
+type LiveblocksAuthorizeUserAPI = "v2" :> "authorize-user" :> Header' '[Required, Strict] "Authorization" Text :> ReqBody '[JSON] LiveblocksAuthorizeUserRequest :> Post '[JSON] LiveblocksAuthorizeUserResponse
+
+type LiveblocksUpdateRoomAPI = "v2" :> "rooms" :> Header' '[Required, Strict] "Authorization" Text :> Capture "roomId" Text :> ReqBody '[JSON] LiveblocksUpdateRoomRequest :> Post '[JSON] LiveblocksUpdateRoomResponse
+
+type LiveblocksCreateRoomAPI = "v2" :> "rooms" :> Header' '[Required, Strict] "Authorization" Text :> ReqBody '[JSON] LiveblocksCreateRoomRequest :> Post '[JSON] LiveblocksCreateRoomResponse
+
+type LiveblocksAPI = LiveblocksAuthorizeUserAPI :<|> LiveblocksUpdateRoomAPI :<|> LiveblocksCreateRoomAPI
+
+liveblocksAPI :: Proxy LiveblocksAPI
+liveblocksAPI = Proxy
+
+liveblocksAuthorizeUser :: Text -> LiveblocksAuthorizeUserRequest -> ClientM LiveblocksAuthorizeUserResponse
+liveblocksUpdateRoom :: Text -> Text -> LiveblocksUpdateRoomRequest -> ClientM LiveblocksUpdateRoomResponse
+liveblocksCreateRoom :: Text -> LiveblocksCreateRoomRequest -> ClientM LiveblocksCreateRoomResponse
+liveblocksAuthorizeUser :<|> liveblocksUpdateRoom :<|> liveblocksCreateRoom = client liveblocksAPI
+

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -142,6 +142,7 @@ data ServiceCallsF a = NotFound
                      | SaveGithubAsset Text Text Text Text Text [Text] (GithubSaveAssetResponse -> a)
                      | GetPullRequestForBranch Text Text Text Text (GetBranchPullRequestResponse -> a)
                      | GetGithubUserDetails Text (GetGithubUserResponse -> a)
+                     | AuthLiveblocksUser Text Text (Text -> a)
                      deriving Functor
 
 {-
@@ -236,3 +237,12 @@ data UserConfigurationRequest = UserConfigurationRequest
                               } deriving (Eq, Show, Generic)
 
 $(makeFieldsNoPrefix ''UserConfigurationRequest)
+
+data LiveblocksAuthenticationRequest = LiveblocksAuthenticationRequest
+                                       { _room :: Text
+                                       } deriving (Eq, Show, Generic)
+
+data LiveblocksAuthenticationResponse = LiveblocksAuthenticationResponse
+                                      { _token :: Text
+                                      } deriving (Eq, Show, Generic)
+

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -51,6 +51,10 @@ $(deriveJSON jsonOptions ''UserConfigurationRequest)
 
 $(deriveJSON jsonOptions ''UserConfigurationResponse)
 
+$(deriveJSON jsonOptions ''LiveblocksAuthenticationRequest)
+
+$(deriveJSON jsonOptions ''LiveblocksAuthenticationResponse)
+
 {-
   The following types define the endpoints that we expose to the world.
   * 'Get' and 'Post' define the HTTP method used to access the endpoint,
@@ -129,6 +133,8 @@ type GithubStartAuthenticationAPI = "v1" :> "github" :> "authentication" :> "sta
 
 type GithubFinishAuthenticationAPI = "v1" :> "github" :> "authentication" :> "finish" :> QueryParam "code" ExchangeToken :> Get '[HTML] H.Html
 
+type LiveblocksAuthenticationAPI = "v1" :> "liveblocks" :> "authentication" :> ReqBody '[JSON] LiveblocksAuthenticationRequest :> Post '[JSON] LiveblocksAuthenticationResponse
+
 type GithubSaveAPI = "v1" :> "github" :> "save" :> Capture "project_id" Text :> QueryParam "branch_name" Text :> QueryParam "commit_message" Text :> ReqBody '[JSON] PersistentModel :> Post '[JSON] SaveToGithubResponse
 
 type GithubBranchesAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> Get '[JSON] GetBranchesResponse
@@ -202,6 +208,7 @@ type Protected = LogoutAPI
             :<|> GithubUsersRepositoriesAPI
             :<|> GithubSaveAssetAPI
             :<|> GithubUserAPI
+            :<|> LiveblocksAuthenticationAPI
 
 type Unprotected = AuthenticateAPI H.Html
               :<|> EmptyProjectPageAPI

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -43,6 +43,9 @@ executable utopia-web
       Utopia.Web.Github
       Utopia.Web.Github.Types
       Utopia.Web.JSON
+      Utopia.Web.Liveblocks
+      Utopia.Web.Liveblocks.API
+      Utopia.Web.Liveblocks.Types
       Utopia.Web.Logging
       Utopia.Web.Metrics
       Utopia.Web.Packager.Locking
@@ -182,6 +185,9 @@ test-suite utopia-web-test
       Utopia.Web.Github
       Utopia.Web.Github.Types
       Utopia.Web.JSON
+      Utopia.Web.Liveblocks
+      Utopia.Web.Liveblocks.API
+      Utopia.Web.Liveblocks.Types
       Utopia.Web.Logging
       Utopia.Web.Metrics
       Utopia.Web.Packager.Locking


### PR DESCRIPTION
**Problem:**
We want to integrate the work previously done for Liveblocks, but need to have the authentication be integrated with ours.

**Fix:**
This includes the smallest sliver of the previously implemented Liveblocks work in the frontend, so that it has enough to prove it works but not pull in all of the implementation of the features.

The integration of the authentication does the following:
- Take the room ID and produce a project ID from it, this may fail the request instantly if the room ID is a generated one passed in early because the Liveblocks API demands _a_ room ID.
- Authorizes the user with Liveblocks, which gives us a token.
- Checks if the user is the owner of the project, if they are then creates the room in Liveblocks.
- Returns the token to the frontend.

**Commit Details:**
- `EditorComponent` pulls in `RoomProvider` for the context it provides.
- `EditorComponentInner` includes a call to `useRoom` to check that it is connecting correctly.
- Included `liveblocks.config.ts` from the earlier collaboration work.
- In the server added a `AuthLiveblocksUser` service call.
- `LiveblocksResources` are created on startup of the server as appropriate.
- `Utopia.Web.Liveblocks.Types` module added containing the code for calling Liveblocks.
- `Utopia.Web.Liveblocks.API` module added to wrap the calls from the above module.
- `Utopia.Web.Liveblocks` module added, contains the interesting logic for calling Liveblocks authorization and creating the Liveblocks room if the user is the owner.