### PR TITLE
Assorted Commenting test improvements

### DIFF
--- a/puppeteer-tests/jest.config.js
+++ b/puppeteer-tests/jest.config.js
@@ -2,4 +2,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  testTimeout: 120000,
 }

--- a/puppeteer-tests/src/comments/commenting.spec.tsx
+++ b/puppeteer-tests/src/comments/commenting.spec.tsx
@@ -1,7 +1,6 @@
 import { wait } from '../utils'
 import type { BoundingBox, Page, Point } from 'puppeteer'
 import {
-  TIMEOUT,
   enterCommentMode,
   getElementWithSelector,
   initBrowserTest,
@@ -61,356 +60,329 @@ async function dismissHoverPreview(page: Page) {
 
 describe('Comments test', () => {
   let utopiaBrowser = createUtopiaPuppeteerBrowser()
-  it(
-    'Basic comment workflow (place, reply)',
-    async () => {
-      const page = await initSignedInBrowserTest(utopiaBrowser)
 
-      // Enter comment mode using the toolbar
-      const commentModeButton = await getElementWithSelector(
-        page,
-        'div[data-testid="canvas-toolbar-comment-mode-connected"]',
-      )
-      await commentModeButton!.click()
+  it('Basic comment workflow (place, reply)', async () => {
+    const page = await initSignedInBrowserTest(utopiaBrowser)
 
-      // Click on the canvas to open the comment popup
-      const canvasControlsContainer = await getElementWithSelector(
-        page,
-        '#new-canvas-controls-container',
-      )
-      await canvasControlsContainer!.click({ offset: { x: 500, y: 500 } })
-
-      // Write to comment text and submit it
-      const commentBox = await getElementWithSelector(page, '[contenteditable="true"]')
-      await commentBox!.focus()
-      await commentBox!.type('hello comments')
-      await page.keyboard.press('Enter')
-
-      // Check if the comment text is on the screen
-      console.info(
-        'waiting for element with function',
-        'document.querySelector("body").innerText.includes("hello comments")',
-      )
-      const thread = await page.waitForFunction(
-        'document.querySelector("body").innerText.includes("hello comments")',
-      )
-      expect(thread).not.toBeNull()
-
-      // Click away to close the comment popup
-      await canvasControlsContainer!.click({ offset: { x: 700, y: 700 } })
-
-      // Check if the comment indicator is still visible
-      const commentIndicator = await getElementWithSelector(page, CommentIndicatorSelector)
-
-      expect(commentIndicator).not.toBeNull()
-
-      // Check that the comment popup is closed
-      const popupAfterClose = await page.$$('div[data-testid="comment-popup"]')
-      expect(popupAfterClose).toHaveLength(0)
-
-      // Open the comment popup again
-      const comment = await page.waitForSelector('div[data-testid="comment-indicator-wrapper"]')
-      await comment!.click({ offset: { x: 10, y: 10 } })
-
-      // Check that the comment popup is open
-      const popupAfterReopen = await page.$$('div[data-testid="comment-popup"]')
-      expect(popupAfterReopen).toHaveLength(1)
-
-      // Submit a reply
-      const commentBox2 = await getElementWithSelector(page, '[contenteditable="true"]')
-      await commentBox2!.focus()
-      await commentBox2!.type('this is a reply')
-      await page.keyboard.press('Enter')
-
-      // Check if the original comment and the reply comment are both on the screen
-      console.info(
-        'waiting for element with function',
-        'document.querySelector("body").innerText.includes("hello comments")',
-      )
-      const originalComment = await page.waitForFunction(
-        'document.querySelector("body").innerText.includes("hello comments")',
-      )
-      expect(originalComment).not.toBeNull()
-
-      console.info(
-        'waiting for element with function',
-        'document.querySelector("body").innerText.includes("this is a reply")',
-      )
-      const replyComment = await page.waitForFunction(
-        'document.querySelector("body").innerText.includes("this is a reply")',
-      )
-      expect(replyComment).not.toBeNull()
-
-      // Leave comment mode by pressing ESC
-      await page.keyboard.press('Escape')
-
-      // Check that the comment popup is closed
-      const popupAfterEsc = await page.$$('div[data-testid="comment-popup"]')
-      expect(popupAfterEsc).toHaveLength(0)
-    },
-    TIMEOUT,
-  )
-  it(
-    'Placing a comment without submitting does not create a comment',
-    async () => {
-      const page = await initSignedInBrowserTest(utopiaBrowser)
-
-      await enterCommentMode(page)
-
-      // Clicking to add a comment
-      const canvasControlsContainer = await getElementWithSelector(
-        page,
-        '#new-canvas-controls-container',
-      )
-      await canvasControlsContainer!.click({ offset: { x: 500, y: 500 } })
-
-      // Pressing escape without submitting
-      await page.keyboard.press('Escape')
-
-      // There are no comment indicators on the canvas
-      const commentIndicators = await page.$$(CommentIndicatorSelector)
-      expect(commentIndicators).toHaveLength(0)
-    },
-    TIMEOUT,
-  )
-  it(
-    'Resolve comment',
-    async () => {
-      const page = await initSignedInBrowserTest(utopiaBrowser)
-
-      await enterCommentMode(page)
-      await placeCommentOnCanvas(page, 'hello comments', 500, 500)
-
-      // Resolve the comment
-
-      const resolveButton = await getElementWithSelector(
-        page,
-        'div[data-testid="resolve-thread-button"]',
-      )
-      await resolveButton!.click()
-
-      // Check that the comment indicator is gone
-      const commentIndicators = await page.$$(CommentIndicatorSelector)
-      expect(commentIndicators).toHaveLength(0)
-    },
-    TIMEOUT,
-  )
-  it(
-    'Close comment popup with the mouse',
-    async () => {
-      const page = await initSignedInBrowserTest(utopiaBrowser)
-
-      await enterCommentMode(page)
-      await placeCommentOnCanvas(page, 'hello comments', 500, 500)
-
-      const closeCommentButton = await getElementWithSelector(
-        page,
-        'div[data-testid="close-comment"]',
-      )
-      await closeCommentButton!.click()
-
-      // Check that the comment popup is closed but the indicator is still there
-      const commentPopups = await page.$$('div[data-testid="comment-popup"]')
-      expect(commentPopups).toHaveLength(0)
-
-      const commentIndicators = await page.$$(CommentIndicatorSelector)
-      expect(commentIndicators).toHaveLength(1)
-    },
-    TIMEOUT,
-  ),
-    it(
-      'There is a comment tab when logged in',
-      async () => {
-        const page = await initSignedInBrowserTest(utopiaBrowser)
-
-        const commentTabs = await getElementWithSelector(page, 'div[data-testid="comments-tab"]')
-        expect(commentTabs).not.toBeNull()
-      },
-      TIMEOUT,
-    ),
-    it(
-      'There is no comment tab when logged out',
-      async () => {
-        const page = await initBrowserTest(utopiaBrowser)
-
-        const commentsTabs = await page.$$('div[data-testid="comments-tab"]')
-        expect(commentsTabs).toHaveLength(0)
-      },
-      TIMEOUT,
-    ),
-    it(
-      'can reparent comment',
-      async () => {
-        const page = await initSignedInBrowserTest(utopiaBrowser)
-        await enterCommentMode(page)
-
-        const playgroundSceneBoundingBox = roundBoundingBox(
-          await getBoundingBox(page, PlaygroundSceneSelector),
-        )
-
-        await placeCommentOnCanvas(
-          page,
-          'hello comments',
-          playgroundSceneBoundingBox.x - 100,
-          playgroundSceneBoundingBox.y - 100,
-        )
-
-        const originalCommentIndicatorBoundingBox = roundBoundingBox(
-          await getBoundingBox(page, CommentIndicatorSelector),
-        )
-
-        expect(originalCommentIndicatorBoundingBox).toEqual({
-          height: 26,
-          width: 26,
-          x: 486,
-          y: 63,
-        })
-
-        // drag the comment on the scene
-        await drag(
-          page,
-          center(originalCommentIndicatorBoundingBox),
-          center(playgroundSceneBoundingBox),
-        )
-
-        await dismissHoverPreview(page)
-        const commentBoundingBoxInScene = roundBoundingBox(
-          await getBoundingBox(page, CommentIndicatorSelector),
-        )
-        expect(commentBoundingBoxInScene).toEqual({
-          height: 26,
-          width: 26,
-          x: 918,
-          y: 555,
-        })
-        expect(commentBoundingBoxInScene).not.toEqual(originalCommentIndicatorBoundingBox)
-
-        const sceneToolBarBoundingBox = roundBoundingBox(
-          await getBoundingBox(page, SceneToolbarSelector),
-        )
-        const sceneToolBarCenter = roundPoint(center(sceneToolBarBoundingBox))
-
-        // move the scene, the comment indicator shoud move with the scene
-        await drag(
-          page,
-          sceneToolBarCenter,
-          offsetPoint(sceneToolBarCenter, { offsetX: 50, offsetY: 50 }),
-        )
-
-        const commentBoundingBoxInMovedScene = roundBoundingBox(
-          await getBoundingBox(page, CommentIndicatorSelector),
-        )
-        expect(commentBoundingBoxInMovedScene).toEqual({
-          height: 26,
-          width: 26,
-          x: 968,
-          y: 605,
-        })
-
-        const movedSceneBoundingBox = roundBoundingBox(
-          await getBoundingBox(page, PlaygroundSceneSelector),
-        )
-        const commentBoundingBoxInMovedSceneCenter = center(commentBoundingBoxInMovedScene)
-
-        // drag the comment indicator out of the scene, back to the canvas
-        await drag(page, commentBoundingBoxInMovedSceneCenter, {
-          x: movedSceneBoundingBox.x - 50,
-          y: movedSceneBoundingBox.y - 50,
-        })
-
-        await dismissHoverPreview(page)
-        const commentBoundingBoxBackOnCanvasBeforeMove = roundBoundingBox(
-          await getBoundingBox(page, CommentIndicatorSelector),
-        )
-
-        expect(commentBoundingBoxBackOnCanvasBeforeMove).toEqual({
-          height: 26,
-          width: 26,
-          x: 568,
-          y: 176,
-        })
-
-        const movedSceneLabelCenter = center(
-          roundBoundingBox(await getBoundingBox(page, SceneToolbarSelector)),
-        )
-
-        // drag the scene, the comment indicator should not move with it
-        await drag(
-          page,
-          movedSceneLabelCenter,
-          offsetPoint(movedSceneLabelCenter, { offsetX: 150, offsetY: 150 }),
-        )
-        const commentBoundingBoxBackOnCanvasAfterMove = roundBoundingBox(
-          await getBoundingBox(page, CommentIndicatorSelector),
-        )
-
-        expect(commentBoundingBoxBackOnCanvasAfterMove).toEqual({
-          height: 26,
-          width: 26,
-          x: 568,
-          y: 176,
-        })
-        expect(commentBoundingBoxBackOnCanvasBeforeMove).toEqual(
-          commentBoundingBoxBackOnCanvasAfterMove,
-        )
-      },
-      TIMEOUT,
-    ),
-    it(
-      'scene comment canvas coordinates are maintained when scene is moved',
-      async () => {
-        const page = await initSignedInBrowserTest(utopiaBrowser)
-        await enterCommentMode(page)
-
-        const playgroundSceneBoundingBox = roundBoundingBox(
-          await getBoundingBox(page, PlaygroundSceneSelector),
-        )
-
-        // Add a scene comment
-        await placeCommentOnCanvas(
-          page,
-          'hello comments',
-          playgroundSceneBoundingBox.x + 100,
-          playgroundSceneBoundingBox.y + 100,
-        )
-
-        // Leave comment mode by pressing ESC twice
-        await page.keyboard.press('Escape')
-        await page.keyboard.press('Escape')
-
-        const sceneToolBarBoundingBox = roundBoundingBox(
-          await getBoundingBox(page, SceneToolbarSelector),
-        )
-        const sceneToolBarCenter = roundPoint(center(sceneToolBarBoundingBox))
-
-        // move the scene, the comment indicator should move with the scene
-        await drag(
-          page,
-          sceneToolBarCenter,
-          offsetPoint(sceneToolBarCenter, { offsetX: 50, offsetY: 50 }),
-        )
-
-        const movedSceneBoundingBox = roundBoundingBox(
-          await getBoundingBox(page, SceneToolbarSelector),
-        )
-        const movedSceneBoundingBoxCenter = roundPoint(center(movedSceneBoundingBox))
-
-        await page.mouse.click(movedSceneBoundingBoxCenter.x, movedSceneBoundingBoxCenter.y)
-
-        const commentBoundingBoxBackOnCanvasBeforeDelete = roundBoundingBox(
-          await getBoundingBox(page, CommentIndicatorSelector),
-        )
-        // delete the scene
-        await page.keyboard.press('Backspace')
-
-        const commentBoundingBoxBackOnCanvasAfterDelete = roundBoundingBox(
-          await getBoundingBox(page, CommentIndicatorSelector),
-        )
-        // the comment indicator should not move on the canvas
-        expect(commentBoundingBoxBackOnCanvasAfterDelete).toEqual(
-          commentBoundingBoxBackOnCanvasBeforeDelete,
-        )
-      },
-      TIMEOUT,
+    // Enter comment mode using the toolbar
+    const commentModeButton = await getElementWithSelector(
+      page,
+      'div[data-testid="canvas-toolbar-comment-mode-connected"]',
     )
+    await commentModeButton!.click()
+
+    // Click on the canvas to open the comment popup
+    const canvasControlsContainer = await getElementWithSelector(
+      page,
+      '#new-canvas-controls-container',
+    )
+    await canvasControlsContainer!.click({ offset: { x: 500, y: 500 } })
+
+    // Write to comment text and submit it
+    const commentBox = await getElementWithSelector(page, '[contenteditable="true"]')
+    await commentBox!.focus()
+    await commentBox!.type('hello comments')
+    await page.keyboard.press('Enter')
+
+    // Check if the comment text is on the screen
+    console.info(
+      'waiting for element with function',
+      'document.querySelector("body").innerText.includes("hello comments")',
+    )
+    const thread = await page.waitForFunction(
+      'document.querySelector("body").innerText.includes("hello comments")',
+    )
+    expect(thread).not.toBeNull()
+
+    // Click away to close the comment popup
+    await canvasControlsContainer!.click({ offset: { x: 700, y: 700 } })
+
+    // Check if the comment indicator is still visible
+    const commentIndicator = await getElementWithSelector(page, CommentIndicatorSelector)
+
+    expect(commentIndicator).not.toBeNull()
+
+    // Check that the comment popup is closed
+    const popupAfterClose = await page.$$('div[data-testid="comment-popup"]')
+    expect(popupAfterClose).toHaveLength(0)
+
+    // Open the comment popup again
+    const comment = await page.waitForSelector('div[data-testid="comment-indicator-wrapper"]')
+    await comment!.click({ offset: { x: 10, y: 10 } })
+
+    // Check that the comment popup is open
+    const popupAfterReopen = await page.$$('div[data-testid="comment-popup"]')
+    expect(popupAfterReopen).toHaveLength(1)
+
+    // Submit a reply
+    const commentBox2 = await getElementWithSelector(page, '[contenteditable="true"]')
+    await commentBox2!.focus()
+    await commentBox2!.type('this is a reply')
+    await page.keyboard.press('Enter')
+
+    // Check if the original comment and the reply comment are both on the screen
+    console.info(
+      'waiting for element with function',
+      'document.querySelector("body").innerText.includes("hello comments")',
+    )
+    const originalComment = await page.waitForFunction(
+      'document.querySelector("body").innerText.includes("hello comments")',
+    )
+    expect(originalComment).not.toBeNull()
+
+    console.info(
+      'waiting for element with function',
+      'document.querySelector("body").innerText.includes("this is a reply")',
+    )
+    const replyComment = await page.waitForFunction(
+      'document.querySelector("body").innerText.includes("this is a reply")',
+    )
+    expect(replyComment).not.toBeNull()
+
+    // Leave comment mode by pressing ESC
+    await page.keyboard.press('Escape')
+
+    // Check that the comment popup is closed
+    const popupAfterEsc = await page.$$('div[data-testid="comment-popup"]')
+    expect(popupAfterEsc).toHaveLength(0)
+  })
+
+  it('Placing a comment without submitting does not create a comment', async () => {
+    const page = await initSignedInBrowserTest(utopiaBrowser)
+
+    await enterCommentMode(page)
+
+    // Clicking to add a comment
+    const canvasControlsContainer = await getElementWithSelector(
+      page,
+      '#new-canvas-controls-container',
+    )
+    await canvasControlsContainer!.click({ offset: { x: 500, y: 500 } })
+
+    // Pressing escape without submitting
+    await page.keyboard.press('Escape')
+
+    // There are no comment indicators on the canvas
+    const commentIndicators = await page.$$(CommentIndicatorSelector)
+    expect(commentIndicators).toHaveLength(0)
+  })
+  it('Resolve comment', async () => {
+    const page = await initSignedInBrowserTest(utopiaBrowser)
+
+    await enterCommentMode(page)
+    await placeCommentOnCanvas(page, 'hello comments', 500, 500)
+
+    // Resolve the comment
+
+    const resolveButton = await getElementWithSelector(
+      page,
+      'div[data-testid="resolve-thread-button"]',
+    )
+    await resolveButton!.click()
+
+    // Check that the comment indicator is gone
+    const commentIndicators = await page.$$(CommentIndicatorSelector)
+    expect(commentIndicators).toHaveLength(0)
+  })
+
+  it('Close comment popup with the mouse', async () => {
+    const page = await initSignedInBrowserTest(utopiaBrowser)
+
+    await enterCommentMode(page)
+    await placeCommentOnCanvas(page, 'hello comments', 500, 500)
+
+    const closeCommentButton = await getElementWithSelector(
+      page,
+      'div[data-testid="close-comment"]',
+    )
+    await closeCommentButton!.click()
+
+    // Check that the comment popup is closed but the indicator is still there
+    const commentPopups = await page.$$('div[data-testid="comment-popup"]')
+    expect(commentPopups).toHaveLength(0)
+
+    const commentIndicators = await page.$$(CommentIndicatorSelector)
+    expect(commentIndicators).toHaveLength(1)
+  })
+
+  it('There is a comment tab when logged in', async () => {
+    const page = await initSignedInBrowserTest(utopiaBrowser)
+
+    const commentTabs = await getElementWithSelector(page, 'div[data-testid="comments-tab"]')
+    expect(commentTabs).not.toBeNull()
+  })
+
+  it('There is no comment tab when logged out', async () => {
+    const page = await initBrowserTest(utopiaBrowser)
+
+    const commentsTabs = await page.$$('div[data-testid="comments-tab"]')
+    expect(commentsTabs).toHaveLength(0)
+  })
+
+  it('can reparent comment', async () => {
+    const page = await initSignedInBrowserTest(utopiaBrowser)
+    await enterCommentMode(page)
+
+    const playgroundSceneBoundingBox = roundBoundingBox(
+      await getBoundingBox(page, PlaygroundSceneSelector),
+    )
+
+    await placeCommentOnCanvas(
+      page,
+      'hello comments',
+      playgroundSceneBoundingBox.x - 100,
+      playgroundSceneBoundingBox.y - 100,
+    )
+
+    const originalCommentIndicatorBoundingBox = roundBoundingBox(
+      await getBoundingBox(page, CommentIndicatorSelector),
+    )
+
+    expect(originalCommentIndicatorBoundingBox).toEqual({
+      height: 26,
+      width: 26,
+      x: 486,
+      y: 63,
+    })
+
+    // drag the comment on the scene
+    await drag(
+      page,
+      center(originalCommentIndicatorBoundingBox),
+      center(playgroundSceneBoundingBox),
+    )
+
+    await dismissHoverPreview(page)
+    const commentBoundingBoxInScene = roundBoundingBox(
+      await getBoundingBox(page, CommentIndicatorSelector),
+    )
+    expect(commentBoundingBoxInScene).toEqual({
+      height: 26,
+      width: 26,
+      x: 918,
+      y: 555,
+    })
+    expect(commentBoundingBoxInScene).not.toEqual(originalCommentIndicatorBoundingBox)
+
+    const sceneToolBarBoundingBox = roundBoundingBox(
+      await getBoundingBox(page, SceneToolbarSelector),
+    )
+    const sceneToolBarCenter = roundPoint(center(sceneToolBarBoundingBox))
+
+    // move the scene, the comment indicator shoud move with the scene
+    await drag(
+      page,
+      sceneToolBarCenter,
+      offsetPoint(sceneToolBarCenter, { offsetX: 50, offsetY: 50 }),
+    )
+
+    const commentBoundingBoxInMovedScene = roundBoundingBox(
+      await getBoundingBox(page, CommentIndicatorSelector),
+    )
+    expect(commentBoundingBoxInMovedScene).toEqual({
+      height: 26,
+      width: 26,
+      x: 968,
+      y: 605,
+    })
+
+    const movedSceneBoundingBox = roundBoundingBox(
+      await getBoundingBox(page, PlaygroundSceneSelector),
+    )
+    const commentBoundingBoxInMovedSceneCenter = center(commentBoundingBoxInMovedScene)
+
+    // drag the comment indicator out of the scene, back to the canvas
+    await drag(page, commentBoundingBoxInMovedSceneCenter, {
+      x: movedSceneBoundingBox.x - 50,
+      y: movedSceneBoundingBox.y - 50,
+    })
+
+    await dismissHoverPreview(page)
+    const commentBoundingBoxBackOnCanvasBeforeMove = roundBoundingBox(
+      await getBoundingBox(page, CommentIndicatorSelector),
+    )
+
+    expect(commentBoundingBoxBackOnCanvasBeforeMove).toEqual({
+      height: 26,
+      width: 26,
+      x: 568,
+      y: 176,
+    })
+
+    const movedSceneLabelCenter = center(
+      roundBoundingBox(await getBoundingBox(page, SceneToolbarSelector)),
+    )
+
+    // drag the scene, the comment indicator should not move with it
+    await drag(
+      page,
+      movedSceneLabelCenter,
+      offsetPoint(movedSceneLabelCenter, { offsetX: 150, offsetY: 150 }),
+    )
+    const commentBoundingBoxBackOnCanvasAfterMove = roundBoundingBox(
+      await getBoundingBox(page, CommentIndicatorSelector),
+    )
+
+    expect(commentBoundingBoxBackOnCanvasAfterMove).toEqual({
+      height: 26,
+      width: 26,
+      x: 568,
+      y: 176,
+    })
+    expect(commentBoundingBoxBackOnCanvasBeforeMove).toEqual(
+      commentBoundingBoxBackOnCanvasAfterMove,
+    )
+  })
+
+  it('scene comment canvas coordinates are maintained when scene is moved', async () => {
+    const page = await initSignedInBrowserTest(utopiaBrowser)
+    await enterCommentMode(page)
+
+    const playgroundSceneBoundingBox = roundBoundingBox(
+      await getBoundingBox(page, PlaygroundSceneSelector),
+    )
+
+    // Add a scene comment
+    await placeCommentOnCanvas(
+      page,
+      'hello comments',
+      playgroundSceneBoundingBox.x + 100,
+      playgroundSceneBoundingBox.y + 100,
+    )
+
+    // Leave comment mode by pressing ESC twice
+    await page.keyboard.press('Escape')
+    await page.keyboard.press('Escape')
+
+    const sceneToolBarBoundingBox = roundBoundingBox(
+      await getBoundingBox(page, SceneToolbarSelector),
+    )
+    const sceneToolBarCenter = roundPoint(center(sceneToolBarBoundingBox))
+
+    // move the scene, the comment indicator should move with the scene
+    await drag(
+      page,
+      sceneToolBarCenter,
+      offsetPoint(sceneToolBarCenter, { offsetX: 50, offsetY: 50 }),
+    )
+
+    const movedSceneBoundingBox = roundBoundingBox(await getBoundingBox(page, SceneToolbarSelector))
+    const movedSceneBoundingBoxCenter = roundPoint(center(movedSceneBoundingBox))
+
+    await page.mouse.click(movedSceneBoundingBoxCenter.x, movedSceneBoundingBoxCenter.y)
+
+    const commentBoundingBoxBackOnCanvasBeforeDelete = roundBoundingBox(
+      await getBoundingBox(page, CommentIndicatorSelector),
+    )
+    // delete the scene
+    await page.keyboard.press('Backspace')
+
+    const commentBoundingBoxBackOnCanvasAfterDelete = roundBoundingBox(
+      await getBoundingBox(page, CommentIndicatorSelector),
+    )
+    // the comment indicator should not move on the canvas
+    expect(commentBoundingBoxBackOnCanvasAfterDelete).toEqual(
+      commentBoundingBoxBackOnCanvasBeforeDelete,
+    )
+  })
 })

--- a/puppeteer-tests/src/utils.ts
+++ b/puppeteer-tests/src/utils.ts
@@ -16,7 +16,7 @@ export const setupBrowser = async (
   defaultTimeout: number,
 ): Promise<BrowserForPuppeteerTest> => {
   const browser = await puppeteer.launch({
-    args: ['--no-sandbox', '--enable-thread-instruction-count'],
+    args: ['--no-sandbox', '--enable-thread-instruction-count', `--window-size=1500,940`],
     headless: yn(process.env.HEADLESS) ?? false,
     executablePath: process.env.BROWSER,
   })

--- a/puppeteer-tests/src/utils.ts
+++ b/puppeteer-tests/src/utils.ts
@@ -24,6 +24,11 @@ export const setupBrowser = async (
   page.on('dialog', async (dialog) => {
     await dialog.dismiss()
   })
+  page.on('console', async (e) => {
+    const args = await Promise.all(e.args().map((a) => a.jsonValue()))
+    // replay all console messages to the Node.js console
+    console.log(...args)
+  })
   page.setDefaultNavigationTimeout(120000)
   page.setDefaultTimeout(defaultTimeout)
   await page.setViewport({ width: 1500, height: 768 })


### PR DESCRIPTION
- moving test timeout to global jest config instead of specifying it in every single test `it()`
- printing every browser console message to the node.js console for better debugging (should probably put all console messages behind a verbose flag)
- change the chrome window size to match the tab viewport size
- I noticed some `it()`s were weirdly comma separated, fixed that which changed their indentation, please use "hide whitespace"
- while I was there, I added a newline between every `it()` because why weren't there before?
