### PR TITLE
Don't squash mappings used to update highlight bounds

### DIFF
--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -169,8 +169,6 @@ export function updateHighlightBounds(
         ...bounds,
         uid: newUID,
       }
-    } else {
-      throw new Error(`Invalid mapping: ${JSON.stringify(mapping)}`)
     }
   }
 

--- a/editor/src/core/workers/parser-printer/uid-fix.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.ts
@@ -143,14 +143,7 @@ function updateUID<T>(
   baseValue: T,
 ): T {
   function addMapping(originalUID: string, newUID: string): void {
-    const priorMapping = fixUIDsState.mappings.find((mapping) => {
-      return mapping.newUID === originalUID
-    })
-    if (priorMapping == null) {
-      fixUIDsState.mappings.push({ originalUID: originalUID, newUID: newUID })
-    } else {
-      priorMapping.newUID = newUID
-    }
+    fixUIDsState.mappings.push({ originalUID: originalUID, newUID: newUID })
   }
 
   const newUID = unsafeGet(uidOptic, baseValue)


### PR DESCRIPTION
**Problem:**
When a code file has multiple elements that are identical (with identical code), making a change (via the design tool) to one such element results in the highlight bounds being swapped with another element from later on.

**Fix:**
This is caused by the way we fix the highlight bounds as part of fixing UIDs after parsing the updated code. We have logic in there for capturing the mappings from new UID to old UID, which is used to update the highlight bounds, which was introduced in https://github.com/concrete-utopia/utopia/pull/3891. Whenever we had a mapping from A -> B and from B -> C, we would squash the two together to end up with A -> C. The problem here is that editing the first element updates the UID to say A', meaning the second element steals the original UID A. The result is that when fixing the UIDs we end up with a mapping A' -> A, and A -> B, meaning they are squashed into A' -> B. Then when this mapping is used to fix the highlight bounds, the result is that they are swapped.

**Sample Project:**
To repro, select the top most inner white `div`, and then give it a border via the Inspector. The result will be that in the code you will now have the second one selected, even though the canvas and navigator show the first one as being selected.

Before: https://utopia.pizza/p/1c7a5208-funky-knight/
After: https://utopia.pizza/p/1c7a5208-funky-knight/?branch_name=fix-identical-code-highlight-bounds