### PR TITLE
sigh

### DIFF
--- a/puppeteer-tests/src/comments/commenting.spec.tsx
+++ b/puppeteer-tests/src/comments/commenting.spec.tsx
@@ -55,7 +55,9 @@ async function drag(page: Page, from: { x: number; y: number }, to: { x: number;
 
 async function dismissHoverPreview(page: Page) {
   await page.mouse.move(500, 500)
-  await wait(101) // the duration of the comment hover animation + 1ms
+
+  // TODO instead of this horrible timer, actually away the animation finishing on screen, probably using selectors!
+  await wait(1000) // wait for the animation duration (100ms) + flaky test buffer (900ms)
 }
 
 describe('Comments test', () => {


### PR DESCRIPTION
**Problem:**
There's a commenting test `can reparent comment` that is noticeably flaky. 

I was looking into what are the most brittle parts of the actual test and one stood out to me:

We move the mouse to trigger an animation and await "animation duration + 1ms". That's a very slim error margin!

**Fix:**
the REAL fix would be to not use a timer here and actually await the animation to finish.

for now though, I just change this timer to 1 second