### PR TITLE
Update puppeteer to 22.2.0

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -191,7 +191,7 @@
     "prettier": "2.8.8",
     "prop-types": "15.6.2",
     "pubsub-js": "1.9.3",
-    "puppeteer": "21.6.0",
+    "puppeteer": "22.2.0",
     "rc-slider": "git://github.com/momentumworks/slider.git#93a6ef5d67845a340bb1847be4e7fc9b3f5c9c5f",
     "rc-table": "7.8.6",
     "re-reselect": "4.0.1",

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -261,7 +261,7 @@ specifiers:
   pretty-format: 26.1.0
   prop-types: 15.6.2
   pubsub-js: 1.9.3
-  puppeteer: 21.6.0
+  puppeteer: 22.2.0
   rc-slider: git://github.com/momentumworks/slider.git#93a6ef5d67845a340bb1847be4e7fc9b3f5c9c5f
   rc-table: 7.8.6
   re-reselect: 4.0.1
@@ -435,7 +435,7 @@ dependencies:
   prettier: 2.8.8
   prop-types: 15.6.2
   pubsub-js: 1.9.3
-  puppeteer: 21.6.0_typescript@5.2.2
+  puppeteer: 22.2.0_typescript@5.2.2
   rc-slider: github.com/momentumworks/slider/93a6ef5d67845a340bb1847be4e7fc9b3f5c9c5f_ef5jwxihqo6n7gxfmzogljlgcm
   rc-table: 7.8.6_ef5jwxihqo6n7gxfmzogljlgcm
   re-reselect: 4.0.1_reselect@4.1.7
@@ -3300,16 +3300,17 @@ packages:
     resolution: {integrity: sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==}
     dev: false
 
-  /@puppeteer/browsers/1.9.0:
-    resolution: {integrity: sha512-QwguOLy44YBGC8vuPP2nmpX4MUN2FzWbsnvZJtiCzecU3lHmVZkaC1tq6rToi9a200m8RzlVtDyxCS0UIDrxUg==}
-    engines: {node: '>=16.3.0'}
+  /@puppeteer/browsers/2.1.0:
+    resolution: {integrity: sha512-xloWvocjvryHdUjDam/ZuGMh7zn4Sn3ZAaV4Ah2e2EwEt90N3XphZlSsU3n0VDc1F7kggCjMuH0UuxfPQ5mD9w==}
+    engines: {node: '>=18'}
     hasBin: true
     dependencies:
       debug: 4.3.4
       extract-zip: 2.0.1
       progress: 2.0.3
-      proxy-agent: 6.3.1
-      tar-fs: 3.0.4
+      proxy-agent: 6.4.0
+      semver: 7.6.0
+      tar-fs: 3.0.5
       unbzip2-stream: 1.4.3
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -5382,7 +5383,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.4
+      semver: 7.6.0
       tsutils: 3.21.0_typescript@5.2.2
       typescript: 5.2.2
     transitivePeerDependencies:
@@ -6577,6 +6578,34 @@ packages:
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  /bare-events/2.2.0:
+    resolution: {integrity: sha512-Yyyqff4PIFfSuthCZqLlPISTWHmnQxoPuAvkmgzsJEmG3CesdIv6Xweayl0JkCZJSB2yYIdJyEz97tpxNhgjbg==}
+    dev: false
+    optional: true
+
+  /bare-fs/2.1.5:
+    resolution: {integrity: sha512-5t0nlecX+N2uJqdxe9d18A98cp2u9BETelbjKpiVgQqzzmVNFYWEAjQHqS+2Khgto1vcwhik9cXucaj5ve2WWA==}
+    requiresBuild: true
+    dependencies:
+      bare-events: 2.2.0
+      bare-os: 2.2.0
+      bare-path: 2.1.0
+      streamx: 2.15.5
+    dev: false
+    optional: true
+
+  /bare-os/2.2.0:
+    resolution: {integrity: sha512-hD0rOPfYWOMpVirTACt4/nK8mC55La12K5fY1ij8HAdfQakD62M+H4o4tpfKzVGLgRDTuk3vjA4GqGXXCeFbag==}
+    dev: false
+    optional: true
+
+  /bare-path/2.1.0:
+    resolution: {integrity: sha512-DIIg7ts8bdRKwJRJrUMy/PICEaQZaPGZ26lsSx9MJSwIhSrcdHn7/C8W+XmnG/rKi6BaRcz+JO00CjZteybDtw==}
+    dependencies:
+      bare-os: 2.2.0
+    dev: false
+    optional: true
+
   /base/0.11.2:
     resolution: {integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==}
     engines: {node: '>=0.10.0'}
