### PR TITLE
Set ipv4 resolution only for local dev

### DIFF
--- a/utopia-remix/.env.sample
+++ b/utopia-remix/.env.sample
@@ -1,2 +1,3 @@
 CORS_ORIGIN="http://localhost:8000"
 BACKEND_URL="http://localhost:8001"
+SERVER_ENV="local"

--- a/utopia-remix/app/env.server.ts
+++ b/utopia-remix/app/env.server.ts
@@ -1,5 +1,5 @@
 export const ServerEnvironment = {
-  environment: process.env.NODE_ENV ?? "development",
+  environment: process.env.SERVER_ENV,
   // The URL of the actual backend server in the form <scheme>://<host>:<port>
   BackendURL: process.env.BACKEND_URL ?? "",
   // the CORS allowed origin for incoming requests

--- a/utopia-remix/app/env.server.ts
+++ b/utopia-remix/app/env.server.ts
@@ -1,3 +1,11 @@
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      SERVER_ENV?: "local" | "stage" | "prod" | "test";
+    }
+  }
+}
+
 export const ServerEnvironment = {
   environment: process.env.SERVER_ENV,
   // The URL of the actual backend server in the form <scheme>://<host>:<port>

--- a/utopia-remix/app/env.server.ts
+++ b/utopia-remix/app/env.server.ts
@@ -1,4 +1,5 @@
 export const ServerEnvironment = {
+  environment: process.env.NODE_ENV ?? "development",
   // The URL of the actual backend server in the form <scheme>://<host>:<port>
   BackendURL: process.env.BACKEND_URL ?? "",
   // the CORS allowed origin for incoming requests

--- a/utopia-remix/app/util/proxy.server.ts
+++ b/utopia-remix/app/util/proxy.server.ts
@@ -3,9 +3,11 @@ import { ServerEnvironment } from "../env.server";
 import { proxiedResponse } from "./api.server";
 import dns from "dns";
 
-// this is a workaround for default DNS resolution order with Node > 17 (where ipv6 is first)
-// https://github.com/node-fetch/node-fetch/issues/1624#issuecomment-1235826631
-dns.setDefaultResultOrder("ipv4first");
+if (ServerEnvironment.environment === "development") {
+  // this is a workaround for default DNS resolution order with Node > 17 (where ipv6 is first)
+  // https://github.com/node-fetch/node-fetch/issues/1624#issuecomment-1235826631
+  dns.setDefaultResultOrder("ipv4first");
+}
 
 const BASE_URL = ServerEnvironment.BackendURL;
 

--- a/utopia-remix/app/util/proxy.server.ts
+++ b/utopia-remix/app/util/proxy.server.ts
@@ -3,8 +3,8 @@ import { ServerEnvironment } from "../env.server";
 import { proxiedResponse } from "./api.server";
 import dns from "dns";
 
-if (ServerEnvironment.environment === "development") {
-  // this is a workaround for default DNS resolution order with Node > 17 (where ipv6 is first)
+if (ServerEnvironment.environment === "local") {
+  // this is a workaround for default DNS resolution order with Node > 17 (where ipv6 comes first)
   // https://github.com/node-fetch/node-fetch/issues/1624#issuecomment-1235826631
   dns.setDefaultResultOrder("ipv4first");
 }


### PR DESCRIPTION
**Problem:**
We don't need to set the dns resolution order for anything else other than local dev

**Fix:**
Check server env before setting the resolution order

#### This requires adding this line to your `utopia-remix/.env`:
```
SERVER_ENV="local"
```
