### PR TITLE
Fix dark mode in portaled floating liveblocks elements

### DIFF
--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -39,7 +39,7 @@ import { canvasPointToWindowPoint } from '../dom-lookup'
 import { useRemixNavigationContext } from '../remix/utopia-remix-root-component'
 import { optionalMap } from '../../../core/shared/optional-utils'
 import { setRightMenuTab } from '../../editor/actions/action-creators'
-import { RightMenuTab, getCurrentTheme } from '../../editor/store/editor-state'
+import { RightMenuTab } from '../../editor/store/editor-state'
 import { when } from '../../../utils/react-conditionals'
 import { CommentRepliesCounter } from './comment-replies-counter'
 
@@ -363,11 +363,6 @@ const HoveredCommentIndicator = React.memo((props: HoveredCommentIndicatorProps)
   const { thread, hidden, cancelHover, draggingCallback } = props
 
   const dispatch = useDispatch()
-  const theme = useEditorState(
-    Substores.userState,
-    (store) => getCurrentTheme(store.userState),
-    'HoveredCommentIndicator theme',
-  )
 
   const { location, scene: commentScene } = useCanvasLocationOfThread(thread)
 
@@ -461,7 +456,6 @@ const HoveredCommentIndicator = React.memo((props: HoveredCommentIndicatorProps)
           overflow: 'auto',
           background: 'transparent',
         }}
-        data-theme={theme}
         user={user}
         comment={comment}
         showActions={false}

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -24,16 +24,7 @@ import { create } from '../../../core/shared/property-path'
 import { assertNever } from '../../../core/shared/utils'
 import { CommentWrapper, MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
 import { when } from '../../../utils/react-conditionals'
-import {
-  Button,
-  FlexColumn,
-  FlexRow,
-  Icn,
-  Tooltip,
-  UtopiaStyles,
-  colorTheme,
-  useColorTheme,
-} from '../../../uuiui'
+import { Button, FlexRow, Icn, Tooltip, UtopiaStyles, colorTheme } from '../../../uuiui'
 import {
   setProp_UNSAFE,
   setRightMenuTab,
@@ -47,14 +38,13 @@ import {
   isNewComment,
 } from '../../editor/editor-modes'
 import { useDispatch } from '../../editor/store/dispatch-context'
-import { RightMenuTab, getCurrentTheme } from '../../editor/store/editor-state'
+import { RightMenuTab } from '../../editor/store/editor-state'
 import { Substores, useEditorState } from '../../editor/store/store-hook'
 import { stopPropagation } from '../../inspector/common/inspector-utils'
 import { canvasPointToWindowPoint } from '../dom-lookup'
 import { RemixNavigationAtom } from '../remix/utopia-remix-root-component'
 import { getIdOfScene } from './comment-mode/comment-mode-hooks'
 import { motion, useAnimation } from 'framer-motion'
-import { CSSCursor } from '../canvas-types'
 import type { EditorDispatch } from '../../editor/action-types'
 
 export const ComposerEditorClassName = 'lb-composer-editor'
@@ -146,12 +136,6 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
       })
     }
   }, [])
