### PR TITLE
Another try to fix flaky remix tests

### DIFF
--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -23,10 +23,10 @@ type RouteModule = RouteModules[keyof RouteModules]
 type RouterType = ReturnType<typeof createMemoryRouter>
 
 interface RemixNavigationContext {
-  forward: () => void
-  back: () => void
-  home: () => void
-  navigate: (loc: string) => void
+  forward: () => Promise<void>
+  back: () => Promise<void>
+  home: () => Promise<void>
+  navigate: (loc: string) => Promise<void>
   location: Location
   entries: Array<Location>
 }
@@ -258,10 +258,10 @@ export const UtopiaRemixRootComponent = (props: UtopiaRemixRootComponentProps) =
         return {
           ...current,
           [EP.toString(basePath)]: {
-            forward: () => void innerRouter.navigate(1),
-            back: () => void innerRouter.navigate(-1),
-            home: () => void innerRouter.navigate('/'),
-            navigate: (loc: string) => void innerRouter.navigate(loc),
+            forward: () => innerRouter.navigate(1),
+            back: () => innerRouter.navigate(-1),
+            home: () => innerRouter.navigate('/'),
+            navigate: (loc: string) => innerRouter.navigate(loc),
             location: location,
             entries: updatedEntries,
           },

--- a/editor/src/components/editor/remix-navigation-bar.tsx
+++ b/editor/src/components/editor/remix-navigation-bar.tsx
@@ -7,11 +7,13 @@ import {
   ActiveRemixSceneAtom,
   RemixNavigationAtom,
 } from '../canvas/remix/utopia-remix-root-component'
+import type { RemixNavigationAtomData } from '../canvas/remix/utopia-remix-root-component'
 import { Substores, useEditorState } from './store/store-hook'
 import { FlexRow, Tooltip, colorTheme } from '../../uuiui'
 import { stopPropagation } from '../inspector/common/inspector-utils'
 import * as EP from '../../core/shared/element-path'
 import { getRemixLocationLabel } from '../canvas/remix/remix-utils'
+import { IS_TEST_ENVIRONMENT } from '../../common/env-vars'
 
 export const RemixNavigationBarPathTestId = 'remix-navigation-bar-path'
 
@@ -20,8 +22,13 @@ export type RemixSceneLabelButtonType = 'back' | 'forward' | 'home'
 export const RemixNavigationBarButtonTestId = (button: RemixSceneLabelButtonType): string =>
   `remix-navigation-bar-button-${button}`
 
+export const RemixNavigationForTests: { current: RemixNavigationAtomData | null } = {
+  current: null,
+}
+
 export const RemixNavigationBar = React.memo(() => {
-  const [navigationControls] = useAtom(RemixNavigationAtom)
+  const navigationControls = useRemixNavigationAndExposeForTests()
+
   const [activeRemixScene] = useAtom(ActiveRemixSceneAtom)
 
   const isLiveMode = useEditorState(
@@ -121,3 +128,15 @@ export const RemixNavigationBar = React.memo(() => {
     </FlexRow>
   )
 })
+
+function useRemixNavigationAndExposeForTests() {
+  const [navigationControls] = useAtom(RemixNavigationAtom)
+
+  React.useEffect(() => {
+    if (IS_TEST_ENVIRONMENT) {
+      RemixNavigationForTests.current = navigationControls
+    }
+  }, [navigationControls])
+
+  return navigationControls
+}


### PR DESCRIPTION
**Description:**
I wanted to write a new version for the remix navigation tests where we directly use the remix navigation context stored in an atom (instead of clicking on the ui buttons).
It turned out that these new testa are even worse than the original ones: they fail quite frequently even locally. However, if I wait a bit before doing any expectation, they were always successful locally.
It seems to me that this navigation step is more async than we thought, and there is something to wait for (maybe inside the remix implementation?)
This gave me the idea to keep the original tests too, just add some extra `wait` calls, to check if those tests are fixed or not by that.