### PR TITLE
Stable Function Parameter Handling.

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`UiJsxCanvas render Label carried through for generated elements 1`] = `
     id=\\"canvas-container\\"
     data-testid=\\"canvas-container\\"
     style=\\"position: absolute\\"
-    data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/2c3 utopia-storyboard-uid/scene-aaa/app-entity:aaa/2c3/bbb\\"
+    data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/4e3 utopia-storyboard-uid/scene-aaa/app-entity:aaa/4e3/bbb\\"
     data-utopia-root-element-path=\\"utopia-storyboard-uid\\"
   >
     <div
@@ -41,17 +41,17 @@ exports[`UiJsxCanvas render Label carried through for generated elements 1`] = `
         <div
           data-uid=\\"bbb~~~1\\"
           data-label=\\"Plane\\"
-          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/2c3/bbb~~~1\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/4e3/bbb~~~1\\"
         ></div>
         <div
           data-uid=\\"bbb~~~2\\"
           data-label=\\"Plane\\"
-          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/2c3/bbb~~~2\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/4e3/bbb~~~2\\"
         ></div>
         <div
           data-uid=\\"bbb~~~3\\"
           data-label=\\"Plane\\"
-          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/2c3/bbb~~~3\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/4e3/bbb~~~3\\"
         ></div>
       </div>
     </div>
@@ -471,7 +471,7 @@ Object {
           })",
             "sourceMap": Object {
               "file": "code.tsx",
-              "mappings": "OAAE,CAAD,CAAC,EAAD,CAAC,EAAD,CAAC,EAAD,GAAC,CAAa,UAAC,CAAD,EAAK;AACR;AAAA;AAAA;AADZ,CAAE,CAAD",
+              "mappings": "OAAE,CAAD,CAAC,EAAD,CAAC,EAAD,CAAC,EAAD,GAAC,CAAa,UAAC,CAAD,EAAK;AACR;AAAA;AAAA;AAAA;AADZ,CAAE,CAAD",
               "names": Array [],
               "sources": Array [
                 "code.tsx",
@@ -508,6 +508,7 @@ Object {
             },
             "transpiledJavascript": "return [1, 2, 3].map(function (n) {
   return utopiaCanvasJSXLookup(\\"bbb\\", {
+    n: n,
     callerThis: this
   });
 });",
@@ -709,7 +710,7 @@ Object {
     },
     "textContent": null,
   },
-  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/2c3": Object {
+  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/4e3": Object {
     "attributeMetadatada": Object {},
     "componentInstance": false,
     "computedStyle": Object {},
@@ -782,7 +783,7 @@ Object {
           })",
         "sourceMap": Object {
           "file": "code.tsx",
-          "mappings": "OAAE,CAAD,CAAC,EAAD,CAAC,EAAD,CAAC,EAAD,GAAC,CAAa,UAAC,CAAD,EAAK;AACR;AAAA;AAAA;AADZ,CAAE,CAAD",
+          "mappings": "OAAE,CAAD,CAAC,EAAD,CAAC,EAAD,CAAC,EAAD,GAAC,CAAa,UAAC,CAAD,EAAK;AACR;AAAA;AAAA;AAAA;AADZ,CAAE,CAAD",
           "names": Array [],
           "sources": Array [
             "code.tsx",
@@ -819,6 +820,7 @@ Object {
         },
         "transpiledJavascript": "return [1, 2, 3].map(function (n) {
   return utopiaCanvasJSXLookup(\\"bbb\\", {
+    n: n,
     callerThis: this
   });
 });",
@@ -838,7 +840,7 @@ Object {
         ],
         Array [
           "aaa",
-          "2c3",
+          "4e3",
         ],
       ],
       "type": "elementpath",
@@ -908,7 +910,7 @@ Object {
     },
     "textContent": null,
   },
-  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/2c3/bbb~~~1": Object {
+  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/4e3/bbb~~~1": Object {
     "attributeMetadatada": Object {},
     "componentInstance": false,
     "computedStyle": Object {},
@@ -972,7 +974,7 @@ Object {
         ],
         Array [
           "aaa",
-          "2c3",
+          "4e3",
           "bbb~~~1",
         ],
       ],
@@ -1047,7 +1049,7 @@ Object {
     },
     "textContent": null,
   },
-  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/2c3/bbb~~~2": Object {
+  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/4e3/bbb~~~2": Object {
     "attributeMetadatada": Object {},
     "componentInstance": false,
     "computedStyle": Object {},
