### PR TITLE
Collaborative editing unit tests.

### DIFF
--- a/editor/src/components/editor/store/collaborative-editing.spec.ts
+++ b/editor/src/components/editor/store/collaborative-editing.spec.ts
@@ -1,0 +1,354 @@
+import { setFeatureForUnitTestsUseInDescribeBlockOnly, wait } from '../../../utils/utils.test-utils'
+import { Y } from '../../../core/shared/yjs'
+import {
+  RevisionsState,
+  isParseSuccess,
+  textFile,
+  textFileContents,
+} from '../../../core/shared/project-file-types'
+import type { ProjectContentTreeRoot } from '../../assets'
+import { addFileToProjectContents, removeFromProjectContents } from '../../assets'
+import {
+  addHookForProjectChanges,
+  collateCollaborativeProjectChanges,
+  updateCollaborativeProjectContents,
+} from './collaborative-editing'
+import type { EditorAction } from '../action-types'
+import type { CollaborativeEditingSupportSession } from './editor-state'
+import { emptyCollaborativeEditingSupportSession } from './editor-state'
+import { testParseCode } from '../../../core/workers/parser-printer/parser-printer.test-utils'
+import {
+  deleteFileFromCollaboration,
+  updateExportsDetailFromCollaborationUpdate,
+  updateImportsFromCollaborationUpdate,
+  updateTopLevelElementsFromCollaborationUpdate,
+} from '../actions/action-creators'
+import { fromField, fromTypeGuard, traverseArray } from '../../../core/shared/optics/optic-creators'
+import type { TopLevelElement } from '../../../core/shared/element-template'
+import { isArbitraryJSBlock } from '../../../core/shared/element-template'
+import { set } from '../../../core/shared/optics/optic-utilities'
+import type { Optic } from '../../../core/shared/optics/optics'
+import type { RawSourceMap } from '../../../core/workers/ts/ts-typings/RawSourceMap'
+
+interface AddHookForProjectChangesTest {
+  initialState: ProjectContentTreeRoot
+  changesToApply: (
+    firstSession: CollaborativeEditingSupportSession,
+    secondSession: CollaborativeEditingSupportSession,
+  ) => void
+  expectations: (
+    firstSessionPromises: Array<EditorAction>,
+    secondSessionPromises: Array<EditorAction>,
+  ) => void
+}
+
+const elementArrayToSourceMapOptic: Optic<
+  Array<TopLevelElement>,
+  RawSourceMap | null
+> = traverseArray<TopLevelElement>()
+  .compose(fromTypeGuard(isArbitraryJSBlock))
+  .compose(fromField('sourceMap'))
+
+async function runAddHookForProjectChangesTest(test: AddHookForProjectChangesTest): Promise<void> {
+  // Create the first collaboration session.
+  const firstCollaborationSession = emptyCollaborativeEditingSupportSession()
+
+  // A fake dispatch for the first session to be used with `addHookForProjectChanges`.
+  let firstDispatchPromises: Array<EditorAction> = []
+  function firstDispatch(actions: ReadonlyArray<EditorAction>): void {
+    firstDispatchPromises.push(...actions)
+  }
+
+  // Create the second collaboration session.
+  const secondCollaborationSession = emptyCollaborativeEditingSupportSession()
+
+  // A fake dispatch for the second session to be used with `addHookForProjectChanges`.
+  let secondDispatchPromises: Array<EditorAction> = []
+  function secondDispatch(actions: ReadonlyArray<EditorAction>): void {
+    secondDispatchPromises.push(...actions)
+  }
+
+  try {
+    // Updates to the first doc should be applied to the second doc.
+    // Currently this includes updates from everywhere, including itsef.
+    firstCollaborationSession.mergeDoc.on('update', (update) => {
+      Y.applyUpdate(secondCollaborationSession.mergeDoc, update)
+    })
+    // Updates to the second doc should be applied to the first doc.
+    // Currently this includes updates from everywhere, including itsef.
+    secondCollaborationSession.mergeDoc.on('update', (update) => {
+      Y.applyUpdate(firstCollaborationSession.mergeDoc, update)
+    })
+
+    // Hook into changes to the `projectContents` to have them dispatch actions into
+    // the fake dispatch calls which record those actions.
+    addHookForProjectChanges(firstCollaborationSession, firstDispatch)
+    addHookForProjectChanges(secondCollaborationSession, secondDispatch)
+
+    // Apply the initial state.
+    const initialStateChanges = collateCollaborativeProjectChanges({}, test.initialState)
+    updateCollaborativeProjectContents(firstCollaborationSession, initialStateChanges, [])
+
+    // Blank out the recorded promises which will have likely been modified by the change
+    // to the initial state.
+    firstDispatchPromises = []
+    secondDispatchPromises = []
+
+    // Apply the changes for this test case.
+    test.changesToApply(firstCollaborationSession, secondCollaborationSession)
+
+    // Test the result of the above changes.
+    test.expectations(firstDispatchPromises, secondDispatchPromises)
+  } finally {
+    // Cleanup the `Doc` instances.
+    secondCollaborationSession.mergeDoc.destroy()
+    firstCollaborationSession.mergeDoc.destroy()
+  }
+}
+
+describe('addHookForProjectChanges', () => {
+  setFeatureForUnitTestsUseInDescribeBlockOnly('Collaboration', true)
+
+  it('adding file causes it to be added to the project contents', async () => {
+    const code = 'export const A = <div />'
+    const newParsedCode = testParseCode(code)
+    if (!isParseSuccess(newParsedCode)) {
+      throw new Error('Code should parse.')
+    }
+
+    await runAddHookForProjectChangesTest({
+      initialState: {},
+      changesToApply: (firstSession, secondSession) => {
+        const newFile = textFile(
+          textFileContents(code, newParsedCode, RevisionsState.BothMatch),
+          null,
+          null,
+          1,
+        )
+        const updatedProjectContents = addFileToProjectContents({}, '/assets/test1.js', newFile)
+        const collaborationChanges = collateCollaborativeProjectChanges({}, updatedProjectContents)
+        updateCollaborativeProjectContents(firstSession, collaborationChanges, [])
+      },
+      expectations: (firstSessionPromises, secondSessionPromises) => {
+        const fixedElements = set(
+          elementArrayToSourceMapOptic,
+          null,
+          newParsedCode.topLevelElements,
+        )
+        expect(secondSessionPromises).toEqual([
+          updateTopLevelElementsFromCollaborationUpdate('/assets/test1.js', fixedElements),
+          updateExportsDetailFromCollaborationUpdate(
+            '/assets/test1.js',
+            newParsedCode.exportsDetail,
+          ),
+          updateImportsFromCollaborationUpdate('/assets/test1.js', newParsedCode.imports),
+        ])
+      },
+    })
+  })
+
+  it('adding file causes it to be added to the project contents, unless the file was modified by another user', async () => {
+    const code = 'export const A = <div />'
+    const newParsedCode = testParseCode(code)
+    if (!isParseSuccess(newParsedCode)) {
+      throw new Error('Code should parse.')
+    }
+
+    await runAddHookForProjectChangesTest({
+      initialState: {},
+      changesToApply: (firstSession, secondSession) => {
+        const newFile = textFile(
+          textFileContents(code, newParsedCode, RevisionsState.BothMatch),
+          null,
+          null,
+          1,
+        )
+        const updatedProjectContents = addFileToProjectContents({}, '/assets/test1.js', newFile)
+        const collaborationChanges = collateCollaborativeProjectChanges({}, updatedProjectContents)
+        updateCollaborativeProjectContents(firstSession, collaborationChanges, ['/assets/test1.js'])
+      },
+      expectations: (firstSessionPromises, secondSessionPromises) => {
+        expect(secondSessionPromises).toEqual([])
+      },
+    })
+  })
+
+  it('adding two files cause them to be added to the project contents', async () => {
+    const firstFileCode = 'export const A = <div />'
+    const firstFileParsedCode = testParseCode(firstFileCode)
+    if (!isParseSuccess(firstFileParsedCode)) {
+      throw new Error('Code should parse.')
+    }
+
+    const secondFileCode = 'export const A = <div />'
+    const secondFileParsedCode = testParseCode(secondFileCode)
+    if (!isParseSuccess(secondFileParsedCode)) {
+      throw new Error('Code should parse.')
+    }
+
+    await runAddHookForProjectChangesTest({
+      initialState: {},
+      changesToApply: (firstSession, secondSession) => {
+        const firstFile = textFile(
+          textFileContents(firstFileCode, firstFileParsedCode, RevisionsState.BothMatch),
+          null,
+          null,
+          1,
+        )
+        const secondFile = textFile(
+          textFileContents(secondFileCode, secondFileParsedCode, RevisionsState.BothMatch),
+          null,
+          null,
+          1,
+        )
+        const updatedProjectContents = addFileToProjectContents(
+          addFileToProjectContents({}, '/assets/test1.js', firstFile),
+          '/assets/test2.js',
+          secondFile,
+        )
+        const collaborationChanges = collateCollaborativeProjectChanges({}, updatedProjectContents)
+        updateCollaborativeProjectContents(firstSession, collaborationChanges, [])
+      },
+      expectations: (firstSessionPromises, secondSessionPromises) => {
+        const firstFileFixedElements = set(
+          elementArrayToSourceMapOptic,
+          null,
+          firstFileParsedCode.topLevelElements,
+        )
+        const secondFileFixedElements = set(
+          elementArrayToSourceMapOptic,
+          null,
+          secondFileParsedCode.topLevelElements,
+        )
+        expect(secondSessionPromises).toEqual([
+          updateTopLevelElementsFromCollaborationUpdate('/assets/test1.js', firstFileFixedElements),
+          updateExportsDetailFromCollaborationUpdate(
+            '/assets/test1.js',
+            firstFileParsedCode.exportsDetail,
+          ),
+          updateImportsFromCollaborationUpdate('/assets/test1.js', firstFileParsedCode.imports),
+          updateTopLevelElementsFromCollaborationUpdate(
+            '/assets/test2.js',
+            secondFileFixedElements,
+          ),
+          updateExportsDetailFromCollaborationUpdate(
+            '/assets/test2.js',
+            secondFileParsedCode.exportsDetail,
+          ),
+          updateImportsFromCollaborationUpdate('/assets/test2.js', secondFileParsedCode.imports),
+        ])
+      },
+    })
+  })
+
+  it('adding a new file to the project contents is resolved correctly', async () => {
+    const firstFileCode = 'export const A = <div />'
+    const firstFileParsedCode = testParseCode(firstFileCode)
+    if (!isParseSuccess(firstFileParsedCode)) {
+      throw new Error('Code should parse.')
+    }
+
+    const secondFileCode = 'export const A = <div />'
+    const secondFileParsedCode = testParseCode(secondFileCode)
+    if (!isParseSuccess(secondFileParsedCode)) {
+      throw new Error('Code should parse.')
+    }
+
+    const firstFile = textFile(
+      textFileContents(firstFileCode, firstFileParsedCode, RevisionsState.BothMatch),
+      null,
+      null,
+      1,
+    )
+    const startingProjectContents = addFileToProjectContents({}, '/assets/test1.js', firstFile)
+
+    await runAddHookForProjectChangesTest({
+      initialState: startingProjectContents,
+      changesToApply: (firstSession, secondSession) => {
+        const secondFile = textFile(
+          textFileContents(secondFileCode, secondFileParsedCode, RevisionsState.BothMatch),
+          null,
+          null,
+          1,
+        )
+        const updatedProjectContents = addFileToProjectContents(
+          startingProjectContents,
+          '/assets/test2.js',
+          secondFile,
+        )
+        const collaborationChanges = collateCollaborativeProjectChanges(
+          startingProjectContents,
+          updatedProjectContents,
+        )
+        updateCollaborativeProjectContents(firstSession, collaborationChanges, [])
+      },
+      expectations: (firstSessionPromises, secondSessionPromises) => {
+        const secondFileFixedElements = set(
+          elementArrayToSourceMapOptic,
+          null,
+          secondFileParsedCode.topLevelElements,
+        )
+        expect(secondSessionPromises).toEqual([
+          updateTopLevelElementsFromCollaborationUpdate(
+            '/assets/test2.js',
+            secondFileFixedElements,
+          ),
+          updateExportsDetailFromCollaborationUpdate(
+            '/assets/test2.js',
+            secondFileParsedCode.exportsDetail,
+          ),
+          updateImportsFromCollaborationUpdate('/assets/test2.js', secondFileParsedCode.imports),
+        ])
+      },
+    })
+  })
+
+  it('deleting a file causes it to be removed from the project contents', async () => {
+    const firstFileCode = 'export const A = <div />'
+    const firstFileParsedCode = testParseCode(firstFileCode)
+    if (!isParseSuccess(firstFileParsedCode)) {
+      throw new Error('Code should parse.')
+    }
+
+    const secondFileCode = 'export const A = <div />'
+    const secondFileParsedCode = testParseCode(secondFileCode)
+    if (!isParseSuccess(secondFileParsedCode)) {
+      throw new Error('Code should parse.')
+    }
+    const firstFile = textFile(
+      textFileContents(firstFileCode, firstFileParsedCode, RevisionsState.BothMatch),
+      null,
+      null,
+      1,
+    )
+    const secondFile = textFile(
+      textFileContents(secondFileCode, secondFileParsedCode, RevisionsState.BothMatch),
+      null,
+      null,
+      1,
+    )
+    const startingProjectContents = addFileToProjectContents(
+      addFileToProjectContents({}, '/assets/test1.js', firstFile),
+      '/assets/test2.js',
+      secondFile,
+    )
+
+    await runAddHookForProjectChangesTest({
+      initialState: startingProjectContents,
+      changesToApply: (firstSession, secondSession) => {
+        const updatedProjectContents = removeFromProjectContents(
+          startingProjectContents,
+          '/assets/test1.js',
+        )
+        const collaborationChanges = collateCollaborativeProjectChanges(
+          startingProjectContents,
+          updatedProjectContents,
+        )
+        updateCollaborativeProjectContents(firstSession, collaborationChanges, [])
+      },
+      expectations: (firstSessionPromises, secondSessionPromises) => {
+        expect(secondSessionPromises).toEqual([deleteFileFromCollaboration('/assets/test1.js')])
+      },
+    })
+  })
+})

