### PR TITLE
Use beforeunload event to catch unintended navigation in live mode

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -159,6 +159,17 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
     }, 0)
   }, [mode.type, dispatch])
 
+  const onBeforeUnload = React.useCallback(
+    (event: BeforeUnloadEvent) => {
+      if (mode.type === 'live') {
+        // Catch and check unintended navigation when the user is in live mode
+        event.preventDefault()
+        event.returnValue = ''
+      }
+    },
+    [mode.type],
+  )
+
   const onWindowKeyDown = React.useCallback(
     (event: KeyboardEvent) => {
       let actions: Array<EditorAction> = []
@@ -272,18 +283,13 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
   React.useEffect(() => {
     window.addEventListener('contextmenu', preventDefault)
     window.addEventListener('mousedown', inputBlurForce, true)
+    window.addEventListener('beforeunload', onBeforeUnload)
     return function cleanup() {
       window.removeEventListener('contextmenu', preventDefault)
       window.removeEventListener('mousedown', inputBlurForce, true)
+      window.addEventListener('beforeunload', onBeforeUnload)
     }
-  }, [
-    onWindowMouseDown,
-    onWindowMouseUp,
-    onWindowKeyDown,
-    onWindowKeyUp,
-    preventDefault,
-    inputBlurForce,
-  ])
+  }, [onBeforeUnload, preventDefault, inputBlurForce])
 
   const projectName = useEditorState(
     Substores.restOfEditor,

--- a/editor/src/core/shared/javascript-cache.ts
+++ b/editor/src/core/shared/javascript-cache.ts
@@ -97,17 +97,6 @@ function resolveDefinedElsewhere(
       continue
     }
 
-    if (elsewhere === 'window') {
-      // By spreading the `window.location` we can prevent redirection via e.g. `window.location.href = '...'`
-      definedElsewhereInfo[elsewhere] = {
-        ...window,
-        location: {
-          ...window.location,
-        },
-      }
-      continue
-    }
-
     if ((global as any).hasOwnProperty(elsewhere) as boolean) {
       definedElsewhereInfo[elsewhere] = (global as any)[elsewhere]
       continue


### PR DESCRIPTION
**Problem:**
We currently use a `window.location` shim (introduced in https://github.com/concrete-utopia/utopia/pull/4452) to prevent users from accidentally redirecting the browser whilst testing their project. This was introduced whilst working on ensuring support for more real life projects, but we later discovered that the real reason we were seeing the browser reload with the H2 project was because of a prefetch failing and throwing an error, which was fixed in https://github.com/concrete-utopia/utopia/pull/4686. Since we don't really want to interfere with the user project, we don't want to keep the `window.location` shim, but still want to prevent accidental redirection.

**Fix:**
Given that the main cause of the browser reloading has now been fixed, this PR removes the `window.location` shim, and instead uses the `beforeunload` event whilst in Live mode to check that the user actually intended to leave the editor.