### PR TITLE
Remix: rename projects

### DIFF
--- a/utopia-remix/app/models/project.server.spec.ts
+++ b/utopia-remix/app/models/project.server.spec.ts
@@ -60,30 +60,6 @@ describe('project model', () => {
         const aliceProjects = await listProjects({ ownerId: 'alice' })
         expect(aliceProjects.map((p) => p.proj_id)).toEqual(['baz'])
       })
-
-      it('can paginate results', async () => {
-        await createTestProject(prisma, { id: 'one', ownerId: 'bob' })
-        await createTestProject(prisma, { id: 'two', ownerId: 'bob' })
-        await createTestProject(prisma, { id: 'three', ownerId: 'bob' })
-        await createTestProject(prisma, { id: 'four', ownerId: 'bob' })
-        await createTestProject(prisma, { id: 'five', ownerId: 'bob' })
-        await createTestProject(prisma, { id: 'six', ownerId: 'bob' })
-        await createTestProject(prisma, { id: 'seven', ownerId: 'bob' })
-
-        expect((await listProjects({ ownerId: 'bob', limit: 3 })).map((p) => p.proj_id)).toEqual([
-          'seven',
-          'six',
-          'five',
-        ])
-
-        expect(
-          (await listProjects({ ownerId: 'bob', limit: 3, offset: 3 })).map((p) => p.proj_id),
-        ).toEqual(['four', 'three', 'two'])
-
-        expect(
-          (await listProjects({ ownerId: 'bob', limit: 3, offset: 6 })).map((p) => p.proj_id),
-        ).toEqual(['one'])
-      })
     })
   })
 })

--- a/utopia-remix/app/models/project.server.ts
+++ b/utopia-remix/app/models/project.server.ts
@@ -3,18 +3,33 @@ import { prisma } from '../db.server'
 
 export type ProjectWithoutContent = Omit<Project, 'content'>
 
+const selectProjectWithoutContent: Record<keyof ProjectWithoutContent, true> = {
+  id: true,
+  proj_id: true,
+  owner_id: true,
+  title: true,
+  created_at: true,
+  modified_at: true,
+  deleted: true,
+}
+
 export async function listProjects(params: { ownerId: string }): Promise<ProjectWithoutContent[]> {
   return prisma.project.findMany({
-    select: {
-      id: true,
-      proj_id: true,
-      owner_id: true,
-      title: true,
-      created_at: true,
-      modified_at: true,
-      deleted: true,
-    },
+    select: selectProjectWithoutContent,
     where: { owner_id: params.ownerId },
     orderBy: { modified_at: 'desc' },
+  })
+}
+
+export async function renameProject(params: {
+  id: string
+  userId: string
+  title: string
+}): Promise<ProjectWithoutContent> {
+  console.log('RENAMING WITH', params.title)
+  return prisma.project.update({
+    where: { proj_id: params.id, owner_id: params.userId },
+    data: { title: params.title },
+    select: selectProjectWithoutContent,
   })
 }

--- a/utopia-remix/app/models/project.server.ts
+++ b/utopia-remix/app/models/project.server.ts
@@ -1,15 +1,20 @@
 import { Project } from 'prisma-client'
 import { prisma } from '../db.server'
 
