### PR TITLE
Internal property controls

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/component-renderer-component.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/component-renderer-component.tsx
@@ -1,4 +1,4 @@
-import type { PropertyControls } from 'utopia-api/core'
+import type { PropertyControls } from '../../custom-code/internal-property-controls'
 import type { UTOPIA_INSTANCE_PATH, UTOPIA_PATH_KEY } from '../../../core/model/utopia-constants'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -16,7 +16,8 @@ import type { RawSourceMap } from '../../core/workers/ts/ts-typings/RawSourceMap
 import type { EmitFileResult } from '../../core/workers/ts/ts-worker'
 import Utils from '../../utils/utils'
 
-import type { PreferredChildComponent, PropertyControls } from 'utopia-api/core'
+import type { PropertyControls } from './internal-property-controls'
+import type { PreferredChildComponent } from 'utopia-api/core'
 import type { BuiltInDependencies } from '../../core/es-modules/package-manager/built-in-dependencies-list'
 import { resolveModulePath } from '../../core/es-modules/package-manager/module-resolution'
 import type { EvaluationCache } from '../../core/es-modules/package-manager/package-manager'
@@ -119,6 +120,12 @@ export function componentInfo(
     elementToInsert: elementToInsert,
     importsToAdd: importsToAdd,
   }
+}
+
+export interface PreferredChildComponentDescriptor {
+  name: string
+  imports: Imports
+  variants: Array<ComponentInfo>
 }
 
 export interface ComponentDescriptor {

--- a/editor/src/components/custom-code/internal-property-controls.ts
+++ b/editor/src/components/custom-code/internal-property-controls.ts
@@ -1,0 +1,348 @@
+import type { CSSProperties } from 'react'
+import type { PreferredChildComponent } from 'utopia-api'
+
+export type BaseControlType =
+  | 'checkbox'
+  | 'color'
+  | 'euler'
+  | 'expression-input'
+  | 'expression-popuplist'
+  | 'matrix3'
+  | 'matrix4'
+  | 'none'
+  | 'number-input'
+  | 'popuplist'
+  | 'radio'
+  | 'string-input'
+  | 'html-input'
+  | 'style-controls'
+  | 'vector2'
+  | 'vector3'
+  | 'vector4'
+  | 'jsx'
+
+export interface CheckboxControlDescription {
+  control: 'checkbox'
+  label?: string
+  visibleByDefault?: boolean
+  disabledTitle?: string
+  enabledTitle?: string
+  required?: boolean
+  defaultValue?: unknown
+}
+
+export interface ColorControlDescription {
+  control: 'color'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: unknown
+}
+
+export type AllowedEnumType = string | boolean | number | undefined | null
+
+export interface BasicControlOption<T> {
+  value: T
+  label: string
+}
+
+export type BasicControlOptions<T> = AllowedEnumType[] | BasicControlOption<T>[]
+
+export interface PopUpListControlDescription {
+  control: 'popuplist'
+  label?: string
+  visibleByDefault?: boolean
+  options: BasicControlOptions<unknown>
+  required?: boolean
+  defaultValue?: AllowedEnumType | BasicControlOption<unknown>
+}
+export interface ImportType {
+  source: string
+  name: string | null
+  type: 'star' | 'default' | null
+}
+
+export interface ExpressionControlOption<T> {
+  value: T
+  expression: string
+  label?: string
+  requiredImport?: ImportType
+}
+
+export interface ExpressionPopUpListControlDescription {
+  control: 'expression-popuplist'
+  label?: string
+  visibleByDefault?: boolean
+  options: ExpressionControlOption<unknown>[]
+  required?: boolean
+  defaultValue?: unknown
+}
+
+export interface EulerControlDescription {
+  control: 'euler'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: [number, number, number, string]
+}
+
+export interface NoneControlDescription {
+  control: 'none'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: unknown
+}
+
+export type Matrix3 = [number, number, number, number, number, number, number, number, number]
+
+export interface Matrix3ControlDescription {
+  control: 'matrix3'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: Matrix3
+}
+
+export type Matrix4 = [
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+]
+
+export interface Matrix4ControlDescription {
+  control: 'matrix4'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: Matrix4
+}
+
+export interface NumberInputControlDescription {
+  control: 'number-input'
+  label?: string
+  visibleByDefault?: boolean
+  max?: number
+  min?: number
+  unit?: string
+  step?: number
+  displayStepper?: boolean
+  required?: boolean
+  defaultValue?: unknown
+}
+
+export interface RadioControlDescription {
+  control: 'radio'
+  label?: string
+  visibleByDefault?: boolean
+  options: BasicControlOptions<unknown>
+  required?: boolean
+  defaultValue?: AllowedEnumType | BasicControlOption<unknown>
+}
+
+export interface ExpressionInputControlDescription {
+  control: 'expression-input'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: unknown
+}
+
+export interface StringInputControlDescription {
+  control: 'string-input'
+  label?: string
+  visibleByDefault?: boolean
+  placeholder?: string
+  obscured?: boolean
+  required?: boolean
+  defaultValue?: unknown
+}
+
+export interface HtmlInputControlDescription {
+  control: 'html-input'
+  label?: string
+  visibleByDefault?: boolean
+  placeholder?: string
+  obscured?: boolean
+  required?: boolean
+  defaultValue?: unknown
+}
+
+export interface StyleControlsControlDescription {
+  control: 'style-controls'
+  label?: string
+  visibleByDefault?: boolean
+  placeholder?: CSSProperties
+  required?: boolean
+  defaultValue?: unknown
+}
+
+export interface Vector2ControlDescription {
+  control: 'vector2'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: [number, number]
+}
+
+export interface Vector3ControlDescription {
+  control: 'vector3'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: [number, number, number]
+}
+
+export interface Vector4ControlDescription {
+  control: 'vector4'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: [number, number, number, number]
+}
+
+export interface JSXControlDescription {
+  control: 'jsx'
+  label?: string
+  visibleByDefault?: boolean
+  preferredChildComponents?: Array<PreferredChildComponent>
+  required?: boolean
+  defaultValue?: unknown
+}
+export declare type BaseControlDescription =
+  | CheckboxControlDescription
+  | ColorControlDescription
+  | ExpressionInputControlDescription
+  | ExpressionPopUpListControlDescription
+  | EulerControlDescription
+  | NoneControlDescription
+  | Matrix3ControlDescription
+  | Matrix4ControlDescription
+  | NumberInputControlDescription
+  | RadioControlDescription
+  | PopUpListControlDescription
+  | StringInputControlDescription
+  | HtmlInputControlDescription
+  | StyleControlsControlDescription
+  | Vector2ControlDescription
+  | Vector3ControlDescription
+  | Vector4ControlDescription
+  | JSXControlDescription
+
+export type HigherLevelControlType = 'array' | 'tuple' | 'object' | 'union'
+
+export type RegularControlType = BaseControlType | HigherLevelControlType
+
+export type ControlType = RegularControlType | 'folder'
+
+export interface ArrayControlDescription {
+  control: 'array'
+  label?: string
+  visibleByDefault?: boolean
+  propertyControl: RegularControlDescription
+  maxCount?: number
+  required?: boolean
+  defaultValue?: unknown
+}
+
+export interface ObjectControlDescription {
+  control: 'object'
+  label?: string
+  visibleByDefault?: boolean
+  object: {
+    [prop: string]: RegularControlDescription
+  }
+  required?: boolean
+  defaultValue?: unknown
+}
+
+export interface UnionControlDescription {
+  control: 'union'
+  label?: string
+  visibleByDefault?: boolean
+  controls: Array<RegularControlDescription>
+  required?: boolean
+  defaultValue?: unknown
+}
+
+export interface TupleControlDescription {
+  control: 'tuple'
+  label?: string
+  visibleByDefault?: boolean
+  propertyControls: RegularControlDescription[]
+  required?: boolean
+  defaultValue?: unknown
+}
+
+export interface FolderControlDescription {
+  control: 'folder'
+  label?: string
+  controls: PropertyControls
+}
+
+export type HigherLevelControlDescription =
+  | ArrayControlDescription
+  | ObjectControlDescription
+  | TupleControlDescription
+  | UnionControlDescription
+
+export type RegularControlDescription = BaseControlDescription | HigherLevelControlDescription
+export type ControlDescription = RegularControlDescription | FolderControlDescription
+
+export type PropertyControls = {
+  [key: string]: ControlDescription
+}
+
+export function isBaseControlDescription(
+  control: ControlDescription,
+): control is BaseControlDescription {
+  switch (control.control) {
+    case 'checkbox':
+    case 'color':
+    case 'euler':
+    case 'expression-input':
+    case 'expression-popuplist':
+    case 'matrix3':
+    case 'matrix4':
+    case 'none':
+    case 'number-input':
+    case 'popuplist':
+    case 'radio':
+    case 'string-input':
+    case 'html-input':
+    case 'style-controls':
+    case 'vector2':
+    case 'vector3':
+    case 'vector4':
+    case 'jsx':
+      return true
+    case 'array':
+    case 'object':
+    case 'tuple':
+    case 'union':
+    case 'folder':
+      return false
+    default:
+      const _exhaustiveCheck: never = control
+      throw new Error(`Unhandled controls ${JSON.stringify(control)}`)
+  }
+}
+
+export function isHigherLevelControlDescription(
+  control: ControlDescription,
+): control is HigherLevelControlDescription {
+  return !isBaseControlDescription(control)
+}

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -78,7 +78,7 @@ import {
   exportType,
   singleFileBuildResult,
 } from '../../../core/workers/common/worker-types'
-import type { PreferredChildComponent, PropertyControls, Sides } from 'utopia-api/core'
+import type { PreferredChildComponent, Sides } from 'utopia-api/core'
 import type {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
@@ -575,6 +575,7 @@ import type {
 import type { CommentFilterMode } from '../../inspector/sections/comment-section'
 import type { Collaborator } from '../../../core/shared/multiplayer'
 import type { MultiplayerSubstate } from './store-hook-substore-types'
+import type { PropertyControls } from '../../custom-code/internal-property-controls'
 
 export const ProjectMetadataFromServerKeepDeepEquality: KeepDeepEqualityCall<ProjectMetadataFromServer> =
   combine3EqualityCalls(

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -32,7 +32,7 @@ import {
   jsxElementWithoutUID,
   sameFileOrigin,
 } from '../../../core/shared/element-template'
-import type { PropertyControls } from 'utopia-api/core'
+import type { PropertyControls } from '../../custom-code/internal-property-controls'
 import { emptyProjectServerState } from '../../editor/store/project-server-state'
 
 const TestAppUID2 = 'app-entity-2'

--- a/editor/src/components/inspector/common/property-controls-hooks.ts
+++ b/editor/src/components/inspector/common/property-controls-hooks.ts
@@ -9,7 +9,10 @@ import {
   controlToUseForUnion,
   getPropertyControlNames,
 } from '../../../core/property-controls/property-control-values'
-import type { UnionControlDescription, RegularControlDescription } from 'utopia-api/core'
+import type {
+  UnionControlDescription,
+  RegularControlDescription,
+} from '../../custom-code/internal-property-controls'
 import type { InspectorInfo, InspectorInfoWithRawValue } from './property-path-hooks'
 import {
   filterUtopiaSpecificProps,
@@ -45,9 +48,9 @@ import {
 } from '../../editor/store/store-deep-equality-instances'
 import { arrayDeepEquality } from '../../../utils/deep-equality'
 import { omit } from '../../../core/shared/object-utils'
-import type { PropertyControls } from 'utopia-api/core'
 import type { AllElementProps } from '../../../components/editor/store/editor-state'
 import * as EP from '../../../core/shared/element-path'
+import type { PropertyControls } from '../../custom-code/internal-property-controls'
 
 type RawValues = Either<string, ModifiableAttribute>[]
 type RealValues = unknown[]

--- a/editor/src/components/inspector/sections/component-section/component-section-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/component-section-utils.ts
@@ -1,5 +1,5 @@
 import React from 'react'
-import type { RegularControlDescription } from 'utopia-api/core'
+import type { RegularControlDescription } from '../../../custom-code/internal-property-controls'
 import { parseStringValidateAsColor } from '../../../../core/property-controls/property-controls-parser'
 import { isLeft } from '../../../../core/shared/either'
 import { mapValues } from '../../../../core/shared/object-utils'

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -12,13 +12,8 @@ import type {
   RegularControlDescription,
   TupleControlDescription,
   UnionControlDescription,
-} from 'utopia-api/core'
-import {
-  FolderControlDescription,
-  HigherLevelControlDescription,
-  isBaseControlDescription,
-  PropertyControls,
-} from 'utopia-api/core'
+} from '../../../custom-code/internal-property-controls'
+import { isBaseControlDescription } from '../../../custom-code/internal-property-controls'
 import { PathForSceneProps } from '../../../../core/model/scene-utils'
 import { mapToArray } from '../../../../core/shared/object-utils'
 import type { PropertyPath } from '../../../../core/shared/project-file-types'

--- a/editor/src/components/inspector/sections/component-section/folder-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/folder-section.tsx
@@ -4,7 +4,10 @@ import React from 'react'
 import { css, jsx } from '@emotion/react'
 import { unless, when } from '../../../../utils/react-conditionals'
 import type { CSSCursor } from '../../../canvas/canvas-types'
-import type { ControlDescription } from 'utopia-api/core'
+import type {
+  ControlDescription,
+  PropertyControls,
+} from '../../../custom-code/internal-property-controls'
 import { inferControlTypeBasedOnValue } from './component-section-utils'
 import { HiddenControls } from './hidden-controls-section'
 import * as PP from '../../../../core/shared/property-path'
@@ -14,7 +17,6 @@ import { RowForControl } from './component-section'
 import { InspectorWidthAtom } from '../../common/inspector-atoms'
 import { useAtom } from 'jotai'
 import { specialPropertiesToIgnore } from '../../../../core/property-controls/property-controls-utils'
-import type { PropertyControls } from 'utopia-api/core'
 
 interface FolderSectionProps {
   isRoot: boolean

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -24,7 +24,7 @@ import type {
   Vector2ControlDescription,
   Vector3ControlDescription,
   Vector4ControlDescription,
-} from 'utopia-api/core'
+} from '../../../custom-code/internal-property-controls'
 import type { InspectorInfo, InspectorInfoWithRawValue } from '../../common/property-path-hooks'
 import { BooleanControl } from '../../controls/boolean-control'
 import type { NumberInputProps } from '../../../../uuiui'

--- a/editor/src/components/inspector/sections/component-section/property-controls-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-controls-section.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
-import type { PropertyControls } from 'utopia-api/core'
+import type { PropertyControls } from '../../../custom-code/internal-property-controls'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { setCursorOverlay } from '../../../editor/actions/action-creators'
 import { useKeepReferenceEqualityIfPossible } from '../../../../utils/react-performance'

--- a/editor/src/components/inspector/sections/component-section/row-or-folder-wrapper.tsx
+++ b/editor/src/components/inspector/sections/component-section/row-or-folder-wrapper.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type { ControlDescription } from 'utopia-api/core'
+import type { ControlDescription } from '../../../custom-code/internal-property-controls'
 import type { PropertyPath } from '../../../../core/shared/project-file-types'
 import type { CSSCursor } from '../../../canvas/canvas-types'
 import { UIGridRow } from '../../widgets/ui-grid-row'

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -2,7 +2,7 @@ import type {
   ControlDescription,
   ArrayControlDescription,
   ObjectControlDescription,
-} from 'utopia-api/core'
+} from '../../../custom-code/internal-property-controls'
 import type { ElementPath, PropertyPath } from '../../../../core/shared/project-file-types'
 import type { VariableData } from '../../../canvas/ui-jsx-canvas'
 import { useEditorState, Substores } from '../../../editor/store/store-hook'

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -37,7 +37,7 @@ import { findUtopiaCommentFlag, isUtopiaCommentFlagMapCount } from '../../core/s
 import { getPropertyControlsForTarget } from '../../core/property-controls/property-controls-utils'
 import type { PropertyControlsInfo } from '../custom-code/code-file'
 import type { ProjectContentTreeRoot } from '../assets'
-import type { PropertyControls } from 'utopia-api/core'
+import type { PropertyControls } from '../custom-code/internal-property-controls'
 import { isFeatureEnabled } from '../../utils/feature-switches'
 
 export function baseNavigatorDepth(path: ElementPath): number {

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -1,4 +1,4 @@
-import type { PropertyControls } from 'utopia-api/core'
+import type { PropertyControls } from '../custom-code/internal-property-controls'
 import { URL_HASH } from '../../common/env-vars'
 import {
   hasStyleControls,

--- a/editor/src/core/property-controls/property-control-values.spec.ts
+++ b/editor/src/core/property-controls/property-control-values.spec.ts
@@ -11,8 +11,7 @@ import type {
   UnionControlDescription,
   RegularControlDescription,
   ExpressionInputControlDescription,
-} from 'utopia-api/core'
-import { ControlDescription } from 'utopia-api/core'
+} from '../../components/custom-code/internal-property-controls'
 import type { JSExpression } from '../shared/element-template'
 import {
   jsxArrayValue,

--- a/editor/src/core/property-controls/property-control-values.ts
+++ b/editor/src/core/property-controls/property-control-values.ts
@@ -20,8 +20,7 @@ import type {
   FolderControlDescription,
   PropertyControls,
   RegularControlDescription,
-} from 'utopia-api/core'
-import { isBaseControlDescription, HigherLevelControlDescription } from 'utopia-api/core'
+} from '../../components/custom-code/internal-property-controls'
 import type { CSSColor } from '../../components/inspector/common/css-utils'
 import {
   parseColor,
@@ -58,6 +57,7 @@ import type { PropertyPathPart } from '../shared/project-file-types'
 import * as PP from '../shared/property-path'
 import { forEachValue, mapToArray, objectValues } from '../shared/object-utils'
 import { jsxSimpleAttributeToValue } from '../shared/jsx-attribute-utils'
+
 type Printer<T> = (value: T) => JSExpression
 
 export function parseColorValue(value: unknown): ParseResult<CSSColor> {

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -7,7 +7,7 @@ import type {
   ComponentInsertOption,
   PreferredChildComponent,
 } from 'utopia-api/core'
-import type { PropertyControls } from '../../components/custom-code/internal-property-controls'
+import type { PropertyControls } from 'utopia-api/core'
 import type { ProjectContentTreeRoot } from '../../components/assets'
 import { packageJsonFileFromProjectContents } from '../../components/assets'
 import type {
@@ -106,7 +106,6 @@ async function componentDescriptorForComponentToRegister(
   const parsedVariantsUnsequenced = await Promise.all(parsedInsertOptionPromises)
   const parsedVariants = sequenceEither(parsedVariantsUnsequenced)
 
-  // TODO
   return mapEither((variants) => {
     return {
       componentName: componentName,

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -5,9 +5,9 @@ import type {
   registerExternalComponent as registerExternalComponentAPI,
   ComponentToRegister,
   ComponentInsertOption,
-  PropertyControls,
   PreferredChildComponent,
 } from 'utopia-api/core'
+import type { PropertyControls } from '../../components/custom-code/internal-property-controls'
 import type { ProjectContentTreeRoot } from '../../components/assets'
 import { packageJsonFileFromProjectContents } from '../../components/assets'
 import type {
@@ -106,6 +106,7 @@ async function componentDescriptorForComponentToRegister(
   const parsedVariantsUnsequenced = await Promise.all(parsedInsertOptionPromises)
   const parsedVariants = sequenceEither(parsedVariantsUnsequenced)
 
+  // TODO
   return mapEither((variants) => {
     return {
       componentName: componentName,

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -1,25 +1,13 @@
 import type { PropertyControlsInfo } from '../../components/custom-code/code-file'
-import { ParsedPropertyControls } from './property-controls-parser'
-import type { PropertyControls } from 'utopia-api/core'
-import { ImportType } from 'utopia-api/core'
-import { isRight, foldEither, left, maybeEitherToMaybe, eitherToMaybe } from '../shared/either'
-import { forEachValue } from '../shared/object-utils'
-import { descriptionParseError, ParseResult } from '../../utils/value-parser-utils'
 import type { JSXElementChild } from '../shared/element-template'
 import {
   getJSXElementNameAsString,
   isIntrinsicHTMLElement,
-  JSXElement,
   isIntrinsicElement,
   isJSXElement,
 } from '../shared/element-template'
-import type {
-  NodeModules,
-  ParseSuccess,
-  StaticElementPath,
-  ElementPath,
-} from '../shared/project-file-types'
-import type { DerivedState, EditorState } from '../../components/editor/store/editor-state'
+import type { ParseSuccess, StaticElementPath, ElementPath } from '../shared/project-file-types'
+import type { EditorState } from '../../components/editor/store/editor-state'
 import {
   getOpenUIJSFileKey,
   withUnderlyingTarget,
@@ -29,7 +17,7 @@ import type { ProjectContentTreeRoot } from '../../components/assets'
 import { importedFromWhere } from '../../components/editor/import-utils'
 import { absolutePathFromRelativePath } from '../../utils/path-utils'
 import { getThirdPartyControlsIntrinsic } from './property-controls-local'
-import type { RemixRoutingTable } from '../../components/editor/store/remix-derived-data'
+import type { PropertyControls } from '../../components/custom-code/internal-property-controls'
 
 export function propertyControlsForComponentInFile(
   componentName: string,

--- a/editor/src/core/property-controls/third-party-property-controls/antd-controls.ts
+++ b/editor/src/core/property-controls/third-party-property-controls/antd-controls.ts
@@ -1,4 +1,4 @@
-import type { PropertyControls } from 'utopia-api/core'
+import type { PropertyControls } from '../../../components/custom-code/internal-property-controls'
 
 const Button: PropertyControls = {
   href: {

--- a/editor/src/core/property-controls/third-party-property-controls/react-three-fiber-controls.ts
+++ b/editor/src/core/property-controls/third-party-property-controls/react-three-fiber-controls.ts
@@ -1,12 +1,11 @@
-import type { MapLike } from 'typescript'
+import { expression, importStar } from 'utopia-api/core'
 import type {
-  ControlDescription,
   ObjectControlDescription,
   Vector2ControlDescription,
-  Vector3ControlDescription,
+  ControlDescription,
   PropertyControls,
-} from 'utopia-api/core'
-import { expression, importStar } from 'utopia-api/core'
+  Vector3ControlDescription,
+} from '../../../components/custom-code/internal-property-controls'
 
 const Vector3: Vector3ControlDescription = {
   control: 'vector3',

--- a/editor/src/core/property-controls/third-party-property-controls/utopia-api-controls.ts
+++ b/editor/src/core/property-controls/third-party-property-controls/utopia-api-controls.ts
@@ -1,4 +1,4 @@
-import type { PropertyControls } from 'utopia-api/core'
+import type { PropertyControls } from '../../../components/custom-code/internal-property-controls'
 
 const StyleObjectProps: PropertyControls = {
   style: {

--- a/editor/src/core/third-party/antd-components.ts
+++ b/editor/src/core/third-party/antd-components.ts
@@ -1,5 +1,5 @@
 import { AntdControls } from '../property-controls/third-party-property-controls/antd-controls'
-import type { PropertyControls } from 'utopia-api/core'
+import type { PropertyControls } from '../../components/custom-code/internal-property-controls'
 import type {
   ComponentDescriptor,
   ComponentDescriptorsForFile,

--- a/editor/src/core/third-party/html-intrinsic-elements.ts
+++ b/editor/src/core/third-party/html-intrinsic-elements.ts
@@ -1,4 +1,4 @@
-import type { PropertyControls } from 'utopia-api/core'
+import type { PropertyControls } from '../../components/custom-code/internal-property-controls'
 
 export const HtmlElementStyleObjectProps: PropertyControls = {
   style: {

--- a/editor/src/core/third-party/react-three-fiber-components.ts
+++ b/editor/src/core/third-party/react-three-fiber-components.ts
@@ -1,4 +1,4 @@
-import type { PropertyControls } from 'utopia-api/core'
+import type { PropertyControls } from '../../components/custom-code/internal-property-controls'
 import { ReactThreeFiberControls } from '../property-controls/third-party-property-controls/react-three-fiber-controls'
 import type {
   ComponentDescriptor,


### PR DESCRIPTION
## Problem
Consider the following `registerInteralComponent` call:
```typescript
registerInternalComponent(Chapter, {
  supportsChildren: false,
  properties: {
    title: {
      control: 'jsx',
      preferredChildComponents: [
        {
          name: 'Heading',
          additionalImports: 'src/ui-ib/heading',
          variants: [
            code: '<Heading>Chapter 1</Heading>
          ]
        }
      ]
    },
  },
  variants: []
}
```

To correctly insert the `Heading` element into the `title` prop, we need to insert the imports specified in the `additionalImports` corresponding to the `preferredChildComponents` in the `title` prop. However, in the `registerInternalComponent` schema, `PreferredChildComponent.additionalImports` is a string, so it needs to be parsed and turned into an `Imports` object that the editor can work with. This would be all well and good (we already do this for `ComponentToRegister.variants`, however, this isn't straightforward for `JSXControlDescription.preferredChildComponents`, since the types for the control definitions are shared between the editor and `utopia-api`. To have a parsed representation of `additionalImports` (and the actual elements to insert in `variants`), we need a different type for the JSX control in the editor (a type where `additionalImports` is `Imports`, instead of `string`).  This separation already exists for components passed to `registerInternalComponent` (`ComponentInsertOption` vs `ComponentDescriptor`).

## Fix

For now, duplicate the property control types in `utopia-api/src/property-control/property-controls.ts` to a new file, `editor/src/components/custom-code/internal-property-controls.ts`. In the editor, update all imports importing a property control to import the same thing from `internal-property-controls.ts`.