### PR TITLE
Delete cartouche handles required and default values. 

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -127,10 +127,27 @@ const ControlForProp = React.memo((props: ControlForPropProps<RegularControlDesc
   const { controlDescription, showHiddenControl } = props
   const onSubmitValue = props.propMetadata.onSubmitValue
 
+  const isRequired: boolean = props.controlDescription.required ?? false
+  const hasDefaultValue: boolean = 'defaultValue' in props.controlDescription
+  const safeToDelete = !isRequired || hasDefaultValue
+
   const onDeleteCartouche = React.useCallback(() => {
-    onSubmitValue(null, false)
-    showHiddenControl(PP.firstPartToString(props.propPath))
-  }, [onSubmitValue, showHiddenControl, props.propPath])
+    if (safeToDelete) {
+      if (isRequired) {
+        onSubmitValue(props.controlDescription.defaultValue, false)
+      } else {
+        onSubmitValue(null, false)
+        showHiddenControl(PP.firstPartToString(props.propPath))
+      }
+    }
+  }, [
+    safeToDelete,
+    isRequired,
+    onSubmitValue,
+    props.controlDescription.defaultValue,
+    props.propPath,
+    showHiddenControl,
+  ])
 
   if (controlDescription == null) {
     return null
@@ -150,6 +167,8 @@ const ControlForProp = React.memo((props: ControlForPropProps<RegularControlDesc
           matchType='full'
           onOpenDataPicker={props.onOpenDataPicker}
           onDeleteCartouche={onDeleteCartouche}
+          testId={`cartouche-${PP.toString(props.propPath)}`}
+          safeToDelete={safeToDelete}
         />
       )
     }
@@ -166,6 +185,8 @@ const ControlForProp = React.memo((props: ControlForPropProps<RegularControlDesc
             matchType='partial'
             onOpenDataPicker={props.onOpenDataPicker}
             onDeleteCartouche={onDeleteCartouche}
+            testId={`cartouche-${PP.toString(props.propPath)}`}
+            safeToDelete={safeToDelete}
           />
         )
       }

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -812,9 +812,7 @@ export const IdentifierExpressionCartoucheControl = React.memo(
     const onDelete = React.useCallback<React.MouseEventHandler<HTMLDivElement>>(
       (e) => {
         stopPropagation(e)
-        if (onDeleteCartouche != null) {
-          onDeleteCartouche()
-        }
+        onDeleteCartouche()
       },
       [onDeleteCartouche],
     )

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -71,6 +71,7 @@ import {
 import type { JSXParsedType, JSXParsedValue } from '../../../../utils/value-parser-utils'
 import { assertNever } from '../../../../core/shared/utils'
 import { preventDefault, stopPropagation } from '../../common/inspector-utils'
+import { unless, when } from '../../../../utils/react-conditionals'
 
 export interface ControlForPropProps<T extends RegularControlDescription> {
   propPath: PropertyPath
@@ -802,14 +803,18 @@ interface IdentifierExpressionCartoucheControlProps {
   matchType: 'full' | 'partial'
   onOpenDataPicker: () => void
   onDeleteCartouche: () => void
+  safeToDelete: boolean
+  testId: string
 }
 export const IdentifierExpressionCartoucheControl = React.memo(
   (props: IdentifierExpressionCartoucheControlProps) => {
-    const { onDeleteCartouche } = props
+    const { onDeleteCartouche, testId, safeToDelete } = props
     const onDelete = React.useCallback<React.MouseEventHandler<HTMLDivElement>>(
       (e) => {
         stopPropagation(e)
-        onDeleteCartouche()
+        if (onDeleteCartouche != null) {
+          onDeleteCartouche()
+        }
       },
       [onDeleteCartouche],
     )
@@ -854,9 +859,16 @@ export const IdentifierExpressionCartoucheControl = React.memo(
             {/* the &lrm; non-printing character is added to fix the punctuation marks disappearing because of direction: rtl */}
           </div>
         </Tooltip>
-        <div style={{ paddingLeft: 5, paddingRight: 5, marginRight: -5 }} onClick={onDelete}>
-          {/* TODO replace the X button with a real icon */}×
-        </div>
+        {when(
+          safeToDelete,
+          <div
+            style={{ paddingLeft: 5, paddingRight: 5, marginRight: -5 }}
+            onClick={onDelete}
+            data-testid={`delete-${testId}`}
+          >
+            {/* TODO replace the X button with a real icon */}×
+          </div>,
+        )}
       </FlexRow>
     )
   },


### PR DESCRIPTION
**Problem:**
Now that we have the required and default value fields for the properties and the ability to delete a cartouche, we need to support the following cases:
- If field is optional: Keep what is now the current behavior.
- If field is required and there's a default value: Just replace the field with the default value.
- If field is required and there's no default value: do not show the X to delete.

**Fix:**
Now when constructing the delete handler and the control for each property, take into account the required and default value fields.

**Commit Details:**
- Changed the `onDeleteCartouche` event handler to use the default value
  when the property is required, as well as only running if it is safe to
  do so.
- `ControlForProp` takes a `safeToDelete` property now which is used to
  determine if the delete option is shown.
