### PR TITLE
Remix projects pending operations

### DIFF
--- a/utopia-remix/app/components/projectActionContextMenu.tsx
+++ b/utopia-remix/app/components/projectActionContextMenu.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { useProjectsStore } from '../store'
 import { contextMenuDropdown, contextMenuItem } from '../styles/contextMenu.css'
 import { sprinkles } from '../styles/sprinkles.css'
-import { ProjectWithoutContent } from '../types'
+import { ProjectWithoutContent, operation } from '../types'
 import { assertNever } from '../util/assertNever'
 import { projectEditorLink } from '../util/links'
 import { useFetcherWithOperation } from '../hooks/useFetcherWithOperation'
@@ -16,10 +16,10 @@ type ContextMenuEntry =
   | 'separator'
 
 export const ProjectContextMenu = React.memo(({ project }: { project: ProjectWithoutContent }) => {
-  const deleteFetcher = useFetcherWithOperation(project, 'delete')
-  const destroyFetcher = useFetcherWithOperation(project, 'destroy')
-  const restoreFetcher = useFetcherWithOperation(project, 'restore')
-  const renameFetcher = useFetcherWithOperation(project, 'rename')
+  const deleteFetcher = useFetcherWithOperation(operation(project, 'delete'))
+  const destroyFetcher = useFetcherWithOperation(operation(project, 'destroy'))
+  const restoreFetcher = useFetcherWithOperation(operation(project, 'restore'))
+  const renameFetcher = useFetcherWithOperation(operation(project, 'rename'))
 
   const selectedCategory = useProjectsStore((store) => store.selectedCategory)
 

--- a/utopia-remix/app/components/projectActionContextMenu.tsx
+++ b/utopia-remix/app/components/projectActionContextMenu.tsx
@@ -1,5 +1,4 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import { useFetcher } from '@remix-run/react'
 import React from 'react'
 import { useProjectsStore } from '../store'
 import { contextMenuDropdown, contextMenuItem } from '../styles/contextMenu.css'
@@ -7,6 +6,7 @@ import { sprinkles } from '../styles/sprinkles.css'
 import { ProjectWithoutContent } from '../types'
 import { assertNever } from '../util/assertNever'
 import { projectEditorLink } from '../util/links'
+import { useFetcherWithOperation } from '../hooks/useFetcherWithOperation'
 
 type ContextMenuEntry =
   | {
@@ -16,41 +16,51 @@ type ContextMenuEntry =
   | 'separator'
 
 export const ProjectContextMenu = React.memo(({ project }: { project: ProjectWithoutContent }) => {
-  const fetcher = useFetcher()
+  const deleteFetcher = useFetcherWithOperation(project, 'delete')
+  const destroyFetcher = useFetcherWithOperation(project, 'destroy')
+  const restoreFetcher = useFetcherWithOperation(project, 'restore')
+  const renameFetcher = useFetcherWithOperation(project, 'rename')
+
   const selectedCategory = useProjectsStore((store) => store.selectedCategory)
 
   const deleteProject = React.useCallback(
     (projectId: string) => {
-      fetcher.submit({}, { method: 'POST', action: `/internal/projects/${projectId}/delete` })
+      deleteFetcher.submit({}, { method: 'POST', action: `/internal/projects/${projectId}/delete` })
     },
-    [fetcher],
+    [deleteFetcher],
   )
 
   const destroyProject = React.useCallback(
     (projectId: string) => {
       const ok = window.confirm('Are you sure? The project contents will be deleted permanently.')
       if (ok) {
-        fetcher.submit({}, { method: 'POST', action: `/internal/projects/${projectId}/destroy` })
+        destroyFetcher.submit(
+          {},
+          { method: 'POST', action: `/internal/projects/${projectId}/destroy` },
+        )
       }
     },
-    [fetcher],
+    [destroyFetcher],
   )
 
   const restoreProject = React.useCallback(
     (projectId: string) => {
-      fetcher.submit({}, { method: 'POST', action: `/internal/projects/${projectId}/restore` })
+      restoreFetcher.submit(
+        {},
+        { method: 'POST', action: `/internal/projects/${projectId}/restore` },
+      )
     },
-    [fetcher],
+    [restoreFetcher],
   )
 
   const renameProject = React.useCallback(
     (projectId: string, newTitle: string) => {
-      fetcher.submit(
+      renameFetcher.submit(
         { title: newTitle },
         { method: 'POST', action: `/internal/projects/${projectId}/rename` },
       )
     },
-    [fetcher],
+    [renameFetcher],
   )
 
   const menuEntries = React.useMemo((): ContextMenuEntry[] => {

--- a/utopia-remix/app/hooks/useFetcherWithOperation.tsx
+++ b/utopia-remix/app/hooks/useFetcherWithOperation.tsx
@@ -1,0 +1,42 @@
+import { useFetcher } from '@remix-run/react'
+import React from 'react'
+import { Operation, OperationType, ProjectWithoutContent } from '../types'
+import { useProjectsStore } from '../store'
+
+/**
+ * This is a specialized that returns a fetcher that also updates a given project operation.
+ */
+export function useFetcherWithOperation(project: ProjectWithoutContent, type: OperationType) {
+  const fetcher = useFetcher()
+  const [operation, setOperation] = React.useState<Operation | null>(null)
+  const addOperation = useProjectsStore((store) => store.addOperation)
+  const removeOperation = useProjectsStore((store) => store.removeOperation)
+
+  const submit = React.useCallback(
+    (data: any, options: { method: 'GET' | 'PUT' | 'POST' | 'DELETE'; action: string }) => {
+      setOperation(() => {
+        const operation: Operation = {
+          projectId: project.proj_id,
+          type: type,
+          projectName: project.title,
+        }
+        addOperation(operation)
+        fetcher.submit(data, options)
+        return operation
+      })
+    },
+    [fetcher, addOperation],
+  )
+
+  React.useEffect(() => {
+    if (fetcher.data != null && fetcher.state !== 'submitting' && operation != null) {
+      setOperation(null)
+      removeOperation(operation)
+    }
+  }, [fetcher, operation, removeOperation])
+
+  return {
+    ...fetcher,
+    submit: submit,
+  }
+}

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -826,9 +826,6 @@ ProjectCardActions.displayName = 'ProjectCardActions'
 
 const ActiveOperations = React.memo(() => {
   const operations = useProjectsStore((store) => store.operations)
-  if (operations == null) {
-    return null
-  }
 
   function getOperationVerb(op: Operation) {
     switch (op.type) {

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -827,6 +827,29 @@ ProjectCardActions.displayName = 'ProjectCardActions'
 const ActiveOperations = React.memo(() => {
   const operations = useProjectsStore((store) => store.operations)
 
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 0,
+        right: 0,
+        margin: 10,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+      }}
+    >
+      {operations
+        .sort((a, b) => -(a.startedAt - b.startedAt))
+        .map((operation) => {
+          return <ActiveOperation operation={operation} key={operation.key} />
+        })}
+    </div>
+  )
+})
+ActiveOperations.displayName = 'ActiveOperations'
+
+const ActiveOperation = React.memo(({ operation }: { operation: Operation }) => {
   function getOperationVerb(op: Operation) {
     switch (op.type) {
       case 'delete':
@@ -845,52 +868,33 @@ const ActiveOperations = React.memo(() => {
   return (
     <div
       style={{
-        position: 'fixed',
-        bottom: 0,
-        right: 0,
-        margin: 10,
+        padding: 10,
         display: 'flex',
-        flexDirection: 'column',
         gap: 10,
+        alignItems: 'center',
+        animation: 'spin 2s linear infinite',
       }}
+      className={sprinkles({
+        boxShadow: 'shadow',
+        borderRadius: 'small',
+        backgroundColor: 'primary',
+        color: 'white',
+      })}
     >
-      {operations
-        .sort((a, b) => -(a.startedAt - b.startedAt))
-        .map((op) => {
-          return (
-            <div
-              key={`${op.projectId}-${op.type}`}
-              style={{
-                padding: 10,
-                display: 'flex',
-                gap: 10,
-                alignItems: 'center',
-                animation: 'spin 2s linear infinite',
-              }}
-              className={sprinkles({
-                boxShadow: 'shadow',
-                borderRadius: 'small',
-                backgroundColor: 'primary',
-                color: 'white',
-              })}
-            >
-              <motion.div
-                style={{
-                  width: 8,
-                  height: 8,
-                }}
-                className={sprinkles({ backgroundColor: 'white' })}
-                initial={{ rotate: 0 }}
-                animate={{ rotate: 100 }}
-                transition={{ ease: 'linear', repeatType: 'loop', repeat: Infinity }}
-              />
-              <div>
-                {getOperationVerb(op)} project {op.projectName}
-              </div>
-            </div>
-          )
-        })}
+      <motion.div
+        style={{
+          width: 8,
+          height: 8,
+        }}
+        className={sprinkles({ backgroundColor: 'white' })}
+        initial={{ rotate: 0 }}
+        animate={{ rotate: 100 }}
+        transition={{ ease: 'linear', repeatType: 'loop', repeat: Infinity }}
+      />
+      <div>
+        {getOperationVerb(operation)} project {operation.projectName}
+      </div>
     </div>
   )
 })
-ActiveOperations.displayName = 'ActiveOperations'
+ActiveOperation.displayName = 'ActiveOperation'

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -825,7 +825,9 @@ const ProjectCardActions = React.memo(({ project }: { project: ProjectWithoutCon
 ProjectCardActions.displayName = 'ProjectCardActions'
 
 const ActiveOperations = React.memo(() => {
-  const operations = useProjectsStore((store) => store.operations)
+  const operations = useProjectsStore((store) =>
+    store.operations.sort((a, b) => b.startedAt - a.startedAt),
+  )
 
   return (
     <div
@@ -839,11 +841,9 @@ const ActiveOperations = React.memo(() => {
         gap: 10,
       }}
     >
-      {operations
-        .sort((a, b) => -(a.startedAt - b.startedAt))
-        .map((operation) => {
-          return <ActiveOperation operation={operation} key={operation.key} />
-        })}
+      {operations.map((operation) => {
+        return <ActiveOperation operation={operation} key={operation.key} />
+      })}
     </div>
   )
 })

--- a/utopia-remix/app/store.tsx
+++ b/utopia-remix/app/store.tsx
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { devtools, persist } from 'zustand/middleware'
 import { Category, SortCriteria } from './routes/projects'
-import { Operation, operationsEqual } from './types'
+import { Operation, areBaseOperationsEquivalent } from './types'
 
 // State portion that will be persisted
 interface ProjectsStoreStatePersisted {
@@ -74,7 +74,7 @@ export const useProjectsStore = create<ProjectsStore>()(
         addOperation: (operation, key) => {
           return set(({ operations }) => ({
             operations: operations
-              .filter((other) => !operationsEqual(other, operation))
+              .filter((other) => !areBaseOperationsEquivalent(other, operation))
               .concat(operationWithKey(operation, key)),
           }))
         },

--- a/utopia-remix/app/types.ts
+++ b/utopia-remix/app/types.ts
@@ -40,7 +40,7 @@ export interface Operation {
 
 export type OperationType = 'rename' | 'delete' | 'destroy' | 'restore'
 
-export function operationsEqual(a: Operation, b: Operation): boolean {
+export function areBaseOperationsEquivalent(a: Operation, b: Operation): boolean {
   return a.projectId === b.projectId && a.type === b.type
 }
 

--- a/utopia-remix/app/types.ts
+++ b/utopia-remix/app/types.ts
@@ -32,7 +32,7 @@ export function userToCollaborator(user: UserDetails): Collaborator {
   }
 }
 
-export type Operation = {
+export interface Operation {
   projectId: string
   projectName: string
   type: OperationType
@@ -42,4 +42,12 @@ export type OperationType = 'rename' | 'delete' | 'destroy' | 'restore'
 
 export function operationsEqual(a: Operation, b: Operation): boolean {
   return a.projectId === b.projectId && a.type === b.type
+}
+
+export function operation(project: ProjectWithoutContent, type: OperationType): Operation {
+  return {
+    projectId: project.proj_id,
+    projectName: project.title,
+    type: type,
+  }
 }

--- a/utopia-remix/app/types.ts
+++ b/utopia-remix/app/types.ts
@@ -31,3 +31,15 @@ export function userToCollaborator(user: UserDetails): Collaborator {
     avatar: user.picture,
   }
 }
+
+export type Operation = {
+  projectId: string
+  projectName: string
+  type: OperationType
+}
+
+export type OperationType = 'rename' | 'delete' | 'destroy' | 'restore'
+
+export function operationsEqual(a: Operation, b: Operation): boolean {
+  return a.projectId === b.projectId && a.type === b.type
+}

--- a/utopia-remix/package.json
+++ b/utopia-remix/package.json
@@ -23,6 +23,7 @@
     "@remix-run/serve": "2.5.1",
     "cookie": "0.6.0",
     "dotenv": "16.4.1",
+    "framer-motion": "11.0.6",
     "isbot": "4",
     "moment": "2.30.1",
     "prisma-client": "link:node_modules/@utopia/prisma-client",

--- a/utopia-remix/pnpm-lock.yaml
+++ b/utopia-remix/pnpm-lock.yaml
@@ -30,6 +30,7 @@ specifiers:
   eslint-plugin-jsx-a11y: 6.7.1
   eslint-plugin-react: 7.33.2
   eslint-plugin-react-hooks: 4.6.0
+  framer-motion: 11.0.6
   isbot: '4'
   jest: 29.7.0
   moment: 2.30.1
@@ -55,6 +56,7 @@ dependencies:
   '@remix-run/serve': 2.5.1_typescript@5.1.6
   cookie: 0.6.0
   dotenv: 16.4.1
+  framer-motion: 11.0.6_biqbaboplfbrettd7655fr4n2y
   isbot: 4.4.0
   moment: 2.30.1
   prisma-client: link:node_modules/@utopia/prisma-client
@@ -1351,6 +1353,19 @@ packages:
   /@emotion/hash/0.9.1:
     resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
     dev: true
+
+  /@emotion/is-prop-valid/0.8.8:
+    resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
+    requiresBuild: true
+    dependencies:
+      '@emotion/memoize': 0.7.4
+    dev: false
+    optional: true
+
+  /@emotion/memoize/0.7.4:
+    resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+    dev: false
+    optional: true
 
   /@esbuild/aix-ppc64/0.19.12:
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -5221,6 +5236,24 @@ packages:
   /forwarded/0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+
+  /framer-motion/11.0.6_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-BpO3mWF8UwxzO3Ca5AmSkrg14QYTeJa9vKgoLOoBdBdTPj0e81i1dMwnX6EQJXRieUx20uiDBXq8bA6y7N6b8Q==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      tslib: 2.6.2
+    optionalDependencies:
+      '@emotion/is-prop-valid': 0.8.8
+    dev: false
 
   /fresh/0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}

--- a/utopia-remix/remix.config.js
+++ b/utopia-remix/remix.config.js
@@ -1,6 +1,9 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 export default {
   ignoredRouteFiles: ['**/.*'],
+  future: {
+    v3_fetcherPersist: true,
+  },
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // publicPath: "/build/",


### PR DESCRIPTION
Fix #4969

**Problem:**

In the Remix projects it's impossible to know whether a pending operation is completed or not, and fetchers gets canceled when unmounted, not triggering data reloads.

**Fix:**

1. Use a specialized version of fetchers that adds an ongoing operations for the project actions
2. Display the ongoing actions stacked in the bottom right corner of the page
3. When the fetchers complete, remove the pending operations
4. Turn on the future `v3_fetcherPersist` feature of Remix (https://remix.run/docs/en/main/file-conventions/remix-config#future) that allows the fetchers to keep going after being unmounted _and_ being available through the `useFetchers` hook
5. Refactor the `ProjectsStore` object so it's composed of persistable and non-persistable fields, so we don't e.g. persist pending operations (and other transient things like the selected category)

The video below should give a good example of all of the above in action:


https://github.com/concrete-utopia/utopia/assets/1081051/87c042a5-dc7f-4102-b58d-e4b82221838f

(Delay added for dramatic purposes!)
