### PR TITLE
Continuous new comments, escape handling

### DIFF
--- a/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
@@ -72,7 +72,7 @@ export function useCommentModeSelectAndHover(comment: CommentId | null): MouseCa
 
   const onMouseUp = React.useCallback(
     (event: React.MouseEvent) => {
-      if (comment == null || isExistingComment(comment)) {
+      if (comment == null) {
         const loc = windowToCanvasCoordinates(
           storeRef.current.scale,
           storeRef.current.canvasOffset,
@@ -109,6 +109,8 @@ export function useCommentModeSelectAndHover(comment: CommentId | null): MouseCa
             ),
           ),
         ])
+      } else {
+        dispatch([switchEditorMode(EditorModes.commentMode(null, 'not-dragging'))])
       }
     },
     [dispatch, comment, storeRef, scenes],

--- a/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
@@ -12,7 +12,6 @@ import type { CommentId } from '../../../editor/editor-modes'
 import {
   EditorModes,
   canvasCommentLocation,
-  isExistingComment,
   newComment,
   sceneCommentLocation,
 } from '../../../editor/editor-modes'

--- a/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
@@ -12,6 +12,7 @@ import type { CommentId } from '../../../editor/editor-modes'
 import {
   EditorModes,
   canvasCommentLocation,
+  isExistingComment,
   newComment,
   sceneCommentLocation,
 } from '../../../editor/editor-modes'
@@ -71,7 +72,7 @@ export function useCommentModeSelectAndHover(comment: CommentId | null): MouseCa
 
   const onMouseUp = React.useCallback(
     (event: React.MouseEvent) => {
-      if (comment == null) {
+      if (comment == null || isExistingComment(comment)) {
         const loc = windowToCanvasCoordinates(
           storeRef.current.scale,
           storeRef.current.canvasOffset,
@@ -108,8 +109,6 @@ export function useCommentModeSelectAndHover(comment: CommentId | null): MouseCa
             ),
           ),
         ])
-      } else {
-        dispatch([switchEditorMode(EditorModes.selectMode(null, false, 'none'))])
       }
     },
     [dispatch, comment, storeRef, scenes],

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -46,6 +46,7 @@ import { RemixNavigationAtom } from '../remix/utopia-remix-root-component'
 import { getIdOfScene } from './comment-mode/comment-mode-hooks'
 import { motion, useAnimation } from 'framer-motion'
 import { CSSCursor } from '../canvas-types'
+import type { EditorDispatch } from '../../editor/action-types'
 
 export const ComposerEditorClassName = 'lb-composer-editor'
 
@@ -65,6 +66,12 @@ const ComposerStyle: CSSProperties = {
   wordWrap: 'break-word',
   whiteSpace: 'normal',
   zIndex: 10,
+}
+
+function switchToBasicCommentModeOnEscape(e: React.KeyboardEvent, dispatch: EditorDispatch) {
+  if (e.key === 'Escape') {
+    dispatch([switchEditorMode(EditorModes.commentMode(null, 'not-dragging'))])
+  }
 }
 
 export const CommentPopup = React.memo(() => {
@@ -294,11 +301,7 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
   }, [threadId, scrollToBottom])
 
   const onExistingCommentComposerKeyDown = React.useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        dispatch([switchEditorMode(EditorModes.commentMode(null, 'not-dragging'))])
-      }
-    },
+    (e: React.KeyboardEvent) => switchToBasicCommentModeOnEscape(e, dispatch),
     [dispatch],
   )
   if (location == null) {
@@ -434,11 +437,7 @@ const NewCommentPopup = React.memo((props: NewCommentPopupProps) => {
   )
 
   const onNewCommentComposerKeyDown = React.useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        dispatch([switchEditorMode(EditorModes.commentMode(null, 'not-dragging'))])
-      }
-    },
+    (e: React.KeyboardEvent) => switchToBasicCommentModeOnEscape(e, dispatch),
     [dispatch],
   )
 

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -29,7 +29,12 @@ import * as EditorActions from '../components/editor/actions/action-creators'
 import type { HandleInteractionSession } from '../components/editor/actions/meta-actions'
 import { cancelInsertModeActions } from '../components/editor/actions/meta-actions'
 import type { Mode } from '../components/editor/editor-modes'
-import { EditorModes, isFollowMode, isLiveMode } from '../components/editor/editor-modes'
+import {
+  EditorModes,
+  isCommentMode,
+  isFollowMode,
+  isLiveMode,
+} from '../components/editor/editor-modes'
 import { saveAssets } from '../components/editor/server'
 import type {
   CanvasCursor,
@@ -151,7 +156,7 @@ function getDefaultCursorForMode(mode: Mode): CSSCursor {
     case 'textEdit':
       return CSSCursor.Select
     case 'comment':
-      if (mode.comment == null && mode.isDragging === 'not-dragging') {
+      if (isCommentMode(mode)) {
         return CSSCursor.Comment
       }
       return CSSCursor.Select


### PR DESCRIPTION
Fix #4656

This PR addresses some of the current issues with the comment popups and mode management.


https://github.com/concrete-utopia/utopia/assets/1081051/651fb2cd-bf34-4d86-8924-2145776767ae



What it does:

1. When in comment mode and a thread is open, clicking on the canvas closes the popup but keeps the mode as comment (instead of switching back to select mode)
2. If the open comment is a new comment and it's empty, clicking away will make the comment shake to indicate there are pending changes
3. When pressing `Escape` in comment mode and a comment is open and focused, it will close the comment (and another `Escape` will switch back to select mode, as you would expect)
4. Added a close button (`X`) to the thread tabs