### PR TITLE
Stub some more of the hydrogen dependencies that aren't needed in browser

### DIFF
--- a/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
@@ -117,8 +117,11 @@ export function createBuiltInDependenciesList(
     ),
 
     // Stubs for the hydrogen projects. this is here to prevent our backend from downloading a massive amount of files into the editor
-    builtInDependency('@remix-run/dev/server-build', RemixServerBuild, '1.19.1'),
-    builtInDependency('@shopify/cli', Stub, '3.49.2'),
-    builtInDependency('@shopify/cli-hydrogen', Stub, '5.4.2'),
+    builtInDependency('@remix-run/dev/server-build', RemixServerBuild, '2.1.0'),
+    builtInDependency('@remix-run/dev', Stub, '2.1.0'),
+    // FIXME this shouldn't be stubbed when we support configurable eslint
+    builtInDependency('@remix-run/eslint-config', Stub, '2.1.0'),
+    builtInDependency('@shopify/cli', Stub, '3.50.0'),
+    builtInDependency('@shopify/cli-hydrogen', Stub, '6.0.0'),
   ]
 }

--- a/server/src/Utopia/Web/Packager/NPM.hs
+++ b/server/src/Utopia/Web/Packager/NPM.hs
@@ -169,7 +169,7 @@ projectFileToCodeLens = _Ctor @"ProjectTextFile" . field @"fileContents" . field
 -- Ensure this is kept up to date with:
 -- editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
 providedDependencies :: [Text]
-providedDependencies = ["utopia-api", "uuiui", "uuiui-deps", "react/jsx-runtime", "react", "react-dom", "@emotion/react", "@emotion/core", "@emotion/styled", "@remix-run/react", "react-router", "@remix-run/server-runtime", "@shopify/hydrogen", "@remix-run/dev", "@shopify/cli", "@shopify/cli-hydrogen"]
+providedDependencies = ["utopia-api", "uuiui", "uuiui-deps", "react/jsx-runtime", "react", "react-dom", "@emotion/react", "@emotion/core", "@emotion/styled", "@remix-run/react", "react-router", "@remix-run/server-runtime", "@shopify/hydrogen", "@remix-run/dev", "@remix-run/eslint-config", "@shopify/cli", "@shopify/cli-hydrogen"]
 
 getProjectDependenciesFromPackageJSON :: DB.DecodedProject -> [ProjectDependency]
 getProjectDependenciesFromPackageJSON decodedProject = either (const []) identity $ do


### PR DESCRIPTION
**Problem:**
When running the same Hydrogen project in the editor we are still attempting to download dependencies that aren't needed in the browser. This is makes it painfully slow to load the editor with that project.

**Fix:**
Stub those dependencies