@@ -7277,14 +7306,14 @@ packages:
     engines: {node: '>=6.0'}
     dev: true
 
-  /chromium-bidi/0.5.1_6l3ta6d4k37jlx7r4do7wz4j2a:
-    resolution: {integrity: sha512-dcCqOgq9fHKExc2R4JZs/oKbOghWpUNFAJODS8WKRtLhp3avtIH5UDCBrutdqZdh3pARogH8y1ObXm87emwb3g==}
+  /chromium-bidi/0.5.9_74t7hwmhzgczi6zz4gvli4zmpa:
+    resolution: {integrity: sha512-wOTX3m2zuHX0zRX4h7Ol1DAGz0cqHzo2IrAPvOqBxdd4ZR32vxg4FKNjmBihi1oP9b1QGSBBG5VNUUXUCsxDfg==}
     peerDependencies:
       devtools-protocol: '*'
     dependencies:
-      devtools-protocol: 0.0.1203626
+      devtools-protocol: 0.0.1249869
       mitt: 3.0.1
-      urlpattern-polyfill: 9.0.0
+      urlpattern-polyfill: 10.0.0
     dev: false
 
   /ci-info/3.2.0:
@@ -7832,8 +7861,8 @@ packages:
       yaml: 1.10.2
     dev: true
 
-  /cosmiconfig/8.3.6_typescript@5.2.2:
-    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
+  /cosmiconfig/9.0.0_typescript@5.2.2:
+    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
     engines: {node: '>=14'}
     peerDependencies:
       typescript: '>=4.9.5'
@@ -7841,10 +7870,10 @@ packages:
       typescript:
         optional: true
     dependencies:
+      env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
-      path-type: 4.0.0
       typescript: 5.2.2
     dev: false
 
@@ -8477,8 +8506,8 @@ packages:
       defined: 1.0.0
     dev: true
 
-  /devtools-protocol/0.0.1203626:
-    resolution: {integrity: sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g==}
+  /devtools-protocol/0.0.1249869:
+    resolution: {integrity: sha512-Ctp4hInA0BEavlUoRy9mhGq0i+JSo/AwVyX2EFgZmV1kYB+Zq+EMBAn52QWu6FbRr10hRb6pBl420upbp4++vg==}
     dev: false
 
   /di/0.0.1:
@@ -8871,6 +8900,11 @@ packages:
   /entities/4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  /env-paths/2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+    dev: false
 
   /envinfo/7.8.1:
     resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
@@ -11060,8 +11094,8 @@ packages:
       - supports-color
     dev: true
 
-  /http-proxy-agent/7.0.0:
-    resolution: {integrity: sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==}
+  /http-proxy-agent/7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
@@ -11132,8 +11166,8 @@ packages:
       - supports-color
     dev: true
 
-  /https-proxy-agent/7.0.2:
-    resolution: {integrity: sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==}
+  /https-proxy-agent/7.0.4:
+    resolution: {integrity: sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==}
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
@@ -12512,7 +12546,7 @@ packages:
       jest-util: 27.2.4
       natural-compare: 1.4.0
       pretty-format: 27.2.4
-      semver: 7.5.4
+      semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13783,10 +13817,6 @@ packages:
       is-extendable: 1.0.1
     dev: true
 
-  /mkdirp-classic/0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
-    dev: false
-
   /mkdirp/0.5.5:
     resolution: {integrity: sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==}
     hasBin: true
@@ -14468,8 +14498,8 @@ packages:
       agent-base: 7.1.0
       debug: 4.3.4
       get-uri: 6.0.2
-      http-proxy-agent: 7.0.0
-      https-proxy-agent: 7.0.2
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.4
       pac-resolver: 7.0.0
       socks-proxy-agent: 8.0.2
     transitivePeerDependencies:
@@ -15190,14 +15220,14 @@ packages:
       ipaddr.js: 1.9.1
     dev: true
 
