### PR TITLE
Hide code panel for viewers

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -895,7 +895,6 @@ export function restoreEditorState(
     localProjectList: currentEditor.localProjectList,
     projectList: currentEditor.projectList,
     showcaseProjects: currentEditor.showcaseProjects,
-    codeEditingEnabled: desiredEditor.codeEditingEnabled,
     thumbnailLastGenerated: currentEditor.thumbnailLastGenerated,
     pasteTargetsToIgnore: desiredEditor.pasteTargetsToIgnore,
     codeEditorErrors: currentEditor.codeEditorErrors,
@@ -3385,7 +3384,10 @@ export const UPDATE_FNS = {
   ): EditorModel => {
     return {
       ...editor,
-      codeEditingEnabled: action.value,
+      interfaceDesigner: {
+        ...editor.interfaceDesigner,
+        codePaneVisible: action.value,
+      },
     }
   },
   OPEN_CODE_EDITOR: (editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -68,7 +68,7 @@ import LiveblocksProvider from '@liveblocks/yjs'
 import { isRoomId, projectIdToRoomId } from '../../core/shared/multiplayer'
 import { useDisplayOwnershipWarning } from './project-owner-hooks'
 import { EditorModes } from './editor-modes'
-import { allowedToEditProject } from './store/collaborative-editing'
+import { checkIsMyProject } from './store/collaborative-editing'
 import { useDataThemeAttributeOnBody } from '../../core/commenting/comment-hooks'
 import { CollaborationStateUpdater } from './store/collaboration-state'
 
@@ -359,13 +359,18 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
   useSelectorWithCallback(
     Substores.projectServerState,
     (store) => store.projectServerState,
-    (isMyProject) => {
-      if (!allowedToEditProject(isMyProject)) {
-        dispatch([
+    (serverState) => {
+      let actions: EditorAction[] = []
+      if (!checkIsMyProject(serverState)) {
+        actions.push(
           EditorActions.switchEditorMode(EditorModes.commentMode(null, 'not-dragging')),
           EditorActions.setRightMenuTab(RightMenuTab.Comments),
-        ])
+          EditorActions.setCodeEditorVisibility(false),
+        )
+      } else {
+        actions.push(EditorActions.setCodeEditorVisibility(true))
       }
+      dispatch(actions)
     },
     'EditorComponentInner viewer mode',
   )

--- a/editor/src/components/editor/store/collaborative-editing.ts
+++ b/editor/src/components/editor/store/collaborative-editing.ts
@@ -779,7 +779,7 @@ export function allowedToEditProject(serverState: ProjectServerState): boolean {
   if (isFeatureEnabled('Baton Passing For Control')) {
     return serverState.currentlyHolderOfTheBaton
   } else {
-    return serverState.isMyProject === 'yes'
+    return checkIsMyProject(serverState)
   }
 }
 
@@ -794,7 +794,11 @@ export function useAllowedToEditProject(): boolean {
 export function useIsMyProject(): boolean {
   return useEditorState(
     Substores.projectServerState,
-    (store) => store.projectServerState.isMyProject === 'yes',
+    (store) => checkIsMyProject(store.projectServerState),
     'useIsMyProject',
   )
+}
+
+export function checkIsMyProject(serverState: ProjectServerState): boolean {
+  return serverState.isMyProject === 'yes'
 }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1427,7 +1427,6 @@ export interface EditorState {
   localProjectList: Array<ProjectListing>
   projectList: Array<ProjectListing>
   showcaseProjects: Array<ProjectListing>
-  codeEditingEnabled: boolean
   codeEditorErrors: EditorStateCodeEditorErrors
   thumbnailLastGenerated: number
   pasteTargetsToIgnore: ElementPath[]
@@ -1508,7 +1507,6 @@ export function editorState(
   localProjectList: Array<ProjectListing>,
   projectList: Array<ProjectListing>,
   showcaseProjects: Array<ProjectListing>,
-  codeEditingEnabled: boolean,
   codeEditorErrors: EditorStateCodeEditorErrors,
   thumbnailLastGenerated: number,
   pasteTargetsToIgnore: ElementPath[],
@@ -1590,7 +1588,6 @@ export function editorState(
     localProjectList: localProjectList,
     projectList: projectList,
     showcaseProjects: showcaseProjects,
-    codeEditingEnabled: codeEditingEnabled,
     codeEditorErrors: codeEditorErrors,
     thumbnailLastGenerated: thumbnailLastGenerated,
     pasteTargetsToIgnore: pasteTargetsToIgnore,
@@ -2480,7 +2477,6 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     localProjectList: [],
     projectList: [],
     showcaseProjects: [],
-    codeEditingEnabled: false,
     codeEditorErrors: {
       buildErrors: {},
       lintErrors: {},
@@ -2846,7 +2842,6 @@ export function editorModelFromPersistentModel(
     localProjectList: [],
     projectList: [],
     showcaseProjects: [],
-    codeEditingEnabled: false,
     thumbnailLastGenerated: 0,
     pasteTargetsToIgnore: [],
     parseOrPrintInFlight: false,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -4428,10 +4428,6 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     oldValue.showcaseProjects,
     newValue.showcaseProjects,
   )
-  const codeEditingEnabledResults = BooleanKeepDeepEquality(
-    oldValue.codeEditingEnabled,
-    newValue.codeEditingEnabled,
-  )
   const codeEditorErrorsResults = EditorStateCodeEditorErrorsKeepDeepEquality(
     oldValue.codeEditorErrors,
     newValue.codeEditorErrors,
@@ -4592,7 +4588,6 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     localProjectListResults.areEqual &&
     projectListResults.areEqual &&
     showcaseProjectsResults.areEqual &&
-    codeEditingEnabledResults.areEqual &&
     codeEditorErrorsResults.areEqual &&
     thumbnailLastGeneratedResults.areEqual &&
     pasteTargetsToIgnoreResults.areEqual &&
@@ -4675,7 +4670,6 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
       localProjectListResults.value,
       projectListResults.value,
       showcaseProjectsResults.value,
-      codeEditingEnabledResults.value,
       codeEditorErrorsResults.value,
       thumbnailLastGeneratedResults.value,
       pasteTargetsToIgnoreResults.value,

--- a/editor/src/components/editor/store/store-hook-substore-helpers.ts
+++ b/editor/src/components/editor/store/store-hook-substore-helpers.ts
@@ -138,7 +138,6 @@ export const EmptyEditorStateForKeysOnly: EditorState = {
   localProjectList: [],
   projectList: [],
   showcaseProjects: [],
-  codeEditingEnabled: false,
   codeEditorErrors: {
     buildErrors: {},
     lintErrors: {},


### PR DESCRIPTION
Fix #4728 

**Problem:**

The code panel is shown expanded for viewers, although it should instead be hidden by default.

**Fix:**

1. Hide the code panel by default when loading the editor if the user is not an owner of the project
2. Additionally, I removed the **unused** `codeEditingEnabled` field from the editor state