### PR TITLE
Remix scenes and commenting

### DIFF
--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -36,6 +36,14 @@ export interface RemixNavigationAtomData {
 export const ActiveRemixSceneAtom = atom<ElementPath>(EP.emptyElementPath)
 export const RemixNavigationAtom = atom<RemixNavigationAtomData>({})
 
+export function useRemixNavigationContext(
+  scenePath: ElementPath | null,
+): RemixNavigationContext | null {
+  const [remixNavigationState] = useAtom(RemixNavigationAtom)
+  const remixContext = scenePath != null ? remixNavigationState[EP.toString(scenePath)] : null
+  return remixContext ?? null
+}
+
 function useGetRouteModules(basePath: ElementPath) {
   const remixDerivedDataRef = useRefEditorState((store) => store.derived.remixData)
   const projectContentsRef = useRefEditorState((store) => store.editor.projectContents)

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -19,11 +19,9 @@ import {
 } from '../../editor/actions/action-creators'
 import { EditorModes, isCommentMode, isExistingComment } from '../../editor/editor-modes'
 import { CommentWrapper, MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
-import { useAtom } from 'jotai'
-import { RemixNavigationAtom } from '../../canvas/remix/utopia-remix-root-component'
+import { useRemixNavigationContext } from '../../canvas/remix/utopia-remix-root-component'
 import {
   useUnresolvedThreads,
-  useIsOnAnotherRemixRoute,
   useResolveThread,
   useResolvedThreads,
   useCanvasLocationOfThread,
@@ -106,11 +104,8 @@ interface ThreadPreviewProps {
 const ThreadPreview = React.memo(({ thread }: ThreadPreviewProps) => {
   const dispatch = useDispatch()
   const colorTheme = useColorTheme()
-  const [remixNavigationState] = useAtom(RemixNavigationAtom)
 
   const { remixLocationRoute } = thread.metadata
-
-  const isOnAnotherRoute = useIsOnAnotherRemixRoute(remixLocationRoute ?? null)
 
   const isSelected = useEditorState(
     Substores.restOfEditor,
@@ -124,28 +119,28 @@ const ThreadPreview = React.memo(({ thread }: ThreadPreviewProps) => {
 
   const { location, scene: commentScene } = useCanvasLocationOfThread(thread)
 
-  const onClick = React.useCallback(() => {
-    const rect = canvasRectangle({ x: location.x, y: location.y, width: 25, height: 25 })
+  const remixState = useRemixNavigationContext(commentScene)
 
-    if (isOnAnotherRoute && remixLocationRoute != null) {
-      // TODO: after we have scene identifier in the comment metadata we should only navigate the scene with the comment
-      Object.keys(remixNavigationState).forEach((scene) => {
-        const remixState = remixNavigationState[scene]
-        if (remixState == null) {
-          return
-        }
-        remixState.navigate(remixLocationRoute)
-      })
+  const isOnAnotherRoute =
+    remixLocationRoute != null && remixLocationRoute !== remixState?.location.pathname
+
+  const onClick = React.useCallback(() => {
+    if (isOnAnotherRoute) {
+      if (remixState == null) {
+        return
+      }
+      remixState.navigate(remixLocationRoute)
     }
+    const rect = canvasRectangle({ x: location.x, y: location.y, width: 25, height: 25 })
     dispatch([
       ...openCommentThreadActions(thread.id, commentScene),
       scrollToPosition(rect, 'to-center'),
     ])
   }, [
     dispatch,
-    remixNavigationState,
     isOnAnotherRoute,
     remixLocationRoute,
+    remixState,
     location,
     thread.id,
     commentScene,

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -25,6 +25,7 @@ import {
 import { MetadataUtils } from '../model/element-metadata-utils'
 import { getIdOfScene } from '../../components/canvas/controls/comment-mode/comment-mode-hooks'
 import type { ElementPath } from '../shared/project-file-types'
+import type { ElementInstanceMetadata } from '../shared/element-template'
 
 export function useCanvasCommentThreadAndLocation(comment: CommentId): {
   location: CanvasPoint | null
@@ -177,17 +178,7 @@ export function useCollaborators() {
   return useStorage((store) => store.collaborators)
 }
 
-export function useIsOnAnotherRemixRoute(remixLocationRoute: string | null) {
-  const me = useSelf()
-
-  return (
-    me.presence.remix?.locationRoute != null &&
-    remixLocationRoute != null &&
-    remixLocationRoute !== me.presence.remix.locationRoute
-  )
-}
-
-export function useScenesWithId() {
+export function useScenesWithId(): Array<ElementInstanceMetadata> {
   return useEditorState(
     Substores.metadata,
     (store) => {
@@ -195,6 +186,20 @@ export function useScenesWithId() {
       return scenes.filter((s) => getIdOfScene(s) != null)
     },
     'useScenesWithId scenes',
+  )
+}
+
+export function useSceneWithId(sceneId: string | null): ElementInstanceMetadata | null {
+  return useEditorState(
+    Substores.metadata,
+    (store) => {
+      if (sceneId == null) {
+        return null
+      }
+      const scenes = MetadataUtils.getScenesMetadata(store.editor.jsxMetadata)
+      return scenes.find((s) => getIdOfScene(s) != sceneId) ?? null
+    },
+    'useSceneWithId scene',
   )
 }
 


### PR DESCRIPTION
**Problem:**
We store scene id and the remix location with the metadata, but the two concepts were not connected.
I changed our logic the following way:
- We only store the remix route when the comment is connected to a remix scene.
- Until now we hid the comment indicator when the active remix route was not the same as the comment route. From now on, we only hide the comment indicator when the route of the remix scene of the comment is on a different route (and that might not be the active route if currently a different scene is active)
- We only navigate the remix scene of the comment to the comment route when we open the comment (and not all the remix scenes).