### PR TITLE
Remove always empty `InsertChildAndDetails.importsToAdd`

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1568,7 +1568,7 @@ export function duplicate(
 
             return {
               ...success,
-              imports: mergeImports(underlyingFilePath, success.imports, insertResult.importsToAdd),
+              imports: success.imports,
               topLevelElements: applyUtopiaJSXComponentsChanges(
                 success.topLevelElements,
                 utopiaComponents,

--- a/editor/src/components/canvas/commands/add-element-command.ts
+++ b/editor/src/components/canvas/commands/add-element-command.ts
@@ -72,11 +72,7 @@ export const runAddElement: CommandFunction<AddElement> = (
         mergeImports(
           underlyingFilePathNewParent,
           parentSuccess.imports,
-          mergeImports(
-            underlyingFilePathNewParent,
-            insertionResult.importsToAdd,
-            command.importsToAdd ?? {},
-          ),
+          command.importsToAdd ?? {},
         ),
         underlyingFilePathNewParent,
       )

--- a/editor/src/components/canvas/commands/add-elements-command.ts
+++ b/editor/src/components/canvas/commands/add-elements-command.ts
@@ -73,11 +73,7 @@ export const runAddElements: CommandFunction<AddElements> = (
         mergeImports(
           underlyingFilePathNewParent,
           parentSuccess.imports,
-          mergeImports(
-            underlyingFilePathNewParent,
-            insertionResult.importsToAdd,
-            command.importsToAdd ?? {},
-          ),
+          command.importsToAdd ?? {},
         ),
         underlyingFilePathNewParent,
       )

--- a/editor/src/components/canvas/commands/insert-element-insertion-subject.ts
+++ b/editor/src/components/canvas/commands/insert-element-insertion-subject.ts
@@ -52,11 +52,7 @@ export const runInsertElementInsertionSubject: CommandFunction<InsertElementInse
         null,
       )
 
-      const updatedImports = mergeImports(
-        underlyingFilePath,
-        success.imports,
-        mergeImports(underlyingFilePath, insertionResult.importsToAdd, subject.importsToAdd),
-      )
+      const updatedImports = mergeImports(underlyingFilePath, success.imports, subject.importsToAdd)
 
       editorStatePatches.push(
         getPatchForComponentChange(

--- a/editor/src/components/canvas/commands/reparent-element-command.ts
+++ b/editor/src/components/canvas/commands/reparent-element-command.ts
@@ -71,11 +71,7 @@ export const runReparentElement: CommandFunction<ReparentElement> = (
             const editorStatePatchOldParentFile = getPatchForComponentChange(
               successTarget.topLevelElements,
               insertionResult.components,
-              mergeImports(
-                underlyingFilePathTarget,
-                successTarget.imports,
-                insertionResult.importsToAdd,
-              ),
+              successTarget.imports,
               underlyingFilePathTarget,
             )
 
@@ -105,11 +101,7 @@ export const runReparentElement: CommandFunction<ReparentElement> = (
             const editorStatePatchNewParentFile = getPatchForComponentChange(
               successNewParent.topLevelElements,
               insertionResult.components,
-              mergeImports(
-                underlyingFilePathNewParent,
-                successNewParent.imports,
-                insertionResult.importsToAdd,
-              ),
+              successNewParent.imports,
               underlyingFilePathNewParent,
             )
 

--- a/editor/src/components/canvas/commands/wrap-in-container-command.ts
+++ b/editor/src/components/canvas/commands/wrap-in-container-command.ts
@@ -115,11 +115,7 @@ export const runWrapInContainerCommand: CommandFunction<WrapInContainerCommand> 
         getPatchForComponentChange(
           success.topLevelElements,
           insertionResult.components,
-          mergeImports(
-            underlyingFilePath,
-            success.imports,
-            mergeImports(underlyingFilePath, imports, insertionResult.importsToAdd),
-          ),
+          mergeImports(underlyingFilePath, success.imports, imports),
           underlyingFilePath,
         ),
       )

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2227,7 +2227,7 @@ export const UPDATE_FNS = {
         const updatedImports = mergeImports(
           underlyingFilePath,
           success.imports,
-          mergeImports(underlyingFilePath, action.importsToAdd, withInsertedElement.importsToAdd),
+          action.importsToAdd,
         )
         return {
           ...success,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4948,11 +4948,7 @@ export const UPDATE_FNS = {
           const updatedImports = mergeImports(
             underlyingFilePath,
             success.imports,
-            mergeImports(
-              underlyingFilePath,
-              withInsertedElement.importsToAdd,
-              action.toInsert.importsToAdd,
-            ),
+            action.toInsert.importsToAdd,
           )
           return {
             ...success,

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -485,20 +485,17 @@ export interface InsertChildAndDetails {
   components: Array<UtopiaJSXComponent>
   insertionDetails: string | null
   insertedChildrenPaths: Array<ElementPath>
-  importsToAdd: Imports
 }
 
 export function insertChildAndDetails(
   components: Array<UtopiaJSXComponent>,
   insertionDetails: string | null,
   insertedChildrenPaths: Array<ElementPath>,
-  importsToAdd: Imports = {},
 ): InsertChildAndDetails {
   return {
     components: components,
     insertionDetails: insertionDetails,
     insertedChildrenPaths: insertedChildrenPaths,
-    importsToAdd: importsToAdd,
   }
 }
 
@@ -509,7 +506,6 @@ export function insertJSXElementChildren(
   indexPosition: IndexPosition | null,
 ): InsertChildAndDetails {
   const parentPath: StaticElementPath = targetParent.intendedParentPath
-  let importsToAdd: Imports = {}
   let insertedChildrenPaths: Array<ElementPath> = []
   const updatedComponents = transformJSXComponentAtPath(components, parentPath, (parentElement) => {
     if (isChildInsertionPath(targetParent)) {
@@ -601,7 +597,7 @@ export function insertJSXElementChildren(
       assertNever(targetParent)
     }
   })
-  return insertChildAndDetails(updatedComponents, null, insertedChildrenPaths, importsToAdd)
+  return insertChildAndDetails(updatedComponents, null, insertedChildrenPaths)
 }
 
 export function elementPathFromInsertionPath(


### PR DESCRIPTION
**Problem:**
In `insertJSXElementChildren` we return a key called `importsToAdd` which holds an always empty imports object - that can be misleading if someone relies on that.

**Fix:**
Removing this key from the returned object, fixing it in all locations.
