### PR TITLE
Collaboration table cleanup.

### DIFF
--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -515,6 +515,7 @@ serverAPI resources = hoistServer apiProxy (serverMonadToHandler resources) serv
 startup :: DevServerResources -> IO Stop
 startup DevServerResources{..} = do
   migrateDatabase (not _silentMigration) True _projectPool
+  DB.cleanupCollaborationControl _databaseMetrics _projectPool getCurrentTime
   hashedFilenamesThread <- forkIO $ watchFilenamesWithHashes (_hashCache _assetsCaches) (_assetResultCache _assetsCaches) assetPathsAndBuilders
   return $ do
         killThread hashedFilenamesThread

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -461,6 +461,7 @@ initialiseResources = do
 startup :: ProductionServerResources -> IO Stop
 startup ProductionServerResources{..} = do
   migrateDatabase True False _projectPool
+  DB.cleanupCollaborationControl _databaseMetrics _projectPool getCurrentTime
   hashedFilenamesThread <- forkIO $ watchFilenamesWithHashes (_hashCache _assetsCaches) (_assetResultCache _assetsCaches) assetPathsAndBuilders
   return $ do
         killThread hashedFilenamesThread


### PR DESCRIPTION
**Problem:**
With time the table used to store the collaboration state will fill up with entries that have expired, which isn't ideal.

**Fix:**
Added a call during startup of the server that will remove any old entries from the database.

**Commit Details:**
- Added `cleanupCollaborationControl` function to remove old entries.
- Hooked `cleanupCollaborationControl` into the startup functions of the server.
- Updated some underscore suffixed versions to the non-suffixed versions for Opaleye as apparently the former are deprecated.