### PR TITLE
Liveblocks front end and server feature flagging.

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -57,6 +57,7 @@ import { isFeatureEnabled } from '../../utils/feature-switches'
 import { ProjectServerStateUpdater } from './store/project-server-state'
 import { useRoom, RoomProvider } from '../../../liveblocks.config'
 import { generateUUID } from '../../utils/utils'
+import { isLiveblocksEnabled } from './liveblocks-utils'
 
 const liveModeToastId = 'play-mode-toast'
 
@@ -514,7 +515,7 @@ export function EditorComponent(props: EditorProps) {
   return indexedDBFailed ? (
     <FatalIndexedDBErrorComponent />
   ) : (
-    <RoomProvider id={roomId} autoConnect={true} initialPresence={{}}>
+    <RoomProvider id={roomId} autoConnect={isLiveblocksEnabled()} initialPresence={{}}>
       <DndProvider backend={HTML5Backend} context={window}>
         <ProjectServerStateUpdater
           projectId={projectId}

--- a/editor/src/components/editor/liveblocks-utils.ts
+++ b/editor/src/components/editor/liveblocks-utils.ts
@@ -1,0 +1,45 @@
+import { IS_TEST_ENVIRONMENT, UTOPIA_BACKEND } from '../../common/env-vars'
+import { HEADERS, MODE } from '../../common/server'
+import { cachedPromise } from '../../core/shared/promise-utils'
+import { isFeatureEnabled } from '../../utils/feature-switches'
+
+let isLiveblocksEnabledOnServer: boolean = false
+
+export async function checkLiveblocksEnabledOnServer(): Promise<void> {
+  if (IS_TEST_ENVIRONMENT) {
+    isLiveblocksEnabledOnServer = false
+  } else {
+    return cachedPromise('liveblocks-enabled', async () => {
+      try {
+        const response = await fetch(`${UTOPIA_BACKEND}liveblocks/enabled`, {
+          method: 'GET',
+          credentials: 'include',
+          headers: HEADERS,
+          mode: MODE,
+        })
+        if (response.ok) {
+          const jsonResponse = await response.json()
+          if (typeof jsonResponse === 'boolean') {
+            isLiveblocksEnabledOnServer = jsonResponse
+          } else {
+            console.error(
+              `Invalid response body when checking Liveblocks availability: ${JSON.stringify(
+                jsonResponse,
+              )}`,
+            )
+          }
+        } else {
+          console.error(
+            `Unexpected response when checking Liveblocks availability (${response.status}): ${response.statusText}`,
+          )
+        }
+      } catch (error) {
+        console.error('Error response when checking Liveblocks availability.', error)
+      }
+    })
+  }
+}
+
+export function isLiveblocksEnabled(): boolean {
+  return isLiveblocksEnabledOnServer && isFeatureEnabled('Collaboration')
+}

--- a/editor/src/templates/editor-entry-point-imports.tsx
+++ b/editor/src/templates/editor-entry-point-imports.tsx
@@ -10,6 +10,10 @@ import '../vite-shims'
 import { loadFeatureSwitches } from '../utils/feature-switches'
 await loadFeatureSwitches()
 
+// Check to see if the server supports Liveblocks currently.
+import { checkLiveblocksEnabledOnServer } from '../components/editor/liveblocks-utils'
+await checkLiveblocksEnabledOnServer()
+
 // Fire off server requests that later block, to improve initial load on slower connections. These will still block,
 // but this gives us a chance to cache the result first
 import { getLoginState } from '../common/server'

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -13,6 +13,7 @@ export type FeatureName =
   | 'Canvas Strategies Debug Panel'
   | 'Project Thumbnail Generation'
   | 'Debug - Print UIDs'
+  | 'Collaboration'
 
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
@@ -26,6 +27,7 @@ export const AllFeatureNames: FeatureName[] = [
   'Canvas Strategies Debug Panel',
   'Project Thumbnail Generation',
   'Debug - Print UIDs',
+  'Collaboration',
 ]
 
 let FeatureSwitches: { [feature in FeatureName]: boolean } = {
@@ -39,6 +41,7 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Canvas Strategies Debug Panel': false,
   'Project Thumbnail Generation': false,
   'Debug - Print UIDs': false,
+  Collaboration: false,
 }
 
 let FeatureSwitchLoaded: { [feature in FeatureName]?: boolean } = {}

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -711,6 +711,11 @@ liveblocksAuthenticationEndpoint cookie authBody = requireUser cookie $ \session
   token <- authLiveblocksUser (view (field @"_id") sessionUser) roomID
   pure $ LiveblocksAuthenticationResponse { _token = token }
 
+liveblocksEnabledEndpoint :: ServerMonad Bool
+liveblocksEnabledEndpoint = do
+  liveblocksEnabled <- isLiveblocksEnabled
+  pure liveblocksEnabled
+
 {-|
   Compose together all the individual endpoints into a definition for the whole server.
 -}
@@ -757,6 +762,7 @@ unprotected = authenticate
          :<|> loadProjectFileEndpoint
          :<|> loadProjectFileEndpoint
          :<|> loadProjectThumbnailEndpoint
+         :<|> liveblocksEnabledEndpoint
          :<|> monitoringEndpoint
          :<|> clearBranchCacheEndpoint
          :<|> packagePackagerEndpoint

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -432,6 +432,9 @@ innerServerExecutor (AuthLiveblocksUser user roomID action) = do
       case errorOrToken of
         Left errorMessage -> putStrLn errorMessage >> throwError err500
         Right token       -> pure $ action token
+innerServerExecutor (IsLiveblocksEnabled action) = do
+  possibleLiveblocksResources <- fmap _liveblocksResources ask
+  pure $ action $ isJust possibleLiveblocksResources
 
 {-|
   Invokes a service call using the supplied resources.

--- a/server/src/Utopia/Web/Liveblocks/Types.hs
+++ b/server/src/Utopia/Web/Liveblocks/Types.hs
@@ -67,7 +67,7 @@ data LiveblocksCreateRoomRequest = LiveblocksCreateRoomRequest
 $(deriveJSON jsonOptions ''LiveblocksCreateRoomRequest)
 
 data LiveblocksCreateRoomResponse = LiveblocksCreateRoomResponse
-                                     {
+                                     { _id     :: Text
                                      } deriving (Eq, Show, Generic)
 
 $(deriveJSON jsonOptions ''LiveblocksCreateRoomResponse)

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -143,6 +143,7 @@ data ServiceCallsF a = NotFound
                      | GetPullRequestForBranch Text Text Text Text (GetBranchPullRequestResponse -> a)
                      | GetGithubUserDetails Text (GetGithubUserResponse -> a)
                      | AuthLiveblocksUser Text Text (Text -> a)
+                     | IsLiveblocksEnabled (Bool -> a)
                      deriving Functor
 
 {-

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -135,6 +135,8 @@ type GithubFinishAuthenticationAPI = "v1" :> "github" :> "authentication" :> "fi
 
 type LiveblocksAuthenticationAPI = "v1" :> "liveblocks" :> "authentication" :> ReqBody '[JSON] LiveblocksAuthenticationRequest :> Post '[JSON] LiveblocksAuthenticationResponse
 
+type LiveblocksEnabledAPI = "v1" :> "liveblocks" :> "enabled" :> Get '[JSON] Bool
+
 type GithubSaveAPI = "v1" :> "github" :> "save" :> Capture "project_id" Text :> QueryParam "branch_name" Text :> QueryParam "commit_message" Text :> ReqBody '[JSON] PersistentModel :> Post '[JSON] SaveToGithubResponse
 
 type GithubBranchesAPI = "v1" :> "github" :> "branches" :> Capture "owner" Text :> Capture "repository" Text :> Get '[JSON] GetBranchesResponse
@@ -224,6 +226,7 @@ type Unprotected = AuthenticateAPI H.Html
               :<|> LoadProjectFileAPI
               :<|> PreviewProjectFileAPI
               :<|> LoadProjectThumbnailAPI
+              :<|> LiveblocksEnabledAPI
               :<|> MonitoringAPI
               :<|> ClearBranchAPI
               :<|> PackagePackagerAPI


### PR DESCRIPTION
**Problem:**
Currently Liveblocks support is enabled by default and tries to talk to the authentication endpoint repeatedly even if that environment is not configured for Liveblocks.

**Fix:**
The focal point of this fix is `isLiveblocksEnabled`, which checks not only the feature flag `Collaboration` but also checks a value populated from the server on startup that determines if the server is configured for Liveblocks. That is used to prevent auto connection to Liveblocks on the `RoomProvider` component.

**Commit Details:**
- Added feature flag `Collaboration`.
- Added `checkLiveblocksEnabledOnServer` which calls the endpoint on the server to check if the server has Liveblocks enabled.
- Added `isLiveblocksEnabled` which checks the server feature setting and the local feature switch.
- The `RoomProvider` property `autoConnect` is now assigned to the result of `isLiveblocksEnabled`.
- `checkLiveblocksEnabledOnServer` is executed in `editor-entry-point-imports.tsx`.
- Added `IsLiveblocksEnabled` server service type.
- Added endpoint to the server for querying the result of `isLiveblocksEnabled`.
- `_liveblocksResources` for production is now optional.
