### PR TITLE
Array pagination in picker

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
@@ -38,33 +38,32 @@ describe('Set element prop via the data picker', () => {
       'titleIdeas',
       'titleIdeas[0]',
     ])
-
     // choose a string-valued variable
-    let currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId(0))
+    let currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId('0'))
     await mouseClickAtPoint(currentOption, { x: 2, y: 2 })
     expect(within(theScene).queryByText('Title too')).not.toBeNull()
     expect(within(theInspector).queryByText('Title too')).not.toBeNull()
 
     // choose another string-valued variable
-    currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId(1))
+    currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId('1'))
     await mouseClickAtPoint(currentOption, { x: 2, y: 2 })
     expect(within(theScene).queryByText('Alternate title')).not.toBeNull()
     expect(within(theInspector).queryByText('Alternate title')).not.toBeNull()
 
     // choose an object prop
-    currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId(3))
+    currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId('2-0'))
     await mouseClickAtPoint(currentOption, { x: 2, y: 2 })
     expect(within(theScene).queryByText('The First Title')).not.toBeNull()
     expect(within(theInspector).queryByText('The First Title')).not.toBeNull()
 
     // choose an object prop
-    currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId(4))
+    currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId('2-1'))
     await mouseClickAtPoint(currentOption, { x: 2, y: 2 })
     expect(within(theScene).queryByText('Sweet')).not.toBeNull()
     expect(within(theInspector).queryByText('Sweet')).not.toBeNull()
 
     // choose an array element
-    currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId(6))
+    currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId('3-0'))
     await mouseClickAtPoint(currentOption, { x: 2, y: 2 })
     expect(within(theScene).queryByText('Chapter One')).not.toBeNull()
     expect(within(theInspector).queryByText('Chapter One')).not.toBeNull()

