### PR TITLE
Shadow actions for duplicate and reparent

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -10,6 +10,7 @@ import type { CanvasCommand } from '../commands/commands'
 import type { StrategyApplicationStatus } from './interaction-state'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import type { RemixRoutingTable } from '../../editor/store/remix-derived-data'
+import type { ActiveFrameAction } from '../commands/set-active-frames-command'
 
 // TODO: fill this in, maybe make it an ADT for different strategies
 export interface CustomStrategyState {
@@ -18,6 +19,7 @@ export interface CustomStrategyState {
   duplicatedElementNewUids: { [elementPath: string]: string }
   strategyGeneratedUidsCache: { [elementPath: string]: string | undefined }
   elementsToRerender: Array<ElementPath>
+  action: ActiveFrameAction | null
 }
 
 export type CustomStrategyStatePatch = Partial<CustomStrategyState>
@@ -29,6 +31,7 @@ export function defaultCustomStrategyState(): CustomStrategyState {
     duplicatedElementNewUids: {},
     strategyGeneratedUidsCache: {},
     elementsToRerender: [],
+    action: null,
   }
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.tsx
@@ -163,7 +163,7 @@ function runMoveStrategy(
     absoluteMoveStrategy(
       canvasState,
       interactionSession,
-      defaultCustomStrategyState(),
+      { ...defaultCustomStrategyState(), action: 'duplicate' },
       'do-not-run-applicability-check',
     )?.strategy.apply(strategyLifecycle).commands ?? []
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.tsx
@@ -29,7 +29,7 @@ export type ShouldRunApplicabilityCheck =
 export function absoluteMoveStrategy(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
-  _: CustomStrategyState,
+  customStrategyState: CustomStrategyState,
   runApplicabilityCheck: ShouldRunApplicabilityCheck = 'run-applicability-check',
 ): MoveStrategy | null {
   const originalTargets = flattenSelection(
@@ -102,6 +102,7 @@ export function absoluteMoveStrategy(
             canvasState,
             interactionSession,
             getAdjustMoveCommands(retargetedTargets, canvasState, interactionSession),
+            customStrategyState.action ?? 'move',
           )
         }
         // Fallback for when the checks above are not satisfied.

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
@@ -173,7 +173,7 @@ export function baseAbsoluteReparentStrategy(
                     ...interactionSession,
                     updatedTargetPaths: updatedTargetPaths,
                   },
-                  defaultCustomStrategyState(),
+                  { ...defaultCustomStrategyState(), action: 'reparent' },
                 )?.strategy.apply(strategyLifecycle).commands ?? []
 
               const elementsToRerender = EP.uniqueElementPaths([
@@ -202,11 +202,10 @@ export function baseAbsoluteReparentStrategy(
               )
             } else {
               const moveCommands =
-                absoluteMoveStrategy(
-                  canvasState,
-                  interactionSession,
-                  defaultCustomStrategyState(),
-                )?.strategy.apply(strategyLifecycle).commands ?? []
+                absoluteMoveStrategy(canvasState, interactionSession, {
+                  ...defaultCustomStrategyState(),
+                  action: 'reparent',
+                })?.strategy.apply(strategyLifecycle).commands ?? []
               return strategyApplicationResult(moveCommands)
             }
           },

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -254,6 +254,7 @@ function convertToAbsoluteAndMoveStrategyFactory(setHuggingParentToFixed: SetHug
             canvasState,
             interactionSession,
             getConversionAndMoveCommands,
+            'move',
           )
 
           const strategyIndicatorCommand = wildcardPatch('mid-interaction', {

--- a/editor/src/components/canvas/canvas-strategies/strategies/relative-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/relative-move-strategy.tsx
@@ -98,6 +98,7 @@ export function relativeMoveStrategy(
             getAdjustMoveCommands(filteredSelectedElements, canvasState, interactionSession, {
               ignoreLocalFrame: true,
             }),
+            'move',
           )
         } else {
           return emptyStrategyApplicationResult

--- a/editor/src/components/canvas/commands/set-active-frames-command.ts
+++ b/editor/src/components/canvas/commands/set-active-frames-command.ts
@@ -11,6 +11,8 @@ export type ActiveFrameAction =
   | 'set-padding'
   | 'set-radius'
   | 'reorder'
+  | 'duplicate'
+  | 'reparent'
 
 export function activeFrameActionToString(action: ActiveFrameAction): string {
   switch (action) {
@@ -26,6 +28,10 @@ export function activeFrameActionToString(action: ActiveFrameAction): string {
       return 'Padding'
     case 'set-radius':
       return 'Radius'
+    case 'duplicate':
+      return 'Duplicate'
+    case 'reparent':
+      return 'Reparent'
     default:
       assertNever(action)
   }

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -189,6 +189,7 @@ describe('interactionStart', () => {
         "currentStrategyFitness": 0,
         "currentStrategyIcon": null,
         "customStrategyState": Object {
+          "action": null,
           "duplicatedElementNewUids": Object {},
           "elementsToRerender": Array [],
           "escapeHatchActivated": false,
@@ -250,6 +251,7 @@ describe('interactionStart', () => {
         "currentStrategyFitness": 0,
         "currentStrategyIcon": null,
         "customStrategyState": Object {
+          "action": null,
           "duplicatedElementNewUids": Object {},
           "elementsToRerender": Array [],
           "escapeHatchActivated": false,
@@ -331,6 +333,7 @@ describe('interactionUpdate', () => {
           "type": "magic-large",
         },
         "customStrategyState": Object {
+          "action": null,
           "duplicatedElementNewUids": Object {},
           "elementsToRerender": Array [],
           "escapeHatchActivated": false,
@@ -412,6 +415,7 @@ describe('interactionUpdate', () => {
         "currentStrategyFitness": 0,
         "currentStrategyIcon": null,
         "customStrategyState": Object {
+          "action": null,
           "duplicatedElementNewUids": Object {},
           "elementsToRerender": Array [],
           "escapeHatchActivated": false,
@@ -487,6 +491,7 @@ describe('interactionHardReset', () => {
           "type": "magic-large",
         },
         "customStrategyState": Object {
+          "action": null,
           "duplicatedElementNewUids": Object {},
           "elementsToRerender": Array [],
           "escapeHatchActivated": false,
@@ -570,6 +575,7 @@ describe('interactionHardReset', () => {
         "currentStrategyFitness": 0,
         "currentStrategyIcon": null,
         "customStrategyState": Object {
+          "action": null,
           "duplicatedElementNewUids": Object {},
           "elementsToRerender": Array [],
           "escapeHatchActivated": false,
@@ -659,6 +665,7 @@ describe('interactionUpdate with user changed strategy', () => {
           "type": "magic-large",
         },
         "customStrategyState": Object {
+          "action": null,
           "duplicatedElementNewUids": Object {},
           "elementsToRerender": Array [],
           "escapeHatchActivated": false,
@@ -743,6 +750,7 @@ describe('interactionUpdate with user changed strategy', () => {
         "currentStrategyFitness": 0,
         "currentStrategyIcon": null,
         "customStrategyState": Object {
+          "action": null,
           "duplicatedElementNewUids": Object {},
           "elementsToRerender": Array [],
           "escapeHatchActivated": false,


### PR DESCRIPTION
Fix #4537 

**Problem:**
https://github.com/concrete-utopia/utopia/pull/4519 introduced multiplayer shadows, but it was not discriminating between the other two variants of the `Move` action: `duplicate` and `reparent`.

**Fix:**

https://github.com/concrete-utopia/utopia/assets/1081051/6438a454-3498-4d37-b6ce-03e79294edf1

This PR fixes that by adding two new `ActiveFrameAction` values, and passing them down to the underlying move action from their respective strategies.