### PR TITLE
Snatch control on click.

### DIFF
--- a/editor/src/components/editor/collaborative-endpoints.ts
+++ b/editor/src/components/editor/collaborative-endpoints.ts
@@ -1,0 +1,181 @@
+import { v4 as UUID } from 'uuid'
+import { IS_TEST_ENVIRONMENT, UTOPIA_BACKEND } from '../../common/env-vars'
+import { HEADERS, MODE } from '../../common/server'
+import { isFeatureEnabled } from '../../utils/feature-switches'
+import type { EditorDispatch } from './action-types'
+import { showToast } from './actions/action-creators'
+import { notice } from '../common/notice'
+
+export interface ClaimProjectControl {
+  type: 'CLAIM_PROJECT_CONTROL'
+  projectID: string
+  collaborationEditor: string
+}
+
+function claimProjectControl(projectID: string, collaborationEditor: string): ClaimProjectControl {
+  return {
+    type: 'CLAIM_PROJECT_CONTROL',
+    projectID: projectID,
+    collaborationEditor: collaborationEditor,
+  }
+}
+
+export interface SnatchProjectControl {
+  type: 'SNATCH_PROJECT_CONTROL'
+  projectID: string
+  collaborationEditor: string
+}
+
+function snatchProjectControl(
+  projectID: string,
+  collaborationEditor: string,
+): SnatchProjectControl {
+  return {
+    type: 'SNATCH_PROJECT_CONTROL',
+    projectID: projectID,
+    collaborationEditor: collaborationEditor,
+  }
+}
+
+export interface ReleaseProjectControl {
+  type: 'RELEASE_PROJECT_CONTROL'
+  projectID: string
+  collaborationEditor: string
+}
+
+function releaseProjectControl(
+  projectID: string,
+  collaborationEditor: string,
+): ReleaseProjectControl {
+  return {
+    type: 'RELEASE_PROJECT_CONTROL',
+    projectID: projectID,
+    collaborationEditor: collaborationEditor,
+  }
+}
+
+export interface ClearAllOfCollaboratorsControl {
+  type: 'CLEAR_ALL_OF_COLLABORATORS_CONTROL'
+  collaborationEditor: string
+}
+
+function clearAllOfCollaboratorsControl(
+  collaborationEditor: string,
+): ClearAllOfCollaboratorsControl {
+  return {
+    type: 'CLEAR_ALL_OF_COLLABORATORS_CONTROL',
+    collaborationEditor: collaborationEditor,
+  }
+}
+
+export type CollaborationRequest =
+  | ClaimProjectControl
+  | SnatchProjectControl
+  | ReleaseProjectControl
+  | ClearAllOfCollaboratorsControl
+
+export interface RequestProjectControlResult {
+  type: 'REQUEST_PROJECT_CONTROL_RESULT'
+  successfullyClaimed: boolean
+}
+
+export interface ReleaseControlResponse {
+  type: 'RELEASE_CONTROL_RESULT'
+}
+
+export type CollaborationResponse = RequestProjectControlResult | ReleaseControlResponse
+
+const collaborationEditor = UUID()
+
+async function callCollaborationEndpoint(
+  request: CollaborationRequest,
+): Promise<CollaborationResponse> {
+  const url = `${UTOPIA_BACKEND}collaboration`
+  const response = await fetch(url, {
+    method: 'PUT',
+    credentials: 'include',
+    headers: HEADERS,
+    mode: MODE,
+    body: JSON.stringify(request),
+  })
+  if (response.ok) {
+    return response.json()
+  } else {
+    throw new Error(`server responded with ${response.status} ${response.statusText}`)
+  }
+}
+
+async function claimControlOverProject(projectID: string | null): Promise<boolean | null> {
+  if (IS_TEST_ENVIRONMENT) {
+    return true
+  }
+  if (projectID == null || !isFeatureEnabled('Baton Passing For Control')) {
+    return null
+  }
+
+  const request = claimProjectControl(projectID, collaborationEditor)
+  const response = await callCollaborationEndpoint(request)
+  if (response.type === 'REQUEST_PROJECT_CONTROL_RESULT') {
+    return response.successfullyClaimed
+  } else {
+    throw new Error(`Unexpected response: ${JSON.stringify(response)}`)
+  }
+}
+
+async function snatchControlOverProject(projectID: string | null): Promise<boolean | null> {
+  if (IS_TEST_ENVIRONMENT) {
+    return true
+  }
+  if (projectID == null || !isFeatureEnabled('Baton Passing For Control')) {
+    return null
+  }
+
+  const request = snatchProjectControl(projectID, collaborationEditor)
+  const response = await callCollaborationEndpoint(request)
+  if (response.type === 'REQUEST_PROJECT_CONTROL_RESULT') {
+    return response.successfullyClaimed
+  } else {
+    throw new Error(`Unexpected response: ${JSON.stringify(response)}`)
+  }
+}
+
+async function releaseControlOverProject(projectID: string | null): Promise<void> {
+  if (IS_TEST_ENVIRONMENT) {
+    return
+  }
+  if (projectID == null || !isFeatureEnabled('Baton Passing For Control')) {
+    return
+  }
+
+  const request = releaseProjectControl(projectID, collaborationEditor)
+  const response = await callCollaborationEndpoint(request)
+  if (response.type !== 'RELEASE_CONTROL_RESULT') {
+    throw new Error(`Unexpected response: ${JSON.stringify(response)}`)
+  }
+}
+
+function displayControlErrorToast(dispatch: EditorDispatch, message: string): void {
+  dispatch([showToast(notice(message, 'ERROR', false, 'control-error'))])
+}
+
+async function clearAllControlFromThisEditor(): Promise<void> {
+  if (IS_TEST_ENVIRONMENT) {
+    return
+  }
+  if (isFeatureEnabled('Baton Passing For Control')) {
+    const request = clearAllOfCollaboratorsControl(collaborationEditor)
+
+    const response = await callCollaborationEndpoint(request)
+    if (response.type !== 'RELEASE_CONTROL_RESULT') {
+      throw new Error(`Unexpected response: ${JSON.stringify(response)}`)
+    }
+  }
+}
+
+export const CollaborationEndpoints = {
+  snatchControlOverProject: snatchControlOverProject,
+  claimControlOverProject: claimControlOverProject,
+  releaseControlOverProject: releaseControlOverProject,
+  clearAllControlFromThisEditor: clearAllControlFromThisEditor,
+  displayControlErrorToast: displayControlErrorToast,
+}

