### PR TITLE
Test project validator

### DIFF
--- a/utopia-remix/app/handlers/validators.spec.ts
+++ b/utopia-remix/app/handlers/validators.spec.ts
@@ -1,0 +1,160 @@
+import { prisma } from '../db.server'
+import {
+  createTestProject,
+  createTestProjectAccess,
+  createTestSession,
+  createTestUser,
+  newTestRequest,
+  truncateTables,
+} from '../test-util'
+import { validateProjectAccess } from './validators'
+import * as permissionsService from '../services/permissionsService.server'
+import { AccessLevel, UserProjectPermission } from '../types'
+import { ApiError } from '../util/errors'
+import type { ValidationResult } from '../util/api.server'
+import { Status } from '../util/statusCodes'
+
+describe('validators', () => {
+  describe('validateProjectAccess', () => {
+    afterEach(async () => {
+      await truncateTables([
+        prisma.projectID,
+        prisma.projectAccess,
+        prisma.project,
+        prisma.userDetails,
+        prisma.persistentSession,
+      ])
+
+      jest.spyOn(permissionsService, 'hasUserProjectPermission').mockRestore()
+    })
+
+    beforeEach(async () => {
+      await createTestUser(prisma, { id: 'bob' })
+      await createTestUser(prisma, { id: 'alice' })
+      await createTestSession(prisma, { key: 'bob-key', userId: 'bob' })
+      await createTestSession(prisma, { key: 'alice-key', userId: 'alice' })
+      await createTestProject(prisma, { id: 'one', ownerId: 'bob' })
+    })
+
+    const perm = UserProjectPermission.CAN_COMMENT_PROJECT // just any of the permissions is fine
+
+    afterAll(async () => {
+      jest.restoreAllMocks()
+    })
+
+    it('errors if the project id is not passed', async () => {
+      const got = await validateProjectAccess(perm, { getProjectId: () => null })(
+        newTestRequest(),
+        {},
+      )
+
+      const error = mustBeApiErrorValidator(got)
+      expect(error.status).toBe(Status.BAD_REQUEST)
+    })
+
+    it('errors if the project does not exist', async () => {
+      const got = await validateProjectAccess(perm, { getProjectId: () => 'unknown' })(
+        newTestRequest(),
+        {},
+      )
+
+      const error = mustBeApiErrorValidator(got)
+      expect(error.status).toBe(Status.NOT_FOUND)
+    })
+
+    it('does nothing if the user is the owner', async () => {
+      await createTestProjectAccess(prisma, {
+        projectId: 'one',
+        accessLevel: AccessLevel.PRIVATE,
+      })
+      const got = await validateProjectAccess(perm, { getProjectId: () => 'one' })(
+        newTestRequest({ authCookie: 'bob-key' }),
+        {},
+      )
+      expect(got.ok).toBe(true)
+    })
+
+    it('does nothing if the user has access', async () => {
+      jest.spyOn(permissionsService, 'hasUserProjectPermission').mockResolvedValue(true)
+
+      const got = await validateProjectAccess(perm, { getProjectId: () => 'one' })(
+        newTestRequest({ authCookie: 'alice-key' }),
+        {},
+      )
+      expect(got.ok).toBe(true)
+    })
+
+    describe('when access can be requested', () => {
+      it('returns a 404 if the user cannot request access', async () => {
+        jest.spyOn(permissionsService, 'hasUserProjectPermission').mockResolvedValue(false)
+
+        const got = await validateProjectAccess(perm, {
+          getProjectId: () => 'one',
+          canRequestAccess: true,
+        })(newTestRequest({ authCookie: 'alice-key' }), {})
+
+        const error = mustBeApiErrorValidator(got)
+        expect(error.status).toBe(Status.NOT_FOUND)
+      })
+
+      it('returns a 403 if the user can request access', async () => {
+        jest
+          .spyOn(permissionsService, 'hasUserProjectPermission')
+          .mockImplementation(async (_, __, p) => {
+            return p === UserProjectPermission.CAN_REQUEST_ACCESS
+          })
+
+        const got = await validateProjectAccess(perm, {
+          getProjectId: () => 'one',
+          canRequestAccess: true,
+        })(newTestRequest({ authCookie: 'alice-key' }), {})
+
+        const error = mustBeApiErrorValidator(got)
+        expect(error.status).toBe(Status.FORBIDDEN)
+      })
+    })
+
+    describe('when access cannot be requested', () => {
+      it('returns a 404 even if the user can request access', async () => {
+        jest
+          .spyOn(permissionsService, 'hasUserProjectPermission')
+          .mockImplementation(async (_, __, p) => {
+            return p === UserProjectPermission.CAN_REQUEST_ACCESS
+          })
+
+        const got = await validateProjectAccess(perm, {
+          getProjectId: () => 'one',
+        })(newTestRequest({ authCookie: 'alice-key' }), {})
+
+        const error = mustBeApiErrorValidator(got)
+        expect(error.status).toBe(Status.NOT_FOUND)
+      })
+
+      it('returns a 404', async () => {
+        await createTestProjectAccess(prisma, {
+          projectId: 'one',
+          accessLevel: AccessLevel.COLLABORATIVE,
+        })
+
+        jest.spyOn(permissionsService, 'hasUserProjectPermission').mockResolvedValue(false)
+
+        const got = await validateProjectAccess(perm, {
+          getProjectId: () => 'one',
+        })(newTestRequest({ authCookie: 'alice-key' }), {})
+
+        const error = mustBeApiErrorValidator(got)
+        expect(error.status).toBe(Status.NOT_FOUND)
+      })
+    })
+  })
+})
+
+function mustBeApiErrorValidator(got: ValidationResult): ApiError {
+  if (got.ok) {
+    throw new Error('expected validation error')
+  }
+  if (!(got.error instanceof ApiError)) {
+    throw new Error('expected api error')
+  }
+  return got.error
+}

