### PR TITLE
Fix/inspector resize to fit

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/group-conversion-helpers.ts
@@ -489,8 +489,11 @@ export function convertSizelessDivToFrameCommands(
   elementPath: ElementPath,
 ): CanvasCommand[] | null {
   const element = MetadataUtils.findElementByElementPath(metadata, elementPath)
-
-  const childrenBoundingFrame = MetadataUtils.getFrameInCanvasCoords(elementPath, metadata)
+  const childrenBoundingFrame = MetadataUtils.getBoundingRectangleOfChildren(
+    metadata,
+    pathTrees,
+    elementPath,
+  )
   if (childrenBoundingFrame == null || isInfinityRectangle(childrenBoundingFrame)) {
     return null
   }

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -44,6 +44,7 @@ import {
 import {
   setPropFillStrategies,
   setPropHugStrategies,
+  setPropHugAbsoluteStrategies,
 } from './inspector-strategies/inspector-strategies'
 import { commandsForFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
 import type { Size } from '../../core/shared/math-utils'
@@ -896,6 +897,14 @@ export function resizeToFitCommands(
       setPropHugStrategies(metadata, selectedViews, elementPathTree, 'vertical'),
     ) ?? []),
   ]
+
+  if (commands.length == 0) {
+    return (
+      commandsForFirstApplicableStrategy(
+        setPropHugAbsoluteStrategies(metadata, selectedViews, elementPathTree, allElementProps),
+      ) ?? []
+    )
+  }
   return commands
 }
 

--- a/editor/src/components/inspector/inspector-strategies/hug-contents-basic-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/hug-contents-basic-strategy.ts
@@ -1,6 +1,10 @@
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import type { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
+import {
+  isJSXElementLike,
+  type ElementInstanceMetadataMap,
+  jsxFragment,
+} from '../../../core/shared/element-template'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
 import type { CanvasCommand } from '../../canvas/commands/commands'
@@ -26,6 +30,17 @@ import {
 import type { InspectorStrategy } from './inspector-strategy'
 import { queueTrueUpElement } from '../../canvas/commands/queue-true-up-command'
 import { trueUpGroupElementChanged } from '../../../components/editor/store/editor-state'
+import type { AllElementProps } from '../../../components/editor/store/editor-state'
+import { mapDropNulls } from '../../../core/shared/array-utils'
+import { actuallyConvertFramentToFrame } from '../../canvas/canvas-strategies/strategies/group-conversion-helpers'
+import type { JSXFragmentConversion } from '../../canvas/canvas-strategies/strategies/group-conversion-helpers'
+import {
+  boundingRectangleArray,
+  nullIfInfinity,
+  zeroCanvasRect,
+} from '../../../core/shared/math-utils'
+import { isLeft } from '../../../core/shared/either'
+import { convertToAbsolute } from '../../canvas/commands/convert-to-absolute-command'
 
 const CHILDREN_CONVERTED_TOAST_ID = 'CHILDREN_CONVERTED_TOAST_ID'
 
@@ -104,5 +119,54 @@ export const hugContentsBasicStrategy = (
     }
 
     return elements.flatMap((path) => hugContentsSingleElement(axis, metadata, pathTrees, path))
+  },
+})
+export const hugContentsAbsoluteStrategy = (
+  metadata: ElementInstanceMetadataMap,
+  targets: ElementPath[],
+  pathTrees: ElementPathTrees,
+  allElementProps: AllElementProps,
+): InspectorStrategy => ({
+  name: 'Set to Hug Absolute',
+  strategy: () => {
+    const targetsWithOnlyAbsoluteChildren = targets.filter((target) => {
+      const children = MetadataUtils.getChildrenOrdered(metadata, pathTrees, target)
+      return children.length > 0 && children.every(MetadataUtils.isPositionAbsolute)
+    })
+
+    if (targetsWithOnlyAbsoluteChildren.length === 0) {
+      return null
+    }
+
+    return targetsWithOnlyAbsoluteChildren.flatMap((path) => {
+      const element = MetadataUtils.findElementByElementPath(metadata, path)
+      if (element == null || isLeft(element.element) || !isJSXElementLike(element.element.value)) {
+        return []
+      }
+      const childInstances = mapDropNulls(
+        (childPath) => MetadataUtils.findElementByElementPath(metadata, childPath),
+        MetadataUtils.getChildrenPathsOrdered(metadata, pathTrees, path),
+      )
+
+      const childrenBoundingFrame =
+        boundingRectangleArray(
+          mapDropNulls(
+            (rect) => nullIfInfinity(rect),
+            childInstances.map((c) => c.globalFrame),
+          ),
+        ) ?? zeroCanvasRect
+
+      // well this looks like a fake fragment
+      const instance: JSXFragmentConversion = {
+        element: jsxFragment(element.element.value.uid, element.element.value.children, false),
+        childInstances: childInstances,
+        childrenBoundingFrame: childrenBoundingFrame,
+        specialSizeMeasurements: { ...element.specialSizeMeasurements, position: 'absolute' }, // this is not so nice here
+      }
+      return [
+        convertToAbsolute('always', path), // should this be included in actuallyConvertFramentToFrame??
+        ...actuallyConvertFramentToFrame(metadata, pathTrees, instance, path),
+      ]
+    })
   },
 })