--- a/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
@@ -115,7 +115,6 @@ describe('Set element prop via the data picker', () => {
     expect(options).toEqual([
       'titleIdeas', // the array is at the top because of the array descriptor
       'titleIdeas[0]', // <- array element
-      'titleIdeas[1]', // <- array element
       'titleToo',
       'currentCount',
       'bookInfo',
@@ -153,7 +152,6 @@ describe('Set element prop via the data picker', () => {
       'currentCount',
       'titleIdeas',
       'titleIdeas[0]',
-      'titleIdeas[1]',
     ])
   })
 
@@ -201,10 +199,8 @@ describe('Set element prop via the data picker', () => {
     expect(options).toEqual([
       'authors', // at the top because it's an array of string, same as titleIdeas
       'authors[0]',
-      'authors[1]',
       'titleIdeas', // the original array of string
       'titleIdeas[0]',
-      'titleIdeas[1]',
       'titleToo',
       'currentCount',
     ])
@@ -326,10 +322,8 @@ describe('Set element prop via the data picker', () => {
     expect(options).toEqual([
       'authors',
       'authors[0]',
-      'authors[1]',
       'titleIdeas',
       'titleIdeas[0]',
-      'titleIdeas[1]',
       'props',
       'titleToo',
       'currentCount',
@@ -380,10 +374,8 @@ describe('Set element prop via the data picker', () => {
     expect(options).toEqual([
       'authors',
       'authors[0]',
-      'authors[1]',
       'titleIdeas',
       'titleIdeas[0]',
-      'titleIdeas[1]',
       'titleToo',
       'currentCount',
     ])

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -103,7 +103,7 @@ import { array } from 'prop-types'
 import { useVariablesInScopeForSelectedElement } from './variables-in-scope-utils'
 import { DataPickerPopup } from './data-picker-popup'
 
-export const VariableFromScopeOptionTestId = (idx: number) => `variable-from-scope-${idx}`
+export const VariableFromScopeOptionTestId = (idx: string) => `variable-from-scope-${idx}`
 export const DataPickerPopupButtonTestId = `data-picker-popup-button-test-id`
 export const DataPickerPopupTestId = `data-picker-popup-test-id`
 

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -141,7 +141,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
         data-testid={VariableFromScopeOptionTestId(idx)}
         key={variableName}
         style={{ width: '100%', height: 25 }}
-        onClick={stopPropagation}
+        onClick={isArray ? stopPropagation : tweakProperty}
       >
         <UIGridRow
           padded={false}

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -17,6 +17,7 @@ export interface VariableOption {
   definedElsewhere: string | null
   value: string
   depth: number
+  variableChildren?: Array<VariableOption>
 }
 
 export interface DataPickerPopupProps {
@@ -93,91 +94,130 @@ export const DataPickerPopup = React.memo(
           <div style={{ fontSize: 14, fontWeight: 400, marginBottom: 16 }}>
             <span>Data</span>
           </div>
-          {variableNamesInScope.map(
-            ({ variableName, definedElsewhere, value, displayName, depth = 0 }, idx) => {
-              return (
-                <Button
-                  data-testid={VariableFromScopeOptionTestId(idx)}
-                  key={variableName}
-                  onClick={onTweakProperty(variableName, definedElsewhere)}
-                  style={{ width: '100%', height: 25 }}
-                >
-                  <UIGridRow
-                    padded={false}
-                    variant='<--1fr--><--1fr-->'
-                    style={{
-                      justifyContent: 'space-between',
-                      alignItems: 'flex-start',
-                      gap: 8,
-                      width: '100%',
-                      minHeight: 'auto',
-                      gridTemplateColumns: '48% 48%',
-                    }}
-                  >
-                    <div>
-                      <span
-                        style={{
-                          marginLeft: 4 * depth,
-                          borderRadius: 2,
-                          fontWeight: 400,
-                          display: 'flex',
-                          maxWidth: '100%',
-                        }}
-                      >
-                        {depth > 0 ? (
-                          <span
-                            style={{
-                              borderLeft: `1px solid ${colorTheme.neutralBorder.value}`,
-                              borderBottom: `1px solid ${colorTheme.neutralBorder.value}`,
-                              width: 5,
-                              display: 'inline-block',
-                              height: 10,
-                              marginRight: 4,
-                              position: 'relative',
-                              top: 0,
-                              marginLeft: (depth - 1) * 8,
-                              flex: 'none',
-                              textOverflow: 'ellipsis',
-                              overflow: 'hidden',
-                            }}
-                          ></span>
-                        ) : null}
-                        <span
-                          style={{
-                            textOverflow: 'ellipsis',
-                            overflow: 'hidden',
-                          }}
-                        >
-                          {displayName}
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      style={{
-                        display: 'flex',
-                        justifyContent: 'flex-end',
-                        width: '94%',
-                      }}
-                    >
-                      <span
-                        style={{
-                          fontWeight: 400,
-                          color: colorTheme.neutralForeground.value,
-                          textOverflow: 'ellipsis',
-                          maxWidth: 130,
-                          overflow: 'hidden',
-                        }}
-                      >
-                        {value}
-                      </span>
-                    </div>
-                  </UIGridRow>
-                </Button>
-              )
-            },
-          )}
+          {variableNamesInScope.map((variableOption, idx) => {
+            return (
+              <ValueRow
+                key={variableOption.variableName}
+                variableOption={variableOption}
+                idx={idx}
+                onTweakProperty={onTweakProperty}
+              />
+            )
+          })}
         </FlexColumn>
       </div>
     )
   }),
 )
+
+interface ValueRowProps {
+  variableOption: VariableOption
+  idx: number
+  onTweakProperty: (name: string, definedElsewhere: string | null) => (e: React.MouseEvent) => void
+}
+
+function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
+  const colorTheme = useColorTheme()
+
+  const {
+    variableName,
+    definedElsewhere,
+    value,
+    displayName,
+    depth = 0,
+    variableChildren,
+  } = variableOption
+  return (
+    <>
+      <Button
+        data-testid={VariableFromScopeOptionTestId(idx)}
+        key={variableName}
+        onClick={onTweakProperty(variableName, definedElsewhere)}
+        style={{ width: '100%', height: 25 }}
+      >
+        <UIGridRow
+          padded={false}
+          variant='<--1fr--><--1fr-->'
+          style={{
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            gap: 8,
+            width: '100%',
+            minHeight: 'auto',
+            gridTemplateColumns: '48% 48%',
+          }}
+        >
+          <div>
+            <span
+              style={{
+                marginLeft: 4 * depth,
+                borderRadius: 2,
+                fontWeight: 400,
+                display: 'flex',
+                maxWidth: '100%',
+              }}
+            >
+              {depth > 0 ? (
+                <span
+                  style={{
+                    borderLeft: `1px solid ${colorTheme.neutralBorder.value}`,
+                    borderBottom: `1px solid ${colorTheme.neutralBorder.value}`,
+                    width: 5,
+                    display: 'inline-block',
+                    height: 10,
+                    marginRight: 4,
+                    position: 'relative',
+                    top: 0,
+                    marginLeft: (depth - 1) * 8,
+                    flex: 'none',
+                    textOverflow: 'ellipsis',
+                    overflow: 'hidden',
+                  }}
+                ></span>
+              ) : null}
+              <span
+                style={{
+                  textOverflow: 'ellipsis',
+                  overflow: 'hidden',
+                }}
+              >
+                {displayName}
+              </span>
+            </span>
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              width: '94%',
+            }}
+          >
+            <span
+              style={{
+                fontWeight: 400,
+                color: colorTheme.neutralForeground.value,
+                textOverflow: 'ellipsis',
+                maxWidth: 130,
+                overflow: 'hidden',
+              }}
+            >
+              {value}
+            </span>
+          </div>
+        </UIGridRow>
+      </Button>
+      {variableChildren != null
+        ? variableChildren.map((child, index) => {
+            return (
+              <ValueRow
+                key={child.variableName}
+                variableOption={child}
+                idx={index}
+                onTweakProperty={onTweakProperty}
+              />
+            )
+          })
+        : null}
+    </>
+  )
+}

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -211,7 +211,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
               }}
             >
               {isArray ? (
-                <Selector
+                <ArrayPaginator
                   selectedIndex={selectedIndex}
                   totalChildCount={totalChildCount}
                   setSelectedIndex={setSelectedIndex}
@@ -248,7 +248,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
   )
 }
 
-function Selector({
+function ArrayPaginator({
   selectedIndex,
   totalChildCount,
   setSelectedIndex,

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -100,7 +100,7 @@ export const DataPickerPopup = React.memo(
               <ValueRow
                 key={variableOption.variableName}
                 variableOption={variableOption}
-                idx={idx}
+                idx={`${idx}`}
                 onTweakProperty={onTweakProperty}
               />
             )
@@ -113,7 +113,7 @@ export const DataPickerPopup = React.memo(
 
 interface ValueRowProps {
   variableOption: VariableOption
-  idx: number
+  idx: string
   onTweakProperty: (name: string, definedElsewhere: string | null) => (e: React.MouseEvent) => void
 }
 
@@ -228,7 +228,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
           <ValueRow
             key={variableChildren[selectedIndex].variableName}
             variableOption={variableChildren[selectedIndex]}
-            idx={idx + 1}
+            idx={`${idx}-${selectedIndex}`}
             onTweakProperty={onTweakProperty}
           />
         ) : (
@@ -237,7 +237,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
               <ValueRow
                 key={child.variableName}
                 variableOption={child}
-                idx={idx + 1 + index}
+                idx={`${idx}-${index}`}
                 onTweakProperty={onTweakProperty}
               />
             )

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -237,7 +237,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
               <ValueRow
                 key={child.variableName}
                 variableOption={child}
-                idx={index}
+                idx={idx + 1 + index}
                 onTweakProperty={onTweakProperty}
               />
             )

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -36,6 +36,7 @@ function valuesFromObject(
     definedElsewhere: objectName,
     displayName: variable.displayName,
     depth: variable.depth,
+    variableChildren: variable.variableChildren,
   })
 
   if (Array.isArray(value)) {
@@ -46,14 +47,13 @@ function valuesFromObject(
         definedElsewhere: objectName,
         value: `[ ]`,
         depth: depth,
-      }),
-    ].concat(
-      value.flatMap((v, idx) =>
-        valuesFromVariable(`${name}[${idx}]`, v, depth + 1, `${displayName}[${idx}]`).map(
-          (variable) => patchDefinedElsewhereInfo(variable),
+        variableChildren: value.flatMap((v, idx) =>
+          valuesFromVariable(`${name}[${idx}]`, v, depth + 1, `${displayName}[${idx}]`).map(
+            (variable) => patchDefinedElsewhereInfo(variable),
+          ),
         ),
-      ),
-    )
+      }),
+    ]
   }
 
   return [

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -51,9 +51,13 @@ function valuesFromObject(
         depth: depth,
         variableType: 'array',
         variableChildren: value.flatMap((v, idx) =>
-          valuesFromVariable(`${name}[${idx}]`, v, depth + 1, `${displayName}[${idx}]`).map(
-            (variable) => patchDefinedElsewhereInfo(variable),
-          ),
+          valuesFromVariable(
+            `${name}[${idx}]`,
+            v,
+            depth + 1,
+            `${displayName}[${idx}]`,
+            objectName,
+          ).map((variable) => patchDefinedElsewhereInfo(variable)),
         ),
       }),
     ]
