### PR TITLE
Show non jsx element render props

### DIFF
--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -147,23 +147,21 @@ export function getNavigatorTargets(
             return
           }
 
-          if (isJSXElement(propValue)) {
-            const childPath = EP.appendToPath(path, propValue.uid)
-            const entry = renderPropNavigatorEntry(fakeRenderPropPath, prop)
-            navigatorTargets.push(entry)
-            visibleNavigatorTargets.push(entry)
+          const childPath = EP.appendToPath(path, propValue.uid)
+          const entry = renderPropNavigatorEntry(fakeRenderPropPath, prop)
+          navigatorTargets.push(entry)
+          visibleNavigatorTargets.push(entry)
 
-            const subTreeChild = subTree?.children.find((child) =>
-              EP.pathsEqual(child.path, childPath),
-            )
-            if (subTreeChild != null) {
-              processedPathsAsRenderProp.add(EP.toString(subTreeChild.path))
-              walkAndAddKeys(subTreeChild, collapsedAncestor)
-            } else {
-              const synthEntry = syntheticNavigatorEntry(childPath, propValue)
-              navigatorTargets.push(synthEntry)
-              visibleNavigatorTargets.push(synthEntry)
-            }
+          const subTreeChild = subTree?.children.find((child) =>
+            EP.pathsEqual(child.path, childPath),
+          )
+          if (subTreeChild != null) {
+            processedPathsAsRenderProp.add(EP.toString(subTreeChild.path))
+            walkAndAddKeys(subTreeChild, collapsedAncestor)
+          } else {
+            const synthEntry = syntheticNavigatorEntry(childPath, propValue)
+            navigatorTargets.push(synthEntry)
+            visibleNavigatorTargets.push(synthEntry)
           }
         })
       }

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -5241,6 +5241,39 @@ describe('Navigator row order', () => {
       'regular-sb/scene/pg:dbc/78c/88b',
     ])
   })
+  it('is correct for a project with elements with string render prop', async () => {
+    const renderResult = await renderTestEditorWithModel(
+      projectWithRenderProp('header={"Title"}'),
+      'await-first-dom-report',
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey)).toEqual(
+      [
+        'regular-sb/scene',
+        'regular-sb/scene/pg',
+        'regular-sb/scene/pg:dbc',
+        'regular-sb/scene/pg:dbc/78c',
+        'render-prop-sb/scene/pg:dbc/78c/prop-label-header-header',
+        'synthetic-sb/scene/pg:dbc/78c/d4a-attribute',
+        'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
+        'regular-sb/scene/pg:dbc/78c/88b',
+      ],
+    )
+    expect(
+      renderResult.getEditorState().derived.visibleNavigatorTargets.map(navigatorEntryToKey),
+    ).toEqual([
+      'regular-sb/scene',
+      'regular-sb/scene/pg',
+      'regular-sb/scene/pg:dbc',
+      'regular-sb/scene/pg:dbc/78c',
+      'render-prop-sb/scene/pg:dbc/78c/prop-label-header-header',
+      'synthetic-sb/scene/pg:dbc/78c/d4a-attribute',
+      'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
+      'regular-sb/scene/pg:dbc/78c/88b',
+    ])
+  })
   it('is correct for a project with elements with missing render prop', async () => {
     const renderResult = await renderTestEditorWithModel(
       projectWithRenderProp(''), // <- no render prop


### PR DESCRIPTION
**Description:**
We filter out render props from the navigator which are not jsx element values.
However, render props can be strings, numbers, conditionals, etc, we can always show them in the navigator when the property is registered as a render prop.

<img width="562" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/4bdb0911-58fc-4e9c-be4a-b02e83388188">
