### PR TITLE
Update prettier

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -186,7 +186,7 @@
     "path-browserify": "1.0.1",
     "path-parse": "1.0.6",
     "platform-detect": "3.0.0",
-    "prettier": "2.6.2",
+    "prettier": "2.8.8",
     "prop-types": "15.6.2",
     "pubsub-js": "^1.9.2",
     "puppeteer": "19.6.0",

--- a/editor/package.json
+++ b/editor/package.json
@@ -287,7 +287,7 @@
     "@types/object-path": "0.9.29",
     "@types/path-browserify": "1.0.0",
     "@types/path-parse": "1.0.19",
-    "@types/prettier": "2.0.1",
+    "@types/prettier": "2.7.3",
     "@types/prop-types": "15.5.6",
     "@types/pubsub-js": "1.8.2",
     "@types/rc-slider": "8.2.2",

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -254,7 +254,7 @@ specifiers:
   path-parse: 1.0.6
   pegjs: 0.10.0
   platform-detect: 3.0.0
-  prettier: 2.6.2
+  prettier: 2.8.8
   pretty-format: 26.1.0
   prop-types: 15.6.2
   pubsub-js: ^1.9.2
@@ -429,7 +429,7 @@ dependencies:
   path-browserify: 1.0.1
   path-parse: 1.0.6
   platform-detect: 3.0.0
-  prettier: 2.6.2
+  prettier: 2.8.8
   prop-types: 15.6.2
   pubsub-js: 1.9.3
   puppeteer: 19.6.0
@@ -575,7 +575,7 @@ devDependencies:
   eslint: 7.32.0
   eslint-config-prettier: 6.9.0_eslint@7.32.0
   eslint-plugin-jest: 25.3.0_qopkyehznc3hanpl3gqceqvzdu
-  eslint-plugin-prettier: 3.1.2_lk2fkjavihlcu7p5a3tdxfycz4
+  eslint-plugin-prettier: 3.1.2_5tpslmch32lidtsjs5w6ze4pka
   expect: 26.1.0
   fast-check: 1.15.0
   file-loader: 5.0.2_webpack@5.88.2
@@ -683,7 +683,7 @@ packages:
       '@ant-design/icons-svg': 4.2.1
       '@babel/runtime': 7.20.13
       classnames: 2.2.6
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
     dev: false
@@ -5557,8 +5557,8 @@ packages:
       '@types/yargs-parser': 20.2.1
     dev: true
 
-  /@types/yauzl/2.10.1:
-    resolution: {integrity: sha512-CHzgNU3qYBnp/O4S3yv2tXPlvMTq0YWSTVg2/JYLqWZGHwwgJGAwd00poay/11asPq8wLFwHzubyInqHIFmmiw==}
+  /@types/yauzl/2.10.3:
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
       '@types/node': 16.10.2
@@ -9718,7 +9718,7 @@ packages:
     dev: false
     patched: true
 