@@ -68,7 +72,7 @@ function valuesFromObject(
       depth: depth,
       variableType: 'object',
       variableChildren: Object.entries(value).flatMap(([key, field]) =>
-        valuesFromVariable(`${name}['${key}']`, field, depth + 1, key).map((variable) =>
+        valuesFromVariable(`${name}['${key}']`, field, depth + 1, key, objectName).map((variable) =>
           patchDefinedElsewhereInfo(variable),
         ),
       ),
@@ -81,6 +85,7 @@ function valuesFromVariable(
   value: unknown,
   depth: number,
   displayName: string,
+  originalObjectName: string,
 ): Array<VariableOption> {
   switch (typeof value) {
     case 'bigint':
@@ -99,7 +104,7 @@ function valuesFromVariable(
         },
       ]
     case 'object':
-      return valuesFromObject(name, name, value, depth, displayName)
+      return valuesFromObject(name, originalObjectName, value, depth, displayName)
     case 'function':
     case 'symbol':
       return []
@@ -212,7 +217,7 @@ export function useVariablesInScopeForSelectedElement(
     )
 
     return orderedVariablesInScope.flatMap(([name, variable]) =>
-      valuesFromVariable(name, variable, 0, name),
+      valuesFromVariable(name, variable, 0, name, name),
     )
   }, [controlDescriptions, currentPropertyValue, selectedViewPath, variablesInScope])
 

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -26,6 +26,7 @@ function valuesFromObject(
         definedElsewhere: null,
         value: `null`,
         depth: depth,
+        variableType: 'primitive',
       },
     ]
   }
