### PR TITLE
Projects page: categories for public/private/shared

### DIFF
--- a/utopia-remix/app/components/projectActionContextMenu.tsx
+++ b/utopia-remix/app/components/projectActionContextMenu.tsx
@@ -93,6 +93,9 @@ export const ProjectActionsMenu = React.memo(
     const menuEntries = React.useMemo((): ContextMenuEntry[] => {
       switch (selectedCategory) {
         case 'allProjects':
+        case 'public':
+        case 'shared':
+        case 'private':
           return [
             {
               text: 'Open',

--- a/utopia-remix/app/components/projectActionContextMenu.tsx
+++ b/utopia-remix/app/components/projectActionContextMenu.tsx
@@ -192,7 +192,7 @@ export const ProjectActionsMenu = React.memo(
                 onSelect={onOpenShareDialog}
               >
                 <Flex justify={'between'} align={'center'} width={'100%'}>
-                  <Text>Share</Text>
+                  <Text>Sharing…</Text>
                   {when(
                     pendingAccessRequests.length > 0,
                     <DotFilledIcon color='red' height={22} width={22} />,

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -581,7 +581,7 @@ const NoProjectsMessage = React.memo(() => {
       case 'private':
         return 'Projects you create that are private to you.'
       case 'shared':
-        return 'Projects that you shared to other collaborators.'
+        return 'Projects that you have shared with other collaborators.'
       default:
         assertNever(cat)
     }

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -261,27 +261,17 @@ const Sidebar = React.memo(({ user }: { user: UserDetails }) => {
         <Flex direction='column' gap='2'>
           {Object.entries(categories).map(([category, data]) => {
             return (
-              <React.Fragment key={`category-${category}`}>
-                {when(
-                  category === 'trash',
-                  <div
-                    style={{
-                      height: 1,
-                      background: '#eee', // TODO pick a good color
-                    }}
-                  />,
-                )}
-                <button
-                  className={projectCategoryButton({
-                    color:
-                      category === selectedCategory && searchQuery === '' ? 'selected' : 'neutral',
-                  })}
-                  onClick={handleSelectCategory(category)}
-                >
-                  {data.icon}
-                  <Text size='1'>{data.name}</Text>
-                </button>
-              </React.Fragment>
+              <button
+                key={`category-${category}`}
+                className={projectCategoryButton({
+                  color:
+                    category === selectedCategory && searchQuery === '' ? 'selected' : 'neutral',
+                })}
+                onClick={handleSelectCategory(category)}
+              >
+                {data.icon}
+                <Text size='1'>{data.name}</Text>
+              </button>
             )
           })}
         </Flex>

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -69,7 +69,7 @@ export type Category = (typeof Categories)[number]
 const categories: { [key in Category]: { name: string; icon: React.ReactNode } } = {
   allProjects: { name: 'All My Projects', icon: <CubeIcon width='16' height='16' /> },
   private: { name: 'Private', icon: <LockClosedIcon width='16' height='16' /> },
-  shared: { name: 'Shared', icon: <PersonIcon width='16' height='16' /> },
+  shared: { name: 'Sharing', icon: <PersonIcon width='16' height='16' /> },
   public: { name: 'Public', icon: <GlobeIcon width='16' height='16' /> },
   trash: { name: 'Trash', icon: <TrashIcon width='16' height='16' /> },
 }

--- a/utopia-remix/app/util/use-sort-compare-project.tsx
+++ b/utopia-remix/app/util/use-sort-compare-project.tsx
@@ -53,6 +53,9 @@ export function useProjectIsOnActiveOperation() {
       return !activeOperations.some((op) => {
         switch (selectedCategory) {
           case 'allProjects':
+          case 'public':
+          case 'private':
+          case 'shared':
             return op.type === 'delete' && op.projectId === project.proj_id
           case 'trash':
             return (


### PR DESCRIPTION
Fix #5083

https://github.com/concrete-utopia/utopia/assets/1081051/5827e236-72b6-4d06-b8cb-6720c12f64f4

This PR adds three categories to the sidebar: private, public, and shared (as in: collaborative projects you own).

This is just UI work, more will come later including `shared with me` which involves backend stuff.

An incremental PR should also add category separators/groups for the sidebar.