### PR TITLE
Highlight selected data picker expression.

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
@@ -10,16 +10,23 @@ import {
   VariableFromScopeOptionTestId,
 } from './component-section'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
-import { isRight, type Right } from '../../../../core/shared/either'
+import { isRight } from '../../../../core/shared/either'
 import {
   isJSElementAccess,
   isJSExpressionValue,
   isJSIdentifier,
-  type JSExpressionOtherJavaScript,
 } from '../../../../core/shared/element-template'
 
 describe('Set element prop via the data picker', () => {
   it('can pick from the property data picker', async () => {
+    function checkIsItalicised(testID: string, shouldBeItalicised: boolean): void {
+      const htmlElement = editor.renderedDOM.getByTestId(testID)
+      if (shouldBeItalicised) {
+        expect(htmlElement.style.getPropertyValue('font-style')).toContain('italic')
+      } else {
+        expect(htmlElement.style.getPropertyValue('font-style')).not.toContain('italic')
+      }
+    }
     const editor = await renderTestEditorWithCode(project, 'await-first-dom-report')
     await selectComponentsForTest(editor, [EP.fromString('sb/scene/pg:root/title')])
 
@@ -50,30 +57,65 @@ describe('Set element prop via the data picker', () => {
     await mouseClickAtPoint(currentOption, { x: 2, y: 2 })
     expect(within(theScene).queryByText('Title too')).not.toBeNull()
     expect(within(theInspector).queryByText('Title too')).not.toBeNull()
+    checkIsItalicised(`variable-from-scope-span-titleToo`, true)
+    checkIsItalicised(`variable-from-scope-span-alternateTitle`, false)
+    checkIsItalicised(`variable-from-scope-span-titles`, false)
+    checkIsItalicised(`variable-from-scope-span-titles,one`, false)
+    checkIsItalicised(`variable-from-scope-span-titles,also JS`, false)
+    checkIsItalicised(`variable-from-scope-span-titleIdeas`, false)
+    checkIsItalicised(`variable-from-scope-span-titleIdeas,0`, false)
 
     // choose another string-valued variable
     currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId('1'))
     await mouseClickAtPoint(currentOption, { x: 2, y: 2 })
     expect(within(theScene).queryByText('Alternate title')).not.toBeNull()
     expect(within(theInspector).queryByText('Alternate title')).not.toBeNull()
+    checkIsItalicised(`variable-from-scope-span-titleToo`, false)
+    checkIsItalicised(`variable-from-scope-span-alternateTitle`, true)
+    checkIsItalicised(`variable-from-scope-span-titles`, false)
+    checkIsItalicised(`variable-from-scope-span-titles,one`, false)
+    checkIsItalicised(`variable-from-scope-span-titles,also JS`, false)
+    checkIsItalicised(`variable-from-scope-span-titleIdeas`, false)
+    checkIsItalicised(`variable-from-scope-span-titleIdeas,0`, false)
 
     // choose an object prop
     currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId('2-0'))
     await mouseClickAtPoint(currentOption, { x: 2, y: 2 })
     expect(within(theScene).queryByText('The First Title')).not.toBeNull()
     expect(within(theInspector).queryByText('The First Title')).not.toBeNull()
+    checkIsItalicised(`variable-from-scope-span-titleToo`, false)
+    checkIsItalicised(`variable-from-scope-span-alternateTitle`, false)
+    checkIsItalicised(`variable-from-scope-span-titles`, true)
+    checkIsItalicised(`variable-from-scope-span-titles,one`, true)
+    checkIsItalicised(`variable-from-scope-span-titles,also JS`, false)
+    checkIsItalicised(`variable-from-scope-span-titleIdeas`, false)
+    checkIsItalicised(`variable-from-scope-span-titleIdeas,0`, false)
 
     // choose an object prop
     currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId('2-1'))
     await mouseClickAtPoint(currentOption, { x: 2, y: 2 })
     expect(within(theScene).queryByText('Sweet')).not.toBeNull()
     expect(within(theInspector).queryByText('Sweet')).not.toBeNull()
+    checkIsItalicised(`variable-from-scope-span-titleToo`, false)
+    checkIsItalicised(`variable-from-scope-span-alternateTitle`, false)
+    checkIsItalicised(`variable-from-scope-span-titles`, true)
+    checkIsItalicised(`variable-from-scope-span-titles,one`, false)
+    checkIsItalicised(`variable-from-scope-span-titles,also JS`, true)
+    checkIsItalicised(`variable-from-scope-span-titleIdeas`, false)
+    checkIsItalicised(`variable-from-scope-span-titleIdeas,0`, false)
 
     // choose an array element
     currentOption = editor.renderedDOM.getByTestId(VariableFromScopeOptionTestId('3-0'))
     await mouseClickAtPoint(currentOption, { x: 2, y: 2 })
     expect(within(theScene).queryByText('Chapter One')).not.toBeNull()
     expect(within(theInspector).queryByText('Chapter One')).not.toBeNull()
+    checkIsItalicised(`variable-from-scope-span-titleToo`, false)
+    checkIsItalicised(`variable-from-scope-span-alternateTitle`, false)
+    checkIsItalicised(`variable-from-scope-span-titles`, false)
+    checkIsItalicised(`variable-from-scope-span-titles,one`, false)
+    checkIsItalicised(`variable-from-scope-span-titles,also JS`, false)
+    checkIsItalicised(`variable-from-scope-span-titleIdeas`, true)
+    checkIsItalicised(`variable-from-scope-span-titleIdeas,0`, true)
   })
 
   it('with number input control descriptor present', async () => {
@@ -324,7 +366,7 @@ describe('Set element prop via the data picker', () => {
     ])
   })
 
-  it('style props are filterd from destructured props', async () => {
+  it('style props are filtered from destructured props', async () => {
     const editor = await renderTestEditorWithCode(
       DataPickerProjectShell(`
       function TableOfContents({ titles }) {

--- a/editor/src/core/shared/array-utils.ts
+++ b/editor/src/core/shared/array-utils.ts
@@ -489,3 +489,18 @@ export function possiblyUniqueInArray(
   }
   return index
 }
+
+export function isPrefixOf<T>(
+  possiblePrefix: Array<T>,
+  checkAgainst: Array<T>,
+  equals: (first: T, second: T) => boolean = (first, second) => first === second,
+): boolean {
+  if (possiblePrefix.length <= checkAgainst.length) {
+    return possiblePrefix.every((prefixValue, prefixIndex) => {
+      return equals(prefixValue, checkAgainst[prefixIndex])
+    })
+  } else {
+    // Prefix is too long to be a prefix.
+    return false
+  }
+}


### PR DESCRIPTION
**Problem:**
It's helpful to be able to see what expression is currently being used in the data picker.

**Fix:**
The entire hierarchy of the expression (should any apply) is italicised in the data picker if it matches.
![image](https://github.com/concrete-utopia/utopia/assets/217400/7f08a9c5-72b2-496c-bb38-06e449fb9e38)

For an expression we produce a simple path representation that is matched against the same path representation produced for the variables listed in the data picker.

**Commit Details:**
- `useDataPickerButton` takes two more properties so that `useComponentPropsInspectorInfo` can be called within it.
- Added `valuePath` field to `PrimitiveOption`, `ArrayOption`, `ObjectOption` and `JSXOption`.
- `DataPickerPopup` now takes an additional `propExpressionPath` property.
- `ValueRow` takes a `currentPropExpressionPath` to represent what is currently being used for a property if an appropriate expression is being used.
- Span in `ValueRow` gets italicised if the current expression matches.
- Slightly rejigged the fields of the `VariableInfo` types to make them a little clearer and get the appropriate values needed now.
- Added `isPrefixOf` utility function.
- Added `modifiableAttributeToValuePath` utility function.
