### PR TITLE
Store user info in liveblocks room

### DIFF
--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -16,22 +16,16 @@ export const liveblocksClient = createClient({
 // and that will automatically be kept in sync. Accessible through the
 // `user.presence` property. Must be JSON-serializable.
 export type Presence = {
-  name: string | null
   cursor: WindowPoint | null
   canvasScale: number | null
   canvasOffset: CanvasVector | null
-  colorIndex: number | null
-  picture: string | null // TODO remove this once able to resolve users
 }
 
 export function initialPresence(): Presence {
   return {
-    name: null,
     cursor: null,
     canvasScale: null,
     canvasOffset: null,
-    colorIndex: null,
-    picture: null,
   }
 }
 

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -63,17 +63,6 @@ function CommentThread({ x, y }: CommentThreadProps) {
 
   const createThread = useCreateThread()
 
-  const colorIndex = useMyMultiplayerColorIndex() ?? -1
-
-  // TODO: Unify getting name in different multiplayer components
-  const loginState = useEditorState(
-    Substores.userState,
-    (store) => store.userState.loginState,
-    'CommentThread loginState',
-  )
-
-  const name = isLoggedIn(loginState) ? loginState.user.name : null
-
   const onCreateThread = React.useCallback(
     ({ body }: ComposerSubmitComment, event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault()
@@ -81,10 +70,10 @@ function CommentThread({ x, y }: CommentThreadProps) {
       // Create a new thread
       createThread({
         body,
-        metadata: { type: 'canvas', x: x, y: y, name: name ?? 'Anonymous', colorIndex: colorIndex },
+        metadata: { type: 'canvas', x: x, y: y },
       })
     },
-    [createThread, x, y, name, colorIndex],
+    [createThread, x, y],
   )
 
   if (thread == null) {

--- a/editor/src/components/canvas/multiplayer-cursors.tsx
+++ b/editor/src/components/canvas/multiplayer-cursors.tsx
@@ -12,13 +12,8 @@ import {
 import type { Presence, UserMeta } from '../../../liveblocks.config'
 import type { CanvasPoint } from '../../core/shared/math-utils'
 import { pointsEqual, windowPoint } from '../../core/shared/math-utils'
-import {
-  multiplayerColorFromIndex,
-  normalizeOthersList,
-  possiblyUniqueColor,
-} from '../../core/shared/multiplayer'
+import { multiplayerColorFromIndex, normalizeOthersList } from '../../core/shared/multiplayer'
 import { assertNever } from '../../core/shared/utils'
-import { useKeepShallowReferenceEquality } from '../../utils/react-performance'
 import { UtopiaTheme, useColorTheme } from '../../uuiui'
 import type { EditorAction } from '../editor/action-types'
 import { isLoggedIn } from '../editor/action-types'
@@ -28,6 +23,7 @@ import { useDispatch } from '../editor/store/dispatch-context'
 import { Substores, useEditorState } from '../editor/store/store-hook'
 import CanvasActions from './canvas-actions'
 import { canvasPointToWindowPoint, windowToCanvasCoordinates } from './dom-lookup'
+import { useAddMyselfToCollaborators } from '../../core/commenting/comment-hooks'
 
 export const MultiplayerPresence = React.memo(() => {
   const dispatch = useDispatch()

--- a/editor/src/components/canvas/multiplayer-cursors.tsx
+++ b/editor/src/components/canvas/multiplayer-cursors.tsx
@@ -94,8 +94,8 @@ const MultiplayerCursors = React.memo(() => {
   const others = useOthers((list) => {
     const presences = normalizeOthersList(me.id, list)
     return presences.map((p) => ({
-      presence: p,
-      user: collabs[p.id],
+      presenceInfo: p,
+      userInfo: collabs[p.id],
     }))
   })
 
@@ -110,22 +110,22 @@ const MultiplayerCursors = React.memo(() => {
     >
       {others.map((other) => {
         if (
-          other.presence.presence.cursor == null ||
-          other.presence.presence.canvasOffset == null ||
-          other.presence.presence.canvasScale == null
+          other.presenceInfo.presence.cursor == null ||
+          other.presenceInfo.presence.canvasOffset == null ||
+          other.presenceInfo.presence.canvasScale == null
         ) {
           return null
         }
         const position = windowToCanvasCoordinates(
-          other.presence.presence.canvasScale,
-          other.presence.presence.canvasOffset,
-          other.presence.presence.cursor,
+          other.presenceInfo.presence.canvasScale,
+          other.presenceInfo.presence.canvasOffset,
+          other.presenceInfo.presence.cursor,
         ).canvasPositionRounded
         return (
           <MultiplayerCursor
-            key={`cursor-${other.presence.id}`}
-            name={other.user.name}
-            colorIndex={other.user.colorIndex}
+            key={`cursor-${other.presenceInfo.id}`}
+            name={other.userInfo.name}
+            colorIndex={other.userInfo.colorIndex}
             position={position}
           />
         )

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -34,7 +34,6 @@ import { ConfirmOverwriteDialog } from '../filebrowser/confirm-overwrite-dialog'
 import { ConfirmRevertDialog } from '../filebrowser/confirm-revert-dialog'
 import { ConfirmRevertAllDialog } from '../filebrowser/confirm-revert-all-dialog'
 import { PreviewColumn } from '../preview/preview-pane'
-import TitleBar from '../titlebar/title-bar'
 import * as EditorActions from './actions/action-creators'
 import { FatalIndexedDBErrorComponent } from './fatal-indexeddb-error-component'
 import { editorIsTarget, handleKeyDown, handleKeyUp } from './global-shortcuts'
@@ -47,19 +46,19 @@ import {
 } from './store/editor-state'
 import { Substores, useEditorState, useRefEditorState } from './store/store-hook'
 import { ConfirmDisconnectBranchDialog } from '../filebrowser/confirm-branch-disconnect'
-import { unless, when } from '../../utils/react-conditionals'
+import { when } from '../../utils/react-conditionals'
 import { LowPriorityStoreProvider } from './store/store-context-providers'
 import { useDispatch } from './store/dispatch-context'
 import type { EditorAction } from './action-types'
 import { EditorCommon } from './editor-component-common'
 import { notice } from '../common/notice'
-import { isFeatureEnabled } from '../../utils/feature-switches'
 import { ProjectServerStateUpdater } from './store/project-server-state'
 import { RoomProvider, initialPresence, useRoom, initialStorage } from '../../../liveblocks.config'
 import { generateUUID } from '../../utils/utils'
 import { isLiveblocksEnabled } from './liveblocks-utils'
 import type { Storage, Presence, RoomEvent, UserMeta } from '../../../liveblocks.config'
 import LiveblocksProvider from '@liveblocks/yjs'
+import { projectIdToRoomId } from '../../core/shared/multiplayer'
 
 const liveModeToastId = 'play-mode-toast'
 
@@ -72,25 +71,6 @@ function pushProjectURLToBrowserHistory(projectId: string, projectName: string):
 }
 
 export interface EditorProps {}
-
-function useDelayedValueHook(inputValue: boolean, delayMs: number): boolean {
-  const [returnValue, setReturnValue] = React.useState(inputValue)
-  React.useEffect(() => {
-    let timerID: any = undefined
-    if (inputValue) {
-      // we do not delay the toggling if the input value is true
-      setReturnValue(true)
-    } else {
-      timerID = setTimeout(() => {
-        setReturnValue(false)
-      }, delayMs)
-    }
-    return function cleanup() {
-      clearTimeout(timerID)
-    }
-  }, [inputValue, delayMs])
-  return returnValue
-}
 
 export const EditorComponentInner = React.memo((props: EditorProps) => {
   const room = useRoom()
@@ -529,7 +509,7 @@ export function EditorComponent(props: EditorProps) {
   const dispatch = useDispatch()
 
   const roomId = React.useMemo(
-    () => (projectId == null ? generateUUID() : `project-room-${projectId}`),
+    () => (projectId == null ? generateUUID() : projectIdToRoomId(projectId)),
     [projectId],
   )
   return indexedDBFailed ? (

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -17,6 +17,7 @@ import { useDispatch } from './editor/store/dispatch-context'
 import { switchEditorMode } from './editor/actions/action-creators'
 import type { EditorAction } from './editor/action-types'
 import { EditorModes, isFollowMode } from './editor/editor-modes'
+import { useMyUserAndPresence } from '../core/commenting/comment-hooks'
 
 const MAX_VISIBLE_OTHER_PLAYERS = 4
 
@@ -61,12 +62,11 @@ const MultiplayerUserBar = React.memo(() => {
   const dispatch = useDispatch()
   const colorTheme = useColorTheme()
 
-  const me = useSelf()
-  const myUser = useStorage((store) => store.collaborators[me.id])
+  const { user: myUser } = useMyUserAndPresence()
   const myName = normalizeMultiplayerName(myUser.name)
 
   const others = useOthers((list) =>
-    normalizeOthersList(me.id, list).map((other) => ({
+    normalizeOthersList(myUser.id, list).map((other) => ({
       id: other.id,
       name: myUser.name,
       colorIndex: myUser.colorIndex,

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useOthers, useSelf, useStatus } from '../../liveblocks.config'
+import { useOthers, useSelf, useStatus, useStorage } from '../../liveblocks.config'
 import { getUserPicture, isLoggedIn } from '../common/user'
 import type { MultiplayerColor } from '../core/shared/multiplayer'
 import {
@@ -62,14 +62,15 @@ const MultiplayerUserBar = React.memo(() => {
   const colorTheme = useColorTheme()
 
   const me = useSelf()
-  const myName = normalizeMultiplayerName(me.presence.name)
+  const myUser = useStorage((store) => store.collaborators[me.id])
+  const myName = normalizeMultiplayerName(myUser.name)
 
   const others = useOthers((list) =>
     normalizeOthersList(me.id, list).map((other) => ({
       id: other.id,
-      name: other.presence.name,
-      colorIndex: other.presence.colorIndex,
-      picture: other.presence.picture, // TODO remove this once able to resolve users
+      name: myUser.name,
+      colorIndex: myUser.colorIndex,
+      picture: myUser.avatar,
     })),
   )
 
@@ -98,7 +99,7 @@ const MultiplayerUserBar = React.memo(() => {
     [dispatch, mode],
   )
 
-  if (me.presence.name == null) {
+  if (myUser.name == null) {
     // it may still be loading, so fallback until it sorts itself out
     return <SinglePlayerUserBar />
   }
@@ -162,7 +163,7 @@ const MultiplayerUserBar = React.memo(() => {
           name={multiplayerInitialsFromName(myName)}
           tooltip={`${myName} (you)`}
           color={{ background: colorTheme.bg3.value, foreground: colorTheme.fg1.value }}
-          picture={me.presence.picture}
+          picture={myUser.avatar}
         />
       </a>
     </div>

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -12,10 +12,18 @@ export function useCanvasCommentThread(x: number, y: number): ThreadData<ThreadM
   return thread
 }
 
-export function useMyMultiplayerColorIndex() {
+export function useMyUserAndPresence() {
   const me = useSelf()
   const myUser = useStorage((store) => store.collaborators[me.id])
-  return myUser.colorIndex
+  return {
+    presence: me,
+    user: myUser,
+  }
+}
+
+export function useMyMultiplayerColorIndex() {
+  const me = useMyUserAndPresence()
+  return me.user.colorIndex
 }
 
 export function useAddMyselfToCollaborators() {

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -21,7 +21,7 @@ export function useAddMyselfToCollaborators() {
   const loginState = useEditorState(
     Substores.userState,
     (store) => store.userState.loginState,
-    'MultiplayerCursors loginState',
+    'useAddMyselfToCollaborators loginState',
   )
 
   const addMyselfToCollaborators = useMutation(

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
-import type { ThreadData } from '@liveblocks/client'
+import { LiveObject, type ThreadData } from '@liveblocks/client'
 import type { ThreadMetadata } from '../../../liveblocks.config'
-import { useMutation, useSelf, useStorage, useThreads } from '../../../liveblocks.config'
+import { useMutation, useRoom, useSelf, useStorage, useThreads } from '../../../liveblocks.config'
+import { Substores, useEditorState } from '../../components/editor/store/store-hook'
+import { normalizeMultiplayerName, possiblyUniqueColor } from '../shared/multiplayer'
+import { isLoggedIn } from '../../common/user'
 
 export function useCanvasCommentThread(x: number, y: number): ThreadData<ThreadMetadata> | null {
   const { threads } = useThreads()
@@ -15,13 +18,35 @@ export function useMyMultiplayerColorIndex() {
 }
 
 export function useAddMyselfToCollaborators() {
-  const addMyselfToCollaborators = useMutation(({ storage, self }) => {
-    const collaborators = storage.get('collaborators')
+  const loginState = useEditorState(
+    Substores.userState,
+    (store) => store.userState.loginState,
+    'MultiplayerCursors loginState',
+  )
 
-    if (collaborators.get(self.id) !== true) {
-      collaborators.set(self.id, true)
-    }
-  }, [])
+  const addMyselfToCollaborators = useMutation(
+    ({ storage, self }) => {
+      if (!isLoggedIn(loginState)) {
+        return
+      }
+      const collaborators = storage.get('collaborators')
+
+      const otherColorIndices = Object.values(collaborators).map((u) => u.colorIndex)
+
+      if (collaborators.get(self.id) == null) {
+        collaborators.set(
+          self.id,
+          new LiveObject({
+            id: loginState.user.userId,
+            name: normalizeMultiplayerName(loginState.user.name ?? null),
+            avatar: loginState.user.picture ?? null,
+            colorIndex: possiblyUniqueColor(otherColorIndices),
+          }),
+        )
+      }
+    },
+    [loginState],
+  )
 
   const collabs = useStorage((store) => store.collaborators)
 

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -14,7 +14,8 @@ export function useCanvasCommentThread(x: number, y: number): ThreadData<ThreadM
 
 export function useMyMultiplayerColorIndex() {
   const me = useSelf()
-  return me.presence.colorIndex
+  const myUser = useStorage((store) => store.collaborators[me.id])
+  return myUser.colorIndex
 }
 
 export function useAddMyselfToCollaborators() {

--- a/editor/src/core/shared/multiplayer.ts
+++ b/editor/src/core/shared/multiplayer.ts
@@ -106,3 +106,7 @@ export function isDefaultAuth0AvatarURL(s: string | null): boolean {
     (s.match(reAuth0DefaultAvatarURLEncoded) != null || s.match(reAuth0DefaultAvatar) != null)
   )
 }
+
+export function projectIdToRoomId(projectId: string): string {
+  return `project-room-${projectId}`
+}


### PR DESCRIPTION
**Problem:**
1. The commenting components can not show user information, because we don't provide a `resolveUsers` function to `createRoomContext`
2. `Presence` stores user related persistent information (name, avatar and colorIndex), even though the role of that should be to only show the transient state to of presence.

**Fix:**
Theoretically, we should provide an endpoint which can be used get user information from our backend. However, as a quick solution I decided to store the name/avatar/colorIndex in the Liveblocks room storage.

I deleted all redundant information from liveblocks:
- name from the thread metadata
- name, avatar and colorIndex from Presence

The extra upside of this is that in a single project your color remains the same across presence sessions.