-export async function listProjects(params: {
-  ownerId: string
-  offset?: number
-  limit?: number
-}): Promise<Project[]> {
+export type ProjectWithoutContent = Omit<Project, 'content'>
+
+export async function listProjects(params: { ownerId: string }): Promise<ProjectWithoutContent[]> {
   return prisma.project.findMany({
+    select: {
+      id: true,
+      proj_id: true,
+      owner_id: true,
+      title: true,
+      created_at: true,
+      modified_at: true,
+      deleted: true,
+    },
     where: { owner_id: params.ownerId },
     orderBy: { modified_at: 'desc' },
-    take: params.limit,
-    skip: params.offset,
   })
 }

--- a/utopia-remix/app/routes-test/projects.$id.rename.spec.ts
+++ b/utopia-remix/app/routes-test/projects.$id.rename.spec.ts
@@ -1,0 +1,92 @@
+import { prisma } from '../db.server'
+import {
+  createTestProject,
+  createTestSession,
+  createTestUser,
+  newFormData,
+  newTestRequest,
+  truncateTables,
+} from '../test-util'
+import { ApiError } from '../util/api.server'
+import { handleRenameProject } from '../routes/projects.$id.rename'
+
+describe('handleRenameProject', () => {
+  afterEach(async () => {
+    await truncateTables([
+      prisma.userDetails,
+      prisma.persistentSession,
+      prisma.project,
+      prisma.projectID,
+    ])
+  })
+
+  beforeEach(async () => {
+    await createTestUser(prisma, { id: 'foo' })
+    await createTestUser(prisma, { id: 'bar' })
+    await createTestSession(prisma, { key: 'the-key', userId: 'foo' })
+    await createTestProject(prisma, { id: 'one', ownerId: 'foo', title: 'project-one' })
+    await createTestProject(prisma, { id: 'two', ownerId: 'bar', title: 'project-two' })
+  })
+
+  it('requires a POST method', async () => {
+    const fn = async () => handleRenameProject(newTestRequest(), {})
+    await expect(fn).rejects.toThrow(ApiError)
+    await expect(fn).rejects.toThrow('invalid method')
+  })
+  it('requires a user', async () => {
+    const fn = async () =>
+      handleRenameProject(newTestRequest({ method: 'POST', authCookie: 'wrong-key' }), {})
+    await expect(fn).rejects.toThrow(ApiError)
+    await expect(fn).rejects.toThrow('session not found')
+  })
+  it('requires a valid id', async () => {
+    const fn = async () =>
+      handleRenameProject(newTestRequest({ method: 'POST', authCookie: 'the-key' }), {})
+    await expect(fn).rejects.toThrow(ApiError)
+    await expect(fn).rejects.toThrow('id is null')
+  })
+  it('requires a valid title', async () => {
+    const fn = (data: FormData) => async () => {
+      const req = newTestRequest({ method: 'POST', authCookie: 'the-key', formData: data })
+      return handleRenameProject(req, { id: 'project-one' })
+    }
+
+    await expect(fn(newFormData({}))).rejects.toThrow(ApiError)
+    await expect(fn(newFormData({}))).rejects.toThrow('title is null')
+
+    await expect(fn(newFormData({ title: '' }))).rejects.toThrow(ApiError)
+    await expect(fn(newFormData({ title: '' }))).rejects.toThrow('title is too short')
+  })
+  it('requires a valid project', async () => {
+    const fn = (data: FormData) => async () => {
+      const req = newTestRequest({ method: 'POST', authCookie: 'the-key', formData: data })
+      return handleRenameProject(req, { id: 'doesnt-exist' })
+    }
+
+    await expect(fn(newFormData({ title: 'hello' }))).rejects.toThrow('Record to update not found')
+  })
+  it('requires ownership of the project', async () => {
+    const fn = (data: FormData) => async () => {
+      const req = newTestRequest({ method: 'POST', authCookie: 'the-key', formData: data })
+      return handleRenameProject(req, { id: 'two' })
+    }
+
+    await expect(fn(newFormData({ title: 'hello' }))).rejects.toThrow('Record to update not found')
+  })
+  it('renames the project', async () => {
+    const fn = async (data: FormData) => {
+      const req = newTestRequest({ method: 'POST', authCookie: 'the-key', formData: data })
+      return handleRenameProject(req, { id: 'one' })
+    }
+
+    await fn(newFormData({ title: 'hello' }))
+    let project = await prisma.project.findFirst({ where: { proj_id: 'one' } })
+
+    expect(project?.title).toEqual('hello')
+
+    await fn(newFormData({ title: 'hello AGAIN!' }))
+    project = await prisma.project.findFirst({ where: { proj_id: 'one' } })
+
+    expect(project?.title).toEqual('hello-again')
+  })
+})

--- a/utopia-remix/app/routes/projects.$id.rename.tsx
+++ b/utopia-remix/app/routes/projects.$id.rename.tsx
@@ -1,9 +1,11 @@
 import { ActionFunctionArgs } from '@remix-run/node'
 import { renameProject } from '../models/project.server'
 import { ensure, handle, requireUser } from '../util/api.server'
-import { slugify } from '../util/slugify'
+import slugify from 'slugify'
 import { Status } from '../util/statusCodes.server'
 import { Params } from '@remix-run/react'
+
+export const SLUGIFY_OPTIONS = { lower: true, remove: /[^a-z0-9A-Z ]/ }
 
 export async function action(args: ActionFunctionArgs) {
   return handle(args, { POST: handleRenameProject })
@@ -23,7 +25,7 @@ export async function handleRenameProject(req: Request, params: Params<string>) 
   ensure(title != null, 'title is null', Status.BAD_REQUEST)
   ensure(typeof title === 'string', 'title is not a string', Status.BAD_REQUEST)
 
-  const slug = slugify(title)
+  const slug = slugify(title, SLUGIFY_OPTIONS)
   ensure(slug.length > 0, 'title is too short', Status.BAD_REQUEST)
 
   await renameProject({ id: id, userId: user.user_id, title: slug })

--- a/utopia-remix/app/routes/projects.$id.rename.tsx
+++ b/utopia-remix/app/routes/projects.$id.rename.tsx
@@ -1,0 +1,32 @@
+import { ActionFunctionArgs } from '@remix-run/node'
+import { renameProject } from '../models/project.server'
+import { ensure, handle, requireUser } from '../util/api.server'
+import { slugify } from '../util/slugify'
+import { Status } from '../util/statusCodes.server'
+import { Params } from '@remix-run/react'
+
+export async function action(args: ActionFunctionArgs) {
+  return handle(args, { POST: handleRenameProject })
+}
+
+export async function handleRenameProject(req: Request, params: Params<string>) {
+  ensure(req.method === 'POST', 'invalid method', Status.METHOD_NOT_ALLOWED)
+
+  const user = await requireUser(req)
+
+  const { id } = params
+  ensure(id != null, 'id is null', Status.BAD_REQUEST)
+
+  const formData = await req.formData()
+
+  const title = formData.get('title')
+  ensure(title != null, 'title is null', Status.BAD_REQUEST)
+  ensure(typeof title === 'string', 'title is not a string', Status.BAD_REQUEST)
+
+  const slug = slugify(title)
+  ensure(slug.length > 0, 'title is too short', Status.BAD_REQUEST)
+
+  await renameProject({ id: id, userId: user.user_id, title: slug })
+
+  return {}
+}

--- a/utopia-remix/app/routes/v1.asset.$id.assets.$name.tsx
+++ b/utopia-remix/app/routes/v1.asset.$id.assets.$name.tsx
@@ -3,13 +3,13 @@ import { proxy } from '../util/proxy.server'
 import { handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
   })
 }
 
 export async function action(args: ActionFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     POST: (req) => proxy(req, { rawOutput: true }),
   })
 }

