### PR TITLE
refactor VariableData to contain VariableMetadata

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -33,6 +33,7 @@ import { useGetCodeAndHighlightBounds } from './ui-jsx-canvas-execution-scope'
 import { usePubSubAtomReadOnly } from '../../../core/shared/atom-with-pub-sub'
 import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../../core/shared/dom-utils'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
+import { objectMap } from '../../../core/shared/object-utils'
 
 export type ComponentRendererComponent = React.ComponentType<
   React.PropsWithChildren<{
@@ -183,7 +184,7 @@ export function createComponentRendererComponent(params: {
       })
     }
 
-    let definedWithinWithValues: MapLike<any> = {}
+    let definedWithinWithValues: MapLike<unknown> = {}
 
     if (utopiaJsxComponent.arbitraryJSBlock != null) {
       const lookupRenderer = createLookupRender(
@@ -228,6 +229,13 @@ export function createComponentRendererComponent(params: {
         instancePath,
       )
 
+      const spiedVariablesInScope = objectMap(
+        (spiedValue) => ({
+          spiedValue: spiedValue,
+        }),
+        definedWithinWithValues,
+      )
+
       const renderedCoreElement = renderCoreElement(
         element,
         ownElementPath,
@@ -251,7 +259,7 @@ export function createComponentRendererComponent(params: {
         code,
         highlightBounds,
         rerenderUtopiaContext.editedText,
-        definedWithinWithValues,
+        spiedVariablesInScope,
       )
 
       if (typeof renderedCoreElement === 'string' || typeof renderedCoreElement === 'number') {

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-scope-utils.ts
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-scope-utils.ts
@@ -7,7 +7,7 @@ export function runBlockUpdatingScope(
   requireResult: MapLike<any>,
   block: ArbitraryJSBlock,
   currentScope: MapLike<any>,
-): MapLike<any> {
+): MapLike<unknown> {
   const result = resolveParamsAndRunJsCode(filePath, block, requireResult, currentScope)
   const definedWithinWithValues: MapLike<any> = {}
   for (const within of block.definedWithin) {

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -102,8 +102,12 @@ export const ElementsToRerenderGLOBAL: { current: ElementsToRerender } = {
   current: 'rerender-all-elements',
 }
 
+export interface VariableMetadata {
+  spiedValue: unknown
+}
+
 export interface VariableData {
-  [name: string]: unknown
+  [name: string]: VariableMetadata
 }
 
 export interface VariablesInScope {

--- a/editor/src/components/shared/scoped-variables.ts
+++ b/editor/src/components/shared/scoped-variables.ts
@@ -141,7 +141,7 @@ function getContainerPropsValue(
       if (isJSXAttributesEntry(prop)) {
         const value = simplifyAttributeIfPossible(prop.value)
         if (isJSXAttributeValue(value)) {
-          runtimeProps[prop.key] = value.value
+          runtimeProps[prop.key] = { spiedValue: value.value as unknown }
         }
       }
     })
@@ -151,7 +151,8 @@ function getContainerPropsValue(
 }
 
 function generateVariableTypes(variables: VariableData): Variable[] {
-  return Object.entries(variables).flatMap(([name, value]) => {
+  return Object.entries(variables).flatMap(([name, valueMetadata]) => {
+    const value = valueMetadata.spiedValue
     const type = getTypeByValue(value)
     const variable = {
       name,

--- a/editor/src/core/model/element-metadata.spec.browser2.tsx
+++ b/editor/src/core/model/element-metadata.spec.browser2.tsx
@@ -37,6 +37,7 @@ import { elementOnlyHasTextChildren } from './element-template-utils'
 import { BakedInStoryboardUID, BakedInStoryboardVariableName } from './scene-utils'
 import type { HugPropertyWidthHeight } from '../shared/element-template'
 import { contentsToTree } from '../../components/assets'
+import type { VariableData } from '../../components/canvas/ui-jsx-canvas'
 
 describe('Frame calculation for fragments', () => {
   // Components with root fragments do not appear in the DOM, so the dom walker does not find them, and they
@@ -1323,37 +1324,45 @@ describe('record variable values', () => {
   it('records variables that are defined inside the component', async () => {
     const editor = await renderTestEditorWithCode(ProjectWithVariables, 'await-first-dom-report')
     const { variablesInScope } = editor.getEditorState().editor
-    expect(variablesInScope['sb/scene/pg:root']).toEqual({
-      definedInsideNumber: 12,
+    expect(variablesInScope['sb/scene/pg:root']).toEqual<VariableData>({
+      definedInsideNumber: { spiedValue: 12 },
       definedInsideObject: {
-        prop: [33],
+        spiedValue: {
+          prop: [33],
+        },
       },
-      definedInsideString: 'hello',
-      functionResult: 35,
+      definedInsideString: { spiedValue: 'hello' },
+      functionResult: { spiedValue: 35 },
     })
-    expect(variablesInScope['sb/scene/pg:root/111']).toEqual({
-      definedInsideNumber: 12,
+    expect(variablesInScope['sb/scene/pg:root/111']).toEqual<VariableData>({
+      definedInsideNumber: { spiedValue: 12 },
       definedInsideObject: {
-        prop: [33],
+        spiedValue: {
+          prop: [33],
+        },
       },
-      definedInsideString: 'hello',
-      functionResult: 35,
+      definedInsideString: { spiedValue: 'hello' },
+      functionResult: { spiedValue: 35 },
     })
-    expect(variablesInScope['sb/scene/pg:root/222']).toEqual({
-      definedInsideNumber: 12,
+    expect(variablesInScope['sb/scene/pg:root/222']).toEqual<VariableData>({
+      definedInsideNumber: { spiedValue: 12 },
       definedInsideObject: {
-        prop: [33],
+        spiedValue: {
+          prop: [33],
+        },
       },
-      definedInsideString: 'hello',
-      functionResult: 35,
+      definedInsideString: { spiedValue: 'hello' },
+      functionResult: { spiedValue: 35 },
     })
-    expect(variablesInScope['sb/scene/pg:root/333']).toEqual({
-      definedInsideNumber: 12,
+    expect(variablesInScope['sb/scene/pg:root/333']).toEqual<VariableData>({
+      definedInsideNumber: { spiedValue: 12 },
       definedInsideObject: {
-        prop: [33],
+        spiedValue: {
+          prop: [33],
+        },
       },
-      definedInsideString: 'hello',
-      functionResult: 35,
+      definedInsideString: { spiedValue: 'hello' },
+      functionResult: { spiedValue: 35 },
     })
   })
 })


### PR DESCRIPTION
Today `EditorState.variablesInScope` contains a map like this:
```
{
  'sb/scene/pg:app': {
    'variableName': 15 // we store a map where the key is the variable's name, and the value is the spied value
  }
}
```

this is making it hard to store extra information about a given variable, and it also makes it hard to store the variable name for a variable in scope where we do not want to store the spied value (e.g. because it may be a function reference etc)

This PR is changing the code to this:
```
{
  'sb/scene/pg:app': {
    'variableName': { spiedValue: 15 }
  }
}
```

this extra wrapper object helps in the following ways:
- makes refactoring easier, because the outer map is no longer name -> any, so it makes it possible in the future to search for usages of spiedValue
- creates a place where we can add extra fields in the future
- makes it possible to make spiedValue optional in the future (if we don't want to store a spiedValue for something)