### PR TITLE
Fix deleting a component descriptor file

### DIFF
--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -370,7 +370,6 @@ describe('registered property controls', () => {
 })
 
 describe('Lifecycle management of registering components', () => {
-  // eslint-disable-next-line
   it('Deleting a component descriptor file removes the property controls from that file', async () => {
     const descriptorFileName1 = '/utopia/components1.utopia.js'
     const descriptorFileName2 = '/utopia/components2.utopia.js'

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -274,7 +274,7 @@ export function updatePropertyControlsOnDescriptorFileDelete(
   componentDescriptorFile: string,
 ): PropertyControlsInfo {
   return updatePropertyControlsOnDescriptorFileUpdate(previousPropertyControlsInfo, {
-    componentDescriptorFile: [],
+    [componentDescriptorFile]: [],
   })
 }
 


### PR DESCRIPTION
**Problem:**
I introduced a regression in https://github.com/concrete-utopia/utopia/pull/5104 , deleting a component descriptor file does not remove the property controls defined in there.

**Fix:**
Fix the code and added the first component registration lifecycle test.