### PR TITLE
Hover effect on comment indicator

### DIFF
--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -67,11 +67,15 @@ const CommentIndicatorInner = React.memo(() => {
         return (
           <div
             key={thread.id}
-            style={{
+            css={{
               position: 'absolute',
               top: point.y,
               left: point.x,
               width: 20,
+              '&:hover': {
+                transform: 'scale(1.15)',
+                transitionDuration: '0.1s',
+              },
             }}
             onClick={() => {
               dispatch([switchEditorMode(EditorModes.commentMode(point))])

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -151,7 +151,10 @@ function getDefaultCursorForMode(mode: Mode): CSSCursor {
     case 'textEdit':
       return CSSCursor.Select
     case 'comment':
-      return CSSCursor.Comment
+      if (mode.location == null) {
+        return CSSCursor.Comment
+      }
+      return CSSCursor.Select
     case 'follow':
       return CSSCursor.Select
     default:


### PR DESCRIPTION
**Problem:**
Simple hover effect on the comment indicator

https://github.com/concrete-utopia/utopia/assets/127662/b409d442-86d8-40c3-8e17-7984f8ec5461

I also changed the comment cursor behavior, now it is only shown when you are inserting a comment, and not when you are viewing/editing one.