### PR TITLE
Fix data picker ordering

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
@@ -810,7 +810,7 @@ const projectWithObjectsAndArrays =
 
 registerInternalComponent(BookDetail, {
   properties: {
-    titles: Utopia.objectControl({
+    book: Utopia.objectControl({
       title: Utopia.stringControl(),
       published: Utopia.stringControl(),
       description: Utopia.stringControl(),

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -73,10 +73,19 @@ function valuesFromVariable(
   }
 }
 
-function usePropertyControlDescriptions(): Array<ControlDescription> {
-  return useGetPropertyControlsForSelectedComponents().flatMap((controls) =>
-    Object.values(controls.controls),
+function usePropertyControlDescriptions(selectedProperty: PropertyPath): Array<ControlDescription> {
+  const controls = useGetPropertyControlsForSelectedComponents()
+  if (
+    selectedProperty.propertyElements.length === 0 ||
+    typeof selectedProperty.propertyElements[0] !== 'string'
+  ) {
+    // currently we only support picking data for props on components
+    return []
+  }
+  const controlForProp = controls.flatMap(
+    (c) => c.controls[selectedProperty.propertyElements[0]] ?? [],
   )
+  return controlForProp
 }
 
 export interface PrimitiveInfo {
@@ -269,7 +278,7 @@ export function useVariablesInScopeForSelectedElement(
     'useVariablesInScopeForSelectedElement variablesInScope',
   )
 
-  const controlDescriptions = usePropertyControlDescriptions()
+  const controlDescriptions = usePropertyControlDescriptions(propertyPath)
   const currentPropertyValue = usePropertyValue(selectedView, propertyPath)
 
   const variableNamesInScope = React.useMemo((): Array<VariableOption> => {

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -73,19 +73,19 @@ function valuesFromVariable(
   }
 }
 
-function usePropertyControlDescriptions(selectedProperty: PropertyPath): Array<ControlDescription> {
+function usePropertyControlDescriptions(selectedProperty: PropertyPath): ControlDescription | null {
   const controls = useGetPropertyControlsForSelectedComponents()
   if (
     selectedProperty.propertyElements.length === 0 ||
     typeof selectedProperty.propertyElements[0] !== 'string'
   ) {
     // currently we only support picking data for props on components
-    return []
+    return null
   }
   const controlForProp = controls.flatMap(
     (c) => c.controls[selectedProperty.propertyElements[0]] ?? [],
   )
-  return controlForProp
+  return controlForProp[0] ?? null
 }
 
 export interface PrimitiveInfo {
@@ -185,7 +185,7 @@ function variableInfoFromVariableData(variableNamesInScope: VariableData): Array
 
 function orderVariablesForRelevance(
   variableNamesInScope: Array<VariableInfo>,
-  controlDescriptions: Array<ControlDescription>,
+  controlDescription: ControlDescription | null,
   currentPropertyValue: PropertyValue,
 ): Array<VariableInfo> {
   let valuesMatchingPropertyDescription: Array<VariableInfo> = []
@@ -197,20 +197,20 @@ function orderVariablesForRelevance(
     if (variable.type === 'array') {
       variable.elements = orderVariablesForRelevance(
         variable.elements,
-        controlDescriptions,
+        controlDescription,
         currentPropertyValue,
       )
     } else if (variable.type === 'object') {
       variable.props = orderVariablesForRelevance(
         variable.props,
-        controlDescriptions,
+        controlDescription,
         currentPropertyValue,
       )
     }
 
-    const valueMatchesControlDescription = controlDescriptions.some((description) =>
-      variableMatchesControlDescription(variable.value, description),
-    )
+    const valueMatchesControlDescription =
+      controlDescription != null &&
+      variableMatchesControlDescription(variable.value, controlDescription)
 
     const valueMatchesCurrentPropValue =
       currentPropertyValue.type === 'existing' &&


### PR DESCRIPTION
## Problem

When determining whether a variable matches a property control description of a component, the code accidentally checked all control descriptions for the selected element, instead of just the control description of the prop being picked for.

## Fix 
Fix `usePropertyControlDescriptions` so that it only uses the control description for the currently selected prop (if there's one).