### PR TITLE
SPIKE: add require info to component

### DIFF
--- a/editor/src/core/es-modules/package-manager/package-manager.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.ts
@@ -101,9 +101,12 @@ export function getRequireFn(
 ): RequireFn {
   function extendExportsWithInfo(exports: any, toImport: string): any {
     Object.entries(exports).forEach(([name, exp]) => {
-      if (toImport === '@shopify/hydrogen' && name === 'Image') {
+      try {
         ;(exp as any)[NameSymbol] = name
         ;(exp as any)[ModuleSymbol] = toImport
+        console.debug('Successfully extended exports with info', name, toImport)
+      } catch (e) {
+        console.debug('Failed to extend exports with info', name, toImport)
       }
     })
     return exports
@@ -182,7 +185,7 @@ export function getRequireFn(
             throw e
           }
         }
-        return fileCache.exports
+        return extendExportsWithInfo(fileCache.exports, toImport)
       } else if (isEsRemoteDependencyPlaceholder(resolvedFile)) {
         if (!resolvedFile.downloadStarted) {
           // return empty exports object, fire off an async job to fetch the dependency from jsdelivr

--- a/editor/src/core/es-modules/package-manager/package-manager.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.ts
@@ -1,4 +1,3 @@
-import React from 'react'
 import type { NodeModules, ESCodeFile } from '../../shared/project-file-types'
 import { isEsCodeFile, isEsRemoteDependencyPlaceholder } from '../../shared/project-file-types'
 import type { RequireFn, TypeDefinitions } from '../../shared/npm-dependency-types'

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -48,6 +48,7 @@ import fastDeepEqual from 'fast-deep-equal'
 import { TimedCacheMap } from '../shared/timed-cache-map'
 import { dropFileExtension } from '../shared/file-utils'
 import { isComponentRendererComponent } from '../../components/canvas/ui-jsx-canvas-renderer/component-renderer-component'
+import { ModuleSymbol, NameSymbol } from '../es-modules/package-manager/package-manager'
 
 async function parseInsertOption(
   insertOption: ComponentInsertOption,
@@ -296,6 +297,10 @@ export function createRegisterModuleAndComponentFunction(workers: UtopiaTsWorker
     component: React.FunctionComponent,
     properties: ComponentToRegister,
   ): void {
+    console.log('registerComponent')
+    console.log('Name: ', (component as any)[NameSymbol])
+    console.log('Module: ', (component as any)[ModuleSymbol])
+
     // when the recieved component is an internal component, it is wrapped into a ComponentRendererComponent
     if (!isComponentRendererComponent(component)) {
       console.warn(


### PR DESCRIPTION
**Problem:**
We need to access the name and the module of an imported external component

**Fix:**
Add two new symbol properties to store this in our require function.