### PR TITLE
Cleanup of gated actions for collaboration.

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -5357,204 +5357,171 @@ export const UPDATE_FNS = {
   UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE: (
     action: UpdateTopLevelElementsFromCollaborationUpdate,
     editor: EditorModel,
-    serverState: ProjectServerState,
   ): EditorModel => {
-    // When the current user does own the project...
-    if (serverState.isMyProject === 'yes') {
-      // ...Disallow these updates as they're coming from non-owners.
-      return editor
-    } else {
-      let updatedEditor: EditorModel = editor
-      if (fileExists(editor.projectContents, action.fullPath)) {
-        updatedEditor = modifyParseSuccessAtPath(
-          action.fullPath,
-          editor,
-          (parsed) => {
-            const newTopLevelElementsDeepEquals = arrayDeepEquality(
-              TopLevelElementKeepDeepEquality,
-            )(parsed.topLevelElements, action.topLevelElements)
+    let updatedEditor: EditorModel = editor
+    if (fileExists(editor.projectContents, action.fullPath)) {
+      updatedEditor = modifyParseSuccessAtPath(
+        action.fullPath,
+        editor,
+        (parsed) => {
+          const newTopLevelElementsDeepEquals = arrayDeepEquality(TopLevelElementKeepDeepEquality)(
+            parsed.topLevelElements,
+            action.topLevelElements,
+          )
 
-            if (newTopLevelElementsDeepEquals.areEqual) {
-              return parsed
-            } else {
-              return {
-                ...parsed,
-                topLevelElements: newTopLevelElementsDeepEquals.value,
-              }
+          if (newTopLevelElementsDeepEquals.areEqual) {
+            return parsed
+          } else {
+            return {
+              ...parsed,
+              topLevelElements: newTopLevelElementsDeepEquals.value,
             }
-          },
-          false,
-        )
-      } else {
-        const newParseSuccess = parseSuccess({}, action.topLevelElements, {}, null, null, [], {})
-        const newFile = textFile(
-          textFileContents('', newParseSuccess, RevisionsState.ParsedAhead),
-          null,
-          null,
-          1,
-        )
-        const updatedProjectContents = addFileToProjectContents(
-          editor.projectContents,
-          action.fullPath,
-          newFile,
-        )
-        updatedEditor = {
-          ...editor,
-          projectContents: updatedProjectContents,
-        }
+          }
+        },
+        false,
+      )
+    } else {
+      const newParseSuccess = parseSuccess({}, action.topLevelElements, {}, null, null, [], {})
+      const newFile = textFile(
+        textFileContents('', newParseSuccess, RevisionsState.ParsedAhead),
+        null,
+        null,
+        1,
+      )
+      const updatedProjectContents = addFileToProjectContents(
+        editor.projectContents,
+        action.fullPath,
+        newFile,
+      )
+      updatedEditor = {
+        ...editor,
+        projectContents: updatedProjectContents,
       }
+    }
 
-      return {
-        ...updatedEditor,
-        filesModifiedByAnotherUser: updatedEditor.filesModifiedByAnotherUser.concat(
-          action.fullPath,
-        ),
-      }
+    return {
+      ...updatedEditor,
+      filesModifiedByAnotherUser: updatedEditor.filesModifiedByAnotherUser.concat(action.fullPath),
     }
   },
   UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE: (
     action: UpdateExportsDetailFromCollaborationUpdate,
     editor: EditorModel,
-    serverState: ProjectServerState,
   ): EditorModel => {
-    // When the current user does own the project...
-    if (serverState.isMyProject === 'yes') {
-      // ...Disallow these updates as they're coming from non-owners.
-      return editor
-    } else {
-      let updatedEditor: EditorModel = editor
-      if (fileExists(editor.projectContents, action.fullPath)) {
-        updatedEditor = modifyParseSuccessAtPath(
-          action.fullPath,
-          editor,
-          (parsed) => {
-            const newExportsDetailsDeepEquals = arrayDeepEquality(ExportDetailKeepDeepEquality)(
-              parsed.exportsDetail,
-              action.exportsDetail,
-            )
+    let updatedEditor: EditorModel = editor
+    if (fileExists(editor.projectContents, action.fullPath)) {
+      updatedEditor = modifyParseSuccessAtPath(
+        action.fullPath,
+        editor,
+        (parsed) => {
+          const newExportsDetailsDeepEquals = arrayDeepEquality(ExportDetailKeepDeepEquality)(
+            parsed.exportsDetail,
+            action.exportsDetail,
+          )
 
-            if (newExportsDetailsDeepEquals.areEqual) {
-              return parsed
-            } else {
-              return {
-                ...parsed,
-                exportsDetail: newExportsDetailsDeepEquals.value,
-              }
+          if (newExportsDetailsDeepEquals.areEqual) {
+            return parsed
+          } else {
+            return {
+              ...parsed,
+              exportsDetail: newExportsDetailsDeepEquals.value,
             }
-          },
-          false,
-        )
-      } else {
-        const newParseSuccess = parseSuccess({}, [], {}, null, null, action.exportsDetail, {})
-        const newFile = textFile(
-          textFileContents('', newParseSuccess, RevisionsState.ParsedAhead),
-          null,
-          null,
-          1,
-        )
-        const updatedProjectContents = addFileToProjectContents(
-          editor.projectContents,
-          action.fullPath,
-          newFile,
-        )
-        updatedEditor = {
-          ...editor,
-          projectContents: updatedProjectContents,
-        }
+          }
+        },
+        false,
+      )
+    } else {
+      const newParseSuccess = parseSuccess({}, [], {}, null, null, action.exportsDetail, {})
+      const newFile = textFile(
+        textFileContents('', newParseSuccess, RevisionsState.ParsedAhead),
+        null,
+        null,
+        1,
+      )
+      const updatedProjectContents = addFileToProjectContents(
+        editor.projectContents,
+        action.fullPath,
+        newFile,
+      )
+      updatedEditor = {
+        ...editor,
+        projectContents: updatedProjectContents,
       }
+    }
 
-      return {
-        ...updatedEditor,
-        filesModifiedByAnotherUser: updatedEditor.filesModifiedByAnotherUser.concat(
-          action.fullPath,
-        ),
-      }
+    return {
+      ...updatedEditor,
+      filesModifiedByAnotherUser: updatedEditor.filesModifiedByAnotherUser.concat(action.fullPath),
     }
   },
   UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE: (
     action: UpdateImportsFromCollaborationUpdate,
     editor: EditorModel,
-    serverState: ProjectServerState,
   ): EditorModel => {
-    // When the current user does own the project...
-    if (serverState.isMyProject === 'yes') {
-      // ...Disallow these updates as they're coming from non-owners.
-      return editor
-    } else {
-      let updatedEditor: EditorModel = editor
-      if (fileExists(editor.projectContents, action.fullPath)) {
-        updatedEditor = modifyParseSuccessAtPath(
-          action.fullPath,
-          editor,
-          (parsed) => {
-            const newImportsDeepEquals = objectDeepEquality(ImportDetailsKeepDeepEquality)(
-              parsed.imports,
-              action.imports,
-            )
+    let updatedEditor: EditorModel = editor
+    if (fileExists(editor.projectContents, action.fullPath)) {
+      updatedEditor = modifyParseSuccessAtPath(
+        action.fullPath,
+        editor,
+        (parsed) => {
+          const newImportsDeepEquals = objectDeepEquality(ImportDetailsKeepDeepEquality)(
+            parsed.imports,
+            action.imports,
+          )
 
-            if (newImportsDeepEquals.areEqual) {
-              return parsed
-            } else {
-              return {
-                ...parsed,
-                imports: newImportsDeepEquals.value,
-              }
+          if (newImportsDeepEquals.areEqual) {
+            return parsed
+          } else {
+            return {
+              ...parsed,
+              imports: newImportsDeepEquals.value,
             }
-          },
-          false,
-        )
-      } else {
-        const newParseSuccess = parseSuccess(action.imports, [], {}, null, null, [], {})
-        const newFile = textFile(
-          textFileContents('', newParseSuccess, RevisionsState.ParsedAhead),
-          null,
-          null,
-          1,
-        )
-        const updatedProjectContents = addFileToProjectContents(
-          editor.projectContents,
-          action.fullPath,
-          newFile,
-        )
-        updatedEditor = {
-          ...editor,
-          projectContents: updatedProjectContents,
-        }
+          }
+        },
+        false,
+      )
+    } else {
+      const newParseSuccess = parseSuccess(action.imports, [], {}, null, null, [], {})
+      const newFile = textFile(
+        textFileContents('', newParseSuccess, RevisionsState.ParsedAhead),
+        null,
+        null,
+        1,
+      )
+      const updatedProjectContents = addFileToProjectContents(
+        editor.projectContents,
+        action.fullPath,
+        newFile,
+      )
+      updatedEditor = {
+        ...editor,
+        projectContents: updatedProjectContents,
       }
+    }
 
-      return {
-        ...updatedEditor,
-        filesModifiedByAnotherUser: updatedEditor.filesModifiedByAnotherUser.concat(
-          action.fullPath,
-        ),
-      }
+    return {
+      ...updatedEditor,
+      filesModifiedByAnotherUser: updatedEditor.filesModifiedByAnotherUser.concat(action.fullPath),
     }
   },
   UPDATE_CODE_FROM_COLLABORATION_UPDATE: (
     action: UpdateCodeFromCollaborationUpdate,
     editor: EditorModel,
-    serverState: ProjectServerState,
     dispatch: EditorDispatch,
     builtInDependencies: BuiltInDependencies,
   ): EditorModel => {
-    // When the current user does own the project...
-    if (serverState.isMyProject === 'yes') {
-      // ...Disallow these updates as they're coming from non-owners.
-      return editor
+    const existing = getProjectFileByFilePath(editor.projectContents, action.fullPath)
+
+    let updatedFile: ProjectFile
+    if (existing == null || !isTextFile(existing)) {
+      const contents = textFileContents(action.code, unparsed, RevisionsState.CodeAhead)
+      updatedFile = textFile(contents, null, null, 0)
     } else {
-      const existing = getProjectFileByFilePath(editor.projectContents, action.fullPath)
-
-      let updatedFile: ProjectFile
-      if (existing == null || !isTextFile(existing)) {
-        const contents = textFileContents(action.code, unparsed, RevisionsState.CodeAhead)
-        updatedFile = textFile(contents, null, null, 0)
-      } else {
-        updatedFile = updateFileContents(action.code, existing, false)
-      }
-
-      const updateAction = updateFile(action.fullPath, updatedFile, true)
-      return UPDATE_FNS.UPDATE_FILE(updateAction, editor, dispatch, builtInDependencies)
+      updatedFile = updateFileContents(action.code, existing, false)
     }
+
+    const updateAction = updateFile(action.fullPath, updatedFile, true)
+    return UPDATE_FNS.UPDATE_FILE(updateAction, editor, dispatch, builtInDependencies)
   },
   SET_SHOW_RESOLVED_THREADS: (action: SetShowResolvedThreads, editor: EditorModel): EditorModel => {
     return { ...editor, showResolvedThreads: action.showResolvedThreads }

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -47,6 +47,7 @@ import {
   storedEditorStateFromEditorState,
 } from './editor-state'
 import {
+  gatedActions,
   runClearPostActionSession,
   runExecuteStartPostActionMenuAction,
   runExecuteWithPostActionMenuAction,
@@ -99,210 +100,191 @@ export type DispatchResult = EditorStoreFull & DispatchResultFields
 
 const cannotUndoRedoToastId = 'cannot-undo-or-redo'
 
-function checkIfActionShouldBeProcessed(
-  editorStoreUnpatched: EditorStoreUnpatched,
-  action: EditorAction,
-): boolean {
-  // Default to true.
-  let shouldProcessAction: boolean = true
-  // By default when the current user does not own the project and the action is non-transient prevent actions from running...
-  if (editorStoreUnpatched.projectServerState.isMyProject === 'no' && !isTransientAction(action)) {
-    // ...Unless they're more critical to the running of the editor in this case.
-    const allowedNonOwnerAction =
-      action.action === 'UPDATE_FROM_WORKER' ||
-      action.action === 'UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE' ||
-      action.action === 'UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE' ||
-      action.action === 'UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE' ||
-      action.action === 'UPDATE_CODE_FROM_COLLABORATION_UPDATE' ||
-      action.action === 'DELETE_FILE_FROM_COLLABORATION'
-    shouldProcessAction = allowedNonOwnerAction
-  }
-  return shouldProcessAction
-}
-
 function processAction(
   dispatchEvent: EditorDispatch,
   editorStoreUnpatched: EditorStoreUnpatched,
   action: EditorAction,
   spyCollector: UiJsxCanvasContextData,
 ): EditorStoreUnpatched {
-  const shouldProcessAction = checkIfActionShouldBeProcessed(editorStoreUnpatched, action)
-
-  let working = editorStoreUnpatched
-  if (shouldProcessAction) {
-    // Sidestep around the local actions so that we definitely run them locally.
-    if (action.action === 'TRANSIENT_ACTIONS') {
-      // Drill into the array.
-      return processActions(dispatchEvent, working, action.transientActions, spyCollector)
-    } else if (action.action === 'ATOMIC' || action.action === 'MERGE_WITH_PREV_UNDO') {
-      // Drill into the array.
-      return processActions(dispatchEvent, working, action.actions, spyCollector)
-    } else if (action.action === 'UNDO' && !History.canUndo(working.history)) {
-      // Bail early and make no changes.
-      return processActions(
-        dispatchEvent,
-        working,
-        [
-          EditorActions.addToast(
-            notice(
-              `Can't undo, reached the end of the undo history.`,
-              'NOTICE',
-              false,
-              cannotUndoRedoToastId,
+  return gatedActions(
+    action,
+    editorStoreUnpatched.projectServerState,
+    editorStoreUnpatched.unpatchedEditor,
+    editorStoreUnpatched,
+    () => {
+      let working = editorStoreUnpatched
+      // Sidestep around the local actions so that we definitely run them locally.
+      if (action.action === 'TRANSIENT_ACTIONS') {
+        // Drill into the array.
+        return processActions(dispatchEvent, working, action.transientActions, spyCollector)
+      } else if (action.action === 'ATOMIC' || action.action === 'MERGE_WITH_PREV_UNDO') {
+        // Drill into the array.
+        return processActions(dispatchEvent, working, action.actions, spyCollector)
+      } else if (action.action === 'UNDO' && !History.canUndo(working.history)) {
+        // Bail early and make no changes.
+        return processActions(
+          dispatchEvent,
+          working,
+          [
+            EditorActions.addToast(
+              notice(
+                `Can't undo, reached the end of the undo history.`,
+                'NOTICE',
+                false,
+                cannotUndoRedoToastId,
+              ),
             ),
-          ),
-        ],
-        spyCollector,
-      )
-    } else if (action.action === 'REDO' && !History.canRedo(working.history)) {
-      // Bail early and make no changes.
-      return processActions(
-        dispatchEvent,
-        working,
-        [
-          EditorActions.addToast(
-            notice(
-              `Can't redo, reached the end of the undo history.`,
-              'NOTICE',
-              false,
-              cannotUndoRedoToastId,
+          ],
+          spyCollector,
+        )
+      } else if (action.action === 'REDO' && !History.canRedo(working.history)) {
+        // Bail early and make no changes.
+        return processActions(
+          dispatchEvent,
+          working,
+          [
+            EditorActions.addToast(
+              notice(
+                `Can't redo, reached the end of the undo history.`,
+                'NOTICE',
+                false,
+                cannotUndoRedoToastId,
+              ),
             ),
-          ),
-        ],
+          ],
+          spyCollector,
+        )
+      } else if (action.action === 'SET_SHORTCUT') {
+        return {
+          ...working,
+          userState: UPDATE_FNS.SET_SHORTCUT(action, working.userState),
+        }
+      } else if (action.action === 'SET_CURRENT_THEME') {
+        return {
+          ...working,
+          userState: UPDATE_FNS.SET_CURRENT_THEME(action, working.userState),
+        }
+      } else if (action.action === 'SET_LOGIN_STATE') {
+        return {
+          ...working,
+          userState: UPDATE_FNS.SET_LOGIN_STATE(action, working.userState),
+        }
+      } else if (action.action === 'SET_GITHUB_STATE') {
+        return {
+          ...working,
+          userState: UPDATE_FNS.SET_GITHUB_STATE(action, working.userState),
+        }
+      } else if (action.action === 'SET_USER_CONFIGURATION') {
+        return {
+          ...working,
+          userState: UPDATE_FNS.SET_USER_CONFIGURATION(action, working.userState),
+        }
+      }
+
+      if (action.action === 'UPDATE_TEXT') {
+        working = UPDATE_FNS.UPDATE_TEXT(action, working)
+      }
+
+      if (action.action === 'TRUNCATE_HISTORY') {
+        working = UPDATE_FNS.TRUNCATE_HISTORY(working)
+      }
+
+      if (action.action === 'START_POST_ACTION_SESSION') {
+        working = runExecuteStartPostActionMenuAction(action, working)
+      }
+
+      if (action.action === 'EXECUTE_POST_ACTION_MENU_CHOICE') {
+        working = runExecuteWithPostActionMenuAction(action, working)
+      }
+
+      if (action.action === 'CLEAR_POST_ACTION_SESSION') {
+        working = runClearPostActionSession(working)
+      }
+
+      if (action.action === 'UPDATE_PROJECT_SERVER_STATE') {
+        working = runUpdateProjectServerState(working, action)
+      }
+
+      // Process action on the JS side.
+      const editorAfterUpdateFunction = runLocalEditorAction(
+        working.unpatchedEditor,
+        working.unpatchedDerived,
+        working.userState,
+        working.workers,
+        action as EditorAction,
+        working.history,
+        dispatchEvent,
         spyCollector,
+        working.builtInDependencies,
+        working.collaborativeEditingSupport,
+        working.projectServerState,
       )
-    } else if (action.action === 'SET_SHORTCUT') {
-      return {
-        ...working,
-        userState: UPDATE_FNS.SET_SHORTCUT(action, working.userState),
+      const editorAfterCanvas = runLocalCanvasAction(
+        dispatchEvent,
+        editorAfterUpdateFunction,
+        working.unpatchedDerived,
+        working.builtInDependencies,
+        action as CanvasAction,
+      )
+      const editorAfterNavigator = runLocalNavigatorAction(
+        editorAfterCanvas,
+        working.unpatchedDerived,
+        action as LocalNavigatorAction,
+      )
+      const withPossiblyClearedPseudoInsert = maybeClearPseudoInsertMode(
+        editorStoreUnpatched.unpatchedEditor,
+        editorAfterNavigator,
+        action,
+      )
+
+      let newStateHistory: StateHistory
+      switch (action.action) {
+        case 'UNDO':
+          newStateHistory = History.undo(
+            working.unpatchedEditor.id,
+            working.history,
+            'no-side-effects',
+          )
+          working.postActionInteractionSession = null
+          break
+        case 'REDO':
+          newStateHistory = History.redo(
+            working.unpatchedEditor.id,
+            working.history,
+            'no-side-effects',
+          )
+          break
+        case 'NEW':
+        case 'LOAD':
+          const derivedState = deriveState(
+            withPossiblyClearedPseudoInsert,
+            null,
+            'unpatched',
+            unpatchedCreateRemixDerivedDataMemo,
+          )
+          newStateHistory = History.init(withPossiblyClearedPseudoInsert, derivedState)
+          break
+        default:
+          newStateHistory = working.history
+          break
       }
-    } else if (action.action === 'SET_CURRENT_THEME') {
+
       return {
-        ...working,
-        userState: UPDATE_FNS.SET_CURRENT_THEME(action, working.userState),
+        unpatchedEditor: withPossiblyClearedPseudoInsert,
+        unpatchedDerived: working.unpatchedDerived,
+        strategyState: working.strategyState, // this means the actions cannot update strategyState – this piece of state lives outside our "redux" state
+        postActionInteractionSession: working.postActionInteractionSession,
+        history: newStateHistory,
+        userState: working.userState,
+        workers: working.workers,
+        persistence: working.persistence,
+        saveCountThisSession: working.saveCountThisSession,
+        builtInDependencies: working.builtInDependencies,
+        projectServerState: working.projectServerState,
+        collaborativeEditingSupport: working.collaborativeEditingSupport,
       }
-    } else if (action.action === 'SET_LOGIN_STATE') {
-      return {
-        ...working,
-        userState: UPDATE_FNS.SET_LOGIN_STATE(action, working.userState),
-      }
-    } else if (action.action === 'SET_GITHUB_STATE') {
-      return {
-        ...working,
-        userState: UPDATE_FNS.SET_GITHUB_STATE(action, working.userState),
-      }
-    } else if (action.action === 'SET_USER_CONFIGURATION') {
-      return {
-        ...working,
-        userState: UPDATE_FNS.SET_USER_CONFIGURATION(action, working.userState),
-      }
-    }
-
-    if (action.action === 'UPDATE_TEXT') {
-      working = UPDATE_FNS.UPDATE_TEXT(action, working)
-    }
-
-    if (action.action === 'TRUNCATE_HISTORY') {
-      working = UPDATE_FNS.TRUNCATE_HISTORY(working)
-    }
-
-    if (action.action === 'START_POST_ACTION_SESSION') {
-      working = runExecuteStartPostActionMenuAction(action, working)
-    }
-
-    if (action.action === 'EXECUTE_POST_ACTION_MENU_CHOICE') {
-      working = runExecuteWithPostActionMenuAction(action, working)
-    }
-
-    if (action.action === 'CLEAR_POST_ACTION_SESSION') {
-      working = runClearPostActionSession(working)
-    }
-
-    if (action.action === 'UPDATE_PROJECT_SERVER_STATE') {
-      working = runUpdateProjectServerState(working, action)
-    }
-
-    // Process action on the JS side.
-    const editorAfterUpdateFunction = runLocalEditorAction(
-      working.unpatchedEditor,
-      working.unpatchedDerived,
-      working.userState,
-      working.workers,
-      action as EditorAction,
-      working.history,
-      dispatchEvent,
-      spyCollector,
-      working.builtInDependencies,
-      working.collaborativeEditingSupport,
-      working.projectServerState,
-    )
-    const editorAfterCanvas = runLocalCanvasAction(
-      dispatchEvent,
-      editorAfterUpdateFunction,
-      working.unpatchedDerived,
-      working.builtInDependencies,
-      action as CanvasAction,
-    )
-    const editorAfterNavigator = runLocalNavigatorAction(
-      editorAfterCanvas,
-      working.unpatchedDerived,
-      action as LocalNavigatorAction,
-    )
-    const withPossiblyClearedPseudoInsert = maybeClearPseudoInsertMode(
-      editorStoreUnpatched.unpatchedEditor,
-      editorAfterNavigator,
-      action,
-    )
-
-    let newStateHistory: StateHistory
-    switch (action.action) {
-      case 'UNDO':
-        newStateHistory = History.undo(
-          working.unpatchedEditor.id,
-          working.history,
-          'no-side-effects',
-        )
-        working.postActionInteractionSession = null
-        break
-      case 'REDO':
-        newStateHistory = History.redo(
-          working.unpatchedEditor.id,
-          working.history,
-          'no-side-effects',
-        )
-        break
-      case 'NEW':
-      case 'LOAD':
-        const derivedState = deriveState(
-          withPossiblyClearedPseudoInsert,
-          null,
-          'unpatched',
-          unpatchedCreateRemixDerivedDataMemo,
-        )
-        newStateHistory = History.init(withPossiblyClearedPseudoInsert, derivedState)
-        break
-      default:
-        newStateHistory = working.history
-        break
-    }
-
-    return {
-      unpatchedEditor: withPossiblyClearedPseudoInsert,
-      unpatchedDerived: working.unpatchedDerived,
-      strategyState: working.strategyState, // this means the actions cannot update strategyState – this piece of state lives outside our "redux" state
-      postActionInteractionSession: working.postActionInteractionSession,
-      history: newStateHistory,
-      userState: working.userState,
-      workers: working.workers,
-      persistence: working.persistence,
-      saveCountThisSession: working.saveCountThisSession,
-      builtInDependencies: working.builtInDependencies,
-      projectServerState: working.projectServerState,
-      collaborativeEditingSupport: working.collaborativeEditingSupport,
-    }
-  } else {
-    return working
-  }
+    },
+  )
 }
 
 function processActions(

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -20,6 +20,7 @@ import type { UiJsxCanvasContextData } from '../../canvas/ui-jsx-canvas'
 import type { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { foldAndApplyCommandsSimple } from '../../canvas/commands/commands'
 import type { ProjectServerState } from './project-server-state'
+import { isTransientAction } from '../actions/action-utils'
 
 export function runLocalEditorAction(
   state: EditorState,
@@ -57,6 +58,54 @@ export function runLocalEditorAction(
         collaborativeEditingSupport,
         serverState,
       )
+  }
+}
+
+export function gatedActions<T>(
+  action: EditorAction,
+  serverState: ProjectServerState,
+  editorState: EditorState,
+  defaultValue: T,
+  updateCallback: () => T,
+): T {
+  // Determine if this is a collaboration update, which is to say it's an update
+  // which is only for viewers in a collaboration scenario.
+  let isCollaborationUpdate: boolean = false
+  let alwaysRun: boolean = false
+  switch (action.action) {
+    case 'UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE':
+    case 'UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE':
+    case 'UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE':
+    case 'UPDATE_CODE_FROM_COLLABORATION_UPDATE':
+    case 'DELETE_FILE_FROM_COLLABORATION':
+      isCollaborationUpdate = true
+      break
+    case 'UPDATE_FROM_WORKER':
+      alwaysRun = true
+      break
+    default:
+      break
+  }
+
+  if (alwaysRun) {
+    // If it should always run.
+    return updateCallback()
+  } else if (isCollaborationUpdate && serverState.isMyProject === 'yes') {
+    // If this action is something that would've originated with an owner,
+    // it shouldn't run on an owner.
+    return defaultValue
+  } else if (
+    !isTransientAction(action) &&
+    serverState.isMyProject == 'no' &&
+    !isCollaborationUpdate
+  ) {
+    // If this is a change that will modify the project contents, the current user
+    // is not the owner and it's not a collaboration update (those intended directly
+    // for viewers in a collaboration session) do not run the action.
+    return defaultValue
+  } else {
+    // Otherwise, run the action as a fallback.
+    return updateCallback()
   }
 }
 
@@ -390,20 +439,15 @@ export function runSimpleLocalEditorAction(
     case 'SWITCH_CONDITIONAL_BRANCHES':
       return UPDATE_FNS.SWITCH_CONDITIONAL_BRANCHES(action, state)
     case 'UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE':
-      return UPDATE_FNS.UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE(
-        action,
-        state,
-        serverState,
-      )
+      return UPDATE_FNS.UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE(action, state)
     case 'UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE':
-      return UPDATE_FNS.UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE(action, state, serverState)
+      return UPDATE_FNS.UPDATE_EXPORTS_DETAIL_FROM_COLLABORATION_UPDATE(action, state)
     case 'UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE':
-      return UPDATE_FNS.UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE(action, state, serverState)
+      return UPDATE_FNS.UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE(action, state)
     case 'UPDATE_CODE_FROM_COLLABORATION_UPDATE':
       return UPDATE_FNS.UPDATE_CODE_FROM_COLLABORATION_UPDATE(
         action,
         state,
-        serverState,
         dispatch,
         builtInDependencies,
       )


### PR DESCRIPTION
**Problem:**
The codebase ended up with a variety of disparate locations for the checks that determine if an action should be run that were introduced for the collaborative editing work. Which means that it's easy to not change one of the many places when making further changes.

**Fix:**
All of the logic has now been moved to a single function `gatedActions` which is called in a single place: `processAction`.

**Commit Details:**
- Removed previous checks of `isMyProject` in the various collaboration actions.
- Removed `checkIfActionShouldBeProcessed`.
- Implemented all of the logic for handling if the actions should run into `gatedActions`.
- Incorporated `gatedActions` into `processAction`.