### PR TITLE
show remix scene label for viewers

### DIFF
--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -543,6 +543,14 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
             <ZeroSizedElementControls.control showAllPossibleElements={false} />
 
             {when(
+              isSelectMode(editorMode),
+              <RemixSceneLabelControl
+                maybeHighlightOnHover={maybeHighlightOnHover}
+                maybeClearHighlightsOnHoverEnd={maybeClearHighlightsOnHoverEnd}
+              />,
+            )}
+
+            {when(
               isMyProject,
               <>
                 {inspectorFocusedControls.map((c) => (
@@ -559,13 +567,6 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
                     propsForControl={c.props}
                   />
                 ))}
-                {when(
-                  isSelectMode(editorMode),
-                  <RemixSceneLabelControl
-                    maybeHighlightOnHover={maybeHighlightOnHover}
-                    maybeClearHighlightsOnHoverEnd={maybeClearHighlightsOnHoverEnd}
-                  />,
-                )}
                 {when(isSelectMode(editorMode) && !anyStrategyActive, <PinLines />)}
                 {when(isSelectMode(editorMode), <InsertionControls />)}
                 {renderTextEditableControls()}


### PR DESCRIPTION
## Problem
We don't show the remix scene label for viewers, which means they cannot navigate back/forward with the navigation buttons in the scene label

## Fix
Render the remix scene label for viewers too