### PR TITLE
Remix: list deleted projects

### DIFF
--- a/utopia-remix/app/models/project.server.ts
+++ b/utopia-remix/app/models/project.server.ts
@@ -61,3 +61,16 @@ export async function restoreDeletedProject(params: { id: string; userId: string
     data: { deleted: null },
   })
 }
+
+export async function listDeletedProjects(params: {
+  ownerId: string
+}): Promise<ProjectWithoutContent[]> {
+  return await prisma.project.findMany({
+    select: selectProjectWithoutContent,
+    where: {
+      owner_id: params.ownerId,
+      deleted: true,
+    },
+    orderBy: { modified_at: 'desc' },
+  })
+}

--- a/utopia-remix/app/routes-test/projects.deleted.spec.ts
+++ b/utopia-remix/app/routes-test/projects.deleted.spec.ts
@@ -1,0 +1,64 @@
+import { prisma } from '../db.server'
+import { handleListDeletedProjects } from '../routes/projects.deleted'
+import {
+  createTestProject,
+  createTestSession,
+  createTestUser,
+  newTestRequest,
+  truncateTables,
+} from '../test-util'
+import { ApiError } from '../util/api.server'
+
+describe('handleDeleteProject', () => {
+  afterEach(async () => {
+    await truncateTables([
+      prisma.userDetails,
+      prisma.persistentSession,
+      prisma.project,
+      prisma.projectID,
+    ])
+  })
+
+  beforeEach(async () => {
+    await createTestUser(prisma, { id: 'foo' })
+    await createTestUser(prisma, { id: 'bar' })
+    await createTestSession(prisma, { key: 'the-key', userId: 'foo' })
+    await createTestProject(prisma, { id: 'one', ownerId: 'foo', title: 'project-one' })
+    await createTestProject(prisma, {
+      id: 'two',
+      ownerId: 'foo',
+      title: 'project-two',
+      deleted: true,
+    })
+    await createTestProject(prisma, { id: 'three', ownerId: 'bar', title: 'project-three' })
+    await createTestProject(prisma, {
+      id: 'four',
+      ownerId: 'foo',
+      title: 'project-four',
+      deleted: true,
+    })
+    await createTestProject(prisma, {
+      id: 'five',
+      ownerId: 'foo',
+      title: 'project-five',
+      deleted: true,
+    })
+  })
+
+  it('requires a user', async () => {
+    const fn = async () =>
+      handleListDeletedProjects(newTestRequest({ method: 'POST', authCookie: 'wrong-key' }), {})
+    await expect(fn).rejects.toThrow(ApiError)
+    await expect(fn).rejects.toThrow('session not found')
+  })
+  it('returns deleted projects', async () => {
+    const fn = async () => {
+      const req = newTestRequest({ method: 'POST', authCookie: 'the-key' })
+      return handleListDeletedProjects(req, {})
+    }
+
+    const got = await fn()
+    expect(got.projects).toHaveLength(3)
+    expect(got.projects.map((p) => p.proj_id)).toEqual(['five', 'four', 'two'])
+  })
+})

--- a/utopia-remix/app/routes/projects.deleted.tsx
+++ b/utopia-remix/app/routes/projects.deleted.tsx
@@ -1,0 +1,18 @@
+import { LoaderFunctionArgs } from '@remix-run/node'
+import { Params } from '@remix-run/react'
+import { listDeletedProjects } from '../models/project.server'
+import { handle, requireUser } from '../util/api.server'
+
+export async function loader(args: LoaderFunctionArgs) {
+  return handle(args, { GET: handleListDeletedProjects })
+}
+
+export async function handleListDeletedProjects(req: Request, params: Params<string>) {
+  const user = await requireUser(req)
+
+  const projects = await listDeletedProjects({ ownerId: user.user_id })
+
+  return {
+    projects,
+  }
+}


### PR DESCRIPTION
Fix #4876 

Followup to https://github.com/concrete-utopia/utopia/pull/4874, this PR adds a new Remix route to list soft-deleted projects that can be used to populate a `Trash` page.