### PR TITLE
Correct types in persistence machine relating to ownership.

### DIFF
--- a/editor/src/components/editor/persistence/generic/persistence-machine.ts
+++ b/editor/src/components/editor/persistence/generic/persistence-machine.ts
@@ -6,6 +6,7 @@ import type {
   PersistenceContext,
   ProjectLoadResult,
   ProjectModel,
+  ProjectOwnership,
   ProjectWithFileChanges,
 } from './persistence-types'
 const { choose } = actions
@@ -159,13 +160,13 @@ function downloadAssetsCompleteEvent<ModelType, FileType>(
 
 interface CheckOwnershipCompleteEvent {
   type: 'CHECK_OWNERSHIP_COMPLETE'
-  isOwner: boolean
+  ownership: ProjectOwnership
 }
 
-function checkOwnershipCompleteEvent(isOwner: boolean): CheckOwnershipCompleteEvent {
+function checkOwnershipCompleteEvent(ownership: ProjectOwnership): CheckOwnershipCompleteEvent {
   return {
     type: 'CHECK_OWNERSHIP_COMPLETE',
-    isOwner: isOwner,
+    ownership: ownership,
   }
 }
 
@@ -408,7 +409,7 @@ export function createPersistenceMachine<ModelType, FileType>(
     {
       id: 'persistence-parallel',
       type: 'parallel',
-      context: { projectOwned: false, loggedIn: false },
+      context: { projectOwnership: { ownerId: null, isOwner: false }, loggedIn: false },
       states: {
         // Backend Communication
         backend: {
@@ -448,7 +449,7 @@ export function createPersistenceMachine<ModelType, FileType>(
                 onDone: {
                   target: BackendIdle,
                   actions: [
-                    send((_, event: DoneInvokeEvent<boolean>) =>
+                    send((_, event: DoneInvokeEvent<ProjectOwnership>) =>
                       checkOwnershipCompleteEvent(event.data),
                     ),
                   ],
@@ -580,14 +581,16 @@ export function createPersistenceMachine<ModelType, FileType>(
                 LOAD: Loading,
                 SAVE: [
                   {
-                    cond: (context, _) => context.projectOwned,
+                    cond: (context, _) => {
+                      return context.projectOwnership.isOwner
+                    },
                     target: Saving,
                   },
                 ],
                 FORK: Forking,
                 USER_LOG_IN: [
                   {
-                    cond: (context, _) => context.projectOwned,
+                    cond: (context, _) => context.projectOwnership.isOwner,
                     actions: send((context, _) => saveEvent(context.project!)),
                   },
                 ],
@@ -600,12 +603,15 @@ export function createPersistenceMachine<ModelType, FileType>(
               states: {
                 [CreatingProjectId]: {
                   entry: [
-                    assign((_, event) => {
+                    assign((currentContext, event) => {
                       return {
                         projectId: undefined,
                         project: (event as NewEvent<ModelType>).projectModel,
                         queuedSave: undefined,
-                        projectOwned: true,
+                        projectOwnership: {
+                          isOwner: true,
+                          ownerId: currentContext.projectOwnership.ownerId,
+                        },
                       }
                     }),
                     send(backendCreateProjectIdEvent()),
@@ -667,7 +673,7 @@ export function createPersistenceMachine<ModelType, FileType>(
                     CHECK_OWNERSHIP_COMPLETE: {
                       target: ProjectLoaded,
                       actions: assign({
-                        projectOwned: (_, event) => event.isOwner,
+                        projectOwnership: (_, event) => event.ownership,
                       }),
                     },
                   },
@@ -687,7 +693,10 @@ export function createPersistenceMachine<ModelType, FileType>(
                       projectId: undefined,
                       project: undefined,
                       queuedSave: undefined,
-                      projectOwned: false,
+                      projectOwnership: {
+                        ownerId: null,
+                        isOwner: false,
+                      },
                     }
                   }),
                 },
@@ -721,7 +730,10 @@ export function createPersistenceMachine<ModelType, FileType>(
                   target: Ready,
                   actions: assign((_context, event) => {
                     return {
-                      projectOwned: true,
+                      projectOwnership: {
+                        isOwner: true,
+                        ownerId: null,
+                      },
                       project: event.saveResult.projectModel,
                     }
                   }),

--- a/editor/src/components/editor/persistence/generic/persistence-types.ts
+++ b/editor/src/components/editor/persistence/generic/persistence-types.ts
@@ -24,7 +24,7 @@ export interface PersistenceContext<ModelType> {
   rollbackProjectId?: string
   rollbackProject?: ProjectModel<ModelType>
   queuedSave?: ProjectModel<ModelType>
-  projectOwned: boolean
+  projectOwnership: ProjectOwnership
   loggedIn: boolean
 }
 

--- a/editor/src/components/editor/persistence/persistence.spec.tsx
+++ b/editor/src/components/editor/persistence/persistence.spec.tsx
@@ -176,7 +176,10 @@ function setupTest(saveThrottle: number = 0) {
     dispatchedActions: [] as Array<EditorAction>,
     projectNotFound: false,
     createdOrLoadedProject: undefined as PersistentModel | undefined,
-    latestContext: { projectOwned: false, loggedIn: false } as PersistenceContext<PersistentModel>,
+    latestContext: {
+      projectOwnership: { ownerId: null, isOwner: false },
+      loggedIn: false,
+    } as PersistenceContext<PersistentModel>,
   }
   const testDispatch: EditorDispatch = (actions: ReadonlyArray<EditorAction>) => {
     capturedData.dispatchedActions.push(...actions)


### PR DESCRIPTION
**Problem:**
Viewers in a collaborative editing session now attempt to save the project, causing an error to fire along with a big error warning in the editor each time.

**Cause:**
The type returned from a service call was changed in a separate piece of work so that the owner ID of a project could be retrieved. However the persistence machine appears to use the value and its own type definition and there's no validation of the type against the value done. Since the type changed from a boolean to an interface like type, there were boolean checks for ownership which returned true because of the truthiness of a JavaScript object.

**Fix:**
Corrected the types for the fields relating to this value in the persistence machine logic and then fixed up the remaining errors that then arose.

**Commit Details:**
- Changed `isOwner` to `ownership` in `CheckOwnershipCompleteEvent`, also changing the type to `ProjectOwnership`.
- Changed `projectOwned` to `projectOwnership` in `PersistenceContext`, also changing the type to `ProjectOwnership`.
- Fixed the context and various callbacks inside the persistence machine.
