### PR TITLE
Unify our edit permissions mechanism

### DIFF
--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -67,7 +67,7 @@ import {
 import { useSelectionArea } from './selection-area-hooks'
 import { RemixSceneLabelControl } from './select-mode/remix-scene-label'
 import { NO_OP } from '../../../core/shared/utils'
-import { useIsMyProject } from '../../editor/store/collaborative-editing'
+import { useIsProjectOwner } from '../../editor/store/collaborative-editing'
 import { useStatus } from '../../../../liveblocks.config'
 import { MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
 import { MultiplayerPresence } from '../multiplayer-presence'
@@ -506,7 +506,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       })
   }
 
-  const isMyProject = useIsMyProject()
+  const isProjectOwner = useIsProjectOwner()
 
   const resizeStatus = getResizeStatus()
 
@@ -552,7 +552,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
             )}
 
             {when(
-              isMyProject,
+              isProjectOwner,
               <>
                 {inspectorFocusedControls.map((c) => (
                   <RenderControlMemoized

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -69,7 +69,7 @@ import {
 } from '../canvas/ui/floating-insert-menu'
 import { RightMenuTab, floatingInsertMenuStateSwap } from './store/editor-state'
 import { useStatus, useThreads } from '../../../liveblocks.config'
-import { useAllowedToEditProject, useIsMyProject } from './store/collaborative-editing'
+import { useAllowedToEditProject, useIsProjectOwner } from './store/collaborative-editing'
 import { useCanComment, useReadThreads } from '../../core/commenting/comment-hooks'
 import { pluck } from '../../core/shared/array-utils'
 import { MultiplayerWrapper } from '../../utils/multiplayer-wrapper'
@@ -469,7 +469,7 @@ export const CanvasToolbar = React.memo(() => {
       : CommentModeButtonTestId('disconnected')
   const allowedToEdit = useAllowedToEditProject()
 
-  const isMyProject = useIsMyProject()
+  const isProjectOwner = useIsProjectOwner()
 
   return (
     <FlexColumn
@@ -589,7 +589,7 @@ export const CanvasToolbar = React.memo(() => {
           />
         </Tooltip>
         <ElementsOutsideVisibleAreaIndicator />
-        {unless(isMyProject, <ViewOnlyBadge />)}
+        {unless(isProjectOwner, <ViewOnlyBadge />)}
       </div>
       {/* Edit Mode submenus */}
       {when(

--- a/editor/src/components/editor/store/collaborative-editing.ts
+++ b/editor/src/components/editor/store/collaborative-editing.ts
@@ -57,6 +57,7 @@ import { Y } from '../../../core/shared/yjs'
 import type { ProjectServerState } from './project-server-state'
 import { Substores, useEditorState } from './store-hook'
 import { forceNotNull } from '../../../core/shared/optional-utils'
+import { hasEditPermissions, usePermissions } from './permissions'
 
 const CodeKey = 'code'
 const TopLevelElementsKey = 'topLevelElements'
@@ -771,37 +772,21 @@ export function allowedToEditProject(
   loginState: LoginState,
   serverState: ProjectServerState,
 ): boolean {
-  if (isLoggedIn(loginState)) {
-    return serverState.currentlyHolderOfTheBaton
-  } else {
-    return checkIsMyProject(serverState)
-  }
+  return hasEditPermissions(serverState, loginState)
 }
 
 export function useAllowedToEditProject(): boolean {
-  const projectServerState = useEditorState(
-    Substores.projectServerState,
-    (store) => store.projectServerState,
-    'useAllowedToEditProject projectServerState',
-  )
-
-  const loginState = useEditorState(
-    Substores.userState,
-    (store) => store.userState.loginState,
-    'useAllowedToEditProject loginState',
-  )
-
-  return allowedToEditProject(loginState, projectServerState)
+  return usePermissions().edit
 }
 
-export function useIsMyProject(): boolean {
+export function useIsProjectOwner(): boolean {
   return useEditorState(
     Substores.projectServerState,
-    (store) => checkIsMyProject(store.projectServerState),
-    'useIsMyProject',
+    (store) => checkIsProjectOwner(store.projectServerState),
+    'useIsProjectOwner',
   )
 }
 
-export function checkIsMyProject(serverState: ProjectServerState): boolean {
+export function checkIsProjectOwner(serverState: ProjectServerState): boolean {
   return serverState.isMyProject === 'yes'
 }

--- a/editor/src/components/editor/store/permissions.ts
+++ b/editor/src/components/editor/store/permissions.ts
@@ -1,6 +1,6 @@
 import type { LoginState } from '../action-types'
 import { isLoggedIn } from '../action-types'
-import { checkIsMyProject } from './collaborative-editing'
+import { checkIsProjectOwner } from './collaborative-editing'
 import type { ProjectServerState } from './project-server-state'
 import { Substores, useEditorState } from './store-hook'
 import type { ProjectServerStateSubstate, UserStateSubstate } from './store-hook-substore-types'
@@ -20,13 +20,20 @@ export function usePermissions(): Permissions {
 
 export function getPermissions(store: ProjectServerStateSubstate & UserStateSubstate): Permissions {
   return {
-    edit: hasEditPermissions(store.projectServerState),
+    edit: hasEditPermissions(store.projectServerState, store.userState.loginState),
     comment: hasCommentPermission(store.userState.loginState),
   }
 }
 
-export function hasEditPermissions(projectServerState: ProjectServerState): boolean {
-  return checkIsMyProject(projectServerState)
+export function hasEditPermissions(
+  projectServerState: ProjectServerState,
+  loginState: LoginState,
+): boolean {
+  if (isLoggedIn(loginState)) {
+    return projectServerState.currentlyHolderOfTheBaton
+  } else {
+    return checkIsProjectOwner(projectServerState)
+  }
 }
 
 export function hasCommentPermission(loginState: LoginState): boolean {

--- a/editor/src/components/inspector/controls/color-control.tsx
+++ b/editor/src/components/inspector/controls/color-control.tsx
@@ -8,7 +8,6 @@ import type { ControlStyles } from '../common/control-styles'
 import type { ControlStatus } from '../common/control-status'
 import { useColorTheme, UtopiaTheme } from '../../../uuiui'
 import Utils from '../../../utils/utils'
-import { useIsMyProject } from '../../editor/store/collaborative-editing'
 import { useControlsDisabledInSubtree } from '../../../uuiui/utilities/disable-subtree'
 
 export interface ColorControlProps {

--- a/editor/src/components/inspector/controls/color-picker-swatches.tsx
+++ b/editor/src/components/inspector/controls/color-picker-swatches.tsx
@@ -15,7 +15,6 @@ import { useDispatch } from '../../editor/store/dispatch-context'
 import type { ColorSwatch } from '../../editor/store/editor-state'
 import { Substores, useEditorState } from '../../editor/store/store-hook'
 import { cssColorToChromaColorOrDefault } from '../common/css-utils'
-import { useIsMyProject } from '../../editor/store/collaborative-editing'
 import { useControlsDisabledInSubtree } from '../../../uuiui/utilities/disable-subtree'
 
 const { checkerboardBackground } = UtopiaStyles.backgrounds

--- a/editor/src/components/inspector/controls/option-control.tsx
+++ b/editor/src/components/inspector/controls/option-control.tsx
@@ -6,7 +6,6 @@ import type { DEPRECATEDControlProps, DEPRECATEDGenericControlOptions } from './
 import { colorTheme } from '../../../uuiui'
 import type { IcnProps } from '../../../uuiui'
 import { UtopiaTheme, Tooltip, Icn } from '../../../uuiui'
-import { useIsMyProject } from '../../editor/store/collaborative-editing'
 import { useControlsDisabledInSubtree } from '../../../uuiui/utilities/disable-subtree'
 
 export interface DEPRECATEDOptionControlOptions extends DEPRECATEDGenericControlOptions {

--- a/editor/src/components/inspector/controls/slider-control.tsx
+++ b/editor/src/components/inspector/controls/slider-control.tsx
@@ -3,7 +3,6 @@ import Slider from 'rc-slider'
 import React from 'react'
 import { FlexRow, UtopiaTheme } from '../../../uuiui'
 import type { DEPRECATEDControlProps, DEPRECATEDGenericControlOptions } from './control'
-import { useIsMyProject } from '../../editor/store/collaborative-editing'
 import { useControlsDisabledInSubtree } from '../../../uuiui/utilities/disable-subtree'
 
 export interface DEPRECATEDSliderControlOptions extends DEPRECATEDGenericControlOptions {

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -80,7 +80,6 @@ import { SettingsPanel } from './sections/settings-panel/inspector-settingspanel
 import { strictEvery } from '../../core/shared/array-utils'
 import { SimplifiedLayoutSubsection } from './sections/layout-section/self-layout-subsection/simplified-layout-subsection'
 import { ConstraintsSection } from './constraints-section'
-import { useIsMyProject } from '../editor/store/collaborative-editing'
 import { usePermissions } from '../editor/store/permissions'
 import { DisableControlsInSubtree } from '../../uuiui/utilities/disable-subtree'
 

--- a/editor/src/components/inspector/sections/style-section/background-subsection/background-picker.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/background-picker.tsx
@@ -73,7 +73,6 @@ import { GradientStopsEditor } from './gradient-stop-editor'
 import { getIndexedUpdateCSSBackgroundLayerLinearGradientAngle } from './linear-gradient-layer'
 import { PickerImagePreview } from './picker-image-preview'
 import { setProp_UNSAFE } from '../../../../editor/actions/action-creators'
-import { useIsMyProject } from '../../../../editor/store/collaborative-editing'
 import { useControlsDisabledInSubtree } from '../../../../../uuiui/utilities/disable-subtree'
 
 const backgroundLayerOptionsByValue: {

--- a/editor/src/components/navigator/left-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/index.tsx
@@ -17,7 +17,7 @@ import { NavigatorComponent } from '../navigator'
 import { ContentsPane } from './contents-pane'
 import { GithubPane } from './github-pane'
 import type { StoredPanel } from '../../canvas/stored-layout'
-import { useIsMyProject } from '../../editor/store/collaborative-editing'
+import { useIsProjectOwner } from '../../editor/store/collaborative-editing'
 import { when } from '../../../utils/react-conditionals'
 
 export interface LeftPaneProps {
@@ -65,7 +65,7 @@ export const LeftPaneComponent = React.memo<LeftPaneComponentProps>((props) => {
     onClickTab(LeftMenuTab.Github)
   }, [onClickTab])
 
-  const isMyProject = useIsMyProject()
+  const isProjectOwner = useIsProjectOwner()
 
   return (
     <LowPriorityStoreProvider>
@@ -93,7 +93,7 @@ export const LeftPaneComponent = React.memo<LeftPaneComponentProps>((props) => {
           }}
         >
           {when(
-            isMyProject,
+            isProjectOwner,
             <FlexRow style={{ marginBottom: 10, gap: 10 }} css={undefined}>
               <MenuTab
                 label={'Navigator'}
@@ -113,8 +113,8 @@ export const LeftPaneComponent = React.memo<LeftPaneComponentProps>((props) => {
             </FlexRow>,
           )}
           {when(selectedTab === LeftMenuTab.Navigator, <NavigatorComponent />)}
-          {when(isMyProject && selectedTab === LeftMenuTab.Project, <ContentsPane />)}
-          {when(isMyProject && selectedTab === LeftMenuTab.Github, <GithubPane />)}
+          {when(isProjectOwner && selectedTab === LeftMenuTab.Project, <ContentsPane />)}
+          {when(isProjectOwner && selectedTab === LeftMenuTab.Github, <GithubPane />)}
         </div>
       </FlexColumn>
     </LowPriorityStoreProvider>

--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -30,7 +30,7 @@ import { showToast, switchEditorMode } from './editor/actions/action-creators'
 import { EditorModes, isFollowMode } from './editor/editor-modes'
 import { useDispatch } from './editor/store/dispatch-context'
 import { Substores, useEditorState } from './editor/store/store-hook'
-import { useIsMyProject } from './editor/store/collaborative-editing'
+import { useIsProjectOwner } from './editor/store/collaborative-editing'
 import { motion } from 'framer-motion'
 import { useIsBeingFollowed, useSortMultiplayerUsers } from '../core/shared/multiplayer-hooks'
 
@@ -84,7 +84,7 @@ const SinglePlayerUserBar = React.memo(() => {
     (store) => getUserPicture(store.userState.loginState),
     'SinglePlayerUserBar userPicture',
   )
-  const isMyProject = useIsMyProject()
+  const isProjectOwner = useIsProjectOwner()
 
   return (
     <FlexRow
@@ -110,7 +110,7 @@ const SinglePlayerUserBar = React.memo(() => {
         size={AvatarSize}
         style={{ outline: 'undefined' }}
       />
-      {isMyProject ? <OwnerBadge /> : null}
+      {isProjectOwner ? <OwnerBadge /> : null}
       <div style={{ padding: '0 8px 0 5px', fontWeight: 500 }}>Share</div>
     </FlexRow>
   )

--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -50,7 +50,6 @@ import {
   InspectorInput,
 } from './base-input'
 import { usePropControlledStateV2 } from '../../components/inspector/common/inspector-utils'
-import { useIsMyProject } from '../../components/editor/store/collaborative-editing'
 import { useControlsDisabledInSubtree } from '../utilities/disable-subtree'
 
 export type LabelDragDirection = 'horizontal' | 'vertical'

--- a/editor/src/uuiui/widgets/popup-list/popup-list.tsx
+++ b/editor/src/uuiui/widgets/popup-list/popup-list.tsx
@@ -27,7 +27,6 @@ import type { ControlStyles, SelectOption } from '../../../uuiui-deps'
 import { CommonUtils, getControlStyles } from '../../../uuiui-deps'
 import { SmallerIcons } from '../../../uuiui/icons'
 import { Tooltip } from '../../tooltip'
-import { useIsMyProject } from '../../../components/editor/store/collaborative-editing'
 import { useControlsDisabledInSubtree } from '../../utilities/disable-subtree'
 
 type ContainerMode = 'default' | 'showBorderOnHover' | 'noBorder'


### PR DESCRIPTION
A small PR to unify our permissions mechanisms.
Instead of using two separate mechanisms (`hasEditPermissions` and `allowedToEditProject`) - now the permissions check is in `permissions.ts` (via the `usePermissions` hook) and the semantic checks  (`canEdit`, `canComment`, etc) can be in the specific usage areas.