### PR TITLE
Handle updates to files that can't normally be parsed.

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -1077,6 +1077,12 @@ export interface UpdateImportsFromCollaborationUpdate {
   imports: MapLike<ImportDetails>
 }
 
+export interface UpdateCodeFromCollaborationUpdate {
+  action: 'UPDATE_CODE_FROM_COLLABORATION_UPDATE'
+  fullPath: string
+  code: string
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertJSXElement
@@ -1251,6 +1257,7 @@ export type EditorAction =
   | UpdateTopLevelElementsFromCollaborationUpdate
   | UpdateExportsDetailFromCollaborationUpdate
   | UpdateImportsFromCollaborationUpdate
+  | UpdateCodeFromCollaborationUpdate
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -225,6 +225,7 @@ import type {
   DeleteFileFromCollaboration,
   UpdateExportsDetailFromCollaborationUpdate,
   UpdateImportsFromCollaborationUpdate,
+  UpdateCodeFromCollaborationUpdate,
 } from '../action-types'
 import type { InsertionSubjectWrapper, Mode } from '../editor-modes'
 import { EditorModes, insertionSubject } from '../editor-modes'
@@ -1705,5 +1706,16 @@ export function updateImportsFromCollaborationUpdate(
     action: 'UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE',
     fullPath: fullPath,
     imports: imports,
+  }
+}
+
+export function updateCodeFromCollaborationUpdate(
+  fullPath: string,
+  code: string,
+): UpdateCodeFromCollaborationUpdate {
+  return {
+    action: 'UPDATE_CODE_FROM_COLLABORATION_UPDATE',
+    fullPath: fullPath,
+    code: code,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -200,6 +200,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE':
     case 'UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE':
     case 'UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE':
+    case 'UPDATE_CODE_FROM_COLLABORATION_UPDATE':
       return false
     case 'SAVE_ASSET':
       return (

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -113,6 +113,7 @@ function checkIfActionShouldBeProcessed(
       action.action === 'UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE' ||
       action.action === 'UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE' ||
       action.action === 'UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE' ||
+      action.action === 'UPDATE_CODE_FROM_COLLABORATION_UPDATE' ||
       action.action === 'DELETE_FILE_FROM_COLLABORATION'
     shouldProcessAction = allowedNonOwnerAction
   }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -405,7 +405,11 @@ export type CollabTextFileExportsDetail = Y.Array<ExportDetail>
 export type CollabTextFileImports = Y.Map<ImportDetails>
 
 export type CollabTextFile = Y.Map<
-  'TEXT_FILE' | CollabTextFileTopLevelElements | CollabTextFileExportsDetail | CollabTextFileImports
+  | 'TEXT_FILE'
+  | CollabTextFileTopLevelElements
+  | CollabTextFileExportsDetail
+  | CollabTextFileImports
+  | string
 >
 
 export type CollabFile = CollabTextFile //| CollabImageFileUpdate | CollabAssetFileUpdate | CollabDirectoryFileUpdate

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -399,6 +399,14 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE(action, state, serverState)
     case 'UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE':
       return UPDATE_FNS.UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE(action, state, serverState)
+    case 'UPDATE_CODE_FROM_COLLABORATION_UPDATE':
+      return UPDATE_FNS.UPDATE_CODE_FROM_COLLABORATION_UPDATE(
+        action,
+        state,
+        serverState,
+        dispatch,
+        builtInDependencies,
+      )
     default:
       return state
   }


### PR DESCRIPTION
**Problem:**
Currently if a file like `package.json` is updated via the collaboration, the viewer is completely unaware of the change and potentially even breaks if a new dependency is added.

**Cause:**
This originates with our design that currently only looks at the parsed content of text files, which works well for source code. But for anything (like `/package.json`) that is a text file but will never parse successfully that results in their content never make it to a viewer.

**Fix:**
This fix splits text files into two categories, those which appear to be parseable (by filename) and those that are not. For those that are not we have a path that sends those files directly as straight code to the viewer.

**Commit Details:**
- Added `UPDATE_CODE_FROM_COLLABORATION_UPDATE` action.
- `collateCollaborativeProjectChanges` treats normally parseable files differently to those that aren't normally parseable.
- Added `looksLikeParseableSourceCode` utility function.
- `applyFileChangeToMap` also handles files that aren't normally parseable slightly differently.
- Broke out some existing logic into `updateFromParseSuccess` and added `updateNonParseable` alongside it.
- Ported over some existing changes to `updateCollaborativeProjectContents`.
- Refactored the innards of `addHookForProjectChanges` slightly into a function `fileAndPropertyUpdate`.
- Updated `updateEntireProjectContents` to also handle `code` fields.
- Added `updateEditorWithTextChanges` and `updateCodeOfFile` utility functions.
