### PR TITLE
JSX control

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -79,6 +79,7 @@ import {
   StringInputPropertyControl,
   VectorPropertyControl,
   HtmlInputPropertyControl,
+  JSXPropertyControl,
 } from './property-control-controls'
 import { ExpandableIndicator } from '../../../navigator/navigator-item/expandable-indicator'
 import { unless, when } from '../../../../utils/react-conditionals'
@@ -156,6 +157,8 @@ const ControlForProp = React.memo((props: ControlForPropProps<BaseControlDescrip
       case 'vector3':
       case 'vector4':
         return <VectorPropertyControl {...props} controlDescription={controlDescription} />
+      case 'jsx':
+        return <JSXPropertyControl {...props} controlDescription={controlDescription} />
       default:
         return null
     }

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -13,7 +13,13 @@ import { useRefEditorState } from '../../../editor/store/store-hook'
 import { UIGridRow } from '../../widgets/ui-grid-row'
 import { DataPickerPopupTestId, VariableFromScopeOptionTestId } from './component-section'
 import * as EP from '../../../../core/shared/element-path'
-import type { ArrayInfo, ObjectInfo, PrimitiveInfo, VariableInfo } from './variables-in-scope-utils'
+import type {
+  ArrayInfo,
+  JSXInfo,
+  ObjectInfo,
+  PrimitiveInfo,
+  VariableInfo,
+} from './variables-in-scope-utils'
 import { useVariablesInScopeForSelectedElement } from './variables-in-scope-utils'
 import { assertNever } from '../../../../core/shared/utils'
 
@@ -40,7 +46,14 @@ export interface ObjectOption {
   children: Array<VariableOption>
 }
 
-export type VariableOption = PrimitiveOption | ArrayOption | ObjectOption
+export interface JSXOption {
+  type: 'jsx'
+  variableInfo: JSXInfo
+  definedElsewhere: string
+  depth: number
+}
+
+export type VariableOption = PrimitiveOption | ArrayOption | ObjectOption | JSXOption
 
 function valueToDisplay(option: VariableOption): string {
   switch (option.variableInfo.type) {
@@ -49,6 +62,8 @@ function valueToDisplay(option: VariableOption): string {
     case 'object':
       return `{}`
     case 'primitive':
+      return `${option.variableInfo.value}`
+    case 'jsx':
       return `${option.variableInfo.value}`
     default:
       assertNever(option.variableInfo)

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -64,7 +64,7 @@ function valueToDisplay(option: VariableOption): string {
     case 'primitive':
       return `${option.variableInfo.value}`
     case 'jsx':
-      return `${option.variableInfo.value}`
+      return `JSX`
     default:
       assertNever(option.variableInfo)
   }

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -12,6 +12,7 @@ import type {
   ExpressionInputControlDescription,
   ExpressionPopUpListControlDescription,
   HtmlInputControlDescription,
+  JSXControlDescription,
   Matrix3ControlDescription,
   Matrix4ControlDescription,
   NumberInputControlDescription,
@@ -502,6 +503,29 @@ export const HtmlInputPropertyControl = React.memo(
           focus={props.focusOnMount}
         />
         <HtmlPreview html={safeValue} />
+      </div>
+    )
+  },
+)
+
+export const JSXPropertyControl = React.memo(
+  (props: ControlForPropProps<JSXControlDescription>) => {
+    const { propMetadata } = props
+
+    const value = propMetadata.propertyStatus.set ? propMetadata.value : undefined
+
+    const safeValue = value ?? ''
+
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          flexBasis: 0,
+          gap: 5,
+        }}
+      >
+        {safeValue}
       </div>
     )
   },

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -35,6 +35,7 @@ import {
   FlexColumn,
   FlexRow,
   UtopiaTheme,
+  useColorTheme,
 } from '../../../../uuiui'
 import type { CSSNumber } from '../../common/css-utils'
 import { printCSSNumber, cssNumber, defaultCSSColor } from '../../common/css-utils'
@@ -512,10 +513,13 @@ export const JSXPropertyControl = React.memo(
   (props: ControlForPropProps<JSXControlDescription>) => {
     const { propMetadata } = props
 
+    const theme = useColorTheme()
+
     const value = propMetadata.propertyStatus.set ? propMetadata.value : undefined
 
     const safeValue = value ?? ''
 
+    // TODO: temporary solution, needs a real control
     return (
       <div
         style={{
@@ -525,7 +529,15 @@ export const JSXPropertyControl = React.memo(
           gap: 5,
         }}
       >
-        {safeValue}
+        <span
+          style={{
+            background: theme.dynamicBlue30.value,
+            textAlign: 'center',
+            borderRadius: 5,
+          }}
+        >
+          {`<${safeValue} />`}
+        </span>
       </div>
     )
   },

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -536,7 +536,7 @@ export const JSXPropertyControl = React.memo(
             borderRadius: 5,
           }}
         >
-          {`<${safeValue} />`}
+          {safeValue}
         </span>
       </div>
     )

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -85,10 +85,19 @@ function valuesFromVariable(
   }
 }
 
