### PR TITLE
do not actually throw on NaN array access

### DIFF
--- a/editor/src/core/shared/jsx-attribute-utils.ts
+++ b/editor/src/core/shared/jsx-attribute-utils.ts
@@ -182,9 +182,6 @@ export function getJSExpressionAtPathParts(
     case 'ATTRIBUTE_NESTED_ARRAY': {
       const possibleIndex = path[pathIndex]
       const index = typeof possibleIndex === 'number' ? possibleIndex : parseInt(possibleIndex)
-      if (isNaN(index)) {
-        throw new Error(`Attempted to access an array item at index ${possibleIndex}`)
-      }
       const foundProp = attribute.content[index]
       if (foundProp == null) {
         return getJSXAttributeResult(jsxAttributeNotFound())

--- a/editor/src/core/shared/jsx-attributes.spec.ts
+++ b/editor/src/core/shared/jsx-attributes.spec.ts
@@ -1033,6 +1033,13 @@ describe('getModifiableJSXAttributeAtPath', () => {
     )
     expect(isRight(impossibleAttributeInsideNestedArray)).toBeTruthy()
     expect(impossibleAttributeInsideNestedArray.value).toEqual(jsxAttributeNotFound())
+
+    const impossibleAttributeInsideNestedArrayNotNumberIndex = getModifiableJSXAttributeAtPath(
+      advancedJSXSampleAttributes(),
+      PP.create('fancyArray', 'five'),
+    )
+    expect(isRight(impossibleAttributeInsideNestedArrayNotNumberIndex)).toBeTruthy()
+    expect(impossibleAttributeInsideNestedArrayNotNumberIndex.value).toEqual(jsxAttributeNotFound())
   })
 
   it('simple array access works', () => {
@@ -1045,15 +1052,6 @@ describe('getModifiableJSXAttributeAtPath', () => {
     if (isRight(foundAttributeObject)) {
       expect(foundAttributeObject.value.type).toEqual('ATTRIBUTE_NESTED_OBJECT')
     }
-  })
-
-  it('throws on wrong array access', () => {
-    const impossibleAttributeInsideNestedArray = expect(() =>
-      getModifiableJSXAttributeAtPath(
-        advancedJSXSampleAttributes(),
-        PP.create('fancyArray', 'lol'),
-      ),
-    ).toThrow()
   })
 
   it('returns Left on a path that points into a non-simple-value expression', () => {


### PR DESCRIPTION
**Context**
<img width="289" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/de60fa1f-83e0-4f02-8ff9-b50bf20587ab">
When changing selection between various elements, the Component Inspector would sometimes claim it encountered an invalid propertyControls value.

The reason is because due to some messy internal state management, there is a transient state similar to the ghost child problem, where we try to access the new selected element's data with the old selected element's paths. This would sometimes mean we index into an array using a non-number index. 

As @bkrmendy pointed out yesterday, the internals of `getModifiableJSXAttributeAtPath` throw an error in this case. The only reason why this was a silent bug so far is because the Component Inspector is wrapped in an error boundary, because the handling of user-written `propertyControls` is unsafe and must be treated in a try-catch. 

But the error boundary is placed a bit too high, and it doesn't just catch-and-hide problems with propertyControls, it catches _all_ errors, even ones thrown by our own code :) 

**Fix**
The fix is very simply to stop throwing an error `getModifiableJSXAttributeAtPath`. It's actually _wrong_ to throw an error, because in Javascript it's fully allowed to access object properties on arrays, and our own `setJSXValueInAttributeAtPath` setter function also correctly handles setting a non-integer property on an array.

So the error was both wrong in a theoretical way and also not anticipated by the call sites of the function, the only reason it could remain silent was a misplaced error boundary hiding it.