### PR TITLE
Feature/render props in navigator

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -2276,6 +2276,12 @@ export function isSyntheticNavigatorEntry(entry: NavigatorEntry): entry is Synth
 export const syntheticNavigatorEntryOptic: Optic<NavigatorEntry, SyntheticNavigatorEntry> =
   fromTypeGuard(isSyntheticNavigatorEntry)
 
+export function isRenderPropNavigatorEntry(
+  entry: NavigatorEntry,
+): entry is RenderPropNavigatorEntry {
+  return entry.type === 'RENDER_PROP'
+}
+
 export interface DerivedState {
   navigatorTargets: Array<NavigatorEntry>
   visibleNavigatorTargets: Array<NavigatorEntry>

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -125,6 +125,7 @@ import {
   DerivedStateKeepDeepEquality,
   ElementInstanceMetadataMapKeepDeepEquality,
   InvalidOverrideNavigatorEntryKeepDeepEquality,
+  RenderPropNavigatorEntryKeepDeepEquality,
   SyntheticNavigatorEntryKeepDeepEquality,
 } from './store-deep-equality-instances'
 
@@ -2123,6 +2124,33 @@ export function syntheticNavigatorEntriesEqual(
   return SyntheticNavigatorEntryKeepDeepEquality(first, second).areEqual
 }
 
+export interface RenderPropNavigatorEntry {
+  type: 'RENDER_PROP'
+  elementPath: ElementPath
+  propName: string
+  childOrAttribute: JSXElementChild | null
+}
+
+export function renderPropNavigatorEntry(
+  elementPath: ElementPath,
+  propName: string,
+  childOrAttribute: JSXElementChild | null,
+): RenderPropNavigatorEntry {
+  return {
+    type: 'RENDER_PROP',
+    elementPath: elementPath,
+    propName: propName,
+    childOrAttribute: childOrAttribute,
+  }
+}
+
+export function renderPropNavigatorEntriesEqual(
+  first: RenderPropNavigatorEntry,
+  second: RenderPropNavigatorEntry,
+): boolean {
+  return RenderPropNavigatorEntryKeepDeepEquality(first, second).areEqual
+}
+
 export interface InvalidOverrideNavigatorEntry {
   type: 'INVALID_OVERRIDE'
   elementPath: ElementPath
@@ -2158,6 +2186,7 @@ export type NavigatorEntry =
   | ConditionalClauseNavigatorEntry
   | SyntheticNavigatorEntry
   | InvalidOverrideNavigatorEntry
+  | RenderPropNavigatorEntry
 
 export function navigatorEntriesEqual(
   first: NavigatorEntry | null,
@@ -2173,6 +2202,8 @@ export function navigatorEntriesEqual(
     return conditionalClauseNavigatorEntriesEqual(first, second)
   } else if (first.type === 'SYNTHETIC' && second.type === 'SYNTHETIC') {
     return syntheticNavigatorEntriesEqual(first, second)
+  } else if (first.type === 'RENDER_PROP' && second.type === 'RENDER_PROP') {
+    return renderPropNavigatorEntriesEqual(first, second)
   } else {
     return false
   }
@@ -2184,11 +2215,15 @@ export function navigatorEntryToKey(entry: NavigatorEntry): string {
       return `regular-${EP.toComponentId(entry.elementPath)}`
     case 'CONDITIONAL_CLAUSE':
       return `conditional-clause-${EP.toComponentId(entry.elementPath)}-${entry.clause}`
-    case 'SYNTHETIC':
+    case 'SYNTHETIC': {
       const childOrAttributeDetails = isJSExpression(entry.childOrAttribute)
         ? `attribute`
         : `element-${getUtopiaID(entry.childOrAttribute)}`
       return `synthetic-${EP.toComponentId(entry.elementPath)}-${childOrAttributeDetails}`
+    }
+    case 'RENDER_PROP': {
+      return `render-prop-${EP.toComponentId(entry.elementPath)}-${entry.propName}}`
+    }
     case 'INVALID_OVERRIDE':
       return `error-${EP.toComponentId(entry.elementPath)}`
     default:
@@ -2207,6 +2242,8 @@ export function varSafeNavigatorEntryToKey(entry: NavigatorEntry): string {
         ? `attribute`
         : `element_${getUtopiaID(entry.childOrAttribute)}`
       return `synthetic_${EP.toVarSafeComponentId(entry.elementPath)}_${childOrAttributeDetails}`
+    case 'RENDER_PROP':
+      return `renderprop_${EP.toVarSafeComponentId(entry.elementPath)}_${entry.propName}`
     case 'INVALID_OVERRIDE':
       return `error_${EP.toVarSafeComponentId(entry.elementPath)}`
     default:
@@ -2616,12 +2653,17 @@ function deriveCacheableStateInner(
   allElementProps: AllElementProps,
   collapsedViews: ElementPath[],
   hiddenInNavigator: ElementPath[],
+  propertyControlsInfo: PropertyControlsInfo,
+  openFilePath: string | null,
 ): CacheableDerivedState {
   const { navigatorTargets, visibleNavigatorTargets } = getNavigatorTargets(
     jsxMetadata,
     elementPathTree,
     collapsedViews,
     hiddenInNavigator,
+    propertyControlsInfo,
+    openFilePath,
+    projectContents,
   )
 
   const warnings = getElementWarnings(
@@ -2671,6 +2713,8 @@ export function deriveState(
     editor.allElementProps,
     editor.navigator.collapsedViews,
     editor.navigator.hiddenInNavigator,
+    editor.propertyControlsInfo,
+    getOpenUIJSFileKey(editor),
   )
 
   const remixDerivedData = createRemixDerivedDataMemo(

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -324,12 +324,14 @@ import type {
   TrueUpTarget,
   InvalidOverrideNavigatorEntry,
   TrueUpHuggingElement,
+  RenderPropNavigatorEntry,
 } from './editor-state'
 import {
   trueUpGroupElementChanged,
   trueUpChildrenOfGroupChanged,
   invalidOverrideNavigatorEntry,
   trueUpHuggingElement,
+  renderPropNavigatorEntry,
 } from './editor-state'
 import {
   editorStateNodeModules,
@@ -635,6 +637,17 @@ export const SyntheticNavigatorEntryKeepDeepEquality: KeepDeepEqualityCall<Synth
     syntheticNavigatorEntry,
   )
 
+export const RenderPropNavigatorEntryKeepDeepEquality: KeepDeepEqualityCall<RenderPropNavigatorEntry> =
+  combine3EqualityCalls(
+    (entry) => entry.elementPath,
+    ElementPathKeepDeepEquality,
+    (entry) => entry.propName,
+    StringKeepDeepEquality,
+    (entry) => entry.childOrAttribute,
+    nullableDeepEquality(JSXElementChildKeepDeepEquality()),
+    renderPropNavigatorEntry,
+  )
+
 export const InvalidOverrideNavigatorEntryKeepDeepEquality: KeepDeepEqualityCall<InvalidOverrideNavigatorEntry> =
   combine2EqualityCalls(
     (entry) => entry.elementPath,
@@ -662,6 +675,11 @@ export const NavigatorEntryKeepDeepEquality: KeepDeepEqualityCall<NavigatorEntry
     case 'SYNTHETIC':
       if (oldValue.type === newValue.type) {
         return SyntheticNavigatorEntryKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'RENDER_PROP':
+      if (oldValue.type === newValue.type) {
+        return RenderPropNavigatorEntryKeepDeepEquality(oldValue, newValue)
       }
       break
     case 'INVALID_OVERRIDE':

--- a/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/conditional-section.tsx
@@ -97,6 +97,9 @@ const branchNavigatorEntriesSelector = createCachedSelector(
       elementPathTree,
       [],
       [],
+      {},
+      null,
+      {},
     ).navigatorTargets
 
     function getNavigatorEntry(clause: JSXElementChild): NavigatorEntry | null {

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -29,6 +29,7 @@ import {
   CanvasSizeAtom,
   navigatorEntriesEqual,
   regularNavigatorEntry,
+  renderPropNavigatorEntry,
   syntheticNavigatorEntry,
   varSafeNavigatorEntryToKey,
 } from '../../editor/store/editor-state'
@@ -126,6 +127,14 @@ export interface SyntheticNavigatorItemContainerProps
   isOutletOrDescendantOfOutlet: boolean
   elementPath: ElementPath
   childOrAttribute: JSXElementChild
+}
+
+export interface RenderPropNavigatorItemContainerProps
+  extends NavigatorItemDragAndDropWrapperPropsBase {
+  isOutletOrDescendantOfOutlet: boolean
+  elementPath: ElementPath
+  propName: string
+  childOrAttribute: JSXElementChild | null
 }
 
 export interface ConditionalClauseNavigatorItemContainerProps
@@ -1025,6 +1034,48 @@ export const SyntheticNavigatorItemContainer = React.memo(
             collapsed={props.collapsed}
             selected={props.selected}
             parentOutline={parentOutline}
+            visibleNavigatorTargets={props.visibleNavigatorTargets}
+            isOutletOrDescendantOfOutlet={props.isOutletOrDescendantOfOutlet}
+          />
+        </div>
+      </div>
+    )
+  },
+)
+
+export const RenderPropNavigatorItemContainer = React.memo(
+  (props: RenderPropNavigatorItemContainerProps) => {
+    const navigatorEntry = React.useMemo(
+      () => renderPropNavigatorEntry(props.elementPath, props.propName, props.childOrAttribute),
+      [props.childOrAttribute, props.propName, props.elementPath],
+    )
+
+    const safeComponentId = varSafeNavigatorEntryToKey(navigatorEntry)
+    return (
+      <div
+        data-testid={DragItemTestId(safeComponentId)}
+        style={{
+          ...props.windowStyle,
+        }}
+      >
+        <div
+          key='navigatorItem'
+          id={`navigator-item-${safeComponentId}`}
+          data-testid={`navigator-item-${safeComponentId}`}
+        >
+          <NavigatorItem
+            navigatorEntry={navigatorEntry}
+            index={props.index}
+            getSelectedViewsInRange={props.getSelectedViewsInRange}
+            noOfChildren={props.noOfChildren}
+            label={props.label}
+            dispatch={props.editorDispatch}
+            isHighlighted={props.highlighted}
+            isElementVisible={props.isElementVisible}
+            renamingTarget={props.renamingTarget}
+            collapsed={props.collapsed}
+            selected={props.selected}
+            parentOutline={'none'}
             visibleNavigatorTargets={props.visibleNavigatorTargets}
             isOutletOrDescendantOfOutlet={props.isOutletOrDescendantOfOutlet}
           />

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -39,6 +39,7 @@ import {
   isConditionalClauseNavigatorEntry,
   isInvalidOverrideNavigatorEntry,
   isRegularNavigatorEntry,
+  isRenderPropNavigatorEntry,
   isSyntheticNavigatorEntry,
   navigatorEntryToKey,
   varSafeNavigatorEntryToKey,
@@ -140,7 +141,8 @@ function selectItem(
   const elementPath = navigatorEntry.elementPath
   const selectionActions =
     isConditionalClauseNavigatorEntry(navigatorEntry) ||
-    isInvalidOverrideNavigatorEntry(navigatorEntry)
+    isInvalidOverrideNavigatorEntry(navigatorEntry) ||
+    isRenderPropNavigatorEntry(navigatorEntry)
       ? []
       : getSelectionActions(getSelectedViewsInRange, index, elementPath, selected, event)
 
@@ -734,7 +736,7 @@ export const NavigatorItem: React.FunctionComponent<
   )
 
   const isComponentScene = useIsProbablyScene(navigatorEntry) && childComponentCount === 1
-  const isRenderProp = navigatorEntry.type === 'RENDER_PROP'
+  const isRenderProp = isRenderPropNavigatorEntry(navigatorEntry)
 
   const containerStyle: React.CSSProperties = React.useMemo(() => {
     return {

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -821,8 +821,6 @@ export const NavigatorItem: React.FunctionComponent<
               width: 140,
               height: 19,
               borderRadius: 20,
-              textAlign: 'center',
-              textTransform: 'lowercase',
               backgroundColor: colorTheme.dynamicBlue10.value,
               color: colorTheme.navigatorResizeHintBorder.value,
               border: colorTheme.navigatorResizeHintBorder.value,

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -734,6 +734,7 @@ export const NavigatorItem: React.FunctionComponent<
   )
 
   const isComponentScene = useIsProbablyScene(navigatorEntry) && childComponentCount === 1
+  const isRenderProp = navigatorEntry.type === 'RENDER_PROP'
 
   const containerStyle: React.CSSProperties = React.useMemo(() => {
     return {
@@ -812,6 +813,25 @@ export const NavigatorItem: React.FunctionComponent<
             }}
           >
             Empty
+          </div>
+        ) : isRenderProp ? (
+          <div
+            key={`label-${props.label}-slot`}
+            style={{
+              width: 140,
+              height: 19,
+              borderRadius: 20,
+              textAlign: 'center',
+              textTransform: 'lowercase',
+              backgroundColor: colorTheme.dynamicBlue10.value,
+              color: colorTheme.navigatorResizeHintBorder.value,
+              border: colorTheme.navigatorResizeHintBorder.value,
+              marginLeft: 28,
+              padding: '0px 10px 0px 10px',
+              overflow: 'hidden',
+            }}
+          >
+            {props.label}
           </div>
         ) : (
           <FlexRow style={{ justifyContent: 'space-between', ...containerStyle }}>
@@ -926,7 +946,8 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
       }}
     >
       {unless(
-        props.navigatorEntry.type === 'CONDITIONAL_CLAUSE',
+        props.navigatorEntry.type === 'CONDITIONAL_CLAUSE' ||
+          props.navigatorEntry.type === 'RENDER_PROP',
         <LayoutIcon
           key={`layout-type-${props.label}`}
           navigatorEntry={props.navigatorEntry}

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -33,6 +33,7 @@ import { getPropertyControlsForTarget } from '../../core/property-controls/prope
 import type { PropertyControlsInfo } from '../custom-code/code-file'
 import type { ProjectContentTreeRoot } from '../assets'
 import type { PropertyControls } from 'utopia-api/core'
+import { isFeatureEnabled } from '../../utils/feature-switches'
 
 export function baseNavigatorDepth(path: ElementPath): number {
   // The storyboard means that this starts at -1,
@@ -140,7 +141,7 @@ export function getNavigatorTargets(
         openFilePath,
         projectContents,
       )
-      if (propertyControls != null) {
+      if (isFeatureEnabled('Render Props in Navigator') && propertyControls != null) {
         walkPropertyControls(propertyControls)
       }
 

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -15,6 +15,7 @@ export type FeatureName =
   | 'Debug - Print UIDs'
   | 'Steganography'
   | 'Debug – Connections'
+  | 'Render Props in Navigator'
 
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
@@ -30,6 +31,7 @@ export const AllFeatureNames: FeatureName[] = [
   'Debug - Print UIDs',
   'Steganography',
   'Debug – Connections',
+  'Render Props in Navigator',
 ]
 
 let FeatureSwitches: { [feature in FeatureName]: boolean } = {
@@ -45,6 +47,7 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Debug - Print UIDs': false,
   Steganography: false,
   'Debug – Connections': false,
+  'Render Props in Navigator': false,
 }
 
 let FeatureSwitchLoaded: { [feature in FeatureName]?: boolean } = {}


### PR DESCRIPTION
**Problem:**
Absolutely minimal render props in the navigator, just to start from somewhere. Hidden behind feature switch.

- New feature switch `'Render Props in Navigator'`
- New navigator entry type for render props
- Put the name of the prop and the javascript code of the value into the render prop navigator entry

<img width="215" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/2c67f3e0-eedf-4941-96dd-52652b7cd867">

Important missing things:
- The prop name and the value is just concatenated as the entry label. Later this could be more structured (e.g. separate lines for the prop name (like in the conditional clause label) and the value (like the conditional branch content), or any other more structured design.
- The prop value is just a js expression and it is not connected at all to rendered elements yet! So if the render prop is really rendered, it will appear twice for focused components: once as a render prop, and once as a child.