### PR TITLE
Separate share dialog from context menu

### DIFF
--- a/utopia-remix/app/components/projectActionContextMenu.tsx
+++ b/utopia-remix/app/components/projectActionContextMenu.tsx
@@ -14,9 +14,8 @@ import { useProjectEditorLink } from '../util/links'
 import { useFetcherWithOperation } from '../hooks/useFetcherWithOperation'
 import slugify from 'slugify'
 import { SLUGIFY_OPTIONS } from '../routes/internal.projects.$id.rename'
-import { ContextMenu, Separator, Dialog, Flex, Text } from '@radix-ui/themes'
+import { ContextMenu, Separator, Flex, Text } from '@radix-ui/themes'
 import { DotFilledIcon } from '@radix-ui/react-icons'
-import { SharingDialog } from './sharingDialog'
 import { when } from '~/util/react-conditionals'
 import { useCopyProjectLinkToClipboard } from '../util/copyProjectLink'
 
@@ -159,14 +158,16 @@ export const ProjectActionsMenu = React.memo(
       copyProjectLink,
     ])
 
-    const preventDefault = React.useCallback((event: Event) => {
-      event.preventDefault()
-    }, [])
-
     const pendingAccessRequests = React.useMemo(
       () => accessRequests.filter((r) => r.status === AccessRequestStatus.PENDING),
       [accessRequests],
     )
