### PR TITLE
Sort threads by last update in comment section

### DIFF
--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -36,7 +36,11 @@ import {
 } from '../../../core/commenting/comment-hooks'
 import { Substores, useEditorState, useSelectorWithCallback } from '../../editor/store/store-hook'
 import { when } from '../../../utils/react-conditionals'
-import { getFirstComment, openCommentThreadActions } from '../../../core/shared/multiplayer'
+import {
+  getFirstComment,
+  openCommentThreadActions,
+  sortThreadsByDescendingUpdateTimeInPlace,
+} from '../../../core/shared/multiplayer'
 import { getRemixLocationLabel } from '../../canvas/remix/remix-utils'
 import type { RestOfEditorState } from '../../editor/store/store-hook-substore-types'
 import { getCurrentTheme } from '../../editor/store/editor-state'
@@ -72,6 +76,9 @@ const ThreadPreviews = React.memo(() => {
 
   const { threads: activeThreads } = useUnresolvedThreads()
   const { threads: resolvedThreads } = useResolvedThreads()
+
+  sortThreadsByDescendingUpdateTimeInPlace(activeThreads)
+  sortThreadsByDescendingUpdateTimeInPlace(resolvedThreads)
 
   const showResolved = useEditorState(
     Substores.restOfEditor,

--- a/editor/src/core/shared/multiplayer.ts
+++ b/editor/src/core/shared/multiplayer.ts
@@ -165,3 +165,13 @@ export function openCommentThreadActions(threadId: string, scene: ElementPath | 
 export function getFirstComment(thread: ThreadData<ThreadMetadata>): CommentData | null {
   return thread.comments.filter((c) => c.deletedAt == null)[0] ?? null
 }
+
+export function sortThreadsByDescendingUpdateTimeInPlace(
+  threads: Array<ThreadData<ThreadMetadata>>,
+) {
+  function lastModificationDate(t: ThreadData<ThreadMetadata>) {
+    return t.updatedAt ?? t.createdAt
+  }
+
+  threads.sort((t1, t2) => lastModificationDate(t2).getTime() - lastModificationDate(t1).getTime())
+}


### PR DESCRIPTION
**Problem:**
Most recently edited comment thread should be on top in comment section.

**Fix:**
Sort the threads by last update time