### PR TITLE
Single wrapper for multiplayer components

### DIFF
--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -4,19 +4,18 @@ import { jsx } from '@emotion/react'
 import React from 'react'
 import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
 import { EditorModes } from '../../editor/editor-modes'
-import { ClientSideSuspense } from '@liveblocks/react'
 import { useThreads } from '../../../../liveblocks.config'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { switchEditorMode } from '../../editor/actions/action-creators'
 import { canvasPoint } from '../../../core/shared/math-utils'
 import { UtopiaTheme } from '../../../uuiui'
-import { ErrorBoundary } from '../../../utils/react-error-boundary'
 import { Substores, useEditorState } from '../../editor/store/store-hook'
 import {
   multiplayerColorFromIndex,
   multiplayerInitialsFromName,
   normalizeMultiplayerName,
 } from '../../../core/shared/multiplayer'
+import { MultiplayerWrap } from '../../../utils/multiplayer-wrap'
 
 export const CommentIndicator = React.memo(() => {
   const projectId = useEditorState(
@@ -31,9 +30,9 @@ export const CommentIndicator = React.memo(() => {
 
   return (
     <CanvasOffsetWrapper>
-      <ErrorBoundary fallback={null}>
-        <ClientSideSuspense fallback={null}>{() => <CommentIndicatorInner />}</ClientSideSuspense>
-      </ErrorBoundary>
+      <MultiplayerWrap errorFallback={null} suspenseFallback={null}>
+        <CommentIndicatorInner />
+      </MultiplayerWrap>
     </CanvasOffsetWrapper>
   )
 })

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -15,7 +15,7 @@ import {
   multiplayerInitialsFromName,
   normalizeMultiplayerName,
 } from '../../../core/shared/multiplayer'
-import { MultiplayerWrap } from '../../../utils/multiplayer-wrap'
+import { MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
 
 export const CommentIndicator = React.memo(() => {
   const projectId = useEditorState(
@@ -30,9 +30,9 @@ export const CommentIndicator = React.memo(() => {
 
   return (
     <CanvasOffsetWrapper>
-      <MultiplayerWrap errorFallback={null} suspenseFallback={null}>
+      <MultiplayerWrapper errorFallback={null} suspenseFallback={null}>
         <CommentIndicatorInner />
-      </MultiplayerWrap>
+      </MultiplayerWrapper>
     </CanvasOffsetWrapper>
   )
 })

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -3,18 +3,17 @@ import React from 'react'
 import { Substores, useEditorState } from '../../editor/store/store-hook'
 import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
 import { isCommentMode } from '../../editor/editor-modes'
-import { ClientSideSuspense } from '@liveblocks/react'
 import { useCreateThread } from '../../../../liveblocks.config'
 import type { ComposerSubmitComment } from '@liveblocks/react-comments'
 import { Comment, Composer } from '@liveblocks/react-comments'
 import { stopPropagation } from '../../inspector/common/inspector-utils'
 import { UtopiaTheme } from '../../../uuiui'
-import { ErrorBoundary } from '../../../utils/react-error-boundary'
 import {
   useCanvasCommentThread,
   useMyMultiplayerColorIndex,
 } from '../../../core/commenting/comment-hooks'
 import { isLoggedIn } from '../../editor/action-types'
+import { MultiplayerWrap } from '../../../utils/multiplayer-wrap'
 
 export const CommentPopup = React.memo(() => {
   const mode = useEditorState(
@@ -43,11 +42,12 @@ export const CommentPopup = React.memo(() => {
         onKeyUp={stopPropagation}
         onMouseUp={stopPropagation}
       >
-        <ErrorBoundary fallback={<div>Can not load comments</div>}>
-          <ClientSideSuspense fallback={<div>Loading…</div>}>
-            {() => <CommentThread x={location.x} y={location.y} />}
-          </ClientSideSuspense>
-        </ErrorBoundary>
+        <MultiplayerWrap
+          errorFallback={<div>Can not load comments</div>}
+          suspenseFallback={<div>Loading…</div>}
+        >
+          <CommentThread x={location.x} y={location.y} />
+        </MultiplayerWrap>
       </div>
     </CanvasOffsetWrapper>
   )

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -13,7 +13,7 @@ import {
   useMyMultiplayerColorIndex,
 } from '../../../core/commenting/comment-hooks'
 import { isLoggedIn } from '../../editor/action-types'
-import { MultiplayerWrap } from '../../../utils/multiplayer-wrap'
+import { MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
 
 export const CommentPopup = React.memo(() => {
   const mode = useEditorState(
@@ -42,12 +42,12 @@ export const CommentPopup = React.memo(() => {
         onKeyUp={stopPropagation}
         onMouseUp={stopPropagation}
       >
-        <MultiplayerWrap
+        <MultiplayerWrapper
           errorFallback={<div>Can not load comments</div>}
           suspenseFallback={<div>Loading…</div>}
         >
           <CommentThread x={location.x} y={location.y} />
-        </MultiplayerWrap>
+        </MultiplayerWrapper>
       </div>
     </CanvasOffsetWrapper>
   )

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -32,7 +32,7 @@ import { FlexRow } from 'utopia-api'
 import type { StoredPanel } from './stored-layout'
 import { MultiplayerCursors } from './multiplayer-cursors'
 import { useStatus } from '../../../liveblocks.config'
-import { MultiplayerWrap } from '../../utils/multiplayer-wrap'
+import { MultiplayerWrapper } from '../../utils/multiplayer-wrapper'
 
 interface NumberSize {
   width: number
@@ -146,9 +146,9 @@ const DesignPanelRootInner = React.memo(() => {
             <CanvasWrapperComponent />
             {when(
               roomStatus === 'connected',
-              <MultiplayerWrap errorFallback={null} suspenseFallback={null}>
+              <MultiplayerWrapper errorFallback={null} suspenseFallback={null}>
                 <MultiplayerCursors />
-              </MultiplayerWrap>,
+              </MultiplayerWrapper>,
             )}
             <GridPanelsContainer />
           </SimpleFlexColumn>

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -32,7 +32,7 @@ import { FlexRow } from 'utopia-api'
 import type { StoredPanel } from './stored-layout'
 import { MultiplayerCursors } from './multiplayer-cursors'
 import { useStatus } from '../../../liveblocks.config'
-import { ClientSideSuspense } from '@liveblocks/react'
+import { MultiplayerWrap } from '../../utils/multiplayer-wrap'
 
 interface NumberSize {
   width: number
@@ -146,9 +146,9 @@ const DesignPanelRootInner = React.memo(() => {
             <CanvasWrapperComponent />
             {when(
               roomStatus === 'connected',
-              <ClientSideSuspense fallback={<div />}>
-                {() => <MultiplayerCursors />}
-              </ClientSideSuspense>,
+              <MultiplayerWrap errorFallback={null} suspenseFallback={null}>
+                <MultiplayerCursors />
+              </MultiplayerWrap>,
             )}
             <GridPanelsContainer />
           </SimpleFlexColumn>

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -12,7 +12,7 @@ import {
 import { Avatar, Tooltip, useColorTheme } from '../uuiui'
 import { Substores, useEditorState } from './editor/store/store-hook'
 import { unless, when } from '../utils/react-conditionals'
-import { MultiplayerWrap } from '../utils/multiplayer-wrap'
+import { MultiplayerWrapper } from '../utils/multiplayer-wrapper'
 
 const MAX_VISIBLE_OTHER_PLAYERS = 4
 
@@ -31,9 +31,9 @@ export const UserBar = React.memo(() => {
     return <SinglePlayerUserBar />
   } else {
     return (
-      <MultiplayerWrap errorFallback={null} suspenseFallback={null}>
+      <MultiplayerWrapper errorFallback={null} suspenseFallback={null}>
         <MultiplayerUserBar />
-      </MultiplayerWrap>
+      </MultiplayerWrapper>
     )
   }
 })

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -1,4 +1,3 @@
-import { ClientSideSuspense } from '@liveblocks/react'
 import React from 'react'
 import { useOthers, useSelf, useStatus } from '../../liveblocks.config'
 import { getUserPicture, isLoggedIn } from '../common/user'
@@ -13,6 +12,7 @@ import {
 import { Avatar, Tooltip, useColorTheme } from '../uuiui'
 import { Substores, useEditorState } from './editor/store/store-hook'
 import { unless, when } from '../utils/react-conditionals'
+import { MultiplayerWrap } from '../utils/multiplayer-wrap'
 
 const MAX_VISIBLE_OTHER_PLAYERS = 4
 
@@ -31,7 +31,9 @@ export const UserBar = React.memo(() => {
     return <SinglePlayerUserBar />
   } else {
     return (
-      <ClientSideSuspense fallback={<div />}>{() => <MultiplayerUserBar />}</ClientSideSuspense>
+      <MultiplayerWrap errorFallback={null} suspenseFallback={null}>
+        <MultiplayerUserBar />
+      </MultiplayerWrap>
     )
   }
 })

--- a/editor/src/utils/multiplayer-wrap.tsx
+++ b/editor/src/utils/multiplayer-wrap.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { ErrorBoundary } from './react-error-boundary'
+import { ClientSideSuspense } from '@liveblocks/react'
+
+export const MultiplayerWrap = React.memo(
+  (props: {
+    errorFallback: React.ReactNode
+    suspenseFallback: NonNullable<React.ReactNode> | null
+    children: any
+  }) => {
+    return (
+      <ErrorBoundary fallback={props.errorFallback}>
+        <ClientSideSuspense fallback={props.suspenseFallback}>
+          {() => props.children}
+        </ClientSideSuspense>
+      </ErrorBoundary>
+    )
+  },
+)

--- a/editor/src/utils/multiplayer-wrap.tsx
+++ b/editor/src/utils/multiplayer-wrap.tsx
@@ -2,12 +2,10 @@ import React from 'react'
 import { ErrorBoundary } from './react-error-boundary'
 import { ClientSideSuspense } from '@liveblocks/react'
 
+type Fallback = NonNullable<React.ReactNode> | null
+
 export const MultiplayerWrap = React.memo(
-  (props: {
-    errorFallback: React.ReactNode
-    suspenseFallback: NonNullable<React.ReactNode> | null
-    children: any
-  }) => {
+  (props: { errorFallback: Fallback; suspenseFallback: Fallback; children: any }) => {
     return (
       <ErrorBoundary fallback={props.errorFallback}>
         <ClientSideSuspense fallback={props.suspenseFallback}>

--- a/editor/src/utils/multiplayer-wrapper.tsx
+++ b/editor/src/utils/multiplayer-wrapper.tsx
@@ -4,7 +4,7 @@ import { ClientSideSuspense } from '@liveblocks/react'
 
 type Fallback = NonNullable<React.ReactNode> | null
 
-export const MultiplayerWrap = React.memo(
+export const MultiplayerWrapper = React.memo(
   (props: { errorFallback: Fallback; suspenseFallback: Fallback; children: any }) => {
     return (
       <ErrorBoundary fallback={props.errorFallback}>


### PR DESCRIPTION
Fix #4510 

**Problem:**

Multiplayer components need a `ClientSideSuspense` wrapper and an `ErrorBoundary` wrapper.

**Fix:**

This PR does not change the existing behavior of multiplayer components but wraps them in a shared component that provides both the error boundary and the suspense wrapper, which we can expand later on.