### PR TITLE
Fix: Change dns resolution order to ipv4 inBFF server

### DIFF
--- a/utopia-remix/app/util/proxy.server.ts
+++ b/utopia-remix/app/util/proxy.server.ts
@@ -1,6 +1,11 @@
 import urljoin from "url-join";
 import { ServerEnvironment } from "../env.server";
 import { proxiedResponse } from "./api.server";
+import dns from "dns";
+
+// this is a workaround for default DNS resolution order with Node > 17 (where ipv6 is first)
+// https://github.com/node-fetch/node-fetch/issues/1624#issuecomment-1235826631
+dns.setDefaultResultOrder("ipv4first");
 
 const BASE_URL = ServerEnvironment.BackendURL;
 


### PR DESCRIPTION
**Problem:**
In Node > 17, the default dns resolution is ipv6, which maps `localhost` to `::1`, and breaks the proxy.

**Fix:**
Setting the default dns resolving to ipv4 (the other workaround is to aloways call `127.0.0.1`, but that's a more robust fix)