### PR TITLE
Remix router navigation functions are async

### DIFF
--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -321,7 +321,7 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
           return
         }
         if (isOnAnotherRoute && remixLocationRoute != null && remixState != null) {
-          remixState.navigate(remixLocationRoute)
+          void remixState.navigate(remixLocationRoute)
         }
         cancelHover()
         dispatch([

--- a/editor/src/components/canvas/controls/select-mode/remix-scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/remix-scene-label.tsx
@@ -139,15 +139,15 @@ const RemixSceneLabel = React.memo<RemixSceneLabelProps>((props) => {
   const currentLocationMatchesRoutes = useCurrentLocationMatchesRoutes(props.target)
 
   const forward = React.useCallback(
-    () => navigationData[EP.toString(props.target)]?.forward(),
+    () => void navigationData[EP.toString(props.target)]?.forward(),
     [navigationData, props.target],
   )
   const back = React.useCallback(
-    () => navigationData[EP.toString(props.target)]?.back(),
+    () => void navigationData[EP.toString(props.target)]?.back(),
     [navigationData, props.target],
   )
   const home = React.useCallback(
-    () => navigationData[EP.toString(props.target)]?.home(),
+    () => void navigationData[EP.toString(props.target)]?.home(),
     [navigationData, props.target],
   )
 

--- a/editor/src/components/canvas/multiplayer-presence.tsx
+++ b/editor/src/components/canvas/multiplayer-presence.tsx
@@ -395,7 +395,7 @@ const FollowingOverlay = React.memo(() => {
         const sceneState = remixNavigationState[presence.remix.scene]
         if (sceneState != null && presence.remix.locationRoute != null) {
           setActiveRemixScene(EP.fromString(presence.remix.scene))
-          sceneState.navigate(presence.remix.locationRoute)
+          void sceneState.navigate(presence.remix.locationRoute)
           actions.push(
             showToast(
               notice(

--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -23,10 +23,10 @@ type RouteModule = RouteModules[keyof RouteModules]
 type RouterType = ReturnType<typeof createMemoryRouter>
 
 interface RemixNavigationContext {
-  forward: () => void
-  back: () => void
-  home: () => void
-  navigate: (loc: string) => void
+  forward: () => Promise<void>
+  back: () => Promise<void>
+  home: () => Promise<void>
+  navigate: (loc: string) => Promise<void>
   location: Location
   entries: Array<Location>
 }
@@ -287,10 +287,10 @@ export const UtopiaRemixRootComponent = (props: UtopiaRemixRootComponentProps) =
         return {
           ...current,
           [EP.toString(basePath)]: {
-            forward: () => void innerRouter.navigate(1),
-            back: () => void innerRouter.navigate(-1),
-            home: () => void innerRouter.navigate('/'),
-            navigate: (loc: string) => void innerRouter.navigate(loc),
+            forward: () => innerRouter.navigate(1),
+            back: () => innerRouter.navigate(-1),
+            home: () => innerRouter.navigate('/'),
+            navigate: (loc: string) => innerRouter.navigate(loc),
             location: location,
             entries: updatedEntries,
           },

--- a/editor/src/components/editor/remix-navigation-bar.tsx
+++ b/editor/src/components/editor/remix-navigation-bar.tsx
@@ -31,15 +31,15 @@ export const RemixNavigationBar = React.memo(() => {
   )
 
   const forward = React.useCallback(
-    () => navigationControls[EP.toString(activeRemixScene)]?.forward(),
+    () => void navigationControls[EP.toString(activeRemixScene)]?.forward(),
     [activeRemixScene, navigationControls],
   )
   const back = React.useCallback(
-    () => navigationControls[EP.toString(activeRemixScene)]?.back(),
+    () => void navigationControls[EP.toString(activeRemixScene)]?.back(),
     [activeRemixScene, navigationControls],
   )
   const home = React.useCallback(
-    () => navigationControls[EP.toString(activeRemixScene)]?.home(),
+    () => void navigationControls[EP.toString(activeRemixScene)]?.home(),
     [activeRemixScene, navigationControls],
   )
 

--- a/editor/src/components/inspector/sections/comment-section.tsx
+++ b/editor/src/components/inspector/sections/comment-section.tsx
@@ -198,7 +198,7 @@ const ThreadPreview = React.memo(({ thread }: ThreadPreviewProps) => {
       if (remixState == null) {
         return
       }
-      remixState.navigate(remixLocationRoute)
+      void remixState.navigate(remixLocationRoute)
     }
     let actions: EditorAction[] = [...openCommentThreadActions(thread.id, commentScene)]
 


### PR DESCRIPTION
**Problem:**
`Router.navigate` is an async function. We have our own `RemixNavigationContext` type, which implement `back`, `forward` and `home` functions. These functions are sync, and they call the async `navigate` function with void.

So our context type gives the impression that these are sync operations, but they are not!

I modified the RemixNavigationContext interface to include async functions.
