### PR TITLE
Make comment popups/indicators ignore zoom

### DIFF
--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -13,7 +13,7 @@ import { EditorModes, isCommentMode } from '../../editor/editor-modes'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { Substores, useEditorState } from '../../editor/store/store-hook'
 import { stopPropagation } from '../../inspector/common/inspector-utils'
-import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
+import { canvasPointToWindowPoint } from '../dom-lookup'
 
 export const CommentPopup = React.memo(() => {
   const mode = useEditorState(
@@ -22,34 +22,46 @@ export const CommentPopup = React.memo(() => {
     'CommentPopup mode',
   )
 
+  const canvasScale = useEditorState(
+    Substores.canvasOffset,
+    (store) => store.editor.canvas.scale,
+    'CommentPopup canvasScale',
+  )
+  const canvasOffset = useEditorState(
+    Substores.canvasOffset,
+    (store) => store.editor.canvas.roundedCanvasOffset,
+    'CommentPopup canvasScale',
+  )
+
   if (!isCommentMode(mode) || mode.location == null) {
     return null
   }
   const { location } = mode
 
+  const point = canvasPointToWindowPoint(location, canvasScale, canvasOffset)
+
   return (
-    <CanvasOffsetWrapper>
-      <div
-        style={{
-          position: 'absolute',
-          top: location.y,
-          left: location.x + 30,
-          cursor: 'text',
-          minWidth: 250,
-          boxShadow: UtopiaTheme.panelStyles.shadows.medium,
-        }}
-        onKeyDown={stopPropagation}
-        onKeyUp={stopPropagation}
-        onMouseUp={stopPropagation}
+    <div
+      style={{
+        position: 'fixed',
+        top: point.y,
+        left: point.x + 30,
+        cursor: 'text',
+        minWidth: 250,
+        boxShadow: UtopiaTheme.panelStyles.shadows.medium,
+        zoom: 1 / canvasScale,
+      }}
+      onKeyDown={stopPropagation}
+      onKeyUp={stopPropagation}
+      onMouseUp={stopPropagation}
+    >
+      <MultiplayerWrapper
+        errorFallback={<div>Can not load comments</div>}
+        suspenseFallback={<div>Loading…</div>}
       >
-        <MultiplayerWrapper
-          errorFallback={<div>Can not load comments</div>}
-          suspenseFallback={<div>Loading…</div>}
-        >
-          <CommentThread x={location.x} y={location.y} />
-        </MultiplayerWrapper>
-      </div>
-    </CanvasOffsetWrapper>
+        <CommentThread x={location.x} y={location.y} />
+      </MultiplayerWrapper>
+    </div>
   )
 })
 CommentPopup.displayName = 'CommentPopup'


### PR DESCRIPTION
Fix #4567 

**Problem:**

Comment popups and indicators are currently affected by the canvas zoom, but they should not be.

**Fix:**

Make their positioning relative to the window and down/upscale them. Also, fix the transition of the indicators so it's only tied to the transform.