### PR TITLE
Fix uid duplication during paste

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
@@ -20,6 +20,7 @@ import {
   offsetPoint,
 } from '../../../../core/shared/math-utils'
 import type { CanvasPoint } from '../../../../core/shared/math-utils'
+import { optionalMap } from '../../../../core/shared/optional-utils'
 import type {
   ElementPath,
   ElementPathPart,
@@ -42,6 +43,7 @@ import type {
 import { trueUpGroupElementChanged } from '../../../editor/store/editor-state'
 import {
   childInsertionPath,
+  getFragmentUidFromInsertionPath,
   replaceWithElementsWrappedInFragmentBehaviour,
 } from '../../../editor/store/insertion-path'
 import type { CanvasCommand } from '../../commands/commands'
@@ -166,7 +168,10 @@ function pasteChoiceCommon(
         )
       : front()
 
-  let fixedUIDMappingNewUIDS: Array<string> = []
+  let fixedUIDMappingNewUIDS: Array<string> =
+    optionalMap((wrapperUid) => [wrapperUid], getFragmentUidFromInsertionPath(target.parentPath)) ??
+    []
+
   let oldPathToNewPathMapping: OldPathToNewPathMapping = {}
   const elementsToInsert: Array<ElementOrPathToInsert> =
     pasteContext.elementPasteWithMetadata.elements.map((elementPaste) => {

--- a/editor/src/components/editor/store/insertion-path.ts
+++ b/editor/src/components/editor/store/insertion-path.ts
@@ -113,6 +113,30 @@ export function insertionPathToString(insertionPath: InsertionPath): string {
     assertNever(insertionPath)
   }
 }
+export function getFragmentUidFromInsertionBehaviour(
+  insertionBehaviour: ConditionalClauseInsertBehavior,
+): string | null {
+  switch (insertionBehaviour.type) {
+    case 'replace-with-elements-wrapped-in-fragment':
+    case 'wrap-in-fragment-and-append-elements':
+      return insertionBehaviour.fragmentUID
+    case 'replace-with-single-element':
+      return null
+    default:
+      assertNever(insertionBehaviour)
+  }
+}
+
+export function getFragmentUidFromInsertionPath(insertionPath: InsertionPath): string | null {
+  switch (insertionPath.type) {
+    case 'CHILD_INSERTION':
+      return null
+    case 'CONDITIONAL_CLAUSE_INSERTION':
+      return getFragmentUidFromInsertionBehaviour(insertionPath.insertBehavior)
+    default:
+      assertNever(insertionPath)
+  }
+}
 
 export function commonInsertionPath(
   metadata: ElementInstanceMetadataMap,


### PR DESCRIPTION
## Problem
Pasting into slots might introduce duplicate uids into projects

## Root cause
When an element is pasted, we first look for a target parent, and then "fix" the uids of the pasted elements (to avoid duplicate uids). However, if an element is pasted into a slot, we need to pre-generate a uid for the fragment the pasted element might be wrapped into. The uid of this fragment wrapper might clash with one of the new uids generated during the fixing process.

The reason this only came out now is that
- pasting into a slot with a fragment wrapper is an edge case in itself (since it only happens when the content of a slot goes from a single child to multiple children)
- the fragment uid is generated from a UUID() call, while the new uids of the pasted elements are deterministically generated based on the uids already present in the project, and the test project is very small, so it's very unlikely that an already-existing uid would be generated

## Fix
When initializing the mapping for new uids (`fixedUIDMappingNewUIDS`), consider the uid of the fragment wrapper (if one is used).