### PR TITLE
Component descriptor validation for external components

### DIFF
--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -218,7 +218,7 @@ describe('registered property controls', () => {
 
     expect(srcCardKey).toBeUndefined()
   })
-  it('control registration fails when the imported component does not match the name of registration key', async () => {
+  it('control registration fails when the imported internal component does not match the name of registration key', async () => {
     const renderResult = await renderTestEditorWithModel(
       project({
         ['/utopia/components.utopia.js']: `import { Card } from '../src/card'
@@ -253,6 +253,58 @@ describe('registered property controls', () => {
             fileName: '/utopia/components.utopia.js',
             message:
               'Validation failed: Component name (Card) does not match the registration key (Cart)',
+            passTime: null,
+            severity: 'fatal',
+            source: 'eslint',
+            startColumn: null,
+            startLine: null,
+            type: '',
+          },
+        ],
+      },
+    })
+
+    const srcCardKey = Object.keys(renderResult.getEditorState().editor.propertyControlsInfo).find(
+      (key) => key === '/src/card',
+    )
+
+    expect(srcCardKey).toBeUndefined()
+  })
+  it('control registration fails when the imported external component does not match the name of registration key', async () => {
+    const renderResult = await renderTestEditorWithModel(
+      project({
+        ['/utopia/components.utopia.js']: `import { View } from 'utopia-api'
+        
+        const Components = {
+      'utopia-api': {
+        Vieww: {
+          component: View,
+          supportsChildren: false,
+          properties: { },
+          variants: [ ],
+        },
+      },
+    }
+    
+    export default Components
+  `,
+      }),
+      'await-first-dom-report',
+    )
+    const editorState = renderResult.getEditorState().editor
+
+    expect(editorState.codeEditorErrors).toEqual({
+      buildErrors: {},
+      lintErrors: {
+        '/utopia/components.utopia.js': [
+          {
+            codeSnippet: '',
+            endColumn: null,
+            endLine: null,
+            errorCode: '',
+            fileName: '/utopia/components.utopia.js',
+            message:
+              'Validation failed: Component name (View) does not match the registration key (Vieww)',
             passTime: null,
             severity: 'fatal',
             source: 'eslint',

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -125,11 +125,13 @@ export function setRequireInfoOnComponent(exported: any, name: string, moduleNam
 
 function extendExportsWithInfo(exports: any, toImport: string): any {
   Object.entries(exports).forEach(([name, exp]) => {
-    try {
-      ;(exp as any)[exportedNameSymbol] = name
-      ;(exp as any)[moduleNameSymbol] = toImport
-      // eslint-disable-next-line no-empty
-    } catch (e) {}
+    if (typeof exp === 'object') {
+      try {
+        ;(exp as any)[exportedNameSymbol] = name
+        ;(exp as any)[moduleNameSymbol] = toImport
+        // eslint-disable-next-line no-empty
+      } catch (e) {}
+    }
   })
   return exports
 }

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -125,7 +125,7 @@ export function setRequireInfoOnComponent(exported: any, name: string, moduleNam
 
 function extendExportsWithInfo(exports: any, toImport: string): any {
   Object.entries(exports).forEach(([name, exp]) => {
-    if (typeof exp === 'object') {
+    if (typeof exp === 'object' || typeof exp === 'function') {
       try {
         ;(exp as any)[exportedNameSymbol] = name
         ;(exp as any)[moduleNameSymbol] = toImport

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -195,7 +195,7 @@ export function createModuleEvaluator(editor: EditorState): ModuleEvaluator {
         },
         resolvedParseSuccess,
       )
-      const absoluteFilenameOrPackage = isRight(filePathResolveResult)
+      const absoluteFilenameOrPackage = defaultEither(toImport, filePathResolveResult)
         ? filePathResolveResult.value
         : toImport
       return extendExportsWithInfo(result, absoluteFilenameOrPackage)

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -48,6 +48,7 @@ import {
   foldEither,
   forEachRight,
   isLeft,
+  isRight,
   left,
   mapEither,
   right,
@@ -194,7 +195,10 @@ export function createModuleEvaluator(editor: EditorState): ModuleEvaluator {
         },
         resolvedParseSuccess,
       )
-      return extendExportsWithInfo(result, toImport)
+      const absoluteFilenameOrPackage = isRight(filePathResolveResult)
+        ? filePathResolveResult.value
+        : toImport
+      return extendExportsWithInfo(result, absoluteFilenameOrPackage)
     }
     return createExecutionScope(
       moduleName,

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -45,6 +45,7 @@ import {
   applicative3Either,
   applicative4Either,
   applicative5Either,
+  defaultEither,
   foldEither,
   forEachRight,
   isLeft,
@@ -196,8 +197,6 @@ export function createModuleEvaluator(editor: EditorState): ModuleEvaluator {
         resolvedParseSuccess,
       )
       const absoluteFilenameOrPackage = defaultEither(toImport, filePathResolveResult)
-        ? filePathResolveResult.value
-        : toImport
       return extendExportsWithInfo(result, absoluteFilenameOrPackage)
     }
     return createExecutionScope(


### PR DESCRIPTION
**Problem:**
https://github.com/concrete-utopia/utopia/pull/5118 introduced component validation in component descriptor parsing.
However, that solution only worked for internal components, and this PR extends the validation to external components too.

**Fix:**
We use a custom require function when we parse the component descriptor file. I extended this require function so it attached two new symbol properties to the exported object/function: the exported name of the component and where it was imported from.
These new properties can be used in `isComponentRegistrationValid` to compare the name of the imported component and the key in the descriptor file.

**Todo:** 
Validate the module name too!