### PR TITLE
Data picker - dim options that don't match

### DIFF
--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -19,6 +19,7 @@ export interface VariableOption {
   depth: number
   variableChildren?: Array<VariableOption>
   variableType: 'primitive' | 'array' | 'object'
+  valueMatchesPropType: boolean
 }
 
 export interface DataPickerPopupProps {
@@ -129,6 +130,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
     displayName,
     depth = 0,
     variableChildren,
+    valueMatchesPropType,
   } = variableOption
   const isArray = variableOption.variableType === 'array'
   const tweakProperty = onTweakProperty(variableName, definedElsewhere)
@@ -187,6 +189,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
                 style={{
                   textOverflow: 'ellipsis',
                   overflow: 'hidden',
+                  opacity: valueMatchesPropType ? 1 : 0.5,
                 }}
               >
                 {displayName}
@@ -208,6 +211,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
                 textOverflow: 'ellipsis',
                 maxWidth: 130,
                 overflow: 'hidden',
+                opacity: valueMatchesPropType ? 1 : 0.5,
               }}
             >
               {isArray ? (

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -132,11 +132,13 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
     variableChildren,
     valueMatchesPropType,
   } = variableOption
+
   const isArray = variableOption.variableType === 'array'
   const tweakProperty = onTweakProperty(variableName, definedElsewhere)
   const stopPropagation = useCallback((e: React.MouseEvent) => {
     e.stopPropagation()
   }, [])
+  const shouldDim = depth > 0 || !valueMatchesPropType
   return (
     <>
       <Button
@@ -189,7 +191,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
                 style={{
                   textOverflow: 'ellipsis',
                   overflow: 'hidden',
-                  opacity: valueMatchesPropType ? 1 : 0.5,
+                  opacity: shouldDim ? 0.5 : 1,
                 }}
               >
                 {displayName}
@@ -211,7 +213,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
                 textOverflow: 'ellipsis',
                 maxWidth: 130,
                 overflow: 'hidden',
-                opacity: valueMatchesPropType ? 1 : 0.5,
+                opacity: shouldDim ? 0.5 : 1,
               }}
             >
               {isArray ? (


### PR DESCRIPTION
## Description

This PR improves that data picker so that options that don't match any control descriptions / the existing property value are dimmed out. 

<img width="279" alt="image" src="https://github.com/concrete-utopia/utopia/assets/16385508/a2e883ab-040a-4f94-ae16-b77de295696e">

