### PR TITLE
Strip source maps from the outgoing top level elements.

### DIFF
--- a/editor/src/components/editor/store/collaborative-editing.ts
+++ b/editor/src/components/editor/store/collaborative-editing.ts
@@ -50,6 +50,11 @@ const TopLevelElementsKey = 'topLevelElements'
 const ExportsDetailKey = 'exportsDetail'
 const ImportsKey = 'imports'
 
+// FIXME: This is very slow an inefficient, but is a stopgap measure for right now.
+function removeSourceMaps(topLevelElements: Array<TopLevelElement>): Array<TopLevelElement> {
+  return JSON.parse(JSON.stringify(topLevelElements, (k, v) => (k === 'sourceMap' ? null : v)))
+}
+
 export function collateCollaborativeProjectChanges(
   oldContents: ProjectContentTreeRoot,
   newContents: ProjectContentTreeRoot,
@@ -468,9 +473,11 @@ function synchroniseParseSuccessToCollabFile(
   success: ParseSuccess,
   collabFile: CollabTextFile,
 ): void {
+  // Source maps tend to bloat the data but are not necessary.
+  const strippedTopLevelElements = removeSourceMaps(success.topLevelElements)
   // Updates to the `topLevelElements`.
   syncArrayChanges<TopLevelElement>(
-    success.topLevelElements,
+    strippedTopLevelElements,
     collabFile,
     TopLevelElementsKey,
     TopLevelElementKeepDeepEquality,


### PR DESCRIPTION
**Problem:**
The messages that we send to Liveblocks for the collaboration on realistic projects tends to cause disconnections as each message can exceed 5MB.

**Cause:**
Most of the bloat comes from the source maps that are extraneous to the needs of the collaboration functionality.

**Fix:**
Utilising the replacer parameter of `JSON.stringify`, we replace the source maps content with a null.

**Commit Details:**
- Added `removeSourceMaps` to strip those from the outgoing top level elements.