### PR TITLE
Ensure that the /utopia directory exists before writing to it

### DIFF
--- a/utopia-vscode-common/package.json
+++ b/utopia-vscode-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utopia-vscode-common",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "MIT",
   "private": true,
   "description": "Common code for bridging VSCode and Utopia",

--- a/utopia-vscode-common/src/vscode-communication.ts
+++ b/utopia-vscode-common/src/vscode-communication.ts
@@ -126,6 +126,7 @@ async function initIndexedDBBridge(
     stopWatchingAll()
     stopPollingMailbox()
     await initializeFS(vsCodeSessionID, UtopiaFSUser)
+    await ensureDirectoryExists(RootDir)
     await clearBothMailboxes()
     for (const projectFile of projectContents) {
       await writeProjectFile(projectFile)


### PR DESCRIPTION
**Problem:**
There exists a race condition in the VSCode build vs extension projects, whereby we could end up attempting to write project files into the `/utopia` directory before it exists. This can be triggered by sufficiently sized projects, and when it does happens the code editor fails to load.

**Fix:**
Add an `await ensureDirectoryExists(RootDir)` inside the function that initialised the bridge on the VSCode side.