### PR TITLE
Module validation in component registration

### DIFF
--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -28,7 +28,7 @@ const project = (componentDescriptorFiles: { [filename: string]: string }) =>
       return <div>{label}</div>
     }
     `,
-    ['/src/newmodule.js']: `import React from 'react'
+    ['/src/new-module.js']: `import React from 'react'
     
     export const NewCard = ({ label }) => {
       return <div>{label}</div>
@@ -1321,9 +1321,9 @@ describe('Lifecycle management of registering components', () => {
                 "Card",
               ]
           `)
-      // /src/newmodule is not registered yet
+      // /src/new-module is not registered yet
       expect(
-        renderResult.getEditorState().editor.propertyControlsInfo['/src/newmodule'],
+        renderResult.getEditorState().editor.propertyControlsInfo['/src/new-module'],
       ).toBeUndefined()
       // The Card2 component is registered from the second descriptor file
       expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
@@ -1334,7 +1334,7 @@ describe('Lifecycle management of registering components', () => {
           `)
 
       const updatedDescriptorFileContent = `import { Card } from '../src/card'
-      import { NewCard } from '../src/newmodule'
+      import { NewCard } from '../src/new-module'
       
       const Components = {
       '/src/card': {
@@ -1349,7 +1349,7 @@ describe('Lifecycle management of registering components', () => {
           variants: [],
         },
       },
-      '/src/newmodule': {
+      '/src/new-module': {
         NewCard: {
           component: NewCard,
           supportsChildren: false,
@@ -1383,9 +1383,9 @@ describe('Lifecycle management of registering components', () => {
                 "Card",
               ]
           `)
-      // The NewComp from the newly added /src/newmodule from the first descriptor is registered
+      // The NewComp from the newly added /src/new-module from the first descriptor is registered
       expect(
-        Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/newmodule']),
+        Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/new-module']),
       ).toMatchInlineSnapshot(`
               Array [
                 "NewCard",
@@ -1486,7 +1486,7 @@ describe('Lifecycle management of registering components', () => {
           `)
       // The /src/module-to-delete module is deleted
       expect(
-        renderResult.getEditorState().editor.propertyControlsInfo['/src/newmodule'],
+        renderResult.getEditorState().editor.propertyControlsInfo['/src/new-module'],
       ).toBeUndefined()
       // The second descriptor file has not been changed
       expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -28,6 +28,12 @@ const project = (componentDescriptorFiles: { [filename: string]: string }) =>
       return <div>{label}</div>
     }
     `,
+    ['/src/newmodule.js']: `import React from 'react'
+    
+    export const NewCard = ({ label }) => {
+      return <div>{label}</div>
+    }
+    `,
     [StoryboardFilePath]: `import * as React from 'react'
   import { Scene, Storyboard, View } from 'utopia-api'
 
@@ -609,7 +615,6 @@ describe('registered property controls', () => {
     expect(Object.keys(editorState.propertyControlsInfo['/src/card'])).toMatchInlineSnapshot(`
       Array [
         "Card",
-        "Card2",
       ]
     `)
   })
@@ -1212,9 +1217,9 @@ describe('Lifecycle management of registering components', () => {
                 "Card",
               ]
           `)
-      // /src/new-module is not registered yet
+      // /src/newmodule is not registered yet
       expect(
-        renderResult.getEditorState().editor.propertyControlsInfo['/src/new-module'],
+        renderResult.getEditorState().editor.propertyControlsInfo['/src/newmodule'],
       ).toBeUndefined()
       // The Card2 component is registered from the second descriptor file
       expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))
@@ -1224,7 +1229,8 @@ describe('Lifecycle management of registering components', () => {
               ]
           `)
 
-      const updatedDescriptorFileContent = `import { Card, NewCard } from '../src/card'
+      const updatedDescriptorFileContent = `import { Card } from '../src/card'
+      import { NewCard } from '../src/newmodule'
       
       const Components = {
       '/src/card': {
@@ -1239,7 +1245,7 @@ describe('Lifecycle management of registering components', () => {
           variants: [],
         },
       },
-      '/src/new-module': {
+      '/src/newmodule': {
         NewCard: {
           component: NewCard,
           supportsChildren: false,
@@ -1273,9 +1279,9 @@ describe('Lifecycle management of registering components', () => {
                 "Card",
               ]
           `)
-      // The NewComp from the newly added /src/new-module from the first descriptor is registered
+      // The NewComp from the newly added /src/newmodule from the first descriptor is registered
       expect(
-        Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/new-module']),
+        Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/newmodule']),
       ).toMatchInlineSnapshot(`
               Array [
                 "NewCard",
@@ -1376,7 +1382,7 @@ describe('Lifecycle management of registering components', () => {
           `)
       // The /src/module-to-delete module is deleted
       expect(
-        renderResult.getEditorState().editor.propertyControlsInfo['/src/new-module'],
+        renderResult.getEditorState().editor.propertyControlsInfo['/src/newmodule'],
       ).toBeUndefined()
       // The second descriptor file has not been changed
       expect(Object.keys(renderResult.getEditorState().editor.propertyControlsInfo['/src/card2']))

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -276,6 +276,58 @@ describe('registered property controls', () => {
 
     expect(srcCardKey).toBeUndefined()
   })
+  it('control registration fails when the module name of an imported internal component does not match the name of the registration key', async () => {
+    const renderResult = await renderTestEditorWithModel(
+      project({
+        ['/utopia/components.utopia.js']: `import { Card } from '../src/card'
+        
+        const Components = {
+      '/src/cardd': {
+        Card: {
+          component: Card,
+          supportsChildren: false,
+          properties: { },
+          variants: [ ],
+        },
+      },
+    }
+    
+    export default Components
+  `,
+      }),
+      'await-first-dom-report',
+    )
+    const editorState = renderResult.getEditorState().editor
+
+    expect(editorState.codeEditorErrors).toEqual({
+      buildErrors: {},
+      lintErrors: {
+        '/utopia/components.utopia.js': [
+          {
+            codeSnippet: '',
+            endColumn: null,
+            endLine: null,
+            errorCode: '',
+            fileName: '/utopia/components.utopia.js',
+            message:
+              'Validation failed: Module name (/src/card) does not match the module key (/src/cardd)',
+            passTime: null,
+            severity: 'fatal',
+            source: 'eslint',
+            startColumn: null,
+            startLine: null,
+            type: '',
+          },
+        ],
+      },
+    })
+
+    const srcCardKey = Object.keys(renderResult.getEditorState().editor.propertyControlsInfo).find(
+      (key) => key === '/src/card',
+    )
+
+    expect(srcCardKey).toBeUndefined()
+  })
   it('control registration fails when the imported external component does not match the name of registration key', async () => {
     const renderResult = await renderTestEditorWithModel(
       project({
@@ -311,6 +363,58 @@ describe('registered property controls', () => {
             fileName: '/utopia/components.utopia.js',
             message:
               'Validation failed: Component name (View) does not match the registration key (Vieww)',
+            passTime: null,
+            severity: 'fatal',
+            source: 'eslint',
+            startColumn: null,
+            startLine: null,
+            type: '',
+          },
+        ],
+      },
+    })
+
+    const srcCardKey = Object.keys(renderResult.getEditorState().editor.propertyControlsInfo).find(
+      (key) => key === '/src/card',
+    )
+
+    expect(srcCardKey).toBeUndefined()
+  })
+  it('control registration fails when the module name of an imported external component does not match the name of registration key', async () => {
+    const renderResult = await renderTestEditorWithModel(
+      project({
+        ['/utopia/components.utopia.js']: `import { View } from 'utopia-api'
+        
+        const Components = {
+      'utopia-apii': {
+        View: {
+          component: View,
+          supportsChildren: false,
+          properties: { },
+          variants: [ ],
+        },
+      },
+    }
+    
+    export default Components
+  `,
+      }),
+      'await-first-dom-report',
+    )
+    const editorState = renderResult.getEditorState().editor
+
+    expect(editorState.codeEditorErrors).toEqual({
+      buildErrors: {},
+      lintErrors: {
+        '/utopia/components.utopia.js': [
+          {
+            codeSnippet: '',
+            endColumn: null,
+            endLine: null,
+            errorCode: '',
+            fileName: '/utopia/components.utopia.js',
+            message:
+              'Validation failed: Module name (utopia-api) does not match the module key (utopia-apii)',
             passTime: null,
             severity: 'fatal',
             source: 'eslint',

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -275,6 +275,7 @@ function isComponentRegistrationValid(
     return { type: 'component-undefined', registrationKey: registrationKey }
   }
 
+  // check validity of internal component
   if (isComponentRendererComponent(component)) {
     if (component.originalName !== registrationKey) {
       return {
@@ -291,8 +292,10 @@ function isComponentRegistrationValid(
         moduleName: moduleName,
       }
     }
+    return { type: 'valid' }
   }
 
+  // check validity of external component
   const { name, moduleName } = getRequireInfoFromComponent(component)
   if (name != null && name !== registrationKey) {
     return {

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -79,6 +79,7 @@ import type { ProjectContentTreeRoot } from '../../components/assets'
 import { isIntrinsicHTMLElement } from '../shared/element-template'
 import type { ErrorMessage } from '../shared/error-messages'
 import { errorMessage } from '../shared/error-messages'
+import { dropFileExtension } from '../shared/file-utils'
 
 async function parseInsertOption(
   insertOption: ComponentInsertOption,
@@ -224,6 +225,7 @@ export const isComponentDescriptorFile = (filename: string) =>
 type ComponentRegistrationValidationError =
   | { type: 'component-undefined'; registrationKey: string }
   | { type: 'component-name-does-not-match'; componentName: string; registrationKey: string }
+  | { type: 'module-name-does-not-match'; moduleName: string; moduleKey: string }
 
 function messageForComponentRegistrationValidationError(
   error: ComponentRegistrationValidationError,
@@ -231,6 +233,8 @@ function messageForComponentRegistrationValidationError(
   switch (error.type) {
     case 'component-name-does-not-match':
       return `Component name (${error.componentName}) does not match the registration key (${error.registrationKey})`
+    case 'module-name-does-not-match':
+      return `Module name (${error.moduleName}) does not match the module key (${error.moduleKey})`
     case 'component-undefined':
       return `Component registered for key '${error.registrationKey}' is undefined`
     default:
@@ -262,29 +266,46 @@ interface ComponentDescriptorRegistrationResult {
 
 function isComponentRegistrationValid(
   registrationKey: string,
+  moduleKey: string,
   registration: ComponentToRegister,
 ): ComponentRegistrationValidationResult {
-  if (typeof registration.component === 'undefined') {
+  const { component } = registration
+
+  if (typeof component === 'undefined') {
     return { type: 'component-undefined', registrationKey: registrationKey }
   }
 
-  if (
-    isComponentRendererComponent(registration.component) &&
-    registration.component.originalName !== registrationKey
-  ) {
-    return {
-      type: 'component-name-does-not-match',
-      registrationKey: registrationKey,
-      componentName: registration.component.originalName ?? 'null',
+  if (isComponentRendererComponent(component)) {
+    if (component.originalName !== registrationKey) {
+      return {
+        type: 'component-name-does-not-match',
+        registrationKey: registrationKey,
+        componentName: component.originalName ?? 'null',
+      }
+    }
+    const moduleName = dropFileExtension(component.filePath)
+    if (moduleName !== moduleKey) {
+      return {
+        type: 'module-name-does-not-match',
+        moduleKey: moduleKey,
+        moduleName: moduleName,
+      }
     }
   }
 
-  const { name } = getRequireInfoFromComponent(registration.component)
+  const { name, moduleName } = getRequireInfoFromComponent(component)
   if (name != null && name !== registrationKey) {
     return {
       type: 'component-name-does-not-match',
       registrationKey: registrationKey,
-      componentName: name ?? 'null',
+      componentName: name,
+    }
+  }
+  if (moduleName != null && moduleName !== moduleKey) {
+    return {
+      type: 'module-name-does-not-match',
+      moduleKey: moduleKey,
+      moduleName: moduleName,
     }
   }
 
@@ -337,7 +358,11 @@ async function getComponentDescriptorPromisesFromParseResult(
       for await (const [componentName, componentToRegister] of Object.entries(
         parsedComponents.value,
       )) {
-        const validationResult = isComponentRegistrationValid(componentName, componentToRegister)
+        const validationResult = isComponentRegistrationValid(
+          componentName,
+          moduleName,
+          componentToRegister,
+        )
         if (validationResult.type !== 'valid') {
           errors.push({ type: 'registration-validation-failed', validationError: validationResult })
           continue


### PR DESCRIPTION
**Description:**
Next step in component registration validation: check if the module name of the imported internal or external component in the `component` property is the same as the key in the descriptor object.

E.g. the following descriptor file is valid, because `Card` is imported from `/src/card/` and that is the key in the `Components` object too.

```javascript
import { Card } from '../src/card'

const Components = {
  '/src/card': {
    Card: {
      component: Card,
      supportsChildren: false,
      properties: {
        label2: {
          control: 'string-input',
        },
      },
      variants: [],
    },
  },
}

export default Components
```
