### PR TITLE
Store threadId in CommentMode

### DIFF
--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -17,7 +17,7 @@ import {
 import { MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
 import { UtopiaStyles } from '../../../uuiui'
 import { switchEditorMode } from '../../editor/actions/action-creators'
-import { EditorModes } from '../../editor/editor-modes'
+import { EditorModes, existingComment } from '../../editor/editor-modes'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { Substores, useEditorState, useRefEditorState } from '../../editor/store/store-hook'
 import { AvatarPicture } from '../../user-bar'
@@ -96,8 +96,10 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
         remixState.navigate(remixLocationRoute)
       })
     }
-    dispatch([switchEditorMode(EditorModes.commentMode(point, 'not-dragging'))])
-  }, [dispatch, point, remixNavigationState, remixLocationRoute, isOnAnotherRoute])
+    dispatch([
+      switchEditorMode(EditorModes.commentMode(existingComment(thread.id), 'not-dragging')),
+    ])
+  }, [dispatch, thread.id, remixNavigationState, remixLocationRoute, isOnAnotherRoute])
 
   const { initials, color, avatar } = (() => {
     const firstComment = thread.comments[0]

--- a/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
@@ -4,13 +4,13 @@ import { NO_OP } from '../../../../core/shared/utils'
 import { useKeepShallowReferenceEquality } from '../../../../utils/react-performance'
 import { useDispatch } from '../../../editor/store/dispatch-context'
 import { switchEditorMode } from '../../../editor/actions/action-creators'
-import { EditorModes } from '../../../editor/editor-modes'
+import type { CommentId } from '../../../editor/editor-modes'
+import { EditorModes, newComment } from '../../../editor/editor-modes'
 import { useRefEditorState } from '../../../editor/store/store-hook'
 import { windowToCanvasCoordinates } from '../../dom-lookup'
-import type { CanvasPoint } from '../../../../core/shared/math-utils'
 import { windowPoint } from '../../../../core/shared/math-utils'
 
-export function useCommentModeSelectAndHover(location: CanvasPoint | null): MouseCallbacks {
+export function useCommentModeSelectAndHover(comment: CommentId | null): MouseCallbacks {
   const dispatch = useDispatch()
 
   const storeRef = useRefEditorState((store) => {
@@ -22,20 +22,22 @@ export function useCommentModeSelectAndHover(location: CanvasPoint | null): Mous
 
   const onMouseUp = React.useCallback(
     (event: React.MouseEvent) => {
-      if (location == null) {
+      if (comment == null) {
         const loc = windowToCanvasCoordinates(
           storeRef.current.scale,
           storeRef.current.canvasOffset,
           windowPoint({ x: event.clientX, y: event.clientY }),
         )
         dispatch([
-          switchEditorMode(EditorModes.commentMode(loc.canvasPositionRounded, 'not-dragging')),
+          switchEditorMode(
+            EditorModes.commentMode(newComment(loc.canvasPositionRounded), 'not-dragging'),
+          ),
         ])
       } else {
         dispatch([switchEditorMode(EditorModes.selectMode(null, false, 'none'))])
       }
     },
-    [dispatch, location, storeRef],
+    [dispatch, comment, storeRef],
   )
 
   return useKeepShallowReferenceEquality({

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -111,26 +111,6 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
 
   const point = canvasPointToWindowPoint(location, canvasScale, canvasOffset)
 
-  if (thread == null) {
-    return (
-      <div
-        style={{
-          position: 'fixed',
-          top: point.y,
-          left: point.x + 30,
-          cursor: 'text',
-          minWidth: 250,
-          boxShadow: UtopiaStyles.shadowStyles.mid.boxShadow,
-        }}
-        onKeyDown={stopPropagation}
-        onKeyUp={stopPropagation}
-        onMouseUp={stopPropagation}
-      >
-        <Composer autoFocus onComposerSubmit={onCreateThread} />
-      </div>
-    )
-  }
-
   return (
     <div
       style={{
@@ -145,10 +125,16 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
       onKeyUp={stopPropagation}
       onMouseUp={stopPropagation}
     >
-      {thread.comments.map((c) => (
-        <Comment key={c.id} comment={c} onCommentDelete={onCommentDelete} />
-      ))}
-      <Composer autoFocus threadId={thread.id} />
+      {thread == null ? (
+        <Composer autoFocus onComposerSubmit={onCreateThread} />
+      ) : (
+        <>
+          {thread.comments.map((c) => (
+            <Comment key={c.id} comment={c} onCommentDelete={onCommentDelete} />
+          ))}
+          <Composer autoFocus threadId={thread.id} />
+        </>
+      )}
     </div>
   )
 })

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -6,11 +6,17 @@ import { UtopiaStyles } from '../../../uuiui'
 import React from 'react'
 import { useCreateThread } from '../../../../liveblocks.config'
 import '../../../../resources/editor/css/liveblocks-comments.css'
-import { useCanvasCommentThread } from '../../../core/commenting/comment-hooks'
+import { useCanvasCommentThreadAndLocation } from '../../../core/commenting/comment-hooks'
 import { useRemixPresence } from '../../../core/shared/multiplayer-hooks'
 import { MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
 import { switchEditorMode } from '../../editor/actions/action-creators'
-import { EditorModes, isCommentMode } from '../../editor/editor-modes'
+import type { CommentId } from '../../editor/editor-modes'
+import {
+  EditorModes,
+  existingComment,
+  isCommentMode,
+  isNewComment,
+} from '../../editor/editor-modes'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { Substores, useEditorState } from '../../editor/store/store-hook'
 import { canvasPointToWindowPoint } from '../dom-lookup'
@@ -20,6 +26,72 @@ export const CommentPopup = React.memo(() => {
     Substores.restOfEditor,
     (store) => store.editor.mode,
     'CommentPopup mode',
+  )
+
+  if (!isCommentMode(mode) || mode.comment == null) {
+    return null
+  }
+
+  return (
+    <MultiplayerWrapper
+      errorFallback={<div>Can not load comments</div>}
+      suspenseFallback={<div>Loading…</div>}
+    >
+      <CommentThread comment={mode.comment} />
+    </MultiplayerWrapper>
+  )
+})
+CommentPopup.displayName = 'CommentPopup'
+
+interface CommentThreadProps {
+  comment: CommentId
+}
+
+const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
+  const dispatch = useDispatch()
+
+  const { location, thread } = useCanvasCommentThreadAndLocation(comment)
+
+  const commentsCount = React.useMemo(
+    () => thread?.comments.filter((c) => c.deletedAt == null).length ?? 0,
+    [thread],
+  )
+
+  const createThread = useCreateThread()
+
+  const remixPresence = useRemixPresence()
+
+  const onCreateThread = React.useCallback(
+    ({ body }: ComposerSubmitComment, event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      if (!isNewComment(comment)) {
+        return
+      }
+      // Create a new thread
+      const newThread = createThread({
+        body,
+        metadata: {
+          type: 'canvas',
+          x: comment.location.x,
+          y: comment.location.y,
+          remixLocationRoute: remixPresence?.locationRoute ?? undefined,
+        },
+      })
+      dispatch([
+        switchEditorMode(EditorModes.commentMode(existingComment(newThread.id), 'not-dragging')),
+      ])
+    },
+    [createThread, comment, remixPresence, dispatch],
+  )
+
+  const onCommentDelete = React.useCallback(
+    (_deleted: CommentData) => {
+      if (commentsCount - 1 <= 0) {
+        dispatch([switchEditorMode(EditorModes.selectMode(null, false, 'none'))])
+      }
+    },
+    [commentsCount, dispatch],
   )
 
   const canvasScale = useEditorState(
@@ -33,12 +105,31 @@ export const CommentPopup = React.memo(() => {
     'CommentPopup canvasScale',
   )
 
-  if (!isCommentMode(mode) || mode.location == null) {
+  if (location == null) {
     return null
   }
-  const { location } = mode
 
   const point = canvasPointToWindowPoint(location, canvasScale, canvasOffset)
+
+  if (thread == null) {
+    return (
+      <div
+        style={{
+          position: 'fixed',
+          top: point.y,
+          left: point.x + 30,
+          cursor: 'text',
+          minWidth: 250,
+          boxShadow: UtopiaStyles.shadowStyles.mid.boxShadow,
+        }}
+        onKeyDown={stopPropagation}
+        onKeyUp={stopPropagation}
+        onMouseUp={stopPropagation}
+      >
+        <Composer autoFocus onComposerSubmit={onCreateThread} />
+      </div>
+    )
+  }
 
   return (
     <div
@@ -54,69 +145,8 @@ export const CommentPopup = React.memo(() => {
       onKeyUp={stopPropagation}
       onMouseUp={stopPropagation}
     >
-      <MultiplayerWrapper
-        errorFallback={<div>Can not load comments</div>}
-        suspenseFallback={<div>Loading…</div>}
-      >
-        <CommentThread x={location.x} y={location.y} />
-      </MultiplayerWrapper>
-    </div>
-  )
-})
-CommentPopup.displayName = 'CommentPopup'
-
-interface CommentThreadProps {
-  x: number
-  y: number
-}
-
-const CommentThread = React.memo(({ x, y }: CommentThreadProps) => {
-  const dispatch = useDispatch()
-  const thread = useCanvasCommentThread(x, y)
-  const commentsCount = React.useMemo(
-    () => thread?.comments.filter((c) => c.deletedAt == null).length ?? 0,
-    [thread],
-  )
-
-  const createThread = useCreateThread()
-
-  const remixPresence = useRemixPresence()
-
-  const onCreateThread = React.useCallback(
-    ({ body }: ComposerSubmitComment, event: React.FormEvent<HTMLFormElement>) => {
-      event.preventDefault()
-
-      // Create a new thread
-      createThread({
-        body,
-        metadata: {
-          type: 'canvas',
-          x: x,
-          y: y,
-          remixLocationRoute: remixPresence?.locationRoute ?? undefined,
-        },
-      })
-    },
-    [createThread, x, y, remixPresence],
-  )
-
-  const onCommentDelete = React.useCallback(
-    (_deleted: CommentData) => {
-      if (commentsCount - 1 <= 0) {
-        dispatch([switchEditorMode(EditorModes.selectMode(null, false, 'none'))])
-      }
-    },
-    [commentsCount, dispatch],
-  )
-
-  if (thread == null) {
-    return <Composer autoFocus onComposerSubmit={onCreateThread} />
-  }
-
-  return (
-    <div>
-      {thread.comments.map((comment) => (
-        <Comment key={comment.id} comment={comment} onCommentDelete={onCommentDelete} />
+      {thread.comments.map((c) => (
+        <Comment key={c.id} comment={c} onCommentDelete={onCommentDelete} />
       ))}
       <Composer autoFocus threadId={thread.id} />
     </div>

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -792,7 +792,7 @@ export function useSelectAndHover(
   const insertModeCallbacks = useInsertModeSelectAndHover(modeType === 'insert', cmdPressed)
   const textEditModeCallbacks = useTextEditModeSelectAndHover(modeType === 'textEdit')
   const commentModeCallbacks = useCommentModeSelectAndHover(
-    mode?.type === 'comment' ? mode.location : null,
+    mode?.type === 'comment' ? mode.comment : null,
   )
   const followModeCallbacks = useFollowModeSelectAndHover()
 

--- a/editor/src/components/canvas/multiplayer-presence.tsx
+++ b/editor/src/components/canvas/multiplayer-presence.tsx
@@ -123,7 +123,7 @@ export const MultiplayerPresence = React.memo(() => {
       <MultiplayerShadows />
       {when(isFeatureEnabled('Commenting'), <CommentIndicators />)}
       <MultiplayerCursors />
-      {when(isCommentMode(mode) && mode.location != null, <CommentPopup />)}
+      {when(isCommentMode(mode) && mode.comment != null, <CommentPopup />)}
     </>
   )
 })

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -91,9 +91,43 @@ export interface InsertMode {
 
 export type IsDragging = 'dragging' | 'not-dragging'
 
+export type CommentId = NewComment | ExistingComment
+
+export interface NewComment {
+  type: 'new'
+  location: CanvasPoint
+}
+
+export function newComment(location: CanvasPoint): NewComment {
+  return {
+    type: 'new',
+    location: location,
+  }
+}
+
+export function isNewComment(comment: CommentId): comment is NewComment {
+  return comment.type === 'new'
+}
+
+export interface ExistingComment {
+  type: 'existing'
+  threadId: string
+}
+
+export function existingComment(threadId: string): ExistingComment {
+  return {
+    type: 'existing',
+    threadId: threadId,
+  }
+}
+
+export function isExistingComment(comment: CommentId): comment is ExistingComment {
+  return comment.type === 'existing'
+}
+
 export interface CommentMode {
   type: 'comment'
-  location: CanvasPoint | null
+  comment: CommentId | null
   isDragging: IsDragging
 }
 
@@ -179,10 +213,10 @@ export const EditorModes = {
       selectOnFocus: selectOnFocus,
     }
   },
-  commentMode: function (location: CanvasPoint | null, isDragging: IsDragging): CommentMode {
+  commentMode: function (comment: CommentId | null, isDragging: IsDragging): CommentMode {
     return {
       type: 'comment',
-      location: location,
+      comment: comment,
       isDragging: isDragging,
     }
   },

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -9,7 +9,7 @@ import type { ThreadData } from '@liveblocks/client'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
 import { scrollToPosition, switchEditorMode } from '../../editor/actions/action-creators'
-import { EditorModes } from '../../editor/editor-modes'
+import { EditorModes, existingComment } from '../../editor/editor-modes'
 import { MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
 import { useAtom } from 'jotai'
 import { RemixNavigationAtom } from '../../canvas/remix/utopia-remix-root-component'
@@ -77,10 +77,10 @@ const ThreadPreview = React.memo(({ thread }: ThreadPreviewProps) => {
       })
     }
     dispatch([
-      switchEditorMode(EditorModes.commentMode(point, 'not-dragging')),
+      switchEditorMode(EditorModes.commentMode(existingComment(thread.id), 'not-dragging')),
       scrollToPosition(rect, 'to-center'),
     ])
-  }, [dispatch, remixNavigationState, isOnAnotherRoute, remixLocationRoute, point])
+  }, [dispatch, remixNavigationState, isOnAnotherRoute, remixLocationRoute, point, thread.id])
 
   const comment = thread.comments[0]
   if (comment == null) {

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -6,8 +6,6 @@ import { useMutation, useSelf, useStorage, useThreads } from '../../../liveblock
 import { Substores, useEditorState } from '../../components/editor/store/store-hook'
 import { normalizeMultiplayerName, possiblyUniqueColor } from '../shared/multiplayer'
 import { isLoggedIn } from '../../common/user'
-import { useAtom } from 'jotai'
-import { RemixNavigationAtom } from '../../components/canvas/remix/utopia-remix-root-component'
 
 export function useCanvasCommentThread(x: number, y: number): ThreadData<ThreadMetadata> | null {
   const { threads } = useThreads()

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -11,7 +11,22 @@ import { RemixNavigationAtom } from '../../components/canvas/remix/utopia-remix-
 
 export function useCanvasCommentThread(x: number, y: number): ThreadData<ThreadMetadata> | null {
   const { threads } = useThreads()
-  const thread = threads.find((t) => t.metadata.x === x && t.metadata.y === y) ?? null
+  const [threadId, setThreadId] = React.useState<string | null>(null)
+
+  const thread = React.useMemo(() => {
+    if (threadId != null) {
+      const originalThread = threads.find((t) => t.id === threadId) ?? null
+      if (originalThread != null) {
+        return originalThread
+      }
+    }
+    const threadFromLocation = threads.find((t) => t.metadata.x === x && t.metadata.y === y) ?? null
+    if (threadFromLocation != null) {
+      setThreadId(threadFromLocation.id)
+    }
+    return threadFromLocation
+  }, [threadId, threads, x, y])
+
   return thread
 }
 

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -151,7 +151,7 @@ function getDefaultCursorForMode(mode: Mode): CSSCursor {
     case 'textEdit':
       return CSSCursor.Select
     case 'comment':
-      if (mode.location == null && mode.isDragging === 'not-dragging') {
+      if (mode.comment == null && mode.isDragging === 'not-dragging') {
         return CSSCursor.Comment
       }
       return CSSCursor.Select


### PR DESCRIPTION
**Problem:**
The following scenario works incorrectly in multiplayer mode:
- user A has the comment popup open for comment X
- user B drags/deletes comment X
- the comment popup stays open for user A, but its contents become empty (and if user A edited a comment, the unsubmitted content is lost)

**Fix:**
The problem is that we store the comment location in CommentMode to identify a comment.
However, the comment location can change, so it is not a good identifier. I still need to store the comment location when we are editing a new comment which is not submitted yet, but for existing comments, the thread id is the valid identifier.

So I created a new ADT called CommentId to identify a new or existing comment thread, and use that in CommentMode. I updated all the components and hooks which use comment mode information to use this new kind of data source.

With this change, the comment popup moves together with the indicator even when it is dragged by another user when it is open.