### PR TITLE
Clean up comment filtering in comment section

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -8,7 +8,6 @@ import type {
   JSXFragment,
   TopLevelElement,
 } from '../../core/shared/element-template'
-import { SettableLayoutSystem } from '../../core/shared/element-template'
 import type { KeysPressed, Key } from '../../utils/keyboard'
 import type { IndexPosition } from '../../utils/utils'
 import type { CanvasRectangle, Size, WindowPoint, CanvasPoint } from '../../core/shared/math-utils'
@@ -30,7 +29,6 @@ import type {
   ExportDetail,
   ImportDetails,
 } from '../../core/shared/project-file-types'
-import { StaticElementPathPart } from '../../core/shared/project-file-types'
 import type { CodeResultCache, PropertyControlsInfo } from '../custom-code/code-file'
 import type { ElementContextMenuInstance } from '../element-context-menu'
 import type { FontSettings } from '../inspector/common/css-utils'
@@ -63,9 +61,7 @@ import type {
   ThemeSetting,
   ColorSwatch,
   PostActionMenuData,
-  CollabFile,
 } from './store/editor-state'
-import { NavigatorEntry } from './store/editor-state'
 import type { Notice } from '../common/notice'
 import type { LoginState } from '../../common/user'
 import type { InsertableComponent, StylePropOption } from '../shared/project-components'
@@ -76,12 +72,12 @@ import type { GithubOperationType } from './actions/action-creators'
 import type { CanvasCommand } from '../canvas/commands/commands'
 import type { InsertionPath } from './store/insertion-path'
 import type { TextProp } from '../text-editor/text-editor'
-import { ElementPathTrees } from '../../core/shared/element-path-tree'
 import type { PostActionChoice } from '../canvas/canvas-strategies/post-action-options/post-action-options'
 import type { FromVSCodeAction } from './actions/actions-from-vscode'
 import type { ProjectServerState } from './store/project-server-state'
 import type { SetHuggingParentToFixed } from '../canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy'
 import type { MapLike } from 'typescript'
+import type { CommentFilterMode } from '../inspector/sections/comment-section'
 export { isLoggedIn, loggedInUser, notLoggedIn } from '../../common/user'
 export type { LoginState, UserDetails } from '../../common/user'
 
@@ -1083,9 +1079,9 @@ export interface UpdateCodeFromCollaborationUpdate {
   code: string
 }
 
