### PR TITLE
More agressive scroll to comment

### DIFF
--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -289,17 +289,25 @@ const ThreadPreview = React.memo(({ thread }: ThreadPreviewProps) => {
         width: canvasArea.width - visibleAreaTolerance * 2,
         height: canvasArea.height,
       })
-      const rect = canvasRectangle({ x: location.x, y: location.y, width: 25, height: 25 })
+
       const windowLocation = canvasPointToWindowPoint(location, canvasScale, canvasOffset)
+
+      // adds a padding of 250px around `location`
       const windowRect = canvasRectangle({
-        x: windowLocation.x,
-        y: windowLocation.y,
-        width: rect.width,
-        height: rect.height,
+        x: windowLocation.x - 250,
+        y: windowLocation.y - 250,
+        width: 500,
+        height: 500,
       })
       const isVisible = rectangleContainsRectangle(visibleArea, windowRect)
       if (!isVisible) {
-        actions.push(scrollToPosition(rect, 'to-center'))
+        const scrollToRect = canvasRectangle({
+          x: location.x,
+          y: location.y,
+          width: 25,
+          height: 25,
+        })
+        actions.push(scrollToPosition(scrollToRect, 'to-center'))
       }
     }
     dispatch(actions)


### PR DESCRIPTION
## Problem
We only scroll to a comment marker when it's off-screen (or partially off-screen). This is problematic when a comment marker is on one of the edges of the screen, and so it might be hard to notice when it's opened.

## Fix
"Pad" the bounding area of the comment marker by 250px, so if the comment marker is within 250pxs of any edge, we scroll to it