### PR TITLE
Expose Early Return Values.

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
@@ -49,6 +49,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -220,6 +221,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -67,6 +67,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -261,6 +262,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -401,6 +403,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -761,6 +764,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -970,6 +974,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -1109,6 +1114,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -1248,6 +1254,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -1437,6 +1444,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -1631,6 +1639,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -1771,6 +1780,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -2066,6 +2076,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -2260,6 +2271,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -2400,6 +2412,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -2587,6 +2600,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -2781,6 +2795,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -2921,6 +2936,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -3193,6 +3209,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -3431,6 +3448,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -3599,6 +3617,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -3733,6 +3752,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -3901,6 +3921,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -4035,6 +4056,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -4203,6 +4225,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -4455,6 +4478,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -4649,6 +4673,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -4789,6 +4814,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -5207,6 +5233,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -5591,6 +5618,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -5890,6 +5918,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -6155,6 +6184,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -6343,6 +6373,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -6497,6 +6528,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -6685,6 +6717,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -6839,6 +6872,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -7027,6 +7061,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -7181,6 +7216,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -7480,6 +7516,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -7745,6 +7782,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -7933,6 +7971,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -8087,6 +8126,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -8275,6 +8315,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -8429,6 +8470,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -8617,6 +8659,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -8771,6 +8814,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -9070,6 +9114,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -9335,6 +9380,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -9523,6 +9569,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -9677,6 +9724,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -9865,6 +9913,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -10019,6 +10068,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -10207,6 +10257,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -10422,6 +10473,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -10616,6 +10668,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -10756,6 +10809,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -10937,6 +10991,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -11058,6 +11113,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -11228,6 +11284,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -11422,6 +11479,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -11562,6 +11620,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -11862,6 +11921,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -12056,6 +12116,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -12196,6 +12257,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -12485,6 +12547,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -12739,6 +12802,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -12927,6 +12991,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -13115,6 +13180,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -13370,6 +13436,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -13564,6 +13631,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -13704,6 +13772,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -13993,6 +14062,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -14247,6 +14317,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -14435,6 +14506,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -14623,6 +14695,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -14872,6 +14945,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -15066,6 +15140,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -15206,6 +15281,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -15387,6 +15463,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -15508,6 +15585,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -15690,6 +15768,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -15884,6 +15963,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -16024,6 +16104,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -16251,6 +16332,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -16444,6 +16526,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -16566,6 +16649,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -16750,6 +16834,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -16959,6 +17044,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -17114,6 +17200,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -17548,6 +17635,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -17862,6 +17950,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -18071,6 +18160,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -18226,6 +18316,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -18660,6 +18751,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -18975,6 +19067,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -19184,6 +19277,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -19339,6 +19433,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -19824,6 +19919,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -20190,6 +20286,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -20399,6 +20496,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -20554,6 +20652,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -21039,6 +21138,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -21391,6 +21491,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -21585,6 +21686,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -21725,6 +21827,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -22016,6 +22119,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -22210,6 +22314,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -22350,6 +22455,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -24118,6 +24224,7 @@ export var storyboard = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -25432,6 +25539,7 @@ export var storyboard = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -26712,6 +26820,7 @@ export var storyboard = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -27304,6 +27413,7 @@ export var storyboard = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -27624,6 +27734,7 @@ export var storyboard = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -28216,6 +28327,7 @@ export var storyboard = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -28536,6 +28648,7 @@ export var storyboard = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -29128,6 +29241,7 @@ export var storyboard = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -29448,6 +29562,7 @@ export var storyboard = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -30078,6 +30193,7 @@ export var storyboard = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -30440,6 +30556,7 @@ export var storyboard = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -31070,6 +31187,7 @@ export var storyboard = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -31432,6 +31550,7 @@ export var storyboard = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -32062,6 +32181,7 @@ export var storyboard = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -32495,6 +32615,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -32689,6 +32810,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -32829,6 +32951,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -33044,6 +33167,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -33182,6 +33306,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -33370,6 +33495,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -33564,6 +33690,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -33704,6 +33831,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -33940,6 +34068,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -34134,6 +34263,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -34274,6 +34404,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -34660,6 +34791,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -34854,6 +34986,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -34994,6 +35127,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -35242,6 +35376,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -35439,6 +35574,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -35647,6 +35783,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -35856,6 +35993,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -36011,6 +36149,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -36336,6 +36475,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -36545,6 +36685,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -36907,6 +37048,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -37062,6 +37204,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -37389,6 +37532,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -37699,6 +37843,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -37891,6 +38036,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -38030,6 +38176,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -38794,6 +38941,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -38916,6 +39064,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -39038,6 +39187,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -39160,6 +39310,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -39282,6 +39433,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -39404,6 +39556,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -39526,6 +39679,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -39716,6 +39870,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -39867,6 +40022,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -39989,6 +40145,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -40111,6 +40268,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -40233,6 +40391,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -40355,6 +40514,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -40477,6 +40637,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -40601,6 +40762,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -40723,6 +40885,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -40845,6 +41008,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -40967,6 +41131,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -41089,6 +41254,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -41211,6 +41377,7 @@ export var App = (props) => {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -41402,6 +41569,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -41596,6 +41764,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -41736,6 +41905,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -42025,6 +42195,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -42279,6 +42450,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -42467,6 +42639,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -42655,6 +42828,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -42910,6 +43084,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -43104,6 +43279,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -43244,6 +43420,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -43532,6 +43709,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -43785,6 +43963,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -43973,6 +44152,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -44161,6 +44341,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -44416,6 +44597,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -44610,6 +44792,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -44750,6 +44933,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -45046,6 +45230,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -45307,6 +45492,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -45495,6 +45681,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -45683,6 +45870,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -45929,6 +46117,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -46138,6 +46327,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -46293,6 +46483,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -46527,6 +46718,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -46731,6 +46923,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -46919,6 +47112,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -47036,6 +47230,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -47201,6 +47396,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -47328,6 +47524,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -47516,6 +47713,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -47687,6 +47885,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -47804,6 +48003,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -48027,6 +48227,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -48192,6 +48393,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -48369,6 +48571,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -48540,6 +48743,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -48657,6 +48861,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -48890,6 +49095,7 @@ export var storyboard = (
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -49081,6 +49287,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -49252,6 +49459,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -49369,6 +49577,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -49546,6 +49755,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -49717,6 +49927,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -49834,6 +50045,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -50032,6 +50244,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -50230,6 +50443,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -50401,6 +50615,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -50518,6 +50733,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -50813,6 +51029,7 @@ export var storyboard = (
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -50974,6 +51191,7 @@ export var storyboard = (
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -51185,6 +51403,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -51356,6 +51575,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -51473,6 +51693,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -51682,6 +51903,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -51876,6 +52098,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -52016,6 +52239,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -52493,6 +52717,7 @@ export var storyboard = (
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -52620,6 +52845,7 @@ export var storyboard = (
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -52861,6 +53087,7 @@ export var storyboard = (
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -53100,6 +53327,7 @@ export var storyboard = (
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -53263,6 +53491,7 @@ export var storyboard = (
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -53478,6 +53707,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -53672,6 +53902,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -53812,6 +54043,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -53981,6 +54213,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -54171,6 +54404,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -54365,6 +54599,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -54505,6 +54740,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -54707,6 +54943,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -54901,6 +55138,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -55041,6 +55279,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -55355,6 +55594,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -55634,6 +55874,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -55836,6 +56077,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -56008,6 +56250,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -56146,6 +56389,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -56348,6 +56592,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -56520,6 +56765,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -56658,6 +56904,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -56860,6 +57107,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -57032,6 +57280,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -57221,6 +57470,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -57415,6 +57665,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -57555,6 +57806,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -57736,6 +57988,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -57930,6 +58183,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -58070,6 +58324,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -58258,6 +58513,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {
@@ -58416,6 +58672,7 @@ Object {
     "componentInstance": false,
     "computedStyle": Object {},
     "conditionValue": "not-a-conditional",
+    "earlyReturn": null,
     "element": Object {
       "type": "RIGHT",
       "value": Object {

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -813,6 +813,7 @@ function collectAndCreateMetadataForElement(
       null,
       'not-a-conditional',
       textContentsMaybe,
+      null,
     )
   })
 
@@ -1193,6 +1194,7 @@ function walkCanvasRootFragment(
       null,
       null, // this comes from the Spy Wrapper
       'not-a-conditional',
+      null,
       null,
     )
 

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -256,6 +256,7 @@ export function renderCoreElement(
           filePath,
           imports,
           'not-a-conditional',
+          null,
         )
       }
 
@@ -379,10 +380,19 @@ export function renderCoreElement(
           elementPath,
         )
 
-        addFakeSpyEntry(validPaths, metadataContext, elementPath, element, filePath, imports, {
-          active: activeConditionValue,
-          default: defaultConditionValue,
-        })
+        addFakeSpyEntry(
+          validPaths,
+          metadataContext,
+          elementPath,
+          element,
+          filePath,
+          imports,
+          {
+            active: activeConditionValue,
+            default: defaultConditionValue,
+          },
+          null,
+        )
       }
 
       const childPath = optionalMap(
@@ -455,6 +465,7 @@ export function renderCoreElement(
           filePath,
           imports,
           'not-a-conditional',
+          null,
         )
       }
 

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
@@ -7,6 +7,7 @@ import type {
   JSXElementChild,
   JSXConditionalExpression,
   ConditionValue,
+  EarlyReturn,
 } from '../../../core/shared/element-template'
 import {
   emptyAttributeMetadata,
@@ -61,6 +62,7 @@ export function addFakeSpyEntry(
   filePath: string,
   imports: Imports,
   conditionValue: ConditionValue,
+  earlyReturn: EarlyReturn | null,
 ): void {
   // Ensure that entries are not created which aren't included in `validPaths`,
   // so that ghost like entries are not created.
@@ -93,6 +95,7 @@ export function addFakeSpyEntry(
       ),
       conditionValue: conditionValue,
       textContent: null,
+      earlyReturn: earlyReturn,
     }
     const elementPathString = EP.toComponentId(elementPath)
     metadataContext.current.spyValues.metadata[elementPathString] = instanceMetadata
@@ -148,6 +151,7 @@ export function buildSpyWrappedElement(
         : null,
       conditionValue: 'not-a-conditional',
       textContent: null,
+      earlyReturn: null,
     }
     if (!EP.isStoryboardPath(elementPath) || shouldIncludeCanvasRootInTheSpy) {
       const elementPathString = EP.toComponentId(elementPath)

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -989,6 +989,7 @@ describe('SET_FOCUSED_ELEMENT', () => {
       null,
       'not-a-conditional',
       null,
+      null,
     )
     const fakeMetadata: ElementInstanceMetadataMap = {
       [EP.toString(pathToFocus)]: divElementMetadata,
@@ -1025,6 +1026,7 @@ describe('SET_FOCUSED_ELEMENT', () => {
       null,
       null,
       'not-a-conditional',
+      null,
       null,
     )
     const fakeMetadata: ElementInstanceMetadataMap = {

--- a/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
@@ -548,6 +548,7 @@ describe('ElementInstanceMetadataKeepDeepEquality', () => {
     importInfo: createImportedFrom('old', 'old', 'old'),
     conditionValue: 'not-a-conditional',
     textContent: null,
+    earlyReturn: null,
   }
   const newDifferentValue: ElementInstanceMetadata = {
     elementPath: EP.elementPath([['scene'], ['aaa', 'bbb']]),
@@ -674,6 +675,7 @@ describe('ElementInstanceMetadataKeepDeepEquality', () => {
     importInfo: createImportedFrom('old', 'old', 'old'),
     conditionValue: 'not-a-conditional',
     textContent: null,
+    earlyReturn: null,
   }
 
   it('same reference returns the same reference', () => {
@@ -826,6 +828,7 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
       importInfo: createImportedFrom('old', 'old', 'old'),
       conditionValue: 'not-a-conditional',
       textContent: null,
+      earlyReturn: null,
     },
   }
   const newSameValue: ElementInstanceMetadataMap = {
@@ -954,6 +957,7 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
       importInfo: createImportedFrom('old', 'old', 'old'),
       conditionValue: 'not-a-conditional',
       textContent: null,
+      earlyReturn: null,
     },
   }
   const newDifferentValue: ElementInstanceMetadataMap = {
@@ -1082,6 +1086,7 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
       importInfo: createImportedFrom('old', 'old', 'old'),
       conditionValue: 'not-a-conditional',
       textContent: 'hello',
+      earlyReturn: null,
     },
   }
 

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -125,6 +125,7 @@ function callPropertyControlsHook(
       importInfos[0],
       'not-a-conditional',
       null,
+      null,
     ),
   }
   let allElementProps: AllElementProps = {
@@ -147,6 +148,7 @@ function callPropertyControlsHook(
       importInfos[1],
       'not-a-conditional',
       null,
+      null,
     )
     allElementProps[EP.toString(selectedViews[1])] = {
       propWithControlButNoValue: 'but there is a value!',
@@ -167,6 +169,7 @@ function callPropertyControlsHook(
       null,
       importInfos[2],
       'not-a-conditional',
+      null,
       null,
     )
 

--- a/editor/src/core/model/element-metadata-utils.spec.tsx
+++ b/editor/src/core/model/element-metadata-utils.spec.tsx
@@ -72,6 +72,7 @@ const testComponentMetadataChild1: ElementInstanceMetadata = {
   importInfo: null,
   conditionValue: 'not-a-conditional',
   textContent: null,
+  earlyReturn: null,
 }
 const testComponentMetadataChild2: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
@@ -91,6 +92,7 @@ const testComponentMetadataChild2: ElementInstanceMetadata = {
   importInfo: null,
   conditionValue: 'not-a-conditional',
   textContent: null,
+  earlyReturn: null,
 }
 
 const testComponentMetadataGrandchild: ElementInstanceMetadata = {
@@ -111,6 +113,7 @@ const testComponentMetadataGrandchild: ElementInstanceMetadata = {
   importInfo: null,
   conditionValue: 'not-a-conditional',
   textContent: null,
+  earlyReturn: null,
 }
 
 const testComponentPropsGrandchild: ElementProps = {
@@ -135,6 +138,7 @@ const testComponentMetadataChild3: ElementInstanceMetadata = {
   importInfo: null,
   conditionValue: 'not-a-conditional',
   textContent: null,
+  earlyReturn: null,
 }
 
 const testComponentRoot1: ElementInstanceMetadata = {
@@ -152,6 +156,7 @@ const testComponentRoot1: ElementInstanceMetadata = {
   importInfo: null,
   conditionValue: 'not-a-conditional',
   textContent: null,
+  earlyReturn: null,
 }
 
 const testComponentSceneChildElementRootChild: ElementInstanceMetadata = {
@@ -172,6 +177,7 @@ const testComponentSceneChildElementRootChild: ElementInstanceMetadata = {
   importInfo: null,
   conditionValue: 'not-a-conditional',
   textContent: null,
+  earlyReturn: null,
 }
 
 const testComponentSceneChildElementRoot: ElementInstanceMetadata = {
@@ -192,6 +198,7 @@ const testComponentSceneChildElementRoot: ElementInstanceMetadata = {
   importInfo: null,
   conditionValue: 'not-a-conditional',
   textContent: null,
+  earlyReturn: null,
 }
 
 const testComponentSceneChildElement: ElementInstanceMetadata = {
@@ -209,6 +216,7 @@ const testComponentSceneChildElement: ElementInstanceMetadata = {
   importInfo: null,
   conditionValue: 'not-a-conditional',
   textContent: null,
+  earlyReturn: null,
 }
 
 const testComponentSceneElement: ElementInstanceMetadata = {
@@ -226,6 +234,7 @@ const testComponentSceneElement: ElementInstanceMetadata = {
   importInfo: null,
   conditionValue: 'not-a-conditional',
   textContent: null,
+  earlyReturn: null,
 }
 
 const testComponentSceneElementProps: ElementProps = {
@@ -250,6 +259,7 @@ const testStoryboardGrandChildElement: ElementInstanceMetadata = {
   importInfo: null,
   conditionValue: 'not-a-conditional',
   textContent: null,
+  earlyReturn: null,
 }
 
 const testStoryboardChildElement: ElementInstanceMetadata = {
@@ -267,6 +277,7 @@ const testStoryboardChildElement: ElementInstanceMetadata = {
   importInfo: null,
   conditionValue: 'not-a-conditional',
   textContent: null,
+  earlyReturn: null,
 }
 
 const testStoryboardElement: ElementInstanceMetadata = {
@@ -284,6 +295,7 @@ const testStoryboardElement: ElementInstanceMetadata = {
   importInfo: null,
   conditionValue: 'not-a-conditional',
   textContent: null,
+  earlyReturn: null,
 }
 
 const testElementMetadataMap: ElementInstanceMetadataMap = {
@@ -375,6 +387,7 @@ function dummyInstanceDataForElementType(
     importInfo: importInfo,
     conditionValue: 'not-a-conditional',
     textContent: null,
+    earlyReturn: null,
   }
 }
 
@@ -903,6 +916,7 @@ describe('getElementLabel', () => {
     null,
     'not-a-conditional',
     null,
+    null,
   )
   const spanElementProps: ElementProps = {
     'data-uid': 'span-1',
@@ -927,6 +941,7 @@ describe('getElementLabel', () => {
     null,
     null,
     'not-a-conditional',
+    null,
     null,
   )
   const divElementProps: ElementProps = {

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -2809,6 +2809,7 @@ export function createFakeMetadataForElement(
     null,
     'not-a-conditional',
     null,
+    null,
   )
 }
 

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -2396,7 +2396,9 @@ export function arbitraryBlockRanToEnd(scope: MapLike<unknown>): ArbitraryBlockR
   }
 }
 
-export type ArbitraryBlockResult = EarlyReturnVoid | EarlyReturnResult | ArbitraryBlockRanToEnd
+export type EarlyReturn = EarlyReturnVoid | EarlyReturnResult
+
+export type ArbitraryBlockResult = EarlyReturn | ArbitraryBlockRanToEnd
 
 export interface ElementInstanceMetadata {
   elementPath: ElementPath
@@ -2413,6 +2415,7 @@ export interface ElementInstanceMetadata {
   importInfo: ImportInfo | null
   conditionValue: ConditionValue
   textContent: string | null
+  earlyReturn: EarlyReturn | null
 }
 
 export function elementInstanceMetadata(
@@ -2430,6 +2433,7 @@ export function elementInstanceMetadata(
   importInfo: ImportInfo | null,
   conditionValue: ConditionValue,
   textContent: string | null,
+  earlyReturn: EarlyReturnResult | EarlyReturnVoid | null,
 ): ElementInstanceMetadata {
   return {
     elementPath: elementPath,
@@ -2446,6 +2450,7 @@ export function elementInstanceMetadata(
     importInfo: importInfo,
     conditionValue: conditionValue,
     textContent: textContent,
+    earlyReturn: earlyReturn,
   }
 }
 

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -1450,7 +1450,6 @@ export function parseJSExpressionMapOrOtherJavascript(
             expressionFullText,
             rawMap,
             parsedElementsWithin,
-            true,
             false,
             sourceFile.fileName,
           )
@@ -3654,7 +3653,6 @@ export function parseArbitraryNodes(
         code,
         rawMap,
         parsedElementsWithin,
-        false,
         rootLevel,
         sourceFile.fileName,
       )

--- a/editor/src/core/workers/parser-printer/parser-printer-transpiling.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-transpiling.ts
@@ -532,48 +532,46 @@ export function insertDataUIDsIntoCode(
   code: string,
   map: RawSourceMap,
   elementsWithin: ElementsWithinInPosition,
-  wrapInParens: boolean,
   rootLevel: boolean,
   filename: string,
 ): Either<string, CodeWithMap> {
-  if (wrapInParens) {
-    const wrappedInParensResult = insertDataUIDsIntoCodeInner(
-      sourceFileName,
-      sourceFileText,
-      code,
-      map,
-      elementsWithin,
-      'wrap-in-parens',
-      rootLevel,
-      filename,
-    )
-
-    if (isRight(wrappedInParensResult)) {
-      return wrappedInParensResult
-    } else {
-      return insertDataUIDsIntoCodeInner(
-        sourceFileName,
-        sourceFileText,
-        code,
-        map,
-        elementsWithin,
-        'wrap-in-anon-fn',
-        rootLevel,
-        filename,
-      )
-    }
-  } else {
-    return insertDataUIDsIntoCodeInner(
-      sourceFileName,
-      sourceFileText,
-      code,
-      map,
-      elementsWithin,
-      'do-not-wrap',
-      rootLevel,
-      filename,
-    )
+  const wrappedInParensResult = insertDataUIDsIntoCodeInner(
+    sourceFileName,
+    sourceFileText,
+    code,
+    map,
+    elementsWithin,
+    'wrap-in-parens',
+    rootLevel,
+    filename,
+  )
+  if (isRight(wrappedInParensResult)) {
+    return wrappedInParensResult
   }
+  const wrappedInAnonFunctionResult = insertDataUIDsIntoCodeInner(
+    sourceFileName,
+    sourceFileText,
+    code,
+    map,
+    elementsWithin,
+    'wrap-in-anon-fn',
+    rootLevel,
+    filename,
+  )
+  if (isRight(wrappedInAnonFunctionResult)) {
+    return wrappedInAnonFunctionResult
+  }
+  const doNotWrapResult = insertDataUIDsIntoCodeInner(
+    sourceFileName,
+    sourceFileText,
+    code,
+    map,
+    elementsWithin,
+    'do-not-wrap',
+    rootLevel,
+    filename,
+  )
+  return doNotWrapResult
 }
 
 function getAbsoluteOffsetFromFile(

--- a/editor/src/utils/deep-equality.ts
+++ b/editor/src/utils/deep-equality.ts
@@ -809,6 +809,116 @@ export function combine14EqualityCalls<A, B, C, D, E, F, G, H, I, J, K, L, M, N,
   }
 }
 
+export function combine15EqualityCalls<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, X>(
+  getAValue: (x: X) => A,
+  callA: KeepDeepEqualityCall<A>,
+  getBValue: (x: X) => B,
+  callB: KeepDeepEqualityCall<B>,
+  getCValue: (x: X) => C,
+  callC: KeepDeepEqualityCall<C>,
+  getDValue: (x: X) => D,
+  callD: KeepDeepEqualityCall<D>,
+  getEValue: (x: X) => E,
+  callE: KeepDeepEqualityCall<E>,
+  getFValue: (x: X) => F,
+  callF: KeepDeepEqualityCall<F>,
+  getGValue: (x: X) => G,
+  callG: KeepDeepEqualityCall<G>,
+  getHValue: (x: X) => H,
+  callH: KeepDeepEqualityCall<H>,
+  getIValue: (x: X) => I,
+  callI: KeepDeepEqualityCall<I>,
+  getJValue: (x: X) => J,
+  callJ: KeepDeepEqualityCall<J>,
+  getKValue: (x: X) => K,
+  callK: KeepDeepEqualityCall<K>,
+  getLValue: (x: X) => L,
+  callL: KeepDeepEqualityCall<L>,
+  getMValue: (x: X) => M,
+  callM: KeepDeepEqualityCall<M>,
+  getNValue: (x: X) => N,
+  callN: KeepDeepEqualityCall<N>,
+  getOValue: (x: X) => O,
+  callO: KeepDeepEqualityCall<O>,
+  combine: (
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O,
+  ) => X,
+): KeepDeepEqualityCall<X> {
+  return (oldValue, newValue) => {
+    if (oldValue === newValue) {
+      return keepDeepEqualityResult(oldValue, true)
+    }
+
+    const resultA = callA(getAValue(oldValue), getAValue(newValue))
+    const resultB = callB(getBValue(oldValue), getBValue(newValue))
+    const resultC = callC(getCValue(oldValue), getCValue(newValue))
+    const resultD = callD(getDValue(oldValue), getDValue(newValue))
+    const resultE = callE(getEValue(oldValue), getEValue(newValue))
+    const resultF = callF(getFValue(oldValue), getFValue(newValue))
+    const resultG = callG(getGValue(oldValue), getGValue(newValue))
+    const resultH = callH(getHValue(oldValue), getHValue(newValue))
+    const resultI = callI(getIValue(oldValue), getIValue(newValue))
+    const resultJ = callJ(getJValue(oldValue), getJValue(newValue))
+    const resultK = callK(getKValue(oldValue), getKValue(newValue))
+    const resultL = callL(getLValue(oldValue), getLValue(newValue))
+    const resultM = callM(getMValue(oldValue), getMValue(newValue))
+    const resultN = callN(getNValue(oldValue), getNValue(newValue))
+    const resultO = callO(getOValue(oldValue), getOValue(newValue))
+    const areEqual =
+      resultA.areEqual &&
+      resultB.areEqual &&
+      resultC.areEqual &&
+      resultD.areEqual &&
+      resultE.areEqual &&
+      resultF.areEqual &&
+      resultG.areEqual &&
+      resultH.areEqual &&
+      resultI.areEqual &&
+      resultJ.areEqual &&
+      resultK.areEqual &&
+      resultL.areEqual &&
+      resultM.areEqual &&
+      resultN.areEqual &&
+      resultO.areEqual
+    if (areEqual) {
+      return keepDeepEqualityResult(oldValue, true)
+    } else {
+      const value = combine(
+        resultA.value,
+        resultB.value,
+        resultC.value,
+        resultD.value,
+        resultE.value,
+        resultF.value,
+        resultG.value,
+        resultH.value,
+        resultI.value,
+        resultJ.value,
+        resultK.value,
+        resultL.value,
+        resultM.value,
+        resultN.value,
+        resultO.value,
+      )
+      return keepDeepEqualityResult(value, false)
+    }
+  }
+}
+
 export function createCallWithTripleEquals<T>(): KeepDeepEqualityCall<T> {
   return (oldValue, newValue) => {
     const areEqual = oldValue === newValue

--- a/editor/src/utils/utils.test-utils.tsx
+++ b/editor/src/utils/utils.test-utils.tsx
@@ -390,6 +390,7 @@ function createFakeMetadataForJSXElement(
       importInfo: null,
       conditionValue: 'not-a-conditional',
       textContent: textContents,
+      earlyReturn: null,
     })
     elements.push(...children)
   } else if (isJSXFragment(element)) {
@@ -427,6 +428,7 @@ function createFakeMetadataForStoryboard(elementPath: ElementPath): ElementInsta
     importInfo: null,
     conditionValue: 'not-a-conditional',
     textContent: null,
+    earlyReturn: null,
   }
 }
 


### PR DESCRIPTION
**Problem:**
We momentarily capture early return values from components, but there's no way to see what they were after the fact.

**Fix:**
Our metadata is now slightly extended to include an early return value, so that it can be stored at the point where it's captured during the rendering of the component. The type of that field is `EarlyReturn | null` so that it's possible to capture the case where the early return itself is null.

There was also a small fix to `insertDataUIDsIntoCode` to make it try a series of "wrapping" approaches when processing the code. This was done because it can be quite situational which is best to try, so having particular call sites picking and choosing didn't make much sense.

**Notes:**
This does not represent the early returns in the UI, that will be in some follow up work.

**Commit Details:**
- In `createComponentRendererComponent`, call `addFakeSpyEntry` when an early return value is returned from a component.
- Added an `EarlyReturn` type to cover the two types of early returns.
- Remove the early returning code when an early return comes into `createComponentRendererComponent`.
- Added `earlyReturn` field to `ElementInstanceMetadata`.
- Reworked `insertDataUIDsIntoCode` to try the various approaches for wrapping the expression instead of the previous style of specifying but having a single alternative approach.
