### PR TITLE
Viewers should not send collab edit updates

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -686,7 +686,10 @@ export function editorDispatchClosingOut(
       updatedFromVSCodeOrParsedAfterCodeChange,
     )
     applyProjectChangesToVSCode(frozenEditorState, projectChanges)
-    if (finalStore.collaborativeEditingSupport.session != null) {
+    if (
+      finalStore.collaborativeEditingSupport.session != null &&
+      finalStore.projectServerState.isMyProject === 'yes'
+    ) {
       updateCollaborativeProjectContents(
         finalStore.collaborativeEditingSupport.session,
         projectChanges,


### PR DESCRIPTION
Problem:
Viewers can send out collab edit messages which can make them enter into a feedback loop

Fix:
Never send collab edit update when you are not the owner of the project

