### PR TITLE
Show resolved comment indicators

### DIFF
--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -165,7 +165,6 @@ const CommentIndicatorsInner = React.memo(() => {
       {temporaryIndicatorData != null ? (
         <CommentIndicatorUI
           position={temporaryIndicatorData.position}
-          opacity={1}
           resolved={false}
           bgColor={temporaryIndicatorData.bgColor}
           fgColor={temporaryIndicatorData.fgColor}
@@ -181,7 +180,6 @@ CommentIndicatorsInner.displayName = 'CommentIndicatorInner'
 
 interface CommentIndicatorUIProps {
   position: WindowPoint
-  opacity: number
   resolved: boolean
   bgColor: string
   fgColor: string
@@ -192,24 +190,13 @@ interface CommentIndicatorUIProps {
 }
 
 export const CommentIndicatorUI = React.memo<CommentIndicatorUIProps>((props) => {
-  const {
-    position,
-    bgColor,
-    fgColor,
-    avatarUrl,
-    avatarInitials,
-    opacity,
-    resolved,
-    isActive,
-    read,
-  } = props
+  const { position, bgColor, fgColor, avatarUrl, avatarInitials, resolved, isActive, read } = props
 
   function getIndicatorStyle() {
     const base: Interpolation<Theme> = {
       position: 'fixed',
       top: position.y + 3,
       left: position.x - 3,
-      opacity: opacity,
       filter: resolved ? 'grayscale(1)' : undefined,
       width: IndicatorSize,
       height: IndicatorSize,
@@ -339,7 +326,6 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
         (isActive || !hovered) && !dragging,
         <CommentIndicatorUI
           position={position}
-          opacity={isOnAnotherRoute || thread.metadata.resolved ? 0 : 1}
           resolved={thread.metadata.resolved}
           bgColor={color.background}
           fgColor={color.foreground}

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -32,7 +32,7 @@ export function useCanvasCommentThreadAndLocation(comment: CommentId): {
   location: CanvasPoint | null
   thread: ThreadData<ThreadMetadata> | null
 } {
-  const { threads } = useThreads()
+  const threads = useActiveThreads()
 
   const thread = React.useMemo(() => {
     switch (comment.type) {

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -32,7 +32,7 @@ export function useCanvasCommentThreadAndLocation(comment: CommentId): {
   location: CanvasPoint | null
   thread: ThreadData<ThreadMetadata> | null
 } {
-  const threads = useActiveThreads()
+  const { threads } = useThreads()
 
   const thread = React.useMemo(() => {
     switch (comment.type) {
@@ -233,37 +233,32 @@ export function useResolveThread() {
 }
 
 export function useActiveThreads() {
-  const { threads: unresolvedThreads } = useUnresolvedThreads()
-  const { threads: resolvedThreads } = useResolvedThreads()
+  const { threads } = useThreads()
   const showResolved = useEditorState(
     Substores.restOfEditor,
     (store) => store.editor.showResolvedThreads,
     'useActiveThreads showResolved',
   )
   if (!showResolved) {
-    return unresolvedThreads
+    return threads.filter((t) => !t.metadata.resolved)
   }
-  return [...unresolvedThreads, ...resolvedThreads]
+  return threads
 }
 
 export function useResolvedThreads() {
-  return useThreads({
-    query: {
-      metadata: {
-        resolved: true,
-      },
-    },
-  })
+  const threads = useThreads()
+  return {
+    ...threads,
+    threads: threads.threads.filter((t) => t.metadata.resolved),
+  }
 }
 
 export function useUnresolvedThreads() {
-  return useThreads({
-    query: {
-      metadata: {
-        resolved: false,
-      },
-    },
-  })
+  const threads = useThreads()
+  return {
+    ...threads,
+    threads: threads.threads.filter((t) => !t.metadata.resolved),
+  }
 }
 
 export function useSetThreadReadStatusOnMount(thread: ThreadData<ThreadMetadata> | null) {


### PR DESCRIPTION
## Problem
We don't show comment indicators for resolved threads even if the `Show resolved thread` is clicked in the comment sidebar

## Fix
Remove the check for resolved status in `CommentIndicatorUI`