### PR TITLE
Remove minimap from VS code

### DIFF
--- a/vscode-build/vscode.patch
+++ b/vscode-build/vscode.patch
@@ -194,19 +194,6 @@ index 7b60eac641d..b37ebcd9f73 100644
 +		"version": "1.62.0"
 +	}
  }
-diff --git a/src/vs/editor/common/config/editorOptions.ts b/src/vs/editor/common/config/editorOptions.ts
-index 1c6b481c70..87caa70c5e 100644
---- a/src/vs/editor/common/config/editorOptions.ts
-+++ b/src/vs/editor/common/config/editorOptions.ts
-@@ -2434,7 +2434,7 @@ class EditorMinimap extends BaseEditorOption<EditorOption.minimap, EditorMinimap
- 
-        constructor() {
-                const defaults: EditorMinimapOptions = {
--                       enabled: true,
-+                       enabled: false,
-                        size: 'proportional',
-                        side: 'right',
-                        showSlider: 'mouseover',
 diff --git a/src/vs/base/browser/dom.ts b/src/vs/base/browser/dom.ts
 index 6148eb30092..6948ededa4a 100644
 --- a/src/vs/base/browser/dom.ts

--- a/vscode-build/vscode.patch
+++ b/vscode-build/vscode.patch
@@ -854,6 +854,19 @@ index 534fe232636..b41446430f0 100644
 +  create(document.body, config)
 +})()
 \ No newline at end of file
+diff --git a/src/vs/editor/common/config/editorOptions.ts b/src/vs/editor/common/config/editorOptions.ts
+index 7d8189c50be..125b6c89d0b 100644
+--- a/src/vs/editor/common/config/editorOptions.ts
++++ b/src/vs/editor/common/config/editorOptions.ts
+@@ -2560,7 +2560,7 @@ class EditorMinimap extends BaseEditorOption<EditorOption.minimap, EditorMinimap
+ 
+ 	constructor() {
+ 		const defaults: EditorMinimapOptions = {
+-			enabled: true,
++			enabled: false,
+ 			size: 'proportional',
+ 			side: 'right',
+ 			showSlider: 'mouseover',
 diff --git a/src/vs/workbench/browser/layout.ts b/src/vs/workbench/browser/layout.ts
 index 6b59c1e9faa..a9192e938ef 100644
 --- a/src/vs/workbench/browser/layout.ts

--- a/vscode-build/vscode.patch
+++ b/vscode-build/vscode.patch
@@ -194,6 +194,19 @@ index 7b60eac641d..b37ebcd9f73 100644
 +		"version": "1.62.0"
 +	}
  }
+diff --git a/src/vs/editor/common/config/editorOptions.ts b/src/vs/editor/common/config/editorOptions.ts
+index 1c6b481c70..87caa70c5e 100644
+--- a/src/vs/editor/common/config/editorOptions.ts
++++ b/src/vs/editor/common/config/editorOptions.ts
+@@ -2434,7 +2434,7 @@ class EditorMinimap extends BaseEditorOption<EditorOption.minimap, EditorMinimap
+ 
+        constructor() {
+                const defaults: EditorMinimapOptions = {
+-                       enabled: true,
++                       enabled: false,
+                        size: 'proportional',
+                        side: 'right',
+                        showSlider: 'mouseover',
 diff --git a/src/vs/base/browser/dom.ts b/src/vs/base/browser/dom.ts
 index 6148eb30092..6948ededa4a 100644
 --- a/src/vs/base/browser/dom.ts


### PR DESCRIPTION
**Problem:**
Today we have the minimap toggled on by default in our vscode, and it's taking up precious real estate

**Fix:**
Add a patch to `vscode.patch` to disable the minimap by default

Before:
<img width="274" alt="image" src="https://github.com/concrete-utopia/utopia/assets/7003853/8581ab68-f421-4414-97e5-97d20b020e66">


After:
<img width="305" alt="image" src="https://github.com/concrete-utopia/utopia/assets/7003853/7846cec6-8b5e-45d2-a427-9b786db032f0">

