### PR TITLE
Cursors Based On Connections Instead Of Users.

### DIFF
--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -74,6 +74,7 @@ export type ConnectionInfo = {
   id: number
   startedAt: number
   lastSeen: number
+  colorIndex: number | null
 }
 
 // Optionally, UserMeta represents static/readonly metadata on each user, as
@@ -83,7 +84,6 @@ export type UserMeta = {
   id: string // Accessible through `user.id`
   name: string | null
   avatar: string | null
-  colorIndex: number | null
 }
 
 // Optionally, the type of custom events broadcast and listened to in this

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -92,8 +92,6 @@ CommentIndicators.displayName = 'CommentIndicators'
 
 interface TemporaryCommentIndicatorProps {
   position: CanvasPoint
-  bgColor: string
-  fgColor: string
   avatarUrl: string | null
   initials: string
 }
@@ -123,14 +121,12 @@ function useCommentBeingComposed(): TemporaryCommentIndicatorProps | null {
     if (collaborator == null) {
       return {
         initials: 'AN',
-        color: multiplayerColorFromIndex(null),
         avatar: null,
       }
     }
 
     return {
       initials: multiplayerInitialsFromName(normalizeMultiplayerName(collaborator.name)),
-      color: multiplayerColorFromIndex(collaborator.colorIndex),
       avatar: collaborator.avatar,
     }
   }, [collabs, myUserId])