@@ -1111,7 +1113,7 @@ Object {
         ],
         Array [
           "aaa",
-          "2c3",
+          "4e3",
           "bbb~~~2",
         ],
       ],
@@ -1186,7 +1188,7 @@ Object {
     },
     "textContent": null,
   },
-  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/2c3/bbb~~~3": Object {
+  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/4e3/bbb~~~3": Object {
     "attributeMetadatada": Object {},
     "componentInstance": false,
     "computedStyle": Object {},
@@ -1250,7 +1252,7 @@ Object {
         ],
         Array [
           "aaa",
-          "2c3",
+          "4e3",
           "bbb~~~3",
         ],
       ],
@@ -15396,7 +15398,7 @@ exports[`UiJsxCanvas render function component works inside a map 1`] = `
     id=\\"canvas-container\\"
     data-testid=\\"canvas-container\\"
     style=\\"position: absolute\\"
-    data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity:zzz/fc2 utopia-storyboard-uid/scene-aaa/app-entity:zzz/fc2/aaa\\"
+    data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity:zzz/dcf utopia-storyboard-uid/scene-aaa/app-entity:zzz/dcf/aaa\\"
     data-utopia-root-element-path=\\"utopia-storyboard-uid\\"
   >
     <div
@@ -15429,13 +15431,13 @@ exports[`UiJsxCanvas render function component works inside a map 1`] = `
       >
         <div
           data-uid=\\"ccc\\"
-          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/fc2/aaa~~~1:ccc\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/dcf/aaa~~~1:ccc\\"
         >
           Thing
         </div>
         <div
           data-uid=\\"ccc\\"
-          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/fc2/aaa~~~2:ccc\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/dcf/aaa~~~2:ccc\\"
         >
           Thing
         </div>
@@ -15841,7 +15843,7 @@ Object {
             })",
             "sourceMap": Object {
               "file": "code.tsx",
-              "mappings": "OAAE,CAAD,CAAC,EAAD,CAAC,EAAD,GAAC,CAAWA,UAAD,IAACA,EAAS;AACR;AAAA;AAAA;AADd,CAAE,CAAD",
+              "mappings": "OAAE,CAAD,CAAC,EAAD,CAAC,EAAD,GAAC,CAAWA,UAAD,IAACA,EAAS;AACR;AAAA;AAAA;AAAA;AADd,CAAE,CAAD",
               "names": Array [
                 "data",
               ],
@@ -15881,6 +15883,7 @@ Object {
             },
             "transpiledJavascript": "return [1, 2].map(function (data) {
   return utopiaCanvasJSXLookup(\\"aaa\\", {
+    data: data,
     callerThis: this
   });
 });",
@@ -16002,7 +16005,7 @@ Object {
     },
     "textContent": null,
   },
-  "utopia-storyboard-uid/scene-aaa/app-entity:zzz/fc2": Object {
+  "utopia-storyboard-uid/scene-aaa/app-entity:zzz/dcf": Object {
     "attributeMetadatada": Object {},
     "componentInstance": false,
     "computedStyle": Object {},
@@ -16059,7 +16062,7 @@ Object {
             })",
         "sourceMap": Object {
           "file": "code.tsx",
-          "mappings": "OAAE,CAAD,CAAC,EAAD,CAAC,EAAD,GAAC,CAAWA,UAAD,IAACA,EAAS;AACR;AAAA;AAAA;AADd,CAAE,CAAD",
+          "mappings": "OAAE,CAAD,CAAC,EAAD,CAAC,EAAD,GAAC,CAAWA,UAAD,IAACA,EAAS;AACR;AAAA;AAAA;AAAA;AADd,CAAE,CAAD",
           "names": Array [
             "data",
           ],
@@ -16099,6 +16102,7 @@ Object {
         },
         "transpiledJavascript": "return [1, 2].map(function (data) {
   return utopiaCanvasJSXLookup(\\"aaa\\", {
+    data: data,
     callerThis: this
   });
 });",
@@ -16118,7 +16122,7 @@ Object {
         ],
         Array [
           "zzz",
-          "fc2",
+          "dcf",
         ],
       ],
       "type": "elementpath",
@@ -16188,7 +16192,7 @@ Object {
     },
     "textContent": null,
   },
-  "utopia-storyboard-uid/scene-aaa/app-entity:zzz/fc2/aaa~~~1": Object {
+  "utopia-storyboard-uid/scene-aaa/app-entity:zzz/dcf/aaa~~~1": Object {
     "attributeMetadatada": Object {},
     "componentInstance": false,
     "computedStyle": Object {},
@@ -16235,7 +16239,7 @@ Object {
         ],
         Array [
           "zzz",
-          "fc2",
+          "dcf",
           "aaa~~~1",
         ],
       ],
@@ -16310,7 +16314,7 @@ Object {
     },
     "textContent": null,
   },
