### PR TITLE
Fix Flaky Comment Tests

### DIFF
--- a/puppeteer-tests/src/comments/commenting.spec.tsx
+++ b/puppeteer-tests/src/comments/commenting.spec.tsx
@@ -221,7 +221,7 @@ describe('Comments test', () => {
     expect(commentsTabs).toHaveLength(0)
   })
 
-  it.only('can reparent comment', async () => {
+  it('can reparent comment', async () => {
     const page = await initSignedInBrowserTest(utopiaBrowser)
     await enterCommentMode(page)
     await wait(1000)

--- a/puppeteer-tests/src/comments/commenting.spec.tsx
+++ b/puppeteer-tests/src/comments/commenting.spec.tsx
@@ -221,7 +221,7 @@ describe('Comments test', () => {
     expect(commentsTabs).toHaveLength(0)
   })
 
-  it('can reparent comment', async () => {
+  it.only('can reparent comment', async () => {
     const page = await initSignedInBrowserTest(utopiaBrowser)
     await enterCommentMode(page)
 

--- a/puppeteer-tests/src/comments/commenting.spec.tsx
+++ b/puppeteer-tests/src/comments/commenting.spec.tsx
@@ -224,6 +224,7 @@ describe('Comments test', () => {
   it.only('can reparent comment', async () => {
     const page = await initSignedInBrowserTest(utopiaBrowser)
     await enterCommentMode(page)
+    await wait(1000)
 
     const playgroundSceneBoundingBox = roundBoundingBox(
       await getBoundingBox(page, PlaygroundSceneSelector),
@@ -235,6 +236,7 @@ describe('Comments test', () => {
       playgroundSceneBoundingBox.x - 100,
       playgroundSceneBoundingBox.y - 100,
     )
+    await wait(1000)
 
     const originalCommentIndicatorBoundingBox = roundBoundingBox(
       await getBoundingBox(page, CommentIndicatorSelector),
@@ -253,8 +255,10 @@ describe('Comments test', () => {
       center(originalCommentIndicatorBoundingBox),
       center(playgroundSceneBoundingBox),
     )
+    await wait(1000)
 
     await dismissHoverPreview(page)
+    await wait(1000)
     const commentBoundingBoxInScene = roundBoundingBox(
       await getBoundingBox(page, CommentIndicatorSelector),
     )
@@ -278,6 +282,7 @@ describe('Comments test', () => {
       offsetPoint(sceneToolBarCenter, { offsetX: 50, offsetY: 50 }),
     )
 
+    await wait(1000)
     const commentBoundingBoxInMovedScene = roundBoundingBox(
       await getBoundingBox(page, CommentIndicatorSelector),
     )
@@ -298,8 +303,10 @@ describe('Comments test', () => {
       x: movedSceneBoundingBox.x - 50,
       y: movedSceneBoundingBox.y - 50,
     })
+    await wait(1000)
 
     await dismissHoverPreview(page)
+    await wait(1000)
     const commentBoundingBoxBackOnCanvasBeforeMove = roundBoundingBox(
       await getBoundingBox(page, CommentIndicatorSelector),
     )
@@ -321,6 +328,7 @@ describe('Comments test', () => {
       movedSceneLabelCenter,
       offsetPoint(movedSceneLabelCenter, { offsetX: 150, offsetY: 150 }),
     )
+    await wait(1000)
     const commentBoundingBoxBackOnCanvasAfterMove = roundBoundingBox(
       await getBoundingBox(page, CommentIndicatorSelector),
     )

--- a/puppeteer-tests/src/comments/commenting.spec.tsx
+++ b/puppeteer-tests/src/comments/commenting.spec.tsx
@@ -222,6 +222,12 @@ describe('Comments test', () => {
   })
 
   it('can reparent comment', async () => {
+    // The `wait` calls sprinkled through this test appear to give the Liveblocks
+    // backend a chance to stabilise the values that we repeatedly update relating to the
+    // position of the comment thread. Otherwise every so often the position seems to
+    // "reset" and the comment indicator snaps back to a previous position.
+    // As the test runs unnaturally fast, perhaps multiple changes are inflight behind the
+    // scenes and then they have to resolve that conflict.
     const page = await initSignedInBrowserTest(utopiaBrowser)
     await enterCommentMode(page)
     await wait(1000)

--- a/puppeteer-tests/src/comments/commenting.spec.tsx
+++ b/puppeteer-tests/src/comments/commenting.spec.tsx
@@ -351,8 +351,15 @@ describe('Comments test', () => {
   })
 
   it('scene comment canvas coordinates are maintained when scene is moved', async () => {
+    // The `wait` calls sprinkled through this test appear to give the Liveblocks
+    // backend a chance to stabilise the values that we repeatedly update relating to the
+    // position of the comment thread. Otherwise every so often the position seems to
+    // "reset" and the comment indicator snaps back to a previous position.
+    // As the test runs unnaturally fast, perhaps multiple changes are inflight behind the
+    // scenes and then they have to resolve that conflict.
     const page = await initSignedInBrowserTest(utopiaBrowser)
     await enterCommentMode(page)
+    await wait(1000)
 
     const playgroundSceneBoundingBox = roundBoundingBox(
       await getBoundingBox(page, PlaygroundSceneSelector),
@@ -365,10 +372,12 @@ describe('Comments test', () => {
       playgroundSceneBoundingBox.x + 100,
       playgroundSceneBoundingBox.y + 100,
     )
+    await wait(1000)
 
     // Leave comment mode by pressing ESC twice
     await page.keyboard.press('Escape')
     await page.keyboard.press('Escape')
+    await wait(1000)
 
     const sceneToolBarBoundingBox = roundBoundingBox(
       await getBoundingBox(page, SceneToolbarSelector),
@@ -381,17 +390,20 @@ describe('Comments test', () => {
       sceneToolBarCenter,
       offsetPoint(sceneToolBarCenter, { offsetX: 50, offsetY: 50 }),
     )
+    await wait(1000)
 
     const movedSceneBoundingBox = roundBoundingBox(await getBoundingBox(page, SceneToolbarSelector))
     const movedSceneBoundingBoxCenter = roundPoint(center(movedSceneBoundingBox))
 
     await page.mouse.click(movedSceneBoundingBoxCenter.x, movedSceneBoundingBoxCenter.y)
+    await wait(1000)
 
     const commentBoundingBoxBackOnCanvasBeforeDelete = roundBoundingBox(
       await getBoundingBox(page, CommentIndicatorSelector),
     )
     // delete the scene
     await page.keyboard.press('Backspace')
+    await wait(1000)
 
     const commentBoundingBoxBackOnCanvasAfterDelete = roundBoundingBox(
       await getBoundingBox(page, CommentIndicatorSelector),

--- a/puppeteer-tests/src/comments/commenting.spec.tsx
+++ b/puppeteer-tests/src/comments/commenting.spec.tsx
@@ -60,6 +60,8 @@ async function dismissHoverPreview(page: Page) {
   await wait(1000) // wait for the animation duration (100ms) + flaky test buffer (900ms)
 }
 
+const PauseTimeForLiveblocksSettling = 2000
+
 describe('Comments test', () => {
   let utopiaBrowser = createUtopiaPuppeteerBrowser()
 
@@ -230,7 +232,7 @@ describe('Comments test', () => {
     // scenes and then they have to resolve that conflict.
     const page = await initSignedInBrowserTest(utopiaBrowser)
     await enterCommentMode(page)
-    await wait(1000)
+    await wait(PauseTimeForLiveblocksSettling)
 
     const playgroundSceneBoundingBox = roundBoundingBox(
       await getBoundingBox(page, PlaygroundSceneSelector),
@@ -242,7 +244,7 @@ describe('Comments test', () => {
       playgroundSceneBoundingBox.x - 100,
       playgroundSceneBoundingBox.y - 100,
     )
-    await wait(1000)
+    await wait(PauseTimeForLiveblocksSettling)
 
     const originalCommentIndicatorBoundingBox = roundBoundingBox(
       await getBoundingBox(page, CommentIndicatorSelector),
@@ -261,10 +263,10 @@ describe('Comments test', () => {
       center(originalCommentIndicatorBoundingBox),
       center(playgroundSceneBoundingBox),
     )
-    await wait(1000)
+    await wait(PauseTimeForLiveblocksSettling)
 
     await dismissHoverPreview(page)
-    await wait(1000)
+    await wait(PauseTimeForLiveblocksSettling)
     const commentBoundingBoxInScene = roundBoundingBox(
       await getBoundingBox(page, CommentIndicatorSelector),
     )
@@ -288,7 +290,7 @@ describe('Comments test', () => {
       offsetPoint(sceneToolBarCenter, { offsetX: 50, offsetY: 50 }),
     )
 
-    await wait(1000)
+    await wait(PauseTimeForLiveblocksSettling)
     const commentBoundingBoxInMovedScene = roundBoundingBox(
       await getBoundingBox(page, CommentIndicatorSelector),
     )
@@ -309,10 +311,10 @@ describe('Comments test', () => {
       x: movedSceneBoundingBox.x - 50,
       y: movedSceneBoundingBox.y - 50,
     })
-    await wait(1000)
+    await wait(PauseTimeForLiveblocksSettling)
 
     await dismissHoverPreview(page)
-    await wait(1000)
+    await wait(PauseTimeForLiveblocksSettling)
     const commentBoundingBoxBackOnCanvasBeforeMove = roundBoundingBox(
       await getBoundingBox(page, CommentIndicatorSelector),
     )
@@ -334,7 +336,7 @@ describe('Comments test', () => {
       movedSceneLabelCenter,
       offsetPoint(movedSceneLabelCenter, { offsetX: 150, offsetY: 150 }),
     )
-    await wait(1000)
+    await wait(PauseTimeForLiveblocksSettling)
     const commentBoundingBoxBackOnCanvasAfterMove = roundBoundingBox(
       await getBoundingBox(page, CommentIndicatorSelector),
     )
@@ -359,7 +361,7 @@ describe('Comments test', () => {
     // scenes and then they have to resolve that conflict.
     const page = await initSignedInBrowserTest(utopiaBrowser)
     await enterCommentMode(page)
-    await wait(1000)
+    await wait(PauseTimeForLiveblocksSettling)
 
     const playgroundSceneBoundingBox = roundBoundingBox(
       await getBoundingBox(page, PlaygroundSceneSelector),
@@ -372,12 +374,12 @@ describe('Comments test', () => {
       playgroundSceneBoundingBox.x + 100,
       playgroundSceneBoundingBox.y + 100,
     )
-    await wait(1000)
+    await wait(PauseTimeForLiveblocksSettling)
 
     // Leave comment mode by pressing ESC twice
     await page.keyboard.press('Escape')
     await page.keyboard.press('Escape')
-    await wait(1000)
+    await wait(PauseTimeForLiveblocksSettling)
 
     const sceneToolBarBoundingBox = roundBoundingBox(
       await getBoundingBox(page, SceneToolbarSelector),
@@ -390,20 +392,20 @@ describe('Comments test', () => {
       sceneToolBarCenter,
       offsetPoint(sceneToolBarCenter, { offsetX: 50, offsetY: 50 }),
     )
-    await wait(1000)
+    await wait(PauseTimeForLiveblocksSettling)
 
     const movedSceneBoundingBox = roundBoundingBox(await getBoundingBox(page, SceneToolbarSelector))
     const movedSceneBoundingBoxCenter = roundPoint(center(movedSceneBoundingBox))
 
     await page.mouse.click(movedSceneBoundingBoxCenter.x, movedSceneBoundingBoxCenter.y)
-    await wait(1000)
+    await wait(PauseTimeForLiveblocksSettling)
 
     const commentBoundingBoxBackOnCanvasBeforeDelete = roundBoundingBox(
       await getBoundingBox(page, CommentIndicatorSelector),
     )
     // delete the scene
     await page.keyboard.press('Backspace')
-    await wait(1000)
+    await wait(PauseTimeForLiveblocksSettling)
 
     const commentBoundingBoxBackOnCanvasAfterDelete = roundBoundingBox(
       await getBoundingBox(page, CommentIndicatorSelector),


### PR DESCRIPTION
**Problem:**
A couple of the comments tests fail somewhat randomly, especially when run on the CI servers.

**Cause:**
The root of this seems to be (from examining the state with logging) of changes being fed into the thread metadata then reverting shortly afterwards. Since the tests run at an inhumanely fast pace, those changes fire rapidly and potentially end up in a state of conflict behind the scenes in however Liveblocks store that data.

**Fix:**
The two tests that appear to suffer from this issue have now had a series of short pauses added after user events are fired, to give the change a chance to resolve before moving onto another.

**Commit Details:**
- Tests have pauses added after each action to hopefully give things a chance to settle.