### PR TITLE
Remix projects: don't use colors directly

### DIFF
--- a/utopia-remix/app/components/projectActionContextMenu.tsx
+++ b/utopia-remix/app/components/projectActionContextMenu.tsx
@@ -129,7 +129,7 @@ export const ProjectContextMenu = React.memo(({ project }: { project: ProjectWit
             return (
               <DropdownMenu.Separator
                 key={`separator-${index}`}
-                className={sprinkles({ background: 'separator' })}
+                className={sprinkles({ backgroundColor: 'separator' })}
                 style={{ height: 1 }}
               />
             )

--- a/utopia-remix/app/components/projectActionContextMenu.tsx
+++ b/utopia-remix/app/components/projectActionContextMenu.tsx
@@ -1,14 +1,9 @@
-import {
-  Content as DropdownMenuContent,
-  Portal as DropdownMenuPortal,
-  Item as DropdownMenuItem,
-  Separator as DropdownMenuSeparator,
-} from '@radix-ui/react-dropdown-menu'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { useFetcher } from '@remix-run/react'
 import React from 'react'
 import { useProjectsStore } from '../store'
 import { contextMenuDropdown, contextMenuItem } from '../styles/contextMenu.css'
-import { colors } from '../styles/sprinkles.css'
+import { sprinkles } from '../styles/sprinkles.css'
 import { ProjectWithoutContent } from '../types'
 import { assertNever } from '../util/assertNever'
 import { projectEditorLink } from '../util/links'
@@ -121,8 +116,8 @@ export const ProjectContextMenu = React.memo(({ project }: { project: ProjectWit
   }, [selectedCategory])
 
   return (
-    <DropdownMenuPortal>
-      <DropdownMenuContent
+    <DropdownMenu.Portal>
+      <DropdownMenu.Content
         className={contextMenuDropdown()}
         style={{
           right: 75,
@@ -132,24 +127,25 @@ export const ProjectContextMenu = React.memo(({ project }: { project: ProjectWit
         {menuEntries.map((entry, index) => {
           if (entry === 'separator') {
             return (
-              <DropdownMenuSeparator
+              <DropdownMenu.Separator
                 key={`separator-${index}`}
-                style={{ backgroundColor: colors.separator, height: 1 }}
+                className={sprinkles({ background: 'separator' })}
+                style={{ height: 1 }}
               />
             )
           }
           return (
-            <DropdownMenuItem
+            <DropdownMenu.Item
               key={`entry-${index}`}
               onClick={() => entry.onClick(project)}
               className={contextMenuItem()}
             >
               {entry.text}
-            </DropdownMenuItem>
+            </DropdownMenu.Item>
           )
         })}
-      </DropdownMenuContent>
-    </DropdownMenuPortal>
+      </DropdownMenu.Content>
+    </DropdownMenu.Portal>
   )
 })
 ProjectContextMenu.displayName = 'ProjectContextMenu'

--- a/utopia-remix/app/components/sortProjectsContextMenu.tsx
+++ b/utopia-remix/app/components/sortProjectsContextMenu.tsx
@@ -1,15 +1,8 @@
-import {
-  Portal as DropdownMenuPortal,
-  Content as DropdownMenuContent,
-  Label as DropdownMenuLabel,
-  Separator as DropdownMenuSeparator,
-  CheckboxItem as DropdownMenuCheckboxItem,
-  ItemIndicator as DropdownMenuItemIndicator,
-} from '@radix-ui/react-dropdown-menu'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import React from 'react'
 import { useProjectsStore } from '../store'
 import { contextMenuDropdown, contextMenuItem } from '../styles/contextMenu.css'
-import { colors } from '../styles/sprinkles.css'
+import { sprinkles } from '../styles/sprinkles.css'
 import { CheckIcon } from '@radix-ui/react-icons'
 
 export const SortingContextMenu = React.memo(() => {
@@ -19,80 +12,83 @@ export const SortingContextMenu = React.memo(() => {
   const setSortAscending = useProjectsStore((store) => store.setSortAscending)
 
   return (
-    <DropdownMenuPortal>
-      <DropdownMenuContent
+    <DropdownMenu.Portal>
+      <DropdownMenu.Content
         className={contextMenuDropdown()}
         style={{
           right: 30,
         }}
         sideOffset={5}
       >
-        <DropdownMenuLabel style={{ color: 'grey', padding: 5 }}>Sort by</DropdownMenuLabel>
-        <DropdownMenuCheckboxItem
+        <DropdownMenu.Label style={{ color: 'grey', padding: 5 }}>Sort by</DropdownMenu.Label>
+        <DropdownMenu.CheckboxItem
           className={contextMenuItem()}
           checked={sortCriteria === 'title'}
           onCheckedChange={() => setSortCriteria('title')}
         >
           <div style={{ width: 20 }}>
-            <DropdownMenuItemIndicator className='DropdownMenuItemIndicator'>
+            <DropdownMenu.ItemIndicator className='DropdownMenuItemIndicator'>
               <CheckIcon />
-            </DropdownMenuItemIndicator>
+            </DropdownMenu.ItemIndicator>
           </div>
           Alphabetical
-        </DropdownMenuCheckboxItem>
+        </DropdownMenu.CheckboxItem>
 
-        <DropdownMenuCheckboxItem
+        <DropdownMenu.CheckboxItem
           className={contextMenuItem()}
           checked={sortCriteria === 'dateCreated'}
           onCheckedChange={() => setSortCriteria('dateCreated')}
         >
           <div style={{ width: 20 }}>
-            <DropdownMenuItemIndicator className='DropdownMenuItemIndicator'>
+            <DropdownMenu.ItemIndicator className='DropdownMenuItemIndicator'>
               <CheckIcon />
-            </DropdownMenuItemIndicator>
+            </DropdownMenu.ItemIndicator>
           </div>
           Date Created
-        </DropdownMenuCheckboxItem>
-        <DropdownMenuCheckboxItem
+        </DropdownMenu.CheckboxItem>
+        <DropdownMenu.CheckboxItem
           className={contextMenuItem()}
           checked={sortCriteria === 'dateModified'}
           onCheckedChange={() => setSortCriteria('dateModified')}
         >
           <div style={{ width: 20 }}>
-            <DropdownMenuItemIndicator className='DropdownMenuItemIndicator'>
+            <DropdownMenu.ItemIndicator className='DropdownMenuItemIndicator'>
               <CheckIcon />
-            </DropdownMenuItemIndicator>
+            </DropdownMenu.ItemIndicator>
           </div>
           Date Modified
-        </DropdownMenuCheckboxItem>
-        <DropdownMenuSeparator style={{ backgroundColor: colors.separator, height: 1 }} />
-        <DropdownMenuLabel style={{ color: 'grey', padding: 5 }}>Order</DropdownMenuLabel>
-        <DropdownMenuCheckboxItem
+        </DropdownMenu.CheckboxItem>
+        <DropdownMenu.Separator
+          className={sprinkles({ background: 'separator' })}
+          style={{ height: 1 }}
+        />
+        <DropdownMenu.Label style={{ color: 'grey', padding: 5 }}>Order</DropdownMenu.Label>
+        <DropdownMenu.CheckboxItem
           className={contextMenuItem()}
           checked={sortAscending}
           onCheckedChange={() => setSortAscending(true)}
         >
           <div style={{ width: 20 }}>
-            <DropdownMenuItemIndicator className='DropdownMenuItemIndicator'>
+            <DropdownMenu.ItemIndicator className='DropdownMenuItemIndicator'>
               <CheckIcon />
-            </DropdownMenuItemIndicator>
+            </DropdownMenu.ItemIndicator>
           </div>
           Ascending
-        </DropdownMenuCheckboxItem>
-        <DropdownMenuCheckboxItem
+        </DropdownMenu.CheckboxItem>
+        <DropdownMenu.CheckboxItem
           className={contextMenuItem()}
           checked={!sortAscending}
           onCheckedChange={() => setSortAscending(false)}
         >
           <div style={{ width: 20 }}>
-            <DropdownMenuItemIndicator className='DropdownMenuItemIndicator'>
+            <DropdownMenu.ItemIndicator className='DropdownMenuItemIndicator'>
               <CheckIcon />
-            </DropdownMenuItemIndicator>
+            </DropdownMenu.ItemIndicator>
           </div>
           Descending
-        </DropdownMenuCheckboxItem>
-      </DropdownMenuContent>
-    </DropdownMenuPortal>
+        </DropdownMenu.CheckboxItem>
+      </DropdownMenu.Content>
+    </DropdownMenu.Portal>
   )
 })
 SortingContextMenu.displayName = 'ProjectContextMenu'

--- a/utopia-remix/app/components/sortProjectsContextMenu.tsx
+++ b/utopia-remix/app/components/sortProjectsContextMenu.tsx
@@ -59,7 +59,7 @@ export const SortingContextMenu = React.memo(() => {
           Date Modified
         </DropdownMenu.CheckboxItem>
         <DropdownMenu.Separator
-          className={sprinkles({ background: 'separator' })}
+          className={sprinkles({ backgroundColor: 'separator' })}
           style={{ height: 1 }}
         />
         <DropdownMenu.Label style={{ color: 'grey', padding: 5 }}>Order</DropdownMenu.Label>

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -549,7 +549,7 @@ const ProjectCard = React.memo(
                   className={sprinkles({
                     boxShadow: 'shadow',
                     color: 'white',
-                    background: 'primary',
+                    backgroundColor: 'primary',
                   })}
                 >
                   {when(collaborator.avatar === '', multiplayerInitialsFromName(collaborator.name))}

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -1,8 +1,5 @@
 import React from 'react'
-import {
-  Root as DropdownMenuRoot,
-  Trigger as DropdownMenuTrigger,
-} from '@radix-ui/react-dropdown-menu'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { DotsHorizontalIcon } from '@radix-ui/react-icons'
 import { LoaderFunctionArgs, json } from '@remix-run/node'
 import { useFetcher, useLoaderData } from '@remix-run/react'
@@ -16,7 +13,7 @@ import { useProjectsStore } from '../store'
 import { button } from '../styles/button.css'
 import { newProjectButton } from '../styles/newProjectButton.css'
 import { projectCategoryButton, userName } from '../styles/sidebarComponents.css'
-import { colors, sprinkles } from '../styles/sprinkles.css'
+import { sprinkles } from '../styles/sprinkles.css'
 import { Collaborator, CollaboratorsByProject, ProjectWithoutContent } from '../types'
 import { requireUser } from '../util/api.server'
 import { assertNever } from '../util/assertNever'
@@ -397,8 +394,8 @@ const ProjectsHeader = React.memo(({ projects }: { projects: ProjectWithoutConte
           <CategoryActions projects={projects} />
           {when(
             projects.length > 1,
-            <DropdownMenuRoot>
-              <DropdownMenuTrigger asChild>
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger asChild>
                 <div
                   className={button()}
                   style={{
@@ -409,9 +406,9 @@ const ProjectsHeader = React.memo(({ projects }: { projects: ProjectWithoutConte
                   <div>{convertToTitleCase(sortCriteria)} </div>
                   <div>{sortAscending ? '↑' : '↓'}</div>
                 </div>
-              </DropdownMenuTrigger>
+              </DropdownMenu.Trigger>
               <SortingContextMenu />
-            </DropdownMenuRoot>,
+            </DropdownMenu.Root>,
           )}
         </div>,
       )}
@@ -555,10 +552,8 @@ const ProjectCard = React.memo(
                     borderRadius: '100%',
                     width: 24,
                     height: 24,
-                    backgroundColor: colors.primary,
                     backgroundImage: `url("${collaborator.avatar}")`,
                     backgroundSize: 'cover',
-                    color: colors.white,
                     display: 'flex',
                     justifyContent: 'center',
                     alignItems: 'center',
@@ -568,7 +563,11 @@ const ProjectCard = React.memo(
                     filter: project.deleted === true ? 'grayscale(1)' : undefined,
                   }}
                   title={collaborator.name}
-                  className={sprinkles({ boxShadow: 'shadow' })}
+                  className={sprinkles({
+                    boxShadow: 'shadow',
+                    color: 'white',
+                    background: 'primary',
+                  })}
                 >
                   {when(collaborator.avatar === '', multiplayerInitialsFromName(collaborator.name))}
                 </div>
@@ -591,12 +590,12 @@ const ProjectCardActions = React.memo(({ project }: { project: ProjectWithoutCon
         <div>{moment(project.modified_at).fromNow()}</div>
       </div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
-        <DropdownMenuRoot>
-          <DropdownMenuTrigger asChild>
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger asChild>
             <DotsHorizontalIcon className={button()} />
-          </DropdownMenuTrigger>
+          </DropdownMenu.Trigger>
           <ProjectContextMenu project={project} />
-        </DropdownMenuRoot>
+        </DropdownMenu.Root>
       </div>
     </div>
   )

--- a/utopia-remix/app/styles/contextMenu.css.ts
+++ b/utopia-remix/app/styles/contextMenu.css.ts
@@ -28,7 +28,7 @@ export const contextMenuDropdown = recipe({
   base: [
     sprinkles({
       borderRadius: 'small',
-      background: 'white',
+      backgroundColor: 'white',
       color: 'lightModeBlack',
     }),
     {

--- a/utopia-remix/app/styles/contextMenu.css.ts
+++ b/utopia-remix/app/styles/contextMenu.css.ts
@@ -29,10 +29,9 @@ export const contextMenuDropdown = recipe({
     sprinkles({
       borderRadius: 'small',
       background: 'white',
-      color: 'lightModeBlack'
+      color: 'lightModeBlack',
     }),
     {
-      
       padding: 4,
       boxShadow: '2px 3px 4px #00000030',
       border: '1px solid #ccc',

--- a/utopia-remix/app/styles/sprinkles.css.ts
+++ b/utopia-remix/app/styles/sprinkles.css.ts
@@ -18,7 +18,7 @@ const colorProperties = defineProperties({
   defaultCondition: 'lightMode',
   properties: {
     color: colors,
-    background: colors,
+    backgroundColor: colors,
   },
 })
 

--- a/utopia-remix/app/styles/sprinkles.css.ts
+++ b/utopia-remix/app/styles/sprinkles.css.ts
@@ -10,7 +10,7 @@ export const colors = {
   separator: '#dddddd',
 }
 
-const colorProperties = defineProperties({
+export const colorProperties = defineProperties({
   conditions: {
     lightMode: {},
     darkMode: { '@media': '(prefers-color-scheme: dark)' },

--- a/utopia-remix/app/styles/sprinkles.css.ts
+++ b/utopia-remix/app/styles/sprinkles.css.ts
@@ -10,7 +10,7 @@ export const colors = {
   separator: '#dddddd',
 }
 
-export const colorProperties = defineProperties({
+const colorProperties = defineProperties({
   conditions: {
     lightMode: {},
     darkMode: { '@media': '(prefers-color-scheme: dark)' },

--- a/utopia-remix/app/styles/styles.css.ts
+++ b/utopia-remix/app/styles/styles.css.ts
@@ -8,7 +8,7 @@ export const styles = {
       fontSize: '11px',
     },
     sprinkles({
-      background: {
+      backgroundColor: {
         lightMode: 'white',
         darkMode: 'darkModeBlack',
       },


### PR DESCRIPTION
**Problem:**

The `colors` object is used directly in multiple places inside `style` props, but that _may_ be responsible for the hydration problems we're seeing in production.

**Fix:**

This PR gets rid of that and instead uses `sprinkle` classnames.

(Also reverted to a more sane usage of radix UI's component imports).