### PR TITLE
Remix: remove pagination, return all projects

### DIFF
--- a/utopia-remix/app/models/project.server.spec.ts
+++ b/utopia-remix/app/models/project.server.spec.ts
@@ -60,30 +60,6 @@ describe('project model', () => {
         const aliceProjects = await listProjects({ ownerId: 'alice' })
         expect(aliceProjects.map((p) => p.proj_id)).toEqual(['baz'])
       })
-
-      it('can paginate results', async () => {
-        await createTestProject(prisma, { id: 'one', ownerId: 'bob' })
-        await createTestProject(prisma, { id: 'two', ownerId: 'bob' })
-        await createTestProject(prisma, { id: 'three', ownerId: 'bob' })
-        await createTestProject(prisma, { id: 'four', ownerId: 'bob' })
-        await createTestProject(prisma, { id: 'five', ownerId: 'bob' })
-        await createTestProject(prisma, { id: 'six', ownerId: 'bob' })
-        await createTestProject(prisma, { id: 'seven', ownerId: 'bob' })
-
-        expect((await listProjects({ ownerId: 'bob', limit: 3 })).map((p) => p.proj_id)).toEqual([
-          'seven',
-          'six',
-          'five',
-        ])
-
-        expect(
-          (await listProjects({ ownerId: 'bob', limit: 3, offset: 3 })).map((p) => p.proj_id),
-        ).toEqual(['four', 'three', 'two'])
-
-        expect(
-          (await listProjects({ ownerId: 'bob', limit: 3, offset: 6 })).map((p) => p.proj_id),
-        ).toEqual(['one'])
-      })
     })
   })
 })

--- a/utopia-remix/app/models/project.server.ts
+++ b/utopia-remix/app/models/project.server.ts
@@ -1,15 +1,20 @@
 import { Project } from 'prisma-client'
 import { prisma } from '../db.server'
 
-export async function listProjects(params: {
-  ownerId: string
-  offset?: number
-  limit?: number
-}): Promise<Project[]> {
+export type ProjectWithoutContent = Omit<Project, 'content'>
+
+export async function listProjects(params: { ownerId: string }): Promise<ProjectWithoutContent[]> {
   return prisma.project.findMany({
+    select: {
+      id: true,
+      proj_id: true,
+      owner_id: true,
+      title: true,
+      created_at: true,
+      modified_at: true,
+      deleted: true,
+    },
     where: { owner_id: params.ownerId },
     orderBy: { modified_at: 'desc' },
-    take: params.limit,
-    skip: params.offset,
   })
 }


### PR DESCRIPTION
Fix #4861

**Problem:**

The Remix projects page should not bother with paginating the results, as the client should be doing it (and even for large projects collections it should not be a problem for a long while).

**Fix:**

Don't limit/offset the query selection (and make sure the content is filtered out!).