### PR TITLE
Ensure scene id props exist

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -1,4 +1,8 @@
-import { PERFORMANCE_MARKS_ALLOWED, PRODUCTION_ENV } from '../../../common/env-vars'
+import {
+  IS_TEST_ENVIRONMENT,
+  PERFORMANCE_MARKS_ALLOWED,
+  PRODUCTION_ENV,
+} from '../../../common/env-vars'
 import { isParseSuccess, isTextFile } from '../../../core/shared/project-file-types'
 import {
   codeNeedsParsing,
@@ -868,7 +872,7 @@ function setIdPropOnJSXElement(element: JSXElement, idPropValueToUse: string): J
     jsExpressionValue(idPropValueToUse, emptyComments),
   )
 
-  if (isLeft(updatedProps)) {
+  if (IS_TEST_ENVIRONMENT || isLeft(updatedProps)) {
     return element
   }
   return { ...element, props: updatedProps.value }

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -107,7 +107,7 @@ import {
 import * as PP from '../../../core/shared/property-path'
 import { setJSXValueAtPath } from '../../../core/shared/jsx-attributes'
 import { isLeft } from '../../../core/shared/either'
-import { transformJSXComponentAtElementPathRecursively } from '../../../core/model/element-template-utils'
+import { transformJSXElementChildrenRecursively } from '../../../core/model/element-template-utils'
 
 type DispatchResultFields = {
   nothingChanged: boolean
@@ -863,34 +863,31 @@ function ensureSceneIdsExist(editor: EditorState): EditorState {
         return e
       }
 
-      const nextRootElement = transformJSXComponentAtElementPathRecursively(
-        e.rootElement,
-        (child) => {
-          const isConsideredScene =
-            isSceneAgainstImports(child, imports) || isRemixSceneAgainstImports(child, imports)
+      const nextRootElement = transformJSXElementChildrenRecursively(e.rootElement, (child) => {
+        const isConsideredScene =
+          isSceneAgainstImports(child, imports) || isRemixSceneAgainstImports(child, imports)
 
-          if (child.type !== 'JSX_ELEMENT' || !isConsideredScene) {
-            return child
-          }
+        if (child.type !== 'JSX_ELEMENT' || !isConsideredScene) {
+          return child
+        }
 
-          const idPropValue = getIdPropFromJSXElement(child)
+        const idPropValue = getIdPropFromJSXElement(child)
 
-          if (idPropValue != null && !seenIdProps.has(idPropValue)) {
-            seenIdProps.add(idPropValue)
-            return child
-          }
+        if (idPropValue != null && !seenIdProps.has(idPropValue)) {
+          seenIdProps.add(idPropValue)
+          return child
+        }
 
-          const idPropValueToUse = child.uid
-          const updatedChild = setIdPropOnJSXElement(child, idPropValueToUse)
-          if (updatedChild == null) {
-            return child
-          }
+        const idPropValueToUse = child.uid
+        const updatedChild = setIdPropOnJSXElement(child, idPropValueToUse)
+        if (updatedChild == null) {
+          return child
+        }
 
-          seenIdProps.add(idPropValueToUse)
-          anyIdPropUpdated = true
-          return updatedChild
-        },
-      )
+        seenIdProps.add(idPropValueToUse)
+        anyIdPropUpdated = true
+        return updatedChild
+      })
 
       return { ...e, rootElement: nextRootElement }
     },

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -873,7 +873,7 @@ function setIdPropOnJSXElement(element: JSXElement, idPropValueToUse: string): J
   )
 
   if (IS_TEST_ENVIRONMENT || isLeft(updatedProps)) {
-    return element
+    return null
   }
   return { ...element, props: updatedProps.value }
 }

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -58,7 +58,12 @@ import {
   runLocalEditorAction,
   runUpdateProjectServerState,
 } from './editor-update'
-import { assertNever, fastForEach, isBrowserEnvironment } from '../../../core/shared/utils'
+import {
+  assertNever,
+  fastForEach,
+  identity,
+  isBrowserEnvironment,
+} from '../../../core/shared/utils'
 import type { UiJsxCanvasContextData } from '../../canvas/ui-jsx-canvas'
 import type { ProjectContentTreeRoot } from '../../assets'
 import { transformContentsTree, treeToContents, walkContentsTree } from '../../assets'
