### PR TITLE
Fix issue with Prisma binaries being incompatible.

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -12,7 +12,15 @@ let
     sha256 = "11w3wn2yjhaa5pv20gbfbirvjq6i3m7pqrq2msf0g7cv44vijwgw";
   }) { inherit config; };
 
+  recentPkgs = import (builtins.fetchTarball {
+    name = "nixos-23.11";
+    url = https://github.com/NixOS/nixpkgs/archive/23.11.tar.gz;
+    # Hash obtained using `nix-prefetch-url --unpack <url>`
+    sha256 = "1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k";
+  }) { inherit config; };
+
 in
   { 
     pkgs = pkgs;
+    recentPkgs = recentPkgs;
   }

--- a/shell.nix
+++ b/shell.nix
@@ -10,6 +10,7 @@
 let
   release = (import ./release.nix {});
   pkgs = release.pkgs;
+  recentPkgs = release.recentPkgs;
   lib = pkgs.lib;
   node = pkgs.nodejs-18_x;
   postgres = pkgs.postgresql_13;
@@ -775,9 +776,8 @@ in pkgs.mkShell {
   npm_config_force_process_config = true;
 
   # Make Prisma work.
-  PRISMA_SCHEMA_ENGINE_BINARY = if stdenv.isLinux then "${pkgs.prisma-engines}/bin/migration-engine" else null;
-  PRISMA_QUERY_ENGINE_BINARY = if stdenv.isLinux then "${pkgs.prisma-engines}/bin/query-engine" else null;
-  PRISMA_INTROSPECTION_ENGINE_BINARY = if stdenv.isLinux then "${pkgs.prisma-engines}/bin/introspection-engine" else null;
-  PRISMA_QUERY_ENGINE_LIBRARY = if stdenv.isLinux then "${pkgs.prisma-engines}/lib/libquery_engine.node" else null;
-  PRISMA_FMT_BINARY = if stdenv.isLinux then "${pkgs.prisma-engines}/bin/prisma-fmt" else null;
+  PRISMA_SCHEMA_ENGINE_BINARY = if stdenv.isLinux then "${recentPkgs.prisma-engines}/bin/schema-engine" else null;
+  PRISMA_QUERY_ENGINE_BINARY = if stdenv.isLinux then "${recentPkgs.prisma-engines}/bin/query-engine" else null;
+  PRISMA_FMT_BINARY = if stdenv.isLinux then "${recentPkgs.prisma-engines}/bin/prisma-fmt" else null;
+  PRISMA_QUERY_ENGINE_LIBRARY = if stdenv.isLinux then "${recentPkgs.prisma-engines}/lib/libquery_engine.node" else null;
 }


### PR DESCRIPTION
**Problem:**
Prisma has some binary components and they need to match versions with the node libraries that use them or it'll just explode with a mystery error when it tries to use an incompatible API.

**Cause:**
The current version of nixpkgs that we're tracking is 22.11 which has the 4.xx version of the `query-engines` package, but our Remix app is using 5.xx.

**Fix:**
The 5.xx version of `query-engines` is available in the 23.11 nixpkgs so this PR adds that as an additional reference and uses it for the environment variables. The environment variables themselves were also updated as they have changed between 4.xx and 5.xx.

**Commit Details:**
- Added new nixpkgs version to `release.nix`.
- Updated the Prisma environment variables for version 5.xx.