### PR TITLE
Fix response for listing requests

### DIFF
--- a/utopia-remix/app/routes/internal.projects.$id.access.requests.tsx
+++ b/utopia-remix/app/routes/internal.projects.$id.access.requests.tsx
@@ -24,7 +24,7 @@ export async function handleListAccessRequests(req: Request, params: Params<stri
   const projectId = params.id
   ensure(projectId != null, 'project id is null', Status.BAD_REQUEST)
 
-  return await listProjectAccessRequests({
+  return listProjectAccessRequests({
     projectId: projectId,
     userId: user.user_id,
   })

--- a/utopia-remix/app/routes/internal.projects.$id.access.requests.tsx
+++ b/utopia-remix/app/routes/internal.projects.$id.access.requests.tsx
@@ -24,9 +24,8 @@ export async function handleListAccessRequests(req: Request, params: Params<stri
   const projectId = params.id
   ensure(projectId != null, 'project id is null', Status.BAD_REQUEST)
 
-  const requests = await listProjectAccessRequests({
+  return await listProjectAccessRequests({
     projectId: projectId,
     userId: user.user_id,
   })
-  return json(requests, { headers: { 'cache-control': 'no-cache' } })
 }


### PR DESCRIPTION
**Problem:**

The endpoint to list requests returns a `Response`, which is incorrect/unnecessary and forces us to explicitly add the no-cache header.

**Fix:**

Just return it straight from the querier.