### PR TITLE
Fix loading YJS doc/provider

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -58,7 +58,7 @@ import { generateUUID } from '../../utils/utils'
 import { isLiveblocksEnabled } from './liveblocks-utils'
 import type { Storage, Presence, RoomEvent, UserMeta } from '../../../liveblocks.config'
 import LiveblocksProvider from '@liveblocks/yjs'
-import { projectIdToRoomId } from '../../core/shared/multiplayer'
+import { isRoomId, projectIdToRoomId } from '../../core/shared/multiplayer'
 import { useDisplayOwnershipWarning } from './project-owner-hooks'
 
 const liveModeToastId = 'play-mode-toast'
@@ -298,11 +298,10 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
   )
 
   React.useEffect(() => {
-    if (yDoc != null) {
+    if (yDoc != null && isRoomId(room.id)) {
       const yProvider = new LiveblocksProvider<Presence, Storage, UserMeta, RoomEvent>(room, yDoc)
 
       return () => {
-        yDoc.destroy()
         yProvider.destroy()
       }
     }

--- a/editor/src/core/shared/multiplayer.ts
+++ b/editor/src/core/shared/multiplayer.ts
@@ -128,6 +128,12 @@ export function canFollowTarget(
   return !followChain.has(selfId)
 }
 
+const roomIdPrefix = `project-room-`
+
 export function projectIdToRoomId(projectId: string): string {
-  return `project-room-${projectId}`
+  return `${roomIdPrefix}${projectId}`
+}
+
+export function isRoomId(s: string): boolean {
+  return s.startsWith(roomIdPrefix)
 }


### PR DESCRIPTION
Fix #4548 

The YJS loading can break and enter an endless loop of connecting and disconnecting, due to the doc being destroyed (but not recreated) and when the room is not ready for consumption yet.

This PR fixes it.