### PR TITLE
(mini pr) no test should change the project URL

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -6,7 +6,7 @@ import { chrome as isChrome } from 'platform-detect'
 import React from 'react'
 import { DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
-import { IS_BROWSER_TEST_DEBUG } from '../../common/env-vars'
+import { IS_TEST_ENVIRONMENT } from '../../common/env-vars'
 import { projectURLForProject } from '../../core/shared/utils'
 import Keyboard from '../../utils/keyboard'
 import { Modifier } from '../../utils/modifiers'
@@ -349,7 +349,7 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
   const forking = useEditorState(Substores.restOfEditor, (store) => store.editor.forking, '')
 
   React.useEffect(() => {
-    if (IS_BROWSER_TEST_DEBUG) {
+    if (IS_TEST_ENVIRONMENT) {
       return
     }
     if (projectId != null) {

--- a/website-next/components/common/env-vars.ts
+++ b/website-next/components/common/env-vars.ts
@@ -23,9 +23,6 @@ export const IS_TEST_ENVIRONMENT: boolean =
   IS_JEST_ENVIRONMENT ||
   (typeof window != 'undefined' && (window as any)?.KarmaTestEnvironment != null)
 
-export const IS_BROWSER_TEST_DEBUG: boolean =
-  IS_TEST_ENVIRONMENT && process.env.REACT_APP_BROWSER_TEST_DEBUG === 'true'
-
 export const DEVELOPMENT_ENV: boolean =
   !PRODUCTION_OR_STAGING_CONFIG && !IS_TEST_ENVIRONMENT && HOSTNAME === 'localhost'
 


### PR DESCRIPTION
We previously only prevented the URL rewriting if we were in a _debug_ test environment, but I realized there's no reason to ever rewrite the URL in _any_ test environment. 

This makes debugging Karma tests easier if we just append the `--debug` flag to any npm script