### PR TITLE
Prevent Slate errors when adding comments.

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -413,7 +413,8 @@
       "react@18.1.0": "patches/react@18.1.0.patch",
       "reselect@4.1.7": "patches/reselect@4.1.7.patch",
       "use-context-selector@1.3.9": "patches/use-context-selector@1.3.9.patch",
-      "@remix-run/react@2.0.1": "patches/@remix-run__react@2.0.1.patch"
+      "@remix-run/react@2.0.1": "patches/@remix-run__react@2.0.1.patch",
+      "slate-react@0.98.4": "patches/slate-react@0.98.4.patch"
     }
   }
 }

--- a/editor/patches/slate-react@0.98.4.patch
+++ b/editor/patches/slate-react@0.98.4.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/index.es.js b/dist/index.es.js
+index 3d18e69b2f1dd9333722da043c50c72813bfec23..1d7f43cf0854ff6cb19e208066735452cff666fd 100644
+--- a/dist/index.es.js
++++ b/dist/index.es.js
+@@ -420,12 +420,16 @@ var ReactEditor = {
+     (_EDITOR_TO_SCHEDULE_F = EDITOR_TO_SCHEDULE_FLUSH.get(editor)) === null || _EDITOR_TO_SCHEDULE_F === void 0 ? void 0 : _EDITOR_TO_SCHEDULE_F();
+   },
+   blur: editor => {
+-    var el = ReactEditor.toDOMNode(editor, editor);
+-    var root = ReactEditor.findDocumentOrShadowRoot(editor);
+-    IS_FOCUSED.set(editor, false);
++    try {
++      var el = ReactEditor.toDOMNode(editor, editor);
++      var root = ReactEditor.findDocumentOrShadowRoot(editor);
++      IS_FOCUSED.set(editor, false);
+ 
+-    if (root.activeElement === el) {
+-      el.blur();
++      if (root.activeElement === el) {
++        el.blur();
++      }
++    } catch (error) {
++      // Ignore error.
+     }
+   },
+   deselect: editor => {

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -40,6 +40,9 @@ patchedDependencies:
   '@remix-run/react@2.0.1':
     hash: 4uzd4uhfxjy6hfd2xmixhrzbqy
     path: patches/@remix-run__react@2.0.1.patch
+  slate-react@0.98.4:
+    hash: wwmfqejkng33nhl36szrqpzsjq
+    path: patches/slate-react@0.98.4.patch
 
 specifiers:
   '@babel/cli': 7.23.4
@@ -3350,7 +3353,7 @@ packages:
       react-virtuoso: 4.6.2_ef5jwxihqo6n7gxfmzogljlgcm
       slate: 0.94.1
       slate-history: 0.93.0_slate@0.94.1
-      slate-react: 0.98.4_qzwh76fhzug5wjgep5oh76uery
+      slate-react: 0.98.4_wwmfqejkng33nhl36szrqpzsjq_qzwh76fhzug5wjgep5oh76uery
       use-sync-external-store: 1.2.0_react@18.1.0
     transitivePeerDependencies:
       - '@types/react'
@@ -17613,7 +17616,7 @@ packages:
       slate: 0.94.1
     dev: false
 
-  /slate-react/0.98.4_qzwh76fhzug5wjgep5oh76uery:
+  /slate-react/0.98.4_wwmfqejkng33nhl36szrqpzsjq_qzwh76fhzug5wjgep5oh76uery:
     resolution: {integrity: sha512-8Of3v9hFuX8rIRc86LuuBhU9t8ps+9ARKL4yyhCrKQYZ93Ep/LFA3GvPGvtf3zYuVadZ8tkhRH8tbHOGNAndLw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -17633,6 +17636,7 @@ packages:
       slate: 0.94.1
       tiny-invariant: 1.0.6
     dev: false
+    patched: true
 
   /slate/0.94.1:
     resolution: {integrity: sha512-GH/yizXr1ceBoZ9P9uebIaHe3dC/g6Plpf9nlUwnvoyf6V1UOYrRwkabtOCd3ZfIGxomY4P7lfgLr7FPH8/BKA==}


### PR DESCRIPTION
**Problem:**
When adding a comment, an exception is thrown from Slate when confirming the comment contents.

**Cause:**
In the `blur` handler of `ReactEditor` in `react-slate`, there's a lookup which attempts to find the underling DOM node of the text editor in question. For whatever reason (potentially related to the weakmap it uses under the hood of this) it is unable to match the editor and then throws an exception as a result.

**Fix:**
This doesn't really fix the failure because it seems like that potentially involves fixing some of the internals of slate and it's React integration, but merely hides the exception so that it doesn't get surfaced to the user.

**Commit Details:**
- Adds patch that catches exception in the `blur` handler of `slate-react`.
