### PR TITLE
Add a login route

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -555,7 +555,7 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:password@localhost:54322/utopia-test?sslmode=disable
           APP_ENV: 'test'
-          CORS_ORIGIN: '*'
+          CORS_ORIGIN: 'http://localhost:8000'
           BACKEND_URL: ''
           REACT_APP_EDITOR_URL: ''
           LIVEBLOCKS_SECRET_KEY: 'secret'

--- a/utopia-remix/app/routes-test/login.spec.ts
+++ b/utopia-remix/app/routes-test/login.spec.ts
@@ -3,17 +3,6 @@ import { handleLogin } from '../routes/login'
 import { ServerEnvironment } from '../env.server'
 
 describe('handleLogin', () => {
-  let corsOrigin: string
-  beforeAll(() => {
-    corsOrigin = ServerEnvironment.CORS_ORIGIN
-    // this is since in the tests we set CORS_ORIGIN to '*',
-    // so we can't rely on it in URLs
-    ServerEnvironment.CORS_ORIGIN = 'http://localhost:8000'
-  })
-  afterAll(() => {
-    ServerEnvironment.CORS_ORIGIN = corsOrigin
-  })
-
   it('should redirect to auth0 login with the correct redirectTo param', async () => {
     const request = newTestRequest({
       method: 'GET',

--- a/utopia-remix/app/routes-test/login.spec.ts
+++ b/utopia-remix/app/routes-test/login.spec.ts
@@ -1,0 +1,69 @@
+import { newTestRequest } from '../test-util'
+import { handleLogin } from '../routes/login'
+import { ServerEnvironment } from '../env.server'
+
+describe('handleLogin', () => {
+  let corsOrigin: string
+  beforeAll(() => {
+    corsOrigin = ServerEnvironment.CORS_ORIGIN
+    // this is since in the tests we set CORS_ORIGIN to '*',
+    // so we can't rely on it in URLs
+    ServerEnvironment.CORS_ORIGIN = 'http://localhost:8000'
+  })
+  afterAll(() => {
+    ServerEnvironment.CORS_ORIGIN = corsOrigin
+  })
+
+  it('should redirect to auth0 login with the correct redirectTo param', async () => {
+    const request = newTestRequest({
+      method: 'GET',
+      path: '/login',
+      search: { redirectTo: encodeURIComponent('/p/test-project') },
+    })
+    const response = await handleLogin(request, {})
+    expect(response.status).toBe(302)
+    const redirectLocation = response.headers.get('Location')
+    expect(redirectLocation).toContain(`${ServerEnvironment.AUTH0_ENDPOINT}/authorize`)
+    const redirectToParam = getParamFromLoginURL(redirectLocation ?? '', 'redirectTo')
+    expect(redirectToParam).toBe('/p/test-project')
+  })
+
+  it('should redirect to auth0 login without redirectTo if not specified', async () => {
+    const request = newTestRequest({
+      method: 'GET',
+      path: '/login',
+    })
+    const response = await handleLogin(request, {})
+    expect(response.status).toBe(302)
+    const redirectLocation = response.headers.get('Location')
+    expect(redirectLocation).toContain(`${ServerEnvironment.AUTH0_ENDPOINT}/authorize`)
+    const redirectToParam = getParamFromLoginURL(redirectLocation ?? '', 'redirectTo')
+    expect(redirectToParam).toBe(null)
+  })
+
+  it('should redirect to authenticate login with the correct redirectTo param and fakeUser', async () => {
+    const request = newTestRequest({
+      method: 'GET',
+      path: '/login',
+      search: { redirectTo: encodeURIComponent('/p/test-project'), fakeUser: 'alice' },
+    })
+    const response = await handleLogin(request, {})
+    expect(response.status).toBe(302)
+    const redirectLocation = response.headers.get('Location')
+    expect(redirectLocation).toContain(`${ServerEnvironment.CORS_ORIGIN}/authenticate`)
+    const redirectToParam = getDecodedParam(redirectLocation, 'redirectTo')
+    expect(redirectToParam).toBe('/p/test-project')
+    const codeParam = getDecodedParam(redirectLocation, 'code')
+    expect(codeParam).toBe('alice')
+  })
+})
+
+function getParamFromLoginURL(url: string, param: string): string | null {
+  const redirect_uri = getDecodedParam(url ?? '', 'redirect_uri')
+  return getDecodedParam(redirect_uri ?? '', param)
+}
+
+function getDecodedParam(url: string | null, param: string): string | null {
+  const value = new URL(url ?? '').searchParams.get(param)
+  return value ? decodeURIComponent(value) : null
+}

--- a/utopia-remix/app/routes-test/login.spec.ts
+++ b/utopia-remix/app/routes-test/login.spec.ts
@@ -12,7 +12,6 @@ describe('handleLogin', () => {
     const response = await handleLogin(request, {})
     expect(response.status).toBe(302)
     const redirectLocation = response.headers.get('Location')
-    expect(redirectLocation).toContain(`${ServerEnvironment.AUTH0_ENDPOINT}/authorize`)
     const redirectToParam = getParamFromLoginURL(redirectLocation ?? '', 'redirectTo')
     expect(redirectToParam).toBe('/p/test-project')
   })
@@ -25,7 +24,6 @@ describe('handleLogin', () => {
     const response = await handleLogin(request, {})
     expect(response.status).toBe(302)
     const redirectLocation = response.headers.get('Location')
-    expect(redirectLocation).toContain(`${ServerEnvironment.AUTH0_ENDPOINT}/authorize`)
     const redirectToParam = getParamFromLoginURL(redirectLocation ?? '', 'redirectTo')
     expect(redirectToParam).toBe(null)
   })
@@ -48,7 +46,9 @@ describe('handleLogin', () => {
 })
 
 function getParamFromLoginURL(url: string, param: string): string | null {
-  const redirect_uri = getDecodedParam(url ?? '', 'redirect_uri')
+  const redirect_uri = url.includes(`${ServerEnvironment.AUTH0_ENDPOINT}/authorize`)
+    ? getDecodedParam(url ?? '', 'redirect_uri')
+    : url
   return getDecodedParam(redirect_uri ?? '', param)
 }
 

--- a/utopia-remix/app/routes/authenticate.tsx
+++ b/utopia-remix/app/routes/authenticate.tsx
@@ -15,6 +15,7 @@ export async function loader(args: LoaderFunctionArgs) {
 async function handleAuthenticate(req: Request) {
   const url = new URL(req.url)
   const autoClose = url.searchParams.get('onto') === 'auto-close'
+  const redirectTo = url.searchParams.get('redirectTo')
   const resp = await proxy(req, { rawOutput: true })
 
   if (resp instanceof Response && resp.ok) {
@@ -22,7 +23,7 @@ async function handleAuthenticate(req: Request) {
       ? // auto-close the window when logins come from the editor
         authFromEditor(resp)
       : // redirect to projects
-        authFromRemix(resp)
+        authFromRemix(resp, redirectTo)
   }
 
   return resp
@@ -39,6 +40,6 @@ function authFromEditor(resp: Response) {
   })
 }
 
-function authFromRemix(resp: Response) {
-  return redirect('/projects', { headers: resp.headers })
+function authFromRemix(resp: Response, redirectTo: string | null) {
+  return redirect(redirectTo ?? '/projects', { headers: resp.headers })
 }

--- a/utopia-remix/app/routes/login.tsx
+++ b/utopia-remix/app/routes/login.tsx
@@ -1,0 +1,25 @@
+import { redirect, type LoaderFunctionArgs } from '@remix-run/node'
+import { ALLOW } from '../handlers/validators'
+import { handle } from '../util/api.server'
+import type { Params } from '@remix-run/react'
+import { auth0LoginURL } from '../util/auth0.server'
+
+export async function loader(args: LoaderFunctionArgs) {
+  return handle(args, {
+    GET: {
+      validator: ALLOW,
+      handler: handleLogin,
+    },
+  })
+}
+
+export async function handleLogin(req: Request, params: Params<string>) {
+  const url = new URL(req.url)
+  const redirectTo = url.searchParams.get('redirectTo')
+  const fakeUser = url.searchParams.get('fakeUser')
+  const auth0Login = auth0LoginURL({
+    redirectTo: redirectTo,
+    fakeUser: fakeUser,
+  })
+  return redirect(auth0Login)
+}

--- a/utopia-remix/app/test-util.ts
+++ b/utopia-remix/app/test-util.ts
@@ -124,6 +124,7 @@ export async function truncateTables(models: DeletableModel[]) {
 
 export function newTestRequest(params?: {
   path?: string
+  search?: Record<string, string>
   method?: string
   headers?: { [key: string]: string }
   authCookie?: string
@@ -131,7 +132,13 @@ export function newTestRequest(params?: {
   body?: string
 }): Request {
   const path = (params?.path ?? '').replace(/^\/+/, '')
-  const req = new Request(`http://localhost:8000/` + path, {
+  const url = new URL(`http://localhost:8000/${path}`)
+  if (params?.search != null) {
+    for (const key of Object.keys(params.search)) {
+      url.searchParams.set(key, params.search[key])
+    }
+  }
+  const req = new Request(url, {
     method: params?.method,
     body: params?.formData ?? params?.body,
   })

--- a/utopia-remix/app/util/auth0.server.ts
+++ b/utopia-remix/app/util/auth0.server.ts
@@ -1,8 +1,21 @@
 import urlJoin from 'url-join'
 import { ServerEnvironment } from '../env.server'
 
-export function auth0LoginURL(): string {
+export function auth0LoginURL({
+  redirectTo,
+  fakeUser,
+}: { redirectTo?: string | null; fakeUser?: string | null } = {}): string {
   const behaviour: 'auto-close' | 'authd-redirect' = 'authd-redirect'
+
+  if (fakeUser != null) {
+    const url = new URL(urlJoin(ServerEnvironment.CORS_ORIGIN, 'authenticate'))
+    url.searchParams.set('code', fakeUser)
+    url.searchParams.set('onto', behaviour)
+    if (redirectTo != null) {
+      url.searchParams.set('redirectTo', redirectTo)
+    }
+    return url.href
+  }
 
   const useAuth0 =
     ServerEnvironment.AUTH0_ENDPOINT !== '' &&
@@ -15,6 +28,9 @@ export function auth0LoginURL(): string {
     const url = new URL(urlJoin(ServerEnvironment.CORS_ORIGIN, 'authenticate'))
     url.searchParams.set('code', 'logmein')
     url.searchParams.set('onto', behaviour)
+    if (redirectTo != null) {
+      url.searchParams.set('redirectTo', redirectTo)
+    }
     return url.href
   }
 
@@ -25,6 +41,9 @@ export function auth0LoginURL(): string {
 
   const redirectURL = new URL(ServerEnvironment.AUTH0_REDIRECT_URI)
   redirectURL.searchParams.set('onto', behaviour)
+  if (redirectTo != null) {
+    redirectURL.searchParams.set('redirectTo', redirectTo)
+  }
 
   url.searchParams.set('redirect_uri', redirectURL.href)
   return url.href

--- a/utopia-remix/run-integration-tests.sh
+++ b/utopia-remix/run-integration-tests.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-podman compose down -v
-podman compose up -d
+docker compose down -v
+docker compose up -d
 
-until podman exec utopia-remix-db-test pg_isready ; do sleep 1 ; done
+until docker exec utopia-remix-db-test pg_isready ; do sleep 1 ; done
 
 export APP_ENV='test'
 export DATABASE_URL='postgres://postgres:password@localhost:54322/postgres?sslmode=disable'
@@ -14,6 +14,6 @@ export BACKEND_URL=''
 export REACT_APP_EDITOR_URL=''
 
 pnpm exec prisma db push
-jest --runInBand --verbose --watch
+jest --runInBand --verbose
 
-podman compose down -v
+docker compose down -v

--- a/utopia-remix/run-integration-tests.sh
+++ b/utopia-remix/run-integration-tests.sh
@@ -9,7 +9,7 @@ until docker exec utopia-remix-db-test pg_isready ; do sleep 1 ; done
 
 export APP_ENV='test'
 export DATABASE_URL='postgres://postgres:password@localhost:54322/postgres?sslmode=disable'
-export CORS_ORIGIN='*'
+export CORS_ORIGIN='http://localhost:8000'
 export BACKEND_URL=''
 export REACT_APP_EDITOR_URL=''
 

--- a/utopia-remix/run-integration-tests.sh
+++ b/utopia-remix/run-integration-tests.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-docker compose down -v
-docker compose up -d
+podman compose down -v
+podman compose up -d
 
-until docker exec utopia-remix-db-test pg_isready ; do sleep 1 ; done
+until podman exec utopia-remix-db-test pg_isready ; do sleep 1 ; done
 
 export APP_ENV='test'
 export DATABASE_URL='postgres://postgres:password@localhost:54322/postgres?sslmode=disable'
@@ -14,6 +14,6 @@ export BACKEND_URL=''
 export REACT_APP_EDITOR_URL=''
 
 pnpm exec prisma db push
-jest --runInBand --verbose
+jest --runInBand --verbose --watch
 
-docker compose down -v
+podman compose down -v


### PR DESCRIPTION
This adds a new `/login` route to Remix, that calls the Auth0 url method in order to login and redirect if needed.
This is required for completion of #5113.

The route supports `/login?redirectTo={path}&fakeUser={alice|bob}`:

<video src="https://github.com/concrete-utopia/utopia/assets/7003853/fddd5ca3-4442-4546-aa8f-8f4d8b0f1e3c"/>

