### PR TITLE
Fixed URLs in env-vars.ts

### DIFF
--- a/website-next/components/common/env-vars.ts
+++ b/website-next/components/common/env-vars.ts
@@ -59,7 +59,7 @@ const SECONDARY_BASE_URL: string = PRODUCTION_CONFIG
   : BRANCHES_CONFIG
   ? 'https://momentumworks.co/'
   : BARE_HOST === 'localhost:8000'
-  ? 'http://localhost:8002'
+  ? 'http://localhost:8001'
   : BASE_URL
 
 export const PROBABLY_ELECTRON: boolean =
@@ -85,7 +85,7 @@ export const VSCODE_EDITOR_IFRAME_BASE_URL: string = PRODUCTION_CONFIG
   : STAGING_CONFIG
   ? 'https://utopia.pizza/'
   : BRANCHES_CONFIG
-  ? 'https://momentumworks.co/'
+  ? 'https://utopia.fish/'
   : BARE_HOST === 'localhost:8000' || BARE_HOST === 'localhost:8001'
   ? 'http://localhost:8000'
   : BASE_URL

--- a/website-next/components/common/env-vars.ts
+++ b/website-next/components/common/env-vars.ts
@@ -80,15 +80,6 @@ export const STATIC_BASE_URL: string =
 export const FLOATING_PREVIEW_BASE_URL: string = SECONDARY_BASE_URL
 export const PROPERTY_CONTROLS_INFO_BASE_URL: string = SECONDARY_BASE_URL
 export const MONACO_EDITOR_IFRAME_BASE_URL: string = SECONDARY_BASE_URL
-export const VSCODE_EDITOR_IFRAME_BASE_URL: string = PRODUCTION_CONFIG
-  ? `https://utopia.app/`
-  : STAGING_CONFIG
-  ? 'https://utopia.pizza/'
-  : BRANCHES_CONFIG
-  ? 'https://utopia.fish/'
-  : BARE_HOST === 'localhost:8000' || BARE_HOST === 'localhost:8001'
-  ? 'http://localhost:8000'
-  : BASE_URL
 
 export const ASSET_ENDPOINT = UTOPIA_BACKEND + 'asset/'
 export const THUMBNAIL_ENDPOINT = UTOPIA_BACKEND + 'thumbnail/'


### PR DESCRIPTION
`SECONDARY_BASE_URL` is used for loading iframes in the editor on a different TLD so that chrome will run those in a separate process for performance reasons. Therefore, that URL should be serving up the exact same content as the primary URL. To achieve this locally, we run the local server on 2 ports (8000 and 8001), but I've just noticed that we were pointing `SECONDARY_BASE_URL` at the haskell server locally, so I've just fixed that.

I also noticed that we aren't using `VSCODE_EDITOR_IFRAME_BASE_URL` anymore (and haven't been for a while), so I've removed that one. This was previously used to double wrap the code editor (wrap in different TLD for the same performance hack as above, then inner wrap in the same TLD to share access to the same IndexedDB), but that approach broke and had to be changed a while back, so we now just use a single iframe on the secondary TLD.