### PR TITLE
Convert liveblocks thread metadata to our own typed representation

### DIFF
--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -3,13 +3,9 @@ import { createRoomContext } from '@liveblocks/react'
 import { getProjectID } from './src/common/env-vars'
 import type { ActiveFrameAction } from './src/components/canvas/commands/set-active-frames-command'
 import {
-  localPoint,
-  type CanvasPoint,
   type CanvasRectangle,
   type CanvasVector,
-  type LocalPoint,
   type WindowPoint,
-  canvasPoint,
 } from './src/core/shared/math-utils'
 import type { RemixPresence } from './src/core/shared/multiplayer'
 import { projectIdToRoomId } from './src/core/shared/multiplayer'

--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -2,7 +2,15 @@ import { LiveObject, createClient } from '@liveblocks/client'
 import { createRoomContext } from '@liveblocks/react'
 import { getProjectID } from './src/common/env-vars'
 import type { ActiveFrameAction } from './src/components/canvas/commands/set-active-frames-command'
-import type { CanvasRectangle, CanvasVector, WindowPoint } from './src/core/shared/math-utils'
+import {
+  localPoint,
+  type CanvasPoint,
+  type CanvasRectangle,
+  type CanvasVector,
+  type LocalPoint,
+  type WindowPoint,
+  canvasPoint,
+} from './src/core/shared/math-utils'
 import type { RemixPresence } from './src/core/shared/multiplayer'
 import { projectIdToRoomId } from './src/core/shared/multiplayer'
 
@@ -95,27 +103,15 @@ export type RoomEvent = ControlChangedRoomEvent
 
 // Optionally, when using Comments, ThreadMetadata represents metadata on
 // each thread. Can only contain booleans, strings, and numbers.
-export type ThreadMetadata = CanvasThreadMetadata | SceneThreadMetadata
 
