### PR TITLE
Restore cartouche delete and image preview tests

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.spec.browser2.tsx
@@ -737,37 +737,37 @@ describe('Set element prop via the data picker', () => {
 })
 
 // comment out tests temporarily because it causes a dom-walker test to fail
-describe('Image preview for string control', () => {
-  it('shows image preview for urls with image extension', async () => {
-    const editor = await renderTestEditorWithModel(
-      projectWithImage(
-        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEklEQVQIW2P8z8AARAwMjDAGACwBA/+8RVWvAAAAAElFTkSuQmCC',
-      ),
-      'await-first-dom-report',
-    )
-    await selectComponentsForTest(editor, [EP.fromString('sb/scene/pg:root/image')])
+// describe('Image preview for string control', () => {
+//   it('shows image preview for urls with image extension', async () => {
+//     const editor = await renderTestEditorWithModel(
+//       projectWithImage(
+//         'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEklEQVQIW2P8z8AARAwMjDAGACwBA/+8RVWvAAAAAElFTkSuQmCC',
+//       ),
+//       'await-first-dom-report',
+//     )
+//     await selectComponentsForTest(editor, [EP.fromString('sb/scene/pg:root/image')])
 
-    expect(editor.renderedDOM.queryAllByTestId(ImagePreviewTestId)).toHaveLength(1)
-  })
-  it('does not show image preview for urls without image extension', async () => {
-    const editor = await renderTestEditorWithModel(
-      projectWithImage('https://i.pinimg.com/474x/4d/79/99/4d7999a51a1a397189a6f98168bcde45'),
-      'await-first-dom-report',
-    )
-    await selectComponentsForTest(editor, [EP.fromString('sb/scene/pg:root/image')])
+//     expect(editor.renderedDOM.queryAllByTestId(ImagePreviewTestId)).toHaveLength(1)
+//   })
+//   it('does not show image preview for urls without image extension', async () => {
+//     const editor = await renderTestEditorWithModel(
+//       projectWithImage('https://i.pinimg.com/474x/4d/79/99/4d7999a51a1a397189a6f98168bcde45'),
+//       'await-first-dom-report',
+//     )
+//     await selectComponentsForTest(editor, [EP.fromString('sb/scene/pg:root/image')])
 
-    expect(editor.renderedDOM.queryAllByTestId(ImagePreviewTestId)).toHaveLength(0)
-  })
-  it('does not show image preview for non-urls', async () => {
-    const editor = await renderTestEditorWithModel(
-      projectWithImage('hello'),
-      'await-first-dom-report',
-    )
-    await selectComponentsForTest(editor, [EP.fromString('sb/scene/pg:root/image')])
+//     expect(editor.renderedDOM.queryAllByTestId(ImagePreviewTestId)).toHaveLength(0)
+//   })
+//   it('does not show image preview for non-urls', async () => {
+//     const editor = await renderTestEditorWithModel(
+//       projectWithImage('hello'),
+//       'await-first-dom-report',
+//     )
+//     await selectComponentsForTest(editor, [EP.fromString('sb/scene/pg:root/image')])
 
-    expect(editor.renderedDOM.queryAllByTestId(ImagePreviewTestId)).toHaveLength(0)
-  })
-})
+//     expect(editor.renderedDOM.queryAllByTestId(ImagePreviewTestId)).toHaveLength(0)
+//   })
+// })
 
 describe('Controls from registering components', () => {
   it('registering internal component', async () => {
@@ -1005,52 +1005,52 @@ describe('Controls from registering components', () => {
   })
 })
 
-describe('Delete cartouche handling', () => {
-  async function getEditorWithPropertyExtras(
-    propertyExtras: string,
-    textField: string,
-  ): Promise<EditorRenderResult> {
-    const editor = await renderTestEditorWithModel(
-      registerInternalComponentProjectWithCartouche(propertyExtras, textField),
-      'await-first-dom-report',
-    )
-    await selectComponentsForTest(editor, [EP.fromString('sb/scene/pg:root/title')])
-    return editor
-  }
-  it('optional field', async () => {
-    const editor = await getEditorWithPropertyExtras(``, `text={textForTitle}`)
-    const deleteCartoucheButton = editor.renderedDOM.getByTestId(`delete-cartouche-text`)
-    await mouseClickAtPoint(deleteCartoucheButton, { x: 2, y: 2 })
-    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-      registerInternalComponentProjectWithCartoucheStoryboard(``, ``),
-    )
-  })
-  it('required field without default value', async () => {
-    const editor = await getEditorWithPropertyExtras(`required: true`, `text={textForTitle}`)
-    const deleteCartoucheButton = editor.renderedDOM.queryByTestId(`delete-cartouche-text`)
-    expect(deleteCartoucheButton).toBeNull()
-    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-      registerInternalComponentProjectWithCartoucheStoryboard(
-        `required: true`,
-        `text={textForTitle}`,
-      ),
-    )
-  })
-  it('required field with default value', async () => {
-    const editor = await getEditorWithPropertyExtras(
-      `required: true, defaultValue: 'Placeholder!'`,
-      `text={textForTitle}`,
-    )
-    const deleteCartoucheButton = editor.renderedDOM.getByTestId(`delete-cartouche-text`)
-    await mouseClickAtPoint(deleteCartoucheButton, { x: 2, y: 2 })
-    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
-      registerInternalComponentProjectWithCartoucheStoryboard(
-        `required: true, defaultValue: 'Placeholder!'`,
-        `text='Placeholder!'`,
-      ),
-    )
-  })
-})
+// describe('Delete cartouche handling', () => {
+//   async function getEditorWithPropertyExtras(
+//     propertyExtras: string,
+//     textField: string,
+//   ): Promise<EditorRenderResult> {
+//     const editor = await renderTestEditorWithModel(
+//       registerInternalComponentProjectWithCartouche(propertyExtras, textField),
+//       'await-first-dom-report',
+//     )
+//     await selectComponentsForTest(editor, [EP.fromString('sb/scene/pg:root/title')])
+//     return editor
+//   }
+//   it('optional field', async () => {
+//     const editor = await getEditorWithPropertyExtras(``, `text={textForTitle}`)
+//     const deleteCartoucheButton = editor.renderedDOM.getByTestId(`delete-cartouche-text`)
+//     await mouseClickAtPoint(deleteCartoucheButton, { x: 2, y: 2 })
+//     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+//       registerInternalComponentProjectWithCartoucheStoryboard(``, ``),
+//     )
+//   })
+//   it('required field without default value', async () => {
+//     const editor = await getEditorWithPropertyExtras(`required: true`, `text={textForTitle}`)
+//     const deleteCartoucheButton = editor.renderedDOM.queryByTestId(`delete-cartouche-text`)
+//     expect(deleteCartoucheButton).toBeNull()
+//     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+//       registerInternalComponentProjectWithCartoucheStoryboard(
+//         `required: true`,
+//         `text={textForTitle}`,
+//       ),
+//     )
+//   })
+//   it('required field with default value', async () => {
+//     const editor = await getEditorWithPropertyExtras(
+//       `required: true, defaultValue: 'Placeholder!'`,
+//       `text={textForTitle}`,
+//     )
+//     const deleteCartoucheButton = editor.renderedDOM.getByTestId(`delete-cartouche-text`)
+//     await mouseClickAtPoint(deleteCartoucheButton, { x: 2, y: 2 })
+//     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(
+//       registerInternalComponentProjectWithCartoucheStoryboard(
+//         `required: true, defaultValue: 'Placeholder!'`,
+//         `text='Placeholder!'`,
+//       ),
+//     )
+//   })
+// })
 
 const project = DataPickerProjectShell(`
 function Title({ text }) {


### PR DESCRIPTION
**Problem:**
These tests have been commented out for a while because they mysteriously caused dom walker tests to fail.
I removed them in https://github.com/concrete-utopia/utopia/pull/5070 , because there were lot of changes in this test file, and I did not want to increase the PR size by updating dead code.

However, these tests are valid and successful tests, so I updated them to check if they still break the dom walker tests.

Unfortunately, they do, but I still think they are valuable tests which we should fix later, so I readded their updated version and commented them out again.