### PR TITLE
Remove `expect` from test dispatch

### DIFF
--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -717,7 +717,11 @@ function expectUpdatedFilesUpdateTimestamp(
 function expectNoActionsCausedDuplicateUids(
   actionsCausingDuplicateUIDs: ActionsCausingDuplicateUIDs,
 ) {
-  expect(actionsCausingDuplicateUIDs).toHaveLength(0)
+  if (actionsCausingDuplicateUIDs.length > 0) {
+    throw new Error(
+      `Actions introduced duplicate uids: ${JSON.stringify(actionsCausingDuplicateUIDs)}`,
+    )
+  }
 }
 
 export function getPrintedUiJsCode(

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -718,7 +718,13 @@ function expectNoActionsCausedDuplicateUids(
   actionsCausingDuplicateUIDs: ActionsCausingDuplicateUIDs,
 ) {
   if (actionsCausingDuplicateUIDs.length > 0) {
-    expect(actionsCausingDuplicateUIDs).toHaveLength(0)
+    expect({
+      actionsCausingDuplicateUIDs: actionsCausingDuplicateUIDs,
+      message: 'No actions have introduced duplicate uids',
+    }).toEqual({
+      actionsCausingDuplicateUIDs: actionsCausingDuplicateUIDs,
+      message: 'Some actions have introduced duplicate uids!',
+    })
   }
 }
 

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -718,9 +718,7 @@ function expectNoActionsCausedDuplicateUids(
   actionsCausingDuplicateUIDs: ActionsCausingDuplicateUIDs,
 ) {
   if (actionsCausingDuplicateUIDs.length > 0) {
-    throw new Error(
-      `Actions introduced duplicate uids: ${JSON.stringify(actionsCausingDuplicateUIDs)}`,
-    )
+    expect(actionsCausingDuplicateUIDs).toHaveLength(0)
   }
 }
 

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -894,6 +894,8 @@ describe('only update metadata on SAVE_DOM_REPORT', () => {
 
     // dispatching a no-op change to the interaction session to trigger the strategies
 
+    let testStrategyRan = false
+
     await renderResult.dispatch(
       [
         CanvasActions.updateInteractionSession(
@@ -947,6 +949,7 @@ describe('only update metadata on SAVE_DOM_REPORT', () => {
                 interactionSession.latestAllElementProps[EP.toString(targetElement)].style
                   .backgroundColor,
               ).toBeDefined()
+              testStrategyRan = true
               return strategyApplicationResult([])
             },
           },
@@ -954,6 +957,6 @@ describe('only update metadata on SAVE_DOM_REPORT', () => {
       ],
     )
 
-    expect.assertions(16) // this ensures that the test fails if the expects inside the apply function are not called
+    expect(testStrategyRan).toEqual(true)
   })
 })


### PR DESCRIPTION
## Problems
- adding `expect`s in the test dispatch function can mess with tests that assert the number of `expect` calls
- the duplicate uid check in the dispatch flow fails with a rather unhelpful message (`Expected length: 0 vs ...`)

## Fixes
- Refactor `dispatch-strategies.spec.tsx` so that it's not dependent on the number of `expect`s called
- Update the duplicate uid check so that it fails with a more bespoke error message that makes it easier to track down the problem