### PR TITLE
Comment Tab Fixes

### DIFF
--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -198,21 +198,21 @@ const ThreadPreviews = React.memo(() => {
       </FlexRow>
       {when(
         threads.length > 1,
-        <FlexColumn
+        <FlexRow
           style={{
-            gap: 6,
-            overflow: 'hidden',
-            padding: filtersOpen ? 8 : 0,
-            height: filtersOpen ? 'auto' : 0,
+            justifyContent: 'space-between',
+            display: filtersOpen ? 'inherit' : 'none',
+            padding: 8,
           }}
         >
+          Filter By
           <PopupList
             value={filter}
             options={filterOptions}
             onSubmitValue={handleSubmitValueFilter}
             style={{ width: 150 }}
           />
-        </FlexColumn>,
+        </FlexRow>,
       )}
       {when(
         sortedThreads.length === 0,
@@ -224,7 +224,6 @@ const ThreadPreviews = React.memo(() => {
             overflowWrap: 'break-word',
           }}
         >
-          {' '}
           {commentFilterMode == 'unread-only'
             ? 'No Unread Comments.'
             : 'Use the commenting tool to leave comments on the canvas. They will also show up here.'}

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -49,7 +49,7 @@ const filterOptions = [
     value: 'all',
   },
   {
-    label: 'All Including Resolved',
+    label: 'All (and Resolved)',
     value: 'all-including-resolved',
   },
   {
@@ -172,6 +172,8 @@ const ThreadPreviews = React.memo(() => {
                   background:
                     commentFilterMode !== 'all' ? colorTheme.bg1.value : colorTheme.fg1.value,
                   borderRadius: 2,
+                  flexGrow: 0,
+                  flexShrink: 0,
                 }}
               />
               <div
@@ -181,6 +183,8 @@ const ThreadPreviews = React.memo(() => {
                   background:
                     commentFilterMode !== 'all' ? colorTheme.bg1.value : colorTheme.fg1.value,
                   borderRadius: 2,
+                  flexGrow: 0,
+                  flexShrink: 0,
                 }}
               />
               <div
@@ -190,6 +194,8 @@ const ThreadPreviews = React.memo(() => {
                   background:
                     commentFilterMode !== 'all' ? colorTheme.bg1.value : colorTheme.fg1.value,
                   borderRadius: 2,
+                  flexGrow: 0,
+                  flexShrink: 0,
                 }}
               />
             </div>
@@ -205,12 +211,13 @@ const ThreadPreviews = React.memo(() => {
             padding: 8,
           }}
         >
-          Filter By
+          Filter By:
           <PopupList
             value={filter}
             options={filterOptions}
             onSubmitValue={handleSubmitValueFilter}
-            style={{ width: 150 }}
+            style={{ marginLeft: 5 }}
+            containerMode='noBorder'
           />
         </FlexRow>,
       )}

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -73,11 +73,6 @@ const ThreadPreviews = React.memo(() => {
   const dispatch = useDispatch()
   const colorTheme = useColorTheme()
 
-  const [filtersOpen, setOpen] = React.useState(false)
-  const toggleOpen = React.useCallback(() => {
-    setOpen((prevOpen) => !prevOpen)
-  }, [setOpen])
-
   const { threads } = useThreads()
   const { threads: readThreads } = useReadThreads()
 
@@ -123,104 +118,27 @@ const ThreadPreviews = React.memo(() => {
     <FlexColumn>
       <FlexRow
         style={{
-          flexGrow: 1,
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          fontWeight: 600,
           margin: 8,
+          gap: 12,
         }}
       >
-        <span>Comments</span>
-        <Tooltip title='Sort/Filter' placement='bottom'>
-          <div
-            css={{
-              display: threads.length > 1 ? 'flex' : 'none',
-              width: 20,
-              height: 20,
-              borderRadius: 3,
-              justifyContent: 'center',
-              alignItems: 'center',
-              '&:hover': {
-                backgroundColor: colorTheme.bg3.value,
-              },
+        <span style={{ fontWeight: 600 }}>Comments</span>
+        {when(
+          threads.length > 1,
+          <FlexRow
+            style={{
+              justifyContent: 'flex-end',
             }}
           >
-            <div
-              css={{
-                height: 14,
-                width: 14,
-                borderRadius: 14,
-                border:
-                  commentFilterMode !== 'all'
-                    ? `1px solid ${colorTheme.dynamicBlue.value}`
-                    : `1px solid ${colorTheme.fg1.value}`,
-                background:
-                  commentFilterMode !== 'all' ? colorTheme.dynamicBlue.value : 'transparent',
-                cursor: 'pointer',
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'center',
-                alignItems: 'center',
-                gap: 1,
-              }}
-              onClick={toggleOpen}
-            >
-              <div
-                style={{
-                  width: 8,
-                  height: 1,
-                  background:
-                    commentFilterMode !== 'all' ? colorTheme.bg1.value : colorTheme.fg1.value,
-                  borderRadius: 2,
-                  flexGrow: 0,
-                  flexShrink: 0,
-                }}
-              />
-              <div
-                style={{
-                  width: 6,
-                  height: 1,
-                  background:
-                    commentFilterMode !== 'all' ? colorTheme.bg1.value : colorTheme.fg1.value,
-                  borderRadius: 2,
-                  flexGrow: 0,
-                  flexShrink: 0,
-                }}
-              />
-              <div
-                style={{
-                  width: 4,
-                  height: 1,
-                  background:
-                    commentFilterMode !== 'all' ? colorTheme.bg1.value : colorTheme.fg1.value,
-                  borderRadius: 2,
-                  flexGrow: 0,
-                  flexShrink: 0,
-                }}
-              />
-            </div>
-          </div>
-        </Tooltip>
+            <PopupList
+              value={filter}
+              options={filterOptions}
+              onSubmitValue={handleSubmitValueFilter}
+              containerMode='noBorder'
+            />
+          </FlexRow>,
+        )}
       </FlexRow>
-      {when(
-        threads.length > 1,
-        <FlexRow
-          style={{
-            justifyContent: 'space-between',
-            display: filtersOpen ? 'inherit' : 'none',
-            padding: 8,
-          }}
-        >
-          Filter By:
-          <PopupList
-            value={filter}
-            options={filterOptions}
-            onSubmitValue={handleSubmitValueFilter}
-            style={{ marginLeft: 5 }}
-            containerMode='noBorder'
-          />
-        </FlexRow>,
-      )}
       {when(
         sortedThreads.length === 0,
         <div

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -125,7 +125,7 @@ const ThreadPreviews = React.memo(() => {
       >
         <span style={{ fontWeight: 600 }}>Comments</span>
         {when(
-          threads.length > 1,
+          threads.length > 0,
           <FlexRow
             style={{
               justifyContent: 'flex-end',

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -411,7 +411,7 @@ const ThreadPreview = React.memo(({ thread }: ThreadPreviewProps) => {
         )}
         <CommentRepliesCounter thread={thread} />
       </div>
-      <Tooltip title='Resolve' placement='top'>
+      <Tooltip title={thread.metadata.resolved ? 'Unresolve' : 'Mark Resolved'} placement='top'>
         <Button
           css={{
             position: 'absolute',

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -49,11 +49,11 @@ const filterOptions = [
     value: 'all',
   },
   {
-    label: 'All including resolved',
+    label: 'All Including Resolved',
     value: 'all-including-resolved',
   },
   {
-    label: 'Unread only',
+    label: 'Unread Only',
     value: 'unread-only',
   },
 ]
@@ -150,7 +150,12 @@ const ThreadPreviews = React.memo(() => {
                 height: 14,
                 width: 14,
                 borderRadius: 14,
-                border: `1px solid ${colorTheme.fg1.value}`,
+                border:
+                  commentFilterMode !== 'all'
+                    ? `1px solid ${colorTheme.dynamicBlue.value}`
+                    : `1px solid ${colorTheme.fg1.value}`,
+                background:
+                  commentFilterMode !== 'all' ? colorTheme.dynamicBlue.value : 'transparent',
                 cursor: 'pointer',
                 display: 'flex',
                 flexDirection: 'column',
@@ -161,13 +166,31 @@ const ThreadPreviews = React.memo(() => {
               onClick={toggleOpen}
             >
               <div
-                style={{ width: 8, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
+                style={{
+                  width: 8,
+                  height: 1,
+                  background:
+                    commentFilterMode !== 'all' ? colorTheme.bg1.value : colorTheme.fg1.value,
+                  borderRadius: 2,
+                }}
               />
               <div
-                style={{ width: 6, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
+                style={{
+                  width: 6,
+                  height: 1,
+                  background:
+                    commentFilterMode !== 'all' ? colorTheme.bg1.value : colorTheme.fg1.value,
+                  borderRadius: 2,
+                }}
               />
               <div
-                style={{ width: 4, height: 1, background: colorTheme.fg1.value, borderRadius: 2 }}
+                style={{
+                  width: 4,
+                  height: 1,
+                  background:
+                    commentFilterMode !== 'all' ? colorTheme.bg1.value : colorTheme.fg1.value,
+                  borderRadius: 2,
+                }}
               />
             </div>
           </div>
@@ -201,7 +224,10 @@ const ThreadPreviews = React.memo(() => {
             overflowWrap: 'break-word',
           }}
         >
-          Use the commenting tool to leave comments on the canvas. They will also show up here.
+          {' '}
+          {commentFilterMode == 'unread-only'
+            ? 'No Unread Comments.'
+            : 'Use the commenting tool to leave comments on the canvas. They will also show up here.'}
         </div>,
       )}
       {sortedThreads.map((thread) => (

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -120,6 +120,7 @@ const ThreadPreviews = React.memo(() => {
         style={{
           margin: 8,
           gap: 12,
+          height: 22,
         }}
       >
         <span style={{ fontWeight: 600 }}>Comments</span>

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -134,10 +134,10 @@ const ThreadPreviews = React.memo(() => {
         <Tooltip title='Sort/Filter' placement='bottom'>
           <div
             css={{
+              display: threads.length > 1 ? 'flex' : 'none',
               width: 20,
               height: 20,
               borderRadius: 3,
-              display: 'flex',
               justifyContent: 'center',
               alignItems: 'center',
               '&:hover': {
@@ -174,7 +174,7 @@ const ThreadPreviews = React.memo(() => {
         </Tooltip>
       </FlexRow>
       {when(
-        sortedThreads.length > 0,
+        threads.length > 1,
         <FlexColumn
           style={{
             gap: 6,


### PR DESCRIPTION
A few changes to the comments section:

- the filter options only show when there are in fact, comments to filter 
<img width="300" alt="Screenshot 2024-01-09 at 11 02 10 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/3fb94fc6-792e-49a6-acef-1b04c1831493">

- reorganized the layout a bit, no more toggle button to show the filter popup
<img width="301" alt="Screenshot 2024-01-09 at 1 52 23 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/fc3664db-d87b-4f74-8989-7a50c21fbdfb">


- when there's comments to sort but no unread comments specifically, it says that
<img width="304" alt="Screenshot 2024-01-09 at 1 52 40 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/c1a3745f-53cb-4d9f-8624-e9e920958d96">


- Fixing the tooltip on the thread previews to say 'Unresolve' if resolved, and 'Mark Resolved' if not
<img width="300" alt="Screenshot 2024-01-09 at 11 11 34 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/bcc49769-56a0-442d-a010-312a3ae275f6">
<img width="300" alt="Screenshot 2024-01-09 at 11 12 01 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/59cbf03d-5cc4-44b2-ab6d-e16f260116be">



