### PR TITLE
Pick (possibly) unique colors for players in the same room

### DIFF
--- a/editor/src/core/shared/array-utils.spec.ts
+++ b/editor/src/core/shared/array-utils.spec.ts
@@ -1,4 +1,10 @@
-import { aperture, intersection, mapAndFilter, strictEvery } from './array-utils'
+import {
+  aperture,
+  intersection,
+  mapAndFilter,
+  possiblyUniqueInArray,
+  strictEvery,
+} from './array-utils'
 
 describe('intersection', () => {
   it('two empty arrays should return an empty array', () => {
@@ -82,4 +88,16 @@ describe('strictEvery', () => {
     expect([1].every(() => false)).toBeFalsy()
     expect(strictEvery([1], () => false)).toBeFalsy()
   })
+})
+
+it('possiblyUniqueInArray', () => {
+  const arr = [0, 1, 2, 3, 4]
+  expect(possiblyUniqueInArray(arr, [1, 2, 4], 3)).toEqual(3)
+  expect(possiblyUniqueInArray(arr, [1, 2, 4], 4)).toEqual(0)
+  expect(possiblyUniqueInArray(arr, [1, 2, 4], 0)).toEqual(0)
+  expect(possiblyUniqueInArray(arr, [1, 2, 4], 1)).toEqual(3)
+  expect(possiblyUniqueInArray(arr, [1, 2, 4], 2)).toEqual(3)
+  expect(possiblyUniqueInArray(arr, [1, 2, 4], 5)).toEqual(5)
+  expect(possiblyUniqueInArray(arr, arr, 2)).toEqual(2)
+  expect(possiblyUniqueInArray([], [], 2)).toEqual(2)
 })

--- a/editor/src/core/shared/array-utils.ts
+++ b/editor/src/core/shared/array-utils.ts
@@ -471,3 +471,21 @@ export function isNonEmptyArray<T>(array: T[]): array is NonEmptyArray<T> {
 export function isEmptyArray<T>(array: T[]): array is [] {
   return array.length === 0
 }
+
+export function possiblyUniqueInArray(
+  array: number[],
+  existing: (number | null)[],
+  start: number,
+): number {
+  let index = start
+  while (existing.includes(index)) {
+    index++
+    if (index >= array.length) {
+      index = 0
+    }
+    if (index === start) {
+      return start
+    }
+  }
+  return index
+}

--- a/editor/src/core/shared/multiplayer.ts
+++ b/editor/src/core/shared/multiplayer.ts
@@ -1,6 +1,6 @@
 import type { User } from '@liveblocks/client'
 import type { Presence, UserMeta } from '../../../liveblocks.config'
-import { safeIndex, uniqBy } from './array-utils'
+import { possiblyUniqueInArray, safeIndex, uniqBy } from './array-utils'
 import { getPreferredColorScheme } from '../../uuiui'
 
 export type MultiplayerColor = {
@@ -33,6 +33,18 @@ export const multiplayerColors = {
     { background: '#FFBA08', foreground: 'black' },
     { background: '#FFFF00', foreground: 'black' },
   ],
+}
+
+function randomMultiplayerColor(): number {
+  return Math.floor(Math.random() * multiplayerColors.light.length)
+}
+
+export function possiblyUniqueColor(existing: (number | null)[]): number {
+  return possiblyUniqueInArray(
+    multiplayerColors.light.map((_, index) => index),
+    existing,
+    randomMultiplayerColor(),
+  )
 }
 
 export function multiplayerColorFromIndex(colorIndex: number | null): MultiplayerColor {


### PR DESCRIPTION
Fixes #4498

**Problem:**

The player colors are picked randomly from the list in `multiplayer.ts`. However, since there are only a few colors, there's a good chance you'll see different players with the same color in a room with few people.

**Fix:**

1. pick a random color
2. see if it's already being used by somebody else
3. if so, pick another color
4. if all colors are taken, just use the original random one