### PR TITLE
Remix: include query string when redirecting from /p and /project

### DIFF
--- a/utopia-remix/app/routes/p.$id.tsx
+++ b/utopia-remix/app/routes/p.$id.tsx
@@ -22,6 +22,7 @@ export async function loader(args: LoaderFunctionArgs) {
       { validator: validator, excludeHeaders: excludeHeaders },
     )
   } catch (e) {
-    throw redirect(`/project/${args.params.id}`)
+    const url = new URL(args.request.url)
+    throw redirect(`/project/${args.params.id}${url.search}`)
   }
 }

--- a/utopia-remix/app/routes/project.$id.tsx
+++ b/utopia-remix/app/routes/project.$id.tsx
@@ -23,7 +23,8 @@ export async function getProjectForEditor(req: Request, params: Params<string>) 
   const user = await getUser(req)
   const validatorResult = await validator(req, params)
   if (validatorResult.ok) {
-    throw redirect(`/p/${params.id}`)
+    const url = new URL(req.url)
+    throw redirect(`/p/${params.id}${url.search}`)
   }
   const error = validatorResult.error as ApiError
   if (error.status === Status.NOT_FOUND) {


### PR DESCRIPTION
Fix #5144 

The redirect from `/p` to `/project` should include any search params used in the original URL.