@@ -141,8 +137,6 @@ function useCommentBeingComposed(): TemporaryCommentIndicatorProps | null {
 
   return {
     position: location,
-    bgColor: collaboratorInfo.color.background,
-    fgColor: collaboratorInfo.color.foreground,
     avatarUrl: collaboratorInfo.avatar,
     initials: collaboratorInfo.initials,
   }
@@ -161,8 +155,6 @@ const CommentIndicatorsInner = React.memo(() => {
         <CommentIndicatorUI
           position={temporaryIndicatorData.position}
           resolved={false}
-          bgColor={temporaryIndicatorData.bgColor}
-          fgColor={temporaryIndicatorData.fgColor}
           avatarUrl={temporaryIndicatorData.avatarUrl}
           avatarInitials={temporaryIndicatorData.initials}
           isActive={true}
@@ -177,8 +169,6 @@ CommentIndicatorsInner.displayName = 'CommentIndicatorInner'
 interface CommentIndicatorUIProps {
   position: CanvasPoint
   resolved: boolean
-  bgColor: string
-  fgColor: string
   avatarInitials: string
   avatarUrl?: string | null
   isActive: boolean
@@ -232,8 +222,7 @@ function useIndicatorStyle(
 }
 
 export const CommentIndicatorUI = React.memo<CommentIndicatorUIProps>((props) => {
-  const { position, bgColor, fgColor, avatarUrl, avatarInitials, resolved, isActive, isRead } =
-    props
+  const { position, avatarUrl, avatarInitials, resolved, isActive, isRead } = props
 
   const style = useIndicatorStyle(position, {
     isRead: isRead ?? true,
@@ -246,7 +235,7 @@ export const CommentIndicatorUI = React.memo<CommentIndicatorUIProps>((props) =>
   return (
     <div style={style}>
       <MultiplayerAvatar
-        color={{ background: bgColor, foreground: fgColor }}
+        color={multiplayerColorFromIndex(null)}
         picture={avatarUrl}
         name={avatarInitials}
       />
@@ -626,7 +615,7 @@ const CommentIndicatorWrapper = React.memo((props: CommentIndicatorWrapper) => {
       >
         <MultiplayerAvatar
           name={multiplayerInitialsFromName(normalizeMultiplayerName(user.name))}
-          color={multiplayerColorFromIndex(user.colorIndex)}
+          color={multiplayerColorFromIndex(null)}
           picture={user.avatar}
           style={{ outline: 'none' }}
         />

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -5,10 +5,17 @@ import { jsx } from '@emotion/react'
 import type { CSSProperties } from 'react'
 import { useOthers, useStatus, useStorage } from '../../liveblocks.config'
 import { getUserPicture, isLoggedIn } from '../common/user'
-import { getCollaborator, useMyUserAndPresence } from '../core/commenting/comment-hooks'
+import {
+  getCollaborator,
+  getConnectionById,
+  useConnections,
+  useGetMyConnection,
+  useMyUserAndPresence,
+} from '../core/commenting/comment-hooks'
 import type { FollowTarget, MultiplayerColor } from '../core/shared/multiplayer'
 import {
   canFollowTarget,
+  excludeMyConnection,
   followTarget,
   isDefaultAuth0AvatarURL,
   multiplayerColorFromIndex,
@@ -127,24 +134,25 @@ const MultiplayerUserBar = React.memo(() => {
   }, [dispatch, url])
 
   const collabs = useStorage((store) => store.collaborators)
-  const connections = useStorage((store) => store.connections)
+
+  const connections = useConnections()
 
   const { user: myUser, presence: myPresence } = useMyUserAndPresence()
   const sortAvatars = useSortMultiplayerUsers()
   const isBeingFollowed = useIsBeingFollowed()
 
-  const others = useOthers((list) =>
-    list
-      .filter((entry) => entry.connectionId !== myPresence.connectionId)
-      .map((other) => {
-        return {
-          ...getCollaborator(collabs, other),
-          following: other.presence.following,
-          connectionId: other.connectionId,
-          connectedAt: connections?.[other.id]?.[other.connectionId]?.startedAt ?? 0,
-        }
-      }),
-  )
+  const others = useOthers((list) => {
+    return excludeMyConnection(myPresence.id, myPresence.connectionId, list).map((other) => {
+      return {
+        ...getCollaborator(collabs, other),
+        following: other.presence.following,
+        colorIndex:
+          getConnectionById(connections, other.id, other.connectionId)?.colorIndex ?? null,
+        connectionId: other.connectionId,
+        connectedAt: connections?.[other.id]?.[other.connectionId]?.startedAt ?? 0,
+      }
+    })
+  })
 
   const mode = useEditorState(
     Substores.restOfEditor,
@@ -278,7 +286,6 @@ const MultiplayerUserBar = React.memo(() => {
               <MultiplayerAvatar
                 name={multiplayerInitialsFromName(name)}
                 tooltip={{ text: name, colored: false }}
-                color={multiplayerColorFromIndex(other.colorIndex)}
                 picture={other.avatar}
                 isOwner={isOwner}
                 isOffline={true}
@@ -307,7 +314,9 @@ const MultiplayerUserBar = React.memo(() => {
       >
         <MultiplayerAvatar
           name={multiplayerInitialsFromName(myUser.name)}
-          color={multiplayerColorFromIndex(myUser.colorIndex)}
+          color={multiplayerColorFromIndex(
+            getConnectionById(connections, myUser.id, myPresence.connectionId)?.colorIndex ?? null,
+          )}
           picture={myUser.avatar}
           isOwner={amIOwner}
           size={AvatarSize}
@@ -322,7 +331,7 @@ MultiplayerUserBar.displayName = 'MultiplayerUserBar'
 
 export type MultiplayerAvatarProps = {
   name: string
-  color: MultiplayerColor
+  color?: MultiplayerColor
   picture?: string | null
   onClick?: () => void
   isBeingFollowed?: boolean
@@ -356,15 +365,21 @@ export const MultiplayerAvatar = React.memo((props: MultiplayerAvatarProps) => {
       disabled={props.tooltip == null}
       title={tooltipWithLineBreak}
       placement='bottom'
-      backgroundColor={props.tooltip?.colored === true ? props.color.background : undefined}
-      textColor={props.tooltip?.colored === true ? props.color.foreground : undefined}
+      backgroundColor={
+        props.tooltip?.colored === true && props.color != null ? props.color.background : undefined
+      }
+      textColor={
+        props.tooltip?.colored === true && props.color != null ? props.color.foreground : undefined
+      }
     >
       <div
         style={{
           width: props.size ?? 25.5,
           height: props.size ?? 25.5,
-          backgroundColor: props.isOffline ? colorTheme.bg4.value : props.color.background,
-          color: props.isOffline ? colorTheme.fg2.value : props.color.foreground,
+          backgroundColor:
+            props.isOffline || props.color == null ? colorTheme.bg4.value : props.color.background,
+          color:
+            props.isOffline || props.color == null ? colorTheme.fg2.value : props.color.foreground,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -378,7 +393,7 @@ export const MultiplayerAvatar = React.memo((props: MultiplayerAvatarProps) => {
               ? `1px solid ${colorTheme.bg1.value}`
               : `1px solid ${colorTheme.transparent.value}`,
           boxShadow:
-            props.isBeingFollowed === true
+            props.isBeingFollowed === true && props.color != null
               ? `0px 0px 0px 2.5px ${props.color.background}`
               : `0px 0px 0px 2.5px ${colorTheme.transparent.value}`,
           ...props.style,

--- a/editor/src/core/commenting/comment-hooks.tsx
+++ b/editor/src/core/commenting/comment-hooks.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { User } from '@liveblocks/client'
 import { LiveObject, type ThreadData } from '@liveblocks/client'
-import type { Presence, ThreadMetadata, UserMeta } from '../../../liveblocks.config'
+import type { ConnectionInfo, Presence, ThreadMetadata, UserMeta } from '../../../liveblocks.config'
 import {
   useEditThreadMetadata,
   useMutation,
@@ -31,6 +31,9 @@ import { getCurrentTheme } from '../../components/editor/store/editor-state'
 import { useMyUserId } from '../shared/multiplayer-hooks'
 import { usePermissions } from '../../components/editor/store/permissions'
 import { isFeatureEnabled } from '../../utils/feature-switches'
+import { modify, toFirst } from '../shared/optics/optic-utilities'
+import { filtered, fromObjectField, traverseArray } from '../shared/optics/optic-creators'
+import { foldEither } from '../shared/either'
 
 export function useCanvasCommentThreadAndLocation(comment: CommentId): {
   location: CanvasPoint | null
@@ -101,7 +104,6 @@ function placeholderUserMeta(user: User<Presence, UserMeta>): UserMeta {
     id: user.id,
     name: null,
     avatar: null,
-    colorIndex: null,
   }
 }
 
@@ -120,6 +122,66 @@ export function getCollaboratorById(collabs: Collaborators, id: string): UserMet
   return collabs[id] ?? null
 }
 
+interface Connections {
+  [key: string]: Array<ConnectionInfo>
+}
+
+export function getConnectionById(
+  connections: Connections,
+  userId: string,
+  connectionId: number,
+): ConnectionInfo | null {
+  const connectionOptic = fromObjectField<Array<ConnectionInfo>, Connections>(userId)
+    .compose(traverseArray())
+    .compose(filtered((connection) => connection.id === connectionId))
+  return foldEither(
+    () => null,
+    (result) => result,
+    toFirst(connectionOptic, connections),
+  )
+}
+
+export function setConnectionById(
+  allConnections: Connections,
+  userId: string,
+  connectionId: number,
+  updatedConnection: ConnectionInfo,
+): void {
+  const connectionsOptic = fromObjectField<Array<ConnectionInfo>, Connections>(userId)
+  modify(
+    connectionsOptic,
+    (connections) => {
+      const alreadyExisting = connections.some((connection) => connection.id === connectionId)
+      if (alreadyExisting) {
+        return connections.map((connection) => {
+          if (connection.id === connectionId) {
+            return updatedConnection
+          } else {
+            return connection
+          }
+        })
+      } else {
+        return [...connections, updatedConnection]
+      }
+    },
+    allConnections,
+  )
+}
+
+export function useConnections(): Connections {
+  return useStorage((store) => store.connections)
+}
+
+export function useGetConnection(userId: string, connectionId: number): ConnectionInfo | null {
+  const connections = useConnections()
+  return getConnectionById(connections, userId, connectionId)
+}
+
+export function useGetMyConnection(): ConnectionInfo | null {
+  const me = useSelf()
+  return useGetConnection(me.id, me.connectionId)
+}
+
 export function useMyUserAndPresence(): {
   presence: User<Presence, UserMeta>
   user: UserMeta
@@ -131,11 +193,6 @@ export function useMyUserAndPresence(): {
     presence: me,
     user: myUser ?? placeholderUserMeta(me),
   }
-}
-
-export function useMyMultiplayerColorIndex() {
-  const me = useMyUserAndPresence()
-  return me.user.colorIndex
 }
 
 export function useAddMyselfToCollaborators() {
@@ -153,17 +210,12 @@ export function useAddMyselfToCollaborators() {
       const collaborators = storage.get('collaborators')
 
       if (collaborators.get(self.id) == null) {
-        const otherColorIndices = Object.values(collaborators.toObject()).map((u) =>
-          u.get('colorIndex'),
-        )
-
         collaborators.set(
           self.id,
           new LiveObject({
             id: loginState.user.userId,
             name: normalizeMultiplayerName(loginState.user.name ?? null),
             avatar: loginState.user.picture ?? null,
-            colorIndex: possiblyUniqueColor(otherColorIndices),
           }),
         )
       }

--- a/editor/src/core/shared/multiplayer.ts
+++ b/editor/src/core/shared/multiplayer.ts
@@ -95,6 +95,16 @@ export function normalizeOthersList(
   )
 }
 
+export function excludeMyConnection(
+  myUserId: string,
+  myConnectionId: number,
+  others: readonly User<Presence, UserMeta>[],
+): User<Presence, UserMeta>[] {
+  return others.filter((other) => {
+    return other.id !== myUserId || other.connectionId !== myConnectionId
+  })
+}
+
 const reAuth0DefaultAvatarURLEncoded = /https%3A%2F%2Fcdn\.auth0\.com%2Favatars%2F.{2}\.png$/
 const reAuth0DefaultAvatar = /https:\/\/cdn\.auth0\.com\/avatars\/.{2}\.png$/
 

--- a/editor/src/utils/multiplayer-wrapper.tsx
+++ b/editor/src/utils/multiplayer-wrapper.tsx
@@ -56,7 +56,7 @@ export const CommentWrapper = React.memo((props: CommentWrapperProps) => {
     <div data-testid='comment-wrapper' style={{ position: 'relative' }}>
       <MultiplayerAvatar
         name={multiplayerInitialsFromName(normalizeMultiplayerName(user.name))}
-        color={multiplayerColorFromIndex(user.colorIndex)}
+        color={multiplayerColorFromIndex(null)}
         style={baseMultiplayerAvatarStyle}
         picture={user.avatar}
       />


### PR DESCRIPTION
**Problem:**
We want to see multiplayer cursors for our user if they're on a different instance of the editor.

**Fix:**
There's two main changes:
- Attaching the `colorIndex` to the connection.
- Creating cursors based off of individual connections and not excluding those which are present for another connection for the same user.
A lot of the work was mostly just making sure those requirements were satisfied. However one outcome was that as the `colorIndex` value was previously connected to the user for the comment listing it wouldn't make sense to have a colour for the connection and for the user, as they would likely be inconsistent. So the decision was made to remove the colours for comments and their avatars.

**Commit Details:**
- Comments now lose their user specific colours as the colours are now attached to connections, which would result in some inconsistent colours against comments versus the cursor for them.
- `MultiplayerCursors` now uses `excludeMyConnection` to get everything but the current connection for the current user.
- When calling `multiplayerColorFromIndex`, the `getConnectionById` function is used to obtain the `colorIndex` for the connection if it exists.
- `MultiplayerUserBar` now uses `excludeMyConnection` to get the connections excluding the current connection used by the current user.
- Added some utility functions related to connections in `comment-hooks.tsx`.
- Moved `colorIndex` from `UserMeta` to `ConnectionInfo`.