### PR TITLE
Fix circular dependency.

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -27,7 +27,6 @@ import {
   switchToFileType,
   uniqueProjectContentID,
   updateFileContents,
-  updateFileIfPossible,
 } from '../../../core/model/project-file-utils'
 import { getStoryboardElementPath, PathForSceneDataLabel } from '../../../core/model/scene-utils'
 import type { Either } from '../../../core/shared/either'
@@ -546,6 +545,7 @@ import { convertToAbsoluteAndReparentToUnwrapStrategy } from '../one-shot-unwrap
 import { addHookForProjectChanges } from '../store/collaborative-editing'
 import { arrayDeepEquality, objectDeepEquality } from '../../../utils/deep-equality'
 import type { ProjectServerState } from '../store/project-server-state'
+import { updateFileIfPossible } from './can-update-file'
 
 export const MIN_CODE_PANE_REOPEN_WIDTH = 100
 

--- a/editor/src/components/editor/actions/can-update-file.ts
+++ b/editor/src/components/editor/actions/can-update-file.ts
@@ -1,0 +1,42 @@
+import { isOlderThan, canUpdateRevisionsState } from '../../../core/model/project-file-utils'
+import type { ProjectFile } from '../../../core/shared/project-file-types'
+import { isTextFile, isImageFile, isAssetFile } from '../../../core/shared/project-file-types'
+import {
+  ImageFileKeepDeepEquality,
+  AssetFileKeepDeepEquality,
+} from '../store/store-deep-equality-instances'
+
+export function updateFileIfPossible(
+  updated: ProjectFile,
+  existing: ProjectFile | null,
+): ProjectFile | 'cant-update' {
+  if (existing == null || existing.type !== updated.type) {
+    return updated
+  }
+
+  if (
+    isTextFile(updated) &&
+    isTextFile(existing) &&
+    isOlderThan(existing, updated) &&
+    canUpdateRevisionsState(
+      updated.fileContents.revisionsState,
+      existing.fileContents.revisionsState,
+    )
+  ) {
+    return updated
+  }
+
+  if (isImageFile(updated) && existing != null && isImageFile(existing)) {
+    if (ImageFileKeepDeepEquality(existing, updated).areEqual) {
+      return 'cant-update'
+    }
+  }
+
+  if (isAssetFile(updated) && existing != null && isAssetFile(existing)) {
+    if (AssetFileKeepDeepEquality(existing, updated).areEqual) {
+      return 'cant-update'
+    }
+  }
+
+  return 'cant-update'
+}

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -77,10 +77,6 @@ import { memoize } from '../shared/memoize'
 import { filenameFromParts, getFilenameParts } from '../../components/images'
 import globToRegexp from 'glob-to-regexp'
 import { is } from '../shared/equality-utils'
-import {
-  AssetFileKeepDeepEquality,
-  ImageFileKeepDeepEquality,
-} from '../../components/editor/store/store-deep-equality-instances'
 
 export const sceneMetadata = _sceneMetadata // This is a hotfix for a circular dependency AND a leaking of utopia-api into the workers
 
@@ -535,41 +531,6 @@ export function isOlderThan(maybeNew: ProjectFile, existing: ProjectFile | null)
   return (
     isTextFile(maybeNew) && isTextFile(existing) && maybeNew.versionNumber < existing.versionNumber
   )
-}
-
-export function updateFileIfPossible(
-  updated: ProjectFile,
-  existing: ProjectFile | null,
-): ProjectFile | 'cant-update' {
-  if (existing == null || existing.type !== updated.type) {
-    return updated
-  }
-
-  if (
-    isTextFile(updated) &&
-    isTextFile(existing) &&
-    isOlderThan(existing, updated) &&
-    canUpdateRevisionsState(
-      updated.fileContents.revisionsState,
-      existing.fileContents.revisionsState,
-    )
-  ) {
-    return updated
-  }
-
-  if (isImageFile(updated) && existing != null && isImageFile(existing)) {
-    if (ImageFileKeepDeepEquality(existing, updated).areEqual) {
-      return 'cant-update'
-    }
-  }
-
-  if (isAssetFile(updated) && existing != null && isAssetFile(existing)) {
-    if (AssetFileKeepDeepEquality(existing, updated).areEqual) {
-      return 'cant-update'
-    }
-  }
-
-  return 'cant-update'
 }
 
 export function updateUiJsCode(file: TextFile, code: string, codeIsNowAhead: boolean): TextFile {


### PR DESCRIPTION
**Problem:**
With Vite, a `window is not defined` occurs when the editor starts up.

**Cause:**
This appears to be a circular dependency issue.

**Fix:**
Moving the function `updateFileIfPossible` to a new file appears to have resolved the issue where the bridge point of the circular dependency was the deep equality functions used in the recent changes to the function.

**Commit Details:**
- Moved `updateFileIfPossible` to a new file so that it doesn't cause a circular dependency issue that only seems to arise with Vite.
