### PR TITLE
Remix: destroy access requests

### DIFF
--- a/utopia-remix/app/routes-test/internal.projects.$id.access.request.$token.destroy.spec.ts
+++ b/utopia-remix/app/routes-test/internal.projects.$id.access.request.$token.destroy.spec.ts
@@ -1,0 +1,70 @@
+import { prisma } from '../db.server'
+import { handleDestroyAccessRequest } from '../routes/internal.projects.$id.access.request.$token.destroy'
+import {
+  createTestProject,
+  createTestProjectAccessRequest,
+  createTestSession,
+  createTestUser,
+  newTestRequest,
+  truncateTables,
+} from '../test-util'
+import { AccessRequestStatus } from '../types'
+
+describe('handleDestroyAccessRequest', () => {
+  afterEach(async () => {
+    await truncateTables([
+      prisma.projectID,
+      prisma.projectAccessRequest,
+      prisma.projectAccess,
+      prisma.persistentSession,
+      prisma.project,
+      prisma.userDetails,
+    ])
+  })
+
+  beforeEach(async () => {
+    await createTestUser(prisma, { id: 'bob' })
+    await createTestUser(prisma, { id: 'alice' })
+    await createTestUser(prisma, { id: 'carol' })
+    await createTestSession(prisma, { userId: 'bob', key: 'the-key' })
+    await createTestProject(prisma, { id: 'one', ownerId: 'bob' })
+    await createTestProjectAccessRequest(prisma, {
+      projectId: 'one',
+      userId: 'alice',
+      status: AccessRequestStatus.PENDING,
+      token: 'alice-token',
+    })
+    await createTestProjectAccessRequest(prisma, {
+      projectId: 'one',
+      userId: 'carol',
+      status: AccessRequestStatus.PENDING,
+      token: 'carol-token',
+    })
+  })
+
+  it('requires a user', async () => {
+    const fn = async () => handleDestroyAccessRequest(newTestRequest(), {})
+    await expect(fn).rejects.toThrow('missing session cookie')
+  })
+
+  it('requires a project id', async () => {
+    const fn = async () => handleDestroyAccessRequest(newTestRequest({ authCookie: 'the-key' }), {})
+    await expect(fn).rejects.toThrow('invalid project id')
+  })
+
+  it('requires a token', async () => {
+    const fn = async () =>
+      handleDestroyAccessRequest(newTestRequest({ authCookie: 'the-key' }), { id: 'one' })
+    await expect(fn).rejects.toThrow('invalid token')
+  })
+
+  it('destroys the access request', async () => {
+    await handleDestroyAccessRequest(newTestRequest({ authCookie: 'the-key' }), {
+      id: 'one',
+      token: 'alice-token',
+    })
+    const reqs = await prisma.projectAccessRequest.findMany({ where: { project_id: 'one' } })
+    expect(reqs.length).toBe(1)
+    expect(reqs[0].user_id).toBe('carol')
+  })
+})

--- a/utopia-remix/app/routes-test/internal.projects.$id.access.request.$token.destroy.spec.ts
+++ b/utopia-remix/app/routes-test/internal.projects.$id.access.request.$token.destroy.spec.ts
@@ -1,5 +1,6 @@
+import type { Params } from '@remix-run/react'
 import { prisma } from '../db.server'
