### PR TITLE
Fix comment thread with first comment deleted

### DIFF
--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -22,6 +22,7 @@ import {
   windowPoint,
 } from '../../../core/shared/math-utils'
 import {
+  getFirstComment,
   multiplayerColorFromIndex,
   multiplayerInitialsFromName,
   normalizeMultiplayerName,
@@ -427,7 +428,7 @@ const HoveredCommentIndicator = React.memo((props: HoveredCommentIndicatorProps)
     return null
   }
 
-  const comment = thread.comments[0]
+  const comment = getFirstComment(thread)
   if (comment == null) {
     return null
   }

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -36,7 +36,7 @@ import {
 } from '../../../core/commenting/comment-hooks'
 import { Substores, useEditorState, useSelectorWithCallback } from '../../editor/store/store-hook'
 import { when } from '../../../utils/react-conditionals'
-import { openCommentThreadActions } from '../../../core/shared/multiplayer'
+import { getFirstComment, openCommentThreadActions } from '../../../core/shared/multiplayer'
 import { getRemixLocationLabel } from '../../canvas/remix/remix-utils'
 import type { RestOfEditorState } from '../../editor/store/store-hook-substore-types'
 import { getCurrentTheme } from '../../editor/store/editor-state'
@@ -215,7 +215,8 @@ const ThreadPreview = React.memo(({ thread }: ThreadPreviewProps) => {
     'ThreadPreview theme',
   )
 
-  const comment = thread.comments[0]
+  const comment = getFirstComment(thread)
+
   if (comment == null) {
     return null
   }

--- a/editor/src/core/shared/multiplayer.ts
+++ b/editor/src/core/shared/multiplayer.ts
@@ -1,5 +1,5 @@
-import type { User } from '@liveblocks/client'
-import type { Presence, UserMeta } from '../../../liveblocks.config'
+import type { CommentData, ThreadData, User } from '@liveblocks/client'
+import type { Presence, ThreadMetadata, UserMeta } from '../../../liveblocks.config'
 import { possiblyUniqueInArray, safeIndex, stripNulls, uniqBy } from './array-utils'
 import { colorTheme, getPreferredColorScheme } from '../../uuiui'
 import type { ElementPath } from './project-file-types'
@@ -160,4 +160,8 @@ export function openCommentThreadActions(threadId: string, scene: ElementPath | 
     switchEditorMode(EditorModes.commentMode(existingComment(threadId), 'not-dragging')),
     scene != null ? setHighlightedView(scene) : null,
   ])
+}
+
+export function getFirstComment(thread: ThreadData<ThreadMetadata>): CommentData | null {
+  return thread.comments.filter((c) => c.deletedAt == null)[0] ?? null
 }


### PR DESCRIPTION
**Problem:**
When the first comment of a thread is deleted, the comment text in the right sidebar and in the hovered comment marker is empty.

**Fix:**
The problem is that the deleted comment still exists in `thread.comments`, it just receives a `deletedAt` flag.
This means we can not find the first non-deleted comment in `comments[0]`.
I implemented a helper called `getFirstComment` instead of just using `comments[0]`.