### PR TITLE
Adding property access, element access and JS identifiers.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-helpers.ts
@@ -380,6 +380,9 @@ function getComponentNamesFromJSXElementChild(element: JSXElementChild): Array<J
     case 'ATTRIBUTE_OTHER_JAVASCRIPT':
     case 'ATTRIBUTE_VALUE':
     case 'JSX_TEXT_BLOCK':
+    case 'JS_IDENTIFIER':
+    case 'JS_ELEMENT_ACCESS':
+    case 'JS_PROPERTY_ACCESS':
       return []
     default:
       assertNever(element)

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -605,6 +605,10 @@ export function renderCoreElement(
       }
 
       return jsxAttributeToValue(filePath, inScope, requireResult, element)
+    case 'JS_PROPERTY_ACCESS':
+    case 'JS_ELEMENT_ACCESS':
+    case 'JS_IDENTIFIER':
+      return jsxAttributeToValue(filePath, inScope, requireResult, element)
     default:
       const _exhaustiveCheck: never = element
       throw new Error(`Unhandled type ${JSON.stringify(element)}`)
@@ -686,6 +690,9 @@ function jsxElementChildToText(
     case 'ATTRIBUTE_NESTED_ARRAY':
     case 'ATTRIBUTE_NESTED_OBJECT':
     case 'ATTRIBUTE_FUNCTION_CALL':
+    case 'JS_IDENTIFIER':
+    case 'JS_ELEMENT_ACCESS':
+    case 'JS_PROPERTY_ACCESS':
       return ''
     default:
       assertNever(element)
@@ -1028,6 +1035,9 @@ function runJSExpression(
     case 'ATTRIBUTE_NESTED_ARRAY':
     case 'ATTRIBUTE_NESTED_OBJECT':
     case 'ATTRIBUTE_FUNCTION_CALL':
+    case 'JS_PROPERTY_ACCESS':
+    case 'JS_ELEMENT_ACCESS':
+    case 'JS_IDENTIFIER':
       return jsxAttributeToValue(filePath, block, requireResult, block)
     case 'JSX_MAP_EXPRESSION':
     case 'ATTRIBUTE_OTHER_JAVASCRIPT':

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -182,6 +182,12 @@ export function getNavigatorEntryLabel(
           return '(code)'
         case 'ATTRIBUTE_FUNCTION_CALL':
           return '(code)'
+        case 'JS_IDENTIFIER':
+          return '(code)'
+        case 'JS_ELEMENT_ACCESS':
+          return '(code)'
+        case 'JS_PROPERTY_ACCESS':
+          return '(code)'
         default:
           throw assertNever(navigatorEntry.childOrAttribute)
       }

--- a/editor/src/core/layout/layout-utils.ts
+++ b/editor/src/core/layout/layout-utils.ts
@@ -790,6 +790,9 @@ export function roundAttributeLayoutValues(
       case 'ATTRIBUTE_FUNCTION_CALL':
       case 'JSX_MAP_EXPRESSION':
       case 'ATTRIBUTE_OTHER_JAVASCRIPT':
+      case 'JS_PROPERTY_ACCESS':
+      case 'JS_ELEMENT_ACCESS':
+      case 'JS_IDENTIFIER':
         return workingAttributes
       default:
         const _exhaustiveCheck: never = value

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -179,6 +179,7 @@ export const getChildrenOfCollapsedViews = (
   }, collapsedViews)
 }
 
+// eslint-disable-next-line object-shorthand
 export const MetadataUtils = {
   isElementGenerated(target: ElementPath): boolean {
     const staticTarget = EP.dynamicPathToStaticPath(target)
@@ -1589,6 +1590,12 @@ export const MetadataUtils = {
             case 'ATTRIBUTE_NESTED_OBJECT':
               return '(code)'
             case 'ATTRIBUTE_FUNCTION_CALL':
+              return '(code)'
+            case 'JS_IDENTIFIER':
+              return '(code)'
+            case 'JS_ELEMENT_ACCESS':
+              return '(code)'
+            case 'JS_PROPERTY_ACCESS':
               return '(code)'
             default:
               const _exhaustiveCheck: never = jsxElement

--- a/editor/src/core/model/get-unique-ids.ts
+++ b/editor/src/core/model/get-unique-ids.ts
@@ -138,6 +138,15 @@ function extractUidFromJSXElementChild(
         extractUidFromJSXElementChild(workingResult, filePath, newDebugPath, parameter)
       }
       break
+    case 'JS_IDENTIFIER':
+      break
+    case 'JS_PROPERTY_ACCESS':
+      extractUidFromJSXElementChild(workingResult, filePath, newDebugPath, element.onValue)
+      break
+    case 'JS_ELEMENT_ACCESS':
+      extractUidFromJSXElementChild(workingResult, filePath, newDebugPath, element.onValue)
+      extractUidFromJSXElementChild(workingResult, filePath, newDebugPath, element.element)
+      break
     default:
       assertNever(element)
   }

--- a/editor/src/core/model/scene-id-utils.ts
+++ b/editor/src/core/model/scene-id-utils.ts
@@ -49,6 +49,9 @@ function transformJSXElementChildRecursively(
     case 'ATTRIBUTE_OTHER_JAVASCRIPT':
     case 'ATTRIBUTE_VALUE':
     case 'JSX_TEXT_BLOCK':
+    case 'JS_IDENTIFIER':
+    case 'JS_ELEMENT_ACCESS':
+    case 'JS_PROPERTY_ACCESS':
       return element
     case 'JSX_CONDITIONAL_EXPRESSION':
       const whenTrue = transform(element.whenTrue)

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -31,6 +31,7 @@ import type { MapLike } from 'typescript'
 import { forceNotNull } from './optional-utils'
 import type { FlexAlignment, FlexJustifyContent } from '../../components/inspector/inspector-common'
 import { allComments } from './comment-flags'
+import { defaultIndexHtmlFilePath } from '../../components/editor/store/editor-state'
 
 export interface ParsedComments {
   leadingComments: Array<Comment>
@@ -426,7 +427,69 @@ export function jsExpressionFunctionCall(
   }
 }
 
+export interface JSIdentifier extends WithComments {
+  type: 'JS_IDENTIFIER'
+  name: string
+  uid: string
+}
+
+export function jsIdentifier(name: string, uid: string, comments: ParsedComments): JSIdentifier {
+  return {
+    type: 'JS_IDENTIFIER',
+    name: name,
+    uid: uid,
+    comments: comments,
+  }
+}
+
+export interface JSPropertyAccess extends WithComments {
+  type: 'JS_PROPERTY_ACCESS'
+  onValue: JSExpression
+  property: string
+  uid: string
+}
+
+export function jsPropertyAccess(
+  onValue: JSExpression,
+  property: string,
+  uid: string,
+  comments: ParsedComments,
+): JSPropertyAccess {
+  return {
+    type: 'JS_PROPERTY_ACCESS',
+    onValue: onValue,
+    property: property,
+    uid: uid,
+    comments: comments,
+  }
+}
+
+export interface JSElementAccess extends WithComments {
+  type: 'JS_ELEMENT_ACCESS'
+  onValue: JSExpression
+  element: JSExpression
+  uid: string
+}
+
+export function jsElementAccess(
+  onValue: JSExpression,
+  element: JSExpression,
+  uid: string,
+  comments: ParsedComments,
+): JSElementAccess {
+  return {
+    type: 'JS_ELEMENT_ACCESS',
+    onValue: onValue,
+    element: element,
+    uid: uid,
+    comments: comments,
+  }
+}
+
 export type JSExpression =
+  | JSIdentifier
+  | JSPropertyAccess
+  | JSElementAccess
   | JSExpressionValue<any>
   | JSExpressionOtherJavaScript
   | JSExpressionNestedArray
@@ -474,6 +537,9 @@ export function simplifyAttributeIfPossible(attribute: JSExpression): JSExpressi
     case 'JSX_MAP_EXPRESSION':
     case 'ATTRIBUTE_OTHER_JAVASCRIPT':
     case 'ATTRIBUTE_FUNCTION_CALL':
+    case 'JS_IDENTIFIER':
+    case 'JS_ELEMENT_ACCESS': // FIXME: Probably can boil down something if it contains a `ATTRIBUTE_VALUE`.
+    case 'JS_PROPERTY_ACCESS':
       return attribute
     case 'ATTRIBUTE_NESTED_ARRAY':
       let simpleArray: Array<unknown> = []
@@ -583,6 +649,22 @@ export function clearExpressionUniqueIDs(attribute: JSExpression): JSExpression 
         attribute.comments,
         '',
       )
+    case 'JS_IDENTIFIER':
+      return jsIdentifier(attribute.name, '', attribute.comments)
+    case 'JS_PROPERTY_ACCESS':
+      return jsPropertyAccess(
+        clearExpressionUniqueIDs(attribute.onValue),
+        attribute.property,
+        '',
+        attribute.comments,
+      )
+    case 'JS_ELEMENT_ACCESS':
+      return jsElementAccess(
+        clearExpressionUniqueIDs(attribute.onValue),
+        clearExpressionUniqueIDs(attribute.element),
+        '',
+        attribute.comments,
+      )
     case 'ATTRIBUTE_FUNCTION_CALL':
       return jsExpressionFunctionCall(
         attribute.functionName,
@@ -647,6 +729,22 @@ export function clearAttributeSourceMaps(attribute: JSExpression): JSExpression 
         }),
         emptyComments,
         attribute.uid,
+      )
+    case 'JS_IDENTIFIER':
+      return jsIdentifier(attribute.name, attribute.uid, attribute.comments)
+    case 'JS_PROPERTY_ACCESS':
+      return jsPropertyAccess(
+        clearAttributeSourceMaps(attribute.onValue),
+        attribute.property,
+        attribute.uid,
+        attribute.comments,
+      )
+    case 'JS_ELEMENT_ACCESS':
+      return jsElementAccess(
+        clearAttributeSourceMaps(attribute.onValue),
+        clearAttributeSourceMaps(attribute.element),
+        attribute.uid,
+        attribute.comments,
       )
     case 'ATTRIBUTE_FUNCTION_CALL':
       return jsExpressionFunctionCall(
@@ -899,6 +997,15 @@ export function attributeReferencesElsewhere(attribute: JSExpression): boolean {
       return attribute.content.some((subAttr) => {
         return attributeReferencesElsewhere(subAttr.value)
       })
+    case 'JS_IDENTIFIER':
+      return true
+    case 'JS_ELEMENT_ACCESS':
+      return (
+        attributeReferencesElsewhere(attribute.element) ||
+        attributeReferencesElsewhere(attribute.onValue)
+      )
+    case 'JS_PROPERTY_ACCESS':
+      return attributeReferencesElsewhere(attribute.onValue)
     case 'ATTRIBUTE_FUNCTION_CALL':
       return true
     default:
@@ -988,7 +1095,15 @@ export function getElementReferencesElsewherePathsFromProps(
     case 'ATTRIBUTE_FUNCTION_CALL':
     case 'JSX_MAP_EXPRESSION':
     case 'ATTRIBUTE_OTHER_JAVASCRIPT':
+    case 'JS_IDENTIFIER':
       return [pathSoFar] // replace the property corresponding to these values
+    case 'JS_PROPERTY_ACCESS':
+      return [PP.append(pathSoFar, PP.create(element.property))]
+    case 'JS_ELEMENT_ACCESS':
+      const onValuePaths = getElementReferencesElsewherePathsFromProps(element.onValue, pathSoFar)
+      return onValuePaths.flatMap((onValuePath) => {
+        return getElementReferencesElsewherePathsFromProps(element.element, onValuePath)
+      })
     default:
       assertNever(element)
   }
@@ -1041,10 +1156,37 @@ function getDefinedElsewhereFromElementChild(
     case 'JSX_TEXT_BLOCK':
     case 'JSX_FRAGMENT':
     case 'ATTRIBUTE_VALUE':
-    case 'ATTRIBUTE_NESTED_ARRAY':
-    case 'ATTRIBUTE_NESTED_OBJECT':
     case 'ATTRIBUTE_FUNCTION_CALL':
       return working
+    case 'ATTRIBUTE_NESTED_ARRAY':
+      return child.content.reduce((innerWorking, contentElement) => {
+        switch (contentElement.type) {
+          case 'ARRAY_VALUE':
+            return getDefinedElsewhereFromElementChild(innerWorking, contentElement.value)
+          case 'ARRAY_SPREAD':
+            return getDefinedElsewhereFromElementChild(innerWorking, contentElement.value)
+          default:
+            return assertNever(contentElement)
+        }
+      }, working)
+    case 'ATTRIBUTE_NESTED_OBJECT':
+      return child.content.reduce((innerWorking, contentElement) => {
+        switch (contentElement.type) {
+          case 'PROPERTY_ASSIGNMENT':
+            return getDefinedElsewhereFromElementChild(innerWorking, contentElement.value)
+          case 'SPREAD_ASSIGNMENT':
+            return getDefinedElsewhereFromElementChild(innerWorking, contentElement.value)
+          default:
+            return assertNever(contentElement)
+        }
+      }, working)
+    case 'JS_IDENTIFIER':
+      return working
+    case 'JS_ELEMENT_ACCESS':
+      const withOnValue = getDefinedElsewhereFromElementChild(working, child.onValue)
+      return getDefinedElsewhereFromElementChild(withOnValue, child.element)
+    case 'JS_PROPERTY_ACCESS':
+      return getDefinedElsewhereFromElementChild(working, child.onValue)
     default:
       assertNever(child)
   }
@@ -1404,6 +1546,9 @@ export function isJSExpression(element: JSXElementChild): element is JSExpressio
     case 'ATTRIBUTE_NESTED_ARRAY':
     case 'ATTRIBUTE_NESTED_OBJECT':
     case 'ATTRIBUTE_FUNCTION_CALL':
+    case 'JS_ELEMENT_ACCESS':
+    case 'JS_PROPERTY_ACCESS':
+    case 'JS_IDENTIFIER':
       return true
     default:
       assertNever(element)
@@ -1488,6 +1633,9 @@ export function clearJSXElementChildUniqueIDs(element: JSXElementChild): JSXElem
     case 'ATTRIBUTE_FUNCTION_CALL':
     case 'JSX_MAP_EXPRESSION':
     case 'ATTRIBUTE_OTHER_JAVASCRIPT':
+    case 'JS_IDENTIFIER':
+    case 'JS_PROPERTY_ACCESS':
+    case 'JS_ELEMENT_ACCESS':
       return clearExpressionUniqueIDs(element)
     default:
       assertNever(element)
@@ -2330,6 +2478,18 @@ export function walkElement(
       fastForEach(element.parameters, (elem) => {
         forEach(elem, parentPath, depth + 1)
       })
+      break
+    case 'JS_IDENTIFIER':
+      forEach(element, parentPath, depth)
+      break
+    case 'JS_PROPERTY_ACCESS':
+      forEach(element, parentPath, depth)
+      walkElement(element.onValue, parentPath, depth + 1, forEach)
+      break
+    case 'JS_ELEMENT_ACCESS':
+      forEach(element, parentPath, depth)
+      walkElement(element.onValue, parentPath, depth + 1, forEach)
+      walkElement(element.element, parentPath, depth + 1, forEach)
       break
     default:
       const _exhaustiveCheck: never = element

--- a/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
@@ -324,6 +324,9 @@ export function simplifyJSXElementChildAttributes(element: JSXElementChild): JSX
     case 'ATTRIBUTE_FUNCTION_CALL':
     case 'JSX_MAP_EXPRESSION':
     case 'ATTRIBUTE_OTHER_JAVASCRIPT':
+    case 'JS_IDENTIFIER':
+    case 'JS_ELEMENT_ACCESS':
+    case 'JS_PROPERTY_ACCESS':
       return simplifyAttributeIfPossible(element)
     case 'JSX_FRAGMENT':
       const updatedChildren = element.children.map(simplifyJSXElementChildAttributes)
@@ -1002,6 +1005,32 @@ function walkElements(
       )
       break
     case 'ATTRIBUTE_VALUE':
+    case 'JS_IDENTIFIER':
+      break
+    case 'JS_PROPERTY_ACCESS':
+      walkElements(
+        jsxElementChild.onValue,
+        includeDataUIDAttribute,
+        walkWith,
+        shouldWalkElement,
+        shouldWalkAttributes,
+      )
+      break
+    case 'JS_ELEMENT_ACCESS':
+      walkElements(
+        jsxElementChild.onValue,
+        includeDataUIDAttribute,
+        walkWith,
+        shouldWalkElement,
+        shouldWalkAttributes,
+      )
+      walkElements(
+        jsxElementChild.element,
+        includeDataUIDAttribute,
+        walkWith,
+        shouldWalkElement,
+        shouldWalkAttributes,
+      )
       break
     case 'ATTRIBUTE_NESTED_ARRAY':
       fastForEach(jsxElementChild.content, (contentElement) => {


### PR DESCRIPTION
**Problem:**
We currently can't express expressions like `props.something`, `props.something[1]` or even an identifier without them being treated as arbitrary blocks which makes them black boxes to our understanding.

**Fix:**
Created the representations of property accessors, element accessors and identifiers and made them part of the `JSExpression` type. But critically this does not change the parser, so currently these values are not produced by anything. That and a couple of `FIXME` cases will be addressed in subsequent work.

**Commit Details:**
- Added `JSIdentifier`, `JSPropertyAccess` and `JSElementAccess` types along with supporting factory functions.
- Incorporated the new types as new cases of `JSExpression`.
- Filled in a lot of cases that handle the new types in various functions.
