### PR TITLE
Don't render multiplayer UI with fs off

### DIFF
--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -382,6 +382,8 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
 
   const roomStatus = useStatus()
 
+  const multiplayerEnabled = isFeatureEnabled('Multiplayer') && roomStatus === 'connected'
+
   const getResizeStatus = () => {
     const selectedViews = localSelectedViews
     if (textEditor != null || keysPressed['z']) {
@@ -586,7 +588,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
               </>,
             )}
             {when(
-              isFeatureEnabled('Multiplayer') && roomStatus === 'connected',
+              multiplayerEnabled,
               <MultiplayerWrapper errorFallback={null} suspenseFallback={null}>
                 <MultiplayerPresence />
               </MultiplayerWrapper>,

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -382,7 +382,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
 
   const roomStatus = useStatus()
 
-  const multiplayerEnabled = isFeatureEnabled('Multiplayer') && roomStatus === 'connected'
+  const multiplayerActive = isFeatureEnabled('Multiplayer') && roomStatus === 'connected'
 
   const getResizeStatus = () => {
     const selectedViews = localSelectedViews
@@ -588,7 +588,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
               </>,
             )}
             {when(
-              multiplayerEnabled,
+              multiplayerActive,
               <MultiplayerWrapper errorFallback={null} suspenseFallback={null}>
                 <MultiplayerPresence />
               </MultiplayerWrapper>,

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -70,6 +70,7 @@ import { useIsMyProject } from '../../editor/store/collaborative-editing'
 import { useStatus } from '../../../../liveblocks.config'
 import { MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
 import { MultiplayerPresence } from '../multiplayer-presence'
+import { isFeatureEnabled } from '../../../utils/feature-switches'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
@@ -585,7 +586,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
               </>,
             )}
             {when(
-              roomStatus === 'connected',
+              isFeatureEnabled('Multiplayer') && roomStatus === 'connected',
               <MultiplayerWrapper errorFallback={null} suspenseFallback={null}>
                 <MultiplayerPresence />
               </MultiplayerWrapper>,


### PR DESCRIPTION
**Problem:**
More defensive code to make sure multiplayer UI is not rendered when the `Multiplayer` FS is off
