### PR TITLE
Smooth follow mode canvas pan

### DIFF
--- a/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
+++ b/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
@@ -43,12 +43,10 @@ export function useApplyCanvasOffsetToStyle(setScaleToo: boolean): React.RefObje
           setScaleToo && scaleRef.current >= 1 ? `${scaleRef.current * 100}%` : '1',
         )
 
-        if (isFollowMode(mode)) {
-          elementRef.current.style.setProperty(
-            'transition',
-            `transform ${liveblocksThrottle}ms linear`,
-          )
-        }
+        elementRef.current.style.setProperty(
+          'transition',
+          isFollowMode(mode) ? `transform ${liveblocksThrottle}ms linear` : 'none',
+        )
       }
     },
     [elementRef, setScaleToo, scaleRef, mode],


### PR DESCRIPTION
Fix #4526 

**Problem:**

The follow mode works fine but panning the canvas results in a non-smooth animation for followers.

**Fix:**

This is a very naive solution, but _for now_ it should work a lot better than the existing situation while being not too complicated to change in the future.

https://github.com/concrete-utopia/utopia/assets/1081051/6865b127-1227-41f9-add6-7bbf227009a6

For followers, if in follow mode, add a linear transition to the canvas wrapper that matches the Liveblocks throttle delta.

This will result in a smooth pan and a somewhat "bouncy" zoom (since scale is in the same transform) but I would consider this acceptable.