### PR TITLE
Subtle Border for the Comment Markers

### DIFF
--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -207,6 +207,7 @@ export const CommentIndicatorUI = React.memo<CommentIndicatorUIProps>((props) =>
       alignItems: 'center',
       justifyContent: 'center',
       boxShadow: UtopiaStyles.shadowStyles.mid.boxShadow,
+      border: '.4px solid #a3a3a340',
       opacity: resolved ? 0.6 : 'undefined',
     }
 
@@ -445,6 +446,7 @@ const HoveredCommentIndicator = React.memo((props: HoveredCommentIndicatorProps)
         width: 250,
         boxShadow: UtopiaStyles.shadowStyles.mid.boxShadow,
         background: colorTheme.bg1.value,
+        border: '.4px solid #a3a3a340',
         zIndex: 1,
         position: 'fixed',
         bottom: canvasHeight - IndicatorSize - position.y,


### PR DESCRIPTION
The contrast between the Comment Indicators and the background (when it was exactly the same color) was too low. Now they have a very subtle grey border to emphasize it's edges.

![light](https://github.com/concrete-utopia/utopia/assets/47405698/16177bf4-d97a-4681-8d78-b3b5088b3cec)
![dark](https://github.com/concrete-utopia/utopia/assets/47405698/05e9730d-4e46-4a97-bccd-644d222d6530)