@@ -880,6 +885,7 @@ function setIdPropOnJSXElement(element: JSXElement, idPropValueToUse: string): J
 
 function ensureSceneIdsExist(editor: EditorState): EditorState {
   let seenIdProps: Set<string> = new Set()
+  let anyIdPropUpdated = false
 
   const nextProjectContents = transformContentsTree(editor.projectContents, (tree) => {
     if (
@@ -919,6 +925,7 @@ function ensureSceneIdsExist(editor: EditorState): EditorState {
         }
 
         seenIdProps.add(idPropValueToUse)
+        anyIdPropUpdated = true
         return updatedChild
       })
 
@@ -937,6 +944,10 @@ function ensureSceneIdsExist(editor: EditorState): EditorState {
       },
     }
   })
+
+  if (!anyIdPropUpdated) {
+    return editor
+  }
 
   return { ...editor, projectContents: nextProjectContents }
 }

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -1,8 +1,4 @@
-import {
-  IS_TEST_ENVIRONMENT,
-  PERFORMANCE_MARKS_ALLOWED,
-  PRODUCTION_ENV,
-} from '../../../common/env-vars'
+import { IS_TEST_ENVIRONMENT, PERFORMANCE_MARKS_ALLOWED } from '../../../common/env-vars'
 import { isParseSuccess, isTextFile } from '../../../core/shared/project-file-types'
 import {
   codeNeedsParsing,
@@ -58,12 +54,7 @@ import {
   runLocalEditorAction,
   runUpdateProjectServerState,
 } from './editor-update'
-import {
-  assertNever,
-  fastForEach,
-  identity,
-  isBrowserEnvironment,
-} from '../../../core/shared/utils'
+import { assertNever, isBrowserEnvironment } from '../../../core/shared/utils'
 import type { UiJsxCanvasContextData } from '../../canvas/ui-jsx-canvas'
 import type { ProjectContentTreeRoot } from '../../assets'
 import { transformContentsTree, treeToContents, walkContentsTree } from '../../assets'
@@ -932,7 +923,6 @@ function ensureSceneIdsExist(editor: EditorState): EditorState {
       return { ...e, rootElement: nextRootElement }
     })
 
