### PR TITLE
No comment section when logged out, aka fix constant reconnects for logged out users

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -209,6 +209,7 @@ export const RightPane = React.memo<ResizableRightPaneProps>((props) => {
         {when(
           isLoggedIn && isFeatureEnabled('Multiplayer'),
           <MenuTab
+            testId='comments-tab'
             label={'Comments'}
             selected={selectedTab === RightMenuTab.Comments}
             onClick={onClickCommentsTab}

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -36,6 +36,7 @@ import { isFeatureEnabled } from '../../utils/feature-switches'
 import { CommentsPane } from '../inspector/comments-pane'
 import { EditorModes, isCommentMode } from '../editor/editor-modes'
 import { useAllowedToEditProject } from '../editor/store/collaborative-editing'
+import { useIsLoggedIn } from '../../core/shared/multiplayer-hooks'
 
 function isCodeEditorEnabled(): boolean {
   if (typeof window !== 'undefined') {
@@ -162,6 +163,8 @@ export const RightPane = React.memo<ResizableRightPaneProps>((props) => {
     onClickTab(RightMenuTab.Settings)
   }, [onClickTab])
 
+  const isLoggedIn = useIsLoggedIn()
+
   const allowedToEdit = useAllowedToEditProject()
 
   if (!isRightMenuExpanded) {
@@ -204,7 +207,7 @@ export const RightPane = React.memo<ResizableRightPaneProps>((props) => {
           </>,
         )}
         {when(
-          isFeatureEnabled('Multiplayer'),
+          isLoggedIn && isFeatureEnabled('Multiplayer'),
           <MenuTab
             label={'Comments'}
             selected={selectedTab === RightMenuTab.Comments}

--- a/editor/src/core/shared/multiplayer-hooks.tsx
+++ b/editor/src/core/shared/multiplayer-hooks.tsx
@@ -37,3 +37,11 @@ export function useMyUserId(): string | null {
   )
   return myUserId
 }
+
+export function useIsLoggedIn(): boolean {
+  return useEditorState(
+    Substores.restOfStore,
+    (store) => isLoggedIn(store.userState.loginState),
+    'useIsLoggedIn',
+  )
+}

--- a/editor/src/uuiui/menu-tab.tsx
+++ b/editor/src/uuiui/menu-tab.tsx
@@ -21,6 +21,7 @@ interface MenuTabProps {
   onClick?: () => void
   onMouseDown?: () => void
   className?: string
+  testId?: string
 }
 
 export const MenuTab: React.FunctionComponent<React.PropsWithChildren<MenuTabProps>> = React.memo(
@@ -49,9 +50,9 @@ export const MenuTab: React.FunctionComponent<React.PropsWithChildren<MenuTabPro
         : colorTheme.tabSelectedForeground.value,
       opacity: selected ? 1 : 0.4,
     }
-
     return (
       <SimpleFlexRow
+        data-testid={props.testId}
         onClick={props.onClick}
         onMouseDown={props.onMouseDown}
         css={{

--- a/puppeteer-tests/src/comments/comment-utils.ts
+++ b/puppeteer-tests/src/comments/comment-utils.ts
@@ -11,15 +11,20 @@ export async function initBrowserTest(utopiaBrowser: UtopiaPuppeteerBrowser) {
     url: `${BASE_URL}/p/?fakeUser=alice&Multiplayer=true${BRANCH_NAME}`,
     timeout: TIMEOUT,
   })
+  await page.waitForSelector('#playground-scene') // wait for the scene to render
 
   return page
 }
 
 export async function initSignedInBrowserTest(utopiaBrowser: UtopiaPuppeteerBrowser) {
-  const page = await initBrowserTest(utopiaBrowser)
+  const { page } = await utopiaBrowser.setup({
+    url: `${BASE_URL}/p/?fakeUser=alice&Multiplayer=true${BRANCH_NAME}`,
+    timeout: TIMEOUT,
+  })
 
   const signInButton = await page.waitForSelector('div[data-testid="sign-in-button"]')
   await signInButton!.click()
+
   await page.waitForSelector('#playground-scene') // wait for the scene to render
 
   return page

--- a/puppeteer-tests/src/comments/comment-utils.ts
+++ b/puppeteer-tests/src/comments/comment-utils.ts
@@ -6,11 +6,17 @@ export const TIMEOUT = 120000
 const BRANCH_NAME = process.env.BRANCH_NAME ? `&branch_name=${process.env.BRANCH_NAME}` : ''
 const BASE_URL = process.env.BASE_URL ?? 'http://localhost:8000'
 
-export async function initSignedInBrowserTest(utopiaBrowser: UtopiaPuppeteerBrowser) {
+export async function initBrowserTest(utopiaBrowser: UtopiaPuppeteerBrowser) {
   const { page } = await utopiaBrowser.setup({
     url: `${BASE_URL}/p/?fakeUser=alice&Multiplayer=true${BRANCH_NAME}`,
     timeout: TIMEOUT,
   })
+
+  return page
+}
+
+export async function initSignedInBrowserTest(utopiaBrowser: UtopiaPuppeteerBrowser) {
+  const page = await initBrowserTest(utopiaBrowser)
 
   const signInButton = await page.waitForSelector('div[data-testid="sign-in-button"]')
   await signInButton!.click()

--- a/puppeteer-tests/src/comments/commenting.spec.tsx
+++ b/puppeteer-tests/src/comments/commenting.spec.tsx
@@ -3,6 +3,7 @@ import type { Browser } from 'puppeteer'
 import {
   TIMEOUT,
   enterCommentMode,
+  initBrowserTest,
   initSignedInBrowserTest,
   placeCommentOnCanvas,
 } from './comment-utils'
@@ -141,5 +142,25 @@ describe('Comments test', () => {
       expect(commentIndicators).toHaveLength(1)
     },
     TIMEOUT,
-  )
+  ),
+    it(
+      'There is a comment tab when logged in',
+      async () => {
+        const page = await initSignedInBrowserTest(utopiaBrowser)
+
+        const commentTabs = await page.waitForSelector('div[data-testid="comments-tab"]')
+        expect(commentTabs).not.toBeNull()
+      },
+      TIMEOUT,
+    ),
+    it(
+      'There is no comment tab when logged out',
+      async () => {
+        const page = await initBrowserTest(utopiaBrowser)
+
+        const commentsTabs = await page.$$('div[data-testid="comments-tab"]')
+        expect(commentsTabs).toHaveLength(0)
+      },
+      TIMEOUT,
+    )
 })


### PR DESCRIPTION
**Problem:**
When the user is logged out, the liveblocks client constantly calls our authentication endpoint.

**Fix:**
The call of the `useThreads` hook triggers a call to the auth endpoint if the user was not successfully authenticated yet.
Since we use this hook in all our components which work with comments, it is important to not render those components when the user is logged out.

For the comment indicators this is already solved, but for the comment section in the sidebar i had to add an extra isLoggedIn check.

And there are tests too :)