-  /proxy-agent/6.3.1:
-    resolution: {integrity: sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==}
+  /proxy-agent/6.4.0:
+    resolution: {integrity: sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==}
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
       debug: 4.3.4
-      http-proxy-agent: 7.0.0
-      https-proxy-agent: 7.0.2
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.4
       lru-cache: 7.18.3
       pac-proxy-agent: 7.0.1
       proxy-from-env: 1.1.0
@@ -15251,16 +15281,16 @@ packages:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
 
-  /puppeteer-core/21.6.0:
-    resolution: {integrity: sha512-1vrzbp2E1JpBwtIIrriWkN+A0afUxkqRuFTC3uASc5ql6iuK9ppOdIU/CPGKwOyB4YFIQ16mRbK0PK19mbXnaQ==}
-    engines: {node: '>=16.13.2'}
+  /puppeteer-core/22.2.0:
+    resolution: {integrity: sha512-rxLM860FP05CxCPAn6dwY0KnVhbnogsXu4XORb+2hb/va69v7R1VdJWLMGHd7EE5wfpT8oFZ7Q6NN85OhOtV9Q==}
+    engines: {node: '>=18'}
     dependencies:
-      '@puppeteer/browsers': 1.9.0
-      chromium-bidi: 0.5.1_6l3ta6d4k37jlx7r4do7wz4j2a
+      '@puppeteer/browsers': 2.1.0
+      chromium-bidi: 0.5.9_74t7hwmhzgczi6zz4gvli4zmpa
       cross-fetch: 4.0.0
       debug: 4.3.4
-      devtools-protocol: 0.0.1203626
-      ws: 8.14.2
+      devtools-protocol: 0.0.1249869
+      ws: 8.16.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -15268,15 +15298,15 @@ packages:
       - utf-8-validate
     dev: false
 
-  /puppeteer/21.6.0_typescript@5.2.2:
-    resolution: {integrity: sha512-u6JhSF7xaPYZ2gd3tvhYI8MwVAjLc3Cazj7UWvMV95A07/y7cIjBwYUiMU9/jm4z0FSUORriLX/RZRaiASNWPw==}
-    engines: {node: '>=16.13.2'}
+  /puppeteer/22.2.0_typescript@5.2.2:
+    resolution: {integrity: sha512-0Ax7zeqqbQL6Zcpo1WAvrqWQAnGsLB4tmQUUwsb5Cfo05XaQ78LWUUjaO4um7qaddKpZfk0vXlGcRVwtedpWfg==}
+    engines: {node: '>=18'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@puppeteer/browsers': 1.9.0
-      cosmiconfig: 8.3.6_typescript@5.2.2
-      puppeteer-core: 21.6.0
+      '@puppeteer/browsers': 2.1.0
+      cosmiconfig: 9.0.0_typescript@5.2.2
+      puppeteer-core: 22.2.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -17192,6 +17222,13 @@ packages:
     dependencies:
       lru-cache: 6.0.0
 
+  /semver/7.6.0:
+    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+
   /send/0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
     engines: {node: '>= 0.8.0'}
@@ -18186,12 +18223,14 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /tar-fs/3.0.4:
-    resolution: {integrity: sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==}
+  /tar-fs/3.0.5:
+    resolution: {integrity: sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==}
     dependencies:
-      mkdirp-classic: 0.5.3
       pump: 3.0.0
       tar-stream: 3.1.6
+    optionalDependencies:
+      bare-fs: 2.1.5
+      bare-path: 2.1.0
     dev: false
 
   /tar-stream/3.1.6:
@@ -18878,8 +18917,8 @@ packages:
       querystring: 0.2.0
     dev: true
 
-  /urlpattern-polyfill/9.0.0:
-    resolution: {integrity: sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==}
+  /urlpattern-polyfill/10.0.0:
+    resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
     dev: false
 
   /use-callback-ref/1.3.0_7cpxmzzodpxnolj5zcc5cr63ji:
@@ -19592,8 +19631,8 @@ packages:
         optional: true
     dev: true
 
-  /ws/8.14.2:
-    resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}
+  /ws/8.16.0:
+    resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1

--- a/puppeteer-tests/package.json
+++ b/puppeteer-tests/package.json
@@ -25,7 +25,7 @@
     "multer": "1.4.2",
     "multer-s3": "2.9.0",
     "plotly": "1.0.6",
