### PR TITLE
Specify preferred children in `registerModule` & co

### DIFF
--- a/editor/src/components/canvas/canvas-globals.spec.ts
+++ b/editor/src/components/canvas/canvas-globals.spec.ts
@@ -28,6 +28,7 @@ const cardComponentDescriptor: ComponentDescriptor = {
     },
   },
   supportsChildren: false,
+  preferredChildComponents: [],
   variants: [
     {
       insertMenuLabel: 'Card Default',
@@ -79,6 +80,7 @@ const modifiedCardComponentDescriptor: ComponentDescriptor = {
     },
   },
   supportsChildren: false,
+  preferredChildComponents: [],
   variants: [
     {
       insertMenuLabel: 'Card Default',
@@ -126,6 +128,7 @@ const selectorComponentDescriptor: ComponentDescriptor = {
     },
   },
   supportsChildren: false,
+  preferredChildComponents: [],
   variants: [
     {
       insertMenuLabel: 'True False Selector',

--- a/editor/src/components/canvas/canvas-globals.spec.ts
+++ b/editor/src/components/canvas/canvas-globals.spec.ts
@@ -213,6 +213,7 @@ describe('validateControlsToCheck', () => {
           "propertyControlsInfo": Object {
             "/src/card": Object {
               "Card": Object {
+                "preferredChildComponents": Array [],
                 "properties": Object {
                   "title": Object {
                     "control": "string-input",
@@ -352,6 +353,7 @@ describe('validateControlsToCheck', () => {
             "propertyControlsInfo": Object {
               "/src/card": Object {
                 "Card": Object {
+                  "preferredChildComponents": Array [],
                   "properties": Object {
                     "title": Object {
                       "control": "string-input",
@@ -403,6 +405,7 @@ describe('validateControlsToCheck', () => {
           "propertyControlsInfo": Object {
             "/src/selector": Object {
               "Selector": Object {
+                "preferredChildComponents": Array [],
                 "properties": Object {
                   "value": Object {
                     "control": "popuplist",
@@ -467,6 +470,7 @@ describe('validateControlsToCheck', () => {
           "propertyControlsInfo": Object {
             "/src/card": Object {
               "Card": Object {
+                "preferredChildComponents": Array [],
                 "properties": Object {
                   "border": Object {
                     "control": "string-input",
@@ -522,6 +526,7 @@ describe('validateControlsToCheck', () => {
           "propertyControlsInfo": Object {
             "/src/card": Object {
               "Card": Object {
+                "preferredChildComponents": Array [],
                 "properties": Object {
                   "title": Object {
                     "control": "string-input",
@@ -549,6 +554,7 @@ describe('validateControlsToCheck', () => {
                 ],
               },
               "Other Card": Object {
+                "preferredChildComponents": Array [],
                 "properties": Object {
                   "title": Object {
                     "control": "string-input",

--- a/editor/src/components/canvas/canvas-globals.ts
+++ b/editor/src/components/canvas/canvas-globals.ts
@@ -89,6 +89,7 @@ export async function validateControlsToCheck(
               properties: descriptorWithName.properties,
               supportsChildren: descriptorWithName.supportsChildren,
               variants: descriptorWithName.variants,
+              preferredChildComponents: descriptorWithName.preferredChildComponents ?? [],
             }
           },
         )

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -16,7 +16,7 @@ import type { RawSourceMap } from '../../core/workers/ts/ts-typings/RawSourceMap
 import type { EmitFileResult } from '../../core/workers/ts/ts-worker'
 import Utils from '../../utils/utils'
 
-import type { PropertyControls } from 'utopia-api/core'
+import type { PreferredChildComponent, PropertyControls } from 'utopia-api/core'
 import type { BuiltInDependencies } from '../../core/es-modules/package-manager/built-in-dependencies-list'
 import { resolveModulePath } from '../../core/es-modules/package-manager/module-resolution'
 import type { EvaluationCache } from '../../core/es-modules/package-manager/package-manager'
@@ -124,6 +124,7 @@ export function componentInfo(
 export interface ComponentDescriptor {
   properties: PropertyControls
   supportsChildren: boolean
+  preferredChildComponents: Array<PreferredChildComponent>
   variants: ComponentInfo[]
 }
 
@@ -131,11 +132,13 @@ export function componentDescriptor(
   properties: PropertyControls,
   supportsChildren: boolean,
   variants: Array<ComponentInfo>,
+  preferredChildComponents: Array<PreferredChildComponent>,
 ): ComponentDescriptor {
   return {
     properties: properties,
     supportsChildren: supportsChildren,
     variants: variants,
+    preferredChildComponents: preferredChildComponents,
   }
 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -78,7 +78,7 @@ import {
   exportType,
   singleFileBuildResult,
 } from '../../../core/workers/common/worker-types'
-import type { PropertyControls, Sides } from 'utopia-api/core'
+import type { PreferredChildComponent, PropertyControls, Sides } from 'utopia-api/core'
 import type {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
@@ -3067,14 +3067,27 @@ export function PropertyControlsKeepDeepEquality(
   return getIntrospectiveKeepDeepResult<PropertyControls>(oldValue, newValue) // Do these lazily for now.
 }
 
-export const ComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<ComponentDescriptor> =
+const PreferredChildComponentKeepDeepEquality: KeepDeepEqualityCall<PreferredChildComponent> =
   combine3EqualityCalls(
+    (d) => d.name,
+    StringKeepDeepEquality,
+    (d) => d.additionalImports,
+    createCallWithTripleEquals(),
+    (d) => d.variants,
+    undefinableDeepEquality(arrayDeepEquality(createCallWithTripleEquals())),
+    (name, additionalImports, variants) => ({ name, additionalImports, variants }),
+  )
+
+export const ComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<ComponentDescriptor> =
+  combine4EqualityCalls(
     (descriptor) => descriptor.properties,
     PropertyControlsKeepDeepEquality,
     (descriptor) => descriptor.supportsChildren,
     BooleanKeepDeepEquality,
     (descriptor) => descriptor.variants,
     arrayDeepEquality(ComponentInfoKeepDeepEquality),
+    (descriptor) => descriptor.preferredChildComponents,
+    arrayDeepEquality(PreferredChildComponentKeepDeepEquality),
     componentDescriptor,
   )
 

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -182,6 +182,7 @@ function callPropertyControlsHook(
         App: {
           properties: propertyControlsForApp,
           supportsChildren: false,
+          preferredChildComponents: [],
           variants: [
             {
               insertMenuLabel: 'App',
@@ -193,6 +194,7 @@ function callPropertyControlsHook(
         OtherComponent: {
           properties: propertyControlsForOtherComponent,
           supportsChildren: false,
+          preferredChildComponents: [],
           variants: [
             {
               insertMenuLabel: 'OtherComponent',

--- a/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
@@ -689,13 +689,6 @@ describe('Controls from registering components', () => {
       }
       
       var Playground = ({ style }) => {
-        const alternateBookInfo = {
-          title: 'Frankenstein',
-          published: 'August 1866',
-          description: 'Short, fun read',
-          likes: 66,
-        }
-      
         return (
           <div style={style} data-uid='dbc'>
             <Link href='/new' data-uid='78c'>
@@ -707,6 +700,7 @@ describe('Controls from registering components', () => {
         'await-first-dom-report',
       )
 
+      // elementToInsert is omitted from the object below because it's a function
       expect(
         editor.getEditorState().editor.propertyControlsInfo['/utopia/storyboard'],
       ).toMatchObject({
@@ -746,6 +740,92 @@ describe('Controls from registering components', () => {
                 },
               },
               insertMenuLabel: 'Link',
+            },
+          ],
+        },
+      })
+    })
+
+    it('preferred child components with render prop', async () => {
+      const editor = await renderTestEditorWithCode(
+        DataPickerProjectShell(`registerInternalComponent(Card, {
+          properties: {
+            header: Utopia.arrayControl({
+              control: 'jsx',
+              preferredChildComponents: [
+                {
+                  name: 'span',
+                  variants: [{ code: '<span>Title</span>' }],
+                },
+              ],
+            }),
+          },
+          supportsChildren: true,
+          variants: [],
+        })
+      
+      function Card({ header, children }) {
+        return (
+          <div data-uid='root'>
+            <h2>{header}</h2>
+            {children}
+          </div>
+        )
+      }
+      
+      var Playground = ({ style }) => {
+        return (
+          <div style={style} data-uid='dbc'>
+            <Card header={<span>Title</span>} data-uid='78c'>
+              <p>Card contents</p>
+            </Card>
+          </div>
+        )
+      }`),
+        'await-first-dom-report',
+      )
+
+      // elementToInsert is omitted from the object below because it's a function
+      expect(
+        editor.getEditorState().editor.propertyControlsInfo['/utopia/storyboard'],
+      ).toMatchObject({
+        Card: {
+          preferredChildComponents: [],
+          properties: {
+            header: {
+              control: 'array',
+              propertyControl: {
+                control: 'jsx',
+                preferredChildComponents: [
+                  {
+                    additionalImports: undefined,
+                    name: 'span',
+                    variants: [
+                      {
+                        code: '<span>Title</span>',
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+          supportsChildren: true,
+          variants: [
+            {
+              importsToAdd: {
+                '/utopia/storyboard': {
+                  importedAs: null,
+                  importedFromWithin: [
+                    {
+                      alias: 'Card',
+                      name: 'Card',
+                    },
+                  ],
+                  importedWithName: null,
+                },
+              },
+              insertMenuLabel: 'Card',
             },
           ],
         },

--- a/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
@@ -662,6 +662,96 @@ describe('Controls from registering components', () => {
     const theView = editor.renderedDOM.getByTestId('view')
     expect(theView.outerHTML).toContain('sampleprop="New props value"')
   })
+
+  describe('preferred child components', () => {
+    it('preferred child components with internal component', async () => {
+      const editor = await renderTestEditorWithCode(
+        DataPickerProjectShell(`registerInternalComponent(Link, {
+          properties: {
+            children: Utopia.arrayControl({ control: 'jsx' }),
+          },
+          preferredChildComponents: [
+            {
+              name: 'span',
+              variants: [{ code: '<span>Link</span>' }],
+            },
+          ],
+          supportsChildren: true,
+          variants: [],
+        })
+      
+      function Link({ href, children }) {
+        return (
+          <a href={href} data-uid='root'>
+            {children}
+          </a>
+        )
+      }
+      
+      var Playground = ({ style }) => {
+        const alternateBookInfo = {
+          title: 'Frankenstein',
+          published: 'August 1866',
+          description: 'Short, fun read',
+          likes: 66,
+        }
+      
+        return (
+          <div style={style} data-uid='dbc'>
+            <Link href='/new' data-uid='78c'>
+              nowhere
+            </Link>
+          </div>
+        )
+      }`),
+        'await-first-dom-report',
+      )
+
+      expect(
+        editor.getEditorState().editor.propertyControlsInfo['/utopia/storyboard'],
+      ).toMatchObject({
+        Link: {
+          preferredChildComponents: [
+            {
+              additionalImports: undefined,
+              name: 'span',
+              variants: [
+                {
+                  code: '<span>Link</span>',
+                },
+              ],
+            },
+          ],
+          properties: {
+            children: {
+              control: 'array',
+              propertyControl: {
+                control: 'jsx',
+              },
+            },
+          },
+          supportsChildren: true,
+          variants: [
+            {
+              importsToAdd: {
+                '/utopia/storyboard': {
+                  importedAs: null,
+                  importedFromWithin: [
+                    {
+                      alias: 'Link',
+                      name: 'Link',
+                    },
+                  ],
+                  importedWithName: null,
+                },
+              },
+              insertMenuLabel: 'Link',
+            },
+          ],
+        },
+      })
+    })
+  })
 })
 
 const project = DataPickerProjectShell(`

--- a/editor/src/components/shared/project-components.spec.ts
+++ b/editor/src/components/shared/project-components.spec.ts
@@ -48,6 +48,7 @@ describe('getComponentGroups', () => {
         BeakerIcon: {
           properties: {},
           supportsChildren: false,
+          preferredChildComponents: [],
           variants: [],
         },
       },
@@ -72,6 +73,7 @@ describe('getDependencyStatus', () => {
         BeakerIcon: {
           properties: {},
           supportsChildren: false,
+          preferredChildComponents: [],
           variants: [],
         },
       },

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -352,6 +352,7 @@ function makeHTMLDescriptor(
   return {
     properties: propertyControls,
     supportsChildren: supportsChildren,
+    preferredChildComponents: [],
     variants: [
       {
         insertMenuLabel: tag,
@@ -441,6 +442,7 @@ const conditionalElementsDescriptors: ComponentDescriptorsForFile = {
   conditional: {
     properties: {},
     supportsChildren: true,
+    preferredChildComponents: [],
     variants: [
       {
         insertMenuLabel: 'Conditional',
@@ -462,6 +464,7 @@ const groupElementsDescriptors: ComponentDescriptorsForFile = {
   group: {
     properties: {},
     supportsChildren: true,
+    preferredChildComponents: [],
     variants: [
       {
         insertMenuLabel: 'Group',
@@ -489,6 +492,7 @@ const fragmentElementsDescriptors: ComponentDescriptorsForFile = {
     properties: {},
     supportsChildren: true,
     variants: [fragmentComponentInfo],
+    preferredChildComponents: [],
   },
 }
 
@@ -496,6 +500,7 @@ const samplesDescriptors: ComponentDescriptorsForFile = {
   sampleText: {
     properties: {},
     supportsChildren: false,
+    preferredChildComponents: [],
     variants: [
       {
         insertMenuLabel: 'Sample text',

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -72,6 +72,7 @@ describe('registered property controls', () => {
     expect(editorState.propertyControlsInfo['/src/card']).toMatchInlineSnapshot(`
       Object {
         "Card": Object {
+          "preferredChildComponents": Array [],
           "properties": Object {
             "background": Object {
               "control": "color",

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -110,6 +110,7 @@ async function componentDescriptorForComponentToRegister(
     return {
       componentName: componentName,
       supportsChildren: componentToRegister.supportsChildren,
+      preferredChildComponents: componentToRegister.preferredChildComponents ?? [],
       properties: componentToRegister.properties,
       variants: variants,
     }

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -173,7 +173,7 @@ function parseComponentInsertOption(value: unknown): ParseResult<ComponentInsert
   )
 }
 
-function parsePreferredChild(value: unknown): ParseResult<PreferredChildComponent> {
+export function parsePreferredChild(value: unknown): ParseResult<PreferredChildComponent> {
   return applicative3Either(
     (name, additionalImports, variants) => ({ name, additionalImports, variants }),
     objectKeyParser(parseString, 'name')(value),

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -6,6 +6,7 @@ import type {
   ComponentToRegister,
   ComponentInsertOption,
   PropertyControls,
+  PreferredChildComponent,
 } from 'utopia-api/core'
 import type { ProjectContentTreeRoot } from '../../components/assets'
 import { packageJsonFileFromProjectContents } from '../../components/assets'
@@ -32,6 +33,7 @@ import type { Either } from '../shared/either'
 import {
   applicative2Either,
   applicative3Either,
+  applicative4Either,
   bimapEither,
   foldEither,
   mapEither,
@@ -170,18 +172,29 @@ function parseComponentInsertOption(value: unknown): ParseResult<ComponentInsert
   )
 }
 
-function parseComponentToRegister(value: unknown): ParseResult<ComponentToRegister> {
+function parsePreferredChild(value: unknown): ParseResult<PreferredChildComponent> {
   return applicative3Either(
-    (properties, supportsChildren, variants) => {
+    (name, additionalImports, variants) => ({ name, additionalImports, variants }),
+    objectKeyParser(parseString, 'name')(value),
+    optionalObjectKeyParser(parseString, 'additionalImports')(value),
+    optionalObjectKeyParser(parseArray(parseComponentInsertOption), 'variants')(value),
+  )
+}
+
+function parseComponentToRegister(value: unknown): ParseResult<ComponentToRegister> {
+  return applicative4Either(
+    (properties, supportsChildren, variants, preferredChildComponents) => {
       return {
         properties: properties,
         supportsChildren: supportsChildren,
         variants: variants,
+        preferredChildComponents: preferredChildComponents,
       }
     },
     objectKeyParser(fullyParsePropertyControls, 'properties')(value),
     objectKeyParser(parseBoolean, 'supportsChildren')(value),
     objectKeyParser(parseArray(parseComponentInsertOption), 'variants')(value),
+    optionalObjectKeyParser(parseArray(parsePreferredChild), 'preferredChildComponents')(value),
   )
 }
 

--- a/editor/src/core/property-controls/property-controls-parser.ts
+++ b/editor/src/core/property-controls/property-controls-parser.ts
@@ -77,6 +77,7 @@ import {
   objectMapDropNulls,
 } from '../shared/object-utils'
 import { parseEnumValue } from './property-control-values'
+import { parsePreferredChild } from './property-controls-local'
 
 export function parseNumberInputControlDescription(
   value: unknown,
@@ -651,19 +652,21 @@ export function parseFolderControlDescription(
 }
 
 export function parseJSXControlDescription(value: unknown): ParseResult<JSXControlDescription> {
-  return applicative3Either(
-    (label, control, visibleByDefault) => {
+  return applicative4Either(
+    (label, control, visibleByDefault, preferredChildComponents) => {
       let jsxControlDescription: JSXControlDescription = {
         control: control,
       }
       setOptionalProp(jsxControlDescription, 'label', label)
       setOptionalProp(jsxControlDescription, 'visibleByDefault', visibleByDefault)
+      setOptionalProp(jsxControlDescription, 'preferredChildComponents', preferredChildComponents)
 
       return jsxControlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
     objectKeyParser(parseConstant('jsx'), 'control')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
+    optionalObjectKeyParser(parseArray(parsePreferredChild), 'preferredChildComponents')(value),
   )
 }
 

--- a/editor/src/core/third-party/antd-components.ts
+++ b/editor/src/core/third-party/antd-components.ts
@@ -23,6 +23,7 @@ function createBasicComponent(
   return {
     properties: { ...StyleObjectProps, ...propertyControls },
     supportsChildren: false, // TODO
+    preferredChildComponents: [],
     variants: [
       {
         insertMenuLabel: [baseVariable, ...propertyPathParts].join('.'),

--- a/editor/src/core/third-party/react-three-fiber-components.ts
+++ b/editor/src/core/third-party/react-three-fiber-components.ts
@@ -41,6 +41,7 @@ function createBasicComponent(
   return {
     properties: propertyControls,
     supportsChildren: false,
+    preferredChildComponents: [],
     variants: [
       {
         insertMenuLabel: name,

--- a/editor/src/core/third-party/remix-controls.ts
+++ b/editor/src/core/third-party/remix-controls.ts
@@ -13,6 +13,7 @@ export const RemixRunReactComponents: ComponentDescriptorsForFile = {
       to: { control: 'string-input' },
     },
     supportsChildren: true,
+    preferredChildComponents: [],
     variants: [
       {
         insertMenuLabel: 'Link',
@@ -40,6 +41,7 @@ export const RemixRunReactComponents: ComponentDescriptorsForFile = {
   Outlet: {
     properties: {},
     supportsChildren: false,
+    preferredChildComponents: [],
     variants: [
       {
         insertMenuLabel: 'Outlet',

--- a/editor/src/core/third-party/utopia-api-components.ts
+++ b/editor/src/core/third-party/utopia-api-components.ts
@@ -28,6 +28,7 @@ const BasicUtopiaComponentDescriptor = (
       },
     },
     supportsChildren: supportsChildren,
+    preferredChildComponents: [],
     variants: [
       {
         insertMenuLabel: name,
@@ -62,6 +63,7 @@ const BasicUtopiaSceneDescriptor = (
       },
     },
     supportsChildren: supportsChildren,
+    preferredChildComponents: [],
     variants: [
       {
         insertMenuLabel: name,

--- a/utopia-api/src/helpers/helper-functions.ts
+++ b/utopia-api/src/helpers/helper-functions.ts
@@ -7,9 +7,16 @@ export interface ComponentInsertOption {
   label?: string
 }
 
+export interface PreferredChildComponent {
+  name: string
+  additionalImports?: string
+  variants?: Array<ComponentInsertOption>
+}
+
 export interface ComponentToRegister {
   properties: PropertyControls
   supportsChildren: boolean
+  preferredChildComponents?: Array<PreferredChildComponent>
   variants: Array<ComponentInsertOption>
 }
 

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -1,5 +1,6 @@
 import type { CSSProperties } from 'react'
 import { fastForEach } from '../utils'
+import type { PreferredChildComponent } from '../core'
 
 // these fields are shared among all RegularControlDescription. the helper function getControlSharedFields makes sure the types line up
 interface ControlBaseFields {
@@ -179,6 +180,7 @@ export interface JSXControlDescription {
   control: 'jsx'
   label?: string
   visibleByDefault?: boolean
+  preferredChildComponents?: Array<PreferredChildComponent>
 }
 
 export type BaseControlDescription =


### PR DESCRIPTION
## Problem
We want to provide a way for users to specify preferred components for the `children` prop or the render props of components.

## Fix
This PR adds a new optional prop to `ComponentToRegister` and a new prop to `JSXControlDescription`, `preferredChildComponents`, which lets user specify the preferred components for that prop.

This PR only implements the `preferredChildComponents`, not the code that consumes the preferred components from this prop.