### PR TITLE
Only comment creation/editing should affect thread update time.

### DIFF
--- a/editor/src/core/shared/multiplayer.ts
+++ b/editor/src/core/shared/multiplayer.ts
@@ -180,11 +180,12 @@ export function getFirstComment(thread: ThreadData<ThreadMetadata>): CommentData
 export function sortThreadsByDescendingUpdateTimeInPlace(
   threads: Array<ThreadData<ThreadMetadata>>,
 ) {
-  function lastModificationDate(t: ThreadData<ThreadMetadata>) {
-    return t.updatedAt ?? t.createdAt
+  function lastModifiedAt(t: ThreadData<ThreadMetadata>) {
+    const commentsUpdatedAt = t.comments.map((c) => (c.editedAt ?? c.createdAt)?.getTime())
+    return Math.max(...commentsUpdatedAt)
   }
 
-  threads.sort((t1, t2) => lastModificationDate(t2).getTime() - lastModificationDate(t1).getTime())
+  threads.sort((t1, t2) => lastModifiedAt(t2) - lastModifiedAt(t1))
 }
 
 export function useUpdateRemixSceneRouteInLiveblocks() {


### PR DESCRIPTION
**Problem:**
We sort the comment threads in the comment sidebar in the order of most recent updatedAt time.
However, this updatedAt field in Liveblocks is modified even when only the metadata of the thread is changed, but none of the comments are updatedAt. This means that e.g. comment threads appear as new when you drag them on the canvas, which is not the desired behavior.

**Fix:**
Instead of using the built-in updatedAt field, check all the comments `createdAt` and `editedAt` fields, and use the most recent one as the update time of the thread.