### PR TITLE
Better jsx control

### DIFF
--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -51,7 +51,7 @@ import { importDetailsFromImportOption } from '../../../../core/shared/project-f
 import { Substores, useEditorState } from '../../../editor/store/store-hook'
 import { addImports, forceParseFile } from '../../../editor/actions/action-creators'
 import type { EditorAction } from '../../../editor/action-types'
-import { forceNotNull } from '../../../../core/shared/optional-utils'
+import { forceNotNull, optionalMap } from '../../../../core/shared/optional-utils'
 import type { DEPRECATEDSliderControlOptions } from '../../controls/slider-control'
 import {
   normalisePathSuccessOrThrowError,
@@ -59,6 +59,8 @@ import {
 } from '../../../custom-code/code-file'
 import { useDispatch } from '../../../editor/store/dispatch-context'
 import { HtmlPreview, ImagePreview } from './property-content-preview'
+import { regularNavigatorEntry } from '../../../editor/store/editor-state'
+import { LayoutIcon } from '../../../navigator/navigator-item/layout-icon'
 
 export interface ControlForPropProps<T extends BaseControlDescription> {
   propPath: PropertyPath
@@ -513,31 +515,34 @@ export const JSXPropertyControl = React.memo(
   (props: ControlForPropProps<JSXControlDescription>) => {
     const { propMetadata } = props
 
-    const theme = useColorTheme()
+    const colorTheme = useColorTheme()
 
     const value = propMetadata.propertyStatus.set ? propMetadata.value : undefined
 
-    const safeValue = value ?? ''
+    const safeValue = value ?? { path: null, name: '' }
 
-    // TODO: temporary solution, needs a real control
+    const navigatorEntry = safeValue.path != null ? regularNavigatorEntry(safeValue.path) : null
+
+    // TODO: this is copy paste from conditional section
     return (
       <div
         style={{
+          borderRadius: 2,
+          padding: '4px 0px 4px 6px',
+          background: colorTheme.bg2.value,
+          fontWeight: 600,
           display: 'flex',
-          flexDirection: 'column',
-          flexBasis: 0,
-          gap: 5,
+          justifyContent: 'flex-start',
+          alignItems: 'center',
+          gap: 6,
+          overflowX: 'scroll',
+          whiteSpace: 'nowrap',
         }}
       >
-        <span
-          style={{
-            background: theme.dynamicBlue30.value,
-            textAlign: 'center',
-            borderRadius: 5,
-          }}
-        >
-          {safeValue}
-        </span>
+        {navigatorEntry != null ? (
+          <LayoutIcon navigatorEntry={navigatorEntry} color='main' warningText={null} />
+        ) : null}
+        <span>{safeValue.name}</span>
       </div>
     )
   },

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -36,6 +36,7 @@ import {
   FlexRow,
   UtopiaTheme,
   useColorTheme,
+  Icn,
 } from '../../../../uuiui'
 import type { CSSNumber } from '../../common/css-utils'
 import { printCSSNumber, cssNumber, defaultCSSColor } from '../../common/css-utils'
@@ -61,6 +62,8 @@ import { useDispatch } from '../../../editor/store/dispatch-context'
 import { HtmlPreview, ImagePreview } from './property-content-preview'
 import { regularNavigatorEntry } from '../../../editor/store/editor-state'
 import { LayoutIcon } from '../../../navigator/navigator-item/layout-icon'
+import type { JSXParsedType, JSXParsedValue } from '../../../../utils/value-parser-utils'
+import { assertNever } from '../../../../core/shared/utils'
 
 export interface ControlForPropProps<T extends BaseControlDescription> {
   propPath: PropertyPath
@@ -519,9 +522,7 @@ export const JSXPropertyControl = React.memo(
 
     const value = propMetadata.propertyStatus.set ? propMetadata.value : undefined
 
-    const safeValue = value ?? { path: null, name: '' }
-
-    const navigatorEntry = safeValue.path != null ? regularNavigatorEntry(safeValue.path) : null
+    const safeValue: JSXParsedValue = value ?? { type: 'unknown', name: 'JSX' }
 
     // TODO: this is copy paste from conditional section
     return (
@@ -539,14 +540,31 @@ export const JSXPropertyControl = React.memo(
           whiteSpace: 'nowrap',
         }}
       >
-        {navigatorEntry != null ? (
-          <LayoutIcon navigatorEntry={navigatorEntry} color='main' warningText={null} />
-        ) : null}
+        <JSXPropIcon jsxType={safeValue.type} />
         <span>{safeValue.name}</span>
       </div>
     )
   },
 )
+
+// TODO: this is just a dummy component we need more and better icons
+const JSXPropIcon = React.memo((props: { jsxType: JSXParsedType }) => {
+  switch (props.jsxType) {
+    case 'external-component':
+      return <Icn category={'component'} type={'npm'} width={18} height={18} />
+    case 'internal-component':
+      return <Icn category={'component'} type={'default'} width={18} height={18} />
+    case 'html':
+      return <Icn category={'element'} type={'div'} width={18} height={18} />
+    case 'unknown':
+    case 'string':
+    case 'number':
+    case 'null':
+      return null
+    default:
+      assertNever(props.jsxType)
+  }
+})
 
 function keysForVectorOfType(vectorType: 'vector2' | 'vector3' | 'vector4'): Array<string> {
   switch (vectorType) {

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -52,7 +52,7 @@ import { importDetailsFromImportOption } from '../../../../core/shared/project-f
 import { Substores, useEditorState } from '../../../editor/store/store-hook'
 import { addImports, forceParseFile } from '../../../editor/actions/action-creators'
 import type { EditorAction } from '../../../editor/action-types'
-import { forceNotNull, optionalMap } from '../../../../core/shared/optional-utils'
+import { forceNotNull } from '../../../../core/shared/optional-utils'
 import type { DEPRECATEDSliderControlOptions } from '../../controls/slider-control'
 import {
   normalisePathSuccessOrThrowError,
@@ -60,8 +60,6 @@ import {
 } from '../../../custom-code/code-file'
 import { useDispatch } from '../../../editor/store/dispatch-context'
 import { HtmlPreview, ImagePreview } from './property-content-preview'
-import { regularNavigatorEntry } from '../../../editor/store/editor-state'
-import { LayoutIcon } from '../../../navigator/navigator-item/layout-icon'
 import type { JSXParsedType, JSXParsedValue } from '../../../../utils/value-parser-utils'
 import { assertNever } from '../../../../core/shared/utils'
 

--- a/editor/src/core/property-controls/property-control-values.ts
+++ b/editor/src/core/property-controls/property-control-values.ts
@@ -308,7 +308,7 @@ export function unwrapperAndParserForBaseControl(
     case 'style-controls':
       return defaultUnwrapFirst(parseAny)
     case 'jsx':
-      return jsUnwrapFirst(parseJsx)
+      return parseJsx
     case 'vector2':
     case 'vector3':
     case 'vector4':

--- a/editor/src/utils/value-parser-utils.ts
+++ b/editor/src/utils/value-parser-utils.ts
@@ -13,6 +13,7 @@ import {
 } from '../core/shared/either'
 import * as EP from '../core/shared/element-path'
 import type { ElementPath } from '../core/shared/project-file-types'
+import type { ComponentRendererComponent } from '../components/canvas/ui-jsx-canvas-renderer/component-renderer-component'
 
 export interface ArrayIndexNotPresentParseError {
   type: 'ARRAY_INDEX_NOT_PRESENT_PARSE_ERROR'
@@ -322,16 +323,34 @@ export function parseJsx(
     if (React.isValidElement(value)) {
       const { type } = value
 
+      // if this is an html element, we want to return the tag name
       if (typeof type === 'string') {
         return type
       }
+      // if it is a spied internal component, the original type is stored in theOriginalType
+      if (type.hasOwnProperty('theOriginalType')) {
+        const originalType = (type as any).theOriginalType
+        if (originalType.hasOwnProperty('originalName')) {
+          return (originalType as ComponentRendererComponent).originalName
+        }
+      }
+      // if it is an external component, try returning displayName or name
+      if (type.hasOwnProperty('displayName')) {
+        return (type as any).displayName
+      }
+      if (type.hasOwnProperty('name')) {
+        return (type as any).displayName
+      }
     }
+
     if (typeof value === 'string') {
       return value
     }
+
     if (typeof value === 'number') {
       return value.toString()
     }
+
     if (value == null) {
       return 'null'
     }

--- a/editor/src/utils/value-parser-utils.ts
+++ b/editor/src/utils/value-parser-utils.ts
@@ -330,7 +330,7 @@ export function parseJsx(_: unknown, value: unknown): ParseResult<JSXParsedValue
     if (type.hasOwnProperty('theOriginalType')) {
       const originalType = (type as any).theOriginalType
       // if it is an internal component, it has an originalName property
-      if (originalType.hasOwnProperty('originalName')) {
+      if (originalType.hasOwnProperty('originalName') === true) {
         const originalName = (originalType as ComponentRendererComponent).originalName
         return right({
           type: 'internal-component',
@@ -339,13 +339,13 @@ export function parseJsx(_: unknown, value: unknown): ParseResult<JSXParsedValue
       }
 
       // if it is an external component, try returning displayName or name
-      if (originalType.hasOwnProperty('displayName')) {
+      if (originalType.hasOwnProperty('displayName') === true) {
         return right({
           type: 'external-component',
           name: (originalType as ComponentRendererComponent).displayName ?? 'JSX',
         })
       }
-      if (originalType.hasOwnProperty('name')) {
+      if (originalType.hasOwnProperty('name') === true) {
         right({
           type: 'external-component',
           name: (originalType as ComponentRendererComponent).name ?? 'JSX',


### PR DESCRIPTION
**Description:**
Make the jsx control better: it looks like the branch in the conditional inspector section.

<img width="258" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/f60fda52-2a7c-4991-9036-e7651778c544">

- I could not directly use code from the conditional inspector section, because that heavily uses metadata based decisions (e.g. see LayoutIcon component which receives a navigator entry as prop), and prop values do not have metadata.
- Instead of that I added additional information (whether it is an element, external component, internal component, etc.) during parsing based on the runtime value of the component, and chose an icon according to that. This could be surely improved, e.g. find conditional expressions, etc.
- Later we can even unify some of the icon choosing code in the navigator/conditional-section and in the jsx property control, but that only makes sense if we are going forward with this kind of ui design.