### PR TITLE
Offline Avatars

### DIFF
--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -253,7 +253,7 @@ export const MultiplayerAvatar = React.memo((props: MultiplayerAvatarProps) => {
 
   const tooltipText = <strong>{props.tooltip?.text}</strong>
   const tooltipSubtext =
-    props.follower === true ? ' (following you)' : props.isOffline ? ' (offline)' : ''
+    props.follower === true ? ' following you' : props.isOffline ? ' offline' : ''
 
   const tooltipWithLineBreak = (
     <>

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -102,6 +102,10 @@ const MultiplayerUserBar = React.memo(() => {
     return others.slice(MAX_VISIBLE_OTHER_PLAYERS)
   }, [others])
 
+  const offlineOthers = Object.values(collabs).filter((collab) => {
+    return !others.some((other) => other.id === collab.id) && collab.id !== myUser.id
+  })
+
   const mode = useEditorState(
     Substores.restOfEditor,
     (store) => store.editor.mode,
@@ -194,6 +198,27 @@ const MultiplayerUserBar = React.memo(() => {
           picture={null}
         />,
       )}
+      {when(
+        offlineOthers.length > 0,
+        offlineOthers.map((other) => {
+          if (other == null) {
+            return null
+          }
+          const name = normalizeMultiplayerName(other.name)
+          const isOwner = ownerId === other.id
+          return (
+            <MultiplayerAvatar
+              key={`avatar-${other.id}`}
+              name={multiplayerInitialsFromName(name)}
+              tooltip={{ text: name, colored: false }}
+              color={multiplayerColorFromIndex(other.colorIndex)}
+              picture={other.avatar}
+              isOwner={isOwner}
+              isOffline={true}
+            />
+          )
+        }),
+      )}
       <a href='/projects' target='_blank' rel='noopener rofererrer'>
         <MultiplayerAvatar
           name={multiplayerInitialsFromName(myUser.name)}
@@ -218,6 +243,7 @@ export type MultiplayerAvatarProps = {
   isOwner?: boolean
   style?: CSSProperties
   tooltip?: { text: string; colored: boolean }
+  isOffline?: boolean
 }
 
 export const MultiplayerAvatar = React.memo((props: MultiplayerAvatarProps) => {
@@ -225,10 +251,22 @@ export const MultiplayerAvatar = React.memo((props: MultiplayerAvatarProps) => {
     return isDefaultAuth0AvatarURL(props.picture ?? null) ? null : props.picture
   }, [props.picture])
 
+  const tooltipText = <strong>{props.tooltip?.text}</strong>
+  const tooltipSubtext =
+    props.follower === true ? ' (following you)' : props.isOffline ? ' (offline)' : ''
+
+  const tooltipWithLineBreak = (
+    <>
+      {tooltipText}
+      {<br />}
+      {tooltipSubtext}
+    </>
+  )
+
   return (
     <Tooltip
       disabled={props.tooltip == null}
-      title={`${props.tooltip?.text}${props.follower === true ? ' (following you)' : ''}`}
+      title={tooltipWithLineBreak}
       placement='bottom'
       backgroundColor={props.tooltip?.colored === true ? props.color.background : undefined}
       textColor={props.tooltip?.colored === true ? props.color.foreground : undefined}
@@ -237,8 +275,8 @@ export const MultiplayerAvatar = React.memo((props: MultiplayerAvatarProps) => {
         style={{
           width: props.size ?? 24,
           height: props.size ?? 24,
-          backgroundColor: props.color.background,
-          color: props.color.foreground,
+          backgroundColor: props.isOffline ? colorTheme.bg4.value : props.color.background,
+          color: props.isOffline ? colorTheme.fg2.value : props.color.foreground,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -256,7 +294,7 @@ export const MultiplayerAvatar = React.memo((props: MultiplayerAvatarProps) => {
         }}
         onClick={props.onClick}
       >
-        <AvatarPicture url={picture} size={24} initials={props.name} />
+        <AvatarPicture url={picture} size={24} initials={props.name} isOffline={props.isOffline} />
         {props.isOwner ? <OwnerBadge /> : null}
         {props.follower ? <FollowerBadge /> : null}
       </div>
@@ -306,6 +344,7 @@ interface AvatarPictureProps {
   url: string | null | undefined
   initials: string
   size?: number
+  isOffline?: boolean
 }
 
 export const AvatarPicture = React.memo((props: AvatarPictureProps) => {
@@ -335,6 +374,7 @@ export const AvatarPicture = React.memo((props: AvatarPictureProps) => {
         width: size ?? '100%',
         height: size ?? '100%',
         borderRadius: '100%',
+        filter: props.isOffline ? 'grayscale(1)' : undefined,
       }}
       src={url}
       referrerPolicy='no-referrer'

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -103,7 +103,7 @@ const MultiplayerUserBar = React.memo(() => {
   }, [others])
 
   const offlineOthers = Object.values(collabs).filter((collab) => {
-    return !others.some((other) => other.id === collab.id) && collab.id !== myUser.id
+    return collab.id !== myUser.id && !others.some((other) => other.id === collab.id)
   })
 
   const mode = useEditorState(

--- a/editor/src/uuiui/tooltip.tsx
+++ b/editor/src/uuiui/tooltip.tsx
@@ -43,6 +43,7 @@ export class Tooltip extends React.Component<React.PropsWithChildren<TooltipProp
         css={{
           fontWeight: 400,
           fontSize: 11,
+          textAlign: 'center',
           fontFamily:
             "utopian-inter, -apple-system, BlinkMacSystemFont, Helvetica, 'Segoe UI', Roboto, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'",
           backgroundColor: `${backgroundColor} !important`,


### PR DESCRIPTION
As of now, any user who has ever opened the project is considered a "collaborator." If a user is a collaborator but they do not actively have the project open, they are now considered part of the `offlineOthers` object, and those avatars are rendered in the `userBar` in greyscale. 

<img width="309" alt="Screenshot 2023-12-11 at 11 27 25 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/b92f458c-e1ff-47f5-8cee-0f8d092cf5d8">

<img width="314" alt="Screenshot 2023-12-11 at 11 27 46 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/4844d70d-8479-4187-8f04-d066290ae6c5">


I also updated the tooltip to say if a user is offline, in addition to if they are following you.

<img width="300" alt="Screenshot 2023-12-12 at 11 16 42 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/8aee817b-6602-4015-ae71-4ac89fd167f7">
<img width="300" alt="Screenshot 2023-12-12 at 11 16 59 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/ff719ca9-8cf7-4291-a956-bbae36440c1c">

<img width="300" alt="Screenshot 2023-12-12 at 11 17 13 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/235c0906-a0a5-4426-aa36-c5ceb62527bb">
<img width="300" alt="Screenshot 2023-12-12 at 11 17 28 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/cbd69b6a-9671-49c6-ba2d-f311ccc54886">


