### PR TITLE
Follow based on connection id, disallow chained follows

### DIFF
--- a/editor/src/components/canvas/multiplayer-presence.tsx
+++ b/editor/src/components/canvas/multiplayer-presence.tsx
@@ -338,7 +338,9 @@ const FollowingOverlay = React.memo(() => {
 
   const isFollowTarget = React.useCallback(
     (other: User<Presence, UserMeta>): boolean => {
-      return isFollowMode(mode) && other.id === mode.playerId
+      return (
+        isFollowMode(mode) && other.id === mode.playerId && other.connectionId === mode.connectionId
+      )
     },
     [mode],
   )

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -191,6 +191,7 @@ export interface LiveCanvasMode {
 export interface FollowMode {
   type: 'follow'
   playerId: string // the ID of the followed player
+  connectionId: number // the connection ID of the followed player
 }
 
 export type Mode =
@@ -248,10 +249,11 @@ export const EditorModes = {
       isDragging: isDragging,
     }
   },
-  followMode: function (playerId: string): FollowMode {
+  followMode: function (playerId: string, connectionId: number): FollowMode {
     return {
       type: 'follow',
       playerId: playerId,
+      connectionId: connectionId,
     }
   },
 }

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -3295,9 +3295,11 @@ export const CommentModeKeepDeepEquality: KeepDeepEqualityCall<CommentMode> = co
   EditorModes.commentMode,
 )
 
-export const FollowModeKeepDeepEquality: KeepDeepEqualityCall<FollowMode> = combine1EqualityCall(
+export const FollowModeKeepDeepEquality: KeepDeepEqualityCall<FollowMode> = combine2EqualityCalls(
   (mode) => mode.playerId,
   StringKeepDeepEquality,
+  (mode) => mode.connectionId,
+  NumberKeepDeepEquality,
   EditorModes.followMode,
 )
 

--- a/editor/src/core/shared/multiplayer.spec.ts
+++ b/editor/src/core/shared/multiplayer.spec.ts
@@ -1,4 +1,4 @@
-import { canFollowTarget, multiplayerInitialsFromName } from './multiplayer'
+import { canFollowTarget, followTarget, multiplayerInitialsFromName } from './multiplayer'
 
 describe('multiplayer', () => {
   describe('multiplayerInitialsFromName', () => {
@@ -21,34 +21,56 @@ describe('multiplayer', () => {
 
   describe('canFollowTarget', () => {
     it('can follow a single player', () => {
-      expect(canFollowTarget('foo', 'bar', [{ id: 'bar', following: null }])).toBe(true)
-    })
-    it('can follow a player that follows another player', () => {
       expect(
-        canFollowTarget('foo', 'bar', [
-          { id: 'bar', following: 'baz' },
-          { id: 'baz', following: null },
+        canFollowTarget(followTarget('foo', 0), followTarget('bar', 0), [
+          { id: 'bar', connectionId: 0, following: null },
         ]),
       ).toBe(true)
     })
-    it('can follow a player that follows another player indirectly', () => {
+    it('cannot follow self', () => {
       expect(
-        canFollowTarget('foo', 'bar', [
-          { id: 'bar', following: 'baz' },
-          { id: 'baz', following: 'qux' },
-          { id: 'qux', following: null },
+        canFollowTarget(followTarget('foo', 0), followTarget('foo', 0), [
+          { id: 'foo', connectionId: 1, following: null },
+        ]),
+      ).toBe(false)
+    })
+    it('can follow a single player with the same ID but on another connection', () => {
+      expect(
+        canFollowTarget(followTarget('foo', 0), followTarget('foo', 1), [
+          { id: 'foo', connectionId: 1, following: null },
         ]),
       ).toBe(true)
+    })
+    it('cannot follow a player that follows another player', () => {
+      expect(
+        canFollowTarget(followTarget('foo', 0), followTarget('bar', 0), [
+          { id: 'bar', connectionId: 0, following: 'baz' },
+          { id: 'baz', connectionId: 0, following: null },
+        ]),
+      ).toBe(false)
+    })
+    it('cannot follow a player that follows another player indirectly', () => {
+      expect(
+        canFollowTarget(followTarget('foo', 0), followTarget('bar', 0), [
+          { id: 'bar', connectionId: 0, following: 'baz' },
+          { id: 'baz', connectionId: 0, following: 'qux' },
+          { id: 'qux', connectionId: 0, following: null },
+        ]),
+      ).toBe(false)
     })
     it('cannot follow a player back', () => {
-      expect(canFollowTarget('foo', 'bar', [{ id: 'bar', following: 'foo' }])).toBe(false)
+      expect(
+        canFollowTarget(followTarget('foo', 0), followTarget('bar', 0), [
+          { id: 'bar', connectionId: 0, following: 'foo' },
+        ]),
+      ).toBe(false)
     })
     it('cannot follow a player that has an indirect loop', () => {
       expect(
-        canFollowTarget('foo', 'bar', [
-          { id: 'bar', following: 'baz' },
-          { id: 'baz', following: 'qux' },
-          { id: 'qux', following: 'foo' },
+        canFollowTarget(followTarget('foo', 0), followTarget('bar', 0), [
+          { id: 'bar', connectionId: 0, following: 'baz' },
+          { id: 'baz', connectionId: 0, following: 'qux' },
+          { id: 'qux', connectionId: 0, following: 'foo' },
         ]),
       ).toBe(false)
     })


### PR DESCRIPTION
Fix #4761 

**Problem:**

Right now it's not possible to follow self on different tabs, because the follow logic only takes the player ID into account.
Also, we should not allow chained follows.

**Fix:**

Include the connection ID into the follow logic calculations, and keep it in the editor mode. Also, simplify the `canFollowTarget` logic so that it only allows direct follows and prevent from following users that are already following another user.