### PR TITLE
Access requests

### DIFF
--- a/server/migrations/009.sql
+++ b/server/migrations/009.sql
@@ -13,3 +13,6 @@ CREATE INDEX "idx_project_access_request_project_id" ON "public"."project_access
 ALTER TABLE ONLY "project_access_request"
     ADD CONSTRAINT "unique_project_access_request_project_id_user_id" UNIQUE ("project_id", "user_id");
 
+ALTER TABLE ONLY "project_access_request"
+    ADD CONSTRAINT "unique_project_access_request_project_id_token" UNIQUE ("project_id", "token");
+

--- a/server/migrations/009.sql
+++ b/server/migrations/009.sql
@@ -1,0 +1,15 @@
+CREATE TABLE project_access_request(
+    id serial,
+    project_id text NOT NULL REFERENCES project(proj_id) ON DELETE CASCADE,
+    user_id character varying NOT NULL REFERENCES user_details(user_id) ON DELETE CASCADE,
+    token text NOT NULL,
+    status integer NOT NULL DEFAULT 0,
+    created_at timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at timestamp with time zone NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX "idx_project_access_request_project_id" ON "public"."project_access_request"(project_id);
+
+ALTER TABLE ONLY "project_access_request"
+    ADD CONSTRAINT "unique_project_access_request_project_id_user_id" UNIQUE ("project_id", "user_id");
+

--- a/server/src/Utopia/Web/Database/Migrations.hs
+++ b/server/src/Utopia/Web/Database/Migrations.hs
@@ -28,8 +28,9 @@ migrateDatabase verbose includeInitial pool = withResource pool $ \connection ->
                               , MigrationFile "004.sql" "./migrations/004.sql"
                               , MigrationFile "005.sql" "./migrations/005.sql"
                               , MigrationFile "006.sql" "./migrations/006.sql"
-                              , MigrationFile "007.sql" "./migrations/007.sql"                              
+                              , MigrationFile "007.sql" "./migrations/007.sql"
                               , MigrationFile "008.sql" "./migrations/008.sql"
+                              , MigrationFile "009.sql" "./migrations/009.sql"
                               ]
   let initialMigrationCommand = if includeInitial
                                    then [MigrationFile "initial.sql" "./migrations/initial.sql"]

--- a/utopia-remix/app/models/projectAccessRequest.server.spec.ts
+++ b/utopia-remix/app/models/projectAccessRequest.server.spec.ts
@@ -122,7 +122,7 @@ describe('projectAccessRequest', () => {
           token: 'WRONG',
           status: AccessRequestStatus.APPROVED,
         })
