### PR TITLE
Always include owners in shared with me

### DIFF
--- a/utopia-remix/app/models/project.server.spec.ts
+++ b/utopia-remix/app/models/project.server.spec.ts
@@ -411,12 +411,14 @@ describe('project model', () => {
 
       expect(Object.keys(got.collaborators).length).toBe(2)
       expect(Object.keys(got.collaborators)[0]).toBe('seven')
-      expect(got.collaborators['seven'].length).toBe(1)
+      expect(got.collaborators['seven'].length).toBe(2)
       expect(got.collaborators['seven'].map((c) => c.id)[0]).toBe('bob')
+      expect(got.collaborators['seven'].map((c) => c.id)[1]).toBe('carol') // the owner is included implicitly!
       expect(Object.keys(got.collaborators)[1]).toBe('four')
-      expect(got.collaborators['four'].length).toBe(2)
+      expect(got.collaborators['four'].length).toBe(3)
       expect(got.collaborators['four'].map((c) => c.id)[0]).toBe('bob')
       expect(got.collaborators['four'].map((c) => c.id)[1]).toBe('carol')
+      expect(got.collaborators['four'].map((c) => c.id)[2]).toBe('alice') // the owner is included implicitly!
     })
   })
 })

--- a/utopia-remix/app/models/project.server.ts
+++ b/utopia-remix/app/models/project.server.ts
@@ -166,7 +166,7 @@ export async function listSharedWithMeProjectsAndCollaborators(params: {
   projects: ProjectListing[]
   collaborators: CollaboratorsByProject
 }> {
-  // 1. grab the projects IDs for which the user is a collaborator, are not deleted, are
+  // 1. grab the projects for which the user is a collaborator, are not deleted, are
   // collaborative, and the user is not the owner.
   const projectsAndCollaborators = await prisma.projectCollaborator.findMany({
     where: {


### PR DESCRIPTION
**Problem:**

The `listSharedWithMeProjectsAndCollaborators` logic might not return the owner as part of the collaborators, which should implicitly be part of that list.

**Fix:**

- Make sure owner data is patched onto the collaborators map if missing
- Rework the Prisma querying so it's still a single query but is clearer, and uses the collaborators table as the main source for the join to work around some Prisma building quirks
- Add a lot of comments explaining what the different pieces of the query do, so everyone can understand what's going on _and why_
- Adjust the tests accordingly