### PR TITLE
Don't animate comment indicator if ref is null

### DIFF
--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -1,7 +1,7 @@
 import type { ThreadData } from '@liveblocks/client'
-import { Comment } from '@liveblocks/react-comments'
 import type { CommentProps } from '@liveblocks/react-comments'
-import { AnimatePresence, motion, useAnimate } from 'framer-motion'
+import { Comment } from '@liveblocks/react-comments'
+import { AnimatePresence, motion } from 'framer-motion'
 import type { CSSProperties } from 'react'
 import React from 'react'
 import type { ThreadMetadata, UserMeta } from '../../../../liveblocks.config'
@@ -15,6 +15,10 @@ import {
   useCollaborators,
   useMyThreadReadStatus,
 } from '../../../core/commenting/comment-hooks'
+import { utopiaThreadMetadataToLiveblocksPartial } from '../../../core/commenting/comment-types'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import * as EP from '../../../core/shared/element-path'
+import { emptyComments, jsExpressionValue } from '../../../core/shared/element-template'
 import type { CanvasPoint } from '../../../core/shared/math-utils'
 import {
   canvasPoint,
@@ -33,6 +37,7 @@ import {
 } from '../../../core/shared/multiplayer'
 import { useMyUserId } from '../../../core/shared/multiplayer-hooks'
 import { optionalMap } from '../../../core/shared/optional-utils'
+import * as PP from '../../../core/shared/property-path'
 import { MultiplayerWrapper, baseMultiplayerAvatarStyle } from '../../../utils/multiplayer-wrapper'
 import { when } from '../../../utils/react-conditionals'
 import { UtopiaStyles, colorTheme } from '../../../uuiui'
@@ -42,6 +47,7 @@ import {
   switchEditorMode,
 } from '../../editor/actions/action-creators'
 import { EditorModes, isCommentMode, isExistingComment } from '../../editor/editor-modes'
+import { useRefAtom } from '../../editor/hook-utils'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { RightMenuTab } from '../../editor/store/editor-state'
 import { Substores, useEditorState, useRefEditorState } from '../../editor/store/store-hook'
@@ -51,15 +57,9 @@ import {
   RemixNavigationAtom,
   useRemixNavigationContext,
 } from '../remix/utopia-remix-root-component'
-import { CommentRepliesCounter } from './comment-replies-counter'
-import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { getIdOfScene, getSceneUnderPoint } from './comment-mode/comment-mode-hooks'
-import * as EP from '../../../core/shared/element-path'
-import { useRefAtom } from '../../editor/hook-utils'
-import { emptyComments, jsExpressionValue } from '../../../core/shared/element-template'
-import * as PP from '../../../core/shared/property-path'
 import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
-import { utopiaThreadMetadataToLiveblocksPartial } from '../../../core/commenting/comment-types'
+import { getIdOfScene, getSceneUnderPoint } from './comment-mode/comment-mode-hooks'
+import { CommentRepliesCounter } from './comment-replies-counter'
 
 export const CommentIndicators = React.memo(() => {
   const projectId = useEditorState(
@@ -555,25 +555,7 @@ type CommentIndicatorWrapper = {
 const CommentIndicatorWrapper = React.memo((props: CommentIndicatorWrapper) => {
   const { thread, expanded, user, forceDarkMode, animatable, ...commentProps } = props
 
-  const [avatarRef, animateAvatar] = useAnimate()
-
   const animDuration = 0.1
-
-  React.useEffect(() => {
-    if (avatarRef.current == null || !animatable) {
-      return
-    }
-    void animateAvatar(
-      avatarRef.current,
-      {
-        top: expanded ? baseMultiplayerAvatarStyle.top : 0,
-        left: expanded ? baseMultiplayerAvatarStyle.left : 0,
-      },
-      {
-        duration: expanded ? animDuration : animDuration / 2,
-      },
-    )
-  }, [expanded, avatarRef, animateAvatar, animatable])
 
   // This is a hack: when the comment is unread, we show a dark background, so we need light foreground colors.
   // So we trick the Liveblocks Comment component and lie to it that the theme is dark mode.
@@ -597,8 +579,14 @@ const CommentIndicatorWrapper = React.memo((props: CommentIndicatorWrapper) => {
     >
       <motion.div
         data-testid='comment-indicator-div'
-        ref={avatarRef}
         style={{ ...baseMultiplayerAvatarStyle, left: 0, top: 0 }}
+        animate={{
+          top: expanded ? baseMultiplayerAvatarStyle.top : 0,
+          left: expanded ? baseMultiplayerAvatarStyle.left : 0,
+          transition: {
+            duration: expanded ? animDuration : animDuration / 2,
+          },
+        }}
       >
         <MultiplayerAvatar
           name={multiplayerInitialsFromName(normalizeMultiplayerName(user.name))}

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -262,7 +262,7 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
   const readByMe = useMyThreadReadStatus(thread)
   const isRead = readByMe === 'read'
 
-  const { hovered, onMouseOver, onMouseOut: onHoverMouseOut, cancelHover, wasHovered } = useHover()
+  const { hovered, onMouseOver, onMouseOut: onHoverMouseOut, cancelHover } = useHover()
 
   const [dragging, setDragging] = React.useState(false)
   const draggingCallback = React.useCallback((isDragging: boolean) => setDragging(isDragging), [])
@@ -351,7 +351,6 @@ const CommentIndicator = React.memo(({ thread }: CommentIndicatorProps) => {
       <CommentIndicatorWrapper
         thread={thread}
         expanded={preview}
-        animatable={wasHovered}
         user={user}
         comment={firstComment}
         showActions={false}
@@ -526,10 +525,8 @@ function useDragging(
 
 function useHover() {
   const [hovered, setHovered] = React.useState(false)
-  const [wasHovered, setWasHovered] = React.useState(false)
 
   const onMouseOver = React.useCallback(() => {
-    setWasHovered(true)
     setHovered(true)
   }, [])
 
@@ -541,19 +538,18 @@ function useHover() {
     setHovered(false)
   }, [])
 
-  return { hovered, onMouseOver, onMouseOut, cancelHover, wasHovered }
+  return { hovered, onMouseOver, onMouseOut, cancelHover }
 }
 
 type CommentIndicatorWrapper = {
   thread: ThreadData<ThreadMetadata>
   user: UserMeta | null
   expanded: boolean
-  animatable: boolean
   forceDarkMode: boolean
 } & CommentProps
 
 const CommentIndicatorWrapper = React.memo((props: CommentIndicatorWrapper) => {
-  const { thread, expanded, user, forceDarkMode, animatable, ...commentProps } = props
+  const { thread, expanded, user, forceDarkMode, ...commentProps } = props
 
   const animDuration = 0.1
 

--- a/editor/src/components/canvas/controls/comment-indicator.tsx
+++ b/editor/src/components/canvas/controls/comment-indicator.tsx
@@ -556,6 +556,9 @@ const CommentIndicatorWrapper = React.memo((props: CommentIndicatorWrapper) => {
   const animDuration = 0.1
 
   React.useEffect(() => {
+    if (avatarRef.current == null) {
+      return
+    }
     void animateAvatar(
       avatarRef.current,
       {


### PR DESCRIPTION
**Problem:**

When loading comment indicators, if the `avatarRef` is null the whole wrapper component breaks after trying to animate it.

**Fix:**

1. Do not run the animation for the avatar if the ref is null
2. Track whether the animation should play at all, meaning the indicator has been hovered at least once, so to avoid a loading animation glitch (the animation would go from 1 to 0 immediately after loading the component)