-
-  const theme = useEditorState(
-    Substores.userState,
-    (store) => getCurrentTheme(store.userState),
-    'CommentThread theme',
-  )
 
   const onCreateThread = React.useCallback(
     ({ body }: ComposerSubmitComment, event: React.FormEvent<HTMLFormElement>) => {
@@ -406,7 +390,6 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
           </div>
           <Composer
             ref={composerRef}
-            data-theme={theme}
             autoFocus
             threadId={thread.id}
             onComposerSubmit={onSubmitComment}
@@ -429,12 +412,6 @@ type NewCommentPopupProps = {
 
 const NewCommentPopup = React.memo((props: NewCommentPopupProps) => {
   const dispatch = useDispatch()
-
-  const theme = useEditorState(
-    Substores.userState,
-    (store) => getCurrentTheme(store.userState),
-    'NewCommentPopup theme',
-  )
 
   const onNewCommentComposerKeyDown = React.useCallback(
     (e: React.KeyboardEvent) => switchToBasicCommentModeOnEscape(e, dispatch),
@@ -525,7 +502,6 @@ const NewCommentPopup = React.memo((props: NewCommentPopupProps) => {
       </div>
       <motion.div animate={newCommentComposerAnimation}>
         <Composer
-          data-theme={theme}
           autoFocus
           onComposerSubmit={props.onComposerSubmit}
           style={ComposerStyle}

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -69,6 +69,7 @@ import { isRoomId, projectIdToRoomId } from '../../core/shared/multiplayer'
 import { useDisplayOwnershipWarning } from './project-owner-hooks'
 import { EditorModes } from './editor-modes'
 import { allowedToEditProject } from './store/collaborative-editing'
+import { useDataThemeAttributeOnBody } from '../../core/commenting/comment-hooks'
 
 const liveModeToastId = 'play-mode-toast'
 
@@ -533,6 +534,8 @@ export function EditorComponent(props: EditorProps) {
   )
 
   const dispatch = useDispatch()
+
+  useDataThemeAttributeOnBody()
 
   const roomId = React.useMemo(
     () => (projectId == null ? generateUUID() : projectIdToRoomId(projectId)),

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -27,6 +27,7 @@ import { getIdOfScene } from '../../components/canvas/controls/comment-mode/comm
 import type { ElementPath } from '../shared/project-file-types'
 import type { ElementInstanceMetadata } from '../shared/element-template'
 import * as EP from '../shared/element-path'
+import { getCurrentTheme } from '../../components/editor/store/editor-state'
 
 export function useCanvasCommentThreadAndLocation(comment: CommentId): {
   location: CanvasPoint | null
@@ -356,4 +357,15 @@ export function useDeleteThreadReadStatus() {
       statusesForThread.delete(threadId)
     }
   }, [])
+}
+
+export function useDataThemeAttributeOnBody() {
+  const theme = useEditorState(
+    Substores.userState,
+    (store) => getCurrentTheme(store.userState),
+    'useDataThemeAttributeOnBody theme',
+  )
+  React.useEffect(() => {
+    document.body.setAttribute('data-theme', theme)
+  }, [theme])
 }

--- a/editor/src/utils/multiplayer-wrapper.tsx
+++ b/editor/src/utils/multiplayer-wrapper.tsx
@@ -10,8 +10,6 @@ import {
   normalizeMultiplayerName,
 } from '../core/shared/multiplayer'
 import { ErrorBoundary } from './react-error-boundary'
-import { Substores, useEditorState } from '../components/editor/store/store-hook'
-import { getCurrentTheme } from '../components/editor/store/editor-state'
 
 type Fallback = NonNullable<React.ReactNode> | null
 
@@ -30,14 +28,8 @@ MultiplayerWrapper.displayName = 'MultiplayerWrapper'
 
 export const CommentWrapper = React.memo(
   ({ user, ...commentProps }: { user: UserMeta | null } & CommentProps) => {
-    const theme = useEditorState(
-      Substores.userState,
-      (store) => getCurrentTheme(store.userState),
-      'CommentWrapper theme',
-    )
-
     if (user == null) {
-      return <Comment data-theme={theme} {...commentProps} />
+      return <Comment {...commentProps} />
     }
     return (
       <div style={{ position: 'relative' }}>
@@ -54,7 +46,7 @@ export const CommentWrapper = React.memo(
           }}
           picture={user.avatar}
         />
-        <Comment data-theme={theme} {...commentProps} />
+        <Comment {...commentProps} />
       </div>
     )
   },


### PR DESCRIPTION
**Problem:**
Portaled floating liveblocks elements (e.g. emoji menu, "More" menu to edit/delete comment, etc) are always shown in light mode:
![image](https://github.com/concrete-utopia/utopia/assets/127662/922412b7-1c8f-4d69-8e1e-5f551949bc7d)


**Fix:**
The problem is that we only set the `data-theme` attribute on the `Comment` component, and these floating elements are portaled to the end of the documen. The solution is to add the `data-theme` attribute to the document body (and update when necessary).

<img width="343" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/436f4824-ebba-48b3-a8f0-37190ffacf48">
