### PR TITLE
Remix projects: projects loader return pending requests flag

### DIFF
--- a/utopia-remix/app/components/projectActionContextMenu.tsx
+++ b/utopia-remix/app/components/projectActionContextMenu.tsx
@@ -27,174 +27,181 @@ function contextMenuEntry(
   return { text, onClick }
 }
 
-export const ProjectActionsMenu = React.memo(({ project }: { project: ProjectListing }) => {
-  const deleteFetcher = useFetcherWithOperation(project.proj_id, 'delete')
-  const destroyFetcher = useFetcherWithOperation(project.proj_id, 'destroy')
-  const restoreFetcher = useFetcherWithOperation(project.proj_id, 'restore')
-  const renameFetcher = useFetcherWithOperation(project.proj_id, 'rename')
-  const selectedCategory = useProjectsStore((store) => store.selectedCategory)
+export const ProjectActionsMenu = React.memo(
+  ({
+    // the project that can receive actions
+    project,
+  }: {
+    project: ProjectListing
+  }) => {
+    const deleteFetcher = useFetcherWithOperation(project.proj_id, 'delete')
+    const destroyFetcher = useFetcherWithOperation(project.proj_id, 'destroy')
+    const restoreFetcher = useFetcherWithOperation(project.proj_id, 'restore')
+    const renameFetcher = useFetcherWithOperation(project.proj_id, 'rename')
+    const selectedCategory = useProjectsStore((store) => store.selectedCategory)
 
-  const deleteProject = React.useCallback(
-    (projectId: string) => {
-      deleteFetcher.submit(
-        operationDelete(project),
-        {},
-        { method: 'POST', action: `/internal/projects/${projectId}/delete` },
-      )
-    },
-    [deleteFetcher, project],
-  )
-  const destroyProject = React.useCallback(
-    (projectId: string) => {
-      const ok = window.confirm('Are you sure? The project contents will be deleted permanently.')
-      if (ok) {
-        destroyFetcher.submit(
-          operationDestroy(project),
+    const deleteProject = React.useCallback(
+      (projectId: string) => {
+        deleteFetcher.submit(
+          operationDelete(project),
           {},
-          { method: 'POST', action: `/internal/projects/${projectId}/destroy` },
+          { method: 'POST', action: `/internal/projects/${projectId}/delete` },
         )
-      }
-    },
-    [destroyFetcher, project],
-  )
-
-  const restoreProject = React.useCallback(
-    (projectId: string) => {
-      restoreFetcher.submit(
-        operationRestore(project),
-        {},
-        { method: 'POST', action: `/internal/projects/${projectId}/restore` },
-      )
-    },
-    [restoreFetcher, project],
-  )
-
-  const renameProject = React.useCallback(
-    (projectId: string, newTitle: string) => {
-      renameFetcher.submit(
-        operationRename(project, slugify(newTitle, SLUGIFY_OPTIONS)),
-        { title: newTitle },
-        { method: 'POST', action: `/internal/projects/${projectId}/rename` },
-      )
-    },
-    [renameFetcher, project],
-  )
-
-  const projectEditorLink = useProjectEditorLink()
-  const copyProjectLink = useCopyProjectLinkToClipboard()
-
-  const actions = React.useMemo(
-    () => ({
-      open: contextMenuEntry('Open', (selectedProject) => {
-        window.open(projectEditorLink(selectedProject.proj_id), '_blank')
-      }),
-      copyLink: contextMenuEntry('Copy Link', (selectedProject) =>
-        copyProjectLink(selectedProject.proj_id),
-      ),
-      fork: contextMenuEntry('Fork', (selectedProject) => {
-        window.open(projectEditorLink(selectedProject.proj_id) + '/?fork=true', '_blank')
-      }),
-      rename: contextMenuEntry('Rename', (selectedProject) => {
-        const newTitle = window.prompt('New title:', selectedProject.title)
-        if (newTitle != null) {
-          renameProject(selectedProject.proj_id, newTitle)
-        }
-      }),
-      delete: contextMenuEntry('Delete', (selectedProject) => {
-        deleteProject(selectedProject.proj_id)
-      }),
-      restore: contextMenuEntry('Restore', (selectedProject) => {
-        restoreProject(selectedProject.proj_id)
-      }),
-      destroy: contextMenuEntry('Delete Permanently', (selectedProject) => {
-        destroyProject(selectedProject.proj_id)
-      }),
-    }),
-    [
-      projectEditorLink,
-      copyProjectLink,
-      renameProject,
-      deleteProject,
-      restoreProject,
-      destroyProject,
-    ],
-  )
-
-  const menuEntries = React.useMemo((): ContextMenuEntry[] => {
-    switch (selectedCategory) {
-      case 'allProjects':
-      case 'public':
-      case 'sharing':
-      case 'private':
-        return [
-          actions.open,
-          'separator',
-          actions.copyLink,
-          actions.fork,
-          'sharing-dialog',
-          'separator',
-          actions.rename,
-          actions.delete,
-        ]
-      case 'sharedWithMe':
-        return [actions.open, 'separator', actions.copyLink, actions.fork]
-      case 'trash':
-        return [actions.restore, 'separator', actions.destroy]
-      default:
-        assertNever(selectedCategory)
-    }
-  }, [selectedCategory, actions])
-
-  const setSharingProjectId = useProjectsStore((store) => store.setSharingProjectId)
-
-  const onOpenShareDialog = React.useCallback(() => {
-    setSharingProjectId(project.proj_id)
-  }, [project, setSharingProjectId])
-
-  return (
-    <ContextMenu.Content style={{ width: 170 }}>
-      {menuEntries.map((entry, index) => {
-        if (entry === 'separator') {
-          return (
-            <Separator
-              key={`separator-${index}`}
-              size='4'
-              style={{ marginTop: 5, marginBottom: 5 }}
-            />
+      },
+      [deleteFetcher, project],
+    )
+    const destroyProject = React.useCallback(
+      (projectId: string) => {
+        const ok = window.confirm('Are you sure? The project contents will be deleted permanently.')
+        if (ok) {
+          destroyFetcher.submit(
+            operationDestroy(project),
+            {},
+            { method: 'POST', action: `/internal/projects/${projectId}/destroy` },
           )
         }
-        if (entry === 'sharing-dialog') {
+      },
+      [destroyFetcher, project],
+    )
+
+    const restoreProject = React.useCallback(
+      (projectId: string) => {
+        restoreFetcher.submit(
+          operationRestore(project),
+          {},
+          { method: 'POST', action: `/internal/projects/${projectId}/restore` },
+        )
+      },
+      [restoreFetcher, project],
+    )
+
+    const renameProject = React.useCallback(
+      (projectId: string, newTitle: string) => {
+        renameFetcher.submit(
+          operationRename(project, slugify(newTitle, SLUGIFY_OPTIONS)),
+          { title: newTitle },
+          { method: 'POST', action: `/internal/projects/${projectId}/rename` },
+        )
+      },
+      [renameFetcher, project],
+    )
+
+    const projectEditorLink = useProjectEditorLink()
+    const copyProjectLink = useCopyProjectLinkToClipboard()
+
+    const actions = React.useMemo(
+      () => ({
+        open: contextMenuEntry('Open', (selectedProject) => {
+          window.open(projectEditorLink(selectedProject.proj_id), '_blank')
+        }),
+        copyLink: contextMenuEntry('Copy Link', (selectedProject) =>
+          copyProjectLink(selectedProject.proj_id),
+        ),
+        fork: contextMenuEntry('Fork', (selectedProject) => {
+          window.open(projectEditorLink(selectedProject.proj_id) + '/?fork=true', '_blank')
+        }),
+        rename: contextMenuEntry('Rename', (selectedProject) => {
+          const newTitle = window.prompt('New title:', selectedProject.title)
+          if (newTitle != null) {
+            renameProject(selectedProject.proj_id, newTitle)
+          }
+        }),
+        delete: contextMenuEntry('Delete', (selectedProject) => {
+          deleteProject(selectedProject.proj_id)
+        }),
+        restore: contextMenuEntry('Restore', (selectedProject) => {
+          restoreProject(selectedProject.proj_id)
+        }),
+        destroy: contextMenuEntry('Delete Permanently', (selectedProject) => {
+          destroyProject(selectedProject.proj_id)
+        }),
+      }),
+      [
+        projectEditorLink,
+        copyProjectLink,
+        renameProject,
+        deleteProject,
+        restoreProject,
+        destroyProject,
+      ],
+    )
+
+    const menuEntries = React.useMemo((): ContextMenuEntry[] => {
+      switch (selectedCategory) {
+        case 'allProjects':
+        case 'public':
+        case 'sharing':
+        case 'private':
+          return [
+            actions.open,
+            'separator',
+            actions.copyLink,
+            actions.fork,
+            'sharing-dialog',
+            'separator',
+            actions.rename,
+            actions.delete,
+          ]
+        case 'sharedWithMe':
+          return [actions.open, 'separator', actions.copyLink, actions.fork]
+        case 'trash':
+          return [actions.restore, 'separator', actions.destroy]
+        default:
+          assertNever(selectedCategory)
+      }
+    }, [selectedCategory, actions])
+
+    const setSharingProjectId = useProjectsStore((store) => store.setSharingProjectId)
+
+    const onOpenShareDialog = React.useCallback(() => {
+      setSharingProjectId(project.proj_id)
+    }, [project, setSharingProjectId])
+
+    return (
+      <ContextMenu.Content style={{ width: 170 }}>
+        {menuEntries.map((entry, index) => {
+          if (entry === 'separator') {
+            return (
+              <Separator
+                key={`separator-${index}`}
+                size='4'
+                style={{ marginTop: 5, marginBottom: 5 }}
+              />
+            )
+          }
+          if (entry === 'sharing-dialog') {
+            return (
+              <ContextMenu.Item
+                key={`entry-${index}`}
+                style={{ height: 28, fontSize: 12 }}
+                onSelect={onOpenShareDialog}
+              >
+                <Flex justify={'between'} align={'center'} width={'100%'}>
+                  <Text>Sharing…</Text>
+                  {when(
+                    project.hasPendingRequests === true,
+                    <DotFilledIcon color='red' height={22} width={22} />,
+                  )}
+                </Flex>
+              </ContextMenu.Item>
+            )
+          }
           return (
             <ContextMenu.Item
               key={`entry-${index}`}
+              /* eslint-disable-next-line react/jsx-no-bind */
+              onSelect={() => entry.onClick(project)}
               style={{ height: 28, fontSize: 12 }}
-              onSelect={onOpenShareDialog}
+              color={
+                entry.text === 'Delete Permanently' || entry.text === 'Delete' ? 'red' : undefined
+              }
             >
-              <Flex justify={'between'} align={'center'} width={'100%'}>
-                <Text>Sharing…</Text>
-                {when(
-                  project.hasPendingRequests === true,
-                  <DotFilledIcon color='red' height={22} width={22} />,
-                )}
-              </Flex>
+              {entry.text}
             </ContextMenu.Item>
           )
-        }
-        return (
-          <ContextMenu.Item
-            key={`entry-${index}`}
-            /* eslint-disable-next-line react/jsx-no-bind */
-            onSelect={() => entry.onClick(project)}
-            style={{ height: 28, fontSize: 12 }}
-            color={
-              entry.text === 'Delete Permanently' || entry.text === 'Delete' ? 'red' : undefined
-            }
-          >
-            {entry.text}
-          </ContextMenu.Item>
-        )
-      })}
-    </ContextMenu.Content>
-  )
-})
+        })}
+      </ContextMenu.Content>
+    )
+  },
+)
 ProjectActionsMenu.displayName = 'ProjectActionsMenu'

--- a/utopia-remix/app/components/projectActionContextMenu.tsx
+++ b/utopia-remix/app/components/projectActionContextMenu.tsx
@@ -6,14 +6,8 @@ import { when } from '~/util/react-conditionals'
 import { useFetcherWithOperation } from '../hooks/useFetcherWithOperation'
 import { SLUGIFY_OPTIONS } from '../routes/internal.projects.$id.rename'
 import { useProjectsStore } from '../store'
-import type { ProjectAccessRequestWithUserDetails, ProjectWithoutContent } from '../types'
-import {
-  AccessRequestStatus,
-  operationDelete,
-  operationDestroy,
-  operationRename,
-  operationRestore,
-} from '../types'
+import type { ProjectListing, ProjectWithoutContent } from '../types'
+import { operationDelete, operationDestroy, operationRename, operationRestore } from '../types'
 import { assertNever } from '../util/assertNever'
 import { useCopyProjectLinkToClipboard } from '../util/copyProjectLink'
 import { useProjectEditorLink } from '../util/links'
@@ -33,187 +27,174 @@ function contextMenuEntry(
   return { text, onClick }
 }
 
-export const ProjectActionsMenu = React.memo(
-  ({
-    project,
-    accessRequests,
-  }: {
-    project: ProjectWithoutContent
-    accessRequests: ProjectAccessRequestWithUserDetails[]
-  }) => {
-    const deleteFetcher = useFetcherWithOperation(project.proj_id, 'delete')
-    const destroyFetcher = useFetcherWithOperation(project.proj_id, 'destroy')
-    const restoreFetcher = useFetcherWithOperation(project.proj_id, 'restore')
-    const renameFetcher = useFetcherWithOperation(project.proj_id, 'rename')
-    const selectedCategory = useProjectsStore((store) => store.selectedCategory)
+export const ProjectActionsMenu = React.memo(({ project }: { project: ProjectListing }) => {
+  const deleteFetcher = useFetcherWithOperation(project.proj_id, 'delete')
+  const destroyFetcher = useFetcherWithOperation(project.proj_id, 'destroy')
+  const restoreFetcher = useFetcherWithOperation(project.proj_id, 'restore')
+  const renameFetcher = useFetcherWithOperation(project.proj_id, 'rename')
+  const selectedCategory = useProjectsStore((store) => store.selectedCategory)
 
-    const deleteProject = React.useCallback(
-      (projectId: string) => {
-        deleteFetcher.submit(
-          operationDelete(project),
+  const deleteProject = React.useCallback(
+    (projectId: string) => {
+      deleteFetcher.submit(
+        operationDelete(project),
+        {},
+        { method: 'POST', action: `/internal/projects/${projectId}/delete` },
+      )
+    },
+    [deleteFetcher, project],
+  )
+  const destroyProject = React.useCallback(
+    (projectId: string) => {
+      const ok = window.confirm('Are you sure? The project contents will be deleted permanently.')
+      if (ok) {
+        destroyFetcher.submit(
+          operationDestroy(project),
           {},
-          { method: 'POST', action: `/internal/projects/${projectId}/delete` },
+          { method: 'POST', action: `/internal/projects/${projectId}/destroy` },
         )
-      },
-      [deleteFetcher, project],
-    )
-    const destroyProject = React.useCallback(
-      (projectId: string) => {
-        const ok = window.confirm('Are you sure? The project contents will be deleted permanently.')
-        if (ok) {
-          destroyFetcher.submit(
-            operationDestroy(project),
-            {},
-            { method: 'POST', action: `/internal/projects/${projectId}/destroy` },
+      }
+    },
+    [destroyFetcher, project],
+  )
+
+  const restoreProject = React.useCallback(
+    (projectId: string) => {
+      restoreFetcher.submit(
+        operationRestore(project),
+        {},
+        { method: 'POST', action: `/internal/projects/${projectId}/restore` },
+      )
+    },
+    [restoreFetcher, project],
+  )
+
+  const renameProject = React.useCallback(
+    (projectId: string, newTitle: string) => {
+      renameFetcher.submit(
+        operationRename(project, slugify(newTitle, SLUGIFY_OPTIONS)),
+        { title: newTitle },
+        { method: 'POST', action: `/internal/projects/${projectId}/rename` },
+      )
+    },
+    [renameFetcher, project],
+  )
+
+  const projectEditorLink = useProjectEditorLink()
+  const copyProjectLink = useCopyProjectLinkToClipboard()
+
+  const actions = React.useMemo(
+    () => ({
+      open: contextMenuEntry('Open', (selectedProject) => {
+        window.open(projectEditorLink(selectedProject.proj_id), '_blank')
+      }),
+      copyLink: contextMenuEntry('Copy Link', (selectedProject) =>
+        copyProjectLink(selectedProject.proj_id),
+      ),
+      fork: contextMenuEntry('Fork', (selectedProject) => {
+        window.open(projectEditorLink(selectedProject.proj_id) + '/?fork=true', '_blank')
+      }),
+      rename: contextMenuEntry('Rename', (selectedProject) => {
+        const newTitle = window.prompt('New title:', selectedProject.title)
+        if (newTitle != null) {
+          renameProject(selectedProject.proj_id, newTitle)
+        }
+      }),
+      delete: contextMenuEntry('Delete', (selectedProject) => {
+        deleteProject(selectedProject.proj_id)
+      }),
+      restore: contextMenuEntry('Restore', (selectedProject) => {
+        restoreProject(selectedProject.proj_id)
+      }),
+      destroy: contextMenuEntry('Delete Permanently', (selectedProject) => {
+        destroyProject(selectedProject.proj_id)
+      }),
+    }),
+    [
+      projectEditorLink,
+      copyProjectLink,
+      renameProject,
+      deleteProject,
+      restoreProject,
+      destroyProject,
+    ],
+  )
+
+  const menuEntries = React.useMemo((): ContextMenuEntry[] => {
+    switch (selectedCategory) {
+      case 'allProjects':
+      case 'public':
+      case 'sharing':
+      case 'private':
+        return [
+          actions.open,
+          'separator',
+          actions.copyLink,
+          actions.fork,
+          'sharing-dialog',
+          'separator',
+          actions.rename,
+          actions.delete,
+        ]
+      case 'sharedWithMe':
+        return [actions.open, 'separator', actions.copyLink, actions.fork]
+      case 'trash':
+        return [actions.restore, 'separator', actions.destroy]
+      default:
+        assertNever(selectedCategory)
+    }
+  }, [selectedCategory, actions])
+
+  const setSharingProjectId = useProjectsStore((store) => store.setSharingProjectId)
+
+  const onOpenShareDialog = React.useCallback(() => {
+    setSharingProjectId(project.proj_id)
+  }, [project, setSharingProjectId])
+
+  return (
+    <ContextMenu.Content style={{ width: 170 }}>
+      {menuEntries.map((entry, index) => {
+        if (entry === 'separator') {
+          return (
+            <Separator
+              key={`separator-${index}`}
+              size='4'
+              style={{ marginTop: 5, marginBottom: 5 }}
+            />
           )
         }
-      },
-      [destroyFetcher, project],
-    )
-
-    const restoreProject = React.useCallback(
-      (projectId: string) => {
-        restoreFetcher.submit(
-          operationRestore(project),
-          {},
-          { method: 'POST', action: `/internal/projects/${projectId}/restore` },
-        )
-      },
-      [restoreFetcher, project],
-    )
-
-    const renameProject = React.useCallback(
-      (projectId: string, newTitle: string) => {
-        renameFetcher.submit(
-          operationRename(project, slugify(newTitle, SLUGIFY_OPTIONS)),
-          { title: newTitle },
-          { method: 'POST', action: `/internal/projects/${projectId}/rename` },
-        )
-      },
-      [renameFetcher, project],
-    )
-
-    const projectEditorLink = useProjectEditorLink()
-    const copyProjectLink = useCopyProjectLinkToClipboard()
-
-    const actions = React.useMemo(
-      () => ({
-        open: contextMenuEntry('Open', (selectedProject) => {
-          window.open(projectEditorLink(selectedProject.proj_id), '_blank')
-        }),
-        copyLink: contextMenuEntry('Copy Link', (selectedProject) =>
-          copyProjectLink(selectedProject.proj_id),
-        ),
-        fork: contextMenuEntry('Fork', (selectedProject) => {
-          window.open(projectEditorLink(selectedProject.proj_id) + '/?fork=true', '_blank')
-        }),
-        rename: contextMenuEntry('Rename', (selectedProject) => {
-          const newTitle = window.prompt('New title:', selectedProject.title)
-          if (newTitle != null) {
-            renameProject(selectedProject.proj_id, newTitle)
-          }
-        }),
-        delete: contextMenuEntry('Delete', (selectedProject) => {
-          deleteProject(selectedProject.proj_id)
-        }),
-        restore: contextMenuEntry('Restore', (selectedProject) => {
-          restoreProject(selectedProject.proj_id)
-        }),
-        destroy: contextMenuEntry('Delete Permanently', (selectedProject) => {
-          destroyProject(selectedProject.proj_id)
-        }),
-      }),
-      [
-        projectEditorLink,
-        copyProjectLink,
-        renameProject,
-        deleteProject,
-        restoreProject,
-        destroyProject,
-      ],
-    )
-
-    const menuEntries = React.useMemo((): ContextMenuEntry[] => {
-      switch (selectedCategory) {
-        case 'allProjects':
-        case 'public':
-        case 'sharing':
-        case 'private':
-          return [
-            actions.open,
-            'separator',
-            actions.copyLink,
-            actions.fork,
-            'sharing-dialog',
-            'separator',
-            actions.rename,
-            actions.delete,
-          ]
-        case 'sharedWithMe':
-          return [actions.open, 'separator', actions.copyLink, actions.fork]
-        case 'trash':
-          return [actions.restore, 'separator', actions.destroy]
-        default:
-          assertNever(selectedCategory)
-      }
-    }, [selectedCategory, actions])
-
-    const pendingAccessRequests = React.useMemo(
-      () => accessRequests.filter((r) => r.status === AccessRequestStatus.PENDING),
-      [accessRequests],
-    )
-
-    const setSharingProjectId = useProjectsStore((store) => store.setSharingProjectId)
-
-    const onOpenShareDialog = React.useCallback(() => {
-      setSharingProjectId(project.proj_id)
-    }, [project, setSharingProjectId])
-
-    return (
-      <ContextMenu.Content style={{ width: 170 }}>
-        {menuEntries.map((entry, index) => {
-          if (entry === 'separator') {
-            return (
-              <Separator
-                key={`separator-${index}`}
-                size='4'
-                style={{ marginTop: 5, marginBottom: 5 }}
-              />
-            )
-          }
-          if (entry === 'sharing-dialog') {
-            return (
-              <ContextMenu.Item
-                key={`entry-${index}`}
-                style={{ height: 28, fontSize: 12 }}
-                onSelect={onOpenShareDialog}
-              >
-                <Flex justify={'between'} align={'center'} width={'100%'}>
-                  <Text>Sharing…</Text>
-                  {when(
-                    pendingAccessRequests.length > 0,
-                    <DotFilledIcon color='red' height={22} width={22} />,
-                  )}
-                </Flex>
-              </ContextMenu.Item>
-            )
-          }
+        if (entry === 'sharing-dialog') {
           return (
             <ContextMenu.Item
               key={`entry-${index}`}
-              /* eslint-disable-next-line react/jsx-no-bind */
-              onSelect={() => entry.onClick(project)}
               style={{ height: 28, fontSize: 12 }}
-              color={
-                entry.text === 'Delete Permanently' || entry.text === 'Delete' ? 'red' : undefined
-              }
+              onSelect={onOpenShareDialog}
             >
-              {entry.text}
+              <Flex justify={'between'} align={'center'} width={'100%'}>
+                <Text>Sharing…</Text>
+                {when(
+                  project.hasPendingRequests === true,
+                  <DotFilledIcon color='red' height={22} width={22} />,
+                )}
+              </Flex>
             </ContextMenu.Item>
           )
-        })}
-      </ContextMenu.Content>
-    )
-  },
-)
+        }
+        return (
+          <ContextMenu.Item
+            key={`entry-${index}`}
+            /* eslint-disable-next-line react/jsx-no-bind */
+            onSelect={() => entry.onClick(project)}
+            style={{ height: 28, fontSize: 12 }}
+            color={
+              entry.text === 'Delete Permanently' || entry.text === 'Delete' ? 'red' : undefined
+            }
+          >
+            {entry.text}
+          </ContextMenu.Item>
+        )
+      })}
+    </ContextMenu.Content>
+  )
+})
 ProjectActionsMenu.displayName = 'ProjectActionsMenu'

--- a/utopia-remix/app/components/projectActionContextMenu.tsx
+++ b/utopia-remix/app/components/projectActionContextMenu.tsx
@@ -6,7 +6,7 @@ import { when } from '~/util/react-conditionals'
 import { useFetcherWithOperation } from '../hooks/useFetcherWithOperation'
 import { SLUGIFY_OPTIONS } from '../routes/internal.projects.$id.rename'
 import { useProjectsStore } from '../store'
-import type { ProjectListing, ProjectWithoutContent } from '../types'
+import type { ProjectListing } from '../types'
 import { operationDelete, operationDestroy, operationRename, operationRestore } from '../types'
 import { assertNever } from '../util/assertNever'
 import { useCopyProjectLinkToClipboard } from '../util/copyProjectLink'
@@ -15,14 +15,14 @@ import { useProjectEditorLink } from '../util/links'
 type ContextMenuEntry =
   | {
       text: string
-      onClick: (project: ProjectWithoutContent) => void
+      onClick: (project: ProjectListing) => void
     }
   | 'separator'
   | 'sharing-dialog'
 
 function contextMenuEntry(
   text: string,
-  onClick: (project: ProjectWithoutContent) => void,
+  onClick: (project: ProjectListing) => void,
 ): ContextMenuEntry {
   return { text, onClick }
 }

--- a/utopia-remix/app/components/sharingDialog.tsx
+++ b/utopia-remix/app/components/sharingDialog.tsx
@@ -11,7 +11,7 @@ import {
   asAccessLevel,
   operationApproveAccessRequest,
   operationChangeAccess,
-  type ProjectWithoutContent,
+  type ProjectListing,
   AccessRequestStatus,
   type ProjectAccessRequestWithUserDetails,
 } from '../types'
@@ -30,7 +30,7 @@ export const SharingDialogWrapper = React.memo(
     project,
     accessRequests,
   }: {
-    project: ProjectWithoutContent
+    project: ProjectListing
     accessRequests: ProjectAccessRequestWithUserDetails[]
   }) => {
     const sharingProjectId = useProjectsStore((store) => store.sharingProjectId)
@@ -60,7 +60,7 @@ function SharingDialog({
   project,
   accessRequests,
 }: {
-  project: ProjectWithoutContent
+  project: ProjectListing
   accessRequests: ProjectAccessRequestWithUserDetails[]
 }) {
   const accessLevel = asAccessLevel(project.ProjectAccess?.access_level) ?? AccessLevel.PRIVATE
@@ -146,7 +146,7 @@ function AccessRequests({
   approveAccessRequest,
   accessRequests,
 }: {
-  project: ProjectWithoutContent
+  project: ProjectListing
   approveAccessRequest: (projectId: string, tokenId: string) => void
   accessRequests: ProjectAccessRequestWithUserDetails[]
 }) {

--- a/utopia-remix/app/handlers/listProjects.ts
+++ b/utopia-remix/app/handlers/listProjects.ts
@@ -1,10 +1,10 @@
 import { listProjects } from '../models/project.server'
 import { getManyUserDetails } from '../models/userDetails.server'
-import type { ListProjectsResponse } from '../types'
+import type { ListProjectsResponseV1 } from '../types'
 import { requireUser, ensure } from '../util/api.server'
 import { Status } from '../util/statusCodes'
 
-export async function handleListProjects(req: Request): Promise<ListProjectsResponse> {
+export async function handleListProjects(req: Request): Promise<ListProjectsResponseV1> {
   const user = await requireUser(req)
 
   const projects = await listProjects({ ownerId: user.user_id })

--- a/utopia-remix/app/models/project.server.spec.ts
+++ b/utopia-remix/app/models/project.server.spec.ts
@@ -3,6 +3,7 @@ import { prisma } from '../db.server'
 import {
   createTestProject,
   createTestProjectAccess,
+  createTestProjectAccessRequest,
   createTestProjectCollaborator,
   createTestUser,
   truncateTables,
@@ -18,7 +19,7 @@ import {
   restoreDeletedProject,
   softDeleteProject,
 } from './project.server'
-import { AccessLevel } from '../types'
+import { AccessLevel, AccessRequestStatus } from '../types'
 
 describe('project model', () => {
   afterEach(async () => {
@@ -26,6 +27,7 @@ describe('project model', () => {
     await truncateTables([
       prisma.projectID,
       prisma.projectAccess,
+      prisma.projectAccessRequest,
       prisma.projectCollaborator,
       prisma.project,
       prisma.userDetails,
@@ -92,6 +94,36 @@ describe('project model', () => {
         const bobProjects = await listProjects({ ownerId: 'bob' })
         expect(bobProjects.length).toBe(2)
         expect(bobProjects.map((p) => p.proj_id)).toEqual(['baz', 'foo'])
+      })
+
+      it('returns whether projects have pending requests', async () => {
+        await createTestProject(prisma, { id: 'foo', ownerId: 'bob' })
+        await createTestProject(prisma, {
+          id: 'bar',
+          ownerId: 'bob',
+          accessLevel: AccessLevel.COLLABORATIVE,
+        })
+        await createTestProject(prisma, { id: 'baz', ownerId: 'alice' })
+        await createTestProject(prisma, { id: 'qux', ownerId: 'bob' })
+
+        await createTestUser(prisma, { id: 'p1' })
+        await createTestProjectAccessRequest(prisma, {
+          projectId: 'bar',
+          userId: 'p1',
+          status: AccessRequestStatus.PENDING,
+          token: 't1',
+        })
+        await createTestProjectAccessRequest(prisma, {
+          projectId: 'qux',
+          userId: 'p1',
+          status: AccessRequestStatus.APPROVED,
+          token: 't2',
+        })
+
+        const bobProjects = await listProjects({ ownerId: 'bob' })
+        expect(bobProjects.find((p) => p.proj_id === 'foo')?.hasPendingRequests).toBe(false)
+        expect(bobProjects.find((p) => p.proj_id === 'bar')?.hasPendingRequests).toBe(true)
+        expect(bobProjects.find((p) => p.proj_id === 'qux')?.hasPendingRequests).toBe(false)
       })
     })
   })

--- a/utopia-remix/app/models/project.server.ts
+++ b/utopia-remix/app/models/project.server.ts
@@ -1,7 +1,8 @@
 import { prisma } from '../db.server'
-import type { CollaboratorsByProject } from '../types'
+import type { CollaboratorsByProject, ProjectListing } from '../types'
 import {
   AccessLevel,
+  AccessRequestStatus,
   asAccessLevel,
   userToCollaborator,
   type ProjectWithoutContent,
@@ -20,14 +21,33 @@ const selectProjectWithoutContent: Record<keyof ProjectWithoutContent, true> = {
   ProjectAccess: true,
 }
 
-export async function listProjects(params: { ownerId: string }): Promise<ProjectWithoutContent[]> {
-  return prisma.project.findMany({
+export async function listProjects(params: { ownerId: string }): Promise<ProjectListing[]> {
+  const projects = await prisma.project.findMany({
     select: selectProjectWithoutContent,
     where: {
       owner_id: params.ownerId,
       OR: [{ deleted: null }, { deleted: false }],
     },
     orderBy: { modified_at: 'desc' },
+  })
+
+  const pendingRequests = await prisma.projectAccessRequest.findMany({
+    where: {
+      project_id: {
+        in: projects
+          .filter((p) => p.ProjectAccess?.access_level === AccessLevel.COLLABORATIVE)
+          .map((p) => p.proj_id),
+      },
+      status: AccessRequestStatus.PENDING,
+    },
+    select: { project_id: true },
+  })
+
+  return projects.map((project) => {
+    return {
+      ...project,
+      hasPendingRequests: pendingRequests.some((r) => r.project_id === project.proj_id),
+    }
   })
 }
 
@@ -99,9 +119,7 @@ export async function restoreDeletedProject(params: { id: string; userId: string
   })
 }
 
-export async function listDeletedProjects(params: {
-  ownerId: string
-}): Promise<ProjectWithoutContent[]> {
+export async function listDeletedProjects(params: { ownerId: string }): Promise<ProjectListing[]> {
   return await prisma.project.findMany({
     select: selectProjectWithoutContent,
     where: {
@@ -145,7 +163,7 @@ export async function getProjectAccessLevel(params: { projectId: string }): Prom
 export async function listSharedWithMeProjectsAndCollaborators(params: {
   userId: string
 }): Promise<{
-  projects: ProjectWithoutContent[]
+  projects: ProjectListing[]
   collaborators: CollaboratorsByProject
 }> {
   // 1. grab the project IDs where the user is the collaborator,

--- a/utopia-remix/app/models/project.server.ts
+++ b/utopia-remix/app/models/project.server.ts
@@ -5,12 +5,12 @@ import {
   AccessRequestStatus,
   asAccessLevel,
   userToCollaborator,
-  type ProjectWithoutContent,
+  type ProjectWithoutContentFromDB,
 } from '../types'
 import { ensure } from '../util/api.server'
 import { Status } from '../util/statusCodes'
 
-const selectProjectWithoutContent: Record<keyof ProjectWithoutContent, true> = {
+const selectProjectWithoutContent: Record<keyof ProjectWithoutContentFromDB, true> = {
   id: true,
   proj_id: true,
   owner_id: true,
@@ -85,7 +85,7 @@ export async function renameProject(params: {
   id: string
   userId: string
   title: string
-}): Promise<ProjectWithoutContent> {
+}): Promise<ProjectListing> {
   return prisma.project.update({
     where: {
       proj_id: params.id,

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -12,15 +12,17 @@ import {
   TrashIcon,
 } from '@radix-ui/react-icons'
 import { Badge, Button, ContextMenu, DropdownMenu, Flex, Text, TextField } from '@radix-ui/themes'
-import { type LoaderFunctionArgs, json } from '@remix-run/node'
+import { json, type LoaderFunctionArgs } from '@remix-run/node'
 import { useFetcher, useLoaderData } from '@remix-run/react'
 import moment from 'moment'
 import type { UserDetails } from 'prisma-client'
 import React from 'react'
 import { ProjectActionsMenu } from '../components/projectActionContextMenu'
+import { SharingDialogWrapper } from '../components/sharingDialog'
 import { SortingContextMenu } from '../components/sortProjectsContextMenu'
 import { Spinner } from '../components/spinner'
 import { useCleanupOperations } from '../hooks/useCleanupOperations'
+import { useFetcherData } from '../hooks/useFetcherData'
 import { useIsDarkMode } from '../hooks/useIsDarkMode'
 import {
   listDeletedProjects,
@@ -38,16 +40,15 @@ import type {
   Collaborator,
   CollaboratorsByProject,
   Operation,
+  ProjectAccessRequestWithUserDetails,
   ProjectListing,
-  ProjectWithoutContent,
 } from '../types'
 import {
   AccessLevel,
-  getOperationDescription,
   asAccessLevel,
+  getOperationDescription,
   isProjectAccessRequestWithUserDetailsArray,
 } from '../types'
-import type { ProjectAccessRequestWithUserDetails } from '../types'
 import { requireUser } from '../util/api.server'
 import { assertNever } from '../util/assertNever'
 import { auth0LoginURL } from '../util/auth0.server'
@@ -59,8 +60,6 @@ import {
   useProjectMatchesQuery,
   useSortCompareProject,
 } from '../util/use-sort-compare-project'
-import { SharingDialogWrapper } from '../components/sharingDialog'
-import { useFetcherData } from '../hooks/useFetcherData'
 
 const SortOptions = ['title', 'dateCreated', 'dateModified'] as const
 export type SortCriteria = (typeof SortOptions)[number]
@@ -383,7 +382,7 @@ const TopActionBar = React.memo(() => {
 })
 TopActionBar.displayName = 'TopActionBar'
 
-const ProjectsHeader = React.memo(({ projects }: { projects: ProjectWithoutContent[] }) => {
+const ProjectsHeader = React.memo(({ projects }: { projects: ProjectListing[] }) => {
   const searchQuery = useProjectsStore((store) => store.searchQuery)
   const setSearchQuery = useProjectsStore((store) => store.setSearchQuery)
   const selectedCategory = useProjectsStore((store) => store.selectedCategory)
@@ -511,7 +510,7 @@ const ProjectsHeader = React.memo(({ projects }: { projects: ProjectWithoutConte
 })
 ProjectsHeader.displayName = 'CategoryHeader'
 
-const CategoryActions = React.memo(({ projects }: { projects: ProjectWithoutContent[] }) => {
+const CategoryActions = React.memo(({ projects }: { projects: ProjectListing[] }) => {
   const selectedCategory = useProjectsStore((store) => store.selectedCategory)
 
   switch (selectedCategory) {
@@ -529,7 +528,7 @@ const CategoryActions = React.memo(({ projects }: { projects: ProjectWithoutCont
 })
 CategoryActions.displayName = 'CategoryActions'
 
-const CategoryTrashActions = React.memo(({ projects }: { projects: ProjectWithoutContent[] }) => {
+const CategoryTrashActions = React.memo(({ projects }: { projects: ProjectListing[] }) => {
   const fetcher = useFetcher()
 
   const handleEmptyTrash = React.useCallback(() => {
@@ -571,7 +570,7 @@ const Projects = React.memo(
     const setSelectedProjectId = useProjectsStore((store) => store.setSelectedProjectId)
 
     const handleProjectSelect = React.useCallback(
-      (project: ProjectWithoutContent) =>
+      (project: ProjectListing) =>
         setSelectedProjectId(project.proj_id === selectedProjectId ? null : project.proj_id),
       [setSelectedProjectId, selectedProjectId],
     )
@@ -1031,7 +1030,7 @@ const ProjectBadge = React.memo(({ accessLevel }: { accessLevel: AccessLevel }) 
 })
 ProjectBadge.displayName = 'ProjectBadge'
 
-const ActiveOperations = React.memo(({ projects }: { projects: ProjectWithoutContent[] }) => {
+const ActiveOperations = React.memo(({ projects }: { projects: ProjectListing[] }) => {
   const operations = useProjectsStore((store) =>
     store.operations.sort((a, b) => b.startedAt - a.startedAt),
   )
@@ -1068,7 +1067,7 @@ const ActiveOperations = React.memo(({ projects }: { projects: ProjectWithoutCon
 ActiveOperations.displayName = 'ActiveOperations'
 
 const ActiveOperationToast = React.memo(
-  ({ operation, project }: { operation: OperationWithKey; project: ProjectWithoutContent }) => {
+  ({ operation, project }: { operation: OperationWithKey; project: ProjectListing }) => {
     const removeOperation = useProjectsStore((store) => store.removeOperation)
 
     const dismiss = React.useCallback(() => {

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -38,6 +38,7 @@ import type {
   Collaborator,
   CollaboratorsByProject,
   Operation,
+  ProjectListing,
   ProjectWithoutContent,
 } from '../types'
 import {
@@ -137,9 +138,9 @@ const ProjectsPage = React.memo(() => {
 
   const data = useLoaderData() as unknown as {
     user: UserDetails
-    projects: ProjectWithoutContent[]
-    deletedProjects: ProjectWithoutContent[]
-    projectsSharedWithMe: ProjectWithoutContent[]
+    projects: ProjectListing[]
+    deletedProjects: ProjectListing[]
+    projectsSharedWithMe: ProjectListing[]
     collaborators: CollaboratorsByProject
   }
 
@@ -560,7 +561,7 @@ const Projects = React.memo(
     collaborators,
     myUserId,
   }: {
-    projects: ProjectWithoutContent[]
+    projects: ProjectListing[]
     collaborators: CollaboratorsByProject
     myUserId: string
   }) => {
@@ -636,7 +637,7 @@ const ProjectCard = React.memo(
     selected,
     onSelect,
   }: {
-    project: ProjectWithoutContent
+    project: ProjectListing
     isSharedWithMe: boolean
     collaborators: Collaborator[]
     selected: boolean
@@ -804,7 +805,7 @@ const ProjectCard = React.memo(
             </div>
           </div>
         </ContextMenu.Trigger>
-        <ProjectActionsMenu project={project} accessRequests={accessRequests} />
+        <ProjectActionsMenu project={project} />
         <SharingDialogWrapper project={project} accessRequests={accessRequests} />
       </ContextMenu.Root>
     )
@@ -820,7 +821,7 @@ const ProjectRow = React.memo(
     isSharedWithMe,
     onSelect,
   }: {
-    project: ProjectWithoutContent
+    project: ProjectListing
     collaborators: Collaborator[]
     selected: boolean
     isSharedWithMe: boolean
@@ -976,7 +977,7 @@ const ProjectRow = React.memo(
             </div>
           </div>
         </ContextMenu.Trigger>
-        <ProjectActionsMenu project={project} accessRequests={accessRequests} />
+        <ProjectActionsMenu project={project} />
         <SharingDialogWrapper project={project} accessRequests={accessRequests} />
       </ContextMenu.Root>
     )

--- a/utopia-remix/app/routes/v1.showcase.tsx
+++ b/utopia-remix/app/routes/v1.showcase.tsx
@@ -1,6 +1,6 @@
 import type { LoaderFunctionArgs } from '@remix-run/node'
 import { handle, handleOptions } from '../util/api.server'
-import type { ListProjectsResponse } from '../types'
+import type { ListProjectsResponseV1 } from '../types'
 import { ALLOW } from '../handlers/validators'
 
 export async function loader(args: LoaderFunctionArgs) {
@@ -10,6 +10,6 @@ export async function loader(args: LoaderFunctionArgs) {
   })
 }
 
-export async function handleShowcase(): Promise<ListProjectsResponse> {
+export async function handleShowcase(): Promise<ListProjectsResponseV1> {
   return { projects: [] }
 }

--- a/utopia-remix/app/types.ts
+++ b/utopia-remix/app/types.ts
@@ -10,7 +10,12 @@ const fullProject = Prisma.validator<Prisma.ProjectDefaultArgs>()({
 
 type FullProject = Prisma.ProjectGetPayload<typeof fullProject>
 
-export interface ProjectListing {
+export type ProjectListing = ProjectWithoutContent & {
+  hasPendingRequests?: boolean
+}
+
+// Legacy response
+export interface ProjectListingV1 {
   id: string
   ownerName: string | null
   ownerPicture: string | null
@@ -20,8 +25,8 @@ export interface ProjectListing {
   modifiedAt: string
 }
 
-export type ListProjectsResponse = {
-  projects: ProjectListing[]
+export type ListProjectsResponseV1 = {
+  projects: ProjectListingV1[]
 }
 
 export type ProjectWithoutContent = Omit<FullProject, 'content'>

--- a/utopia-remix/app/util/use-sort-compare-project.tsx
+++ b/utopia-remix/app/util/use-sort-compare-project.tsx
@@ -1,7 +1,7 @@
 import moment from 'moment'
 import React from 'react'
 import { useProjectsStore } from '../store'
-import type { ProjectWithoutContent } from '../types'
+import type { ProjectListing } from '../types'
 import { assertNever } from './assertNever'
 
 export function useSortCompareProject() {
@@ -9,7 +9,7 @@ export function useSortCompareProject() {
   const sortAscending = useProjectsStore((store) => store.sortAscending)
 
   return React.useCallback(
-    (a: ProjectWithoutContent, b: ProjectWithoutContent): number => {
+    (a: ProjectListing, b: ProjectListing): number => {
       switch (sortCriteria) {
         case 'title':
           return sortAscending ? a.title.localeCompare(b.title) : b.title.localeCompare(a.title)
@@ -34,7 +34,7 @@ export function useProjectMatchesQuery() {
   const sanitizedQuery = React.useMemo(() => searchQuery.trim().toLowerCase(), [searchQuery])
 
   return React.useCallback(
-    (project: ProjectWithoutContent): boolean => {
+    (project: ProjectListing): boolean => {
       if (sanitizedQuery.length === 0) {
         return true
       }
@@ -49,7 +49,7 @@ export function useProjectIsOnActiveOperation() {
   const selectedCategory = useProjectsStore((store) => store.selectedCategory)
 
   return React.useCallback(
-    (project: ProjectWithoutContent): boolean => {
+    (project: ProjectListing): boolean => {
       return !activeOperations.some((op) => {
         switch (selectedCategory) {
           case 'allProjects':


### PR DESCRIPTION
**Problem:**

The pending requests badge/info needs to be available for all projects, immediately.

**Fix:**

This is a PR required for incremental work.

1. Return the `hasPendingRequests` flag with the projects obtained via `listProjects`, and use that instead of checking the requests list
2. The type naming is getting tricky so, as part of this PR, as I think it should be part of **this** PR, the naming is adjusted a bit:
	- types related to Prisma DB data are marked with the `FromDB` suffix
	- the `ProjectListing` is used as a decoration type on top of that, so it includes the DB data _and_ the accessory data we add
	- the legacy `ProjectListing` used by Haskell is renamed to `ProjectListingV1`

Again I know the type renaming is a bit noisy but I think it should definitely be part of this PR as the scope is all here.