### PR TITLE
CI job for collab test

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -398,3 +398,44 @@ jobs:
           BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
         run: |
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "xvfb-run --server-args='-screen 0 1920x1080x24 -ac -nolisten tcp -dpi 96 +extension RANDR' run-comments-test"
+
+  collaboration-test:
+    name: Run Collaboration Tests
+    timeout-minutes: 12
+    runs-on: ubuntu-latest
+    needs: [deploy-staging, cache-pnpm-store]
+    env:
+      UTOPIA_SHA: ${{ github.sha }}
+      AUTH0_CLIENT_ID: KB7euFO46rVYeOaWmrEdktdhAFxEO266
+      AUTH0_ENDPOINT: enter.utopia.app
+      AUTH0_REDIRECT_URI: https://utopia.pizza/authenticate
+    steps:
+      # Gets the branch that this PR is targeting and replaces forward slashes in the name with hyphens.
+      # So that later steps can produce a bundle incorporating that into the name and upload it.
+      - name: Extract branch name
+        shell: bash
+        run: |
+          FIXED_REF="${GITHUB_HEAD_REF////-}"
+          echo "##[set-output name=branch;]$FIXED_REF"
+        id: extract_branch
+      - name: Install nix
+        uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Cache .pnpm-store
+        uses: actions/cache@v2
+        with:
+          path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
+      - name: Build Comments Tests
+        run: |
+          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "build-puppeteer-tests"
+      - name: Run Comments Test
+        id: run-comments-test
+        env:
+          BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
+          BASE_URL: 'https://utopia.pizza'
+        run: |
+          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "xvfb-run --server-args='-screen 0 1920x1080x24 -ac -nolisten tcp -dpi 96 +extension RANDR' run-collaboration-test"

--- a/editor/src/components/editor/persistence/generic/persistence-machine.ts
+++ b/editor/src/components/editor/persistence/generic/persistence-machine.ts
@@ -109,14 +109,17 @@ export function saveEvent<ModelType>(projectModel: ProjectModel<ModelType>): Sav
 interface SaveCompleteEvent<ModelType, FileType> {
   type: 'SAVE_COMPLETE'
   saveResult: ProjectWithFileChanges<ModelType, FileType>
+  source: 'local' | 'server'
 }
 
 function saveCompleteEvent<ModelType, FileType>(
   saveResult: ProjectWithFileChanges<ModelType, FileType>,
+  source: 'local' | 'server',
 ): SaveCompleteEvent<ModelType, FileType> {
   return {
     type: 'SAVE_COMPLETE',
     saveResult: saveResult,
+    source: source,
   }
 }
 
@@ -486,7 +489,7 @@ export function createPersistenceMachine<ModelType, FileType>(
                   target: BackendIdle,
                   actions: send(
                     (_, event: DoneInvokeEvent<ProjectWithFileChanges<ModelType, FileType>>) =>
-                      saveCompleteEvent(event.data),
+                      saveCompleteEvent(event.data, 'server'),
                   ),
                 },
                 onError: {
@@ -503,7 +506,7 @@ export function createPersistenceMachine<ModelType, FileType>(
                   target: BackendIdle,
                   actions: send(
                     (_, event: DoneInvokeEvent<ProjectWithFileChanges<ModelType, FileType>>) =>
-                      saveCompleteEvent(event.data),
+                      saveCompleteEvent(event.data, 'local'),
                   ),
                 },
                 onError: {

--- a/puppeteer-tests/src/comments/collaboration-test.spec.tsx
+++ b/puppeteer-tests/src/comments/collaboration-test.spec.tsx
@@ -23,8 +23,6 @@ async function expectNSelectors(page: Page, selector: string, n: number) {
   expect(elementsMatchingSelector).toHaveLength(n)
 }
 
-// TODO: CI job
-
 describe('Collaboration test', () => {
   it(
     'can collaboratively add an element',
@@ -36,6 +34,7 @@ describe('Collaboration test', () => {
 
       await page1.waitForNavigation()
       await signIn(page1)
+      // wait for project to be saved
       await wait(5000) // TODO
 
       const newProjectUrl = new url.URL(page1.url()).pathname

--- a/puppeteer-tests/src/comments/collaboration-test.spec.tsx
+++ b/puppeteer-tests/src/comments/collaboration-test.spec.tsx
@@ -18,11 +18,6 @@ async function clickCanvasContainer(page: Page, { x, y }: { x: number; y: number
   await canvasControlsContainer!.click({ offset: { x, y } })
 }
 
-async function expectNSelectors(page: Page, selector: string, n: number) {
-  const elementsMatchingSelector = await page.$$(selector)
-  expect(elementsMatchingSelector).toHaveLength(n)
-}
-
 describe('Collaboration test', () => {
   it(
     'can collaboratively add an element',
@@ -35,7 +30,10 @@ describe('Collaboration test', () => {
       await page1.waitForNavigation()
       await signIn(page1)
       // wait for project to be saved
-      await wait(5000) // TODO
+      await page1.waitForFunction(
+        'document.querySelector("body").innerText.includes("Project successfully uploaded!")',
+        { polling: 'mutation' },
+      )
 
       const newProjectUrl = new url.URL(page1.url()).pathname
 

--- a/shell.nix
+++ b/shell.nix
@@ -260,6 +260,13 @@ let
       ${pnpm}/bin/pnpm install --unsafe-perm
       ${pnpm}/bin/pnpm run comments-test
     '')
+    (pkgs.writeScriptBin "run-collaboration-test" ''
+      #!/usr/bin/env bash
+      set -e
+      cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/puppeteer-tests
+      ${pnpm}/bin/pnpm install --unsafe-perm
+      ${pnpm}/bin/pnpm run collaboration-test
+    '')
   ];
 
   withPuppeteerScripts = withBaseEditorScripts ++ (lib.optionals stdenv.isLinux puppeteerScripts);


### PR DESCRIPTION
## Description
This PR adds a CI job that runs the test for commenting.

### Also
- makes it possible to run this test locally, the same way as implemented in https://github.com/concrete-utopia/utopia/pull/4715
- tweaks the test so that no hardcoded project name is necessary, the second browser navigates to the URL the first one is redirected to after the project is created.