### PR TITLE
Proxy: ignore host instead of allowing cherry-picked keys

### DIFF
--- a/utopia-remix/app/util/proxy.server.ts
+++ b/utopia-remix/app/util/proxy.server.ts
@@ -27,12 +27,12 @@ export async function proxy(req: Request, options?: { rawOutput?: boolean; path?
   const url = buildProxyUrl(new URL(req.url), options?.path ?? null)
 
   let headers = new Headers()
-
-  setCopyHeader(req.headers, headers, 'accept-encoding')
-  setCopyHeader(req.headers, headers, 'connection')
-  setCopyHeader(req.headers, headers, 'content-length')
-  setCopyHeader(req.headers, headers, 'content-type')
-  setCopyHeader(req.headers, headers, 'cookie')
+  req.headers.forEach((value, key) => {
+    // add headers to ignore here, with simple comparisons to make it faster than i.e. an array lookup
+    if (key !== 'host') {
+      headers.set(key, value)
+    }
+  })
 
   const response = await fetch(url, {
     credentials: 'include',

--- a/utopia-remix/server.js
+++ b/utopia-remix/server.js
@@ -92,22 +92,15 @@ const remixHandler =
     : createRequestHandler({ build: initialBuild })
 // -----------------------------------------------------------------------------
 
-function setCopyHeader(originalHeaders, targetHeaders, key) {
-  let value = originalHeaders[key]
-  if (value != null) {
-    targetHeaders[key] = value
-  }
-}
-
 function proxy(originalRequest, originalResponse) {
   let headers = new Headers()
 
-  setCopyHeader(originalRequest.headers, headers, 'accept-encoding')
-  setCopyHeader(originalRequest.headers, headers, 'accept')
-  setCopyHeader(originalRequest.headers, headers, 'connection')
-  setCopyHeader(originalRequest.headers, headers, 'content-length')
-  setCopyHeader(originalRequest.headers, headers, 'content-type')
-  setCopyHeader(originalRequest.headers, headers, 'cookie')
+  for (const [key, value] of Object.entries(originalRequest.headers)) {
+    // add headers to ignore here, with simple comparisons to make it faster than i.e. an array lookup
+    if (key !== 'host') {
+      headers[key] = value
+    }
+  }
 
   const proxyRequest = http.request(
     {


### PR DESCRIPTION
**Problem:**

https://github.com/concrete-utopia/utopia/pull/5030 was just a band-aid, not solving a deeper issue.

**Fix:**

Instead of allow-listing header keys to proxy, just ignore the ones we want to disallow (`host`). This should hopefully save us _a ton_ of headaches in the future.