### PR TITLE
Remix: empty trash

### DIFF
--- a/utopia-remix/app/components/projectActionContextMenu.tsx
+++ b/utopia-remix/app/components/projectActionContextMenu.tsx
@@ -116,46 +116,42 @@ export const ProjectContextMenu = React.memo(({ project }: { project: ProjectWit
   }, [selectedCategory])
 
   return (
-    <>
-      <DropdownMenu.Portal>
-        <DropdownMenu.Content
-          style={{
-            background: 'white',
-            padding: 4,
-            boxShadow: '2px 3px 4px #dddddd',
-            border: '1px solid #ccc',
-            borderRadius: 4,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 4,
-            minWidth: 100,
-          }}
-          sideOffset={5}
-        >
-          {menuEntries.map((entry, index) => {
-            if (entry === 'separator') {
-              return (
-                <DropdownMenu.Separator
-                  key={`separator-${index}`}
-                  style={{ backgroundColor: colors.separator, height: 1 }}
-                />
-              )
-            }
+    <DropdownMenu.Portal>
+      <DropdownMenu.Content
+        style={{
+          background: 'white',
+          padding: 4,
+          boxShadow: '2px 3px 4px #dddddd',
+          border: '1px solid #ccc',
+          borderRadius: 4,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 4,
+          minWidth: 100,
+        }}
+        sideOffset={5}
+      >
+        {menuEntries.map((entry, index) => {
+          if (entry === 'separator') {
             return (
-              <DropdownMenu.Item
-                key={`entry-${index}`}
-                onClick={() => entry.onClick(project)}
-                className={contextMenuItem()}
-              >
-                {entry.text}
-              </DropdownMenu.Item>
+              <DropdownMenu.Separator
+                key={`separator-${index}`}
+                style={{ backgroundColor: colors.separator, height: 1 }}
+              />
             )
-          })}
-        </DropdownMenu.Content>
-      </DropdownMenu.Portal>
-
-      <fetcher.Form />
-    </>
+          }
+          return (
+            <DropdownMenu.Item
+              key={`entry-${index}`}
+              onClick={() => entry.onClick(project)}
+              className={contextMenuItem()}
+            >
+              {entry.text}
+            </DropdownMenu.Item>
+          )
+        })}
+      </DropdownMenu.Content>
+    </DropdownMenu.Portal>
   )
 })
 ProjectContextMenu.displayName = 'ProjectContextMenu'

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -52,7 +52,7 @@ const ProjectsPage = React.memo(() => {
 
   const fetcher = useFetcher()
 
-  const [projects, setProjects] = React.useState<ProjectWithoutContent[]>([])
+  const [projects, setProjects] = React.useState<ProjectWithoutContent[]>(data.projects)
   const [searchQuery, setSearchQuery] = useState<string>('')
   const [isDarkMode, setIsDarkMode] = useState<boolean>(false)
 
@@ -106,20 +106,20 @@ const ProjectsPage = React.memo(() => {
 
   const handleCategoryClick = React.useCallback(
     (category: React.SetStateAction<string>) => {
-      setCategory(category as Category)
+      udpateCategory(category as Category)
     },
     [setCategory],
   )
 
-  // when the category changes:
-  // 1. reset the search query
-  // 2. reset the selected project
-  // 3. update the projects
-  React.useEffect(() => {
-    setSearchQuery('')
-    setSelectedProjectId(null)
-    updateProjects(selectedCategory)
-  }, [selectedCategory, setSelectedProjectId, updateProjects])
+  const udpateCategory = React.useCallback(
+    (category: Category) => {
+      setCategory(category)
+      setSearchQuery('')
+      setSelectedProjectId(null)
+      updateProjects(category)
+    },
+    [selectedCategory, setSelectedProjectId, updateProjects],
+  )
 
   // when the media query changes, update the theme
   React.useEffect(() => {

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -104,13 +104,6 @@ const ProjectsPage = React.memo(() => {
     [selectedProjectId, setSelectedProjectId],
   )
 
-  const handleCategoryClick = React.useCallback(
-    (category: React.SetStateAction<string>) => {
-      udpateCategory(category as Category)
-    },
-    [setCategory],
-  )
-
   const udpateCategory = React.useCallback(
     (category: Category) => {
       setCategory(category)
@@ -119,6 +112,13 @@ const ProjectsPage = React.memo(() => {
       updateProjects(category)
     },
     [selectedCategory, setSelectedProjectId, updateProjects],
+  )
+
+  const handleCategoryClick = React.useCallback(
+    (category: React.SetStateAction<string>) => {
+      udpateCategory(category as Category)
+    },
+    [udpateCategory],
   )
 
   // when the media query changes, update the theme

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -1,9 +1,9 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { LoaderFunctionArgs, json } from '@remix-run/node'
-import { useLoaderData } from '@remix-run/react'
+import { useFetcher, useLoaderData } from '@remix-run/react'
 import moment from 'moment'
 import { UserDetails } from 'prisma-client'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { ProjectContextMenu } from '../components/projectActionContextMenu'
 import { listDeletedProjects, listProjects } from '../models/project.server'
 import { useStore } from '../store'
@@ -15,6 +15,7 @@ import { ProjectWithoutContent } from '../types'
 import { requireUser } from '../util/api.server'
 import { assertNever } from '../util/assertNever'
 import { projectEditorLink } from '../util/links'
+import { when } from '../util/react-conditionals'
 
 export async function loader(args: LoaderFunctionArgs) {
   const user = await requireUser(args.request)
@@ -30,10 +31,6 @@ export async function loader(args: LoaderFunctionArgs) {
   return json({ projects, deletedProjects, user })
 }
 
-type ProjectsPageState = {
-  selectedProjectId: string | null
-}
-
 const Categories = ['allProjects', 'trash'] as const
 
 export type Category = (typeof Categories)[number]
@@ -47,104 +44,85 @@ const ProjectsPage = React.memo(() => {
   const marginSize = 30
   const rowHeight = 30
 
-  const [selectedProject, setSelectedProject] = useState<ProjectsPageState>({
-    selectedProjectId: null,
-  })
-
-  const handleProjectSelect = (projectId: string) => {
-    setSelectedProject({ selectedProjectId: projectId })
-  }
-  const clearSelectedProject = () => setSelectedProject({ selectedProjectId: null })
-
-  const selectedCategory = useStore((store) => store.selectedCategory)
-  const setCategory = useStore((store) => store.setSelectedCategory)
-
-  const handleCategoryClick = (category: React.SetStateAction<string>) => {
-    setCategory(category as Category)
-  }
-
   const data = useLoaderData() as unknown as {
     projects: ProjectWithoutContent[]
     user: UserDetails
     deletedProjects: ProjectWithoutContent[]
   }
 
+  const fetcher = useFetcher()
+
   const [projects, setProjects] = React.useState<ProjectWithoutContent[]>([])
+  const [searchQuery, setSearchQuery] = useState<string>('')
+  const [isDarkMode, setIsDarkMode] = useState<boolean>(false)
 
-  const [searchValue, setSearchValue] = useState('')
-  const [searchQuery, setSearchQuery] = useState('')
-  const [filteredProjects, setFilteredProjects] = useState<ProjectWithoutContent[]>([])
-
-  const updateProjects = React.useCallback(() => {
-    switch (selectedCategory) {
-      case 'allProjects':
-        setProjects(data.projects)
-        break
-      case 'trash':
-        setProjects(data.deletedProjects)
-        break
-      default:
-        assertNever(selectedCategory)
+  const filteredProjects = React.useMemo(() => {
+    const sanitizedQuery = searchQuery.trim().toLowerCase()
+    if (sanitizedQuery.length === 0) {
+      return projects
     }
-  }, [selectedCategory, data.projects, data.deletedProjects])
+    return projects.filter((project) => project.title.toLowerCase().includes(sanitizedQuery))
+  }, [projects, searchQuery])
 
-  React.useEffect(() => {
-    updateProjects()
-  }, [updateProjects])
+  const selectedProjectId = useStore((store) => store.selectedProjectId)
+  const setSelectedProjectId = useStore((store) => store.setSelectedProjectId)
+  const selectedCategory = useStore((store) => store.selectedCategory)
+  const setCategory = useStore((store) => store.setSelectedCategory)
 
-  const filterProjects = React.useCallback(() => {
-    if (searchValue === '') {
-      setFilteredProjects(projects)
-      setSearchQuery('')
-    } else {
-      const filteredProjects = projects.filter((project) =>
-        project.title.toLowerCase().includes(searchValue.toLowerCase()),
-      )
-      setFilteredProjects(filteredProjects)
-      setSearchQuery(searchValue)
-    }
-  }, [projects])
-
-  React.useEffect(() => {
-    filterProjects()
-  }, [searchValue, projects])
-
-  const createNewProject = () => {
-    window.open(projectEditorLink(null), '_blank')
-  }
-
-  const newProjectButtons = [
-    {
-      id: 'createProject',
-      title: '+ Blank Project',
-      onClick: createNewProject,
-      color: 'orange',
+  const updateProjects = React.useCallback(
+    (category: Category) => {
+      switch (category) {
+        case 'allProjects':
+          setProjects(data.projects)
+          break
+        case 'trash':
+          setProjects(data.deletedProjects)
+          break
+        default:
+          assertNever(category)
+      }
     },
-    // {
-    //   title: '+ Project On GitHub',
-    //   onClick: createNewProject,
-    //   color: 'pink',
-    // },
-    // {
-    //   title: '+ Import From GitHub',
-    //   onClick: createNewProject,
-    //   color: 'purple',
-    // },
-    // {
-    //   title: '+ Remix Project',
-    //   onClick: createNewProject,
-    //   color: 'blue',
-    // },
-    // {
-    //   title: '+ Shopify Store',
-    //   onClick: createNewProject,
-    //   color: 'green',
-    // },
-  ] as const
+    [data.projects, data.deletedProjects],
+  )
 
-  const [isDarkMode, setIsDarkMode] = useState(false)
+  const handleEmptyTrash = React.useCallback(() => {
+    const ok = window.confirm(
+      'Are you sure? ALL projects in the trash will be deleted permanently.',
+    )
+    if (ok) {
+      fetcher.submit({}, { method: 'POST', action: `/internal/projects/destroy` })
+    }
+  }, [fetcher])
 
-  useEffect(() => {
+  const handleProjectSelect = React.useCallback(
+    (project: ProjectWithoutContent) => {
+      if (project.deleted) {
+        return
+      }
+      setSelectedProjectId(project.proj_id === selectedProjectId ? null : project.proj_id)
+    },
+    [selectedProjectId, setSelectedProjectId],
+  )
+
+  const handleCategoryClick = React.useCallback(
+    (category: React.SetStateAction<string>) => {
+      setCategory(category as Category)
+    },
+    [setCategory],
+  )
+
+  // when the category changes:
+  // 1. reset the search query
+  // 2. reset the selected project
+  // 3. update the projects
+  React.useEffect(() => {
+    setSearchQuery('')
+    setSelectedProjectId(null)
+    updateProjects(selectedCategory)
+  }, [selectedCategory, setSelectedProjectId, updateProjects])
+
+  // when the media query changes, update the theme
+  React.useEffect(() => {
     const handleColorSchemeChange = (event: {
       matches: boolean | ((prevState: boolean) => boolean)
     }) => {
@@ -159,6 +137,35 @@ const ProjectsPage = React.memo(() => {
       mediaQuery.removeListener(handleColorSchemeChange)
     }
   }, [])
+
+  const newProjectButtons = [
+    {
+      id: 'createProject',
+      title: '+ Blank Project',
+      onClick: () => window.open(projectEditorLink(null), '_blank'),
+      color: 'orange',
+    },
+    // {
+    //   title: '+ Project On GitHub',
+    //   onClick: () => {},
+    //   color: 'pink',
+    // },
+    // {
+    //   title: '+ Import From GitHub',
+    //   onClick: () => {},
+    //   color: 'purple',
+    // },
+    // {
+    //   title: '+ Remix Project',
+    //   onClick: () => {},
+    //   color: 'blue',
+    // },
+    // {
+    //   title: '+ Shopify Store',
+    //   onClick: () => {},
+    //   color: 'green',
+    // },
+  ] as const
 
   const logoPic = isDarkMode ? 'url(/assets/pyramid_dark.png)' : 'url(/assets/pyramid_light.png)'
 
@@ -177,7 +184,6 @@ const ProjectsPage = React.memo(() => {
       }}
     >
       <div
-        onMouseDown={clearSelectedProject}
         style={{
           display: 'flex',
           flexDirection: 'column',
@@ -212,11 +218,9 @@ const ProjectsPage = React.memo(() => {
           <input
             id='search-input'
             autoFocus={true}
-            onChange={(e) => setSearchValue(e.target.value)}
-            onKeyPress={(e) => {
-              if (e.key === 'Enter') {
-                filterProjects()
-              }
+            value={searchQuery}
+            onChange={(e) => {
+              setSearchQuery(e.target.value)
             }}
             style={{
               border: 'none',
@@ -230,7 +234,7 @@ const ProjectsPage = React.memo(() => {
               alignItems: 'center',
               padding: '0 14px',
             }}
-            placeholder='Search...'
+            placeholder='Search…'
           />
           <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
             {Object.entries(categories).map(([category, data]) => {
@@ -279,7 +283,6 @@ const ProjectsPage = React.memo(() => {
         }}
       >
         <div
-          onMouseDown={clearSelectedProject}
           style={{
             height: 60,
             flex: 0,
@@ -294,35 +297,53 @@ const ProjectsPage = React.memo(() => {
             </button>
           ))}
         </div>
-        <div
-          onMouseDown={clearSelectedProject}
-          style={{ fontSize: 16, fontWeight: 600, padding: '5px 10px' }}
-        >
-          {searchQuery !== '' ? (
-            <span>
-              <span style={{ color: 'gray', paddingRight: 3 }}>
-                <span
-                  onClick={() => {
-                    setSearchValue('')
-                    setFilteredProjects(projects)
-                    setSearchQuery('')
-                    const inputElement = document.getElementById('search-input') as HTMLInputElement
-                    if (inputElement) {
-                      inputElement.value = ''
-                    }
-                  }}
-                  style={{ cursor: 'pointer' }}
+        <div style={{ fontSize: 16, fontWeight: 600, padding: '5px 10px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', height: 40 }}>
+            <div style={{ flex: 'auto' }}>
+              {when(
+                searchQuery !== '',
+                <span>
+                  <span style={{ color: 'gray', paddingRight: 3 }}>
+                    <span
+                      onClick={() => {
+                        setSearchQuery('')
+                        const inputElement = document.getElementById(
+                          'search-input',
+                        ) as HTMLInputElement
+                        if (inputElement) {
+                          inputElement.value = ''
+                        }
+                      }}
+                      style={{ cursor: 'pointer' }}
+                    >
+                      ←{' '}
+                    </span>{' '}
+                    Search results for
+                  </span>
+                  <span> "{searchQuery}"</span>
+                </span>,
+              )}
+              {when(
+                searchQuery === '',
+                <div style={{ flex: 1 }}>{categories[selectedCategory].name}</div>,
+              )}
+            </div>
+
+            <div>
+              {when(
+                selectedCategory === 'trash',
+                <button
+                  className={button({ size: 'small' })}
+                  onClick={handleEmptyTrash}
+                  disabled={filteredProjects.length === 0}
                 >
-                  ←{' '}
-                </span>{' '}
-                Search results for
-              </span>
-              <span> "{searchQuery}"</span>
-            </span>
-          ) : (
-            categories[selectedCategory].name
-          )}
+                  Empty trash
+                </button>,
+              )}
+            </div>
+          </div>
         </div>
+
         <div
           style={{
             display: 'flex',
@@ -339,8 +360,8 @@ const ProjectsPage = React.memo(() => {
             <ProjectCard
               key={project.proj_id}
               project={project}
-              selected={project.proj_id === selectedProject.selectedProjectId}
-              onSelect={() => handleProjectSelect(project.proj_id)}
+              selected={project.proj_id === selectedProjectId}
+              onSelect={() => handleProjectSelect(project)}
             />
           ))}
         </div>

--- a/utopia-remix/app/store.tsx
+++ b/utopia-remix/app/store.tsx
@@ -3,6 +3,8 @@ import { devtools, persist } from 'zustand/middleware'
 import { Category } from './routes/projects'
 
 interface Store {
+  selectedProjectId: string | null
+  setSelectedProjectId: (projectId: string | null) => void
   selectedCategory: Category
   setSelectedCategory: (category: Category) => void
 }
@@ -13,6 +15,9 @@ export const useStore = create<Store>()(
       (set) => ({
         selectedCategory: 'allProjects',
         setSelectedCategory: (category: Category) => set(() => ({ selectedCategory: category })),
+        selectedProjectId: null,
+        setSelectedProjectId: (projectId: string | null) =>
+          set(() => ({ selectedProjectId: projectId })),
       }),
       {
         name: 'store',

--- a/utopia-remix/app/styles/button.css.ts
+++ b/utopia-remix/app/styles/button.css.ts
@@ -15,6 +15,10 @@ export const button = recipe({
       alignItems: 'center',
       justifyContent: 'center',
       gap: 4,
+      ':disabled': {
+        opacity: 0.5,
+        cursor: 'not-allowed',
+      },
     },
   ],
 
@@ -26,9 +30,9 @@ export const button = recipe({
       danger: { background: 'red' },
     },
     size: {
-      small: { padding: 8 },
-      medium: { padding: 10 },
-      large: { padding: 16 },
+      small: { padding: 8, fontSize: '.9em' },
+      medium: { padding: 10, fontSize: '1em' },
+      large: { padding: 16, fontSize: '1.1em' },
     },
   },
 

--- a/utopia-remix/app/util/react-conditionals.ts
+++ b/utopia-remix/app/util/react-conditionals.ts
@@ -1,0 +1,28 @@
+import React from 'react'
+import type { ReactNode } from 'react'
+
+function elementFromElementOrFunction(element: ReactNode | (() => ReactNode)): ReactNode {
+  if (React.isValidElement(element)) {
+    return element
+  } else if (typeof element === 'function') {
+    return element()
+  } else {
+    return element
+  }
+}
+
+export function when(condition: boolean, element: ReactNode | (() => ReactNode)): ReactNode {
+  if (condition) {
+    return elementFromElementOrFunction(element)
+  } else {
+    return null
+  }
+}
+
+export function unless(condition: boolean, element: ReactNode | (() => ReactNode)): ReactNode {
+  if (condition) {
+    return null
+  } else {
+    return elementFromElementOrFunction(element)
+  }
+}


### PR DESCRIPTION
Fix #4912 

This PR adds a button to empty the soft-deleted projects (`Empty Trash`) in the Remix projects page.

Also, the PR does a bit of housecleaning in the main component of the page, as it was starting to grown a bit cluttered.
There's still _a lot_ of room for improvement (e.g. we should split into multiple components for the different sections) but it can be done separately.