### PR TITLE
Puppeteer - headless mode 

### DIFF
--- a/puppeteer-tests/package.json
+++ b/puppeteer-tests/package.json
@@ -7,8 +7,8 @@
     "screenshot-test": "ts-node --files src/screenshot-test.ts",
     "system-test": "ts-node --files src/system-test.ts",
     "preinstall": "npx only-allow pnpm",
-    "comments-test": "jest --config ./jest.config.js comments/commenting.spec.ts",
-    "collaboration-test": "jest --config ./jest.config.js comments/collaboration-test.spec.ts",
+    "comments-test": "HEADLESS=true jest --config ./jest.config.js comments/commenting.spec.ts",
+    "collaboration-test": "HEADLESS=true jest --config ./jest.config.js comments/collaboration-test.spec.ts",
     "build": "tsc"
   },
   "author": "",

--- a/puppeteer-tests/src/utils.ts
+++ b/puppeteer-tests/src/utils.ts
@@ -15,9 +15,12 @@ export const setupBrowser = async (
   url: string,
   defaultTimeout: number,
 ): Promise<BrowserForPuppeteerTest> => {
+  const headlessModeEnabled = yn(process.env.HEADLESS) ?? false
+
   const browser = await puppeteer.launch({
     args: ['--no-sandbox', '--enable-thread-instruction-count', `--window-size=1500,940`],
-    headless: yn(process.env.HEADLESS) ?? false,
+    // see https://developer.chrome.com/docs/chromium/new-headless
+    headless: headlessModeEnabled ? 'new' : false,
     executablePath: process.env.BROWSER,
   })
   const page = await browser.newPage()


### PR DESCRIPTION
## Description
This PR enables headless mode for the multiplayer-related puppeteer tests, and enables Chrome's "new" headless mode. For more info on the new headless mode, see https://developer.chrome.com/docs/chromium/new-headless