### PR TITLE
Better Offline Style for Avatars

### DIFF
--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -391,7 +391,7 @@ export const MultiplayerAvatar = React.memo((props: MultiplayerAvatarProps) => {
           initials={props.name}
           isOffline={props.isOffline}
         />
-        {props.isOwner ? <OwnerBadge /> : null}
+        {props.isOwner ? <OwnerBadge isOffline={props.isOffline} /> : null}
         {props.follower ? <FollowerBadge /> : null}
       </div>
     </Tooltip>
@@ -421,7 +421,11 @@ const FollowerBadge = React.memo(() => {
 })
 FollowerBadge.displayName = 'FollowerBadge'
 
-const OwnerBadge = React.memo(() => {
+interface OwnerBadge {
+  isOffline?: boolean
+}
+
+const OwnerBadge = React.memo((props: OwnerBadge) => {
   return (
     <Icn
       category='semantic'
@@ -429,7 +433,13 @@ const OwnerBadge = React.memo(() => {
       width={14}
       height={14}
       color='main'
-      style={{ position: 'absolute', zIndex: 1, bottom: -4, left: -4 }}
+      style={{
+        position: 'absolute',
+        zIndex: 1,
+        bottom: -4,
+        left: -4,
+        filter: props.isOffline ? 'grayscale(1)' : 'undefined',
+      }}
     />
   )
 })
@@ -472,6 +482,7 @@ const AvatarPicture = React.memo((props: AvatarPictureProps) => {
         height: size ?? '100%',
         borderRadius: '100%',
         filter: props.isOffline || props.resolved ? 'grayscale(1)' : undefined,
+        opacity: props.isOffline ? 0.6 : 'undefined',
         pointerEvents: 'none',
       }}
       src={url}


### PR DESCRIPTION
Making the avatars for disconnected users look more clearly disconnected. 

| Before  | After |
| ------------- | ------------- |
| <img width="306" alt="Screenshot 2024-01-22 at 10 47 24 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/f1b88e53-932f-4b86-b8ab-5f62f3e3c21e"> | <img width="305" alt="Screenshot 2024-01-22 at 10 47 53 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/e61ff0fb-ce31-4937-bb18-862c7d04ace9"> |
| <img width="306" alt="Screenshot 2024-01-22 at 10 49 00 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/f4914cc6-cca9-4823-a9d7-528b50355b5b"> | <img width="306" alt="Screenshot 2024-01-22 at 10 48 34 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/ec0e702e-e747-4ec3-80fd-bfdc622ad49c"> |
