### PR TITLE
Fix register component lifecycle after a sidecar file rename

### DIFF
--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -3,7 +3,7 @@ import { BakedInStoryboardUID } from '../model/scene-utils'
 import { TestScene0UID } from '../model/test-ui-js-file.test-utils'
 import { createModifiedProject } from '../../sample-projects/sample-project-utils.test-utils'
 import { StoryboardFilePath } from '../../components/editor/store/editor-state'
-import { deleteFile } from '../../components/editor/actions/action-creators'
+import { deleteFile, updateFilePath } from '../../components/editor/actions/action-creators'
 import { updateFromCodeEditor } from '../../components/editor/actions/actions-from-vscode'
 
 const project = (componentDescriptorFiles: { [filename: string]: string }) =>
@@ -371,12 +371,13 @@ describe('registered property controls', () => {
 })
 
 describe('Lifecycle management of registering components', () => {
-  it('Deleting a component descriptor file removes the property controls from that file', async () => {
-    const descriptorFileName1 = '/utopia/components1.utopia.js'
-    const descriptorFileName2 = '/utopia/components2.utopia.js'
-    const renderResult = await renderTestEditorWithModel(
-      project({
-        [descriptorFileName1]: `const Components = {
+  const descriptorFileName1 = '/utopia/components1.utopia.js'
+  const descriptorFileName2 = '/utopia/components2.utopia.js'
+  describe('Deleting a component descriptor file', () => {
+    it('Deleting a component descriptor file removes the property controls from that file', async () => {
+      const renderResult = await renderTestEditorWithModel(
+        project({
+          [descriptorFileName1]: `const Components = {
       '/src/card': {
         Card: {
           supportsChildren: false,
@@ -392,7 +393,7 @@ describe('Lifecycle management of registering components', () => {
     
     export default Components
   `,
-        [descriptorFileName2]: `const Components = {
+          [descriptorFileName2]: `const Components = {
     '/src/card2': {
       Card2: {
         supportsChildren: false,
@@ -408,58 +409,58 @@ describe('Lifecycle management of registering components', () => {
   
   export default Components
 `,
-      }),
-      'await-first-dom-report',
-    )
+        }),
+        'await-first-dom-report',
+      )
 
-    // Property controls from both descriptors files are there
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card",
-      ]
-    `)
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card2",
-      ]
-    `)
+      // Property controls from both descriptors files are there
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card",
+              ]
+          `)
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card2",
+              ]
+          `)
 
-    // delete the first descriptor file
-    await renderResult.dispatch([deleteFile(descriptorFileName1)], true)
+      // delete the first descriptor file
+      await renderResult.dispatch([deleteFile(descriptorFileName1)], true)
 
-    // property controls from the first descriptor file are gone
-    expect(renderResult.getEditorState().editor.propertyControlsInfo).not.toContain('/src/card')
-    // property controls from the second descriptor file are still there
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card2",
-      ]
-    `)
+      // property controls from the first descriptor file are gone
+      expect(renderResult.getEditorState().editor.propertyControlsInfo).not.toContain('/src/card')
+      // property controls from the second descriptor file are still there
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card2",
+              ]
+          `)
+    })
   })
-  const descriptorFileName1 = '/utopia/components1.utopia.js'
-  const descriptorFileName2 = '/utopia/components2.utopia.js'
-  const descriptorFileContent2 = `const Components = {
-    '/src/card2': {
-      Card2: {
-        supportsChildren: false,
-        properties: {
-          label: {
-            control: 'string-input',
+  describe('Updating a component descriptor file', () => {
+    const descriptorFileContent2 = `const Components = {
+      '/src/card2': {
+        Card2: {
+          supportsChildren: false,
+          properties: {
+            label: {
+              control: 'string-input',
+            },
           },
+          variants: [],
         },
-        variants: [],
       },
-    },
-  }
-  
-  export default Components
-`
+    }
+    
+    export default Components
+  `
 