--- a/utopia-remix/app/routes/v1.collaboration.tsx
+++ b/utopia-remix/app/routes/v1.collaboration.tsx
@@ -3,13 +3,13 @@ import { handle, handleOptions } from '../util/api.server'
 import { proxy } from '../util/proxy.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
   })
 }
 
 export async function action(args: ActionFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     PUT: proxy,
   })
 }

--- a/utopia-remix/app/routes/v1.github.authentication.finish.tsx
+++ b/utopia-remix/app/routes/v1.github.authentication.finish.tsx
@@ -3,7 +3,7 @@ import { handle, handleOptions } from '../util/api.server'
 import { proxy } from '../util/proxy.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: proxy,
   })

--- a/utopia-remix/app/routes/v1.github.authentication.start.tsx
+++ b/utopia-remix/app/routes/v1.github.authentication.start.tsx
@@ -3,7 +3,7 @@ import { handle, handleOptions } from '../util/api.server'
 import { proxy } from '../util/proxy.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: proxy,
   })

--- a/utopia-remix/app/routes/v1.github.authentication.status.tsx
+++ b/utopia-remix/app/routes/v1.github.authentication.status.tsx
@@ -3,7 +3,7 @@ import { handle, handleOptions } from '../util/api.server'
 import { proxy } from '../util/proxy.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: proxy,
   })

--- a/utopia-remix/app/routes/v1.github.branches.$owner.$repository.asset.$assetSha.tsx
+++ b/utopia-remix/app/routes/v1.github.branches.$owner.$repository.asset.$assetSha.tsx
@@ -3,13 +3,13 @@ import { handle, handleOptions } from '../util/api.server'
 import { proxy } from '../util/proxy.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
   })
 }
 
 export async function action(args: ActionFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     POST: (req) => proxy(req, { rawOutput: true }),
   })
 }

--- a/utopia-remix/app/routes/v1.github.branches.$owner.$repository.branch.$branchName.pullrequest.tsx
+++ b/utopia-remix/app/routes/v1.github.branches.$owner.$repository.branch.$branchName.pullrequest.tsx
@@ -3,7 +3,7 @@ import { handle, handleOptions } from '../util/api.server'
 import { proxy } from '../util/proxy.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: proxy,
   })

