### PR TITLE
Project control exponential backoff.

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -166,7 +166,7 @@ function processAction(
           userState: UPDATE_FNS.SET_CURRENT_THEME(action, working.userState),
         }
       } else if (action.action === 'SET_LOGIN_STATE') {
-        updateProjectServerStateInStore(
+        void updateProjectServerStateInStore(
           editorStoreUnpatched.unpatchedEditor.id,
           editorStoreUnpatched.unpatchedEditor.forkedFromProjectId,
           dispatchEvent,


### PR DESCRIPTION
**Problem:**
The project control acquisition runs every 10 seconds even if a failure occurred.

**Fix:**
On a failure the claim control polling does exponential backoff on a failure.

**Commit Details:**
- `restartServerStateWatcher` increases the wait time exponentially on a failure.