-export type SceneThreadMetadata = {
+export type ThreadMetadata = {
   x: number
   y: number
-  sceneId: string
-  sceneX: number
-  sceneY: number
+  sceneId?: string
+  sceneX?: number
+  sceneY?: number
   remixLocationRoute?: string
   resolved: boolean
-}
-
-export type CanvasThreadMetadata = {
-  x: number
-  y: number
-  remixLocationRoute?: string
-  resolved: boolean
-}
-
-export function isSceneThreadMetadata(metadata: ThreadMetadata): metadata is SceneThreadMetadata {
-  return metadata.hasOwnProperty('sceneId')
 }
 
 export const {

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -8,18 +8,24 @@ import type { ThreadMetadata, UserMeta } from '../../../../liveblocks.config'
 import { useEditThreadMetadata, useStorage } from '../../../../liveblocks.config'
 import {
   getCollaboratorById,
-  getThreadLocationOnCanvas,
   useActiveThreads,
   useCanvasCommentThreadAndLocation,
   useCanvasLocationOfThread,
   useMyThreadReadStatus,
 } from '../../../core/commenting/comment-hooks'
-import type { CanvasPoint } from '../../../core/shared/math-utils'
+import type {
+  CanvasPoint,
+  CanvasRectangle,
+  LocalPoint,
+  MaybeInfinityCanvasRectangle,
+} from '../../../core/shared/math-utils'
 import {
   canvasPoint,
   distance,
   getLocalPointInNewParentContext,
   isNotNullFiniteRectangle,
+  localPoint,
+  nullIfInfinity,
   offsetPoint,
   pointDifference,
   windowPoint,
@@ -58,6 +64,10 @@ import { useRefAtom } from '../../editor/hook-utils'
 import { emptyComments, jsExpressionValue } from '../../../core/shared/element-template'
 import * as PP from '../../../core/shared/property-path'
 import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
+import {
+  isCanvasThreadMetadata,
+  liveblocksThreadMetadataToUtopia,
+} from '../../../core/commenting/comment-types'
 
 export const CommentIndicators = React.memo(() => {
   const projectId = useEditorState(
@@ -363,6 +373,34 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
 })
 CommentIndicator.displayName = 'CommentIndicator'
 
+function canvasPositionOfThread(
+  sceneGlobalFrame: CanvasRectangle,
+  locationInScene: LocalPoint,
+): CanvasPoint {
+  return canvasPoint({
+    x: sceneGlobalFrame.x + locationInScene.x,
+    y: sceneGlobalFrame.y + locationInScene.y,
+  })
+}
+
+function getThreadOriginalLocationOnCanvas(
+  thread: ThreadData<ThreadMetadata>,
+  startingSceneGlobalFrame: MaybeInfinityCanvasRectangle | null,
+): CanvasPoint {
+  const metadata = liveblocksThreadMetadataToUtopia(thread.metadata)
+  switch (metadata.type) {
+    case 'canvas':
+      return metadata.position
+    case 'scene':
+      const globalFrame = nullIfInfinity(startingSceneGlobalFrame)
+      if (globalFrame == null) {
+        throw new Error('Found thread attached to scene with invalid global frame')
+      }
+
+      return canvasPositionOfThread(globalFrame, metadata.scenePosition)
+  }
+}
+
 const COMMENT_DRAG_THRESHOLD = 5 // square px
 
 function useDragging(
@@ -397,7 +435,7 @@ function useDragging(
         scenesRef.current,
       )
 
-      const originalThreadPosition = getThreadLocationOnCanvas(
+      const originalThreadPosition = getThreadOriginalLocationOnCanvas(
         thread,
         maybeStartingSceneUnderPoint?.globalFrame ?? null,
       )
@@ -483,11 +521,9 @@ function useDragging(
         editThreadMetadata({
           threadId: thread.id,
           metadata: {
-            sceneX: localPointInScene.x,
-            sceneY: localPointInScene.y,
+            x: localPointInScene.x,
+            y: localPointInScene.y,
             sceneId: sceneIdToUse,
-            x: newPositionOnCanvas.x,
-            y: newPositionOnCanvas.y,
             remixLocationRoute: remixRoute != null ? remixRoute.location.pathname : undefined,
           },
         })

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -45,7 +45,11 @@ import { RemixNavigationAtom } from '../remix/utopia-remix-root-component'
 import { getIdOfScene } from './comment-mode/comment-mode-hooks'
 import { motion, useAnimation } from 'framer-motion'
 import type { EditorDispatch } from '../../editor/action-types'
-import { utopiaThreadMetadataToLiveblocks } from '../../../core/commenting/comment-types'
+import {
+  canvasThreadMetadata,
+  sceneThreadMetadata,
+  utopiaThreadMetadataToLiveblocks,
+} from '../../../core/commenting/comment-types'
 
 export const ComposerEditorClassName = 'lb-composer-editor'
 
@@ -153,11 +157,12 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
           case 'canvas':
             const newThreadOnCanvas = createThread({
               body,
-              metadata: utopiaThreadMetadataToLiveblocks({
-                type: 'canvas',
-                resolved: false,
-                position: comment.location.position,
-              }),
+              metadata: utopiaThreadMetadataToLiveblocks(
+                canvasThreadMetadata({
+                  resolved: false,
+                  position: comment.location.position,
+                }),
+              ),
             })
             return [newThreadOnCanvas, []]
           case 'scene':
@@ -181,14 +186,15 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
 
             const newThreadOnScene = createThread({
               body,
-              metadata: utopiaThreadMetadataToLiveblocks({
-                type: 'scene',
-                resolved: false,
-                position: comment.location.position,
-                sceneId: sceneId,
-                scenePosition: comment.location.offset,
-                remixLocationRoute: remixRoute != null ? remixRoute.location.pathname : undefined,
-              }),
+              metadata: utopiaThreadMetadataToLiveblocks(
+                sceneThreadMetadata({
+                  resolved: false,
+                  position: comment.location.position,
+                  sceneId: sceneId,
+                  scenePosition: comment.location.offset,
+                  remixLocationRoute: remixRoute != null ? remixRoute.location.pathname : undefined,
+                }),
+              ),
             })
             return [newThreadOnScene, addSceneIdPropAction]
           default:

--- a/editor/src/components/canvas/controls/comment-popup.tsx
+++ b/editor/src/components/canvas/controls/comment-popup.tsx
@@ -8,7 +8,6 @@ import { useCreateThread, useStorage } from '../../../../liveblocks.config'
 import '../../../../resources/editor/css/liveblocks/react-comments/styles.css'
 import '../../../../resources/editor/css/liveblocks/react-comments/dark/attributes.css'
 import {
-  getCollaboratorById,
   useCanvasCommentThreadAndLocation,
   useCreateNewThreadReadStatus,
   useDeleteThreadReadStatus,
@@ -46,6 +45,7 @@ import { RemixNavigationAtom } from '../remix/utopia-remix-root-component'
 import { getIdOfScene } from './comment-mode/comment-mode-hooks'
 import { motion, useAnimation } from 'framer-motion'
 import type { EditorDispatch } from '../../editor/action-types'
+import { utopiaThreadMetadataToLiveblocks } from '../../../core/commenting/comment-types'
 
 export const ComposerEditorClassName = 'lb-composer-editor'
 
@@ -153,11 +153,11 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
           case 'canvas':
             const newThreadOnCanvas = createThread({
               body,
-              metadata: {
+              metadata: utopiaThreadMetadataToLiveblocks({
+                type: 'canvas',
                 resolved: false,
-                x: comment.location.position.x,
-                y: comment.location.position.y,
-              },
+                position: comment.location.position,
+              }),
             })
             return [newThreadOnCanvas, []]
           case 'scene':
@@ -181,15 +181,14 @@ const CommentThread = React.memo(({ comment }: CommentThreadProps) => {
 
             const newThreadOnScene = createThread({
               body,
-              metadata: {
+              metadata: utopiaThreadMetadataToLiveblocks({
+                type: 'scene',
                 resolved: false,
-                x: comment.location.position.x,
-                y: comment.location.position.x,
+                position: comment.location.position,
                 sceneId: sceneId,
-                sceneX: comment.location.offset.x,
-                sceneY: comment.location.offset.y,
+                scenePosition: comment.location.offset,
                 remixLocationRoute: remixRoute != null ? remixRoute.location.pathname : undefined,
-              },
+              }),
             })
             return [newThreadOnScene, addSceneIdPropAction]
           default:

--- a/editor/src/core/commenting/comment-maintainer.tsx
+++ b/editor/src/core/commenting/comment-maintainer.tsx
@@ -1,14 +1,11 @@
 import React from 'react'
 import { MultiplayerWrapper } from '../../utils/multiplayer-wrapper'
 import { getThreadLocationOnCanvas, useCanComment, useScenes } from './comment-hooks'
-import {
-  isSceneThreadMetadata,
-  useEditThreadMetadata,
-  useThreads,
-} from '../../../liveblocks.config'
+import { useEditThreadMetadata, useThreads } from '../../../liveblocks.config'
 import { getIdOfScene } from '../../components/canvas/controls/comment-mode/comment-mode-hooks'
 import * as EP from '../shared/element-path'
 import { isNotNullFiniteRectangle } from '../shared/math-utils'
+import { isCanvasThreadMetadata, liveblocksThreadMetadataToUtopia } from './comment-types'
 
 export const CommentMaintainer = React.memo(() => {
   const canComment = useCanComment()
@@ -38,10 +35,11 @@ function useMaintainComments() {
   const editThreadMetadata = useEditThreadMetadata()
 
   threads.forEach(async (t): Promise<void> => {
-    if (!isSceneThreadMetadata(t.metadata)) {
+    const metadata = liveblocksThreadMetadataToUtopia(t.metadata)
+    if (isCanvasThreadMetadata(metadata)) {
       return
     }
-    const { sceneId } = t.metadata
+    const { sceneId } = metadata
 
     const scene = scenes.find(
       (s) => getIdOfScene(s) === sceneId || EP.toUid(s.elementPath) === sceneId,
@@ -53,7 +51,7 @@ function useMaintainComments() {
     }
 
     const p = getThreadLocationOnCanvas(t, globalFrame)
-    if (p.x === t.metadata.x && p.y === t.metadata.y) {
+    if (p.x === metadata.position.x && p.y === metadata.position.y) {
       return
     }
 

--- a/editor/src/core/commenting/comment-types.tsx
+++ b/editor/src/core/commenting/comment-types.tsx
@@ -22,31 +22,13 @@ export type SceneThreadMetadata = BaseThreadMetadata & {
 }
 
 export function canvasThreadMetadata(
-  position: CanvasPoint,
-  resolved: boolean = false,
+  data: Omit<CanvasThreadMetadata, 'type'>,
 ): CanvasThreadMetadata {
-  return {
-    type: 'canvas',
-    position: position,
-    resolved: resolved,
-  }
+  return { ...data, type: 'canvas' }
 }
 
-export function sceneThreadMetadata(
-  position: CanvasPoint,
-  sceneId: string,
-  scenePosition: LocalPoint,
-  remixLocationRoute?: string,
-  resolved: boolean = false,
-): SceneThreadMetadata {
-  return {
-    type: 'scene',
-    position: position,
-    sceneId: sceneId,
-    scenePosition: scenePosition,
-    remixLocationRoute: remixLocationRoute,
-    resolved: resolved,
-  }
+export function sceneThreadMetadata(data: Omit<SceneThreadMetadata, 'type'>): SceneThreadMetadata {
+  return { ...data, type: 'scene' }
 }
 
 export function isSceneThreadMetadata(
@@ -63,19 +45,17 @@ export function isCanvasThreadMetadata(
 
 export function liveblocksThreadMetadataToUtopia(metadata: ThreadMetadata): UtopiaThreadMetadata {
   if (metadata.sceneId != null && metadata.sceneX != null && metadata.sceneY != null) {
-    return {
-      type: 'scene',
+    return sceneThreadMetadata({
       position: canvasPoint(metadata),
       sceneId: metadata.sceneId,
       scenePosition: localPoint({ x: metadata.sceneX, y: metadata.sceneY }),
       resolved: metadata.resolved,
-    }
+    })
   } else {
-    return {
-      type: 'canvas',
+    return canvasThreadMetadata({
       position: canvasPoint(metadata),
       resolved: metadata.resolved,
-    }
+    })
   }
 }
 

--- a/editor/src/core/commenting/comment-types.tsx
+++ b/editor/src/core/commenting/comment-types.tsx
@@ -106,27 +106,34 @@ type PartialNullable<T> = {
   [P in keyof T]?: T[P] | null | undefined
 }
 
+type UtopiaThreadMetadataQuery = PartialNullable<UtopiaThreadMetadata> &
+  Pick<UtopiaThreadMetadata, 'type'>
+
 export function utopiaThreadMetadataToLiveblocksPartial(
-  metadata: PartialNullable<UtopiaThreadMetadata>,
+  metadata: UtopiaThreadMetadataQuery,
 ): PartialNullable<ThreadMetadata> {
-  if (metadata.type === 'scene') {
-    return {
-      x: metadata.position?.x,
-      y: metadata.position?.y,
-      sceneId: metadata.sceneId,
-      sceneX: metadata.scenePosition?.x,
-      sceneY: metadata.scenePosition?.y,
-      resolved: metadata.resolved,
-      remixLocationRoute: metadata.remixLocationRoute,
-    }
-  }
-  return {
-    x: metadata.position?.x,
-    y: metadata.position?.y,
-    sceneId: null, // the null fields are necessary so we delete these fields on update from liveblocks
-    sceneX: null,
-    sceneY: null,
-    remixLocationRoute: null,
-    resolved: metadata.resolved,
+  switch (metadata.type) {
+    case 'scene':
+      return {
+        x: metadata.position?.x,
+        y: metadata.position?.y,
+        sceneId: metadata.sceneId,
+        sceneX: metadata.scenePosition?.x,
+        sceneY: metadata.scenePosition?.y,
+        resolved: metadata.resolved,
+        remixLocationRoute: metadata.remixLocationRoute,
+      }
+    case 'canvas':
+      return {
+        x: metadata.position?.x,
+        y: metadata.position?.y,
+        sceneId: null, // the null fields are necessary so we delete these fields on update from liveblocks
+        sceneX: null,
+        sceneY: null,
+        remixLocationRoute: null,
+        resolved: metadata.resolved,
+      }
+    default:
+      assertNever(metadata)
   }
 }

--- a/editor/src/core/commenting/comment-types.tsx
+++ b/editor/src/core/commenting/comment-types.tsx
@@ -1,0 +1,106 @@
+import type { ThreadMetadata } from '../../../liveblocks.config'
+import type { CanvasPoint, LocalPoint } from '../shared/math-utils'
+import { canvasPoint, localPoint } from '../shared/math-utils'
+
+export function liveblocksThreadMetadataToUtopia(metadata: ThreadMetadata): UtopiaThreadMetadata {
+  if (metadata.sceneId != null && metadata.sceneX != null && metadata.sceneY != null) {
+    return {
+      type: 'scene',
+      position: canvasPoint(metadata),
+      sceneId: metadata.sceneId,
+      scenePosition: localPoint({ x: metadata.sceneX, y: metadata.sceneY }),
+      resolved: metadata.resolved,
+    }
+  } else {
+    return {
+      type: 'canvas',
+      position: canvasPoint(metadata),
+      resolved: metadata.resolved,
+    }
+  }
+}
+
+export function utopiaThreadMetadataToLiveblocks(metadata: UtopiaThreadMetadata): ThreadMetadata {
+  switch (metadata.type) {
+    case 'canvas':
+      return {
+        x: metadata.position.x,
+        y: metadata.position.y,
+        sceneId: undefined, // the undefined fields are necessary so we delete these fields on update from liveblocks
+        sceneX: undefined,
+        sceneY: undefined,
+        resolved: metadata.resolved,
+        remixLocationRoute: metadata.remixLocationRoute,
+      }
+    case 'scene':
+      return {
+        x: metadata.position.x,
+        y: metadata.position.y,
+        sceneId: metadata.sceneId,
+        sceneX: metadata.scenePosition.x,
+        sceneY: metadata.scenePosition.x,
+        resolved: metadata.resolved,
+        remixLocationRoute: metadata.remixLocationRoute,
+      }
+  }
+}
+
+export type UtopiaThreadMetadata = CanvasThreadMetadata | SceneThreadMetadata
+
+type BaseThreadMetadata = {
+  position: CanvasPoint
+  remixLocationRoute?: string
+  resolved: boolean
+}
+
+export type CanvasThreadMetadata = BaseThreadMetadata & {
+  type: 'canvas'
+}
+
+export function canvasMetadata(
+  position: CanvasPoint,
+  remixLocationRoute?: string,
+  resolved: boolean = false,
+): CanvasThreadMetadata {
+  return {
+    type: 'canvas',
+    position: position,
+    remixLocationRoute: remixLocationRoute,
+    resolved: resolved,
+  }
+}
+
+export type SceneThreadMetadata = BaseThreadMetadata & {
+  type: 'scene'
+  sceneId: string
+  scenePosition: LocalPoint
+}
+
+export function sceneThreadMetadata(
+  position: CanvasPoint,
+  sceneId: string,
+  scenePosition: LocalPoint,
+  remixLocationRoute?: string,
+  resolved: boolean = false,
+): SceneThreadMetadata {
+  return {
+    type: 'scene',
+    position: position,
+    sceneId: sceneId,
+    scenePosition: scenePosition,
+    remixLocationRoute: remixLocationRoute,
+    resolved: resolved,
+  }
+}
+
+export function isSceneThreadMetadata(
+  metadata: UtopiaThreadMetadata,
+): metadata is SceneThreadMetadata {
+  return metadata.type === 'scene'
+}
+
+export function isCanvasThreadMetadata(
+  metadata: UtopiaThreadMetadata,
+): metadata is CanvasThreadMetadata {
+  return metadata.type === 'canvas'
+}

--- a/editor/src/core/commenting/comment-types.tsx
+++ b/editor/src/core/commenting/comment-types.tsx
@@ -26,9 +26,6 @@ export function utopiaThreadMetadataToLiveblocks(metadata: UtopiaThreadMetadata)
       return {
         x: metadata.position.x,
         y: metadata.position.y,
-        sceneId: undefined, // the undefined fields are necessary so we delete these fields on update from liveblocks
-        sceneX: undefined,
-        sceneY: undefined,
         resolved: metadata.resolved,
         remixLocationRoute: metadata.remixLocationRoute,
       }

--- a/editor/src/core/commenting/comment-types.tsx
+++ b/editor/src/core/commenting/comment-types.tsx
@@ -38,7 +38,7 @@ export function utopiaThreadMetadataToLiveblocks(metadata: UtopiaThreadMetadata)
         y: metadata.position.y,
         sceneId: metadata.sceneId,
         sceneX: metadata.scenePosition.x,
-        sceneY: metadata.scenePosition.x,
+        sceneY: metadata.scenePosition.y,
         resolved: metadata.resolved,
         remixLocationRoute: metadata.remixLocationRoute,
       }


### PR DESCRIPTION
**Problem:**
Liveblocks does not allow us to create structured typing for the thread metadata.

**Fix:**
- Create our own discriminated union based type system for threads.
- Create conversion functions from liveblocks to utopia and the other way around
- Create a converter from utopia to liveblocks for the partial types, which is useful for editing the metadata.