### PR TITLE
relevant object / array elements

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
@@ -364,6 +364,58 @@ describe('Set element prop via the data picker', () => {
       'currentCount',
     ])
   })
+
+  it('object props are reordered by relevance', async () => {
+    const editor = await renderTestEditorWithCode(
+      DataPickerProjectShell(`
+      function Title({ text }) {
+        const content = 'Content'
+      
+        return <h2 data-uid='aam'>{text}</h2>
+      }
+      
+      var Playground = ({ style }) => {
+        const titles = {
+          aNumber: 2,
+          aBoolean: true,
+          actualStringTitle: 'The First Title',
+        }
+      
+        return (
+          <div style={style} data-uid='root'>
+            <Title
+              text={'hi'}
+              data-uid='bd'
+              style={{
+                width: 134,
+                height: 28,
+                position: 'absolute',
+                left: 160,
+                top: 75,
+              }}
+            />
+          </div>
+        )
+      }`),
+      'await-first-dom-report',
+    )
+    await selectComponentsForTest(editor, [EP.fromString('sb/scene/pg:root/bd')])
+
+    const dataPickerOpenerButton = editor.renderedDOM.getByTestId(DataPickerPopupButtonTestId)
+    await mouseClickAtPoint(dataPickerOpenerButton, { x: 2, y: 2 })
+
+    const dataPickerPopup = editor.renderedDOM.queryByTestId(DataPickerPopupTestId)
+    expect(dataPickerPopup).not.toBeNull()
+
+    const options = getRenderedOptions(editor)
+
+    expect(options).toEqual([
+      'titles', // the name of the object
+      'actualStringTitle', // the actual string prop
+      'aNumber', // the rest of the props
+      'aBoolean',
+    ])
+  })
 })
 
 // comment out tests temporarily because it causes a dom-walker test to fail

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -9,20 +9,20 @@ import { useRefEditorState } from '../../../editor/store/store-hook'
 import { UIGridRow } from '../../widgets/ui-grid-row'
 import { DataPickerPopupTestId, VariableFromScopeOptionTestId } from './component-section'
 import * as EP from '../../../../core/shared/element-path'
