### PR TITLE
Collapse / Expand objects in data picker

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
@@ -24,8 +24,10 @@ describe('Set element prop via the data picker', () => {
     const theInspector = editor.renderedDOM.getByTestId('inspector-sections-container')
 
     const options = [
-      ...editor.renderedDOM.baseElement.querySelectorAll(`[data-testid^="variable-from-scope"]`),
-    ].map((node) => node.firstChild!.firstChild!.textContent)
+      ...editor.renderedDOM.baseElement.querySelectorAll(
+        `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
+      ),
+    ].map((node) => node.textContent)
 
     // the items from the data picker are expected here, so that the numbers in `VariableFromScopeOptionTestId`
     // below are put in context
@@ -83,8 +85,10 @@ describe('Set element prop via the data picker', () => {
     expect(dataPickerPopup).not.toBeNull()
 
     const options = [
-      ...editor.renderedDOM.baseElement.querySelectorAll(`[data-testid^="variable-from-scope"]`),
-    ].map((node) => node.firstChild!.firstChild!.textContent)
+      ...editor.renderedDOM.baseElement.querySelectorAll(
+        `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
+      ),
+    ].map((node) => node.textContent)
 
     expect(options).toEqual([
       'currentCount', // at the top because the number input control descriptor is present
@@ -108,8 +112,10 @@ describe('Set element prop via the data picker', () => {
     expect(dataPickerPopup).not.toBeNull()
 
     const options = [
-      ...editor.renderedDOM.baseElement.querySelectorAll(`[data-testid^="variable-from-scope"]`),
-    ].map((node) => node.firstChild!.firstChild!.textContent)
+      ...editor.renderedDOM.baseElement.querySelectorAll(
+        `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
+      ),
+    ].map((node) => node.textContent)
 
     expect(options).toEqual([
       'titleIdeas', // the array is at the top because of the array descriptor
@@ -138,8 +144,10 @@ describe('Set element prop via the data picker', () => {
     expect(dataPickerPopup).not.toBeNull()
 
     const options = [
-      ...editor.renderedDOM.baseElement.querySelectorAll(`[data-testid^="variable-from-scope"]`),
-    ].map((node) => node.firstChild!.firstChild!.textContent)
+      ...editor.renderedDOM.baseElement.querySelectorAll(
+        `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
+      ),
+    ].map((node) => node.textContent)
 
     expect(options).toEqual([
       'bookInfo', // object is at the top because of the object descriptor
@@ -192,8 +200,10 @@ describe('Set element prop via the data picker', () => {
     expect(dataPickerPopup).not.toBeNull()
 
     const options = [
-      ...editor.renderedDOM.baseElement.querySelectorAll(`[data-testid^="variable-from-scope"]`),
-    ].map((node) => node.firstChild!.firstChild!.textContent)
+      ...editor.renderedDOM.baseElement.querySelectorAll(
+        `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
+      ),
+    ].map((node) => node.textContent)
 
     expect(options).toEqual([
       'authors', // at the top because it's an array of string, same as titleIdeas
@@ -256,8 +266,10 @@ describe('Set element prop via the data picker', () => {
     expect(dataPickerPopup).not.toBeNull()
 
     const options = [
-      ...editor.renderedDOM.baseElement.querySelectorAll(`[data-testid^="variable-from-scope"]`),
-    ].map((node) => node.firstChild!.firstChild!.textContent)
+      ...editor.renderedDOM.baseElement.querySelectorAll(
+        `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
+      ),
+    ].map((node) => node.textContent)
 
     expect(options).toEqual([
       'bookInfo', // object with matching shape
@@ -315,8 +327,10 @@ describe('Set element prop via the data picker', () => {
     expect(dataPickerPopup).not.toBeNull()
 
     const options = [
-      ...editor.renderedDOM.baseElement.querySelectorAll(`[data-testid^="variable-from-scope"]`),
-    ].map((node) => node.firstChild!.firstChild!.textContent)
+      ...editor.renderedDOM.baseElement.querySelectorAll(
+        `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
+      ),
+    ].map((node) => node.textContent)
 
     expect(options).toEqual([
       'authors',
@@ -367,8 +381,10 @@ describe('Set element prop via the data picker', () => {
     expect(dataPickerPopup).not.toBeNull()
 
     const options = [
-      ...editor.renderedDOM.baseElement.querySelectorAll(`[data-testid^="variable-from-scope"]`),
-    ].map((node) => node.firstChild!.firstChild!.textContent)
+      ...editor.renderedDOM.baseElement.querySelectorAll(
+        `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
+      ),
+    ].map((node) => node.textContent)
 
     expect(options).toEqual([
       'authors',

--- a/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
@@ -2,6 +2,7 @@ import { within } from '@testing-library/react'
 import * as EP from '../../../../core/shared/element-path'
 import { selectComponentsForTest, wait } from '../../../../utils/utils.test-utils'
 import { mouseClickAtPoint, pressKey } from '../../../canvas/event-helpers.test-utils'
+import type { EditorRenderResult } from '../../../canvas/ui-jsx.test-utils'
 import { renderTestEditorWithCode } from '../../../canvas/ui-jsx.test-utils'
 import {
   DataPickerPopupButtonTestId,
@@ -23,11 +24,7 @@ describe('Set element prop via the data picker', () => {
     const theScene = editor.renderedDOM.getByTestId('scene')
     const theInspector = editor.renderedDOM.getByTestId('inspector-sections-container')
 
-    const options = [
-      ...editor.renderedDOM.baseElement.querySelectorAll(
-        `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
-      ),
-    ].map((node) => node.textContent)
+    const options = getRenderedOptions(editor)
 
     // the items from the data picker are expected here, so that the numbers in `VariableFromScopeOptionTestId`
     // below are put in context
@@ -84,11 +81,7 @@ describe('Set element prop via the data picker', () => {
     const dataPickerPopup = editor.renderedDOM.queryByTestId(DataPickerPopupTestId)
     expect(dataPickerPopup).not.toBeNull()
 
-    const options = [
-      ...editor.renderedDOM.baseElement.querySelectorAll(
-        `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
-      ),
-    ].map((node) => node.textContent)
+    const options = getRenderedOptions(editor)
 
     expect(options).toEqual([
       'currentCount', // at the top because the number input control descriptor is present
@@ -111,11 +104,7 @@ describe('Set element prop via the data picker', () => {
     const dataPickerPopup = editor.renderedDOM.queryByTestId(DataPickerPopupTestId)
     expect(dataPickerPopup).not.toBeNull()
 
-    const options = [
-      ...editor.renderedDOM.baseElement.querySelectorAll(
-        `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
-      ),
-    ].map((node) => node.textContent)
+    const options = getRenderedOptions(editor)
 
     expect(options).toEqual([
       'titleIdeas', // the array is at the top because of the array descriptor
@@ -143,11 +132,7 @@ describe('Set element prop via the data picker', () => {
     const dataPickerPopup = editor.renderedDOM.queryByTestId(DataPickerPopupTestId)
     expect(dataPickerPopup).not.toBeNull()
 
-    const options = [
-      ...editor.renderedDOM.baseElement.querySelectorAll(
-        `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
-      ),
-    ].map((node) => node.textContent)
+    const options = getRenderedOptions(editor)
 
     expect(options).toEqual([
       'bookInfo', // object is at the top because of the object descriptor
@@ -199,11 +184,7 @@ describe('Set element prop via the data picker', () => {
     const dataPickerPopup = editor.renderedDOM.queryByTestId(DataPickerPopupTestId)
     expect(dataPickerPopup).not.toBeNull()
 
-    const options = [
-      ...editor.renderedDOM.baseElement.querySelectorAll(
-        `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
-      ),
-    ].map((node) => node.textContent)
+    const options = getRenderedOptions(editor)
 
     expect(options).toEqual([
       'authors', // at the top because it's an array of string, same as titleIdeas
@@ -265,11 +246,7 @@ describe('Set element prop via the data picker', () => {
     const dataPickerPopup = editor.renderedDOM.queryByTestId(DataPickerPopupTestId)
     expect(dataPickerPopup).not.toBeNull()
 
-    const options = [
-      ...editor.renderedDOM.baseElement.querySelectorAll(
-        `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
-      ),
-    ].map((node) => node.textContent)
+    const options = getRenderedOptions(editor)
 
     expect(options).toEqual([
       'bookInfo', // object with matching shape
@@ -326,11 +303,7 @@ describe('Set element prop via the data picker', () => {
     const dataPickerPopup = editor.renderedDOM.queryByTestId(DataPickerPopupTestId)
     expect(dataPickerPopup).not.toBeNull()
 
-    const options = [
-      ...editor.renderedDOM.baseElement.querySelectorAll(
-        `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
-      ),
-    ].map((node) => node.textContent)
+    const options = getRenderedOptions(editor)
 
     expect(options).toEqual([
       'authors',
@@ -380,11 +353,7 @@ describe('Set element prop via the data picker', () => {
     const dataPickerPopup = editor.renderedDOM.queryByTestId(DataPickerPopupTestId)
     expect(dataPickerPopup).not.toBeNull()
 
-    const options = [
-      ...editor.renderedDOM.baseElement.querySelectorAll(
-        `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
-      ),
-    ].map((node) => node.textContent)
+    const options = getRenderedOptions(editor)
 
     expect(options).toEqual([
       'authors',
@@ -994,3 +963,11 @@ registerInternalComponent(Title, {
 //     },
 //   ],
 // })
+
+function getRenderedOptions(editor: EditorRenderResult) {
+  return [
+    ...editor.renderedDOM.baseElement.querySelectorAll(
+      `[data-testid^="variable-from-scope"] [data-testid="variable-name"]`,
+    ),
+  ].map((node) => node.textContent)
+}

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -120,7 +120,14 @@ interface ValueRowProps {
 function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
   const colorTheme = useColorTheme()
   const [selectedIndex, setSelectedIndex] = React.useState<number>(0)
+  const childrenLength = variableOption.variableChildren?.length ?? 0
+  const [childrenOpen, setChildrenOpen] = React.useState<boolean>(
+    variableOption.depth < 2 || childrenLength < 4,
+  )
   const totalChildCount = variableOption.variableChildren?.length ?? 0
+  const toggleChildrenOpen = useCallback(() => {
+    setChildrenOpen(!childrenOpen)
+  }, [childrenOpen, setChildrenOpen])
 
   const {
     variableName,
@@ -135,6 +142,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
   const stopPropagation = useCallback((e: React.MouseEvent) => {
     e.stopPropagation()
   }, [])
+  const hasObjectChildren = variableChildren != null && variableChildren.length > 0 && !isArray
   return (
     <>
       <Button
@@ -165,24 +173,12 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
                 maxWidth: '100%',
               }}
             >
-              {depth > 0 ? (
-                <span
-                  style={{
-                    borderLeft: `1px solid ${colorTheme.neutralBorder.value}`,
-                    borderBottom: `1px solid ${colorTheme.neutralBorder.value}`,
-                    width: 5,
-                    display: 'inline-block',
-                    height: 10,
-                    marginRight: 4,
-                    position: 'relative',
-                    top: 0,
-                    marginLeft: (depth - 1) * 8,
-                    flex: 'none',
-                    textOverflow: 'ellipsis',
-                    overflow: 'hidden',
-                  }}
-                ></span>
-              ) : null}
+              <PrefixIcon
+                depth={depth}
+                hasObjectChildren={hasObjectChildren}
+                onIconClick={toggleChildrenOpen}
+                open={childrenOpen}
+              />
               <span
                 style={{
                   textOverflow: 'ellipsis',
@@ -231,7 +227,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
             idx={`${idx}-${selectedIndex}`}
             onTweakProperty={onTweakProperty}
           />
-        ) : (
+        ) : childrenOpen ? (
           variableChildren.map((child, index) => {
             return (
               <ValueRow
@@ -242,10 +238,63 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
               />
             )
           })
-        )
+        ) : null
       ) : null}
     </>
   )
+}
+
+function PrefixIcon({
+  depth,
+  hasObjectChildren,
+  onIconClick,
+  open,
+}: {
+  depth: number
+  hasObjectChildren: boolean
+  onIconClick: () => void
+  open: boolean
+}) {
+  const colorTheme = useColorTheme()
+  const style = {
+    width: 5,
+    display: 'inline-block',
+    height: 10,
+    marginRight: 4,
+    position: 'relative',
+    top: 0,
+    marginLeft: (depth - 1) * 8,
+    flex: 'none',
+  } as const
+  const onClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onIconClick()
+    },
+    [onIconClick],
+  )
+  if (hasObjectChildren) {
+    return (
+      <span
+        style={{ color: colorTheme.neutralBorder.value, fontSize: 6, ...style }}
+        onClick={onClick}
+      >
+        {open ? '▼' : '▶'}
+      </span>
+    )
+  }
+  if (depth > 0) {
+    return (
+      <span
+        style={{
+          borderLeft: `1px solid ${colorTheme.neutralBorder.value}`,
+          borderBottom: `1px solid ${colorTheme.neutralBorder.value}`,
+          ...style,
+        }}
+      ></span>
+    )
+  }
+  return null
 }
 
 function ArrayPaginator({

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -180,6 +180,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
                 open={childrenOpen}
               />
               <span
+                data-testid='variable-name'
                 style={{
                   textOverflow: 'ellipsis',
                   overflow: 'hidden',


### PR DESCRIPTION
Add an object collapse arrow to long or deeply nested objects in data picker.
Currently all objects are collapsed by default, unless they are under two levels of indentation, or have less than four keys.
(in order to keep small/shallow objects visible) 

<video src="https://github.com/concrete-utopia/utopia/assets/7003853/e87508ac-19f0-4f30-87a7-df9f77de6fd6" />

