### PR TITLE
Change dark mode background of liveblocks

### DIFF
--- a/editor/resources/editor/css/liveblocks/react-comments/dark/attributes.css
+++ b/editor/resources/editor/css/liveblocks/react-comments/dark/attributes.css
@@ -3,7 +3,7 @@
 .lb-root:where(:is(.dark, [data-theme='dark'], [data-dark])),
 :is(.dark, [data-theme='dark'], [data-dark]) :where(.lb-root) {
   --lb-accent: #4af;
-  --lb-background: #222;
+  --lb-background: 'lch(99.5 0.01 0)'; /* colorTheme.bg1.value in dark mode */
   --lb-foreground: #fff;
   --lb-elevation-background: #333;
   --lb-tooltip-background: #333;

--- a/editor/resources/editor/css/liveblocks/react-comments/dark/attributes.css
+++ b/editor/resources/editor/css/liveblocks/react-comments/dark/attributes.css
@@ -3,7 +3,7 @@
 .lb-root:where(:is(.dark, [data-theme='dark'], [data-dark])),
 :is(.dark, [data-theme='dark'], [data-dark]) :where(.lb-root) {
   --lb-accent: #4af;
-  --lb-background: 'lch(99.5 0.01 0)'; /* colorTheme.bg1.value in dark mode */
+  --lb-background: transparent;
   --lb-foreground: #fff;
   --lb-elevation-background: #333;
   --lb-tooltip-background: #333;


### PR DESCRIPTION
**Problem:**
We need a different dark mode background than the default one in liveblocks.

**Fix:**
The background of liveblocks components is defined by the `--lb-background` css variable.