-      await expect(fn).rejects.toThrow('request not found')
+      await expect(fn).rejects.toThrow('not found')
     })
     it("updates the request's status", async () => {
       await createTestProjectAccessRequest(prisma, {

--- a/utopia-remix/app/models/projectAccessRequest.server.spec.ts
+++ b/utopia-remix/app/models/projectAccessRequest.server.spec.ts
@@ -1,0 +1,147 @@
+import { prisma } from '../db.server'
+import {
+  createTestProject,
+  createTestProjectAccessRequest,
+  createTestUser,
+  truncateTables,
+} from '../test-util'
+import { AccessRequestStatus } from '../types'
+import { createAccessRequest, updateAccessRequestStatus } from './projectAccessRequest.server'
+
+describe('projectAccessRequest', () => {
+  describe('createAccessRequest', () => {
+    afterEach(async () => {
+      await truncateTables([
+        prisma.projectID,
+        prisma.projectAccessRequest,
+        prisma.project,
+        prisma.userDetails,
+      ])
+    })
+    beforeEach(async () => {
+      await createTestUser(prisma, { id: 'bob' })
+      await createTestUser(prisma, { id: 'alice' })
+      await createTestUser(prisma, { id: 'that-guy' })
+      await createTestProject(prisma, { id: 'one', ownerId: 'bob' })
+      await createTestProject(prisma, { id: 'two', ownerId: 'alice' })
+    })
+    it('requires an existing project', async () => {
+      const fn = async () => createAccessRequest({ projectId: 'unknown', userId: 'that-guy' })
+      await expect(fn).rejects.toThrow('project not found')
+    })
+    it('requires a non-deleted project', async () => {
+      await createTestProject(prisma, { id: 'deleted', ownerId: 'bob', deleted: true })
+      const fn = async () => createAccessRequest({ projectId: 'deleted', userId: 'that-guy' })
+      await expect(fn).rejects.toThrow('project not found')
+    })
+    describe('when the project is ok', () => {
+      it('does nothing if the user is the owner', async () => {
+        await createAccessRequest({ projectId: 'one', userId: 'bob' })
+        const requests = await prisma.projectAccessRequest.count()
+        expect(requests).toBe(0)
+      })
+      it('creates the new request in a pending state', async () => {
+        await createAccessRequest({ projectId: 'one', userId: 'that-guy' })
+        const requests = await prisma.projectAccessRequest.findMany()
+        expect(requests.length).toBe(1)
+        expect(requests[0].project_id).toBe('one')
+        expect(requests[0].user_id).toBe('that-guy')
+        expect(requests[0].status).toBe(AccessRequestStatus.PENDING)
+        expect(requests[0].token.length).toBeGreaterThan(0)
+      })
+      it('errors if the request is for a non existing user', async () => {
+        const fn = async () =>
+          createAccessRequest({ projectId: 'one', userId: 'a-guy-that-doesnt-exist' })
+        await expect(fn).rejects.toThrow()
+      })
+      it('does nothing if the request already exists for the same user', async () => {
+        await createTestProjectAccessRequest(prisma, {
+          projectId: 'one',
+          userId: 'that-guy',
+          status: AccessRequestStatus.REJECTED,
+          token: 'something',
+        })
+        await createAccessRequest({ projectId: 'one', userId: 'that-guy' })
+        const requests = await prisma.projectAccessRequest.findMany()
+        expect(requests.length).toBe(1)
+        expect(requests[0].project_id).toBe('one')
+        expect(requests[0].user_id).toBe('that-guy')
+        expect(requests[0].status).toBe(AccessRequestStatus.REJECTED)
+        expect(requests[0].token.length).toBeGreaterThan(0)
+      })
+    })
+  })
+
+  describe('updateAccessRequestStatus', () => {
+    afterEach(async () => {
+      await truncateTables([
+        prisma.projectID,
+        prisma.projectAccessRequest,
+        prisma.project,
+        prisma.userDetails,
+      ])
+    })
+    beforeEach(async () => {
+      await createTestUser(prisma, { id: 'bob' })
+      await createTestUser(prisma, { id: 'alice' })
+      await createTestUser(prisma, { id: 'that-guy' })
+      await createTestProject(prisma, { id: 'one', ownerId: 'bob' })
+      await createTestProject(prisma, { id: 'two', ownerId: 'alice' })
+    })
+    it('requires an existing project', async () => {
+      const fn = async () =>
+        updateAccessRequestStatus({
+          projectId: 'unknown',
+          ownerId: 'that-guy',
+          token: 'something',
+          status: AccessRequestStatus.APPROVED,
+        })
+      await expect(fn).rejects.toThrow('project not found')
+    })
+    it('requires the user to be the owner of the project', async () => {
+      const fn = async () =>
+        updateAccessRequestStatus({
+          projectId: 'one',
+          ownerId: 'alice',
+          token: 'something',
+          status: AccessRequestStatus.APPROVED,
+        })
+      await expect(fn).rejects.toThrow('project not found')
+    })
+    it('errors if the request is not find by its token', async () => {
+      await createTestProjectAccessRequest(prisma, {
+        projectId: 'one',
+        userId: 'alice',
+        token: 'something',
+        status: AccessRequestStatus.PENDING,
+      })
+      const fn = async () =>
+        updateAccessRequestStatus({
+          projectId: 'one',
+          ownerId: 'bob',
+          token: 'WRONG',
+          status: AccessRequestStatus.APPROVED,
+        })
+      await expect(fn).rejects.toThrow('request not found')
+    })
+    it("updates the request's status", async () => {
+      await createTestProjectAccessRequest(prisma, {
+        projectId: 'one',
+        userId: 'alice',
+        token: 'something',
+        status: AccessRequestStatus.PENDING,
+      })
+      await updateAccessRequestStatus({
+        projectId: 'one',
+        ownerId: 'bob',
+        token: 'something',
+        status: AccessRequestStatus.APPROVED,
+      })
+      const requests = await prisma.projectAccessRequest.findMany()
+      expect(requests.length).toBe(1)
+      expect(requests[0].project_id).toBe('one')
+      expect(requests[0].user_id).toBe('alice')
+      expect(requests[0].status).toBe(AccessRequestStatus.APPROVED)
+    })
+  })
+})

--- a/utopia-remix/app/models/projectAccessRequest.server.ts
+++ b/utopia-remix/app/models/projectAccessRequest.server.ts
@@ -8,9 +8,16 @@ function makeRequestToken(): string {
   return uuid.v4()
 }
 
+/**
+ * Create a new access request for a given project and the given user.
+ * The user must not be an owner of the project.
+ * If successful, a new request in the pending state will be created.
+ * If there already is a request for the projectId+userId pair, nothing happens.
+ */
 export async function createAccessRequest(params: { projectId: string; userId: string }) {
   const token = makeRequestToken()
   await prisma.$transaction(async (tx) => {
+    // let's check that the project exists, is not soft-deleted, and is not owned by the user
     const project = await tx.project.findFirst({
       where: {
         proj_id: params.projectId,
@@ -43,6 +50,9 @@ export async function createAccessRequest(params: { projectId: string; userId: s
   })
 }
 
+/**
+ * Update the status for the given request (via its token) for the given project owned by ownerId.
+ */
 export async function updateAccessRequestStatus(params: {
   projectId: string
   ownerId: string
@@ -50,17 +60,19 @@ export async function updateAccessRequestStatus(params: {
   status: AccessRequestStatus
 }) {
   await prisma.$transaction(async (tx) => {
-    const project = await tx.project.findFirst({
+    // check that the project exists
+    const projectCount = await tx.project.count({
       where: { proj_id: params.projectId, owner_id: params.ownerId },
-      include: { ProjectAccessRequest: { select: { id: true, token: true } } },
     })
-    ensure(project != null, 'project not found', Status.NOT_FOUND)
-
-    const request = project.ProjectAccessRequest.find((r) => r.token === params.token)
-    ensure(request != null, 'request not found', Status.NOT_FOUND)
+    ensure(projectCount === 1, 'project not found', Status.NOT_FOUND)
 
     await tx.projectAccessRequest.update({
-      where: { id: request.id },
+      where: {
+        project_id_token: {
+          project_id: params.projectId,
+          token: params.token,
+        },
+      },
       data: {
         status: params.status,
         updated_at: new Date(),

--- a/utopia-remix/app/models/projectAccessRequest.server.ts
+++ b/utopia-remix/app/models/projectAccessRequest.server.ts
@@ -1,0 +1,70 @@
+import { prisma } from '../db.server'
+import { AccessRequestStatus } from '../types'
+import * as uuid from 'uuid'
+import { ensure } from '../util/api.server'
+import { Status } from '../util/statusCodes'
+
+function makeRequestToken(): string {
+  return uuid.v4()
+}
+
+export async function createAccessRequest(params: { projectId: string; userId: string }) {
+  const token = makeRequestToken()
+  await prisma.$transaction(async (tx) => {
+    const project = await tx.project.findFirst({
+      where: {
+        proj_id: params.projectId,
+        OR: [{ deleted: null }, { deleted: false }],
+      },
+      select: { owner_id: true },
+    })
+    ensure(project != null, 'project not found', Status.NOT_FOUND)
+    if (project.owner_id === params.userId) {
+      // nothing to do
+      return
+    }
+
+    // the request can be created. it cannot be re-issued (for now…?)
+    await tx.projectAccessRequest.upsert({
+      where: {
+        project_id_user_id: {
+          project_id: params.projectId,
+          user_id: params.userId,
+        },
+      },
+      update: {}, // ON CONFLICT DO NOTHING
+      create: {
+        status: AccessRequestStatus.PENDING,
+        project_id: params.projectId,
+        user_id: params.userId,
+        token: token,
+      },
+    })
+  })
+}
+
+export async function updateAccessRequestStatus(params: {
+  projectId: string
+  ownerId: string
+  token: string
+  status: AccessRequestStatus
+}) {
+  await prisma.$transaction(async (tx) => {
+    const project = await tx.project.findFirst({
+      where: { proj_id: params.projectId, owner_id: params.ownerId },
+      include: { ProjectAccessRequest: { select: { id: true, token: true } } },
+    })
+    ensure(project != null, 'project not found', Status.NOT_FOUND)
+
+    const request = project.ProjectAccessRequest.find((r) => r.token === params.token)
+    ensure(request != null, 'request not found', Status.NOT_FOUND)
+
+    await tx.projectAccessRequest.update({
+      where: { id: request.id },
+      data: {
+        status: params.status,
+        updated_at: new Date(),
+      },
+    })
+  })
+}

--- a/utopia-remix/app/models/projectAccessRequest.server.ts
+++ b/utopia-remix/app/models/projectAccessRequest.server.ts
@@ -26,8 +26,9 @@ export async function createAccessRequest(params: { projectId: string; userId: s
       select: { owner_id: true },
     })
     ensure(project != null, 'project not found', Status.NOT_FOUND)
+
+    // if the request is coming from the owner of the project, there's nothing to do
     if (project.owner_id === params.userId) {
-      // nothing to do
       return
     }
 

--- a/utopia-remix/app/routes/internal.projects.$id.access.request.$token.approve.tsx
+++ b/utopia-remix/app/routes/internal.projects.$id.access.request.$token.approve.tsx
@@ -1,0 +1,37 @@
+import type { ActionFunctionArgs } from '@remix-run/node'
+import type { Params } from '@remix-run/react'
+import { ensure, handle, requireUser } from '../util/api.server'
+import { Status } from '../util/statusCodes'
+import { validateProjectAccess } from '../handlers/validators'
+import { updateAccessRequestStatus } from '../models/projectAccessRequest.server'
+import { AccessRequestStatus, UserProjectPermission } from '../types'
+
+export async function action(args: ActionFunctionArgs) {
+  return handle(args, {
+    POST: {
+      handler: handleApproveAccessRequest,
+      validator: validateProjectAccess(UserProjectPermission.CAN_MANAGE_PROJECT, {
+        getProjectId: (params) => params.id,
+      }),
+    },
+  })
+}
+
+export async function handleApproveAccessRequest(req: Request, params: Params<string>) {
+  const user = await requireUser(req)
+
+  const projectId = params.id
+  ensure(projectId != null, 'project id is null', Status.BAD_REQUEST)
+
+  const token = params.token
+  ensure(token != null && typeof token === 'string', 'token is invalid', Status.BAD_REQUEST)
+
+  await updateAccessRequestStatus({
+    projectId: projectId,
+    ownerId: user.user_id,
+    token: token,
+    status: AccessRequestStatus.APPROVED,
+  })
+
+  return {}
+}

--- a/utopia-remix/app/routes/internal.projects.$id.access.request.$token.reject.tsx
+++ b/utopia-remix/app/routes/internal.projects.$id.access.request.$token.reject.tsx
@@ -1,0 +1,37 @@
+import type { ActionFunctionArgs } from '@remix-run/node'
+import type { Params } from '@remix-run/react'
+import { ensure, handle, requireUser } from '../util/api.server'
+import { Status } from '../util/statusCodes'
+import { validateProjectAccess } from '../handlers/validators'
+import { updateAccessRequestStatus } from '../models/projectAccessRequest.server'
+import { AccessRequestStatus, UserProjectPermission } from '../types'
+
+export async function action(args: ActionFunctionArgs) {
+  return handle(args, {
+    POST: {
+      handler: handleApproveAccessRequest,
+      validator: validateProjectAccess(UserProjectPermission.CAN_MANAGE_PROJECT, {
+        getProjectId: (params) => params.id,
+      }),
+    },
+  })
+}
+
+export async function handleApproveAccessRequest(req: Request, params: Params<string>) {
+  const user = await requireUser(req)
+
+  const projectId = params.id
+  ensure(projectId != null, 'project id is null', Status.BAD_REQUEST)
+
+  const token = params.token
+  ensure(token != null && typeof token === 'string', 'token is invalid', Status.BAD_REQUEST)
+
+  await updateAccessRequestStatus({
+    projectId: projectId,
+    ownerId: user.user_id,
+    token: token,
+    status: AccessRequestStatus.REJECTED,
+  })
+
+  return {}
+}

--- a/utopia-remix/app/routes/internal.projects.$id.access.request.tsx
+++ b/utopia-remix/app/routes/internal.projects.$id.access.request.tsx
@@ -1,0 +1,29 @@
+import type { ActionFunctionArgs } from '@remix-run/node'
+import type { Params } from '@remix-run/react'
+import { ensure, handle, requireUser } from '../util/api.server'
+import { Status } from '../util/statusCodes'
+import { ALLOW } from '../handlers/validators'
+import { createAccessRequest } from '../models/projectAccessRequest.server'
+
+export async function action(args: ActionFunctionArgs) {
+  return handle(args, {
+    POST: {
+      handler: handleRequestAccess,
+      validator: ALLOW,
+    },
+  })
+}
+
+export async function handleRequestAccess(req: Request, params: Params<string>) {
+  const user = await requireUser(req)
+
+  const projectId = params.id
+  ensure(projectId != null, 'project id is null', Status.BAD_REQUEST)
+
+  await createAccessRequest({
+    projectId: projectId,
+    userId: user.user_id,
+  })
+
+  return {}
+}

--- a/utopia-remix/app/test-util.ts
+++ b/utopia-remix/app/test-util.ts
@@ -91,6 +91,20 @@ export async function createTestProjectAccess(
   })
 }
 
+export async function createTestProjectAccessRequest(
+  client: UtopiaPrismaClient,
+  params: { projectId: string; userId: string; status: AccessLevel; token: string },
+) {
+  await client.projectAccessRequest.create({
+    data: {
+      project_id: params.projectId,
+      user_id: params.userId,
+      status: params.status,
+      token: params.token,
+    },
+  })
+}
+
 interface DeletableModel {
   /* eslint-disable-next-line no-empty-pattern */
   deleteMany: ({}) => Promise<any>

--- a/utopia-remix/app/types.ts
+++ b/utopia-remix/app/types.ts
@@ -165,3 +165,9 @@ export function getOperationDescription(op: Operation, project: ProjectWithoutCo
       assertNever(op)
   }
 }
+
+export enum AccessRequestStatus {
+  PENDING,
+  APPROVED,
+  REJECTED,
+}

--- a/utopia-remix/package.json
+++ b/utopia-remix/package.json
@@ -14,8 +14,8 @@
     "test-ci": "./run-integration-tests-ci.sh"
   },
   "dependencies": {
-    "@openfga/sdk": "0.3.2",
     "@headlessui/react": "1.7.18",
+    "@openfga/sdk": "0.3.2",
     "@prisma/client": "5.9.0",
     "@radix-ui/react-direction": "1.0.1",
     "@radix-ui/react-dropdown-menu": "2.0.6",
@@ -28,9 +28,9 @@
     "@remix-run/node": "2.5.1",
     "@remix-run/react": "2.5.1",
     "@remix-run/serve": "2.5.1",
-    "classnames": "2.5.1",
     "@tailwindcss/aspect-ratio": "0.4.2",
     "@tailwindcss/typography": "0.5.10",
+    "classnames": "2.5.1",
     "cookie": "0.6.0",
     "cors": "2.8.5",
     "dotenv": "16.4.1",
@@ -58,6 +58,7 @@
     "@types/node": "20.11.15",
     "@types/react": "18.2.20",
     "@types/react-dom": "18.2.7",
+    "@types/uuid": "9.0.8",
     "@typescript-eslint/eslint-plugin": "6.7.4",
     "@typescript-eslint/parser": ">=6.0.0 <7.0.0",
     "@vanilla-extract/css": "1.14.1",
@@ -77,7 +78,8 @@
     "source-map-support": "0.5.21",
     "tailwindcss": "3.4.1",
     "ts-node": "10.9.2",
-    "typescript": "5.1.6"
+    "typescript": "5.1.6",
+    "uuid": "9.0.1"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/utopia-remix/pnpm-lock.yaml
+++ b/utopia-remix/pnpm-lock.yaml
@@ -27,6 +27,7 @@ specifiers:
   '@types/node': 20.11.15
   '@types/react': 18.2.20
   '@types/react-dom': 18.2.7
+  '@types/uuid': 9.0.8
   '@typescript-eslint/eslint-plugin': 6.7.4
   '@typescript-eslint/parser': '>=6.0.0 <7.0.0'
   '@vanilla-extract/css': 1.14.1
@@ -62,6 +63,7 @@ specifiers:
   ts-node: 10.9.2
   typescript: 5.1.6
   url-join: 5.0.0
+  uuid: 9.0.1
   zustand: 4.5.0
 
 dependencies:
@@ -109,6 +111,7 @@ devDependencies:
   '@types/node': 20.11.15
   '@types/react': 18.2.20
   '@types/react-dom': 18.2.7
+  '@types/uuid': 9.0.8
   '@typescript-eslint/eslint-plugin': 6.7.4_shtvzkt6s7gm4npckmp2z5nvfi
   '@typescript-eslint/parser': 6.20.0_mcioginrgbuoxxpmyisevjswdq
   '@vanilla-extract/css': 1.14.1
@@ -129,6 +132,7 @@ devDependencies:
   tailwindcss: 3.4.1_ts-node@10.9.2
   ts-node: 10.9.2_jl7o2ctqvp5kcdsgrtcvc5qrce
   typescript: 5.1.6
+  uuid: 9.0.1
 
 packages:
 
@@ -4087,6 +4091,10 @@ packages:
 
   /@types/unist/2.0.10:
     resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
+    dev: true
+
+  /@types/uuid/9.0.8:
+    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
     dev: true
 
   /@types/yargs-parser/21.0.3:
@@ -10046,6 +10054,11 @@ packages:
   /utils-merge/1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  /uuid/9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+    dev: true
 
   /uvu/0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}

--- a/utopia-remix/schema.prisma
+++ b/utopia-remix/schema.prisma
@@ -29,16 +29,17 @@ model PersistentSession {
 }
 
 model Project {
-    id                  Int                   @id @default(autoincrement())
-    proj_id             String                @unique(map: "unique_project") @db.VarChar
-    owner_id            String                @db.VarChar
-    title               String                @db.VarChar
-    created_at          DateTime              @db.Timestamptz(6)
-    modified_at         DateTime              @db.Timestamptz(6)
-    content             Bytes
-    deleted             Boolean?
-    ProjectCollaborator ProjectCollaborator[]
-    ProjectAccess       ProjectAccess?
+    id                   Int                    @id @default(autoincrement())
+    proj_id              String                 @unique(map: "unique_project") @db.VarChar
+    owner_id             String                 @db.VarChar
+    title                String                 @db.VarChar
+    created_at           DateTime               @db.Timestamptz(6)
+    modified_at          DateTime               @db.Timestamptz(6)
+    content              Bytes
+    deleted              Boolean?
+    ProjectCollaborator  ProjectCollaborator[]
+    ProjectAccess        ProjectAccess?
+    ProjectAccessRequest ProjectAccessRequest[]
 
     @@map("project")
 }
@@ -68,12 +69,13 @@ model UserConfiguration {
 }
 
 model UserDetails {
-    id                  Int                   @id @default(autoincrement())
-    user_id             String                @unique(map: "unique_user_details") @db.VarChar
-    email               String?               @db.VarChar
-    name                String?               @db.VarChar
-    picture             String?               @db.VarChar
-    ProjectCollaborator ProjectCollaborator[]
+    id                   Int                    @id @default(autoincrement())
+    user_id              String                 @unique(map: "unique_user_details") @db.VarChar
+    email                String?                @db.VarChar
+    name                 String?                @db.VarChar
+    picture              String?                @db.VarChar
+    ProjectCollaborator  ProjectCollaborator[]
+    ProjectAccessRequest ProjectAccessRequest[]
 
     @@map("user_details")
 }
@@ -103,4 +105,24 @@ model ProjectCollaborator {
 
     @@unique([project_id, user_id], name: "unique_project_collaborator_project_id_user_id")
     @@map("project_collaborators")
+}
+
+model ProjectAccessRequest {
+    id Int @id @default(autoincrement())
+
+    Project    Project @relation(fields: [project_id], references: [proj_id])
+    project_id String  @db.VarChar
+
+    User    UserDetails @relation(fields: [user_id], references: [user_id])
+    user_id String      @db.VarChar
+
+    status Int @db.Integer
+
+    token String
+
+    created_at DateTime @default(now()) @db.Timestamptz(6)
+    updated_at DateTime @default(now()) @db.Timestamptz(6)
+
+    @@unique([project_id, user_id])
+    @@map("project_access_request")
 }

--- a/utopia-remix/schema.prisma
+++ b/utopia-remix/schema.prisma
@@ -124,5 +124,6 @@ model ProjectAccessRequest {
     updated_at DateTime @default(now()) @db.Timestamptz(6)
 
     @@unique([project_id, user_id])
+    @@unique([project_id, token])
     @@map("project_access_request")
 }


### PR DESCRIPTION
Fix #5038 

**Problem:**

We need a way to create and update project access requests.

**Fix:**

- Added a new table, `project_access_request` which holds the requests. They are unique per user, per project, and can be in either of three states: pending, accepted, or rejected.
- Added logic to create a new access request on a project (for which the user is _not_ the owner), as pending
- Added logic to update an existing access request on an owned project
- Added three routes for the operations above (CRU)
- Added tests for the DB operations - I did not add the tests for the routes themselves, but the meat should be fairly solid
- Requests are addressed via their random token, so not to expose incremental ids, etc etc

**Notes**
- I'm keeping things deliberately simple here, in terms of functionality (e.g. no re-issuing of a request, etc.) because we don't have the full functional picture complete yet, but this should be a good-enough foundation.
- Moreover this is not taking any perms actions per se, as this will need to be integrated with https://github.com/concrete-utopia/utopia/pull/5033 whenever that gets merged, but it can be easily done separately so we keep things small and simple.