### PR TITLE
Remix: state management

### DIFF
--- a/utopia-remix/app/components/projectActionContextMenu.tsx
+++ b/utopia-remix/app/components/projectActionContextMenu.tsx
@@ -1,13 +1,12 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-
 import { useFetcher } from '@remix-run/react'
 import React from 'react'
-import { Category } from '../routes/projects'
+import { useStore } from '../store'
+import { contextMenuItem } from '../styles/contextMenuItem.css'
+import { colors } from '../styles/sprinkles.css'
 import { ProjectWithoutContent } from '../types'
 import { assertNever } from '../util/assertNever'
 import { projectEditorLink } from '../util/links'
-import { contextMenuItem } from '../styles/contextMenuItem.css'
-import { colors } from '../styles/sprinkles.css'
 
 type ContextMenuEntry =
   | {
@@ -16,148 +15,141 @@ type ContextMenuEntry =
     }
   | 'separator'
 
-export const ProjectContextMenu = React.memo(
-  ({
-    selectedCategory,
-    project,
-  }: {
-    selectedCategory: Category
-    project: ProjectWithoutContent
-  }) => {
-    const fetcher = useFetcher()
+export const ProjectContextMenu = React.memo(({ project }: { project: ProjectWithoutContent }) => {
+  const fetcher = useFetcher()
+  const selectedCategory = useStore((store) => store.selectedCategory)
 
-    const deleteProject = React.useCallback(
-      (projectId: string) => {
-        fetcher.submit({}, { method: 'POST', action: `/internal/projects/${projectId}/delete` })
-      },
-      [fetcher],
-    )
+  const deleteProject = React.useCallback(
+    (projectId: string) => {
+      fetcher.submit({}, { method: 'POST', action: `/internal/projects/${projectId}/delete` })
+    },
+    [fetcher],
+  )
 
-    const destroyProject = React.useCallback(
-      (projectId: string) => {
-        const ok = window.confirm('Are you sure? The project contents will be deleted permanently.')
-        if (ok) {
-          fetcher.submit({}, { method: 'POST', action: `/internal/projects/${projectId}/destroy` })
-        }
-      },
-      [fetcher],
-    )
-
-    const restoreProject = React.useCallback(
-      (projectId: string) => {
-        fetcher.submit({}, { method: 'POST', action: `/internal/projects/${projectId}/restore` })
-      },
-      [fetcher],
-    )
-
-    const renameProject = React.useCallback(
-      (projectId: string, newTitle: string) => {
-        fetcher.submit(
-          { title: newTitle },
-          { method: 'POST', action: `/internal/projects/${projectId}/rename` },
-        )
-      },
-      [fetcher],
-    )
-
-    const menuEntries = React.useMemo((): ContextMenuEntry[] => {
-      switch (selectedCategory) {
-        case 'allProjects':
-          return [
-            {
-              text: 'Open',
-              onClick: (project) => {
-                window.open(projectEditorLink(project.proj_id), '_blank')
-              },
-            },
-            'separator',
-            {
-              text: 'Copy Link',
-              onClick: (project) => {
-                navigator.clipboard.writeText(projectEditorLink(project.proj_id))
-                // TODO notification toast
-              },
-            },
-            'separator',
-            {
-              text: 'Rename',
-              onClick: (project) => {
-                const newTitle = window.prompt('New title:', project.title)
-                if (newTitle != null) {
-                  renameProject(project.proj_id, newTitle)
-                }
-              },
-            },
-            {
-              text: 'Delete',
-              onClick: (project) => {
-                deleteProject(project.proj_id)
-              },
-            },
-          ]
-        case 'trash':
-          return [
-            {
-              text: 'Restore',
-              onClick: (project) => {
-                restoreProject(project.proj_id)
-              },
-            },
-            'separator',
-            {
-              text: 'Delete permanently',
-              onClick: (project) => {
-                destroyProject(project.proj_id)
-              },
-            },
-          ]
-        default:
-          assertNever(selectedCategory)
+  const destroyProject = React.useCallback(
+    (projectId: string) => {
+      const ok = window.confirm('Are you sure? The project contents will be deleted permanently.')
+      if (ok) {
+        fetcher.submit({}, { method: 'POST', action: `/internal/projects/${projectId}/destroy` })
       }
-    }, [selectedCategory])
+    },
+    [fetcher],
+  )
 
-    return (
-      <>
-        <DropdownMenu.Portal>
-          <DropdownMenu.Content
-            style={{
-              background: 'white',
-              padding: 4,
-              boxShadow: '2px 3px 4px #dddddd',
-              border: '1px solid #ccc',
-              borderRadius: 4,
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 4,
-              minWidth: 100,
-            }}
-            sideOffset={5}
-          >
-            {menuEntries.map((entry, index) => {
-              if (entry === 'separator') {
-                return (
-                  <DropdownMenu.Separator
-                    key={`separator-${index}`}
-                    style={{ backgroundColor: colors.separator, height: 1 }}
-                  />
-                )
+  const restoreProject = React.useCallback(
+    (projectId: string) => {
+      fetcher.submit({}, { method: 'POST', action: `/internal/projects/${projectId}/restore` })
+    },
+    [fetcher],
+  )
+
+  const renameProject = React.useCallback(
+    (projectId: string, newTitle: string) => {
+      fetcher.submit(
+        { title: newTitle },
+        { method: 'POST', action: `/internal/projects/${projectId}/rename` },
+      )
+    },
+    [fetcher],
+  )
+
+  const menuEntries = React.useMemo((): ContextMenuEntry[] => {
+    switch (selectedCategory) {
+      case 'allProjects':
+        return [
+          {
+            text: 'Open',
+            onClick: (project) => {
+              window.open(projectEditorLink(project.proj_id), '_blank')
+            },
+          },
+          'separator',
+          {
+            text: 'Copy Link',
+            onClick: (project) => {
+              navigator.clipboard.writeText(projectEditorLink(project.proj_id))
+              // TODO notification toast
+            },
+          },
+          'separator',
+          {
+            text: 'Rename',
+            onClick: (project) => {
+              const newTitle = window.prompt('New title:', project.title)
+              if (newTitle != null) {
+                renameProject(project.proj_id, newTitle)
               }
-              return (
-                <DropdownMenu.Item
-                  key={`entry-${index}`}
-                  onClick={() => entry.onClick(project)}
-                  className={contextMenuItem()}
-                >
-                  {entry.text}
-                </DropdownMenu.Item>
-              )
-            })}
-          </DropdownMenu.Content>
-        </DropdownMenu.Portal>
+            },
+          },
+          {
+            text: 'Delete',
+            onClick: (project) => {
+              deleteProject(project.proj_id)
+            },
+          },
+        ]
+      case 'trash':
+        return [
+          {
+            text: 'Restore',
+            onClick: (project) => {
+              restoreProject(project.proj_id)
+            },
+          },
+          'separator',
+          {
+            text: 'Delete permanently',
+            onClick: (project) => {
+              destroyProject(project.proj_id)
+            },
+          },
+        ]
+      default:
+        assertNever(selectedCategory)
+    }
+  }, [selectedCategory])
 
-        <fetcher.Form />
-      </>
-    )
-  },
-)
+  return (
+    <>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          style={{
+            background: 'white',
+            padding: 4,
+            boxShadow: '2px 3px 4px #dddddd',
+            border: '1px solid #ccc',
+            borderRadius: 4,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 4,
+            minWidth: 100,
+          }}
+          sideOffset={5}
+        >
+          {menuEntries.map((entry, index) => {
+            if (entry === 'separator') {
+              return (
+                <DropdownMenu.Separator
+                  key={`separator-${index}`}
+                  style={{ backgroundColor: colors.separator, height: 1 }}
+                />
+              )
+            }
+            return (
+              <DropdownMenu.Item
+                key={`entry-${index}`}
+                onClick={() => entry.onClick(project)}
+                className={contextMenuItem()}
+              >
+                {entry.text}
+              </DropdownMenu.Item>
+            )
+          })}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+
+      <fetcher.Form />
+    </>
+  )
+})
 ProjectContextMenu.displayName = 'ProjectContextMenu'

--- a/utopia-remix/app/store.tsx
+++ b/utopia-remix/app/store.tsx
@@ -1,0 +1,22 @@
+import { create } from 'zustand'
+import { devtools, persist } from 'zustand/middleware'
+import { Category } from './routes/projects'
+
+interface Store {
+  selectedCategory: Category
+  setSelectedCategory: (category: Category) => void
+}
+
+export const useStore = create<Store>()(
+  devtools(
+    persist(
+      (set) => ({
+        selectedCategory: 'allProjects',
+        setSelectedCategory: (category: Category) => set(() => ({ selectedCategory: category })),
+      }),
+      {
+        name: 'store',
+      },
+    ),
+  ),
+)

--- a/utopia-remix/package.json
+++ b/utopia-remix/package.json
@@ -29,7 +29,8 @@
     "react-dom": "18.2.0",
     "slugify": "1.6.6",
     "tiny-invariant": "1.3.1",
-    "url-join": "5.0.0"
+    "url-join": "5.0.0",
+    "zustand": "4.5.0"
   },
   "devDependencies": {
     "@babel/core": "7.23.9",

--- a/utopia-remix/pnpm-lock.yaml
+++ b/utopia-remix/pnpm-lock.yaml
@@ -42,6 +42,7 @@ specifiers:
   ts-node: 10.9.2
   typescript: 5.1.6
   url-join: 5.0.0
+  zustand: 4.5.0
 
 dependencies:
   '@prisma/client': 5.9.0_prisma@5.9.0
@@ -60,6 +61,7 @@ dependencies:
   slugify: 1.6.6
   tiny-invariant: 1.3.1
   url-join: 5.0.0
+  zustand: 4.5.0_j3ahe22lw6ac2w6qvqp4kjqnqy
 
 devDependencies:
   '@babel/core': 7.23.9
@@ -8979,6 +8981,14 @@ packages:
       tslib: 2.6.2
     dev: false
 
+  /use-sync-external-store/1.2.0_react@18.2.0:
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
+
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
@@ -9290,6 +9300,26 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /zustand/4.5.0_j3ahe22lw6ac2w6qvqp4kjqnqy:
+    resolution: {integrity: sha512-zlVFqS5TQ21nwijjhJlx4f9iGrXSL0o/+Dpy4txAP22miJ8Ti6c1Ol1RLNN98BMib83lmDH/2KmLwaNXpjrO1A==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      '@types/react': 18.2.20
+      react: 18.2.0
+      use-sync-external-store: 1.2.0_react@18.2.0
+    dev: false
 
   /zwitch/2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}


### PR DESCRIPTION
Fix #4903 

**Problem:**

The Remix app needs a simple state management solution so we don't have to pass around variables through components.

**Fix:**

- Add `zustand`
- Init a simple store with a field and a setter for the current `Category`
- Use the store data where applicable