### PR TITLE
Allow canvas focusing of components with children

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -685,9 +685,8 @@ function useSelectOrLiveModeSelectAndHover(
 
         if (foundTarget != null && foundTargetIsSelected && doubleClick) {
           // for components without passed children doubleclicking enters focus mode
-          const isFocusableLeaf = MetadataUtils.isManuallyFocusableLeafComponent(
+          const isFocusableLeaf = MetadataUtils.isManuallyFocusableComponent(
             foundTarget.elementPath,
-            editorStoreRef.current.editor.elementPathTree,
             editorStoreRef.current.editor.jsxMetadata,
             editorStoreRef.current.derived.autoFocusedPaths,
             editorStoreRef.current.derived.filePathMappings,

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -684,7 +684,6 @@ function useSelectOrLiveModeSelectAndHover(
         const foundTargetIsSelected = foundTarget?.isSelected ?? false
 
         if (foundTarget != null && foundTargetIsSelected && doubleClick) {
-          // for components without passed children doubleclicking enters focus mode
           const isFocusableLeaf = MetadataUtils.isManuallyFocusableComponent(
             foundTarget.elementPath,
             editorStoreRef.current.editor.jsxMetadata,

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -684,13 +684,13 @@ function useSelectOrLiveModeSelectAndHover(
         const foundTargetIsSelected = foundTarget?.isSelected ?? false
 
         if (foundTarget != null && foundTargetIsSelected && doubleClick) {
-          const isFocusableLeaf = MetadataUtils.isManuallyFocusableComponent(
+          const isFocusableComponent = MetadataUtils.isManuallyFocusableComponent(
             foundTarget.elementPath,
             editorStoreRef.current.editor.jsxMetadata,
             editorStoreRef.current.derived.autoFocusedPaths,
             editorStoreRef.current.derived.filePathMappings,
           )
-          if (isFocusableLeaf) {
+          if (isFocusableComponent) {
             editorActions.push(CanvasActions.clearInteractionSession(false))
             editorActions.push(setFocusedElement(foundTarget.elementPath))
           }

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1937,18 +1937,6 @@ export const MetadataUtils = {
       return false
     }
   },
-  isManuallyFocusableLeafComponent(
-    path: ElementPath,
-    pathTree: ElementPathTrees,
-    metadata: ElementInstanceMetadataMap,
-    autoFocusedPaths: Array<ElementPath>,
-    filePathMappings: FilePathMappings,
-  ): boolean {
-    return (
-      MetadataUtils.getChildrenPathsOrdered(metadata, pathTree, path).length === 0 &&
-      MetadataUtils.isManuallyFocusableComponent(path, metadata, autoFocusedPaths, filePathMappings)
-    )
-  },
   isEmotionOrStyledComponent(path: ElementPath, metadata: ElementInstanceMetadataMap): boolean {
     const element = MetadataUtils.findElementByElementPath(metadata, path)
     return element?.isEmotionOrStyledComponent ?? false


### PR DESCRIPTION
**Problem:**
When we introduced the canvas feature for focusing a component via double clicking back in https://github.com/concrete-utopia/utopia/pull/1092, we explicitly prevented focusing of components that had at least one child passed in. This appears to have been based on an incorrect assumption (that it would interfere with canvas interactions with the component's children), and has instead resulted in a lot of elements that just can't be selected via the canvas with any amount of clicking, when they clearly should be.

**Fix:**
Remove the restriction

**Sample project:**
Before: https://utopia.pizza/p/f76d24c0-learned-plutonium/
After: https://utopia.pizza/p/f76d24c0-learned-plutonium/?branch_name=fix-canvas-focusing-components-with-children