### PR TITLE
Remix projects remove rogue parenthesis

### DIFF
--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -136,7 +136,7 @@ const ProjectsPage = React.memo(() => {
       >
         <TopActionBar />
         <ProjectsHeader projects={activeProjects} />
-        <ProjectCards projects={filteredProjects} collaborators={data.collaborators} />)
+        <ProjectCards projects={filteredProjects} collaborators={data.collaborators} />
       </div>
     </div>
   )


### PR DESCRIPTION
There's a rogue parentheses rendered at the bottom of the project cards. It needs to be zapped.