### PR TITLE
Comment Sorting and Filtering

### DIFF
--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -6,6 +6,7 @@ import '../../../../resources/editor/css/liveblocks/react-comments/dark/attribut
 import React from 'react'
 import {
   Button,
+  CheckboxInput,
   FlexColumn,
   FlexRow,
   Icn,
@@ -33,6 +34,7 @@ import {
   useCanvasLocationOfThread,
   getCollaboratorById,
   useMyThreadReadStatus,
+  useReadThreads,
 } from '../../../core/commenting/comment-hooks'
 import { Substores, useEditorState, useSelectorWithCallback } from '../../editor/store/store-hook'
 import { when } from '../../../utils/react-conditionals'
@@ -95,19 +97,66 @@ const ThreadPreviews = React.memo(() => {
     ])
   }, [showResolved, dispatch])
 
+  const showRead = useEditorState(
+    Substores.restOfEditor,
+    (store) => store.editor.showResolvedThreads,
+    'ThreadPreviews showResolvedThreads',
+  )
+
+  const toggleShowRead = React.useCallback(() => {
+    dispatch([
+      setShowResolvedThreads(!showResolved),
+      switchEditorMode(EditorModes.selectMode(null, false, 'none')),
+    ])
+  }, [showResolved, dispatch])
+
   return (
     <FlexColumn style={{ gap: 5 }}>
-      {when(
-        resolvedThreads.length > 0,
-        <Button
-          highlight
-          spotlight
-          style={{ padding: 10, margin: '10px' }}
-          onClick={toggleShowResolved}
-        >
-          {showResolved ? 'Hide' : 'Show'} resolved threads
-        </Button>,
-      )}
+      <FlexColumn style={{ margin: '0 8px 8px 8px', gap: 6 }}>
+        <FlexRow>
+          <CheckboxInput
+            style={{ marginRight: 8 }}
+            id='showResolved'
+            checked={showResolved}
+            onChange={toggleShowResolved}
+          />
+          <label htmlFor='showResolved'>Sort By Date</label>
+        </FlexRow>
+        <FlexRow>
+          <CheckboxInput
+            style={{ marginRight: 8 }}
+            id='showResolved'
+            checked={showResolved}
+            onChange={toggleShowResolved}
+          />
+          <label htmlFor='showResolved'>Sort By Unread</label>
+        </FlexRow>
+        <div style={{ flexGrow: 1, background: colorTheme.bg2.value, height: 1 }} />
+        {when(
+          resolvedThreads.length > 0,
+          <FlexRow>
+            <CheckboxInput
+              style={{ marginRight: 8 }}
+              id='showResolved'
+              checked={showResolved}
+              onChange={toggleShowResolved}
+            />
+            <label htmlFor='showResolved'>Show Resolved Comments</label>
+          </FlexRow>,
+        )}
+        {when(
+          readThreads.length > 0,
+          <FlexRow>
+            <CheckboxInput
+              style={{ marginRight: 8 }}
+              id='showRead'
+              checked={showRead}
+              onChange={toggleShowRead}
+            />
+            <label htmlFor='showResolved'>Show Read Comments</label>
+          </FlexRow>,
+        )}
+      </FlexColumn>
       {when(
         activeThreads.length === 0,
         <div style={{ padding: '0px 8px', color: colorTheme.fg6.value }}>

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -14,7 +14,7 @@ import {
   useColorTheme,
 } from '../../../uuiui'
 import { stopPropagation } from '../common/inspector-utils'
-import { useStorage, type ThreadMetadata } from '../../../../liveblocks.config'
+import { useStorage, type ThreadMetadata, useThreads } from '../../../../liveblocks.config'
 import type { ThreadData } from '@liveblocks/client'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { canvasRectangle, rectangleContainsRectangle } from '../../../core/shared/math-utils'
@@ -73,6 +73,15 @@ const ThreadPreviews = React.memo(() => {
   const { threads: activeThreads } = useUnresolvedThreads()
   const { threads: resolvedThreads } = useResolvedThreads()
 
+  const { threads: readThreads } = useReadThreads()
+
+  const allThreadsResolvedLast = [...activeThreads, ...resolvedThreads]
+  const { threads: allThreads } = useThreads()
+
+  const unreadThreads = allThreadsResolvedLast.filter((thread) => !readThreads.includes(thread))
+
+  const threads = allThreads
+
   const showResolved = useEditorState(
     Substores.restOfEditor,
     (store) => store.editor.showResolvedThreads,
@@ -88,15 +97,6 @@ const ThreadPreviews = React.memo(() => {
 
   return (
     <FlexColumn style={{ gap: 5 }}>
-      {activeThreads.map((thread) => (
-        <ThreadPreview key={thread.id} thread={thread} />
-      ))}
-      {when(
-        activeThreads.length === 0,
-        <div style={{ padding: '0px 8px', color: colorTheme.fg6.value }}>
-          No active comment threads.
-        </div>,
-      )}
       {when(
         resolvedThreads.length > 0,
         <Button
@@ -108,6 +108,15 @@ const ThreadPreviews = React.memo(() => {
           {showResolved ? 'Hide' : 'Show'} resolved threads
         </Button>,
       )}
+      {when(
+        activeThreads.length === 0,
+        <div style={{ padding: '0px 8px', color: colorTheme.fg6.value }}>
+          No active comment threads.
+        </div>,
+      )}
+      {activeThreads.map((thread) => (
+        <ThreadPreview key={thread.id} thread={thread} />
+      ))}
       {when(
         showResolved,
         resolvedThreads.map((thread) => <ThreadPreview key={thread.id} thread={thread} />),

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -106,13 +106,22 @@ const ThreadPreviews = React.memo(() => {
   }, [showResolved, dispatch])
 
   const [sortedByDateNewestFirst, setSortByDateNewestFirst] = React.useState(true)
+  const [sortedByUnreadFirst, setSortedByUnreadFirst] = React.useState(false)
+
   const toggleSortByDateNewestFirst = React.useCallback(() => {
     setSortByDateNewestFirst((prevValue) => !prevValue)
+  }, [])
+  const toggleSortByUnreadFirst = React.useCallback(() => {
+    setSortedByUnreadFirst((prevValue) => !prevValue)
   }, [])
 
   const sortedActiveThreads = sortedByDateNewestFirst
     ? activeThreads
     : activeThreads.slice().reverse()
+
+  const sortedThreads = sortedByUnreadFirst
+    ? [...unreadThreads, ...sortedActiveThreads.filter((thread) => !unreadThreads.includes(thread))]
+    : sortedActiveThreads
 
   return (
     <FlexColumn style={{ gap: 5 }}>
@@ -179,20 +188,20 @@ const ThreadPreviews = React.memo(() => {
           <FlexRow>
             <CheckboxInput
               style={{ marginRight: 8 }}
-              id='showResolved'
+              id='showNewestFirst'
               checked={sortedByDateNewestFirst}
               onChange={toggleSortByDateNewestFirst}
             />
-            <label htmlFor='showResolved'>Newest First</label>
+            <label htmlFor='showNewestFirst'>Newest First</label>
           </FlexRow>
           <FlexRow>
             <CheckboxInput
               style={{ marginRight: 8 }}
-              id='showResolved'
-              checked={showResolved}
-              onChange={toggleShowResolved}
+              id='showUnreadFirst'
+              checked={sortedByUnreadFirst}
+              onChange={toggleSortByUnreadFirst}
             />
-            <label htmlFor='showResolved'>Unread First</label>
+            <label htmlFor='showUnreadFirst'>Unread First</label>
           </FlexRow>
           {when(
             resolvedThreads.length > 0 || readThreads.length > 0,
@@ -210,25 +219,13 @@ const ThreadPreviews = React.memo(() => {
               <label htmlFor='showResolved'>Show Resolved Comments</label>
             </FlexRow>,
           )}
-          {when(
-            readThreads.length > 0,
-            <FlexRow>
-              <CheckboxInput
-                style={{ marginRight: 8 }}
-                id='showRead'
-                checked={showRead}
-                onChange={toggleShowRead}
-              />
-              <label htmlFor='showResolved'>Show Read Comments</label>
-            </FlexRow>,
-          )}
         </FlexColumn>,
       )}
       {when(
         activeThreads.length === 0,
         <div style={{ padding: 8, color: colorTheme.fg6.value }}>No active comment threads.</div>,
       )}
-      {sortedActiveThreads.map((thread) => (
+      {sortedThreads.map((thread) => (
         <ThreadPreview key={thread.id} thread={thread} />
       ))}
       {when(

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -131,45 +131,47 @@ const ThreadPreviews = React.memo(() => {
         }}
       >
         <span>Comments</span>
-        <div
-          css={{
-            width: 20,
-            height: 20,
-            borderRadius: 3,
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            '&:hover': {
-              backgroundColor: colorTheme.bg3.value,
-            },
-          }}
-        >
+        <Tooltip title='Sort/Filter' placement='bottom'>
           <div
             css={{
-              height: 14,
-              width: 14,
-              borderRadius: 14,
-              border: `1px solid ${colorTheme.fg1.value}`,
-              cursor: 'pointer',
+              width: 20,
+              height: 20,
+              borderRadius: 3,
               display: 'flex',
-              flexDirection: 'column',
               justifyContent: 'center',
               alignItems: 'center',
-              gap: 1,
+              '&:hover': {
+                backgroundColor: colorTheme.bg3.value,
+              },
             }}
-            onClick={toggleOpen}
           >
             <div
-              style={{ width: 8, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
-            />
-            <div
-              style={{ width: 6, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
-            />
-            <div
-              style={{ width: 4, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
-            />
+              css={{
+                height: 14,
+                width: 14,
+                borderRadius: 14,
+                border: `1px solid ${colorTheme.fg1.value}`,
+                cursor: 'pointer',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                alignItems: 'center',
+                gap: 1,
+              }}
+              onClick={toggleOpen}
+            >
+              <div
+                style={{ width: 8, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
+              />
+              <div
+                style={{ width: 6, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
+              />
+              <div
+                style={{ width: 4, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
+              />
+            </div>
           </div>
-        </div>
+        </Tooltip>
       </FlexRow>
       {when(
         sortedThreads.length > 0,
@@ -200,7 +202,7 @@ const ThreadPreviews = React.memo(() => {
             <label htmlFor='showUnreadFirst'>Unread First</label>
           </FlexRow>
           {when(
-            resolvedThreads.length > 0 || readThreads.length > 0,
+            resolvedThreads.length > 0,
             <div style={{ width: '100%', background: colorTheme.bg3.value, height: 1 }} />,
           )}
           {when(

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -46,7 +46,6 @@ import { getCurrentTheme } from '../../editor/store/editor-state'
 import type { EditorAction } from '../../editor/action-types'
 import { canvasPointToWindowPoint } from '../../canvas/dom-lookup'
 import { CommentRepliesCounter } from '../../canvas/controls/comment-replies-counter'
-import { filter } from 'jszip'
 
 export const CommentSection = React.memo(() => {
   return (
@@ -106,6 +105,15 @@ const ThreadPreviews = React.memo(() => {
     ])
   }, [showResolved, dispatch])
 
+  const [sortedByDateNewestFirst, setSortByDateNewestFirst] = React.useState(true)
+  const toggleSortByDateNewestFirst = React.useCallback(() => {
+    setSortByDateNewestFirst((prevValue) => !prevValue)
+  }, [])
+
+  const sortedActiveThreads = sortedByDateNewestFirst
+    ? activeThreads
+    : activeThreads.slice().reverse()
+
   return (
     <FlexColumn style={{ gap: 5 }}>
       <InspectorSubsectionHeader>
@@ -132,9 +140,9 @@ const ThreadPreviews = React.memo(() => {
           >
             <div
               css={{
-                height: 16,
-                width: 16,
-                borderRadius: 16,
+                height: 14,
+                width: 14,
+                borderRadius: 14,
                 border: `1px solid ${colorTheme.fg1.value}`,
                 cursor: 'pointer',
                 display: 'flex',
@@ -145,9 +153,15 @@ const ThreadPreviews = React.memo(() => {
               }}
               onClick={toggleOpen}
             >
-              <div style={{ width: 6, height: 1, background: colorTheme.fg1.value }} />
-              <div style={{ width: 4, height: 1, background: colorTheme.fg1.value }} />
-              <div style={{ width: 3, height: 1, background: colorTheme.fg1.value }} />
+              <div
+                style={{ width: 8, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
+              />
+              <div
+                style={{ width: 6, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
+              />
+              <div
+                style={{ width: 4, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
+              />
             </div>
           </div>
         </FlexRow>
@@ -166,10 +180,10 @@ const ThreadPreviews = React.memo(() => {
             <CheckboxInput
               style={{ marginRight: 8 }}
               id='showResolved'
-              checked={showResolved}
-              onChange={toggleShowResolved}
+              checked={sortedByDateNewestFirst}
+              onChange={toggleSortByDateNewestFirst}
             />
-            <label htmlFor='showResolved'>Sort By Date</label>
+            <label htmlFor='showResolved'>Newest First</label>
           </FlexRow>
           <FlexRow>
             <CheckboxInput
@@ -178,7 +192,7 @@ const ThreadPreviews = React.memo(() => {
               checked={showResolved}
               onChange={toggleShowResolved}
             />
-            <label htmlFor='showResolved'>Sort By Unread</label>
+            <label htmlFor='showResolved'>Unread First</label>
           </FlexRow>
           {when(
             resolvedThreads.length > 0 || readThreads.length > 0,
@@ -214,7 +228,7 @@ const ThreadPreviews = React.memo(() => {
         activeThreads.length === 0,
         <div style={{ padding: 8, color: colorTheme.fg6.value }}>No active comment threads.</div>,
       )}
-      {activeThreads.map((thread) => (
+      {sortedActiveThreads.map((thread) => (
         <ThreadPreview key={thread.id} thread={thread} />
       ))}
       {when(

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -73,11 +73,8 @@ const ThreadPreviews = React.memo(() => {
   const { threads: readThreads } = useReadThreads()
 
   const allThreadsResolvedLast = [...activeThreads, ...resolvedThreads]
-  const { threads: allThreads } = useThreads()
 
   const unreadThreads = allThreadsResolvedLast.filter((thread) => !readThreads.includes(thread))
-
-  const threads = allThreads
 
   const showResolved = useEditorState(
     Substores.restOfEditor,
@@ -86,19 +83,6 @@ const ThreadPreviews = React.memo(() => {
   )
 
   const toggleShowResolved = React.useCallback(() => {
-    dispatch([
-      setShowResolvedThreads(!showResolved),
-      switchEditorMode(EditorModes.selectMode(null, false, 'none')),
-    ])
-  }, [showResolved, dispatch])
-
-  const showRead = useEditorState(
-    Substores.restOfEditor,
-    (store) => store.editor.showResolvedThreads,
-    'ThreadPreviews showResolvedThreads',
-  )
-
-  const toggleShowRead = React.useCallback(() => {
     dispatch([
       setShowResolvedThreads(!showResolved),
       switchEditorMode(EditorModes.selectMode(null, false, 'none')),
@@ -116,8 +100,8 @@ const ThreadPreviews = React.memo(() => {
   }, [])
 
   const sortedActiveThreads = sortedByDateNewestFirst
-    ? activeThreads
-    : activeThreads.slice().reverse()
+    ? activeThreads.slice().reverse()
+    : activeThreads
 
   const sortedThreads = sortedByUnreadFirst
     ? [...unreadThreads, ...sortedActiveThreads.filter((thread) => !unreadThreads.includes(thread))]

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -62,7 +62,7 @@ const ThreadPreviews = React.memo(() => {
   const dispatch = useDispatch()
   const colorTheme = useColorTheme()
 
-  const [filtersOpen, setOpen] = React.useState(true)
+  const [filtersOpen, setOpen] = React.useState(false)
   const toggleOpen = React.useCallback(() => {
     setOpen((prevOpen) => !prevOpen)
   }, [setOpen])
@@ -108,57 +108,57 @@ const ThreadPreviews = React.memo(() => {
     : sortedActiveThreads
 
   return (
-    <FlexColumn style={{ gap: 5 }}>
-      <InspectorSubsectionHeader>
-        <FlexRow
-          style={{
-            flexGrow: 1,
-            justifyContent: 'space-between',
+    <FlexColumn>
+      <FlexRow
+        style={{
+          flexGrow: 1,
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          fontWeight: 600,
+          margin: 8,
+        }}
+      >
+        <span>Comments</span>
+        <div
+          css={{
+            width: 20,
+            height: 20,
+            borderRadius: 3,
+            display: 'flex',
+            justifyContent: 'center',
             alignItems: 'center',
+            '&:hover': {
+              backgroundColor: colorTheme.bg3.value,
+            },
           }}
         >
-          <span>Comments</span>
           <div
             css={{
-              width: 20,
-              height: 20,
-              borderRadius: 3,
+              height: 14,
+              width: 14,
+              borderRadius: 14,
+              border: `1px solid ${colorTheme.fg1.value}`,
+              cursor: 'pointer',
               display: 'flex',
+              flexDirection: 'column',
               justifyContent: 'center',
               alignItems: 'center',
-              '&:hover': {
-                backgroundColor: colorTheme.bg3.value,
-              },
+              gap: 1,
             }}
+            onClick={toggleOpen}
           >
             <div
-              css={{
-                height: 14,
-                width: 14,
-                borderRadius: 14,
-                border: `1px solid ${colorTheme.fg1.value}`,
-                cursor: 'pointer',
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'center',
-                alignItems: 'center',
-                gap: 1,
-              }}
-              onClick={toggleOpen}
-            >
-              <div
-                style={{ width: 8, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
-              />
-              <div
-                style={{ width: 6, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
-              />
-              <div
-                style={{ width: 4, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
-              />
-            </div>
+              style={{ width: 8, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
+            />
+            <div
+              style={{ width: 6, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
+            />
+            <div
+              style={{ width: 4, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
+            />
           </div>
-        </FlexRow>
-      </InspectorSubsectionHeader>
+        </div>
+      </FlexRow>
       {when(
         activeThreads.length > 0,
         <FlexColumn

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -247,23 +247,19 @@ export function useActiveThreads() {
 }
 
 export function useResolvedThreads() {
-  return useThreads({
-    query: {
-      metadata: {
-        resolved: true,
-      },
-    },
-  })
+  const threads = useThreads()
+  return {
+    ...threads,
+    threads: threads.threads.filter((t) => t.metadata.resolved === true),
+  }
 }
 
 export function useUnresolvedThreads() {
-  return useThreads({
-    query: {
-      metadata: {
-        resolved: false,
-      },
-    },
-  })
+  const threads = useThreads()
+  return {
+    ...threads,
+    threads: threads.threads.filter((t) => t.metadata.resolved !== true),
+  }
 }
 
 export function useSetThreadReadStatusOnMount(thread: ThreadData<ThreadMetadata> | null) {

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -262,6 +262,27 @@ export function useUnresolvedThreads() {
   }
 }
 
+export function useReadThreads() {
+  const threads = useThreads()
+  const self = useSelf()
+  const threadReadStatuses = useStorage((store) => store.userReadStatusesByThread)
+
+  const filteredThreads = threads.threads.filter((thread) => {
+    if (thread == null) {
+      return false
+    }
+    if (threadReadStatuses[thread.id] == null) {
+      return false
+    }
+    return threadReadStatuses[thread.id][self.id] === true
+  })
+
+  return {
+    ...threads,
+    threads: filteredThreads,
+  }
+}
+
 export function useSetThreadReadStatusOnMount(thread: ThreadData<ThreadMetadata> | null) {
   const setThreadReadStatus = useSetThreadReadStatus()
 


### PR DESCRIPTION
Adding a filter section to the comments tab! Now you can sort comments by date, put unread comments first, and show/hide resolved comments within the same list that gets returned. 

<img width="200" alt="Screenshot 2024-01-03 at 6 06 44 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/46173622-1512-4008-b26f-e58ed160ff17">

<img width="200" alt="Screenshot 2024-01-03 at 6 08 21 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/182b745d-c21e-4773-9af4-409b3a8f3d44">

<img width="200" alt="Screenshot 2024-01-03 at 6 10 03 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/ae0eb3a3-037d-48e3-b4bc-021c27bbf4e5">

<img width="160" alt="Screenshot 2024-01-03 at 6 17 25 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/abdb95d1-b0a5-41f6-9d63-75c5d204795d">

https://github.com/concrete-utopia/utopia/assets/47405698/77b76827-714b-4b6a-8abb-bd3bd0e785c8


