### PR TITLE
Basic comments resolution

### DIFF
--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -78,7 +78,6 @@ export type RoomEvent = {
 // Optionally, when using Comments, ThreadMetadata represents metadata on
 // each thread. Can only contain booleans, strings, and numbers.
 export type ThreadMetadata = {
-  // resolved: boolean;
   // quote: string;
   // time: number;
   type: 'canvas'
@@ -86,6 +85,7 @@ export type ThreadMetadata = {
   y: number
   sceneId?: string
   remixLocationRoute?: string
+  resolved: boolean
 }
 
 export const {

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -5,10 +5,11 @@ import type { ThreadData } from '@liveblocks/client'
 import { useAtom } from 'jotai'
 import React from 'react'
 import type { ThreadMetadata } from '../../../../liveblocks.config'
-import { useEditThreadMetadata, useStorage, useThreads } from '../../../../liveblocks.config'
+import { useEditThreadMetadata, useStorage } from '../../../../liveblocks.config'
 import {
   useCanvasLocationOfThread,
   useIsOnAnotherRemixRoute,
+  useActiveThreads,
 } from '../../../core/commenting/comment-hooks'
 import type { CanvasPoint, CanvasVector, WindowPoint } from '../../../core/shared/math-utils'
 import {
@@ -55,7 +56,7 @@ export const CommentIndicators = React.memo(() => {
 CommentIndicators.displayName = 'CommentIndicators'
 
 const CommentIndicatorsInner = React.memo(() => {
-  const { threads } = useThreads()
+  const threads = useActiveThreads()
 
   return (
     <React.Fragment>
@@ -138,7 +139,8 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
         position: 'fixed',
         top: position.y,
         left: position.x,
-        opacity: isOnAnotherRoute ? 0.25 : 1,
+        opacity: isOnAnotherRoute || thread.metadata.resolved ? 0.25 : 1,
+        filter: thread.metadata.resolved ? 'grayscale(1)' : undefined,
         width: IndicatorSize,
         '&:hover': {
           transform: 'scale(1.15)',

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -76,6 +76,7 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
             return createThread({
               body,
               metadata: {
+                resolved: false,
                 type: 'canvas',
                 x: comment.location.position.x,
                 y: comment.location.position.y,
@@ -86,6 +87,7 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
             return createThread({
               body,
               metadata: {
+                resolved: false,
                 type: 'canvas',
                 x: comment.location.offset.x,
                 y: comment.location.offset.y,

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -1077,6 +1077,11 @@ export interface UpdateImportsFromCollaborationUpdate {
   imports: MapLike<ImportDetails>
 }
 
+export interface SetShowResolvedThreads {
+  action: 'SET_SHOW_RESOLVED_THREADS'
+  showResolvedThreads: boolean
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertJSXElement
@@ -1251,6 +1256,7 @@ export type EditorAction =
   | UpdateTopLevelElementsFromCollaborationUpdate
   | UpdateExportsDetailFromCollaborationUpdate
   | UpdateImportsFromCollaborationUpdate
+  | SetShowResolvedThreads
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -225,6 +225,7 @@ import type {
   DeleteFileFromCollaboration,
   UpdateExportsDetailFromCollaborationUpdate,
   UpdateImportsFromCollaborationUpdate,
+  SetShowResolvedThreads,
 } from '../action-types'
 import type { InsertionSubjectWrapper, Mode } from '../editor-modes'
 import { EditorModes, insertionSubject } from '../editor-modes'
@@ -1705,5 +1706,12 @@ export function updateImportsFromCollaborationUpdate(
     action: 'UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE',
     fullPath: fullPath,
     imports: imports,
+  }
+}
+
+export function setShowResolvedThreads(showResolvedThreads: boolean): SetShowResolvedThreads {
+  return {
+    action: 'SET_SHOW_RESOLVED_THREADS',
+    showResolvedThreads: showResolvedThreads,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -130,6 +130,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'START_POST_ACTION_SESSION':
     case 'TRUNCATE_HISTORY':
     case 'UPDATE_PROJECT_SERVER_STATE':
+    case 'SET_SHOW_RESOLVED_THREADS':
       return true
 
     case 'TRUE_UP_ELEMENTS':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -317,6 +317,7 @@ import type {
   DeleteFileFromCollaboration,
   UpdateExportsDetailFromCollaborationUpdate,
   UpdateImportsFromCollaborationUpdate,
+  SetShowResolvedThreads,
 } from '../action-types'
 import { isLoggedIn } from '../action-types'
 import type { Mode } from '../editor-modes'
@@ -920,6 +921,7 @@ export function restoreEditorState(
     internalClipboard: currentEditor.internalClipboard,
     filesModifiedByAnotherUser: currentEditor.filesModifiedByAnotherUser,
     activeFrames: currentEditor.activeFrames,
+    showResolvedThreads: currentEditor.showResolvedThreads,
   }
 }
 
@@ -5526,6 +5528,9 @@ export const UPDATE_FNS = {
         ),
       }
     }
+  },
+  SET_SHOW_RESOLVED_THREADS: (action: SetShowResolvedThreads, editor: EditorModel): EditorModel => {
+    return { ...editor, showResolvedThreads: action.showResolvedThreads }
   },
 }
 

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1479,6 +1479,7 @@ export interface EditorState {
   internalClipboard: InternalClipboard
   filesModifiedByAnotherUser: Array<string>
   activeFrames: ActiveFrame[]
+  showResolvedThreads: boolean
 }
 
 export function editorState(
@@ -1561,6 +1562,7 @@ export function editorState(
   internalClipboardData: InternalClipboard,
   filesModifiedByAnotherUser: Array<string>,
   activeFrames: ActiveFrame[],
+  showResolvedThreads: boolean,
 ): EditorState {
   return {
     id: id,
@@ -1642,6 +1644,7 @@ export function editorState(
     internalClipboard: internalClipboardData,
     filesModifiedByAnotherUser: filesModifiedByAnotherUser,
     activeFrames: activeFrames,
+    showResolvedThreads: showResolvedThreads,
   }
 }
 
@@ -2518,6 +2521,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     },
     filesModifiedByAnotherUser: [],
     activeFrames: [],
+    showResolvedThreads: false,
   }
 }
 
@@ -2894,6 +2898,7 @@ export function editorModelFromPersistentModel(
     },
     filesModifiedByAnotherUser: [],
     activeFrames: [],
+    showResolvedThreads: false,
   }
   return editor
 }

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -399,6 +399,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE(action, state, serverState)
     case 'UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE':
       return UPDATE_FNS.UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE(action, state, serverState)
+    case 'SET_SHOW_RESOLVED_THREADS':
+      return UPDATE_FNS.SET_SHOW_RESOLVED_THREADS(action, state)
     default:
       return state
   }

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -4570,6 +4570,11 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     newValue.activeFrames,
   )
 
+  const showResolvedThreadsResults = BooleanKeepDeepEquality(
+    oldValue.showResolvedThreads,
+    newValue.showResolvedThreads,
+  )
+
   const areEqual =
     idResult.areEqual &&
     vscodeBridgeIdResult.areEqual &&
@@ -4648,7 +4653,8 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     colorSwatchesResults.areEqual &&
     internalClipboardResults.areEqual &&
     filesModifiedByAnotherUserResults.areEqual &&
-    activeFramesResults.areEqual
+    activeFramesResults.areEqual &&
+    showResolvedThreadsResults.areEqual
 
   if (areEqual) {
     return keepDeepEqualityResult(oldValue, true)
@@ -4733,6 +4739,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
       internalClipboardResults.value,
       filesModifiedByAnotherUserResults.value,
       activeFramesResults.value,
+      showResolvedThreadsResults.value,
     )
 
     return keepDeepEqualityResult(newEditorState, false)

--- a/editor/src/components/editor/store/store-hook-substore-helpers.ts
+++ b/editor/src/components/editor/store/store-hook-substore-helpers.ts
@@ -173,4 +173,5 @@ export const EmptyEditorStateForKeysOnly: EditorState = {
   },
   filesModifiedByAnotherUser: [],
   activeFrames: [],
+  showResolvedThreads: false,
 }


### PR DESCRIPTION
Fix #4593 

This PR introduces basic comment resolution via the sidebar.

https://github.com/concrete-utopia/utopia/assets/1081051/bb3fa0c4-8931-43ae-a896-96d776e2b448

- The sidebar shows the usual list of comments
- If there are resolved comments, a button at the bottom to show/hide them appears
- The unresolved comments are shown at the top, and the resolved ones at the bottom
- A thread can be unresolved as well from there
- When it's chosen to show the resolved comments, their indicators will also reappear, but dimmed and greyed-out to distinguish them from unresolved ones
- A couple of hooks are added for convenience: `useUnresolvedThreads`, `useResolvedThreads`, and `useActiveThreads` (which returns either the unresolved threads _or_ the union with the resolved threads as well depending on whether the editor is set to show those)