### PR TITLE
RemixScene getLoadContext

### DIFF
--- a/editor/src/components/canvas/remix/remix-rendering.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-rendering.spec.browser2.tsx
@@ -797,6 +797,73 @@ describe('Remix content', () => {
   })
 })
 
+describe('Remix getLoadContext', () => {
+  it('Renders the remix project that relies on loader context', async () => {
+    const project = createModifiedProject({
+      [StoryboardFilePath]: `import * as React from 'react'
+      import { RemixScene, Storyboard } from 'utopia-api'
+      const getLoadContext = async (request) => {
+        return {
+          request: request,
+          otherStuff: 'hello!'
+        }
+      }
+      
+      export var storyboard = (
+        <Storyboard>
+          <RemixScene
+            style={{
+              width: 700,
+              height: 759,
+              position: 'absolute',
+              left: 212,
+              top: 128,
+            }}
+            data-label='Playground'
+            getLoadContext={getLoadContext}
+          />
+        </Storyboard>
+      )
+      `,
+      ['/app/root.js']: `import React from 'react'
+      import { Outlet } from '@remix-run/react'
+      import { json, useLoaderData } from 'react-router'
+      export function loader({params, request, context}) {
+        console.log('loader called', params, request, context)
+        return json({
+          contextEqualsRequest: context.request === request,
+        })
+      }
+      
+      export default function Root() {
+        const loaderData = useLoaderData()
+        return (
+          <div>
+            Request given to loader matches the request given to getLoadContext: {JSON.stringify(loaderData.contextEqualsRequest)}
+            <div>${RootTextContent}</div>
+            <Outlet />
+          </div>
+        )
+      }
+      `,
+      ['/app/routes/_index.js']: `import React from 'react'
+      const Index = () => (<h1>${DefaultRouteTextContent}</h1>)
+      export default Index
+      `,
+    })
+
+    const renderResult = await renderRemixProject(project)
+
+    expect(
+      renderResult.renderedDOM.getByText(
+        'Request given to loader matches the request given to getLoadContext: true',
+      ),
+    ).toBeTruthy()
+
+    await expectRemixSceneToBeRendered(renderResult)
+  })
+})
+
 describe('Remix navigation', () => {
   const projectWithMultipleRoutes = () =>
     createModifiedProject({

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/remix-scene-component.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/remix-scene-component.tsx
@@ -7,19 +7,21 @@ import { UtopiaStyles, useColorTheme } from '../../../uuiui'
 import { UTOPIA_PATH_KEY } from '../../../core/model/utopia-constants'
 import * as EP from '../../../core/shared/element-path'
 import { useSetAtom } from 'jotai'
+import type { AppLoadContext } from '@remix-run/server-runtime'
 
 export const REMIX_SCENE_TESTID = 'remix-scene'
 
 export interface RemixSceneProps {
   style?: React.CSSProperties
   [UTOPIA_PATH_KEY]?: string
+  getLoadContext?: (request: Request) => Promise<AppLoadContext> | AppLoadContext
 }
 
 export const RemixSceneComponent = React.memo((props: React.PropsWithChildren<RemixSceneProps>) => {
   const colorTheme = useColorTheme()
   const canvasIsLive = false
 
-  const { style, ...remainingProps } = props
+  const { style, getLoadContext, ...remainingProps } = props
 
   const sceneStyle: React.CSSProperties = {
     position: 'relative',
@@ -49,7 +51,7 @@ export const RemixSceneComponent = React.memo((props: React.PropsWithChildren<Re
       style={sceneStyle}
       onMouseDown={onMouseDown}
     >
-      <UtopiaRemixRootComponent data-path={path} />
+      <UtopiaRemixRootComponent data-path={path} getLoadContext={getLoadContext} />
     </div>
   )
 })

--- a/editor/src/third-party/remix/create-remix-stub.ts
+++ b/editor/src/third-party/remix/create-remix-stub.ts
@@ -1,0 +1,41 @@
+import type { AppLoadContext } from '@remix-run/server-runtime'
+import type { DataRouteObject, RouteObject } from 'react-router'
+
+// adopted from https://github.com/remix-run/remix/blob/4a8f558d16b8739d7f70903958ac5792e050f3e9/packages/remix-testing/create-remix-stub.tsx#L55
+// replaced the types with the vanilla types from react-router
+export function patchRoutesWithContext(
+  routes: Array<RouteObject | DataRouteObject>,
+  getLoadContext?: (request: Request) => Promise<AppLoadContext> | AppLoadContext, // the async getLoadContext has been lifted from the server adapter https://remix.run/docs/en/main/route/loader#context
+): (RouteObject | DataRouteObject)[] {
+  if (getLoadContext == null) {
+    // no context to patch with
+    return routes
+  }
+
+  return routes.map((route) => {
+    if (route.loader) {
+      let loader = route.loader
+      route.loader = async (args) => {
+        const context = await getLoadContext(args.request)
+        return loader({ ...args, context: context })
+      }
+    }
+
+    if (route.action) {
+      let action = route.action
+      route.action = async (args) => {
+        const context = await getLoadContext(args.request)
+        return action({ ...args, context: context })
+      }
+    }
+
+    if (route.children) {
+      return {
+        ...route,
+        children: patchRoutesWithContext(route.children, getLoadContext),
+      }
+    }
+
+    return route as RouteObject | DataRouteObject
+  }) as (RouteObject | DataRouteObject)[]
+}


### PR DESCRIPTION
**Problem:**
Hydrogen projects sneak a context into Remix using `getLoadContext` in the remix adapter's `createRequestHandler` [link](https://remix.run/docs/en/main/other-api/adapter#createrequesthandler). 

When trying to load a hydrogen project in Utopia, our entry point is _not_ the runtime Oxygen entry point located in `server.js`. Our entry point is the `RemixScene` in the storyboard.js file. So this context is entirely missing, and it makes the loaders and the routes sad.

Remix's own made-for-testing `createRemixStub` function takes an optional context ([link](https://remix.run/docs/en/main/utils/create-remix-stub#:~:text=If%20your%20loaders%20rely%20on%20the%20getLoadContext%20method%2C%20you%20can%20provide%20a%20stubbed%20context%20via%20the%20second%20parameter%20to%20createRemixStub)).

However! the Remix testing API takes Context as an object ([link](https://github.com/remix-run/remix/blob/018d5da59363980ebe53667339454e4bb347f6c3/packages/remix-testing/create-remix-stub.tsx#L93)), which is inconvenient for us, because the default Hydrogen project uses the incoming `request` to create the context. To be able to create the same context for the storyboard, we need access to the `request` at the context creation. 

**Fix:**
The solution is a sort of hybrid of createRemixStub and createRequestHandler:
Our `RemixScene` component takes an optional parameter `getLoadContext` which has a similar signature as the one passed in to `createRequestHandler`:
`getLoadContext?: (request: Request) => Promise<AppLoadContext> | AppLoadContext`

**Warning!** Unfortunately the signature of `getLoadContext` depends on the Remix adapter. Depending on the Remix adapter, getLoadContext may receive a `(req, res)` or an `(event)` or a `(request)`. 

This PR matches the Remix Hydrogen adapter ([link](https://github.com/Shopify/hydrogen/blob/dc56d296c5abf572c19046756ad5b27f8b98a7b3/packages/remix-oxygen/src/server.ts#L23)) regardless of which adapter the user's project uses. 
If this becomes untenable, we will have two options:
1. (more likely) rename the callback and keep the fixed signature. I suspect _most_ code using getLoadContext only cares about the request, but this is an unverified assumption.
2. (less likely) somehow utilize the user project's remix adapter. this _definitely_ will need some re-thinking of what we are doing here, we'll have to ask for feedback from the Remix team.

**Commit Details:** 
- `RemixScene` gets optional `getLoadContext` callback
- `patchRoutesWithContext` lifted from remix/testing, but modified to call the `getLoadContext` instead of getting context as an object 
- `UtopiaRemixRootComponent`'s `useGetRoutes` uses `patchRoutesWithContext`
- Tests!
