### PR TITLE
Scene comments

### DIFF
--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -82,7 +82,7 @@ export type ThreadMetadata = {
   // quote: string;
   // time: number;
   type: 'canvas'
-  x: number
+  x: number // x and y is global when sceneId is undefined, and local to the scene when sceneId is not null
   y: number
   sceneId?: string
   remixLocationRoute?: string

--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -84,6 +84,7 @@ export type ThreadMetadata = {
   type: 'canvas'
   x: number
   y: number
+  sceneId?: string
   remixLocationRoute?: string
 }
 

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -13,6 +13,8 @@ import {
   distance,
   isNotNullFiniteRectangle,
   offsetPoint,
+  pointDifference,
+  scalePoint,
   windowPoint,
 } from '../../../core/shared/math-utils'
 import {
@@ -93,7 +95,7 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
     'useCommentModeSelectAndHover scenes',
   )
 
-  const point = (() => {
+  const canvasLocation = (() => {
     if (thread.metadata.sceneId == null) {
       return canvasPoint(thread.metadata)
     }
@@ -144,10 +146,10 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
     }
   })()
 
-  const { onMouseDown, dragPosition } = useDragging(thread)
+  const { onMouseDown, dragPosition } = useDragging(thread, canvasLocation)
   const position = React.useMemo(
-    () => canvasPointToWindowPoint(dragPosition ?? point, canvasScale, canvasOffset),
-    [point, canvasScale, canvasOffset, dragPosition],
+    () => canvasPointToWindowPoint(dragPosition ?? canvasLocation, canvasScale, canvasOffset),
+    [canvasLocation, canvasScale, canvasOffset, dragPosition],
   )
 
   return (
@@ -203,13 +205,12 @@ CommentIndicator.displayName = 'CommentIndicator'
 
 const COMMENT_DRAG_THRESHOLD = 5 // square px
 
-function useDragging(thread: ThreadData<ThreadMetadata>) {
+function useDragging(thread: ThreadData<ThreadMetadata>, originalLocation: CanvasPoint) {
   const editThreadMetadata = useEditThreadMetadata()
   const dispatch = useDispatch()
   const [dragPosition, setDragPosition] = React.useState<CanvasPoint | null>(null)
 
   const canvasScaleRef = useRefEditorState((store) => store.editor.canvas.scale)
-  const canvasOffsetRef = useRefEditorState((store) => store.editor.canvas.realCanvasOffset)
 
   const onMouseDown = React.useCallback(
     (event: React.MouseEvent) => {
@@ -223,12 +224,12 @@ function useDragging(thread: ThreadData<ThreadMetadata>) {
         draggedPastThreshold ||= distance(mouseDownPoint, mouseMovePoint) > COMMENT_DRAG_THRESHOLD
 
         if (draggedPastThreshold) {
-          const newCanvasPoint = mousePositionToIndicatorPosition(
-            canvasScaleRef.current,
-            canvasOffsetRef.current,
-            mouseMovePoint,
-          )
-          setDragPosition(newCanvasPoint)
+          const dragVectorWindow = pointDifference(mouseDownPoint, mouseMovePoint)
+          const dragVectorCanvas = canvasPoint({
+            x: dragVectorWindow.x / canvasScaleRef.current,
+            y: dragVectorWindow.y / canvasScaleRef.current,
+          })
+          setDragPosition(offsetPoint(originalLocation, dragVectorCanvas))
         }
       }
 
@@ -240,19 +241,16 @@ function useDragging(thread: ThreadData<ThreadMetadata>) {
         const mouseUpPoint = windowPoint({ x: upEvent.clientX, y: upEvent.clientY })
 
         if (draggedPastThreshold) {
-          const newCanvasPosition = mousePositionToIndicatorPosition(
-            canvasScaleRef.current,
-            canvasOffsetRef.current,
-            mouseUpPoint,
-          )
+          const dragVectorWindow = pointDifference(mouseDownPoint, mouseUpPoint)
+          const dragVectorCanvas = canvasPoint({
+            x: dragVectorWindow.x / canvasScaleRef.current,
+            y: dragVectorWindow.y / canvasScaleRef.current,
+          })
           setDragPosition(null)
 
           editThreadMetadata({
             threadId: thread.id,
-            metadata: {
-              x: newCanvasPosition.x,
-              y: newCanvasPosition.y,
-            },
+            metadata: offsetPoint(canvasPoint(thread.metadata), dragVectorCanvas),
           })
         }
       }
@@ -262,7 +260,7 @@ function useDragging(thread: ThreadData<ThreadMetadata>) {
       window.addEventListener('mousemove', onMouseMove)
       window.addEventListener('mouseup', onMouseUp)
     },
-    [dispatch, canvasOffsetRef, canvasScaleRef, editThreadMetadata, thread.id],
+    [dispatch, canvasScaleRef, editThreadMetadata, thread.id, originalLocation, thread.metadata],
   )
 
   return { onMouseDown, dragPosition }

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -6,7 +6,7 @@ import { useAtom } from 'jotai'
 import React from 'react'
 import type { ThreadMetadata } from '../../../../liveblocks.config'
 import { useEditThreadMetadata, useStorage, useThreads } from '../../../../liveblocks.config'
-import { useIsOnAnotherRemixRoute } from '../../../core/commenting/comment-hooks'
+import { useIsOnAnotherRemixRoute, useScenesWithId } from '../../../core/commenting/comment-hooks'
 import type { CanvasPoint, CanvasVector, WindowPoint } from '../../../core/shared/math-utils'
 import {
   canvasPoint,
@@ -89,11 +89,7 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
 
   const [remixNavigationState] = useAtom(RemixNavigationAtom)
 
-  const scenes = useEditorState(
-    Substores.metadata,
-    (store) => MetadataUtils.getScenesMetadata(store.editor.jsxMetadata),
-    'CommentIndicator scenes',
-  )
+  const scenes = useScenesWithId()
 
   const canvasLocation = (() => {
     if (thread.metadata.sceneId == null) {

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -92,7 +92,7 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
   const scenes = useEditorState(
     Substores.metadata,
     (store) => MetadataUtils.getScenesMetadata(store.editor.jsxMetadata),
-    'useCommentModeSelectAndHover scenes',
+    'CommentIndicator scenes',
   )
 
   const canvasLocation = (() => {

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -6,12 +6,14 @@ import { useAtom } from 'jotai'
 import React from 'react'
 import type { ThreadMetadata } from '../../../../liveblocks.config'
 import { useEditThreadMetadata, useStorage, useThreads } from '../../../../liveblocks.config'
-import { useIsOnAnotherRemixRoute, useScenesWithId } from '../../../core/commenting/comment-hooks'
+import {
+  useCanvasLocationOfThread,
+  useIsOnAnotherRemixRoute,
+} from '../../../core/commenting/comment-hooks'
 import type { CanvasPoint, CanvasVector, WindowPoint } from '../../../core/shared/math-utils'
 import {
   canvasPoint,
   distance,
-  isNotNullFiniteRectangle,
   offsetPoint,
   pointDifference,
   windowPoint,
@@ -30,7 +32,6 @@ import { Substores, useEditorState, useRefEditorState } from '../../editor/store
 import { AvatarPicture } from '../../user-bar'
 import { canvasPointToWindowPoint, windowToCanvasCoordinates } from '../dom-lookup'
 import { RemixNavigationAtom } from '../remix/utopia-remix-root-component'
-import { getIdOfScene } from './comment-mode/comment-mode-hooks'
 
 const IndicatorSize = 20
 
@@ -87,22 +88,7 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
 
   const [remixNavigationState] = useAtom(RemixNavigationAtom)
 
-  const scenes = useScenesWithId()
-
-  const canvasLocation = (() => {
-    if (thread.metadata.sceneId == null) {
-      return canvasPoint(thread.metadata)
-    }
-    const scene = scenes.find((s) => getIdOfScene(s) === thread.metadata.sceneId)
-
-    if (scene == null) {
-      return canvasPoint(thread.metadata)
-    }
-    if (!isNotNullFiniteRectangle(scene.globalFrame)) {
-      return canvasPoint(thread.metadata)
-    }
-    return offsetPoint(canvasPoint(thread.metadata), scene.globalFrame)
-  })()
+  const canvasLocation = useCanvasLocationOfThread(thread)
 
   const remixLocationRoute = thread.metadata.remixLocationRoute ?? null
 

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -14,7 +14,6 @@ import {
   isNotNullFiniteRectangle,
   offsetPoint,
   pointDifference,
-  scalePoint,
   windowPoint,
 } from '../../../core/shared/math-utils'
 import {
@@ -32,7 +31,6 @@ import { AvatarPicture } from '../../user-bar'
 import { canvasPointToWindowPoint, windowToCanvasCoordinates } from '../dom-lookup'
 import { RemixNavigationAtom } from '../remix/utopia-remix-root-component'
 import { getIdOfScene } from './comment-mode/comment-mode-hooks'
-import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 
 const IndicatorSize = 20
 

--- a/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
@@ -15,6 +15,7 @@ import { Substores, useEditorState, useRefEditorState } from '../../../editor/st
 import { windowToCanvasCoordinates } from '../../dom-lookup'
 import {
   canvasPoint,
+  getLocalPointInNewParentContext,
   isNotNullFiniteRectangle,
   offsetPoint,
   pointDifference,
@@ -66,7 +67,7 @@ export function useCommentModeSelectAndHover(comment: CommentId | null): MouseCa
         const sceneId = getIdOfScene(scene)
         const offset =
           sceneId != null && isNotNullFiniteRectangle(scene.globalFrame)
-            ? pointDifference(scene.globalFrame, loc.canvasPositionRounded)
+            ? getLocalPointInNewParentContext(scene.globalFrame, loc.canvasPositionRounded)
             : null
 
         if (scene == null || sceneId == null || offset == null) {

--- a/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
@@ -16,6 +16,8 @@ import { windowToCanvasCoordinates } from '../../dom-lookup'
 import {
   canvasPoint,
   isNotNullFiniteRectangle,
+  offsetPoint,
+  pointDifference,
   rectContainsPoint,
   windowPoint,
 } from '../../../../core/shared/math-utils'
@@ -29,15 +31,12 @@ import {
 } from '../../../../core/shared/jsx-attributes'
 import { create } from '../../../../core/shared/property-path'
 import { optionalMap } from '../../../../core/shared/optional-utils'
+import { useScenesWithId } from '../../../../core/commenting/comment-hooks'
 
 export function useCommentModeSelectAndHover(comment: CommentId | null): MouseCallbacks {
   const dispatch = useDispatch()
 
-  const scenes = useEditorState(
-    Substores.metadata,
-    (store) => MetadataUtils.getScenesMetadata(store.editor.jsxMetadata),
-    'useCommentModeSelectAndHover scenes',
-  )
+  const scenes = useScenesWithId()
 
   const storeRef = useRefEditorState((store) => {
     return {
@@ -54,6 +53,7 @@ export function useCommentModeSelectAndHover(comment: CommentId | null): MouseCa
           storeRef.current.canvasOffset,
           windowPoint({ x: event.clientX, y: event.clientY }),
         )
+
         const scenesUnderTheMouse = scenes.filter((scene) => {
           const sceneId = getIdOfScene(scene)
           return (
@@ -66,10 +66,7 @@ export function useCommentModeSelectAndHover(comment: CommentId | null): MouseCa
         const sceneId = getIdOfScene(scene)
         const offset =
           sceneId != null && isNotNullFiniteRectangle(scene.globalFrame)
-            ? canvasPoint({
-                x: loc.canvasPositionRounded.x - scene.globalFrame.x,
-                y: loc.canvasPositionRounded.y - scene.globalFrame.y,
-              })
+            ? pointDifference(scene.globalFrame, loc.canvasPositionRounded)
             : null
 
         if (scene == null || sceneId == null || offset == null) {

--- a/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
@@ -29,6 +29,7 @@ import {
 import { create } from '../../../../core/shared/property-path'
 import { optionalMap } from '../../../../core/shared/optional-utils'
 import { useScenesWithId } from '../../../../core/commenting/comment-hooks'
+import { safeIndex } from '../../../../core/shared/array-utils'
 
 export function useCommentModeSelectAndHover(comment: CommentId | null): MouseCallbacks {
   const dispatch = useDispatch()
@@ -59,10 +60,11 @@ export function useCommentModeSelectAndHover(comment: CommentId | null): MouseCa
             rectContainsPoint(scene.globalFrame, loc.canvasPositionRaw)
           )
         })
-        const scene = scenesUnderTheMouse[0]
-        const sceneId = getIdOfScene(scene)
+        const scene = safeIndex(scenesUnderTheMouse, 0) // TODO: choose the topmost one in z-order
+        const sceneId = optionalMap(getIdOfScene, scene)
+
         const offset =
-          sceneId != null && isNotNullFiniteRectangle(scene.globalFrame)
+          scene != null && sceneId != null && isNotNullFiniteRectangle(scene.globalFrame)
             ? getLocalPointInNewParentContext(scene.globalFrame, loc.canvasPositionRounded)
             : null
 

--- a/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
@@ -11,18 +11,14 @@ import {
   newComment,
   sceneCommentLocation,
 } from '../../../editor/editor-modes'
-import { Substores, useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
+import { useRefEditorState } from '../../../editor/store/store-hook'
 import { windowToCanvasCoordinates } from '../../dom-lookup'
 import {
-  canvasPoint,
   getLocalPointInNewParentContext,
   isNotNullFiniteRectangle,
-  offsetPoint,
-  pointDifference,
   rectContainsPoint,
   windowPoint,
 } from '../../../../core/shared/math-utils'
-import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { isLeft } from '../../../../core/shared/either'
 import type { ElementInstanceMetadata } from '../../../../core/shared/element-template'
 import { isJSXElement } from '../../../../core/shared/element-template'

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -95,10 +95,38 @@ export type CommentId = NewComment | ExistingComment
 
 export interface NewComment {
   type: 'new'
-  location: CanvasPoint
+  location: NewCommentLocation
 }
 
-export function newComment(location: CanvasPoint): NewComment {
+export type NewCommentLocation = CanvasCommentLocation | SceneCommentLocation
+
+export interface CanvasCommentLocation {
+  type: 'canvas'
+  position: CanvasPoint
+}
+
+export function canvasCommentLocation(canvasPoint: CanvasPoint): CanvasCommentLocation {
+  return {
+    type: 'canvas',
+    position: canvasPoint,
+  }
+}
+
+export interface SceneCommentLocation {
+  type: 'scene'
+  sceneId: string
+  offset: CanvasPoint
+}
+
+export function sceneCommentLocation(sceneId: string, offset: CanvasPoint): SceneCommentLocation {
+  return {
+    type: 'scene',
+    sceneId: sceneId,
+    offset: offset,
+  }
+}
+
+export function newComment(location: NewCommentLocation): NewComment {
   return {
     type: 'new',
     location: location,

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -5,7 +5,7 @@ import type {
   ImageFile,
 } from '../../core/shared/project-file-types'
 import type { JSXElement } from '../../core/shared/element-template'
-import type { CanvasPoint, Size } from '../../core/shared/math-utils'
+import type { CanvasPoint, LocalPoint, Size } from '../../core/shared/math-utils'
 
 export const DefaultInsertSize: Size = { width: 100, height: 100 }
 
@@ -115,10 +115,10 @@ export function canvasCommentLocation(canvasPoint: CanvasPoint): CanvasCommentLo
 export interface SceneCommentLocation {
   type: 'scene'
   sceneId: string
-  offset: CanvasPoint
+  offset: LocalPoint
 }
 
-export function sceneCommentLocation(sceneId: string, offset: CanvasPoint): SceneCommentLocation {
+export function sceneCommentLocation(sceneId: string, offset: LocalPoint): SceneCommentLocation {
   return {
     type: 'scene',
     sceneId: sceneId,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -477,6 +477,9 @@ import type {
   CommentId,
   NewComment,
   ExistingComment,
+  NewCommentLocation,
+  CanvasCommentLocation,
+  SceneCommentLocation,
 } from '../editor-modes'
 import {
   EditorModes,
@@ -485,6 +488,8 @@ import {
   imageInsertionSubject,
   newComment,
   existingComment,
+  canvasCommentLocation,
+  sceneCommentLocation,
 } from '../editor-modes'
 import type { EditorPanel } from '../../common/actions'
 import type { Notice, NoticeLevel } from '../../common/notice'
@@ -3252,9 +3257,42 @@ export const TextEditModeKeepDeepEquality: KeepDeepEqualityCall<TextEditMode> =
     EditorModes.textEditMode,
   )
 
+export const CanvasCommentLocationKeepDeepEquality: KeepDeepEqualityCall<CanvasCommentLocation> =
+  combine1EqualityCall((loc) => loc.position, CanvasPointKeepDeepEquality, canvasCommentLocation)
+
+export const SceneCommentLocationKeepDeepEquality: KeepDeepEqualityCall<SceneCommentLocation> =
+  combine2EqualityCalls(
+    (loc) => loc.sceneId,
+    StringKeepDeepEquality,
+    (loc) => loc.offset,
+    CanvasPointKeepDeepEquality,
+    sceneCommentLocation,
+  )
+
+export const NewCommentLocationKeepDeepEquality: KeepDeepEqualityCall<NewCommentLocation> = (
+  oldValue,
+  newValue,
+) => {
+  switch (oldValue.type) {
+    case 'canvas':
+      if (newValue.type === oldValue.type) {
+        return CanvasCommentLocationKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'scene':
+      if (newValue.type === oldValue.type) {
+        return SceneCommentLocationKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    default:
+      assertNever(oldValue)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
+
 export const NewCommentKeepDeepEquality: KeepDeepEqualityCall<NewComment> = combine1EqualityCall(
   (mode) => mode.location,
-  CanvasPointKeepDeepEquality,
+  NewCommentLocationKeepDeepEquality,
   newComment,
 )
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -3265,7 +3265,7 @@ export const SceneCommentLocationKeepDeepEquality: KeepDeepEqualityCall<SceneCom
     (loc) => loc.sceneId,
     StringKeepDeepEquality,
     (loc) => loc.offset,
-    CanvasPointKeepDeepEquality,
+    LocalPointKeepDeepEquality,
     sceneCommentLocation,
   )
 

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -30,11 +30,7 @@ export function useCanvasCommentThreadAndLocation(comment: CommentId): {
     }
   }, [threads, comment])
 
-  const scenes = useEditorState(
-    Substores.metadata,
-    (store) => MetadataUtils.getScenesMetadata(store.editor.jsxMetadata),
-    'useCommentModeSelectAndHover scenes',
-  )
+  const scenes = useScenesWithId()
 
   const location = React.useMemo(() => {
     switch (comment.type) {
@@ -174,5 +170,16 @@ export function useIsOnAnotherRemixRoute(remixLocationRoute: string | null) {
     me.presence.remix?.locationRoute != null &&
     remixLocationRoute != null &&
     remixLocationRoute !== me.presence.remix.locationRoute
+  )
+}
+
+export function useScenesWithId() {
+  return useEditorState(
+    Substores.metadata,
+    (store) => {
+      const scenes = MetadataUtils.getScenesMetadata(store.editor.jsxMetadata)
+      return scenes.filter((s) => getIdOfScene(s) != null)
+    },
+    'useScenesWithId scenes',
   )
 }

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -14,7 +14,6 @@ import {
   getCanvasPointWithCanvasOffset,
   isNotNullFiniteRectangle,
   localPoint,
-  offsetPoint,
   zeroCanvasPoint,
 } from '../shared/math-utils'
 import { MetadataUtils } from '../model/element-metadata-utils'

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -9,7 +9,14 @@ import { isLoggedIn } from '../../common/user'
 import type { CommentId, SceneCommentLocation } from '../../components/editor/editor-modes'
 import { assertNever } from '../shared/utils'
 import type { CanvasPoint } from '../shared/math-utils'
-import { canvasPoint, isNotNullFiniteRectangle, offsetPoint } from '../shared/math-utils'
+import {
+  canvasPoint,
+  getCanvasPointWithCanvasOffset,
+  isNotNullFiniteRectangle,
+  localPoint,
+  offsetPoint,
+  zeroCanvasPoint,
+} from '../shared/math-utils'
 import { MetadataUtils } from '../model/element-metadata-utils'
 import { getIdOfScene } from '../../components/canvas/controls/comment-mode/comment-mode-hooks'
 
@@ -43,13 +50,10 @@ export function useCanvasCommentThreadAndLocation(comment: CommentId): {
               (s) => getIdOfScene(s) === (comment.location as SceneCommentLocation).sceneId,
             )
 
-            if (scene == null) {
-              return comment.location.offset
+            if (scene == null || !isNotNullFiniteRectangle(scene.globalFrame)) {
+              return getCanvasPointWithCanvasOffset(zeroCanvasPoint, comment.location.offset)
             }
-            if (!isNotNullFiniteRectangle(scene.globalFrame)) {
-              return comment.location.offset
-            }
-            return offsetPoint(comment.location.offset, scene.globalFrame)
+            return getCanvasPointWithCanvasOffset(scene.globalFrame, comment.location.offset)
           default:
             assertNever(comment.location)
         }
@@ -69,7 +73,7 @@ export function useCanvasCommentThreadAndLocation(comment: CommentId): {
         if (!isNotNullFiniteRectangle(scene.globalFrame)) {
           return canvasPoint(thread.metadata)
         }
-        return offsetPoint(canvasPoint(thread.metadata), scene.globalFrame)
+        return getCanvasPointWithCanvasOffset(scene.globalFrame, localPoint(thread.metadata))
 
       default:
         assertNever(comment)

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -186,3 +186,17 @@ export function useScenesWithId() {
     'useScenesWithId scenes',
   )
 }
+
+export function useCanvasLocationOfThread(thread: ThreadData<ThreadMetadata>): CanvasPoint {
+  const scenes = useScenesWithId()
+
+  if (thread.metadata.sceneId == null) {
+    return canvasPoint(thread.metadata)
+  }
+  const scene = scenes.find((s) => getIdOfScene(s) === thread.metadata.sceneId)
+
+  if (scene == null || !isNotNullFiniteRectangle(scene.globalFrame)) {
+    return canvasPoint(thread.metadata)
+  }
+  return getCanvasPointWithCanvasOffset(scene.globalFrame, localPoint(thread.metadata))
+}

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -743,6 +743,13 @@ export const MetadataUtils = {
     }
     return null
   },
+  getScenesMetadata(metadata: ElementInstanceMetadataMap): Array<ElementInstanceMetadata> {
+    return Object.values(metadata).filter(
+      (metadataEntry) =>
+        MetadataUtils.isProbablySceneFromMetadata(metadataEntry) ||
+        MetadataUtils.isProbablyRemixSceneFromMetadata(metadataEntry),
+    )
+  },
   getAllStoryboardChildrenPathsOrdered(
     metadata: ElementInstanceMetadataMap,
     pathTree: ElementPathTrees,

--- a/editor/src/core/shared/math-utils.ts
+++ b/editor/src/core/shared/math-utils.ts
@@ -41,6 +41,9 @@ export function canvasSegment(a: CanvasPoint, b: CanvasPoint): CanvasSegment {
 export function canvasPoint(p: PointInner): CanvasPoint {
   return p as CanvasPoint
 }
+export function localPoint(p: PointInner): LocalPoint {
+  return p as LocalPoint
+}
 export function windowPoint(p: PointInner): WindowPoint {
   return p as WindowPoint
 }

--- a/editor/src/sample-projects/sample-project-utils.ts
+++ b/editor/src/sample-projects/sample-project-utils.ts
@@ -237,7 +237,7 @@ function createBeachesProjectContents(): ProjectContentTreeRoot {
             lastParseSuccess: null,
             lastSavedContents: null,
             fileContents: {
-              code: "import * as React from 'react'\nimport { Scene, Storyboard } from 'utopia-api'\nimport { App } from '/src/app.js'\nimport { Playground } from '/src/playground.js'\n\nexport var storyboard = (\n  <Storyboard>\n    <Scene\n      style={{\n        width: 700,\n        height: 759,\n        position: 'absolute',\n        left: 212,\n        top: 128,\n      }}\n      data-label='Playground'\n    >\n      <Playground style={{}} />\n    </Scene>\n    <Scene\n      style={{\n        width: 744,\n        height: 1133,\n        position: 'absolute',\n        left: 1036,\n        top: 128,\n      }}\n      data-label='My App'\n    >\n      <App style={{}} />\n    </Scene>\n  </Storyboard>\n)\n",
+              code: "import * as React from 'react'\nimport { Scene, Storyboard } from 'utopia-api'\nimport { App } from '/src/app.js'\nimport { Playground } from '/src/playground.js'\n\nexport var storyboard = (\n  <Storyboard>\n    <Scene\n      id='playground-scene'\n      style={{\n        width: 700,\n        height: 759,\n        position: 'absolute',\n        left: 212,\n        top: 128,\n      }}\n      data-label='Playground'\n    >\n      <Playground style={{}} />\n    </Scene>\n    <Scene\n      id='app-scene'\n      style={{\n        width: 744,\n        height: 1133,\n        position: 'absolute',\n        left: 1036,\n        top: 128,\n      }}\n      data-label='My App'\n    >\n      <App style={{}} />\n    </Scene>\n  </Storyboard>\n)\n",
               parsed: {
                 type: 'UNPARSED',
               },

--- a/utopia-api/src/primitives/remix-scene.tsx
+++ b/utopia-api/src/primitives/remix-scene.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { View } from './view'
 
 export interface RemixSceneProps {
+  id?: string
   style?: React.CSSProperties
   'data-label'?: string
   'data-uid'?: string

--- a/utopia-api/src/primitives/scene.tsx
+++ b/utopia-api/src/primitives/scene.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { View } from './view'
 
 export interface SceneProps {
+  id?: string
   style?: React.CSSProperties
   'data-label'?: string
   'data-uid'?: string


### PR DESCRIPTION
**Description:**
New comment type: scene comments!
- Scenes have a new optional prop `id`, which is used to identify a scene in the comment metadata. I made it optional so I don't break all the existing utopia projects. Later we can implement id generation when it is missing.
- Comment metadata has a new optional property `sceneId`. When this is not undefined, the comment is a scene comment, and its x and y coordinates are local coordinates in the scene.
- Instead of storing a CanvasPoint in NewComment.location, I created a new ADT `NewCommentLocation`, which is either a global location on the canvas, or a scene id and a local position in that scene.
- I updated comment mode so it inserts a scene comment when you are clicking over a scene.
- I updated comment indicator and comment popup to properly handle the position of the two kind of comments (scene and canvas)
- I updated the default project, so the scenes in them have ids
- When the scene is not found for a comment (e.g. it is deleted), then the comment is just shown on the same canvas position as its local position in the scene (maybe later we should store the scene coordinates in the comment metadata for safety).

**Missing things:**
- dragging a scene comment outside of the scene still keeps it as a comment of the original scene (no "comment reparenting")
- scenes on top of each others are not handled, z-order of scenes is not taken into account
- no UI improvements yet, you can't see if a comment is a scene comment or a canvas comment anywhere (the only difference is that scene comments move together with a dragged scene).
- scene ids are not generated, so if you don't add an id to your scenes, you can't add comments to it
- even if you insert a scene using the utopia UI, no id will be added (which is fine in my opinion, since the UI for scene comments is basically missing)