### PR TITLE
New Multiplay Colors, Without Theming 

### DIFF
--- a/editor/src/core/shared/multiplayer.ts
+++ b/editor/src/core/shared/multiplayer.ts
@@ -8,40 +8,26 @@ export type MultiplayerColor = {
   foreground: string
 }
 
-export const multiplayerColors = {
-  light: [
-    { background: '#0092C0', foreground: 'white' },
-    { background: '#128400', foreground: 'white' },
-    { background: '#2A00D1', foreground: 'white' },
-    { background: '#5C00D1', foreground: 'white' },
-    { background: '#87C700', foreground: 'black' },
-    { background: '#8C6D00', foreground: 'white' },
-    { background: '#9C0000', foreground: 'white' },
-    { background: '#B16CB7', foreground: 'white' },
-    { background: '#B60479', foreground: 'white' },
-    { background: '#E7B400', foreground: 'black' },
-  ],
-  dark: [
-    { background: '#007DA4', foreground: 'white' },
-    { background: '#19B500', foreground: 'black' },
-    { background: '#3EFFF3', foreground: 'black' },
-    { background: '#6842FF', foreground: 'white' },
-    { background: '#C4FF46', foreground: 'black' },
-    { background: '#CE00D3', foreground: 'white' },
-    { background: '#DD0000', foreground: 'white' },
-    { background: '#FF00A8', foreground: 'white' },
-    { background: '#FFBA08', foreground: 'black' },
-    { background: '#FFFF00', foreground: 'black' },
-  ],
-}
+export const multiplayerColors = [
+  { background: '#E72861', foreground: 'white' },
+  { background: '#DF65A7', foreground: 'black' },
+  { background: '#EB6837', foreground: 'white' },
+  { background: '#D1B143', foreground: 'black' },
+  { background: '#7EC609', foreground: 'black' },
+  { background: '#0CB04E', foreground: 'white' },
+  { background: '#25B5B5', foreground: 'black' },
+  { background: '#547ADA', foreground: 'white' },
+  { background: '#A05FD3', foreground: 'white' },
+  { background: '#7382A7', foreground: 'white' },
+]
 
 function randomMultiplayerColor(): number {
-  return Math.floor(Math.random() * multiplayerColors.light.length)
+  return Math.floor(Math.random() * multiplayerColors.length)
 }
 
 export function possiblyUniqueColor(existing: (number | null)[]): number {
   return possiblyUniqueInArray(
-    multiplayerColors.light.map((_, index) => index),
+    multiplayerColors.map((_, index) => index),
     existing,
     randomMultiplayerColor(),
   )
@@ -56,8 +42,7 @@ export function multiplayerColorFromIndex(colorIndex: number | null): Multiplaye
     return fallbackColor
   }
 
-  const colors =
-    getPreferredColorScheme() === 'dark' ? multiplayerColors.dark : multiplayerColors.light
+  const colors = multiplayerColors
   return safeIndex(colors, colorIndex) ?? fallbackColor
 }
 


### PR DESCRIPTION
New colors for the multiplayer cursors, avatars, etc. that are perceptually uniform, and do not change with the theme.

<img width="450" alt="Screenshot 2023-11-28 at 4 40 44 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/9d20a044-0b3e-48c8-9f13-c4a7c2726668">

<img width="380" alt="Screenshot 2023-11-28 at 4 49 08 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/da5bdba5-d805-429f-8d35-dc74132f0eeb">
<img width="370" alt="Screenshot 2023-11-28 at 4 46 25 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/a6489bb8-ea5c-4580-a941-899cdf53d7f0">

![these-colors](https://github.com/concrete-utopia/utopia/assets/47405698/3771cbaf-4404-4a51-aba6-e41d2a1ced94)




