### PR TITLE
Apply custom avatar on top of fallback comment avatar

### DIFF
--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -1,17 +1,17 @@
 import type { CommentData } from '@liveblocks/client'
 import type { ComposerSubmitComment } from '@liveblocks/react-comments'
-import { Comment, Composer } from '@liveblocks/react-comments'
+import { Composer } from '@liveblocks/react-comments'
 import { stopPropagation } from '../../inspector/common/inspector-utils'
 import { Button, UtopiaStyles, useColorTheme } from '../../../uuiui'
 import React from 'react'
-import { useCreateThread } from '../../../../liveblocks.config'
+import { useCreateThread, useStorage } from '../../../../liveblocks.config'
 import '../../../../resources/editor/css/liveblocks-comments.css'
 import {
   useCanvasCommentThreadAndLocation,
   useResolveThread,
 } from '../../../core/commenting/comment-hooks'
 import { useRemixPresence } from '../../../core/shared/multiplayer-hooks'
-import { MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
+import { CommentWrapper, MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
 import { switchEditorMode } from '../../editor/actions/action-creators'
 import type { CommentId } from '../../editor/editor-modes'
 import {
@@ -140,6 +140,8 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
     resolveThread(thread)
   }, [thread, resolveThread])
 
+  const collabs = useStorage((storage) => storage.collaborators)
+
   if (location == null) {
     return null
   }
@@ -191,9 +193,17 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
         <Composer autoFocus onComposerSubmit={onCreateThread} />
       ) : (
         <>
-          {thread.comments.map((c) => (
-            <Comment key={c.id} comment={c} onCommentDelete={onCommentDelete} />
-          ))}
+          {thread.comments.map((c) => {
+            const user = collabs[c.userId]
+            return (
+              <CommentWrapper
+                key={c.id}
+                user={user}
+                comment={c}
+                onCommentDelete={onCommentDelete}
+              />
+            )
+          })}
           <Composer autoFocus threadId={thread.id} />
         </>
       )}

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -7,9 +7,8 @@ import {
   InspectorSubsectionHeader,
   useColorTheme,
 } from '../../../uuiui'
-import { Comment } from '@liveblocks/react-comments'
 import { stopPropagation } from '../common/inspector-utils'
-import type { ThreadMetadata } from '../../../../liveblocks.config'
+import { useStorage, type ThreadMetadata } from '../../../../liveblocks.config'
 import type { ThreadData } from '@liveblocks/client'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { canvasRectangle } from '../../../core/shared/math-utils'
@@ -19,7 +18,7 @@ import {
   switchEditorMode,
 } from '../../editor/actions/action-creators'
 import { EditorModes, isCommentMode, isExistingComment } from '../../editor/editor-modes'
-import { MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
+import { CommentWrapper, MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
 import { useAtom } from 'jotai'
 import { RemixNavigationAtom } from '../../canvas/remix/utopia-remix-root-component'
 import {
@@ -161,12 +160,16 @@ const ThreadPreview = React.memo(({ thread }: ThreadPreviewProps) => {
     [resolveThread, dispatch, thread],
   )
 
+  const collabs = useStorage((storage) => storage.collaborators)
+
   const comment = thread.comments[0]
   if (comment == null) {
     return null
   }
 
   const repliesCount = thread.comments.length - 1
+  const user = collabs[comment.userId]
+
   return (
     <div
       key={comment.id}
@@ -179,7 +182,12 @@ const ThreadPreview = React.memo(({ thread }: ThreadPreviewProps) => {
           : 'transparent',
       }}
     >
-      <Comment comment={comment} showActions={false} style={{ backgroundColor: 'transparent' }} />
+      <CommentWrapper
+        user={user}
+        comment={comment}
+        showActions={false}
+        style={{ backgroundColor: 'transparent' }}
+      />
       <div
         style={{
           paddingBottom: 10,

--- a/editor/src/utils/multiplayer-wrapper.tsx
+++ b/editor/src/utils/multiplayer-wrapper.tsx
@@ -1,6 +1,15 @@
-import React from 'react'
-import { ErrorBoundary } from './react-error-boundary'
 import { ClientSideSuspense } from '@liveblocks/react'
+import type { CommentProps } from '@liveblocks/react-comments'
+import { Comment } from '@liveblocks/react-comments'
+import React from 'react'
+import type { UserMeta } from '../../liveblocks.config'
+import { MultiplayerAvatar } from '../components/user-bar'
+import {
+  multiplayerColorFromIndex,
+  multiplayerInitialsFromName,
+  normalizeMultiplayerName,
+} from '../core/shared/multiplayer'
+import { ErrorBoundary } from './react-error-boundary'
 
 type Fallback = NonNullable<React.ReactNode> | null
 
@@ -15,3 +24,31 @@ export const MultiplayerWrapper = React.memo(
     )
   },
 )
+MultiplayerWrapper.displayName = 'MultiplayerWrapper'
+
+export const CommentWrapper = React.memo(
+  ({ user, ...commentProps }: { user: UserMeta | null } & CommentProps) => {
+    if (user == null) {
+      return <Comment {...commentProps} />
+    }
+    return (
+      <div style={{ position: 'relative' }}>
+        <MultiplayerAvatar
+          name={multiplayerInitialsFromName(normalizeMultiplayerName(user.name))}
+          color={multiplayerColorFromIndex(user.colorIndex)}
+          style={{
+            position: 'absolute',
+            top: 11,
+            zIndex: 1,
+            left: 11,
+            width: 25.5, // matching the size of the liveblocks component
+            height: 25.5, // matching the size of the liveblocks component
+          }}
+          picture={user.avatar}
+        />
+        <Comment {...commentProps} />
+      </div>
+    )
+  },
+)
+CommentWrapper.displayName = 'CommentWrapper'


### PR DESCRIPTION
Fix #4599 

**Problem:**

Comment avatars only show the fallback/default avatar without matching the custom avatar (incl. colored initials) used elsewhere (user bars, cursors, comment indicators, …).

**Fix:**

Without delving deep into the guts of the comment component, this PR simply applies the custom avatar on top of the default one, effectively showing it.

<img width="1505" alt="Screenshot 2023-12-05 at 11 23 39 AM" src="https://github.com/concrete-utopia/utopia/assets/1081051/1e143087-d8f4-4aaf-a38a-7b2074d4aef2">