--- a/utopia-remix/app/routes/v1.github.branches.$owner.$repository.branch.$branchName.tsx
+++ b/utopia-remix/app/routes/v1.github.branches.$owner.$repository.branch.$branchName.tsx
@@ -3,7 +3,7 @@ import { proxy } from '../util/proxy.server'
 import { handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: proxy,
   })

--- a/utopia-remix/app/routes/v1.github.branches.$owner.$repository.branch.default-branch.tsx
+++ b/utopia-remix/app/routes/v1.github.branches.$owner.$repository.branch.default-branch.tsx
@@ -3,7 +3,7 @@ import { proxy } from '../util/proxy.server'
 import { handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: proxy,
   })

--- a/utopia-remix/app/routes/v1.github.branches.$owner.$repository.tsx
+++ b/utopia-remix/app/routes/v1.github.branches.$owner.$repository.tsx
@@ -3,7 +3,7 @@ import { proxy } from '../util/proxy.server'
 import { handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: proxy,
   })

--- a/utopia-remix/app/routes/v1.github.save.$projectId.tsx
+++ b/utopia-remix/app/routes/v1.github.save.$projectId.tsx
@@ -3,13 +3,13 @@ import { proxy } from '../util/proxy.server'
 import { handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
   })
 }
 
 export async function action(args: ActionFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     POST: proxy,
   })
 }

--- a/utopia-remix/app/routes/v1.github.user.repositories.tsx
+++ b/utopia-remix/app/routes/v1.github.user.repositories.tsx
@@ -3,7 +3,7 @@ import { proxy } from '../util/proxy.server'
 import { handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: proxy,
   })

--- a/utopia-remix/app/routes/v1.github.user.tsx
+++ b/utopia-remix/app/routes/v1.github.user.tsx
@@ -3,7 +3,7 @@ import { proxy } from '../util/proxy.server'
 import { handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: proxy,
   })

--- a/utopia-remix/app/routes/v1.javascript.package.versions.$name.$version.tsx
+++ b/utopia-remix/app/routes/v1.javascript.package.versions.$name.$version.tsx
@@ -3,7 +3,7 @@ import { handle, handleOptions } from '../util/api.server'
 import { proxy } from '../util/proxy.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: proxy,
   })

--- a/utopia-remix/app/routes/v1.liveblocks.authentication.tsx
+++ b/utopia-remix/app/routes/v1.liveblocks.authentication.tsx
@@ -3,13 +3,13 @@ import { proxy } from '../util/proxy.server'
 import { handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
   })
 }
 
 export async function action(args: ActionFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     POST: proxy,
   })
 }

--- a/utopia-remix/app/routes/v1.liveblocks.enabled.tsx
+++ b/utopia-remix/app/routes/v1.liveblocks.enabled.tsx
@@ -3,7 +3,7 @@ import { proxy } from '../util/proxy.server'
 import { handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: proxy,
   })

--- a/utopia-remix/app/routes/v1.project.$id.metadata.tsx
+++ b/utopia-remix/app/routes/v1.project.$id.metadata.tsx
@@ -3,7 +3,7 @@ import { proxy } from '../util/proxy.server'
 import { handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: proxy,
   })

--- a/utopia-remix/app/routes/v1.project.$id.owner.tsx
+++ b/utopia-remix/app/routes/v1.project.$id.owner.tsx
@@ -3,7 +3,7 @@ import { proxy } from '../util/proxy.server'
 import { handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: proxy,
   })

--- a/utopia-remix/app/routes/v1.project.$id.tsx
+++ b/utopia-remix/app/routes/v1.project.$id.tsx
@@ -3,14 +3,14 @@ import { proxy } from '../util/proxy.server'
 import { handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: proxy,
   })
 }
 
 export async function action(args: ActionFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     PUT: proxy,
   })
 }

--- a/utopia-remix/app/routes/v1.projectid.tsx
+++ b/utopia-remix/app/routes/v1.projectid.tsx
@@ -3,13 +3,13 @@ import { proxy } from '../util/proxy.server'
 import { handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
   })
 }
 
 export async function action(args: ActionFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     POST: proxy,
   })
 }

