### PR TITLE
Fix vscode iframe loading

### DIFF
--- a/utopia-remix/server.js
+++ b/utopia-remix/server.js
@@ -103,6 +103,7 @@ function proxy(originalRequest, originalResponse) {
   let headers = new Headers()
 
   setCopyHeader(originalRequest.headers, headers, 'accept-encoding')
+  setCopyHeader(originalRequest.headers, headers, 'accept')
   setCopyHeader(originalRequest.headers, headers, 'connection')
   setCopyHeader(originalRequest.headers, headers, 'content-length')
   setCopyHeader(originalRequest.headers, headers, 'content-type')


### PR DESCRIPTION
**Problem:**

The vscode iframe url fails to load because the `accept` header is not proxied.

**Fix**

Add the missing header.