--- a/utopia-remix/app/routes-test/internal.projects.$id.access.spec.ts
+++ b/utopia-remix/app/routes-test/internal.projects.$id.access.spec.ts
@@ -93,8 +93,8 @@ describe('handleChangeAccess', () => {
     })
     const error = await getActionResult('two', AccessLevel.PRIVATE)
     expect(error).toEqual({
-      message: 'Unauthorized Access',
-      status: Status.FORBIDDEN,
+      message: 'Project not found',
+      status: Status.NOT_FOUND,
       error: 'Error',
     })
   })

--- a/utopia-remix/app/routes/v1.project.$id.tsx
+++ b/utopia-remix/app/routes/v1.project.$id.tsx
@@ -1,7 +1,6 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
 import { handle, handleOptions } from '../util/api.server'
-import { Status } from '../util/statusCodes'
 import { UserProjectPermission } from '../types'
 import { ALLOW, validateProjectAccess } from '../handlers/validators'
 
@@ -11,8 +10,6 @@ export async function loader(args: LoaderFunctionArgs) {
     GET: {
       handler: proxy,
       validator: validateProjectAccess(UserProjectPermission.CAN_VIEW_PROJECT, {
-        errorMessage: 'Project not found',
-        status: Status.NOT_FOUND,
         canRequestAccess: true,
         getProjectId: (params) => params.id,
       }),

--- a/utopia-remix/app/util/api.server.spec.ts
+++ b/utopia-remix/app/util/api.server.spec.ts
@@ -1,7 +1,7 @@
 import { prisma } from '../db.server'
 import { createTestSession, createTestUser, newTestRequest, truncateTables } from '../test-util'
 import type { ApiResponse } from './api.server'
-import { handle, requireUser } from './api.server'
+import { handle, requireUser, validationOk } from './api.server'
 import { ApiError } from './errors'
 import { Status } from './statusCodes'
 
@@ -66,7 +66,7 @@ describe('handle', () => {
             return { data: 'success' }
           },
           validator: async () => {
-            // passes
+            return validationOk()
           },
         },
       },


### PR DESCRIPTION
(sharded out of https://github.com/concrete-utopia/utopia/pull/5072 for scope's sake)

**Problem:**

The project validator is not tested itself.

**Fix:**

1. Refactor the validator and its logic so it's easier to test and to follow (it can and will get complicated)
2. Simplify it a bit so it always returns consistent status codes (404 by default, 403 if the project is not accessible but the user can request access to it _and_ the related flag is set)
3. Test it