--- a/utopia-remix/app/routes/v1.projects.tsx
+++ b/utopia-remix/app/routes/v1.projects.tsx
@@ -3,7 +3,7 @@ import { handleListProjects } from '../handlers/listProjects'
 import { handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: handleListProjects,
   })

--- a/utopia-remix/app/routes/v1.showcase.tsx
+++ b/utopia-remix/app/routes/v1.showcase.tsx
@@ -3,7 +3,7 @@ import { handle, handleOptions } from '../util/api.server'
 import { ListProjectsResponse } from '../types'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: handleShowcase,
   })

--- a/utopia-remix/app/routes/v1.thumbnail.$projectId.tsx
+++ b/utopia-remix/app/routes/v1.thumbnail.$projectId.tsx
@@ -4,14 +4,14 @@ import { ensure, handle, handleOptions } from '../util/api.server'
 import { Params } from '@remix-run/react'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: handleGetThumbnail(args.params),
   })
 }
 
 export async function action(args: ActionFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     POST: proxy,
   })
 }

--- a/utopia-remix/app/routes/v1.user.config.tsx
+++ b/utopia-remix/app/routes/v1.user.config.tsx
@@ -3,7 +3,7 @@ import { proxy } from '../util/proxy.server'
 import { handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: proxy,
   })