-  "utopia-storyboard-uid/scene-aaa/app-entity:zzz/fc2/aaa~~~2": Object {
+  "utopia-storyboard-uid/scene-aaa/app-entity:zzz/dcf/aaa~~~2": Object {
     "attributeMetadatada": Object {},
     "componentInstance": false,
     "computedStyle": Object {},
@@ -16357,7 +16361,7 @@ Object {
         ],
         Array [
           "zzz",
-          "fc2",
+          "dcf",
           "aaa~~~2",
         ],
       ],
@@ -40201,7 +40205,7 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block with 
     id=\\"canvas-container\\"
     data-testid=\\"canvas-container\\"
     style=\\"position: absolute\\"
-    data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/4c9 utopia-storyboard-uid/scene-aaa/app-entity:aaa/4c9/bbb\\"
+    data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/1f1 utopia-storyboard-uid/scene-aaa/app-entity:aaa/1f1/bbb\\"
     data-utopia-root-element-path=\\"utopia-storyboard-uid\\"
   >
     <div
@@ -40234,19 +40238,19 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block with 
       >
         <div
           data-uid=\\"xxx\\"
-          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/4c9/bbb~~~1:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/1f1/bbb~~~1:xxx\\"
         >
           n1
         </div>
         <div
           data-uid=\\"xxx\\"
-          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/4c9/bbb~~~2:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/1f1/bbb~~~2:xxx\\"
         >
           n2
         </div>
         <div
           data-uid=\\"xxx\\"
-          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/4c9/bbb~~~3:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/1f1/bbb~~~3:xxx\\"
         >
           n3
         </div>
@@ -40717,7 +40721,7 @@ Object {
            ))",
             "sourceMap": Object {
               "file": "code.tsx",
-              "mappings": "OAACA,YAAaC,CAAbD,IAAkB;AAAA,mDAAG,CAAH,CAAQ,CAAR,CAAa,CAAb;AAAA,MAAD,CAAC;;AAAA;AAAA;AAAA;AAAA;AAAA,CAAlBA",
+              "mappings": "OAACA,YAAaC,CAAbD,IAAkB;AAAA,mDAAG,CAAH,CAAQ,CAAR,CAAa,CAAb;AAAA,MAAD,CAAC;;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,CAAlBA",
               "names": Array [
                 "nestedThings",
                 "map",
@@ -40762,6 +40766,7 @@ Object {
       n = _ref$a$b$c[0];
 
   return utopiaCanvasJSXLookup(\\"bbb\\", {
+    _ref: _ref,
     n: n,
     callerThis: this
   });
@@ -40885,7 +40890,7 @@ Object {
     },
     "textContent": null,
   },
-  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/4c9": Object {
+  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/1f1": Object {
     "attributeMetadatada": Object {},
     "componentInstance": false,
     "computedStyle": Object {},
@@ -41007,7 +41012,7 @@ Object {
            ))",
         "sourceMap": Object {
           "file": "code.tsx",
-          "mappings": "OAACA,YAAaC,CAAbD,IAAkB;AAAA,mDAAG,CAAH,CAAQ,CAAR,CAAa,CAAb;AAAA,MAAD,CAAC;;AAAA;AAAA;AAAA;AAAA;AAAA,CAAlBA",
+          "mappings": "OAACA,YAAaC,CAAbD,IAAkB;AAAA,mDAAG,CAAH,CAAQ,CAAR,CAAa,CAAb;AAAA,MAAD,CAAC;;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,CAAlBA",
           "names": Array [
             "nestedThings",
             "map",
@@ -41052,6 +41057,7 @@ Object {
       n = _ref$a$b$c[0];
 
   return utopiaCanvasJSXLookup(\\"bbb\\", {
+    _ref: _ref,
     n: n,
     callerThis: this
   });
@@ -41072,7 +41078,7 @@ Object {
         ],
         Array [
           "aaa",
-          "4c9",
+          "1f1",
         ],
       ],
       "type": "elementpath",
@@ -41142,7 +41148,7 @@ Object {
     },
     "textContent": null,
   },
-  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/4c9/bbb~~~1": Object {
+  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/1f1/bbb~~~1": Object {
     "attributeMetadatada": Object {},
     "componentInstance": false,
     "computedStyle": Object {},
@@ -41254,7 +41260,7 @@ Object {
         ],
         Array [
           "aaa",
-          "4c9",
+          "1f1",
           "bbb~~~1",
         ],
       ],
@@ -41329,7 +41335,7 @@ Object {
     },
     "textContent": null,
   },
