### PR TITLE
fix(commenting) Fixing the editor root divs size 

### DIFF
--- a/editor/src/templates/index.html
+++ b/editor/src/templates/index.html
@@ -121,7 +121,7 @@
     <div id="text-field-placeholder"></div>
     <div
       id="application-wrapper"
-      style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px"
+      style="position: absolute; left: 0px; top: 0px; right: 0px;"
     >
       <div
         id="utopia-editor-root"

--- a/editor/src/templates/index.html
+++ b/editor/src/templates/index.html
@@ -121,7 +121,7 @@
     <div id="text-field-placeholder"></div>
     <div
       id="application-wrapper"
-      style="position: absolute; left: 0px; top: 0px; right: 0px;"
+      style="position: fixed; left: 0px; top: 0px; right: 0px; bottom: 0px"
     >
       <div
         id="utopia-editor-root"


### PR DESCRIPTION
**Problem:**

A liveblocks comment popup menu would somehow make the entire editor disappear by making the `utopia-editor-root` root div 0px high. (I didn't investigate what is the exact mechanism that made it 0 high.)

**Solution**
By making the editor root position: fixed, it is always positioned relative to the viewport, meaning no matter what happens to the surrounding context, the size should remain _fixed_.