### PR TITLE
Fix getModifiableJSXAttributeAtPath

### DIFF
--- a/editor/src/core/shared/jsx-attribute-utils.ts
+++ b/editor/src/core/shared/jsx-attribute-utils.ts
@@ -200,11 +200,7 @@ export function getJSExpressionAtPathParts(
     case 'JS_ELEMENT_ACCESS':
     case 'JS_PROPERTY_ACCESS':
     case 'JS_IDENTIFIER':
-      if (path.length - pathIndex <= 1) {
-        return getJSXAttributeResult(attribute)
-      } else {
-        return getJSXAttributeResult(attribute, PP.createFromArray(path.slice(pathIndex)))
-      }
+      return getJSXAttributeResult(attribute, PP.createFromArray(path.slice(pathIndex)))
     default:
       const _exhaustiveCheck: never = attribute
       throw new Error(`Cannot resolve attribute ${JSON.stringify(attribute)}`)

--- a/editor/src/core/shared/jsx-attributes.spec.ts
+++ b/editor/src/core/shared/jsx-attributes.spec.ts
@@ -37,6 +37,8 @@ import {
   jsPropertyAccess,
   jsElementAccess,
   jsExpressionOtherJavaScriptSimple,
+  modifiableAttributeIsJsxElement,
+  isJSIdentifier,
 } from '../shared/element-template'
 import {
   getAllPathsFromAttributes,
@@ -168,6 +170,25 @@ function sampleJsxAttributes(): JSXAttributes {
         null,
         {},
         emptyComments,
+      ),
+      identifier: jsIdentifier('hello', 'identifier', null, emptyComments),
+      propertyAccess: jsPropertyAccess(
+        jsIdentifier('hello', 'identifier', null, emptyComments),
+        'propA',
+        'propertyAccess',
+        null,
+        emptyComments,
+        'hello.propA',
+        'not-optionally-chained',
+      ),
+      elementAccess: jsElementAccess(
+        jsIdentifier('hello', 'identifier', null, emptyComments),
+        jsExpressionValue(5, emptyComments),
+        'elementAccess',
+        null,
+        emptyComments,
+        'hello[5]',
+        'not-optionally-chained',
       ),
       'data-uid': jsExpressionValue('aaa', emptyComments),
     }),
@@ -952,6 +973,15 @@ describe('getModifiableJSXAttributeAtPath', () => {
     )
     expect(isRight(impossibleAttributeInsideAValue)).toBeTruthy()
     expect(impossibleAttributeInsideAValue.value).toEqual(jsxAttributeNotFound())
+  })
+
+  it('should return not modifiable at a _path into_ a JSIdentifier', () => {
+    const foundAttribute = getModifiableJSXAttributeAtPath(
+      sampleJsxAttributes(),
+      PP.create('identifier', 'oh no'),
+    )
+
+    expect(isLeft(foundAttribute)).toBeTruthy()
   })
 })
 

--- a/editor/src/core/shared/jsx-attributes.spec.ts
+++ b/editor/src/core/shared/jsx-attributes.spec.ts
@@ -181,6 +181,15 @@ function sampleJsxAttributes(): JSXAttributes {
         {},
         emptyComments,
       ),
+      'data-uid': jsExpressionValue('aaa', emptyComments),
+    }),
+  ) as JSXAttributes
+}
+
+function advancedJSXSampleAttributes() {
+  return [
+    ...sampleJsxAttributes(),
+    ...jsxAttributesFromMap({
       jsFunctionCall: jsExpressionFunctionCall('myFunction', []),
       identifier: jsIdentifier('hello', 'identifier', null, emptyComments),
       propertyAccess: jsPropertyAccess(
@@ -227,9 +236,8 @@ function sampleJsxAttributes(): JSXAttributes {
           emptyComments,
         ),
       ]),
-      'data-uid': jsExpressionValue('aaa', emptyComments),
     }),
-  ) as JSXAttributes
+  ]
 }
 
 const expectedCompiledProps = {
@@ -266,6 +274,7 @@ const expectedCompiledProps = {
     },
   },
   otherJs: 10,
+  otherJsReturningObject: { value: 10 },
   'data-uid': 'aaa',
 }
 
