### PR TITLE
Fix navigator label of imgs

### DIFF
--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -66,8 +66,11 @@ import {
   hasElementsWithin,
   isJSExpressionOtherJavaScript,
   isJSXMapExpression,
+  getJSXAttribute,
+  isJSXAttributeValue,
 } from '../shared/element-template'
 import {
+  getJSXAttributesAtPath,
   getModifiableJSXAttributeAtPath,
   jsxSimpleAttributeToValue,
 } from '../shared/jsx-attributes'
@@ -1540,12 +1543,25 @@ export const MetadataUtils = {
               // With images, take their alt and src properties as possible names first.
               const elementProps = allElementProps[EP.toString(element.elementPath)] ?? {}
               if (lastNamePart === 'img') {
-                const alt = elementProps['alt']
-                if (alt != null && typeof alt === 'string' && alt.length > 0) {
+                const getProp = (prop: string): string | null => {
+                  const value = elementProps[prop]
+                  if (value != null && typeof value === 'string' && value.length > 0) {
+                    return value
+                  }
+                  const attr = getJSXAttribute(jsxElement.props, prop)
+                  if (attr != null && isJSXAttributeValue(attr) && typeof attr.value === 'string') {
+                    return attr.value
+                  }
+                  return null
+                }
+
+                const alt = getProp('alt')
+                if (alt != null) {
                   return alt
                 }
-                const src = elementProps['src']
-                if (src != null && typeof src === 'string' && src.length > 0) {
+
+                const src = getProp('src')
+                if (src != null) {
                   if (src.startsWith('data:') && src.includes('base64')) {
                     return '<Base64 data>'
                   }

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1548,6 +1548,8 @@ export const MetadataUtils = {
                   if (value != null && typeof value === 'string' && value.length > 0) {
                     return value
                   }
+                  // Sometimes allElementProps doesn't contain the props yet
+                  // This is just a quick fix, the real fix is to fix allElementProps
                   const attr = getJSXAttribute(jsxElement.props, prop)
                   if (attr != null && isJSXAttributeValue(attr) && typeof attr.value === 'string') {
                     return attr.value


### PR DESCRIPTION
**Problem:**
When you copy paste image elements with alt name in the code editor, they have `img` label for a while, and only later (sometimes in a frame, sometimes only on mouse move) they receive the string in the alt prop as the navigator label.

**Fix:**
This is just a quick fix, not the fix of the real root cause.

The problem is that for at least a frame allElementProps doesn't contain props for the new img element. But we should have up-to-date ellelementprops when we already have metadata! So this causes a little blink in the label, but  what is a bigger problem that in some cases, mostly when you add the new element in the code editor, the navigator is not rerendered until the first mouse move. 
My quick fix is to check the props in the element itself. The real fix would be too make sure allelementprops is not late in storing the props.
