### PR TITLE
Add highlight bounds to render props

### DIFF
--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -209,6 +209,13 @@ return { cakeFn: cakeFn, otherFn: otherFn };",
     },
   },
   "highlightBounds": Object {
+    "8f7": Object {
+      "endCol": 38,
+      "endLine": 23,
+      "startCol": 14,
+      "startLine": 23,
+      "uid": "8f7",
+    },
     "aaa": Object {
       "endCol": 11,
       "endLine": 25,

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -5258,14 +5258,14 @@ export var whatever2 = (props) => <View data-uid='aaa'>
                       topLevelElement.rootElement,
                       uids,
                       isWantedElement,
-                      'do-not-walk-attributes',
+                      'walk-attributes',
                     )
                     if (topLevelElement.arbitraryJSBlock != null) {
                       ensureArbitraryBlocksHaveUID(
                         topLevelElement.arbitraryJSBlock,
                         uids,
                         isWantedElement,
-                        'do-not-walk-attributes',
+                        'walk-attributes',
                       )
                     }
                     break
@@ -5274,7 +5274,7 @@ export var whatever2 = (props) => <View data-uid='aaa'>
                       topLevelElement,
                       uids,
                       isWantedElement,
-                      'do-not-walk-attributes',
+                      'walk-attributes',
                     )
                     break
                   case 'IMPORT_STATEMENT':

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -1863,10 +1863,18 @@ export function trimHighlightBounds(success: ParseSuccess): ParseSuccess {
       function walkJSXElementChild(element: JSXElementChild): void {
         switch (element.type) {
           case 'JSX_ELEMENT':
+            includeElement(element)
+            for (const child of element.children) {
+              walkJSXElementChild(child)
+            }
+            for (const prop of element.props) {
+              if (prop.type === 'JSX_ATTRIBUTES_ENTRY') {
+                walkJSXElementChild(prop.value)
+              }
+            }
+            break
           case 'JSX_FRAGMENT':
             includeElement(element)
-            // Don't include the properties of elements, but concievably we would want
-            // to include things like render props which include an element.
             for (const child of element.children) {
               walkJSXElementChild(child)
             }


### PR DESCRIPTION
**Problem:**
We can select elements in render props, but their highlight bounds is not shown, because we filter props out when collecting the highlight bounds.

**Fix:**
Allow highlight bounds of props