### PR TITLE
show remix route in comment pane

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/remix-scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/remix-scene-label.tsx
@@ -18,6 +18,7 @@ import { useAtom } from 'jotai'
 import { RemixNavigationAtom } from '../../remix/utopia-remix-root-component'
 import { matchRoutes } from 'react-router'
 import { unless } from '../../../../utils/react-conditionals'
+import { getRemixLocationLabel } from '../../remix/remix-utils'
 
 export const RemixSceneLabelPathTestId = (path: ElementPath): string =>
   `${EP.toString(path)}-remix-scene-label-path`
@@ -26,8 +27,6 @@ export const RemixSceneLabelTestId = (path: ElementPath): string =>
   `${EP.toString(path)}-remix-scene-label-test-id`
 
 export const LocationDoesNotMatchRoutesTestId = 'location-does-not-match-routes'
-
-export const RemixSceneHomeLabel = '(home)'
 
 export type RemixSceneLabelButtonType = 'back' | 'forward' | 'home'
 
@@ -95,9 +94,8 @@ const RemixSceneLabel = React.memo<RemixSceneLabelProps>((props) => {
   const [navigationData] = useAtom(RemixNavigationAtom)
 
   const currentPath = (navigationData[EP.toString(props.target)] ?? null)?.location.pathname
-  const isIndexRoute = currentPath === '/'
 
-  const pathLabel = isIndexRoute ? RemixSceneHomeLabel : currentPath
+  const pathLabel = getRemixLocationLabel(currentPath)
 
   const scenelabel = useEditorState(
     Substores.metadata,

--- a/editor/src/components/canvas/remix/remix-navigator.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-navigator.spec.browser2.tsx
@@ -15,6 +15,7 @@ import { NavigatorItemTestId } from '../../navigator/navigator-item/navigator-it
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
 import { dragElementWithDNDEvents } from '../event-helpers.test-utils'
 import { windowPoint } from '../../../core/shared/math-utils'
+import { RemixIndexPathLabel } from './remix-utils'
 
 const DefaultRouteTextContent = 'Hello Remix!'
 const RootTextContent = 'This is root!'
@@ -276,7 +277,7 @@ describe('Remix navigator', () => {
         ),
       ),
     )
-    expect(outletItemElement.textContent).toEqual('Outlet: (home)')
+    expect(outletItemElement.textContent).toEqual(`Outlet: ${RemixIndexPathLabel}`)
   })
 })
 describe('Reparenting in Remix projects in the navigator', () => {

--- a/editor/src/components/canvas/remix/remix-rendering.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-rendering.spec.browser2.tsx
@@ -24,7 +24,6 @@ import { CanvasControlsContainerID } from '../controls/new-canvas-controls'
 import type { RemixSceneLabelButtonType } from '../controls/select-mode/remix-scene-label'
 import {
   LocationDoesNotMatchRoutesTestId,
-  RemixSceneHomeLabel,
   RemixSceneLabelButtonTestId,
   RemixSceneLabelPathTestId,
 } from '../controls/select-mode/remix-scene-label'
@@ -47,7 +46,6 @@ import {
 } from '../ui-jsx.test-utils'
 import {
   RemixNavigationBarButtonTestId,
-  RemixNavigationBarHomeLabel,
   RemixNavigationBarPathTestId,
 } from '../../editor/remix-navigation-bar'
 import { NonResizableControlTestId } from '../controls/select-mode/non-resizable-control'
@@ -56,6 +54,7 @@ import {
   getMultiSelectElementOutlineTestId,
 } from '../controls/select-mode/simple-outline-control'
 import { updateFromCodeEditor } from '../../editor/actions/actions-from-vscode'
+import { RemixIndexPathLabel } from './remix-utils'
 
 const DefaultRouteTextContent = 'Hello Remix!'
 const RootTextContent = 'This is root!'
@@ -429,7 +428,7 @@ describe('Remix content', () => {
     const pathToRemixScene = EP.fromString('sb/remix-scene')
     await navigateWithRemixSceneLabelButton(renderResult, pathToRemixScene, 'back')
     expect(renderResult.renderedDOM.queryByText(newRouteTextContent)).not.toBeNull()
-    expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene)).toEqual('(home)')
+    expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene)).toEqual(RemixIndexPathLabel)
   })
 
   it('Two remix scenes, both have metadata', async () => {
@@ -1185,7 +1184,7 @@ describe('Remix navigation', () => {
       const pathToRemixScene = EP.fromString('storyboard/remix')
 
       await switchToLiveMode(renderResult)
-      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene)).toEqual(RemixSceneHomeLabel)
+      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene)).toEqual(RemixIndexPathLabel)
 
       await clickRemixLink(renderResult)
 
