### PR TITLE
Start using branches url for CI tests

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -139,8 +139,8 @@ jobs:
         if: steps.cache-server-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeEditorBuildSupport false --arg includeRunLocallySupport false --run test-server-ci
 
-  deploy-staging:
-    name: Deploy Staging Editor
+  deploy-branch:
+    name: Deploy Branch Editor
     timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: [cache-pnpm-store]
@@ -148,7 +148,7 @@ jobs:
       UTOPIA_SHA: ${{ github.sha }}
       AUTH0_CLIENT_ID: KB7euFO46rVYeOaWmrEdktdhAFxEO266
       AUTH0_ENDPOINT: enter.utopia.app
-      AUTH0_REDIRECT_URI: https://utopia.pizza/authenticate
+      AUTH0_REDIRECT_URI: https://utopia.fish/authenticate
     steps:
       # Create a comment immediately so that the first comment can be used as a "Try me" link
       - name: Find Comment
@@ -265,7 +265,7 @@ jobs:
       UTOPIA_SHA: ${{ github.sha }}
       AUTH0_CLIENT_ID: KB7euFO46rVYeOaWmrEdktdhAFxEO266
       AUTH0_ENDPOINT: enter.utopia.app
-      AUTH0_REDIRECT_URI: https://utopia.pizza/authenticate
+      AUTH0_REDIRECT_URI: https://utopia.fish/authenticate
     steps:
       # Gets the branch that this PR is targeting and replaces forward slashes in the name with hyphens.
       # So that later steps can produce a bundle incorporating that into the name and upload it.
@@ -410,7 +410,7 @@ jobs:
       UTOPIA_SHA: ${{ github.sha }}
       AUTH0_CLIENT_ID: KB7euFO46rVYeOaWmrEdktdhAFxEO266
       AUTH0_ENDPOINT: enter.utopia.app
-      AUTH0_REDIRECT_URI: https://utopia.pizza/authenticate
+      AUTH0_REDIRECT_URI: https://utopia.fish/authenticate
     steps:
       # Gets the branch that this PR is targeting and replaces forward slashes in the name with hyphens.
       # So that later steps can produce a bundle incorporating that into the name and upload it.
@@ -438,7 +438,7 @@ jobs:
         id: run-comments-test
         env:
           BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
-          BASE_URL: 'https://utopia.pizza'
+          BASE_URL: 'https://utopia.fish'
         run: |
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "xvfb-run --server-args='-screen 0 1920x1080x24 -ac -nolisten tcp -dpi 96 +extension RANDR' run-comments-test"
 
@@ -451,7 +451,7 @@ jobs:
       UTOPIA_SHA: ${{ github.sha }}
       AUTH0_CLIENT_ID: KB7euFO46rVYeOaWmrEdktdhAFxEO266
       AUTH0_ENDPOINT: enter.utopia.app
-      AUTH0_REDIRECT_URI: https://utopia.pizza/authenticate
+      AUTH0_REDIRECT_URI: https://utopia.fish/authenticate
     steps:
       # Gets the branch that this PR is targeting and replaces forward slashes in the name with hyphens.
       # So that later steps can produce a bundle incorporating that into the name and upload it.
@@ -479,6 +479,6 @@ jobs:
         id: run-comments-test
         env:
           BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
-          BASE_URL: 'https://utopia.pizza'
+          BASE_URL: 'https://utopia.fish'
         run: |
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "xvfb-run --server-args='-screen 0 1920x1080x24 -ac -nolisten tcp -dpi 96 +extension RANDR' run-collaboration-test"

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -260,7 +260,7 @@ jobs:
     name: Run Performance Tests
     timeout-minutes: 15
     runs-on: self-hosted
-    needs: [deploy-staging, cache-pnpm-store]
+    needs: [deploy-branch, cache-pnpm-store]
     env:
       UTOPIA_SHA: ${{ github.sha }}
       AUTH0_CLIENT_ID: KB7euFO46rVYeOaWmrEdktdhAFxEO266
@@ -366,7 +366,7 @@ jobs:
     name: Run System Tests
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    needs: [deploy-staging, cache-pnpm-store]
+    needs: [deploy-branch, cache-pnpm-store]
     env:
       UTOPIA_SHA: ${{ github.sha }}
     steps:
@@ -405,7 +405,7 @@ jobs:
     name: Run Comments Tests
     timeout-minutes: 12
     runs-on: ubuntu-latest
