### PR TITLE
Remix: hard-delete projects

### DIFF
--- a/utopia-remix/app/models/project.server.ts
+++ b/utopia-remix/app/models/project.server.ts
@@ -1,7 +1,5 @@
-import { Project } from 'prisma-client'
 import { prisma } from '../db.server'
-
-export type ProjectWithoutContent = Omit<Project, 'content'>
+import { ProjectWithoutContent } from '../types'
 
 const selectProjectWithoutContent: Record<keyof ProjectWithoutContent, true> = {
   id: true,
@@ -72,5 +70,24 @@ export async function listDeletedProjects(params: {
       deleted: true,
     },
     orderBy: { modified_at: 'desc' },
+  })
+}
+
+export async function hardDeleteProject(params: { id: string; userId: string }): Promise<void> {
+  await prisma.project.delete({
+    where: {
+      proj_id: params.id,
+      owner_id: params.userId,
+      deleted: true,
+    },
+  })
+}
+
+export async function hardDeleteAllProjects(params: { userId: string }): Promise<void> {
+  await prisma.project.deleteMany({
+    where: {
+      owner_id: params.userId,
+      deleted: true,
+    },
   })
 }

--- a/utopia-remix/app/routes-test/projects.$id.destroy.spec.ts
+++ b/utopia-remix/app/routes-test/projects.$id.destroy.spec.ts
@@ -1,0 +1,91 @@
+import { prisma } from '../db.server'
+import { handleDestroyProject } from '../routes/projects.$id.destroy'
+import {
+  createTestProject,
+  createTestSession,
+  createTestUser,
+  newTestRequest,
+  truncateTables,
+} from '../test-util'
+import { ApiError } from '../util/api.server'
+
+describe('handleDestroyProject', () => {
+  afterEach(async () => {
+    await truncateTables([
+      prisma.userDetails,
+      prisma.persistentSession,
+      prisma.project,
+      prisma.projectID,
+    ])
+  })
+
+  beforeEach(async () => {
+    await createTestUser(prisma, { id: 'foo' })
+    await createTestUser(prisma, { id: 'bar' })
+    await createTestSession(prisma, { key: 'the-key', userId: 'foo' })
+    await createTestProject(prisma, {
+      id: 'one',
+      ownerId: 'foo',
+      title: 'project-one',
+    })
+    await createTestProject(prisma, {
+      id: 'two',
+      ownerId: 'foo',
+      title: 'project-two',
+      deleted: true,
+    })
+    await createTestProject(prisma, {
+      id: 'three',
+      ownerId: 'bar',
+      title: 'project-three',
+      deleted: true,
+    })
+  })
+
+  it('requires a user', async () => {
+    const fn = async () =>
+      handleDestroyProject(newTestRequest({ method: 'POST', authCookie: 'wrong-key' }), {})
+    await expect(fn).rejects.toThrow(ApiError)
+    await expect(fn).rejects.toThrow('session not found')
+  })
+  it('requires a valid id', async () => {
+    const fn = async () =>
+      handleDestroyProject(newTestRequest({ method: 'POST', authCookie: 'the-key' }), {})
+    await expect(fn).rejects.toThrow(ApiError)
+    await expect(fn).rejects.toThrow('id is null')
+  })
+  it('requires a valid project', async () => {
+    const fn = async () => {
+      const req = newTestRequest({ method: 'POST', authCookie: 'the-key' })
+      return handleDestroyProject(req, { id: 'doesnt-exist' })
+    }
+
+    await expect(fn).rejects.toThrow('Record to delete does not exist')
+  })
+  it('requires ownership of the project', async () => {
+    const fn = async () => {
+      const req = newTestRequest({ method: 'POST', authCookie: 'the-key' })
+      return handleDestroyProject(req, { id: 'three' })
+    }
+
+    await expect(fn).rejects.toThrow('Record to delete does not exist')
+  })
+  it('requires soft-deletion of the project', async () => {
+    const fn = async () => {
+      const req = newTestRequest({ method: 'POST', authCookie: 'the-key' })
+      return handleDestroyProject(req, { id: 'one' })
+    }
+
+    await expect(fn).rejects.toThrow('Record to delete does not exist')
+  })
+  it('hard-deletes the project', async () => {
+    const fn = async () => {
+      const req = newTestRequest({ method: 'POST', authCookie: 'the-key' })
+      return handleDestroyProject(req, { id: 'two' })
+    }
+
+    await fn()
+    const got = await prisma.project.count({ where: { proj_id: 'two' } })
+    expect(got).toEqual(0)
+  })
+})

