### PR TITLE
Remove React.memo use in UtopiaRemixRootComponent

### DIFF
--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -211,7 +211,7 @@ export interface UtopiaRemixRootComponentProps {
   getLoadContext?: (request: Request) => Promise<AppLoadContext> | AppLoadContext
 }
 
-export const UtopiaRemixRootComponent = React.memo((props: UtopiaRemixRootComponentProps) => {
+export const UtopiaRemixRootComponent = (props: UtopiaRemixRootComponentProps) => {
   const remixDerivedDataRef = useRefEditorState((store) => store.derived.remixData)
 
   const routes = useGetRoutes(props.getLoadContext)
@@ -335,4 +335,4 @@ export const UtopiaRemixRootComponent = React.memo((props: UtopiaRemixRootCompon
       </OutletPathContext.Provider>
     </RemixContext.Provider>
   )
-})
+}


### PR DESCRIPTION
**Problem:**
A canvas interaction that results in no changes to the project model will trash the metadata for a Remix project.

**Fix:**
The problem here was that we wrap `UtopiaRemixRootComponent` in `React.memo`, which meant that a if we re-render the canvas without a project model change then the contents of any Remix scenes would not re-render. Since we trash the spy metadata on a canvas render (this is our crude way of handling deleted or re-parented elements), we rely on all spy wrapped elements to be rendered so that we can capture that metadata again.

In investigating this issue, I noticed that we weren't actually gaining anything by using that `React.memo`, as we would still be rendering the component during the same canvas interactions with or without that wrapping, with the only exception seeming to be where there are no project changes upon completion of a canvas interaction. As a result, I've simply removed the wrapping.