-    needs: [deploy-staging, cache-pnpm-store]
+    needs: [deploy-branch, cache-pnpm-store]
     env:
       UTOPIA_SHA: ${{ github.sha }}
       AUTH0_CLIENT_ID: KB7euFO46rVYeOaWmrEdktdhAFxEO266
@@ -446,7 +446,7 @@ jobs:
     name: Run Collaboration Tests
     timeout-minutes: 12
     runs-on: ubuntu-latest
-    needs: [deploy-staging, cache-pnpm-store]
+    needs: [deploy-branch, cache-pnpm-store]
     env:
       UTOPIA_SHA: ${{ github.sha }}
       AUTH0_CLIENT_ID: KB7euFO46rVYeOaWmrEdktdhAFxEO266

--- a/.github/workflows/tag-release-automated.yml
+++ b/.github/workflows/tag-release-automated.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Run System Test
         id: run-system-test
         env:
+          EDITOR_URL: https://utopia.pizza/p/
           HEADLESS: 'true'
         run: |
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "cd puppeteer-tests; pnpm install --unsafe-perm; pnpm run system-test"

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -13,10 +13,10 @@ const TARGET_BRANCH_NAME = process.env.TARGET_BRANCH_NAME
   ? `&branch_name=${process.env.TARGET_BRANCH_NAME}`
   : ''
 const STAGING_EDITOR_URL =
-  process.env.EDITOR_URL ?? `https://utopia.pizza/p?code_editor_disabled=true${BRANCH_NAME}`
+  process.env.EDITOR_URL ?? `https://utopia.fish/p?code_editor_disabled=true${BRANCH_NAME}`
 const MASTER_EDITOR_URL =
   process.env.MASTER_EDITOR_URL ??
-  `https://utopia.pizza/p?code_editor_disabled=true${TARGET_BRANCH_NAME}`
+  `https://utopia.fish/p?code_editor_disabled=true${TARGET_BRANCH_NAME}`
 
 interface FrameResult {
   title: string

--- a/puppeteer-tests/src/system-test.ts
+++ b/puppeteer-tests/src/system-test.ts
@@ -1,16 +1,15 @@
 /* eslint-disable no-console */
 require('dotenv').config({ path: 'src/.env' })
-import * as puppeteer from 'puppeteer'
-import type { PageEventObject } from 'puppeteer'
+import type { ElementHandle, Page, PageEventObject } from 'puppeteer'
 import { initialiseTests, ONE_MINUTE_IN_MS, setupBrowser, timeLimitPromise } from './utils'
 
 const PROJECT_ID = process.env.PROJECT_ID ?? ''
 const BRANCH_NAME = process.env.BRANCH_NAME ? `?branch_name=${process.env.BRANCH_NAME}` : ''
 const STAGING_EDITOR_URL =
-  process.env.EDITOR_URL ?? `https://utopia.pizza/p/${PROJECT_ID}${BRANCH_NAME}`
+  process.env.EDITOR_URL ?? `https://utopia.fish/p/${PROJECT_ID}${BRANCH_NAME}`
 
 async function clickOnce(
-  page: puppeteer.Page,
+  page: Page,
   xpath: string,
   expectedConsoleMessage: string,
   errorMessage?: string,
@@ -35,7 +34,7 @@ async function clickOnce(
     page.on('console', handler)
   })
 
-  await (button as puppeteer.ElementHandle<HTMLButtonElement>)!.click()
+  await (button as ElementHandle<HTMLButtonElement>)!.click()
 
   return timeLimitPromise(
     consoleDonePromise,
@@ -74,7 +73,7 @@ async function testCodeEditor() {
   }
 }
 
-async function checkCodeEditor(page: puppeteer.Page): Promise<boolean> {
+async function checkCodeEditor(page: Page): Promise<boolean> {
   const desiredReadyState = {
     vscodeReady: true,
     loadingScreenVisible: false,

--- a/website-next/components/hosted-image.tsx
+++ b/website-next/components/hosted-image.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
-import { STATIC_BASE_URL } from './common/env-vars'
+
+const cdnUrl = process.env.UTOPIA_CDN_URL ?? ''
 
 export function srcToCdn(src: string): string {
-  return `${STATIC_BASE_URL}${src}`
+  return `${cdnUrl}${src}`
 }
 
 type HostedImageProps = React.DetailedHTMLProps<


### PR DESCRIPTION
This PR is a follow up to #4796, and updates the various CI tests to point to the new branches URL