### PR TITLE
Render prop picker improvements

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -2323,6 +2323,10 @@ export function isRenderPropNavigatorEntry(
   return entry.type === 'RENDER_PROP'
 }
 
+export function isSlotNavigatorEntry(entry: NavigatorEntry): entry is SlotNavigatorEntry {
+  return entry.type === 'SLOT'
+}
+
 export interface DerivedState {
   navigatorTargets: Array<NavigatorEntry>
   visibleNavigatorTargets: Array<NavigatorEntry>

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -148,7 +148,7 @@ const ComponentPickerTopSection = React.memo((props: ComponentPickerTopSectionPr
         <div style={{ flexGrow: 1 }} />
         {onClickCloseButton != null ? (
           <div
-            style={{ fontWeight: 600 }}
+            style={{ fontWeight: 600, cursor: 'pointer' }}
             onClick={onClickCloseButton}
             data-testId={componentPickerCloseButtonTestId}
           >
@@ -175,6 +175,7 @@ const PickerTabButton = React.memo((props: PickerTabButtonProps) => {
       style={{
         fontWeight: 600,
         color: isSelected ? colorTheme.black.value : colorTheme.subduedForeground.value,
+        cursor: 'pointer',
       }}
       onClick={onClick}
     >
@@ -433,6 +434,7 @@ const ComponentPickerVariant = React.memo((props: ComponentPickerVariantProps) =
         '&:hover': {
           backgroundColor: colorTheme.dynamicBlue10.value,
         },
+        cursor: 'pointer',
       }}
       data-testId={componentPickerOptionTestId(componentName, variant.insertMenuLabel)}
     >

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -9,6 +9,7 @@ import { jsxElementWithoutUID, type JSXElementChild } from '../../../core/shared
 import { type Imports } from '../../../core/shared/project-file-types'
 import { elementFromInsertMenuItem } from '../../editor/insert-callbacks'
 import { componentInfo, type ComponentInfo } from '../../custom-code/code-file'
+import { when } from '../../../utils/react-conditionals'
 
 export interface ComponentPickerProps {
   insertionTargetName: string
@@ -146,7 +147,7 @@ const ComponentPickerTopSection = React.memo((props: ComponentPickerTopSectionPr
           onClick={switchToAllTab}
         />
         <div style={{ flexGrow: 1 }} />
-        {onClickCloseButton != null ? (
+        {when(onClickCloseButton != null, () => (
           <div
             style={{ fontWeight: 600, cursor: 'pointer' }}
             onClick={onClickCloseButton}
@@ -154,7 +155,7 @@ const ComponentPickerTopSection = React.memo((props: ComponentPickerTopSectionPr
           >
             X
           </div>
-        ) : null}
+        ))}
       </div>
       <FilterBar onFilterChange={onFilterChange} />
     </div>

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -8,6 +8,7 @@ import { type PreferredChildComponentDescriptor } from '../../custom-code/intern
 import { type JSXElementChild } from '../../../core/shared/element-template'
 import { type Imports } from '../../../core/shared/project-file-types'
 import { elementFromInsertMenuItem } from '../../editor/insert-callbacks'
+import { type ComponentInfo } from '../../custom-code/code-file'
 
 export interface ComponentPickerProps {
   insertionTargetName: string
@@ -37,21 +38,7 @@ export function componentPickerOptionTestId(componentName: string, variant?: str
 export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
   const colorTheme = useColorTheme()
   const [selectedTab, setSelectedTab] = React.useState<'preferred' | 'all'>('preferred')
-  const switchToPreferredTab = React.useCallback(() => setSelectedTab('preferred'), [])
-  const switchToAllTab = React.useCallback(() => setSelectedTab('all'), [])
   const [filter, setFilter] = React.useState<string>('')
-  const handleFilterKeydown = React.useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      ;(e.target as HTMLInputElement).blur()
-    } else if (e.key === 'Escape') {
-      setFilter('')
-      ;(e.target as HTMLInputElement).blur()
-    }
-    e.stopPropagation()
-  }, [])
-  const handleFilterChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setFilter(e.target.value)
-  }, [])
 
   const unfilteredComponentsToShow =
     selectedTab === 'preferred' ? props.preferredComponents : props.allComponents
@@ -76,135 +63,12 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
       }}
       data-testId={componentPickerTestIdForProp(props.insertionTargetName)}
     >
-      <div
-        style={{
-          padding: '16px 16px',
-          display: 'flex',
-          flexDirection: 'column',
-          width: '100%',
-          alignItems: 'flex-start',
-          justifyContent: 'flex-start',
-          gap: 10,
-          height: 'max-content',
-        }}
-      >
-        <div
-          style={{
-            width: '100%',
-            display: 'flex',
-            flexDirection: 'row',
-            gap: 5,
-            fontFamily: 'Utopian-Inter',
-            fontWeight: 700,
-            fontSize: '11px',
-          }}
-        >
-          <div>Insert into</div>
-          <div
-            style={{
-              border: '1px solid rgb(0, 0, 0, 1)',
-              borderRadius: 3,
-              height: 21,
-              contain: 'layout',
-            }}
-          >
-            <div
-              style={{
-                border: '1px solid rgb(0, 0, 0, 1)',
-                height: 21,
-                borderRadius: 3,
-                padding: 3,
-                margin: -1, // Honestly I give up
-                position: 'relative',
-                left: 3,
-                top: -2,
-                lineHeight: 'normal',
-                backgroundColor: colorTheme.white.value,
-              }}
-              data-testId={`${componentPickerTestIdForProp(props.insertionTargetName)}-prop-field`}
-            >
-              {capitalize(props.insertionTargetName)}
-            </div>
-          </div>
-          <div style={{ flexGrow: 100 }} />
-          <div
-            style={{
-              fontWeight: 600,
-              color:
-                selectedTab === 'preferred'
-                  ? colorTheme.black.value
-                  : colorTheme.subduedForeground.value,
-            }}
-            onMouseDown={switchToPreferredTab}
-          >
-            Preferred
-          </div>
-          <div
-            style={{
-              fontWeight: 600,
-              color:
-                selectedTab === 'all' ? colorTheme.black.value : colorTheme.subduedForeground.value,
-            }}
-            onMouseDown={switchToAllTab}
-          >
-            All Components
-          </div>
-          <div style={{ flexGrow: 1 }} />
-          {props.onClickCloseButton != null ? (
-            <div
-              style={{ fontWeight: 600 }}
-              onClick={props.onClickCloseButton}
-              data-testId={componentPickerCloseButtonTestId}
-            >
-              X
-            </div>
-          ) : null}
-        </div>
-        <div
-          style={{
-            padding: '10px 6px',
-            display: 'flex',
-            flexDirection: 'row',
-            width: '100%',
-            height: 27,
-            alignItems: 'center',
-            justifyContent: 'flex-start',
-            gap: 8,
-            border: '1px solid #989999',
-            borderColor: colorTheme.subduedBorder.value,
-            borderRadius: 6,
-          }}
-        >
-          <div
-            style={{
-              fontFamily: 'Utopian-Inter',
-              fontStyle: 'normal',
-              fontWeight: 500,
-              fontSize: '11px',
-              color: colorTheme.subduedForeground.value,
-            }}
-          >
-            🔍
-          </div>
-          <input
-            style={{
-              fontFamily: 'Utopian-Inter',
-              fontStyle: 'normal',
-              fontWeight: 500,
-              fontSize: '11px',
-              width: '100%',
-              border: 'none',
-            }}
-            placeholder='Filter...'
-            autoComplete='off'
-            spellCheck={false}
-            onKeyDown={handleFilterKeydown}
-            onChange={handleFilterChange}
-            value={filter}
-            data-testId={componentPickerFilterInputTestId}
-          />
-        </div>
-      </div>
+      <ComponentPickerTopSection
+        targetProp={props.insertionTargetName}
+        onFilterChange={setFilter}
+        onSelectTab={setSelectedTab}
+        onClickCloseButton={props.onClickCloseButton}
+      />
       <div
         style={{
           width: '100%',
@@ -213,6 +77,244 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
           borderColor: colorTheme.subduedBorder.value,
         }}
       />
+      <ComponentPickerComponentSection
+        components={componentsToShow}
+        onItemClick={props.onItemClick}
+      />
+    </div>
+  )
+})
+
+interface ComponentPickerTopSectionProps {
+  targetProp: string
+  onFilterChange: (filter: string) => void
+  onSelectTab: (tab: 'preferred' | 'all') => void
+  onClickCloseButton?: React.MouseEventHandler
+}
+
+const ComponentPickerTopSection = React.memo((props: ComponentPickerTopSectionProps) => {
+  const { targetProp, onFilterChange, onSelectTab, onClickCloseButton } = props
+  const [selectedTab, setSelectedTabState] = React.useState<'preferred' | 'all'>('preferred')
+  const setSelectedTab = React.useCallback(
+    (tab: 'preferred' | 'all') => {
+      setSelectedTabState(tab)
+      onSelectTab(tab)
+    },
+    [onSelectTab],
+  )
+  const switchToPreferredTab = React.useCallback(
+    () => setSelectedTab('preferred'),
+    [setSelectedTab],
+  )
+  const switchToAllTab = React.useCallback(() => setSelectedTab('all'), [setSelectedTab])
+
+  return (
+    <div
+      style={{
+        padding: '16px 16px',
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%',
+        alignItems: 'flex-start',
+        justifyContent: 'flex-start',
+        gap: 10,
+        height: 'max-content',
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'row',
+          gap: 5,
+          fontFamily: 'Utopian-Inter',
+          fontWeight: 700,
+          fontSize: '11px',
+        }}
+      >
+        <div>Insert into</div>
+        <PickerPropLabel targetProp={targetProp} />
+        <div style={{ flexGrow: 100 }} />
+        <PickerTabButton
+          title={'Preferred'}
+          isSelected={selectedTab === 'preferred'}
+          onClick={switchToPreferredTab}
+        />
+        <PickerTabButton
+          title={'All Components'}
+          isSelected={selectedTab === 'all'}
+          onClick={switchToAllTab}
+        />
+        <div style={{ flexGrow: 1 }} />
+        {onClickCloseButton != null ? (
+          <div
+            style={{ fontWeight: 600 }}
+            onClick={onClickCloseButton}
+            data-testId={componentPickerCloseButtonTestId}
+          >
+            X
+          </div>
+        ) : null}
+      </div>
+      <FilterBar onFilterChange={onFilterChange} />
+    </div>
+  )
+})
+
+interface PickerTabButtonProps {
+  title: string
+  isSelected: boolean
+  onClick: React.MouseEventHandler
+}
+
+const PickerTabButton = React.memo((props: PickerTabButtonProps) => {
+  const colorTheme = useColorTheme()
+  const { title, isSelected, onClick } = props
+  return (
+    <div
+      style={{
+        fontWeight: 600,
+        color: isSelected ? colorTheme.black.value : colorTheme.subduedForeground.value,
+      }}
+      onClick={onClick}
+    >
+      {title}
+    </div>
+  )
+})
+
+interface PickerPropLabelProps {
+  targetProp: string
+}
+
+const PickerPropLabel = React.memo((props: PickerPropLabelProps) => {
+  const { targetProp } = props
+  const colorTheme = useColorTheme()
+
+  return (
+    <div
+      style={{
+        border: '1px solid rgb(0, 0, 0, 1)',
+        borderRadius: 3,
+        height: 21,
+        contain: 'layout',
+      }}
+    >
+      <div
+        style={{
+          border: '1px solid rgb(0, 0, 0, 1)',
+          height: 21,
+          borderRadius: 3,
+          padding: 3,
+          margin: -1, // Honestly I give up
+          position: 'relative',
+          left: 3,
+          top: -2,
+          lineHeight: 'normal',
+          backgroundColor: colorTheme.white.value,
+        }}
+        data-testId={`${componentPickerTestIdForProp(targetProp)}-prop-field`}
+      >
+        {capitalize(targetProp)}
+      </div>
+    </div>
+  )
+})
+
+interface FilterBarProps {
+  onFilterChange: (filter: string) => void
+}
+
+const FilterBar = React.memo((props: FilterBarProps) => {
+  const colorTheme = useColorTheme()
+  const { onFilterChange } = props
+
+  const [filter, setFilterState] = React.useState<string>('')
+  const setFilter = React.useCallback(
+    (s: string) => {
+      setFilterState(s)
+      onFilterChange(s)
+    },
+    [onFilterChange],
+  )
+
+  const handleFilterKeydown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        ;(e.target as HTMLInputElement).blur() // Not sure why I need the cast here
+      } else if (e.key === 'Escape') {
+        setFilter('')
+        ;(e.target as HTMLInputElement).blur()
+      }
+      e.stopPropagation()
+    },
+    [setFilter],
+  )
+  const handleFilterChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setFilter(e.target.value)
+    },
+    [setFilter],
+  )
+
+  return (
+    <div
+      style={{
+        padding: '10px 6px',
+        display: 'flex',
+        flexDirection: 'row',
+        width: '100%',
+        height: 27,
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+        gap: 8,
+        border: '1px solid #989999',
+        borderColor: colorTheme.subduedBorder.value,
+        borderRadius: 6,
+      }}
+    >
+      <div
+        style={{
+          fontFamily: 'Utopian-Inter',
+          fontStyle: 'normal',
+          fontWeight: 500,
+          fontSize: '11px',
+          color: colorTheme.subduedForeground.value,
+        }}
+      >
+        🔍
+      </div>
+      <input
+        style={{
+          fontFamily: 'Utopian-Inter',
+          fontStyle: 'normal',
+          fontWeight: 500,
+          fontSize: '11px',
+          width: '100%',
+          border: 'none',
+        }}
+        placeholder='Filter...'
+        autoComplete='off'
+        spellCheck={false}
+        onKeyDown={handleFilterKeydown}
+        onChange={handleFilterChange}
+        value={filter}
+        data-testId={componentPickerFilterInputTestId}
+      />
+    </div>
+  )
+})
+
+interface ComponentPickerComponentSectionProps {
+  components: PreferredChildComponentDescriptor[]
+  onItemClick: (elementToInsert: ElementToInsert) => React.MouseEventHandler
+}
+
+const ComponentPickerComponentSection = React.memo(
+  (props: ComponentPickerComponentSectionProps) => {
+    const { components, onItemClick } = props
+
+    return (
       <div
         style={{
           padding: 16,
@@ -223,73 +325,109 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
           gap: 10,
         }}
       >
-        {componentsToShow.map((option, idx) => {
+        {components.map((componentDescriptor) => {
           return (
-            <div
-              style={{
-                backgroundColor: colorTheme.bg2.value,
-                borderRadius: 5,
-                display: 'flex',
-                flexDirection: 'column',
-                width: '100%',
-                height: 'max-content',
-                gap: 5,
-                padding: 10,
-                fontFamily: 'Utopian-Inter',
-                fontWeight: 500,
-                fontSize: '11px',
-              }}
-              key={`${idx}-label`}
-              data-testId={componentPickerOptionTestId(option.name)}
-            >
-              <div style={{ fontWeight: 700 }}>{option.name}</div>
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'row',
-                  width: '100%',
-                  height: 'max-content',
-                  alignItems: 'center',
-                  justifyContent: 'flex-start',
-                  flexWrap: 'wrap',
-                  gap: 9,
-                }}
-              >
-                {option.variants?.map((v, i) => (
-                  <div
-                    key={`${idx}-${v.insertMenuLabel}`}
-                    onClick={props.onItemClick({
-                      elementToInsert: (uid) => elementFromInsertMenuItem(v.elementToInsert(), uid),
-                      additionalImports: v.importsToAdd,
-                    })}
-                    css={{
-                      backgroundColor: colorTheme.bg5.value,
-                      paddingTop: 5,
-                      paddingRight: 5,
-                      paddingBottom: 5,
-                      paddingLeft: 5,
-                      borderTopLeftRadius: 3,
-                      borderTopRightRadius: 3,
-                      borderBottomRightRadius: 3,
-                      borderBottomLeftRadius: 3,
-                      color:
-                        v.insertMenuLabel === '(empty)'
-                          ? colorTheme.subduedForeground.value
-                          : colorTheme.black.value,
-                      '&:hover': {
-                        backgroundColor: colorTheme.dynamicBlue10.value,
-                      },
-                    }}
-                    data-testId={componentPickerOptionTestId(option.name, v.insertMenuLabel)}
-                  >
-                    {v.insertMenuLabel}
-                  </div>
-                ))}
-              </div>
-            </div>
+            <ComponentPickerOption
+              key={`${componentDescriptor.name}-label`}
+              componentDescriptor={componentDescriptor}
+              onItemClick={onItemClick}
+            />
           )
         })}
       </div>
+    )
+  },
+)
+
+interface ComponentPickerOptionProps {
+  componentDescriptor: PreferredChildComponentDescriptor
+  onItemClick: (elementToInsert: ElementToInsert) => React.MouseEventHandler
+}
+
+const ComponentPickerOption = React.memo((props: ComponentPickerOptionProps) => {
+  const colorTheme = useColorTheme()
+  const { componentDescriptor, onItemClick } = props
+
+  return (
+    <div
+      style={{
+        backgroundColor: colorTheme.bg2.value,
+        borderRadius: 5,
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%',
+        height: 'max-content',
+        gap: 5,
+        padding: 10,
+        fontFamily: 'Utopian-Inter',
+        fontWeight: 500,
+        fontSize: '11px',
+      }}
+      data-testId={componentPickerOptionTestId(componentDescriptor.name)}
+    >
+      <div style={{ fontWeight: 700 }}>{componentDescriptor.name}</div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          width: '100%',
+          height: 'max-content',
+          alignItems: 'center',
+          justifyContent: 'flex-start',
+          flexWrap: 'wrap',
+          gap: 9,
+        }}
+      >
+        {componentDescriptor.variants?.map((v) => (
+          <ComponentPickerVariant
+            key={`${componentDescriptor.name}-${v.insertMenuLabel}`}
+            componentName={componentDescriptor.name}
+            variant={v}
+            onItemClick={onItemClick}
+          />
+        ))}
+      </div>
+    </div>
+  )
+})
+
+interface ComponentPickerVariantProps {
+  componentName: string
+  variant: ComponentInfo
+  onItemClick: (elementToInsert: ElementToInsert) => React.MouseEventHandler
+}
+
+const ComponentPickerVariant = React.memo((props: ComponentPickerVariantProps) => {
+  const colorTheme = useColorTheme()
+  const { onItemClick, variant, componentName } = props
+
+  return (
+    <div
+      onClick={onItemClick({
+        elementToInsert: (uid) => elementFromInsertMenuItem(variant.elementToInsert(), uid),
+        additionalImports: variant.importsToAdd,
+      })}
+      css={{
+        backgroundColor: colorTheme.bg5.value,
+        paddingTop: 5,
+        paddingRight: 5,
+        paddingBottom: 5,
+        paddingLeft: 5,
+        borderTopLeftRadius: 3,
+        borderTopRightRadius: 3,
+        borderBottomRightRadius: 3,
+        borderBottomLeftRadius: 3,
+        color:
+          variant.insertMenuLabel === '(empty)'
+            ? colorTheme.subduedForeground.value
+            : colorTheme.black.value,
+        '&:hover': {
+          backgroundColor: colorTheme.dynamicBlue10.value,
+        },
+      }}
+      data-testId={componentPickerOptionTestId(componentName, variant.insertMenuLabel)}
+    >
+      {variant.insertMenuLabel}
     </div>
   )
 })

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -5,10 +5,10 @@ import React from 'react'
 import { useColorTheme } from '../../../uuiui'
 import { capitalize } from '../../../core/shared/string-utils'
 import { type PreferredChildComponentDescriptor } from '../../custom-code/internal-property-controls'
