### PR TITLE
Turn on unstable_fallbackToHTTP option in liveblocks

### DIFF
--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -11,6 +11,7 @@ export const liveblocksThrottle = 100 // ms
 export const liveblocksClient = createClient({
   throttle: liveblocksThrottle,
   authEndpoint: '/v1/liveblocks/authentication',
+  unstable_fallbackToHTTP: true,
 })
 
 // Presence represents the properties that exist on every user in the Room


### PR DESCRIPTION
**Problem:**
Liveblocks backend has a 1MB limit for websocket messages. That is easily reached by the initial yjs message of bigger utopia projects. 

**Fix:**
There is an option to turn on http fallback for too large messages.