### PR TITLE
Show avatars for every connection instead of every user.

### DIFF
--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -82,15 +82,17 @@ const MultiplayerUserBar = React.memo(() => {
   const dispatch = useDispatch()
   const collabs = useStorage((store) => store.collaborators)
 
-  const { user: myUser } = useMyUserAndPresence()
+  const { user: myUser, presence: myPresence } = useMyUserAndPresence()
 
   const others = useOthers((list) =>
-    normalizeOthersList(myUser.id, list).map((other) => {
-      return {
-        ...getCollaborator(collabs, other),
-        following: other.presence.following,
-      }
-    }),
+    list
+      .filter((entry) => entry.connectionId !== myPresence.connectionId)
+      .map((other) => {
+        return {
+          ...getCollaborator(collabs, other),
+          following: other.presence.following,
+        }
+      }),
   )
 
   const visibleOthers = React.useMemo(() => {


### PR DESCRIPTION
**Problem:**
Currently we show a badge for each Liveblocks user, but a single user can have multiple sessions open so it doesn't really represent what is happening.

**Fix:**
Removed the normalisation that makes entries unique by user ID, only exclude the current connection ID.

**Commit Details:**
- `MultiplayerUserBar` now only filters the entries for `others` by exclusing the current Liveblocks `connectionId`.
