### PR TITLE
do not open the data editor by default

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -779,7 +779,7 @@ interface RowForObjectControlProps extends AbstractRowForControlProps {
 }
 
 const RowForObjectControl = React.memo((props: RowForObjectControlProps) => {
-  const [open, setOpen] = React.useState(true)
+  const [open, setOpen] = React.useState(false)
   const handleOnClick = React.useCallback(() => {
     if (!props.disableToggling) {
       setOpen(!open)


### PR DESCRIPTION
## Problem
The data editor is open by default, which is distracting when the object is large

For example: 
<img width="450" alt="image" src="https://github.com/concrete-utopia/utopia/assets/16385508/3518ff77-06c7-4c10-a658-adf38d1c5899">

## Fix
Render that data editor in the closed state by default.

<img width="455" alt="image" src="https://github.com/concrete-utopia/utopia/assets/16385508/5e29c3a7-5c7a-42bd-adf3-8f01b4e2c30a">


