### PR TITLE
Dont call set project access if not provided

### DIFF
--- a/utopia-remix/app/models/projectAccess.server.spec.ts
+++ b/utopia-remix/app/models/projectAccess.server.spec.ts
@@ -115,5 +115,7 @@ describe('create project access', () => {
       where: { project_id: 'one' },
     })
     expect(projectAccess?.access_level).toEqual(1)
+    expect(permissionsService.setProjectAccess).not.toHaveBeenCalledWith('one', 0)
+    expect(permissionsService.setProjectAccess).toHaveBeenCalledTimes(1)
   })
 })

--- a/utopia-remix/app/models/projectAccess.server.ts
+++ b/utopia-remix/app/models/projectAccess.server.ts
@@ -29,6 +29,16 @@ export async function createProjectAccess(params: {
   projectId: string
   accessLevel: AccessLevel
 }): Promise<void> {
+  // check if access level already exists
+  const projectAccess = await prisma.projectAccess.findUnique({
+    where: {
+      project_id: params.projectId,
+    },
+  })
+  if (projectAccess != null) {
+    console.error(`Project access already exists for project ${params.projectId}`)
+    return
+  }
   await prisma.$transaction(async (tx) => {
     await tx.projectAccess.upsert({
       where: {

--- a/utopia-remix/app/routes-test/v1.project.$id.spec.ts
+++ b/utopia-remix/app/routes-test/v1.project.$id.spec.ts
@@ -183,7 +183,7 @@ describe('create new project', () => {
         accessLevel: AccessLevel.PUBLIC,
       })
     })
-    it('should set access level to PRIVATE for a new project if not provided', async () => {
+    it('shouldnt set access level for a new project if not provided', async () => {
       projectProxy.mockResolvedValue({ id: projectId, ownerId: userId })
       createProjectAccessMock.mockResolvedValue(null)
       const req = newTestRequest({
@@ -198,10 +198,7 @@ describe('create new project', () => {
       }) as Promise<ApiResponse<{ id: string; projectId: string }>>)
       const project = await response.json()
       expect(project).toEqual({ id: projectId, ownerId: userId })
-      expect(createProjectAccessMock).toHaveBeenCalledWith({
-        projectId: projectId,
-        accessLevel: AccessLevel.PRIVATE,
-      })
+      expect(createProjectAccessMock).not.toHaveBeenCalled()
     })
     it('should throw an error for a new project if access level is invalid', async () => {
       projectProxy.mockResolvedValue({ id: projectId, ownerId: userId })

--- a/utopia-remix/app/routes/v1.project.$id.tsx
+++ b/utopia-remix/app/routes/v1.project.$id.tsx
@@ -44,9 +44,10 @@ async function createProject(req: Request, params: Params<string>) {
   // handle access level setting
   const url = new URL(req.url)
   const accessLevelParam = url.searchParams.get('accessLevel')
-  const accessLevel: AccessLevel =
-    accessLevelParamToAccessLevel(accessLevelParam) ?? AccessLevel.PRIVATE
-  await createProjectAccess({ projectId: id, accessLevel: accessLevel })
+  const accessLevel: AccessLevel | null = accessLevelParamToAccessLevel(accessLevelParam)
+  if (accessLevel != null) {
+    await createProjectAccess({ projectId: id, accessLevel: accessLevel })
+  }
 
   return project
 }


### PR DESCRIPTION
**Problem:**
Currently our editor calls PUT `/project/project-id` for every project save. We have a code in the PUT method that sets the access level to PRIVATE if not provided - and while it knows not to override it in the DB - it sets it in FGA on every save.

**Fix:**
This is a TEMP fix - change the route code not to set the access level if not provided - and check in the `createProjectAccess` method that the project access is indeed empty.

The proper fix will be to have the editor not call the PUT endpoint on every project save
