### PR TITLE
Fix registering external components

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
@@ -50,7 +50,7 @@ describe('Set element prop via the data picker', () => {
   })
 })
 
-describe('Controls from registerComponent', () => {
+describe('Controls from registering components', () => {
   it('registering internal component', async () => {
     const editor = await renderTestEditorWithCode(
       registerInternalComponentProject,
@@ -155,7 +155,7 @@ const registerInternalComponentProject = `import * as React from 'react'
 import {
   Storyboard,
   Scene,
-  registerComponent,
+  registerInternalComponent,
 } from 'utopia-api'
 
 function Title({ text }) {
@@ -204,7 +204,7 @@ export var storyboard = (
   </Storyboard>
 )
 
-registerComponent(Title, {
+registerInternalComponent(Title, {
   supportsChildren: false,
   properties: {
     text: {
@@ -225,7 +225,7 @@ import {
   Storyboard,
   Scene,
   View,
-  registerComponent,
+  registerExternalComponent,
 } from 'utopia-api'
 
 var Playground = ({ style }) => {
@@ -272,8 +272,9 @@ export var storyboard = (
   </Storyboard>
 )
 
-registerComponent(
+registerExternalComponent(
   View,
+  'utopia-api',
   {
     supportsChildren: false,
     properties: {
@@ -287,5 +288,4 @@ registerComponent(
       },
     ],
   },
-  'utopia-api',
 )`

--- a/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
@@ -61,11 +61,13 @@ function builtInDependency(
 export function createBuiltInDependenciesList(
   workers: UtopiaTsWorkers | null,
 ): BuiltInDependencies {
-  const { registerModule, registerComponent } = createRegisterModuleAndComponentFunction(workers)
+  const { registerModule, registerInternalComponent, registerExternalComponent } =
+    createRegisterModuleAndComponentFunction(workers)
   const UtopiaAPISpecial: typeof UtopiaAPI & { Group: any } = {
     ...UtopiaAPI,
     registerModule: registerModule,
-    registerComponent: registerComponent,
+    registerInternalComponent: registerInternalComponent,
+    registerExternalComponent: registerExternalComponent,
     Group: UtopiaApiGroup,
   }
 

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -107,19 +107,29 @@ export function getPropertyControlsForTarget(
         if (filenameForLookup == null) {
           return null
         } else {
+          const originalName =
+            importedFrom?.type === 'IMPORTED_ORIGIN' ? importedFrom.exportedName : null
+          const nameAsString = originalName ?? getJSXElementNameAsString(element.name)
+
+          const props = propertyControlsInfo[filenameForLookup]?.[nameAsString]?.properties
+
+          // if the filename works as it is, then it is either a package name or an absolute file name and
+          // we can just use it as it is
+          if (props != null) {
+            return props
+          }
+
+          // We need to create the absolute path to the file to look up the property controls
           const absolutePath = absolutePathFromRelativePath(
             underlyingFilePath,
             false,
             filenameForLookup,
           )
-          // If it's pointing at a path (as opposed to a package), strip off the filename extension.
+
           const trimmedPath = absolutePath.includes('/')
             ? absolutePath.replace(/\.(js|jsx|ts|tsx)$/, '')
             : absolutePath
 
-          const originalName =
-            importedFrom?.type === 'IMPORTED_ORIGIN' ? importedFrom.exportedName : null
-          const nameAsString = originalName ?? getJSXElementNameAsString(element.name)
           return propertyControlsInfo[trimmedPath]?.[nameAsString]?.properties
         }
       } else {

--- a/utopia-api/src/helpers/helper-functions.ts
+++ b/utopia-api/src/helpers/helper-functions.ts
@@ -20,10 +20,17 @@ export function registerModule(
   // Function is deliberately empty. If called inside the Utopia Editor, it has effect to the running environment
 }
 
-export function registerComponent(
+export function registerInternalComponent(
   component: React.FunctionComponent,
   properties: ComponentToRegister,
-  moduleName?: string,
+): void {
+  // Function is deliberately empty. If called inside the Utopia Editor, it has effect to the running environment
+}
+
+export function registerExternalComponent(
+  componentName: string,
+  packageName: string,
+  properties: ComponentToRegister,
 ): void {
   // Function is deliberately empty. If called inside the Utopia Editor, it has effect to the running environment
 }


### PR DESCRIPTION
**Problem:**
Registering the `Image` component from `@shopify/hydrogen` failed.

**Fix:**
There were 2 problems which needed to be fixed:
- We decided whether a module is an external package or an internal file based on whether it includes a `/`. However, packages can include `/` character too.
- Components do not necessarily store their names in `displayName` or `name` so it was not a good idea to rely on that for external components. For now I just decided to simplify the api, and require the component name for external components and not the component reference itself. This resulted in separate functions for internal and external components: `registerInternalComponent` and `registerExternalComponent`