### PR TITLE
Fix/reconnect-to-room-after-login

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -32,7 +32,7 @@ import { MenuTab } from '../../uuiui/menu-tab'
 import { FlexRow } from 'utopia-api'
 import type { StoredPanel } from './stored-layout'
 import { MultiplayerPresence } from './multiplayer-presence'
-import { useStatus } from '../../../liveblocks.config'
+import { useRoom, useStatus } from '../../../liveblocks.config'
 import { MultiplayerWrapper } from '../../utils/multiplayer-wrapper'
 import { isFeatureEnabled } from '../../utils/feature-switches'
 import { CommentsPane } from '../inspector/comments-pane'
@@ -49,6 +49,20 @@ function isCodeEditorEnabled(): boolean {
 
 const DesignPanelRootInner = React.memo(() => {
   const roomStatus = useStatus()
+
+  const room = useRoom()
+  const loginStateType = useEditorState(
+    Substores.userState,
+    (store) => store.userState.loginState.type,
+    'DesignPanelRootInner loginStateType',
+  )
+
+  React.useEffect(() => {
+    if (loginStateType === 'LOGGED_IN' && roomStatus !== 'connected') {
+      room.reconnect()
+    }
+  }, [loginStateType, room, roomStatus])
+
   return (
     <>
       <SimpleFlexRow

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -58,7 +58,7 @@ const DesignPanelRootInner = React.memo(() => {
   )
 
   React.useEffect(() => {
-    if (loginStateType === 'LOGGED_IN' && roomStatus !== 'connected') {
+    if (loginStateType === 'LOGGED_IN' && roomStatus === 'disconnected') {
       room.reconnect()
     }
   }, [loginStateType, room, roomStatus])

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -70,6 +70,7 @@ import {
 import { isFeatureEnabled } from '../../utils/feature-switches'
 import { RightMenuTab, floatingInsertMenuStateSwap } from './store/editor-state'
 import { useIsViewer } from './store/project-server-state-hooks'
+import { useStatus } from '../../../liveblocks.config'
 
 export const InsertMenuButtonTestId = 'insert-menu-button'
 export const PlayModeButtonTestId = 'canvas-toolbar-play-mode'
@@ -416,6 +417,14 @@ export const CanvasToolbar = React.memo(() => {
     'TopMenu loggedIn',
   )
 
+  const roomStatus = useStatus()
+  const commentButtonDisabled = !loggedIn || roomStatus !== 'connected'
+  const commentButtonTooltip = !loggedIn
+    ? 'Sign in to comment'
+    : roomStatus !== 'connected'
+    ? 'Not connected to room'
+    : 'Comment Mode'
+
   const isViewer = useIsViewer()
 
   return (
@@ -489,7 +498,7 @@ export const CanvasToolbar = React.memo(() => {
         </Tooltip>
         {when(
           isFeatureEnabled('Commenting'),
-          <Tooltip title='Comment Mode' placement='bottom'>
+          <Tooltip title={commentButtonTooltip} placement='bottom'>
             <InsertModeButton
               testid={CommentModeButtonTestId}
               iconType={'comment'}
@@ -498,7 +507,7 @@ export const CanvasToolbar = React.memo(() => {
               onClick={toggleCommentMode}
               keepActiveInLiveMode
               style={{ width: 36 }}
-              disabled={!loggedIn}
+              disabled={commentButtonDisabled}
             />
           </Tooltip>,
         )}


### PR DESCRIPTION
## Problem
If a user logs in after creating a project, we don't reconnect to Liveblocks, making commenting impossible

## FIx
- Reconnect to liveblocks on login
- Improve canvas toolbar tooltips to indicate what's going on