### PR TITLE
Get Remix to work with local webpack.

### DIFF
--- a/editor/webpack.config.js
+++ b/editor/webpack.config.js
@@ -166,7 +166,7 @@ const config = {
       'process.env.JEST_WORKER_ID': 'undefined',
       'process.env.HOT_MODE': hot,
       'process.env.HMR': false,
-      'process.env.REMIX_DEV_ORIGIN': "'http://localhost:8000'",
+      'process.env.REMIX_DEV_ORIGIN': isDev ? "'http://localhost:8000'" : 'undefined',
     }),
 
     // setting up the various process.env.VARIABLE replacements

--- a/editor/webpack.config.js
+++ b/editor/webpack.config.js
@@ -166,6 +166,7 @@ const config = {
       'process.env.JEST_WORKER_ID': 'undefined',
       'process.env.HOT_MODE': hot,
       'process.env.HMR': false,
+      'process.env.REMIX_DEV_ORIGIN': "'http://localhost:8000'",
     }),
 
     // setting up the various process.env.VARIABLE replacements


### PR DESCRIPTION
**Problem:**
When loading any project using Remix in the editor with local webpack building the editor, you get a big error about `env` not being defined on `undefined`.

**Cause:**
In a function `remixLiveReloadConnect` there's some logic that checks `process.env.REMIX_DEV_ORIGIN` which webpack turns into `undefined.env.REMIX_DEV_ORIGIN` which fails for fairly obvious reasons.

**Fix:**
This provides a value for the specific case of `process.env.REMIX_DEV_ORIGIN`.

**Commit Details:**
- Assigns a value to `process.env.REMIX_DEV_ORIGIN`.
