### PR TITLE
Smooth scroll to comments

### DIFF
--- a/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
+++ b/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
@@ -25,6 +25,9 @@ export function useApplyCanvasOffsetToStyle(setScaleToo: boolean): React.RefObje
   const elementRef = React.useRef<HTMLDivElement>(null)
   const canvasOffsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
   const scaleRef = useRefEditorState((store) => store.editor.canvas.scale)
+  const isScrollAnimationActiveRef = useRefEditorState(
+    (store) => store.editor.canvas.scrollAnimation,
+  )
 
   const mode = useEditorState(
     Substores.restOfEditor,
@@ -45,13 +48,15 @@ export function useApplyCanvasOffsetToStyle(setScaleToo: boolean): React.RefObje
           setScaleToo && scaleRef.current >= 1 ? `${scaleRef.current * 100}%` : '1',
         )
 
-        elementRef.current.style.setProperty(
-          'transition',
-          isFollowMode(mode) ? `transform ${liveblocksThrottle}ms linear` : 'none',
-        )
+        if (!isScrollAnimationActiveRef.current) {
+          elementRef.current.style.setProperty(
+            'transition',
+            isFollowMode(mode) ? `transform ${liveblocksThrottle}ms linear` : 'none',
+          )
+        }
       }
     },
-    [elementRef, setScaleToo, scaleRef, mode],
+    [setScaleToo, scaleRef, isScrollAnimationActiveRef, mode],
   )
 
   useSelectorWithCallback(


### PR DESCRIPTION
## Problem
When clicking on a comment in the comment sidebar, the canvas jumps to the comment, instead of smoothly scrolling there

## Fix
A side effect of `useApplyCanvasOffsetToStyle` is that switching over to comment mode removes the CSS prop that implements smooth scrolling. The fix is to check `store.editor.canvas.scrollAnimation` when setting the `transition` prop on the canvas container element