### PR TITLE
Better data picker filtering for jsx props

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section-utils.spec.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section-utils.spec.tsx
@@ -109,9 +109,9 @@ describe('inferControlTypeBasedOnValue', () => {
     expect(result.control).toEqual('none')
   })
 
-  it('Treats a React element as expression-input', () => {
+  it('Treats a React element as jsx', () => {
     const result = inferControlTypeBasedOnValue(<div />)
-    expect(result.control).toEqual('expression-input')
+    expect(result.control).toEqual('jsx')
   })
 
   it('treats a function as expression-input', () => {

--- a/editor/src/components/inspector/sections/component-section/component-section-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/component-section-utils.ts
@@ -20,6 +20,13 @@ function inferControlTypeBasedOnValueInner(
     }
   }
 
+  if (React.isValidElement(propValue)) {
+    return {
+      control: 'jsx',
+      label: propName,
+    }
+  }
+
   switch (typeof propValue) {
     case 'number':
       return {

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -255,8 +255,7 @@ function orderVariablesForRelevance(
 
     if (valueExactlyMatchesControlDescription) {
       valuesExactlyMatchingPropertyDescription.push({ ...variable, matches: true })
-    }
-    if (valueMatchesControlDescription) {
+    } else if (valueMatchesControlDescription) {
       valuesMatchingPropertyDescription.push({ ...variable, matches: true })
     } else if (arrayOrObjectChildMatches) {
       valueElementMatches.push({ ...variable, matches: false })

--- a/editor/src/utils/react-utils.ts
+++ b/editor/src/utils/react-utils.ts
@@ -83,4 +83,13 @@ class RU {
   }
 }
 
+export function isValidReactNode(node: unknown) {
+  return (
+    React.isValidElement(node) ||
+    typeof node === 'string' ||
+    typeof node === 'number' ||
+    node === null
+  )
+}
+
 export default RU


### PR DESCRIPTION
**Description:**
Strings and numbers are valid React elements, so you should be able pick them in the data picker. On the other hand, in real life there can be a lot of string and number data sources which are irrelevant in a jsx context.
So I allowed string and number sources in the data picker, but I ordered them with a lower priority than real react elements.
I also added the jsx control as the inferred control for react elements (useful when registerComponent is missing).
