### PR TITLE
Render props in valid paths

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -47258,7 +47258,7 @@ exports[`UiJsxCanvas render renders correctly when a component is passed in via 
     id=\\"canvas-container\\"
     data-testid=\\"canvas-container\\"
     style=\\"position: absolute\\"
-    data-utopia-valid-paths=\\"eee eee/fff eee/fff/app-entity eee/fff/app-entity:aaa eee/fff/app-entity:aaa/bbb\\"
+    data-utopia-valid-paths=\\"eee eee/fff eee/fff/app-entity eee/fff/app-entity:aaa eee/fff/app-entity:aaa/bbb eee/fff/app-entity:aaa/bbb/ccc\\"
     data-utopia-root-element-path=\\"eee\\"
   >
     <div
@@ -47922,6 +47922,134 @@ Object {
       "filePath": "test.js",
       "type": "SAME_FILE_ORIGIN",
       "variableName": "Thing",
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "nonRoundedGlobalFrame": null,
+    "specialSizeMeasurements": Object {
+      "alignItems": null,
+      "borderRadius": null,
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "closestOffsetParentPath": Object {
+        "parts": Array [],
+        "type": "elementpath",
+      },
+      "computedHugProperty": Object {
+        "height": null,
+        "width": null,
+      },
+      "coordinateSystemBounds": null,
+      "display": "initial",
+      "flexDirection": null,
+      "float": "none",
+      "fontSize": null,
+      "fontStyle": null,
+      "fontWeight": null,
+      "gap": null,
+      "globalContentBoxForChildren": null,
+      "globalFrameWithTextContent": null,
+      "hasPositionOffset": false,
+      "hasTransform": false,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "justifyContent": null,
+      "layoutSystemForChildren": null,
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentFlexGap": 0,
+      "parentHugsOnMainAxis": false,
+      "parentJustifyContent": null,
+      "parentLayoutSystem": "flow",
+      "parentPadding": Object {},
+      "parentTextDirection": "ltr",
+      "position": "static",
+      "providesBoundsForAbsoluteChildren": false,
+      "renderedChildrenCount": 0,
+      "textBounds": null,
+      "textDecorationLine": null,
+      "usesParentBounds": false,
+    },
+    "textContent": null,
+  },
+  "eee/fff/app-entity:aaa/bbb/ccc": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "conditionValue": "not-a-conditional",
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [
+          Object {
+            "text": "test",
+            "type": "JSX_TEXT_BLOCK",
+            "uid": "",
+          },
+        ],
+        "name": Object {
+          "baseVariable": "div",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "uid": "",
+              "value": "ccc",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "eee",
+          "fff",
+          "app-entity",
+        ],
+        Array [
+          "aaa",
+          "bbb",
+          "ccc",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "filePath": "test.js",
+      "type": "SAME_FILE_ORIGIN",
+      "variableName": "div",
     },
     "isEmotionOrStyledComponent": false,
     "label": null,

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1822,6 +1822,30 @@ function getValidElementPathsFromElement(
       ),
     )
 
+    if (element.type === 'JSX_ELEMENT') {
+      fastForEach(element.props, (p) => {
+        if (p.type === 'JSX_ATTRIBUTES_ENTRY') {
+          const prop = p.value
+          if (prop.type === 'JSX_ELEMENT') {
+            paths.push(
+              ...getValidElementPathsFromElement(
+                focusedElementPath,
+                prop,
+                path,
+                projectContents,
+                filePath,
+                uiFilePath,
+                isSceneWithOneChild,
+                false,
+                resolve,
+                getRemixValidPathsGenerationContext,
+              ),
+            )
+          }
+        }
+      })
+    }
+
     const name = isJSXElement(element) ? getJSXElementNameAsString(element.name) : 'Fragment'
     const lastElementPathPart = EP.lastElementPathForPath(path)
     const matchingFocusedPathPart =

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -193,6 +193,32 @@ function transformAtPathOptionally(
           }
         }
       }
+      if (isJSXElement(element)) {
+        let propsUpdated: boolean = false
+        const updatedProps = element.props.map((prop) => {
+          if (prop.type === 'JSX_ATTRIBUTES_ENTRY') {
+            const propValue = prop.value
+            if (isJSXElement(propValue)) {
+              const updated = findAndTransformAtPathInner(propValue, tailPath)
+              if (updated != null && isJSXElement(updated)) {
+                propsUpdated = true
+                return {
+                  ...prop,
+                  value: updated,
+                }
+              }
+            }
+          }
+          return prop
+        })
+
+        if (propsUpdated) {
+          return {
+            ...element,
+            props: updatedProps,
+          }
+        }
+      }
     } else if (isJSExpressionMapOrOtherJavaScript(element)) {
       if (element.uid === firstUIDOrIndex) {
         let childrenUpdated: boolean = false
@@ -338,6 +364,19 @@ export function findJSXElementChildAtPath(
             const childResult = findAtPathInner(child, tailPath)
             if (childResult != null) {
               return childResult
+            }
+          }
+          if (isJSXElement(element)) {
+            for (const prop of element.props) {
+              if (prop.type === 'JSX_ATTRIBUTES_ENTRY') {
+                const propValue = prop.value
+                if (isJSXElement(propValue)) {
+                  const propResult = findAtPathInner(propValue, tailPath)
+                  if (propResult != null) {
+                    return propResult
+                  }
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
**Description:**
Followup to https://github.com/concrete-utopia/utopia/pull/4990
Now we have jsx elements in render props, but we still can not select them, because their element path is not in the valid paths list. Also the element path lookup functions do not dive into the props of an element to find the element with the next uid there.
