### PR TITLE
Remove useEffect from FollowingOverlay

### DIFF
--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -85,6 +85,7 @@ export const {
     useUpdateMyPresence,
     useSelf,
     useOthers,
+    useOthersListener,
     useOthersMapped,
     useOthersConnectionIds,
     useOther,

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -59,11 +59,11 @@ const MultiplayerUserBar = React.memo(() => {
   const dispatch = useDispatch()
   const colorTheme = useColorTheme()
 
-  const self = useSelf()
-  const myName = normalizeMultiplayerName(self.presence.name)
+  const me = useSelf()
+  const myName = normalizeMultiplayerName(me.presence.name)
 
   const others = useOthers((list) =>
-    normalizeOthersList(self.id, list).map((other) => ({
+    normalizeOthersList(me.id, list).map((other) => ({
       id: other.id,
       name: other.presence.name,
       colorIndex: other.presence.colorIndex,
@@ -96,7 +96,7 @@ const MultiplayerUserBar = React.memo(() => {
     [dispatch, mode],
   )
 
-  if (self.presence.name == null) {
+  if (me.presence.name == null) {
     // it may still be loading, so fallback until it sorts itself out
     return <SinglePlayerUserBar />
   }
@@ -160,7 +160,7 @@ const MultiplayerUserBar = React.memo(() => {
           name={multiplayerInitialsFromName(myName)}
           tooltip={`${myName} (you)`}
           color={{ background: colorTheme.bg3.value, foreground: colorTheme.fg1.value }}
-          picture={self.presence.picture}
+          picture={me.presence.picture}
         />
       </a>
     </div>

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -10,8 +10,8 @@ export function useCanvasCommentThread(x: number, y: number): ThreadData<ThreadM
 }
 
 export function useMyMultiplayerColorIndex() {
-  const self = useSelf()
-  return self.presence.colorIndex
+  const me = useSelf()
+  return me.presence.colorIndex
 }
 
 export function useAddMyselfToCollaborators() {


### PR DESCRIPTION
Fixes #4512 

This PR removes the `useEffect` in `FollowingOverlay` replacing it with `Others` callbacks.

It also renames `const self = useSelf` to `const me = useSelf`.