### PR TITLE
Scene dragging: do not save new scene comment canvas position in every frame

### DIFF
--- a/editor/src/core/commenting/comment-maintainer.tsx
+++ b/editor/src/core/commenting/comment-maintainer.tsx
@@ -6,6 +6,7 @@ import { getIdOfScene } from '../../components/canvas/controls/comment-mode/comm
 import * as EP from '../shared/element-path'
 import { isNotNullFiniteRectangle } from '../shared/math-utils'
 import { isCanvasThreadMetadata, liveblocksThreadMetadataToUtopia } from './comment-types'
+import { Substores, useEditorState } from '../../components/editor/store/store-hook'
 
 export const CommentMaintainer = React.memo(() => {
   const canComment = useCanComment()
@@ -33,6 +34,16 @@ function useMaintainComments() {
   const { threads } = useThreads()
   const scenes = useScenes()
   const editThreadMetadata = useEditThreadMetadata()
+
+  const isInteraction = useEditorState(
+    Substores.canvas,
+    (store) => store.editor.canvas.interactionSession != null,
+    'useMaintainComments isInteraction',
+  )
+
+  if (isInteraction) {
+    return
+  }
 
   threads.forEach(async (t): Promise<void> => {
     const metadata = liveblocksThreadMetadataToUtopia(t.metadata)


### PR DESCRIPTION
**Problem:**
`CommentMaintainer` saves the new global position of scene comments when there is a position change, even during interactions. Updating liveblocks like this is waaay too frequent, and causes bugs and test failures.

**Fix:**
Do not do anything during canvas interactions. The new position is stored right after the interaction is over.