@@ -37,6 +38,7 @@ function valuesFromObject(
     displayName: variable.displayName,
     depth: variable.depth,
     variableChildren: variable.variableChildren,
+    variableType: variable.variableType,
   })
 
   if (Array.isArray(value)) {
@@ -47,6 +49,7 @@ function valuesFromObject(
         definedElsewhere: objectName,
         value: `[ ]`,
         depth: depth,
+        variableType: 'array',
         variableChildren: value.flatMap((v, idx) =>
           valuesFromVariable(`${name}[${idx}]`, v, depth + 1, `${displayName}[${idx}]`).map(
             (variable) => patchDefinedElsewhereInfo(variable),
@@ -63,14 +66,14 @@ function valuesFromObject(
       definedElsewhere: objectName,
       value: `{ }`,
       depth: depth,
-    }),
-  ].concat(
-    Object.entries(value).flatMap(([key, field]) =>
-      valuesFromVariable(`${name}['${key}']`, field, depth + 1, key).map((variable) =>
-        patchDefinedElsewhereInfo(variable),
+      variableType: 'object',
+      variableChildren: Object.entries(value).flatMap(([key, field]) =>
+        valuesFromVariable(`${name}['${key}']`, field, depth + 1, key).map((variable) =>
+          patchDefinedElsewhereInfo(variable),
+        ),
       ),
-    ),
-  )
+    }),
+  ]
 }
 
 function valuesFromVariable(
@@ -92,6 +95,7 @@ function valuesFromVariable(
           definedElsewhere: name,
           value: `${value}`,
           depth: depth,
+          variableType: 'primitive',
         },
       ]
     case 'object':


### PR DESCRIPTION
Show arrays in a paginated way (instead of a flat list). Allow selecting the entire array as well as entire objects within.

<video src="https://github.com/concrete-utopia/utopia/assets/7003853/adf04691-d9b0-48fd-9e7a-f3f84e679499"/>

