### PR TITLE
Projects link in settings

### DIFF
--- a/editor/src/components/navigator/left-pane/settings-pane.tsx
+++ b/editor/src/components/navigator/left-pane/settings-pane.tsx
@@ -254,7 +254,6 @@ export const SettingsPane = React.memo(() => {
               highlight
               spotlight
               outline={false}
-              onClick={onForkProjectClicked}
               style={{
                 width: '100%',
                 cursor: 'pointer',

--- a/editor/src/components/navigator/left-pane/settings-pane.tsx
+++ b/editor/src/components/navigator/left-pane/settings-pane.tsx
@@ -11,6 +11,7 @@ import {
   FlexRow,
   H2,
   HeadlessStringInput,
+  Icons,
   PopupList,
   Section,
   SectionBodyArea,
@@ -247,6 +248,26 @@ export const SettingsPane = React.memo(() => {
     >
       <Section>
         {isMyProject === 'yes' ? null : <ForksGiven />}
+        <UIGridRow padded variant='<-------------1fr------------->' style={{ marginBottom: 8 }}>
+          <a href='/projects' target='_blank' rel='noopener rofererrer'>
+            <Button
+              highlight
+              spotlight
+              outline={false}
+              onClick={onForkProjectClicked}
+              style={{
+                width: '100%',
+                cursor: 'pointer',
+                height: UtopiaTheme.layout.inputHeight.default,
+                background: colorTheme.dynamicBlue.value,
+                color: colorTheme.bg1.value,
+                gap: 4,
+              }}
+            >
+              <Icons.ExternalLinkSmaller color='black' /> All projects
+            </Button>
+          </a>
+        </UIGridRow>
         <UIGridRow padded variant='<---1fr--->|------172px-------|'>
           <span style={{ color: colorTheme.fg2.value }}>Name</span>
           {userState.loginState.type !== 'LOGGED_IN' ? (

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -64,18 +64,16 @@ export const SinglePlayerUserBar = React.memo(() => {
     'SinglePlayerUserBar amIOwner',
   )
   return (
-    <a href='/projects' target='_blank' rel='noopener rofererrer'>
-      <div
-        style={{
-          width: 24,
-          height: 24,
-          position: 'relative',
-        }}
-      >
-        <Avatar userPicture={userPicture} isLoggedIn={true} />
-        {amIOwner ? <OwnerBadge /> : null}
-      </div>
-    </a>
+    <div
+      style={{
+        width: 24,
+        height: 24,
+        position: 'relative',
+      }}
+    >
+      <Avatar userPicture={userPicture} isLoggedIn={true} />
+      {amIOwner ? <OwnerBadge /> : null}
+    </div>
   )
 })
 SinglePlayerUserBar.displayName = 'SinglePlayerUserBar'
@@ -219,14 +217,12 @@ const MultiplayerUserBar = React.memo(() => {
           )
         }),
       )}
-      <a href='/projects' target='_blank' rel='noopener rofererrer'>
-        <MultiplayerAvatar
-          name={multiplayerInitialsFromName(myUser.name)}
-          color={multiplayerColorFromIndex(myUser.colorIndex)}
-          picture={myUser.avatar}
-          isOwner={amIOwner}
-        />
-      </a>
+      <MultiplayerAvatar
+        name={multiplayerInitialsFromName(myUser.name)}
+        color={multiplayerColorFromIndex(myUser.colorIndex)}
+        picture={myUser.avatar}
+        isOwner={amIOwner}
+      />
     </div>
   )
 })

--- a/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
@@ -168,11 +168,11 @@ describe('Parsing and printing code with comments', () => {
             }
             someProp2={{
               /* Comment before object key */ someKey /* Comment after object key */:
-                /* Comment before object value */ 'someValue' /* Comment after object value */ /* Comment after object separator */,
+                /* Comment before object value */ 'someValue' /* Comment after object separator */ /* Comment after object value */,
               someKey2: 'someValue2',
             }}
             someProp3={[
-              /* Comment before array value */ 100 /* Comment after array value */ /* Comment after array separator */,
+              /* Comment before array value */ 100 /* Comment after array separator */ /* Comment after array value */,
               200,
             ]} /* Comment after all attributes */
           >

--- a/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
@@ -168,11 +168,11 @@ describe('Parsing and printing code with comments', () => {
             }
             someProp2={{
               /* Comment before object key */ someKey /* Comment after object key */:
-                /* Comment before object value */ 'someValue' /* Comment after object separator */ /* Comment after object value */,
+                /* Comment before object value */ 'someValue' /* Comment after object value */ /* Comment after object separator */,
               someKey2: 'someValue2',
             }}
             someProp3={[
-              /* Comment before array value */ 100 /* Comment after array separator */ /* Comment after array value */,
+              /* Comment before array value */ 100 /* Comment after array value */ /* Comment after array separator */,
               200,
             ]} /* Comment after all attributes */
           >


### PR DESCRIPTION
Fix #4662 

**Problem:**

The user bar avatar for the self one is a link to `/projects`, which is inconsistent.

**Fix:**

- Remove the link from the user bar
- Add a new link in the Settings tab

<img width="286" alt="Screenshot 2023-12-15 at 1 40 09 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/c066bfe5-4c37-4278-a5f4-e4a164c5a5a5">
