### PR TITLE
Read only indicator.

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -59,6 +59,7 @@ import { isLiveblocksEnabled } from './liveblocks-utils'
 import type { Storage, Presence, RoomEvent, UserMeta } from '../../../liveblocks.config'
 import LiveblocksProvider from '@liveblocks/yjs'
 import { projectIdToRoomId } from '../../core/shared/multiplayer'
+import { useDisplayOwnershipWarning } from './project-owner-hooks'
 
 const liveModeToastId = 'play-mode-toast'
 
@@ -147,6 +148,7 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
       }
     }, 0)
   }, [mode.type, dispatch])
+  useDisplayOwnershipWarning()
 
   const onWindowKeyDown = React.useCallback(
     (event: KeyboardEvent) => {

--- a/editor/src/components/editor/project-owner-hooks.ts
+++ b/editor/src/components/editor/project-owner-hooks.ts
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import { useDispatch } from './store/dispatch-context'
+import { Substores, useSelectorWithCallback } from './store/store-hook'
+import type { ProjectServerState } from './store/project-server-state'
+import { removeToast, showToast } from './actions/action-creators'
+import { notice } from '../common/notice'
+import { assertNever } from '../../core/shared/utils'
+
+const OwnershipToastID = 'project-ownership-toast'
+
+export function useDisplayOwnershipWarning(): void {
+  const dispatch = useDispatch()
+  const showOrHideWarning = React.useCallback(
+    (projectOwnership: ProjectServerState['isMyProject']) => {
+      switch (projectOwnership) {
+        case 'yes':
+          dispatch([removeToast(OwnershipToastID)])
+          break
+        case 'no':
+          dispatch([
+            showToast(
+              notice(
+                'Viewer Mode: Project is read only in this session.',
+                'INFO',
+                true,
+                OwnershipToastID,
+              ),
+            ),
+          ])
+          break
+        case 'unknown':
+          // Do nothing.
+          break
+        default:
+          assertNever(projectOwnership)
+      }
+    },
+    [dispatch],
+  )
+  useSelectorWithCallback(
+    Substores.projectServerState,
+    (store) => store.projectServerState.isMyProject,
+    showOrHideWarning,
+    'useDisplayOwnershipWarning useSelectorWithCallback',
+  )
+}


### PR DESCRIPTION
**Problem:**
Currently users that are not the owner of a project can't make changes but they probably have no clue why.

**Fix:**
For those users that are not owners of a project, display a persistent toast indicating that they are in a view only mode.
![image](https://github.com/concrete-utopia/utopia/assets/217400/bab25e38-ebcb-4a62-8437-eb2e78fd1809)


**Commit Details:**
- Added `useDisplayOwnershipWarning` hook.
- Invoked hook in `EditorComponentInner`.