### PR TITLE
Fix grid width by setting 'minmax' in fr units

### DIFF
--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -527,7 +527,6 @@ export const JSXPropertyControl = React.memo(
       <div
         style={{
           borderRadius: 2,
-          padding: '4px 0px 4px 6px',
           background: colorTheme.bg2.value,
           fontWeight: 600,
           display: 'flex',
@@ -536,10 +535,11 @@ export const JSXPropertyControl = React.memo(
           gap: 6,
           overflowX: 'scroll',
           whiteSpace: 'nowrap',
+          padding: '2px 6px',
         }}
       >
         <JSXPropIcon jsxType={safeValue.type} />
-        <span>{safeValue.name}</span>
+        <span style={{ overflow: 'hidden' }}>{safeValue.name}</span>
       </div>
     )
   },

--- a/editor/src/components/inspector/widgets/ui-grid-row.tsx
+++ b/editor/src/components/inspector/widgets/ui-grid-row.tsx
@@ -68,7 +68,10 @@ const gridTemplates = {
   },
   '<--1fr--><--1fr-->|-18px-|': {
     gridColumnGap: 4,
-    gridTemplateColumns: '1fr 1fr 18px',
+    // multiple columns with 1fr don't actually resize evenly as expected,
+    // so we need to use minmax(0, 1fr) to get the expected behavior
+    // https://discourse.webflow.com/t/2-column-grid-set-to-1fr-1fr-not-resizing-evenly/93863
+    gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr) 18px',
   },
   '<-------------1fr------------->': {
     gridColumnGap: 4,


### PR DESCRIPTION
**Problem:**
Grid `1fr` columns don't always behave as expected.
<img width="282" alt="image" src="https://github.com/concrete-utopia/utopia/assets/7003853/2c5b8575-472f-417c-a4c3-243372b0bdc0">


**Fix:**
In places where we want the exact "split" behavior we should use `minmax(<min>, 1fr)`
<img width="264" alt="image" src="https://github.com/concrete-utopia/utopia/assets/7003853/0e99c79f-a696-4edd-a3aa-b42eb454afd3">

See here:
https://css-tricks.com/you-want-minmax10px-1fr-not-1fr/
