### PR TITLE
Avoid follow mode loops

### DIFF
--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -20,6 +20,7 @@ export type Presence = {
   canvasOffset: CanvasVector | null
   colorIndex: number | null
   picture: string | null // TODO remove this once able to resolve users
+  following: string | null
 }
 
 export function initialPresence(): Presence {
@@ -30,6 +31,7 @@ export function initialPresence(): Presence {
     canvasOffset: null,
     colorIndex: null,
     picture: null,
+    following: null,
   }
 }
 

--- a/editor/src/components/canvas/multiplayer-cursors.tsx
+++ b/editor/src/components/canvas/multiplayer-cursors.tsx
@@ -52,6 +52,11 @@ export const MultiplayerPresence = React.memo(() => {
     (store) => store.editor.canvas.roundedCanvasOffset,
     'MultiplayerPresence canvasOffset',
   )
+  const mode = useEditorState(
+    Substores.restOfEditor,
+    (store) => store.editor.mode,
+    'MultiplayerPresence mode',
+  )
 
   useAddMyselfToCollaborators()
 
@@ -64,8 +69,9 @@ export const MultiplayerPresence = React.memo(() => {
       name: normalizeMultiplayerName(loginState.user.name ?? null),
       picture: loginState.user.picture ?? null, // TODO remove this once able to resolve users
       colorIndex: getColorIndex(),
+      following: isFollowMode(mode) ? mode.playerId : null,
     })
-  }, [loginState, updateMyPresence, getColorIndex])
+  }, [loginState, updateMyPresence, getColorIndex, mode])
 
   React.useEffect(() => {
     if (!isLoggedIn(loginState)) {

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -94,7 +94,7 @@ const MultiplayerUserBar = React.memo(() => {
   const toggleFollowing = React.useCallback(
     (id: string) => () => {
       let actions: EditorAction[] = []
-      if (!canFollowTarget(self.id, id, others)) {
+      if (!canFollowTarget(me.id, id, others)) {
         actions.push(
           showToast(
             notice(
@@ -114,7 +114,7 @@ const MultiplayerUserBar = React.memo(() => {
       }
       dispatch(actions)
     },
-    [dispatch, mode, self, others],
+    [dispatch, mode, me, others],
   )
 
   if (me.presence.name == null) {

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -92,9 +92,9 @@ const MultiplayerUserBar = React.memo(() => {
   )
 
   const toggleFollowing = React.useCallback(
-    (id: string) => () => {
+    (targetId: string) => () => {
       let actions: EditorAction[] = []
-      if (!canFollowTarget(me.id, id, others)) {
+      if (!canFollowTarget(me.id, targetId, others)) {
         actions.push(
           showToast(
             notice(
@@ -107,9 +107,9 @@ const MultiplayerUserBar = React.memo(() => {
         )
       } else {
         const newMode =
-          isFollowMode(mode) && mode.playerId === id
+          isFollowMode(mode) && mode.playerId === targetId
             ? EditorModes.selectMode(null, false, 'none')
-            : EditorModes.followMode(id)
+            : EditorModes.followMode(targetId)
         actions.push(switchEditorMode(newMode))
       }
       dispatch(actions)

--- a/editor/src/core/shared/multiplayer.spec.ts
+++ b/editor/src/core/shared/multiplayer.spec.ts
@@ -1,4 +1,4 @@
-import { multiplayerInitialsFromName } from './multiplayer'
+import { canFollowTarget, multiplayerInitialsFromName } from './multiplayer'
 
 describe('multiplayer', () => {
   describe('multiplayerInitialsFromName', () => {
@@ -16,6 +16,41 @@ describe('multiplayer', () => {
     })
     it('no name at all', () => {
       expect(multiplayerInitialsFromName('')).toEqual('XX')
+    })
+  })
+
+  describe('canFollowTarget', () => {
+    it('can follow a single player', () => {
+      expect(canFollowTarget('foo', 'bar', [{ id: 'bar', following: null }])).toBe(true)
+    })
+    it('can follow a player that follows another player', () => {
+      expect(
+        canFollowTarget('foo', 'bar', [
+          { id: 'bar', following: 'baz' },
+          { id: 'baz', following: null },
+        ]),
+      ).toBe(true)
+    })
+    it('can follow a player that follows another player indirectly', () => {
+      expect(
+        canFollowTarget('foo', 'bar', [
+          { id: 'bar', following: 'baz' },
+          { id: 'baz', following: 'qux' },
+          { id: 'qux', following: null },
+        ]),
+      ).toBe(true)
+    })
+    it('cannot follow a player back', () => {
+      expect(canFollowTarget('foo', 'bar', [{ id: 'bar', following: 'foo' }])).toBe(false)
+    })
+    it('cannot follow a player that has an indirect loop', () => {
+      expect(
+        canFollowTarget('foo', 'bar', [
+          { id: 'bar', following: 'baz' },
+          { id: 'baz', following: 'qux' },
+          { id: 'qux', following: 'foo' },
+        ]),
+      ).toBe(false)
     })
   })
 })

--- a/editor/src/core/shared/multiplayer.ts
+++ b/editor/src/core/shared/multiplayer.ts
@@ -106,3 +106,22 @@ export function isDefaultAuth0AvatarURL(s: string | null): boolean {
     (s.match(reAuth0DefaultAvatarURLEncoded) != null || s.match(reAuth0DefaultAvatar) != null)
   )
 }
+
+export function canFollowTarget(
+  selfId: string,
+  targetId: string | null,
+  others: { id: string; following: string | null }[],
+): boolean {
+  let followChain: Set<string> = new Set()
+
+  let id = targetId
+  while (id != null) {
+    if (!followChain.has(id)) {
+      followChain.add(id)
+    }
+    const target = others.find((o) => o.id === id)
+    id = target?.following ?? null
+  }
+
+  return !followChain.has(selfId)
+}

--- a/editor/src/core/shared/multiplayer.ts
+++ b/editor/src/core/shared/multiplayer.ts
@@ -116,9 +116,11 @@ export function canFollowTarget(
 
   let id = targetId
   while (id != null) {
-    if (!followChain.has(id)) {
-      followChain.add(id)
+    if (followChain.has(id)) {
+      return false
     }
+    followChain.add(id)
+
     const target = others.find((o) => o.id === id)
     id = target?.following ?? null
   }


### PR DESCRIPTION
Fix #4514 

**Problem:**

It should not be possible to have follow mode loops that would lock the editor for all players (e.g. `a` → `b` → `c` → `a`).

**Fix:**

Prevent those loops when turning follow mode on.