### PR TITLE
Store canvas position of scene comments.

### DIFF
--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -98,10 +98,11 @@ export type RoomEvent = ControlChangedRoomEvent
 export type ThreadMetadata = {
   // quote: string;
   // time: number;
-  type: 'canvas'
-  x: number // x and y is global when sceneId is undefined, and local to the scene when sceneId is not null
+  x: number
   y: number
   sceneId?: string
+  sceneX?: number
+  sceneY?: number
   remixLocationRoute?: string
   resolved: boolean
 }

--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -107,6 +107,22 @@ export type ThreadMetadata = {
   resolved: boolean
 }
 
+export type SceneThreadMetadata = {
+  // quote: string;
+  // time: number;
+  x: number
+  y: number
+  sceneId: string
+  sceneX: number
+  sceneY: number
+  remixLocationRoute?: string
+  resolved: boolean
+}
+
+export function isSceneThreadMetadata(metadata: ThreadMetadata): metadata is SceneThreadMetadata {
+  return metadata.sceneId != null && metadata.sceneX != null && metadata.sceneY != null
+}
+
 export const {
   suspense: {
     RoomProvider,

--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -95,21 +95,9 @@ export type RoomEvent = ControlChangedRoomEvent
 
 // Optionally, when using Comments, ThreadMetadata represents metadata on
 // each thread. Can only contain booleans, strings, and numbers.
-export type ThreadMetadata = {
-  // quote: string;
-  // time: number;
-  x: number
-  y: number
-  sceneId?: string
-  sceneX?: number
-  sceneY?: number
-  remixLocationRoute?: string
-  resolved: boolean
-}
+export type ThreadMetadata = CanvasThreadMetadata | SceneThreadMetadata
 
 export type SceneThreadMetadata = {
-  // quote: string;
-  // time: number;
   x: number
   y: number
   sceneId: string
@@ -119,8 +107,15 @@ export type SceneThreadMetadata = {
   resolved: boolean
 }
 
+export type CanvasThreadMetadata = {
+  x: number
+  y: number
+  remixLocationRoute?: string
+  resolved: boolean
+}
+
 export function isSceneThreadMetadata(metadata: ThreadMetadata): metadata is SceneThreadMetadata {
-  return metadata.sceneId != null && metadata.sceneX != null && metadata.sceneY != null
+  return metadata.hasOwnProperty('sceneId')
 }
 
 export const {

--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -97,18 +97,17 @@ export type RoomEvent = ControlChangedRoomEvent
 // each thread. Can only contain booleans, strings, and numbers.
 export type ThreadMetadata = CanvasThreadMetadata | SceneThreadMetadata
 
-export type SceneThreadMetadata = BaseThreadMetadata & {
-  type: 'scene'
+export type SceneThreadMetadata = {
+  x: number
+  y: number
   sceneId: string
   sceneX: number
   sceneY: number
+  remixLocationRoute?: string
+  resolved: boolean
 }
 
-export type CanvasThreadMetadata = BaseThreadMetadata & {
-  type: 'canvas'
-}
-
-type BaseThreadMetadata = {
+export type CanvasThreadMetadata = {
   x: number
   y: number
   remixLocationRoute?: string
@@ -116,7 +115,7 @@ type BaseThreadMetadata = {
 }
 
 export function isSceneThreadMetadata(metadata: ThreadMetadata): metadata is SceneThreadMetadata {
-  return metadata.type === 'scene'
+  return metadata.hasOwnProperty('sceneId')
 }
 
 export const {

--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -97,17 +97,18 @@ export type RoomEvent = ControlChangedRoomEvent
 // each thread. Can only contain booleans, strings, and numbers.
 export type ThreadMetadata = CanvasThreadMetadata | SceneThreadMetadata
 
-export type SceneThreadMetadata = {
-  x: number
-  y: number
+export type SceneThreadMetadata = BaseThreadMetadata & {
+  type: 'scene'
   sceneId: string
   sceneX: number
   sceneY: number
-  remixLocationRoute?: string
-  resolved: boolean
 }
 
-export type CanvasThreadMetadata = {
+export type CanvasThreadMetadata = BaseThreadMetadata & {
+  type: 'canvas'
+}
+
+type BaseThreadMetadata = {
   x: number
   y: number
   remixLocationRoute?: string
@@ -115,7 +116,7 @@ export type CanvasThreadMetadata = {
 }
 
 export function isSceneThreadMetadata(metadata: ThreadMetadata): metadata is SceneThreadMetadata {
-  return metadata.hasOwnProperty('sceneId')
+  return metadata.type === 'scene'
 }
 
 export const {

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -452,9 +452,9 @@ function useDragging(
           editThreadMetadata({
             threadId: thread.id,
             metadata: {
+              type: 'canvas',
               x: newPositionOnCanvas.x,
               y: newPositionOnCanvas.y,
-              sceneId: null,
               remixLocationRoute: null,
             },
           })
@@ -483,6 +483,7 @@ function useDragging(
         editThreadMetadata({
           threadId: thread.id,
           metadata: {
+            type: 'scene',
             sceneX: localPointInScene.x,
             sceneY: localPointInScene.y,
             sceneId: sceneIdToUse,

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -452,9 +452,9 @@ function useDragging(
           editThreadMetadata({
             threadId: thread.id,
             metadata: {
-              type: 'canvas',
               x: newPositionOnCanvas.x,
               y: newPositionOnCanvas.y,
+              sceneId: null,
               remixLocationRoute: null,
             },
           })
@@ -483,7 +483,6 @@ function useDragging(
         editThreadMetadata({
           threadId: thread.id,
           metadata: {
-            type: 'scene',
             sceneX: localPointInScene.x,
             sceneY: localPointInScene.y,
             sceneId: sceneIdToUse,

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -7,7 +7,7 @@ import type { ThreadMetadata } from '../../../../liveblocks.config'
 import { useEditThreadMetadata, useStorage } from '../../../../liveblocks.config'
 import {
   getCollaboratorById,
-  getThreadOriginalLocationOnCanvas,
+  getThreadLocationOnCanvas,
   useActiveThreads,
   useCanvasCommentThreadAndLocation,
   useCanvasLocationOfThread,
@@ -412,7 +412,7 @@ function useDragging(
         scenesRef.current,
       )
 
-      const originalThreadPosition = getThreadOriginalLocationOnCanvas(
+      const originalThreadPosition = getThreadLocationOnCanvas(
         thread,
         maybeStartingSceneUnderPoint?.globalFrame ?? null,
       )

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -7,24 +7,18 @@ import type { ThreadMetadata } from '../../../../liveblocks.config'
 import { useEditThreadMetadata, useStorage } from '../../../../liveblocks.config'
 import {
   getCollaboratorById,
+  getThreadOriginalLocationOnCanvas,
   useActiveThreads,
   useCanvasCommentThreadAndLocation,
   useCanvasLocationOfThread,
   useMyThreadReadStatus,
 } from '../../../core/commenting/comment-hooks'
-import type {
-  CanvasPoint,
-  CanvasRectangle,
-  LocalPoint,
-  MaybeInfinityCanvasRectangle,
-} from '../../../core/shared/math-utils'
+import type { CanvasPoint } from '../../../core/shared/math-utils'
 import {
   canvasPoint,
   distance,
   getLocalPointInNewParentContext,
   isNotNullFiniteRectangle,
-  localPoint,
-  nullIfInfinity,
   offsetPoint,
   pointDifference,
   windowPoint,
@@ -383,32 +377,6 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
   )
 })
 CommentIndicator.displayName = 'CommentIndicator'
-
-function canvasPositionOfThread(
-  sceneGlobalFrame: CanvasRectangle,
-  locationInScene: LocalPoint,
-): CanvasPoint {
-  return canvasPoint({
-    x: sceneGlobalFrame.x + locationInScene.x,
-    y: sceneGlobalFrame.y + locationInScene.y,
-  })
-}
-
-export function getThreadOriginalLocationOnCanvas(
-  thread: ThreadData<ThreadMetadata>,
-  startingSceneGlobalFrame: MaybeInfinityCanvasRectangle | null,
-): CanvasPoint {
-  const sceneId = thread.metadata.sceneId
-  const globalFrame = nullIfInfinity(startingSceneGlobalFrame)
-  if (sceneId == null || globalFrame == null) {
-    return canvasPoint(thread.metadata)
-  }
-
-  return canvasPositionOfThread(
-    globalFrame,
-    localPoint({ x: thread.metadata.sceneX!, y: thread.metadata.sceneY! }),
-  )
-}
 
 const COMMENT_DRAG_THRESHOLD = 5 // square px
 

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -399,18 +399,14 @@ function getThreadOriginalLocationOnCanvas(
   startingSceneGlobalFrame: MaybeInfinityCanvasRectangle | null,
 ): CanvasPoint {
   const sceneId = thread.metadata.sceneId
-  if (sceneId == null) {
-    return canvasPoint({ x: thread.metadata.x, y: thread.metadata.y })
-  }
-
   const globalFrame = nullIfInfinity(startingSceneGlobalFrame)
-  if (globalFrame == null) {
-    throw new Error('Found thread attached to scene with invalid global frame')
+  if (sceneId == null || globalFrame == null) {
+    return canvasPoint({ x: thread.metadata.x, y: thread.metadata.y })
   }
 
   return canvasPositionOfThread(
     globalFrame,
-    localPoint({ x: thread.metadata.x, y: thread.metadata.y }),
+    localPoint({ x: thread.metadata.sceneX!, y: thread.metadata.sceneY! }),
   )
 }
 
@@ -534,9 +530,11 @@ function useDragging(
         editThreadMetadata({
           threadId: thread.id,
           metadata: {
-            x: localPointInScene.x,
-            y: localPointInScene.y,
+            sceneX: localPointInScene.x,
+            sceneY: localPointInScene.y,
             sceneId: sceneIdToUse,
+            x: newPositionOnCanvas.x,
+            y: newPositionOnCanvas.y,
             remixLocationRoute: remixRoute != null ? remixRoute.location.pathname : undefined,
           },
         })

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -394,14 +394,14 @@ function canvasPositionOfThread(
   })
 }
 
-function getThreadOriginalLocationOnCanvas(
+export function getThreadOriginalLocationOnCanvas(
   thread: ThreadData<ThreadMetadata>,
   startingSceneGlobalFrame: MaybeInfinityCanvasRectangle | null,
 ): CanvasPoint {
   const sceneId = thread.metadata.sceneId
   const globalFrame = nullIfInfinity(startingSceneGlobalFrame)
   if (sceneId == null || globalFrame == null) {
-    return canvasPoint({ x: thread.metadata.x, y: thread.metadata.y })
+    return canvasPoint(thread.metadata)
   }
 
   return canvasPositionOfThread(

--- a/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/comment-mode/comment-mode-hooks.tsx
@@ -103,7 +103,7 @@ export function useCommentModeSelectAndHover(comment: CommentId | null): MouseCa
           setHighlightedView(scene.elementPath),
           switchEditorMode(
             EditorModes.commentMode(
-              newComment(sceneCommentLocation(sceneIdToUse, offset)),
+              newComment(sceneCommentLocation(sceneIdToUse, offset, loc.canvasPositionRounded)),
               'not-dragging',
             ),
           ),

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -155,7 +155,6 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
               body,
               metadata: {
                 resolved: false,
-                type: 'canvas',
                 x: comment.location.position.x,
                 y: comment.location.position.y,
               },
@@ -184,10 +183,11 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
               body,
               metadata: {
                 resolved: false,
-                type: 'canvas',
-                x: comment.location.offset.x,
-                y: comment.location.offset.y,
+                x: comment.location.position.x,
+                y: comment.location.position.x,
                 sceneId: sceneId,
+                sceneX: comment.location.offset.x,
+                sceneY: comment.location.offset.y,
                 remixLocationRoute: remixRoute != null ? remixRoute.location.pathname : undefined,
               },
             })

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -154,6 +154,7 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
             const newThreadOnCanvas = createThread({
               body,
               metadata: {
+                type: 'canvas',
                 resolved: false,
                 x: comment.location.position.x,
                 y: comment.location.position.y,
@@ -182,6 +183,7 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
             const newThreadOnScene = createThread({
               body,
               metadata: {
+                type: 'scene',
                 resolved: false,
                 x: comment.location.position.x,
                 y: comment.location.position.x,

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -154,7 +154,6 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
             const newThreadOnCanvas = createThread({
               body,
               metadata: {
-                type: 'canvas',
                 resolved: false,
                 x: comment.location.position.x,
                 y: comment.location.position.y,
@@ -183,7 +182,6 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
             const newThreadOnScene = createThread({
               body,
               metadata: {
-                type: 'scene',
                 resolved: false,
                 x: comment.location.position.x,
                 y: comment.location.position.x,

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -67,8 +67,7 @@ import type { Storage, Presence, RoomEvent, UserMeta } from '../../../liveblocks
 import LiveblocksProvider from '@liveblocks/yjs'
 import { isRoomId, projectIdToRoomId } from '../../core/shared/multiplayer'
 import { EditorModes } from './editor-modes'
-import { checkIsMyProject } from './store/collaborative-editing'
-import { useCanComment, useDataThemeAttributeOnBody } from '../../core/commenting/comment-hooks'
+import { useDataThemeAttributeOnBody } from '../../core/commenting/comment-hooks'
 import { CollaborationStateUpdater } from './store/collaboration-state'
 import { GithubRepositoryCloneFlow } from '../github/github-repository-clone-flow'
 import { getPermissions } from './store/permissions'
@@ -363,8 +362,6 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
     },
     [dispatch],
   )
-
-  const canComment = useCanComment()
 
   useSelectorWithCallback(
     Substores.userStateAndProjectServerState,

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -72,6 +72,7 @@ import { useCanComment, useDataThemeAttributeOnBody } from '../../core/commentin
 import { CollaborationStateUpdater } from './store/collaboration-state'
 import { GithubRepositoryCloneFlow } from '../github/github-repository-clone-flow'
 import { getPermissions } from './store/permissions'
+import { CommentMaintainer } from '../../core/commenting/comment-maintainer'
 
 const liveModeToastId = 'play-mode-toast'
 
@@ -485,6 +486,7 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
         keyDown={onWindowKeyDown}
         keyUp={onWindowKeyUp}
       />
+      <CommentMaintainer />
     </>
   )
 })

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -116,13 +116,19 @@ export interface SceneCommentLocation {
   type: 'scene'
   sceneId: string
   offset: LocalPoint
+  position: CanvasPoint
 }
 
-export function sceneCommentLocation(sceneId: string, offset: LocalPoint): SceneCommentLocation {
+export function sceneCommentLocation(
+  sceneId: string,
+  offset: LocalPoint,
+  position: CanvasPoint,
+): SceneCommentLocation {
   return {
     type: 'scene',
     sceneId: sceneId,
     offset: offset,
+    position: position,
   }
 }
 

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -91,7 +91,6 @@ import { maybeClearPseudoInsertMode } from '../canvas-toolbar-states'
 import { isSteganographyEnabled } from '../../../core/shared/stegano-text'
 import { updateCollaborativeProjectContents } from './collaborative-editing'
 import { updateProjectServerStateInStore } from './project-server-state'
-import { maintainComments } from '../../../core/commenting/comment-hooks'
 
 type DispatchResultFields = {
   nothingChanged: boolean
@@ -851,13 +850,6 @@ function editorDispatchInner(
 
     if (metadataChanged) {
       const { metadata, elementPathTree } = reconstructJSXMetadata(result.unpatchedEditor)
-
-      void maintainComments(
-        result.unpatchedEditor.id,
-        result.unpatchedEditor,
-        storedState.unpatchedEditor.jsxMetadata,
-      )
-
       // Cater for the strategies wiping out the metadata on completion.
       const storedStateHasEmptyElementPathTree = isEmptyObject(
         storedState.unpatchedEditor.elementPathTree,

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -91,6 +91,7 @@ import { maybeClearPseudoInsertMode } from '../canvas-toolbar-states'
 import { isSteganographyEnabled } from '../../../core/shared/stegano-text'
 import { updateCollaborativeProjectContents } from './collaborative-editing'
 import { updateProjectServerStateInStore } from './project-server-state'
+import { maintainComments } from '../../../core/commenting/comment-hooks'
 
 type DispatchResultFields = {
   nothingChanged: boolean
@@ -850,6 +851,13 @@ function editorDispatchInner(
 
     if (metadataChanged) {
       const { metadata, elementPathTree } = reconstructJSXMetadata(result.unpatchedEditor)
+
+      void maintainComments(
+        result.unpatchedEditor.id,
+        result.unpatchedEditor,
+        storedState.unpatchedEditor.jsxMetadata,
+      )
+
       // Cater for the strategies wiping out the metadata on completion.
       const storedStateHasEmptyElementPathTree = isEmptyObject(
         storedState.unpatchedEditor.elementPathTree,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -3231,11 +3231,13 @@ export const CanvasCommentLocationKeepDeepEquality: KeepDeepEqualityCall<CanvasC
   combine1EqualityCall((loc) => loc.position, CanvasPointKeepDeepEquality, canvasCommentLocation)
 
 export const SceneCommentLocationKeepDeepEquality: KeepDeepEqualityCall<SceneCommentLocation> =
-  combine2EqualityCalls(
+  combine3EqualityCalls(
     (loc) => loc.sceneId,
     StringKeepDeepEquality,
     (loc) => loc.offset,
     LocalPointKeepDeepEquality,
+    (loc) => loc.position,
+    CanvasPointKeepDeepEquality,
     sceneCommentLocation,
   )
 

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -3,6 +3,7 @@ import type { User } from '@liveblocks/client'
 import { LiveObject, type ThreadData } from '@liveblocks/client'
 import type { Presence, ThreadMetadata, UserMeta } from '../../../liveblocks.config'
 import {
+  isSceneThreadMetadata,
   useEditThreadMetadata,
   useMutation,
   useSelf,
@@ -80,7 +81,8 @@ export function useCanvasCommentThreadAndLocation(comment: CommentId): {
         if (thread == null) {
           return null
         }
-        if (thread.metadata.sceneId == null) {
+
+        if (!isSceneThreadMetadata(thread.metadata)) {
           return canvasPoint(thread.metadata)
         }
         const scene = scenes.find((s) => getIdOfScene(s) === thread.metadata.sceneId)
@@ -93,7 +95,7 @@ export function useCanvasCommentThreadAndLocation(comment: CommentId): {
         }
         return getCanvasPointWithCanvasOffset(
           scene.globalFrame,
-          localPoint({ x: thread.metadata.sceneX!, y: thread.metadata.sceneY! }),
+          localPoint({ x: thread.metadata.sceneX, y: thread.metadata.sceneY }),
         )
 
       default:
@@ -217,7 +219,7 @@ export function useCanvasLocationOfThread(thread: ThreadData<ThreadMetadata>): {
 } {
   const scenes = useScenesWithId()
 
-  if (thread.metadata.sceneId == null) {
+  if (!isSceneThreadMetadata(thread.metadata)) {
     return { location: canvasPoint(thread.metadata), scene: null }
   }
   const scene = scenes.find((s) => getIdOfScene(s) === thread.metadata.sceneId)
@@ -228,7 +230,7 @@ export function useCanvasLocationOfThread(thread: ThreadData<ThreadMetadata>): {
   return {
     location: getCanvasPointWithCanvasOffset(
       scene.globalFrame,
-      localPoint({ x: thread.metadata.sceneX!, y: thread.metadata.sceneY! }),
+      localPoint({ x: thread.metadata.sceneX, y: thread.metadata.sceneY }),
     ),
     scene: scene.elementPath,
   }
@@ -404,15 +406,14 @@ export function getThreadOriginalLocationOnCanvas(
   thread: ThreadData<ThreadMetadata>,
   startingSceneGlobalFrame: MaybeInfinityCanvasRectangle | null,
 ): CanvasPoint {
-  const sceneId = thread.metadata.sceneId
   const globalFrame = nullIfInfinity(startingSceneGlobalFrame)
-  if (sceneId == null || globalFrame == null) {
+  if (!isSceneThreadMetadata(thread.metadata) || globalFrame == null) {
     return canvasPoint(thread.metadata)
   }
 
   return canvasPositionOfThread(
     globalFrame,
-    localPoint({ x: thread.metadata.sceneX!, y: thread.metadata.sceneY! }),
+    localPoint({ x: thread.metadata.sceneX, y: thread.metadata.sceneY }),
   )
 }
 

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import type { User } from '@liveblocks/client'
 import { LiveObject, type ThreadData } from '@liveblocks/client'
-import type { Presence, ThreadMetadata, UserMeta } from '../../../liveblocks.config'
+import type {
+  Presence,
+  SceneThreadMetadata,
+  ThreadMetadata,
+  UserMeta,
+} from '../../../liveblocks.config'
 import {
   isSceneThreadMetadata,
   useEditThreadMetadata,
@@ -93,10 +98,7 @@ export function useCanvasCommentThreadAndLocation(comment: CommentId): {
         if (!isNotNullFiniteRectangle(scene.globalFrame)) {
           return canvasPoint(thread.metadata)
         }
-        return getCanvasPointWithCanvasOffset(
-          scene.globalFrame,
-          localPoint({ x: thread.metadata.sceneX, y: thread.metadata.sceneY }),
-        )
+        return getCanvasPointWithCanvasOffset(scene.globalFrame, positionInScene(thread.metadata))
 
       default:
         assertNever(comment)
@@ -228,10 +230,7 @@ export function useCanvasLocationOfThread(thread: ThreadData<ThreadMetadata>): {
     return { location: canvasPoint(thread.metadata), scene: null }
   }
   return {
-    location: getCanvasPointWithCanvasOffset(
-      scene.globalFrame,
-      localPoint({ x: thread.metadata.sceneX, y: thread.metadata.sceneY }),
-    ),
+    location: getCanvasPointWithCanvasOffset(scene.globalFrame, positionInScene(thread.metadata)),
     scene: scene.elementPath,
   }
 }
@@ -402,7 +401,7 @@ export function useCanComment() {
   return isFeatureEnabled('Multiplayer') && canComment
 }
 
-export function getThreadOriginalLocationOnCanvas(
+export function getThreadLocationOnCanvas(
   thread: ThreadData<ThreadMetadata>,
   startingSceneGlobalFrame: MaybeInfinityCanvasRectangle | null,
 ): CanvasPoint {
@@ -411,10 +410,7 @@ export function getThreadOriginalLocationOnCanvas(
     return canvasPoint(thread.metadata)
   }
 
-  return canvasPositionOfThread(
-    globalFrame,
-    localPoint({ x: thread.metadata.sceneX, y: thread.metadata.sceneY }),
-  )
+  return canvasPositionOfThread(globalFrame, positionInScene(thread.metadata))
 }
 
 function canvasPositionOfThread(
@@ -425,4 +421,8 @@ function canvasPositionOfThread(
     x: sceneGlobalFrame.x + locationInScene.x,
     y: sceneGlobalFrame.y + locationInScene.y,
   })
+}
+
+export function positionInScene(metadata: SceneThreadMetadata): LocalPoint {
+  return localPoint({ x: metadata.sceneX, y: metadata.sceneY })
 }

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -87,18 +87,19 @@ export function useCanvasCommentThreadAndLocation(comment: CommentId): {
           return null
         }
 
-        if (!isSceneThreadMetadata(thread.metadata)) {
-          return canvasPoint(thread.metadata)
+        const { metadata } = thread
+        if (!isSceneThreadMetadata(metadata)) {
+          return canvasPoint(metadata)
         }
-        const scene = scenes.find((s) => getIdOfScene(s) === thread.metadata.sceneId)
+        const scene = scenes.find((s) => getIdOfScene(s) === metadata.sceneId)
 
         if (scene == null) {
           return canvasPoint(thread.metadata)
         }
         if (!isNotNullFiniteRectangle(scene.globalFrame)) {
-          return canvasPoint(thread.metadata)
+          return canvasPoint(metadata)
         }
-        return getCanvasPointWithCanvasOffset(scene.globalFrame, positionInScene(thread.metadata))
+        return getCanvasPointWithCanvasOffset(scene.globalFrame, positionInScene(metadata))
 
       default:
         assertNever(comment)
@@ -221,16 +222,17 @@ export function useCanvasLocationOfThread(thread: ThreadData<ThreadMetadata>): {
 } {
   const scenes = useScenesWithId()
 
-  if (!isSceneThreadMetadata(thread.metadata)) {
-    return { location: canvasPoint(thread.metadata), scene: null }
+  const { metadata } = thread
+  if (!isSceneThreadMetadata(metadata)) {
+    return { location: canvasPoint(metadata), scene: null }
   }
-  const scene = scenes.find((s) => getIdOfScene(s) === thread.metadata.sceneId)
+  const scene = scenes.find((s) => getIdOfScene(s) === metadata.sceneId)
 
   if (scene == null || !isNotNullFiniteRectangle(scene.globalFrame)) {
-    return { location: canvasPoint(thread.metadata), scene: null }
+    return { location: canvasPoint(metadata), scene: null }
   }
   return {
-    location: getCanvasPointWithCanvasOffset(scene.globalFrame, positionInScene(thread.metadata)),
+    location: getCanvasPointWithCanvasOffset(scene.globalFrame, positionInScene(metadata)),
     scene: scene.elementPath,
   }
 }

--- a/editor/src/core/commenting/comment-maintainer.tsx
+++ b/editor/src/core/commenting/comment-maintainer.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { MultiplayerWrapper } from '../../utils/multiplayer-wrapper'
-import { getThreadOriginalLocationOnCanvas, useScenes } from './comment-hooks'
+import { getThreadLocationOnCanvas, useScenes } from './comment-hooks'
 import { useEditThreadMetadata, useThreads } from '../../../liveblocks.config'
 import { getIdOfScene } from '../../components/canvas/controls/comment-mode/comment-mode-hooks'
 import * as EP from '../shared/element-path'
@@ -42,7 +42,7 @@ function useMaintainComments() {
       return
     }
 
-    const p = getThreadOriginalLocationOnCanvas(t, globalFrame)
+    const p = getThreadLocationOnCanvas(t, globalFrame)
     if (p.x === t.metadata.x && p.y === t.metadata.y) {
       return
     }

--- a/editor/src/core/commenting/comment-maintainer.tsx
+++ b/editor/src/core/commenting/comment-maintainer.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { MultiplayerWrapper } from '../../utils/multiplayer-wrapper'
+import { getThreadOriginalLocationOnCanvas, useScenes } from './comment-hooks'
+import { useEditThreadMetadata, useThreads } from '../../../liveblocks.config'
+import { getIdOfScene } from '../../components/canvas/controls/comment-mode/comment-mode-hooks'
+import * as EP from '../shared/element-path'
+import { isNotNullFiniteRectangle } from '../shared/math-utils'
+
+export const CommentMaintainer = React.memo(() => {
+  return (
+    <MultiplayerWrapper errorFallback={null} suspenseFallback={null}>
+      <CommentMaintainerInner />
+    </MultiplayerWrapper>
+  )
+})
+CommentMaintainer.displayName = 'CommentMaintainer'
+
+const CommentMaintainerInner = React.memo(() => {
+  useMaintainComments()
+
+  return null
+})
+CommentMaintainerInner.displayName = 'CommentMaintainerInner'
+
+function useMaintainComments() {
+  const { threads } = useThreads()
+  const scenes = useScenes()
+  const editThreadMetadata = useEditThreadMetadata()
+
+  threads.forEach(async (t): Promise<void> => {
+    const sceneId = t.metadata.sceneId
+    if (sceneId == null) {
+      return
+    }
+
+    const scene = scenes.find(
+      (s) => getIdOfScene(s) === sceneId || EP.toUid(s.elementPath) === sceneId,
+    )
+
+    const globalFrame = scene?.globalFrame ?? null
+    if (!isNotNullFiniteRectangle(globalFrame)) {
+      return
+    }
+
+    const p = getThreadOriginalLocationOnCanvas(t, globalFrame)
+    if (p.x === t.metadata.x && p.y === t.metadata.y) {
+      return
+    }
+
+    editThreadMetadata({
+      threadId: t.id,
+      metadata: {
+        x: p.x,
+        y: p.y,
+      },
+    })
+  })
+}

--- a/editor/src/core/commenting/comment-maintainer.tsx
+++ b/editor/src/core/commenting/comment-maintainer.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { MultiplayerWrapper } from '../../utils/multiplayer-wrapper'
 import { getThreadLocationOnCanvas, useCanComment, useScenes } from './comment-hooks'
-import { useEditThreadMetadata, useThreads } from '../../../liveblocks.config'
+import {
+  isSceneThreadMetadata,
+  useEditThreadMetadata,
+  useThreads,
+} from '../../../liveblocks.config'
 import { getIdOfScene } from '../../components/canvas/controls/comment-mode/comment-mode-hooks'
 import * as EP from '../shared/element-path'
 import { isNotNullFiniteRectangle } from '../shared/math-utils'
@@ -34,10 +38,10 @@ function useMaintainComments() {
   const editThreadMetadata = useEditThreadMetadata()
 
   threads.forEach(async (t): Promise<void> => {
-    const sceneId = t.metadata.sceneId
-    if (sceneId == null) {
+    if (!isSceneThreadMetadata(t.metadata)) {
       return
     }
+    const { sceneId } = t.metadata
 
     const scene = scenes.find(
       (s) => getIdOfScene(s) === sceneId || EP.toUid(s.elementPath) === sceneId,

--- a/editor/src/core/commenting/comment-maintainer.tsx
+++ b/editor/src/core/commenting/comment-maintainer.tsx
@@ -1,12 +1,18 @@
 import React from 'react'
 import { MultiplayerWrapper } from '../../utils/multiplayer-wrapper'
-import { getThreadLocationOnCanvas, useScenes } from './comment-hooks'
+import { getThreadLocationOnCanvas, useCanComment, useScenes } from './comment-hooks'
 import { useEditThreadMetadata, useThreads } from '../../../liveblocks.config'
 import { getIdOfScene } from '../../components/canvas/controls/comment-mode/comment-mode-hooks'
 import * as EP from '../shared/element-path'
 import { isNotNullFiniteRectangle } from '../shared/math-utils'
 
 export const CommentMaintainer = React.memo(() => {
+  const canComment = useCanComment()
+
+  if (!canComment) {
+    return null
+  }
+
   return (
     <MultiplayerWrapper errorFallback={null} suspenseFallback={null}>
       <CommentMaintainerInner />

--- a/puppeteer-tests/src/comments/commenting.spec.tsx
+++ b/puppeteer-tests/src/comments/commenting.spec.tsx
@@ -377,8 +377,6 @@ describe('Comments test', () => {
         // delete the scene
         await page.keyboard.press('Backspace')
 
-        await wait(500)
-
         const commentBoundingBoxBackOnCanvasAfterDelete = roundBoundingBox(
           await getBoundingBox(page, CommentIndicatorSelector),
         )

--- a/puppeteer-tests/src/comments/commenting.spec.tsx
+++ b/puppeteer-tests/src/comments/commenting.spec.tsx
@@ -377,6 +377,8 @@ describe('Comments test', () => {
         // delete the scene
         await page.keyboard.press('Backspace')
 
+        await wait(500)
+
         const commentBoundingBoxBackOnCanvasAfterDelete = roundBoundingBox(
           await getBoundingBox(page, CommentIndicatorSelector),
         )

--- a/puppeteer-tests/src/comments/commenting.spec.tsx
+++ b/puppeteer-tests/src/comments/commenting.spec.tsx
@@ -329,5 +329,62 @@ describe('Comments test', () => {
         )
       },
       TIMEOUT,
+    ),
+    it(
+      'scene comment canvas coordinates are maintained when scene is moved',
+      async () => {
+        const page = await initSignedInBrowserTest(utopiaBrowser)
+        await enterCommentMode(page)
+
+        const playgroundSceneBoundingBox = roundBoundingBox(
+          await getBoundingBox(page, PlaygroundSceneSelector),
+        )
+
+        // Add a scene comment
+        await placeCommentOnCanvas(
+          page,
+          'hello comments',
+          playgroundSceneBoundingBox.x + 100,
+          playgroundSceneBoundingBox.y + 100,
+        )
+
+        // Leave comment mode by pressing ESC twice
+        await page.keyboard.press('Escape')
+        await page.keyboard.press('Escape')
+
+        const sceneToolBarBoundingBox = roundBoundingBox(
+          await getBoundingBox(page, SceneToolbarSelector),
+        )
+        const sceneToolBarCenter = roundPoint(center(sceneToolBarBoundingBox))
+
+        // move the scene, the comment indicator should move with the scene
+        await drag(
+          page,
+          sceneToolBarCenter,
+          offsetPoint(sceneToolBarCenter, { offsetX: 50, offsetY: 50 }),
+        )
+
+        const movedSceneBoundingBox = roundBoundingBox(
+          await getBoundingBox(page, SceneToolbarSelector),
+        )
+        const movedSceneBoundingBoxCenter = roundPoint(center(movedSceneBoundingBox))
+
+        await page.mouse.click(movedSceneBoundingBoxCenter.x, movedSceneBoundingBoxCenter.y)
+
+        const commentBoundingBoxBackOnCanvasBeforeDelete = roundBoundingBox(
+          await getBoundingBox(page, CommentIndicatorSelector),
+        )
+        // delete the scene
+        await page.keyboard.press('Backspace')
+
+        const commentBoundingBoxBackOnCanvasAfterDelete = roundBoundingBox(
+          await getBoundingBox(page, CommentIndicatorSelector),
+        )
+        // the comment indicator should not move on the canvas
+        expect(commentBoundingBoxBackOnCanvasAfterDelete).toEqual(
+          commentBoundingBoxBackOnCanvasBeforeDelete,
+        )
+      },
+      TIMEOUT,
     )
 })


### PR DESCRIPTION
**Problem:**
When a scene is deleted, the scene comments are orphaned, and we are not able to position them on the canvas.

**Fix:**
Change the liveblocks thread representation to store the local position of the thread in the scene (`sceneX` and `sceneY`) and the canvas position (`x` and `y`) both.

Note, that we can only add strings/numbers/booleans to the thread metadata type, so there is no way to create a more structured typing.

The advantage of this representation is that `x` and `y` always represents the canvas position of the thread, which was a more ambiguous earlier (canvas position for canvas comments and local position for scene comments).

So we do the best effort to position the comment thread in its scene, but if the scene is not available for some reason (e.g. it has been deleted), we still put it on the same canvas position. We do not delete the scene information, so when the user presses undo to put back the scene, the comment thread automatically becomes a scene thread again.

When the scene is moved, we update the canvas location of its scene comments using a React component called CommentMaintainer (which doesn't render anything, its role is just this maintenance step).
