### PR TITLE
Offline Avatars are greyed out

### DIFF
--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -102,7 +102,7 @@ const MultiplayerUserBar = React.memo(() => {
   }, [others])
 
   const offlineOthers = Object.values(collabs).filter((collab) => {
-    return !others.some((other) => other.id === collab.id)
+    return !others.some((other) => other.id === collab.id) && collab.id !== myUser.id
   })
 
   const mode = useEditorState(


### PR DESCRIPTION
As of now, any user who has ever opened the project is considered a "collaborator." If a user is a collaborator but they do not actively have the project open, they are now considered part of the `offlineOthers` object, and those avatars are rendered in the `userBar` in greyscale. 

<img width="309" alt="Screenshot 2023-12-11 at 11 27 25 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/b92f458c-e1ff-47f5-8cee-0f8d092cf5d8">

<img width="314" alt="Screenshot 2023-12-11 at 11 27 46 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/4844d70d-8479-4187-8f04-d066290ae6c5">
