### PR TITLE
do not switch to select mode when user becomes baton holder

### DIFF
--- a/editor/src/components/editor/store/collaboration-state.tsx
+++ b/editor/src/components/editor/store/collaboration-state.tsx
@@ -31,8 +31,6 @@ export const CollaborationStateUpdater = React.memo(
         let actions: Array<EditorAction> = [
           updateProjectServerState({ currentlyHolderOfTheBaton: newHolderOfTheBaton }),
         ]
-        // Makes sense for the editing user to be in control and they probably want to be editing
-        // when they regain control.
         dispatch(actions)
       },
       [dispatch],

--- a/editor/src/components/editor/store/collaboration-state.tsx
+++ b/editor/src/components/editor/store/collaboration-state.tsx
@@ -33,9 +33,6 @@ export const CollaborationStateUpdater = React.memo(
         ]
         // Makes sense for the editing user to be in control and they probably want to be editing
         // when they regain control.
-        if (newHolderOfTheBaton) {
-          actions.push(switchEditorMode(EditorModes.selectMode(null, false, 'none')))
-        }
         dispatch(actions)
       },
       [dispatch],
@@ -50,7 +47,7 @@ export const CollaborationStateUpdater = React.memo(
           void CollaborationEndpoints.claimControlOverProject(projectId)
             .then((controlResult) => {
               const newHolderOfTheBaton = controlResult ?? false
-              handleControlUpdate(newHolderOfTheBaton ?? false)
+              handleControlUpdate(newHolderOfTheBaton)
             })
             .catch((error) => {
               console.error('Error when claiming control.', error)


### PR DESCRIPTION
**Problem:**
The commenting puppeteer tests were flaky. I suspect it's because there was a race condition between liveblocks coming online and the collaboration-state getting hold of the baton. 
My theory is that tests failed if the events happened in the following order:
- test awaits liveblocks to come live, which means the Comment Mode button becomes clickable
- test clicks Comment Mode button, enters comment mode in the editor
- collaboration-state receives word from our server informing the editor it became the baton holder. The `handleControlUpdate` function switches the editor mode to Select Mode
- test tries to click on canvas to place a comment -> click is registered, but since we are no longer in comment mode, nothing happens
- test awaits the floating comment UI to show up -> it never shows up
- it never shows up
- test awaits forever
- test sad
- test fails

**Fix:**
It turns out that switching to Select Mode in `handleControlUpdate` is no longer required, so instead of trying to figure out a smarter solution to avoid this race condition, I just removed the potentially racy code. 