### PR TITLE
Rename JSXElementChildren

### DIFF
--- a/editor/src/components/canvas/commands/insert-element-insertion-subject.ts
+++ b/editor/src/components/canvas/commands/insert-element-insertion-subject.ts
@@ -1,5 +1,8 @@
 import { includeToastPatch } from '../../../components/editor/actions/toast-helpers'
-import { insertJSXElementChildren } from '../../../core/model/element-template-utils'
+import {
+  insertJSXElementChildren,
+  renameJsxElementChild,
+} from '../../../core/model/element-template-utils'
 import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
 import * as EP from '../../../core/shared/element-path'
 import { optionalMap } from '../../../core/shared/optional-utils'
@@ -11,7 +14,7 @@ import { forUnderlyingTargetFromEditorState } from '../../editor/store/editor-st
 import type { InsertionPath } from '../../editor/store/insertion-path'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 import { getPatchForComponentChange } from './commands'
-import { renameIfNeeded, type JSXElement } from '../../../core/shared/element-template'
+import { type JSXElement } from '../../../core/shared/element-template'
 
 export interface InsertElementInsertionSubject extends BaseCommand {
   type: 'INSERT_ELEMENT_INSERTION_SUBJECT'
@@ -50,7 +53,7 @@ export const runInsertElementInsertionSubject: CommandFunction<InsertElementInse
 
       const updatedImports = mergeImports(underlyingFilePath, success.imports, subject.importsToAdd)
 
-      subjectElement = renameIfNeeded(subject.element, updatedImports.duplicateNameMapping)
+      subjectElement = renameJsxElementChild(subject.element, updatedImports.duplicateNameMapping)
 
       const insertionResult = insertJSXElementChildren(
         insertionPath,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -13,6 +13,7 @@ import {
   generateUidWithExistingComponents,
   getIndexInParent,
   insertJSXElementChildren,
+  renameJsxElementChild,
 } from '../../../core/model/element-template-utils'
 import {
   applyToAllUIJSFiles,
@@ -74,7 +75,6 @@ import {
   modifiableAttributeIsAttributeValue,
   isJSExpression,
   isJSXMapExpression,
-  renameIfNeeded,
 } from '../../../core/shared/element-template'
 import type { ValueAtPath } from '../../../core/shared/jsx-attributes'
 import {
@@ -2221,7 +2221,7 @@ export const UPDATE_FNS = {
 
         const { imports, duplicateNameMapping } = updatedImports
 
-        const renamedJsxElement = renameIfNeeded(action.jsxElement, duplicateNameMapping)
+        const renamedJsxElement = renameJsxElementChild(action.jsxElement, duplicateNameMapping)
 
         const withInsertedElement = insertJSXElementChildren(
           childInsertionPath(targetParent),

--- a/editor/src/core/shared/element-template.spec.ts
+++ b/editor/src/core/shared/element-template.spec.ts
@@ -13,6 +13,7 @@ import {
   jsxElement,
   jsxPropertyAssignment,
   setJSXAttributesAttribute,
+  jsxConditionalExpression,
 } from './element-template'
 
 describe('setJSXAttributesAttribute', () => {

--- a/editor/src/core/shared/element-template.spec.ts
+++ b/editor/src/core/shared/element-template.spec.ts
@@ -10,10 +10,8 @@ import {
   jsxAttributesEntry,
   jsxAttributesSpread,
   jsExpressionValue,
-  jsxElement,
   jsxPropertyAssignment,
   setJSXAttributesAttribute,
-  jsxConditionalExpression,
 } from './element-template'
 
 describe('setJSXAttributesAttribute', () => {

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -20,7 +20,7 @@ import type { Sides, LayoutSystem } from 'utopia-api/core'
 import { sides } from 'utopia-api/core'
 import { assertNever, fastForEach, unknownObjectProperty } from './utils'
 import { addAllUniquely, mapDropNulls, reverse } from './array-utils'
-import { objectMap } from './object-utils'
+import { mapValues, objectMap } from './object-utils'
 import type { CSSPosition, FlexDirection } from '../../components/inspector/common/css-utils'
 import type { ModifiableAttribute } from './jsx-attributes'
 import { jsxSimpleAttributeToValue } from './jsx-attributes'
@@ -31,6 +31,7 @@ import type { MapLike } from 'typescript'
 import { forceNotNull } from './optional-utils'
 import type { FlexAlignment, FlexJustifyContent } from '../../components/inspector/inspector-common'
 import { allComments } from './comment-flags'
+import { is } from './equality-utils'
 
 export interface ParsedComments {
   leadingComments: Array<Comment>
@@ -2324,29 +2325,4 @@ export function getElementsByUIDFromTopLevelElements(
     }
   })
   return result
-}
-
-export function renameIfNeeded(
-  element: JSXElement,
-  duplicateNameMapping: Map<string, string>,
-): JSXElement {
-  const newElementName = duplicateNameMapping.get(element.name.baseVariable)
-  if (newElementName != null) {
-    return {
-      ...element,
-      name: {
-        ...element.name,
-        baseVariable: newElementName,
-      },
-      children: element.children.map((child) => {
-        if (isJSXElement(child)) {
-          return renameIfNeeded(child, duplicateNameMapping)
-        } else {
-          return child
-        }
-      }),
-    }
-  } else {
-    return element
-  }
 }


### PR DESCRIPTION
**Problem:**
Currently when we rename elements, we only support renaming JSXElements

**Fix:**
Support renaming all JSXElementChildren
