### PR TITLE
Support adding and deleting files in collaboration.

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -676,6 +676,11 @@ export interface DeleteFile {
   filename: string
 }
 
+export interface DeleteFileFromCollaboration {
+  action: 'DELETE_FILE_FROM_COLLABORATION'
+  filename: string
+}
+
 export interface AddTextFile {
   action: 'ADD_TEXT_FILE'
   fileName: string
@@ -1154,6 +1159,7 @@ export type EditorAction =
   | ClearImageFileBlob
   | AddFolder
   | DeleteFile
+  | DeleteFileFromCollaboration
   | AddTextFile
   | SetMainUIFile
   | SetCodeEditorBuildErrors

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -221,6 +221,7 @@ import type {
   ScrollToPosition,
   UpdateProjectServerState,
   UpdateTopLevelElementsFromCollaborationUpdate,
+  DeleteFileFromCollaboration,
 } from '../action-types'
 import type { InsertionSubjectWrapper, Mode } from '../editor-modes'
 import { EditorModes, insertionSubject } from '../editor-modes'
@@ -957,6 +958,13 @@ export function updateFilePath(oldPath: string, newPath: string): UpdateFilePath
 export function deleteFile(filename: string): DeleteFile {
   return {
     action: 'DELETE_FILE',
+    filename: filename,
+  }
+}
+
+export function deleteFileFromCollaboration(filename: string): DeleteFileFromCollaboration {
+  return {
+    action: 'DELETE_FILE_FROM_COLLABORATION',
     filename: filename,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -167,6 +167,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'ADD_FOLDER':
     case 'DELETE_FILE':
     case 'DELETE_FILE_FROM_VSCODE':
+    case 'DELETE_FILE_FROM_COLLABORATION':
     case 'ADD_TEXT_FILE':
     case 'UPDATE_FILE':
     case 'UPDATE_PROJECT_CONTENTS':

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -110,7 +110,8 @@ function checkIfActionShouldBeProcessed(
     // ...Unless they're more critical to the running of the editor in this case.
     const allowedNonOwnerAction =
       action.action === 'UPDATE_FROM_WORKER' ||
-      action.action === 'UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE'
+      action.action === 'UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE' ||
+      action.action === 'DELETE_FILE_FROM_COLLABORATION'
     shouldProcessAction = allowedNonOwnerAction
   }
   return shouldProcessAction

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -240,6 +240,7 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.ADD_FOLDER(action, state)
     case 'DELETE_FILE':
     case 'DELETE_FILE_FROM_VSCODE':
+    case 'DELETE_FILE_FROM_COLLABORATION':
       return UPDATE_FNS.DELETE_FILE(action, state, derivedState, userState)
     case 'ADD_TEXT_FILE':
       return UPDATE_FNS.ADD_TEXT_FILE(action, state)


### PR DESCRIPTION
**Problem:**
If you add or delete files, the collaboration features don't propagate those changes, which mean that it can break if those new files are referenced from others that are rendered.

**Fix:**
The two main changes are:
- Changes to the top level elements are supported when their target file does not already exist.
- Deletions of files triggered from collaboration updates now trigger a special case action that deletes those files.

**Commit Details:**
- Added `DeleteFileFromCollaboration` action.
- `checkIfActionShouldBeProcessed` now includes `DELETE_FILE_FROM_COLLABORATION`.
- `applyFileChangeToMap` now handles the iterator correctly for deleted files.
- `applyFileChangeToMap` switches out `deleteFile` for `deleteFileFromCollaboration`.
- `updateTopLevelElementsOfFile` now permits the current file to not exist and applies the updates to an empty array.
- Removed old "implicit retain" logic from `updateTopLevelElementsOfFile` as it was duplicating entries.
- `UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE` action handler now checks if the file exists and if it does not creates a new file.