### PR TITLE
Don't re-scope the arguments of almost all CSS pseudo-classes

### DIFF
--- a/editor/src/core/shared/css-utils.spec.ts
+++ b/editor/src/core/shared/css-utils.spec.ts
@@ -317,6 +317,10 @@ describe('rescopeCSSToTargetCanvasOnly', () => {
       :where(h1, h2, h3):has(+ :where(h2, h3, h4)) {
         margin: 0 0 0.25rem 0;
       }
+
+      :not(h1, h2, h3):has(+ :not(h2, h3, h4)) {
+        margin: 0 0 0.25rem 0;
+      }
     `
 
     const output = formatCss(rescopeCSSToTargetCanvasOnly(input))
@@ -329,6 +333,9 @@ describe('rescopeCSSToTargetCanvasOnly', () => {
           margin: 0 0 0.25rem 0;
         }
         :where(#canvas-container h1, #canvas-container h2, #canvas-container h3):has(+ :where(h2, h3, h4)) {
+          margin: 0 0 0.25rem 0;
+        }
+        :not(#canvas-container h1, #canvas-container h2, #canvas-container h3):has(+ :not(h2, h3, h4)) {
           margin: 0 0 0.25rem 0;
         }
       `),

--- a/editor/src/core/shared/css-utils.spec.ts
+++ b/editor/src/core/shared/css-utils.spec.ts
@@ -313,6 +313,10 @@ describe('rescopeCSSToTargetCanvasOnly', () => {
       :is(h1, h2, h3):has(+ :is(h2, h3, h4)) {
         margin: 0 0 0.25rem 0;
       }
+
+      :where(h1, h2, h3):has(+ :where(h2, h3, h4)) {
+        margin: 0 0 0.25rem 0;
+      }
     `
 
     const output = formatCss(rescopeCSSToTargetCanvasOnly(input))
@@ -322,6 +326,9 @@ describe('rescopeCSSToTargetCanvasOnly', () => {
           background-color: aqua;
         }
         :is(#canvas-container h1, #canvas-container h2, #canvas-container h3):has(+ :is(h2, h3, h4)) {
+          margin: 0 0 0.25rem 0;
+        }
+        :where(#canvas-container h1, #canvas-container h2, #canvas-container h3):has(+ :where(h2, h3, h4)) {
           margin: 0 0 0.25rem 0;
         }
       `),

--- a/editor/src/core/shared/css-utils.spec.ts
+++ b/editor/src/core/shared/css-utils.spec.ts
@@ -303,4 +303,28 @@ describe('rescopeCSSToTargetCanvasOnly', () => {
       `),
     )
   })
+
+  it('Skips selectors inside pseudo-class selectors, with the exception of :is()', () => {
+    const input = `
+      .myClass:has(.x) {
+        background-color: aqua;
+      }
+
+      :is(h1, h2, h3):has(+ :is(h2, h3, h4)) {
+        margin: 0 0 0.25rem 0;
+      }
+    `
+
+    const output = formatCss(rescopeCSSToTargetCanvasOnly(input))
+    expect(output).toEqual(
+      formatCss(`
+        #canvas-container .myClass:has(.x) {
+          background-color: aqua;
+        }
+        :is(#canvas-container h1, #canvas-container h2, #canvas-container h3):has(+ :is(h2, h3, h4)) {
+          margin: 0 0 0.25rem 0;
+        }
+      `),
+    )
+  })
 })

--- a/editor/src/core/shared/css-utils.ts
+++ b/editor/src/core/shared/css-utils.ts
@@ -16,6 +16,14 @@ export function rescopeCSSToTargetCanvasOnly(input: string): string {
   let ast = csstree.parse(input)
 
   csstree.walk(ast, (node) => {
+    if (node.type === 'PseudoClassSelector' && node.name !== 'is') {
+      // We don't want to walk pseudo classes with the exception of :is()
+      // We can return the special value csstree.walk.skip to achieve this, though
+      // the types seem to believe this doesn't exist, it does
+      // https://github.com/csstree/csstree/blob/ba6dfd8bb0e33055c05f13803d04825d98dd2d8d/docs/traversal.md#walkast-options
+      return (csstree.walk as any).skip
+    }
+
     // We want to find all selectors, and prepend '#canvas-container ' (i.e. the canvas-container
     // ID Selector and a ' ' combinator) so that they will only apply to descendents of the canvas
     if (node.type === 'Selector') {

--- a/editor/src/core/shared/css-utils.ts
+++ b/editor/src/core/shared/css-utils.ts
@@ -11,13 +11,14 @@ const SelectorsToSkip = [
   'from',
   'to',
 ]
+const PseudoClassSelectorsToWalk = ['is', 'where']
 
 export function rescopeCSSToTargetCanvasOnly(input: string): string {
   let ast = csstree.parse(input)
 
   csstree.walk(ast, (node) => {
-    if (node.type === 'PseudoClassSelector' && node.name !== 'is') {
-      // We don't want to walk pseudo classes with the exception of :is()
+    if (node.type === 'PseudoClassSelector' && !PseudoClassSelectorsToWalk.includes(node.name)) {
+      // We don't want to walk pseudo classes with some exceptions
       // We can return the special value csstree.walk.skip to achieve this, though
       // the types seem to believe this doesn't exist, it does
       // https://github.com/csstree/csstree/blob/ba6dfd8bb0e33055c05f13803d04825d98dd2d8d/docs/traversal.md#walkast-options

--- a/editor/src/core/shared/css-utils.ts
+++ b/editor/src/core/shared/css-utils.ts
@@ -11,7 +11,7 @@ const SelectorsToSkip = [
   'from',
   'to',
 ]
-const PseudoClassSelectorsToWalk = ['is', 'where']
+const PseudoClassSelectorsToWalk = ['is', 'where', 'not']
 
 export function rescopeCSSToTargetCanvasOnly(input: string): string {
   let ast = csstree.parse(input)


### PR DESCRIPTION
**Problem:**
Follow on from #4604 
Some CSS pseudo-classes should have their arguments re-scoped, some should not.

**Fix:**
Prevent traversal of all CSS pseudo-class arguments, with the explicit exception of `:is` and `:where`, using css-tree's `walk.skip`. This means that we **would** rescope the arguments of `:is(h1)` to `:is(#canvas-container h1)`, but not the arguments of `:has(h1)`, or the arguments of a pseudo-class nested inside `:has(:is(h1))`