-import { handleDestroyAccessRequest } from '../routes/internal.projects.$id.access.request.$token.destroy'
+import { action } from '../routes/internal.projects.$id.access.request.$token.destroy'
 import {
   createTestProject,
   createTestProjectAccessRequest,
@@ -9,6 +10,8 @@ import {
   truncateTables,
 } from '../test-util'
 import { AccessRequestStatus } from '../types'
+import type { ApiResponse } from '../util/api.server'
+import { Status } from '../util/statusCodes'
 
 describe('handleDestroyAccessRequest', () => {
   afterEach(async () => {
@@ -28,6 +31,7 @@ describe('handleDestroyAccessRequest', () => {
     await createTestUser(prisma, { id: 'carol' })
     await createTestSession(prisma, { userId: 'bob', key: 'the-key' })
     await createTestProject(prisma, { id: 'one', ownerId: 'bob' })
+    await createTestProject(prisma, { id: 'two', ownerId: 'alice' })
     await createTestProjectAccessRequest(prisma, {
       projectId: 'one',
       userId: 'alice',
@@ -42,29 +46,79 @@ describe('handleDestroyAccessRequest', () => {
     })
   })
 
-  it('requires a user', async () => {
-    const fn = async () => handleDestroyAccessRequest(newTestRequest(), {})
-    await expect(fn).rejects.toThrow('missing session cookie')
-  })
-
   it('requires a project id', async () => {
-    const fn = async () => handleDestroyAccessRequest(newTestRequest({ authCookie: 'the-key' }), {})
-    await expect(fn).rejects.toThrow('invalid project id')
+    const got = await getActionResult(newTestRequest({ method: 'POST' }), {})
+    expect(got).toEqual({
+      message: 'Invalid project id',
+      status: Status.BAD_REQUEST,
+      error: 'Error',
+    })
   })
 
-  it('requires a token', async () => {
-    const fn = async () =>
-      handleDestroyAccessRequest(newTestRequest({ authCookie: 'the-key' }), { id: 'one' })
-    await expect(fn).rejects.toThrow('invalid token')
+  it('requires an existing project', async () => {
+    const got = await getActionResult(
+      newTestRequest({ method: 'POST', authCookie: 'alice-token' }),
+      {
+        id: 'WRONG',
+      },
+    )
+    expect(got).toEqual({
+      message: 'Project not found',
+      status: Status.NOT_FOUND,
+      error: 'Error',
+    })
+  })
+
+  it('requires a valid auth cookie', async () => {
+    const got = await getActionResult(newTestRequest({ method: 'POST' }), { id: 'one' })
+    expect(got).toEqual({
+      message: 'Project not found',
+      status: Status.NOT_FOUND,
+      error: 'Error',
+    })
+  })
+
+  it('requires an accessible project', async () => {
+    const got = await getActionResult(newTestRequest({ method: 'POST', authCookie: 'the-key' }), {
+      id: 'two',
+    })
+    expect(got).toEqual({
+      message: 'Project not found',
+      status: Status.NOT_FOUND,
+      error: 'Error',
+    })
+  })
+
+  it('requires a request token', async () => {
+    const got = await getActionResult(newTestRequest({ method: 'POST', authCookie: 'the-key' }), {
+      id: 'one',
+    })
+    expect(got).toEqual({
+      message: 'invalid token',
+      status: Status.BAD_REQUEST,
+      error: 'Error',
+    })
   })
 
   it('destroys the access request', async () => {
-    await handleDestroyAccessRequest(newTestRequest({ authCookie: 'the-key' }), {
+    const got = await getActionResult(newTestRequest({ method: 'POST', authCookie: 'the-key' }), {
       id: 'one',
       token: 'alice-token',
     })
+    expect(got).toEqual({})
+
     const reqs = await prisma.projectAccessRequest.findMany({ where: { project_id: 'one' } })
     expect(reqs.length).toBe(1)
     expect(reqs[0].user_id).toBe('carol')
   })
 })
+
+// TODO it would be good to make this a separate reausable helper that supports both actions and loaders
+async function getActionResult(req: Request, params: Params<string>) {
+  const response = await (action({
+    request: req,
+    params: params,
+    context: {},
+  }) as Promise<ApiResponse<Record<string, never>>>)
+  return await response.json()
+}

--- a/utopia-remix/app/routes/internal.projects.$id.access.request.$token.destroy.tsx
+++ b/utopia-remix/app/routes/internal.projects.$id.access.request.$token.destroy.tsx
@@ -1,0 +1,36 @@
+import type { ActionFunctionArgs } from '@remix-run/node'
+import type { Params } from '@remix-run/react'
+import { validateProjectAccess } from '../handlers/validators'
+import { UserProjectPermission } from '../types'
+import { ensure, handle, requireUser } from '../util/api.server'
+import { Status } from '../util/statusCodes'
+import { destroyAccessRequest } from '../models/projectAccessRequest.server'
+
+export async function action(args: ActionFunctionArgs) {
+  return handle(args, {
+    POST: {
+      handler: handleDestroyAccessRequest,
+      validator: validateProjectAccess(UserProjectPermission.CAN_MANAGE_PROJECT, {
+        getProjectId: (params) => params.id,
+      }),
+    },
+  })
+}
+
+export async function handleDestroyAccessRequest(req: Request, params: Params<string>) {
+  const user = await requireUser(req)
+
+  const projectId = params.id
+  ensure(projectId != null, 'invalid project id', Status.BAD_REQUEST)
+
+  const token = params.token
+  ensure(token != null && typeof token === 'string', 'invalid token', Status.BAD_REQUEST)
+
+  await destroyAccessRequest({
+    projectId: projectId,
+    ownerId: user.user_id,
+    token: token,
+  })
+
+  return {}
+}


### PR DESCRIPTION
Fix #5141

This is a prep PR following up from https://github.com/concrete-utopia/utopia/pull/5139.

- Add logic for destroying an existing access request
- Add a route for that
- Add tests