### PR TITLE
unify commenting and collaboration FSs

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -211,7 +211,7 @@ export const RightPane = React.memo<ResizableRightPaneProps>((props) => {
           </>,
         )}
         {when(
-          isFeatureEnabled('Commenting'),
+          isFeatureEnabled('Multiplayer'),
           <MenuTab
             label={'Comments'}
             selected={selectedTab === RightMenuTab.Comments}

--- a/editor/src/components/canvas/multiplayer-presence.tsx
+++ b/editor/src/components/canvas/multiplayer-presence.tsx
@@ -140,7 +140,7 @@ export const MultiplayerPresence = React.memo(() => {
     <>
       <FollowingOverlay />
       <MultiplayerShadows />
-      {when(isFeatureEnabled('Commenting'), <CommentIndicators />)}
+      <CommentIndicators />
       <MultiplayerCursors />
       {when(isCommentMode(mode) && mode.comment != null, <CommentPopup />)}
     </>

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -497,7 +497,7 @@ export const CanvasToolbar = React.memo(() => {
           />
         </Tooltip>
         {when(
-          isFeatureEnabled('Commenting'),
+          isFeatureEnabled('Multiplayer'),
           <Tooltip title={commentButtonTooltip} placement='bottom'>
             <InsertModeButton
               testid={CommentModeButtonTestId}

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -453,7 +453,7 @@ export function handleKeyDown(
         return []
       },
       [COMMENT_SHORTCUT]: () => {
-        if (isFeatureEnabled('Commenting')) {
+        if (isFeatureEnabled('Multiplayer')) {
           return [
             EditorActions.switchEditorMode(EditorModes.commentMode(null, 'not-dragging')),
             EditorActions.setRightMenuTab(RightMenuTab.Comments),

--- a/editor/src/components/editor/liveblocks-utils.ts
+++ b/editor/src/components/editor/liveblocks-utils.ts
@@ -41,5 +41,5 @@ export async function checkLiveblocksEnabledOnServer(): Promise<void> {
 }
 
 export function isLiveblocksEnabled(): boolean {
-  return isLiveblocksEnabledOnServer && isFeatureEnabled('Collaboration')
+  return isLiveblocksEnabledOnServer && isFeatureEnabled('Multiplayer')
 }

--- a/editor/src/components/editor/store/collaborative-editing.spec.ts
+++ b/editor/src/components/editor/store/collaborative-editing.spec.ts
@@ -107,7 +107,7 @@ async function runAddHookForProjectChangesTest(test: AddHookForProjectChangesTes
 }
 
 describe('addHookForProjectChanges', () => {
-  setFeatureForUnitTestsUseInDescribeBlockOnly('Collaboration', true)
+  setFeatureForUnitTestsUseInDescribeBlockOnly('Multiplayer', true)
 
   it('adding file causes it to be added to the project contents', async () => {
     const code = 'export const A = <div />'

--- a/editor/src/components/editor/store/collaborative-editing.ts
+++ b/editor/src/components/editor/store/collaborative-editing.ts
@@ -149,7 +149,7 @@ export function collateCollaborativeProjectChanges(
       }
     }
   }
-  if (isFeatureEnabled('Collaboration')) {
+  if (isFeatureEnabled('Multiplayer')) {
     if (oldContents != newContents) {
       zipContentsTree(oldContents, newContents, onElement)
     }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -433,7 +433,7 @@ export function emptyCollaborativeEditingSupportSession(): CollaborativeEditingS
 
 export function emptyCollaborativeEditingSupport(): CollaborativeEditingSupport {
   let session: CollaborativeEditingSupportSession | null = null
-  if (isFeatureEnabled('Collaboration')) {
+  if (isFeatureEnabled('Multiplayer')) {
     session = emptyCollaborativeEditingSupportSession()
   }
   return {

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -12,10 +12,9 @@ export type FeatureName =
   | 'Performance Test Triggers'
   | 'Canvas Strategies Debug Panel'
   | 'Project Thumbnail Generation'
-  | 'Commenting'
   | 'Debug - Print UIDs'
   | 'Steganography'
-  | 'Collaboration'
+  | 'Multiplayer'
   | 'Baton Passing For Control'
 
 export const AllFeatureNames: FeatureName[] = [
@@ -29,10 +28,9 @@ export const AllFeatureNames: FeatureName[] = [
   'Performance Test Triggers',
   'Canvas Strategies Debug Panel',
   'Project Thumbnail Generation',
-  'Commenting',
   'Debug - Print UIDs',
   'Steganography',
-  'Collaboration',
+  'Multiplayer',
   'Baton Passing For Control',
 ]
 
@@ -46,10 +44,9 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Performance Test Triggers': !(PRODUCTION_CONFIG as boolean),
   'Canvas Strategies Debug Panel': false,
   'Project Thumbnail Generation': false,
-  Commenting: false,
   'Debug - Print UIDs': false,
   Steganography: false,
-  Collaboration: false,
+  Multiplayer: false,
   'Baton Passing For Control': false,
 }
 


### PR DESCRIPTION
## Problem
Both the `Commenting` and `Collaboration` FSs need to be turned on for commeting to work

## FIx
Since both commenting and mulitplayer are built on Liveblocks, it makes sense to unify the two feature switches, so this PR does that 