### PR TITLE
(chore) CDN link helpers

### DIFF
--- a/utopia-remix/app/components/next.tsx
+++ b/utopia-remix/app/components/next.tsx
@@ -1,7 +1,7 @@
 import { Popover, Transition } from '@headlessui/react'
 import React, { Fragment } from 'react'
 import { CookieConsent, getCookieConsentValue } from 'react-cookie-consent'
-import { useAppStore } from '../stores/appStore'
+import { useCDNLink } from '../util/cdnLink'
 
 const mainNavigation = [
   { name: ' ', href: '#' },
@@ -311,11 +311,8 @@ type HostedImageProps = React.DetailedHTMLProps<
 > & { src: string }
 
 export function HostedImage(props: HostedImageProps) {
-  const env = useAppStore((store) => store.env)
-  if (env == null) {
-    return null
-  }
-  return <img {...props} src={`${env.UTOPIA_CDN_URL}${props.src}`} />
+  const cdnLink = useCDNLink()
+  return <img {...props} src={cdnLink(props.src)} />
 }
 
 export const BasicEmailSignup = React.memo(() => {

--- a/utopia-remix/app/components/projectNotFound.tsx
+++ b/utopia-remix/app/components/projectNotFound.tsx
@@ -3,11 +3,11 @@ import { useFetcher } from '@remix-run/react'
 import cx from 'classnames'
 import type { UserDetails } from 'prisma-client'
 import React from 'react'
-import { useAppStore } from '../stores/appStore'
 import { colors } from '../styles/sprinkles.css'
 import { when } from '../util/react-conditionals'
 import { Status } from '../util/statusCodes'
 import * as styles from './projectNotFound.css'
+import { useCDNLink } from '../util/cdnLink'
 
 export default function ProjectNotFound({
   projectId,
@@ -43,8 +43,11 @@ export default function ProjectNotFound({
 }
 
 function UnauthorizedPage({ projectId, user }: { projectId: string; user: UserDetails }) {
-  const env = useAppStore((store) => store.env)
-  const hmmPyramidLight = `${env?.UTOPIA_CDN_URL}/editor/hmmm_pyramid_light.png`
+  const cdnLink = useCDNLink()
+  const hmmPyramidLight = React.useMemo(() => {
+    return cdnLink('/editor/hmmm_pyramid_light.png')
+  }, [cdnLink])
+
   const [accessRequested, setAccessRequested] = React.useState(false)
 
   const accessRequestsFetcher = useFetcher()
@@ -98,8 +101,11 @@ function UnauthorizedPage({ projectId, user }: { projectId: string; user: UserDe
 }
 
 function NotFoundPage({ user, projectId }: { user: UserDetails | null; projectId: string | null }) {
-  const env = useAppStore((store) => store.env)
-  const PyramidLight404 = `${env?.UTOPIA_CDN_URL}/editor/404_pyramid_light.png`
+  const cdnLink = useCDNLink()
+  const PyramidLight404 = React.useMemo(() => {
+    return cdnLink('editor/404_pyramid_light.png')
+  }, [cdnLink])
+
   return (
     <>
       <div className={styles.image}>

--- a/utopia-remix/app/components/sharingDialog.tsx
+++ b/utopia-remix/app/components/sharingDialog.tsx
@@ -222,8 +222,8 @@ const OwnerCollaboratorRow = React.memo(() => {
 
   return (
     <CollaboratorRow
-      picture={myUser?.picture ?? null}
-      name={`${myUser?.name ?? myUser?.email ?? myUser?.id} (you)`}
+      picture={myUser.picture ?? null}
+      name={`${myUser.name ?? myUser.email ?? myUser.id} (you)`}
       starBadge={true}
     >
       <Text size='1' style={{ cursor: 'default' }}>

--- a/utopia-remix/app/components/userAvatar.tsx
+++ b/utopia-remix/app/components/userAvatar.tsx
@@ -2,10 +2,10 @@ import classNames from 'classnames'
 import type { CSSProperties } from 'react'
 import React from 'react'
 import { useIsDarkMode } from '../hooks/useIsDarkMode'
-import { useAppStore } from '../stores/appStore'
 import { sprinkles } from '../styles/sprinkles.css'
 import { when } from '../util/react-conditionals'
 import { multiplayerInitialsFromName } from '../util/strings'
+import { useCDNLink } from '../util/cdnLink'
 
 export const UserAvatar = React.memo(
   ({
@@ -23,11 +23,13 @@ export const UserAvatar = React.memo(
     style?: CSSProperties
     className?: string
   }) => {
-    const env = useAppStore((store) => store.env)
+    const cdnLink = useCDNLink()
+
     const isDarkMode = useIsDarkMode()
     const starIcon = React.useMemo(() => {
       return isDarkMode ? 'star-white-14x14@2x.png' : 'star-black-14x14@2x.png'
     }, [isDarkMode])
+
     return (
       <div
         className={classNames(sprinkles({ backgroundColor: 'secondary' }), className)}
@@ -50,7 +52,7 @@ export const UserAvatar = React.memo(
         {when(
           starBadge === true,
           <img
-            src={`${env?.UTOPIA_CDN_URL}/${starIcon}`}
+            src={cdnLink(starIcon)}
             style={{
               width: 13,
               height: 13,

--- a/utopia-remix/app/routes/_index.tsx
+++ b/utopia-remix/app/routes/_index.tsx
@@ -11,10 +11,10 @@ import {
 } from '../components/next'
 
 import stylesheet from '~/styles/next-tailwind.css'
-import urlJoin from 'url-join'
 import type { rootLoader } from '../root'
 import React from 'react'
 import { getUser } from '../util/api.server'
+import { cdnLink } from '../util/cdnLink'
 
 export const links: LinksFunction = () => [
   // css
@@ -58,7 +58,7 @@ export const meta: MetaFunction<typeof rootLoader> = ({ data }) => {
     { name: 'msapplication-TileColor', content: '#da532c' },
     { name: 'theme-color', content: '#ffffff' },
     { property: 'og:title', content: 'Utopia: Design and Code on one platform' },
-    { property: 'og:image', content: urlJoin(data?.env?.UTOPIA_CDN_URL ?? '', '/og-card.png') },
+    { property: 'og:image', content: cdnLink(data?.env?.UTOPIA_CDN_URL ?? null, '/og-card.png') },
     { property: 'og:type', content: 'website' },
     {
       property: 'og:description',

--- a/utopia-remix/app/util/cdnLink.tsx
+++ b/utopia-remix/app/util/cdnLink.tsx
@@ -1,0 +1,17 @@
+import urlJoin from 'url-join'
+import { useAppStore } from '../stores/appStore'
+import React from 'react'
+
+export function cdnLink(host: string | null, relativePath: string): string {
+  return urlJoin(host ?? '', relativePath)
+}
+
+export function useCDNLink() {
+  const env = useAppStore((store) => store.env)
+  return React.useCallback(
+    (relativePath: string) => {
+      return cdnLink(env?.UTOPIA_CDN_URL ?? null, relativePath)
+    },
+    [env],
+  )
+}


### PR DESCRIPTION
This PR does a bit of minor cleanup as a followup to https://github.com/concrete-utopia/utopia/pull/5130 and https://github.com/concrete-utopia/utopia/pull/5129.

1. Add a helper function and hook to generate CDN links
2. Remove unnecessary (and confusing) question marks from the user fields used in `OwnerCollaboratorRow`