-    "puppeteer": "21.6.0",
+    "puppeteer": "22.2.0",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
     "typescript": "4.7.4"

--- a/puppeteer-tests/pnpm-lock.yaml
+++ b/puppeteer-tests/pnpm-lock.yaml
@@ -13,7 +13,7 @@ specifiers:
   multer: 1.4.2
   multer-s3: 2.9.0
   plotly: 1.0.6
-  puppeteer: 21.6.0
+  puppeteer: 22.2.0
   ts-jest: 29.1.1
   ts-node: 10.9.1
   typescript: 4.7.4
@@ -30,7 +30,7 @@ dependencies:
   multer: 1.4.2
   multer-s3: 2.9.0
   plotly: 1.0.6
-  puppeteer: 21.6.0_typescript@4.7.4
+  puppeteer: 22.2.0_typescript@4.7.4
   ts-jest: 29.1.1_m5wu2hnqsxvo5olxq3gfnuhkwe
   ts-node: 10.9.1_435elrtdaw7tspfnscimedxmsi
   typescript: 4.7.4
@@ -46,13 +46,6 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.20
-    dev: false
-
-  /@babel/code-frame/7.21.4:
-    resolution: {integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/highlight': 7.18.6
     dev: false
 
   /@babel/code-frame/7.23.5:
@@ -176,11 +169,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/helper-validator-identifier/7.19.1:
-    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
-    engines: {node: '>=6.9.0'}
-    dev: false
-
   /@babel/helper-validator-identifier/7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
@@ -199,15 +187,6 @@ packages:
       '@babel/types': 7.23.6
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@babel/highlight/7.18.6:
-    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
-      chalk: 2.4.2
-      js-tokens: 4.0.0
     dev: false
 
   /@babel/highlight/7.23.4:
@@ -666,16 +645,17 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: false
 
-  /@puppeteer/browsers/1.9.0:
-    resolution: {integrity: sha512-QwguOLy44YBGC8vuPP2nmpX4MUN2FzWbsnvZJtiCzecU3lHmVZkaC1tq6rToi9a200m8RzlVtDyxCS0UIDrxUg==}
-    engines: {node: '>=16.3.0'}
+  /@puppeteer/browsers/2.1.0:
+    resolution: {integrity: sha512-xloWvocjvryHdUjDam/ZuGMh7zn4Sn3ZAaV4Ah2e2EwEt90N3XphZlSsU3n0VDc1F7kggCjMuH0UuxfPQ5mD9w==}
+    engines: {node: '>=18'}
     hasBin: true
     dependencies:
       debug: 4.3.4
       extract-zip: 2.0.1
       progress: 2.0.3
-      proxy-agent: 6.3.1
-      tar-fs: 3.0.4
+      proxy-agent: 6.4.0
+      semver: 7.6.0
+      tar-fs: 3.0.5
       unbzip2-stream: 1.4.3
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -982,6 +962,34 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: false
 
+  /bare-events/2.2.0:
+    resolution: {integrity: sha512-Yyyqff4PIFfSuthCZqLlPISTWHmnQxoPuAvkmgzsJEmG3CesdIv6Xweayl0JkCZJSB2yYIdJyEz97tpxNhgjbg==}
+    dev: false
+    optional: true
+
+  /bare-fs/2.1.5:
+    resolution: {integrity: sha512-5t0nlecX+N2uJqdxe9d18A98cp2u9BETelbjKpiVgQqzzmVNFYWEAjQHqS+2Khgto1vcwhik9cXucaj5ve2WWA==}
+    requiresBuild: true
+    dependencies:
+      bare-events: 2.2.0
+      bare-os: 2.2.0
+      bare-path: 2.1.0
+      streamx: 2.15.5
+    dev: false
+    optional: true
+
+  /bare-os/2.2.0:
+    resolution: {integrity: sha512-hD0rOPfYWOMpVirTACt4/nK8mC55La12K5fY1ij8HAdfQakD62M+H4o4tpfKzVGLgRDTuk3vjA4GqGXXCeFbag==}
+    dev: false
+    optional: true
+
+  /bare-path/2.1.0:
+    resolution: {integrity: sha512-DIIg7ts8bdRKwJRJrUMy/PICEaQZaPGZ26lsSx9MJSwIhSrcdHn7/C8W+XmnG/rKi6BaRcz+JO00CjZteybDtw==}
+    dependencies:
+      bare-os: 2.2.0
+    dev: false
+    optional: true
+
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: false
@@ -1098,14 +1106,14 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /chromium-bidi/0.5.1_6l3ta6d4k37jlx7r4do7wz4j2a:
-    resolution: {integrity: sha512-dcCqOgq9fHKExc2R4JZs/oKbOghWpUNFAJODS8WKRtLhp3avtIH5UDCBrutdqZdh3pARogH8y1ObXm87emwb3g==}
+  /chromium-bidi/0.5.9_74t7hwmhzgczi6zz4gvli4zmpa:
+    resolution: {integrity: sha512-wOTX3m2zuHX0zRX4h7Ol1DAGz0cqHzo2IrAPvOqBxdd4ZR32vxg4FKNjmBihi1oP9b1QGSBBG5VNUUXUCsxDfg==}
     peerDependencies:
       devtools-protocol: '*'
     dependencies:
-      devtools-protocol: 0.0.1203626
+      devtools-protocol: 0.0.1249869
       mitt: 3.0.1
-      urlpattern-polyfill: 9.0.0
+      urlpattern-polyfill: 10.0.0
     dev: false
 
   /ci-info/3.9.0:
@@ -1173,8 +1181,8 @@ packages:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: false
 
-  /cosmiconfig/8.3.6_typescript@4.7.4:
-    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
+  /cosmiconfig/9.0.0_typescript@4.7.4:
+    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
     engines: {node: '>=14'}
     peerDependencies:
       typescript: '>=4.9.5'
@@ -1182,10 +1190,10 @@ packages:
       typescript:
         optional: true
     dependencies:
+      env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
-      path-type: 4.0.0
       typescript: 4.7.4
     dev: false
 
@@ -1274,8 +1282,8 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /devtools-protocol/0.0.1203626:
-    resolution: {integrity: sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g==}
+  /devtools-protocol/0.0.1249869:
+    resolution: {integrity: sha512-Ctp4hInA0BEavlUoRy9mhGq0i+JSo/AwVyX2EFgZmV1kYB+Zq+EMBAn52QWu6FbRr10hRb6pBl420upbp4++vg==}
     dev: false
 
   /dicer/0.2.5:
@@ -1321,6 +1329,11 @@ packages:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
       once: 1.4.0
+    dev: false
+
+  /env-paths/2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
     dev: false
 
   /error-ex/1.3.2:
@@ -1564,8 +1577,8 @@ packages:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: false
 
-  /http-proxy-agent/7.0.0:
-    resolution: {integrity: sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==}
+  /http-proxy-agent/7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
@@ -1574,8 +1587,8 @@ packages:
       - supports-color
     dev: false
 
-  /https-proxy-agent/7.0.2:
-    resolution: {integrity: sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==}
+  /https-proxy-agent/7.0.4:
+    resolution: {integrity: sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==}
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
@@ -1712,7 +1725,7 @@ packages:
       '@babel/parser': 7.23.6
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.5.4
+      semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2078,7 +2091,7 @@ packages:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.5.4
+      semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2248,7 +2261,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.0
     dev: false
 
   /make-error/1.3.6:
@@ -2306,10 +2319,6 @@ packages:
 
   /mitt/3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
-    dev: false
-
-  /mkdirp-classic/0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
     dev: false
 
   /mkdirp/0.5.5:
@@ -2452,8 +2461,8 @@ packages:
       agent-base: 7.1.0
       debug: 4.3.4
       get-uri: 6.0.2
-      http-proxy-agent: 7.0.0
-      https-proxy-agent: 7.0.2
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.4
       pac-resolver: 7.0.0
       socks-proxy-agent: 8.0.2
     transitivePeerDependencies:
@@ -2480,7 +2489,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.21.4
+      '@babel/code-frame': 7.23.5
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -2503,11 +2512,6 @@ packages:
 
   /path-parse/1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: false
-
-  /path-type/4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
-    engines: {node: '>=8'}
     dev: false
 
   /pend/1.2.0:
@@ -2565,14 +2569,14 @@ packages:
       sisteransi: 1.0.5
     dev: false
 
-  /proxy-agent/6.3.1:
-    resolution: {integrity: sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==}
+  /proxy-agent/6.4.0:
+    resolution: {integrity: sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==}
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
       debug: 4.3.4
-      http-proxy-agent: 7.0.0
-      https-proxy-agent: 7.0.2
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.4
       lru-cache: 7.18.3
       pac-proxy-agent: 7.0.1
       proxy-from-env: 1.1.0
@@ -2596,16 +2600,16 @@ packages:
     resolution: {integrity: sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=}
     dev: false
 
-  /puppeteer-core/21.6.0:
-    resolution: {integrity: sha512-1vrzbp2E1JpBwtIIrriWkN+A0afUxkqRuFTC3uASc5ql6iuK9ppOdIU/CPGKwOyB4YFIQ16mRbK0PK19mbXnaQ==}
-    engines: {node: '>=16.13.2'}
+  /puppeteer-core/22.2.0:
+    resolution: {integrity: sha512-rxLM860FP05CxCPAn6dwY0KnVhbnogsXu4XORb+2hb/va69v7R1VdJWLMGHd7EE5wfpT8oFZ7Q6NN85OhOtV9Q==}
+    engines: {node: '>=18'}
     dependencies:
-      '@puppeteer/browsers': 1.9.0
-      chromium-bidi: 0.5.1_6l3ta6d4k37jlx7r4do7wz4j2a
+      '@puppeteer/browsers': 2.1.0
+      chromium-bidi: 0.5.9_74t7hwmhzgczi6zz4gvli4zmpa
       cross-fetch: 4.0.0
       debug: 4.3.4
-      devtools-protocol: 0.0.1203626
-      ws: 8.14.2
+      devtools-protocol: 0.0.1249869
+      ws: 8.16.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -2613,15 +2617,15 @@ packages:
       - utf-8-validate
     dev: false
 
-  /puppeteer/21.6.0_typescript@4.7.4:
-    resolution: {integrity: sha512-u6JhSF7xaPYZ2gd3tvhYI8MwVAjLc3Cazj7UWvMV95A07/y7cIjBwYUiMU9/jm4z0FSUORriLX/RZRaiASNWPw==}
-    engines: {node: '>=16.13.2'}
+  /puppeteer/22.2.0_typescript@4.7.4:
+    resolution: {integrity: sha512-0Ax7zeqqbQL6Zcpo1WAvrqWQAnGsLB4tmQUUwsb5Cfo05XaQ78LWUUjaO4um7qaddKpZfk0vXlGcRVwtedpWfg==}
+    engines: {node: '>=18'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@puppeteer/browsers': 1.9.0
-      cosmiconfig: 8.3.6_typescript@4.7.4
-      puppeteer-core: 21.6.0
+      '@puppeteer/browsers': 2.1.0
+      cosmiconfig: 9.0.0_typescript@4.7.4
+      puppeteer-core: 22.2.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -2729,6 +2733,14 @@ packages:
 
   /semver/7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: false
+
+  /semver/7.6.0:
+    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -2891,12 +2903,14 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
-  /tar-fs/3.0.4:
-    resolution: {integrity: sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==}
+  /tar-fs/3.0.5:
+    resolution: {integrity: sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==}
     dependencies:
-      mkdirp-classic: 0.5.3
       pump: 3.0.0
       tar-stream: 3.1.6
+    optionalDependencies:
+      bare-fs: 2.1.5
+      bare-path: 2.1.0
     dev: false
 
   /tar-stream/3.1.6:
@@ -3065,8 +3079,8 @@ packages:
       querystring: 0.2.0
     dev: false
 
-  /urlpattern-polyfill/9.0.0:
-    resolution: {integrity: sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==}
+  /urlpattern-polyfill/10.0.0:
+    resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
     dev: false
 
   /util-deprecate/1.0.2:
@@ -3138,8 +3152,8 @@ packages:
       signal-exit: 3.0.7
     dev: false
 
-  /ws/8.14.2:
-    resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}
+  /ws/8.16.0:
+    resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1

--- a/puppeteer-tests/src/comments/collaboration-test.spec.tsx
+++ b/puppeteer-tests/src/comments/collaboration-test.spec.tsx
@@ -60,13 +60,13 @@ describe('Collaboration test', () => {
         clickCanvasContainer(page2, { x: 500, y: 500 }),
       ])
 
-      const insertTab = (await page1.$x(
-        "//div[contains(text(), 'Insert')]",
+      const insertTab = (await page1.$$(
+        "xpath/.//div[contains(text(), 'Insert')]",
       )) as ElementHandle<Element>[]
       await insertTab!.at(0)!.click()
 
-      const sampleTextOptions = (await page1.$x(
-        "//span[contains(text(), 'Sample text')]",
+      const sampleTextOptions = (await page1.$$(
+        "xpath/.//span[contains(text(), 'Sample text')]",
       )) as ElementHandle<Element>[]
       await sampleTextOptions!.at(0)!.click()
       await clickCanvasContainer(page1, { x: 500, y: 500 })

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -157,8 +157,8 @@ async function retryPageCalls<T>(
 ): Promise<T> {
   for (let retryCount: number = 1; retryCount <= 3; retryCount++) {
     const { page, browser } = await setupBrowser(url, 120000)
-    await page.waitForXPath(`//div[contains(@id, "canvas-container")]`)
-    await page.waitForXPath('//div[contains(@class, "item-label-container")]')
+    await page.waitForSelector(`xpath/.//div[contains(@id, "canvas-container")]`)
+    await page.waitForSelector('xpath/.//div[contains(@class, "item-label-container")]')
     try {
       const iterations = await page.evaluate(() => {
         try {
@@ -269,8 +269,8 @@ async function clickOnce(
   expectedConsoleMessage: string,
   errorMessage?: string,
 ): Promise<boolean> {
-  await page.waitForXPath(xpath)
-  const [button] = await page.$x(xpath)
+  await page.waitForSelector(`xpath/.${xpath}`)
+  const [button] = await page.$$(`xpath/.${xpath}`)
   await (button as puppeteer.ElementHandle<HTMLButtonElement>)!.click()
   return consoleDoneMessage(page, expectedConsoleMessage, errorMessage)
 }
@@ -327,7 +327,7 @@ export const testHighlightRegularPerformance = async function (
   page: puppeteer.Page,
 ): Promise<FrameResult> {
   console.log(`Test Regular Highlight Performance`)
-  await page.waitForXPath("//a[contains(., 'PRH')]")
+  await page.waitForSelector("xpath/.//a[contains(., 'PRH')]")
   // we run it twice without measurements to warm up the environment
   await clickOnce(
     page,
@@ -359,7 +359,7 @@ export const testHighlightAllElementsPerformance = async function (
   page: puppeteer.Page,
 ): Promise<FrameResult> {
   console.log(`Test All Elements Highlight Performance`)
-  await page.waitForXPath("//a[contains(., 'PAH')]")
+  await page.waitForSelector("xpath/.//a[contains(., 'PAH')]")
   // we run it twice without measurements to warm up the environment
   await clickOnce(
     page,
@@ -392,7 +392,7 @@ export const testSelectionPerformance = async function (page: puppeteer.Page): P
   deselection: FrameResult
 }> {
   console.log('Test Selection Performance')
-  await page.waitForXPath("//a[contains(., 'P E')]")
+  await page.waitForSelector("xpath/.//a[contains(., 'P E')]")
   // we run it twice without measurements to warm up the environment
   await clickOnce(page, "//a[contains(., 'P E')]", 'SELECT_TEST_FINISHED', 'SELECT_TEST_ERROR')
   await clickOnce(page, "//a[contains(., 'P E')]", 'SELECT_TEST_FINISHED', 'SELECT_TEST_ERROR')
@@ -417,7 +417,7 @@ export const testSelectionChangePerformance = async function (
   page: puppeteer.Page,
 ): Promise<FrameResult> {
   console.log('Test Selection Change Performance')
-  await page.waitForXPath("//a[contains(., 'PSC')]")
+  await page.waitForSelector("xpath/.//a[contains(., 'PSC')]")
   // we run it twice without measurements to warm up the environment
   await clickOnce(
     page,
@@ -450,7 +450,7 @@ export const testAbsoluteMovePerformanceLarge = async function (page: puppeteer.
   move: FrameResult
 }> {
   console.log('Test Absolute Move Performance (Large)')
-  await page.waitForXPath("//a[contains(., 'PAML')]")
+  await page.waitForSelector("xpath/.//a[contains(., 'PAML')]")
   // we run it twice without measurements to warm up the environment
   await clickOnce(
     page,
@@ -495,7 +495,7 @@ export const testAbsoluteMovePerformanceSmall = async function (
   page: puppeteer.Page,
 ): Promise<{ interaction: FrameResult; move: FrameResult }> {
   console.log('Test Absolute Move Performance (Small)')
-  await page.waitForXPath("//a[contains(., 'PAMS')]")
+  await page.waitForSelector("xpath/.//a[contains(., 'PAMS')]")
   // we run it twice without measurements to warm up the environment
   await clickOnce(
     page,

--- a/puppeteer-tests/src/system-test.ts
+++ b/puppeteer-tests/src/system-test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 require('dotenv').config({ path: 'src/.env' })
-import type { ElementHandle, Page, PageEventObject } from 'puppeteer'
+import type { ElementHandle, Page, PageEvents } from 'puppeteer'
 import { initialiseTests, ONE_MINUTE_IN_MS, setupBrowser, timeLimitPromise } from './utils'
 
 const PROJECT_ID = process.env.PROJECT_ID ?? ''
@@ -14,14 +14,14 @@ async function clickOnce(
   expectedConsoleMessage: string,
   errorMessage?: string,
 ): Promise<boolean> {
-  await page.waitForXPath(xpath)
-  const [button] = await page.$x(xpath)
+  await page.waitForSelector(`xpath/.${xpath}`)
+  const [button] = await page.$$(`xpath/.${xpath}`)
 
-  let handler: (message: PageEventObject['console']) => void = () => {
+  let handler: (message: PageEvents['console']) => void = () => {
     console.info('Should not fire.')
   }
   const consoleDonePromise = new Promise<boolean>((resolve, reject) => {
-    handler = (message: PageEventObject['console']) => {
+    handler = (message: PageEvents['console']) => {
       const messageText = message.text()
       if (messageText.includes(expectedConsoleMessage)) {
         console.info(messageText)

--- a/puppeteer-tests/src/utils.ts
+++ b/puppeteer-tests/src/utils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import * as puppeteer from 'puppeteer'
-import type { PageEventObject } from 'puppeteer'
+import type { PageEvents } from 'puppeteer'
 const fs = require('fs')
 const path = require('path')
 const AWS = require('aws-sdk')
@@ -20,7 +20,7 @@ export const setupBrowser = async (
   const browser = await puppeteer.launch({
     args: ['--no-sandbox', '--enable-thread-instruction-count', `--window-size=1500,940`],
     // see https://developer.chrome.com/docs/chromium/new-headless
-    headless: headlessModeEnabled ? 'new' : false,
+    headless: headlessModeEnabled,
     executablePath: process.env.BROWSER,
   })
   const page = await browser.newPage()
@@ -79,11 +79,11 @@ export function consoleDoneMessage(
   expectedConsoleMessage: string,
   errorMessage?: string,
 ): Promise<boolean> {
-  let handler: (message: PageEventObject['console']) => void = () => {
+  let handler: (message: PageEvents['console']) => void = () => {
     console.info('Should not fire.')
   }
   const consoleDonePromise = new Promise<boolean>((resolve, reject) => {
-    handler = (message: PageEventObject['console']) => {
+    handler = (message: PageEvents['console']) => {
       const messageText = message.text()
       if (
         messageText.includes(expectedConsoleMessage) ||
@@ -158,14 +158,14 @@ export async function uploadPNGtoAWS(testFile: string): Promise<string | null> {
 
 export async function initialiseTests(page: puppeteer.Page): Promise<void> {
   console.log('Initialising the project')
-  await page.waitForXPath('//div[contains(@class, "item-label-container")]')
+  await page.waitForSelector('xpath/.//div[contains(@class, "item-label-container")]')
 
   // Select something
   const navigatorElement = await page.$('[class^="item-label-container"]')
   await navigatorElement!.click()
 
   // First selection will open the file in VS Code, triggering a bunch of downloads, so we pause briefly
-  await page.waitForTimeout(15000)
+  await wait(15000)
 
   console.log('Finished initialising')
 }


### PR DESCRIPTION
**Problem:**
The older version of Puppeteer uses a now deprecated URL for downloading Chrome

**Fix:**
Update to the latest version. Note that some parts of the API were removed, specifically:
- https://github.com/puppeteer/puppeteer/pull/11782
- https://github.com/puppeteer/puppeteer/pull/11780
