### PR TITLE
React Router Error Boundaries Refresh Mitigation

### DIFF
--- a/editor/src/components/canvas/remix/remix-error-handling.test-utils.tsx
+++ b/editor/src/components/canvas/remix/remix-error-handling.test-utils.tsx
@@ -11,7 +11,7 @@ import { mouseClickAtPoint } from '../event-helpers.test-utils'
 import { DefaultStartingFeatureSwitches, renderTestEditorWithModel } from '../ui-jsx.test-utils'
 import type { EditorRenderResult } from '../ui-jsx.test-utils'
 
-async function renderRemixProject(project: PersistentModel) {
+export async function renderRemixProject(project: PersistentModel) {
   const renderResult = await renderTestEditorWithModel(
     project,
     'await-first-dom-report',
@@ -103,6 +103,49 @@ function createProject(withBoundary: boolean) {
     export default function Thrower() {
       throw new Error('${ErrorText}')
       return <h1>I won't render</h1>
+    }
+    `,
+  })
+}
+
+export function createMaybeFailingProject(induceFailure: boolean): PersistentModel {
+  return createModifiedProject({
+    [StoryboardFilePath]: `import * as React from 'react'
+    import { RemixScene, Storyboard } from 'utopia-api'
+    
+    export var storyboard = (
+      <Storyboard>
+        <RemixScene
+          style={{
+            width: 700,
+            height: 759,
+            position: 'absolute',
+            left: 212,
+            top: 128,
+          }}
+        />
+      </Storyboard>
+    )
+    `,
+    ['/app/root.js']: `import React from 'react'
+    import { Outlet } from '@remix-run/react'
+    
+    export default function Root() {
+      return (
+        <div>
+          <Outlet />
+        </div>
+      )
+    }
+    `,
+    ['/app/routes/_index.js']: `import React from 'react'
+    import { Link } from '@remix-run/react'
+    
+    export default function Index() {
+      ${induceFailure ? '' : '// '}throw new Error('Failure')
+      return (
+        <span>Index Content</span>
+      )
     }
     `,
   })

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -115,7 +115,10 @@ import {
   updateNodeModulesContents,
 } from '../editor/actions/action-creators'
 import { EditorModes } from '../editor/editor-modes'
-import { useUpdateOnRuntimeErrors } from '../../core/shared/runtime-report-logs'
+import {
+  hasReactRouterErrorBeenLogged,
+  useUpdateOnRuntimeErrors,
+} from '../../core/shared/runtime-report-logs'
 import type { RuntimeErrorInfo } from '../../core/shared/code-exec-utils'
 import { clearListOfEvaluatedFiles } from '../../core/shared/code-exec-utils'
 import { createTestProjectWithCode } from '../../sample-projects/sample-project-utils.test-utils'
@@ -408,6 +411,7 @@ export async function renderTestEditorWithModel(
         'Follow up actions took too long.',
       )
     }
+    const reactRouterErrorPreviouslyLogged = hasReactRouterErrorBeenLogged()
 
     flushSync(() => {
       canvasStoreHook.setState(patchedStoreFromFullStore(workingEditorState, 'canvas-store'))
@@ -520,6 +524,7 @@ export async function renderTestEditorWithModel(
       actions,
       originalEditorState,
       workingEditorState,
+      reactRouterErrorPreviouslyLogged,
     )
 
     // update state with new metadata

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -92,6 +92,7 @@ import { isSteganographyEnabled } from '../../../core/shared/stegano-text'
 import { updateCollaborativeProjectContents } from './collaborative-editing'
 import { updateProjectServerStateInStore } from './project-server-state'
 import { ensureSceneIdsExist } from '../../../core/model/scene-id-utils'
+import { setReactRouterErrorHasBeenLogged } from '../../../core/shared/runtime-report-logs'
 
 type DispatchResultFields = {
   nothingChanged: boolean
@@ -477,11 +478,24 @@ export function editorDispatchActionRunner(
   return result
 }
 
+function reactRouterErrorTriggeredReset(
+  editor: EditorState,
+  reactRouterErrorPreviouslyLogged: boolean,
+): EditorState {
+  if (reactRouterErrorPreviouslyLogged) {
+    setReactRouterErrorHasBeenLogged(false)
+    return UPDATE_FNS.RESET_CANVAS(EditorActions.resetCanvas(), editor)
+  } else {
+    return editor
+  }
+}
+
 export function editorDispatchClosingOut(
   boundDispatch: EditorDispatch,
   dispatchedActions: readonly EditorAction[],
   storedState: EditorStoreFull,
   result: DispatchResult,
+  reactRouterErrorPreviouslyLogged: boolean,
 ): DispatchResult {
   const actionGroupsToProcess = dispatchedActions.reduce(reducerToSplitToActionGroups, [[]])
   const isLoadAction = dispatchedActions.some((a) => a.action === 'LOAD')
@@ -695,6 +709,13 @@ export function editorDispatchClosingOut(
         ...finalStoreV1Final.unpatchedEditor,
         filesModifiedByAnotherUser: updatedFilesModifiedByElsewhere,
       },
+    }
+
+    if (filesChanged.length > 0) {
+      finalStoreV1Final.unpatchedEditor = reactRouterErrorTriggeredReset(
+        finalStoreV1Final.unpatchedEditor,
+        reactRouterErrorPreviouslyLogged,
+      )
     }
   }
 

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -124,6 +124,7 @@ import {
   LoadActionsDispatched,
 } from '../components/github/github-repository-clone-flow'
 import ProjectNotFound from './project-not-found/ProjectNotFound'
+import { hasReactRouterErrorBeenLogged } from '../core/shared/runtime-report-logs'
 
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()
@@ -448,6 +449,8 @@ export class Editor {
       this.storedState = dispatchResult
       let entireUpdateFinished = dispatchResult.entireUpdateFinished
 
+      const reactRouterErrorPreviouslyLogged = hasReactRouterErrorBeenLogged()
+
       const shouldRunDOMWalker =
         !dispatchResult.nothingChanged ||
         dispatchedActions.some((a) => a.action === 'RUN_DOM_WALKER')
@@ -558,6 +561,7 @@ export class Editor {
             entireUpdateFinished: entireUpdateFinished,
             nothingChanged: dispatchResult.nothingChanged,
           },
+          reactRouterErrorPreviouslyLogged,
         )
 
         Measure.taskTime(`Update Editor ${updateId}`, () => {


### PR DESCRIPTION
**Problem:**
If a modification is made to a React Router project such that it causes an error within a component, making a change to fix the error doesn't result in the error going away.

**Cause:**
The origin of this is that the errors are being held in state in some error boundaries, since those are not changing their state does not change so they continue to display the error held in their state.

**Fix:**
This is a candidate fix which specifically catches the error logs which the React Router error boundaries generate. When one of these log lines is observed, a flag is flipped to record that fact. Should another change to the project contents be triggered while that flag is set, then a `RESET_CANVAS` action is fired causing the canvas to remount triggering a full re-render resulting in the error clearing from those error boundaries.

**Commit Details:**
- Added flag to record that a react router error has been logged.
- `useUpdateOnConsoleLogs` checks for the specific log lines that React Router fires from some of its error boundaries.
- Added `reactRouterErrorTriggeredReset` utility function.
- In `editorDispatchClosingOut` if some files have changed (from an update after an error has been seen), then trigger the check to see if the canvas should be reset.