--- a/editor/src/components/inspector/inspector-strategies/hug-contents-basic-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/hug-contents-basic-strategy.ts
@@ -1,10 +1,6 @@
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import {
-  isJSXElementLike,
-  type ElementInstanceMetadataMap,
-  jsxFragment,
-} from '../../../core/shared/element-template'
+import { type ElementInstanceMetadataMap } from '../../../core/shared/element-template'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
 import type { CanvasCommand } from '../../canvas/commands/commands'
@@ -31,20 +27,7 @@ import type { InspectorStrategy } from './inspector-strategy'
 import { queueTrueUpElement } from '../../canvas/commands/queue-true-up-command'
 import { trueUpGroupElementChanged } from '../../../components/editor/store/editor-state'
 import type { AllElementProps } from '../../../components/editor/store/editor-state'
-import { mapDropNulls } from '../../../core/shared/array-utils'
-import {
-  actuallyConvertFramentToFrame,
-  convertSizelessDivToFrameCommands,
-} from '../../canvas/canvas-strategies/strategies/group-conversion-helpers'
-import type { JSXFragmentConversion } from '../../canvas/canvas-strategies/strategies/group-conversion-helpers'
-import {
-  boundingRectangleArray,
-  isInfinityRectangle,
-  nullIfInfinity,
-  zeroCanvasRect,
-} from '../../../core/shared/math-utils'
-import { isLeft } from '../../../core/shared/either'
-import { convertToAbsolute } from '../../canvas/commands/convert-to-absolute-command'
+import { convertSizelessDivToFrameCommands } from '../../canvas/canvas-strategies/strategies/group-conversion-helpers'
 
 const CHILDREN_CONVERTED_TOAST_ID = 'CHILDREN_CONVERTED_TOAST_ID'
 

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.ts
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.ts
@@ -13,7 +13,10 @@ import type { CSSNumber, FlexDirection } from '../common/css-utils'
 import { removeFlexConvertToAbsolute } from './remove-flex-convert-to-absolute-strategy'
 import type { InspectorStrategy } from './inspector-strategy'
 import type { WhenToRun } from '../../../components/canvas/commands/commands'
