### PR TITLE
Revoke FGA roles

### DIFF
--- a/utopia-remix/app/models/projectCollaborators.server.ts
+++ b/utopia-remix/app/models/projectCollaborators.server.ts
@@ -1,8 +1,9 @@
-import type { UserDetails } from 'prisma-client'
+import type { ProjectCollaborator, UserDetails } from 'prisma-client'
 import type { UtopiaPrismaClient } from '../db.server'
 import { prisma } from '../db.server'
 import type { CollaboratorsByProject } from '../types'
 import { userToCollaborator } from '../types'
+import type { GetBatchResult } from 'prisma-client/runtime/library.js'
 
 export async function getCollaborators(params: {
   ids: string[]
@@ -44,6 +45,26 @@ export async function addToProjectCollaboratorsWithRunner(
     create: {
       project_id: params.projectId,
       user_id: params.userId,
+    },
+  })
+}
+
+export async function removeFromProjectCollaborators(params: {
+  projectId: string
+  userId: string
+}): Promise<GetBatchResult> {
+  return removeFromProjectCollaboratorsWithRunner(prisma, params)
+}
+
+export async function removeFromProjectCollaboratorsWithRunner(
+  runner: Pick<UtopiaPrismaClient, 'projectCollaborator'>,
+  params: { projectId: string; userId: string },
+) {
+  // using delete many so not to explode if the record is not found
+  return await runner.projectCollaborator.deleteMany({
+    where: {
+      user_id: params.userId,
+      project_id: params.projectId,
     },
   })
 }

--- a/utopia-remix/app/services/fgaService.server.ts
+++ b/utopia-remix/app/services/fgaService.server.ts
@@ -162,3 +162,13 @@ function accessLevelToFgaWrites(projectId: string, accessLevel: AccessLevel): Cl
       assertNever(accessLevel)
   }
 }
+
+export async function revokeRelations(projectId: string, userId: string, relations: string[]) {
+  return await Promise.all(
+    relations.map((relation) =>
+      fgaClient.write({
+        deletes: [{ user: `user:${userId}`, relation: relation, object: `project:${projectId}` }],
+      }),
+    ),
+  )
+}

--- a/utopia-remix/app/services/permissionsService.server.ts
+++ b/utopia-remix/app/services/permissionsService.server.ts
@@ -73,3 +73,12 @@ export async function grantProjectRoleToUser(
       assertNever(role)
   }
 }
+
+export async function revokeAllRolesFromUser(projectId: string, userId: string) {
+  return await fgaService.revokeRelations(projectId, userId, [
+    'viewer',
+    'collaborator',
+    'editor',
+    'admin',
+  ])
+}


### PR DESCRIPTION
Fix #5138 

_This is a prep PR for incoming work on the share dialog actions._

**Problem:**

The logic for rejecting a pending request is mostly there (although not used), but it's missing the removal of FGA permissions.

**Fix:**

1. Add the functions to revoke all user roles (thanks @liady !)
2. Remove the user from collabs upon rejection (if present)
3. Added tests