-  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/4c9/bbb~~~2": Object {
+  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/1f1/bbb~~~2": Object {
     "attributeMetadatada": Object {},
     "componentInstance": false,
     "computedStyle": Object {},
@@ -41441,7 +41447,7 @@ Object {
         ],
         Array [
           "aaa",
-          "4c9",
+          "1f1",
           "bbb~~~2",
         ],
       ],
@@ -41516,7 +41522,7 @@ Object {
     },
     "textContent": null,
   },
-  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/4c9/bbb~~~3": Object {
+  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/1f1/bbb~~~3": Object {
     "attributeMetadatada": Object {},
     "componentInstance": false,
     "computedStyle": Object {},
@@ -41628,7 +41634,7 @@ Object {
         ],
         Array [
           "aaa",
-          "4c9",
+          "1f1",
           "bbb~~~3",
         ],
       ],

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-utils.ts
@@ -618,7 +618,7 @@ export function applyElementCeilingToReparentTarget(
               // If the intended parent path is above the ceiling path then
               // change it to the ceiling path instead.
               const ceilingStaticPath = EP.dynamicPathToStaticPath(elementCeiling)
-              if (EP.depth(intendedParentPath) < EP.depth(ceilingStaticPath)) {
+              if (EP.fullDepth(intendedParentPath) < EP.fullDepth(ceilingStaticPath)) {
                 // Make sure it's valid to insert into.
                 if (
                   canInsertIntoTarget(

--- a/editor/src/components/editor/variablesmenu.spec.browser2.tsx
+++ b/editor/src/components/editor/variablesmenu.spec.browser2.tsx
@@ -171,7 +171,7 @@ describe('variables menu', () => {
 
       await selectComponentsForTest(editor, [
         EP.fromString(
-          `${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:container/676/020~~~1`,
+          `${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:container/976/020~~~1`,
         ),
       ])
 
@@ -198,10 +198,7 @@ describe('variables menu', () => {
         ),
       ])
     })
-    xit('shows and inserts scoped properties when possible', async () => {
-      // Test disabled because it uncovered an issue with an exception being triggered for a frame on the canvas.
-      // But it has been seemingly impossible to capture the exception in a way that permits the test to continue.
-      // Solution appears to be to fix the flickering of an error in subsequent work.
+    it('shows and inserts scoped properties when possible', async () => {
       const editor = await renderTestEditorWithProjectContent(
         makeMappingFunctionTestProjectContents(),
         'await-first-dom-report',
@@ -209,7 +206,7 @@ describe('variables menu', () => {
 
       await selectComponentsForTest(editor, [
         EP.fromString(
-          `${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:container/1ac/586~~~1`,
+          `${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:container/3e2/586~~~1`,
         ),
       ])
 
@@ -247,19 +244,115 @@ describe('variables menu', () => {
                     src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
                     alt='Utopia logo'
                     style={{ width: 118, height: 150 }}
+                    data-uid='020'
                   />
                 )
               })}
               {[{ thing: 1 }, { thing: 2 }, { thing: 3 }].map(
                 (someValue, index) => {
                   return (
-                    <div
-                    >
+                    <div data-uid='586'>
                       <img
                         src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
                         alt='Utopia logo'
                         style={{ width: 118, height: 150 }}
+                        data-uid='054'
                       />
+                      <span
+                        style={{
+                          width: 100,
+                          height: 100,
+                          position: 'absolute',
+                        }}
+                        data-uid='ele'
+                      >
+                        {index}
+                      </span>
+                    </div>
+                  )
+                },
+              )}
+            </div>
+            )
+          }`,
+          PrettierConfig,
+        ),
+      )
+    })
+
+    it('shows and inserts scoped properties when possible with multiple elements selected', async () => {
+      const editor = await renderTestEditorWithProjectContent(
+        makeMappingFunctionTestProjectContents(),
+        'await-first-dom-report',
+      )
+
+      await selectComponentsForTest(editor, [
+        EP.fromString(
+          `${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:container/3e2/586~~~1`,
+        ),
+        EP.fromString(
+          `${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:container/3e2/586~~~2`,
+        ),
+      ])
+
+      await openVariablesMenu(editor)
+
+      document.execCommand('insertText', false, 'index')
+      expect(getInsertItems().length).toEqual(1)
+      expect(getInsertItems()[0].innerText).toEqual('index')
+
+      const filterBox = await screen.findByTestId(InsertMenuFilterTestId)
+      forceNotNull('the filter box must not be null', filterBox)
+
+      await pressKey('Enter', { targetElement: filterBox })
+
+      expect(getPrintedUiJsCode(editor.getEditorState(), '/src/app.js')).toEqual(
+        Prettier.format(
+          `
+          import * as React from 'react'
+          export function App({objProp, imgProp, unusedProp}) {
+            return (
+              <div
+              style={{
+                backgroundColor: '#aaaaaa33',
+                position: 'absolute',
+                left: 57,
+                top: 168,
+                width: 247,
+                height: 402,
+              }}
+              data-uid='container'
+            >
+              {[1, 2].map((value, index) => {
+                return (
+                  <img
+                    src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
+                    alt='Utopia logo'
+                    style={{ width: 118, height: 150 }}
+                    data-uid='020'
+                  />
+                )
+              })}
+              {[{ thing: 1 }, { thing: 2 }, { thing: 3 }].map(
+                (someValue, index) => {
+                  return (
+                    <div data-uid='586'>
+                      <img
+                        src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
+                        alt='Utopia logo'
+                        style={{ width: 118, height: 150 }}
+                        data-uid='054'
+                      />
+                      <span
+                        style={{
+                          width: 100,
+                          height: 100,
+                          position: 'absolute',
+                        }}
+                        data-uid='ele'
+                      >
+                        {index}
+                      </span>
                     </div>
                   )
                 },

--- a/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.tsx
@@ -304,6 +304,7 @@ export var whatever = (props) => {
           `return arr.map(function (_ref) {
   var n = _ref.n;
   return utopiaCanvasJSXLookup("aab", {
+    _ref: _ref,
     n: n,
     callerThis: this
   });
@@ -410,6 +411,7 @@ export var whatever = (props) => {
           `return arr.map(function (_ref) {
   var n = _ref.a.n;
   return utopiaCanvasJSXLookup("aab", {
+    _ref: _ref,
     n: n,
     callerThis: this
   });
@@ -512,6 +514,7 @@ export var whatever = (props) => {
       n = _ref2[0];
 
   return utopiaCanvasJSXLookup(\"aab\", {
+    _ref: _ref,
     n: n,
     callerThis: this
   });

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -3850,6 +3850,7 @@ export var App = props => {
             `[1, 2, 3].map((x) => <View data-uid='abc' />);`,
             `return [1, 2, 3].map(function (x) {
   return utopiaCanvasJSXLookup("abc", {
+    x: x,
     callerThis: this
   });
 });`,
@@ -3984,6 +3985,7 @@ export var App = props => {
 <div data-uid="abc" />);`,
             `return [1, 2, 3].map(function (n) {
   return utopiaCanvasJSXLookup("abc", {
+    n: n,
     callerThis: this
   });
 });`,
@@ -4048,6 +4050,7 @@ export var App = props => {
 <div data-uid='abc' />);`,
             `return [1, 2, 3].map(function (n) {
   return utopiaCanvasJSXLookup("abc", {
+    n: n,
     callerThis: this
   });
 });`,


### PR DESCRIPTION
**Problem:**
When adding a scoped variable which is a function parameter there's a brief flash of an error before the canvas renders properly immediately after.

**Cause:**
The `utopiaCanvasJSXLookup` function takes an object containing values defined elsewhere ordinarily. But since the snippet of code containing that is only produced during a parse (and put into the `transpiledJavaScript` field) it meant that the code in the situation above would only correctly render once a print-parse pass had completed. This is because the values come from introspecting the children of the map expression and only including the values that are in there. As this doesn't happen during the update itself we end up with a model that fails because the `index` parameter (for example) isn't present in the scope object passed to `utopiaCanvasJSXLookup`.

**Fix:**
This change adds in some additional introspection in the Babel transpilation that inserts the call to `utopiaCanvasJSXLookup`, which adds in all the function parameters up the tree of the AST from the code in question. This results in the scope object being more stable than it was where it would change once a new field was inserted.

This work also includes an additional fix to the multi-selection case not applying the insertion ceiling correctly causing a reference failure in the resultant code.

**Commit Details:**
- `babelRewriteJSExpressionCode` now walks up the tree looking for functions and their parameters to ensure that their values are included in the scope object supplied to `utopiaCanvasJSXLookup`.
- Now `applyElementCeilingToReparentTarget` uses `fullDepth` instead of `depth` so that in a multi-selection case the insertion result works the same as a single-selection case.