-function usePropertyControlDescriptions(): Array<ControlDescription> {
-  return useGetPropertyControlsForSelectedComponents().flatMap((controls) =>
-    Object.values(controls.controls),
+function usePropertyControlDescriptions(selectedProperty: PropertyPath): Array<ControlDescription> {
+  const controls = useGetPropertyControlsForSelectedComponents()
+  if (
+    selectedProperty.propertyElements.length === 0 ||
+    typeof selectedProperty.propertyElements[0] !== 'string'
+  ) {
+    // currently we only support picking data for props on components
+    return []
+  }
+  const controlForProp = controls.flatMap(
+    (c) => c.controls[selectedProperty.propertyElements[0]] ?? [],
   )
+  return controlForProp
 }
 
 export interface PrimitiveInfo {
@@ -298,7 +307,7 @@ export function useVariablesInScopeForSelectedElement(
     'useVariablesInScopeForSelectedElement variablesInScope',
   )
 
-  const controlDescriptions = usePropertyControlDescriptions()
+  const controlDescriptions = usePropertyControlDescriptions(propertyPath)
   const currentPropertyValue = usePropertyValue(selectedView, propertyPath)
 
   const variableNamesInScope = React.useMemo((): Array<VariableOption> => {

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -8,11 +8,10 @@ import type { VariableData } from '../../../canvas/ui-jsx-canvas'
 import { useEditorState, Substores } from '../../../editor/store/store-hook'
 import type { VariableOption } from './data-picker-popup'
 import * as EP from '../../../../core/shared/element-path'
-import React, { ReactNode } from 'react'
+import React from 'react'
 import { useGetPropertyControlsForSelectedComponents } from '../../common/property-controls-hooks'
 import { mapDropNulls } from '../../../../core/shared/array-utils'
 import { assertNever } from '../../../../core/shared/utils'
-import { isValidReactNode } from '../../../../utils/react-utils'
 
 function valuesFromObject(
   variable: ArrayInfo | ObjectInfo,
@@ -370,25 +369,20 @@ function objectShapesMatch(left: object, right: object): boolean {
   return keysFromLeft.every((key) => variableShapesMatch((left as any)[key], (right as any)[key]))
 }
 
-function variableShapesMatch(current: unknown, other: unknown): boolean {
-  if (React.isValidElement(current)) {
-    return isValidReactNode(other)
+function variableShapesMatch(left: unknown, right: unknown): boolean {
+  if (React.isValidElement(left) && React.isValidElement(right)) {
+    return true
   }
 
-  if (Array.isArray(current) && Array.isArray(other)) {
-    return arrayShapesMatch(current, other)
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return arrayShapesMatch(left, right)
   }
 
-  if (
-    typeof current === 'object' &&
-    typeof other === 'object' &&
-    current != null &&
-    other != null
-  ) {
-    return objectShapesMatch(current, other)
+  if (typeof left === 'object' && typeof right === 'object' && left != null && right != null) {
+    return objectShapesMatch(left, right)
   }
 
-  return typeof current === typeof other
+  return typeof left === typeof right
 }
 
 function variableMatchesArrayControlDescription(
@@ -416,7 +410,7 @@ function variableMatchesControlDescription(
   controlDescription: ControlDescription,
 ): boolean {
   const matches =
-    (isValidReactNode(variable) && controlDescription.control === 'jsx') ||
+    (React.isValidElement(variable) && controlDescription.control === 'jsx') ||
     (typeof variable === 'string' && controlDescription.control === 'string-input') ||
     (typeof variable === 'number' && controlDescription.control === 'number-input') ||
     (Array.isArray(variable) &&

--- a/editor/src/core/property-controls/property-control-values.ts
+++ b/editor/src/core/property-controls/property-control-values.ts
@@ -10,6 +10,7 @@ import {
   parseAny,
   parseObject,
   parseArray,
+  parseJsx,
 } from '../../utils/value-parser-utils'
 import type {
   AllowedEnumType,
@@ -306,6 +307,8 @@ export function unwrapperAndParserForBaseControl(
       return defaultUnwrapFirst(parseString)
     case 'style-controls':
       return defaultUnwrapFirst(parseAny)
+    case 'jsx':
+      return jsUnwrapFirst(parseJsx)
     case 'vector2':
     case 'vector3':
     case 'vector4':
@@ -337,6 +340,7 @@ export function unwrapperAndParserForPropertyControl(
     case 'vector2':
     case 'vector3':
     case 'vector4':
+    case 'jsx':
       return unwrapperAndParserForBaseControl(control)
 
     case 'array':
@@ -467,6 +471,8 @@ export function printerForBasePropertyControl(control: BaseControlDescription): 
       return printSimple
     case 'vector4':
       return printSimple
+    case 'jsx':
+      return printSimple
     default:
       const _exhaustiveCheck: never = control
       throw new Error(`Unhandled controls ${JSON.stringify(control)}`)
@@ -545,6 +551,7 @@ export function printerForPropertyControl(control: RegularControlDescription): P
     case 'vector2':
     case 'vector3':
     case 'vector4':
+    case 'jsx':
       return printerForBasePropertyControl(control)
 
     case 'array':

--- a/editor/src/core/property-controls/property-controls-parser.ts
+++ b/editor/src/core/property-controls/property-controls-parser.ts
@@ -29,6 +29,7 @@ import type {
   ExpressionControlOption,
   TupleControlDescription,
   HtmlInputControlDescription,
+  JSXControlDescription,
 } from 'utopia-api/core'
 import { parseColor } from '../../components/inspector/common/css-utils'
 import type { Parser, ParseResult } from '../../utils/value-parser-utils'
@@ -649,6 +650,23 @@ export function parseFolderControlDescription(
   )
 }
 
+export function parseJSXControlDescription(value: unknown): ParseResult<JSXControlDescription> {
+  return applicative3Either(
+    (label, control, visibleByDefault) => {
+      let jsxControlDescription: JSXControlDescription = {
+        control: control,
+      }
+      setOptionalProp(jsxControlDescription, 'label', label)
+      setOptionalProp(jsxControlDescription, 'visibleByDefault', visibleByDefault)
+
+      return jsxControlDescription
+    },
+    optionalObjectKeyParser(parseString, 'label')(value),
+    objectKeyParser(parseConstant('jsx'), 'control')(value),
+    optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
+  )
+}
+
 function parseRegularControlDescription(value: unknown): ParseResult<RegularControlDescription> {
   if (typeof value === 'object' && !Array.isArray(value) && value != null) {
     const controlType = (value as any)['control'] as RegularControlType
@@ -695,6 +713,8 @@ function parseRegularControlDescription(value: unknown): ParseResult<RegularCont
         return parseVector4ControlDescription(value)
       case 'union':
         return parseUnionControlDescription(value)
+      case 'jsx':
+        return parseJSXControlDescription(value)
       case undefined:
         return left(objectFieldNotPresentParseError('control'))
       default:

--- a/editor/src/utils/react-utils.ts
+++ b/editor/src/utils/react-utils.ts
@@ -83,4 +83,11 @@ class RU {
   }
 }
 
+export function isValidReactNode(node: unknown) {
+  return React.isValidElement(node)
+  // typeof node === 'string' ||
+  // typeof node === 'number' ||
+  // node === null
+}
+
 export default RU

--- a/editor/src/utils/react-utils.ts
+++ b/editor/src/utils/react-utils.ts
@@ -83,11 +83,4 @@ class RU {
   }
 }
 
-export function isValidReactNode(node: unknown) {
-  return React.isValidElement(node)
-  // typeof node === 'string' ||
-  // typeof node === 'number' ||
-  // node === null
-}
-
 export default RU

--- a/editor/src/utils/value-parser-utils.ts
+++ b/editor/src/utils/value-parser-utils.ts
@@ -297,6 +297,14 @@ export function parseString(value: unknown): ParseResult<string> {
   }
 }
 
+export function parseJsx(value: unknown): ParseResult<string> {
+  if (typeof value === 'string') {
+    return right(value)
+  } else {
+    return left(descriptionParseError('Not a string.'))
+  }
+}
+
 export function parseEnum<E extends string | number>(possibleValues: Array<E>): Parser<E> {
   return (value: unknown) => {
     for (const possibleValue of possibleValues) {

--- a/editor/src/utils/value-parser-utils.ts
+++ b/editor/src/utils/value-parser-utils.ts
@@ -298,11 +298,7 @@ export function parseString(value: unknown): ParseResult<string> {
 }
 
 export function parseJsx(value: unknown): ParseResult<string> {
-  if (typeof value === 'string' && value.startsWith('<')) {
-    return right(value.slice(1).split(' ')[0]) // TODO: This is a hack, we should get the jsx name properly
-  } else {
-    return left(descriptionParseError('Not a jsx.'))
-  }
+  return right('JSX')
 }
 
 export function parseEnum<E extends string | number>(possibleValues: Array<E>): Parser<E> {

--- a/editor/src/utils/value-parser-utils.ts
+++ b/editor/src/utils/value-parser-utils.ts
@@ -298,10 +298,10 @@ export function parseString(value: unknown): ParseResult<string> {
 }
 
 export function parseJsx(value: unknown): ParseResult<string> {
-  if (typeof value === 'string') {
-    return right(value)
+  if (typeof value === 'string' && value.startsWith('<')) {
+    return right(value.slice(1).split(' ')[0]) // TODO: This is a hack, we should get the jsx name properly
   } else {
-    return left(descriptionParseError('Not a string.'))
+    return left(descriptionParseError('Not a jsx.'))
   }
 }
 

--- a/utopia-api/src/property-controls/factories.ts
+++ b/utopia-api/src/property-controls/factories.ts
@@ -10,6 +10,7 @@ import type {
   FolderControlDescription,
   HtmlInputControlDescription,
   ImportType,
+  JSXControlDescription,
   Matrix3ControlDescription,
   Matrix4ControlDescription,
   NoneControlDescription,
@@ -211,6 +212,12 @@ export function vector3Control(): Vector3ControlDescription {
 export function vector4Control(): Vector4ControlDescription {
   return {
     control: 'vector4',
+  }
+}
+
+export function jsxControl(): JSXControlDescription {
+  return {
+    control: 'jsx',
   }
 }
 

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -35,6 +35,7 @@ export type BaseControlType =
   | 'vector2'
   | 'vector3'
   | 'vector4'
+  | 'jsx'
 
 export interface CheckboxControlDescription {
   control: 'checkbox'
@@ -174,6 +175,12 @@ export interface Vector4ControlDescription {
   visibleByDefault?: boolean
 }
 
+export interface JSXControlDescription {
+  control: 'jsx'
+  label?: string
+  visibleByDefault?: boolean
+}
+
 export type BaseControlDescription =
   | CheckboxControlDescription
   | ColorControlDescription
@@ -192,6 +199,7 @@ export type BaseControlDescription =
   | Vector2ControlDescription
   | Vector3ControlDescription
   | Vector4ControlDescription
+  | JSXControlDescription
 
 // Higher Level Controls
 
@@ -266,6 +274,7 @@ export function isBaseControlDescription(
     case 'vector2':
     case 'vector3':
     case 'vector4':
+    case 'jsx':
       return true
     case 'array':
     case 'object':


### PR DESCRIPTION
**Problem:**
First PR for jsx controls.

**Fix:**
- New control type in `utopia-api` for jsx control.
- Control type Integrated into editor, a dummy control is shown which just displays 'JSX'
- Data picker filters for react element.

**Missing:**
- Showing real parsed value in the jsx control (e.g. name of the root element)
- Showing real parsed value in the data picker (e.g. name of the root element)
- We filter out strings/numbers in the data picker, even though they are valid jsx elements. 
