### PR TITLE
Puppeteer test for collaboration

### DIFF
--- a/puppeteer-tests/package.json
+++ b/puppeteer-tests/package.json
@@ -7,7 +7,8 @@
     "screenshot-test": "ts-node --files src/screenshot-test.ts",
     "system-test": "ts-node --files src/system-test.ts",
     "preinstall": "npx only-allow pnpm",
-    "comments-test": "jest --config ./jest.config.js",
+    "comments-test": "jest --config ./jest.config.js comments/place-comment.spec.ts",
+    "collaboration-test": "jest --config ./jest.config.js comments/collaboration-test.spec.ts",
     "build": "tsc"
   },
   "author": "",

--- a/puppeteer-tests/src/comments/collaboration-test.spec.tsx
+++ b/puppeteer-tests/src/comments/collaboration-test.spec.tsx
@@ -21,6 +21,10 @@ async function expectNSelectors(page: Page, selector: string, n: number) {
   expect(elementsMatchingSelector).toHaveLength(n)
 }
 
+async function waitForCoeditPropagation() {
+  await wait(2000)
+}
+
 describe('Comments test', () => {
   it(
     'can place a comment',
@@ -42,6 +46,7 @@ describe('Comments test', () => {
       await expectNSelectors(page2, 'div[data-testid="scene-label"]', 2)
 
       await clickCanvasContainer(page1, { x: 500, y: 500 })
+      await clickCanvasContainer(page2, { x: 500, y: 500 })
 
       const sceneLabel = await page1.waitForSelector('div[data-testid="scene-label"]')
       sceneLabel!.click({ offset: { x: 5, y: 5 } })
@@ -51,9 +56,7 @@ describe('Comments test', () => {
       await page1.keyboard.press('Backspace')
       await clickCanvasContainer(page2, { x: 500, y: 500 })
 
-      // This is here so that the edit can propagate from one tab to the other
-      // maybe TODO?
-      await wait(2000)
+      await waitForCoeditPropagation()
 
       await expectNSelectors(page2, 'div[data-testid="scene-label"]', 1)
 

--- a/puppeteer-tests/src/comments/collaboration-test.spec.tsx
+++ b/puppeteer-tests/src/comments/collaboration-test.spec.tsx
@@ -25,17 +25,16 @@ describe('Collaboration test', () => {
   it(
     'can place a comment',
     async () => {
-      const [{ page: page1, browser: browser1 }, { page: page2, browser: browser2 }] =
-        await Promise.all([
-          setupBrowser(
-            `http://localhost:8000/p/56a2ac40-caramel-yew?fakeUser=alice&Multiplayer=true${BRANCH_NAME}`,
-            TIMEOUT,
-          ),
-          setupBrowser(
-            `http://localhost:8000/p/56a2ac40-caramel-yew?fakeUser=bob&Multiplayer=true${BRANCH_NAME}`,
-            TIMEOUT,
-          ),
-        ])
+      const setupBrowser1Promise = setupBrowser(
+        `http://localhost:8000/p/56a2ac40-caramel-yew?fakeUser=alice&Multiplayer=true${BRANCH_NAME}`,
+        TIMEOUT,
+      )
+      const setupBrowser2Promise = setupBrowser(
+        `http://localhost:8000/p/56a2ac40-caramel-yew?fakeUser=bob&Multiplayer=true${BRANCH_NAME}`,
+        TIMEOUT,
+      )
+      const { page: page1, browser: browser1 } = await setupBrowser1Promise
+      const { page: page2, browser: browser2 } = await setupBrowser2Promise
 
       await Promise.all([signIn(page1), signIn(page2)])
       await Promise.all([

--- a/puppeteer-tests/src/comments/collaboration-test.spec.tsx
+++ b/puppeteer-tests/src/comments/collaboration-test.spec.tsx
@@ -1,0 +1,72 @@
+import type { Page } from 'puppeteer'
+import { setupBrowser, wait } from '../utils'
+
+const TIMEOUT = 120000
+
+const BRANCH_NAME = process.env.BRANCH_NAME ? `&branch_name=${process.env.BRANCH_NAME}` : ''
+
+async function signIn(page: Page) {
+  const signInButton = await page.waitForSelector('div[data-testid="sign-in-button"]')
+  await signInButton!.click()
+  await page.waitForSelector('#playground-scene') // wait for the scene to render
+}
+
+describe('Comments test', () => {
+  it(
+    'can place a comment',
+    async () => {
+      const [{ page: page1, browser: browser1 }, { page: page2, browser: browser2 }] =
+        await Promise.all([
+          setupBrowser(
+            `http://localhost:8000/p/56a2ac40-caramel-yew?fakeUser=alice&Multiplayer=true${BRANCH_NAME}`,
+            TIMEOUT,
+          ),
+          setupBrowser(
+            `http://localhost:8000/p/56a2ac40-caramel-yew?fakeUser=bob&Multiplayer=true${BRANCH_NAME}`,
+            TIMEOUT,
+          ),
+        ])
+
+      await Promise.all([signIn(page1), signIn(page2)])
+
+      {
+        const canvasControlsContainer = await page1.waitForSelector(
+          '#new-canvas-controls-container',
+        )
+        await canvasControlsContainer!.click({ offset: { x: 500, y: 500 } })
+      }
+
+      const sceneLabel = await page1.waitForSelector('div[data-testid="scene-label"]')
+      sceneLabel!.click({ offset: { x: 5, y: 5 } })
+
+      await wait(2000)
+
+      await page1.keyboard.press('Backspace')
+      await wait(5000)
+      {
+        const canvasControlsContainer = await page2.waitForSelector(
+          '#new-canvas-controls-container',
+        )
+        await canvasControlsContainer!.click({ offset: { x: 500, y: 500 } })
+        await wait(5000)
+      }
+      await page1.keyboard.down('MetaLeft')
+      await page1.keyboard.press('z', {})
+      await page1.keyboard.up('MetaLeft')
+
+      //   const thread = await page1.waitForFunction(
+      //     'document.querySelector("body").innerText.includes("hello comments")',
+      //   )
+
+      //   expect(thread).not.toBeNull()
+
+      await wait(100000)
+
+      await page1.close()
+      await browser1.close()
+      await page2.close()
+      await browser2.close()
+    },
+    TIMEOUT,
+  )
+})

--- a/puppeteer-tests/src/comments/place-comment.spec.tsx
+++ b/puppeteer-tests/src/comments/place-comment.spec.tsx
@@ -6,7 +6,7 @@ const TIMEOUT = 120000
 const BRANCH_NAME = process.env.BRANCH_NAME ? `&branch_name=${process.env.BRANCH_NAME}` : ''
 
 describe('Comments test', () => {
-  xit(
+  it(
     'can place a comment',
     async () => {
       const { page, browser } = await setupBrowser(

--- a/puppeteer-tests/src/comments/place-comment.spec.tsx
+++ b/puppeteer-tests/src/comments/place-comment.spec.tsx
@@ -6,7 +6,7 @@ const TIMEOUT = 120000
 const BRANCH_NAME = process.env.BRANCH_NAME ? `&branch_name=${process.env.BRANCH_NAME}` : ''
 
 describe('Comments test', () => {
-  it(
+  xit(
     'can place a comment',
     async () => {
       const { page, browser } = await setupBrowser(

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -109,11 +109,18 @@ dummyUser cdnRoot = UserDetails { userId  = "1"
                                 }
 
 dummyUserAlice :: Text -> UserDetails
-dummyUserAlice cdnRoot = UserDetails { userId  = "ab9401d8-f6f0-4642-8239-2435656bf0b2 "
+dummyUserAlice cdnRoot = UserDetails { userId  = "ab9401d8-f6f0-4642-8239-2435656bf0b2"
                                      , email   = Just "team1@utopia.app"
                                      , name    = Just "A real human being"
                                      , picture = Just (cdnRoot <> "/editor/avatars/utopino3.png")
                                      }
+
+dummyUserBob :: Text -> UserDetails
+dummyUserBob cdnRoot = UserDetails { userId  = "231f5f05-cac7-4910-8006-d7645c44051c"
+                                    , email   = Just "team1@utopia.app"
+                                    , name    = Just "Also a real human being"
+                                    , picture = Just (cdnRoot <> "/editor/avatars/utopino2.png")
+                                    }
 
 {-|
   Fallback for validating the authentication code in the case where Auth0 isn't setup locally.
@@ -167,6 +174,7 @@ innerServerExecutor (CheckAuthCode authCode action) = do
   let codeCheck = maybe localAuthCodeCheck (auth0CodeCheck metrics pool sessionStore) auth0
   case authCode of
     "alice" -> successfulAuthCheck metrics pool sessionStore action (dummyUserAlice cdnRoot)
+    "bob" -> successfulAuthCheck metrics pool sessionStore action (dummyUserBob cdnRoot)
     _ -> codeCheck authCode action
 innerServerExecutor (Logout cookie pageContents action) = do
   sessionStore <- fmap _sessionState ask

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -84,6 +84,14 @@ dummyUserAlice = UserDetails { userId  = "ab9401d8-f6f0-4642-8239-2435656bf0b2"
                              , picture = Just "/editor/avatars/utopino3.png"
                              }
 
+dummyUserBob :: UserDetails
+dummyUserBob = UserDetails { userId  = "231f5f05-cac7-4910-8006-d7645c44051c"
+                            , email   = Just "team1@utopia.app"
+                            , name    = Just "Also a real human being"
+                            , picture = Just "/editor/avatars/utopino2.png"
+                            }
+
+
 {-|
   Interpretor for a service call, which converts it into side effecting calls ready to be invoked.
 -}
@@ -106,6 +114,7 @@ innerServerExecutor (CheckAuthCode authCode action) = do
   canUseFakeUser <- fmap _shouldUseFakeUser ask
   case (canUseFakeUser, authCode) of
     (True, "alice") -> successfulAuthCheck metrics pool sessionStore action dummyUserAlice
+    (True, "bob") -> successfulAuthCheck metrics pool sessionStore action dummyUserBob
     _ -> auth0CodeCheck metrics pool sessionStore auth0 authCode action
 innerServerExecutor (Logout cookie pageContents action) = do
   sessionStore <- fmap _sessionState ask


### PR DESCRIPTION
# Description
This PR adds a Puppeteer test, which
- opens two browser windows
- with a different fake user in each one
- has one of the users delete one of the scenes in the project
- has the other assert that the scene has been deleted in the other page too

# Follow-up work after this PR
- create a project on pizza that both browsers open (both browser have to open the same project, for the collaboration to work)
- update the localhost link to the new project URL
- create a CI job that runs the collaboration test

## Testing the test locally
- Log out from the editor on localhost (by navigating to `localhost:8000/logout`)
- navigate to `http://localhost:8000/p?fakeUser=alice`
- log in (this will automatically create a project)
- substitute the new project for `http://localhost:8000/p/56a2ac40-caramel-yew` in the new test
- run `pnpm run collaboration-test` from `puppeteer-tests`




