### PR TITLE
Connection tracking and avatar ordering

### DIFF
--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -70,7 +70,12 @@ export function initialStorage(): Storage {
   }
 }
 
-export type Connections = { [connectionId: number]: number } // the key is the connection id, the value is the connection timestamp (Unix)
+export type ConnectionInfo = {
+  startedAt: number
+  lastSeen: number
+}
+
+export type Connections = { [connectionId: number]: ConnectionInfo } // the key is the connection id, the value is the connection timestamp (Unix)
 
 // Optionally, UserMeta represents static/readonly metadata on each user, as
 // provided by your own custom auth back end (if used). Useful for data that

--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -70,7 +70,7 @@ export function initialStorage(): Storage {
   }
 }
 
-export type Connections = { [key: number]: number } // the key is the connection id, the value is the connection timestamp (Unix)
+export type Connections = { [connectionId: number]: number } // the key is the connection id, the value is the connection timestamp (Unix)
 
 // Optionally, UserMeta represents static/readonly metadata on each user, as
 // provided by your own custom auth back end (if used). Useful for data that

--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -53,7 +53,7 @@ export type Storage = {
   collaborators: LiveObject<{ [userId: string]: User }> // this is an object (and not a list) so we can quickly check if a user is a collaborator, but later we can extend the information by storing something more than a boolean (e.g. a permission level)
   userReadStatusesByThread: LiveObject<{ [threadId: string]: UserReadStatuses }>
   remixSceneRoutes: LiveObject<{ [userId: string]: SceneIdToRouteMapping }>
-  connections: LiveObject<{ [userId: string]: Connections }>
+  connections: LiveObject<{ [userId: string]: ConnectionInfo[] }>
 }
 
 export type User = LiveObject<UserMeta>
@@ -71,11 +71,10 @@ export function initialStorage(): Storage {
 }
 
 export type ConnectionInfo = {
+  id: number
   startedAt: number
   lastSeen: number
 }
-
-export type Connections = { [connectionId: number]: ConnectionInfo } // the key is the connection id, the value is the connection timestamp (Unix)
 
 // Optionally, UserMeta represents static/readonly metadata on each user, as
 // provided by your own custom auth back end (if used). Useful for data that

--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -53,6 +53,7 @@ export type Storage = {
   collaborators: LiveObject<{ [userId: string]: User }> // this is an object (and not a list) so we can quickly check if a user is a collaborator, but later we can extend the information by storing something more than a boolean (e.g. a permission level)
   userReadStatusesByThread: LiveObject<{ [threadId: string]: UserReadStatuses }>
   remixSceneRoutes: LiveObject<{ [userId: string]: SceneIdToRouteMapping }>
+  connections: LiveObject<{ [userId: string]: Connections }>
 }
 
 export type User = LiveObject<UserMeta>
@@ -65,8 +66,11 @@ export function initialStorage(): Storage {
     collaborators: new LiveObject(),
     userReadStatusesByThread: new LiveObject(),
     remixSceneRoutes: new LiveObject(),
+    connections: new LiveObject(),
   }
 }
+
+export type Connections = { [key: number]: number } // the key is the connection id, the value is the connection timestamp (Unix)
 
 // Optionally, UserMeta represents static/readonly metadata on each user, as
 // provided by your own custom auth back end (if used). Useful for data that

--- a/editor/src/components/canvas/multiplayer-presence.tsx
+++ b/editor/src/components/canvas/multiplayer-presence.tsx
@@ -52,9 +52,10 @@ import { activeFrameActionToString } from './commands/set-active-frames-command'
 import { canvasPointToWindowPoint, windowToCanvasCoordinates } from './dom-lookup'
 import { ActiveRemixSceneAtom, RemixNavigationAtom } from './remix/utopia-remix-root-component'
 import {
-  useAddConnection,
+  useStoreConnection,
   useMyUserId,
   useRemixPresence,
+  useMonitorConnection,
 } from '../../core/shared/multiplayer-hooks'
 import { CanvasOffsetWrapper } from './controls/canvas-offset-wrapper'
 import { when } from '../../utils/react-conditionals'