@@ -1019,7 +1028,7 @@ describe('getModifiableJSXAttributeAtPath', () => {
     expect(impossibleAttributeInsideNestedObject.value).toEqual(jsxAttributeNotFound())
 
     const impossibleAttributeInsideNestedArray = getModifiableJSXAttributeAtPath(
-      sampleJsxAttributes(),
+      advancedJSXSampleAttributes(),
       PP.create('fancyArray', 5),
     )
     expect(isRight(impossibleAttributeInsideNestedArray)).toBeTruthy()
@@ -1028,7 +1037,7 @@ describe('getModifiableJSXAttributeAtPath', () => {
 
   it('simple array access works', () => {
     const foundAttributeObject = getModifiableJSXAttributeAtPath(
-      sampleJsxAttributes(),
+      advancedJSXSampleAttributes(),
       PP.create('fancyArray', 0),
     )
 
@@ -1040,7 +1049,10 @@ describe('getModifiableJSXAttributeAtPath', () => {
 
   it('throws on wrong array access', () => {
     const impossibleAttributeInsideNestedArray = expect(() =>
-      getModifiableJSXAttributeAtPath(sampleJsxAttributes(), PP.create('fancyArray', 'lol')),
+      getModifiableJSXAttributeAtPath(
+        advancedJSXSampleAttributes(),
+        PP.create('fancyArray', 'lol'),
+      ),
     ).toThrow()
   })
 
@@ -1056,7 +1068,7 @@ describe('getModifiableJSXAttributeAtPath', () => {
     expect(isLeft(foundAttributeOtherJs)).toBeTruthy()
 
     const foundAttributeFunctionCall = getModifiableJSXAttributeAtPath(
-      sampleJsxAttributes(),
+      advancedJSXSampleAttributes(),
       PP.create(
         'jsFunctionCall',
         'value', // accessing this prop should return a Left
@@ -1068,7 +1080,7 @@ describe('getModifiableJSXAttributeAtPath', () => {
 
   it('should return modifiable when pointing at a JSIdentifier / JSElementAccess / JSPropertyAccess', () => {
     const foundAttributeIdentifier = getModifiableJSXAttributeAtPath(
-      sampleJsxAttributes(),
+      advancedJSXSampleAttributes(),
       PP.create('identifier'),
     )
 
@@ -1078,7 +1090,7 @@ describe('getModifiableJSXAttributeAtPath', () => {
     }
 
     const foundAttributePropertyAccess = getModifiableJSXAttributeAtPath(
-      sampleJsxAttributes(),
+      advancedJSXSampleAttributes(),
       PP.create('propertyAccess'),
     )
 
@@ -1088,7 +1100,7 @@ describe('getModifiableJSXAttributeAtPath', () => {
     }
 
     const foundAttributeElementAccess = getModifiableJSXAttributeAtPath(
-      sampleJsxAttributes(),
+      advancedJSXSampleAttributes(),
       PP.create('elementAccess'),
     )
 
@@ -1100,21 +1112,21 @@ describe('getModifiableJSXAttributeAtPath', () => {
 
   it('should return NotModifiable at a _path into_ a JSIdentifier', () => {
     const notModifiableAttributeIdentifier = getModifiableJSXAttributeAtPath(
-      sampleJsxAttributes(),
+      advancedJSXSampleAttributes(),
       PP.create('identifier', 'oh no'),
     )
 
     expect(isLeft(notModifiableAttributeIdentifier)).toBeTruthy()
 
     const notModifiableAttributePropertyAccess = getModifiableJSXAttributeAtPath(
-      sampleJsxAttributes(),
+      advancedJSXSampleAttributes(),
       PP.create('propertyAccess', 'oh no'),
     )
 
     expect(isLeft(notModifiableAttributePropertyAccess)).toBeTruthy()
 
     const notModifiableAttributeElementAccess = getModifiableJSXAttributeAtPath(
-      sampleJsxAttributes(),
+      advancedJSXSampleAttributes(),
       PP.create('elementAccess', 'oh no'),
     )
 
@@ -1123,7 +1135,7 @@ describe('getModifiableJSXAttributeAtPath', () => {
 
   it('should return modifiable when pointing at an array containing an object containing a JSIdentifier / JSElementAccess / JSPropertyAccess', () => {
     const foundAttributeIdentifier = getModifiableJSXAttributeAtPath(
-      sampleJsxAttributes(),
+      advancedJSXSampleAttributes(),
       PP.create('fancyArray', 0, 'identifier'),
     )
 
@@ -1133,7 +1145,7 @@ describe('getModifiableJSXAttributeAtPath', () => {
     }
 
     const foundAttributePropertyAccess = getModifiableJSXAttributeAtPath(
-      sampleJsxAttributes(),
+      advancedJSXSampleAttributes(),
       PP.create('fancyArray', 0, 'propertyAccess'),
     )
 
@@ -1143,7 +1155,7 @@ describe('getModifiableJSXAttributeAtPath', () => {
     }
 
     const foundAttributeElementAccess = getModifiableJSXAttributeAtPath(
-      sampleJsxAttributes(),
+      advancedJSXSampleAttributes(),
       PP.create('fancyArray', 0, 'elementAccess'),
     )
 
@@ -1155,21 +1167,21 @@ describe('getModifiableJSXAttributeAtPath', () => {
 
   it('should return NotModifiable at a path beyond an array containing an object containing a JSIdentifier', () => {
     const notModifiableAttributeIdentifier = getModifiableJSXAttributeAtPath(
-      sampleJsxAttributes(),
+      advancedJSXSampleAttributes(),
       PP.create('fancyArray', 0, 'identifier', 'oh no'),
     )
 
     expect(isLeft(notModifiableAttributeIdentifier)).toBeTruthy()
 
     const notModifiableAttributePropertyAccess = getModifiableJSXAttributeAtPath(
-      sampleJsxAttributes(),
+      advancedJSXSampleAttributes(),
       PP.create('fancyArray', 0, 'propertyAccess', 'oh no'),
     )
 
     expect(isLeft(notModifiableAttributePropertyAccess)).toBeTruthy()
 
     const notModifiableAttributeElementAccess = getModifiableJSXAttributeAtPath(
-      sampleJsxAttributes(),
+      advancedJSXSampleAttributes(),
       PP.create('fancyArray', 0, 'elementAccess', 'oh no'),
     )
 


### PR DESCRIPTION
`<MyComponent data={myData} />`

If we call `getModifiableJSXAttributeAtPath` for the above element with the path `['data']`, it should return a JSIdentifier pointing at `myData`. This is correct.

**Problem:**
However, if we call `getModifiableJSXAttributeAtPath` with the path `['data', 'somePropName']`, it should return a `left` indicating that we are pointing inside a non-modifiable part of our data. Today this function call incorrectly gives us JSIdentifier pointing at `myData`, making the Component Inspector's object and array sections confused and broken.

**Fix**
Turns out the fix is a one liner, but while I was there, I ran Jest in code coverage mode for the `describe('getModifiableJSXAttributeAtPath', () => {` test suit and I made sure that this crucial low-level function has test coverage of all the cases, because this is a tricky function and full test coverage is really warranted for future refactors too.