### PR TITLE
Bigger minWidth for project cards

### DIFF
--- a/utopia-remix/app/styles/projects.css.ts
+++ b/utopia-remix/app/styles/projects.css.ts
@@ -8,7 +8,7 @@ export const projectCards = recipe({
       overflow: 'hidden scroll',
       scrollbarColor: 'lightgrey transparent',
       display: 'grid',
-      gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+      gridTemplateColumns: 'repeat(auto-fill, minmax(270px, 1fr))',
       justifyContent: 'space-between',
       alignContent: 'flex-start',
       gridGap: '40px',


### PR DESCRIPTION
Making the min-width of the project cards a bit bigger.

On a 14-inch laptop:
| Before  | After |
| ------------- | ------------- |
| <img width="1509" alt="Screenshot 2024-03-14 at 10 36 54 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/3ba30e2e-b70f-4fb0-9ab8-cf7862724e02"> | <img width="1512" alt="Screenshot 2024-03-14 at 10 36 05 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/32415891-ff86-4caa-bddf-0e2bf0ea5d35"> |

On a 24-inch monitor:
| Before  | After |
| ------------- | ------------- |
| <img width="1920" alt="Screenshot 2024-03-14 at 10 30 27 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/84870934-dd9a-405a-b2ba-dd73b655f27a">  | <img width="1920" alt="Screenshot 2024-03-14 at 10 32 12 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/0c8838be-77e3-4ae6-9648-bde473b5abec">  |


