### PR TITLE
Minor fixes to shell.nix to support nix docker deployment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -637,9 +637,17 @@ let
   withCustomDevScripts = withServerRunScripts ++ (lib.optionals includeRunLocallySupport customDevScripts);
 
   releaseScripts = [
+    (pkgs.writeScriptBin "prepare-build-editor" ''
+      #!/usr/bin/env bash
+      set -e
+      install-utopia-api
+      build-utopia-vscode-common
+      install-website
+    '')
     (pkgs.writeScriptBin "build-editor-production" ''
       #!/usr/bin/env bash
       set -e
+      prepare-build-editor
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/editor
       ${pnpm}/bin/pnpm install --unsafe-perm
       ${pnpm}/bin/pnpm run production
@@ -647,9 +655,7 @@ let
     (pkgs.writeScriptBin "build-editor-staging" ''
       #!/usr/bin/env bash
       set -e
-      install-utopia-api
-      build-utopia-vscode-common
-      install-website
+      prepare-build-editor
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/editor
       ${pnpm}/bin/pnpm install --unsafe-perm
       ${pnpm}/bin/pnpm run staging

--- a/shell.nix
+++ b/shell.nix
@@ -240,6 +240,12 @@ let
       build-utopia-vscode-extension
       build-vscode
     '')
+    (pkgs.writeScriptBin "pull-extension" ''
+      #!/usr/bin/env bash
+      set -e
+      cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/vscode-build
+      nix-shell --run pull-extension-inner
+    '')
     (pkgs.writeScriptBin "check-tool-versions" ''
       #! /usr/bin/env nix-shell
       #! nix-shell -p "haskellPackages.ghcWithPackages (pkgs: with pkgs; [async process])" -i runhaskell
@@ -525,12 +531,6 @@ let
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/utopia-vscode-extension
       ${pnpm}/bin/pnpm install
       ${pnpm}/bin/pnpm run watch-dev
-    '')
-    (pkgs.writeScriptBin "pull-extension" ''
-      #!/usr/bin/env bash
-      set -e
-      cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/vscode-build
-      nix-shell --run pull-extension-inner
     '')
     (pkgs.writeScriptBin "watch-vscode-build-extension-only" ''
       #!/usr/bin/env bash

--- a/shell.nix
+++ b/shell.nix
@@ -647,6 +647,9 @@ let
     (pkgs.writeScriptBin "build-editor-staging" ''
       #!/usr/bin/env bash
       set -e
+      install-utopia-api
+      build-utopia-vscode-common
+      install-website
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/editor
       ${pnpm}/bin/pnpm install --unsafe-perm
       ${pnpm}/bin/pnpm run staging


### PR DESCRIPTION
- `pull-extension` was not available without including local dev scripts, so I have moved it into `baseEditorScripts`
- The `build-editor-*` scripts need to ensure that some of our other modules are installed before attempting to build the editor (for cases when the deployment doesn't need to build those modules as they are unchanged), so I've added a preparation script which they both call.