### PR TITLE
Data picker - dim options that don't match

### DIFF
--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -17,6 +17,7 @@ export interface VariableOption {
   definedElsewhere: string | null
   value: string
   depth: number
+  advanced: boolean
 }
 
 export interface DataPickerPopupProps {
@@ -94,7 +95,7 @@ export const DataPickerPopup = React.memo(
             <span>Data</span>
           </div>
           {variableNamesInScope.map(
-            ({ variableName, definedElsewhere, value, displayName, depth = 0 }, idx) => {
+            ({ variableName, definedElsewhere, value, displayName, depth, advanced }, idx) => {
               return (
                 <Button
                   data-testid={VariableFromScopeOptionTestId(idx)}
@@ -112,6 +113,7 @@ export const DataPickerPopup = React.memo(
                       width: '100%',
                       minHeight: 'auto',
                       gridTemplateColumns: '48% 48%',
+                      opacity: advanced ? 1 : 0.5,
                     }}
                   >
                     <div>

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -17,7 +17,7 @@ export interface VariableOption {
   definedElsewhere: string | null
   value: string
   depth: number
-  advanced: boolean
+  valueMatchesPropType: boolean
 }
 
 export interface DataPickerPopupProps {
@@ -95,7 +95,10 @@ export const DataPickerPopup = React.memo(
             <span>Data</span>
           </div>
           {variableNamesInScope.map(
-            ({ variableName, definedElsewhere, value, displayName, depth, advanced }, idx) => {
+            (
+              { variableName, definedElsewhere, value, displayName, depth, valueMatchesPropType },
+              idx,
+            ) => {
               return (
                 <Button
                   data-testid={VariableFromScopeOptionTestId(idx)}
@@ -113,7 +116,7 @@ export const DataPickerPopup = React.memo(
                       width: '100%',
                       minHeight: 'auto',
                       gridTemplateColumns: '48% 48%',
-                      opacity: advanced ? 1 : 0.5,
+                      opacity: valueMatchesPropType ? 1 : 0.5,
                     }}
                   >
                     <div>

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -17,7 +17,7 @@ function valuesFromObject(
   value: object | null,
   depth: number,
   displayName: string,
-  advanced: boolean,
+  valueMatchesPropType: boolean,
 ): Array<VariableOption> {
   if (value == null) {
     return [
@@ -27,7 +27,7 @@ function valuesFromObject(
         definedElsewhere: null,
         value: `null`,
         depth: depth,
-        advanced: advanced,
+        valueMatchesPropType: valueMatchesPropType,
       },
     ]
   }
@@ -38,7 +38,7 @@ function valuesFromObject(
     definedElsewhere: objectName,
     displayName: variable.displayName,
     depth: variable.depth,
-    advanced: advanced,
+    valueMatchesPropType: valueMatchesPropType,
   })
 
   if (Array.isArray(value)) {
@@ -49,13 +49,17 @@ function valuesFromObject(
         definedElsewhere: objectName,
         value: `[ ]`,
         depth: depth,
-        advanced: advanced,
+        valueMatchesPropType: valueMatchesPropType,
       }),
     ].concat(
       value.flatMap((v, idx) =>
-        valuesFromVariable(`${name}[${idx}]`, v, depth + 1, `${displayName}[${idx}]`, advanced).map(
-          (variable) => patchDefinedElsewhereInfo(variable),
-        ),
+        valuesFromVariable(
+          `${name}[${idx}]`,
+          v,
+          depth + 1,
+          `${displayName}[${idx}]`,
+          valueMatchesPropType,
+        ).map((variable) => patchDefinedElsewhereInfo(variable)),
       ),
     )
   }
@@ -67,12 +71,12 @@ function valuesFromObject(
       definedElsewhere: objectName,
       value: `{ }`,
       depth: depth,
-      advanced: false,
+      valueMatchesPropType: false,
     }),
   ].concat(
     Object.entries(value).flatMap(([key, field]) =>
-      valuesFromVariable(`${name}['${key}']`, field, depth + 1, key, advanced).map((variable) =>
-        patchDefinedElsewhereInfo(variable),
+      valuesFromVariable(`${name}['${key}']`, field, depth + 1, key, valueMatchesPropType).map(
+        (variable) => patchDefinedElsewhereInfo(variable),
       ),
     ),
   )
@@ -83,7 +87,7 @@ function valuesFromVariable(
   value: unknown,
   depth: number,
   displayName: string,
-  advanced: boolean,
+  valueMatchesPropType: boolean,
 ): Array<VariableOption> {
   switch (typeof value) {
     case 'bigint':
@@ -98,11 +102,11 @@ function valuesFromVariable(
           definedElsewhere: name,
           value: `${value}`,
           depth: depth,
-          advanced: advanced,
+          valueMatchesPropType: valueMatchesPropType,
         },
       ]
     case 'object':
-      return valuesFromObject(name, name, value, depth, displayName, advanced)
+      return valuesFromObject(name, name, value, depth, displayName, valueMatchesPropType)
     case 'function':
     case 'symbol':
       return []


### PR DESCRIPTION
## Description

This PR improves that data picker so that options that don't match any control descriptions / the existing property value are dimmed out. 

<img width="1540" alt="image" src="https://github.com/concrete-utopia/utopia/assets/16385508/5e1580f9-523e-43bf-9ab8-347eb540409c">


