### PR TITLE
use scene id instead of data label

### DIFF
--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -41,7 +41,7 @@ export function initialPresence(): Presence {
   }
 }
 
-type SceneIdToRouteMapping = LiveObject<{ [sceneDataLabel: string]: string }>
+type SceneIdToRouteMapping = LiveObject<{ [sceneId: string]: string }>
 
 // Optionally, Storage represents the shared document that persists in the
 // Room, even after all users leave. Fields under Storage typically are

--- a/editor/src/components/canvas/controls/select-mode/remix-scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/remix-scene-label.tsx
@@ -5,7 +5,7 @@ import { isInfinityRectangle, windowPoint } from '../../../../core/shared/math-u
 import type { ElementPath } from '../../../../core/shared/project-file-types'
 import { NO_OP } from '../../../../core/shared/utils'
 import { Modifier } from '../../../../utils/modifiers'
-import { FlexRow, Icn, Tooltip, useColorTheme } from '../../../../uuiui'
+import { FlexRow, Tooltip, useColorTheme } from '../../../../uuiui'
 import { clearHighlightedViews, selectComponents } from '../../../editor/actions/action-creators'
 import { useDispatch } from '../../../editor/store/dispatch-context'
 import { Substores, useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
@@ -17,11 +17,12 @@ import { isSelectModeWithArea } from '../../../editor/editor-modes'
 import { useAtom } from 'jotai'
 import { RemixNavigationAtom } from '../../remix/utopia-remix-root-component'
 import { matchRoutes } from 'react-router'
-import { unless, when } from '../../../../utils/react-conditionals'
-import { getRemixLocationLabel, getRemixSceneDataLabel } from '../../remix/remix-utils'
+import { unless } from '../../../../utils/react-conditionals'
+import { getRemixLocationLabel } from '../../remix/remix-utils'
 import { useUpdateRemixSceneRouteInLiveblocks } from '../../../../core/shared/multiplayer'
-import { useStatus } from '../../../../../liveblocks.config'
 import { MultiplayerWrapper } from '../../../../utils/multiplayer-wrapper'
+import { getIdOfScene } from '../comment-mode/comment-mode-hooks'
+import { optionalMap } from '../../../../core/shared/optional-utils'
 
 export const RemixSceneLabelPathTestId = (path: ElementPath): string =>
   `${EP.toString(path)}-remix-scene-label-path`
@@ -93,22 +94,22 @@ export const RemixSceneLabelControl = React.memo<RemixSceneLabelControlProps>((p
 const RemixScenePathUpdater = React.memo<{ targetPathString: string }>((props) => {
   const [navigationData] = useAtom(RemixNavigationAtom)
 
-  const sceneDataLabelRef = useRefEditorState((store) =>
-    getRemixSceneDataLabel(store.editor.jsxMetadata[props.targetPathString]),
+  const sceneIdRef = useRefEditorState((store) =>
+    optionalMap(getIdOfScene, store.editor.jsxMetadata[props.targetPathString]),
   )
 
   const updateRemixScenePathInLiveblocks = useUpdateRemixSceneRouteInLiveblocks()
   const currentPath = (navigationData[props.targetPathString] ?? null)?.location.pathname
   React.useEffect(() => {
-    if (sceneDataLabelRef.current == null || currentPath == null) {
+    if (sceneIdRef.current == null || currentPath == null) {
       return
     }
 
     updateRemixScenePathInLiveblocks({
-      sceneDataLabel: sceneDataLabelRef.current,
+      sceneDataLabel: sceneIdRef.current,
       location: currentPath,
     })
-  }, [currentPath, sceneDataLabelRef, updateRemixScenePathInLiveblocks])
+  }, [currentPath, sceneIdRef, updateRemixScenePathInLiveblocks])
 
   return null
 })

--- a/editor/src/components/canvas/multiplayer-presence.tsx
+++ b/editor/src/components/canvas/multiplayer-presence.tsx
@@ -56,8 +56,8 @@ import { CanvasOffsetWrapper } from './controls/canvas-offset-wrapper'
 import { when } from '../../utils/react-conditionals'
 import { CommentIndicators } from './controls/comment-indicator'
 import { CommentPopup } from './controls/comment-popup'
-import { getSceneUnderPoint } from './controls/comment-mode/comment-mode-hooks'
-import { getRemixSceneDataLabel } from './remix/remix-utils'
+import { getIdOfScene, getSceneUnderPoint } from './controls/comment-mode/comment-mode-hooks'
+import { optionalMap } from '../../core/shared/optional-utils'
 
 export const OtherUserPointer = (props: any) => {
   return (
@@ -221,13 +221,13 @@ function useGhostPointerState(position: CanvasPoint, userId: string) {
       const instance =
         // making a new canvasPoint here so that the memo array contains only primitive types
         getSceneUnderPoint(canvasPoint({ x: position.x, y: position.y }), scenesRef.current)
-      const dataLabel = getRemixSceneDataLabel(instance)
+      const remixSceneId = optionalMap(getIdOfScene, instance)
 
-      if (instance == null || dataLabel == null) {
+      if (instance == null || remixSceneId == null) {
         setShouldShowGhostPointer(false)
       } else {
         setShouldShowGhostPointer(
-          !isOnSameRemixRoute({ otherUserId: userId, remixSceneDataLabel: dataLabel }),
+          !isOnSameRemixRoute({ otherUserId: userId, remixSceneId: remixSceneId }),
         )
       }
     }, 1000)

--- a/editor/src/components/canvas/remix/remix-utils.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.tsx
@@ -470,27 +470,3 @@ export function getRemixLocationLabel(location: string | undefined): string | nu
 
   return location
 }
-
-export function getRemixSceneDataLabel(
-  instance: ElementInstanceMetadata | null | undefined,
-): string | null {
-  if (instance == null) {
-    return null
-  }
-
-  const jsxElement = foldEither(() => null, identity, instance.element)
-  if (jsxElement == null || jsxElement.type !== 'JSX_ELEMENT') {
-    return null
-  }
-
-  let dataLabelAttribute = getJSXAttribute(jsxElement.props, 'data-label')
-  if (
-    dataLabelAttribute == null ||
-    dataLabelAttribute.type !== 'ATTRIBUTE_VALUE' ||
-    typeof dataLabelAttribute.value !== 'string'
-  ) {
-    return null
-  }
-
-  return dataLabelAttribute.value
-}

--- a/editor/src/core/shared/multiplayer.ts
+++ b/editor/src/core/shared/multiplayer.ts
@@ -207,11 +207,10 @@ export function useIsOnSameRemixRoute() {
     return () => true
   }
 
-  return (params: { otherUserId: string; remixSceneDataLabel: string }): boolean => {
-    const remixScenePathForMe: string | null =
-      remixSceneRoutes[id]?.[params.remixSceneDataLabel] ?? null
+  return (params: { otherUserId: string; remixSceneId: string }): boolean => {
+    const remixScenePathForMe: string | null = remixSceneRoutes[id]?.[params.remixSceneId] ?? null
     const remixScenePathForOther: string | null =
-      remixSceneRoutes[params.otherUserId]?.[params.remixSceneDataLabel] ?? null
+      remixSceneRoutes[params.otherUserId]?.[params.remixSceneId] ?? null
 
     if (remixScenePathForMe == null || remixScenePathForOther == null) {
       return true


### PR DESCRIPTION
## Problem
We keep track of remix routes in the room storage based on the scene labels (the `data-label` prop). This is not fine, because `data-label` is not guaranteed to be unique.

## Fix
Use `id` instead of `data-label`