### PR TITLE
Initial multiplayer and Remix routes integration

### DIFF
--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -84,7 +84,7 @@ export type ThreadMetadata = {
   type: 'canvas'
   x: number
   y: number
-  remixLocationPath?: string
+  remixLocationRoute?: string
 }
 
 export const {

--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -3,6 +3,7 @@ import { createRoomContext } from '@liveblocks/react'
 import { getProjectID } from './src/common/env-vars'
 import type { ActiveFrameAction } from './src/components/canvas/commands/set-active-frames-command'
 import type { CanvasRectangle, CanvasVector, WindowPoint } from './src/core/shared/math-utils'
+import type { RemixPresence } from './src/core/shared/multiplayer'
 import { projectIdToRoomId } from './src/core/shared/multiplayer'
 
 export const liveblocksThrottle = 100 // ms
@@ -21,6 +22,7 @@ export type Presence = {
   canvasOffset: CanvasVector | null
   activeFrames?: PresenceActiveFrame[]
   following: string | null
+  remix?: RemixPresence | null
 }
 
 export type PresenceActiveFrame = {
@@ -82,6 +84,8 @@ export type ThreadMetadata = {
   type: 'canvas'
   x: number
   y: number
+  remixScene?: string // It would have been nice to have this use the RemixPresence type above, but unfortunately ThreadMetadata only supports strings, bools, and numbers :(
+  remixLocationPath?: string
 }
 
 export const {

--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -84,7 +84,6 @@ export type ThreadMetadata = {
   type: 'canvas'
   x: number
   y: number
-  remixScene?: string // It would have been nice to have this use the RemixPresence type above, but unfortunately ThreadMetadata only supports strings, bools, and numbers :(
   remixLocationPath?: string
 }
 

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -4,13 +4,15 @@ import { jsx } from '@emotion/react'
 import React from 'react'
 import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
 import { EditorModes } from '../../editor/editor-modes'
-import { useStorage, useThreads } from '../../../../liveblocks.config'
+import { useSelf, useStorage, useThreads } from '../../../../liveblocks.config'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { switchEditorMode } from '../../editor/actions/action-creators'
 import { canvasPoint } from '../../../core/shared/math-utils'
 import { UtopiaTheme } from '../../../uuiui'
 import { Substores, useEditorState } from '../../editor/store/store-hook'
 import {
+  isPlayerOnAnotherRemixRoute,
+  maybeRemixPresence,
   multiplayerColorFromIndex,
   multiplayerInitialsFromName,
   normalizeMultiplayerName,
@@ -41,6 +43,7 @@ CommentIndicator.displayName = 'CommentIndicator'
 
 const CommentIndicatorInner = React.memo(() => {
   const { threads } = useThreads()
+  const me = useSelf()
   const dispatch = useDispatch()
   const collabs = useStorage((storage) => storage.collaborators)
 
@@ -64,6 +67,16 @@ const CommentIndicatorInner = React.memo(() => {
           }
         })()
 
+        const remixMetadata = maybeRemixPresence(
+          thread.metadata.remixScene ?? null,
+          thread.metadata.remixLocationPath ?? null,
+        )
+
+        const isOnAnotherRoute = isPlayerOnAnotherRemixRoute(
+          me.presence.remix ?? null,
+          remixMetadata,
+        )
+
         return (
           <div
             key={thread.id}
@@ -71,6 +84,7 @@ const CommentIndicatorInner = React.memo(() => {
               position: 'absolute',
               top: point.y,
               left: point.x,
+              opacity: isOnAnotherRoute ? 0.25 : 1,
               width: 20,
               '&:hover': {
                 transform: 'scale(1.15)',

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -65,12 +65,12 @@ const CommentIndicatorInner = React.memo(() => {
           }
         })()
 
-        const remixLocationPath = thread.metadata.remixLocationPath ?? null
+        const remixLocationRoute = thread.metadata.remixLocationRoute ?? null
 
         const isOnAnotherRoute =
-          me.presence.remix?.locationPath != null &&
-          remixLocationPath != null &&
-          remixLocationPath !== me.presence.remix.locationPath
+          me.presence.remix?.locationRoute != null &&
+          remixLocationRoute != null &&
+          remixLocationRoute !== me.presence.remix.locationRoute
 
         return (
           <div

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -11,8 +11,6 @@ import { canvasPoint } from '../../../core/shared/math-utils'
 import { UtopiaTheme } from '../../../uuiui'
 import { Substores, useEditorState } from '../../editor/store/store-hook'
 import {
-  isPlayerOnAnotherRemixRoute,
-  maybeRemixPresence,
   multiplayerColorFromIndex,
   multiplayerInitialsFromName,
   normalizeMultiplayerName,
@@ -67,15 +65,12 @@ const CommentIndicatorInner = React.memo(() => {
           }
         })()
 
-        const remixMetadata = maybeRemixPresence(
-          thread.metadata.remixScene ?? null,
-          thread.metadata.remixLocationPath ?? null,
-        )
+        const remixLocationPath = thread.metadata.remixLocationPath ?? null
 
-        const isOnAnotherRoute = isPlayerOnAnotherRemixRoute(
-          me.presence.remix ?? null,
-          remixMetadata,
-        )
+        const isOnAnotherRoute =
+          me.presence.remix?.locationPath != null &&
+          remixLocationPath != null &&
+          remixLocationPath !== me.presence.remix.locationPath
 
         return (
           <div

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -74,7 +74,6 @@ const CommentThread = React.memo(({ x, y }: CommentThreadProps) => {
           type: 'canvas',
           x: x,
           y: y,
-          remixScene: remixPresence?.scene,
           remixLocationPath: remixPresence?.locationPath ?? undefined,
         },
       })

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -10,6 +10,7 @@ import { stopPropagation } from '../../inspector/common/inspector-utils'
 import { UtopiaTheme } from '../../../uuiui'
 import { useCanvasCommentThread } from '../../../core/commenting/comment-hooks'
 import { MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
+import { useRemixPresence } from '../../../core/shared/multiplayer-hooks'
 
 export const CommentPopup = React.memo(() => {
   const mode = useEditorState(
@@ -60,6 +61,8 @@ const CommentThread = React.memo(({ x, y }: CommentThreadProps) => {
 
   const createThread = useCreateThread()
 
+  const remixPresence = useRemixPresence()
+
   const onCreateThread = React.useCallback(
     ({ body }: ComposerSubmitComment, event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault()
@@ -67,10 +70,16 @@ const CommentThread = React.memo(({ x, y }: CommentThreadProps) => {
       // Create a new thread
       createThread({
         body,
-        metadata: { type: 'canvas', x: x, y: y },
+        metadata: {
+          type: 'canvas',
+          x: x,
+          y: y,
+          remixScene: remixPresence?.scene,
+          remixLocationPath: remixPresence?.locationPath ?? undefined,
+        },
       })
     },
-    [createThread, x, y],
+    [createThread, x, y, remixPresence],
   )
 
   if (thread == null) {

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -74,7 +74,7 @@ const CommentThread = React.memo(({ x, y }: CommentThreadProps) => {
           type: 'canvas',
           x: x,
           y: y,
-          remixLocationPath: remixPresence?.locationPath ?? undefined,
+          remixLocationRoute: remixPresence?.locationRoute ?? undefined,
         },
       })
     },

--- a/editor/src/components/canvas/multiplayer-presence.tsx
+++ b/editor/src/components/canvas/multiplayer-presence.tsx
@@ -307,14 +307,14 @@ const FollowingOverlay = React.memo(() => {
       if (presence.remix != null && isPlayerOnAnotherRemixRoute(remixPresence, presence.remix)) {
         const newNavigationState = { ...remixNavigationState }
         const sceneState = newNavigationState[presence.remix.scene]
-        if (sceneState != null && presence.remix.locationPath != null) {
-          sceneState.location.pathname = presence.remix.locationPath
+        if (sceneState != null && presence.remix.locationRoute != null) {
+          sceneState.location.pathname = presence.remix.locationRoute
           setActiveRemixScene(EP.fromString(presence.remix.scene))
           setRemixNavigationState(newNavigationState)
           actions.push(
             showToast(
               notice(
-                `The route has been changed to ${presence.remix.locationPath}`,
+                `The route has been changed to ${presence.remix.locationRoute}`,
                 'PRIMARY',
                 false,
                 remixRouteChangedToastId,

--- a/editor/src/components/canvas/multiplayer-presence.tsx
+++ b/editor/src/components/canvas/multiplayer-presence.tsx
@@ -247,6 +247,8 @@ const MultiplayerCursor = React.memo(
 )
 MultiplayerCursor.displayName = 'MultiplayerCursor'
 
+const remixRouteChangedToastId = 'follow-changed-scene'
+
 const FollowingOverlay = React.memo(() => {
   const colorTheme = useColorTheme()
   const dispatch = useDispatch()
@@ -315,7 +317,7 @@ const FollowingOverlay = React.memo(() => {
                 `The route has been changed to ${presence.remix.locationPath}`,
                 'PRIMARY',
                 false,
-                'follow-changed-scene',
+                remixRouteChangedToastId,
               ),
             ),
           )

--- a/editor/src/core/shared/multiplayer-hooks.tsx
+++ b/editor/src/core/shared/multiplayer-hooks.tsx
@@ -16,10 +16,10 @@ export function useRemixPresence(): RemixPresence | null {
       return null
     }
     const scene = EP.toString(activeRemixScene)
-    const locationPath = remixNavigationState[scene]?.location.pathname ?? null
+    const locationRoute = remixNavigationState[scene]?.location.pathname ?? null
     return {
       scene: scene,
-      locationPath: locationPath,
+      locationRoute: locationRoute,
     }
   }, [activeRemixScene, remixNavigationState])
 

--- a/editor/src/core/shared/multiplayer-hooks.tsx
+++ b/editor/src/core/shared/multiplayer-hooks.tsx
@@ -7,7 +7,7 @@ import {
 import type { RemixPresence } from './multiplayer'
 import * as EP from './element-path'
 
-export function useRemixPresence() {
+export function useRemixPresence(): RemixPresence | null {
   const [activeRemixScene] = useAtom(ActiveRemixSceneAtom)
   const [remixNavigationState] = useAtom(RemixNavigationAtom)
 

--- a/editor/src/core/shared/multiplayer-hooks.tsx
+++ b/editor/src/core/shared/multiplayer-hooks.tsx
@@ -1,0 +1,27 @@
+import { useAtom } from 'jotai'
+import React from 'react'
+import {
+  ActiveRemixSceneAtom,
+  RemixNavigationAtom,
+} from '../../components/canvas/remix/utopia-remix-root-component'
+import type { RemixPresence } from './multiplayer'
+import * as EP from './element-path'
+
+export function useRemixPresence() {
+  const [activeRemixScene] = useAtom(ActiveRemixSceneAtom)
+  const [remixNavigationState] = useAtom(RemixNavigationAtom)
+
+  const remixPresence = React.useMemo((): RemixPresence | null => {
+    if (EP.isEmptyPath(activeRemixScene)) {
+      return null
+    }
+    const scene = EP.toString(activeRemixScene)
+    const locationPath = remixNavigationState[scene]?.location.pathname ?? null
+    return {
+      scene: scene,
+      locationPath: locationPath,
+    }
+  }, [activeRemixScene, remixNavigationState])
+
+  return remixPresence
+}

--- a/editor/src/core/shared/multiplayer.ts
+++ b/editor/src/core/shared/multiplayer.ts
@@ -140,26 +140,26 @@ export function isRoomId(s: string): boolean {
 
 export type RemixPresence = {
   scene: string
-  locationPath: string | null
+  locationRoute: string | null
 }
 
 export function isPlayerOnAnotherRemixRoute(
   a: RemixPresence | null,
   b: RemixPresence | null,
 ): boolean {
-  return a != null && b != null && (a.scene !== b.scene || a.locationPath !== b.locationPath)
+  return a != null && b != null && (a.scene !== b.scene || a.locationRoute !== b.locationRoute)
 }
 
-export function remixPresence(scene: string, locationPath: string | null): RemixPresence {
+export function remixPresence(scene: string, locationRoute: string | null): RemixPresence {
   return {
     scene: scene,
-    locationPath: locationPath,
+    locationRoute: locationRoute,
   }
 }
 
 export function maybeRemixPresence(
   scene: string | null,
-  locationPath: string | null,
+  locationRoute: string | null,
 ): RemixPresence | null {
-  return scene != null ? remixPresence(scene, locationPath) : null
+  return scene != null ? remixPresence(scene, locationRoute) : null
 }

--- a/editor/src/core/shared/multiplayer.ts
+++ b/editor/src/core/shared/multiplayer.ts
@@ -137,3 +137,29 @@ export function projectIdToRoomId(projectId: string): string {
 export function isRoomId(s: string): boolean {
   return s.startsWith(roomIdPrefix)
 }
+
+export type RemixPresence = {
+  scene: string
+  locationPath: string | null
+}
+
+export function isPlayerOnAnotherRemixRoute(
+  a: RemixPresence | null,
+  b: RemixPresence | null,
+): boolean {
+  return a != null && b != null && (a.scene !== b.scene || a.locationPath !== b.locationPath)
+}
+
+export function remixPresence(scene: string, locationPath: string | null): RemixPresence {
+  return {
+    scene: scene,
+    locationPath: locationPath,
+  }
+}
+
+export function maybeRemixPresence(
+  scene: string | null,
+  locationPath: string | null,
+): RemixPresence | null {
+  return scene != null ? remixPresence(scene, locationPath) : null
+}


### PR DESCRIPTION
Fix #4551

**Problem:**

Multiplayer features (cursors, commenting, follow mode) are not taking Remix routing into account.

**Fix:**

This PR does some groundwork to have multiplayer behave differently based on active Remix routes.

1. https://github.com/concrete-utopia/utopia/commit/121840241451e86c6cd99a2fcdaa518f51127e5d makes the cursors go down to 25% opacity if the related player is in an active route different from the one currently visible
2. https://github.com/concrete-utopia/utopia/commit/9edb84479c348b63633037487902cdc1803c2dd5 makes the comment indicators go down to 25% opacity if they have been left while in a different route from the one currently visible
3. https://github.com/concrete-utopia/utopia/commit/eb31a565eb082762e19da79d09804a6b49df5165 while in follow mode, the follower active route will match the one of the followed player