### PR TITLE
Cannot click on scene comment

### DIFF
--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -331,10 +331,7 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
     if (didDrag) {
       return
     }
-    if (isOnAnotherRoute && remixLocationRoute != null) {
-      if (remixState == null) {
-        return
-      }
+    if (isOnAnotherRoute && remixLocationRoute != null && remixState != null) {
       remixState.navigate(remixLocationRoute)
     }
     cancelHover()


### PR DESCRIPTION
## Problem
Sometimes scene comments cannot be opened by clicking on them

## Cause
This bug was made possible by multiple small things:
- If a thread has a remix route attached, we try to navigate to that route when the comment is opened. However, if for some reason we can't navigate there, we don't open the comment at all
- If a comment was placed on a scene, we store the value of the `id` prop of the scene in the thread metadata. However, not all scenes have an `id` prop to begin with, so the workaround was to set the `id` prop on the scene when the thread is created. However, viewers can't modify the project, so if a viewer places a comment an scene that doesn't have an `id` prop, the action is simply discarded, and we won't be able to tell which scene that comment belongs to

## FIx
This PR fixes the problem by refactor the comment opening code not to bail out if we can't navigate to the Remix route associated to the thread.