### PR TITLE
Give all of the CI jobs sensible timeouts

### DIFF
--- a/.github/workflows/cache-pnpm-install.yml
+++ b/.github/workflows/cache-pnpm-install.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   cache-pnpm-store:
     name: Install everything with PNPM and cache it
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
       UTOPIA_SHA: ${{ github.sha }}

--- a/.github/workflows/discord-discussion-comments.yml
+++ b/.github/workflows/discord-discussion-comments.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   post-to-discord:
     name: Post Comment To Discord
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - name: Build Embeds JSON

--- a/.github/workflows/discord-discussion-opened.yml
+++ b/.github/workflows/discord-discussion-opened.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   post-to-discord:
     name: Post Notification To Discord
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - name: Build Embeds JSON

--- a/.github/workflows/discord-issue-closed.yml
+++ b/.github/workflows/discord-issue-closed.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   post-to-discord:
     name: Post Notification To Discord
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - name: Build Embeds JSON

--- a/.github/workflows/discord-issue-comments.yml
+++ b/.github/workflows/discord-issue-comments.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   post-to-discord:
     name: Post Comment To Discord
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     if: ${{ !github.event.issue.pull_request }}
     steps:

--- a/.github/workflows/discord-issue-opened.yml
+++ b/.github/workflows/discord-issue-opened.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   post-to-discord:
     name: Post Notification To Discord
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - name: Build Embeds JSON

--- a/.github/workflows/discord-pr-closed.yml
+++ b/.github/workflows/discord-pr-closed.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   post-to-discord:
     name: Post Notification To Discord
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - name: Build Merged Args

--- a/.github/workflows/discord-pr-comments.yml
+++ b/.github/workflows/discord-pr-comments.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   post-to-discord:
     name: Post Notification To Discord
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request || github.event.issue.pull_request }}
     steps:

--- a/.github/workflows/discord-pr-opened.yml
+++ b/.github/workflows/discord-pr-opened.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   post-to-discord:
     name: Post Notification To Discord
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     steps:

--- a/.github/workflows/discord-pr-review.yml
+++ b/.github/workflows/discord-pr-review.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   post-to-discord:
     name: Post Notification To Discord
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     if: ${{ github.event.review.state == 'approved' || github.event.review.state == 'changes_requested' }}
     steps:

--- a/.github/workflows/editor-sharded-tests.yml
+++ b/.github/workflows/editor-sharded-tests.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   test-editor-karma-shard:
     name: Test Editor PR – Karma tests (Shard ${{ inputs.shard_number }})
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
       UTOPIA_SHA: ${{ github.sha }}

--- a/.github/workflows/google-webfonts-list-updater.yml
+++ b/.github/workflows/google-webfonts-list-updater.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   google-web-fonts-updater:
     name: Google Web Fonts Updater
+    timeout-minutes: 5
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code

--- a/.github/workflows/master-pushes.yml
+++ b/.github/workflows/master-pushes.yml
@@ -11,6 +11,7 @@ jobs:
 
   test-editor-code:
     name: Test Editor - TypeScript, ESLint, dependency-cruiser
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: [cache-pnpm-store]
     env:
@@ -44,6 +45,7 @@ jobs:
 
   test-editor-jest:
     name: Test Editor - Jest tests
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: [cache-pnpm-store]
     env:
@@ -97,6 +99,7 @@ jobs:
 
   test-server:
     name: Test Server
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
       UTOPIA_SHA: ${{ github.sha }}
@@ -137,6 +140,7 @@ jobs:
 
   trigger-deploy:
     name: Trigger Deploy
+    timeout-minutes: 5
     needs:
       [
         test-editor-code,
@@ -156,6 +160,7 @@ jobs:
 
   post-failure-to-discord:
     name: Post Failure Message To Discord
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     if: failure()
     needs: [trigger-deploy]

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -9,6 +9,7 @@ jobs:
 
   test-editor-code:
     name: Test Editor PR – TypeScript, ESLint, dependency-cruiser
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: [cache-pnpm-store]
     env:
@@ -41,8 +42,10 @@ jobs:
       - name: Run tsc, eslint, depdendency-cruiser and the website tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-code-ci
+
   test-editor-jest:
     name: Test Editor PR – Jest tests
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: [cache-pnpm-store]
     env:
@@ -96,6 +99,7 @@ jobs:
 
   deploy-staging:
     name: Deploy Staging Editor
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: [cache-pnpm-store]
     env:
@@ -212,6 +216,7 @@ jobs:
 
   performance-test:
     name: Run Performance Tests
+    timeout-minutes: 15
     runs-on: self-hosted
     needs: [deploy-staging, cache-pnpm-store]
     env:
@@ -317,6 +322,7 @@ jobs:
 
   system-test:
     name: Run System Tests
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: [deploy-staging, cache-pnpm-store]
     env:

--- a/.github/workflows/screenshot-production.yml
+++ b/.github/workflows/screenshot-production.yml
@@ -12,6 +12,7 @@ jobs:
 
   take-screenshot:
     name: Take Screenshot
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: [cache-pnpm-store]
     steps:

--- a/.github/workflows/screenshot-staging.yml
+++ b/.github/workflows/screenshot-staging.yml
@@ -12,6 +12,7 @@ jobs:
 
   take-screenshot:
     name: Take Screenshot
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: [cache-pnpm-store]
     steps:

--- a/.github/workflows/tag-release-automated.yml
+++ b/.github/workflows/tag-release-automated.yml
@@ -11,6 +11,7 @@ jobs:
   system-test:
     # For automated releases we want to check it is safe first
     name: Run System Tests
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: [cache-pnpm-store]
     env:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   release:
     name: Create Release
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
**Problem:**
360 minutes of waiting for a test to finish is too long.

**Fix:**
I've given all of the jobs more sensible timeouts. For the simpler jobs that should typically take seconds (e.g. posting to Discord) I've set the timeout to be 5m, and for the longer running jobs (e.g. the tests) I've set it to 15m. Those should be aggressive enough but not too aggressive, though we can always tweak them if they become problematic.
