### PR TITLE
Collaboration UID issues.

### DIFF
--- a/editor/src/core/workers/parser-printer/uid-fix.spec.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.spec.ts
@@ -36,7 +36,7 @@ import {
 } from './parser-printer.test-utils'
 import type { Arbitrary } from 'fast-check'
 import type { FixUIDsState } from './uid-fix'
-import { fixExpressionUIDs, fixJSXElementChildUIDs } from './uid-fix'
+import { fixExpressionUIDs, fixJSXElementChildUIDs, fixParseSuccessUIDs } from './uid-fix'
 import { foldEither } from '../../../core/shared/either'
 import {
   getAllUniqueUids,
@@ -44,12 +44,14 @@ import {
 } from '../../../core/model/get-unique-ids'
 import { contentsToTree } from '../../../components/assets'
 import {
+  filtered,
+  fromArrayIndex,
   fromField,
   fromTypeGuard,
   notNull,
   traverseArray,
 } from '../../../core/shared/optics/optic-creators'
-import { modify } from '../../../core/shared/optics/optic-utilities'
+import { modify, set, unsafeGet } from '../../../core/shared/optics/optic-utilities'
 
 function asParseSuccessOrNull(file: ParsedTextFile): ParseSuccess | null {
   return isParseSuccess(file) ? file : null
@@ -565,6 +567,43 @@ describe('fixParseSuccessUIDs', () => {
         678
           104"
     `)
+  })
+  it(`handles arbitrary JS blocks and their UIDs`, () => {
+    const parsedResult = lintAndParseAndValidateResult(
+      'test.js',
+      fileWithArbitraryBlockInside,
+      null,
+      emptySet(),
+      'trim-bounds',
+    )
+    const toRootElementOptic = fromTypeGuard(isParseSuccess)
+      .compose(fromField('topLevelElements'))
+      .compose(traverseArray())
+      .compose(filtered(isUtopiaJSXComponent))
+      .compose(fromTypeGuard(isUtopiaJSXComponent))
+      .compose(fromField('rootElement'))
+      .compose(fromField('uid'))
+    const toArbitraryBlockOptic = fromTypeGuard(isParseSuccess)
+      .compose(fromField('topLevelElements'))
+      .compose(traverseArray())
+      .compose(filtered(isUtopiaJSXComponent))
+      .compose(fromTypeGuard(isUtopiaJSXComponent))
+      .compose(fromField('arbitraryJSBlock'))
+      .compose(notNull())
+      .compose(fromField('uid'))
+    const uidFromElement = unsafeGet(toRootElementOptic, parsedResult)
+    const fudgedResult = set(toArbitraryBlockOptic, uidFromElement, parsedResult)
+    const fixedResult = fixParseSuccessUIDs(null, fudgedResult, new Set(), new Set())
+    const projectContents = contentsToTree({
+      ['test.js']: textFile(
+        textFileContents(fileWithArbitraryBlockInside, fixedResult, RevisionsState.BothMatch),
+        null,
+        null,
+        0,
+      ),
+    })
+    const duplicateUIDs = getAllUniqueUids(projectContents).duplicateIDs
+    expect(Object.keys(duplicateUIDs)).toHaveLength(0)
   })
 })
 

--- a/editor/src/core/workers/parser-printer/uid-fix.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.ts
@@ -72,6 +72,8 @@ const expressionJSXMapExpressionUIDOptic: Optic<JSXMapExpression, string> = from
 
 const jsExpressionUIDOptic: Optic<JSExpression, string> = fromField('uid')
 
+const arbitraryJSBlockUIDOptic: Optic<ArbitraryJSBlock, string> = fromField('uid')
+
 export interface FixUIDsState {
   mutableAllNewUIDs: Set<string>
   uidsExpectedToBeSeen: Set<string>
@@ -362,10 +364,11 @@ export function fixArbitraryJSBlockUIDs(
     newElement.elementsWithin,
     fixUIDsState,
   )
-  return {
+
+  return updateUID(arbitraryJSBlockUIDOptic, oldElement?.uid ?? newElement.uid, fixUIDsState, {
     ...newElement,
     elementsWithin: fixedElementsWithin,
-  }
+  })
 }
 
 export function fixCombinedArbitraryJSBlockUIDs(
@@ -373,15 +376,16 @@ export function fixCombinedArbitraryJSBlockUIDs(
   newElement: ArbitraryJSBlock,
   fixUIDsState: FixUIDsState,
 ): ArbitraryJSBlock {
+  const useMappingsState: FixUIDsState = { ...fixUIDsState, uidUpdateMethod: 'use-mappings' }
   const fixedElementsWithin = fixElementsWithin(
     oldElement?.elementsWithin ?? {},
     newElement.elementsWithin,
-    { ...fixUIDsState, uidUpdateMethod: 'use-mappings' },
+    useMappingsState,
   )
-  return {
+  return updateUID(arbitraryJSBlockUIDOptic, oldElement?.uid ?? newElement.uid, useMappingsState, {
     ...newElement,
     elementsWithin: fixedElementsWithin,
-  }
+  })
 }
 
 export function fixJSXArrayElement(


### PR DESCRIPTION
**Problem:**
When pulling changes from Github into a collaboration session, the viewers experience the dreaded "irrecoverable error" 
message.

**Cause:**
There were two root causes, each making this slightly worse:
- The file changes were firing through to the viewer effectively at random, which meant that the print-parse flow was happening in a different order for the viewer to that of main session. This then resulted in a lot more cases of trying to assign the old UID to the various parts of the model, changing them. Which exacerbated the second issue.
- The code being pulled in created quite a lot of arbitrary blocks for the components and the UIDs for those weren't being fixed by the logic that fixes up those UIDs at all.

**Fix:**
The two fixes were:
- Make the multiple file changes coming from a big project contents change to be one atomic change to the `yjs` model, instead of lots of individual ones.
- Fix the functions handling the UIDs for the arbitrary blocks to include those fields which were inexplicably omitted.

**Commit Details:**
- `updateCollaborativeProjectContents` delineates a transaction instead of the lower down `applyFileChangeToMap` so that simultaneous file changes come across as one atomic change.
- `fixArbitraryJSBlockUIDs` and `fixCombinedArbitraryJSBlockUIDs` now fix their local UID values.