### PR TITLE
Only include port on localhost

### DIFF
--- a/website-next/components/common/env-vars.ts
+++ b/website-next/components/common/env-vars.ts
@@ -5,7 +5,7 @@ export const SCHEME: string = typeof window === 'undefined' ? 'http' : window.lo
 export const BARE_HOSTNAME = HOSTNAME.startsWith('www.') ? HOSTNAME.slice(4) : HOSTNAME
 const isLocalHost = BARE_HOSTNAME.startsWith('localhost')
 export const PORT: string =
-  typeof window === 'undefined' || window.location.port.length === 0 || !isLocalHost
+  typeof window === 'undefined' || window.location.port.length === 0
     ? ''
     : `:${window.location.port}`
 export const BARE_HOST = `${BARE_HOSTNAME}${PORT}`
@@ -45,9 +45,7 @@ export function isBackendBFF(): boolean {
 }
 
 export const UTOPIA_BACKEND =
-  (PRODUCTION_OR_STAGING_CONFIG
-    ? BASE_URL
-    : `${SCHEME}//${HOSTNAME}:${LOCAL_BACKEND_PORTS[BACKEND_TYPE]}/`) + 'v1/'
+  (isLocalHost ? `${SCHEME}//${HOSTNAME}:${LOCAL_BACKEND_PORTS[BACKEND_TYPE]}/` : BASE_URL) + 'v1/'
 
 const SECONDARY_BASE_URL: string = PRODUCTION_CONFIG
   ? `https://utopia.fm/`

--- a/website-next/components/common/env-vars.ts
+++ b/website-next/components/common/env-vars.ts
@@ -1,12 +1,13 @@
 // you can turn on/off debug features individually here
 
 export const HOSTNAME: string = typeof window === 'undefined' ? '' : window.location.hostname
-export const PORT: string =
-  typeof window === 'undefined' || window.location.port.length === 0
-    ? ''
-    : `:${window.location.port}`
 export const SCHEME: string = typeof window === 'undefined' ? 'http' : window.location.protocol
 export const BARE_HOSTNAME = HOSTNAME.startsWith('www.') ? HOSTNAME.slice(4) : HOSTNAME
+const isLocalHost = BARE_HOSTNAME.startsWith('localhost')
+export const PORT: string =
+  typeof window === 'undefined' || window.location.port.length === 0 || !isLocalHost
+    ? ''
+    : `:${window.location.port}`
 export const BARE_HOST = `${BARE_HOSTNAME}${PORT}`
 export const BASE_URL: string = `${SCHEME}//${HOSTNAME}${PORT}/`
 


### PR DESCRIPTION
**Problem:**
With the introduction of the Remix BFF https://github.com/concrete-utopia/utopia/pull/4807 we began including port numbers in requests when we shouldn't have. This is (I believe) causing CORS errors.

**Fix:**
Only include the port numbers when running locally