### PR TITLE
Fix comment indicators in follow mode

### DIFF
--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -51,7 +51,12 @@ import {
   setRightMenuTab,
   switchEditorMode,
 } from '../../editor/actions/action-creators'
-import { EditorModes, isCommentMode, isExistingComment } from '../../editor/editor-modes'
+import {
+  EditorModes,
+  isCommentMode,
+  isExistingComment,
+  isFollowMode,
+} from '../../editor/editor-modes'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { RightMenuTab } from '../../editor/store/editor-state'
 import { Substores, useEditorState, useRefEditorState } from '../../editor/store/store-hook'
@@ -336,6 +341,12 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
     'CommentIndicator isActive',
   )
 
+  const isFollowing = useEditorState(
+    Substores.restOfEditor,
+    (store) => isFollowMode(store.editor.mode),
+    'CommentIndicator isFollowing',
+  )
+
   const preview = React.useMemo(() => {
     return !isActive && (hovered || dragging)
   }, [hovered, isActive, dragging])
@@ -386,13 +397,16 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
       onMouseDown={onMouseDown}
       onClick={onClick}
       data-testid='comment-indicator'
-      css={getIndicatorStyle(position, {
-        isRead: isRead,
-        resolved: thread.metadata.resolved,
-        isActive: isActive,
-        expanded: preview,
-        dragging: dragging,
-      })}
+      css={{
+        ...getIndicatorStyle(position, {
+          isRead: isRead,
+          resolved: thread.metadata.resolved,
+          isActive: isActive,
+          expanded: preview,
+          dragging: dragging,
+        }),
+        transition: isFollowing ? '0.1s linear' : undefined,
+      }}
     >
       <CommentIndicatorWrapper
         thread={thread}

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -299,21 +299,20 @@ function on(
   }
 
   if (isDragToPan(canvas.editorState.canvas.interactionSession, canvas.keysPressed['space'])) {
-    if (isFollowMode(canvas.mode)) {
+    const canPan =
+      !isFollowMode(canvas.mode) && event.event === 'MOVE' && event.nativeEvent.buttons === 1
+    if (!canPan) {
       return []
     }
-    if (event.event === 'MOVE' && event.nativeEvent.buttons === 1) {
-      return [
-        CanvasActions.scrollCanvas(
-          canvasPoint({
-            x: -event.nativeEvent.movementX / canvas.scale,
-            y: -event.nativeEvent.movementY / canvas.scale,
-          }),
-        ),
-      ]
-    } else {
-      return []
-    }
+
+    return [
+      CanvasActions.scrollCanvas(
+        canvasPoint({
+          x: -event.nativeEvent.movementX / canvas.scale,
+          y: -event.nativeEvent.movementY / canvas.scale,
+        }),
+      ),
+    ]
   } else if (canvas.keysPressed['z']) {
     if (event.event === 'MOUSE_UP') {
       let scale: number

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -299,6 +299,9 @@ function on(
   }
 
   if (isDragToPan(canvas.editorState.canvas.interactionSession, canvas.keysPressed['space'])) {
+    if (isFollowMode(canvas.mode)) {
+      return []
+    }
     if (event.event === 'MOVE' && event.nativeEvent.buttons === 1) {
       return [
         CanvasActions.scrollCanvas(

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -301,18 +301,18 @@ function on(
   if (isDragToPan(canvas.editorState.canvas.interactionSession, canvas.keysPressed['space'])) {
     const canPan =
       !isFollowMode(canvas.mode) && event.event === 'MOVE' && event.nativeEvent.buttons === 1
-    if (!canPan) {
+    if (canPan) {
+      return [
+        CanvasActions.scrollCanvas(
+          canvasPoint({
+            x: -event.nativeEvent.movementX / canvas.scale,
+            y: -event.nativeEvent.movementY / canvas.scale,
+          }),
+        ),
+      ]
+    } else {
       return []
     }
-
-    return [
-      CanvasActions.scrollCanvas(
-        canvasPoint({
-          x: -event.nativeEvent.movementX / canvas.scale,
-          y: -event.nativeEvent.movementY / canvas.scale,
-        }),
-      ),
-    ]
   } else if (canvas.keysPressed['z']) {
     if (event.event === 'MOUSE_UP') {
       let scale: number

--- a/puppeteer-tests/src/comments/commenting.spec.tsx
+++ b/puppeteer-tests/src/comments/commenting.spec.tsx
@@ -236,8 +236,8 @@ describe('Comments test', () => {
         expect(originalCommentIndicatorBoundingBox).toEqual({
           height: 26,
           width: 26,
-          x: 485,
-          y: 67,
+          x: 486,
+          y: 63,
         })
 
         // drag the comment on the scene


### PR DESCRIPTION
Fix #4780 

**Problem:**

Multiplayer cursors move jankily and "detached" from the rest of the canvas while following another user.
Also, trying to pan the canvas while following another user is effectively disabled but results in a very bad canvas jitter.

**Fix:**

1. Disable the canvas pan at all while in follow mode (note: we could also use this as a point where we stop the following, but for now I don't want to introduce new behaviors as part of this fix PR)
2. The cursors need to move along with the canvas, so moved them inside a `CanvasOffsetWrapper`.

| Before | After |
|------|-------|
| https://github.com/concrete-utopia/utopia/assets/1081051/895a1483-86cb-4aea-8a56-32690b96190f | https://github.com/concrete-utopia/utopia/assets/1081051/d9e9aec0-018d-449c-bebf-c661b1201249 |

