### PR TITLE
Permit basic resizing when element has no explicit dimensions

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.spec.browser2.tsx
@@ -164,36 +164,36 @@ describe('Basic Resize', () => {
 describe('when the element has missing dimensions', () => {
   describe('both missing', () => {
     describe('horizontal movement', () => {
-      it('does nothing', async () => {
+      it('adds the width', async () => {
         await resizeWithoutDimensions(
           edgePosition(1, 0),
           canvasPoint({ x: 15, y: 0 }),
           {},
-          {},
+          { width: 415 },
           false,
         )
       })
     })
 
     describe('vertical movement', () => {
-      it('does nothing', async () => {
+      it('adds the height', async () => {
         await resizeWithoutDimensions(
           edgePosition(0, 0),
           canvasPoint({ x: 0, y: 15 }),
           {},
-          {},
+          { height: 15 },
           false,
         )
       })
     })
 
     describe('diagonal movement', () => {
-      it('does nothing', async () => {
+      it('adds both dimensions', async () => {
         await resizeWithoutDimensions(
           edgePosition(0, 0),
           canvasPoint({ x: 10, y: 15 }),
           {},
-          {},
+          { width: 390, height: 15 },
           false,
         )
       })
@@ -202,12 +202,12 @@ describe('when the element has missing dimensions', () => {
 
   describe('width missing', () => {
     describe('horizontal movement', () => {
-      it('does nothing', async () => {
+      it('adds the width', async () => {
         await resizeWithoutDimensions(
           edgePosition(1, 0),
           canvasPoint({ x: 15, y: 0 }),
           {},
-          {},
+          { width: 415 },
           false,
         )
       })
@@ -225,12 +225,12 @@ describe('when the element has missing dimensions', () => {
     })
 
     describe('diagonal movement', () => {
-      it('updates the height, does not add the width', async () => {
+      it('updates the height, and adds the width', async () => {
         await resizeWithoutDimensions(
           edgePosition(0, 0),
           canvasPoint({ x: 10, y: 15 }),
           { height: 20 },
-          { height: 5 },
+          { height: 5, width: 390 },
         )
       })
     })
@@ -249,24 +249,24 @@ describe('when the element has missing dimensions', () => {
     })
 
     describe('vertical movement', () => {
-      it('does nothing', async () => {
+      it('adds the height', async () => {
         await resizeWithoutDimensions(
           edgePosition(0, 0),
           canvasPoint({ x: 0, y: 15 }),
           { width: 15 },
-          { width: 15 },
+          { width: 15, height: 15 },
           false,
         )
       })
     })
 
     describe('diagonal movement', () => {
-      it('does not add the height and updates width', async () => {
+      it('adds the height and updates width', async () => {
         await resizeWithoutDimensions(
           edgePosition(0, 0),
           canvasPoint({ x: 10, y: 15 }),
           { width: 15 },
-          { width: 5 },
+          { width: 5, height: 15 },
         )
       })
     })

--- a/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
@@ -81,13 +81,6 @@ export function basicResizeStrategy(
           height: elementDimensionsProps.height,
         }
 
-  const hasDimensions =
-    elementDimensions != null &&
-    (elementDimensions.width != null || elementDimensions.height != null)
-  const hasSizedParent =
-    elementParentBounds != null &&
-    (elementParentBounds.width !== 0 || elementParentBounds.height !== 0)
-
   return {
     id: BASIC_RESIZE_STRATEGY_ID,
     name: 'Resize (Basic)',
@@ -125,8 +118,7 @@ export function basicResizeStrategy(
     fitness:
       interactionSession != null &&
       interactionSession.interactionData.type === 'DRAG' &&
-      interactionSession.activeControl.type === 'RESIZE_HANDLE' &&
-      (hasDimensions || !hasSizedParent)
+      interactionSession.activeControl.type === 'RESIZE_HANDLE'
         ? 1
         : 0,
     apply: (_strategyLifecycle: InteractionLifecycle) => {
@@ -187,7 +179,7 @@ export function basicResizeStrategy(
             resized: number,
             parent: number | undefined,
           ): void {
-            if (elementDimension == null && (original === resized || hasSizedParent)) {
+            if (original === resized) {
               return
             }
             resizeProperties.push(


### PR DESCRIPTION
**Problem:**
We deliberately restricted the "Resize (Basic)" canvas strategy to only be applicable if the selected element already had an explicitly set value for the affected dimension. This was by choice, as enabling this causes potentially many issues when resizing elements that are sized based on the natural document flow (i.e. elements that aren't laid out by flex or explicitly). However, we've found that it is far too common (especially in the case of the sample Hydrogen store) for nested flow elements to exist in the wild, meaning those then cannot be resized via the canvas, which makes Utopia feel broken.

**Fix:**
Remove that restriction.

**Sample Project:**
Before: https://utopia.pizza/p/f0bd0fa9-diagnostic-badge/
With this change: https://utopia.pizza/p/f0bd0fa9-diagnostic-badge/?branch_name=fix-flow-resizing-no-dimensions