### PR TITLE
Fix cursor over comment threads

### DIFF
--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -315,7 +315,12 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
   const draggingCallback = React.useCallback((isDragging: boolean) => setDragging(isDragging), [])
 
   return (
-    <div onMouseOver={onMouseOver} onMouseOut={onMouseOut} data-testid='comment-indicator'>
+    <div
+      onMouseOver={onMouseOver}
+      onMouseOut={onMouseOut}
+      data-testid='comment-indicator'
+      style={{ cursor: 'auto' }}
+    >
       {when(
         (isActive || !hovered) && !dragging,
         <CommentIndicatorUI

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -319,7 +319,9 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
       onMouseOver={onMouseOver}
       onMouseOut={onMouseOut}
       data-testid='comment-indicator'
-      style={{ cursor: 'auto' }}
+      style={{
+        cursor: 'auto',
+      }}
     >
       {when(
         (isActive || !hovered) && !dragging,

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -318,6 +318,7 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
         borderRadius: 4,
         overflow: 'hidden',
         zoom: 1 / canvasScale,
+        cursor: 'auto',
       }}
       onKeyDown={stopPropagation}
       onKeyUp={stopPropagation}


### PR DESCRIPTION
Fix #4718 

**Problem:**

The mouse cursor is stuck into the comment bubble even when hovering comment threads and indicators.

**Fix:**

Fix that.

| Before | After |
|-------|-------|
| ![Kapture 2024-01-10 at 18 28 44](https://github.com/concrete-utopia/utopia/assets/1081051/2d254259-c0ba-4299-b7be-6dcf679662f7) | ![Kapture 2024-01-10 at 18 27 44](https://github.com/concrete-utopia/utopia/assets/1081051/1f2e4422-e44a-4a29-bec4-bc537e0e359b) |