-    // TODO: optic
     return {
       ...tree,
       content: {

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -107,7 +107,7 @@ import {
 import * as PP from '../../../core/shared/property-path'
 import { setJSXValueAtPath } from '../../../core/shared/jsx-attributes'
 import { isLeft } from '../../../core/shared/either'
-import { transformJSXElementChildrenRecursively } from '../../../core/model/element-template-utils'
+import { transformJSXElementChildRecursively } from '../../../core/model/element-template-utils'
 
 type DispatchResultFields = {
   nothingChanged: boolean
@@ -863,7 +863,7 @@ function ensureSceneIdsExist(editor: EditorState): EditorState {
         return e
       }
 
-      const nextRootElement = transformJSXElementChildrenRecursively(e.rootElement, (child) => {
+      const nextRootElement = transformJSXElementChildRecursively(e.rootElement, (child) => {
         const isConsideredScene =
           isSceneAgainstImports(child, imports) || isRemixSceneAgainstImports(child, imports)
 

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -141,7 +141,7 @@ export function transformJSXComponentAtPath(
     : transformJSXComponentAtElementPath(components, lastElementPathPart, transform)
 }
 
-export function transformJSXComponentAtElementPathRecursively(
+export function transformJSXElementChildrenRecursively(
   element: JSXElementChild,
   transform: (_: JSXElementChild) => JSXElementChild,
 ): JSXElementChild {

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -141,7 +141,7 @@ export function transformJSXComponentAtPath(
     : transformJSXComponentAtElementPath(components, lastElementPathPart, transform)
 }
 
-export function transformJSXElementChildrenRecursively(
+export function transformJSXElementChildRecursively(
   element: JSXElementChild,
   transform: (_: JSXElementChild) => JSXElementChild,
 ): JSXElementChild {

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -141,6 +141,40 @@ export function transformJSXComponentAtPath(
     : transformJSXComponentAtElementPath(components, lastElementPathPart, transform)
 }
 
+export function transformJSXComponentAtElementPathRecursively(
+  element: JSXElementChild,
+  transform: (_: JSXElementChild) => JSXElementChild,
+): JSXElementChild {
+  switch (element.type) {
+    case 'ATTRIBUTE_FUNCTION_CALL':
+    case 'ATTRIBUTE_NESTED_ARRAY':
+    case 'ATTRIBUTE_NESTED_OBJECT':
+    case 'ATTRIBUTE_OTHER_JAVASCRIPT':
+    case 'ATTRIBUTE_VALUE':
+    case 'JSX_TEXT_BLOCK':
+      return element
+    case 'JSX_CONDITIONAL_EXPRESSION':
+      const whenTrue = transform(element.whenTrue)
+      const whenFalse = transform(element.whenTrue)
+      return transform({ ...element, whenTrue, whenFalse })
+    case 'JSX_FRAGMENT': {
+      const children = element.children.map((c) => transform(c))
+      return transform({ ...element, children })
+    }
+    case 'JSX_MAP_EXPRESSION':
+      let elementsWithin: ElementsWithin = {}
+      for (const [key, value] of Object.entries(element.elementsWithin)) {
+        elementsWithin[key] = transform(value) as JSXElement
+      }
+      return transform({ ...element, elementsWithin })
+    case 'JSX_ELEMENT':
+      const children = element.children.map((c) => transform(c))
+      return transform({ ...element, children })
+    default:
+      assertNever(element)
+  }
+}
+
 export function transformJSXComponentAtElementPath(
   components: Array<UtopiaJSXComponent>,
   path: StaticElementPathPart,

--- a/editor/src/core/third-party/utopia-api-components.ts
+++ b/editor/src/core/third-party/utopia-api-components.ts
@@ -9,7 +9,12 @@ import {
   defaultElementStyle,
 } from '../../components/editor/defaults'
 import type { JSExpression } from '../shared/element-template'
-import { emptyComments, jsxAttributesEntry, jsxElementWithoutUID } from '../shared/element-template'
+import {
+  emptyComments,
+  jsExpressionValue,
+  jsxAttributesEntry,
+  jsxElementWithoutUID,
+} from '../shared/element-template'
 
 const BasicUtopiaComponentDescriptor = (
   name: string,
@@ -45,14 +50,53 @@ const BasicUtopiaComponentDescriptor = (
   }
 }
 
+const BasicUtopiaSceneDescriptor = (
+  name: string,
+  supportsChildren: boolean,
+  styleProp: () => JSExpression,
+): ComponentDescriptor => {
+  return {
+    properties: {
+      style: {
+        control: 'style-controls',
+      },
+    },
+    supportsChildren: supportsChildren,
+    variants: [
+      {
+        insertMenuLabel: name,
+        importsToAdd: {
+          'utopia-api': {
+            importedWithName: null,
+            importedFromWithin: [
+              {
+                name: name,
+                alias: name,
+              },
+            ],
+            importedAs: null,
+          },
+        },
+        elementToInsert: () =>
+          jsxElementWithoutUID(
+            name,
+            [
+              jsxAttributesEntry('id', jsExpressionValue('scene', emptyComments), emptyComments),
+              jsxAttributesEntry('style', styleProp(), emptyComments),
+            ],
+            [],
+          ),
+      },
+    ],
+  }
+}
+
 export const UtopiaApiComponents: ComponentDescriptorsForFile = {
   Ellipse: BasicUtopiaComponentDescriptor('Ellipse', false, defaultElementStyle),
   Rectangle: BasicUtopiaComponentDescriptor('Rectangle', false, defaultRectangleElementStyle),
   View: BasicUtopiaComponentDescriptor('View', true, defaultElementStyle),
   FlexRow: BasicUtopiaComponentDescriptor('FlexRow', true, defaultFlexRowOrColStyle),
   FlexCol: BasicUtopiaComponentDescriptor('FlexCol', true, defaultFlexRowOrColStyle),
-  Scene: BasicUtopiaComponentDescriptor('Scene', true, () => defaultSceneElementStyle(null)),
-  RemixScene: BasicUtopiaComponentDescriptor('RemixScene', false, () =>
-    defaultSceneElementStyle(null),
-  ),
+  Scene: BasicUtopiaSceneDescriptor('Scene', true, () => defaultSceneElementStyle(null)),
+  RemixScene: BasicUtopiaSceneDescriptor('RemixScene', false, () => defaultSceneElementStyle(null)),
 }


### PR DESCRIPTION
## Problem
We link threads to scenes by adding the value of a scene's `id` prop to the thread metadata. If a scene doesn't have an `id` prop, we won't be able to link comments to it. Not all scenes may have an `id` prop, so we need a mechanism that adds the `id` prop to scenes without it.

## Fix
Walk the contents tree after each dispatch, and ensure that all scenes have `id`s and their values are all unique. If a scene doesn't have an `id` prop, or another scene already uses it, it's overwritten by the scene's uid.
