### PR TITLE
Position comment preview on bottom left of indicator

### DIFF
--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -418,6 +418,10 @@ const HoveredCommentIndicator = React.memo((props: HoveredCommentIndicatorProps)
     cancelHover,
   ])
 
+  const canvasDiv = document.getElementById('canvas-root')
+
+  const canvasHeight = canvasDiv?.clientHeight ?? 0
+
   const collabs = useStorage((storage) => storage.collaborators)
   if (hidden && dragPosition == null) {
     return null
@@ -443,7 +447,7 @@ const HoveredCommentIndicator = React.memo((props: HoveredCommentIndicatorProps)
         background: colorTheme.bg1.value,
         zIndex: 1,
         position: 'fixed',
-        top: position.y,
+        bottom: canvasHeight - IndicatorSize - position.y,
         // temporarily moving the hovered comment indicator to align with the not hovered version
         left: position.x - 3,
         overflow: 'hidden',


### PR DESCRIPTION
Fix #4700 

**Problem:**
The comment indicator hover preview box is positioned relatively to the top-left corner of the indicator, making it feel in the wrong place, especially during drag.

**Fix:**
Position the preview relative to the bottom left corner of the indicator instead.

**Before**
![Kapture 2024-01-08 at 14 17 48](https://github.com/concrete-utopia/utopia/assets/1081051/737dee5f-51ea-41fd-8cb8-f56139b4e275)

**After**
![Kapture 2024-01-08 at 14 18 46](https://github.com/concrete-utopia/utopia/assets/1081051/c56cc4e5-6c53-423c-9438-ec46f7380be4)

**TODO**
- Add a revealing animation from the bottom left to the top right corner when hovering the indicator