### PR TITLE
Express: don't listen twice unless in dev

### DIFF
--- a/utopia-remix/server.js
+++ b/utopia-remix/server.js
@@ -159,4 +159,6 @@ function listenCallback(portNumber) {
 }
 
 app.listen(port, listenCallback(port))
-app.listen(port + 1, listenCallback(port + 1))
+if (process.env.NODE_ENV === 'development') {
+  app.listen(port + 1, listenCallback(port + 1))
+}


### PR DESCRIPTION
**Problem:**

The Express server should not listen twice on port and port+1 when in prod/stage.

**Fix:**

Disable it.