### PR TITLE
Change "owner" to "admin" in FGA

### DIFF
--- a/utopia-remix/app/services/permissionsService.server.ts
+++ b/utopia-remix/app/services/permissionsService.server.ts
@@ -79,6 +79,6 @@ export async function revokeAllRolesFromUser(projectId: string, userId: string) 
     'viewer',
     'collaborator',
     'editor',
-    'admin',
+    'owner',
   ])
 }

--- a/utopia-remix/app/services/permissionsService.server.ts
+++ b/utopia-remix/app/services/permissionsService.server.ts
@@ -79,6 +79,6 @@ export async function revokeAllRolesFromUser(projectId: string, userId: string) 
     'viewer',
     'collaborator',
     'editor',
-    'owner',
+    'admin',
   ])
 }

--- a/utopia-remix/fga/model.fga
+++ b/utopia-remix/fga/model.fga
@@ -5,20 +5,20 @@ type user
 
 type project
   relations
-    define can_change_owner: owner
-    define can_comment: collaborator or editor or owner
-    define can_edit: editor or owner
-    define can_fork: viewer or collaborator or editor or owner
-    define can_manage: owner
-    define can_play: viewer or collaborator or editor or owner
+    define can_assign_admin: admin
+    define can_comment: collaborator or editor or admin
+    define can_edit: editor or admin
+    define can_fork: viewer or collaborator or editor or admin
+    define can_manage: admin
+    define can_play: viewer or collaborator or editor or admin
     define can_request_access: [user:*]
-    define can_see_live_changes: collaborator or editor or owner
-    define can_show_presence: collaborator or editor or owner
-    define can_view: viewer or collaborator or editor or owner
+    define can_see_live_changes: collaborator or editor or admin
+    define can_show_presence: collaborator or editor or admin
+    define can_view: viewer or collaborator or editor or admin
     define collaborator: [user, user:*, group#member]
     define creator: [user]
     define editor: [user, group#member]
-    define owner: [user] or creator
+    define admin: [user] or creator
     define viewer: [user, user:*, group#member]
 
 type group


### PR DESCRIPTION
This PR changes the name `owner` to `admin` in the model (a moot change for now since we didn't use it).
This is to align with:
- A project always has one `creator`
- A project has multiple `admin`s
- An `admin` can manage the project (projects page, sharing, etc, including assigning new `admin`s)
- The creator is always automatically an admin