### PR TITLE
Check the comment permission instead of login state

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -32,11 +32,10 @@ import { MenuTab } from '../../uuiui/menu-tab'
 import { FlexRow } from 'utopia-api'
 import type { StoredPanel } from './stored-layout'
 import { useRoom, useStatus } from '../../../liveblocks.config'
-import { isFeatureEnabled } from '../../utils/feature-switches'
 import { CommentsPane } from '../inspector/comments-pane'
 import { EditorModes, isCommentMode } from '../editor/editor-modes'
 import { useAllowedToEditProject } from '../editor/store/collaborative-editing'
-import { useIsLoggedIn } from '../../core/shared/multiplayer-hooks'
+import { useCanComment } from '../../core/commenting/comment-hooks'
 
 function isCodeEditorEnabled(): boolean {
   if (typeof window !== 'undefined') {
@@ -163,7 +162,7 @@ export const RightPane = React.memo<ResizableRightPaneProps>((props) => {
     onClickTab(RightMenuTab.Settings)
   }, [onClickTab])
 
-  const isLoggedIn = useIsLoggedIn()
+  const canComment = useCanComment()
 
   const allowedToEdit = useAllowedToEditProject()
 
@@ -213,7 +212,7 @@ export const RightPane = React.memo<ResizableRightPaneProps>((props) => {
           </>,
         )}
         {when(
-          isLoggedIn && isFeatureEnabled('Multiplayer'),
+          canComment,
           <MenuTab
             testId='comments-tab'
             label={'Comments'}

--- a/editor/src/components/canvas/multiplayer-presence.tsx
+++ b/editor/src/components/canvas/multiplayer-presence.tsx
@@ -12,7 +12,11 @@ import {
   useStorage,
   useUpdateMyPresence,
 } from '../../../liveblocks.config'
-import { getCollaborator, useAddMyselfToCollaborators } from '../../core/commenting/comment-hooks'
+import {
+  getCollaborator,
+  useAddMyselfToCollaborators,
+  useCanComment,
+} from '../../core/commenting/comment-hooks'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../core/shared/array-utils'
 import * as EP from '../../core/shared/element-path'
@@ -136,6 +140,8 @@ export const MultiplayerPresence = React.memo(() => {
     }
   }, [room.id, roomId, dispatch])
 
+  const canComment = useCanComment()
+
   if (!isLoggedIn(loginState)) {
     return null
   }
@@ -144,9 +150,9 @@ export const MultiplayerPresence = React.memo(() => {
     <>
       <FollowingOverlay />
       <MultiplayerShadows />
-      <CommentIndicators />
+      {when(canComment, <CommentIndicators />)}
       <MultiplayerCursors />
-      {when(isCommentMode(mode) && mode.comment != null, <CommentPopup />)}
+      {when(canComment && isCommentMode(mode) && mode.comment != null, <CommentPopup />)}
     </>
   )
 })

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -67,11 +67,10 @@ import {
   useComponentSelectorStyles,
   useGetInsertableComponents,
 } from '../canvas/ui/floating-insert-menu'
-import { isFeatureEnabled } from '../../utils/feature-switches'
 import { RightMenuTab, floatingInsertMenuStateSwap } from './store/editor-state'
 import { useStatus, useThreads } from '../../../liveblocks.config'
 import { useAllowedToEditProject, useIsMyProject } from './store/collaborative-editing'
-import { useReadThreads } from '../../core/commenting/comment-hooks'
+import { useCanComment, useReadThreads } from '../../core/commenting/comment-hooks'
 import { pluck } from '../../core/shared/array-utils'
 import { MultiplayerWrapper } from '../../utils/multiplayer-wrapper'
 
@@ -383,6 +382,8 @@ export const CanvasToolbar = React.memo(() => {
     'TopMenu editorMode',
   )
 
+  const canComment = useCanComment()
+
   const isFollowMode = editorMode === 'follow'
   const zoom100pct = React.useCallback(() => {
     if (!isFollowMode) {
@@ -556,7 +557,7 @@ export const CanvasToolbar = React.memo(() => {
           />
         </Tooltip>
         {when(
-          isFeatureEnabled('Multiplayer'),
+          canComment,
           <div style={{ display: 'flex', width: 36 }}>
             <Tooltip title={commentButtonTooltip} placement='bottom'>
               <InsertModeButton

--- a/editor/src/components/editor/store/permissions.ts
+++ b/editor/src/components/editor/store/permissions.ts
@@ -1,5 +1,9 @@
-import { useIsLoggedIn } from '../../../core/shared/multiplayer-hooks'
-import { useIsMyProject } from './collaborative-editing'
+import type { LoginState } from '../action-types'
+import { isLoggedIn } from '../action-types'
+import { checkIsMyProject } from './collaborative-editing'
+import type { ProjectServerState } from './project-server-state'
+import { Substores, useEditorState } from './store-hook'
+import type { ProjectServerStateSubstate, UserStateSubstate } from './store-hook-substore-types'
 
 export type Permissions = {
   edit: boolean // Edit the open project via the canvas, inspector, code editor
@@ -7,8 +11,24 @@ export type Permissions = {
 }
 
 export function usePermissions(): Permissions {
+  return useEditorState(
+    Substores.userStateAndProjectServerState,
+    (store) => getPermissions(store),
+    'usePermissions',
+  )
+}
+
+export function getPermissions(store: ProjectServerStateSubstate & UserStateSubstate): Permissions {
   return {
-    edit: useIsMyProject(),
-    comment: useIsLoggedIn(),
+    edit: hasEditPermissions(store.projectServerState),
+    comment: hasCommentPermission(store.userState.loginState),
   }
+}
+
+export function hasEditPermissions(projectServerState: ProjectServerState): boolean {
+  return checkIsMyProject(projectServerState)
+}
+
+export function hasCommentPermission(loginState: LoginState): boolean {
+  return isLoggedIn(loginState)
 }

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -8,7 +8,7 @@ import {
   NavigatorStateKeepDeepEquality,
   ProjectServerStateKeepDeepEquality,
 } from './store-deep-equality-instances'
-import type { DerivedState, EditorStorePatched } from './editor-state'
+import type { DerivedState, EditorStorePatched, UserState } from './editor-state'
 import {
   logAfterStoreUpdate,
   logBeforeStoreUpdate,
@@ -307,6 +307,15 @@ export const Substores = {
   },
   projectServerState: (a: ProjectServerStateSubstate, b: ProjectServerStateSubstate) => {
     return ProjectServerStateKeepDeepEquality(a.projectServerState, b.projectServerState).areEqual
+  },
+  userStateAndProjectServerState: (
+    a: ProjectServerStateSubstate & UserStateSubstate,
+    b: ProjectServerStateSubstate & UserStateSubstate,
+  ) => {
+    return (
+      a.userState === b.userState &&
+      ProjectServerStateKeepDeepEquality(a.projectServerState, b.projectServerState).areEqual
+    )
   },
   variablesInScope: (a: VariablesInScopeSubstate, b: VariablesInScopeSubstate) => {
     return keysEquality(variablesInScopeSubstateKeys, a.editor, b.editor)

--- a/editor/src/components/inspector/comments-pane.tsx
+++ b/editor/src/components/inspector/comments-pane.tsx
@@ -1,15 +1,8 @@
 import React from 'react'
 import { CommentSection } from './sections/comment-section'
 import { FlexColumn, Section } from '../../uuiui'
-import { useIsLoggedIn } from '../../core/shared/multiplayer-hooks'
 
 export const CommentsPane = React.memo(() => {
-  const isLoggedIn = useIsLoggedIn()
-
-  if (!isLoggedIn) {
-    return null
-  }
-
   return (
     <FlexColumn
       id='leftPaneSettings'

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -29,6 +29,8 @@ import type { ElementInstanceMetadata } from '../shared/element-template'
 import * as EP from '../shared/element-path'
 import { getCurrentTheme } from '../../components/editor/store/editor-state'
 import { useMyUserId } from '../shared/multiplayer-hooks'
+import { usePermissions } from '../../components/editor/store/permissions'
+import { isFeatureEnabled } from '../../utils/feature-switches'
 
 export function useCanvasCommentThreadAndLocation(comment: CommentId): {
   location: CanvasPoint | null
@@ -379,4 +381,10 @@ export function useDataThemeAttributeOnBody() {
   React.useEffect(() => {
     document.body.setAttribute('data-theme', theme)
   }, [theme])
+}
+
+export function useCanComment() {
+  const canComment = usePermissions().comment
+
+  return isFeatureEnabled('Multiplayer') && canComment
 }

--- a/editor/src/core/shared/multiplayer-hooks.tsx
+++ b/editor/src/core/shared/multiplayer-hooks.tsx
@@ -37,11 +37,3 @@ export function useMyUserId(): string | null {
   )
   return myUserId
 }
-
-export function useIsLoggedIn(): boolean {
-  return useEditorState(
-    Substores.restOfStore,
-    (store) => isLoggedIn(store.userState.loginState),
-    'useIsLoggedIn',
-  )
-}


### PR DESCRIPTION
**Problem:**
We have a new comment permission to check if the user can comment, but we don't use it yet to guard the different comment ui elements and features.
We also have some missing guards, e.g. logged out users still have the comments tab as the default pane for the right sidebar, the `c` shortcut still goes to comment mode, etc.

**Fix:**
The original permissions helpers only included hooks, but I need to be able check permissions in non-react code too.
So I slightly refactored usePermissions in a way that the business logic inside is exported as a simple function too.
I replaced the scattered isLoggedIn calls and feature switch checks with this new api.