### PR TITLE
Remix BFF: Chain handlers

### DIFF
--- a/utopia-remix/app/routes/internal.branch.tsx
+++ b/utopia-remix/app/routes/internal.branch.tsx
@@ -1,9 +1,9 @@
 import { ActionFunctionArgs } from '@remix-run/node'
-import { handle } from '../util/api.server'
+import { chain, handle } from '../util/api.server'
 import { proxy } from '../util/proxy.server'
 
 export async function action(args: ActionFunctionArgs) {
   return handle(args, {
-    DELETE: proxy,
+    DELETE: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/internal.projects.$id.collaborators.tsx
+++ b/utopia-remix/app/routes/internal.projects.$id.collaborators.tsx
@@ -1,5 +1,5 @@
 import { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
-import { ensure, handle, requireUser } from '../util/api.server'
+import { chain, ensure, handle, requireUser } from '../util/api.server'
 import { Status } from '../util/statusCodes'
 import { Params } from '@remix-run/react'
 import {
@@ -9,7 +9,7 @@ import {
 import { userToCollaborator } from '../types'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args, { GET: getProjectCollaborators })
+  return handle(args, { GET: chain([getProjectCollaborators]) })
 }
 
 export async function getProjectCollaborators(req: Request, params: Params<string>) {
@@ -23,7 +23,7 @@ export async function getProjectCollaborators(req: Request, params: Params<strin
 }
 
 export async function action(args: ActionFunctionArgs) {
-  return handle(args, { POST: addToCollaborators })
+  return handle(args, { POST: chain([addToCollaborators]) })
 }
 
 export async function addToCollaborators(req: Request, params: Params<string>) {

--- a/utopia-remix/app/routes/internal.projects.$id.delete.tsx
+++ b/utopia-remix/app/routes/internal.projects.$id.delete.tsx
@@ -1,11 +1,11 @@
 import { ActionFunctionArgs } from '@remix-run/node'
 import { Params } from '@remix-run/react'
 import { softDeleteProject } from '../models/project.server'
-import { ensure, handle, requireUser } from '../util/api.server'
+import { chain, ensure, handle, requireUser } from '../util/api.server'
 import { Status } from '../util/statusCodes'
 
 export async function action(args: ActionFunctionArgs) {
-  return handle(args, { POST: handleDeleteProject })
+  return handle(args, { POST: chain([handleDeleteProject]) })
 }
 
 export async function handleDeleteProject(req: Request, params: Params<string>) {

--- a/utopia-remix/app/routes/internal.projects.$id.destroy.tsx
+++ b/utopia-remix/app/routes/internal.projects.$id.destroy.tsx
@@ -1,11 +1,11 @@
 import { ActionFunctionArgs } from '@remix-run/node'
 import { Params } from '@remix-run/react'
-import { ensure, handle, requireUser } from '../util/api.server'
+import { chain, ensure, handle, requireUser } from '../util/api.server'
 import { Status } from '../util/statusCodes'
 import { hardDeleteProject } from '../models/project.server'
 
 export async function action(args: ActionFunctionArgs) {
-  return handle(args, { POST: handleDestroyProject })
+  return handle(args, { POST: chain([handleDestroyProject]) })
 }
 
 export async function handleDestroyProject(req: Request, params: Params<string>) {

--- a/utopia-remix/app/routes/internal.projects.$id.rename.tsx
+++ b/utopia-remix/app/routes/internal.projects.$id.rename.tsx
@@ -1,6 +1,6 @@
 import { ActionFunctionArgs } from '@remix-run/node'
 import { renameProject } from '../models/project.server'
-import { ensure, handle, requireUser } from '../util/api.server'
+import { chain, ensure, handle, requireUser } from '../util/api.server'
 import slugify from 'slugify'
 import { Status } from '../util/statusCodes'
 import { Params } from '@remix-run/react'
@@ -8,7 +8,7 @@ import { Params } from '@remix-run/react'
 export const SLUGIFY_OPTIONS = { lower: true, remove: /[^a-z0-9A-Z ]/ }
 
 export async function action(args: ActionFunctionArgs) {
-  return handle(args, { POST: handleRenameProject })
+  return handle(args, { POST: chain([handleRenameProject]) })
 }
 
 export async function handleRenameProject(req: Request, params: Params<string>) {

--- a/utopia-remix/app/routes/internal.projects.$id.restore.tsx
+++ b/utopia-remix/app/routes/internal.projects.$id.restore.tsx
@@ -1,11 +1,11 @@
 import { ActionFunctionArgs } from '@remix-run/node'
 import { Params } from '@remix-run/react'
 import { restoreDeletedProject } from '../models/project.server'
-import { ensure, handle, requireUser } from '../util/api.server'
+import { chain, ensure, handle, requireUser } from '../util/api.server'
 import { Status } from '../util/statusCodes'
 
 export async function action(args: ActionFunctionArgs) {
-  return handle(args, { POST: handleRestoreDeletedProject })
+  return handle(args, { POST: chain([handleRestoreDeletedProject]) })
 }
 
 export async function handleRestoreDeletedProject(req: Request, params: Params<string>) {

--- a/utopia-remix/app/routes/internal.projects.deleted.tsx
+++ b/utopia-remix/app/routes/internal.projects.deleted.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
 import { Params } from '@remix-run/react'
 import { listDeletedProjects } from '../models/project.server'
-import { handle, requireUser } from '../util/api.server'
+import { chain, handle, requireUser } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
-  return handle(args, { GET: handleListDeletedProjects })
+  return handle(args, { GET: chain([handleListDeletedProjects]) })
 }
 
 export async function handleListDeletedProjects(req: Request, params: Params<string>) {

--- a/utopia-remix/app/routes/internal.projects.destroy.tsx
+++ b/utopia-remix/app/routes/internal.projects.destroy.tsx
@@ -1,10 +1,10 @@
 import { ActionFunctionArgs } from '@remix-run/node'
 import { Params } from '@remix-run/react'
 import { hardDeleteAllProjects } from '../models/project.server'
-import { handle, requireUser } from '../util/api.server'
+import { chain, handle, requireUser } from '../util/api.server'
 
 export async function action(args: ActionFunctionArgs) {
-  return handle(args, { POST: handleDestroyAllProjects })
+  return handle(args, { POST: chain([handleDestroyAllProjects]) })
 }
 
 export async function handleDestroyAllProjects(req: Request, params: Params<string>) {

--- a/utopia-remix/app/routes/v1.asset.$id.assets.$name.tsx
+++ b/utopia-remix/app/routes/v1.asset.$id.assets.$name.tsx
@@ -1,15 +1,15 @@
 import { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
+    OPTIONS: chain([handleOptions]),
   })
 }
 
 export async function action(args: ActionFunctionArgs) {
   return handle(args, {
-    POST: (req) => proxy(req, { rawOutput: true }),
+    POST: chain([(req) => proxy(req, { rawOutput: true })]),
   })
 }

--- a/utopia-remix/app/routes/v1.collaboration.tsx
+++ b/utopia-remix/app/routes/v1.collaboration.tsx
@@ -1,15 +1,15 @@
 import { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 import { proxy } from '../util/proxy.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
+    OPTIONS: chain([handleOptions]),
   })
 }
 
 export async function action(args: ActionFunctionArgs) {
   return handle(args, {
-    PUT: proxy,
+    PUT: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.github.authentication.finish.tsx
+++ b/utopia-remix/app/routes/v1.github.authentication.finish.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 import { proxy } from '../util/proxy.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: proxy,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.github.authentication.start.tsx
+++ b/utopia-remix/app/routes/v1.github.authentication.start.tsx
@@ -1,11 +1,11 @@
 import { LoaderFunctionArgs, redirect } from '@remix-run/node'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 import { ServerEnvironment } from '../env.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: redirectToGithubAuthStart,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([redirectToGithubAuthStart]),
   })
 }
 

--- a/utopia-remix/app/routes/v1.github.authentication.status.tsx
+++ b/utopia-remix/app/routes/v1.github.authentication.status.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 import { proxy } from '../util/proxy.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: proxy,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.github.branches.$owner.$repository.asset.$assetSha.tsx
+++ b/utopia-remix/app/routes/v1.github.branches.$owner.$repository.asset.$assetSha.tsx
@@ -1,15 +1,15 @@
 import { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 import { proxy } from '../util/proxy.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
+    OPTIONS: chain([handleOptions]),
   })
 }
 
 export async function action(args: ActionFunctionArgs) {
   return handle(args, {
-    POST: proxy,
+    POST: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.github.branches.$owner.$repository.branch.$branchName.pullrequest.tsx
+++ b/utopia-remix/app/routes/v1.github.branches.$owner.$repository.branch.$branchName.pullrequest.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 import { proxy } from '../util/proxy.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: proxy,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.github.branches.$owner.$repository.branch.$branchName.tsx
+++ b/utopia-remix/app/routes/v1.github.branches.$owner.$repository.branch.$branchName.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: proxy,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.github.branches.$owner.$repository.default-branch.tsx
+++ b/utopia-remix/app/routes/v1.github.branches.$owner.$repository.default-branch.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: proxy,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.github.branches.$owner.$repository.tsx
+++ b/utopia-remix/app/routes/v1.github.branches.$owner.$repository.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: proxy,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.github.save.$projectId.tsx
+++ b/utopia-remix/app/routes/v1.github.save.$projectId.tsx
@@ -1,15 +1,15 @@
 import { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
+    OPTIONS: chain([handleOptions]),
   })
 }
 
 export async function action(args: ActionFunctionArgs) {
   return handle(args, {
-    POST: proxy,
+    POST: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.github.user.repositories.tsx
+++ b/utopia-remix/app/routes/v1.github.user.repositories.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: proxy,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.github.user.tsx
+++ b/utopia-remix/app/routes/v1.github.user.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: proxy,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.javascript.package.versions.$name.$version.tsx
+++ b/utopia-remix/app/routes/v1.javascript.package.versions.$name.$version.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 import { proxy } from '../util/proxy.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: proxy,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.liveblocks.authentication.tsx
+++ b/utopia-remix/app/routes/v1.liveblocks.authentication.tsx
@@ -1,15 +1,15 @@
 import { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
+    OPTIONS: chain([handleOptions]),
   })
 }
 
 export async function action(args: ActionFunctionArgs) {
   return handle(args, {
-    POST: proxy,
+    POST: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.liveblocks.enabled.tsx
+++ b/utopia-remix/app/routes/v1.liveblocks.enabled.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: proxy,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.project.$id.$filename.tsx
+++ b/utopia-remix/app/routes/v1.project.$id.$filename.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: proxy,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.project.$id.metadata.tsx
+++ b/utopia-remix/app/routes/v1.project.$id.metadata.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: proxy,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.project.$id.owner.tsx
+++ b/utopia-remix/app/routes/v1.project.$id.owner.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: proxy,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.project.$id.tsx
+++ b/utopia-remix/app/routes/v1.project.$id.tsx
@@ -1,16 +1,16 @@
 import { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: proxy,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([proxy]),
   })
 }
 
 export async function action(args: ActionFunctionArgs) {
   return handle(args, {
-    PUT: proxy,
+    PUT: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.projectid.tsx
+++ b/utopia-remix/app/routes/v1.projectid.tsx
@@ -1,15 +1,15 @@
 import { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
+    OPTIONS: chain([handleOptions]),
   })
 }
 
 export async function action(args: ActionFunctionArgs) {
   return handle(args, {
-    POST: proxy,
+    POST: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.projects.tsx
+++ b/utopia-remix/app/routes/v1.projects.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
 import { handleListProjects } from '../handlers/listProjects'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: handleListProjects,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([handleListProjects]),
   })
 }

--- a/utopia-remix/app/routes/v1.showcase.tsx
+++ b/utopia-remix/app/routes/v1.showcase.tsx
@@ -1,11 +1,11 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 import { ListProjectsResponse } from '../types'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: handleShowcase,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([handleShowcase]),
   })
 }
 

--- a/utopia-remix/app/routes/v1.thumbnail.$projectId.tsx
+++ b/utopia-remix/app/routes/v1.thumbnail.$projectId.tsx
@@ -1,18 +1,18 @@
 import { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { ensure, handle, handleOptions } from '../util/api.server'
+import { chain, ensure, handle, handleOptions } from '../util/api.server'
 import { Params } from '@remix-run/react'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: handleGetThumbnail(args.params),
+    OPTIONS: chain([handleOptions]),
+    GET: chain([handleGetThumbnail(args.params)]),
   })
 }
 
 export async function action(args: ActionFunctionArgs) {
   return handle(args, {
-    POST: proxy,
+    POST: chain([proxy]),
   })
 }
 

--- a/utopia-remix/app/routes/v1.user.config.tsx
+++ b/utopia-remix/app/routes/v1.user.config.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: proxy,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([proxy]),
   })
 }

--- a/utopia-remix/app/routes/v1.user.tsx
+++ b/utopia-remix/app/routes/v1.user.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
+import { chain, handle, handleOptions } from '../util/api.server'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
-    OPTIONS: handleOptions,
-    GET: proxy,
+    OPTIONS: chain([handleOptions]),
+    GET: chain([proxy]),
   })
 }


### PR DESCRIPTION
Fix #4994

**Problem:**

As discussed [here](https://github.com/concrete-utopia/utopia/pull/4929#discussion_r1512949454) we need a way to apply middlewares to the Remix API routes.

**Fix:**

This PR adds the `Chain` concept to the current handling logic.

- A chain is just an ordered sequence of equivalent handlers
- If a handler throws an exception in the chain, the chain stops
- The last return value of the chain is returned to the client
- The handlers can share state via the chain's `context`

**Notes**
The diff is large, but it's pure refactoring noise, except for `api.server.ts` (the very first commit).