### PR TITLE
Fix more menu on first comment

### DIFF
--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -566,6 +566,11 @@ const HeaderComment = React.memo(
   ({ comment, enabled }: { comment: CommentData; enabled: boolean }) => {
     const collabs = useStorage((storage) => storage.collaborators)
     const user = getCollaboratorById(collabs, comment.userId)
+
+    if (!enabled) {
+      return null
+    }
+
     return (
       <div
         style={{
@@ -576,7 +581,6 @@ const HeaderComment = React.memo(
           backgroundColor: 'white',
           zIndex: 1,
           boxShadow: UtopiaStyles.shadowStyles.highest.boxShadow,
-          opacity: enabled ? 1 : 0,
           transition: 'all 100ms linear',
           minHeight: 67,
           transform: 'scale(1.01)',


### PR DESCRIPTION
**Problem:**
Buttons to edit or emoji react to the first comment in a thread do not show on hover.

**Fix:**
The HeaderComment component should only be rendered when we are scrolled away from the first comment.