-export interface SetShowResolvedThreads {
-  action: 'SET_SHOW_RESOLVED_THREADS'
-  showResolvedThreads: boolean
+export interface SetCommentFilterMode {
+  action: 'SET_COMMENT_FILTER_MODE'
+  commentFilterMode: CommentFilterMode
 }
 
 export type EditorAction =
@@ -1263,7 +1259,7 @@ export type EditorAction =
   | UpdateExportsDetailFromCollaborationUpdate
   | UpdateImportsFromCollaborationUpdate
   | UpdateCodeFromCollaborationUpdate
-  | SetShowResolvedThreads
+  | SetCommentFilterMode
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -1,5 +1,3 @@
-import { LayoutSystem } from 'utopia-api/core' // TODO fixme this imports utopia-api
-import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
 import type { LoginState } from '../../../common/user'
 import type { LayoutTargetableProp } from '../../../core/layout/layout-helpers-new'
 import type {
@@ -7,10 +5,7 @@ import type {
   JSXElement,
   JSXElementName,
   ElementInstanceMetadataMap,
-  SettableLayoutSystem,
   JSXElementChild,
-  JSXConditionalExpression,
-  JSXFragment,
   TopLevelElement,
 } from '../../../core/shared/element-template'
 import type {
@@ -24,13 +19,11 @@ import type {
   RequestedNpmDependency,
 } from '../../../core/shared/npm-dependency-types'
 import type {
-  HighlightBoundsForUids,
   Imports,
   NodeModules,
   ParsedTextFile,
   ProjectFile,
   PropertyPath,
-  StaticElementPathPart,
   ElementPath,
   ImageFile,
   ExportDetail,
@@ -226,7 +219,7 @@ import type {
   UpdateExportsDetailFromCollaborationUpdate,
   UpdateImportsFromCollaborationUpdate,
   UpdateCodeFromCollaborationUpdate,
-  SetShowResolvedThreads,
+  SetCommentFilterMode,
 } from '../action-types'
 import type { InsertionSubjectWrapper, Mode } from '../editor-modes'
 import { EditorModes, insertionSubject } from '../editor-modes'
@@ -235,7 +228,6 @@ import type {
   DuplicationState,
   ErrorMessages,
   FloatingInsertMenuState,
-  GithubRepo,
   GithubState,
   LeftMenuTab,
   ModalDialog,
@@ -243,20 +235,18 @@ import type {
   ProjectGithubSettings,
   RightMenuTab,
   GithubOperation,
-  FileChecksums,
   GithubData,
   UserConfiguration,
   ThemeSetting,
   ColorSwatch,
   PostActionMenuData,
-  CollabFile,
 } from '../store/editor-state'
 import type { InsertionPath } from '../store/insertion-path'
 import type { TextProp } from '../../text-editor/text-editor'
-import { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import type { PostActionChoice } from '../../canvas/canvas-strategies/post-action-options/post-action-options'
 import type { ProjectServerState } from '../store/project-server-state'
 import type { SetHuggingParentToFixed } from '../../canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy'
+import type { CommentFilterMode } from '../../inspector/sections/comment-section'
 
 export function clearSelection(): EditorAction {
   return {
@@ -1721,9 +1711,9 @@ export function updateCodeFromCollaborationUpdate(
   }
 }
 
-export function setShowResolvedThreads(showResolvedThreads: boolean): SetShowResolvedThreads {
+export function setCommentFilterMode(commentFilterMode: CommentFilterMode): SetCommentFilterMode {
   return {
-    action: 'SET_SHOW_RESOLVED_THREADS',
-    showResolvedThreads: showResolvedThreads,
+    action: 'SET_COMMENT_FILTER_MODE',
+    commentFilterMode: commentFilterMode,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -130,7 +130,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'START_POST_ACTION_SESSION':
     case 'TRUNCATE_HISTORY':
     case 'UPDATE_PROJECT_SERVER_STATE':
-    case 'SET_SHOW_RESOLVED_THREADS':
+    case 'SET_COMMENT_FILTER_MODE':
       return true
 
     case 'TRUE_UP_ELEMENTS':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -318,7 +318,7 @@ import type {
   UpdateExportsDetailFromCollaborationUpdate,
   UpdateImportsFromCollaborationUpdate,
   UpdateCodeFromCollaborationUpdate,
-  SetShowResolvedThreads,
+  SetCommentFilterMode,
 } from '../action-types'
 import { isLoggedIn } from '../action-types'
 import type { Mode } from '../editor-modes'
@@ -920,7 +920,7 @@ export function restoreEditorState(
     internalClipboard: currentEditor.internalClipboard,
     filesModifiedByAnotherUser: currentEditor.filesModifiedByAnotherUser,
     activeFrames: currentEditor.activeFrames,
-    showResolvedThreads: currentEditor.showResolvedThreads,
+    commentFilterMode: currentEditor.commentFilterMode,
   }
 }
 
@@ -5505,8 +5505,8 @@ export const UPDATE_FNS = {
     const updateAction = updateFile(action.fullPath, updatedFile, true)
     return UPDATE_FNS.UPDATE_FILE(updateAction, editor, dispatch, builtInDependencies)
   },
-  SET_SHOW_RESOLVED_THREADS: (action: SetShowResolvedThreads, editor: EditorModel): EditorModel => {
-    return { ...editor, showResolvedThreads: action.showResolvedThreads }
+  SET_SHOW_RESOLVED_THREADS: (action: SetCommentFilterMode, editor: EditorModel): EditorModel => {
+    return { ...editor, commentFilterMode: action.commentFilterMode }
   },
 }
 

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -114,7 +114,7 @@ import { dynamicPathToStaticPath, toUid } from '../../../core/shared/element-pat
 
 import * as friendlyWords from 'friendly-words'
 import type { UtopiaVSCodeConfig } from 'utopia-vscode-common'
-import { ProjectIDPlaceholderPrefix, defaultConfig } from 'utopia-vscode-common'
+import { defaultConfig } from 'utopia-vscode-common'
 import { loginNotYetKnown } from '../../../common/user'
 import * as EP from '../../../core/shared/element-path'
 import { assertNever } from '../../../core/shared/utils'
@@ -182,6 +182,7 @@ import type { VariablesInScope } from '../../canvas/ui-jsx-canvas'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import type { ActiveFrame } from '../../canvas/commands/set-active-frames-command'
 import { Y } from '../../../core/shared/yjs'
+import type { CommentFilterMode } from '../../inspector/sections/comment-section'
 
 const ObjectPathImmutable: any = OPI
 
@@ -1450,7 +1451,7 @@ export interface EditorState {
   internalClipboard: InternalClipboard
   filesModifiedByAnotherUser: Array<string>
   activeFrames: ActiveFrame[]
-  showResolvedThreads: boolean
+  commentFilterMode: CommentFilterMode
 }
 
 export function editorState(
@@ -1532,7 +1533,7 @@ export function editorState(
   internalClipboardData: InternalClipboard,
   filesModifiedByAnotherUser: Array<string>,
   activeFrames: ActiveFrame[],
-  showResolvedThreads: boolean,
+  commentFilterMode: CommentFilterMode,
 ): EditorState {
   return {
     id: id,
@@ -1613,7 +1614,7 @@ export function editorState(
     internalClipboard: internalClipboardData,
     filesModifiedByAnotherUser: filesModifiedByAnotherUser,
     activeFrames: activeFrames,
-    showResolvedThreads: showResolvedThreads,
+    commentFilterMode: commentFilterMode,
   }
 }
 
@@ -2489,7 +2490,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     },
     filesModifiedByAnotherUser: [],
     activeFrames: [],
-    showResolvedThreads: false,
+    commentFilterMode: 'all',
   }
 }
 
@@ -2865,7 +2866,7 @@ export function editorModelFromPersistentModel(
     },
     filesModifiedByAnotherUser: [],
     activeFrames: [],
-    showResolvedThreads: false,
+    commentFilterMode: 'all',
   }
   return editor
 }

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -450,7 +450,7 @@ export function runSimpleLocalEditorAction(
         dispatch,
         builtInDependencies,
       )
-    case 'SET_SHOW_RESOLVED_THREADS':
+    case 'SET_COMMENT_FILTER_MODE':
       return UPDATE_FNS.SET_SHOW_RESOLVED_THREADS(action, state)
     default:
       return state

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -550,6 +550,7 @@ import type {
   ActiveFrameTargetPath,
   ActiveFrameTargetRect,
 } from '../../canvas/commands/set-active-frames-command'
+import type { CommentFilterMode } from '../../inspector/sections/comment-section'
 
 export const ProjectMetadataFromServerKeepDeepEquality: KeepDeepEqualityCall<ProjectMetadataFromServer> =
   combine3EqualityCalls(
@@ -4535,9 +4536,9 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     newValue.activeFrames,
   )
 
-  const showResolvedThreadsResults = BooleanKeepDeepEquality(
-    oldValue.showResolvedThreads,
-    newValue.showResolvedThreads,
+  const commentFilterModeResults = createCallWithTripleEquals<CommentFilterMode>()(
+    oldValue.commentFilterMode,
+    newValue.commentFilterMode,
   )
 
   const areEqual =
@@ -4618,7 +4619,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     internalClipboardResults.areEqual &&
     filesModifiedByAnotherUserResults.areEqual &&
     activeFramesResults.areEqual &&
-    showResolvedThreadsResults.areEqual
+    commentFilterModeResults.areEqual
 
   if (areEqual) {
     return keepDeepEqualityResult(oldValue, true)
@@ -4702,7 +4703,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
       internalClipboardResults.value,
       filesModifiedByAnotherUserResults.value,
       activeFramesResults.value,
-      showResolvedThreadsResults.value,
+      commentFilterModeResults.value,
     )
 
     return keepDeepEqualityResult(newEditorState, false)

--- a/editor/src/components/editor/store/store-hook-substore-helpers.ts
+++ b/editor/src/components/editor/store/store-hook-substore-helpers.ts
@@ -172,5 +172,5 @@ export const EmptyEditorStateForKeysOnly: EditorState = {
   },
   filesModifiedByAnotherUser: [],
   activeFrames: [],
-  showResolvedThreads: false,
+  commentFilterMode: 'all',
 }

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -39,6 +39,7 @@ import { canvasPointToWindowPoint } from '../../canvas/dom-lookup'
 import { CommentRepliesCounter } from '../../canvas/controls/comment-replies-counter'
 import type { SelectOption } from '../controls/select-control'
 import { assertNever } from '../../../core/shared/utils'
+import { pluck } from '../../../core/shared/array-utils'
 
 export type CommentFilterMode = 'all' | 'all-including-resolved' | 'unread-only'
 
@@ -104,7 +105,8 @@ const ThreadPreviews = React.memo(() => {
       case 'all-including-resolved':
         return threads
       case 'unread-only':
-        return threads.filter((t) => !readThreads.includes(t))
+        const readThreadIds = pluck(readThreads, 'id')
+        return threads.filter((t) => !readThreadIds.includes(t.id))
       default:
         assertNever(commentFilterMode)
     }

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -106,7 +106,7 @@ const ThreadPreviews = React.memo(() => {
         return threads
       case 'unread-only':
         const readThreadIds = pluck(readThreads, 'id')
-        return threads.filter((t) => !readThreadIds.includes(t.id))
+        return threads.filter((t) => !t.metadata.resolved && !readThreadIds.includes(t.id))
       default:
         assertNever(commentFilterMode)
     }

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -237,7 +237,7 @@ export function useActiveThreads() {
   const { threads } = useThreads()
   const showResolved = useEditorState(
     Substores.restOfEditor,
-    (store) => store.editor.showResolvedThreads,
+    (store) => store.editor.commentFilterMode === 'all-including-resolved',
     'useActiveThreads showResolved',
   )
   if (!showResolved) {


### PR DESCRIPTION
**Problem:**
Comment sorting and filtering in the comment sidebar is hard to understand and the code is convoluted too.

**Fix:**
Let's simplify how it works:
- comments are always sorted by last modification date
- there are three filtering view modes:
  1. "All" shows all unresolved comments 
  2. "All including resolved" shows all comments
  3. "Unread only" shows only unread and unresolved comments

This preference is persisted into the editor state, so closing and opening the comments tab keeps the previously chosen filter mode.
The same flag is used to decide whether resolved comment markers should be visible on the canvas.

**TODO:**
- Make the design better, I just added a simple PopupList
- In "Unread only" filter mode the canvas markers of the read threads should be filtered (this is only implemented for resolved/unresolved threads).