### PR TITLE
only check the icon's name instead of the full icon url including por…

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-move-strategy.spec.browser2.tsx
@@ -633,9 +633,7 @@ describe('Absolute Move Strategy', () => {
       const toolbarEditButtonImage = renderResult.renderedDOM.getByTestId(
         `${CanvasToolbarEditButtonID}-icon`,
       )
-      expect(toolbarEditButtonImage.getAttribute('src')).toEqual(
-        'http://localhost:9876/editor/icons/light/modalities/moveabs-large-white-18x18@2x.png',
-      )
+      expect(toolbarEditButtonImage.getAttribute('src')).toEqual(expect.stringContaining('moveabs')) // the toolbar shows the Absolute Move icon
     })
 
     await renderResult.getDispatchFollowUpActionsFinished()

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reorder-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reorder-strategy.spec.browser2.tsx
@@ -252,7 +252,7 @@ describe('Flex Reorder Strategy', () => {
               `${CanvasToolbarEditButtonID}-icon`,
             )
             expect(toolbarEditButtonImage.getAttribute('src')).toEqual(
-              'http://localhost:9876/editor/icons/light/modalities/reorder-large-white-18x18@2x.png',
+              expect.stringContaining('reorder'), // check if the toolbar shows the Reorder icon
             )
             expect(renderResult.getEditorState().strategyState.currentStrategy).toEqual(
               'FLEX_REORDER',


### PR DESCRIPTION
**Problem:**
The Karma tests `Flex Reorder Strategy - normal reorder scenarios - works with normal direction` and `Absolute Move Strategy - moves component instances that honour the position properties` are flaky

**Fix:**
Turns out they were checking a toolbar icon's full URL, including the port number, which would sometimes not match.