### PR TITLE
Remix proxy - add missing project file endpoint

### DIFF
--- a/utopia-remix/app/routes/v1.project.$id.$filename.tsx
+++ b/utopia-remix/app/routes/v1.project.$id.$filename.tsx
@@ -1,0 +1,10 @@
+import { LoaderFunctionArgs } from '@remix-run/node'
+import { proxy } from '../util/proxy.server'
+import { handle, handleOptions } from '../util/api.server'
+
+export async function loader(args: LoaderFunctionArgs) {
+  return handle(args, {
+    OPTIONS: handleOptions,
+    GET: proxy,
+  })
+}


### PR DESCRIPTION
This PR adds a missing v1 route for `v1/project/$id/$filename`.