@@ -1195,7 +1194,7 @@ describe('Remix navigation', () => {
       await navigateWithRemixSceneLabelButton(renderResult, pathToRemixScene, 'back')
 
       expect(renderResult.renderedDOM.queryAllByText(RootTextContent)).toHaveLength(1)
-      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene)).toEqual(RemixSceneHomeLabel)
+      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene)).toEqual(RemixIndexPathLabel)
 
       await navigateWithRemixSceneLabelButton(renderResult, pathToRemixScene, 'forward')
       expect(renderResult.renderedDOM.queryAllByText(AboutTextContent)).toHaveLength(1)
@@ -1203,7 +1202,7 @@ describe('Remix navigation', () => {
 
       await navigateWithRemixSceneLabelButton(renderResult, pathToRemixScene, 'home')
       expect(renderResult.renderedDOM.queryAllByText(RootTextContent)).toHaveLength(1)
-      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene)).toEqual(RemixSceneHomeLabel)
+      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene)).toEqual(RemixIndexPathLabel)
     })
 
     it('can navigate with the scene label nav buttons, in edit mode', async () => {
@@ -1212,7 +1211,7 @@ describe('Remix navigation', () => {
       const pathToRemixScene = EP.fromString('storyboard/remix')
 
       await switchToLiveMode(renderResult)
-      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene)).toEqual(RemixSceneHomeLabel)
+      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene)).toEqual(RemixIndexPathLabel)
 
       await clickRemixLink(renderResult)
 
@@ -1228,7 +1227,7 @@ describe('Remix navigation', () => {
       await navigateWithRemixSceneLabelButton(renderResult, pathToRemixScene, 'back')
 
       expect(renderResult.renderedDOM.queryAllByText(RootTextContent)).toHaveLength(1)
-      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene)).toEqual(RemixSceneHomeLabel)
+      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene)).toEqual(RemixIndexPathLabel)
 
       await navigateWithRemixSceneLabelButton(renderResult, pathToRemixScene, 'forward')
       expect(renderResult.renderedDOM.queryAllByText(AboutTextContent)).toHaveLength(1)
@@ -1236,7 +1235,7 @@ describe('Remix navigation', () => {
 
       await navigateWithRemixSceneLabelButton(renderResult, pathToRemixScene, 'home')
       expect(renderResult.renderedDOM.queryAllByText(RootTextContent)).toHaveLength(1)
-      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene)).toEqual(RemixSceneHomeLabel)
+      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene)).toEqual(RemixIndexPathLabel)
     })
 
     it('navigating in one Remix scene does not affect the navigation state in the other', async () => {
@@ -1246,8 +1245,8 @@ describe('Remix navigation', () => {
       const pathToRemixScene2 = EP.fromString('storyboard/remix-2')
 
       await switchToLiveMode(renderResult)
-      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene1)).toEqual(RemixSceneHomeLabel)
-      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene2)).toEqual(RemixSceneHomeLabel)
+      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene1)).toEqual(RemixIndexPathLabel)
+      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene2)).toEqual(RemixIndexPathLabel)
 
       await clickRemixLink(renderResult)
       const remixScene1 = renderResult.renderedDOM.getByTestId(Remix1TestId)
@@ -1257,7 +1256,7 @@ describe('Remix navigation', () => {
       expect(within(remixScene2).queryAllByText(RootTextContent)).toHaveLength(1)
 
       expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene1)).toEqual('/about')
-      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene2)).toEqual(RemixSceneHomeLabel)
+      expect(getPathInRemixSceneLabel(renderResult, pathToRemixScene2)).toEqual(RemixIndexPathLabel)
     })
   })
 
