### PR TITLE
Prevent cyclic dependencies in remix projects

### DIFF
--- a/editor/src/components/canvas/remix/remix-utils.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.tsx
@@ -255,7 +255,7 @@ function getRemixExportsOfModule(
     displayNoneInstances: Array<ElementPath>,
     metadataContext: UiJsxCanvasContextData,
   ) => {
-    let resolvedFiles: MapLike<Array<string>> = {}
+    let resolvedFiles: MapLike<MapLike<any>> = {}
     let resolvedFileNames: Array<string> = [filename]
 
     const requireFn = curriedRequireFn(innerProjectContents)
@@ -267,11 +267,12 @@ function getRemixExportsOfModule(
       }
       let resolvedFromThisOrigin = resolvedFiles[importOrigin]
 
-      const alreadyResolved = resolvedFromThisOrigin.includes(toImport) // We're inside a cyclic dependency, so trigger the below fallback     const filePathResolveResult = alreadyResolved
+      const alreadyResolved = resolvedFromThisOrigin[toImport] !== undefined
+      const filePathResolveResult = alreadyResolved
         ? left<string, string>('Already resolved')
         : resolve(importOrigin, toImport)
 
-      forEachRight(alreadyResolved, (filepath) => resolvedFileNames.push(filepath))
+      forEachRight(filePathResolveResult, (filepath) => resolvedFileNames.push(filepath))
 
       const resolvedParseSuccess: Either<string, MapLike<any>> = attemptToResolveParsedComponents(
         resolvedFromThisOrigin,
@@ -287,7 +288,7 @@ function getRemixExportsOfModule(
         metadataContext,
         NO_OP,
         false,
-        alreadyResolved,
+        filePathResolveResult,
         null,
       )
       return foldEither(


### PR DESCRIPTION
**Problem:**
#4292 was introduced to prevent cyclic dependencies during creation of the execution scope, but that change wasn't included in `remix-utils.ts`, where we also create execution scopes. Unfortunately it seems this slipped under the radar because `Array<string>` is apparently a `MapLike<any>`

**Fix:**
Make the same fix in `remix-utils.ts`
