### PR TITLE
Handle imports and exports correctly in collaboration.

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -27,6 +27,8 @@ import type {
   Imports,
   ParsedTextFile,
   ImageFile,
+  ExportDetail,
+  ImportDetails,
 } from '../../core/shared/project-file-types'
 import { StaticElementPathPart } from '../../core/shared/project-file-types'
 import type { CodeResultCache, PropertyControlsInfo } from '../custom-code/code-file'
@@ -79,6 +81,7 @@ import type { PostActionChoice } from '../canvas/canvas-strategies/post-action-o
 import type { FromVSCodeAction } from './actions/actions-from-vscode'
 import type { ProjectServerState } from './store/project-server-state'
 import type { SetHuggingParentToFixed } from '../canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy'
+import type { MapLike } from 'typescript'
 export { isLoggedIn, loggedInUser, notLoggedIn } from '../../common/user'
 export type { LoginState, UserDetails } from '../../common/user'
 
@@ -1062,6 +1065,18 @@ export interface UpdateTopLevelElementsFromCollaborationUpdate {
   topLevelElements: Array<TopLevelElement>
 }
 
+export interface UpdateExportsDetailFromCollaborationUpdate {
+  action: 'UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE'
+  fullPath: string
+  exportsDetail: Array<ExportDetail>
+}
+
+export interface UpdateImportsFromCollaborationUpdate {
+  action: 'UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE'
+  fullPath: string
+  imports: MapLike<ImportDetails>
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertJSXElement
@@ -1234,6 +1249,8 @@ export type EditorAction =
   | TruncateHistory
   | UpdateProjectServerState
   | UpdateTopLevelElementsFromCollaborationUpdate
+  | UpdateExportsDetailFromCollaborationUpdate
+  | UpdateImportsFromCollaborationUpdate
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -33,6 +33,7 @@ import type {
   StaticElementPathPart,
   ElementPath,
   ImageFile,
+  ExportDetail,
 } from '../../../core/shared/project-file-types'
 import type { BuildType } from '../../../core/workers/common/worker-types'
 import type { Key, KeysPressed } from '../../../utils/keyboard'
@@ -222,6 +223,8 @@ import type {
   UpdateProjectServerState,
   UpdateTopLevelElementsFromCollaborationUpdate,
   DeleteFileFromCollaboration,
+  UpdateExportsDetailFromCollaborationUpdate,
+  UpdateImportsFromCollaborationUpdate,
 } from '../action-types'
 import type { InsertionSubjectWrapper, Mode } from '../editor-modes'
 import { EditorModes, insertionSubject } from '../editor-modes'
@@ -1680,5 +1683,27 @@ export function updateTopLevelElementsFromCollaborationUpdate(
     action: 'UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE',
     fullPath: fullPath,
     topLevelElements: topLevelElements,
+  }
+}
+
+export function updateExportsDetailFromCollaborationUpdate(
+  fullPath: string,
+  exportsDetail: Array<ExportDetail>,
+): UpdateExportsDetailFromCollaborationUpdate {
+  return {
+    action: 'UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE',
+    fullPath: fullPath,
+    exportsDetail: exportsDetail,
+  }
+}
+
+export function updateImportsFromCollaborationUpdate(
+  fullPath: string,
+  imports: Imports,
+): UpdateImportsFromCollaborationUpdate {
+  return {
+    action: 'UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE',
+    fullPath: fullPath,
+    imports: imports,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -198,6 +198,8 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_CONIDTIONAL_EXPRESSION':
     case 'CUT_SELECTION_TO_CLIPBOARD':
     case 'UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE':
+    case 'UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE':
+    case 'UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE':
       return false
     case 'SAVE_ASSET':
       return (

--- a/editor/src/components/editor/store/collaborative-editing.ts
+++ b/editor/src/components/editor/store/collaborative-editing.ts
@@ -50,6 +50,11 @@ const TopLevelElementsKey = 'topLevelElements'
 const ExportsDetailKey = 'exportsDetail'
 const ImportsKey = 'imports'
 
+// FIXME: This is very slow an inefficient, but is a stopgap measure for right now.
+function removeSourceMaps(topLevelElements: Array<TopLevelElement>): Array<TopLevelElement> {
+  return JSON.parse(JSON.stringify(topLevelElements, (k, v) => (k === 'sourceMap' ? null : v)))
+}
+
 export function collateCollaborativeProjectChanges(
   oldContents: ProjectContentTreeRoot,
   newContents: ProjectContentTreeRoot,
@@ -482,9 +487,11 @@ function synchroniseParseSuccessToCollabFile(
   success: ParseSuccess,
   collabFile: CollabTextFile,
 ): void {
+  // Source maps tend to bloat the data but are not necessary.
+  const strippedTopLevelElements = removeSourceMaps(success.topLevelElements)
   // Updates to the `topLevelElements`.
   syncArrayChanges<TopLevelElement>(
-    success.topLevelElements,
+    strippedTopLevelElements,
     collabFile,
     TopLevelElementsKey,
     TopLevelElementKeepDeepEquality,

--- a/editor/src/components/editor/store/collaborative-editing.ts
+++ b/editor/src/components/editor/store/collaborative-editing.ts
@@ -261,27 +261,41 @@ function updateEntireProjectContents(changeEvent: Y.YMapEvent<any>): Array<Edito
   let actions: Array<EditorAction> = []
   // Map from filename to the restricted file contents.
   const targetMap = changeEvent.currentTarget as Y.Map<CollabFile>
-  for (const [filename, mapEntry] of targetMap.entries()) {
-    // Mysteriously the type doesn't really carry over.
-    const entryFile = mapEntry as CollabFile
-    // Handle `topLevelElements`.
-    const topLevelElements = entryFile.get(TopLevelElementsKey) as
-      | CollabTextFileTopLevelElements
-      | undefined
-    if (topLevelElements != null) {
-      actions.push(
-        updateTopLevelElementsFromCollaborationUpdate(filename, topLevelElements.toArray()),
-      )
-    }
-    // Handle `exportsDetail`.
-    const exportsDetail = entryFile.get(ExportsDetailKey) as CollabTextFileExportsDetail | undefined
-    if (exportsDetail != null) {
-      actions.push(updateExportsDetailFromCollaborationUpdate(filename, exportsDetail.toArray()))
-    }
-    // Handle `imports`.
-    const imports = entryFile.get(ImportsKey) as CollabTextFileImports | undefined
-    if (imports != null) {
-      actions.push(updateImportsFromCollaborationUpdate(filename, imports.toJSON()))
+  for (const [filename, change] of changeEvent.keys.entries()) {
+    switch (change.action) {
+      case 'delete':
+        actions.push(deleteFileFromCollaboration(filename))
+        break
+      case 'add':
+      case 'update':
+        // Mysteriously the type doesn't really carry over.
+        const entryFile = targetMap.get(filename) as CollabFile
+        // Handle `topLevelElements`.
+        const topLevelElements = entryFile.get(TopLevelElementsKey) as
+          | CollabTextFileTopLevelElements
+          | undefined
+        if (topLevelElements != null) {
+          actions.push(
+            updateTopLevelElementsFromCollaborationUpdate(filename, topLevelElements.toArray()),
+          )
+        }
+        // Handle `exportsDetail`.
+        const exportsDetail = entryFile.get(ExportsDetailKey) as
+          | CollabTextFileExportsDetail
+          | undefined
+        if (exportsDetail != null) {
+          actions.push(
+            updateExportsDetailFromCollaborationUpdate(filename, exportsDetail.toArray()),
+          )
+        }
+        // Handle `imports`.
+        const imports = entryFile.get(ImportsKey) as CollabTextFileImports | undefined
+        if (imports != null) {
+          actions.push(updateImportsFromCollaborationUpdate(filename, imports.toJSON()))
+        }
+        break
+      default:
+        assertNever(change.action)
     }
   }
 

--- a/editor/src/components/editor/store/collaborative-editing.ts
+++ b/editor/src/components/editor/store/collaborative-editing.ts
@@ -1,27 +1,35 @@
-import * as Y from 'yjs'
-import type { ProjectContentsTree } from '../../../components/assets'
-import {
-  getProjectFileFromTree,
-  isProjectContentFile,
-  zipContentsTree,
-  type ProjectContentTreeRoot,
-} from '../../../components/assets'
-import type { TopLevelElement } from '../../../core/shared/element-template'
-import type { ParseSuccess } from '../../../core/shared/project-file-types'
-import { isTextFile } from '../../../core/shared/project-file-types'
-import { assertNever, isBrowserEnvironment } from '../../../core/shared/utils'
-import { isFeatureEnabled } from '../../../utils/feature-switches'
-import type { EditorAction, EditorDispatch } from '../action-types'
 import {
   deleteFileFromCollaboration,
-  updateTopLevelElementsFromCollaborationUpdate,
+  updateExportsDetailFromCollaborationUpdate,
+  updateImportsFromCollaborationUpdate,
 } from '../actions/action-creators'
 import type {
+  CollabFile,
   CollabTextFile,
+  CollabTextFileExportsDetail,
+  CollabTextFileImports,
   CollabTextFileTopLevelElements,
   CollaborativeEditingSupportSession,
 } from './editor-state'
+import type { ProjectContentsTree } from '../../../components/assets'
 import {
+  type ProjectContentTreeRoot,
+  getProjectFileFromTree,
+  isProjectContentFile,
+  zipContentsTree,
+} from '../../../components/assets'
+import type { EditorAction, EditorDispatch } from '../action-types'
+import { updateTopLevelElementsFromCollaborationUpdate } from '../actions/action-creators'
+import { assertNever, isBrowserEnvironment } from '../../../core/shared/utils'
+import type {
+  ExportDetail,
+  ImportDetails,
+  ParseSuccess,
+} from '../../../core/shared/project-file-types'
+import { isTextFile } from '../../../core/shared/project-file-types'
+import {
+  ExportDetailKeepDeepEquality,
+  ImportDetailsKeepDeepEquality,
   ParsedTextFileKeepDeepEquality,
   TopLevelElementKeepDeepEquality,
 } from './store-deep-equality-instances'
@@ -32,6 +40,15 @@ import {
   type ProjectChanges,
   type ProjectFileChange,
 } from './vscode-changes'
+import * as Y from 'yjs'
+import type { TopLevelElement } from '../../../core/shared/element-template'
+import { isFeatureEnabled } from '../../../utils/feature-switches'
+import type { KeepDeepEqualityCall } from '../../../utils/deep-equality'
+import type { MapLike } from 'typescript'
+
+const TopLevelElementsKey = 'topLevelElements'
+const ExportsDetailKey = 'exportsDetail'
+const ImportsKey = 'imports'
 
 export function collateCollaborativeProjectChanges(
   oldContents: ProjectContentTreeRoot,
@@ -151,7 +168,11 @@ function applyFileChangeToMap(
           collabFile = new Y.Map()
           collabFile.set('type', 'TEXT_FILE')
           const topLevelElementsArray = new Y.Array<TopLevelElement>()
-          collabFile.set('topLevelElements', topLevelElementsArray)
+          collabFile.set(TopLevelElementsKey, topLevelElementsArray)
+          const exportsDetailArray = new Y.Array<ExportDetail>()
+          collabFile.set(ExportsDetailKey, exportsDetailArray)
+          const importsMap = new Y.Map<ImportDetails>()
+          collabFile.set(ImportsKey, importsMap)
         }
 
         mergeDoc.transact(() => {
@@ -188,6 +209,7 @@ export function addHookForProjectChanges(
   dispatch: EditorDispatch,
 ): void {
   session.projectContents.observeDeep((changeEvents) => {
+    let actionsToDispatch: Array<EditorAction> = []
     // TODO Check that this is the array change before doing anything
     for (const changeEvent of changeEvents) {
       switch (changeEvent.path.length) {
@@ -195,7 +217,7 @@ export function addHookForProjectChanges(
         // appears to arise at least on first connection to sync up the entire value.
         case 0: {
           if (changeEvent instanceof Y.YMapEvent) {
-            updateEntireProjectContents(changeEvent as Y.YMapEvent<any>, dispatch)
+            actionsToDispatch.push(...updateEntireProjectContents(changeEvent as Y.YMapEvent<any>))
           } else {
             throw new Error(`Could not treat change event as Y.YMapEvent.`)
           }
@@ -211,129 +233,262 @@ export function addHookForProjectChanges(
         // the string `topLevelElements`.
         case 2: {
           const filePath = changeEvent.path[0] as string
-          if (changeEvent.path[1] !== 'topLevelElements') {
-            throw new Error(`Unexpected second part of change path: ${changeEvent.path[1]}`)
+          const targetProperty = changeEvent.path[1]
+          switch (targetProperty) {
+            case TopLevelElementsKey:
+              actionsToDispatch.push(updateTopLevelElementsOfFile(session, filePath))
+              break
+            case ExportsDetailKey:
+              actionsToDispatch.push(updateExportsDetailOfFile(session, filePath))
+              break
+            case ImportsKey:
+              actionsToDispatch.push(updateImportsOfFile(session, filePath))
+              break
+            default:
+              throw new Error(`Unexpected second part of change path: ${targetProperty}`)
           }
-          updateTopLevelElementsOfFile(session, filePath, changeEvent, dispatch)
           break
         }
         default:
           throw new Error(`Unexpected change path: ${JSON.stringify(changeEvent.path)}`)
       }
     }
+    dispatch(actionsToDispatch)
   })
 }
 
-export interface ArrayChanges {
-  updatesAt: Array<number>
-  deleteFrom: number | null
-}
-
-function updateEntireProjectContents(
-  changeEvent: Y.YMapEvent<any>,
-  dispatch: EditorDispatch,
-): void {
+function updateEntireProjectContents(changeEvent: Y.YMapEvent<any>): Array<EditorAction> {
   let actions: Array<EditorAction> = []
-  const entriesIterator = changeEvent.keys.entries()
-  for (const [filename, changeEntry] of entriesIterator) {
-    switch (changeEntry.action) {
-      case 'update':
-      case 'add':
-        if (changeEntry.newValue != null) {
-          actions.push(
-            updateTopLevelElementsFromCollaborationUpdate(
-              filename,
-              (changeEntry.newValue as CollabTextFileTopLevelElements).toArray(),
-            ),
-          )
-        }
-        break
-      case 'delete':
-        actions.push(deleteFileFromCollaboration(filename))
-        break
-      default:
-        throw new Error(`Unhandled change entry action: ${changeEntry.action}`)
+  // Map from filename to the restricted file contents.
+  const targetMap = changeEvent.currentTarget as Y.Map<CollabFile>
+  for (const [filename, mapEntry] of targetMap.entries()) {
+    // Mysteriously the type doesn't really carry over.
+    const entryFile = mapEntry as CollabFile
+    // Handle `topLevelElements`.
+    const topLevelElements = entryFile.get(TopLevelElementsKey) as
+      | CollabTextFileTopLevelElements
+      | undefined
+    if (topLevelElements != null) {
+      actions.push(
+        updateTopLevelElementsFromCollaborationUpdate(filename, topLevelElements.toArray()),
+      )
+    }
+    // Handle `exportsDetail`.
+    const exportsDetail = entryFile.get(ExportsDetailKey) as CollabTextFileExportsDetail | undefined
+    if (exportsDetail != null) {
+      actions.push(updateExportsDetailFromCollaborationUpdate(filename, exportsDetail.toArray()))
+    }
+    // Handle `imports`.
+    const imports = entryFile.get(ImportsKey) as CollabTextFileImports | undefined
+    if (imports != null) {
+      actions.push(updateImportsFromCollaborationUpdate(filename, imports.toJSON()))
     }
   }
-  dispatch(actions)
+
+  // Return the accumulated editor actions.
+  return actions
+}
+
+function updateEditorWithArrayChanges<T>(
+  session: CollaborativeEditingSupportSession,
+  filePath: string,
+  fileKey: string,
+  makeUpdateAction: (filePath: string, newElements: Array<T>) => EditorAction,
+): EditorAction {
+  const file = session.projectContents.get(filePath)
+  const yjsValue: Y.Array<T> = (file?.get(fileKey) as any as Y.Array<T>) ?? new Y.Array()
+  let editorValue: Array<T> = yjsValue.toArray()
+  return makeUpdateAction(filePath, editorValue)
+}
+
+function updateEditorWithMapChanges<T>(
+  session: CollaborativeEditingSupportSession,
+  filePath: string,
+  fileKey: string,
+  makeUpdateAction: (filePath: string, newValue: MapLike<T>) => EditorAction,
+): EditorAction {
+  const file = session.projectContents.get(filePath)
+  const yjsValue: Y.Map<T> = (file?.get(fileKey) as any as Y.Map<T>) ?? new Y.Map()
+  const editorValue = yjsValue.toJSON()
+  return makeUpdateAction(filePath, editorValue)
 }
 
 function updateTopLevelElementsOfFile(
   session: CollaborativeEditingSupportSession,
   filePath: string,
-  changeEvent: Y.YEvent<any>,
-  dispatch: EditorDispatch,
-): void {
-  const file = session.projectContents.get(filePath)
-  const oldTopLevelElements: CollabTextFileTopLevelElements =
-    (file?.get('topLevelElements') as CollabTextFileTopLevelElements) ?? []
-  let newTopLevelElements: Array<TopLevelElement> = []
-  let readIndex = 0
-  for (const delta of changeEvent.delta) {
-    if (delta.retain != undefined) {
-      const elementsToPush = oldTopLevelElements.slice(readIndex, readIndex + delta.retain)
-      newTopLevelElements.push(...elementsToPush)
-      readIndex += delta.retain
-    }
-    if (delta.insert != null && Array.isArray(delta.insert)) {
-      newTopLevelElements.push(...delta.insert)
-    }
-    if (delta.delete != undefined) {
-      readIndex += delta.delete
-    }
-  }
-
-  dispatch([updateTopLevelElementsFromCollaborationUpdate(filePath, newTopLevelElements)])
+): EditorAction {
+  return updateEditorWithArrayChanges(
+    session,
+    filePath,
+    TopLevelElementsKey,
+    updateTopLevelElementsFromCollaborationUpdate,
+  )
 }
 
-function arrayChanges(updatesAt: Array<number>, deleteFrom: number | null): ArrayChanges {
+function updateExportsDetailOfFile(
+  session: CollaborativeEditingSupportSession,
+  filePath: string,
+): EditorAction {
+  return updateEditorWithArrayChanges(
+    session,
+    filePath,
+    ExportsDetailKey,
+    updateExportsDetailFromCollaborationUpdate,
+  )
+}
+
+function updateImportsOfFile(
+  session: CollaborativeEditingSupportSession,
+  filePath: string,
+): EditorAction {
+  return updateEditorWithMapChanges(
+    session,
+    filePath,
+    ImportsKey,
+    updateImportsFromCollaborationUpdate,
+  )
+}
+
+interface NoChange {
+  type: 'NO_CHANGE'
+}
+
+const noChange: NoChange = {
+  type: 'NO_CHANGE',
+}
+
+interface ChangeHere<T> {
+  type: 'CHANGE_HERE'
+  updatedValue: T
+}
+
+function changeHere<T>(updatedValue: T): ChangeHere<T> {
   return {
-    updatesAt: updatesAt,
-    deleteFrom: deleteFrom,
+    type: 'CHANGE_HERE',
+    updatedValue: updatedValue,
   }
 }
+
+interface Deleted {
+  type: 'DELETED'
+}
+
+const deleted: Deleted = {
+  type: 'DELETED',
+}
+
+type ArrayChange<T> = NoChange | ChangeHere<T> | Deleted
+
+type ArrayChanges<T> = Array<ArrayChange<T>>
 
 export function calculateArrayChanges<T>(
   from: Array<T>,
   into: Y.Array<T>,
   equals: (from: T, into: T) => boolean = (fromToCheck, intoToCheck) => fromToCheck === intoToCheck,
-): ArrayChanges {
-  let updatesAt: Array<number> = []
+): ArrayChanges<T> {
+  let arrayChanges: ArrayChanges<T> = []
+
   for (let index: number = 0; index < Math.max(from.length, into.length); index++) {
-    if (!equals(from[index], into.get(index))) {
-      updatesAt.push(index)
+    if (index > from.length - 1) {
+      arrayChanges.push(deleted)
+    } else if (index > into.length - 1) {
+      arrayChanges.push(changeHere(from[index]))
+    } else if (!equals(from[index], into.get(index))) {
+      arrayChanges.push(changeHere(from[index]))
+    } else {
+      arrayChanges.push(noChange)
     }
   }
 
-  let deleteFrom: number | null = null
-  if (into.length > from.length) {
-    deleteFrom = from.length
-  }
+  return arrayChanges
+}
 
-  return arrayChanges(updatesAt, deleteFrom)
+function syncArrayChanges<T>(
+  fromArray: Array<T>,
+  collabFile: CollabTextFile,
+  fileKey: string,
+  keepDeep: KeepDeepEqualityCall<T>,
+): void {
+  const againstArray = collabFile.get(fileKey) as any as Y.Array<T>
+  const elementChanges = calculateArrayChanges(
+    fromArray,
+    againstArray,
+    (l, r) => l != null && r != null && keepDeep(l, r).areEqual,
+  )
+  let index: number = 0
+  elementChanges.forEach((change) => {
+    switch (change.type) {
+      case 'DELETED':
+        againstArray.delete(index, 1)
+        break
+      case 'CHANGE_HERE':
+        if (againstArray.length > index) {
+          againstArray.delete(index, 1)
+        }
+        againstArray.insert(index, [change.updatedValue])
+        index += 1
+        break
+      case 'NO_CHANGE':
+        index += 1
+        break
+    }
+  })
+}
+
+function syncMapChanges<T>(
+  fromMap: MapLike<T>,
+  collabFile: CollabTextFile,
+  fileKey: string,
+  keepDeep: KeepDeepEqualityCall<T>,
+): void {
+  const againstMap = collabFile.get(fileKey) as any as Y.Map<T>
+  let keysChecked: Set<string> = new Set()
+  for (const [keyFromMap, valueFromMap] of Object.entries(fromMap)) {
+    keysChecked.add(keyFromMap)
+    if (againstMap.has(keyFromMap)) {
+      // Value exists in both maps, but has changed.
+      if (!keepDeep(valueFromMap, againstMap.get(keyFromMap)!).areEqual) {
+        againstMap.set(keyFromMap, valueFromMap)
+      }
+    } else {
+      // Value does not exist in against map, so should be added.
+      againstMap.set(keyFromMap, valueFromMap)
+    }
+  }
+  // For any key that we haven't seen in the from map,
+  // it should be deleted from the against map.
+  for (const keyAgainstMap of againstMap.keys()) {
+    if (!keysChecked.has(keyAgainstMap)) {
+      againstMap.delete(keyAgainstMap)
+    }
+  }
 }
 
 function synchroniseParseSuccessToCollabFile(
   success: ParseSuccess,
   collabFile: CollabTextFile,
 ): void {
-  const collabFileTopLevelElements = collabFile.get('topLevelElements')
-  if (collabFileTopLevelElements === 'TEXT_FILE' || collabFileTopLevelElements === undefined) {
-    throw new Error('Invalid value for topLevelElements.')
-  } else {
-    const changes = calculateArrayChanges(
-      success.topLevelElements,
-      collabFileTopLevelElements,
-      (l, r) => l != null && r != null && TopLevelElementKeepDeepEquality(l, r).areEqual,
-    )
-    for (const updateAtIndex of changes.updatesAt) {
-      if (collabFileTopLevelElements.length > updateAtIndex) {
-        collabFileTopLevelElements.delete(updateAtIndex, 1)
-      }
-      collabFileTopLevelElements.insert(updateAtIndex, [success.topLevelElements[updateAtIndex]])
-    }
-    if (changes.deleteFrom != null) {
-      collabFileTopLevelElements.delete(changes.deleteFrom)
-    }
-  }
+  // Updates to the `topLevelElements`.
+  syncArrayChanges<TopLevelElement>(
+    success.topLevelElements,
+    collabFile,
+    TopLevelElementsKey,
+    TopLevelElementKeepDeepEquality,
+  )
+
+  // Updates to the `exportsDetail`.
+  syncArrayChanges<ExportDetail>(
+    success.exportsDetail,
+    collabFile,
+    ExportsDetailKey,
+    ExportDetailKeepDeepEquality,
+  )
+
+  // Updates to the `imports`.
+  syncMapChanges<ImportDetails>(
+    success.imports,
+    collabFile,
+    ImportsKey,
+    ImportDetailsKeepDeepEquality,
+  )
 }

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -111,6 +111,8 @@ function checkIfActionShouldBeProcessed(
     const allowedNonOwnerAction =
       action.action === 'UPDATE_FROM_WORKER' ||
       action.action === 'UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE' ||
+      action.action === 'UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE' ||
+      action.action === 'UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE' ||
       action.action === 'DELETE_FILE_FROM_COLLABORATION'
     shouldProcessAction = allowedNonOwnerAction
   }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -50,9 +50,11 @@ import { isFiniteRectangle, size } from '../../../core/shared/math-utils'
 import type { PackageStatus, PackageStatusMap } from '../../../core/shared/npm-dependency-types'
 import type {
   ElementPath,
+  ExportDetail,
   HighlightBoundsForUids,
   HighlightBoundsWithFile,
   HighlightBoundsWithFileForUids,
+  ImportDetails,
   Imports,
   NodeModules,
   ParseSuccess,
@@ -397,7 +399,13 @@ export const defaultUserState: UserState = {
 
 export type CollabTextFileTopLevelElements = Y.Array<TopLevelElement>
 
-export type CollabTextFile = Y.Map<'TEXT_FILE' | CollabTextFileTopLevelElements>
+export type CollabTextFileExportsDetail = Y.Array<ExportDetail>
+
+export type CollabTextFileImports = Y.Map<ImportDetails>
+
+export type CollabTextFile = Y.Map<
+  'TEXT_FILE' | CollabTextFileTopLevelElements | CollabTextFileExportsDetail | CollabTextFileImports
+>
 
 export type CollabFile = CollabTextFile //| CollabImageFileUpdate | CollabAssetFileUpdate | CollabDirectoryFileUpdate
 

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -395,6 +395,10 @@ export function runSimpleLocalEditorAction(
         state,
         serverState,
       )
+    case 'UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE':
+      return UPDATE_FNS.UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE(action, state, serverState)
+    case 'UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE':
+      return UPDATE_FNS.UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE(action, state, serverState)
     default:
       return state
   }


### PR DESCRIPTION
**Problem:**
Export details are used as part of the flow for printing components, so that they get the `export` modifier against them. Without that the viewer in a collaboration setting might not have a newly added component exported which would result in the project breaking for them.

Additionally while fixing this issue, the imports were found to be suffering from a related issue. Which could result in the following code when changing the exports and related imports on the other side:
```typescript
import { Playground } from '/src/playground'
import Playground from '/src/playground'
```
The above code would then cause the viewer to be broken from the duplicate reference.

**Fix:**
This consists of a couple of intertwined fixes:
- Carrying over the imports and export details as part of the collaboration updates.
- Fixing the handling of changes from yjs types to our types by getting the yjs types to construct our arrays or maps through `.toArray()` or `.toJSON()` respectively. This removes an entire segment of logic that was using deltas from yjs to reconstruct our types.
- Completely reworking our delta updates from our type to the yjs types as they weren't working correctly in extreme cases like completely deleting the entire contents of a file.

**Commit Details:**
- Added `UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE` and `UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE` editor actions.
- `addHookForProjectChanges` now collates potentially many actions to dispatch at once.
- Reworked `ArrayChanges` as it didn't work very well in its original form.
- Refactored `updateEntireProjectContents` to produce a multitude of editor actions and dispatch all at once.
- Created `updateEditorWithArrayChanges` and `updateEditorWithMapChanges` utility functions.
- Implemented `updateTopLevelElementsOfFile`, `updateExportsDetailOfFile` and `updateImportsOfFile` to carry changes from the yjs types into the editor.
- `calculateArrayChanges` now produces step by step changes.
- Implemented `syncArrayChanges` and `syncMapChanges` utility functions.
- `synchroniseParseSuccesToCollabFile` now much more simplified than the original implementations.
