### PR TITLE
Store ownerId in editor state

### DIFF
--- a/editor/src/components/editor/persistence/generic/dummy-persistence-backend.ts
+++ b/editor/src/components/editor/persistence/generic/dummy-persistence-backend.ts
@@ -2,6 +2,7 @@ import type {
   PersistenceBackendAPI,
   ProjectLoadResult,
   ProjectModel,
+  ProjectOwnership,
   ProjectWithFileChanges,
 } from './persistence-types'
 import { projectWithFileChanges } from './persistence-types'
@@ -13,8 +14,8 @@ function getNewProjectId(): Promise<string> {
   return Promise.resolve(`Project_${projectCounter++}`)
 }
 
-function checkProjectOwned(projectId: string): Promise<boolean> {
-  return Promise.resolve(true)
+function checkProjectOwned(_projectId: string): Promise<ProjectOwnership> {
+  return Promise.resolve({ isOwner: true, ownerId: 'the-owner' })
 }
 
 function loadProject<ModelType>(projectId: string): Promise<ProjectLoadResult<ModelType>> {

--- a/editor/src/components/editor/persistence/generic/persistence-types.ts
+++ b/editor/src/components/editor/persistence/generic/persistence-types.ts
@@ -70,7 +70,7 @@ export function projectWithFileChanges<ModelType, FileType>(
 
 export interface PersistenceBackendAPI<ModelType, FileType> {
   getNewProjectId: () => Promise<string>
-  checkProjectOwned: (projectId: string) => Promise<boolean>
+  checkProjectOwned: (projectId: string) => Promise<{ ownerId: string | null; owned: boolean }>
   loadProject: (projectId: string) => Promise<ProjectLoadResult<ModelType>>
   saveProjectToServer: (
     projectId: string,

--- a/editor/src/components/editor/persistence/generic/persistence-types.ts
+++ b/editor/src/components/editor/persistence/generic/persistence-types.ts
@@ -68,9 +68,14 @@ export function projectWithFileChanges<ModelType, FileType>(
   }
 }
 
+export type ProjectOwnership = {
+  ownerId: string | null
+  isOwner: boolean
+}
+
 export interface PersistenceBackendAPI<ModelType, FileType> {
   getNewProjectId: () => Promise<string>
-  checkProjectOwned: (projectId: string) => Promise<{ ownerId: string | null; owned: boolean }>
+  checkProjectOwned: (projectId: string) => Promise<ProjectOwnership>
   loadProject: (projectId: string) => Promise<ProjectLoadResult<ModelType>>
   saveProjectToServer: (
     projectId: string,

--- a/editor/src/components/editor/persistence/persistence-backend.ts
+++ b/editor/src/components/editor/persistence/persistence-backend.ts
@@ -77,7 +77,7 @@ export async function checkProjectOwned(projectId: string): Promise<ProjectOwner
   } else {
     const ownerState = await checkProjectOwnership(projectId)
     return ownerState === 'unowned'
-      ? { ownerId: null, isOwner: false }
+      ? { ownerId: null, isOwner: true }
       : { ownerId: ownerState.ownerId, isOwner: ownerState.isOwner }
   }
 }

--- a/editor/src/components/editor/persistence/persistence-backend.ts
+++ b/editor/src/components/editor/persistence/persistence-backend.ts
@@ -29,6 +29,7 @@ import type {
   ProjectModel,
   ProjectWithFileChanges,
   LocalProject,
+  ProjectOwnership,
 } from './generic/persistence-types'
 import { fileWithFileName, projectWithFileChanges } from './generic/persistence-types'
 import type { PersistentModel } from '../store/editor-state'
@@ -66,19 +67,18 @@ async function getNewProjectId(): Promise<string> {
   return createNewProjectID()
 }
 
-export async function checkProjectOwned(
-  projectId: string,
-): Promise<{ ownerId: string | null; owned: boolean }> {
+export async function checkProjectOwned(projectId: string): Promise<ProjectOwnership> {
   const existsLocally = await projectIsStoredLocally(projectId)
   if (existsLocally) {
-    return { ownerId: null, owned: true }
+    return {
+      ownerId: null,
+      isOwner: true,
+    }
   } else {
     const ownerState = await checkProjectOwnership(projectId)
-    if (ownerState === 'unowned') {
-      return { ownerId: null, owned: false }
-    } else {
-      return { ownerId: ownerState.ownerId, owned: ownerState.isOwner }
-    }
+    return ownerState === 'unowned'
+      ? { ownerId: null, isOwner: false }
+      : { ownerId: ownerState.ownerId, isOwner: ownerState.isOwner }
   }
 }
 

--- a/editor/src/components/editor/persistence/persistence-backend.ts
+++ b/editor/src/components/editor/persistence/persistence-backend.ts
@@ -66,13 +66,19 @@ async function getNewProjectId(): Promise<string> {
   return createNewProjectID()
 }
 
-export async function checkProjectOwned(projectId: string): Promise<boolean> {
+export async function checkProjectOwned(
+  projectId: string,
+): Promise<{ ownerId: string | null; owned: boolean }> {
   const existsLocally = await projectIsStoredLocally(projectId)
   if (existsLocally) {
-    return true
+    return { ownerId: null, owned: true }
   } else {
     const ownerState = await checkProjectOwnership(projectId)
-    return ownerState === 'unowned' || ownerState.isOwner
+    if (ownerState === 'unowned') {
+      return { ownerId: null, owned: false }
+    } else {
+      return { ownerId: ownerState.ownerId, owned: ownerState.isOwner }
+    }
   }
 }
 

--- a/editor/src/components/editor/store/project-server-state.tsx
+++ b/editor/src/components/editor/store/project-server-state.tsx
@@ -78,7 +78,7 @@ export async function getProjectServerState(
     const forkedFromProjectListing =
       forkedFromProjectId == null ? null : await fetchProjectMetadata(forkedFromProjectId)
     const ownership = projectId == null ? null : await checkProjectOwned(projectId)
-    const isMyProject = ownership == null || ownership.owned ? 'yes' : 'no'
+    const isMyProject = ownership == null || ownership.isOwner ? 'yes' : 'no'
     return {
       isMyProject: isMyProject,
       ownerId: ownership?.ownerId ?? null,

--- a/editor/src/components/editor/store/project-server-state.tsx
+++ b/editor/src/components/editor/store/project-server-state.tsx
@@ -68,15 +68,6 @@ function projectListingToProjectMetadataFromServer(
   }
 }
 
-async function getOwnership(projectId: string | null): Promise<ProjectOwnership> {
-  if (projectId == null) {
-    return { isOwner: true, ownerId: null }
-  }
-
-  const { isOwner, ownerId } = await checkProjectOwned(projectId)
-  return { isOwner, ownerId }
-}
-
 export async function getProjectServerState(
   projectId: string | null,
   forkedFromProjectId: string | null,
@@ -88,7 +79,14 @@ export async function getProjectServerState(
     const forkedFromProjectListing =
       forkedFromProjectId == null ? null : await fetchProjectMetadata(forkedFromProjectId)
 
-    const ownership = await getOwnership(projectId)
+    async function getOwnership(): Promise<ProjectOwnership> {
+      if (projectId == null) {
+        return { isOwner: true, ownerId: null }
+      }
+      const { isOwner, ownerId } = await checkProjectOwned(projectId)
+      return { isOwner, ownerId }
+    }
+    const ownership = await getOwnership()
 
     return {
       isMyProject: ownership.isOwner ? 'yes' : 'no',

--- a/editor/src/components/editor/store/project-server-state.tsx
+++ b/editor/src/components/editor/store/project-server-state.tsx
@@ -26,24 +26,27 @@ export function projectMetadataFromServer(
 
 export interface ProjectServerState {
   isMyProject: 'yes' | 'no' | 'unknown'
+  ownerId: string | null
   projectData: ProjectMetadataFromServer | null
   forkedFromProjectData: ProjectMetadataFromServer | null
 }
 
 export function projectServerState(
   isMyProject: ProjectServerState['isMyProject'],
+  ownerId: string | null,
   projectData: ProjectMetadataFromServer | null,
   forkedFromProjectData: ProjectMetadataFromServer | null,
 ): ProjectServerState {
   return {
     isMyProject: isMyProject,
+    ownerId: ownerId,
     projectData: projectData,
     forkedFromProjectData: forkedFromProjectData,
   }
 }
 
 export function emptyProjectServerState(): ProjectServerState {
-  return projectServerState('unknown', null, null)
+  return projectServerState('unknown', null, null, null)
 }
 
 export const ProjectServerStateContext = React.createContext<ProjectServerState>(
@@ -74,14 +77,11 @@ export async function getProjectServerState(
     const projectListing = projectId == null ? null : await fetchProjectMetadata(projectId)
     const forkedFromProjectListing =
       forkedFromProjectId == null ? null : await fetchProjectMetadata(forkedFromProjectId)
-    const isMyProject =
-      projectId == null
-        ? 'yes'
-        : await checkProjectOwned(projectId).then((isMyProjectFromServer) => {
-            return isMyProjectFromServer ? 'yes' : 'no'
-          })
+    const ownership = projectId == null ? null : await checkProjectOwned(projectId)
+    const isMyProject = ownership == null || ownership.owned ? 'yes' : 'no'
     return {
       isMyProject: isMyProject,
+      ownerId: ownership?.ownerId ?? null,
       projectData: projectListingToProjectMetadataFromServer(projectListing),
       forkedFromProjectData: projectListingToProjectMetadataFromServer(forkedFromProjectListing),
     }

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -563,9 +563,11 @@ export const ProjectMetadataFromServerKeepDeepEquality: KeepDeepEqualityCall<Pro
   )
 
 export const ProjectServerStateKeepDeepEquality: KeepDeepEqualityCall<ProjectServerState> =
-  combine3EqualityCalls(
+  combine4EqualityCalls(
     (entry) => entry.isMyProject,
     createCallWithTripleEquals<ProjectServerState['isMyProject']>(),
+    (entry) => entry.ownerId,
+    NullableStringKeepDeepEquality,
     (entry) => entry.projectData,
     nullableDeepEquality(ProjectMetadataFromServerKeepDeepEquality),
     (entry) => entry.forkedFromProjectData,

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -367,7 +367,9 @@ projectOwnerEndpoint cookie (ProjectIdWithSuffix projectID _) = checkForUser coo
   case (maybeUser, possibleProject) of
     (_, Nothing) -> notFound
     (Nothing, _) -> notAuthenticated
-    (Just sessionUser, Just project) -> return $ ProjectOwnerResponse $ view (field @"_id") sessionUser == view (field @"ownerId") project
+    (Just sessionUser, Just project) -> do
+        let projectOwnerId = view (field @"ownerId") project
+        return $ ProjectOwnerResponse ( view (field @"_id") sessionUser == projectOwnerId ) projectOwnerId
 
 projectChangedSince :: Text -> UTCTime -> ServerMonad (Maybe Bool)
 projectChangedSince projectID lastChangedDate = do

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -170,6 +170,7 @@ $(makeFieldsNoPrefix ''ProjectListResponse)
 
 data ProjectOwnerResponse = ProjectOwnerResponse
                           { _isOwner :: Bool
+                          , _ownerId :: Text
                           } deriving (Eq, Show, Generic)
 
 $(makeFieldsNoPrefix ''ProjectOwnerResponse)

--- a/website-next/components/common/server.ts
+++ b/website-next/components/common/server.ts
@@ -27,6 +27,7 @@ export const HEADERS = {
 
 export interface ProjectOwnerResponse {
   isOwner: boolean
+  ownerId: string | null
 }
 
 export type ProjectOwnerState = ProjectOwnerResponse | 'unowned'
@@ -168,6 +169,7 @@ export async function checkProjectOwnership(projectId: string): Promise<ProjectO
     console.error(`server responded with ${response.status} ${response.statusText}`)
     return {
       isOwner: false,
+      ownerId: null,
     }
   }
 }


### PR DESCRIPTION
Fix #4586 

**Problem:**
There's no way to check the ownership of a project given a user id, which would be necessary for e.g. customizing the user bar.

**Fix:**

Add an `ownerId` field in the project ownership response, and store it in the project server state.