### PR TITLE
use `beforeEach` in `optOutFromCheckFileTimestamps`

### DIFF
--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -284,7 +284,9 @@ export async function renderTestEditorWithProjectContent(
 
 const optedInToCheckFileTimestamps = { current: true }
 export function optOutFromCheckFileTimestamps() {
-  optedInToCheckFileTimestamps.current = false
+  beforeEach(() => {
+    optedInToCheckFileTimestamps.current = false
+  })
   afterEach(() => {
     optedInToCheckFileTimestamps.current = true
   })


### PR DESCRIPTION
## Problem
`optOutFromCheckFileTimestamps` set `optedInToCheckFileTimestamps.current` without using beforeEach, which led to tests failing due to multiple describes setting this flag

## Fix
Wrap the first assignment in `optOutFromCheckFileTimestamps` into a `beforeEach`