### PR TITLE
Remix: useFetcherData hook

### DIFF
--- a/utopia-remix/app/hooks/useFetcherData.tsx
+++ b/utopia-remix/app/hooks/useFetcherData.tsx
@@ -1,0 +1,21 @@
+import type { Fetcher } from '@remix-run/react'
+import React from 'react'
+
+export interface FetcherLike {
+  state: Fetcher['state']
+  data: unknown
+}
+
+export function useFetcherData<T>(
+  fetcher: FetcherLike,
+  dataValidator: (u: unknown) => u is T,
+  callback: (data: T) => void,
+) {
+  React.useEffect(() => {
+    if (fetcher.state === 'idle' && fetcher.data != null) {
+      if (dataValidator(fetcher.data)) {
+        callback(fetcher.data)
+      }
+    }
+  }, [fetcher.state, fetcher.data, dataValidator, callback])
+}

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -59,6 +59,7 @@ import {
   useSortCompareProject,
 } from '../util/use-sort-compare-project'
 import { SharingDialogWrapper } from '../components/sharingDialog'
+import { useFetcherData } from '../hooks/useFetcherData'
 
 const SortOptions = ['title', 'dateCreated', 'dateModified'] as const
 export type SortCriteria = (typeof SortOptions)[number]
@@ -661,13 +662,11 @@ const ProjectCard = React.memo(
       ProjectAccessRequestWithUserDetails[]
     >([])
 
-    React.useEffect(() => {
-      if (accessRequestsFetcher.state === 'idle' && accessRequestsFetcher.data != null) {
-        if (isProjectAccessRequestWithUserDetailsArray(accessRequestsFetcher.data)) {
-          setAccessRequests(accessRequestsFetcher.data)
-        }
-      }
-    }, [accessRequestsFetcher])
+    useFetcherData(
+      accessRequestsFetcher,
+      isProjectAccessRequestWithUserDetailsArray,
+      setAccessRequests,
+    )
 
     const handleSortMenuOpenChange = React.useCallback(() => {
       const action = `/internal/projects/${project.proj_id}/access/requests`
@@ -838,13 +837,11 @@ const ProjectRow = React.memo(
       ProjectAccessRequestWithUserDetails[]
     >([])
 
-    React.useEffect(() => {
-      if (accessRequestsFetcher.state === 'idle' && accessRequestsFetcher.data != null) {
-        if (isProjectAccessRequestWithUserDetailsArray(accessRequestsFetcher.data)) {
-          setAccessRequests(accessRequestsFetcher.data)
-        }
-      }
-    }, [accessRequestsFetcher])
+    useFetcherData(
+      accessRequestsFetcher,
+      isProjectAccessRequestWithUserDetailsArray,
+      setAccessRequests,
+    )
 
     const onContextMenuOpenChange = React.useCallback(() => {
       const action = `/internal/projects/${project.proj_id}/access/requests`


### PR DESCRIPTION
**Problem:**

Reacting to fetcher responses needs the use of a `useEffect` hook, but the usage is cumbersome and error-prone.

**Fix:**

Add a `useFetcherData` hook to make it easier and less error-prone, ensuring to pass a function that ensures the action is performed on the right type that came back with the response.

This also moves `useEffects` in a single place so we can track them down.