### PR TITLE
Disable non-owner editing.

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -5341,31 +5341,40 @@ export const UPDATE_FNS = {
   UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE: (
     action: UpdateTopLevelElementsFromCollaborationUpdate,
     editor: EditorModel,
+    serverState: ProjectServerState,
   ): EditorModel => {
-    const updatedEditor = modifyParseSuccessAtPath(
-      action.fullPath,
-      editor,
-      (parsed) => {
-        const newTopLevelElementsDeepEquals = arrayDeepEquality(TopLevelElementKeepDeepEquality)(
-          parsed.topLevelElements,
-          action.topLevelElements,
-        )
+    // When the current user does own the project...
+    if (serverState.isMyProject === 'yes') {
+      // ...Disallow these updates as they're coming from non-owners.
+      return editor
+    } else {
+      const updatedEditor = modifyParseSuccessAtPath(
+        action.fullPath,
+        editor,
+        (parsed) => {
+          const newTopLevelElementsDeepEquals = arrayDeepEquality(TopLevelElementKeepDeepEquality)(
+            parsed.topLevelElements,
+            action.topLevelElements,
+          )
 
-        if (newTopLevelElementsDeepEquals.areEqual) {
-          return parsed
-        } else {
-          return {
-            ...parsed,
-            topLevelElements: newTopLevelElementsDeepEquals.value,
+          if (newTopLevelElementsDeepEquals.areEqual) {
+            return parsed
+          } else {
+            return {
+              ...parsed,
+              topLevelElements: newTopLevelElementsDeepEquals.value,
+            }
           }
-        }
-      },
-      false,
-    )
+        },
+        false,
+      )
 
-    return {
-      ...updatedEditor,
-      filesModifiedByAnotherUser: updatedEditor.filesModifiedByAnotherUser.concat(action.fullPath),
+      return {
+        ...updatedEditor,
+        filesModifiedByAnotherUser: updatedEditor.filesModifiedByAnotherUser.concat(
+          action.fullPath,
+        ),
+      }
     }
   },
 }

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -654,12 +654,24 @@ export function handleStrategies(
   if (MeasureDispatchTime) {
     window.performance.mark('strategies_begin')
   }
-  const { unpatchedEditorState, patchedEditorState, newStrategyState } = handleStrategiesInner(
-    strategies,
-    dispatchedActions,
-    storedState,
-    result,
-  )
+  let unpatchedEditorState: EditorState
+  let patchedEditorState: EditorState
+  let newStrategyState: StrategyState
+  if (storedState.projectServerState.isMyProject === 'no') {
+    unpatchedEditorState = result.unpatchedEditor
+    patchedEditorState = result.unpatchedEditor
+    newStrategyState = result.strategyState
+  } else {
+    const strategiesResult = handleStrategiesInner(
+      strategies,
+      dispatchedActions,
+      storedState,
+      result,
+    )
+    unpatchedEditorState = strategiesResult.unpatchedEditorState
+    patchedEditorState = strategiesResult.patchedEditorState
+    newStrategyState = strategiesResult.newStrategyState
+  }
 
   const patchedEditorWithMetadata: EditorState = {
     ...patchedEditorState,

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -99,12 +99,11 @@ export type DispatchResult = EditorStoreFull & DispatchResultFields
 
 const cannotUndoRedoToastId = 'cannot-undo-or-redo'
 
-function processAction(
-  dispatchEvent: EditorDispatch,
+function checkIfActionShouldBeProcessed(
   editorStoreUnpatched: EditorStoreUnpatched,
   action: EditorAction,
-  spyCollector: UiJsxCanvasContextData,
-): EditorStoreUnpatched {
+): boolean {
+  // Default to true.
   let shouldProcessAction: boolean = true
   // By default when the current user does not own the project and the action is non-transient prevent actions from running...
   if (editorStoreUnpatched.projectServerState.isMyProject === 'no' && !isTransientAction(action)) {
@@ -114,11 +113,16 @@ function processAction(
       action.action === 'UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE'
     shouldProcessAction = allowedNonOwnerAction
   }
-  // When the current user does own the project...
-  if (editorStoreUnpatched.projectServerState.isMyProject === 'yes') {
-    // ...Disallow these updates as they're coming from non-owners.
-    shouldProcessAction = action.action !== 'UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE'
-  }
+  return shouldProcessAction
+}
+
+function processAction(
+  dispatchEvent: EditorDispatch,
+  editorStoreUnpatched: EditorStoreUnpatched,
+  action: EditorAction,
+  spyCollector: UiJsxCanvasContextData,
+): EditorStoreUnpatched {
+  const shouldProcessAction = checkIfActionShouldBeProcessed(editorStoreUnpatched, action)
 
   let working = editorStoreUnpatched
   if (shouldProcessAction) {

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -105,168 +105,195 @@ function processAction(
   action: EditorAction,
   spyCollector: UiJsxCanvasContextData,
 ): EditorStoreUnpatched {
+  let shouldProcessAction: boolean = true
+  // By default when the current user does not own the project and the action is non-transient prevent actions from running...
+  if (editorStoreUnpatched.projectServerState.isMyProject === 'no' && !isTransientAction(action)) {
+    // ...Unless they're more critical to the running of the editor in this case.
+    const allowedNonOwnerAction =
+      action.action === 'UPDATE_FROM_WORKER' ||
+      action.action === 'UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE'
+    shouldProcessAction = allowedNonOwnerAction
+  }
+  // When the current user does own the project...
+  if (editorStoreUnpatched.projectServerState.isMyProject === 'yes') {
+    // ...Disallow these updates as they're coming from non-owners.
+    shouldProcessAction = action.action !== 'UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE'
+  }
+
   let working = editorStoreUnpatched
-  // Sidestep around the local actions so that we definitely run them locally.
-  if (action.action === 'TRANSIENT_ACTIONS') {
-    // Drill into the array.
-    return processActions(dispatchEvent, working, action.transientActions, spyCollector)
-  } else if (action.action === 'ATOMIC' || action.action === 'MERGE_WITH_PREV_UNDO') {
-    // Drill into the array.
-    return processActions(dispatchEvent, working, action.actions, spyCollector)
-  } else if (action.action === 'UNDO' && !History.canUndo(working.history)) {
-    // Bail early and make no changes.
-    return processActions(
-      dispatchEvent,
-      working,
-      [
-        EditorActions.addToast(
-          notice(
-            `Can't undo, reached the end of the undo history.`,
-            'NOTICE',
-            false,
-            cannotUndoRedoToastId,
+  if (shouldProcessAction) {
+    // Sidestep around the local actions so that we definitely run them locally.
+    if (action.action === 'TRANSIENT_ACTIONS') {
+      // Drill into the array.
+      return processActions(dispatchEvent, working, action.transientActions, spyCollector)
+    } else if (action.action === 'ATOMIC' || action.action === 'MERGE_WITH_PREV_UNDO') {
+      // Drill into the array.
+      return processActions(dispatchEvent, working, action.actions, spyCollector)
+    } else if (action.action === 'UNDO' && !History.canUndo(working.history)) {
+      // Bail early and make no changes.
+      return processActions(
+        dispatchEvent,
+        working,
+        [
+          EditorActions.addToast(
+            notice(
+              `Can't undo, reached the end of the undo history.`,
+              'NOTICE',
+              false,
+              cannotUndoRedoToastId,
+            ),
           ),
-        ),
-      ],
-      spyCollector,
-    )
-  } else if (action.action === 'REDO' && !History.canRedo(working.history)) {
-    // Bail early and make no changes.
-    return processActions(
-      dispatchEvent,
-      working,
-      [
-        EditorActions.addToast(
-          notice(
-            `Can't redo, reached the end of the undo history.`,
-            'NOTICE',
-            false,
-            cannotUndoRedoToastId,
-          ),
-        ),
-      ],
-      spyCollector,
-    )
-  } else if (action.action === 'SET_SHORTCUT') {
-    return {
-      ...working,
-      userState: UPDATE_FNS.SET_SHORTCUT(action, working.userState),
-    }
-  } else if (action.action === 'SET_CURRENT_THEME') {
-    return {
-      ...working,
-      userState: UPDATE_FNS.SET_CURRENT_THEME(action, working.userState),
-    }
-  } else if (action.action === 'SET_LOGIN_STATE') {
-    return {
-      ...working,
-      userState: UPDATE_FNS.SET_LOGIN_STATE(action, working.userState),
-    }
-  } else if (action.action === 'SET_GITHUB_STATE') {
-    return {
-      ...working,
-      userState: UPDATE_FNS.SET_GITHUB_STATE(action, working.userState),
-    }
-  } else if (action.action === 'SET_USER_CONFIGURATION') {
-    return {
-      ...working,
-      userState: UPDATE_FNS.SET_USER_CONFIGURATION(action, working.userState),
-    }
-  }
-
-  if (action.action === 'UPDATE_TEXT') {
-    working = UPDATE_FNS.UPDATE_TEXT(action, working)
-  }
-
-  if (action.action === 'TRUNCATE_HISTORY') {
-    working = UPDATE_FNS.TRUNCATE_HISTORY(working)
-  }
-
-  if (action.action === 'START_POST_ACTION_SESSION') {
-    working = runExecuteStartPostActionMenuAction(action, working)
-  }
-
-  if (action.action === 'EXECUTE_POST_ACTION_MENU_CHOICE') {
-    working = runExecuteWithPostActionMenuAction(action, working)
-  }
-
-  if (action.action === 'CLEAR_POST_ACTION_SESSION') {
-    working = runClearPostActionSession(working)
-  }
-
-  if (action.action === 'UPDATE_PROJECT_SERVER_STATE') {
-    working = runUpdateProjectServerState(working, action)
-  }
-
-  // Process action on the JS side.
-  const editorAfterUpdateFunction = runLocalEditorAction(
-    working.unpatchedEditor,
-    working.unpatchedDerived,
-    working.userState,
-    working.workers,
-    action as EditorAction,
-    working.history,
-    dispatchEvent,
-    spyCollector,
-    working.builtInDependencies,
-    working.collaborativeEditingSupport,
-    working.projectServerState,
-  )
-  const editorAfterCanvas = runLocalCanvasAction(
-    dispatchEvent,
-    editorAfterUpdateFunction,
-    working.unpatchedDerived,
-    working.builtInDependencies,
-    action as CanvasAction,
-  )
-  const editorAfterNavigator = runLocalNavigatorAction(
-    editorAfterCanvas,
-    working.unpatchedDerived,
-    action as LocalNavigatorAction,
-  )
-  const withPossiblyClearedPseudoInsert = maybeClearPseudoInsertMode(
-    editorStoreUnpatched.unpatchedEditor,
-    editorAfterNavigator,
-    action,
-  )
-
-  let newStateHistory: StateHistory
-  switch (action.action) {
-    case 'UNDO':
-      newStateHistory = History.undo(working.unpatchedEditor.id, working.history, 'no-side-effects')
-      working.postActionInteractionSession = null
-      break
-    case 'REDO':
-      newStateHistory = History.redo(working.unpatchedEditor.id, working.history, 'no-side-effects')
-      break
-    case 'NEW':
-    case 'LOAD':
-      const derivedState = deriveState(
-        withPossiblyClearedPseudoInsert,
-        null,
-        'unpatched',
-        unpatchedCreateRemixDerivedDataMemo,
+        ],
+        spyCollector,
       )
-      newStateHistory = History.init(withPossiblyClearedPseudoInsert, derivedState)
-      break
-    default:
-      newStateHistory = working.history
-      break
-  }
+    } else if (action.action === 'REDO' && !History.canRedo(working.history)) {
+      // Bail early and make no changes.
+      return processActions(
+        dispatchEvent,
+        working,
+        [
+          EditorActions.addToast(
+            notice(
+              `Can't redo, reached the end of the undo history.`,
+              'NOTICE',
+              false,
+              cannotUndoRedoToastId,
+            ),
+          ),
+        ],
+        spyCollector,
+      )
+    } else if (action.action === 'SET_SHORTCUT') {
+      return {
+        ...working,
+        userState: UPDATE_FNS.SET_SHORTCUT(action, working.userState),
+      }
+    } else if (action.action === 'SET_CURRENT_THEME') {
+      return {
+        ...working,
+        userState: UPDATE_FNS.SET_CURRENT_THEME(action, working.userState),
+      }
+    } else if (action.action === 'SET_LOGIN_STATE') {
+      return {
+        ...working,
+        userState: UPDATE_FNS.SET_LOGIN_STATE(action, working.userState),
+      }
+    } else if (action.action === 'SET_GITHUB_STATE') {
+      return {
+        ...working,
+        userState: UPDATE_FNS.SET_GITHUB_STATE(action, working.userState),
+      }
+    } else if (action.action === 'SET_USER_CONFIGURATION') {
+      return {
+        ...working,
+        userState: UPDATE_FNS.SET_USER_CONFIGURATION(action, working.userState),
+      }
+    }
 
-  return {
-    unpatchedEditor: withPossiblyClearedPseudoInsert,
-    unpatchedDerived: working.unpatchedDerived,
-    strategyState: working.strategyState, // this means the actions cannot update strategyState – this piece of state lives outside our "redux" state
-    postActionInteractionSession: working.postActionInteractionSession,
-    history: newStateHistory,
-    userState: working.userState,
-    workers: working.workers,
-    persistence: working.persistence,
-    saveCountThisSession: working.saveCountThisSession,
-    builtInDependencies: working.builtInDependencies,
-    projectServerState: working.projectServerState,
-    collaborativeEditingSupport: working.collaborativeEditingSupport,
+    if (action.action === 'UPDATE_TEXT') {
+      working = UPDATE_FNS.UPDATE_TEXT(action, working)
+    }
+
+    if (action.action === 'TRUNCATE_HISTORY') {
+      working = UPDATE_FNS.TRUNCATE_HISTORY(working)
+    }
+
+    if (action.action === 'START_POST_ACTION_SESSION') {
+      working = runExecuteStartPostActionMenuAction(action, working)
+    }
+
+    if (action.action === 'EXECUTE_POST_ACTION_MENU_CHOICE') {
+      working = runExecuteWithPostActionMenuAction(action, working)
+    }
+
+    if (action.action === 'CLEAR_POST_ACTION_SESSION') {
+      working = runClearPostActionSession(working)
+    }
+
+    if (action.action === 'UPDATE_PROJECT_SERVER_STATE') {
+      working = runUpdateProjectServerState(working, action)
+    }
+
+    // Process action on the JS side.
+    const editorAfterUpdateFunction = runLocalEditorAction(
+      working.unpatchedEditor,
+      working.unpatchedDerived,
+      working.userState,
+      working.workers,
+      action as EditorAction,
+      working.history,
+      dispatchEvent,
+      spyCollector,
+      working.builtInDependencies,
+      working.collaborativeEditingSupport,
+      working.projectServerState,
+    )
+    const editorAfterCanvas = runLocalCanvasAction(
+      dispatchEvent,
+      editorAfterUpdateFunction,
+      working.unpatchedDerived,
+      working.builtInDependencies,
+      action as CanvasAction,
+    )
+    const editorAfterNavigator = runLocalNavigatorAction(
+      editorAfterCanvas,
+      working.unpatchedDerived,
+      action as LocalNavigatorAction,
+    )
+    const withPossiblyClearedPseudoInsert = maybeClearPseudoInsertMode(
+      editorStoreUnpatched.unpatchedEditor,
+      editorAfterNavigator,
+      action,
+    )
+
+    let newStateHistory: StateHistory
+    switch (action.action) {
+      case 'UNDO':
+        newStateHistory = History.undo(
+          working.unpatchedEditor.id,
+          working.history,
+          'no-side-effects',
+        )
+        working.postActionInteractionSession = null
+        break
+      case 'REDO':
+        newStateHistory = History.redo(
+          working.unpatchedEditor.id,
+          working.history,
+          'no-side-effects',
+        )
+        break
+      case 'NEW':
+      case 'LOAD':
+        const derivedState = deriveState(
+          withPossiblyClearedPseudoInsert,
+          null,
+          'unpatched',
+          unpatchedCreateRemixDerivedDataMemo,
+        )
+        newStateHistory = History.init(withPossiblyClearedPseudoInsert, derivedState)
+        break
+      default:
+        newStateHistory = working.history
+        break
+    }
+
+    return {
+      unpatchedEditor: withPossiblyClearedPseudoInsert,
+      unpatchedDerived: working.unpatchedDerived,
+      strategyState: working.strategyState, // this means the actions cannot update strategyState – this piece of state lives outside our "redux" state
+      postActionInteractionSession: working.postActionInteractionSession,
+      history: newStateHistory,
+      userState: working.userState,
+      workers: working.workers,
+      persistence: working.persistence,
+      saveCountThisSession: working.saveCountThisSession,
+      builtInDependencies: working.builtInDependencies,
+      projectServerState: working.projectServerState,
+      collaborativeEditingSupport: working.collaborativeEditingSupport,
+    }
+  } else {
+    return working
   }
 }
 

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -389,7 +389,11 @@ export function runSimpleLocalEditorAction(
     case 'SWITCH_CONDITIONAL_BRANCHES':
       return UPDATE_FNS.SWITCH_CONDITIONAL_BRANCHES(action, state)
     case 'UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE':
-      return UPDATE_FNS.UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE(action, state)
+      return UPDATE_FNS.UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE(
+        action,
+        state,
+        serverState,
+      )
     default:
       return state
   }


### PR DESCRIPTION
**Problem:**
When using the editor collaboratively, it doesn't make a lot of sense for non-owners to be able to change the project.

**Fix:**
In two places this prevents changes to the project model from being applied:
- `processAction`: The main hub of where changes are applied we protect against non-owners from applying non-transient editor actions.
- `handleStrategies`: Canvas interactions are disabled by having the entire strategies logic be disabled if the current user is not the owner of the project.

Additionally in `processAction` we prevent changes coming from non-owners via yjs/Liveblocks from being applied to the project model, as it appears initialisation of it in certain circumstances can cause those to be triggered.

**Commit Details:**
- `handleStrategies` now short circuits if the project is not owned by the current user.
- `processAction` now only permits certain actions to run depending on the ownership of the current project.