### PR TITLE
Call dragging callback when dragged past threshold

### DIFF
--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -465,7 +465,6 @@ function useDragging(
   const onMouseDown = React.useCallback(
     (event: React.MouseEvent) => {
       setDidDrag(false)
-      draggingCallback(true)
 
       const mouseDownPoint = windowPoint({ x: event.clientX, y: event.clientY })
       const mouseDownCanvasPoint = windowToCanvasCoordinates(
@@ -492,6 +491,7 @@ function useDragging(
         draggedPastThreshold ||= distance(mouseDownPoint, mouseMovePoint) > COMMENT_DRAG_THRESHOLD
 
         if (draggedPastThreshold) {
+          draggingCallback(true)
           dispatch([switchEditorMode(EditorModes.commentMode(null, 'dragging'))])
 
           setDidDrag(true)


### PR DESCRIPTION
## Problem
We call the dragging callback in `useDragging` immediately after mouse down, which can set `dragging` to true even if no actual drag is in progress. This turned out to be probematic, because `dragging` is used to disable pointer events on the comment indicator while it's being dragged, so that the scene highlight can be toggled on and off, if the comment is dragged over a scene.

## Fix
Only call `draggingCallback` when the drag has passed the dragging threshold