### PR TITLE
Do not show comment indicators in play mode

### DIFF
--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -45,7 +45,13 @@ export const CommentIndicators = React.memo(() => {
     'CommentIndicator projectId',
   )
 
-  if (projectId == null) {
+  const mode = useEditorState(
+    Substores.restOfEditor,
+    (store) => store.editor.mode.type,
+    'CommentIndicators mode',
+  )
+
+  if (projectId == null || mode === 'live') {
     return null
   }
 


### PR DESCRIPTION
## Problem
Comment indicators are shown in play mode, and we want to hide them

## Fix
Check the editor mode in `CommentIndicators` and early return if `mode === live`