### PR TITLE
New registerComponent function in utopia-api

### DIFF
--- a/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
@@ -17,8 +17,8 @@ import { UtopiaApiGroup } from './group-component'
 import utopiaAPIPackageJSON from '../../../../../utopia-api/package.json'
 import editorPackageJSON from '../../../../package.json'
 import { applyUIDMonkeyPatch } from '../../../utils/canvas-react-utils'
-import { createRegisterModuleFunction } from '../../property-controls/property-controls-local'
 import type { UtopiaTsWorkers } from '../../workers/common/worker-types'
+import { createRegisterModuleAndComponentFunction } from '../../property-controls/property-controls-local'
 
 const Stub = {}
 
@@ -61,9 +61,11 @@ function builtInDependency(
 export function createBuiltInDependenciesList(
   workers: UtopiaTsWorkers | null,
 ): BuiltInDependencies {
+  const { registerModule, registerComponent } = createRegisterModuleAndComponentFunction(workers)
   const UtopiaAPISpecial: typeof UtopiaAPI & { Group: any } = {
     ...UtopiaAPI,
-    registerModule: createRegisterModuleFunction(workers),
+    registerModule: registerModule,
+    registerComponent: registerComponent,
     Group: UtopiaApiGroup,
   }
 

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -6,7 +6,7 @@ import * as Prettier from 'prettier/standalone'
 import { wait } from '../model/performance-scripts'
 
 describe('registered property controls', () => {
-  it('registered controls are in editor state', async () => {
+  it('registered controls with registerModule are in editor state', async () => {
     const testCode = Prettier.format(
       `
         import * as React from 'react'
@@ -19,7 +19,7 @@ describe('registered property controls', () => {
         }
 
         registerModule(
-          '/src/card.js',
+          '/src/card',
           {
             Card: {
               supportsChildren: false,
@@ -69,7 +69,7 @@ describe('registered property controls', () => {
     await wait(10) // this is quite ugly but we want to wait for a timeout(0) in ui-jsx-canvas before calling validateControlsToCheck
     const editorState = renderResult.getEditorState().editor
 
-    expect(editorState.propertyControlsInfo['/src/card.js']).toMatchInlineSnapshot(`
+    expect(editorState.propertyControlsInfo['/src/card']).toMatchInlineSnapshot(`
       Object {
         "Card": Object {
           "properties": Object {
@@ -88,7 +88,7 @@ describe('registered property controls', () => {
             Object {
               "elementToInsert": [Function],
               "importsToAdd": Object {
-                "/src/card.js": Object {
+                "/src/card": Object {
                   "importedAs": null,
                   "importedFromWithin": Array [
                     Object {
@@ -104,7 +104,132 @@ describe('registered property controls', () => {
             Object {
               "elementToInsert": [Function],
               "importsToAdd": Object {
-                "/src/card.js": Object {
+                "/src/card": Object {
+                  "importedAs": null,
+                  "importedFromWithin": Array [
+                    Object {
+                      "alias": "Card",
+                      "name": "Card",
+                    },
+                  ],
+                  "importedWithName": null,
+                },
+                "/src/defaults": Object {
+                  "importedAs": null,
+                  "importedFromWithin": Array [
+                    Object {
+                      "alias": "DefaultPerson",
+                      "name": "DefaultPerson",
+                    },
+                  ],
+                  "importedWithName": null,
+                },
+              },
+              "insertMenuLabel": "ID Card",
+            },
+          ],
+        },
+      }
+    `)
+  })
+  it('registered controls with registerComponent are in editor state', async () => {
+    const testCode = Prettier.format(
+      `
+        import * as React from 'react'
+        import { Scene, Storyboard, View, registerComponent } from 'utopia-api'
+
+        export var App = (props) => {
+          return (
+            <div>hello</div>
+          )
+        }
+
+        registerComponent(
+          'Card',
+          '/src/card',
+          {
+            supportsChildren: false,
+            properties: {
+              label: {
+                control: 'string-input',
+              },
+              background: {
+                control: 'color',
+              },
+              visible: {
+                control: 'checkbox',
+                defaultValue: true,
+              },
+            },
+            variants: [
+              {
+                code: '<Card />',
+                label: 'Card',
+              },
+              {
+                code: '<Card person={DefaultPerson} />',
+                label: 'ID Card',
+                additionalImports: "import { DefaultPerson } from '/src/defaults';",
+              },
+            ],
+          },
+        )
+
+        export var storyboard = (props) => {
+          return (
+            <Storyboard data-uid='${BakedInStoryboardUID}'>
+              <Scene
+                style={{ position: 'absolute', left: 0, top: 0, width: 400, height: 400 }}
+                data-uid='${TestScene0UID}'
+              >
+                <App data-uid='${TestAppUID}' />
+              </Scene>
+            </Storyboard>
+          )
+        }`,
+      PrettierConfig,
+    )
+
+    const renderResult = await renderTestEditorWithCode(testCode, 'dont-await-first-dom-report')
+    await wait(10) // this is quite ugly but we want to wait for a timeout(0) in ui-jsx-canvas before calling validateControlsToCheck
+    const editorState = renderResult.getEditorState().editor
+
+    expect(editorState.propertyControlsInfo['/src/card']).toMatchInlineSnapshot(`
+      Object {
+        "Card": Object {
+          "properties": Object {
+            "background": Object {
+              "control": "color",
+            },
+            "label": Object {
+              "control": "string-input",
+            },
+            "visible": Object {
+              "control": "checkbox",
+            },
+          },
+          "supportsChildren": false,
+          "variants": Array [
+            Object {
+              "elementToInsert": [Function],
+              "importsToAdd": Object {
+                "/src/card": Object {
+                  "importedAs": null,
+                  "importedFromWithin": Array [
+                    Object {
+                      "alias": "Card",
+                      "name": "Card",
+                    },
+                  ],
+                  "importedWithName": null,
+                },
+              },
+              "insertMenuLabel": "Card",
+            },
+            Object {
+              "elementToInsert": [Function],
+              "importsToAdd": Object {
+                "/src/card": Object {
                   "importedAs": null,
                   "importedFromWithin": Array [
                     Object {

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -1,5 +1,6 @@
 import type {
   registerModule as registerModuleAPI,
+  registerComponent as registerComponentAPI,
   ComponentToRegister,
   ComponentInsertOption,
   PropertyControls,
@@ -216,16 +217,16 @@ const partiallyParseAndPrepareComponents = (
     parseAndPrepareComponents(workers, moduleNameOrPath, unparsedComponents)
 }
 
-export function createRegisterModuleFunction(
-  workers: UtopiaTsWorkers | null,
-): typeof registerModuleAPI {
+export function createRegisterModuleAndComponentFunction(workers: UtopiaTsWorkers | null): {
+  registerModule: typeof registerModuleAPI
+  registerComponent: typeof registerComponentAPI
+} {
   let cachedParseAndPrepareComponentsMap = new TimedCacheMap<
     string,
     PartiallyAppliedParseAndPrepareComponents
   >()
 
-  // create a function with a signature that matches utopia-api/registerModule
-  return function registerModule(
+  function registerModule(
     unparsedModuleName: string,
     unparsedComponents: { [componentName: string]: ComponentToRegister },
   ): void {
@@ -270,6 +271,19 @@ export function createRegisterModuleFunction(
       },
       parsedModuleName,
     )
+  }
+
+  function registerComponent(
+    componentName: string,
+    unparsedModuleName: string,
+    properties: ComponentToRegister,
+  ): void {
+    return registerModule(unparsedModuleName, { [componentName]: properties })
+  }
+
+  return {
+    registerModule,
+    registerComponent,
   }
 }
 

--- a/utopia-api/src/helpers/helper-functions.ts
+++ b/utopia-api/src/helpers/helper-functions.ts
@@ -1,3 +1,4 @@
+import type React from 'react'
 import type { PropertyControls } from '../property-controls/property-controls'
 
 export interface ComponentInsertOption {
@@ -15,6 +16,14 @@ export interface ComponentToRegister {
 export function registerModule(
   moduleName: string,
   components: { [componentName: string]: ComponentToRegister },
+): void {
+  // Function is deliberately empty. If called inside the Utopia Editor, it has effect to the running environment
+}
+
+export function registerComponent(
+  componentName: string,
+  moduleName: string,
+  properties: ComponentToRegister,
 ): void {
   // Function is deliberately empty. If called inside the Utopia Editor, it has effect to the running environment
 }


### PR DESCRIPTION
**Description:**
First version of registerComponent is just a registerModule call with a single component
Next step is to make it possible to pass in the component object itself, and not its name and module.