-  it('Updating a component in a component descriptor file updates the property controls of that component', async () => {
-    const descriptorFileContent1 = `const Components = {
+    it('Updating a component in a component descriptor file updates the property controls of that component', async () => {
+      const descriptorFileContent1 = `const Components = {
       '/src/card': {
         Card: {
           supportsChildren: false,
@@ -476,36 +477,37 @@ describe('Lifecycle management of registering components', () => {
     export default Components
   `
 
-    const renderResult = await renderTestEditorWithModel(
-      project({
-        [descriptorFileName1]: descriptorFileContent1,
-        [descriptorFileName2]: descriptorFileContent2,
-      }),
-      'await-first-dom-report',
-    )
+      const renderResult = await renderTestEditorWithModel(
+        project({
+          [descriptorFileName1]: descriptorFileContent1,
+          [descriptorFileName2]: descriptorFileContent2,
+        }),
+        'await-first-dom-report',
+      )
 
-    // Card has a label property in the original file
-    expect(
-      Object.keys(
-        renderResult.getEditorState().editor.propertyControlsInfo['/src/card']['Card'].properties,
-      ),
-    ).toMatchInlineSnapshot(`
-      Array [
-        "label",
-      ]
-    `)
-    // Just to check that the property controls from the second descriptor file are there
-    expect(
-      Object.keys(
-        renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']['Card2'].properties,
-      ),
-    ).toMatchInlineSnapshot(`
-      Array [
-        "label",
-      ]
-    `)
+      // Card has a label property in the original file
+      expect(
+        Object.keys(
+          renderResult.getEditorState().editor.propertyControlsInfo['/src/card']['Card'].properties,
+        ),
+      ).toMatchInlineSnapshot(`
+              Array [
+                "label",
+              ]
+          `)
+      // Just to check that the property controls from the second descriptor file are there
+      expect(
+        Object.keys(
+          renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']['Card2']
+            .properties,
+        ),
+      ).toMatchInlineSnapshot(`
+              Array [
+                "label",
+              ]
+          `)
 
-    const updatedDescriptorFileContent = `const Components = {
+      const updatedDescriptorFileContent = `const Components = {
       '/src/card': {
         Card: {
           supportsChildren: false,
@@ -521,40 +523,41 @@ describe('Lifecycle management of registering components', () => {
 
     export default Components`
 
-    await renderResult.dispatch(
-      [
-        updateFromCodeEditor(
-          descriptorFileName1,
-          descriptorFileContent1,
-          updatedDescriptorFileContent,
-        ),
-      ],
-      true,
-    )
+      await renderResult.dispatch(
+        [
+          updateFromCodeEditor(
+            descriptorFileName1,
+            descriptorFileContent1,
+            updatedDescriptorFileContent,
+          ),
+        ],
+        true,
+      )
 
-    // Card has a label2 property in the updated file
-    expect(
-      Object.keys(
-        renderResult.getEditorState().editor.propertyControlsInfo['/src/card']['Card'].properties,
-      ),
-    ).toMatchInlineSnapshot(`
+      // Card has a label2 property in the updated file
+      expect(
+        Object.keys(
+          renderResult.getEditorState().editor.propertyControlsInfo['/src/card']['Card'].properties,
+        ),
+      ).toMatchInlineSnapshot(`
           Array [
             "label2",
           ]
       `)
-    // Card2 has not been changed
-    expect(
-      Object.keys(
-        renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']['Card2'].properties,
-      ),
-    ).toMatchInlineSnapshot(`
-      Array [
-        "label",
-      ]
-    `)
-  })
-  it('Adding a new component in a component descriptor file adds its property controls', async () => {
-    const descriptorFileContent1 = `const Components = {
+      // Card2 has not been changed
+      expect(
+        Object.keys(
+          renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']['Card2']
+            .properties,
+        ),
+      ).toMatchInlineSnapshot(`
+              Array [
+                "label",
+              ]
+          `)
+    })
+    it('Adding a new component in a component descriptor file adds its property controls', async () => {
+      const descriptorFileContent1 = `const Components = {
       '/src/card': {
         Card: {
           supportsChildren: false,
@@ -570,29 +573,29 @@ describe('Lifecycle management of registering components', () => {
     
     export default Components
   `
-    const renderResult = await renderTestEditorWithModel(
-      project({
-        [descriptorFileName1]: descriptorFileContent1,
-        [descriptorFileName2]: descriptorFileContent2,
-      }),
-      'await-first-dom-report',
-    )
-    // The Card component is registered from the first descriptor file
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card",
-      ]
-    `)
-    // The Card2 component is registered from the second descriptor file
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card2",
-      ]
-    `)
+      const renderResult = await renderTestEditorWithModel(
+        project({
+          [descriptorFileName1]: descriptorFileContent1,
+          [descriptorFileName2]: descriptorFileContent2,
+        }),
+        'await-first-dom-report',
+      )
+      // The Card component is registered from the first descriptor file
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card",
+              ]
+          `)
+      // The Card2 component is registered from the second descriptor file
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card2",
+              ]
+          `)
 
-    const updatedDescriptorFileContent = `const Components = {
+      const updatedDescriptorFileContent = `const Components = {
       '/src/card': {
         Card: {
           supportsChildren: false,
@@ -617,35 +620,35 @@ describe('Lifecycle management of registering components', () => {
 
     export default Components`
 
-    await renderResult.dispatch(
-      [
-        updateFromCodeEditor(
-          descriptorFileName1,
-          descriptorFileContent1,
-          updatedDescriptorFileContent,
-        ),
-      ],
-      true,
-    )
+      await renderResult.dispatch(
+        [
+          updateFromCodeEditor(
+            descriptorFileName1,
+            descriptorFileContent1,
+            updatedDescriptorFileContent,
+          ),
+        ],
+        true,
+      )
 
-    // The first descriptor file has a new NewCard component in it
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card",
-        "NewCard",
-      ]
-    `)
-    // The second descriptor file has not been changed
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card2",
-      ]
-    `)
-  })
-  it('Removing a component from a component descriptor file removes its property controls', async () => {
-    const descriptorFileContent1 = `const Components = {
+      // The first descriptor file has a new NewCard component in it
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card",
+                "NewCard",
+              ]
+          `)
+      // The second descriptor file has not been changed
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card2",
+              ]
+          `)
+    })
+    it('Removing a component from a component descriptor file removes its property controls', async () => {
+      const descriptorFileContent1 = `const Components = {
       '/src/card': {
         Card: {
           supportsChildren: false,
@@ -670,31 +673,31 @@ describe('Lifecycle management of registering components', () => {
     
     export default Components
   `
-    const renderResult = await renderTestEditorWithModel(
-      project({
-        [descriptorFileName1]: descriptorFileContent1,
-        [descriptorFileName2]: descriptorFileContent2,
-      }),
-      'await-first-dom-report',
-    )
+      const renderResult = await renderTestEditorWithModel(
+        project({
+          [descriptorFileName1]: descriptorFileContent1,
+          [descriptorFileName2]: descriptorFileContent2,
+        }),
+        'await-first-dom-report',
+      )
 
-    // The Card and CardToDelete component is registered from the first descriptor file
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card",
-        "CardToDelete",
-      ]
-    `)
-    // The Card2 component is registered from the second descriptor file
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card2",
-      ]
-    `)
+      // The Card and CardToDelete component is registered from the first descriptor file
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card",
+                "CardToDelete",
+              ]
+          `)
+      // The Card2 component is registered from the second descriptor file
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card2",
+              ]
+          `)
 
-    const updatedDescriptorFileContent = `const Components = {
+      const updatedDescriptorFileContent = `const Components = {
       '/src/card': {
         Card: {
           supportsChildren: false,
@@ -710,34 +713,34 @@ describe('Lifecycle management of registering components', () => {
 
     export default Components`
 
-    await renderResult.dispatch(
-      [
-        updateFromCodeEditor(
-          descriptorFileName1,
-          descriptorFileContent1,
-          updatedDescriptorFileContent,
-        ),
-      ],
-      true,
-    )
+      await renderResult.dispatch(
+        [
+          updateFromCodeEditor(
+            descriptorFileName1,
+            descriptorFileContent1,
+            updatedDescriptorFileContent,
+          ),
+        ],
+        true,
+      )
 
-    // The CardToDelete from the first descriptor file has been deleted
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card",
-      ]
-    `)
-    // The second descriptor file has not been changed
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card2",
-      ]
-    `)
-  })
-  it('Adding a new module to a component descriptor file adds its components', async () => {
-    const descriptorFileContent1 = `const Components = {
+      // The CardToDelete from the first descriptor file has been deleted
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card",
+              ]
+          `)
+      // The second descriptor file has not been changed
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card2",
+              ]
+          `)
+    })
+    it('Adding a new module to a component descriptor file adds its components', async () => {
+      const descriptorFileContent1 = `const Components = {
       '/src/card': {
         Card: {
           supportsChildren: false,
@@ -753,34 +756,34 @@ describe('Lifecycle management of registering components', () => {
     
     export default Components
   `
-    const renderResult = await renderTestEditorWithModel(
-      project({
-        [descriptorFileName1]: descriptorFileContent1,
-        [descriptorFileName2]: descriptorFileContent2,
-      }),
-      'await-first-dom-report',
-    )
+      const renderResult = await renderTestEditorWithModel(
+        project({
+          [descriptorFileName1]: descriptorFileContent1,
+          [descriptorFileName2]: descriptorFileContent2,
+        }),
+        'await-first-dom-report',
+      )
 
-    // The Card component from /src/card is registered from the first descriptor file
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card",
-      ]
-    `)
-    // /src/new-module is not registered yet
-    expect(
-      renderResult.getEditorState().editor.propertyControlsInfo['/src/new-module'],
-    ).toBeUndefined()
-    // The Card2 component is registered from the second descriptor file
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card2",
-      ]
-    `)
+      // The Card component from /src/card is registered from the first descriptor file
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card",
+              ]
+          `)
+      // /src/new-module is not registered yet
+      expect(
+        renderResult.getEditorState().editor.propertyControlsInfo['/src/new-module'],
+      ).toBeUndefined()
+      // The Card2 component is registered from the second descriptor file
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card2",
+              ]
+          `)
 
-    const updatedDescriptorFileContent = `const Components = {
+      const updatedDescriptorFileContent = `const Components = {
       '/src/card': {
         Card: {
           supportsChildren: false,
@@ -807,42 +810,42 @@ describe('Lifecycle management of registering components', () => {
 
     export default Components`
 
-    await renderResult.dispatch(
-      [
-        updateFromCodeEditor(
-          descriptorFileName1,
-          descriptorFileContent1,
-          updatedDescriptorFileContent,
-        ),
-      ],
-      true,
-    )
+      await renderResult.dispatch(
+        [
+          updateFromCodeEditor(
+            descriptorFileName1,
+            descriptorFileContent1,
+            updatedDescriptorFileContent,
+          ),
+        ],
+        true,
+      )
 
-    // The Card from /src/card from the first descriptor is still there
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card",
-      ]
-    `)
-    // The NewComp from the newly added /src/new-module from the first descriptor is registered
-    expect(
-      Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/new-module']),
-    ).toMatchInlineSnapshot(`
-      Array [
-        "NewComp",
-      ]
-    `)
-    // The second descriptor file has not been changed
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card2",
-      ]
-    `)
-  })
-  it('Deleting a module from a component descriptor file removes it from property controls', async () => {
-    const descriptorFileContent1 = `const Components = {
+      // The Card from /src/card from the first descriptor is still there
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card",
+              ]
+          `)
+      // The NewComp from the newly added /src/new-module from the first descriptor is registered
+      expect(
+        Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/new-module']),
+      ).toMatchInlineSnapshot(`
+              Array [
+                "NewComp",
+              ]
+          `)
+      // The second descriptor file has not been changed
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card2",
+              ]
+          `)
+    })
+    it('Deleting a module from a component descriptor file removes it from property controls', async () => {
+      const descriptorFileContent1 = `const Components = {
       '/src/card': {
         Card: {
           supportsChildren: false,
@@ -859,34 +862,34 @@ describe('Lifecycle management of registering components', () => {
     
     export default Components
   `
-    const renderResult = await renderTestEditorWithModel(
-      project({
-        [descriptorFileName1]: descriptorFileContent1,
-        [descriptorFileName2]: descriptorFileContent2,
-      }),
-      'await-first-dom-report',
-    )
+      const renderResult = await renderTestEditorWithModel(
+        project({
+          [descriptorFileName1]: descriptorFileContent1,
+          [descriptorFileName2]: descriptorFileContent2,
+        }),
+        'await-first-dom-report',
+      )
 
-    // The Card component from /src/card is registered from the first descriptor file
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card",
-      ]
-    `)
-    // The Comp component from /src/module-to-delete is registered from the first descriptor file
-    expect(
-      renderResult.getEditorState().editor.propertyControlsInfo['/src/module-to-delete'],
-    ).toBeUndefined()
-    // The Card2 component is registered from the second descriptor file
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card2",
-      ]
-    `)
+      // The Card component from /src/card is registered from the first descriptor file
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card",
+              ]
+          `)
+      // The Comp component from /src/module-to-delete is registered from the first descriptor file
+      expect(
+        renderResult.getEditorState().editor.propertyControlsInfo['/src/module-to-delete'],
+      ).toBeUndefined()
+      // The Card2 component is registered from the second descriptor file
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card2",
+              ]
+          `)
 