-  /eslint-plugin-prettier/3.1.2_lk2fkjavihlcu7p5a3tdxfycz4:
+  /eslint-plugin-prettier/3.1.2_5tpslmch32lidtsjs5w6ze4pka:
     resolution: {integrity: sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -9726,7 +9726,7 @@ packages:
       prettier: '>= 1.13.0'
     dependencies:
       eslint: 7.32.0
-      prettier: 2.6.2
+      prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
     dev: true
 
@@ -10168,7 +10168,7 @@ packages:
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
-      '@types/yauzl': 2.10.1
+      '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -15109,8 +15109,8 @@ packages:
     hasBin: true
     dev: false
 
-  /prettier/2.6.2:
-    resolution: {integrity: sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==}
+  /prettier/2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
 
@@ -15467,7 +15467,7 @@ packages:
     dependencies:
       babel-runtime: 6.26.0
       dom-align: 1.12.4
-      prop-types: 15.8.1
+      prop-types: 15.6.2
       rc-util: 4.21.1
     dev: false
 
@@ -15480,7 +15480,7 @@ packages:
       '@babel/runtime': 7.20.13
       classnames: 2.2.6
       dom-align: 1.12.4
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.38.1_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
       resize-observer-polyfill: 1.5.1
@@ -15495,7 +15495,7 @@ packages:
       babel-runtime: 6.26.0
       classnames: 2.2.6
       css-animation: 1.6.1
-      prop-types: 15.8.1
+      prop-types: 15.6.2
       raf: 3.4.1
       rc-util: 4.21.1
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
@@ -15522,7 +15522,7 @@ packages:
     dependencies:
       array-tree-filter: 2.1.0
       rc-trigger: 4.3.5_ef5jwxihqo6n7gxfmzogljlgcm
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       warning: 4.0.3
     transitivePeerDependencies:
       - react
@@ -15542,7 +15542,7 @@ packages:
       '@ant-design/css-animation': 1.7.3
       classnames: 2.2.6
       rc-animate: 3.1.1_ef5jwxihqo6n7gxfmzogljlgcm
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       shallowequal: 1.1.0
     transitivePeerDependencies:
       - react
@@ -15554,7 +15554,7 @@ packages:
     dependencies:
       babel-runtime: 6.26.0
       rc-animate: 3.1.1_ef5jwxihqo6n7gxfmzogljlgcm
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
     transitivePeerDependencies:
       - react
       - react-dom
@@ -15567,7 +15567,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       classnames: 2.2.6
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
     transitivePeerDependencies:
       - react-dom
@@ -15594,7 +15594,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       async-validator: 3.5.2
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
     transitivePeerDependencies:
       - react-dom
@@ -15604,7 +15604,7 @@ packages:
     resolution: {integrity: sha512-4GgnJCjllAVNsZ9fPA+3LnoIgwUqM8QAWpyoKiTkPDN1UWapXYsPiKJCXOhnmiR0X8xpEoYHiobUaiquMliWiQ==}
     dependencies:
       classnames: 2.2.6
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
     transitivePeerDependencies:
       - react
       - react-dom
@@ -15619,7 +15619,7 @@ packages:
       classnames: 2.2.6
       rc-menu: 8.3.1_ef5jwxihqo6n7gxfmzogljlgcm
       rc-trigger: 4.3.5_ef5jwxihqo6n7gxfmzogljlgcm
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
     transitivePeerDependencies:
       - react-dom
@@ -15633,7 +15633,7 @@ packages:
       mini-store: 3.0.6_ef5jwxihqo6n7gxfmzogljlgcm
       rc-animate: 3.1.1_ef5jwxihqo6n7gxfmzogljlgcm
       rc-trigger: 4.3.5_ef5jwxihqo6n7gxfmzogljlgcm
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       resize-observer-polyfill: 1.5.1
       shallowequal: 1.1.0
     transitivePeerDependencies:
@@ -15650,7 +15650,7 @@ packages:
       '@babel/runtime': 7.20.13
       classnames: 2.2.6
       raf: 3.4.1
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.38.1_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
     dev: false
@@ -15663,7 +15663,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       classnames: 2.2.6
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.38.1_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
     dev: false
@@ -15678,7 +15678,7 @@ packages:
       '@babel/runtime': 7.20.13
       classnames: 2.2.6
       rc-animate: 3.1.1_ef5jwxihqo6n7gxfmzogljlgcm
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
     dev: false
@@ -15707,7 +15707,7 @@ packages:
       classnames: 2.2.6
       moment: 2.29.1
       rc-trigger: 4.3.5_ef5jwxihqo6n7gxfmzogljlgcm
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
       shallowequal: 1.1.0
@@ -15725,7 +15725,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       classnames: 2.2.6
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
     transitivePeerDependencies:
       - react
       - react-dom
@@ -15739,7 +15739,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       classnames: 2.2.6
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
       resize-observer-polyfill: 1.5.1
@@ -15753,7 +15753,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       classnames: 2.2.6
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.38.1_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
       resize-observer-polyfill: 1.5.1
@@ -15770,7 +15770,7 @@ packages:
       classnames: 2.2.6
       rc-motion: 1.1.2_ef5jwxihqo6n7gxfmzogljlgcm
       rc-trigger: 4.3.5_ef5jwxihqo6n7gxfmzogljlgcm
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       rc-virtual-list: 1.1.6_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
@@ -15787,7 +15787,7 @@ packages:
       '@babel/runtime': 7.20.13
       classnames: 2.2.6
       rc-tooltip: 4.2.3_ef5jwxihqo6n7gxfmzogljlgcm
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
       shallowequal: 1.1.0
@@ -15802,7 +15802,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       classnames: 2.2.6
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
     dev: false
@@ -15815,7 +15815,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       classnames: 2.2.6
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
     dev: false
@@ -15848,7 +15848,7 @@ packages:
       rc-menu: 8.3.1_ef5jwxihqo6n7gxfmzogljlgcm
       rc-resize-observer: 0.2.6_ef5jwxihqo6n7gxfmzogljlgcm
       rc-trigger: 4.3.5_ef5jwxihqo6n7gxfmzogljlgcm
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
     transitivePeerDependencies:
       - react
       - react-dom
@@ -15858,7 +15858,7 @@ packages:
     resolution: {integrity: sha512-dE2ibukxxkrde7wH9W8ozHKUO4aQnPZ6qBHtrTH9LoO836PjDdiaWO73fgPB05VfJs9FbZdmGPVEbXCeOP99Ww==}
     dependencies:
       babel-runtime: 6.26.0
-      prop-types: 15.8.1
+      prop-types: 15.6.2
       rc-trigger: 2.6.5_ef5jwxihqo6n7gxfmzogljlgcm
     transitivePeerDependencies:
       - react
@@ -15885,7 +15885,7 @@ packages:
       classnames: 2.2.6
       rc-select: 11.0.13_ef5jwxihqo6n7gxfmzogljlgcm
       rc-tree: 3.11.0_ef5jwxihqo6n7gxfmzogljlgcm
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
     dev: false
@@ -15900,7 +15900,7 @@ packages:
       '@babel/runtime': 7.20.13
       classnames: 2.2.6
       rc-motion: 2.4.4_ef5jwxihqo6n7gxfmzogljlgcm
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.38.1_ef5jwxihqo6n7gxfmzogljlgcm
       rc-virtual-list: 3.4.1_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
@@ -15916,7 +15916,7 @@ packages:
       '@babel/runtime': 7.20.13
       classnames: 2.2.6
       rc-animate: 3.1.1_ef5jwxihqo6n7gxfmzogljlgcm
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       rc-virtual-list: 1.1.6_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
@@ -15927,7 +15927,7 @@ packages:
     dependencies:
       babel-runtime: 6.26.0
       classnames: 2.2.6
-      prop-types: 15.8.1
+      prop-types: 15.6.2
       rc-align: 2.4.5
       rc-animate: 2.11.1_ef5jwxihqo6n7gxfmzogljlgcm
       rc-util: 4.21.1
@@ -15946,7 +15946,7 @@ packages:
       raf: 3.4.1
       rc-align: 4.0.15_ef5jwxihqo6n7gxfmzogljlgcm
       rc-animate: 3.1.1_ef5jwxihqo6n7gxfmzogljlgcm
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
     transitivePeerDependencies:
       - react
       - react-dom
@@ -15962,7 +15962,7 @@ packages:
     resolution: {integrity: sha512-Z+vlkSQVc1l8O2UjR3WQ+XdWlhj5q9BMQNLk2iOBch75CqPfrJyGtcWMcnhRlNuDu0Ndtt4kLVO8JI8BrABobg==}
     dependencies:
       add-dom-event-listener: 1.1.0
-      prop-types: 15.8.1
+      prop-types: 15.6.2
       react-is: 16.13.1
       react-lifecycles-compat: 3.0.4
       shallowequal: 1.1.0
@@ -15981,8 +15981,8 @@ packages:
       shallowequal: 1.1.0
     dev: false
 
-  /rc-util/5.37.0_ef5jwxihqo6n7gxfmzogljlgcm:
-    resolution: {integrity: sha512-cPMV8DzaHI1KDaS7XPRXAf4J7mtBqjvjikLpQieaeOO7+cEbqY2j7Kso/T0R0OiEZTNcLS/8Zl9YrlXiO9UbjQ==}
+  /rc-util/5.38.1_ef5jwxihqo6n7gxfmzogljlgcm:
+    resolution: {integrity: sha512-e4ZMs7q9XqwTuhIK7zBIVFltUtMSjphuPPQXHoHlzRzNdOwUxDejo0Zls5HYaJfRKNURcsS/ceKVULlhjBrxng==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
@@ -15990,7 +15990,7 @@ packages:
       '@babel/runtime': 7.20.13
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
-      react-is: 16.13.1
+      react-is: 18.2.0
     dev: false
 
   /rc-virtual-list/1.1.6_ef5jwxihqo6n7gxfmzogljlgcm:
@@ -16002,7 +16002,7 @@ packages:
     dependencies:
       classnames: 2.2.6
       raf: 3.4.1
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.38.1_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
     dev: false
@@ -16016,7 +16016,7 @@ packages:
     dependencies:
       classnames: 2.2.6
       rc-resize-observer: 1.0.1_ef5jwxihqo6n7gxfmzogljlgcm
-      rc-util: 5.37.0_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.38.1_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
     dev: false
@@ -16190,7 +16190,7 @@ packages:
     peerDependencies:
       react: ^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0
     dependencies:
-      prop-types: 15.8.1
+      prop-types: 15.7.2
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
     dev: false
 
@@ -16210,7 +16210,7 @@ packages:
     dependencies:
       babel-runtime: 6.26.0
       is-dom: 1.1.0
-      prop-types: 15.8.1
+      prop-types: 15.6.2
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
     dev: false
 
@@ -16220,6 +16220,10 @@ packages:
   /react-is/17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
     dev: true
+
+  /react-is/18.2.0:
+    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+    dev: false
 
   /react-json-tree/0.18.0_7cpxmzzodpxnolj5zcc5cr63ji:
     resolution: {integrity: sha512-Qe6HKSXrr++n9Y31nkRJ3XvQMATISpqigH1vEKhLwB56+nk5thTP0ITThpjxY6ZG/ubpVq/aEHIcyLP/OPHxeA==}
@@ -16418,7 +16422,7 @@ packages:
       '@emotion/cache': 11.4.0
       '@emotion/react': 11.1.2_l23vr2jl6b3o5l3eanlyfmxl6q_hckexctj6og6b6fgnwzdyzgtia
       memoize-one: 5.2.1
-      prop-types: 15.8.1
+      prop-types: 15.7.2
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
       react-input-autosize: 3.0.0_react@18.1.0
@@ -16531,7 +16535,7 @@ packages:
       '@babel/runtime': 7.20.13
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
-      prop-types: 15.8.1
+      prop-types: 15.7.2
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
     dev: false
@@ -19819,7 +19823,7 @@ packages:
     dependencies:
       babel-runtime: 6.26.0
       classnames: 2.2.6
-      prop-types: 15.8.1
+      prop-types: 15.6.2
       rc-tooltip: 3.7.3_ef5jwxihqo6n7gxfmzogljlgcm
       rc-util: 4.21.1
       shallowequal: 1.1.0

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -113,7 +113,7 @@ specifiers:
   '@types/object-path': 0.9.29
   '@types/path-browserify': 1.0.0
   '@types/path-parse': 1.0.19
-  '@types/prettier': 2.0.1
+  '@types/prettier': 2.7.3
   '@types/prop-types': 15.5.6
   '@types/pubsub-js': 1.8.2
   '@types/rc-slider': 8.2.2
@@ -533,7 +533,7 @@ devDependencies:
   '@types/object-path': 0.9.29
   '@types/path-browserify': 1.0.0
   '@types/path-parse': 1.0.19
-  '@types/prettier': 2.0.1
+  '@types/prettier': 2.7.3
   '@types/prop-types': 15.5.6
   '@types/pubsub-js': 1.8.2
   '@types/rc-slider': 8.2.2
@@ -5293,12 +5293,8 @@ packages:
       '@types/node': 16.10.2
     dev: true
 
-  /@types/prettier/2.0.1:
-    resolution: {integrity: sha512-boy4xPNEtiw6N3abRhBi/e7hNvy3Tt8E9ZRAQrwAGzoCGZS/1wjo9KY7JHhnfnEsG5wSjDbymCozUM9a3ea7OQ==}
-    dev: true
-
-  /@types/prettier/2.4.1:
-    resolution: {integrity: sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==}
+  /@types/prettier/2.7.3:
+    resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
     dev: true
 
   /@types/prop-types/15.5.6:
@@ -12645,7 +12641,7 @@ packages:
       '@jest/transform': 27.2.4
       '@jest/types': 27.2.4
       '@types/babel__traverse': 7.18.3
-      '@types/prettier': 2.4.1
+      '@types/prettier': 2.7.3
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.22.9
       chalk: 4.1.2
       expect: 27.2.4
@@ -15467,7 +15463,7 @@ packages:
     dependencies:
       babel-runtime: 6.26.0
       dom-align: 1.12.4
-      prop-types: 15.6.2
+      prop-types: 15.8.1
       rc-util: 4.21.1
     dev: false
 
@@ -15495,7 +15491,7 @@ packages:
       babel-runtime: 6.26.0
       classnames: 2.2.6
       css-animation: 1.6.1
-      prop-types: 15.6.2
+      prop-types: 15.8.1
       raf: 3.4.1
       rc-util: 4.21.1
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
@@ -15650,7 +15646,7 @@ packages:
       '@babel/runtime': 7.20.13
       classnames: 2.2.6
       raf: 3.4.1
-      rc-util: 5.38.1_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
     dev: false
@@ -15858,7 +15854,7 @@ packages:
     resolution: {integrity: sha512-dE2ibukxxkrde7wH9W8ozHKUO4aQnPZ6qBHtrTH9LoO836PjDdiaWO73fgPB05VfJs9FbZdmGPVEbXCeOP99Ww==}
     dependencies:
       babel-runtime: 6.26.0
-      prop-types: 15.6.2
+      prop-types: 15.8.1
       rc-trigger: 2.6.5_ef5jwxihqo6n7gxfmzogljlgcm
     transitivePeerDependencies:
       - react
@@ -15900,7 +15896,7 @@ packages:
       '@babel/runtime': 7.20.13
       classnames: 2.2.6
       rc-motion: 2.4.4_ef5jwxihqo6n7gxfmzogljlgcm
-      rc-util: 5.38.1_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       rc-virtual-list: 3.4.1_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
@@ -15927,7 +15923,7 @@ packages:
     dependencies:
       babel-runtime: 6.26.0
       classnames: 2.2.6
-      prop-types: 15.6.2
+      prop-types: 15.8.1
       rc-align: 2.4.5
       rc-animate: 2.11.1_ef5jwxihqo6n7gxfmzogljlgcm
       rc-util: 4.21.1
@@ -15962,7 +15958,7 @@ packages:
     resolution: {integrity: sha512-Z+vlkSQVc1l8O2UjR3WQ+XdWlhj5q9BMQNLk2iOBch75CqPfrJyGtcWMcnhRlNuDu0Ndtt4kLVO8JI8BrABobg==}
     dependencies:
       add-dom-event-listener: 1.1.0
-      prop-types: 15.6.2
+      prop-types: 15.8.1
       react-is: 16.13.1
       react-lifecycles-compat: 3.0.4
       shallowequal: 1.1.0
@@ -16002,7 +15998,7 @@ packages:
     dependencies:
       classnames: 2.2.6
       raf: 3.4.1
-      rc-util: 5.38.1_ef5jwxihqo6n7gxfmzogljlgcm
+      rc-util: 5.14.0_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
       react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
     dev: false

--- a/editor/src/components/canvas/canvas-strategies/strategies/fragment-like-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/fragment-like-helpers.ts
@@ -222,7 +222,7 @@ export function replaceNonDomElementWithFirstDomAncestorPath(
 
 export const AllFragmentLikeNonDomElementTypes = ['fragment', 'conditional'] as const
 export const AllFragmentLikeTypes = [...AllFragmentLikeNonDomElementTypes, 'sizeless-div'] as const
-export type FragmentLikeType = typeof AllFragmentLikeTypes[number] // <- this gives us the union type of the Array's entries
+export type FragmentLikeType = (typeof AllFragmentLikeTypes)[number] // <- this gives us the union type of the Array's entries
 
 type SizelessDivsConsideredFragmentLike =
   | 'sizeless-div-considered-fragment-like'

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -113,7 +113,7 @@ export type StateSelector<T, U> = (state: T) => U
  * The return value of the function is the return value of useEditorState itself.
  * It is a good practice to use object destructure to consume the return value.
  */
-export const useEditorState = <K extends StoreKey, S extends typeof Substores[K], U>(
+export const useEditorState = <K extends StoreKey, S extends (typeof Substores)[K], U>(
   storeKey_: S,
   selector: StateSelector<Parameters<S>[0], U>,
   selectorName: string,
@@ -130,7 +130,7 @@ export const useEditorState = <K extends StoreKey, S extends typeof Substores[K]
   return context.stores[storeKey](wrappedSelector, equalityFn as EqualityChecker<U>)
 }
 
-export const useSelectorWithCallback = <K extends StoreKey, S extends typeof Substores[K], U>(
+export const useSelectorWithCallback = <K extends StoreKey, S extends (typeof Substores)[K], U>(
   storeKey_: S,
   selector: StateSelector<Parameters<S>[0], U>,
   callback: (newValue: U) => void,

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -972,7 +972,7 @@ function cssBoxShadow(
 export type CSSBoxShadows = ReadonlyArray<CSSBoxShadow>
 
 export const cssLineWidthKeywordValues = ['thin', 'medium', 'thick'] as const
-export type CSSLineWidthKeywordValue = NonNullable<typeof cssLineWidthKeywordValues[number]>
+export type CSSLineWidthKeywordValue = NonNullable<(typeof cssLineWidthKeywordValues)[number]>
 export type CSSLineWidthValue = CSSNumber | CSSKeyword<CSSLineWidthKeywordValue>
 export interface CSSLineWidth {
   type: 'line-width'
@@ -1004,7 +1004,7 @@ export const cssLineStyleKeywordValues = [
   'inset',
   'outset',
 ] as const
-export type CSSLineStyleKeywordValue = NonNullable<typeof cssLineStyleKeywordValues[number]>
+export type CSSLineStyleKeywordValue = NonNullable<(typeof cssLineStyleKeywordValues)[number]>
 export type CSSLineStyleValue = CSSKeyword<CSSLineStyleKeywordValue>
 
 export interface CSSLineStyle {
@@ -2488,7 +2488,7 @@ export type CSSBackgroundLayerType =
   | GradientBackgroundLayerType
 
 export const cssBGSizeKeywordValueValues = ['contain', 'cover'] as const
-export type CSSBGSizeKeywordValueValue = NonNullable<typeof cssBGSizeKeywordValueValues[number]>
+export type CSSBGSizeKeywordValueValue = NonNullable<(typeof cssBGSizeKeywordValueValues)[number]>
 export type CSSBGSizeKeywordValue = CSSKeyword<CSSBGSizeKeywordValueValue>
 export type CSSBGSizeCurlyBraceValueValue = CSSNumber | CSSKeyword<'auto'>
 export type CSSBGSizeCurlyBraceValue = ParsedCurlyBrace<CSSBGSizeCurlyBraceValueValue>
@@ -4702,7 +4702,7 @@ export const DOMEventHandlerNames = [
   'onTransitionEnd',
   'onTransitionEndCapture',
 ] as const
-export type DOMEventHandler = NonNullable<typeof DOMEventHandlerNames[number]>
+export type DOMEventHandler = NonNullable<(typeof DOMEventHandlerNames)[number]>
 
 type DOMEventAttributeProperties = {
   [key in DOMEventHandler]: DOMEventHandlerMetadata

--- a/editor/src/utils/keyboard.ts
+++ b/editor/src/utils/keyboard.ts
@@ -30,7 +30,7 @@ export type Letter =
   | 'z'
 
 const Digits = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'] as const
-export type Digit = typeof Digits[number]
+export type Digit = (typeof Digits)[number]
 
 export const isDigit = (c: string): c is Digit => (Digits as readonly string[]).includes(c)
 


### PR DESCRIPTION
**Problem:**
The following line causes a prettier error:
```typescript
type RoomContextType = ReturnType<typeof createRoomContext<Presence, Storage, UserMeta, RoomEvent, ThreadMetadata>>
```

I tried updating to most recent Prettier (3.1.0), and it fixed the problem, but there is a breaking API change (Prettier.format became async), which causes lot of errors in our code.
To avoid this breaking change, I tried only updating to the last 2.* version (2.8.8), and that fixed the error too.