### PR TITLE
new style for avatar being followed

### DIFF
--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -81,8 +81,8 @@ const SinglePlayerUserBar = React.memo(() => {
       onClick={handleCopyToClipboard}
       css={{
         background: colorTheme.primary30.value,
-        borderRadius: 26,
-        height: 26,
+        borderRadius: 24,
+        height: 24,
         padding: 2,
         border: `1px solid ${colorTheme.transparent.value}`,
         transition: 'all .1s ease-in-out',
@@ -275,8 +275,8 @@ const MultiplayerUserBar = React.memo(() => {
         onClick={handleCopyToClipboard}
         css={{
           background: colorTheme.primary30.value,
-          borderRadius: 26,
-          height: 26,
+          borderRadius: 24,
+          height: 24,
           padding: 2,
           border: `1px solid ${colorTheme.transparent.value}`,
           transition: 'all .1s ease-in-out',

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -97,7 +97,7 @@ const SinglePlayerUserBar = React.memo(() => {
       <Avatar
         userPicture={userPicture}
         isLoggedIn={true}
-        size={22}
+        size={20}
         style={{ outline: 'undefined' }}
       />
       {isMyProject ? <OwnerBadge /> : null}
@@ -229,6 +229,7 @@ const MultiplayerUserBar = React.memo(() => {
             isBeingFollowed={isFollowMode(mode) && mode.connectionId === other.connectionId}
             follower={other.following === myUser.id}
             isOwner={isOwner}
+            size={20}
           />
         )
       })}
@@ -245,6 +246,7 @@ const MultiplayerUserBar = React.memo(() => {
             foreground: colorTheme.fg0.value,
           }}
           picture={null}
+          size={20}
         />,
       )}
       {when(
@@ -264,6 +266,7 @@ const MultiplayerUserBar = React.memo(() => {
               picture={other.avatar}
               isOwner={isOwner}
               isOffline={true}
+              size={20}
             />
           )
         }),
@@ -290,7 +293,7 @@ const MultiplayerUserBar = React.memo(() => {
           color={multiplayerColorFromIndex(myUser.colorIndex)}
           picture={myUser.avatar}
           isOwner={amIOwner}
-          size={22}
+          size={20}
           style={{ outline: 'undefined' }}
         />
         <div style={{ padding: '0 8px 0 5px', fontWeight: 500 }}>Share</div>
@@ -353,12 +356,14 @@ export const MultiplayerAvatar = React.memo((props: MultiplayerAvatarProps) => {
           fontWeight: 700,
           cursor: props.onClick != null ? 'pointer' : 'inherit',
           position: 'relative',
-          outline: `.3px solid ${colorTheme.bg1.value}`,
+          outline:
+            props.isBeingFollowed === true
+              ? `1px solid ${colorTheme.bg1.value}`
+              : `1px solid ${colorTheme.transparent.value}`,
           boxShadow:
             props.isBeingFollowed === true
-              ? `0px 0px 8px ${colorTheme.dynamicBlue.value}`
-              : undefined,
-
+              ? `0px 0px 0px 2.5px ${props.color.background}`
+              : `0px 0px 0px 2.5px ${colorTheme.transparent.value}`,
           ...props.style,
         }}
         onClick={props.onClick}
@@ -407,7 +412,7 @@ const OwnerBadge = React.memo(() => {
       width={14}
       height={14}
       color='main'
-      style={{ position: 'absolute', zIndex: 1, bottom: -1, left: -2 }}
+      style={{ position: 'absolute', zIndex: 1, bottom: -4, left: -4 }}
     />
   )
 })

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -28,6 +28,8 @@ import { useIsMyProject } from './editor/store/collaborative-editing'
 
 const MAX_VISIBLE_OTHER_PLAYERS = 4
 
+const AvatarSize = 20
+
 export const cannotFollowToastId = 'cannot-follow-toast-id'
 
 export const UserBar = React.memo(() => {
@@ -97,7 +99,7 @@ const SinglePlayerUserBar = React.memo(() => {
       <Avatar
         userPicture={userPicture}
         isLoggedIn={true}
-        size={20}
+        size={AvatarSize}
         style={{ outline: 'undefined' }}
       />
       {isMyProject ? <OwnerBadge /> : null}
@@ -229,7 +231,7 @@ const MultiplayerUserBar = React.memo(() => {
             isBeingFollowed={isFollowMode(mode) && mode.connectionId === other.connectionId}
             follower={other.following === myUser.id}
             isOwner={isOwner}
-            size={20}
+            size={AvatarSize}
           />
         )
       })}
@@ -246,7 +248,7 @@ const MultiplayerUserBar = React.memo(() => {
             foreground: colorTheme.fg0.value,
           }}
           picture={null}
-          size={20}
+          size={AvatarSize}
         />,
       )}
       {when(
@@ -266,7 +268,7 @@ const MultiplayerUserBar = React.memo(() => {
               picture={other.avatar}
               isOwner={isOwner}
               isOffline={true}
-              size={20}
+              size={AvatarSize}
             />
           )
         }),
@@ -293,7 +295,7 @@ const MultiplayerUserBar = React.memo(() => {
           color={multiplayerColorFromIndex(myUser.colorIndex)}
           picture={myUser.avatar}
           isOwner={amIOwner}
-          size={20}
+          size={AvatarSize}
           style={{ outline: 'undefined' }}
         />
         <div style={{ padding: '0 8px 0 5px', fontWeight: 500 }}>Share</div>


### PR DESCRIPTION
Changing the style of the user-being-followed’s avatar to have a ring around it in _their color_. Also nudging the owner star over a bit, and tweaking the size of the avatars and share button.

<img width="484" alt="Screenshot 2024-01-18 at 1 26 52 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/6b026bf5-7d39-431a-a3f0-57b7e1d4b824">

![tada](https://github.com/concrete-utopia/utopia/assets/47405698/1e54e702-90c9-4658-aa16-6b4ee5c0f733)