@@ -104,7 +105,8 @@ export const MultiplayerPresence = React.memo(() => {
   )
 
   useAddMyselfToCollaborators()
-  useAddConnection()
+  useStoreConnection()
+  useMonitorConnection()
 
   const remixPresence = useRemixPresence()
 

--- a/editor/src/components/canvas/multiplayer-presence.tsx
+++ b/editor/src/components/canvas/multiplayer-presence.tsx
@@ -13,10 +13,8 @@ import {
 } from '../../../liveblocks.config'
 import {
   getCollaborator,
-  useAddConnection,
   useAddMyselfToCollaborators,
   useCanComment,
-  useMyConnections,
 } from '../../core/commenting/comment-hooks'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../core/shared/array-utils'
@@ -36,7 +34,7 @@ import {
   useIsOnSameRemixRoute,
 } from '../../core/shared/multiplayer'
 import { assertNever } from '../../core/shared/utils'
-import { Button, UtopiaStyles, useColorTheme } from '../../uuiui'
+import { Button, UtopiaStyles } from '../../uuiui'
 import { notice } from '../common/notice'
 import type { EditorAction } from '../editor/action-types'
 import { isLoggedIn } from '../editor/action-types'
@@ -53,7 +51,11 @@ import CanvasActions from './canvas-actions'
 import { activeFrameActionToString } from './commands/set-active-frames-command'
 import { canvasPointToWindowPoint, windowToCanvasCoordinates } from './dom-lookup'
 import { ActiveRemixSceneAtom, RemixNavigationAtom } from './remix/utopia-remix-root-component'
-import { useMyUserId, useRemixPresence } from '../../core/shared/multiplayer-hooks'
+import {
+  useAddConnection,
+  useMyUserId,
+  useRemixPresence,
+} from '../../core/shared/multiplayer-hooks'
 import { CanvasOffsetWrapper } from './controls/canvas-offset-wrapper'
 import { when } from '../../utils/react-conditionals'
 import { CommentIndicators } from './controls/comment-indicator'

--- a/editor/src/components/canvas/multiplayer-presence.tsx
+++ b/editor/src/components/canvas/multiplayer-presence.tsx
@@ -13,8 +13,10 @@ import {
 } from '../../../liveblocks.config'
 import {
   getCollaborator,
+  useAddConnection,
   useAddMyselfToCollaborators,
   useCanComment,
+  useMyConnections,
 } from '../../core/commenting/comment-hooks'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../core/shared/array-utils'
@@ -100,6 +102,7 @@ export const MultiplayerPresence = React.memo(() => {
   )
 
   useAddMyselfToCollaborators()
+  useAddConnection()
 
   const remixPresence = useRemixPresence()
 

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -235,7 +235,6 @@ const MultiplayerUserBar = React.memo(() => {
         return (
           <motion.div key={key} layout={'position'}>
             <MultiplayerAvatar
-              key={`avatar-${other.id}`}
               name={multiplayerInitialsFromName(name)}
               tooltip={{ text: name, colored: true }}
               color={multiplayerColorFromIndex(other.colorIndex)}
@@ -273,17 +272,19 @@ const MultiplayerUserBar = React.memo(() => {
           }
           const name = normalizeMultiplayerName(other.name)
           const isOwner = ownerId === other.id
+          const key = `avatar-${other.id}-offline`
           return (
-            <MultiplayerAvatar
-              key={`avatar-${other.id}`}
-              name={multiplayerInitialsFromName(name)}
-              tooltip={{ text: name, colored: false }}
-              color={multiplayerColorFromIndex(other.colorIndex)}
-              picture={other.avatar}
-              isOwner={isOwner}
-              isOffline={true}
-              size={AvatarSize}
-            />
+            <motion.div key={key} layout={'position'}>
+              <MultiplayerAvatar
+                name={multiplayerInitialsFromName(name)}
+                tooltip={{ text: name, colored: false }}
+                color={multiplayerColorFromIndex(other.colorIndex)}
+                picture={other.avatar}
+                isOwner={isOwner}
+                isOffline={true}
+                size={AvatarSize}
+              />
+            </motion.div>
           )
         }),
       )}

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -130,6 +130,8 @@ const MultiplayerUserBar = React.memo(() => {
   const connections = useStorage((store) => store.connections)
 
   const { user: myUser, presence: myPresence } = useMyUserAndPresence()
+  const sortAvatars = useSortMultiplayerUsers()
+  const isBeingFollowed = useIsBeingFollowed()
 
   const others = useOthers((list) =>
     list
@@ -150,8 +152,11 @@ const MultiplayerUserBar = React.memo(() => {
     'MultiplayerUserBar mode',
   )
 
-  const sortAvatars = useSortMultiplayerUsers()
-  const isBeingFollowed = useIsBeingFollowed()
+  const ownerId = useEditorState(
+    Substores.projectServerState,
+    (store) => store.projectServerState.ownerId,
+    'MultiplayerUserBar ownerId',
+  )
 
   const sortedOthers = React.useMemo(() => {
     return others.sort(sortAvatars)
@@ -167,12 +172,6 @@ const MultiplayerUserBar = React.memo(() => {
   const offlineOthers = Object.values(collabs).filter((collab) => {
     return collab.id !== myUser.id && !sortedOthers.some((other) => other.id === collab.id)
   })
-
-  const ownerId = useEditorState(
-    Substores.projectServerState,
-    (store) => store.projectServerState.ownerId,
-    'MultiplayerUserBar ownerId',
-  )
 
   const amIOwner = React.useMemo(() => {
     return ownerId === myUser.id
@@ -242,7 +241,7 @@ const MultiplayerUserBar = React.memo(() => {
               color={multiplayerColorFromIndex(other.colorIndex)}
               picture={other.avatar}
               onClick={toggleFollowing(followTarget(other.id, other.connectionId))}
-              isBeingFollowed={isFollowMode(mode) && mode.connectionId === other.connectionId}
+              isBeingFollowed={isBeingFollowed(other.connectionId)}
               follower={other.following === myUser.id}
               isOwner={isOwner}
               size={AvatarSize}

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -26,6 +26,7 @@ import { useDispatch } from './editor/store/dispatch-context'
 import { Substores, useEditorState } from './editor/store/store-hook'
 import { useIsMyProject } from './editor/store/collaborative-editing'
 import { motion } from 'framer-motion'
+import { useIsBeingFollowed, useSortMultiplayerUsers } from '../core/shared/multiplayer-hooks'
 
 const MAX_VISIBLE_OTHER_PLAYERS = 4
 
@@ -147,30 +148,12 @@ const MultiplayerUserBar = React.memo(() => {
     'MultiplayerUserBar mode',
   )
 
-  const isBeingFollowed = React.useCallback(
-    (connectionId: number) => {
-      return isFollowMode(mode) && mode.connectionId === connectionId
-    },
-    [mode],
-  )
+  const sortAvatars = useSortMultiplayerUsers()
+  const isBeingFollowed = useIsBeingFollowed()
 
   const sortedOthers = React.useMemo(() => {
-    return others.sort((a, b) => {
-      if (isBeingFollowed(a.connectionId)) {
-        return -1
-      }
-      if (isBeingFollowed(b.connectionId)) {
-        return 1
-      }
-      if (a.connectionId < b.connectionId) {
-        return -1
-      }
-      if (b.connectionId < a.connectionId) {
-        return 1
-      }
-      return 0
-    })
-  }, [others, isBeingFollowed])
+    return others.sort(sortAvatars)
+  }, [others, sortAvatars])
 
   const visibleOthers = React.useMemo(() => {
     return sortedOthers.slice(0, MAX_VISIBLE_OTHER_PLAYERS)
@@ -247,8 +230,9 @@ const MultiplayerUserBar = React.memo(() => {
         }
         const name = normalizeMultiplayerName(other.name)
         const isOwner = ownerId === other.id
+        const key = `avatar-${other.id}-${other.connectionId}`
         return (
-          <motion.div key={`avatar-${other.id}-${other.connectionId}`} layout={true}>
+          <motion.div key={key} layout={'position'}>
             <MultiplayerAvatar
               name={multiplayerInitialsFromName(name)}
               tooltip={{ text: name, colored: true }}

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -240,7 +240,7 @@ const MultiplayerUserBar = React.memo(() => {
               color={multiplayerColorFromIndex(other.colorIndex)}
               picture={other.avatar}
               onClick={toggleFollowing(followTarget(other.id, other.connectionId))}
-              isBeingFollowed={isBeingFollowed(other.connectionId)}
+              isBeingFollowed={isBeingFollowed(other.id, other.connectionId)}
               follower={other.following === myUser.id}
               isOwner={isOwner}
               size={AvatarSize}

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -141,7 +141,7 @@ const MultiplayerUserBar = React.memo(() => {
           ...getCollaborator(collabs, other),
           following: other.presence.following,
           connectionId: other.connectionId,
-          connectedAt: connections?.[other.id]?.[other.connectionId] ?? 0,
+          connectedAt: connections?.[other.id]?.[other.connectionId]?.startedAt ?? 0,
         }
       }),
   )

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { User } from '@liveblocks/client'
 import { LiveObject, type ThreadData } from '@liveblocks/client'
-import type { Connections, Presence, ThreadMetadata, UserMeta } from '../../../liveblocks.config'
+import type { Presence, ThreadMetadata, UserMeta } from '../../../liveblocks.config'
 import {
   useEditThreadMetadata,
   useMutation,
@@ -136,47 +136,6 @@ export function useMyUserAndPresence(): {
 export function useMyMultiplayerColorIndex() {
   const me = useMyUserAndPresence()
   return me.user.colorIndex
-}
-
-export function useMyConnections(): Connections {
-  const myUserId = useMyUserId()
-  const conns = useStorage((store) => store.connections)
-  if (myUserId == null) {
-    return {}
-  }
-  return conns[myUserId] ?? {}
-}
-
-export function useAddConnection() {
-  const loginState = useEditorState(
-    Substores.userState,
-    (store) => store.userState.loginState,
-    'useAddConnection loginState',
-  )
-
-  const update = useMutation(
-    ({ storage, self }) => {
-      if (!isLoggedIn(loginState)) {
-        return
-      }
-      const conns: Connections = storage.get('connections').get(self.id) ?? {}
-      if (conns[self.connectionId] != null) {
-        return
-      }
-      conns[self.connectionId] = Date.now()
-      storage.get('connections').update({ [self.id]: conns })
-    },
-    [loginState],
-  )
-
-  const connections = useStorage((store) => store.connections)
-
-  React.useEffect(() => {
-    if (connections == null) {
-      return
-    }
-    update()
-  }, [connections, update])
 }
 
 export function useAddMyselfToCollaborators() {

--- a/editor/src/core/shared/multiplayer-hooks.tsx
+++ b/editor/src/core/shared/multiplayer-hooks.tsx
@@ -13,8 +13,8 @@ import { Substores, useEditorState } from '../../components/editor/store/store-h
 import * as EP from './element-path'
 import type { RemixPresence } from './multiplayer'
 
-const ConnectionHeartbeatInterval = 3 * 1000 // ms
-const ConnectionExpiredTime = 3 * 1000 * 2 // 1 minute
+const ConnectionHeartbeatInterval = 10 * 1000 // ms
+const ConnectionExpiredTime = 60 * 1000 // 1 minute
 
 export function useRemixPresence(): RemixPresence | null {
   const [activeRemixScene] = useAtom(ActiveRemixSceneAtom)

--- a/editor/src/core/shared/multiplayer-hooks.tsx
+++ b/editor/src/core/shared/multiplayer-hooks.tsx
@@ -8,6 +8,7 @@ import type { RemixPresence } from './multiplayer'
 import * as EP from './element-path'
 import { Substores, useEditorState } from '../../components/editor/store/store-hook'
 import { isLoggedIn } from '../../common/user'
+import { isFollowMode } from '../../components/editor/editor-modes'
 
 export function useRemixPresence(): RemixPresence | null {
   const [activeRemixScene] = useAtom(ActiveRemixSceneAtom)
@@ -36,4 +37,47 @@ export function useMyUserId(): string | null {
     'useMyUserId myUserId',
   )
   return myUserId
+}
+
+export function useIsBeingFollowed() {
+  const mode = useEditorState(
+    Substores.restOfEditor,
+    (store) => store.editor.mode,
+    'useIsBeingFollowed mode',
+  )
+
+  const isBeingFollowed = React.useCallback(
+    (connectionId: number) => {
+      return isFollowMode(mode) && mode.connectionId === connectionId
+    },
+    [mode],
+  )
+
+  return isBeingFollowed
+}
+
+export interface SortableUser {
+  connectionId: number
+}
+
+export function useSortMultiplayerUsers() {
+  const isBeingFollowed = useIsBeingFollowed()
+  return React.useCallback(
+    (a: SortableUser, b: SortableUser) => {
+      if (isBeingFollowed(a.connectionId)) {
+        return -1
+      }
+      if (isBeingFollowed(b.connectionId)) {
+        return 1
+      }
+      if (a.connectionId < b.connectionId) {
+        return -1
+      }
+      if (b.connectionId < a.connectionId) {
+        return 1
+      }
+      return 0
+    },
+    [isBeingFollowed],
+  )
 }

--- a/editor/src/core/shared/multiplayer-hooks.tsx
+++ b/editor/src/core/shared/multiplayer-hooks.tsx
@@ -64,8 +64,8 @@ export function useIsBeingFollowed() {
   )
 
   const isBeingFollowed = React.useCallback(
-    (connectionId: number) => {
-      return isFollowMode(mode) && mode.connectionId === connectionId
+    (playerId: string, connectionId: number) => {
+      return isFollowMode(mode) && mode.connectionId === connectionId && mode.playerId === playerId
     },
     [mode],
   )
@@ -74,6 +74,7 @@ export function useIsBeingFollowed() {
 }
 
 export interface SortableUser {
+  id: string
   connectionId: number
 }
 
@@ -81,10 +82,10 @@ export function useSortMultiplayerUsers() {
   const isBeingFollowed = useIsBeingFollowed()
   return React.useCallback(
     (a: SortableUser, b: SortableUser) => {
-      if (isBeingFollowed(a.connectionId)) {
+      if (isBeingFollowed(a.id, a.connectionId)) {
         return -1
       }
-      if (isBeingFollowed(b.connectionId)) {
+      if (isBeingFollowed(b.id, b.connectionId)) {
         return 1
       }
       if (a.connectionId < b.connectionId) {

--- a/editor/src/core/shared/multiplayer-hooks.tsx
+++ b/editor/src/core/shared/multiplayer-hooks.tsx
@@ -208,8 +208,8 @@ export function useMonitorConnection() {
 
       const selfConns: ConnectionInfo[] = storage.get('connections').get(self.id) ?? []
       // if the current connection is stored, bump its lastSeen field
-      const connIndex = selfConns.findIndex((c) => c.id === self.connectionId)
-      if (connIndex >= 0) {
+      const doUpdate = selfConns.some((c) => c.id === self.connectionId)
+      if (doUpdate) {
         if (debug) {
           console.info(`heartbeat ${self.id}-${self.connectionId}`)
         }

--- a/editor/src/core/shared/multiplayer-hooks.tsx
+++ b/editor/src/core/shared/multiplayer-hooks.tsx
@@ -12,9 +12,20 @@ import { isFollowMode } from '../../components/editor/editor-modes'
 import { Substores, useEditorState } from '../../components/editor/store/store-hook'
 import * as EP from './element-path'
 import type { RemixPresence } from './multiplayer'
+import { PRODUCTION_ENV } from '../../common/env-vars'
+import { isFeatureEnabled } from '../../utils/feature-switches'
 
-const ConnectionHeartbeatInterval = 5 * 1000 // ms
-const ConnectionExpiredTime = 10 * 1000 // 1 minute
+/**
+ * How often to perform heartbeat bumps on connections.
+ * 10s on production, 5s on local/test.
+ */
+const ConnectionHeartbeatInterval = PRODUCTION_ENV ? 10 * 1000 : 5 * 1000
+
+/**
+ * How often to perform heartbeat bumps on connections.
+ * 1 minute on production, 10s on local/test.
+ */
+const ConnectionExpiredTime = PRODUCTION_ENV ? 60 * 1000 : 10 * 1000
 
 export function useRemixPresence(): RemixPresence | null {
   const [activeRemixScene] = useAtom(ActiveRemixSceneAtom)
@@ -143,7 +154,8 @@ export function useStoreConnection() {
 /**
  * Update the stored connection's heartbeat field and cleanup stale connections.
  */
-export function useMonitorConnection(debug: boolean = false) {
+export function useMonitorConnection() {
+  const debug = isFeatureEnabled('Debug – Connections')
   const loginState = useEditorState(
     Substores.userState,
     (store) => store.userState.loginState,

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -16,6 +16,7 @@ export type FeatureName =
   | 'Steganography'
   | 'Multiplayer'
   | 'Baton Passing For Control'
+  | 'Debug – Connections'
 
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
@@ -32,6 +33,7 @@ export const AllFeatureNames: FeatureName[] = [
   'Steganography',
   'Multiplayer',
   'Baton Passing For Control',
+  'Debug – Connections',
 ]
 
 let FeatureSwitches: { [feature in FeatureName]: boolean } = {
@@ -48,6 +50,7 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   Steganography: false,
   Multiplayer: false,
   'Baton Passing For Control': false,
+  'Debug – Connections': false,
 }
 
 let FeatureSwitchLoaded: { [feature in FeatureName]?: boolean } = {}


### PR DESCRIPTION
Fix #4775 

**Problem:**

Multiplayer avatars are not sorted in a clear way / following a fixed pattern.

**Fix:**

This PR does two things:

1. It stores the player connections in the room storage as a map where the keys are player IDs and the values are arrays of `ConnectionInfo` objects.
The `ConnectionInfo` objects contain three fields: the `id` of the connection (the incremental number provided by LB), and two timestamps, one for when the session started and one for the last heartbeat of that connection (`lastSeen`).
A couple of new hooks are used for this: one that stores the connection and one that monitors the connections.
The monitoring hook makes sure that the `lastSeen` field is kept up to date, and it also cleans up expired connections from the storage so that it does not grow indefinitely.
For convenience, I added also a new feature switch (`Debug - Connections`) that will print out log lines for the connection monitoring when enabled.

2. It uses the new connection info to sort the avatars with the following logic:
	- if a user is being followed, its avatar is pinned to the left
	- the active users are shown after the followed ones, with the leftmost being the user with the oldest active connection
	- the avatars move back into place when going in/out of follow mode

https://github.com/concrete-utopia/utopia/assets/1081051/914730cf-7df7-4ccc-9f50-b06265bea952

