### PR TITLE
Close Puppeteer browser after test

### DIFF
--- a/puppeteer-tests/src/comments/collaboration-test.spec.tsx
+++ b/puppeteer-tests/src/comments/collaboration-test.spec.tsx
@@ -1,6 +1,7 @@
 import type { ElementHandle, Page } from 'puppeteer'
 import { setupBrowser, wait } from '../utils'
 import * as url from 'url'
+import { createUtopiaPuppeteerBrowser } from './test-utils'
 
 const TIMEOUT = 120000
 
@@ -19,13 +20,15 @@ async function clickCanvasContainer(page: Page, { x, y }: { x: number; y: number
 }
 
 describe('Collaboration test', () => {
+  let utopiaBrowser1 = createUtopiaPuppeteerBrowser()
+  let utopiaBrowser2 = createUtopiaPuppeteerBrowser()
   it(
     'can collaboratively add an element',
     async () => {
-      const { page: page1, browser: browser1 } = await setupBrowser(
-        `${BASE_URL}/p/?fakeUser=alice&Multiplayer=true${BRANCH_NAME}`,
-        TIMEOUT,
-      )
+      const { page: page1 } = await utopiaBrowser1.setup({
+        url: `${BASE_URL}/p/?fakeUser=alice&Multiplayer=true${BRANCH_NAME}`,
+        timeout: TIMEOUT,
+      })
 
       await page1.waitForNavigation()
       await signIn(page1)
@@ -37,10 +40,11 @@ describe('Collaboration test', () => {
 
       const newProjectUrl = new url.URL(page1.url()).pathname
 
-      const { page: page2, browser: browser2 } = await setupBrowser(
-        `${BASE_URL}${newProjectUrl}?fakeUser=bob&Multiplayer=true${BRANCH_NAME}`,
-        TIMEOUT,
-      )
+      const { page: page2 } = await utopiaBrowser2.setup({
+        url: `${BASE_URL}${newProjectUrl}?fakeUser=bob&Multiplayer=true${BRANCH_NAME}`,
+        timeout: TIMEOUT,
+      })
+
       await signIn(page2)
 
       await Promise.all([signIn(page1), signIn(page2)])
@@ -71,11 +75,6 @@ describe('Collaboration test', () => {
       await page1.keyboard.down('MetaLeft')
       await page1.keyboard.press('z', {})
       await page1.keyboard.up('MetaLeft')
-
-      await page1.close()
-      await browser1.close()
-      await page2.close()
-      await browser2.close()
     },
     TIMEOUT,
   )

--- a/puppeteer-tests/src/comments/place-comment.spec.tsx
+++ b/puppeteer-tests/src/comments/place-comment.spec.tsx
@@ -1,5 +1,4 @@
-import { setupBrowser, wait } from '../utils'
-import type { Browser } from 'puppeteer'
+import { createUtopiaPuppeteerBrowser } from './test-utils'
 
 const TIMEOUT = 120000
 
@@ -7,13 +6,15 @@ const BRANCH_NAME = process.env.BRANCH_NAME ? `&branch_name=${process.env.BRANCH
 const BASE_URL = process.env.BASE_URL ?? 'http://localhost:8000'
 
 describe('Comments test', () => {
+  let utopiaBrowser = createUtopiaPuppeteerBrowser()
+
   it(
     'can place a comment',
     async () => {
-      const { page, browser } = await setupBrowser(
-        `${BASE_URL}/p/?fakeUser=alice&Multiplayer=true${BRANCH_NAME}`,
-        TIMEOUT,
-      )
+      const { page } = await utopiaBrowser.setup({
+        url: `${BASE_URL}/p/?fakeUser=alice&Multiplayer=true${BRANCH_NAME}`,
+        timeout: TIMEOUT,
+      })
 
       const signInButton = await page.waitForSelector('div[data-testid="sign-in-button"]')
       await signInButton!.click()
@@ -41,9 +42,6 @@ describe('Comments test', () => {
 
       const resolveButton = await page.waitForSelector('div[data-testid="resolve-thread-button"]')
       await resolveButton!.click()
-
-      await page.close()
-      await browser.close()
     },
     TIMEOUT,
   )

--- a/puppeteer-tests/src/comments/test-utils.ts
+++ b/puppeteer-tests/src/comments/test-utils.ts
@@ -8,7 +8,6 @@ export interface UtopiaPuppeteerBrowserOptions {
 
 interface UtopiaPuppeteerBrowser {
   setup: (options: UtopiaPuppeteerBrowserOptions) => Promise<BrowserForPuppeteerTest>
-  browserForTest: { current: BrowserForPuppeteerTest | null }
 }
 
 export const createUtopiaPuppeteerBrowser = (): UtopiaPuppeteerBrowser => {
@@ -23,7 +22,6 @@ export const createUtopiaPuppeteerBrowser = (): UtopiaPuppeteerBrowser => {
   })
 
   return {
-    browserForTest: browserForTest,
     setup: async (options: UtopiaPuppeteerBrowserOptions) => {
       browserForTest.current = await setupBrowser(options.url, options.timeout)
       return browserForTest.current

--- a/puppeteer-tests/src/comments/test-utils.ts
+++ b/puppeteer-tests/src/comments/test-utils.ts
@@ -1,0 +1,32 @@
+import type { BrowserForPuppeteerTest } from '../utils'
+import { setupBrowser } from '../utils'
+
+export interface UtopiaPuppeteerBrowserOptions {
+  url: string
+  timeout: number
+}
+
+interface UtopiaPuppeteerBrowser {
+  setup: (options: UtopiaPuppeteerBrowserOptions) => Promise<BrowserForPuppeteerTest>
+  browserForTest: { current: BrowserForPuppeteerTest | null }
+}
+
+export const createUtopiaPuppeteerBrowser = (): UtopiaPuppeteerBrowser => {
+  let browserForTest: { current: BrowserForPuppeteerTest | null } = { current: null }
+
+  afterEach(async () => {
+    if (browserForTest.current?.browser != null) {
+      await browserForTest.current.browser.close()
+    }
+
+    browserForTest.current = null
+  })
+
+  return {
+    browserForTest: browserForTest,
+    setup: async (options: UtopiaPuppeteerBrowserOptions) => {
+      browserForTest.current = await setupBrowser(options.url, options.timeout)
+      return browserForTest.current
+    },
+  }
+}

--- a/puppeteer-tests/src/utils.ts
+++ b/puppeteer-tests/src/utils.ts
@@ -6,13 +6,15 @@ const path = require('path')
 const AWS = require('aws-sdk')
 const yn = require('yn')
 
+export interface BrowserForPuppeteerTest {
+  page: puppeteer.Page
+  browser: puppeteer.Browser
+}
+
 export const setupBrowser = async (
   url: string,
   defaultTimeout: number,
-): Promise<{
-  page: puppeteer.Page
-  browser: puppeteer.Browser
-}> => {
+): Promise<BrowserForPuppeteerTest> => {
   const browser = await puppeteer.launch({
     args: ['--no-sandbox', '--enable-thread-instruction-count'],
     headless: yn(process.env.HEADLESS) ?? false,


### PR DESCRIPTION
## Problem

The Puppeteer browsers aren't closed if the tests end in failure

## Fix
Use an afterEach-based solution to close the browser after the tests are over