+
+    const setSharingProjectId = useProjectsStore((store) => store.setSharingProjectId)
+
+    const onOpenShareDialog = React.useCallback(() => {
+      setSharingProjectId(project.proj_id)
+    }, [project, setSharingProjectId])
 
     return (
       <ContextMenu.Content style={{ width: 170 }}>
@@ -182,22 +183,19 @@ export const ProjectActionsMenu = React.memo(
           }
           if (entry === 'sharing-dialog') {
             return (
-              <Dialog.Root key={`separator-${index}`}>
-                <Dialog.Trigger>
-                  <ContextMenu.Item style={{ height: 28, fontSize: 12 }} onSelect={preventDefault}>
-                    <Flex justify={'between'} align={'center'} width={'100%'}>
-                      <Text>Share</Text>
-                      {when(
-                        pendingAccessRequests.length > 0,
-                        <DotFilledIcon color='red' height={22} width={22} />,
-                      )}
-                    </Flex>
-                  </ContextMenu.Item>
-                </Dialog.Trigger>
-                <Dialog.Content>
-                  <SharingDialog project={project} accessRequests={accessRequests} />
-                </Dialog.Content>
-              </Dialog.Root>
+              <ContextMenu.Item
+                key={`entry-${index}`}
+                style={{ height: 28, fontSize: 12 }}
+                onSelect={onOpenShareDialog}
+              >
+                <Flex justify={'between'} align={'center'} width={'100%'}>
+                  <Text>Share</Text>
+                  {when(
+                    pendingAccessRequests.length > 0,
+                    <DotFilledIcon color='red' height={22} width={22} />,
+                  )}
+                </Flex>
+              </ContextMenu.Item>
             )
           }
           return (

--- a/utopia-remix/app/components/sharingDialog.tsx
+++ b/utopia-remix/app/components/sharingDialog.tsx
@@ -23,8 +23,40 @@ import moment from 'moment'
 import { useProjectEditorLink } from '../util/links'
 import { button } from '../styles/button.css'
 import { useCopyProjectLinkToClipboard } from '../util/copyProjectLink'
+import { useProjectsStore } from '../store'
 
-export function SharingDialog({
+export const SharingDialogWrapper = React.memo(
+  ({
+    project,
+    accessRequests,
+  }: {
+    project: ProjectWithoutContent
+    accessRequests: ProjectAccessRequestWithUserDetails[]
+  }) => {
+    const sharingProjectId = useProjectsStore((store) => store.sharingProjectId)
+    const setSharingProjectId = useProjectsStore((store) => store.setSharingProjectId)
+
+    const onOpenChange = React.useCallback(
+      (open: boolean) => {
+        if (!open) {
+          setSharingProjectId(null)
+        }
+      },
+      [setSharingProjectId],
+    )
+
+    return (
+      <Dialog.Root open={sharingProjectId === project.proj_id} onOpenChange={onOpenChange}>
+        <Dialog.Content>
+          <SharingDialog project={project} accessRequests={accessRequests} />
+        </Dialog.Content>
+      </Dialog.Root>
+    )
+  },
+)
+SharingDialogWrapper.displayName = 'SharingDialogWrapper'
+
+function SharingDialog({
   project,
   accessRequests,
 }: {

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -50,6 +50,7 @@ import {
   useProjectMatchesQuery,
   useSortCompareProject,
 } from '../util/use-sort-compare-project'
+import { SharingDialogWrapper } from '../components/sharingDialog'
 
 const SortOptions = ['title', 'dateCreated', 'dateModified'] as const
 export type SortCriteria = (typeof SortOptions)[number]
@@ -729,6 +730,7 @@ const ProjectCard = React.memo(
           </div>
         </ContextMenu.Trigger>
         <ProjectActionsMenu project={project} accessRequests={accessRequests} />
+        <SharingDialogWrapper project={project} accessRequests={accessRequests} />
       </ContextMenu.Root>
     )
   },
@@ -766,13 +768,13 @@ const ProjectRow = React.memo(
       }
     }, [accessRequestsFetcher])
 
-    const handleSortMenuOpenChange = React.useCallback(() => {
+    const onContextMenuOpenChange = React.useCallback(() => {
       const action = `/internal/projects/${project.proj_id}/access/requests`
       accessRequestsFetcher.submit({}, { method: 'GET', action: action })
     }, [accessRequestsFetcher, project])
 
     return (
-      <ContextMenu.Root onOpenChange={handleSortMenuOpenChange}>
+      <ContextMenu.Root onOpenChange={onContextMenuOpenChange}>
         <ContextMenu.Trigger>
           <div style={{ padding: '8px 0' }}>
             <div

--- a/utopia-remix/app/store.tsx
+++ b/utopia-remix/app/store.tsx
@@ -27,6 +27,7 @@ interface ProjectsStoreStateNonPersisted {
   searchQuery: string
   operations: OperationWithKey[]
   env: BrowserEnvironmentType | null
+  sharingProjectId: string | null
 }
 
 const initialProjectsStoreStateNonPersisted: ProjectsStoreStateNonPersisted = {
@@ -35,6 +36,7 @@ const initialProjectsStoreStateNonPersisted: ProjectsStoreStateNonPersisted = {
   searchQuery: '',
   operations: [],
   env: null,
+  sharingProjectId: null,
 }
 
 type ProjectsStoreState = ProjectsStoreStatePersisted & ProjectsStoreStateNonPersisted
@@ -49,6 +51,7 @@ interface ProjectsStoreActions {
   addOperation: (operation: Operation, key: string) => void
   removeOperation: (key: string) => void
   updateOperation: (key: string, data: { errored: boolean }) => void
+  setSharingProjectId: (projectId: string | null) => void
 }
 
 type ProjectsStore = ProjectsStoreState & ProjectsStoreActions
@@ -106,6 +109,9 @@ export const createProjectsStore = (
                 return other
               }),
             }))
+          },
+          setSharingProjectId: (projectId) => {
+            return set(() => ({ sharingProjectId: projectId }))
           },
         }),
         {


### PR DESCRIPTION
Fix #5709

**Problem:**

The share dialog is placed inside a context menu, which means that when the `Share` button is pressed and the dialog is opened, the context menu stays open, even after the dialog is closed.

https://github.com/concrete-utopia/utopia/assets/1081051/bdd622ea-fe69-44f9-abc5-dfb2cbb3a14f

**Fix:**

Separate the dialog from the context menu, so it lives a separate life, while still respecting the lifecycle of the context menu.


https://github.com/concrete-utopia/utopia/assets/1081051/ef4afb31-fb9d-4fbe-b3ee-8a840b97576f

