### PR TITLE
Logged out handling for collaboration features.

### DIFF
--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -106,7 +106,7 @@ import {
   treeToContents,
 } from '../assets'
 import { testStaticElementPath } from '../../core/shared/element-path.test-utils'
-import { createFakeMetadataForParseSuccess } from '../../utils/utils.test-utils'
+import { createFakeMetadataForParseSuccess, wait } from '../../utils/utils.test-utils'
 import {
   mergeWithPrevUndo,
   saveDOMReport,
@@ -146,7 +146,10 @@ import { carryDispatchResultFields } from './editor-dispatch-flow'
 import type { FeatureName } from '../../utils/feature-switches'
 import { setFeatureEnabled } from '../../utils/feature-switches'
 import { unpatchedCreateRemixDerivedDataMemo } from '../editor/store/remix-derived-data'
-import { emptyProjectServerState } from '../editor/store/project-server-state'
+import {
+  emptyProjectServerState,
+  getUpdateProjectServerStateInStoreRunCount,
+} from '../editor/store/project-server-state'
 
 // eslint-disable-next-line no-unused-expressions
 typeof process !== 'undefined' &&
@@ -626,6 +629,8 @@ label {
     </React.Profiler>,
   )
 
+  const beforeLoadUpdateStoreRunCount = getUpdateProjectServerStateInStoreRunCount()
+
   await act(async () => {
     await new Promise<void>((resolve, reject) => {
       void load(
@@ -655,6 +660,11 @@ label {
       )
     })
   })
+
+  while (getUpdateProjectServerStateInStoreRunCount() <= beforeLoadUpdateStoreRunCount + 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await wait(1)
+  }
 
   return {
     dispatch: async (

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -629,6 +629,7 @@ label {
     </React.Profiler>,
   )
 
+  // Capture how many times the project server state update has been triggered.
   const beforeLoadUpdateStoreRunCount = getUpdateProjectServerStateInStoreRunCount()
 
   await act(async () => {
@@ -661,6 +662,10 @@ label {
     })
   })
 
+  // Check that the project server state update has been triggered twice, which (currently at least)
+  // is the number of times that it runs as a result of the above logic. Once without a project ID and
+  // the second time with the project ID '0', which should then mean that it has stabilised and unless other
+  // changes occur the `UPDATE_PROJECT_SERVER_STATE` action shouldn't be triggered anymore after that.
   while (getUpdateProjectServerStateInStoreRunCount() <= beforeLoadUpdateStoreRunCount + 1) {
     // eslint-disable-next-line no-await-in-loop
     await wait(1)

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -67,11 +67,11 @@ import type { Storage, Presence, RoomEvent, UserMeta } from '../../../liveblocks
 import LiveblocksProvider from '@liveblocks/yjs'
 import { isRoomId, projectIdToRoomId } from '../../core/shared/multiplayer'
 import { EditorModes } from './editor-modes'
-import { checkIsMyProject } from './store/collaborative-editing'
-import { useCanComment, useDataThemeAttributeOnBody } from '../../core/commenting/comment-hooks'
+import { useDataThemeAttributeOnBody } from '../../core/commenting/comment-hooks'
 import { CollaborationStateUpdater } from './store/collaboration-state'
 import { GithubRepositoryCloneFlow } from '../github/github-repository-clone-flow'
 import { getPermissions } from './store/permissions'
+import { useIsLoggedIn } from '../../core/shared/multiplayer-hooks'
 
 const liveModeToastId = 'play-mode-toast'
 
@@ -230,8 +230,8 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
         ...handleKeyDown(
           event,
           editorStoreRef.current.editor,
-          editorStoreRef.current.projectServerState,
           editorStoreRef.current.userState.loginState,
+          editorStoreRef.current.projectServerState,
           metadataRef,
           navigatorTargetsRef,
           namesByKey,
@@ -362,8 +362,6 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
     },
     [dispatch],
   )
-
-  const canComment = useCanComment()
 
   useSelectorWithCallback(
     Substores.userStateAndProjectServerState,
@@ -550,6 +548,8 @@ export function EditorComponent(props: EditorProps) {
     'EditorComponent forkedFromProjectId',
   )
 
+  const loggedIn = useIsLoggedIn()
+
   const dispatch = useDispatch()
 
   useDataThemeAttributeOnBody()
@@ -572,8 +572,9 @@ export function EditorComponent(props: EditorProps) {
           projectId={projectId}
           forkedFromProjectId={forkedFromProjectId}
           dispatch={dispatch}
+          loggedIn={loggedIn}
         >
-          <CollaborationStateUpdater projectId={projectId} dispatch={dispatch}>
+          <CollaborationStateUpdater projectId={projectId} dispatch={dispatch} loggedIn={loggedIn}>
             <EditorComponentInner {...props} />
           </CollaborationStateUpdater>
         </ProjectServerStateUpdater>

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -357,8 +357,8 @@ export function preventBrowserShortcuts(editor: EditorState, event: KeyboardEven
 export function handleKeyDown(
   event: KeyboardEvent,
   editor: EditorState,
-  projectServerState: ProjectServerState,
   loginState: LoginState,
+  projectServerState: ProjectServerState,
   metadataRef: { current: ElementInstanceMetadataMap },
   navigatorTargetsRef: { current: Array<NavigatorEntry> },
   namesByKey: ShortcutNamesByKey,
@@ -367,7 +367,7 @@ export function handleKeyDown(
   // Stop the browser from firing things like save dialogs.
   preventBrowserShortcuts(editor, event)
 
-  const allowedToEdit = allowedToEditProject(projectServerState)
+  const allowedToEdit = allowedToEditProject(loginState, projectServerState)
   const canComment = isFeatureEnabled('Multiplayer') && hasCommentPermission(loginState)
 
   // Ensure that any key presses are appropriately recorded.

--- a/editor/src/components/editor/persistence/generic/dummy-persistence-backend.ts
+++ b/editor/src/components/editor/persistence/generic/dummy-persistence-backend.ts
@@ -14,7 +14,7 @@ function getNewProjectId(): Promise<string> {
   return Promise.resolve(`Project_${projectCounter++}`)
 }
 
-function checkProjectOwned(_projectId: string): Promise<ProjectOwnership> {
+function checkProjectOwned(_loggedIn: boolean, _projectId: string): Promise<ProjectOwnership> {
   return Promise.resolve({ isOwner: true, ownerId: 'the-owner' })
 }
 

--- a/editor/src/components/editor/persistence/generic/persistence-machine.ts
+++ b/editor/src/components/editor/persistence/generic/persistence-machine.ts
@@ -811,9 +811,9 @@ export function createPersistenceMachine<ModelType, FileType>(
     {
       services: {
         getNewProjectId: backendAPI.getNewProjectId,
-        checkProjectOwned: (_, event) => {
+        checkProjectOwned: (context, event) => {
           if (event.type === 'BACKEND_CHECK_OWNERSHIP') {
-            return backendAPI.checkProjectOwned(event.projectId)
+            return backendAPI.checkProjectOwned(context.loggedIn, event.projectId)
           } else {
             throw new Error(
               `Incorrect event type triggered check ownership, ${JSON.stringify(event)}`,

--- a/editor/src/components/editor/persistence/generic/persistence-types.ts
+++ b/editor/src/components/editor/persistence/generic/persistence-types.ts
@@ -75,7 +75,7 @@ export type ProjectOwnership = {
 
 export interface PersistenceBackendAPI<ModelType, FileType> {
   getNewProjectId: () => Promise<string>
-  checkProjectOwned: (projectId: string) => Promise<ProjectOwnership>
+  checkProjectOwned: (loggedIn: boolean, projectId: string) => Promise<ProjectOwnership>
   loadProject: (projectId: string) => Promise<ProjectLoadResult<ModelType>>
   saveProjectToServer: (
     projectId: string,

--- a/editor/src/components/editor/project-owner-hooks.ts
+++ b/editor/src/components/editor/project-owner-hooks.ts
@@ -48,7 +48,7 @@ export function useDisplayOwnershipWarning(): void {
     Substores.fullStore,
     (store) => {
       return {
-        allowedToEdit: allowedToEditProject(store.projectServerState),
+        allowedToEdit: allowedToEditProject(store.userState.loginState, store.projectServerState),
         projectID: store.editor.id,
       }
     },

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -658,7 +658,7 @@ export function handleStrategies(
   let unpatchedEditorState: EditorState
   let patchedEditorState: EditorState
   let newStrategyState: StrategyState
-  if (allowedToEditProject(storedState.projectServerState)) {
+  if (allowedToEditProject(storedState.userState.loginState, storedState.projectServerState)) {
     const strategiesResult = handleStrategiesInner(
       strategies,
       dispatchedActions,

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -705,7 +705,7 @@ export function editorDispatchClosingOut(
   }
 
   maybeCullElementPathCache(
-    storedState.unpatchedEditor.projectContents,
+    finalStoreV1Final.unpatchedEditor.projectContents,
     anyWorkerUpdates ? 'schedule-now' : 'dont-schedule',
   )
 

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -90,7 +90,6 @@ import { unpatchedCreateRemixDerivedDataMemo } from './remix-derived-data'
 import { maybeClearPseudoInsertMode } from '../canvas-toolbar-states'
 import { isSteganographyEnabled } from '../../../core/shared/stegano-text'
 import { updateCollaborativeProjectContents } from './collaborative-editing'
-import { updateProjectServerStateInStore } from './project-server-state'
 
 type DispatchResultFields = {
   nothingChanged: boolean
@@ -109,6 +108,7 @@ function processAction(
 ): EditorStoreUnpatched {
   return gatedActions(
     action,
+    editorStoreUnpatched.userState.loginState,
     editorStoreUnpatched.projectServerState,
     editorStoreUnpatched.unpatchedEditor,
     editorStoreUnpatched,
@@ -166,11 +166,6 @@ function processAction(
           userState: UPDATE_FNS.SET_CURRENT_THEME(action, working.userState),
         }
       } else if (action.action === 'SET_LOGIN_STATE') {
-        void updateProjectServerStateInStore(
-          editorStoreUnpatched.unpatchedEditor.id,
-          editorStoreUnpatched.unpatchedEditor.forkedFromProjectId,
-          dispatchEvent,
-        )
         return {
           ...working,
           userState: UPDATE_FNS.SET_LOGIN_STATE(action, working.userState),

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -9,6 +9,7 @@ import type {
   EditorAction,
   EditorDispatch,
   ExecutePostActionMenuChoice,
+  LoginState,
   StartPostActionSession,
   UpdateProjectServerState,
 } from '../action-types'
@@ -64,6 +65,7 @@ export function runLocalEditorAction(
 
 export function gatedActions<T>(
   action: EditorAction,
+  loginState: LoginState,
   serverState: ProjectServerState,
   editorState: EditorState,
   defaultValue: T,
@@ -88,7 +90,7 @@ export function gatedActions<T>(
       break
   }
 
-  const canEditProject = allowedToEditProject(serverState)
+  const canEditProject = allowedToEditProject(loginState, serverState)
 
   if (alwaysRun) {
     // If it should always run.

--- a/editor/src/components/editor/store/project-server-state.tsx
+++ b/editor/src/components/editor/store/project-server-state.tsx
@@ -4,7 +4,7 @@ import { IS_TEST_ENVIRONMENT } from '../../../common/env-vars'
 import { fetchProjectMetadata } from '../../../common/server'
 import type { EditorDispatch } from '../action-types'
 import { updateProjectServerState } from '../actions/action-creators'
-import { checkProjectOwned } from '../persistence/persistence-backend'
+import { checkProjectOwned, projectIsStoredLocally } from '../persistence/persistence-backend'
 import type { ProjectOwnership } from '../persistence/generic/persistence-types'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { CollaborationEndpoints } from '../collaborative-endpoints'
@@ -76,75 +76,91 @@ function projectListingToProjectMetadataFromServer(
 }
 
 export async function getProjectServerState(
+  loggedIn: boolean,
   dispatch: EditorDispatch,
   projectId: string | null,
   forkedFromProjectId: string | null,
 ): Promise<ProjectServerState> {
-  if (IS_TEST_ENVIRONMENT) {
-    return {
-      ...emptyProjectServerState(),
-      isMyProject: 'yes',
-      currentlyHolderOfTheBaton: true,
-    }
-  } else {
-    const projectListing = projectId == null ? null : await fetchProjectMetadata(projectId)
-    const forkedFromProjectListing =
-      forkedFromProjectId == null ? null : await fetchProjectMetadata(forkedFromProjectId)
+  const existsLocally = projectId == null ? true : await projectIsStoredLocally(projectId)
+  const projectListing =
+    projectId == null || existsLocally ? null : await fetchProjectMetadata(projectId)
+  const forkedFromProjectListing =
+    forkedFromProjectId == null || existsLocally
+      ? null
+      : await fetchProjectMetadata(forkedFromProjectId)
 
-    async function getOwnership(): Promise<ProjectOwnership> {
-      if (projectId == null) {
-        return { isOwner: true, ownerId: null }
-      }
-      const { isOwner, ownerId } = await checkProjectOwned(projectId)
-      return { isOwner, ownerId }
+  async function getOwnership(): Promise<ProjectOwnership> {
+    if (projectId == null) {
+      return { isOwner: true, ownerId: null }
     }
-    const ownership = await getOwnership()
+    const { isOwner, ownerId } = await checkProjectOwned(loggedIn, projectId)
+    return { isOwner, ownerId }
+  }
+  const ownership = await getOwnership()
 
-    const holderOfTheBaton = ownership.isOwner
-      ? await CollaborationEndpoints.claimControlOverProject(projectId)
-          .then((result) => {
-            return result ?? ownership.isOwner
-          })
-          .catch(() => {
-            CollaborationEndpoints.displayControlErrorToast(
-              dispatch,
-              'Error while attempting to claim control over this project.',
-            )
-            return false
-          })
-      : false
-
-    return {
-      isMyProject: ownership.isOwner ? 'yes' : 'no',
-      ownerId: ownership.ownerId,
-      projectData: projectListingToProjectMetadataFromServer(projectListing),
-      forkedFromProjectData: projectListingToProjectMetadataFromServer(forkedFromProjectListing),
-      currentlyHolderOfTheBaton: holderOfTheBaton,
+  async function getHolderOfTheBaton(): Promise<boolean> {
+    if (!loggedIn) {
+      return false
+    } else if (ownership.isOwner) {
+      return CollaborationEndpoints.claimControlOverProject(projectId)
+        .then((result) => {
+          return result ?? ownership.isOwner
+        })
+        .catch(() => {
+          CollaborationEndpoints.displayControlErrorToast(
+            dispatch,
+            'Error while attempting to claim control over this project.',
+          )
+          return false
+        })
+    } else {
+      return false
     }
+  }
+
+  const holderOfTheBaton = await getHolderOfTheBaton()
+
+  return {
+    isMyProject: ownership.isOwner ? 'yes' : 'no',
+    ownerId: ownership.ownerId,
+    projectData: projectListingToProjectMetadataFromServer(projectListing),
+    forkedFromProjectData: projectListingToProjectMetadataFromServer(forkedFromProjectListing),
+    currentlyHolderOfTheBaton: holderOfTheBaton,
   }
 }
 
 type SuccessOrFailure = 'success' | 'failure'
 
+let updateProjectServerStateInStoreRunCount: number = 0
+
+export function getUpdateProjectServerStateInStoreRunCount(): number {
+  return updateProjectServerStateInStoreRunCount
+}
+
 export async function updateProjectServerStateInStore(
+  loggedIn: boolean,
   projectId: string | null,
   forkedFromProjectId: string | null,
   dispatch: EditorDispatch,
 ): Promise<SuccessOrFailure> {
-  return getProjectServerState(dispatch, projectId, forkedFromProjectId)
+  return getProjectServerState(loggedIn, dispatch, projectId, forkedFromProjectId)
     .then<SuccessOrFailure, SuccessOrFailure>((serverState) => {
       dispatch([updateProjectServerState(serverState)], 'everyone')
       return 'success'
     })
-    .catch((error) => {
+    .catch<SuccessOrFailure>((error) => {
       console.error('Error while updating server state.', error)
       return 'failure'
+    })
+    .finally(() => {
+      updateProjectServerStateInStoreRunCount++
     })
 }
 
 export interface ProjectServerStateUpdaterProps {
   projectId: string | null
   forkedFromProjectId: string | null
+  loggedIn: boolean
   dispatch: EditorDispatch
 }
 
@@ -153,12 +169,13 @@ const baseWatcherIntervalTime: number = 10 * 1000
 let currentWatcherIntervalMultiplier: number = 1
 
 function restartServerStateWatcher(
+  loggedIn: boolean,
   projectId: string | null,
   forkedFromProjectId: string | null,
   dispatch: EditorDispatch,
 ): void {
   if (isFeatureEnabled('Baton Passing For Control')) {
-    void updateProjectServerStateInStore(projectId, forkedFromProjectId, dispatch)
+    void updateProjectServerStateInStore(loggedIn, projectId, forkedFromProjectId, dispatch)
     // Reset the multiplier if triggered from outside of `restartWatcherInterval`.
     currentWatcherIntervalMultiplier = 1
 
@@ -167,40 +184,43 @@ function restartServerStateWatcher(
         window.clearInterval(serverStateWatcherInstance)
       }
       serverStateWatcherInstance = window.setInterval(() => {
-        void updateProjectServerStateInStore(projectId, forkedFromProjectId, dispatch).then(
-          (result) => {
-            // If there's a failure, then double the multiplier and recreate the interval.
-            if (result === 'failure') {
-              if (currentWatcherIntervalMultiplier < 10) {
-                currentWatcherIntervalMultiplier = currentWatcherIntervalMultiplier * 2
-                restartWatcherInterval()
-              }
+        void updateProjectServerStateInStore(
+          loggedIn,
+          projectId,
+          forkedFromProjectId,
+          dispatch,
+        ).then((result) => {
+          // If there's a failure, then double the multiplier and recreate the interval.
+          if (result === 'failure') {
+            if (currentWatcherIntervalMultiplier < 10) {
+              currentWatcherIntervalMultiplier = currentWatcherIntervalMultiplier * 2
+              restartWatcherInterval()
             }
+          }
 
-            // If this call succeeds, reset the multiplier and recreate the interval if the multiplier
-            // has changed.
-            if (result === 'success') {
-              if (currentWatcherIntervalMultiplier !== 1) {
-                currentWatcherIntervalMultiplier = 1
-                restartWatcherInterval()
-              }
+          // If this call succeeds, reset the multiplier and recreate the interval if the multiplier
+          // has changed.
+          if (result === 'success') {
+            if (currentWatcherIntervalMultiplier !== 1) {
+              currentWatcherIntervalMultiplier = 1
+              restartWatcherInterval()
             }
-          },
-        )
+          }
+        })
       }, baseWatcherIntervalTime * currentWatcherIntervalMultiplier)
     }
     restartWatcherInterval()
   } else {
-    void updateProjectServerStateInStore(projectId, forkedFromProjectId, dispatch)
+    void updateProjectServerStateInStore(loggedIn, projectId, forkedFromProjectId, dispatch)
   }
 }
 
 export const ProjectServerStateUpdater = React.memo(
   (props: React.PropsWithChildren<ProjectServerStateUpdaterProps>) => {
-    const { projectId, forkedFromProjectId, dispatch, children } = props
+    const { projectId, forkedFromProjectId, dispatch, loggedIn, children } = props
     React.useEffect(() => {
-      restartServerStateWatcher(projectId, forkedFromProjectId, dispatch)
-    }, [dispatch, projectId, forkedFromProjectId])
+      restartServerStateWatcher(loggedIn, projectId, forkedFromProjectId, dispatch)
+    }, [dispatch, projectId, forkedFromProjectId, loggedIn])
     return <>{children}</>
   },
 )

--- a/editor/src/components/navigator/navigator-item/navigator-item.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.spec.browser2.tsx
@@ -171,6 +171,8 @@ describe('Navigator item row icons', () => {
     )
   `
 
+  // The navigator appears to be a little buggy:
+  // https://github.com/concrete-utopia/utopia/issues/4773
   it('Should show the correct icons for each type of row', async () => {
     const editor = await renderTestEditorWithCode(testProjectCode, 'await-first-dom-report')
     const visibleNavigatorTargets = editor.getEditorState().derived.visibleNavigatorTargets
@@ -302,6 +304,8 @@ describe('Navigator item row icons', () => {
     )
   })
 
+  // The navigator appears to be a little buggy:
+  // https://github.com/concrete-utopia/utopia/issues/4773
   it('Should show the correct labels for each type of row', async () => {
     const editor = await renderTestEditorWithCode(testProjectCode, 'await-first-dom-report')
     const visibleNavigatorTargets = editor.getEditorState().derived.visibleNavigatorTargets

--- a/editor/src/core/model/element-metadata.spec.browser2.tsx
+++ b/editor/src/core/model/element-metadata.spec.browser2.tsx
@@ -37,6 +37,7 @@ import { elementOnlyHasTextChildren } from './element-template-utils'
 import { BakedInStoryboardUID, BakedInStoryboardVariableName } from './scene-utils'
 import type { HugPropertyWidthHeight } from '../shared/element-template'
 import { contentsToTree } from '../../components/assets'
+import { CanvasContainerID } from '../../components/canvas/canvas-types'
 
 describe('Frame calculation for fragments', () => {
   // Components with root fragments do not appear in the DOM, so the dom walker does not find them, and they

--- a/editor/src/core/model/element-metadata.spec.browser2.tsx
+++ b/editor/src/core/model/element-metadata.spec.browser2.tsx
@@ -37,7 +37,6 @@ import { elementOnlyHasTextChildren } from './element-template-utils'
 import { BakedInStoryboardUID, BakedInStoryboardVariableName } from './scene-utils'
 import type { HugPropertyWidthHeight } from '../shared/element-template'
 import { contentsToTree } from '../../components/assets'
-import { CanvasContainerID } from '../../components/canvas/canvas-types'
 
 describe('Frame calculation for fragments', () => {
   // Components with root fragments do not appear in the DOM, so the dom walker does not find them, and they

--- a/editor/src/core/shared/element-path.spec.browser2.tsx
+++ b/editor/src/core/shared/element-path.spec.browser2.tsx
@@ -17,7 +17,11 @@ describe('ElementPath Caching', () => {
     const realPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
     const fakePath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb', 'ccc'])
 
-    // Rendering alone will be enough to trigger the timer for culling the cache
+    // let's make sure the paths are currently still in the cache
+    expect(EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])).toBe(realPath)
+    expect(EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb', 'ccc'])).toBe(fakePath)
+
+    // Rendering alone will usually be enough to trigger the timer for culling the cache.
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
       <div data-uid='aaa'>
@@ -26,11 +30,6 @@ describe('ElementPath Caching', () => {
     `),
       'await-first-dom-report',
     )
-
-    // let's make sure the paths are currently still in the cache
-    expect(EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])).toBe(realPath)
-    expect(EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb', 'ccc'])).toBe(fakePath)
-
     setLastProjectContentsForTesting(renderResult.getEditorState().editor.projectContents)
     cullElementPathCache()
 

--- a/editor/src/core/shared/multiplayer-hooks.tsx
+++ b/editor/src/core/shared/multiplayer-hooks.tsx
@@ -37,3 +37,11 @@ export function useMyUserId(): string | null {
   )
   return myUserId
 }
+
+export function useIsLoggedIn(): boolean {
+  return useEditorState(
+    Substores.restOfStore,
+    (store) => isLoggedIn(store.userState.loginState),
+    'useIsLoggedIn',
+  )
+}

--- a/editor/test/karma-custom-reporter/full-console-messages.js
+++ b/editor/test/karma-custom-reporter/full-console-messages.js
@@ -15,7 +15,9 @@ var FullConsoleMessages = function (baseReporterDecorator, formatError, config) 
   function printCleanConsoleMessages(consoleMessages) {
     var messagesFiltered = []
     consoleMessages.forEach((message) => {
-      self.write(`${message.type.toUpperCase()} ${message.log}\n`)
+      self.write(
+        `${message.timestamp.toISOString()} ${message.type.toUpperCase()} ${message.log}\n`,
+      )
       self.write(`this console message is from: \n  ${message.specName}\n`)
       self.write(`\n`)
     })
@@ -23,6 +25,7 @@ var FullConsoleMessages = function (baseReporterDecorator, formatError, config) 
 
   self.onBrowserLog = function (browser, log, type) {
     consoleMessagesForSpec.push({
+      timestamp: new Date(),
       type: type,
       log: log,
     })

--- a/website-next/components/common/server.ts
+++ b/website-next/components/common/server.ts
@@ -7,7 +7,8 @@ import {
   IS_TEST_ENVIRONMENT,
 } from './env-vars'
 import type { ProjectListing } from './persistence'
-import { loggedInUser, LoginState } from './user'
+import type { LoginState } from './user'
+import { loggedInUser } from './user'
 import {
   cookiesOrLocalForageUnavailable,
   isLoggedIn,


### PR DESCRIPTION
**Problem:**
The collaboration functionality makes server calls often without the user initiating anything beyond loading the editor, which are being triggered when the user isn't logged on causing those services to reject the requests. Similarly some of these calls and those like the project metadata calls are being triggered in tests, which we definitely don't want as that could cause weird issues if a server is actually running.

**Fix:**
For when the editor runs normally, the main change is a check to the login state in the editor and only allow those endpoints to be called when the user is logged in. Which has been done at the level above the functions that make those service calls.

For tests, the minor part of this fix was making sure that all of the calls that are being triggered (like claiming/snatching control or the project metadata endpoint) are guarded with a check to `IS_TEST_ENVIRONMENT`.

Around the above changes are mostly fixes to maintain certain expectations about the results that are given in certain states, like when the user isn't logged in but the project still has a project ID, they should still be the "owner" of the project.

**Commit Details:**
- Test dispatch function now waits for 2 calls to update the project server state to apply before continuing.
- Added `loggedIn` parameter to `checkProjectOwned`.
- `checkProjectOwned` now handles if the user is not logged in and if it's running in a test environment to return true against `isOwner`. This is because actions need to run but at a point that does not regularly occur when running normally as the user is either logged in or the project exists locally.
- Added a `loggedIn` condition in `CollaborationStateUpdater`.
- `allowedToEditProject` and `useAllowedToEditProject` now check the login status of the user.
- Removed a call to `updateProjectServerStateInStore` that was running on any change to `SET_LOGIN_STATE`, because it was effectively running at a random point in time.
- `getProjectServerState` now doesn't itself handle `IS_TEST_ENVIRONMENT` as that handling has been pushed down into the various functions it calls.
- Added timestamps to `test-browser-full-output`.
- `getLoginState`, `checkProjectOwnership` and `fetchProjectMetadata` now all check `IS_TEST_ENVIRONMENT` so that they don't try to make calls to the server during tests.