### PR TITLE
Fix: show cartouches even if they are embedded into bigger object literals

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -131,7 +131,7 @@ const ControlForProp = React.memo((props: ControlForPropProps<RegularControlDesc
 
   const attributeExpression = props.propMetadata.attributeExpression
 
-  if (attributeExpression != null && PP.depth(props.propPath) === 1) {
+  if (attributeExpression != null) {
     if (
       attributeExpression.type === 'JS_IDENTIFIER' ||
       attributeExpression.type === 'JS_PROPERTY_ACCESS' ||


### PR DESCRIPTION
**Problem:**
The component `<Component data={{ innerData: data }} />` clearly has a variable named data fed into it, which our parser correctly understands, however the component section doesn't surface this info on master:
<img width="291" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/16df03ae-e9e6-44c0-8649-0623a2cb1549">

( The reason for this behavior was that on master I had to disable cartouches which were not root-level because of a bug in `getModifiableJSXAttributeAtPath` which I fixed in #5029 so now there's no reason to have this limitation )

**Fix:**
Correctly show a Cartouche for `data`:
<img width="276" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/e6479253-7bdb-4d9a-8531-8b65fc7765e0">

