### PR TITLE
Make the RightPane tab menu scroll horizontally

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -183,7 +183,13 @@ export const RightPane = React.memo<ResizableRightPaneProps>((props) => {
     >
       <TitleBarUserProfile panelData={props.panelData} />
       <FlexRow
-        style={{ marginBottom: 10, gap: 2, alignSelf: 'stretch', flexShrink: 0 }}
+        style={{
+          marginBottom: 10,
+          gap: 2,
+          alignSelf: 'stretch',
+          flexShrink: 0,
+          overflowX: 'scroll',
+        }}
         css={undefined}
       >
         <MenuTab


### PR DESCRIPTION
**Problem:**
<img width="321" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/cc41c72f-8a37-4640-8380-5a9fe8eccb78">
This row of pane tabs doesn't scroll horizontally, but over time became wider than the Inspector default width

**Fix:**
make it scroll