### PR TITLE
Re-parse after a parse is skipped

### DIFF
--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -1109,7 +1109,10 @@ describe('UPDATE_FROM_WORKER', () => {
     )
 
     // Check that the model hasn't changed, because of the stale revised time.
-    expect(updatedEditorState).toBe(startingEditorState)
+    expect(updatedEditorState).toEqual({
+      ...startingEditorState,
+      previousParseOrPrintSkipped: true,
+    })
   })
   it('should apply all if none are stale', () => {
     // Setup and getting some starting values.

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -887,6 +887,7 @@ export function restoreEditorState(
     pasteTargetsToIgnore: desiredEditor.pasteTargetsToIgnore,
     codeEditorErrors: currentEditor.codeEditorErrors,
     parseOrPrintInFlight: false,
+    previousParseOrPrintSkipped: desiredEditor.previousParseOrPrintSkipped,
     safeMode: currentEditor.safeMode,
     saveError: currentEditor.saveError,
     vscodeBridgeReady: currentEditor.vscodeBridgeReady,
@@ -3616,7 +3617,11 @@ export const UPDATE_FNS = {
         anyParsedUpdates = true
         const updateIsStale = fileUpdate.versionNumber < existing.versionNumber
         if (updateIsStale && action.updates.length > 1) {
-          return editor
+          return {
+            ...editor,
+            parseOrPrintInFlight: false,
+            previousParseOrPrintSkipped: true,
+          }
         }
       }
     }
@@ -3649,7 +3654,8 @@ export const UPDATE_FNS = {
           ? editor.canvas.domWalkerInvalidateCount + 1
           : editor.canvas.domWalkerInvalidateCount,
       },
-      parseOrPrintInFlight: false, // only ever clear it here
+      parseOrPrintInFlight: false,
+      previousParseOrPrintSkipped: false,
     }
   },
   UPDATE_FROM_CODE_EDITOR: (

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -519,7 +519,10 @@ export function editorDispatchClosingOut(
   const frozenDerivedState = result.unpatchedDerived
 
   const editorWithModelChecked =
-    !anyUndoOrRedo && transientOrNoChange && !anyWorkerUpdates
+    !anyUndoOrRedo &&
+    transientOrNoChange &&
+    !anyWorkerUpdates &&
+    !unpatchedEditorState.previousParseOrPrintSkipped
       ? { editorState: unpatchedEditorState, modelUpdateFinished: Promise.resolve(true) }
       : maybeRequestModelUpdateOnEditor(unpatchedEditorState, storedState.workers, boundDispatch)
 

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1434,6 +1434,7 @@ export interface EditorState {
   thumbnailLastGenerated: number
   pasteTargetsToIgnore: ElementPath[]
   parseOrPrintInFlight: boolean
+  previousParseOrPrintSkipped: boolean
   safeMode: boolean
   saveError: boolean
   vscodeBridgeReady: boolean
@@ -1514,6 +1515,7 @@ export function editorState(
   thumbnailLastGenerated: number,
   pasteTargetsToIgnore: ElementPath[],
   parseOrPrintInFlight: boolean,
+  previousParseOrPrintSkipped: boolean,
   safeMode: boolean,
   saveError: boolean,
   vscodeBridgeReady: boolean,
@@ -1595,6 +1597,7 @@ export function editorState(
     thumbnailLastGenerated: thumbnailLastGenerated,
     pasteTargetsToIgnore: pasteTargetsToIgnore,
     parseOrPrintInFlight: parseOrPrintInFlight,
+    previousParseOrPrintSkipped: previousParseOrPrintSkipped,
     safeMode: safeMode,
     saveError: saveError,
     vscodeBridgeReady: vscodeBridgeReady,
@@ -2487,6 +2490,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     thumbnailLastGenerated: 0,
     pasteTargetsToIgnore: [],
     parseOrPrintInFlight: false,
+    previousParseOrPrintSkipped: false,
     safeMode: false,
     saveError: false,
     vscodeBridgeReady: false,
@@ -2848,6 +2852,7 @@ export function editorModelFromPersistentModel(
     thumbnailLastGenerated: 0,
     pasteTargetsToIgnore: [],
     parseOrPrintInFlight: false,
+    previousParseOrPrintSkipped: false,
     safeMode: false,
     saveError: false,
     navigator: {

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -4464,6 +4464,10 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     oldValue.parseOrPrintInFlight,
     newValue.parseOrPrintInFlight,
   )
+  const previousParseOrPrintSkipped = BooleanKeepDeepEquality(
+    oldValue.previousParseOrPrintSkipped,
+    newValue.previousParseOrPrintSkipped,
+  )
   const safeModeResults = BooleanKeepDeepEquality(oldValue.safeMode, newValue.safeMode)
   const saveErrorResults = BooleanKeepDeepEquality(oldValue.saveError, newValue.saveError)
   const vscodeBridgeReadyResults = BooleanKeepDeepEquality(
@@ -4612,6 +4616,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     thumbnailLastGeneratedResults.areEqual &&
     pasteTargetsToIgnoreResults.areEqual &&
     parseOrPrintInFlightResults.areEqual &&
+    previousParseOrPrintSkipped.areEqual &&
     safeModeResults.areEqual &&
     saveErrorResults.areEqual &&
     vscodeBridgeReadyResults.areEqual &&
@@ -4694,6 +4699,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
       thumbnailLastGeneratedResults.value,
       pasteTargetsToIgnoreResults.value,
       parseOrPrintInFlightResults.value,
+      previousParseOrPrintSkipped.value,
       safeModeResults.value,
       saveErrorResults.value,
       vscodeBridgeReadyResults.value,

--- a/editor/src/components/editor/store/store-hook-substore-helpers.ts
+++ b/editor/src/components/editor/store/store-hook-substore-helpers.ts
@@ -145,6 +145,7 @@ export const EmptyEditorStateForKeysOnly: EditorState = {
   thumbnailLastGenerated: 0,
   pasteTargetsToIgnore: [],
   parseOrPrintInFlight: false,
+  previousParseOrPrintSkipped: false,
   safeMode: false,
   saveError: false,
   vscodeBridgeReady: false,

--- a/editor/src/components/editor/store/worker-update-race.spec.tsx
+++ b/editor/src/components/editor/store/worker-update-race.spec.tsx
@@ -10,7 +10,8 @@ import { renderTestEditorWithModel } from '../../canvas/ui-jsx.test-utils'
 import { updateFile } from '../actions/action-creators'
 import { StoryboardFilePath } from './editor-state'
 
-const mockDefer = defer // honestly
+// We have to prefix all of these with "mock" otherwise Jest won't allow us to use them below
+const mockDefer = defer
 let mockLock1 = defer()
 let mockLock2 = defer()
 let mockParseStartedCount = 0
@@ -58,9 +59,7 @@ describe('Updates from the worker that are skipped', () => {
 
     // Update any existing file so that the worker update is skipped
     const modifiedStoryboard = textFile(startingStoryboard.fileContents, null, null, 2)
-    await act(async () =>
-      renderResult.dispatch([updateFile(StoryboardFilePath, modifiedStoryboard, false)], false),
-    )
+    await renderResult.dispatch([updateFile(StoryboardFilePath, modifiedStoryboard, false)], false)
 
     await renderResult.getDispatchFollowUpActionsFinished()
 

--- a/editor/src/components/editor/store/worker-update-race.spec.tsx
+++ b/editor/src/components/editor/store/worker-update-race.spec.tsx
@@ -1,0 +1,107 @@
+import { act } from '@testing-library/react'
+import { getDefaultUIJsFile } from '../../../core/model/new-project-files'
+import { type TextFile, textFile } from '../../../core/shared/project-file-types'
+import type { ParseOrPrint, ParseOrPrintResult } from '../../../core/workers/common/worker-types'
+import type { SteganographyMode } from '../../../core/workers/parser-printer/parser-printer'
+import { simpleDefaultProject } from '../../../sample-projects/sample-project-utils'
+import { defer } from '../../../utils/utils'
+import { getProjectFileByFilePath } from '../../assets'
+import { renderTestEditorWithModel } from '../../canvas/ui-jsx.test-utils'
+import { updateFile } from '../actions/action-creators'
+import { StoryboardFilePath } from './editor-state'
+
+const mockDefer = defer // honestly
+let mockLock1 = defer()
+let mockLock2 = defer()
+let mockParseStartedCount = 0
+let mockParseCompletedCount = 0
+
+jest.mock('../../../core/workers/common/worker-types', () => ({
+  ...jest.requireActual('../../../core/workers/common/worker-types'),
+  async getParseResult(
+    workers: any,
+    files: Array<ParseOrPrint>,
+    alreadyExistingUIDs: Set<string>,
+    applySteganography: SteganographyMode,
+  ): Promise<Array<ParseOrPrintResult>> {
+    mockParseStartedCount++
+    const result = await jest
+      .requireActual('../../../core/workers/common/worker-types')
+      .getParseResult(workers, files, alreadyExistingUIDs, applySteganography)
+    mockLock2.resolve()
+    await mockLock1
+    mockLock1 = mockDefer()
+    mockParseCompletedCount++
+    return result
+  },
+}))
+
+describe('Updates from the worker that are skipped', () => {
+  it('Trigger a re-parse immediately after', async () => {
+    const renderResult = await renderTestEditorWithModel(
+      simpleDefaultProject(),
+      'dont-await-first-dom-report',
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Check that the parsing has started but not yet completed
+    expect(mockParseStartedCount).toBe(1)
+    expect(mockParseCompletedCount).toBe(0)
+
+    const startingStoryboard = getProjectFileByFilePath(
+      renderResult.getEditorState().editor.projectContents,
+      StoryboardFilePath,
+    ) as TextFile
+    expect(startingStoryboard.versionNumber).toBe(1)
+    expect(startingStoryboard.fileContents.parsed.type).toBe('UNPARSED')
+
+    // Update any existing file so that the worker update is skipped
+    const modifiedStoryboard = textFile(startingStoryboard.fileContents, null, null, 2)
+    await act(async () =>
+      renderResult.dispatch([updateFile(StoryboardFilePath, modifiedStoryboard, false)], false),
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // Ensure the file was updated and is still unparsed
+    const updatedStoryboardFile = getProjectFileByFilePath(
+      renderResult.getEditorState().editor.projectContents,
+      StoryboardFilePath,
+    ) as TextFile
+    expect(updatedStoryboardFile.versionNumber).toBe(2)
+    expect(updatedStoryboardFile.fileContents.parsed.type).toBe('UNPARSED')
+
+    // Unblock and run the parser printer once
+    await mockLock2
+    mockLock2 = defer()
+    mockLock1.resolve()
+    await mockLock2
+
+    // The parse result should have been ignored
+    expect(mockParseStartedCount).toBe(2)
+    expect(mockParseCompletedCount).toBe(1)
+    const storyboardFileAfterIgnoredParse = getProjectFileByFilePath(
+      renderResult.getEditorState().editor.projectContents,
+      StoryboardFilePath,
+    ) as TextFile
+    expect(storyboardFileAfterIgnoredParse.versionNumber).toBe(2)
+    expect(storyboardFileAfterIgnoredParse.fileContents.parsed.type).toBe('UNPARSED')
+
+    await act(async () => renderResult.dispatch([], false))
+
+    // Unblock and run the parser printer again
+    mockLock1.resolve()
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    // The parse result should have been applied
+    expect(mockParseStartedCount).toBe(2)
+    expect(mockParseCompletedCount).toBe(2)
+    const storyboardFileAfterSuccessfulParse = getProjectFileByFilePath(
+      renderResult.getEditorState().editor.projectContents,
+      StoryboardFilePath,
+    ) as TextFile
+    expect(storyboardFileAfterSuccessfulParse.versionNumber).toBe(2)
+    expect(storyboardFileAfterSuccessfulParse.fileContents.parsed.type).toBe('PARSE_SUCCESS')
+  })
+})


### PR DESCRIPTION
**Problem:**
If a project file is updated whilst a parse or print is in flight, the result of that parse or print will be skipped. The previous assumption was that the next dispatch would pick up on this and trigger a new parse. However, as that logic is also only triggered when there has been a change to the project, and only the owner can change the project, it means that a viewer of a project can be stuck in a state where the project is unparsed, meaning the canvas will never load for them.

**Fix:**
Rather than implicitly wait on the next dispatch which modifies the project, we now track if the result of a parse or print was skipped, and trigger a new parse or print if that was the case. This also fixes a bug where the `parseOrPrintInFlight` flag wasn't cleared after a skipped result, meaning that in that case we would never run the parser again!