-    const updatedDescriptorFileContent = `const Components = {
+      const updatedDescriptorFileContent = `const Components = {
       '/src/card': {
         Card: {
           supportsChildren: false,
@@ -902,34 +905,160 @@ describe('Lifecycle management of registering components', () => {
 
     export default Components`
 
-    await renderResult.dispatch(
-      [
-        updateFromCodeEditor(
-          descriptorFileName1,
-          descriptorFileContent1,
-          updatedDescriptorFileContent,
-        ),
-      ],
-      true,
-    )
+      await renderResult.dispatch(
+        [
+          updateFromCodeEditor(
+            descriptorFileName1,
+            descriptorFileContent1,
+            updatedDescriptorFileContent,
+          ),
+        ],
+        true,
+      )
 
-    // The Card from /src/card from the first descriptor is still there
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card",
-      ]
-    `)
-    // The /src/module-to-delete module is deleted
-    expect(
-      renderResult.getEditorState().editor.propertyControlsInfo['/src/new-module'],
-    ).toBeUndefined()
-    // The second descriptor file has not been changed
-    expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
-      .toMatchInlineSnapshot(`
-      Array [
-        "Card2",
-      ]
-    `)
+      // The Card from /src/card from the first descriptor is still there
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card",
+              ]
+          `)
+      // The /src/module-to-delete module is deleted
+      expect(
+        renderResult.getEditorState().editor.propertyControlsInfo['/src/new-module'],
+      ).toBeUndefined()
+      // The second descriptor file has not been changed
+      expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
+        .toMatchInlineSnapshot(`
+              Array [
+                "Card2",
+              ]
+          `)
+    })
+  })
+  describe('Renaming a component descriptor file', () => {
+    it('Renaming a component descriptor file to a different name updates the property controls to the new source file', async () => {
+      const descriptorFileContent1 = `const Components = {
+      '/src/card': {
+        Card: {
+          supportsChildren: false,
+          properties: {
+            label: {
+              control: 'string-input',
+            },
+          },
+          variants: [],
+        },
+      },
+    }
+    
+    export default Components
+  `
+
+      const renderResult = await renderTestEditorWithModel(
+        project({
+          [descriptorFileName1]: descriptorFileContent1,
+        }),
+        'await-first-dom-report',
+      )
+
+      // The Card property control is registered with the correct source descriptor file name
+      expect(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']['Card'].source)
+        .toMatchInlineSnapshot(`
+        Object {
+          "sourceDescriptorFile": "/utopia/components1.utopia.js",
+          "type": "DESCRIPTOR_FILE",
+        }
+      `)
+
+      await renderResult.dispatch([updateFilePath(descriptorFileName1, descriptorFileName2)], true)
+
+      // The Card property control is registered with the new descriptor file name
+      expect(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']['Card'].source)
+        .toMatchInlineSnapshot(`
+        Object {
+          "sourceDescriptorFile": "/utopia/components2.utopia.js",
+          "type": "DESCRIPTOR_FILE",
+        }
+      `)
+    })
+    it('Renaming a component descriptor file to a non-component-descriptor name removes the property controls', async () => {
+      const descriptorFileContent1 = `const Components = {
+      '/src/card': {
+        Card: {
+          supportsChildren: false,
+          properties: {
+            label: {
+              control: 'string-input',
+            },
+          },
+          variants: [],
+        },
+      },
+    }
+    
+    export default Components
+  `
+
+      const renderResult = await renderTestEditorWithModel(
+        project({
+          [descriptorFileName1]: descriptorFileContent1,
+        }),
+        'await-first-dom-report',
+      )
+
+      // The Card property control is registered with the correct source descriptor file name
+      expect(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']['Card'].source)
+        .toMatchInlineSnapshot(`
+        Object {
+          "sourceDescriptorFile": "/utopia/components1.utopia.js",
+          "type": "DESCRIPTOR_FILE",
+        }
+      `)
+
+      await renderResult.dispatch([updateFilePath(descriptorFileName1, 'foo.js')], true)
+
+      // The '/src/card' property controls are removed
+      expect(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']).toBeUndefined()
+    })
+    it('Renaming a regular file to a component descriptor name adds the property controls', async () => {
+      const descriptorFileContent1 = `const Components = {
+      '/src/card': {
+        Card: {
+          supportsChildren: false,
+          properties: {
+            label: {
+              control: 'string-input',
+            },
+          },
+          variants: [],
+        },
+      },
+    }
+    
+    export default Components
+  `
+
+      const renderResult = await renderTestEditorWithModel(
+        project({
+          ['foo.js']: descriptorFileContent1,
+        }),
+        'await-first-dom-report',
+      )
+
+      // The '/src/card' property controls are not registered
+      expect(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']).toBeUndefined()
+
+      await renderResult.dispatch([updateFilePath('foo.js', descriptorFileName1)], true)
+
+      // The Card property control is registered with the correct new source descriptor file name
+      expect(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']['Card'].source)
+        .toMatchInlineSnapshot(`
+        Object {
+          "sourceDescriptorFile": "/utopia/components1.utopia.js",
+          "type": "DESCRIPTOR_FILE",
+        }
+      `)
+    })
   })
 })


### PR DESCRIPTION
**Problem:**
When you rename a file, it can be relevant for property control registration:
1. Renaming a sidecar file to a regular file: remove the property controls registered from that file (same as deletion)
2. Renaming a sidecar file to a different sidecar file name: update the source in the property controls
3. Renaming a regular file to a sidecar file: insert the property controls in it

3 already works, but 1 and 2 does not.

**Fix:**
Delete the property controls when a sidecar file is renamed (they are readded anyway if it stays a sidecar file.
Added tests for all 3 cases.

**Note:** I reorganized the tests a bit, I suggest to "ignore whitespace" for the review.