### PR TITLE
Add collaborator upon granting access

### DIFF
--- a/utopia-remix/app/models/projectAccessRequest.server.ts
+++ b/utopia-remix/app/models/projectAccessRequest.server.ts
@@ -5,6 +5,7 @@ import { ensure } from '../util/api.server'
 import { Status } from '../util/statusCodes'
 import type { ProjectAccessRequestWithUserDetails } from '../types'
 import { AccessRequestStatus, UserProjectRole } from '../types'
+import { addToProjectCollaboratorsWithRunner } from './projectCollaborators.server'
 
 function makeRequestToken(): string {
   return uuid.v4()
@@ -85,6 +86,10 @@ export async function updateAccessRequestStatus(params: {
 
     // …finally, grant the role.
     if (params.status === AccessRequestStatus.APPROVED) {
+      await addToProjectCollaboratorsWithRunner(tx, {
+        projectId: params.projectId,
+        userId: request.user_id,
+      })
       await permissionsService.grantProjectRoleToUser(
         params.projectId,
         request.user_id,

--- a/utopia-remix/app/models/projectCollaborators.server.spec.ts
+++ b/utopia-remix/app/models/projectCollaborators.server.spec.ts
@@ -81,29 +81,29 @@ describe('projectCollaborators model', () => {
     })
 
     it('errors if the project is not found', async () => {
-      const fn = async () => addToProjectCollaborators({ id: 'WRONG', userId: 'bob' })
+      const fn = async () => addToProjectCollaborators({ projectId: 'WRONG', userId: 'bob' })
       await expect(fn).rejects.toThrow('Foreign key constraint failed')
     })
     it('errors if the user is not found', async () => {
-      const fn = async () => addToProjectCollaborators({ id: 'one', userId: 'WRONG' })
+      const fn = async () => addToProjectCollaborators({ projectId: 'one', userId: 'WRONG' })
       await expect(fn).rejects.toThrow('Foreign key constraint failed')
     })
     it('does nothing if the user is already a collaborator', async () => {
-      await addToProjectCollaborators({ id: 'one', userId: 'bob' })
+      await addToProjectCollaborators({ projectId: 'one', userId: 'bob' })
       const collaborators = await prisma.projectCollaborator.findMany({
         where: { project_id: 'one' },
       })
       expect(collaborators.map((p) => p.user_id)).toEqual(['bob'])
     })
     it('adds the user to the collaborators if missing', async () => {
-      await addToProjectCollaborators({ id: 'one', userId: 'alice' })
+      await addToProjectCollaborators({ projectId: 'one', userId: 'alice' })
       let collaborators = await prisma.projectCollaborator.findMany({
         where: { project_id: 'one' },
         orderBy: { id: 'asc' },
       })
       expect(collaborators.map((p) => p.user_id)).toEqual(['bob', 'alice'])
 
-      await addToProjectCollaborators({ id: 'three', userId: 'alice' })
+      await addToProjectCollaborators({ projectId: 'three', userId: 'alice' })
       collaborators = await prisma.projectCollaborator.findMany({
         where: { project_id: 'three' },
         orderBy: { id: 'asc' },

--- a/utopia-remix/app/models/projectCollaborators.server.ts
+++ b/utopia-remix/app/models/projectCollaborators.server.ts
@@ -1,4 +1,5 @@
 import type { UserDetails } from 'prisma-client'
+import type { UtopiaPrismaClient } from '../db.server'
 import { prisma } from '../db.server'
 import type { CollaboratorsByProject } from '../types'
 import { userToCollaborator } from '../types'
@@ -21,20 +22,27 @@ export async function getCollaborators(params: {
 }
 
 export async function addToProjectCollaborators(params: {
-  id: string
+  projectId: string
   userId: string
 }): Promise<void> {
+  return addToProjectCollaboratorsWithRunner(prisma, params)
+}
+
+export async function addToProjectCollaboratorsWithRunner(
+  runner: Pick<UtopiaPrismaClient, 'projectCollaborator'>,
+  params: { projectId: string; userId: string },
+) {
   // the Prisma equivalent of INSERT ... ON CONFLICT DO NOTHING
-  await prisma.projectCollaborator.upsert({
+  await runner.projectCollaborator.upsert({
     where: {
       unique_project_collaborator_project_id_user_id: {
         user_id: params.userId,
-        project_id: params.id,
+        project_id: params.projectId,
       },
     },
     update: {},
     create: {
-      project_id: params.id,
+      project_id: params.projectId,
       user_id: params.userId,
     },
   })

--- a/utopia-remix/app/routes/internal.projects.$id.collaborators.tsx
+++ b/utopia-remix/app/routes/internal.projects.$id.collaborators.tsx
@@ -47,7 +47,7 @@ export async function addToCollaborators(req: Request, params: Params<string>) {
   const { id } = params
   ensure(id != null, 'id is null', Status.BAD_REQUEST)
 
-  await addToProjectCollaborators({ id: id, userId: user.user_id })
+  await addToProjectCollaborators({ projectId: id, userId: user.user_id })
 
   return {}
 }


### PR DESCRIPTION
**Problem:**

When access is granted to a user on a project, its user id should also be added to the collaborators in the DB.

**Fix:**

Do that, test that.