### PR TITLE
Split project creation methods

### DIFF
--- a/utopia-remix/app/models/projectAccess.server.spec.ts
+++ b/utopia-remix/app/models/projectAccess.server.spec.ts
@@ -87,8 +87,6 @@ describe('create project access', () => {
     await createTestUser(prisma, { id: 'alice' })
     await createTestProject(prisma, { id: 'one', ownerId: 'bob' })
     await createTestProject(prisma, { id: 'two', ownerId: 'bob' })
-    await createTestProjectAccess(prisma, { projectId: 'one', accessLevel: 0 })
-    await createTestProjectAccess(prisma, { projectId: 'two', accessLevel: 1 })
     jest.spyOn(permissionsService, 'setProjectAccess').mockResolvedValue()
   })
   afterEach(async () => {

--- a/utopia-remix/app/models/projectAccess.server.ts
+++ b/utopia-remix/app/models/projectAccess.server.ts
@@ -24,3 +24,23 @@ export async function setProjectAccess(params: {
     await permissionsService.setProjectAccess(params.projectId, params.accessLevel)
   })
 }
+
+export async function createProjectAccess(params: {
+  projectId: string
+  accessLevel: AccessLevel
+}): Promise<void> {
+  await prisma.$transaction(async (tx) => {
+    await tx.projectAccess.upsert({
+      where: {
+        project_id: params.projectId,
+      },
+      update: {}, // ON CONFLICT DO NOTHING
+      create: {
+        project_id: params.projectId,
+        access_level: params.accessLevel,
+        modified_at: new Date(),
+      },
+    })
+    await permissionsService.setProjectAccess(params.projectId, params.accessLevel)
+  })
+}

--- a/utopia-remix/app/routes-test/v1.project.$id.spec.ts
+++ b/utopia-remix/app/routes-test/v1.project.$id.spec.ts
@@ -9,7 +9,7 @@ import {
   newTestRequest,
   truncateTables,
 } from '../test-util'
-import { loader } from '../routes/v1.project.$id'
+import { loader, action } from '../routes/v1.project.$id'
 import * as proxyServer from '../util/proxy.server'
 import * as permissionsService from '../services/permissionsService.server'
 import { AccessLevel, UserProjectPermission } from '../types'
@@ -170,7 +170,7 @@ describe('create new project', () => {
         authCookie: 'the-key',
         search: { accessLevel: 'public' },
       })
-      const response = await (loader({
+      const response = await (action({
         request: req,
         params: { id: projectId },
         context: {},
@@ -190,7 +190,7 @@ describe('create new project', () => {
         authCookie: 'the-key',
         search: {},
       })
-      const response = await (loader({
+      const response = await (action({
         request: req,
         params: { id: projectId },
         context: {},
@@ -207,7 +207,7 @@ describe('create new project', () => {
         authCookie: 'the-key',
         search: { accessLevel: 'invalid' },
       })
-      const response = await (loader({
+      const response = await (action({
         request: req,
         params: { id: projectId },
         context: {},
@@ -224,7 +224,7 @@ describe('create new project', () => {
         authCookie: 'the-key',
         search: { accessLevel: 'public' },
       })
-      const response = await (loader({
+      const response = await (action({
         request: req,
         params: { id: projectId },
         context: {},

--- a/utopia-remix/app/routes-test/v1.project.$id.spec.ts
+++ b/utopia-remix/app/routes-test/v1.project.$id.spec.ts
@@ -12,6 +12,7 @@ import {
 import { loader, action } from '../routes/v1.project.$id'
 import * as proxyServer from '../util/proxy.server'
 import * as permissionsService from '../services/permissionsService.server'
+import * as projectAccessModel from '../models/projectAccess.server'
 import { AccessLevel, UserProjectPermission } from '../types'
 import type { ApiResponse } from '../util/api.server'
 import { Status } from '../util/statusCodes'
@@ -159,7 +160,7 @@ describe('create new project', () => {
       await createTestSession(prisma, { key: 'the-key', userId: userId })
 
       projectProxy = jest.spyOn(proxyServer, 'proxy')
-      setProjectAccessMock = jest.spyOn(permissionsService, 'setProjectAccess')
+      setProjectAccessMock = jest.spyOn(projectAccessModel, 'setProjectAccess')
     })
 
     it('should set access level for a new project', async () => {

--- a/utopia-remix/app/routes-test/v1.project.$id.spec.ts
+++ b/utopia-remix/app/routes-test/v1.project.$id.spec.ts
@@ -203,7 +203,7 @@ describe('create new project', () => {
         accessLevel: AccessLevel.PRIVATE,
       })
     })
-    it('should set access level to PRIVATE for a new project if access level is invalid', async () => {
+    it('should throw an error for a new project if access level is invalid', async () => {
       projectProxy.mockResolvedValue({ id: projectId, ownerId: userId })
       createProjectAccessMock.mockResolvedValue(null)
       const req = newTestRequest({
@@ -211,16 +211,16 @@ describe('create new project', () => {
         authCookie: 'the-key',
         search: { accessLevel: 'invalid' },
       })
-      const response = await (action({
+      const response = (await action({
         request: req,
         params: { id: projectId },
         context: {},
-      }) as Promise<ApiResponse<{ id: string; projectId: string }>>)
-      const project = await response.json()
-      expect(project).toEqual({ id: projectId, ownerId: userId })
-      expect(createProjectAccessMock).toHaveBeenCalledWith({
-        projectId: projectId,
-        accessLevel: AccessLevel.PRIVATE,
+      })) as ApiResponse<{ id: string; projectId: string }>
+      const result = await response.json()
+      expect(result).toEqual({
+        error: 'Error',
+        message: 'Invalid access level',
+        status: Status.BAD_REQUEST,
       })
     })
     it('shouldnt set access level if the endpoint is a POST', async () => {

--- a/utopia-remix/app/routes/v1.project.$id.tsx
+++ b/utopia-remix/app/routes/v1.project.$id.tsx
@@ -6,6 +6,7 @@ import { ALLOW, validateProjectAccess } from '../handlers/validators'
 import type { Params } from '@remix-run/react'
 import { createProjectAccess } from '../models/projectAccess.server'
 import { Status } from '../util/statusCodes'
+import { ApiError } from '../util/errors'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
@@ -62,7 +63,6 @@ function accessLevelParamToAccessLevel(accessLevelParam: string | null): AccessL
     case 'collaborative':
       return AccessLevel.COLLABORATIVE
     default:
-      console.error(`Invalid access level: ${accessLevelParam}`)
-      return null
+      throw new ApiError('Invalid access level', Status.BAD_REQUEST)
   }
 }

--- a/utopia-remix/app/routes/v1.project.$id.tsx
+++ b/utopia-remix/app/routes/v1.project.$id.tsx
@@ -4,7 +4,7 @@ import { ensure, handle, handleOptions } from '../util/api.server'
 import { AccessLevel, UserProjectPermission } from '../types'
 import { ALLOW, validateProjectAccess } from '../handlers/validators'
 import type { Params } from '@remix-run/react'
-import { setProjectAccess } from '../models/projectAccess.server'
+import { createProjectAccess } from '../models/projectAccess.server'
 import { Status } from '../util/statusCodes'
 
 export async function loader(args: LoaderFunctionArgs) {
@@ -43,16 +43,15 @@ async function createProject(req: Request, params: Params<string>) {
   // handle access level setting
   const url = new URL(req.url)
   const accessLevelParam = url.searchParams.get('accessLevel')
-  const accessLevel: AccessLevel | null = accessLevelParamToAccessLevel(accessLevelParam)
-  if (accessLevel != null) {
-    await setProjectAccess({ projectId: id, accessLevel: accessLevel })
-  }
+  const accessLevel: AccessLevel | null =
+    accessLevelParamToAccessLevel(accessLevelParam) ?? AccessLevel.PRIVATE
+  await createProjectAccess({ projectId: id, accessLevel: accessLevel })
 
   return project
 }
 
 function accessLevelParamToAccessLevel(accessLevelParam: string | null): AccessLevel | null {
-  if (accessLevelParam == null) {
+  if (accessLevelParam == null || accessLevelParam == '') {
     return null
   }
   switch (accessLevelParam) {

--- a/utopia-remix/app/routes/v1.project.$id.tsx
+++ b/utopia-remix/app/routes/v1.project.$id.tsx
@@ -1,8 +1,11 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import { proxy } from '../util/proxy.server'
-import { handle, handleOptions } from '../util/api.server'
-import { UserProjectPermission } from '../types'
+import { ensure, handle, handleOptions } from '../util/api.server'
+import { AccessLevel, UserProjectPermission } from '../types'
 import { ALLOW, validateProjectAccess } from '../handlers/validators'
+import type { Params } from '@remix-run/react'
+import { setProjectAccess } from '../models/projectAccess.server'
+import { Status } from '../util/statusCodes'
 
 export async function loader(args: LoaderFunctionArgs) {
   return handle(args, {
@@ -20,8 +23,47 @@ export async function loader(args: LoaderFunctionArgs) {
 export async function action(args: ActionFunctionArgs) {
   return handle(args, {
     PUT: {
+      handler: createProject,
+      validator: ALLOW,
+    },
+    POST: {
       handler: proxy,
       validator: ALLOW,
     },
   })
+}
+
+async function createProject(req: Request, params: Params<string>) {
+  const { id } = params
+  ensure(id != null, 'project id is null', Status.BAD_REQUEST)
+
+  // create the project
+  const project = await proxy(req)
+
+  // handle access level setting
+  const url = new URL(req.url)
+  const accessLevelParam = url.searchParams.get('accessLevel')
+  const accessLevel: AccessLevel | null = accessLevelParamToAccessLevel(accessLevelParam)
+  if (accessLevel != null) {
+    await setProjectAccess({ projectId: id, accessLevel: accessLevel })
+  }
+
+  return project
+}
+
+function accessLevelParamToAccessLevel(accessLevelParam: string | null): AccessLevel | null {
+  if (accessLevelParam == null) {
+    return null
+  }
+  switch (accessLevelParam) {
+    case 'private':
+      return AccessLevel.PRIVATE
+    case 'public':
+      return AccessLevel.PUBLIC
+    case 'collaborative':
+      return AccessLevel.COLLABORATIVE
+    default:
+      console.error(`Invalid access level: ${accessLevelParam}`)
+      return null
+  }
 }

--- a/utopia-remix/app/routes/v1.project.$id.tsx
+++ b/utopia-remix/app/routes/v1.project.$id.tsx
@@ -43,7 +43,7 @@ async function createProject(req: Request, params: Params<string>) {
   // handle access level setting
   const url = new URL(req.url)
   const accessLevelParam = url.searchParams.get('accessLevel')
-  const accessLevel: AccessLevel | null =
+  const accessLevel: AccessLevel =
     accessLevelParamToAccessLevel(accessLevelParam) ?? AccessLevel.PRIVATE
   await createProjectAccess({ projectId: id, accessLevel: accessLevel })
 


### PR DESCRIPTION
**Problem:**
Today creation of a new project and saving an existing one both call the PUT method on `/project/{id}`, which makes it difficult to handle creation of access levels upon project creation

**Fix:**
This prep PR splits the methods so that the PUT endpoint will have the access level handling code, while the POST method will not. This will allow us to split the calling code in the editor as well
