### PR TITLE
Hide explorer and Github panes for viewers

### DIFF
--- a/editor/src/components/navigator/left-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/index.tsx
@@ -17,6 +17,8 @@ import { NavigatorComponent } from '../navigator'
 import { ContentsPane } from './contents-pane'
 import { GithubPane } from './github-pane'
 import type { StoredPanel } from '../../canvas/stored-layout'
+import { useIsMyProject } from '../../editor/store/collaborative-editing'
+import { when } from '../../../utils/react-conditionals'
 
 export interface LeftPaneProps {
   editorState: EditorState
@@ -63,6 +65,8 @@ export const LeftPaneComponent = React.memo<LeftPaneComponentProps>((props) => {
     onClickTab(LeftMenuTab.Github)
   }, [onClickTab])
 
+  const isMyProject = useIsMyProject()
+
   return (
     <LowPriorityStoreProvider>
       <FlexColumn
@@ -88,26 +92,29 @@ export const LeftPaneComponent = React.memo<LeftPaneComponentProps>((props) => {
             overflowY: 'scroll',
           }}
         >
-          <FlexRow style={{ marginBottom: 10, gap: 10 }} css={undefined}>
-            <MenuTab
-              label={'Navigator'}
-              selected={selectedTab === LeftMenuTab.Navigator}
-              onClick={onClickNavigatorTab}
-            />
-            <MenuTab
-              label={'Project'}
-              selected={selectedTab === LeftMenuTab.Project}
-              onClick={onClickProjectTab}
-            />
-            <MenuTab
-              label={'Github'}
-              selected={selectedTab === LeftMenuTab.Github}
-              onClick={onClickGithubTab}
-            />
-          </FlexRow>
-          {selectedTab === LeftMenuTab.Navigator ? <NavigatorComponent /> : null}
-          {selectedTab === LeftMenuTab.Project ? <ContentsPane /> : null}
-          {selectedTab === LeftMenuTab.Github ? <GithubPane /> : null}
+          {when(
+            isMyProject,
+            <FlexRow style={{ marginBottom: 10, gap: 10 }} css={undefined}>
+              <MenuTab
+                label={'Navigator'}
+                selected={selectedTab === LeftMenuTab.Navigator}
+                onClick={onClickNavigatorTab}
+              />
+              <MenuTab
+                label={'Project'}
+                selected={selectedTab === LeftMenuTab.Project}
+                onClick={onClickProjectTab}
+              />
+              <MenuTab
+                label={'Github'}
+                selected={selectedTab === LeftMenuTab.Github}
+                onClick={onClickGithubTab}
+              />
+            </FlexRow>,
+          )}
+          {when(selectedTab === LeftMenuTab.Navigator, <NavigatorComponent />)}
+          {when(isMyProject && selectedTab === LeftMenuTab.Project, <ContentsPane />)}
+          {when(isMyProject && selectedTab === LeftMenuTab.Github, <GithubPane />)}
         </div>
       </FlexColumn>
     </LowPriorityStoreProvider>


### PR DESCRIPTION
Fix #4722 

**Problem:**
The file explorer and GH panes are shown alongside the navigator panel for viewers, although they should only be shown for editors.

**Fix:**

For non-editors, hide those two panes and the whole tab bar, leaving only the navigator itself.