### PR TITLE
Configurable base url for comments test

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -396,5 +396,6 @@ jobs:
         id: run-comments-test
         env:
           BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
+          BASE_URL: 'https://utopia.pizza'
         run: |
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "xvfb-run --server-args='-screen 0 1920x1080x24 -ac -nolisten tcp -dpi 96 +extension RANDR' run-comments-test"

--- a/puppeteer-tests/src/comments/place-comment.spec.tsx
+++ b/puppeteer-tests/src/comments/place-comment.spec.tsx
@@ -4,13 +4,14 @@ import type { Browser } from 'puppeteer'
 const TIMEOUT = 120000
 
 const BRANCH_NAME = process.env.BRANCH_NAME ? `&branch_name=${process.env.BRANCH_NAME}` : ''
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:8000'
 
 describe('Comments test', () => {
   it(
     'can place a comment',
     async () => {
       const { page, browser } = await setupBrowser(
-        `https://utopia.pizza/p/?fakeUser=alice&Multiplayer=true${BRANCH_NAME}`,
+        `${BASE_URL}/p/?fakeUser=alice&Multiplayer=true${BRANCH_NAME}`,
         TIMEOUT,
       )
 


### PR DESCRIPTION
## Problem
The test for comments runs on pizza, even if the actual test script is run on localhost. This is not ideal for testing code that's only available locally.

## Fix
Adds an env var to the test called `BASE_URL`, which specifies where the test should run. It defaults to `localhost`, and set to `pizza` in the CI job.