--- a/editor/src/components/editor/store/collaborative-editing.ts
+++ b/editor/src/components/editor/store/collaborative-editing.ts
@@ -134,7 +134,7 @@ export function collateCollaborativeProjectChanges(
       }
     }
   }
-  if (isBrowserEnvironment && isFeatureEnabled('Collaboration')) {
+  if (isFeatureEnabled('Collaboration')) {
     if (oldContents != newContents) {
       zipContentsTree(oldContents, newContents, onElement)
     }
@@ -198,11 +198,11 @@ function applyFileChangeToMap(
 
 export function updateCollaborativeProjectContents(
   session: CollaborativeEditingSupportSession,
-  projectChanges: ProjectChanges,
+  collabProjectChanges: Array<ProjectFileChange>,
   filesModifiedByAnotherUser: Array<string>,
 ): void {
   const projectContentsMap = session.projectContents
-  for (const change of projectChanges.fileChanges.collabProjectChanges) {
+  for (const change of collabProjectChanges) {
     if (!filesModifiedByAnotherUser.includes(change.fullPath)) {
       applyFileChangeToMap(change, projectContentsMap, session.mergeDoc)
     }
@@ -233,9 +233,9 @@ export function addHookForProjectChanges(
         case 1: {
           throw new Error(`Unhandled path length of 1: ${changeEvent.path}`)
         }
-        // When a change happens to the `topLevelElements` in a particular file,
+        // When a change happens to one or more of the fields in a particular file,
         // this case should show up as the path will consist of the filename and
-        // the string `topLevelElements`.
+        // the field name.
         case 2: {
           const filePath = changeEvent.path[0] as string
           const targetProperty = changeEvent.path[1]
@@ -432,7 +432,7 @@ function syncArrayChanges<T>(
   const elementChanges = calculateArrayChanges(
     fromArray,
     againstArray,
-    (l, r) => l != null && r != null && keepDeep(l, r).areEqual,
+    (l, r) => keepDeep(l, r).areEqual,
   )
   let index: number = 0
   elementChanges.forEach((change) => {

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -692,7 +692,7 @@ export function editorDispatchClosingOut(
     ) {
       updateCollaborativeProjectContents(
         finalStore.collaborativeEditingSupport.session,
-        projectChanges,
+        projectChanges.fileChanges.collabProjectChanges,
         frozenEditorState.filesModifiedByAnotherUser,
       )
     }


### PR DESCRIPTION
**Problem:**
Currently a lot of the collaboration features lack any tests and the collaborative editing parts are especially easy to accidentally break because of the API around them.

**Fix:**
Added some tests along some smaller changes suggested in earlier PR feedback which was then tested with the tests.

**Commit Details:**
- Slight change to the parameters of `updateCollaborativeProjectContents`.
- Removed the `isBrowserEnvironment` restriction of `collateCollaborativeProjectChanges`.
- `syncArrayChange` has a slightly simplified call to `calculateArrayChanges` to eliminate the need for null checks as they are redundant now.
- Added a selection of unit tests that cover the main changes that happen to the contents of a project.