--- a/utopia-remix/app/routes-test/projects.destroy.spec.ts
+++ b/utopia-remix/app/routes-test/projects.destroy.spec.ts
@@ -29,6 +29,8 @@ describe('handleDestroyAllProjects', () => {
     await createTestProject(prisma, { id: 'four', ownerId: 'bob' })
     await createTestProject(prisma, { id: 'five', ownerId: 'bob' })
     await createTestProject(prisma, { id: 'six', ownerId: 'bob', deleted: true })
+    await createTestProject(prisma, { id: 'seven', ownerId: 'alice' })
+    await createTestProject(prisma, { id: 'eight', ownerId: 'alice', deleted: true })
   })
 
   it('requires a user', async () => {
@@ -44,7 +46,9 @@ describe('handleDestroyAllProjects', () => {
     }
 
     await fn()
-    const got = await prisma.project.findMany({ where: { owner_id: 'bob' } })
-    expect(got.map((p) => p.proj_id)).toEqual(['one', 'four', 'five'])
+    const bobProjects = await prisma.project.findMany({ where: { owner_id: 'bob' } })
+    expect(bobProjects.map((p) => p.proj_id)).toEqual(['one', 'four', 'five'])
+    const aliceProjects = await prisma.project.findMany({ where: { owner_id: 'alice' } })
+    expect(aliceProjects.map((p) => p.proj_id)).toEqual(['three', 'seven', 'eight'])
   })
 })

--- a/utopia-remix/app/routes/projects.$id.destroy.tsx
+++ b/utopia-remix/app/routes/projects.$id.destroy.tsx
@@ -1,0 +1,20 @@
+import { ActionFunctionArgs } from '@remix-run/node'
+import { Params } from '@remix-run/react'
+import { ensure, handle, requireUser } from '../util/api.server'
+import { Status } from '../util/statusCodes.server'
+import { hardDeleteProject } from '../models/project.server'
+
+export async function action(args: ActionFunctionArgs) {
+  return handle(args, { POST: handleDestroyProject })
+}
+
+export async function handleDestroyProject(req: Request, params: Params<string>) {
+  const user = await requireUser(req)
+
+  const { id } = params
+  ensure(id != null, 'id is null', Status.BAD_REQUEST)
+
+  await hardDeleteProject({ id: id, userId: user.user_id })
+
+  return {}
+}

--- a/utopia-remix/app/routes/projects.destroy.tsx
+++ b/utopia-remix/app/routes/projects.destroy.tsx
@@ -1,0 +1,16 @@
+import { ActionFunctionArgs } from '@remix-run/node'
+import { Params } from '@remix-run/react'
+import { hardDeleteAllProjects } from '../models/project.server'
+import { handle, requireUser } from '../util/api.server'
+
+export async function action(args: ActionFunctionArgs) {
+  return handle(args, { POST: handleDestroyAllProjects })
+}
+
+export async function handleDestroyAllProjects(req: Request, params: Params<string>) {
+  const user = await requireUser(req)
+
+  await hardDeleteAllProjects({ userId: user.user_id })
+
+  return {}
+}

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -3,11 +3,12 @@ import { useLoaderData } from '@remix-run/react'
 import moment from 'moment'
 import { UserDetails } from 'prisma-client'
 import React, { useEffect, useState } from 'react'
-import { ProjectWithoutContent, listProjects } from '../models/project.server'
+import { listProjects } from '../models/project.server'
 import { newProjectButton } from '../styles/newProjectButton.css'
 import { projectCategoryButton, userName } from '../styles/sidebarComponents.css'
 import { sprinkles } from '../styles/sprinkles.css'
 import { requireUser } from '../util/api.server'
+import { ProjectWithoutContent } from '../types'
 
 export async function loader(args: LoaderFunctionArgs) {
   const user = await requireUser(args.request)

--- a/utopia-remix/app/types.ts
+++ b/utopia-remix/app/types.ts
@@ -1,3 +1,5 @@
+import { Project } from 'prisma-client'
+
 export interface ProjectListing {
   id: string
   ownerName: string | null
@@ -11,3 +13,5 @@ export interface ProjectListing {
 export type ListProjectsResponse = {
   projects: ProjectListing[]
 }
+
+export type ProjectWithoutContent = Omit<Project, 'content'>


### PR DESCRIPTION
Fix #4880 

**Problem:**

https://github.com/concrete-utopia/utopia/pull/4874 introduced soft-deleted projects that will end up in a `Trash` or similar concept. Now, we also need a way to destroy (= hard delete) projects as well.

**Fix:**

- Added routes and queries to destroy a single project (that was soft-deleted)
- Added route and queries to destroy _all_ user projects (that were soft-deleted), the equivalent of a `Empty the trash` concept.
- Added tests for both.

Note: it's easy to see a future case of soft/hard-deleting a selection of projects, but we can add it later on as a simple incremental change rather than over-engineering now.