### PR TITLE
Support the jsx file extension

### DIFF
--- a/editor/src/core/es-modules/evaluator/evaluator.ts
+++ b/editor/src/core/es-modules/evaluator/evaluator.ts
@@ -111,6 +111,7 @@ export function evaluator(
   const fileExtension = getFileExtension(filepath)
   switch (fileExtension) {
     case 'js':
+    case 'jsx':
     case 'cjs':
     case 'mjs':
       return evaluateJs(filepath, moduleCode, fileEvaluationCache, requireFn)


### PR DESCRIPTION
**Problem:**
Due to a rather silly oversight on our behalf we weren't actually supporting the `.jsx` file extension, but only in a very specific edge case (when the file is imported, but there are no parseable components within the file, meaning we just eval the raw JS)

**Fix:**
Include `.jsx` in the valid file extensions used in `evaluator.ts`