### PR TITLE
Express: handle pipe errors gracefully

### DIFF
--- a/utopia-remix/server.js
+++ b/utopia-remix/server.js
@@ -8,6 +8,15 @@ import * as path from 'node:path'
 import * as url from 'node:url'
 import sourceMapSupport from 'source-map-support'
 
+// To make sure everything keeps working and the server doesn't crash, if
+// there are any uncaught errors, log them out gracefully
+process.on('uncaughtException', (err) => {
+  console.error('server uncaught exception', err)
+})
+process.on('unhandledRejection', (err) => {
+  console.error('server unhandled rejection', err)
+})
+
 // figlet -f isometric3 'utopia'
 const asciiBanner = `
       ___                       ___           ___                     ___
@@ -198,12 +207,3 @@ app.listen(environment.PORT, listenCallback(environment.PORT))
 if (process.env.NODE_ENV === 'development') {
   app.listen(environment.PORT + 1, listenCallback(environment.PORT + 1))
 }
-
-// To make sure everythin keeps working and the server doesn't crash, if
-// there are any uncaught errors, log them out gracefully
-process.on('uncaughtException', (err) => {
-  console.error('server uncaught exception', err)
-})
-process.on('unhandledRejection', (err) => {
-  console.error('server unhandled rejection', err)
-})


### PR DESCRIPTION
Fix #5051 

**Problem:**

The express server can crash during proxied requests, if they cause unmanaged errors during the piping.

**Fix:**

1. Add an explicit handler for errors happening on the piped requests, returning a graceful error to the client
2. Additionally, make sure that uncaught errors on the whole process are logged out instead of making the whole thing explode, so the lights stay on