### PR TITLE
Do not show extra CHILDREN in navigator without jsx element render props.

### DIFF
--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -134,10 +134,10 @@ export function getNavigatorTargets(
             return
           }
           const propValue = getJSXAttribute(jsxElement.props, prop)
-          renderPropFound = true
           const fakeRenderPropPath = EP.appendToPath(path, renderPropId(prop))
 
           if (propValue == null || (isJSExpressionValue(propValue) && propValue.value == null)) {
+            renderPropFound = true
             const entries = [
               renderPropNavigatorEntry(fakeRenderPropPath, prop),
               slotNavigatorEntry(fakeRenderPropPath, prop),
@@ -148,6 +148,7 @@ export function getNavigatorTargets(
           }
 
           if (isJSXElement(propValue)) {
+            renderPropFound = true
             const childPath = EP.appendToPath(path, propValue.uid)
             const entry = renderPropNavigatorEntry(fakeRenderPropPath, prop)
             navigatorTargets.push(entry)


### PR DESCRIPTION
**Problem:**
1. We only show render props with jsx elements in them
2. We show CHILDREN label before normal children when there ar render props before them
3. We accidentally show the children label even when it has other render props, but not with jsx elements in them (so they are not shown)

**Fix:**
Only set renderPropFound to true when we can really insert something into the navigator targets