### PR TITLE
Comment reparenting

### DIFF
--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -643,7 +643,11 @@ const CommentIndicatorWrapper = React.memo((props: CommentIndicatorWrapper) => {
         minHeight: baseMultiplayerAvatarStyle.height,
       }}
     >
-      <motion.div ref={avatarRef} style={{ ...baseMultiplayerAvatarStyle, left: 0, top: 0 }}>
+      <motion.div
+        data-testid='comment-indicator-div'
+        ref={avatarRef}
+        style={{ ...baseMultiplayerAvatarStyle, left: 0, top: 0 }}
+      >
         <MultiplayerAvatar
           name={multiplayerInitialsFromName(normalizeMultiplayerName(user.name))}
           color={multiplayerColorFromIndex(user.colorIndex)}

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -23,6 +23,7 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { ElementContextMenu } from '../../element-context-menu'
 import type { Mode } from '../../editor/editor-modes'
 import {
+  isCommentMode,
   isLiveMode,
   isSelectMode,
   isSelectModeWithArea,
@@ -535,7 +536,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
         onMouseUp={onMouseUp}
       >
         {when(
-          isSelectMode(editorMode),
+          isSelectMode(editorMode) || isCommentMode(editorMode),
           <SceneLabelControl
             maybeHighlightOnHover={maybeHighlightOnHover}
             maybeClearHighlightsOnHoverEnd={maybeClearHighlightsOnHoverEnd}
@@ -550,7 +551,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
             <ZeroSizedElementControls.control showAllPossibleElements={false} />
 
             {when(
-              isSelectMode(editorMode),
+              isSelectMode(editorMode) || isCommentMode(editorMode),
               <RemixSceneLabelControl
                 maybeHighlightOnHover={maybeHighlightOnHover}
                 maybeClearHighlightsOnHoverEnd={maybeClearHighlightsOnHoverEnd}

--- a/editor/src/components/canvas/controls/select-mode/remix-scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/remix-scene-label.tsx
@@ -13,7 +13,7 @@ import CanvasActions from '../../canvas-actions'
 import { boundingArea, createInteractionViaMouse } from '../../canvas-strategies/interaction-state'
 import { windowToCanvasCoordinates } from '../../dom-lookup'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
-import { isSelectModeWithArea } from '../../../editor/editor-modes'
+import { isCommentMode, isSelectModeWithArea } from '../../../editor/editor-modes'
 import { useAtom } from 'jotai'
 import { RemixNavigationAtom } from '../../remix/utopia-remix-root-component'
 import { matchRoutes } from 'react-router'
@@ -202,7 +202,8 @@ const RemixSceneLabel = React.memo<RemixSceneLabelProps>((props) => {
   const onMouseMove = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       const isSelectingArea = isSelectModeWithArea(editorModeRef.current.mode)
-      if (!isSelectingArea) {
+      const shouldStopPropagation = !isSelectingArea && !isCommentMode(editorModeRef.current.mode)
+      if (shouldStopPropagation) {
         event.stopPropagation()
       }
     },

--- a/editor/src/components/canvas/controls/select-mode/scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/scene-label.tsx
@@ -13,7 +13,7 @@ import CanvasActions from '../../canvas-actions'
 import { boundingArea, createInteractionViaMouse } from '../../canvas-strategies/interaction-state'
 import { windowToCanvasCoordinates } from '../../dom-lookup'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
-import { isSelectModeWithArea } from '../../../editor/editor-modes'
+import { isCommentMode, isSelectModeWithArea } from '../../../editor/editor-modes'
 import { getSubTree } from '../../../../core/shared/element-path-tree'
 
 interface SceneLabelControlProps {
@@ -128,7 +128,8 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
   const onMouseMove = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       const isSelectingArea = isSelectModeWithArea(storeRef.current.mode)
-      if (!isSelectingArea) {
+      const shouldStopPropagation = !isSelectingArea && !isCommentMode(storeRef.current.mode)
+      if (shouldStopPropagation) {
         event.stopPropagation()
       }
     },

--- a/editor/src/components/editor/hook-utils.ts
+++ b/editor/src/components/editor/hook-utils.ts
@@ -1,4 +1,6 @@
 import React from 'react'
+import { useAtomCallback } from 'jotai/utils'
+import type { Atom } from 'jotai'
 
 export function useValueResetState<T>(
   defaultValue: T,
@@ -37,4 +39,32 @@ export function useInputFocusOnCountIncrease<T extends { focus: () => void }>(
     ref.current?.focus()
   }
   return ref
+}
+
+export class Getter<T> {
+  public getter: (() => T) | null = null
+
+  get current(): T {
+    if (this.getter == null) {
+      throw new Error('Getter.getter is null')
+    }
+    return this.getter()
+  }
+}
+
+export function useRefAtom<T>(atom: Atom<T>): Getter<T> {
+  const getAtomValue = useAtomCallback(
+    React.useCallback(
+      (get) => {
+        const currCount = get(atom)
+        return currCount
+      },
+      [atom],
+    ),
+  )
+
+  const getterShell = React.useMemo(() => new Getter<T>(), [])
+  getterShell.getter = () => getAtomValue()
+
+  return getterShell
 }

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -50,6 +50,7 @@ import {
   selectedViewsSubstateKeys,
   variablesInScopeSubstateKeys,
 } from './store-hook-substore-types'
+import { Getter } from '../hook-utils'
 
 // This is how to officially type the store with a subscribeWithSelector middleware as of Zustand 4.1.5 https://github.com/pmndrs/zustand#using-subscribe-with-selector
 type Store<S> = UseBoundStore<Mutate<StoreApi<S>, [['zustand/subscribeWithSelector', never]]>>
@@ -201,17 +202,6 @@ export const useSelectorWithCallback = <K extends StoreKey, S extends (typeof Su
       unsubscribe()
     }
   }, [api, innerCallback, explainMe])
-}
-
-class Getter<T> {
-  public getter: (() => T) | null = null
-
-  get current(): T {
-    if (this.getter == null) {
-      throw new Error('Getter.getter is null')
-    }
-    return this.getter()
-  }
 }
 
 /**

--- a/editor/src/core/shared/optional-utils.ts
+++ b/editor/src/core/shared/optional-utils.ts
@@ -22,13 +22,17 @@ export function forceNotNull<T>(description: string, value: T | null | undefined
   }
 }
 
-// FIXME This shouldn't be converting null into undefined
-export function optionalMap<T, U>(fn: (param: T) => U, t: T | null | undefined): U | null {
+export function optionalMap<T, U>(
+  fn: (param: T) => U,
+  t: T | null | undefined,
+): U | null | undefined {
+  if (typeof t === 'undefined') {
+    return undefined
+  }
   if (t == null) {
     return null
-  } else {
-    return fn(t)
   }
+  return fn(t)
 }
 
 export function forEachOptional<T>(fn: (param: T) => void, t: T | null | undefined): void {

--- a/editor/src/core/shared/optional-utils.ts
+++ b/editor/src/core/shared/optional-utils.ts
@@ -22,17 +22,16 @@ export function forceNotNull<T>(description: string, value: T | null | undefined
   }
 }
 
-export function optionalMap<T, U>(
-  fn: (param: T) => U,
-  t: T | null | undefined,
-): U | null | undefined {
+export function optionalMap<T, U>(fn: (param: T) => U, t: T | null | undefined): U | null {
   if (typeof t === 'undefined') {
-    return undefined
+    // FIXME This shouldn't use an any cast
+    return undefined as any as null
   }
   if (t == null) {
     return null
+  } else {
+    return fn(t)
   }
-  return fn(t)
 }
 
 export function forEachOptional<T>(fn: (param: T) => void, t: T | null | undefined): void {

--- a/editor/src/core/shared/optional-utils.ts
+++ b/editor/src/core/shared/optional-utils.ts
@@ -22,11 +22,8 @@ export function forceNotNull<T>(description: string, value: T | null | undefined
   }
 }
 
+// FIXME This shouldn't be converting null into undefined
 export function optionalMap<T, U>(fn: (param: T) => U, t: T | null | undefined): U | null {
-  if (typeof t === 'undefined') {
-    // FIXME This shouldn't use an any cast
-    return undefined as any as null
-  }
   if (t == null) {
     return null
   } else {


### PR DESCRIPTION
https://screenshot.click/22-02-b3gh0-k1rdm.mp4

## Problem
We cannot reparent comments from the canvas to scenes, and vice-versa

## Fix
Make comment indicator dragging smarter, so that if a drag ends over a scene, the thread metadata is updated with the scene ID of the scene the comment indicator was dragged over and the position of the indicator relative to the scene

### Details
- added `useRefAtom` to make it easier to use atoms as refs
- show the (Remix) scene label in comment mode as well
- add the comment reparenting logic
- the highlight around scenes is triggered in comment mode as well