### PR TITLE
Chore: remove collaborators from liveblocks storage

### DIFF
--- a/editor/liveblocks.config.ts
+++ b/editor/liveblocks.config.ts
@@ -66,7 +66,6 @@ type SceneIdToRouteMapping = LiveObject<{ [sceneId: string]: string }>
 export type Storage = {
   // author: LiveObject<{ firstName: string, lastName: string }>,
   // ...
-  collaborators: LiveObject<{ [userId: string]: User }> // TODO remove collaborators when the BFF is on
   userReadStatusesByThread: LiveObject<{ [threadId: string]: UserReadStatuses }>
   remixSceneRoutes: LiveObject<{ [userId: string]: SceneIdToRouteMapping }>
   connections: LiveObject<{ [userId: string]: ConnectionInfo[] }>
@@ -79,7 +78,6 @@ export type UserReadStatuses = LiveObject<UserReadStatusesMeta>
 
 export function initialStorage(): Storage {
   return {
-    collaborators: new LiveObject(), // TODO remove this when the BFF is on
     userReadStatusesByThread: new LiveObject(),
     remixSceneRoutes: new LiveObject(),
     connections: new LiveObject(),

--- a/editor/src/components/canvas/multiplayer-presence.tsx
+++ b/editor/src/components/canvas/multiplayer-presence.tsx
@@ -22,7 +22,6 @@ import {
   useConnections,
   useCollaborators,
   getCollaboratorById,
-  useAddMyselfToCollaborators_DEPRECATED,
 } from '../../core/commenting/comment-hooks'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../core/shared/array-utils'
@@ -115,7 +114,6 @@ export const MultiplayerPresence = React.memo(() => {
     'MultiplayerPresence mode',
   )
 
-  useAddMyselfToCollaborators_DEPRECATED()
   useLoadCollaborators()
 
   useStoreConnection()

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -28,11 +28,7 @@ import {
 } from './actions/action-creators'
 import { updateUserDetailsWhenAuthenticated } from '../../core/shared/github/helpers'
 import { GithubAuth } from '../../utils/github-auth'
-import type { User } from '../../../liveblocks.config'
-import { liveblocksClient } from '../../../liveblocks.config'
 import type { Collaborator } from '../../core/shared/multiplayer'
-import type { LiveObject } from '@liveblocks/client'
-import { projectIdToRoomId } from '../../utils/room-id'
 
 export { fetchProjectList, fetchShowcaseProjects, getLoginState } from '../../common/server'
 
@@ -516,7 +512,7 @@ export async function updateCollaborators(projectId: string) {
 
 export async function getCollaborators(projectId: string): Promise<Collaborator[]> {
   if (!isBackendBFF()) {
-    return getCollaboratorsFromLiveblocks(projectId)
+    return []
   }
 
   const response = await fetch(
@@ -533,18 +529,4 @@ export async function getCollaborators(projectId: string): Promise<Collaborator[
   } else {
     throw new Error(`Load collaborators failed (${response.status}): ${response.statusText}`)
   }
-}
-
-// TODO remove this once the BFF is on
-async function getCollaboratorsFromLiveblocks(projectId: string): Promise<Collaborator[]> {
-  const room = liveblocksClient.getRoom(projectIdToRoomId(projectId))
-  if (room == null) {
-    return []
-  }
-  const storage = await room.getStorage()
-  const collabs = storage.root.get('collaborators') as LiveObject<{ [userId: string]: User }>
-  if (collabs == null) {
-    return []
-  }
-  return Object.values(collabs.toObject()).map((u) => u.toObject())
 }


### PR DESCRIPTION
Followup to https://github.com/concrete-utopia/utopia/pull/4946

This PR removes the collaborators from the Liveblocks storage so we only rely on the Utopia DB.

**⚠️ DO NOT MERGE UNTIL THE BFF IS ENABLED ⚠️** 