### PR TITLE
Fix GH assets proxy output

### DIFF
--- a/utopia-remix/app/routes/v1.github.branches.$owner.$repository.asset.$assetSha.tsx
+++ b/utopia-remix/app/routes/v1.github.branches.$owner.$repository.asset.$assetSha.tsx
@@ -10,6 +10,6 @@ export async function loader(args: LoaderFunctionArgs) {
 
 export async function action(args: ActionFunctionArgs) {
   return handle(args, {
-    POST: (req) => proxy(req, { rawOutput: true }),
+    POST: proxy,
   })
 }


### PR DESCRIPTION
**Problem:**

The GH assets endpoint incorrectly return the raw output instead of the JSON response.

**Fix:**

Fix that.