### PR TITLE
Follow mode colors, stop button, outline

### DIFF
--- a/editor/src/components/canvas/multiplayer-presence.tsx
+++ b/editor/src/components/canvas/multiplayer-presence.tsx
@@ -439,8 +439,8 @@ const FollowingOverlay = React.memo(() => {
     >
       <div
         style={{
-          backgroundColor: colorTheme.primary.value,
-          color: colorTheme.white.value,
+          backgroundColor: multiplayerColorFromIndex(followedUser.colorIndex).background,
+          color: multiplayerColorFromIndex(followedUser.colorIndex).foreground,
           padding: '2px 10px',
           borderRadius: 10,
           boxShadow: UtopiaStyles.shadowStyles.mid.boxShadow,

--- a/editor/src/components/canvas/multiplayer-presence.tsx
+++ b/editor/src/components/canvas/multiplayer-presence.tsx
@@ -34,7 +34,7 @@ import {
   useIsOnSameRemixRoute,
 } from '../../core/shared/multiplayer'
 import { assertNever } from '../../core/shared/utils'
-import { UtopiaStyles, useColorTheme } from '../../uuiui'
+import { Button, UtopiaStyles, useColorTheme } from '../../uuiui'
 import { notice } from '../common/notice'
 import type { EditorAction } from '../editor/action-types'
 import { isLoggedIn } from '../editor/action-types'
@@ -315,7 +315,6 @@ MultiplayerCursor.displayName = 'MultiplayerCursor'
 const remixRouteChangedToastId = 'follow-changed-scene'
 
 const FollowingOverlay = React.memo(() => {
-  const colorTheme = useColorTheme()
   const dispatch = useDispatch()
 
   const room = useRoom()
@@ -418,6 +417,10 @@ const FollowingOverlay = React.memo(() => {
     }
   })
 
+  const stopFollowing = React.useCallback(() => {
+    dispatch([switchEditorMode(EditorModes.selectMode(null, false, 'none'))])
+  }, [dispatch])
+
   if (followed == null || followedUser == null) {
     return null
   }
@@ -441,12 +444,28 @@ const FollowingOverlay = React.memo(() => {
         style={{
           backgroundColor: multiplayerColorFromIndex(followedUser.colorIndex).background,
           color: multiplayerColorFromIndex(followedUser.colorIndex).foreground,
-          padding: '2px 10px',
-          borderRadius: 10,
+          padding: '4px 4px 4px 12px',
+          borderRadius: 100,
           boxShadow: UtopiaStyles.shadowStyles.mid.boxShadow,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
         }}
       >
-        You're following {followedUser.name}
+        <div>You're following {followedUser.name}</div>
+        <Button
+          highlight
+          spotlight
+          onClick={stopFollowing}
+          style={{
+            backgroundColor: '#00000015',
+            padding: '4px 10px',
+            borderRadius: 100,
+            cursor: 'pointer',
+          }}
+        >
+          Stop following
+        </Button>
       </div>
     </div>
   )

--- a/editor/src/components/canvas/multiplayer-presence.tsx
+++ b/editor/src/components/canvas/multiplayer-presence.tsx
@@ -1,5 +1,5 @@
 import type { User } from '@liveblocks/client'
-import { motion } from 'framer-motion'
+import { AnimatePresence, motion } from 'framer-motion'
 import { useAtom, useSetAtom } from 'jotai'
 import React from 'react'
 import type { Presence, PresenceActiveFrame, UserMeta } from '../../../liveblocks.config'
@@ -421,53 +421,64 @@ const FollowingOverlay = React.memo(() => {
     dispatch([switchEditorMode(EditorModes.selectMode(null, false, 'none'))])
   }, [dispatch])
 
-  if (followed == null || followedUser == null) {
-    return null
-  }
+  const followedUserColor = React.useMemo(() => {
+    return multiplayerColorFromIndex(followedUser?.colorIndex ?? null)
+  }, [followedUser])
+
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        bottom: 0,
-        right: 0,
-        background: 'transparent',
-        display: 'flex',
-        alignItems: 'flex-end',
-        justifyContent: 'center',
-        paddingBottom: 14,
-        cursor: 'default',
-      }}
-    >
-      <div
-        style={{
-          backgroundColor: multiplayerColorFromIndex(followedUser.colorIndex).background,
-          color: multiplayerColorFromIndex(followedUser.colorIndex).foreground,
-          padding: '4px 4px 4px 12px',
-          borderRadius: 100,
-          boxShadow: UtopiaStyles.shadowStyles.mid.boxShadow,
-          display: 'flex',
-          alignItems: 'center',
-          gap: 10,
-        }}
-      >
-        <div>You're following {followedUser.name}</div>
-        <Button
-          highlight
-          spotlight
-          onClick={stopFollowing}
+    <AnimatePresence>
+      {when(
+        followedUser != null,
+        <motion.div
           style={{
-            backgroundColor: '#00000015',
-            padding: '4px 10px',
-            borderRadius: 100,
-            cursor: 'pointer',
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            bottom: 0,
+            right: 0,
+            background: 'transparent',
+            display: 'flex',
+            alignItems: 'flex-end',
+            justifyContent: 'center',
+            paddingBottom: 14,
+            cursor: 'default',
+            border: `3px solid ${followedUserColor.background}`,
           }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.1 }}
         >
-          Stop following
-        </Button>
-      </div>
-    </div>
+          <motion.div
+            style={{
+              backgroundColor: followedUserColor.background,
+              color: followedUserColor.foreground,
+              padding: '4px 4px 4px 12px',
+              borderRadius: 100,
+              boxShadow: UtopiaStyles.shadowStyles.mid.boxShadow,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+            }}
+          >
+            <div>You're following {followedUser?.name}</div>
+            <Button
+              highlight
+              spotlight
+              onClick={stopFollowing}
+              style={{
+                backgroundColor: '#00000015',
+                padding: '4px 10px',
+                borderRadius: 100,
+                cursor: 'pointer',
+              }}
+            >
+              Stop following
+            </Button>
+          </motion.div>
+        </motion.div>,
+      )}
+    </AnimatePresence>
   )
 })
 FollowingOverlay.displayName = 'FollowingOverlay'


### PR DESCRIPTION
Fix #4768 

This PR introduces three tweaks to the follow mode overlay:

1. use the followed user's background color for the toast at the bottom of the page
2. add a button in the persistent toast to stop following
3. add a thick colored border to the overlay, inheriting the user's background color

https://github.com/concrete-utopia/utopia/assets/1081051/85a6048f-0a27-4ed7-817c-79db62b54761

**Note**: we already have a window-wide outline colored border for Play mode. But since the two modes can/should/will/? coexist, I figured we might want to have both borders visible at the same time and so, in that case, it makes sense to have them both at the same time.
