### PR TITLE
Prevent Remix from triggering a reload when prefetching content.

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -410,7 +410,8 @@
       "react-select@3.1.0": "patches/react-select@3.1.0.patch",
       "react@18.1.0": "patches/react@18.1.0.patch",
       "reselect@4.1.7": "patches/reselect@4.1.7.patch",
-      "use-context-selector@1.3.9": "patches/use-context-selector@1.3.9.patch"
+      "use-context-selector@1.3.9": "patches/use-context-selector@1.3.9.patch",
+      "@remix-run/react@2.0.1": "patches/@remix-run__react@2.0.1.patch"
     }
   }
 }

--- a/editor/patches/@remix-run__react@2.0.1.patch
+++ b/editor/patches/@remix-run__react@2.0.1.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/esm/routeModules.js b/dist/esm/routeModules.js
+index 1b15029f2772719232ddf4ae95a2010163321630..891709ac14f533aad20f54709d00e3d35ee914d7 100644
+--- a/dist/esm/routeModules.js
++++ b/dist/esm/routeModules.js
+@@ -44,7 +44,7 @@ async function loadRouteModule(route, routeModulesCache) {
+     // asset we're trying to import! Reload from the server and the user
+     // (should) get the new manifest--unless the developer purged the static
+     // assets, the manifest path, but not the documents 😬
+-    window.location.reload();
++    console.warn('window.location.reload prevented from running.')
+     return new Promise(() => {
+       // check out of this hook cause the DJs never gonna re[s]olve this
+     });
+diff --git a/dist/routeModules.js b/dist/routeModules.js
+index 5f878eaae5262cc68d6b4599dc887413bf359960..76deff82943c55b7f5f0560f8e8d624e8b4ec53c 100644
+--- a/dist/routeModules.js
++++ b/dist/routeModules.js
+@@ -66,7 +66,7 @@ async function loadRouteModule(route, routeModulesCache) {
+     // asset we're trying to import! Reload from the server and the user
+     // (should) get the new manifest--unless the developer purged the static
+     // assets, the manifest path, but not the documents 😬
+-    window.location.reload();
++    console.warn('window.location.reload prevented from running.')
+     return new Promise(() => {
+       // check out of this hook cause the DJs never gonna re[s]olve this
+     });

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -37,6 +37,9 @@ patchedDependencies:
   use-context-selector@1.3.9:
     hash: 2j5b55brghbi7pju3qvaqzwbdi
     path: patches/use-context-selector@1.3.9.patch
+  '@remix-run/react@2.0.1':
+    hash: 4uzd4uhfxjy6hfd2xmixhrzbqy
+    path: patches/@remix-run__react@2.0.1.patch
 
 specifiers:
   '@babel/cli': 7.23.4
@@ -358,7 +361,7 @@ dependencies:
   '@liveblocks/react-comments': 1.9.0_wgqxz3kjpz4ixw4iz4mbg2tk4i
   '@liveblocks/yjs': 1.9.0_yjs@13.6.8
   '@popperjs/core': 2.4.4
-  '@remix-run/react': 2.0.1_njludxb6fcqnim6moy22jieofi
+  '@remix-run/react': 2.0.1_4uzd4uhfxjy6hfd2xmixhrzbqy_njludxb6fcqnim6moy22jieofi
   '@remix-run/server-runtime': 2.3.1_typescript@5.2.2
   '@root/encoding': 1.0.1
   '@seznam/compose-react-refs': 1.0.6
@@ -4403,7 +4406,7 @@ packages:
       java-properties: 1.0.2
     dev: true
 
-  /@remix-run/react/2.0.1_njludxb6fcqnim6moy22jieofi:
+  /@remix-run/react/2.0.1_4uzd4uhfxjy6hfd2xmixhrzbqy_njludxb6fcqnim6moy22jieofi:
     resolution: {integrity: sha512-xZgJcRjzx9gjCzh7dDZGQJcmQPPFisMrDwhUuIzlSHuR2rEQCCGZPBLVCpbD1zhDfbdvOugbf2DLSmP2TEBXNA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -4421,6 +4424,7 @@ packages:
       react-router-dom: 6.16.0_ef5jwxihqo6n7gxfmzogljlgcm
       typescript: 5.2.2
     dev: false
+    patched: true
 
   /@remix-run/router/1.13.0:
     resolution: {integrity: sha512-5dMOnVnefRsl4uRnAdoWjtVTdh8e6aZqgM4puy9nmEADH72ck+uXwzpJLEKE9Q6F8ZljNewLgmTfkxUrBdv4WA==}
@@ -4588,7 +4592,7 @@ packages:
       '@remix-run/server-runtime':
         optional: true
     dependencies:
-      '@remix-run/react': 2.0.1_njludxb6fcqnim6moy22jieofi
+      '@remix-run/react': 2.0.1_4uzd4uhfxjy6hfd2xmixhrzbqy_njludxb6fcqnim6moy22jieofi
       '@remix-run/server-runtime': 2.3.1_typescript@5.2.2
       '@shopify/hydrogen-react': 2023.10.0_2gujrjvyx75a3yizenxbm6c4lu
       content-security-policy-builder: 2.1.1
@@ -7827,7 +7831,7 @@ packages:
     dev: true
 
   /component-indexof/0.0.3:
-    resolution: {integrity: sha512-puDQKvx/64HZXb4hBwIcvQLaLgux8o1CbWl39s41hrIIZDl1lJiD5jc22gj3RBeGK0ovxALDYpIbyjqDUUl0rw==}
+    resolution: {integrity: sha1-EdCRMSI5648yyPJa6csAL/6NPCQ=}
     dev: false
 
   /compressible/2.0.18:


### PR DESCRIPTION
**Problem:**
When a prefetch value of `intent` is set on a `Link`, if a user hovers over the element in live mode then the entire editor reloads in the browser.

**Cause:**
In the handler of the prefetches, if something fails then a `window.location.reload()` is triggered: 
https://github.com/remix-run/remix/blob/main/packages/remix-react/routeModules.ts#L184

**Fix:**
Using our ability to patch dependencies, the `window.location.reload()` call has been replaced with a `console.warn` as an alternative.

**Commit Details:**
- Patched `@remix-run/react` to remove a call to `window.location.reload`.