### PR TITLE
Comments sorted by Last Updated*

### DIFF
--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -92,11 +92,11 @@ const ThreadPreviews = React.memo(() => {
     ])
   }, [showResolved, dispatch])
 
-  const [sortByDateNewestFirst, setSortByDateNewestFirst] = React.useState(true)
+  const [sortByLastUpdatedFirst, setSortByLastUpdatedFirst] = React.useState(true)
   const [sortByUnreadFirst, setSortedByUnreadFirst] = React.useState(false)
 
-  const toggleSortByDateNewestFirst = React.useCallback(() => {
-    setSortByDateNewestFirst((prevValue) => !prevValue)
+  const toggleSortByLastUpdatedFirst = React.useCallback(() => {
+    setSortByLastUpdatedFirst((prevValue) => !prevValue)
   }, [])
   const toggleSortByUnreadFirst = React.useCallback(() => {
     setSortedByUnreadFirst((prevValue) => !prevValue)
@@ -108,7 +108,7 @@ const ThreadPreviews = React.memo(() => {
     if (!showResolved) {
       filteredThreads = filteredThreads.filter((thread) => !resolvedThreads.includes(thread))
     }
-    if (sortByDateNewestFirst) {
+    if (!sortByLastUpdatedFirst) {
       filteredThreads = filteredThreads.slice().reverse()
     }
     if (sortByUnreadFirst) {
@@ -124,7 +124,7 @@ const ThreadPreviews = React.memo(() => {
     readThreads,
     showResolved,
     sortByUnreadFirst,
-    sortByDateNewestFirst,
+    sortByLastUpdatedFirst,
   ])
 
   return (
@@ -195,10 +195,10 @@ const ThreadPreviews = React.memo(() => {
             <CheckboxInput
               style={{ marginRight: 8 }}
               id='showNewestFirst'
-              checked={sortByDateNewestFirst}
-              onChange={toggleSortByDateNewestFirst}
+              checked={sortByLastUpdatedFirst}
+              onChange={toggleSortByLastUpdatedFirst}
             />
-            <label htmlFor='showNewestFirst'>Newest First</label>
+            <label htmlFor='showNewestFirst'>Last Updated First</label>
           </FlexRow>
           <FlexRow>
             <CheckboxInput


### PR DESCRIPTION
Fixing the comment sorting to sort by the date they were last updated, not the date they were created at. And updating all the variable names accordingly!

<img width="267" alt="Screenshot 2024-01-04 at 11 57 46 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/cc805c7b-6d63-4520-b1a1-995f780dcb7c">