--- a/utopia-remix/app/routes/v1.user.tsx
+++ b/utopia-remix/app/routes/v1.user.tsx
@@ -3,7 +3,7 @@ import { proxy } from '../util/proxy.server'
 import { handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args.request, {
+  return handle(args, {
     OPTIONS: handleOptions,
     GET: proxy,
   })

--- a/utopia-remix/app/test-util.ts
+++ b/utopia-remix/app/test-util.ts
@@ -23,6 +23,7 @@ export async function createTestProject(
   params: {
     id: string
     ownerId: string
+    title?: string
     content?: string
     createdAt?: Date
     modifiedAt?: Date
@@ -35,7 +36,7 @@ export async function createTestProject(
   await client.project.create({
     data: {
       proj_id: params.id,
-      title: params.id,
+      title: params.title ?? params.id,
       owner_id: params.ownerId,
       created_at: params.createdAt ?? now,
       modified_at: params.modifiedAt ?? now,
@@ -77,11 +78,16 @@ export async function truncateTables(models: DeletableModel[]) {
 
 export function newTestRequest(params?: {
   path?: string
+  method?: string
   headers?: { [key: string]: string }
   authCookie?: string
+  formData?: FormData
 }): Request {
   const path = (params?.path ?? '').replace(/^\/+/, '')
-  const req = new Request(`http://localhost:8002/` + path)
+  const req = new Request(`http://localhost:8002/` + path, {
+    method: params?.method,
+    body: params?.formData,
+  })
 
   if (params?.headers != null) {
     for (const key of Object.keys(params.headers)) {
@@ -94,4 +100,12 @@ export function newTestRequest(params?: {
   }
 
   return req
+}
+
+export function newFormData(data: { [key: string]: string }): FormData {
+  const formData = new FormData()
+  for (const key of Object.keys(data)) {
+    formData.append(key, data[key])
+  }
+  return formData
 }

--- a/utopia-remix/app/util/slugify.spec.ts
+++ b/utopia-remix/app/util/slugify.spec.ts
@@ -1,4 +1,5 @@
-import { slugify } from './slugify'
+import slugify from 'slugify'
+import { SLUGIFY_OPTIONS } from '../routes/projects.$id.rename'
 
 describe('slugify', () => {
   const tests: { name: string; input: string; wanted: string }[] = [
@@ -46,7 +47,7 @@ describe('slugify', () => {
   for (let i = 0; i < tests.length; i++) {
     const test = tests[i]
     it(`${i + 1}/${tests.length} ${test.name}`, async () => {
-      expect(slugify(test.input)).toEqual(test.wanted)
+      expect(slugify(test.input, SLUGIFY_OPTIONS)).toEqual(test.wanted)
     })
   }
 })

--- a/utopia-remix/app/util/slugify.spec.ts
+++ b/utopia-remix/app/util/slugify.spec.ts
@@ -1,0 +1,52 @@
+import { slugify } from './slugify'
+
+describe('slugify', () => {
+  const tests: { name: string; input: string; wanted: string }[] = [
+    {
+      name: 'a single word',
+      input: 'Hello',
+      wanted: 'hello',
+    },
+    {
+      name: 'alphanumeric',
+      input: 'the Answer is 42',
+      wanted: 'the-answer-is-42',
+    },
+    {
+      name: 'multiple words, mixed case',
+      input: 'Hello WoRld',
+      wanted: 'hello-world',
+    },
+    {
+      name: 'multiple words with trailing non alphanumeric',
+      input: '¡hello WORLD!',
+      wanted: 'hello-world',
+    },
+    {
+      name: 'multiple spaces',
+      input: 'some    large  spacing!!',
+      wanted: 'some-large-spacing',
+    },
+    {
+      name: 'empty string',
+      input: '',
+      wanted: '',
+    },
+    {
+      name: 'uppercase',
+      input: 'ALLCAPS',
+      wanted: 'allcaps',
+    },
+    {
+      name: 'only non alphanumeric',
+      input: '!!?!',
+      wanted: '',
+    },
+  ]
+  for (let i = 0; i < tests.length; i++) {
+    const test = tests[i]
+    it(`${i + 1}/${tests.length} ${test.name}`, async () => {
+      expect(slugify(test.input)).toEqual(test.wanted)
+    })
+  }
+})

--- a/utopia-remix/app/util/slugify.ts
+++ b/utopia-remix/app/util/slugify.ts
@@ -1,0 +1,8 @@
+export function slugify(s: string): string {
+  return s
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+$/, '')
+    .replace(/^-+/, '')
+}

--- a/utopia-remix/app/util/slugify.ts
+++ b/utopia-remix/app/util/slugify.ts
@@ -1,8 +1,0 @@
-export function slugify(s: string): string {
-  return s
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/-+$/, '')
-    .replace(/^-+/, '')
-}

--- a/utopia-remix/package.json
+++ b/utopia-remix/package.json
@@ -26,7 +26,7 @@
     "prisma-client": "link:node_modules/@utopia/prisma-client",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "slugify": "^1.6.6",
+    "slugify": "1.6.6",
     "tiny-invariant": "1.3.1",
     "url-join": "5.0.0"
   },

--- a/utopia-remix/package.json
+++ b/utopia-remix/package.json
@@ -26,6 +26,7 @@
     "prisma-client": "link:node_modules/@utopia/prisma-client",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "slugify": "^1.6.6",
     "tiny-invariant": "1.3.1",
     "url-join": "5.0.0"
   },

--- a/utopia-remix/pnpm-lock.yaml
+++ b/utopia-remix/pnpm-lock.yaml
@@ -36,6 +36,7 @@ specifiers:
   prisma-client: link:node_modules/@utopia/prisma-client
   react: 18.2.0
   react-dom: 18.2.0
+  slugify: ^1.6.6
   tiny-invariant: 1.3.1
   ts-node: 10.9.2
   typescript: 5.1.6
@@ -54,6 +55,7 @@ dependencies:
   prisma-client: link:node_modules/@utopia/prisma-client
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
+  slugify: 1.6.6
   tiny-invariant: 1.3.1
   url-join: 5.0.0
 
@@ -7768,6 +7770,11 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
     dev: true
+
+  /slugify/1.6.6:
+    resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
+    engines: {node: '>=8.0.0'}
+    dev: false
 
   /source-map-js/1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}

--- a/utopia-remix/pnpm-lock.yaml
+++ b/utopia-remix/pnpm-lock.yaml
@@ -36,7 +36,7 @@ specifiers:
   prisma-client: link:node_modules/@utopia/prisma-client
   react: 18.2.0
   react-dom: 18.2.0
-  slugify: ^1.6.6
+  slugify: 1.6.6
   tiny-invariant: 1.3.1
   ts-node: 10.9.2
   typescript: 5.1.6


### PR DESCRIPTION
Fix #4866 

**Problem:**

The Remix projects page will need a way to rename projects.

**Fix:**

- Add an action route to rename projects
- Add the related backend `update` query
- Made sure that Prisma errors coming from handlers are wrapped inside `ApiErrors` and displayed nicely
- Add tests for everything above

**Note**
- ⚠️ The diff is made larger by an adjustment to the first argument of the `handle` function, which now gets an interface instead of a plain `Request`, therefore https://github.com/concrete-utopia/utopia/commit/8af265db1718ea752a31394195dbd4ac2ccd6e31 could be pretty much ignored for reviewing purposes.