### PR TITLE
Session based VS Code storage.

### DIFF
--- a/editor/src/components/code-editor/code-editor-container.tsx
+++ b/editor/src/components/code-editor/code-editor-container.tsx
@@ -7,11 +7,11 @@ import { VSCodeLoadingScreen } from './vscode-editor-loading-screen'
 import { getEditorBranchNameFromURL, setBranchNameFromURL } from '../../utils/branches'
 import { VSCODE_EDITOR_IFRAME_ID } from '../../core/vscode/vscode-bridge'
 
-const VSCodeIframeContainer = React.memo((props: { projectID: string }) => {
-  const projectID = props.projectID
+const VSCodeIframeContainer = React.memo((props: { vsCodeSessionID: string }) => {
+  const vsCodeSessionID = props.vsCodeSessionID
   const baseIframeSrc = createIframeUrl(MONACO_EDITOR_IFRAME_BASE_URL, 'vscode-editor-iframe/')
   const url = new URL(baseIframeSrc)
-  url.searchParams.append('project_id', projectID)
+  url.searchParams.append('vs_code_session_id', vsCodeSessionID)
 
   setBranchNameFromURL(url.searchParams)
 
@@ -46,11 +46,11 @@ export const CodeEditorWrapper = React.memo(() => {
     Substores.restOfEditor,
     (store) => {
       return {
-        vscodeBridgeId: getUnderlyingVSCodeBridgeID(store.editor.vscodeBridgeId),
+        vscodeBridgeId: getUnderlyingVSCodeBridgeID(),
       }
     },
     'CodeEditorWrapper',
   )
 
-  return <VSCodeIframeContainer projectID={selectedProps.vscodeBridgeId} />
+  return <VSCodeIframeContainer vsCodeSessionID={selectedProps.vscodeBridgeId} />
 })

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -387,7 +387,6 @@ import {
   removeElementAtPath,
   StoryboardFilePath,
   updateMainUIInEditorState,
-  vsCodeBridgeIdProjectId,
   withUnderlyingTarget,
   modifyOpenJsxElementOrConditionalAtPath,
   modifyOpenJsxChildAtPath,
@@ -781,7 +780,6 @@ export function restoreEditorState(
   // FIXME Ask Team Components to check over these
   return {
     id: currentEditor.id,
-    vscodeBridgeId: currentEditor.vscodeBridgeId,
     forkedFromProjectId: currentEditor.forkedFromProjectId,
     appID: currentEditor.appID,
     projectName: currentEditor.projectName,
@@ -1594,7 +1592,6 @@ export const UPDATE_FNS = {
       ...editorModelFromPersistentModel(parsedModel, dispatch),
       projectName: action.title,
       id: action.projectId,
-      vscodeBridgeId: vsCodeBridgeIdProjectId(action.projectId), // we assign a first value when loading a project. SET_PROJECT_ID will not change this, saving us from having to reload VSCode
       nodeModules: {
         skipDeepFreeze: true,
         files: action.nodeModules,
@@ -3352,21 +3349,10 @@ export const UPDATE_FNS = {
       return editor
     }
   },
-  SET_PROJECT_ID: (
-    action: SetProjectID,
-    editor: EditorModel,
-    dispatch: EditorDispatch,
-  ): EditorModel => {
-    let vscodeBridgeId = editor.vscodeBridgeId
-    if (vscodeBridgeId.type === 'VSCODE_BRIDGE_ID_DEFAULT') {
-      vscodeBridgeId = vsCodeBridgeIdProjectId(action.id)
-      // Side effect.
-      initVSCodeBridge(editor.projectContents, dispatch, editor.canvas.openFile?.filename ?? null)
-    }
+  SET_PROJECT_ID: (action: SetProjectID, editor: EditorModel): EditorModel => {
     return {
       ...editor,
       id: action.id,
-      vscodeBridgeId: vscodeBridgeId,
     }
   },
   UPDATE_CODE_RESULT_CACHE: (action: UpdateCodeResultCache, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -723,42 +723,10 @@ export function resizeOptions(
   }
 }
 
-export interface VSCodeBridgeIdDefault {
-  type: 'VSCODE_BRIDGE_ID_DEFAULT'
-  defaultID: string
-}
+const UnderlyingVSCodeBridgeId = UUID()
 
-export function vsCodeBridgeIdDefault(defaultID: string): VSCodeBridgeIdDefault {
-  return {
-    type: 'VSCODE_BRIDGE_ID_DEFAULT',
-    defaultID: defaultID,
-  }
-}
-
-export interface VSCodeBridgeIdProjectId {
-  type: 'VSCODE_BRIDGE_ID_PROJECT_ID'
-  projectID: string
-}
-
-export function vsCodeBridgeIdProjectId(projectID: string): VSCodeBridgeIdProjectId {
-  return {
-    type: 'VSCODE_BRIDGE_ID_PROJECT_ID',
-    projectID: projectID,
-  }
-}
-
-export type VSCodeBridgeId = VSCodeBridgeIdDefault | VSCodeBridgeIdProjectId
-
-export function getUnderlyingVSCodeBridgeID(bridgeId: VSCodeBridgeId): string {
-  switch (bridgeId.type) {
-    case 'VSCODE_BRIDGE_ID_DEFAULT':
-      return `${ProjectIDPlaceholderPrefix}_${bridgeId.defaultID}`
-    case 'VSCODE_BRIDGE_ID_PROJECT_ID':
-      return bridgeId.projectID
-    default:
-      const _exhaustiveCheck: never = bridgeId
-      throw new Error(`Unhandled type ${JSON.stringify(bridgeId)}`)
-  }
+export function getUnderlyingVSCodeBridgeID(): string {
+  return UnderlyingVSCodeBridgeId
 }
 
 export interface EditorStateNodeModules {
@@ -1405,7 +1373,6 @@ export type TrueUpTarget =
 // FIXME We need to pull out ProjectState from here
 export interface EditorState {
   id: string | null
-  vscodeBridgeId: VSCodeBridgeId
   forkedFromProjectId: string | null
   appID: string | null
   projectName: string
@@ -1488,7 +1455,6 @@ export interface EditorState {
 
 export function editorState(
   id: string | null,
-  vscodeBridgeId: VSCodeBridgeId,
   forkedFromProjectId: string | null,
   appID: string | null,
   projectName: string,
@@ -1570,7 +1536,6 @@ export function editorState(
 ): EditorState {
   return {
     id: id,
-    vscodeBridgeId: vscodeBridgeId,
     forkedFromProjectId: forkedFromProjectId,
     appID: appID,
     projectName: projectName,
@@ -2354,7 +2319,6 @@ export const BaseCanvasOffsetLeftPane = {
 export function createEditorState(dispatch: EditorDispatch): EditorState {
   return {
     id: null,
-    vscodeBridgeId: vsCodeBridgeIdDefault(UUID()),
     forkedFromProjectId: null,
     appID: null,
     projectName: createNewProjectName(),
@@ -2730,7 +2694,6 @@ export function editorModelFromPersistentModel(
 ): EditorState {
   const editor: EditorState = {
     id: null,
-    vscodeBridgeId: vsCodeBridgeIdDefault(UUID()),
     forkedFromProjectId: persistentModel.forkedFromProjectId,
     appID: persistentModel.appID ?? null,
     projectName: createNewProjectName(),

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -232,7 +232,7 @@ export function runSimpleLocalEditorAction(
     case 'SET_STORED_FONT_SETTINGS':
       return UPDATE_FNS.SET_STORED_FONT_SETTINGS(action, state)
     case 'SET_PROJECT_ID':
-      return UPDATE_FNS.SET_PROJECT_ID(action, state, dispatch)
+      return UPDATE_FNS.SET_PROJECT_ID(action, state)
     case 'UPDATE_CODE_RESULT_CACHE':
       return UPDATE_FNS.UPDATE_CODE_RESULT_CACHE(action, state)
     case 'SET_CODE_EDITOR_VISIBILITY':

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -264,9 +264,6 @@ import type {
   DesignerFile,
   ResizeOptions,
   EditorState,
-  VSCodeBridgeIdDefault,
-  VSCodeBridgeIdProjectId,
-  VSCodeBridgeId,
   CanvasCursor,
   CursorStackItem,
   CursorImportanceLevel,
@@ -343,8 +340,6 @@ import {
   designerFile,
   resizeOptions,
   editorStateCanvas,
-  vsCodeBridgeIdDefault,
-  vsCodeBridgeIdProjectId,
   cursorStackItem,
   canvasCursor,
   floatingInsertMenuStateClosed,
@@ -2555,34 +2550,6 @@ export const EditorStateCanvasKeepDeepEquality: KeepDeepEqualityCall<EditorState
   }
 }
 
-export const VSCodeBridgeIdDefaultKeepDeepEquality: KeepDeepEqualityCall<VSCodeBridgeIdDefault> =
-  combine1EqualityCall((value) => value.defaultID, StringKeepDeepEquality, vsCodeBridgeIdDefault)
-
-export const VSCodeBridgeIdProjectIdKeepDeepEquality: KeepDeepEqualityCall<VSCodeBridgeIdProjectId> =
-  combine1EqualityCall((value) => value.projectID, StringKeepDeepEquality, vsCodeBridgeIdProjectId)
-
-export const VSCodeBridgeIdKeepDeepEquality: KeepDeepEqualityCall<VSCodeBridgeId> = (
-  oldValue,
-  newValue,
-) => {
-  switch (oldValue.type) {
-    case 'VSCODE_BRIDGE_ID_DEFAULT':
-      if (newValue.type === oldValue.type) {
-        return VSCodeBridgeIdDefaultKeepDeepEquality(oldValue, newValue)
-      }
-      break
-    case 'VSCODE_BRIDGE_ID_PROJECT_ID':
-      if (newValue.type === oldValue.type) {
-        return VSCodeBridgeIdProjectIdKeepDeepEquality(oldValue, newValue)
-      }
-      break
-    default:
-      const _exhaustiveCheck: never = oldValue
-      throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
-  }
-  return keepDeepEqualityResult(newValue, false)
-}
-
 export const ExportVariablesWithModifierKeepDeepEquality: KeepDeepEqualityCall<ExportVariablesWithModifier> =
   combine1EqualityCall(
     (exportVars) => exportVars.variables,
@@ -4287,10 +4254,6 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
   }
 
   const idResult = NullableStringKeepDeepEquality(oldValue.id, newValue.id)
-  const vscodeBridgeIdResult = VSCodeBridgeIdKeepDeepEquality(
-    oldValue.vscodeBridgeId,
-    newValue.vscodeBridgeId,
-  )
   const forkedFromProjectIdResult = NullableStringKeepDeepEquality(
     oldValue.forkedFromProjectId,
     newValue.forkedFromProjectId,
@@ -4577,7 +4540,6 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
 
   const areEqual =
     idResult.areEqual &&
-    vscodeBridgeIdResult.areEqual &&
     forkedFromProjectIdResult.areEqual &&
     appIDResult.areEqual &&
     projectNameResult.areEqual &&
@@ -4661,7 +4623,6 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
   } else {
     const newEditorState = editorState(
       idResult.value,
-      vscodeBridgeIdResult.value,
       forkedFromProjectIdResult.value,
       appIDResult.value,
       projectNameResult.value,

--- a/editor/src/components/editor/store/store-hook-substore-helpers.ts
+++ b/editor/src/components/editor/store/store-hook-substore-helpers.ts
@@ -2,7 +2,6 @@ import type { EditorState } from './editor-state'
 
 export const EmptyEditorStateForKeysOnly: EditorState = {
   id: null,
-  vscodeBridgeId: null as any,
   forkedFromProjectId: null,
   appID: null,
   projectName: null as any,

--- a/editor/src/components/editor/store/vscode-changes.ts
+++ b/editor/src/components/editor/store/vscode-changes.ts
@@ -26,7 +26,7 @@ import type {
 } from 'utopia-vscode-common'
 import { accumulatedToVSCodeMessage, toVSCodeExtensionMessage } from 'utopia-vscode-common'
 import type { EditorState } from './editor-state'
-import { getHighlightBoundsForElementPaths, getUnderlyingVSCodeBridgeID } from './editor-state'
+import { getHighlightBoundsForElementPaths } from './editor-state'
 import { shallowEqual } from '../../../core/shared/equality-utils'
 import * as EP from '../../../core/shared/element-path'
 import { collateCollaborativeProjectChanges } from './collaborative-editing'
@@ -80,7 +80,6 @@ export type ProjectFileChange =
   | EnsureDirectoryExistsChange
 
 export function collateProjectChanges(
-  projectID: string,
   oldContents: ProjectContentTreeRoot,
   newContents: ProjectContentTreeRoot,
 ): Array<ProjectFileChange> {
@@ -230,7 +229,6 @@ export function getProjectContentsChanges(
   newEditorState: EditorState,
 ): ProjectContentProjectChanges {
   const projectChanges = collateProjectChanges(
-    getUnderlyingVSCodeBridgeID(oldEditorState.vscodeBridgeId),
     oldEditorState.projectContents,
     newEditorState.projectContents,
   )
@@ -239,16 +237,9 @@ export function getProjectContentsChanges(
     newEditorState.projectContents,
   )
 
-  if (oldEditorState.vscodeBridgeId != null) {
-    return {
-      collabProjectChanges: collabProjectChanges,
-      changesForVSCode: projectChanges,
-    }
-  } else {
-    return {
-      collabProjectChanges: collabProjectChanges,
-      changesForVSCode: [],
-    }
+  return {
+    collabProjectChanges: collabProjectChanges,
+    changesForVSCode: projectChanges,
   }
 }
 

--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -95,12 +95,18 @@ export function initVSCodeBridge(
   openFilePath: string | null,
 ) {
   let loadingScreenHidden = false
+  let seenMessageListenersReadyMessage = false
 
   // Remove any existing message handlers to prevent us accidentally duplicating them
   window.removeEventListener('message', registeredHandlers)
   registeredHandlers = (messageEvent: MessageEvent) => {
     const { data } = messageEvent
-    if (isMessageListenersReady(data) && messageEvent.source != null) {
+    if (
+      isMessageListenersReady(data) &&
+      messageEvent.source != null &&
+      !seenMessageListenersReadyMessage
+    ) {
+      seenMessageListenersReadyMessage = true
       // Don't store the source yet, because we don't want to send any messages
       // until the bridge is ready
 

--- a/shell.nix
+++ b/shell.nix
@@ -224,6 +224,7 @@ let
       #!/usr/bin/env bash
       set -e
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/vscode-build
+      rm -rf ./dist ./node_modules
       yarn
       yarn run build
     '')

--- a/utopia-vscode-common/package.json
+++ b/utopia-vscode-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utopia-vscode-common",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "license": "MIT",
   "private": true,
   "description": "Common code for bridging VSCode and Utopia",

--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -55,7 +55,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   // Send a VSCodeReady message on activation as this might be triggered by an iframe reload,
   // meaning no new UtopiaReady message will have been sent
-  sendMessage(vsCodeReady())
+  await sendMessage(vsCodeReady())
 
   watchForFileDeletions()
 }

--- a/utopia-vscode-extension/src/utopia-fs.ts
+++ b/utopia-vscode-extension/src/utopia-fs.ts
@@ -1,26 +1,28 @@
-import {
+import type {
   CancellationToken,
-  Disposable,
   Event,
-  EventEmitter,
   FileChangeEvent,
-  FileChangeType,
   FileSearchOptions,
   FileSearchProvider,
   FileSearchQuery,
   FileStat,
-  FileSystemError,
   FileSystemProvider,
-  FileType,
-  Position,
   Progress,
-  Range,
   TextSearchComplete,
   TextSearchOptions,
   TextSearchProvider,
   TextSearchQuery,
   TextSearchResult,
   Uri,
+} from 'vscode'
+import {
+  Disposable,
+  EventEmitter,
+  FileChangeType,
+  FileType,
+  FileSystemError,
+  Position,
+  Range,
   workspace,
 } from 'vscode'
 import {

--- a/vscode-build/vscode.patch
+++ b/vscode-build/vscode.patch
@@ -52,7 +52,7 @@ index 2d7da1aecf8..052f52383f0 100644
  
  				<script src="${mainJs}" nonce="${nonce}"></script>
 diff --git a/package.json b/package.json
-index 2bca5115cac..75f06b97e0b 100644
+index 2bca5115cac..53884a9bb17 100644
 --- a/package.json
 +++ b/package.json
 @@ -44,15 +44,15 @@
@@ -212,7 +212,7 @@ index 6148eb30092..6948ededa4a 100644
  
  class SizeUtils {
 diff --git a/src/vs/code/browser/workbench/workbench.ts b/src/vs/code/browser/workbench/workbench.ts
-index 534fe232636..bc8685dc831 100644
+index 534fe232636..b41446430f0 100644
 --- a/src/vs/code/browser/workbench/workbench.ts
 +++ b/src/vs/code/browser/workbench/workbench.ts
 @@ -1,536 +1,101 @@
@@ -821,7 +821,7 @@ index 534fe232636..bc8685dc831 100644
 +
 +  // Inject project specific utopia config into the product.json
 +  const urlParams = new URLSearchParams(window.location.search)
-+  const projectID = urlParams.get('project_id')!
++  const vsCodeSessionID = urlParams.get('vs_code_session_id')!
 +
 +  // Use this instance as the webview provider rather than hitting MS servers
 +  const webviewEndpoint = `${window.location.origin}/vscode/vscode/vs/workbench/contrib/webview/browser/pre`
@@ -829,7 +829,7 @@ index 534fe232636..bc8685dc831 100644
 +  let config = {
 +    ...loadedConfig,
 +    folderUri: {
-+      scheme: projectID,
++      scheme: vsCodeSessionID,
 +      authority: '',
 +      path: `/`,
 +      query: '',
@@ -849,7 +849,7 @@ index 534fe232636..bc8685dc831 100644
 +    config = { ...config, workspaceProvider }
 +  }
 +
-+  setupVSCodeEventListenersForProject(projectID)
++  setupVSCodeEventListenersForProject(vsCodeSessionID)
 +
 +  create(document.body, config)
 +})()
@@ -1212,7 +1212,7 @@ index aedda47bd66..1e685812b0e 100644
  
  		this._registry = new ExtensionDescriptionRegistry([]);
 diff --git a/src/vs/workbench/services/workspaces/browser/workspaces.ts b/src/vs/workbench/services/workspaces/browser/workspaces.ts
-index 3b90080dc3d..a2228f49e9e 100644
+index 3b90080dc3d..cf9ac44fca9 100644
 --- a/src/vs/workbench/services/workspaces/browser/workspaces.ts
 +++ b/src/vs/workbench/services/workspaces/browser/workspaces.ts
 @@ -5,7 +5,6 @@
@@ -1229,10 +1229,10 @@ index 3b90080dc3d..a2228f49e9e 100644
  function getWorkspaceId(uri: URI): string {
 -	return hash(uri.toString()).toString(16);
 +	const urlParams = new URLSearchParams(window.location.search);
-+	return urlParams.get('project_id')!;
++	return urlParams.get('vs_code_session_id')!;
  }
 diff --git a/yarn.lock b/yarn.lock
-index 2f4f87570dd..fe2016e07f8 100644
+index 2f4f87570dd..cdeffa74f26 100644
 --- a/yarn.lock
 +++ b/yarn.lock
 @@ -5248,6 +5248,11 @@ ignore@^5.1.4:
@@ -1279,10 +1279,10 @@ index 2f4f87570dd..fe2016e07f8 100644
    resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
    integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
  
-+prettier@2.0.5:
-+  version "2.0.5"
-+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
-+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
++prettier@2.8.8:
++  version "2.8.8"
++  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
++  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 +
  pretty-hrtime@^1.0.0:
    version "1.0.3"
@@ -1292,10 +1292,10 @@ index 2f4f87570dd..fe2016e07f8 100644
      which-typed-array "^1.1.2"
  
 +"utopia-vscode-common@file:../../utopia-vscode-common":
-+  version "0.1.2"
++  version "0.1.4"
 +  dependencies:
 +    localforage "1.9.0"
-+    prettier "2.0.5"
++    prettier "2.8.8"
 +
  uuid@^3.0.0:
    version "3.1.0"

--- a/vscode-build/yarn.lock
+++ b/vscode-build/yarn.lock
@@ -372,10 +372,10 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
-prettier@2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
-  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+prettier@2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 proxy-addr@~2.0.5:
   version "2.0.6"
@@ -495,10 +495,10 @@ utils-merge@1.0.1:
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
 "utopia-vscode-common@file:../utopia-vscode-common":
-  version "0.1.2"
+  version "0.1.4"
   dependencies:
     localforage "1.9.0"
-    prettier "2.0.5"
+    prettier "2.8.8"
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
**Problem:**
If multiple tabs are open on the same computer then changes via VS Code may oddly propagate between those tabs.

**Cause:**
Currently our VS Code integration uses the project ID to create the storage that is used to communicate with VS Code as well as the filesystem for VS Code. This means that multiple tabs with the same project open can write data to each other in unexpected ways.

**Fix:**
The main fix for the above issue is to have a session based unique ID instead of something based on the project ID as the basis for the name of the IndexedDB storage which is used by VS Code and the editor. Previously we had a unique session based one as a placeholder and then once the project ID was set (crucially not necessarily when it was loaded) we would then reload VS Code with one based on the project ID.

Along with this two longstanding issues have now been fixed:
- Forever loading VS Code, this was due to a race condition between the message listeners ready message and the init project message. If the init project message was fired before the handler was created to wait for it then it would just get missed and then VS Code would never "finish" loading as a result.
- Empty VS Code, this was due to the `SET_PROJECT_ID` action firing before the `LOAD` action which ends up sending an empty project contents to VS Code. With the logic around changes to VS Code's content not being aware that nothing has been sent.

**Commit Details:**
- `VSCodeIframeContainer` now has a property `vsCodeSessionID` and assigns that to a query parameter `vs_code_session_id`.
- Removed `EditorState.vscodeBridgeId` and it's associated type.
- Simplified `SET_PROJECT_ID` action.
- `getUnderlyingVSCodeBridgeID` now returns a value which is assigned to a unique value on startup.
- `initVSCodeBridge` now only permits a single instance of the message listeners ready message to be handled.
- `setupVSCodeEventListenersForProject` repeatedly fires the message listeners ready message until it gets an init project message in return.
- `build-vscode` now clears the `./dist` and `./node_modules` folders.