-import { hugContentsBasicStrategy } from './hug-contents-basic-strategy'
+import {
+  hugContentsAbsoluteStrategy,
+  hugContentsBasicStrategy,
+} from './hug-contents-basic-strategy'
 import {
   fillContainerStrategyFlexParent,
   fillContainerStrategyFlow,
@@ -202,6 +205,15 @@ export const setPropHugStrategies = (
   pathTrees: ElementPathTrees,
   axis: Axis,
 ): Array<InspectorStrategy> => [hugContentsBasicStrategy(metadata, elementPaths, pathTrees, axis)]
+
+export const setPropHugAbsoluteStrategies = (
+  metadata: ElementInstanceMetadataMap,
+  elementPaths: ElementPath[],
+  pathTrees: ElementPathTrees,
+  allElementProps: AllElementProps,
+): Array<InspectorStrategy> => [
+  hugContentsAbsoluteStrategy(metadata, elementPaths, pathTrees, allElementProps),
+]
 
 export const setSpacingModeSpaceBetweenStrategies = (
   metadata: ElementInstanceMetadataMap,

--- a/editor/src/components/inspector/resize-to-fit-control.spec.browser2.tsx
+++ b/editor/src/components/inspector/resize-to-fit-control.spec.browser2.tsx
@@ -109,9 +109,9 @@ describe('Resize to fit control', () => {
     const editor = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
         <div data-uid='component-root'>
-          <div data-uid='container'>
-          <div data-uid='child1' style={{position: 'absolute', left: 50, top: 40, width: 122, height: 112}} />
-          <div data-uid='child2' style={{position: 'absolute', left: 60, top: 30, height: 22}}>hello div</div>
+          <div data-uid='container' style={{backgroundColor: 'red'}}>
+            <div data-uid='child1' style={{position: 'absolute', left: 50, top: 40, width: 122, height: 112, backgroundColor: 'lavender'}} />
+            <div data-uid='child2' style={{position: 'absolute', left: 60, top: 30, height: 22, backgroundColor: 'mistyrose'}}>hello div</div>
         </div>
         </div>
     `),
@@ -130,9 +130,9 @@ describe('Resize to fit control', () => {
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
         `<div data-uid='component-root'>
-          <div data-uid='container' style={{position: 'absolute', top: 30, left: 50, width: 122, height: 122}}>
-            <div data-uid='child1' style={{position: 'absolute', left: 0, top: 10, width: 122, height: 112}} />
-            <div data-uid='child2' style={{position: 'absolute', left: 10, top: 0, height: 22}}>hello div</div>
+          <div data-uid='container' style={{backgroundColor: 'red', position: 'absolute', top: 30, left: 50, width: 122, height: 122}}>
+            <div data-uid='child1' style={{position: 'absolute', left: 0, top: 10, width: 122, height: 112, backgroundColor: 'lavender'}} />
+            <div data-uid='child2' style={{position: 'absolute', left: 10, top: 0, height: 22, backgroundColor: 'mistyrose'}}>hello div</div>
           </div>
         </div>`,
       ),

--- a/editor/src/components/inspector/resize-to-fit-control.tsx
+++ b/editor/src/components/inspector/resize-to-fit-control.tsx
@@ -68,7 +68,9 @@ const isApplicableSelector = createCachedSelector(
 
     const children = MetadataUtils.getChildrenOrdered(metadata, pathTrees, firstSelectedView)
     const targetsWithOnlyAbsoluteChildren =
-      children.length > 0 && children.every(MetadataUtils.isPositionAbsolute)
+      children.length > 0 &&
+      children.every(MetadataUtils.isPositionAbsolute) &&
+      !treatElementAsGroupLike(metadata, firstSelectedView)
 
     const isApplicable: boolean =
       targetsWithOnlyAbsoluteChildren ||

--- a/editor/src/components/inspector/resize-to-fit-control.tsx
+++ b/editor/src/components/inspector/resize-to-fit-control.tsx
@@ -21,6 +21,7 @@ import * as EP from '../../core/shared/element-path'
 import { assertNever } from '../../core/shared/utils'
 import type { ElementPath } from '../../core/shared/project-file-types'
 import type { ElementInstanceMetadataMap } from '../../core/shared/element-template'
+import { MetadataUtils } from '../../core/model/element-metadata-utils'
 
 export const ResizeToFitControlTestId = 'ResizeToFitControlTestId'
 export const ResizeToFillControlTestId = 'ResizeToFillControlTestId'
@@ -65,10 +66,16 @@ const isApplicableSelector = createCachedSelector(
       return false
     }
 
+    const children = MetadataUtils.getChildrenOrdered(metadata, pathTrees, firstSelectedView)
+    const targetsWithOnlyAbsoluteChildren =
+      children.length > 0 && children.every(MetadataUtils.isPositionAbsolute)
+
     const isApplicable: boolean =
-      selectedViews.length > 0 &&
-      checkGroupSuitability(metadata, firstSelectedView, mode) &&
-      getFixedFillHugOptionsForElement(metadata, pathTrees, firstSelectedView).has(mode)
+      targetsWithOnlyAbsoluteChildren ||
+      (selectedViews.length > 0 &&
+        checkGroupSuitability(metadata, firstSelectedView, mode) &&
+        getFixedFillHugOptionsForElement(metadata, pathTrees, firstSelectedView).has(mode))
+
     const isAlreadyApplied = isFixedHugFillModeApplied(metadata, firstSelectedView, mode)
     return isApplicable && !isAlreadyApplied
   },

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1395,6 +1395,17 @@ export const MetadataUtils = {
       return boundingRectangleArray(nonInfinityFrames)
     }
   },
+  getBoundingRectangleOfChildren(
+    metadata: ElementInstanceMetadataMap,
+    pathTree: ElementPathTrees,
+    path: ElementPath,
+  ): MaybeInfinityCanvasRectangle | null {
+    const aabb = MetadataUtils.getBoundingRectangleInCanvasCoords(
+      MetadataUtils.getChildrenPathsOrdered(metadata, pathTree, path),
+      metadata,
+    )
+    return aabb
+  },
   getFrame(
     path: ElementPath,
     metadata: ElementInstanceMetadataMap,


### PR DESCRIPTION
**Problem:**
Resize to fit button is not available for elements with absolute children.

**Fix:**
When an element has only absolute children resize to fit resizes the target element to its children's bounding box. With flow children the behaviour is unchanged.

**Commit Details:**  
- enable the button with absolute children (excluding groups)
- use `convertSizelessDivToFrameCommands` to apply the children bounding box as a frame
- added a test