--- a/editor/src/components/editor/persistence/persistence.ts
+++ b/editor/src/components/editor/persistence/persistence.ts
@@ -27,7 +27,7 @@ import {
   userLogOutEvent,
 } from './generic/persistence-machine'
 import type { PersistenceBackendAPI, PersistenceContext } from './generic/persistence-types'
-import { clearAllControlFromThisEditor } from '../store/collaborative-editing'
+import { CollaborationEndpoints } from '../collaborative-endpoints'
 
 export class PersistenceMachine {
   private interpreter: Interpreter<
@@ -142,7 +142,7 @@ export class PersistenceMachine {
 
     window.addEventListener('beforeunload', async (e) => {
       if (this.isSafeToClose()) {
-        void clearAllControlFromThisEditor()
+        void CollaborationEndpoints.clearAllControlFromThisEditor()
       } else {
         this.sendThrottledSave()
         e.preventDefault()

--- a/editor/src/components/editor/store/collaboration-state.spec.browser2.tsx
+++ b/editor/src/components/editor/store/collaboration-state.spec.browser2.tsx
@@ -1,0 +1,81 @@
+import { canvasPoint } from '../../../core/shared/math-utils'
+import { CanvasContainerID } from '../../canvas/canvas-types'
+import { mouseClickAtPoint } from '../../canvas/event-helpers.test-utils'
+import {
+  makeTestProjectCodeWithSnippet,
+  renderTestEditorWithCode,
+} from '../../canvas/ui-jsx.test-utils'
+import { updateProjectServerState } from '../actions/action-creators'
+import { CollaborationEndpoints } from '../collaborative-endpoints'
+import Sinon from 'sinon'
+
+describe('CollaborationStateUpdater', () => {
+  var sandbox = Sinon.createSandbox()
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it('snatching control on click should gain control', async () => {
+    const snatchControlStub = sandbox.stub(CollaborationEndpoints, 'snatchControlOverProject')
+    snatchControlStub.callsFake(async () => {
+      return true
+    })
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div data-uid='root' style={{top: 0, left: 0, width: 100, height: 100}} />
+      `),
+      'await-first-dom-report',
+    )
+    await renderResult.dispatch(
+      [
+        updateProjectServerState({
+          currentlyHolderOfTheBaton: false,
+        }),
+      ],
+      true,
+    )
+    const canvasRootContainer = renderResult.renderedDOM.getByTestId(CanvasContainerID)
+
+    const rootRect = canvasRootContainer.getBoundingClientRect()
+    const rootRectCenter = canvasPoint({
+      x: rootRect.x + rootRect.width / 2,
+      y: rootRect.y + rootRect.height / 2,
+    })
+    await mouseClickAtPoint(canvasRootContainer, rootRectCenter)
+    expect(renderResult.getEditorState().projectServerState.currentlyHolderOfTheBaton).toEqual(true)
+  })
+  it('snatching control on a bunch of fast clicks should gain control and not make lots of calls to the server', async () => {
+    const snatchControlStub = sandbox.stub(CollaborationEndpoints, 'snatchControlOverProject')
+    snatchControlStub.callsFake(async () => {
+      return true
+    })
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div data-uid='root' style={{top: 0, left: 0, width: 100, height: 100}} />
+      `),
+      'await-first-dom-report',
+    )
+    await renderResult.dispatch(
+      [
+        updateProjectServerState({
+          currentlyHolderOfTheBaton: false,
+        }),
+      ],
+      true,
+    )
+    const canvasRootContainer = renderResult.renderedDOM.getByTestId(CanvasContainerID)
+
+    const rootRect = canvasRootContainer.getBoundingClientRect()
+    const rootRectCenter = canvasPoint({
+      x: rootRect.x + rootRect.width / 2,
+      y: rootRect.y + rootRect.height / 2,
+    })
+    await mouseClickAtPoint(canvasRootContainer, rootRectCenter)
+    await mouseClickAtPoint(canvasRootContainer, rootRectCenter)
+    await mouseClickAtPoint(canvasRootContainer, rootRectCenter)
+    await mouseClickAtPoint(canvasRootContainer, rootRectCenter)
+    await mouseClickAtPoint(canvasRootContainer, rootRectCenter)
+    ;(CollaborationEndpoints.snatchControlOverProject as any).calledOnce
+    expect(renderResult.getEditorState().projectServerState.currentlyHolderOfTheBaton).toEqual(true)
+  })
+})

--- a/editor/src/components/editor/store/collaboration-state.tsx
+++ b/editor/src/components/editor/store/collaboration-state.tsx
@@ -1,11 +1,7 @@
 import React from 'react'
 import type { EditorAction, EditorDispatch } from '../action-types'
-import {
-  claimControlOverProject,
-  displayControlErrorToast,
-  snatchControlOverProject,
-} from './collaborative-editing'
-import { Substores, useEditorState, useRefEditorState } from './store-hook'
+import { CollaborationEndpoints } from '../collaborative-endpoints'
+import { useRefEditorState } from './store-hook'
 import { switchEditorMode, updateProjectServerState } from '../actions/action-creators'
 import { EditorModes } from '../editor-modes'
 import type { ControlChangedRoomEvent } from '../../../../liveblocks.config'
@@ -50,14 +46,14 @@ export const CollaborationStateUpdater = React.memo(
     useEventListener((data) => {
       if (data.event.type === 'CONTROL_CHANGED') {
         if (isMyProjectRef.current === 'yes') {
-          void claimControlOverProject(projectId)
+          void CollaborationEndpoints.claimControlOverProject(projectId)
             .then((controlResult) => {
               const newHolderOfTheBaton = controlResult ?? false
               handleControlUpdate(newHolderOfTheBaton ?? false)
             })
             .catch((error) => {
               console.error('Error when claiming control.', error)
-              displayControlErrorToast(
+              CollaborationEndpoints.displayControlErrorToast(
                 dispatch,
                 'Error while attempting to claim control over this project.',
               )
@@ -80,7 +76,7 @@ export const CollaborationStateUpdater = React.memo(
             !currentlyAttemptingToSnatch
           ) {
             setCurrentlyAttemptingToSnatch(true)
-            void snatchControlOverProject(projectId)
+            void CollaborationEndpoints.snatchControlOverProject(projectId)
               .then((controlResult) => {
                 const newHolderOfTheBaton = controlResult ?? false
                 handleControlUpdate(newHolderOfTheBaton)
@@ -88,7 +84,7 @@ export const CollaborationStateUpdater = React.memo(
               })
               .catch((error) => {
                 console.error('Error when snatching control.', error)
-                displayControlErrorToast(
+                CollaborationEndpoints.displayControlErrorToast(
                   dispatch,
                   'Error while attempting to gain control over this project.',
                 )

--- a/editor/src/components/editor/store/collaborative-editing.ts
+++ b/editor/src/components/editor/store/collaborative-editing.ts
@@ -1,6 +1,5 @@
 import {
   deleteFileFromCollaboration,
-  showToast,
   updateCodeFromCollaborationUpdate,
   updateExportsDetailFromCollaborationUpdate,
   updateImportsFromCollaborationUpdate,
@@ -36,7 +35,6 @@ import {
   TopLevelElementKeepDeepEquality,
 } from './store-deep-equality-instances'
 import type { WriteProjectFileChange } from './vscode-changes'
-import { v4 as UUID } from 'uuid'
 import {
   deletePathChange,
   ensureDirectoryExistsChange,
@@ -48,11 +46,8 @@ import { isFeatureEnabled } from '../../../utils/feature-switches'
 import type { KeepDeepEqualityCall } from '../../../utils/deep-equality'
 import type { MapLike } from 'typescript'
 import { Y } from '../../../core/shared/yjs'
-import { HEADERS, MODE } from '../../../common/server'
-import { UTOPIA_BACKEND } from '../../../common/env-vars'
 import type { ProjectServerState } from './project-server-state'
 import { Substores, useEditorState } from './store-hook'
-import { notice } from '../../common/notice'
 
 const CodeKey = 'code'
 const TopLevelElementsKey = 'topLevelElements'
@@ -613,163 +608,6 @@ function synchroniseParseSuccessToCollabFile(
     ImportsKey,
     ImportDetailsKeepDeepEquality,
   )
-}
-
-export interface ClaimProjectControl {
-  type: 'CLAIM_PROJECT_CONTROL'
-  projectID: string
-  collaborationEditor: string
-}
-
-export function claimProjectControl(
-  projectID: string,
-  collaborationEditor: string,
-): ClaimProjectControl {
-  return {
-    type: 'CLAIM_PROJECT_CONTROL',
-    projectID: projectID,
-    collaborationEditor: collaborationEditor,
-  }
-}
-
-export interface SnatchProjectControl {
-  type: 'SNATCH_PROJECT_CONTROL'
-  projectID: string
-  collaborationEditor: string
-}
-
-export function snatchProjectControl(
-  projectID: string,
-  collaborationEditor: string,
-): SnatchProjectControl {
-  return {
-    type: 'SNATCH_PROJECT_CONTROL',
-    projectID: projectID,
-    collaborationEditor: collaborationEditor,
-  }
-}
-
-export interface ReleaseProjectControl {
-  type: 'RELEASE_PROJECT_CONTROL'
-  projectID: string
-  collaborationEditor: string
-}
-
-export function releaseProjectControl(
-  projectID: string,
-  collaborationEditor: string,
-): ReleaseProjectControl {
-  return {
-    type: 'RELEASE_PROJECT_CONTROL',
-    projectID: projectID,
-    collaborationEditor: collaborationEditor,
-  }
-}
-
-export interface ClearAllOfCollaboratorsControl {
-  type: 'CLEAR_ALL_OF_COLLABORATORS_CONTROL'
-  collaborationEditor: string
-}
-
-export function clearAllOfCollaboratorsControl(
-  collaborationEditor: string,
-): ClearAllOfCollaboratorsControl {
-  return {
-    type: 'CLEAR_ALL_OF_COLLABORATORS_CONTROL',
-    collaborationEditor: collaborationEditor,
-  }
-}
-
-export type CollaborationRequest =
-  | ClaimProjectControl
-  | SnatchProjectControl
-  | ReleaseProjectControl
-  | ClearAllOfCollaboratorsControl
-
-export interface RequestProjectControlResult {
-  type: 'REQUEST_PROJECT_CONTROL_RESULT'
-  successfullyClaimed: boolean
-}
-
-export interface ReleaseControlResponse {
-  type: 'RELEASE_CONTROL_RESULT'
-}
-
-export type CollaborationResponse = RequestProjectControlResult | ReleaseControlResponse
-
-const collaborationEditor = UUID()
-
-async function callCollaborationEndpoint(
-  request: CollaborationRequest,
-): Promise<CollaborationResponse> {
-  const url = `${UTOPIA_BACKEND}collaboration`
-  const response = await fetch(url, {
-    method: 'PUT',
-    credentials: 'include',
-    headers: HEADERS,
-    mode: MODE,
-    body: JSON.stringify(request),
-  })
-  if (response.ok) {
-    return response.json()
-  } else {
-    throw new Error(`server responded with ${response.status} ${response.statusText}`)
-  }
-}
-
-export async function claimControlOverProject(projectID: string | null): Promise<boolean | null> {
-  if (projectID == null || !isFeatureEnabled('Baton Passing For Control')) {
-    return null
-  }
-
-  const request = claimProjectControl(projectID, collaborationEditor)
-  const response = await callCollaborationEndpoint(request)
-  if (response.type === 'REQUEST_PROJECT_CONTROL_RESULT') {
-    return response.successfullyClaimed
-  } else {
-    throw new Error(`Unexpected response: ${JSON.stringify(response)}`)
-  }
-}
-
-export async function snatchControlOverProject(projectID: string | null): Promise<boolean | null> {
-  if (projectID == null || !isFeatureEnabled('Baton Passing For Control')) {
-    return null
-  }
-
-  const request = snatchProjectControl(projectID, collaborationEditor)
-  const response = await callCollaborationEndpoint(request)
-  if (response.type === 'REQUEST_PROJECT_CONTROL_RESULT') {
-    return response.successfullyClaimed
-  } else {
-    throw new Error(`Unexpected response: ${JSON.stringify(response)}`)
-  }
-}
-
-export async function releaseControlOverProject(projectID: string | null): Promise<void> {
-  if (projectID == null || !isFeatureEnabled('Baton Passing For Control')) {
-    return
-  }
-
-  const request = releaseProjectControl(projectID, collaborationEditor)
-  const response = await callCollaborationEndpoint(request)
-  if (response.type !== 'RELEASE_CONTROL_RESULT') {
-    throw new Error(`Unexpected response: ${JSON.stringify(response)}`)
-  }
-}
-
-export function displayControlErrorToast(dispatch: EditorDispatch, message: string): void {
-  dispatch([showToast(notice(message, 'ERROR', false, 'control-error'))])
-}
-
-export async function clearAllControlFromThisEditor(): Promise<void> {
-  if (isFeatureEnabled('Baton Passing For Control')) {
-    const request = clearAllOfCollaboratorsControl(collaborationEditor)
-
-    const response = await callCollaborationEndpoint(request)
-    if (response.type !== 'RELEASE_CONTROL_RESULT') {
-      throw new Error(`Unexpected response: ${JSON.stringify(response)}`)
-    }
-  }
 }
 
 export function allowedToEditProject(serverState: ProjectServerState): boolean {

--- a/editor/src/components/editor/store/project-server-state.tsx
+++ b/editor/src/components/editor/store/project-server-state.tsx
@@ -7,7 +7,7 @@ import { updateProjectServerState } from '../actions/action-creators'
 import { checkProjectOwned } from '../persistence/persistence-backend'
 import type { ProjectOwnership } from '../persistence/generic/persistence-types'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
-import { claimControlOverProject, displayControlErrorToast } from './collaborative-editing'
+import { CollaborationEndpoints } from '../collaborative-endpoints'
 
 export interface ProjectMetadataFromServer {
   title: string
@@ -101,12 +101,12 @@ export async function getProjectServerState(
     const ownership = await getOwnership()
 
     const holderOfTheBaton = ownership.isOwner
-      ? await claimControlOverProject(projectId)
+      ? await CollaborationEndpoints.claimControlOverProject(projectId)
           .then((result) => {
             return result ?? ownership.isOwner
           })
           .catch(() => {
-            displayControlErrorToast(
+            CollaborationEndpoints.displayControlErrorToast(
               dispatch,
               'Error while attempting to claim control over this project.',
             )


### PR DESCRIPTION
**Problem:**
We want to snatch control on clicks so that a user interacting with the editor will be able to maintain control if another instance of the editor had snatched control.

**Fix:**
In addition to the focus event for the window, the editor also tries to snatch control on every click event.

This has necessitated adding some protection against snatching control on _every_ click event, as that is not necessary and would likely cause issues for both the editor and the server.

**Commit Details:**
- Changed `isMyProject` in `CollaborationStateUpdater` to use `useRefEditorState`.
- Added `currentlyHolderOfTheBatonRef` to `CollaborationStateUpdater`.
- Renamed `didFocus` to `attemptToSnatchControl`.
- Changed the innards of `attemptToSnatchControl` so that it doesn't try snatching control if if it already has control or if an attempt is already inflight.