@@ -1266,7 +1265,7 @@ describe('Remix navigation', () => {
       const renderResult = await renderRemixProject(projectWithMultipleRoutes())
 
       await switchToLiveMode(renderResult)
-      expect(getPathInRemixNavigationBar(renderResult)).toEqual(RemixNavigationBarHomeLabel)
+      expect(getPathInRemixNavigationBar(renderResult)).toEqual(RemixIndexPathLabel)
 
       await clickRemixLink(renderResult)
 
@@ -1276,7 +1275,7 @@ describe('Remix navigation', () => {
       await navigateWithRemixNavigationBarButton(renderResult, 'back')
 
       expect(renderResult.renderedDOM.queryAllByText(RootTextContent)).toHaveLength(1)
-      expect(getPathInRemixNavigationBar(renderResult)).toEqual(RemixNavigationBarHomeLabel)
+      expect(getPathInRemixNavigationBar(renderResult)).toEqual(RemixIndexPathLabel)
 
       await navigateWithRemixNavigationBarButton(renderResult, 'forward')
       expect(renderResult.renderedDOM.queryAllByText(AboutTextContent)).toHaveLength(1)
@@ -1284,14 +1283,14 @@ describe('Remix navigation', () => {
 
       await navigateWithRemixNavigationBarButton(renderResult, 'home')
       expect(renderResult.renderedDOM.queryAllByText(RootTextContent)).toHaveLength(1)
-      expect(getPathInRemixNavigationBar(renderResult)).toEqual(RemixNavigationBarHomeLabel)
+      expect(getPathInRemixNavigationBar(renderResult)).toEqual(RemixIndexPathLabel)
     })
 
     it('can navigate inside multiple Remix scenes, using the nav bar in the canvas toolbar', async () => {
       const renderResult = await renderRemixProject(projectWithMultipleRemixScenes())
 
       await switchToLiveMode(renderResult)
-      expect(getPathInRemixNavigationBar(renderResult)).toEqual(RemixNavigationBarHomeLabel)
+      expect(getPathInRemixNavigationBar(renderResult)).toEqual(RemixIndexPathLabel)
 
       await clickRemixLink(renderResult)
 
@@ -1301,7 +1300,7 @@ describe('Remix navigation', () => {
       const remixScene2 = renderResult.renderedDOM.getByTestId(Remix2TestId)
       await mouseClickAtPoint(remixScene2, { x: 10, y: 10 })
 
-      expect(getPathInRemixNavigationBar(renderResult)).toEqual(RemixNavigationBarHomeLabel)
+      expect(getPathInRemixNavigationBar(renderResult)).toEqual(RemixIndexPathLabel)
     })
   })
 })

--- a/editor/src/components/canvas/remix/remix-utils.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.tsx
@@ -452,3 +452,17 @@ export function getRouteComponentNameForOutlet(
 
   return defaultExport.name
 }
+
+export const RemixIndexPathLabel = '(home)'
+
+export function getRemixLocationLabel(location: string | undefined): string | null {
+  if (location == null) {
+    return null
+  }
+
+  if (location === '/') {
+    return 'RemixNavigationBarHomeLabel'
+  }
+
+  return location
+}

--- a/editor/src/components/canvas/remix/remix-utils.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.tsx
@@ -461,7 +461,7 @@ export function getRemixLocationLabel(location: string | undefined): string | nu
   }
 
   if (location === '/') {
-    return 'RemixNavigationBarHomeLabel'
+    return RemixIndexPathLabel
   }
 
   return location

--- a/editor/src/components/editor/remix-navigation-bar.tsx
+++ b/editor/src/components/editor/remix-navigation-bar.tsx
@@ -11,10 +11,9 @@ import { Substores, useEditorState } from './store/store-hook'
 import { FlexRow, Tooltip, UtopiaTheme, colorTheme, useColorTheme } from '../../uuiui'
 import { stopPropagation } from '../inspector/common/inspector-utils'
 import * as EP from '../../core/shared/element-path'
+import { RemixIndexPathLabel, getRemixLocationLabel } from '../canvas/remix/remix-utils'
 
 export const RemixNavigationBarPathTestId = 'remix-navigation-bar-path'
-
-export const RemixNavigationBarHomeLabel = '(home)'
 
 export type RemixSceneLabelButtonType = 'back' | 'forward' | 'home'
 
@@ -30,7 +29,6 @@ export const RemixNavigationBar = React.memo(() => {
     (store) => store.editor.mode.type === 'live',
     'RemixNavigationBar isLiveMode',
   )
-  const theme = useColorTheme()
 
   const forward = React.useCallback(
     () => navigationControls[EP.toString(activeRemixScene)]?.forward(),
@@ -46,9 +44,8 @@ export const RemixNavigationBar = React.memo(() => {
   )
 
   const pathname = navigationControls[EP.toString(activeRemixScene)]?.location?.pathname
-  const isIndexRoute = pathname === '/'
 
-  const label = isIndexRoute ? RemixNavigationBarHomeLabel : pathname
+  const label = getRemixLocationLabel(pathname)
 
   if (!isLiveMode || navigationControls == null || pathname == null) {
     return null

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -32,6 +32,7 @@ import {
 import { Substores, useEditorState } from '../../editor/store/store-hook'
 import { unless, when } from '../../../utils/react-conditionals'
 import { openCommentThreadActions } from '../../../core/shared/multiplayer'
+import { getRemixLocationLabel } from '../../canvas/remix/remix-utils'
 
 export const CommentSection = React.memo(() => {
   return (
@@ -170,7 +171,7 @@ const ThreadPreview = React.memo(({ thread }: ThreadPreviewProps) => {
 
   const repliesCount = thread.comments.length - 1
 
-  const remixLocationRouteLabel = getRemixLocationRoute(remixLocationRoute)
+  const remixLocationRouteLabel = getRemixLocationLabel(remixLocationRoute)
 
   const user = getCollaboratorById(collabs, comment.userId)
 
@@ -244,15 +245,3 @@ const ThreadPreview = React.memo(({ thread }: ThreadPreviewProps) => {
   )
 })
 ThreadPreview.displayName = 'ThreadPreview'
-
-function getRemixLocationRoute(location: string | undefined): string | null {
-  if (location == null) {
-    return null
-  }
-
-  if (location === '/') {
-    return '(home)'
-  }
-
-  return location
-}

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -167,6 +167,9 @@ const ThreadPreview = React.memo(({ thread }: ThreadPreviewProps) => {
   }
 
   const repliesCount = thread.comments.length - 1
+
+  const remixLocationRouteLabel = getRemixLocationRoute(remixLocationRoute)
+
   return (
     <div
       key={comment.id}
@@ -180,9 +183,30 @@ const ThreadPreview = React.memo(({ thread }: ThreadPreviewProps) => {
       }}
     >
       <Comment comment={comment} showActions={false} style={{ backgroundColor: 'transparent' }} />
+      {when(
+        remixLocationRouteLabel != null,
+        <div
+          style={{
+            paddingLeft: 44,
+            paddingBottom: 11,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <div
+            style={{
+              fontSize: 9,
+              color: colorTheme.fg6.value,
+            }}
+          >
+            {thread.metadata.remixLocationRoute ?? ''}
+          </div>
+        </div>,
+      )}
       <div
         style={{
-          paddingBottom: 10,
+          paddingBottom: 11,
           paddingLeft: 44,
           paddingRight: 10,
           marginTop: -5,
@@ -211,3 +235,15 @@ const ThreadPreview = React.memo(({ thread }: ThreadPreviewProps) => {
   )
 })
 ThreadPreview.displayName = 'ThreadPreview'
+
+function getRemixLocationRoute(location: string | undefined): string | null {
+  if (location == null) {
+    return null
+  }
+
+  if (location === '/') {
+    return '(home)'
+  }
+
+  return location
+}

--- a/editor/src/components/navigator/navigator-item/item-label.tsx
+++ b/editor/src/components/navigator/navigator-item/item-label.tsx
@@ -25,6 +25,7 @@ import { RemixNavigationAtom } from '../../canvas/remix/utopia-remix-root-compon
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import type { Location } from 'react-router'
+import { RemixIndexPathLabel, getRemixLocationLabel } from '../../canvas/remix/remix-utils'
 
 export function itemLabelTestIdForEntry(navigatorEntry: NavigatorEntry): string {
   return `${NavigatorItemTestId(varSafeNavigatorEntryToKey(navigatorEntry))}-label`
@@ -120,7 +121,7 @@ export const ItemLabel = React.memo((props: ItemLabelProps) => {
       return maybeLinkTarget
     }
     if (maybePathForOutlet != null) {
-      return maybePathForOutlet === '/' ? 'Outlet: (home)' : `Outlet: ${maybePathForOutlet}`
+      return `Outlet: ${getRemixLocationLabel(maybePathForOutlet)}`
     }
     return suffix == null ? name : `Outlet: ${name} ${suffix}`
   }, [maybeLinkTarget, maybePathForOutlet, suffix, name])


### PR DESCRIPTION

<img width="741" alt="image" src="https://github.com/concrete-utopia/utopia/assets/16385508/eba32498-d3c7-495f-9d5e-fb6785cc86b8">


## Problem
The Remix route corresponding to a comment is not shown in the comment pane

## Fix
Add it to the thread preview