### PR TITLE
Get Prisma working on Linux/NixOS.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -761,4 +761,11 @@ in pkgs.mkShell {
   NODE_OPENSSL_OPTION = "--openssl-legacy-provider";
   # Required for node-gyp, apparently
   npm_config_force_process_config = true;
+
+  # Make Prisma work.
+  PRISMA_SCHEMA_ENGINE_BINARY = if stdenv.isLinux then "${pkgs.prisma-engines}/bin/migration-engine" else null;
+  PRISMA_QUERY_ENGINE_BINARY = if stdenv.isLinux then "${pkgs.prisma-engines}/bin/query-engine" else null;
+  PRISMA_INTROSPECTION_ENGINE_BINARY = if stdenv.isLinux then "${pkgs.prisma-engines}/bin/introspection-engine" else null;
+  PRISMA_QUERY_ENGINE_LIBRARY = if stdenv.isLinux then "${pkgs.prisma-engines}/lib/libquery_engine.node" else null;
+  PRISMA_FMT_BINARY = if stdenv.isLinux then "${pkgs.prisma-engines}/bin/prisma-fmt" else null;
 }


### PR DESCRIPTION
**Problem:**
As Prisma is a Rust binary, it suffers from the usual prebuilt binary issues that can occur with linking.

**Fix:**
Appears the somewhat official fix for this is to provide the environment variables that point to the various binaries: https://github.com/prisma/prisma/issues/3026#issuecomment-927117819

**Commit Details:**
- Added interpolated environment variables to pull in the Prisma binaries.