### PR TITLE
Scoped variables show destructured parameters.

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -37,6 +37,7 @@ import { usePubSubAtomReadOnly } from '../../../core/shared/atom-with-pub-sub'
 import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../../core/shared/dom-utils'
 import { objectMap } from '../../../core/shared/object-utils'
 import type { ComponentRendererComponent } from './component-renderer-component'
+import { mapArrayToDictionary } from '../../../core/shared/array-utils'
 
 function tryToGetInstancePath(
   maybePath: ElementPath | null,
@@ -133,12 +134,18 @@ export function createComponentRendererComponent(params: {
 
     let spiedVariablesInScope: VariableData = {}
     if (utopiaJsxComponent.param != null) {
-      for (const paramName of propertiesExposedByParam(utopiaJsxComponent.param)) {
-        spiedVariablesInScope[paramName] = {
-          spiedValue: scope[paramName],
-          insertionCeiling: instancePath,
-        }
-      }
+      spiedVariablesInScope = mapArrayToDictionary(
+        propertiesExposedByParam(utopiaJsxComponent.param),
+        (paramName) => {
+          return paramName
+        },
+        (paramName) => {
+          return {
+            spiedValue: scope[paramName],
+            insertionCeiling: instancePath,
+          }
+        },
+      )
     }
 
     let codeError: Error | null = null

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -146,7 +146,11 @@ export function useGetInsertableComponents(
     }
   }, [fullPath, scopedVariables])
 
-  return insertableComponents.concat(insertableVariables)
+  if (insertMenuMode === 'insert') {
+    return insertableComponents.concat(insertableVariables)
+  } else {
+    return insertableComponents
+  }
 }
 
 export function useComponentSelectorStyles(): StylesConfig<InsertMenuItem, false> {

--- a/editor/src/components/editor/variablesmenu.spec.browser2.tsx
+++ b/editor/src/components/editor/variablesmenu.spec.browser2.tsx
@@ -140,7 +140,7 @@ describe('variables menu', () => {
         Prettier.format(
           `
         import * as React from 'react'
-        export function App({objProp, imgProp, unusedProp}) {
+          export function App({objProp: bestProp, imgProp, unusedProp, style: { background, position: rightThere }}) {
           return (
             <div
             style={{
@@ -225,7 +225,7 @@ describe('variables menu', () => {
         Prettier.format(
           `
           import * as React from 'react'
-          export function App({objProp, imgProp, unusedProp}) {
+          export function App({objProp: bestProp, imgProp, unusedProp, style: { background, position: rightThere }}) {
             return (
               <div
               style={{
@@ -279,6 +279,333 @@ describe('variables menu', () => {
         ),
       )
     })
+    it('shows and inserts destructured properties when possible', async () => {
+      const editor = await renderTestEditorWithProjectContent(
+        makeMappingFunctionTestProjectContents(),
+        'await-first-dom-report',
+      )
+
+      await selectComponentsForTest(editor, [
+        EP.fromString(
+          `${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:container/3e2/586~~~1`,
+        ),
+      ])
+
+      await openVariablesMenu(editor)
+
+      document.execCommand('insertText', false, 'unused')
+      expect(getInsertItems().length).toEqual(1)
+      expect(getInsertItems()[0].innerText).toEqual('unusedProp')
+
+      const filterBox = await screen.findByTestId(InsertMenuFilterTestId)
+      forceNotNull('the filter box must not be null', filterBox)
+
+      await pressKey('Enter', { targetElement: filterBox })
+
+      expect(getPrintedUiJsCode(editor.getEditorState(), '/src/app.js')).toEqual(
+        Prettier.format(
+          `
+          import * as React from 'react'
+          export function App({objProp: bestProp, imgProp, unusedProp, style: { background, position: rightThere }}) {
+            return (
+              <div
+              style={{
+                backgroundColor: '#aaaaaa33',
+                position: 'absolute',
+                left: 57,
+                top: 168,
+                width: 247,
+                height: 402,
+              }}
+              data-uid='container'
+            >
+              {[1, 2].map((value, index) => {
+                return (
+                  <img
+                    src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
+                    alt='Utopia logo'
+                    style={{ width: 118, height: 150 }}
+                    data-uid='020'
+                  />
+                )
+              })}
+              {[{ thing: 1 }, { thing: 2 }, { thing: 3 }].map(
+                (someValue, index) => {
+                  return (
+                    <div data-uid='586'>
+                      <img
+                        src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
+                        alt='Utopia logo'
+                        style={{ width: 118, height: 150 }}
+                        data-uid='054'
+                      />
+                      <span
+                        style={{
+                          width: 100,
+                          height: 100,
+                          position: 'absolute',
+                        }}
+                        data-uid='ele'
+                      >
+                        {JSON.stringify(unusedProp)}
+                      </span>
+                    </div>
+                  )
+                },
+              )}
+            </div>
+            )
+          }`,
+          PrettierConfig,
+        ),
+      )
+    })
+
+    it('shows and inserts destructured and renamed properties when possible', async () => {
+      const editor = await renderTestEditorWithProjectContent(
+        makeMappingFunctionTestProjectContents(),
+        'await-first-dom-report',
+      )
+
+      await selectComponentsForTest(editor, [
+        EP.fromString(
+          `${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:container/3e2/586~~~1`,
+        ),
+      ])
+
+      await openVariablesMenu(editor)
+
+      document.execCommand('insertText', false, 'bestProp')
+      expect(getInsertItems().length).toEqual(2)
+      expect(getInsertItems()[0].innerText).toEqual('bestProp')
+
+      const filterBox = await screen.findByTestId(InsertMenuFilterTestId)
+      forceNotNull('the filter box must not be null', filterBox)
+
+      await pressKey('Enter', { targetElement: filterBox })
+
+      expect(getPrintedUiJsCode(editor.getEditorState(), '/src/app.js')).toEqual(
+        Prettier.format(
+          `
+          import * as React from 'react'
+          export function App({objProp: bestProp, imgProp, unusedProp, style: { background, position: rightThere }}) {
+            return (
+              <div
+              style={{
+                backgroundColor: '#aaaaaa33',
+                position: 'absolute',
+                left: 57,
+                top: 168,
+                width: 247,
+                height: 402,
+              }}
+              data-uid='container'
+            >
+              {[1, 2].map((value, index) => {
+                return (
+                  <img
+                    src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
+                    alt='Utopia logo'
+                    style={{ width: 118, height: 150 }}
+                    data-uid='020'
+                  />
+                )
+              })}
+              {[{ thing: 1 }, { thing: 2 }, { thing: 3 }].map(
+                (someValue, index) => {
+                  return (
+                    <div data-uid='586'>
+                      <img
+                        src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
+                        alt='Utopia logo'
+                        style={{ width: 118, height: 150 }}
+                        data-uid='054'
+                      />
+                      <span
+                        style={{
+                          width: 100,
+                          height: 100,
+                          position: 'absolute',
+                        }}
+                        data-uid='ele'
+                      >
+                        {JSON.stringify(bestProp)}
+                      </span>
+                    </div>
+                  )
+                },
+              )}
+            </div>
+            )
+          }`,
+          PrettierConfig,
+        ),
+      )
+    })
+
+    it('shows and inserts nested destructured properties when possible', async () => {
+      const editor = await renderTestEditorWithProjectContent(
+        makeMappingFunctionTestProjectContents(),
+        'await-first-dom-report',
+      )
+
+      await selectComponentsForTest(editor, [
+        EP.fromString(
+          `${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:container/3e2/586~~~1`,
+        ),
+      ])
+
+      await openVariablesMenu(editor)
+
+      document.execCommand('insertText', false, 'background')
+      expect(getInsertItems().length).toEqual(1)
+      expect(getInsertItems()[0].innerText).toEqual('background')
+
+      const filterBox = await screen.findByTestId(InsertMenuFilterTestId)
+      forceNotNull('the filter box must not be null', filterBox)
+
+      await pressKey('Enter', { targetElement: filterBox })
+
+      expect(getPrintedUiJsCode(editor.getEditorState(), '/src/app.js')).toEqual(
+        Prettier.format(
+          `
+          import * as React from 'react'
+          export function App({objProp: bestProp, imgProp, unusedProp, style: { background, position: rightThere }}) {
+            return (
+              <div
+              style={{
+                backgroundColor: '#aaaaaa33',
+                position: 'absolute',
+                left: 57,
+                top: 168,
+                width: 247,
+                height: 402,
+              }}
+              data-uid='container'
+            >
+              {[1, 2].map((value, index) => {
+                return (
+                  <img
+                    src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
+                    alt='Utopia logo'
+                    style={{ width: 118, height: 150 }}
+                    data-uid='020'
+                  />
+                )
+              })}
+              {[{ thing: 1 }, { thing: 2 }, { thing: 3 }].map(
+                (someValue, index) => {
+                  return (
+                    <div data-uid='586'>
+                      <img
+                        src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
+                        alt='Utopia logo'
+                        style={{ width: 118, height: 150 }}
+                        data-uid='054'
+                      />
+                      <span
+                        style={{
+                          width: 100,
+                          height: 100,
+                          position: 'absolute',
+                        }}
+                        data-uid='ele'
+                      >
+                        {background}
+                      </span>
+                    </div>
+                  )
+                },
+              )}
+            </div>
+            )
+          }`,
+          PrettierConfig,
+        ),
+      )
+    })
+
+    it('shows and inserts nested destructured and renamed properties when possible', async () => {
+      const editor = await renderTestEditorWithProjectContent(
+        makeMappingFunctionTestProjectContents(),
+        'await-first-dom-report',
+      )
+
+      await selectComponentsForTest(editor, [
+        EP.fromString(
+          `${BakedInStoryboardUID}/${TestSceneUID}/${TestAppUID}:container/3e2/586~~~1`,
+        ),
+      ])
+
+      await openVariablesMenu(editor)
+
+      document.execCommand('insertText', false, 'rightThere')
+      expect(getInsertItems().length).toEqual(1)
+      expect(getInsertItems()[0].innerText).toEqual('rightThere')
+
+      const filterBox = await screen.findByTestId(InsertMenuFilterTestId)
+      forceNotNull('the filter box must not be null', filterBox)
+
+      await pressKey('Enter', { targetElement: filterBox })
+
+      expect(getPrintedUiJsCode(editor.getEditorState(), '/src/app.js')).toEqual(
+        Prettier.format(
+          `
+          import * as React from 'react'
+          export function App({objProp: bestProp, imgProp, unusedProp, style: { background, position: rightThere }}) {
+            return (
+              <div
+              style={{
+                backgroundColor: '#aaaaaa33',
+                position: 'absolute',
+                left: 57,
+                top: 168,
+                width: 247,
+                height: 402,
+              }}
+              data-uid='container'
+            >
+              {[1, 2].map((value, index) => {
+                return (
+                  <img
+                    src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
+                    alt='Utopia logo'
+                    style={{ width: 118, height: 150 }}
+                    data-uid='020'
+                  />
+                )
+              })}
+              {[{ thing: 1 }, { thing: 2 }, { thing: 3 }].map(
+                (someValue, index) => {
+                  return (
+                    <div data-uid='586'>
+                      <img
+                        src='https://github.com/concrete-utopia/utopia/blob/master/editor/resources/editor/pyramid_fullsize@2x.jpg?raw=true'
+                        alt='Utopia logo'
+                        style={{ width: 118, height: 150 }}
+                        data-uid='054'
+                      />
+                      <span
+                        style={{
+                          width: 100,
+                          height: 100,
+                          position: 'absolute',
+                        }}
+                        data-uid='ele'
+                      >
+                        {rightThere}
+                      </span>
+                    </div>
+                  )
+                },
+              )}
+            </div>
+            )
+          }`,
+          PrettierConfig,
+        ),
+      )
+    })
 
     it('shows and inserts scoped properties when possible with multiple elements selected', async () => {
       const editor = await renderTestEditorWithProjectContent(
@@ -310,7 +637,7 @@ describe('variables menu', () => {
         Prettier.format(
           `
           import * as React from 'react'
-          export function App({objProp, imgProp, unusedProp}) {
+          export function App({objProp: bestProp, imgProp, unusedProp, style: { background, position: rightThere }}) {
             return (
               <div
               style={{
@@ -508,7 +835,7 @@ function makeTestProjectContents(): ProjectContentTreeRoot {
     ['/src/app.js']: codeFile(
       `
     import * as React from 'react'
-    export function App({objProp, imgProp, unusedProp}) {
+    export function App({objProp: bestProp, imgProp, unusedProp, style: { background, position: rightThere }}) {
       return (
         <div
         style={{
@@ -550,7 +877,7 @@ function makeTestProjectContents(): ProjectContentTreeRoot {
           data-uid='scene-aaa'
           data-testid='scene-aaa'
         >
-        <App objProp={{key1: 'key1'}} imgProp='test.png' nonExistentProp='non' data-uid='app-entity' data-testid='app-entity' />
+        <App objProp={{key1: 'key1'}} imgProp='test.png' nonExistentProp='non' style={{background: 'white', position: 'absolute'}} data-uid='app-entity' data-testid='app-entity' />
         </Scene>
       </Storyboard>
 )`,
@@ -561,7 +888,7 @@ function makeTestProjectContents(): ProjectContentTreeRoot {
 
 const mappingFunctionAppJS: string = `
     import * as React from 'react'
-    export function App({objProp, imgProp, unusedProp}) {
+    export function App({objProp: bestProp, imgProp, unusedProp, style: { background, position: rightThere }}) {
       return (
         <div
         style={{
@@ -648,7 +975,7 @@ function makeMappingFunctionTestProjectContents(): ProjectContentTreeRoot {
           data-uid='scene-aaa'
           data-testid='scene-aaa'
         >
-        <App objProp={{key1: 'key1'}} imgProp='test.png' nonExistentProp='non' data-uid='app-entity' data-testid='app-entity' />
+        <App objProp={{key1: 'key1'}} imgProp='test.png' nonExistentProp='non' style={{background: 'white', position: 'absolute'}} data-uid='app-entity' data-testid='app-entity' />
         </Scene>
       </Storyboard>
 )`,

--- a/editor/src/components/editor/variablesmenu.spec.browser2.tsx
+++ b/editor/src/components/editor/variablesmenu.spec.browser2.tsx
@@ -65,7 +65,7 @@ describe('variables menu', () => {
 
       await openVariablesMenu(editor)
 
-      expect(getInsertItems().length).toEqual(4)
+      expect(getInsertItems().length).toEqual(7)
 
       document.execCommand('insertText', false, 'myObj.im')
 

--- a/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
@@ -23,27 +23,27 @@ describe('Set element prop via the data picker', () => {
     const theScene = editor.renderedDOM.getByTestId('scene')
     const theInspector = editor.renderedDOM.getByTestId('inspector-sections-container')
 
-    let currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId(0))
+    let currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId(9))
     await mouseClickAtPoint(currentOption, { x: 2, y: 2 })
     expect(within(theScene).queryByText('Title too')).not.toBeNull()
     expect(within(theInspector).queryByText('Title too')).not.toBeNull()
 
-    currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId(1))
+    currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId(10))
     await mouseClickAtPoint(currentOption, { x: 2, y: 2 })
     expect(within(theScene).queryByText('Alternate title')).not.toBeNull()
     expect(within(theInspector).queryByText('Alternate title')).not.toBeNull()
 
-    currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId(2))
+    currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId(11))
     await mouseClickAtPoint(currentOption, { x: 2, y: 2 })
     expect(within(theScene).queryByText('The First Title')).not.toBeNull()
     expect(within(theInspector).queryByText('The First Title')).not.toBeNull()
 
-    currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId(3))
+    currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId(12))
     await mouseClickAtPoint(currentOption, { x: 2, y: 2 })
     expect(within(theScene).queryByText('Sweet')).not.toBeNull()
     expect(within(theInspector).queryByText('Sweet')).not.toBeNull()
 
-    currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId(4))
+    currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId(13))
     await mouseClickAtPoint(currentOption, { x: 2, y: 2 })
     expect(within(theScene).queryByText('Chapter One')).not.toBeNull()
     expect(within(theInspector).queryByText('Chapter One')).not.toBeNull()

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -432,49 +432,51 @@ const DataPickerPopup = React.memo(
           <div style={{ fontSize: 14, fontWeight: 400, marginBottom: 16 }}>
             <span>Data</span>
           </div>
-          {variableNamesInScope.map(({ variableName, definedElsewhere, value }, idx) => (
-            <Button
-              data-testid={VariableFromScopeOptionTestId(idx)}
-              key={variableName}
-              onClick={onTweakProperty(variableName, definedElsewhere)}
-              style={{ width: '100%' }}
-            >
-              <UIGridRow
-                padded={false}
-                variant='<--1fr--><--1fr-->'
-                style={{
-                  justifyContent: 'space-between',
-                  alignItems: 'flex-start',
-                  gap: 8,
-                  width: '100%',
-                }}
+          {variableNamesInScope.map(({ variableName, definedElsewhere, value }, idx) => {
+            return (
+              <Button
+                data-testid={VariableFromScopeOptionTestId(idx)}
+                key={variableName}
+                onClick={onTweakProperty(variableName, definedElsewhere)}
+                style={{ width: '100%' }}
               >
-                <div>
-                  <span
-                    style={{
-                      padding: 4,
-                      borderRadius: 2,
-                      fontWeight: 400,
-                      background: colorTheme.brandNeonGreen.value,
-                    }}
-                  >
-                    {variableName}
-                  </span>
-                </div>
-                <div>
-                  <span
-                    style={{
-                      padding: 4,
-                      fontWeight: 400,
-                      color: colorTheme.neutralForeground.value,
-                    }}
-                  >
-                    {value}
-                  </span>
-                </div>
-              </UIGridRow>
-            </Button>
-          ))}
+                <UIGridRow
+                  padded={false}
+                  variant='<--1fr--><--1fr-->'
+                  style={{
+                    justifyContent: 'space-between',
+                    alignItems: 'flex-start',
+                    gap: 8,
+                    width: '100%',
+                  }}
+                >
+                  <div>
+                    <span
+                      style={{
+                        padding: 4,
+                        borderRadius: 2,
+                        fontWeight: 400,
+                        background: colorTheme.brandNeonGreen.value,
+                      }}
+                    >
+                      {variableName}
+                    </span>
+                  </div>
+                  <div>
+                    <span
+                      style={{
+                        padding: 4,
+                        fontWeight: 400,
+                        color: colorTheme.neutralForeground.value,
+                      }}
+                    >
+                      {value}
+                    </span>
+                  </div>
+                </UIGridRow>
+              </Button>
+            )
+          })}
         </FlexColumn>
       </div>
     )

--- a/editor/src/core/model/element-metadata.spec.browser2.tsx
+++ b/editor/src/core/model/element-metadata.spec.browser2.tsx
@@ -1334,6 +1334,7 @@ describe('record variable values', () => {
       },
       definedInsideString: { spiedValue: 'hello', insertionCeiling: null },
       functionResult: { spiedValue: 35, insertionCeiling: null },
+      style: { spiedValue: {}, insertionCeiling: EP.fromString('sb/scene/pg') },
     })
     expect(variablesInScope['sb/scene/pg:root/111']).toEqual<VariableData>({
       definedInsideNumber: { spiedValue: 12, insertionCeiling: null },
@@ -1345,6 +1346,7 @@ describe('record variable values', () => {
       },
       definedInsideString: { spiedValue: 'hello', insertionCeiling: null },
       functionResult: { spiedValue: 35, insertionCeiling: null },
+      style: { spiedValue: {}, insertionCeiling: EP.fromString('sb/scene/pg') },
     })
     expect(variablesInScope['sb/scene/pg:root/222']).toEqual<VariableData>({
       definedInsideNumber: { spiedValue: 12, insertionCeiling: null },
@@ -1356,6 +1358,7 @@ describe('record variable values', () => {
       },
       definedInsideString: { spiedValue: 'hello', insertionCeiling: null },
       functionResult: { spiedValue: 35, insertionCeiling: null },
+      style: { spiedValue: {}, insertionCeiling: EP.fromString('sb/scene/pg') },
     })
     expect(variablesInScope['sb/scene/pg:root/333']).toEqual<VariableData>({
       definedInsideNumber: { spiedValue: 12, insertionCeiling: null },
@@ -1367,6 +1370,7 @@ describe('record variable values', () => {
       },
       definedInsideString: { spiedValue: 'hello', insertionCeiling: null },
       functionResult: { spiedValue: 35, insertionCeiling: null },
+      style: { spiedValue: {}, insertionCeiling: EP.fromString('sb/scene/pg') },
     })
   })
 })

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -36,6 +36,7 @@ import {
   jsxFragment,
   isJSExpression,
   hasElementsWithin,
+  isUtopiaJSXComponent,
 } from '../shared/element-template'
 import type {
   StaticElementPathPart,
@@ -1246,4 +1247,26 @@ export function renameJsxElementChild<T extends JSXElementChild>(
     }
   }
   return element
+}
+
+export function findContainingComponent(
+  topLevelElements: Array<TopLevelElement>,
+  target: ElementPath,
+): UtopiaJSXComponent | null {
+  // Identify the UID of the containing component.
+  const containingElementPath = EP.getContainingComponent(target)
+  if (!EP.isEmptyPath(containingElementPath)) {
+    const componentUID = EP.toUid(containingElementPath)
+
+    // Find the component in the top level elements that we're looking for.
+    for (const topLevelElement of topLevelElements) {
+      if (isUtopiaJSXComponent(topLevelElement)) {
+        if (topLevelElement.rootElement.uid === componentUID) {
+          return topLevelElement
+        }
+      }
+    }
+  }
+
+  return null
 }

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1777,6 +1777,30 @@ export function propNamesForParam(param: Param): Array<string> {
   }
 }
 
+export function propertiesExposedByParam(param: Param): Array<string> {
+  switch (param.boundParam.type) {
+    case 'REGULAR_PARAM':
+      return [param.boundParam.paramName]
+    case 'DESTRUCTURED_ARRAY':
+      return param.boundParam.parts.flatMap((part) => {
+        switch (part.type) {
+          case 'PARAM':
+            return propertiesExposedByParam(part)
+          case 'OMITTED_PARAM':
+            return []
+          default:
+            return assertNever(part)
+        }
+      })
+    case 'DESTRUCTURED_OBJECT':
+      return param.boundParam.parts.flatMap((part) => {
+        return propertiesExposedByParam(part.param)
+      })
+    default:
+      assertNever(param.boundParam)
+  }
+}
+
 export type VarLetOrConst = 'var' | 'let' | 'const'
 export type FunctionDeclarationSyntax = 'function' | VarLetOrConst
 export type BlockOrExpression = 'block' | 'parenthesized-expression' | 'expression'


### PR DESCRIPTION
**Problem:**
With code like the following in a component:
```typescript
export function App({ style: { background } }) {
```
The destructured values aren't made available into the scoped variables menu.

**Fix:**
The main fixes needed for this to work were the following:
- `createComponentRendererComponent` now uses `propertiesExposedByParam` to identify the properties that are brought into scope from the destructuring, which are added to the dictionary of scoped variables.
- As a result of the above work, it was observed that `applyPropsParamToPassedProps` wasn't properly handled destructured fields that are renamed.

In the process of doing the above work I noticed that `getVariablesInScope` was looking for the first component it could find, not the targeted component. To perform the lookup `findContainingComponent` was implemented.

**Commit Details:**
- Added `propertiesExposedByParam` utility function.
- Added `findContainingComponent` utility function.
- `getVariablesInScope` now finds the correct component and not just the first one.
- Fixed `applyPropsParamToPassedProps` to correctly handle destructured values and repeated field usages.
- `createComponentRendererComponent` includes values exposed by the props param when building `spiedVariablesInScope`.