### PR TITLE
Await Promise.all() instead of for await

### DIFF
--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -53,10 +53,8 @@ import { isExportDefault, isParseSuccess } from '../shared/project-file-types'
 import { resolveParamsAndRunJsCode } from '../shared/javascript-cache'
 import type { EditorDispatch } from '../../components/editor/action-types'
 import { updatePropertyControlsInfo } from '../../components/editor/actions/action-creators'
-import { DefaultThirdPartyControlDefinitions } from '../third-party/third-party-controls'
 import type { ProjectContentTreeRoot } from '../../components/assets'
 import { isIntrinsicHTMLElement } from '../shared/element-template'
-import { stripNulls } from '../shared/array-utils'
 
 async function parseInsertOption(
   insertOption: ComponentInsertOption,


### PR DESCRIPTION
**Problem:**
`for await` makes sense in sequential cases, when we have to wait for the previous iteration to finish before starting the next one.
However, in the `for await` in this PR this is not the case.

**Fix:**
I replaced `for await` with an `await Promise.all()`