### PR TITLE
Remix: don't cache API responses

### DIFF
--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -23,7 +23,7 @@ import { requireUser } from '../util/api.server'
 import { assertNever } from '../util/assertNever'
 import { projectEditorLink } from '../util/links'
 import { when } from '../util/react-conditionals'
-import { multiplayerInitialsFromName } from '../util/strings'
+import { UnknownPlayerName, multiplayerInitialsFromName } from '../util/strings'
 import { useProjectMatchesQuery, useSortCompareProject } from '../util/use-sort-compare-project'
 
 const SortOptions = ['title', 'dateCreated', 'dateModified'] as const
@@ -628,7 +628,7 @@ const ProjectCard = React.memo(
                     fontWeight: 700,
                     filter: project.deleted === true ? 'grayscale(1)' : undefined,
                   }}
-                  title={collaborator.name}
+                  title={collaborator.name ?? UnknownPlayerName}
                   className={sprinkles({
                     boxShadow: 'shadow',
                     color: 'white',
@@ -753,7 +753,7 @@ const ProjectRow = React.memo(
                       fontWeight: 700,
                       filter: project.deleted === true ? 'grayscale(1)' : undefined,
                     }}
-                    title={collaborator.name}
+                    title={collaborator.name ?? UnknownPlayerName}
                     className={sprinkles({
                       boxShadow: 'shadow',
                       color: 'white',

--- a/utopia-remix/app/util/api.server.ts
+++ b/utopia-remix/app/util/api.server.ts
@@ -22,6 +22,7 @@ const responseHeaders: HeadersInit = {
   'Access-Control-Allow-Credentials': 'true',
   'Access-Control-Allow-Headers': 'content-type, origin, cookie',
   'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+  'Cache-control': 'no-cache',
 }
 
 export async function handleOptions(): Promise<TypedResponse<EmptyResponse>> {

--- a/utopia-remix/app/util/strings.ts
+++ b/utopia-remix/app/util/strings.ts
@@ -1,5 +1,8 @@
-export function multiplayerInitialsFromName(name: string): string {
-  const baseName = name.trim().toUpperCase()
+export const UnknownPlayerName = 'Unknown'
+
+export function multiplayerInitialsFromName(name: string | null): string {
+  const nameOrUnknown = name ?? UnknownPlayerName
+  const baseName = nameOrUnknown.trim().toUpperCase()
 
   const words = baseName.split(/\s+/)
   if (words.length >= 2) {


### PR DESCRIPTION
Fix #4953

**Problem:**

The API endpoints can return cached results, which they should not.

**Fix:**

Add `Cache-control: no-cache` to the API response headers.

(Also fix a typing problem _that should have been caught by the CI_, will investigate why that's not the case)