-import { type JSXElementChild } from '../../../core/shared/element-template'
+import { jsxElementWithoutUID, type JSXElementChild } from '../../../core/shared/element-template'
 import { type Imports } from '../../../core/shared/project-file-types'
 import { elementFromInsertMenuItem } from '../../editor/insert-callbacks'
-import { type ComponentInfo } from '../../custom-code/code-file'
+import { componentInfo, type ComponentInfo } from '../../custom-code/code-file'
 
 export interface ComponentPickerProps {
   insertionTargetName: string
@@ -348,6 +348,15 @@ const ComponentPickerOption = React.memo((props: ComponentPickerOptionProps) => 
   const colorTheme = useColorTheme()
   const { componentDescriptor, onItemClick } = props
 
+  const variants: ComponentInfo[] = [
+    componentInfo(
+      '(empty)',
+      () => jsxElementWithoutUID(componentDescriptor.name, [], []),
+      componentDescriptor.imports,
+    ),
+    ...(componentDescriptor.variants ?? []),
+  ]
+
   return (
     <div
       style={{
@@ -378,7 +387,7 @@ const ComponentPickerOption = React.memo((props: ComponentPickerOptionProps) => 
           gap: 9,
         }}
       >
-        {componentDescriptor.variants?.map((v) => (
+        {variants?.map((v) => (
           <ComponentPickerVariant
             key={`${componentDescriptor.name}-${v.insertMenuLabel}`}
             componentName={componentDescriptor.name}

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -344,18 +344,18 @@ interface ComponentPickerOptionProps {
   onItemClick: (elementToInsert: ElementToInsert) => React.MouseEventHandler
 }
 
+function variantsForComponent(component: PreferredChildComponentDescriptor): ComponentInfo[] {
+  return [
+    componentInfo('(empty)', () => jsxElementWithoutUID(component.name, [], []), component.imports),
+    ...(component.variants ?? []),
+  ]
+}
+
 const ComponentPickerOption = React.memo((props: ComponentPickerOptionProps) => {
   const colorTheme = useColorTheme()
   const { componentDescriptor, onItemClick } = props
 
-  const variants: ComponentInfo[] = [
-    componentInfo(
-      '(empty)',
-      () => jsxElementWithoutUID(componentDescriptor.name, [], []),
-      componentDescriptor.imports,
-    ),
-    ...(componentDescriptor.variants ?? []),
-  ]
+  const variants = variantsForComponent(componentDescriptor)
 
   return (
     <div

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -778,9 +778,6 @@ export const NavigatorItem: React.FunctionComponent<
   return (
     <div
       onClick={hideContextMenu}
-      data-testid={`toggle-render-prop-${NavigatorItemTestId(
-        varSafeNavigatorEntryToKey(navigatorEntry),
-      )}`}
       style={{
         outline: `1px solid ${
           props.parentOutline === 'solid' && isOutletOrDescendantOfOutlet
@@ -833,6 +830,9 @@ export const NavigatorItem: React.FunctionComponent<
               marginLeft: 28,
               cursor: navigatorEntry.type === 'SLOT' ? 'pointer' : 'inherit',
             }}
+            data-testid={`toggle-render-prop-${NavigatorItemTestId(
+              varSafeNavigatorEntryToKey(navigatorEntry),
+            )}`}
           >
             Empty
           </div>

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -40,6 +40,7 @@ import {
   isInvalidOverrideNavigatorEntry,
   isRegularNavigatorEntry,
   isRenderPropNavigatorEntry,
+  isSlotNavigatorEntry,
   isSyntheticNavigatorEntry,
   navigatorEntryToKey,
   varSafeNavigatorEntryToKey,
@@ -143,7 +144,8 @@ function selectItem(
   const selectionActions =
     isConditionalClauseNavigatorEntry(navigatorEntry) ||
     isInvalidOverrideNavigatorEntry(navigatorEntry) ||
-    isRenderPropNavigatorEntry(navigatorEntry)
+    isRenderPropNavigatorEntry(navigatorEntry) ||
+    isSlotNavigatorEntry(navigatorEntry)
       ? []
       : getSelectionActions(getSelectedViewsInRange, index, elementPath, selected, event)
 

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -55,7 +55,7 @@ import { ExpandableIndicator } from './expandable-indicator'
 import { ItemLabel } from './item-label'
 import { LayoutIcon } from './layout-icon'
 import { NavigatorItemActionSheet } from './navigator-item-components'
-import { CanvasContextMenuPortalTargetID, assertNever } from '../../../core/shared/utils'
+import { CanvasContextMenuPortalTargetID, NO_OP, assertNever } from '../../../core/shared/utils'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import { MapCounter } from './map-counter'
 import ReactDOM from 'react-dom'
@@ -777,7 +777,7 @@ export const NavigatorItem: React.FunctionComponent<
 
   return (
     <div
-      onClick={navigatorEntry.type === 'SLOT' ? showContextMenu : hideContextMenu}
+      onClick={hideContextMenu}
       data-testid={`toggle-render-prop-${NavigatorItemTestId(
         varSafeNavigatorEntryToKey(navigatorEntry),
       )}`}
@@ -813,6 +813,7 @@ export const NavigatorItem: React.FunctionComponent<
         {isPlaceholder ? (
           <div
             key={`label-${props.label}-slot`}
+            onClick={navigatorEntry.type === 'SLOT' ? showContextMenu : NO_OP}
             style={{
               width: 140,
               height: 19,
@@ -830,6 +831,7 @@ export const NavigatorItem: React.FunctionComponent<
                   : colorTheme.unavailableGrey10.value
               }`,
               marginLeft: 28,
+              cursor: navigatorEntry.type === 'SLOT' ? 'pointer' : 'inherit',
             }}
           >
             Empty

--- a/editor/src/components/navigator/navigator-item/render-prop-selector-popup.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/render-prop-selector-popup.spec.browser2.tsx
@@ -141,7 +141,7 @@ describe('The navigator render prop picker', () => {
     const editor = await renderTestEditorWithModel(TestProject, 'await-first-dom-report')
     await selectComponentsForTest(editor, [EP.fromString('sb/card')])
     const emptySlot = editor.renderedDOM.getByTestId(
-      'NavigatorItemTestId-slot_sb/card/prop_label_title',
+      'toggle-render-prop-NavigatorItemTestId-slot_sb/card/prop_label_title',
     )
     await mouseClickAtPoint(emptySlot, { x: 2, y: 2 })
 
@@ -159,7 +159,7 @@ describe('The navigator render prop picker', () => {
     const editor = await renderTestEditorWithModel(TestProject, 'await-first-dom-report')
     await selectComponentsForTest(editor, [EP.fromString('sb/card')])
     const emptySlot = editor.renderedDOM.getByTestId(
-      'NavigatorItemTestId-slot_sb/card/prop_label_title',
+      'toggle-render-prop-NavigatorItemTestId-slot_sb/card/prop_label_title',
     )
     await mouseClickAtPoint(emptySlot, { x: 2, y: 2 })
 
@@ -182,7 +182,7 @@ describe('The navigator render prop picker', () => {
     const editor = await renderTestEditorWithModel(TestProject, 'await-first-dom-report')
     await selectComponentsForTest(editor, [EP.fromString('sb/card')])
     const emptySlot = editor.renderedDOM.getByTestId(
-      'NavigatorItemTestId-slot_sb/card/prop_label_title',
+      'toggle-render-prop-NavigatorItemTestId-slot_sb/card/prop_label_title',
     )
     await mouseClickAtPoint(emptySlot, { x: 2, y: 2 })
 
@@ -222,7 +222,7 @@ describe('The navigator render prop picker', () => {
     const editor = await renderTestEditorWithModel(TestProject, 'await-first-dom-report')
     await selectComponentsForTest(editor, [EP.fromString('sb/card')])
     const emptySlot = editor.renderedDOM.getByTestId(
-      'NavigatorItemTestId-slot_sb/card/prop_label_title',
+      'toggle-render-prop-NavigatorItemTestId-slot_sb/card/prop_label_title',
     )
     await mouseClickAtPoint(emptySlot, { x: 2, y: 2 })
 
@@ -254,7 +254,7 @@ describe('The navigator render prop picker', () => {
     const editor = await renderTestEditorWithModel(TestProject, 'await-first-dom-report')
     await selectComponentsForTest(editor, [EP.fromString('sb/card')])
     const emptySlot = editor.renderedDOM.getByTestId(
-      'NavigatorItemTestId-slot_sb/card/prop_label_title',
+      'toggle-render-prop-NavigatorItemTestId-slot_sb/card/prop_label_title',
     )
     await mouseClickAtPoint(emptySlot, { x: 2, y: 2 })
 
@@ -276,7 +276,7 @@ describe('The navigator render prop picker', () => {
     const editor = await renderTestEditorWithModel(TestProject, 'await-first-dom-report')
     await selectComponentsForTest(editor, [EP.fromString('sb/card')])
     const emptySlot = editor.renderedDOM.getByTestId(
-      'NavigatorItemTestId-slot_sb/card/prop_label_title',
+      'toggle-render-prop-NavigatorItemTestId-slot_sb/card/prop_label_title',
     )
     await mouseClickAtPoint(emptySlot, { x: 2, y: 2 })
 
@@ -297,7 +297,7 @@ describe('The navigator render prop picker', () => {
     const editor = await renderTestEditorWithModel(TestProject, 'await-first-dom-report')
     await selectComponentsForTest(editor, [EP.fromString('sb/card')])
     const emptySlot = editor.renderedDOM.getByTestId(
-      'NavigatorItemTestId-slot_sb/card/prop_label_title',
+      'toggle-render-prop-NavigatorItemTestId-slot_sb/card/prop_label_title',
     )
     await mouseClickAtPoint(emptySlot, { x: 2, y: 2 })
 

--- a/editor/src/components/navigator/navigator-item/render-prop-selector-popup.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/render-prop-selector-popup.spec.browser2.tsx
@@ -20,26 +20,28 @@ describe('The navigator render prop picker', () => {
     {
       name: 'FlexRow',
       variants: [
-        { label: '(empty)', code: '<div />' },
         {
           label: 'with three placeholders',
-          code: '<div>three totally real placeholders</div>',
+          code: '<FlexRow>three totally real placeholders</FlexRow>',
         },
         {
           label: 'Fully Loaded (limited time only!)',
-          code: '<div>The Fully Loaded one</div>',
+          code: '<FlexRow>The Fully Loaded one</FlexRow>',
         },
         {
           label: 'With Auto-Sizing Content',
-          code: '<div>Sizes automatically</div>',
+          code: '<FlexRow>Sizes automatically</FlexRow>',
         },
       ],
+      additionalImports: '/src/utils',
     },
     {
       name: 'FlexCol',
+      additionalImports: '/src/utils',
     },
     {
       name: 'Flex',
+      additionalImports: '/src/utils',
     },
   ]
 
@@ -91,7 +93,49 @@ describe('The navigator render prop picker', () => {
     
     export default Components    
     `,
+    ['/src/utils.js']: `
+    import * as React from 'react'
+
+    export function FlexRow({ children, style, ...props }) {
+      return (
+        <div
+          {...props}
+          style={{
+            position: 'relative',
+            display: 'flex',
+            flexDirection: 'row',
+            ...style,
+          }}
+        >
+          {children}
+        </div>
+      )
+    }
+
+    export function FlexCol({ children, style, ...props }) {
+      return (
+        <div
+          {...props}
+          style={{
+            position: 'relative',
+            display: 'flex',
+            flexDirection: 'column',
+            ...style,
+          }}
+        >
+          {children}
+        </div>
+      )
+    }
+    `,
   })
+
+  function variantsForComponent(componentName: string) {
+    return [
+      { label: '(empty)', code: `<${componentName} />` },
+      ...(PreferredChildComponents.find((v) => v.name === componentName)?.variants ?? []),
+    ]
+  }
 
   it('Should be displayed with the correct prop when clicking a render prop slot in the navigator', async () => {
     const editor = await renderTestEditorWithModel(TestProject, 'await-first-dom-report')
@@ -125,13 +169,11 @@ describe('The navigator render prop picker', () => {
       )
       expect(renderedOptionLabel).not.toBeNull()
 
-      if (childComponent.variants != null) {
-        for (const variant of childComponent.variants) {
-          const renderedOptionVariant = editor.renderedDOM.queryByTestId(
-            componentPickerOptionTestId(childComponent.name, variant.label),
-          )
-          expect(renderedOptionVariant).not.toBeNull()
-        }
+      for (const variant of variantsForComponent(childComponent.name)) {
+        const renderedOptionVariant = editor.renderedDOM.queryByTestId(
+          componentPickerOptionTestId(childComponent.name, variant.label),
+        )
+        expect(renderedOptionVariant).not.toBeNull()
       }
     }
   })
@@ -162,17 +204,15 @@ describe('The navigator render prop picker', () => {
         expect(renderedOptionLabel).toBeNull()
       }
 
-      if (childComponent.variants != null) {
-        for (const variant of childComponent.variants) {
-          const renderedOptionVariant = editor.renderedDOM.queryByTestId(
-            componentPickerOptionTestId(childComponent.name, variant.label),
-          )
+      for (const variant of variantsForComponent(childComponent.name)) {
+        const renderedOptionVariant = editor.renderedDOM.queryByTestId(
+          componentPickerOptionTestId(childComponent.name, variant.label),
+        )
 
-          if (childComponent.name === 'FlexRow') {
-            expect(renderedOptionVariant).not.toBeNull()
-          } else {
-            expect(renderedOptionVariant).toBeNull()
-          }
+        if (childComponent.name === 'FlexRow') {
+          expect(renderedOptionVariant).not.toBeNull()
+        } else {
+          expect(renderedOptionVariant).toBeNull()
         }
       }
     }
@@ -200,14 +240,12 @@ describe('The navigator render prop picker', () => {
 
       expect(renderedOptionLabel).not.toBeNull()
 
-      if (childComponent.variants != null) {
-        for (const variant of childComponent.variants) {
-          const renderedOptionVariant = editor.renderedDOM.queryByTestId(
-            componentPickerOptionTestId(childComponent.name, variant.label),
-          )
+      for (const variant of variantsForComponent(childComponent.name)) {
+        const renderedOptionVariant = editor.renderedDOM.queryByTestId(
+          componentPickerOptionTestId(childComponent.name, variant.label),
+        )
 
-          expect(renderedOptionVariant).not.toBeNull()
-        }
+        expect(renderedOptionVariant).not.toBeNull()
       }
     }
   })
@@ -275,6 +313,7 @@ describe('The navigator render prop picker', () => {
       formatTestProjectCode(`
     import * as React from 'react'
     import { Storyboard } from 'utopia-api'
+    import { FlexRow } from '/src/utils'
 
     const Card = (props) => {
       return (
@@ -297,9 +336,9 @@ describe('The navigator render prop picker', () => {
             height: 87,
           }}
           title={
-            <div style={{ width: 100, height: 100 }}>
+            <FlexRow style={{ width: 100, height: 100 }}>
               three totally real placeholders
-            </div>
+            </FlexRow>
           }
         />
       </Storyboard>


### PR DESCRIPTION
Follow on from #5101 

This PR introduces the following tweaks to the Component Picker popup that is used for render prop slots:

1. I've split up the `ComponentPicker` component into several components. _For now_ I have kept them all in `component-picker.tsx`, as their individual locations (and that file's location) would have to change anyway when re-using this for the Insert Menu pane, so I'd rather wait until then before further generalising it.
2. We now use the `pointer` cursor when hovering over the clickable elements in the popup
3. We now also use the `pointer` cursor when hovering over the slot itself in the navigator, meaning that it is now clear you can click the slot for a render prop (note also that you now click the empty slot itself rather than the actual row, as per the gif below)
4. All registered components now come with an `(empty)` variant, which just inserts the component as `<MyComponent />`

[**Try it here**](https://utopia.fish/p/2e3389de-emphasized-trumpet/?branch_name=feature-render-prop-insert-picker-2)

![component-picker](https://github.com/concrete-utopia/utopia/assets/1044774/828a4753-6a3c-46e9-b31a-2995263f1489)
