### PR TITLE
Call updateJSXElementsWithin when printing jsx attributes

### DIFF
--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -248,7 +248,12 @@ function jsxAttributeToExpression(
           attribute.javascriptWithUIDs,
         ).statement
         if (TS.isExpressionStatement(maybeExpressionStatement)) {
-          const expression = maybeExpressionStatement.expression
+          const expression = updateJSXElementsWithin(
+            maybeExpressionStatement.expression,
+            attribute.elementsWithin,
+            imports,
+            stripUIDs,
+          )
           addCommentsToNode(expression, attribute.comments)
           return expression
         } else {


### PR DESCRIPTION
**Problem:**
When printing arbitrary JS with JSX elements inside we are supposed to be calling `updateJSXElementsWithin` so that changes to the parsed inner JSX elements can be streamed into the printed JS (via a babel transpile), but were not doing this with `ATTRIBUTE_OTHER_JAVASCRIPT`

**Fix:**
Call it. This is a follow up to #5003 and #5014, and was pulling across a change from the spike PR #4975 
