### PR TITLE
parse self-closing JSX elements as render props

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -2273,7 +2273,7 @@ describe('UiJsxCanvas render multifile projects', () => {
           id=\\"canvas-container\\"
           data-testid=\\"canvas-container\\"
           style=\\"position: absolute\\"
-          data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:outer-div utopia-storyboard-uid/scene-aaa/app-entity:outer-div/aaa utopia-storyboard-uid/scene-aaa/app-entity:outer-div/ccc\\"
+          data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:outer-div utopia-storyboard-uid/scene-aaa/app-entity:outer-div/aaa utopia-storyboard-uid/scene-aaa/app-entity:outer-div/aaa/bbb utopia-storyboard-uid/scene-aaa/app-entity:outer-div/ccc\\"
           data-utopia-root-element-path=\\"utopia-storyboard-uid\\"
         >
           <div
@@ -2309,8 +2309,8 @@ describe('UiJsxCanvas render multifile projects', () => {
                 data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/aaa\\"
               >
                 <div
-                  data-uid=\\"bbb~~~1\\"
-                  data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/aaa/bbb~~~1\\"
+                  data-uid=\\"bbb\\"
+                  data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/aaa/bbb\\"
                 ></div>
               </div>
               <div

--- a/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.tsx
@@ -204,9 +204,9 @@ import { View, Storyboard, Scene } from 'utopia-api';
 
 export var App = props => {
   return (
-    <View thing={<div data-uid='bbb' />} data-uid='aaa' />
-  )
-}
+      <View thing={true ? <div data-uid='bbb' /> : null} data-uid='aaa' />
+    )
+  }
 
 export var ${BakedInStoryboardVariableName} = (props) => {
   return (
@@ -234,7 +234,7 @@ import { View, Storyboard, Scene } from 'utopia-api';
 
 export var App = props => {
   return (
-    <View thing={<div data-uid="bbb" style={{ left: 20, top: 300 }} />} data-uid="aaa" />
+    <View thing={true ? <div data-uid="bbb" style={{ left: 20, top: 300 }} /> : null} data-uid="aaa" />
   );
 };
 

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -2280,7 +2280,10 @@ function getAttributeExpression(
           [],
         ),
       )
-    } else if (TS.isJsxElement(initializer.expression!)) {
+    } else if (
+      TS.isJsxElement(initializer.expression) ||
+      TS.isJsxSelfClosingElement(initializer.expression)
+    ) {
       const parseResult = parseOutJSXElements(
         sourceFile,
         sourceText,


### PR DESCRIPTION
## Problem
Self-clsoing JSX elements (such as `<Title test="Chapter 1" />`) aren't parsed as JSX elements if they are passed as properties (for example, `<Chapter header={<Title test="Chapter 1" />} ... />`).

The concrete reason we want this so because only props parsed as JSX elements will show up in the (upcoming) render props section of the navigator, and self-closing JSX elements shouldn't be an exception to this.

## Fix
Parse them as JSX elements