### PR TITLE
Close thread preview on resolve

### DIFF
--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -273,7 +273,8 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
       return
     }
     resolveThread(thread)
-  }, [thread, resolveThread])
+    dispatch([switchEditorMode(EditorModes.commentMode(null, 'not-dragging'))])
+  }, [thread, resolveThread, dispatch])
 
   const onClickClose = React.useCallback(() => {
     dispatch([switchEditorMode(EditorModes.commentMode(null, 'not-dragging'))])


### PR DESCRIPTION
## Problem
We show the thread preview even after the corresponding thread has been resolved

## Fix
Close the thread preview when the thread has been resolved