### PR TITLE
Clean steganography data when replacing prop values on copy

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
@@ -71,6 +71,7 @@ import { mapDropNulls } from '../../../../../core/shared/array-utils'
 import { treatElementAsFragmentLike } from '../fragment-like-helpers'
 import { setProperty } from '../../../commands/set-property-command'
 import type { ReparentTargetForPaste } from '../reparent-utils'
+import { cleanSteganoTextData } from '../../../../../core/shared/stegano-text'
 
 export function isAllowedToReparent(
   projectContents: ProjectContentTreeRoot,
@@ -175,6 +176,13 @@ export function replacePropsWithRuntimeValues<T extends JSXElementChild>(
   )
 }
 
+function sanitizeProp(prop: any): any {
+  if (typeof prop === 'string') {
+    return cleanSteganoTextData(prop).cleaned
+  }
+  return prop
+}
+
 export function collectValuesAtPathToReplace(
   elementProps: ElementProps,
   element: JSXElementChild,
@@ -183,10 +191,14 @@ export function collectValuesAtPathToReplace(
   const paths = getElementReferencesElsewherePathsFromProps(element, PP.create())
 
   // try and get the values from allElementProps, replace everything else with undefined
-  return paths.map((propertyPath) => ({
-    path: propertyPath,
-    value: jsExpressionValue(Utils.path(PP.getElements(propertyPath), elementProps), emptyComments),
-  }))
+  return paths.map((propertyPath) => {
+    const prop = Utils.path(PP.getElements(propertyPath), elementProps)
+
+    return {
+      path: propertyPath,
+      value: jsExpressionValue(sanitizeProp(prop), emptyComments),
+    }
+  })
 }
 
 export function getReplacePropsWithRuntimeValuesCommands(

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -40,6 +40,7 @@ import {
   expectSingleUndoNSaves,
   searchInFloatingMenu,
   selectComponentsForTest,
+  setFeatureForBrowserTestsUseInDescribeBlockOnly,
 } from '../../../utils/utils.test-utils'
 import {
   firePasteEvent,
@@ -5671,6 +5672,84 @@ export var storyboard = (
           'regular-utopia-storyboard-uid/scene-aaa/app-entity:aaa/abi/aax',
           'regular-utopia-storyboard-uid/scene-aaa/app-entity:aaa/abi/abd',
         ])
+      })
+    })
+
+    describe('Pasting with steganography enabled', () => {
+      setFeatureForBrowserTestsUseInDescribeBlockOnly('Steganography', true)
+
+      it('steganography data is cleaned from replaced props', async () => {
+        const editor = await renderTestEditorWithCode(
+          `import * as React from 'react'
+        import { Storyboard, Scene } from 'utopia-api'
+        
+        const MyComponent = ({ title }) => {
+          return <div data-uid='root'>heeeello</div>
+        }
+        
+        const hello = 'hello'
+        
+        export var storyboard = (
+          <Storyboard data-uid='sb'>
+            <Scene
+            data-uid='scene'
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                left: 567,
+                top: 486,
+                width: 288,
+                height: 362,
+              }}
+            >
+              <MyComponent data-uid='component' title={hello} />
+            </Scene>
+          </Storyboard>
+        )
+        `,
+          'await-first-dom-report',
+        )
+
+        await selectComponentsForTest(editor, [EP.fromString('sb/scene/component')])
+        await pressKey('c', { modifiers: cmdModifier })
+        await runPaste(editor)
+
+        expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+          formatTestProjectCode(`import * as React from 'react'
+        import { Storyboard, Scene } from 'utopia-api'
+
+        const MyComponent = ({ title }) => {
+          return <div data-uid='root'>heeeello</div>
+        }
+
+        const hello = 'hello'
+
+        export var storyboard = (
+          <Storyboard data-uid='sb'>
+            <Scene
+              data-uid='scene'
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                left: 567,
+                top: 486,
+                width: 288,
+                height: 362,
+              }}
+            >
+              <MyComponent data-uid='component' title={hello} />
+              <MyComponent
+                data-uid='com'
+                title='hello'
+                style={{ top: 0, left: 0, position: 'absolute' }}
+              />
+            </Scene>
+          </Storyboard>
+        )
+`),
+        )
+
+        expect(1).toEqual(1)
       })
     })
   })

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -5749,7 +5749,6 @@ export var storyboard = (
 `),
         )
 
-        expect(1).toEqual(1)
       })
     })
   })

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -5748,7 +5748,6 @@ export var storyboard = (
         )
 `),
         )
-
       })
     })
   })


### PR DESCRIPTION
## Problem
When copy-pasting an element, we replace any props coming from variables with their runtime values. However, if these props have steganography data encoded in them, we don't clean out that data, and it shows up as gibberish characters in the pasted component

## Fix
Clean the steganography data on paste

### Out of scope
Since we don't support encoding steganography data into string literals passed in props (ie `<Button label={"OK"} ... />`), the rest of the paste code doesn't need to deal with this problem yet. Solving the cleaning problem for the scenario above is deferred to after we implement steganography for props with string literals.