### PR TITLE
Don't replace auth0 default avatar with our own

### DIFF
--- a/editor/resources/editor/css/liveblocks/react-comments/styles.css
+++ b/editor/resources/editor/css/liveblocks/react-comments/styles.css
@@ -647,7 +647,6 @@
 .lb-comment-avatar {
   inline-size: var(--lb-comment-avatar-size);
   flex: none;
-  visibility: hidden; /* we're rolling our own avatars, for now we just ignore the default LB ones */
 }
 .lb-comment-details-labels {
   gap: calc(0.5 * var(--lb-spacing));

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -1,9 +1,10 @@
 import type { ThreadData } from '@liveblocks/client'
 import { Comment } from '@liveblocks/react-comments'
+import type { CommentProps } from '@liveblocks/react-comments'
 import { AnimatePresence, motion, useAnimate } from 'framer-motion'
 import type { CSSProperties } from 'react'
 import React from 'react'
-import type { ThreadMetadata } from '../../../../liveblocks.config'
+import type { ThreadMetadata, UserMeta } from '../../../../liveblocks.config'
 import { useEditThreadMetadata, useStorage } from '../../../../liveblocks.config'
 import {
   getCollaboratorById,
@@ -37,7 +38,6 @@ import {
 } from '../../../core/shared/multiplayer'
 import { useMyUserId } from '../../../core/shared/multiplayer-hooks'
 import { optionalMap } from '../../../core/shared/optional-utils'
-import type { CommentWrapperProps } from '../../../utils/multiplayer-wrapper'
 import { MultiplayerWrapper, baseMultiplayerAvatarStyle } from '../../../utils/multiplayer-wrapper'
 import { when } from '../../../utils/react-conditionals'
 import { UtopiaStyles, colorTheme } from '../../../uuiui'
@@ -582,8 +582,9 @@ function useHover() {
 
 type CommentIndicatorWrapper = {
   thread: ThreadData<ThreadMetadata>
+  user: UserMeta | null
   expanded: boolean
-} & CommentWrapperProps
+} & CommentProps
 
 const CommentIndicatorWrapper = React.memo((props: CommentIndicatorWrapper) => {
   const { thread, expanded, user, ...commentProps } = props
@@ -662,9 +663,3 @@ const CommentIndicatorWrapper = React.memo((props: CommentIndicatorWrapper) => {
     </div>
   )
 })
-
-function getCanvasHeight(): number {
-  const canvasDiv = document.getElementById('canvas-root')
-  const canvasHeight = canvasDiv?.clientHeight ?? 0
-  return canvasHeight
-}

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -1,6 +1,6 @@
 import type { CommentData } from '@liveblocks/client'
 import type { ComposerSubmitComment } from '@liveblocks/react-comments'
-import { Composer } from '@liveblocks/react-comments'
+import { Comment, Composer } from '@liveblocks/react-comments'
 import { useAtom } from 'jotai'
 import type { CSSProperties } from 'react'
 import React, { useRef } from 'react'
@@ -22,7 +22,7 @@ import * as EP from '../../../core/shared/element-path'
 import { emptyComments, jsExpressionValue } from '../../../core/shared/element-template'
 import { create } from '../../../core/shared/property-path'
 import { assertNever } from '../../../core/shared/utils'
-import { CommentWrapper, MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
+import { MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
 import { when } from '../../../utils/react-conditionals'
 import { Button, FlexRow, Icn, Tooltip, UtopiaStyles, colorTheme } from '../../../uuiui'
 import {
@@ -376,11 +376,9 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
               onScroll={onScroll}
             >
               {thread.comments.map((c) => {
-                const user = getCollaboratorById(collabs, c.userId)
                 return (
-                  <CommentWrapper
+                  <Comment
                     key={c.id}
-                    user={user}
                     comment={c}
                     onCommentDelete={onCommentDelete}
                     style={{ background: colorTheme.bg1.value }}
@@ -546,9 +544,6 @@ ListShadow.displayName = 'ListShadow'
 
 const HeaderComment = React.memo(
   ({ comment, enabled }: { comment: CommentData; enabled: boolean }) => {
-    const collabs = useStorage((storage) => storage.collaborators)
-    const user = getCollaboratorById(collabs, comment.userId)
-
     if (!enabled) {
       return null
     }
@@ -567,8 +562,7 @@ const HeaderComment = React.memo(
           transform: 'scale(1.01)',
         }}
       >
-        <CommentWrapper
-          user={user}
+        <Comment
           comment={comment}
           style={{ background: colorTheme.bg1.value, color: colorTheme.fg1.value }}
         />

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -16,7 +16,7 @@ import {
   switchEditorMode,
 } from '../../editor/actions/action-creators'
 import { EditorModes, isCommentMode, isExistingComment } from '../../editor/editor-modes'
-import { CommentWrapper, MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
+import { MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
 import { useRemixNavigationContext } from '../../canvas/remix/utopia-remix-root-component'
 import {
   useResolveThread,
@@ -45,6 +45,7 @@ import { CommentRepliesCounter } from '../../canvas/controls/comment-replies-cou
 import type { SelectOption } from '../controls/select-control'
 import { assertNever } from '../../../core/shared/utils'
 import { pluck } from '../../../core/shared/array-utils'
+import { Comment } from '@liveblocks/react-comments'
 
 export type CommentFilterMode = 'all' | 'all-including-resolved' | 'unread-only'
 
@@ -319,12 +320,7 @@ const ThreadPreview = React.memo(({ thread }: ThreadPreviewProps) => {
           filter: thread.metadata.resolved ? 'grayscale()' : undefined,
         }}
       >
-        <CommentWrapper
-          user={user}
-          comment={comment}
-          showActions={false}
-          style={{ backgroundColor: 'transparent' }}
-        />
+        <Comment comment={comment} showActions={false} style={{ backgroundColor: 'transparent' }} />
         {when(
           remixLocationRouteLabel != null,
           <div

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -10,7 +10,6 @@ import type { FollowTarget, MultiplayerColor } from '../core/shared/multiplayer'
 import {
   canFollowTarget,
   followTarget,
-  isDefaultAuth0AvatarURL,
   multiplayerColorFromIndex,
   multiplayerInitialsFromName,
   normalizeMultiplayerName,
@@ -335,9 +334,7 @@ export type MultiplayerAvatarProps = {
 }
 
 export const MultiplayerAvatar = React.memo((props: MultiplayerAvatarProps) => {
-  const picture = React.useMemo(() => {
-    return isDefaultAuth0AvatarURL(props.picture ?? null) ? null : props.picture
-  }, [props.picture])
+  const { picture } = props
 
   const tooltipText = <strong>{props.tooltip?.text}</strong>
   const tooltipSubtext =
@@ -432,9 +429,7 @@ interface AvatarPictureProps {
 }
 
 const AvatarPicture = React.memo((props: AvatarPictureProps) => {
-  const url = React.useMemo(() => {
-    return isDefaultAuth0AvatarURL(props.url ?? null) ? null : props.url
-  }, [props.url])
+  const { url } = props
 
   const { initials, size } = props
 

--- a/editor/src/core/shared/multiplayer.ts
+++ b/editor/src/core/shared/multiplayer.ts
@@ -95,16 +95,6 @@ export function normalizeOthersList(
   )
 }
 
-const reAuth0DefaultAvatarURLEncoded = /https%3A%2F%2Fcdn\.auth0\.com%2Favatars%2F.{2}\.png$/
-const reAuth0DefaultAvatar = /https:\/\/cdn\.auth0\.com\/avatars\/.{2}\.png$/
-
-export function isDefaultAuth0AvatarURL(s: string | null): boolean {
-  return (
-    s != null &&
-    (s.match(reAuth0DefaultAvatarURLEncoded) != null || s.match(reAuth0DefaultAvatar) != null)
-  )
-}
-
 export type FollowTarget = {
   playerId: string
   connectionId: number

--- a/editor/src/utils/multiplayer-wrapper.tsx
+++ b/editor/src/utils/multiplayer-wrapper.tsx
@@ -40,28 +40,3 @@ export const baseMultiplayerAvatarStyle: CSSProperties = {
   width: 25.5, // matching the size of the liveblocks component
   height: 25.5, // matching the size of the liveblocks component
 }
-
-export type CommentWrapperProps = {
-  user: UserMeta | null
-} & CommentProps
-
-export const CommentWrapper = React.memo((props: CommentWrapperProps) => {
-  const { user, ...commentProps } = props
-
-  if (user == null) {
-    return <Comment {...commentProps} />
-  }
-
-  return (
-    <div data-testid='comment-wrapper' style={{ position: 'relative' }}>
-      <MultiplayerAvatar
-        name={multiplayerInitialsFromName(normalizeMultiplayerName(user.name))}
-        color={multiplayerColorFromIndex(user.colorIndex)}
-        style={baseMultiplayerAvatarStyle}
-        picture={user.avatar}
-      />
-      <Comment {...commentProps} />
-    </div>
-  )
-})
-CommentWrapper.displayName = 'CommentWrapper'

--- a/puppeteer-tests/src/comments/commenting.spec.tsx
+++ b/puppeteer-tests/src/comments/commenting.spec.tsx
@@ -100,7 +100,7 @@ describe('Comments test', () => {
       expect(popupAfterClose).toHaveLength(0)
 
       // Open the comment popup again
-      const comment = await page.waitForSelector('div[data-testid="comment-wrapper"]')
+      const comment = await page.waitForSelector('div[data-testid="comment-indicator-wrapper"]')
       await comment!.click({ offset: { x: 10, y: 10 } })
 
       // Check that the comment popup is open


### PR DESCRIPTION
**Problem:**
We use generated avatars with the presence colors when the user has the default auth0 avatar. The default auth0 avatar is a green circle with the initials in it, but with the custom avatars we could use the presence colors. The goal was that you can easily match users, their presence cursor and their comments.
But we are starting to use presence colors per sessions and not per user in https://github.com/concrete-utopia/utopia/pull/4794
This means that these colors are not useful for commenting, where we definitely need to identify users and not their sessions. So it doesn't make a lot of sense to keep the generated avatars, and it is also unnecessary extra complexity to use those avatars on top of the default liveblocks ui components.
It is also problematic that with this logic we regularly see mismatched avatars (when in one part of the ui the default avatar loads, but in another part of the ui our custom one)

**Fix:**
Remove the custom avatar logic. I also removed the logic which used the custom avatar in the user bar when there was an image load error. Why? Because we don't have that logic in the liveblocks commenting ui, which means it can result in mismatched avatars (when in the comment indicator the browser can load the avatar, but it fails to load in the user bar, which results in a different avatar). In my opinion failing to load an avatar is better than showing different avatars for the same user. 

Unfortunately, google avatars regularly produce load errors in the local development environment when the browser cache is disabled. But in production, even without browser cache, they should load without errors.