-import type { ArrayMeta, ObjectMeta, PrimitiveMeta } from './variables-in-scope-utils'
+import type { ArrayInfo, ObjectInfo, PrimitiveInfo } from './variables-in-scope-utils'
 import { useVariablesInScopeForSelectedElement } from './variables-in-scope-utils'
 import { assertNever } from '../../../../core/shared/utils'
 
 export interface PrimitiveOption {
   type: 'primitive'
-  variableMeta: PrimitiveMeta
+  variableMeta: PrimitiveInfo
   definedElsewhere: string
   depth: number
 }
 
 export interface ArrayOption {
   type: 'array'
-  variableMeta: ArrayMeta
+  variableMeta: ArrayInfo
   depth: number
   definedElsewhere: string
   children: Array<VariableOption>
@@ -30,7 +30,7 @@ export interface ArrayOption {
 
 export interface ObjectOption {
   type: 'object'
-  variableMeta: ObjectMeta
+  variableMeta: ObjectInfo
   depth: number
   definedElsewhere: string
   children: Array<VariableOption>

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -15,14 +15,14 @@ import { assertNever } from '../../../../core/shared/utils'
 
 export interface PrimitiveOption {
   type: 'primitive'
-  variableMeta: PrimitiveInfo
+  variableInfo: PrimitiveInfo
   definedElsewhere: string
   depth: number
 }
 
 export interface ArrayOption {
   type: 'array'
-  variableMeta: ArrayInfo
+  variableInfo: ArrayInfo
   depth: number
   definedElsewhere: string
   children: Array<VariableOption>
@@ -30,7 +30,7 @@ export interface ArrayOption {
 
 export interface ObjectOption {
   type: 'object'
-  variableMeta: ObjectInfo
+  variableInfo: ObjectInfo
   depth: number
   definedElsewhere: string
   children: Array<VariableOption>
@@ -39,15 +39,15 @@ export interface ObjectOption {
 export type VariableOption = PrimitiveOption | ArrayOption | ObjectOption
 
 function valueToDisplay(option: VariableOption): string {
-  switch (option.variableMeta.type) {
+  switch (option.variableInfo.type) {
     case 'array':
       return `[]`
     case 'object':
       return `{}`
     case 'primitive':
-      return `${option.variableMeta.value}`
+      return `${option.variableInfo.value}`
     default:
-      assertNever(option.variableMeta)
+      assertNever(option.variableInfo)
   }
 }
 
@@ -128,7 +128,7 @@ export const DataPickerPopup = React.memo(
           {variableNamesInScope.map((variableOption, idx) => {
             return (
               <ValueRow
-                key={variableOption.variableMeta.variableName}
+                key={variableOption.variableInfo.variableName}
                 variableOption={variableOption}
                 idx={`${idx}`}
                 onTweakProperty={onTweakProperty}
@@ -160,10 +160,10 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
     setChildrenOpen(!childrenOpen)
   }, [childrenOpen, setChildrenOpen])
 
-  const isArray = variableOption.variableMeta.type === 'array'
+  const isArray = variableOption.variableInfo.type === 'array'
 
   const tweakProperty = onTweakProperty(
-    variableOption.variableMeta.variableName,
+    variableOption.variableInfo.variableName,
     variableOption.definedElsewhere,
   )
   const stopPropagation = useCallback((e: React.MouseEvent) => {
@@ -180,7 +180,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
     <>
       <Button
         data-testid={VariableFromScopeOptionTestId(idx)}
-        key={variableOption.variableMeta.variableName}
+        key={variableOption.variableInfo.variableName}
         style={{ width: '100%', height: 25 }}
         onClick={isArray ? stopPropagation : tweakProperty}
       >
@@ -217,10 +217,10 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
                 style={{
                   textOverflow: 'ellipsis',
                   overflow: 'hidden',
-                  opacity: variableOption.variableMeta.matches ? 1 : 0.5,
+                  opacity: variableOption.variableInfo.matches ? 1 : 0.5,
                 }}
               >
-                {variableOption.variableMeta.displayName}
+                {variableOption.variableInfo.displayName}
               </span>
             </span>
           </div>
@@ -239,7 +239,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
                 textOverflow: 'ellipsis',
                 maxWidth: 130,
                 overflow: 'hidden',
-                opacity: variableOption.variableMeta.matches ? 1 : 0.5,
+                opacity: variableOption.variableInfo.matches ? 1 : 0.5,
               }}
             >
               {isArray ? (
@@ -258,7 +258,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
       {variableChildren != null ? (
         isArray ? (
           <ValueRow
-            key={variableChildren[selectedIndex].variableMeta.variableName}
+            key={variableChildren[selectedIndex].variableInfo.variableName}
             variableOption={variableChildren[selectedIndex]}
             idx={`${idx}-${selectedIndex}`}
             onTweakProperty={onTweakProperty}
@@ -267,7 +267,7 @@ function ValueRow({ variableOption, idx, onTweakProperty }: ValueRowProps) {
           variableChildren.map((child, index) => {
             return (
               <ValueRow
-                key={child.variableMeta.variableName}
+                key={child.variableInfo.variableName}
                 variableOption={child}
                 idx={`${idx}-${index}`}
                 onTweakProperty={onTweakProperty}

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -6,7 +6,7 @@ import type {
 import type { ElementPath, PropertyPath } from '../../../../core/shared/project-file-types'
 import type { VariableData } from '../../../canvas/ui-jsx-canvas'
 import { useEditorState, Substores } from '../../../editor/store/store-hook'
-import type { ArrayOption, ObjectOption, VariableOption } from './data-picker-popup'
+import type { VariableOption } from './data-picker-popup'
 import * as EP from '../../../../core/shared/element-path'
 import React from 'react'
 import { useGetPropertyControlsForSelectedComponents } from '../../common/property-controls-hooks'
@@ -27,7 +27,7 @@ function valuesFromObject(
     return [
       {
         type: 'array',
-        variableMeta: variable,
+        variableInfo: variable,
         depth: depth,
         definedElsewhere: originalObjectName,
         children: variable.elements
@@ -39,7 +39,7 @@ function valuesFromObject(
     return [
       {
         type: 'object',
-        variableMeta: variable,
+        variableInfo: variable,
         depth: depth,
         definedElsewhere: originalObjectName,
         children: variable.props
@@ -62,7 +62,7 @@ function valuesFromVariable(
       return [
         {
           type: 'primitive',
-          variableMeta: variable,
+          variableInfo: variable,
           definedElsewhere: variable.variableName,
           depth: depth,
         },
@@ -107,7 +107,7 @@ export interface ArrayInfo {
 
 export type VariableInfo = PrimitiveInfo | ArrayInfo | ObjectInfo
 
-function variableMetaFromValue(
+function variableInfoFromValue(
   variableName: string,
   displayName: string,
   value: unknown,
@@ -147,7 +147,7 @@ function variableMetaFromValue(
           matches: false,
           elements: mapDropNulls(
             (e, idx) =>
-              variableMetaFromValue(`${variableName}[${idx}]`, `${variableName}[${idx}]`, e),
+              variableInfoFromValue(`${variableName}[${idx}]`, `${variableName}[${idx}]`, e),
             value,
           ),
         }
@@ -159,19 +159,19 @@ function variableMetaFromValue(
         value: value,
         matches: false,
         props: mapDropNulls(([key, propValue]) => {
-          return variableMetaFromValue(`${variableName}['${key}']`, key, propValue)
+          return variableInfoFromValue(`${variableName}['${key}']`, key, propValue)
         }, Object.entries(value)),
       }
   }
 }
 
-function variableMetaFromVariableData(variableNamesInScope: VariableData): Array<VariableInfo> {
-  const meta = mapDropNulls(
-    ([key, { spiedValue }]) => variableMetaFromValue(key, key, spiedValue),
+function variableInfoFromVariableData(variableNamesInScope: VariableData): Array<VariableInfo> {
+  const info = mapDropNulls(
+    ([key, { spiedValue }]) => variableInfoFromValue(key, key, spiedValue),
     Object.entries(variableNamesInScope),
   )
 
-  return meta
+  return info
 }
 
 function orderVariablesForRelevance(
@@ -294,10 +294,10 @@ export function useVariablesInScopeForSelectedElement(
       filterObjectPropFromVariablesInScope({ prop: 'props', key: 'css' }),
     ].reduce((vars, fn) => fn(vars), variablesInScopeForSelectedPath)
 
-    const variableMeta = variableMetaFromVariableData(variablesInScopeForSelectedPath)
+    const variableInfo = variableInfoFromVariableData(variablesInScopeForSelectedPath)
 
     const orderedVariablesInScope = orderVariablesForRelevance(
-      variableMeta,
+      variableInfo,
       controlDescriptions,
       currentPropertyValue,
     )

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -181,6 +181,7 @@ function orderVariablesForRelevance(
 ): Array<VariableMeta> {
   let valuesMatchingPropertyDescription: Array<VariableMeta> = []
   let valuesMatchingPropertyShape: Array<VariableMeta> = []
+  let valueElementMatches: Array<VariableMeta> = []
   let restOfValues: Array<VariableMeta> = []
 
   for (let variable of variableNamesInScope) {
@@ -206,8 +207,14 @@ function orderVariablesForRelevance(
       currentPropertyValue.type === 'existing' &&
       variableShapesMatch(currentPropertyValue.value, variable.value)
 
+    const arrayOrObjectChildMatches =
+      (variable.type === 'array' && variable.elements.some((e) => e.matches)) ||
+      (variable.type === 'object' && variable.props.some((e) => e.matches))
+
     if (valueMatchesControlDescription) {
       valuesMatchingPropertyDescription.push({ ...variable, matches: true })
+    } else if (arrayOrObjectChildMatches) {
+      valueElementMatches.push({ ...variable, matches: false })
     } else if (valueMatchesCurrentPropValue) {
       valuesMatchingPropertyShape.push({ ...variable, matches: true })
     } else {
@@ -215,7 +222,12 @@ function orderVariablesForRelevance(
     }
   }
 
-  return [...valuesMatchingPropertyDescription, ...valuesMatchingPropertyShape, ...restOfValues]
+  return [
+    ...valuesMatchingPropertyDescription,
+    ...valuesMatchingPropertyShape,
+    ...valueElementMatches,
+    ...restOfValues,
+  ]
 }
 
 const filterKeyFromObject =

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -14,7 +14,7 @@ import { mapDropNulls } from '../../../../core/shared/array-utils'
 import { assertNever } from '../../../../core/shared/utils'
 
 function valuesFromObject(
-  variable: ArrayMeta | ObjectMeta,
+  variable: ArrayInfo | ObjectInfo,
   originalObjectName: string,
   depth: number,
 ): Array<VariableOption> {
@@ -53,7 +53,7 @@ function valuesFromObject(
 }
 
 function valuesFromVariable(
-  variable: VariableMeta,
+  variable: VariableInfo,
   originalObjectName: string,
   depth: number,
 ): Array<VariableOption> {
@@ -79,7 +79,7 @@ function usePropertyControlDescriptions(): Array<ControlDescription> {
   )
 }
 
-export interface PrimitiveMeta {
+export interface PrimitiveInfo {
   type: 'primitive'
   variableName: string
   displayName: string
@@ -87,31 +87,31 @@ export interface PrimitiveMeta {
   matches: boolean
 }
 
-export interface ObjectMeta {
+export interface ObjectInfo {
   type: 'object'
   variableName: string
   displayName: string
   value: unknown
-  props: Array<VariableMeta>
+  props: Array<VariableInfo>
   matches: boolean
 }
 
-export interface ArrayMeta {
+export interface ArrayInfo {
   type: 'array'
   variableName: string
   displayName: string
   value: unknown
-  elements: Array<VariableMeta>
+  elements: Array<VariableInfo>
   matches: boolean
 }
 
-export type VariableMeta = PrimitiveMeta | ArrayMeta | ObjectMeta
+export type VariableInfo = PrimitiveInfo | ArrayInfo | ObjectInfo
 
 function variableMetaFromValue(
   variableName: string,
   displayName: string,
   value: unknown,
-): VariableMeta | null {
+): VariableInfo | null {
   switch (typeof value) {
     case 'function':
     case 'symbol':
@@ -165,7 +165,7 @@ function variableMetaFromValue(
   }
 }
 
-function variableMetaFromVariableData(variableNamesInScope: VariableData): Array<VariableMeta> {
+function variableMetaFromVariableData(variableNamesInScope: VariableData): Array<VariableInfo> {
   const meta = mapDropNulls(
     ([key, { spiedValue }]) => variableMetaFromValue(key, key, spiedValue),
     Object.entries(variableNamesInScope),
@@ -175,14 +175,14 @@ function variableMetaFromVariableData(variableNamesInScope: VariableData): Array
 }
 
 function orderVariablesForRelevance(
-  variableNamesInScope: Array<VariableMeta>,
+  variableNamesInScope: Array<VariableInfo>,
   controlDescriptions: Array<ControlDescription>,
   currentPropertyValue: PropertyValue,
-): Array<VariableMeta> {
-  let valuesMatchingPropertyDescription: Array<VariableMeta> = []
-  let valuesMatchingPropertyShape: Array<VariableMeta> = []
-  let valueElementMatches: Array<VariableMeta> = []
-  let restOfValues: Array<VariableMeta> = []
+): Array<VariableInfo> {
+  let valuesMatchingPropertyDescription: Array<VariableInfo> = []
+  let valuesMatchingPropertyShape: Array<VariableInfo> = []
+  let valueElementMatches: Array<VariableInfo> = []
+  let restOfValues: Array<VariableInfo> = []
 
   for (let variable of variableNamesInScope) {
     if (variable.type === 'array') {


### PR DESCRIPTION
## Description

This PR improves the ordering of options in the data picker in two ways:
- Object properties / array elements that match the target prop are moved up in the list
- Objects / arrays that have any props/elements that match the target prop are moved up in the list

The main part of the PR is the `orderVariablesForRelevance` function

### Details
The PR also adds an explicit types for the variables that populate the data picker, so it's easier to see what's going on in `orderVariablesForRelevance`

<img width="1370" alt="image" src="https://github.com/concrete-utopia/utopia/assets/16385508/7e2612e8-a413-4e9f-87aa-418acaf984f7">
<img width="1363" alt="image" src="https://github.com/concrete-utopia/utopia/assets/16385508/19db0e5f-1eff-4f01-b8fa-92e0d3e294d1">


