### PR TITLE
`transpileJavascriptFromCode` with the steganography pass

### DIFF
--- a/editor/src/core/workers/parser-printer/parser-printer-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-utils.ts
@@ -90,7 +90,7 @@ export function wrapCodeInParensWithMap(
   const node = SourceNode.fromStringWithSourceMap(wrappedCode, consumer)
   node.setSourceContent(sourceFileName, sourceFileText)
   const result = node.toStringWithSourceMap({ file: sourceFileName })
-  return { code: result.code, sourceMap: result.map }
+  return { code: result.code, sourceMap: JSON.parse(result.map.toString()) }
 }
 
 export function prependToSourceString(


### PR DESCRIPTION
# Try it [here](https://utopia.pizza/p/673006ee-knowing-crop/?branch_name=fix-parsing-with-steganography)
This project uses the Remix sample project (where the bug was originally discovered). Make sure to turn on the steganography feature switch 

# Don't approve this PR yet!
We still need to figure out why the background colors don't render in the project above (on the collection page)

## Problem
Running  the `applySteganographyPlugin` in `transpileJavascriptFromCode` broke component parsing for some projects

## Root cause
The `applySteganographyPlugin` creates a new `SourceMapConsumer` when it visits a string literal. The `SourceMapConsumer` is passed in a `RawSourceMap`, which either comes from the `transpileJavascript` function, or might be overwritten by the map returned from `wrapCodeInParensWithMap`. The problem was that since we don't have types for the `source-map` library (which manipulates the source maps), `wrapCodeInParensWithMap` returned a malformed source map which made some consistency checks fail in `SourceMapConsumer`'s constructor, which threw an error, which we caught and returned as `left`. This cascaded into the whole component containing the problematic code to be parsed as `ArbitraryJSBlock`.

## Fix
Call `JSON.parse(result.map.toString())` in `wrapCodeInParensWithMap` before returning the new source map