### PR TITLE
Don't count deleted comments in reply count

### DIFF
--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -183,7 +183,7 @@ const ThreadPreview = React.memo(({ thread }: ThreadPreviewProps) => {
     return null
   }
 
-  const repliesCount = thread.comments.length - 1
+  const repliesCount = thread.comments.filter((c) => c.deletedAt == null).length - 1
 
   const remixLocationRouteLabel = getRemixLocationLabel(remixLocationRoute)
 


### PR DESCRIPTION
#4670 

**Problem:**
The replies count considers all comments in a thread, but they also include soft-deleted comments.

**Fix:**

Filter out the deleted comments when calculating the replies count, which will also fix the fact that deleting a comment in a thread does not seem to update the replies count in the sidebar.